### PR TITLE
Improve BLE protocol reliability

### DIFF
--- a/Sources/WendyAgent/Services/BluetoothService.swift
+++ b/Sources/WendyAgent/Services/BluetoothService.swift
@@ -22,12 +22,11 @@ actor BluetoothService: Service {
     private static let legacyAdvertisingMaxBytes = 31
     private static let flagsFieldBytes = 3
     private static let localNameHeaderBytes = 2
-    
+
     private let logger = Logger(label: "BluetoothService")
     private let networkManagerFactory: NetworkConnectionManagerFactory
     private let configuration: WendyAgentConfiguration
     private var peripheralManager: PeripheralManager?
-    private let hardwareDiscoverer = SystemHardwareDiscoverer()
 
     init() {
         let uid = String(getuid())
@@ -214,6 +213,9 @@ actor BluetoothService: Service {
             throw BluetoothServiceError.invalidConfiguration
         }
 
+        // deviceName was already extracted above for logging
+        let shortName = deviceName
+
         // Calculate approximate advertising data size:
         // - Flags: flagsFieldBytes
         // - Complete Local Name: localNameHeaderBytes + name.utf8.count bytes
@@ -221,9 +223,9 @@ actor BluetoothService: Service {
         // If name is too long, truncate it
         let maxNameLength = Self.legacyAdvertisingMaxBytes - Self.flagsFieldBytes - Self.localNameHeaderBytes
         let advertisingName: String
-        if deviceName.utf8.count > maxNameLength {
+        if shortName.utf8.count > maxNameLength {
             // Truncate to fit, ensuring we don't cut in the middle of a multi-byte character
-            var truncated = deviceName
+            var truncated = shortName
             while truncated.utf8.count > maxNameLength && !truncated.isEmpty {
                 truncated.removeLast()
             }
@@ -231,14 +233,14 @@ actor BluetoothService: Service {
             logger.debug(
                 "Truncated advertising name to fit legacy limit",
                 metadata: [
-                    "original": "\(deviceName)",
+                    "original": "\(shortName)",
                     "truncated": "\(advertisingName)",
-                    "originalBytes": "\(deviceName.utf8.count)",
+                    "originalBytes": "\(shortName.utf8.count)",
                     "truncatedBytes": "\(advertisingName.utf8.count)",
                 ]
             )
         } else {
-            advertisingName = deviceName
+            advertisingName = shortName
         }
 
         let advertisementData = AdvertisementData(
@@ -366,63 +368,27 @@ actor BluetoothService: Service {
     private func handleChannel(_ channel: any L2CAPChannel) async {
         logger.debug("Starting to handle Bluetooth channel...")
         var messagesReceived = 0
+        var stream = channel.incoming().makeAsyncIterator()
         var buffer = ByteBuffer()
-        var expectedLength: Int?
 
         do {
-            for try await data in channel.incoming() {
-                logger.debug(
-                    "Received Bluetooth data chunk",
-                    metadata: [
-                        "chunkSize": "\(data.count)",
-                        "bufferSize": "\(buffer.readableBytes)",
-                    ]
-                )
-
-                buffer.writeData(data)
-
-                // Process complete messages from buffer
-                while true {
-                    // If we don't know the expected length yet, try to read it
-                    if expectedLength == nil {
-                        guard buffer.readableBytes >= 4 else { break }
-                        if let lengthPrefix = buffer.readInteger(endianness: .big, as: UInt32.self) {
-                            expectedLength = Int(lengthPrefix)
-                            logger.debug(
-                                "Read message length",
-                                metadata: ["expectedLength": "\(lengthPrefix)"]
-                            )
-                        } else {
-                            logger.error("Failed to read message length from Bluetooth buffer")
-                            expectedLength = nil
-                            break
-                        }
-                    }
-
-                    // Check if we have the complete message
-                    guard let length = expectedLength, buffer.readableBytes >= length else { break }
-
-                    // Extract the complete message
-                    guard let messageData = buffer.readData(length: length) else {
-                        logger.error("Failed to read Bluetooth message data from buffer")
-                        expectedLength = nil
-                        break
-                    }
-                    expectedLength = nil
-
+            while !Task.isCancelled {
+                // Process complete messages from buffer using length-prefixed framing
+                while let messageSlice = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self) {
                     messagesReceived += 1
+
                     logger.debug(
                         "Received complete Bluetooth message",
                         metadata: [
                             "messageNumber": "\(messagesReceived)",
-                            "messageSize": "\(messageData.count)",
+                            "messageSize": "\(messageSlice.readableBytes)",
                         ]
                     )
 
                     // Parse protobuf command and process
                     do {
                         let command = try Wendy_Agent_Services_V1_BluetoothCommand(
-                            serializedBytes: messageData
+                            serializedBytes: messageSlice.readableBytesView
                         )
                         let response = await processCommand(command)
                         let responseData = try response.serializedData()
@@ -444,6 +410,14 @@ actor BluetoothService: Service {
                         }
                     }
                 }
+
+                // Reclaim memory from processed messages
+                buffer.discardReadBytes()
+
+                // Wait for more data
+                // TODO: Add timeout using Swift 6.3's withTimeout
+                guard let data = try await stream.next() else { break }
+                buffer.writeData(data)
             }
         } catch {
             let errorString = String(describing: error)
@@ -472,8 +446,9 @@ actor BluetoothService: Service {
 
     private func sendLengthPrefixed(_ data: Data, on channel: any L2CAPChannel) async throws {
         var buffer = ByteBuffer()
-        buffer.writeInteger(UInt32(data.count), endianness: .big)
-        buffer.writeData(data)
+        try buffer.writeLengthPrefixed(endianness: .big, as: UInt16.self) { buffer in
+            buffer.writeData(data)
+        }
         try await channel.send(Data(buffer.readableBytesView))
     }
 
@@ -671,7 +646,9 @@ actor BluetoothService: Service {
         return response
     }
 
-    private func handleAppsStop(appName: String) async throws
+    private func handleAppsStop(
+        appName: String
+    ) async throws
         -> Wendy_Agent_Services_V1_AppsStopResponse
     {
         logger.debug("Bluetooth: Stopping app", metadata: ["app": "\(appName)"])
@@ -730,7 +707,8 @@ actor BluetoothService: Service {
     {
         logger.debug("Bluetooth: Listing hardware capabilities")
 
-        let capabilities = try await hardwareDiscoverer.discoverCapabilities(categoryFilter: nil)
+        let discoverer = SystemHardwareDiscoverer()
+        let capabilities = try await discoverer.discoverCapabilities(categoryFilter: nil)
 
         var response = Wendy_Agent_Services_V1_HardwareListResponse()
         response.capabilities = capabilities.map { cap in

--- a/Sources/WendyShared/BluetoothProtocol.swift
+++ b/Sources/WendyShared/BluetoothProtocol.swift
@@ -3,13 +3,13 @@ import Foundation
 /// UUIDs for the WendyOS Bluetooth service
 public enum WendyBluetoothUUIDs {
     /// The main service UUID for WendyOS devices
-    public static let serviceUUID = "E7A90001-1234-5678-90AB-CDEF01234567"
+    public static let serviceUUID = "7565E9EB-4C20-4B67-9272-D708B397B631"
 
     /// Characteristic for sending commands to the agent
-    public static let commandCharacteristicUUID = "E7A90002-1234-5678-90AB-CDEF01234567"
+    public static let commandCharacteristicUUID = "7565E9EB-4C20-4B67-9272-D708B397B632"
 
     /// Characteristic for receiving responses from the agent
-    public static let responseCharacteristicUUID = "E7A90003-1234-5678-90AB-CDEF01234567"
+    public static let responseCharacteristicUUID = "7565E9EB-4C20-4B67-9272-D708B397B633"
 
     /// L2CAP PSM for bidirectional communication
     /// BlueZ typically assigns PSM 128 (0x80) for unprivileged L2CAP channels

--- a/Tests/WendyAgentTests/BluetoothLengthPrefixedFramingTests.swift
+++ b/Tests/WendyAgentTests/BluetoothLengthPrefixedFramingTests.swift
@@ -1,0 +1,174 @@
+import NIOCore
+import Testing
+
+@Suite("Bluetooth Length-Prefixed Framing Tests")
+struct BluetoothLengthPrefixedFramingTests {
+
+    @Test("readLengthPrefixedSlice returns nil when buffer is empty")
+    func readFromEmptyBuffer() {
+        var buffer = ByteBuffer()
+        let result = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(result == nil)
+    }
+
+    @Test("readLengthPrefixedSlice returns nil when only length prefix present")
+    func readWithOnlyLengthPrefix() {
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt16(10), endianness: .big)  // Length prefix for 10 bytes
+        let result = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(result == nil)
+        // Buffer should be unchanged (reader index reset)
+        #expect(buffer.readableBytes == 2)
+    }
+
+    @Test("readLengthPrefixedSlice returns nil when partial data present")
+    func readWithPartialData() {
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt16(10), endianness: .big)  // Length prefix for 10 bytes
+        buffer.writeBytes([1, 2, 3, 4, 5])  // Only 5 bytes of data
+        let result = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(result == nil)
+        // Buffer should be unchanged (reader index reset)
+        #expect(buffer.readableBytes == 7)  // 2 + 5
+    }
+
+    @Test("readLengthPrefixedSlice returns complete message")
+    func readCompleteMessage() {
+        var buffer = ByteBuffer()
+        let payload: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        buffer.writeInteger(UInt16(payload.count), endianness: .big)
+        buffer.writeBytes(payload)
+
+        let result = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(result != nil)
+        #expect(result?.readableBytes == 10)
+        #expect(Array(result!.readableBytesView) == payload)
+        #expect(buffer.readableBytes == 0)
+    }
+
+    @Test("readLengthPrefixedSlice handles multiple messages in buffer")
+    func readMultipleMessages() {
+        var buffer = ByteBuffer()
+
+        // First message: [1, 2, 3]
+        buffer.writeInteger(UInt16(3), endianness: .big)
+        buffer.writeBytes([1, 2, 3])
+
+        // Second message: [4, 5, 6, 7]
+        buffer.writeInteger(UInt16(4), endianness: .big)
+        buffer.writeBytes([4, 5, 6, 7])
+
+        // Third message: [8]
+        buffer.writeInteger(UInt16(1), endianness: .big)
+        buffer.writeBytes([8])
+
+        // Read first message
+        let first = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(first != nil)
+        #expect(Array(first!.readableBytesView) == [1, 2, 3])
+
+        // Read second message
+        let second = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(second != nil)
+        #expect(Array(second!.readableBytesView) == [4, 5, 6, 7])
+
+        // Read third message
+        let third = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(third != nil)
+        #expect(Array(third!.readableBytesView) == [8])
+
+        // No more messages
+        let fourth = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(fourth == nil)
+        #expect(buffer.readableBytes == 0)
+    }
+
+    @Test("readLengthPrefixedSlice handles zero-length message")
+    func readZeroLengthMessage() {
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt16(0), endianness: .big)
+
+        let result = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(result != nil)
+        #expect(result?.readableBytes == 0)
+        #expect(buffer.readableBytes == 0)
+    }
+
+    @Test("writeLengthPrefixed writes correct format")
+    func writeLengthPrefixed() throws {
+        var buffer = ByteBuffer()
+        let payload: [UInt8] = [1, 2, 3, 4, 5]
+
+        try buffer.writeLengthPrefixed(endianness: .big, as: UInt16.self) { innerBuffer in
+            innerBuffer.writeBytes(payload)
+        }
+
+        // Should have 2 bytes length prefix + 5 bytes payload
+        #expect(buffer.readableBytes == 7)
+
+        // Read back the length prefix
+        let lengthPrefix = buffer.readInteger(endianness: .big, as: UInt16.self)
+        #expect(lengthPrefix == 5)
+
+        // Read back the payload
+        let readPayload = buffer.readBytes(length: 5)
+        #expect(readPayload == payload)
+    }
+
+    @Test("Round-trip write and read")
+    func roundTrip() throws {
+        var buffer = ByteBuffer()
+        let messages: [[UInt8]] = [
+            [0xDE, 0xAD, 0xBE, 0xEF],
+            [0x01],
+            [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0],
+        ]
+
+        // Write all messages
+        for message in messages {
+            try buffer.writeLengthPrefixed(endianness: .big, as: UInt16.self) { innerBuffer in
+                innerBuffer.writeBytes(message)
+            }
+        }
+
+        // Read all messages back
+        var readMessages: [[UInt8]] = []
+        while let slice = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self) {
+            readMessages.append(Array(slice.readableBytesView))
+        }
+
+        #expect(readMessages == messages)
+    }
+
+    @Test("Incremental data arrival simulation")
+    func incrementalDataArrival() throws {
+        // Simulate BLE data arriving in chunks
+        var buffer = ByteBuffer()
+        var receivedMessages: [[UInt8]] = []
+
+        // Prepare a complete message to send in chunks
+        var messageBuffer = ByteBuffer()
+        try messageBuffer.writeLengthPrefixed(endianness: .big, as: UInt16.self) { innerBuffer in
+            innerBuffer.writeBytes([1, 2, 3, 4, 5, 6, 7, 8])
+        }
+        let fullMessage = Array(messageBuffer.readableBytesView)
+
+        // Send first chunk (partial length prefix)
+        buffer.writeBytes(Array(fullMessage[0..<1]))
+        #expect(buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self) == nil)
+
+        // Send second chunk (complete length prefix, no data)
+        buffer.writeBytes(Array(fullMessage[1..<2]))
+        #expect(buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self) == nil)
+
+        // Send third chunk (partial data)
+        buffer.writeBytes(Array(fullMessage[2..<6]))
+        #expect(buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self) == nil)
+
+        // Send final chunk (remaining data)
+        buffer.writeBytes(Array(fullMessage[6...]))
+        let result = buffer.readLengthPrefixedSlice(endianness: .big, as: UInt16.self)
+        #expect(result != nil)
+        #expect(Array(result!.readableBytesView) == [1, 2, 3, 4, 5, 6, 7, 8])
+    }
+}

--- a/Tests/WendyCLITests/Commands/DevicesCommandTests.swift
+++ b/Tests/WendyCLITests/Commands/DevicesCommandTests.swift
@@ -229,6 +229,10 @@ struct MockDeviceDiscovery: DeviceDiscovery {
     func findLANDevices() async throws -> [LANDevice] {
         return lanDevices
     }
+
+    func findBluetoothDevices() async throws -> [BluetoothDevice] {
+        return []
+    }
 }
 
 // Logger for testing - avoid bootstrapping the global logger


### PR DESCRIPTION
I've split up #252 into multiple parts with the use of Claude. This part focusses on protocol level changes.

- Generate new unique service UUIDs. Maybe we can change them to be some cheeky constant, but I've refrained from that.
- Simplify message buffer reading logic by removing redundant optional bindings
- Create SystemHardwareDiscoverer locally instead of storing as property
- Minor formatting improvements