### PR TITLE
Add audio group to audio entitlement

### DIFF
--- a/Sources/WendyAgent/Services/OCI+Entitlements.swift
+++ b/Sources/WendyAgent/Services/OCI+Entitlements.swift
@@ -284,6 +284,19 @@ extension OCI {
                     )
                 }
             case .audio:
+                logger.info("Audio entitlement detected - adding audio group")
+                // Add audio group (gid 29) for access to ALSA devices
+                // Audio devices on Linux are owned by group 'audio' (gid 29)
+                if !self.process.user.additionalGids.contains(29) {
+                    self.process.user.additionalGids.append(29)
+                    logger.debug(
+                        "Added audio group to additionalGids",
+                        metadata: [
+                            "additionalGids": .stringConvertible(self.process.user.additionalGids)
+                        ]
+                    )
+                }
+
                 // Bind mount the entire /dev/snd directory
                 self.mounts.append(
                     .init(


### PR DESCRIPTION
## Summary
- Add audio group (gid 29) to containers with audio entitlement
- This allows ALSA to access sound devices in /dev/snd

## Problem
The audio entitlement was mounting `/dev/snd` and allowing major 116 devices, but containers still couldn't play or record audio because they weren't in the `audio` group (gid 29).

Error seen:
```
ALSA lib confmisc.c:855:(parse_card) cannot find card '0'
...
aplay: main:831: audio open error: No such file or directory
```

## Solution
Add the audio group (gid 29) to `additionalGids`, mirroring how the GPU entitlement adds the video group (gid 44).

## Test plan
- [ ] Deploy updated agent to Jetson with USB audio device (e.g., Anker PowerConf)
- [ ] Run app with `{ "type": "audio" }` entitlement
- [ ] Verify `aplay` and `arecord` work inside container