### PR TITLE
Update codecov configuration for better PR workflow

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,13 +10,15 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1%
+        threshold: 5%
+        informational: true
         if_ci_failed: error
         only_pulls: false
     patch:
       default:
         target: auto
-        threshold: 1%
+        threshold: 5%
+        informational: true
         if_ci_failed: error
 
 flags:
@@ -36,6 +38,9 @@ ignore:
   - "**/*Tests.swift"
   - "**/*Mock*.swift"
   - "**/resource_bundle_accessor.swift"
+  - "**/*.pb.swift"
+  - "**/*.grpc.swift"
+  - "**/Proto/**"
 
 comment:
   layout: "reach, diff, flags, files"


### PR DESCRIPTION
- Exclude protobuf generated files (*.pb.swift, *.grpc.swift) from coverage
- Set coverage checks to informational mode to prevent PR blocking
- Increase threshold from 1% to 5% for more flexibility
- Add Proto directories to ignore list

This ensures that auto-generated code doesn't affect coverage metrics and prevents coverage checks from blocking PRs unnecessarily.