### PR TITLE
Use NIO's Buffered Asynchronous I/O for disk reading

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1486cad1cb82de14963dc251ce8a500ec23b200d069d6457a7e2a27379f2b1f6",
+  "originHash" : "7f0259bd0668862885be85949530d196469c885622dec0ddda496fcbc077379b",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "a18bddb0acf7a40d982b2f128ce73ce4ee31f352",
-        "version" : "2.86.2"
+        "revision" : "a1605a3303a28e14d822dec8aaa53da8a9490461",
+        "version" : "2.92.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.12.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.7.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.92.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.12.2"),
         .package(
             url: "https://github.com/tuist/Noora.git",

--- a/Sources/Imager/Writer/MacOSDiskWriter.swift
+++ b/Sources/Imager/Writer/MacOSDiskWriter.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
     import Foundation
     import Subprocess
+    import NIOFileSystem
 
     /// A disk writer implementation for macOS that uses the `dd` command.
     public class MacOSDiskWriter: DiskWriter {
@@ -100,7 +101,6 @@
                 // Stream the image to dd via stdin. We count bytes written ourselves for progress.
                 // Use a larger block size on the dd side to improve throughput, and avoid conv=sync
                 // which can slow writes and pad short reads when stdin is a pipe.
-                let chunkSize = 4 * 1024 * 1024  // 4 MiB
                 let result = try await Subprocess.run(
                     Subprocess.Executable.name("sudo"),
                     arguments: [
@@ -111,41 +111,32 @@
                     error: .discarded,
                     preferredBufferSize: nil
                 ) { execution, stdinWriter, _ in
-                    // Feed file chunks to dd's stdin and report progress
-                    let fileURL = URL(fileURLWithPath: imagePath)
-                    guard let handle = try? FileHandle(forReadingFrom: fileURL) else {
-                        throw DiskWriterError.imageNotFoundInPath(path: imagePath)
-                    }
-                    defer { try? handle.close() }
+                    try await FileSystem.shared.withFileHandle(forReadingAt: FilePath(imagePath)) {
+                        handle in
+                        var reader = handle.bufferedReader()
+                        var totalWritten: Int64 = 0
+                        let totalBytes = totalBytes  // capture
 
-                    var totalWritten: Int64 = 0
-                    let totalBytes = totalBytes  // capture
+                        while true {
+                            try Task.checkCancellation()
+                            let chunk = try await reader.read(.bytes(4 * 1024 * 1024))  // 4 MiB
+                            if chunk.readableBytes == 0 {
+                                return execution
+                            }
 
-                    while true {
-                        // Read next chunk synchronously
-                        let data = try? handle.read(upToCount: chunkSize)
-                        guard let data, !data.isEmpty else { break }
-
-                        // Write to dd's stdin (async) and propagate any write error
-                        do {
-                            totalWritten += try await Int64(stdinWriter.write(data.bytes))
-                        } catch {
-                            throw DiskWriterError.writeFailed(
-                                reason: "Failed piping data to dd: \(error.localizedDescription)"
+                            totalWritten += try await Int64(
+                                stdinWriter.write(chunk.readableBytesSpan)
                             )
-                        }
-                        if let totalBytes, totalBytes > 0 {
-                            progressHandler(
-                                DiskWriteProgress(
-                                    bytesWritten: min(totalWritten, totalBytes),
-                                    totalBytes: totalBytes
+                            if let totalBytes, totalBytes > 0 {
+                                progressHandler(
+                                    DiskWriteProgress(
+                                        bytesWritten: min(totalWritten, totalBytes),
+                                        totalBytes: totalBytes
+                                    )
                                 )
-                            )
+                            }
                         }
                     }
-                    // Signal EOF to dd
-                    try? await stdinWriter.finish()
-                    return execution
                 }
 
                 if !result.terminationStatus.isSuccess {


### PR DESCRIPTION
Speedup on macOS from 400 MB/s -> 640MB/s. Likely hitting a cap on either disk I/O or USB. CPU usage is barely breaking a sweat (15-20%)