### PR TITLE
Reduce wendy-agent binary size using UPX and -Osize

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,7 @@ jobs:
 
           # Add optimization flags for wendy-agent builds
           if [ "${{ matrix.product }}" == "wendy-agent" ]; then
+            args+=(-Xswiftc -Osize)
             args+=(-Xswiftc -whole-module-optimization)
             args+=(-Xlinker --gc-sections)
             args+=(-Xlinker --strip-all)
@@ -198,6 +199,13 @@ jobs:
           if [ -d "$BIN_PATH/wendy-agent_${{ matrix.product }}.bundle" ]; then
             cp -r $BIN_PATH/wendy-agent_${{ matrix.product }}.bundle $OUTPUT_DIR/
           fi
+      - name: Compress with UPX
+        if: matrix.product == 'wendy-agent'
+        run: |
+          apt-get update && apt-get install -y upx-ucl
+          echo "Before UPX: $(du -h ${{ matrix.artifact-name }}/${{ matrix.product }})"
+          upx --best --lzma ${{ matrix.artifact-name }}/${{ matrix.product }}
+          echo "After UPX: $(du -h ${{ matrix.artifact-name }}/${{ matrix.product }})"
       - name: Import P12 Certificate
         if: ${{ matrix.artifact-name == 'wendy-cli-macos-arm64' }}
         uses: apple-actions/import-codesign-certs@v3


### PR DESCRIPTION
This PR reduces the binary size to 19MB, at the cost of some launch time for decompression. I don't know how much exactly, but online numbers state 200-500 MB/s decompression speeds. So I expect our agent to take at most 400ms (extra) time to boot, worst case scenario. But possibly the impact is as minimal as 50ms.

If you think this is acceptable, check out the binaries and let's try it out. It's also easily reverted.