### PR TITLE
Fix inconsistent tar execution: use env lookup instead of hardcoded path

### DIFF
--- a/Sources/ContainerBuilder/ContainerBuilder.swift
+++ b/Sources/ContainerBuilder/ContainerBuilder.swift
@@ -231,15 +231,17 @@ private func sha256(data: Data) -> String {
     return digest.map { String(format: "%02x", $0) }.joined()
 }
 
-/// Creates a tarball from the given source directory using /usr/bin/tar.
+/// Creates a tarball from the given source directory using tar via env lookup.
 ///
 /// - Parameter sourceDir: The directory to create a tarball from.
 /// - Parameter destinationURL: The URL to save the tarball to.
 /// - Throws: An error if the tarball cannot be created.
 private func createTarball(from sourceDir: URL, to destinationURL: URL) async throws {
     _ = try await Subprocess.run(
-        Subprocess.Executable.path("/usr/bin/tar"),
-        arguments: Subprocess.Arguments(["-cf", destinationURL.path, "-C", sourceDir.path, "."])
+        Subprocess.Executable.path("/usr/bin/env"),
+        arguments: Subprocess.Arguments([
+            "tar", "-cf", destinationURL.path, "-C", sourceDir.path, ".",
+        ])
     )
 }
 


### PR DESCRIPTION
  Changed createTarball function in ContainerBuilder to use '/usr/bin/env tar'
  instead of hardcoded '/usr/bin/tar' path for better cross-platform compatibility.

  This makes tar execution consistent with other parts of the codebase
  (FetchReleases.swift) and ensures compatibility across different Linux
  distributions where tar may be located in /bin/tar, /usr/bin/tar, or other
  locations in PATH.

  Fixes EDG-273