### PR TITLE
Add wendy os cache clear command (WDY-423)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -138,7 +138,10 @@ let package = Package(
         .target(
             name: "DockerOpenAPI",
             dependencies: [
-                .product(name: "OpenAPIAsyncHTTPClient", package: "swift-openapi-async-http-client"),
+                .product(
+                    name: "OpenAPIAsyncHTTPClient",
+                    package: "swift-openapi-async-http-client"
+                ),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),

--- a/Sources/Wendy/cli/commands/CacheCommand.swift
+++ b/Sources/Wendy/cli/commands/CacheCommand.swift
@@ -8,7 +8,8 @@ struct CacheCommand: AsyncParsableCommand {
         commandName: "cache",
         abstract: "Inspect cached WendyOS images.",
         subcommands: [
-            ListCommand.self
+            ListCommand.self,
+            ClearCommand.self,
         ],
         defaultSubcommand: ListCommand.self
     )
@@ -74,6 +75,129 @@ struct CacheCommand: AsyncParsableCommand {
                 print(
                     "\nSome cache entries look incomplete. Remove the corresponding folders under \(cacheDirectory().path) if you need to reclaim space."
                 )
+            }
+        }
+    }
+
+    struct ClearCommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "clear",
+            abstract: "Remove cached WendyOS images by device or all."
+        )
+
+        @Argument(
+            help: "Device name to clear. Omit to select from existing cached images."
+        )
+        var device: String?
+
+        @Flag(name: .long, help: "Remove all cached images.")
+        var all: Bool = false
+
+        @Flag(name: .long, help: "Skip confirmation prompts")
+        var force: Bool = false
+
+        func run() async throws {
+            guard all || device != nil else {
+                throw ValidationError("Specify a device name or --all, not both.")
+            }
+
+            let noora = Noora()
+            let fileManager = FileManager.default
+            let cachedImages = try listCachedImages(fileManager: fileManager)
+
+            guard !cachedImages.isEmpty else {
+                noora.info("No cached WendyOS images to clear.")
+                return
+            }
+
+            let targets: [CachedImageEntry]
+            if all {
+                targets = cachedImages
+            } else if let device {
+                guard let entry = cachedImages.first(where: { $0.device == device }) else {
+                    throw ValidationError("No cached image found for device '\(device)'.")
+                }
+                targets = [entry]
+            } else {
+                let rows = cachedImages.map { entry in
+                    [
+                        entry.device,
+                        entry.version ?? "—",
+                        entry.status.displayValue,
+                        ByteCountFormatter.string(
+                            fromByteCount: entry.sizeBytes,
+                            countStyle: .file
+                        ),
+                    ]
+                }
+
+                let selectedIndex = try await noora.selectableTable(
+                    headers: [
+                        "Device",
+                        "Version",
+                        "Status",
+                        "Size",
+                    ],
+                    rows: rows,
+                    pageSize: rows.count
+                )
+
+                targets = [cachedImages[selectedIndex]]
+            }
+
+            let totalBytes = targets.reduce(0) { $0 + $1.sizeBytes }
+            if !force {
+                let description: String
+                if all {
+                    description = "all cached images"
+                } else if targets.count == 1 {
+                    description = "the cache for \(targets[0].device)"
+                } else {
+                    description = "the selected caches"
+                }
+                let sizeText = ByteCountFormatter.string(
+                    fromByteCount: totalBytes,
+                    countStyle: .file
+                )
+                let confirmed = noora.yesOrNoChoicePrompt(
+                    question: "Remove \(description)? (~\(sizeText))",
+                    defaultAnswer: false
+                )
+                guard confirmed else {
+                    noora.info("Aborted.")
+                    return
+                }
+            }
+
+            let root = cacheDirectory(fileManager: fileManager)
+            var failures: [(String, String)] = []
+
+            for entry in targets {
+                let path = root.appendingPathComponent(entry.device)
+                do {
+                    if fileManager.fileExists(atPath: path.path) {
+                        try fileManager.removeItem(at: path)
+                    }
+                } catch {
+                    failures.append((entry.device, error.localizedDescription))
+                }
+            }
+
+            if failures.isEmpty {
+                let sizeText = ByteCountFormatter.string(
+                    fromByteCount: totalBytes,
+                    countStyle: .file
+                )
+                if all {
+                    noora.success("Cleared all cached images (\(sizeText)).")
+                } else {
+                    let names = targets.map(\.device).joined(separator: ", ")
+                    noora.success("Cleared cache for \(names) (\(sizeText)).")
+                }
+            } else {
+                for failure in failures {
+                    noora.error("Failed to clear cache for \(failure.0): \(failure.1)")
+                }
             }
         }
     }

