### PR TITLE
Fix CLI reprompting to select a device if initial attempt fails

### DIFF
--- a/Sources/Wendy/utils/AgentClient.swift
+++ b/Sources/Wendy/utils/AgentClient.swift
@@ -4,6 +4,7 @@ import GRPCCore
 import GRPCNIOTransportHTTP2
 import Logging
 import Noora
+import Synchronization
 import WendyAgentGRPC
 import WendyShared
 
@@ -35,12 +36,18 @@ func withAgentClient<R: Sendable>(
             port: port,
             defaultDevice: defaultDevice
         )
+        let connectionSucceeded = Mutex(false)
         do {
             return try await withAgentGRPCClient(endpoint, title: title) { client in
-                try await body(.grpc(client))
+                connectionSucceeded.withLock { $0 = true }
+                return try await body(.grpc(client))
             }
-        } catch  where defaultDevice {
-            // If default device failed, try again without default
+        } catch {
+            // Only retry with device selection if we never successfully connected
+            guard defaultDevice && !connectionSucceeded.withLock({ $0 }) else {
+                throw error
+            }
+            // If default device failed to connect, try again without default
             let newDevice = try await connectionOptions.read(
                 title: title,
                 readDefault: false,

--- a/Sources/Wendy/utils/GRPC+Agent.swift
+++ b/Sources/Wendy/utils/GRPC+Agent.swift
@@ -4,6 +4,7 @@ import Logging
 import NIOCore
 import NIOSSL
 import Noora
+import Synchronization
 import WendyAgentGRPC
 import WendyCloudGRPC
 
@@ -126,6 +127,7 @@ func withAgentGRPCClientAndEndpoint<R: Sendable>(
 
     switch try await connectionOptions.read(title: title) {
     case .lan(let host, let port, let defaultDevice):
+        let connectionSucceeded = Mutex(false)
         do {
             let endpoint = AgentConnectionOptions.Endpoint(
                 host: host,
@@ -133,9 +135,14 @@ func withAgentGRPCClientAndEndpoint<R: Sendable>(
                 defaultDevice: defaultDevice
             )
             return try await withAgentGRPCClient(endpoint, title: title) { client in
+                connectionSucceeded.withLock { $0 = true }
                 return try await body(client, endpoint)
             }
-        } catch  where defaultDevice {
+        } catch {
+            // Only retry with device selection if we never successfully connected
+            guard defaultDevice && !connectionSucceeded.withLock({ $0 }) else {
+                throw error
+            }
             return try await fallback()
         }
     case .bluetooth:


### PR DESCRIPTION
If the connection succeeded, but the "task" failed, it would re-attempt the task at all times. Now the only constraint is the connection failing