### PR TITLE
Fix interactive device selection to show nightly versions

### DIFF
--- a/Sources/Wendy/cli/commands/OSCommand.swift
+++ b/Sources/Wendy/cli/commands/OSCommand.swift
@@ -324,7 +324,12 @@ struct OSCommand: AsyncParsableCommand {
                 let devices = familyOptions[familyIndex].1
 
                 let deviceRows = devices.map { device -> [String] in
-                    let version = device.latestVersion.isEmpty ? "—" : device.latestVersion
+                    let version: String
+                    if nightly {
+                        version = device.latestNightlyVersion ?? "—"
+                    } else {
+                        version = device.latestVersion.isEmpty ? "—" : device.latestVersion
+                    }
                     return [
                         device.name,
                         version,
@@ -334,7 +339,7 @@ struct OSCommand: AsyncParsableCommand {
                 let deviceIndex = try await noora.selectableTable(
                     headers: [
                         "Device",
-                        "Latest Version",
+                        nightly ? "Latest Nightly" : "Latest Version",
                     ],
                     rows: deviceRows,
                     pageSize: deviceRows.count


### PR DESCRIPTION
## Summary

Fixes the interactive device selection when using `--nightly` flag to correctly show nightly versions instead of stable versions.

## Problem

When running `wendy os install --nightly` in interactive mode, the device selection table always showed the stable "Latest Version", making it unclear which nightly version (if any) would be installed.

## Solution

- When `--nightly` flag is used, the device selection table now shows "Latest Nightly" in the column header
- The version column displays the actual nightly version that will be installed
- Devices without nightly builds show "—"

## Example

**Before:**
```
╭─────────────────────┬────────────────╮
│ Device              │ Latest Version │
├─────────────────────┼────────────────┤
│ jetson-orin-nano    │ 0.9.8          │  ← Shows stable, not nightly!
│ raspberry-pi-5      │ 0.6.2          │
╰─────────────────────┴────────────────╯
```

**After:**
```
╭─────────────────────┬────────────────╮
│ Device              │ Latest Nightly │
├─────────────────────┼────────────────┤
│ jetson-orin-nano    │ 0.9.5-nightly  │  ← Shows correct nightly version
│ raspberry-pi-5      │ —              │  ← Clear that no nightly available
╰─────────────────────┴────────────────╯
```