### PR TITLE
When no agent is provided, use the default hostname (edgeos-device.local) for now

### DIFF
--- a/Sources/Edge/AgentConnectionOptions.swift
+++ b/Sources/Edge/AgentConnectionOptions.swift
@@ -77,16 +77,13 @@ struct AgentConnectionOptions: ParsableArguments {
                 return agent
             }
 
-            guard
-                let endpoint = ProcessInfo.processInfo.environment["EDGE_AGENT"],
+            if let endpoint = ProcessInfo.processInfo.environment["EDGE_AGENT"],
                 let endpoint = Endpoint(argument: endpoint)
-            else {
-                throw ValidationError(
-                    "The `--device` option was not provided and the `EDGE_AGENT` environment variable is not set."
-                )
+            {
+                return endpoint
             }
 
-            return endpoint
+            return Endpoint(host: "edgeos-device.local", port: 50051)
         }
     }
 }


### PR DESCRIPTION
Not certain about this on the long term, but for now it's a huge annoyance out the window for me.