### PR TITLE
Fix returned SSID from SSID discovery not matching user input

### DIFF
--- a/Sources/Wendy/cli/Agent.swift
+++ b/Sources/Wendy/cli/Agent.swift
@@ -45,6 +45,7 @@ struct Agent {
         let ssids = networks.map { $0.ssid }
             .sorted()
             .filter { !$0.isEmpty }
+    
 
         let index = try await Noora().selectableTable(
             headers: ["SSID"],
@@ -54,7 +55,7 @@ struct Agent {
             pageSize: networks.count
         )
 
-        return ssids[index].ssid
+        return ssids[index]
     }
 
     func connectToWiFi(


### PR DESCRIPTION
This PR addresses a small bug in the SSID discovery logic that would return seemingly random SSIDs despite what the user selected in the Noora prompt. This was caused by the function returning a result from the unsorted/unfiltered `networks` array instead of the `ssids` array that the Noora prompt references for user input.