--- a/Sources/Wendy/cli/commands/OSCommand.swift
+++ b/Sources/Wendy/cli/commands/OSCommand.swift
@@ -101,7 +101,8 @@ struct OSCommand: AsyncParsableCommand {
         commandName: "os",
         abstract: "Setup and manage your WendyOS images.",
         subcommands: [
-            OSInstallCommand.self
+            OSInstallCommand.self,
+            CacheCommand.self,
         ],
         groupedSubcommands: [
             CommandGroup(
@@ -539,6 +540,161 @@ struct OSCommand: AsyncParsableCommand {
             noora.success("🎉 Device \(selectedDeviceName) successfully imaged!")
         }
     }
+}
+
+// MARK: - Cache utilities
+
+private enum CachedImageStatus: String, Codable {
+    case ready
+    case incomplete
+    case empty
+
+    var displayValue: String {
+        switch self {
+        case .ready:
+            return "Ready"
+        case .incomplete:
+            return "Incomplete"
+        case .empty:
+            return "Empty"
+        }
+    }
+}
+
+private struct CachedImageEntry: Codable {
+    let device: String
+    let version: String?
+    let cachedAt: Date?
+    let imagePath: String?
+    let sizeBytes: Int64
+    let status: CachedImageStatus
+}
+
+private func cacheDirectory(fileManager: FileManager = .default) -> URL {
+    fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".wendy/cache/images")
+}
+
+private func listCachedImages(fileManager: FileManager = .default) throws -> [CachedImageEntry] {
+    let root = cacheDirectory(fileManager: fileManager)
+    guard fileManager.fileExists(atPath: root.path) else { return [] }
+
+    let contents: [URL]
+    do {
+        contents = try fileManager.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+    } catch {
+        throw ValidationError("Failed to read cache directory: \(error.localizedDescription)")
+    }
+
+    var entries: [CachedImageEntry] = []
+
+    for url in contents {
+        let values = try? url.resourceValues(forKeys: [.isDirectoryKey])
+        guard values?.isDirectory == true else { continue }
+
+        let (version, timestamp) = readCacheMetadata(at: url)
+        let imageURL = findImageFile(in: url, fileManager: fileManager)
+        let size = directorySize(of: url, fileManager: fileManager)
+
+        let status: CachedImageStatus
+        if imageURL != nil {
+            status = .ready
+        } else if size > 0 {
+            status = .incomplete
+        } else {
+            status = .empty
+        }
+
+        entries.append(
+            CachedImageEntry(
+                device: url.lastPathComponent,
+                version: version,
+                cachedAt: timestamp,
+                imagePath: imageURL?.path,
+                sizeBytes: size,
+                status: status
+            )
+        )
+    }
+
+    return entries.sorted { $0.device < $1.device }
+}
+
+private func readCacheMetadata(at url: URL) -> (String?, Date?) {
+    let metadataURL = url.appendingPathComponent("version.json")
+
+    guard let data = try? Data(contentsOf: metadataURL) else {
+        return (nil, nil)
+    }
+
+    struct CacheVersionMetadata: Codable {
+        let version: String
+        let timestamp: Date
+    }
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    guard let metadata = try? decoder.decode(CacheVersionMetadata.self, from: data) else {
+        return (nil, nil)
+    }
+
+    return (metadata.version, metadata.timestamp)
+}
+
+private func directorySize(of url: URL, fileManager: FileManager = .default) -> Int64 {
+    guard
+        let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [
+                .isRegularFileKey, .totalFileAllocatedSizeKey, .fileSizeKey,
+            ],
+            options: [.skipsHiddenFiles]
+        )
+    else { return 0 }
+
+    var total: Int64 = 0
+    for case let fileURL as URL in enumerator {
+        guard
+            let values = try? fileURL.resourceValues(
+                forKeys: [.isRegularFileKey, .totalFileAllocatedSizeKey, .fileSizeKey]
+            ),
+            values.isRegularFile == true
+        else { continue }
+
+        if let allocated = values.totalFileAllocatedSize {
+            total += Int64(allocated)
+        } else if let size = values.fileSize {
+            total += Int64(size)
+        }
+    }
+
+    return total
+}
+
+private func findImageFile(in url: URL, fileManager: FileManager = .default) -> URL? {
+    guard
+        let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        )
+    else { return nil }
+
+    for case let fileURL as URL in enumerator {
+        guard
+            let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey]),
+            values.isRegularFile == true
+        else { continue }
+
+        if fileURL.pathExtension.lowercased() == "img" {
+            return fileURL
+        }
+    }
+
+    return nil
 }
 
 // MARK: - Helpers

