### PR TITLE
Brew auto release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,10 +191,6 @@ jobs:
           git tag -fa latest "$TARGET_SHA" -m "Latest prerelease: $TAG"
           git push -f origin refs/tags/latest
 
-      - name: Set up Homebrew
-        run: |
-          sudo apt-get install build-essential procps curl file git
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       # Bump the formula in homebrew-tap
       - name: Create GitHub App Token
         id: app-token


### PR DESCRIPTION
Use scripted formula bump instead of action

  Replace dawidd6/action-homebrew-bump-formula with a custom script
  that works with GitHub App tokens. The action only supports PATs,
  causing authentication errors.

  The script downloads release artifacts, calculates SHA256s, updates
  the formula, and opens a PR automatically.

  Also adds version numbers to tarball names for better Homebrew
  version detection.
