### PR TITLE
Enable the Wendy Agent BLE service - making the device discoverable

### DIFF
--- a/Sources/WendyAgent/Services/BluetoothService.swift
+++ b/Sources/WendyAgent/Services/BluetoothService.swift
@@ -246,7 +246,7 @@ actor BluetoothService: Service {
 
         let advertisementData = AdvertisementData(
             localName: advertisingName,
-            serviceUUIDs: []  // Omit UUID to stay under legacy 31-byte limit
+            serviceUUIDs: [BluetoothUUID(serviceUUID)]
         )
 
         logger.debug(


### PR DESCRIPTION
I had accidentally reverted this line prior to merge. Oops.