### PR TITLE
Bump dbus version and fix wificommand

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
             url: "https://github.com/swift-server/swift-openapi-async-http-client.git",
             from: "1.1.0"
         ),
-        .package(url: "https://github.com/edgeengineer/dbus.git", from: "0.2.2"),
+        .package(url: "https://github.com/edgeengineer/dbus.git", from: "0.2.3"),
         .package(url: "https://github.com/apple/swift-system.git", from: "1.4.2"),
     ],
     targets: [


### PR DESCRIPTION
This small PR fixes an issue with the CLI/agent using an outdated version of DBUS, causing network manager resolution to fail. It also fixes a couple of issues that caused the `wifi list` command to fail and/or have confusing output.