### PR TITLE
Improve error reporting and traces across the swift builds

### DIFF
--- a/Sources/ContainerBuilder/ContainerBuilder.swift
+++ b/Sources/ContainerBuilder/ContainerBuilder.swift
@@ -30,6 +30,7 @@ public func buildDockerContainerLayers(
     imageName: String,
     outputDirectoryPath: URL
 ) async throws -> [ContainerLayer] {
+    logger.debug("Building container layers", metadata: ["image-name": .string(imageName), "output": .string(outputDirectoryPath.path())])
     var layers = [ContainerLayer]()
 
     for (index, layer) in image.layers.enumerated() {
@@ -88,9 +89,9 @@ public func buildDockerContainerLayers(
         }
 
         // If the layer has a predefined diffID, use it
-        logger.debug("Calculating diffID for layer \(layerTarPath.path)")
+        logger.debug("Calculating diffID for layer", metadata: ["path": .string(layerTarPath.path())])
         let layer = try await FileSystem.shared.withFileHandle(
-            forReadingAt: FilePath(layerTarPath.path)
+            forReadingAt: FilePath(layerTarPath.path())
         ) { fileHandle in
             var sha = SHA256()
             var fileSize: Int64 = 0
@@ -104,6 +105,8 @@ public func buildDockerContainerLayers(
 
             let diffID = layer.diffID ?? "sha256:\(layerSHA)"
 
+            logger.trace("Calculated diffID for layer", metadata: ["path": .string(layerTarPath.path()), "diffID": .string(diffID), "size": .string("\(fileSize) bytes")])
+
             return ContainerLayer(
                 path: layerTarPath,
                 hash: layerSHA,
@@ -115,6 +118,7 @@ public func buildDockerContainerLayers(
         layers.append(layer)
     }
 
+    logger.trace("Built container layers")
     return layers
 }
 
@@ -228,8 +232,7 @@ public func buildDockerContainerImage(
     try manifestData.write(to: manifestPath)
 
     try await createTarball(from: imageDir, to: URL(fileURLWithPath: outputPath))
-
-    try FileManager.default.removeItem(at: tempDir)
+    logger.debug("Created container image tarball", metadata: ["output": .string(outputPath)])
 }
 
 // Calculate SHA256 hash using Swift Crypto
@@ -245,9 +248,9 @@ private func sha256(data: Data) -> String {
 /// - Throws: An error if the tarball cannot be created.
 private func createTarball(from sourceDir: URL, to destinationURL: URL) async throws {
     _ = try await Subprocess.run(
-        Subprocess.Executable.path("/usr/bin/env"),
+        .name("tar"),
         arguments: Subprocess.Arguments([
-            "tar", "-cf", destinationURL.path, "-C", sourceDir.path, ".",
+            "-cf", destinationURL.path, "-C", sourceDir.path, ".",
         ]),
         output: .discarded
     )

--- a/Sources/Wendy/cli/Agent.swift
+++ b/Sources/Wendy/cli/Agent.swift
@@ -82,7 +82,6 @@ struct Agent {
     func update(fromBinary path: String) async throws -> Bool {
         let logger = Logger(label: "sh.wendyengineer.agent.update")
         let agent = Wendy_Agent_Services_V1_WendyAgentService.Client(wrapping: client)
-        print("Pushing update...")
         return try await agent.updateAgent { writer in
             logger.debug("Opening file...")
             do {
@@ -113,15 +112,22 @@ struct Agent {
                 throw error
             }
         } onResponse: { response in
-            for try await event in response.messages {
-                switch event.responseType {
-                case .updated:
-                    return true
-                case .none:
-                    ()
+            do {
+                for try await event in response.messages {
+                    switch event.responseType {
+                    case .updated:
+                        return true
+                    case .none:
+                        ()
+                    }
                 }
+                return false
+            } catch {
+                logger.error("Failed to update agent", metadata: [
+                    "error": "\(error)"
+                ])
+                throw error
             }
-            return false
         }
     }
 }

--- a/Sources/Wendy/cli/commands/RunCommand.swift
+++ b/Sources/Wendy/cli/commands/RunCommand.swift
@@ -237,7 +237,8 @@ extension RunCommand {
                 // Construct the full path to the layer file
                 let layerFile = extractDir.appendingPathComponent(layerPath)
 
-                guard let info = try await FileSystem.shared.info(forFileAt: FilePath(layerFile.path()))
+                guard
+                    let info = try await FileSystem.shared.info(forFileAt: FilePath(layerFile.path()))
                 else {
                     logger.warning("Layer file not found: \(layerFile.path)")
                     continue
@@ -275,14 +276,18 @@ extension RunCommand {
         let diffID: String
         let size: Int64
         let gzip: Bool
+        let logger = Logger(label: "sh.wendy.cli.run.containerd.layer.stream")
 
         func withStream(_ write: (ArraySlice<UInt8>) async throws -> Void) async throws {
             switch source {
             case .path(let url):
+                logger.debug("Reading layer from path", metadata: ["path": .string(url.path())])
                 try await FileSystem.shared.withFileHandle(
                     forReadingAt: FilePath(url.path())
                 ) { fileHandle in
+                    logger.debug("Reading layer from file handle")
                     for try await chunk in fileHandle.readChunks() {
+                        logger.trace("Reading layer chunk", metadata: ["size": .string("\(chunk.readableBytesView.count) bytes")])
                         try await write(Array(buffer: chunk)[...])
                     }
                 }
@@ -475,8 +480,20 @@ extension RunCommand {
                                         }
                                     }
                                 ) { response in
-                                    for try await _ in response.messages {
-                                        // Ignore responses
+                                    do {
+                                        for try await message in response.messages {
+                                            // Ignore responses
+                                            logger.trace("Got unknown response", metadata: [
+                                                "digest": .string(layer.digest),
+                                                "response": .string("\(message)")
+                                            ])
+                                        }
+                                    } catch {
+                                        logger.error("Failed to get response", metadata: [
+                                            "digest": .string(layer.digest),
+                                            "error": .string("\(error)")
+                                        ])
+                                        throw error
                                     }
                                 }
                                 logger.debug("Uploaded layer successfully", metadata: ["digest": .string(layer.digest)])
@@ -486,6 +503,7 @@ extension RunCommand {
                                     "digest": .string(layer.digest),
                                     "error": .string("\(error)")
                                 ])
+                                logger.error("Failed to upload layer", metadata: ["error": .string("\(error)")])
                                 await layersUploaded.incrementFailedUploaded(error: error)
                             }
                         }
@@ -1040,9 +1058,9 @@ extension RunCommand {
 
     private func extractTar(from sourceURL: URL, to destinationURL: URL) async throws {
         _ = try await Subprocess.run(
-            Subprocess.Executable.path("/usr/bin/env"),
+            .name("tar"),
             arguments: Subprocess.Arguments([
-                "tar", "-xf", sourceURL.path, "-C", destinationURL.path,
+                "-xf", sourceURL.path, "-C", destinationURL.path,
             ]),
             output: .discarded
         )


### PR DESCRIPTION
This should remove the `CancellationError` if an upload fails - showing the real thing.
Should also give more clarify and means to investigate when tracing