### PR TITLE
Fix .new file path handling in agent updates

### DIFF
--- a/Sources/WendyAgent/Services/WendyAgentService.swift
+++ b/Sources/WendyAgent/Services/WendyAgentService.swift
@@ -242,7 +242,10 @@ struct WendyAgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProto
             // Use atomic rename by moving new binary to temp location first,
             // then renaming it to replace the current binary.
             // On POSIX systems, rename() is atomic when source and dest are on same filesystem.
-            let tempNewBinary = currentBinary.appending(".new")
+            let tempNewBinary =
+                currentBinary
+                .removingLastComponent()
+                .appending(binaryName + ".new")
 
             // First, move update file to temp location next to target
             // This ensures we're on the same filesystem for atomic rename
@@ -275,7 +278,10 @@ struct WendyAgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProto
             logger.error("Update failed: \(error), attempting to restore from backup")
 
             // Clean up temp files
-            let tempNewBinary = currentBinary.appending(".new")
+            let tempNewBinary =
+                currentBinary
+                .removingLastComponent()
+                .appending(binaryName + ".new")
             if (try? await filesystem.info(forFileAt: tempNewBinary)) != nil {
                 _ = try? await filesystem.removeItem(at: tempNewBinary)
             }


### PR DESCRIPTION
Follow-up to #197 to fix the remaining instances where `FilePath.appending(".new")` incorrectly treats the binary name as a directory.

## Problem
Similar to the `.backup` file issue fixed in #197, there were two more places where `currentBinary.appending(".new")` would create `wendy-agent/.new` instead of `wendy-agent.new`:
1. Line 245: Creating temp binary for atomic replacement
2. Line 278: Cleaning up temp binary in error handler

## Solution
Use the same pattern as the backup file fix:
```swift
let tempNewBinary = 
    currentBinary
    .removingLastComponent()
    .appending(binaryName + ".new")
```

## Testing
- ✅ Code compiles successfully
- This ensures atomic binary updates work correctly without creating unwanted directory structures