### PR TITLE
If no appConfig is uploaded, provide an automatic fallback

### DIFF
--- a/Sources/AppConfig/AppConfig.swift
+++ b/Sources/AppConfig/AppConfig.swift
@@ -2,7 +2,7 @@ public struct AppConfig: Codable {
     public let appId: String
     public let version: String
     public let entitlements: [Entitlement]
-    
+
     public init(appId: String, version: String, entitlements: [Entitlement]) {
         self.appId = appId
         self.version = version

--- a/Sources/EdgeAgent/Services/EdgeContainerService.swift
+++ b/Sources/EdgeAgent/Services/EdgeContainerService.swift
@@ -116,9 +116,13 @@ struct EdgeContainerService: Edge_Agent_Services_V1_EdgeContainerService.Service
                 }
 
                 let appConfig: AppConfig
-                
+
                 if request.appConfig.isEmpty {
-                    appConfig = AppConfig(appId: request.appName, version: "0.0.0", entitlements: [])
+                    appConfig = AppConfig(
+                        appId: request.appName,
+                        version: "0.0.0",
+                        entitlements: []
+                    )
                 } else {
                     appConfig = try JSONDecoder().decode(AppConfig.self, from: request.appConfig)
                 }

--- a/Tests/EdgeCLITests/AgentConnectionOptionsTests.swift
+++ b/Tests/EdgeCLITests/AgentConnectionOptionsTests.swift
@@ -153,11 +153,11 @@ struct AgentConnectionOptionsTests {
         // Device should be populated
         #expect(command.agentConnectionOptions.device?.host == "device.server.com")
         #expect(command.agentConnectionOptions.device?.port == 9000)
-        
+
         // Agent should also be populated
         #expect(command.agentConnectionOptions.agent?.host == "agent.server.com")
         #expect(command.agentConnectionOptions.agent?.port == 8000)
-        
+
         // But endpoint should return device (takes precedence)
         let endpoint = try command.agentConnectionOptions.endpoint
         #expect(endpoint.host == "device.server.com")


### PR DESCRIPTION
This allows older CLIs or projects without config to still run