### PR TITLE
Add Discord notification for releases

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
-    # Only notify for semver releases (v0.2.0, v1.0.0-beta.1), not pre-releases like 2025.01.28-123456
-    if: startsWith(github.event.release.tag_name, 'v')
+    # Only notify for stable releases, not pre-releases
+    if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Post to Discord
         env:


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow to notify Discord when semver releases are published
- Only triggers for tags starting with `v` (skips automatic pre-releases)
- Posts a formatted embed with release details

## Setup Required
Add `DISCORD_WEBHOOK_URL` to repository secrets before merging.

Closes WDY-663