### PR TITLE
WDY-647: Remove deprecated --agent flag entirely

### DIFF
--- a/Sources/Wendy/AgentConnectionOptions.swift
+++ b/Sources/Wendy/AgentConnectionOptions.swift
@@ -87,22 +87,11 @@ struct AgentConnectionOptions: ParsableArguments {
     )
     var device: Endpoint?
 
-    @Option(
-        name: .shortAndLong,
-        help:
-            """
-            Alias for the `--device` option. (Deprecated)
-            If both `--device` and `--device` are provided, the `--device` option takes precedence.
-            """
-    )
-    var agent: Endpoint?
-
     init() {}
 
     init(
         endpoint: Endpoint?
     ) {
-        self.agent = nil
         self.device = endpoint
     }
 
@@ -118,10 +107,6 @@ struct AgentConnectionOptions: ParsableArguments {
         get throws {
             if let device {
                 return device
-            }
-
-            if let agent {
-                return agent
             }
 
             if let endpoint = ProcessInfo.processInfo.environment["WENDY_AGENT"],
@@ -184,10 +169,6 @@ extension AgentConnectionOptions {
         // If explicit device specified via CLI, use it as LAN
         if let device {
             return .lan(host: device.host, port: device.port, defaultDevice: false)
-        }
-
-        if let agent {
-            return .lan(host: agent.host, port: agent.port, defaultDevice: false)
         }
 
         if let endpoint = ProcessInfo.processInfo.environment["WENDY_AGENT"],

--- a/Tests/WendyCLITests/AgentConnectionOptionsTests.swift
+++ b/Tests/WendyCLITests/AgentConnectionOptionsTests.swift
@@ -121,46 +121,4 @@ struct AgentConnectionOptionsTests {
         #expect(command.agentConnectionOptions.device?.port == 9000)
     }
 
-    @Test("AgentConnectionOptions parsing with --agent (deprecated)")
-    func testAgentConnectionOptionsParsingWithAgent() throws {
-        struct TestCommand: ParsableCommand {
-            @OptionGroup var agentConnectionOptions: AgentConnectionOptions
-
-            mutating func run() {}
-        }
-
-        let command = try TestCommand.parse([
-            "--agent", "legacy.server.com:8000",
-        ])
-
-        #expect(command.agentConnectionOptions.agent?.host == "legacy.server.com")
-        #expect(command.agentConnectionOptions.agent?.port == 8000)
-    }
-
-    @Test("AgentConnectionOptions device takes precedence over agent")
-    func testDeviceTakesPrecedenceOverAgent() throws {
-        struct TestCommand: ParsableCommand {
-            @OptionGroup var agentConnectionOptions: AgentConnectionOptions
-
-            mutating func run() {}
-        }
-
-        let command = try TestCommand.parse([
-            "--device", "device.server.com:9000",
-            "--agent", "agent.server.com:8000",
-        ])
-
-        // Device should be populated
-        #expect(command.agentConnectionOptions.device?.host == "device.server.com")
-        #expect(command.agentConnectionOptions.device?.port == 9000)
-
-        // Agent should also be populated
-        #expect(command.agentConnectionOptions.agent?.host == "agent.server.com")
-        #expect(command.agentConnectionOptions.agent?.port == 8000)
-
-        // But endpoint should return device (takes precedence)
-        let endpoint = try command.agentConnectionOptions.endpoint
-        #expect(endpoint.host == "device.server.com")
-        #expect(endpoint.port == 9000)
-    }
 }


### PR DESCRIPTION
## Summary
- Remove the deprecated `--agent` CLI flag from `AgentConnectionOptions`
- Remove fallback logic that checked `--agent` when `--device` wasn't provided
- Remove tests for the deprecated flag behavior

The `--agent` flag was previously deprecated in favor of `--device`. Users should use `--device` or the `WENDY_AGENT` environment variable to specify the device endpoint.

## Test plan
- [x] Build succeeds
- [x] All `AgentConnectionOptionsTests` pass (11 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)