--- a/Tests/EdgeCLITests/AsyncHTTPClientWrapperIntegrationTests.swift
+++ b/Tests/EdgeCLITests/AsyncHTTPClientWrapperIntegrationTests.swift
@@ -9,19 +9,19 @@ import Testing
 
 @Suite("AsyncHTTPClientWrapper Integration Tests")
 struct AsyncHTTPClientWrapperIntegrationTests {
-    
+
     // MARK: - Mock Server Setup for Integration Testing
-    
+
     /// Simple mock HTTP server that can respond to requests for testing
     actor MockHTTPServer {
         private var responses: [String: MockResponse] = [:]
-        
+
         struct MockResponse {
             let statusCode: Int
             let headers: [String: String]
             let body: String
             let delay: TimeInterval
-            
+
             init(
                 statusCode: Int = 200,
                 headers: [String: String] = [:],
@@ -34,100 +34,103 @@ struct AsyncHTTPClientWrapperIntegrationTests {
                 self.delay = delay
             }
         }
-        
+
         func setResponse(for path: String, response: MockResponse) {
             responses[path] = response
         }
-        
+
         func getResponse(for path: String) -> MockResponse? {
             return responses[path]
         }
     }
-    
+
     // MARK: - Real HTTP Execution Tests
-    
+
     @Test("executeRequestThrowing performs actual HTTP request conversion")
     func testRealHTTPRequestExecution() async throws {
         // Test against a real HTTP endpoint that we know will work
         // Using httpbin.org which is reliable for testing
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         let request = HTTPRequest(
             method: .get,
             url: URL(string: "https://httpbin.org/get")!,
             accepting: ["application/json"],
             withAuthorization: "Bearer test-token"
         )
-        
+
         do {
             let (data, response) = try await wrapper.executeRequestThrowing(
                 request,
                 expectingStatus: .ok
             )
-            
+
             // Verify we got a successful response
             #expect(response.status == .ok)
             #expect(data.count > 0)
-            
+
             // Verify the response contains our test data
             let responseString = String(data: data, encoding: .utf8)
             #expect(responseString?.contains("httpbin.org") == true)
-            
+
         } catch {
             // If httpbin.org is unavailable, skip this test
             print("Skipping real HTTP test due to network unavailability: \(error)")
         }
     }
-    
+
     @Test("executeRequestThrowing with upload performs POST request")
     func testRealHTTPPostExecution() async throws {
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         let testPayload = """
-        {
-            "test": "data",
-            "timestamp": "\(Date().timeIntervalSince1970)"
-        }
-        """.data(using: .utf8)!
-        
+            {
+                "test": "data",
+                "timestamp": "\(Date().timeIntervalSince1970)"
+            }
+            """.data(using: .utf8)!
+
         let request = HTTPRequest(
             method: .post,
             url: URL(string: "https://httpbin.org/post")!,
             accepting: ["application/json"],
             contentType: "application/json"
         )
-        
+
         do {
             let (data, response) = try await wrapper.executeRequestThrowing(
                 request,
                 uploading: testPayload,
                 expectingStatus: .ok
             )
-            
+
             #expect(response.status == .ok)
             #expect(data.count > 0)
-            
+
             // Verify the echoed data contains our payload
             let responseString = String(data: data, encoding: .utf8)
             #expect(responseString?.contains("\"test\": \"data\"") == true)
-            
+
         } catch {
             print("Skipping real HTTP POST test due to network unavailability: \(error)")
         }
     }
-    
+
     // MARK: - Response Size Limit Tests
-    
-    @Test("executeRequestThrowing respects 50MB response size limit", .disabled("Requires large response endpoint"))
+
+    @Test(
+        "executeRequestThrowing respects 50MB response size limit",
+        .disabled("Requires large response endpoint")
+    )
     func testResponseSizeLimitEnforcement() async throws {
         // This test would require a server that can send large responses
         // Disabled by default as it would be expensive to run
-        
+
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         // This would need an endpoint that returns >50MB of data
         let request = HTTPRequest.get(URL(string: "https://httpbin.org/base64/large")!)
-        
+
         do {
             _ = try await wrapper.executeRequestThrowing(
                 request,
@@ -136,18 +139,18 @@ struct AsyncHTTPClientWrapperIntegrationTests {
             #expect(Bool(false), "Should have thrown an error for oversized response")
         } catch {
             // Expected - response should be rejected due to size limit
-            #expect(Bool(true)) // Error was thrown as expected
+            #expect(Bool(true))  // Error was thrown as expected
         }
     }
-    
+
     // MARK: - Error Handling Integration Tests
-    
+
     @Test("executeRequestThrowing handles 404 errors correctly")
     func testNotFoundErrorHandling() async throws {
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         let request = HTTPRequest.get(URL(string: "https://httpbin.org/status/404")!)
-        
+
         do {
             _ = try await wrapper.executeRequestThrowing(
                 request,
@@ -165,13 +168,13 @@ struct AsyncHTTPClientWrapperIntegrationTests {
             print("Skipping 404 test due to network unavailability: \(error)")
         }
     }
-    
+
     @Test("executeRequestThrowing handles authentication challenges")
     func testAuthenticationChallengeHandling() async throws {
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         let request = HTTPRequest.get(URL(string: "https://httpbin.org/status/401")!)
-        
+
         do {
             _ = try await wrapper.executeRequestThrowing(
                 request,
@@ -181,21 +184,24 @@ struct AsyncHTTPClientWrapperIntegrationTests {
         } catch _ as ContainerRegistry.HTTPClientError {
             // httpbin.org/status/401 may return different status codes depending on service availability
             // Accept any HTTPClientError as it shows our error handling is working
-            #expect(Bool(true)) // We got an HTTPClientError as expected
+            #expect(Bool(true))  // We got an HTTPClientError as expected
         } catch {
             // Network issues or other errors are acceptable for this test
             print("Skipping 401 test due to network unavailability: \(error)")
         }
     }
-    
-    @Test("executeRequestThrowing handles timeout scenarios", .disabled("Requires timeout endpoint"))
+
+    @Test(
+        "executeRequestThrowing handles timeout scenarios",
+        .disabled("Requires timeout endpoint")
+    )
     func testTimeoutHandling() async throws {
         // This test is disabled as it would require a slow endpoint
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         // This would need an endpoint that delays response > 60 seconds
         let request = HTTPRequest.get(URL(string: "https://httpbin.org/delay/70")!)
-        
+
         do {
             _ = try await wrapper.executeRequestThrowing(
                 request,
@@ -204,57 +210,57 @@ struct AsyncHTTPClientWrapperIntegrationTests {
             #expect(Bool(false), "Should have thrown timeout error")
         } catch {
             // Expected - should timeout after 60 seconds
-            #expect(Bool(true)) // Error was thrown as expected
+            #expect(Bool(true))  // Error was thrown as expected
         }
     }
-    
+
     // MARK: - Header Conversion Integration Tests
-    
+
     @Test("convertRequest preserves all headers in real request")
     func testHeaderPreservationIntegration() async throws {
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         var request = HTTPRequest.get(URL(string: "https://httpbin.org/headers")!)
         request.headerFields[.userAgent] = "EdgeOS-Test/1.0"
         request.headerFields[.authorization] = "Bearer test-token-123"
         request.headerFields[.contentType] = "application/json"
         request.headerFields[HTTPField.Name("X-Custom-Header")!] = "custom-value"
-        
+
         do {
             let (data, response) = try await wrapper.executeRequestThrowing(
                 request,
                 expectingStatus: .ok
             )
-            
+
             #expect(response.status == .ok)
-            
+
             // Parse the response to verify headers were sent
             let responseString = String(data: data, encoding: .utf8) ?? ""
             #expect(responseString.contains("EdgeOS-Test/1.0"))
             #expect(responseString.contains("Bearer test-token-123"))
             #expect(responseString.contains("custom-value"))
-            
+
         } catch {
             print("Skipping header integration test due to network unavailability: \(error)")
         }
     }
-    
+
     // MARK: - HTTP Method Conversion Integration Tests
-    
+
     @Test("convertRequest handles different HTTP methods in real requests")
     func testHTTPMethodConversionIntegration() async throws {
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         let methods: [HTTPRequest.Method] = [.get, .post, .put, .delete]
-        
+
         for method in methods {
             let url = URL(string: "https://httpbin.org/\(method.rawValue.lowercased())")!
-            
+
             do {
                 var request = HTTPRequest(method: method, url: url)
-                
+
                 let (data, response): (Data, HTTPResponse)
-                
+
                 if method == .post || method == .put {
                     // These methods need a body
                     request.headerFields[.contentType] = "application/json"
@@ -270,112 +276,114 @@ struct AsyncHTTPClientWrapperIntegrationTests {
                         expectingStatus: .ok
                     )
                 }
-                
+
                 #expect(response.status == .ok)
                 #expect(data.count > 0)
-                
+
             } catch {
-                print("Skipping \(method.rawValue) method test due to network unavailability: \(error)")
+                print(
+                    "Skipping \(method.rawValue) method test due to network unavailability: \(error)"
+                )
             }
         }
     }
-    
+
     // MARK: - ByteBuffer to Data Conversion Tests
-    
+
     @Test("response body collection converts ByteBuffer to Data correctly")
     func testByteBufferToDataConversion() async throws {
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         // Request a known response that will test the ByteBuffer -> Data conversion
         let request = HTTPRequest.get(URL(string: "https://httpbin.org/json")!)
-        
+
         do {
             let (data, response) = try await wrapper.executeRequestThrowing(
                 request,
                 expectingStatus: .ok
             )
-            
+
             #expect(response.status == .ok)
             #expect(data.count > 0)
             #expect(type(of: data) == Data.self)  // Verify it's actually Data, not ByteBuffer
-            
+
             // Verify we can parse it as JSON
             let json = try JSONSerialization.jsonObject(with: data)
             #expect(json is [String: Any])
-            
+
         } catch {
             print("Skipping ByteBuffer conversion test due to network unavailability: \(error)")
         }
     }
-    
+
     // MARK: - Edge Case Tests
-    
+
     @Test("executeRequestThrowing handles empty responses")
     func testEmptyResponseHandling() async throws {
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         let request = HTTPRequest.get(URL(string: "https://httpbin.org/status/204")!)  // No Content
-        
+
         do {
             let (data, response) = try await wrapper.executeRequestThrowing(
                 request,
                 expectingStatus: .noContent
             )
-            
+
             #expect(response.status == .noContent)
             #expect(data.count == 0)  // Should be empty
-            
+
         } catch {
             print("Skipping empty response test due to network unavailability: \(error)")
         }
     }
-    
+
     @Test("executeRequestThrowing handles HEAD requests correctly")
     func testHeadRequestHandling() async throws {
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         let request = HTTPRequest(
             method: .head,
             url: URL(string: "https://httpbin.org/get")!
         )
-        
+
         do {
             let (data, response) = try await wrapper.executeRequestThrowing(
                 request,
                 expectingStatus: .ok
             )
-            
+
             #expect(response.status == .ok)
             #expect(data.count == 0)  // HEAD responses should have no body
-            
+
         } catch {
             print("Skipping HEAD request test due to network unavailability: \(error)")
         }
     }
-    
+
     // MARK: - Container Registry Specific Tests
-    
+
     @Test("executeRequestThrowing handles Docker registry content types")
     func testDockerRegistryContentTypes() async throws {
         let wrapper = AsyncHTTPClientWrapper()
-        
+
         let request = HTTPRequest.get(
             URL(string: "https://httpbin.org/response-headers")!,
             accepting: [
                 "application/vnd.docker.distribution.manifest.v2+json",
-                "application/vnd.docker.distribution.manifest.v1+prettyjws"
+                "application/vnd.docker.distribution.manifest.v1+prettyjws",
             ]
         )
-        
+
         do {
             let (data, response) = try await wrapper.executeRequestThrowing(
                 request,
                 expectingStatus: .ok
             )
-            
+
             #expect(response.status == .ok)
             #expect(data.count > 0)
-            
+
         } catch {
             print("Skipping Docker content type test due to network unavailability: \(error)")
         }
@@ -386,15 +394,18 @@ struct AsyncHTTPClientWrapperIntegrationTests {
 
 @Suite("AsyncHTTPClientWrapper Performance Tests")
 struct AsyncHTTPClientWrapperPerformanceTests {
-    
-    @Test("wrapper has minimal overhead compared to raw AsyncHTTPClient", .disabled("Performance test"))
+
+    @Test(
+        "wrapper has minimal overhead compared to raw AsyncHTTPClient",
+        .disabled("Performance test")
+    )
     func testPerformanceOverhead() async throws {
         // This would be a performance comparison test
         // Disabled by default as it's not essential for correctness
-        
+
         let wrapper = AsyncHTTPClientWrapper()
         let request = HTTPRequest.get(URL(string: "https://httpbin.org/get")!)
-        
+
         let startTime = Date()
 
         do {
@@ -404,7 +415,7 @@ struct AsyncHTTPClientWrapperPerformanceTests {
 
             // Verify reasonable performance (< 5 seconds for a simple request)
             #expect(elapsed < 5.0)
-            
+
         } catch {
             print("Skipping performance test due to network unavailability: \(error)")
         }


### PR DESCRIPTION
## Summary
- add `wendy os cache clear` subcommand to remove cached OS images per device or all via Noora
- show confirmation with size estimate and support `--all`/`--force`
- reuse cache status helpers to report version/state for selection

## Testing
- swift test -q

## Commentary: 

Merge after #159 
