### PR TITLE
WDY-677: weight unpack progress by bytes

### DIFF
--- a/Sources/Wendy/cli/commands/AppBuildHelpers.swift
+++ b/Sources/Wendy/cli/commands/AppBuildHelpers.swift
@@ -25,6 +25,72 @@ private struct SendableProgressUpdater: @unchecked Sendable {
     }
 }
 
+private actor UnpackProgressTracker {
+    private var totalBytes: Int64?
+    private var totalLayers: Int = 0
+    private var completedBytes: Int64 = 0
+    private var seenLayerIndices: Set<Int> = []
+    private var layerSizes: [Int: Int64] = [:]
+
+    func progressValue(
+        for update: Wendy_Agent_Services_V1_CreateContainerProgress
+    ) -> Double? {
+        switch update.phase {
+        case .unpacking:
+            if update.totalLayers > 0 {
+                totalLayers = Int(update.totalLayers)
+            }
+            if update.layerSize > 0 {
+                if totalBytes == nil {
+                    totalBytes = update.layerSize
+                    recomputeCompletedBytes()
+                } else {
+                    totalBytes = update.layerSize
+                }
+            }
+            return 0
+        case .applyingLayer:
+            if totalLayers == 0 && update.totalLayers > 0 {
+                totalLayers = Int(update.totalLayers)
+            }
+            let index = Int(update.layerIndex)
+            if index > 0 {
+                if update.layerSize > 0 {
+                    layerSizes[index] = update.layerSize
+                }
+                if !seenLayerIndices.contains(index) {
+                    seenLayerIndices.insert(index)
+                    if totalBytes != nil {
+                        completedBytes += layerSizes[index] ?? 0
+                    }
+                }
+            }
+
+            if let totalBytes, totalBytes > 0 {
+                let value = Double(completedBytes) / Double(totalBytes)
+                return min(max(value, 0), 1)
+            }
+
+            if totalLayers > 0 {
+                let value = Double(update.layerIndex) / Double(totalLayers)
+                return min(max(value, 0), 1)
+            }
+
+            return nil
+        case .creatingContainer, .complete:
+            return 1
+        case .unspecified, .UNRECOGNIZED:
+            return nil
+        }
+    }
+
+    private func recomputeCompletedBytes() {
+        completedBytes = seenLayerIndices.reduce(Int64(0)) { total, index in
+            total + (layerSizes[index] ?? 0)
+        }
+    }
+}
+
 /// Shared helper methods for building and preparing apps.
 /// Used by both RunCommand and BuildCommand to avoid code duplication.
 enum AppBuildHelpers {
@@ -257,6 +323,7 @@ enum AppBuildHelpers {
         }
 
         let progressHandler = SendableProgressUpdater(progress ?? { _ in })
+        let progressTracker = UnpackProgressTracker()
 
         try await agentContainers.createContainerWithProgress(request) { response in
             switch response.accepted {
@@ -266,19 +333,10 @@ enum AppBuildHelpers {
                     case .message(let message):
                         switch message.responseType {
                         case .progress(let progressUpdate):
-                            switch progressUpdate.phase {
-                            case .unpacking:
-                                await progressHandler.update(0)
-                            case .applyingLayer:
-                                let total = Double(progressUpdate.totalLayers)
-                                let index = Double(progressUpdate.layerIndex)
-                                if total > 0 {
-                                    await progressHandler.update(min(max(index / total, 0), 1))
-                                }
-                            case .creatingContainer, .complete:
-                                await progressHandler.update(1)
-                            case .unspecified, .UNRECOGNIZED:
-                                break
+                            if let value = await progressTracker.progressValue(
+                                for: progressUpdate
+                            ) {
+                                await progressHandler.update(value)
                             }
                         case .completed:
                             await progressHandler.update(1)

--- a/Sources/WendyAgent/Services/ContainerdService.swift
+++ b/Sources/WendyAgent/Services/ContainerdService.swift
@@ -79,7 +79,7 @@ struct NamespaceInterceptor: ClientInterceptor {
 
 public struct ContainerdUnpackProgress: Sendable {
     public enum Phase: Sendable {
-        case start(totalLayers: Int)
+        case start(totalLayers: Int, totalBytes: Int64)
         case layer(index: Int, total: Int, size: Int64, reused: Bool)
         case complete(totalLayers: Int, reused: Int, created: Int)
     }
@@ -694,11 +694,17 @@ public struct Containerd: Sendable {
         // Unpack each layer, reusing existing snapshots when possible
         var previousChainID: String? = nil
         let totalLayers = manifest.layers.count
+        let totalBytes = manifest.layers.reduce(Int64(0)) { $0 + $1.size }
         var snapshotsReused = 0
         var snapshotsCreated = 0
 
         try await progress(
-            ContainerdUnpackProgress(phase: .start(totalLayers: totalLayers))
+            ContainerdUnpackProgress(
+                phase: .start(
+                    totalLayers: totalLayers,
+                    totalBytes: totalBytes
+                )
+            )
         )
 
         for (index, layer) in manifest.layers.enumerated() {

--- a/Sources/WendyAgent/Services/WendyContainerService.swift
+++ b/Sources/WendyAgent/Services/WendyContainerService.swift
@@ -447,9 +447,10 @@ struct WendyContainerService: Wendy_Agent_Services_V1_WendyContainerService.Serv
 
                 let progressMessage = Wendy_Agent_Services_V1_CreateContainerProgress.with {
                     switch unpackProgress.phase {
-                    case .start(let totalLayers):
+                    case .start(let totalLayers, let totalBytes):
                         $0.phase = .unpacking
                         $0.totalLayers = Int32(totalLayers)
+                        $0.layerSize = totalBytes
                     case .layer(let index, let total, let size, let reused):
                         $0.phase = .applyingLayer
                         $0.layerIndex = Int32(index)


### PR DESCRIPTION
## Summary
- include total layer bytes in unpack progress from the agent
- compute size-weighted progress in CLI for more accurate unpack percent

## Testing
- swift format --recursive --in-place Sources/ Tests/
- swift build