### PR TITLE
Upgrade existing Swift package with `wendy init`

### DIFF
--- a/Sources/Wendy/cli/commands/InitCommand.swift
+++ b/Sources/Wendy/cli/commands/InitCommand.swift
@@ -80,6 +80,11 @@ struct InitCommand: AsyncParsableCommand {
     }
 
     private func initializeSwiftProject() async throws {
+        if FileManager.default.fileExists(atPath: "\(projectPath)/Package.swift") {
+            logger.debug("Package.swift already exists, skipping initialization")
+            return
+        }
+
         // Run swift package init in the specified directory using bash -c to cd into the directory first
         let result = try await Subprocess.run(
             .name("swift"),


### PR DESCRIPTION
If applied to a directory with Package.swift, don't re-create the project. Simply add the wendy-specific items (wendy.json)