### PR TITLE
CLI update notification system with package manager detection

### DIFF
--- a/Sources/Wendy/WendyCLI.swift
+++ b/Sources/Wendy/WendyCLI.swift
@@ -75,6 +75,7 @@ struct WendyCommand: AsyncParsableCommand {
                     HelperCommand.self,
                     AnalyticsCommand.self,
                     CacheCommand.self,
+                    UpdateCommand.self,
                     InfoCommand.self,
                 ]
             ),

--- a/Sources/Wendy/cli/Auth/Config.swift
+++ b/Sources/Wendy/cli/Auth/Config.swift
@@ -14,6 +14,49 @@ import X509
     import Darwin
 #endif
 
+/// Represents the package manager used to install the CLI
+public enum PackageManagerType: String, Sendable, Codable {
+    case brew
+    case apt
+    case pacman
+    case yum
+    case dnf
+    case winget
+    case unknown
+}
+
+/// Tracks the state of update checks and user prompts
+public struct UpdateCheckState: Sendable, Codable {
+    /// Last time we checked for updates
+    public var lastCheckTime: Date?
+
+    /// Last time user was prompted about an update
+    public var lastPromptTime: Date?
+
+    /// User's response to the prompt (true = yes, false = no, nil = not asked)
+    public var lastPromptResponse: Bool?
+
+    /// The latest known version from last check
+    public var latestKnownVersion: String?
+
+    /// Detected package manager (cached)
+    public var detectedPackageManager: PackageManagerType?
+
+    public init(
+        lastCheckTime: Date? = nil,
+        lastPromptTime: Date? = nil,
+        lastPromptResponse: Bool? = nil,
+        latestKnownVersion: String? = nil,
+        detectedPackageManager: PackageManagerType? = nil
+    ) {
+        self.lastCheckTime = lastCheckTime
+        self.lastPromptTime = lastPromptTime
+        self.lastPromptResponse = lastPromptResponse
+        self.latestKnownVersion = latestKnownVersion
+        self.detectedPackageManager = detectedPackageManager
+    }
+}
+
 public struct Config: Sendable, Codable {
     public struct Auth: Sendable, Codable, Hashable, CustomStringConvertible {
         public let cloudDashboard: String
@@ -35,13 +78,55 @@ public struct Config: Sendable, Codable {
     public var auth: [Auth]
     public var analytics: WendyAnalyticsConfig
     public var defaultDevice: String?
-    public var lastUpdateCheck: Date?
+    public var updateCheck: UpdateCheckState?
+
+    private enum CodingKeys: String, CodingKey {
+        case auth
+        case analytics
+        case defaultDevice
+        case updateCheck
+        case lastUpdateCheck  // Legacy field for migration
+    }
 
     public init() {
         self.auth = []
         self.defaultDevice = nil
         self.analytics = WendyAnalyticsConfig()
-        self.lastUpdateCheck = nil
+        self.updateCheck = nil
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.auth = try container.decodeIfPresent([Auth].self, forKey: .auth) ?? []
+        self.analytics =
+            try container.decodeIfPresent(WendyAnalyticsConfig.self, forKey: .analytics)
+            ?? WendyAnalyticsConfig()
+        self.defaultDevice = try container.decodeIfPresent(String.self, forKey: .defaultDevice)
+
+        // Handle migration from old lastUpdateCheck to new updateCheck
+        if let updateCheck = try container.decodeIfPresent(
+            UpdateCheckState.self,
+            forKey: .updateCheck
+        ) {
+            self.updateCheck = updateCheck
+        } else if let lastUpdateCheck = try container.decodeIfPresent(
+            Date.self,
+            forKey: .lastUpdateCheck
+        ) {
+            // Migrate old config format
+            self.updateCheck = UpdateCheckState(lastCheckTime: lastUpdateCheck)
+        } else {
+            self.updateCheck = nil
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(auth, forKey: .auth)
+        try container.encode(analytics, forKey: .analytics)
+        try container.encodeIfPresent(defaultDevice, forKey: .defaultDevice)
+        try container.encodeIfPresent(updateCheck, forKey: .updateCheck)
+        // Note: We intentionally don't encode lastUpdateCheck anymore
     }
 
     public mutating func addAuth(_ newAuth: Auth) {

--- a/Sources/Wendy/cli/commands/UpdateCommand.swift
+++ b/Sources/Wendy/cli/commands/UpdateCommand.swift
@@ -1,0 +1,15 @@
+import ArgumentParser
+import Foundation
+import WendyShared
+
+struct UpdateCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "update",
+        abstract: "Check for CLI updates"
+    )
+
+    func run() async throws {
+        // Force check, ignoring cooldowns
+        await UpdateChecker.forceCheck()
+    }
+}

--- a/Sources/Wendy/utils/PackageManagerDetector.swift
+++ b/Sources/Wendy/utils/PackageManagerDetector.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Logging
+import Subprocess
+
+/// Detects the package manager used to install the CLI and provides update commands.
+/// Uses binary path detection as the primary method for accuracy.
+enum PackageManagerDetector {
+    private static let logger = Logger(label: "sh.wendy.utils.packageManagerDetector")
+
+    /// Detect which package manager was used to install the CLI.
+    /// Uses binary path detection first, then falls back to package manager queries.
+    static func detect() async -> PackageManagerType {
+        // First, check the actual executable path (handles swift run case)
+        let executablePath = currentExecutablePath()
+        logger.debug(
+            "Current executable path",
+            metadata: ["path": "\(executablePath ?? "unknown")"]
+        )
+
+        // If running from a .build directory, this is a development build
+        if let path = executablePath, path.contains(".build/") {
+            logger.debug("Detected development build (swift run)")
+            return .unknown
+        }
+
+        // Use the executable path if available, otherwise fall back to `which wendy`
+        let binaryPath: String?
+        if let path = executablePath, !path.isEmpty {
+            binaryPath = path
+        } else {
+            binaryPath = await findBinaryPathViaWhich()
+        }
+
+        guard let binaryPath else {
+            logger.debug("Could not determine wendy binary path")
+            return .unknown
+        }
+
+        logger.debug("Detected wendy binary path", metadata: ["path": "\(binaryPath)"])
+
+        // Determine package manager based on binary path
+        return await detectFromPath(binaryPath)
+    }
+
+    /// Get the path to the currently running executable
+    private static func currentExecutablePath() -> String? {
+        // CommandLine.arguments[0] contains the executable path
+        let arg0 = CommandLine.arguments.first
+        guard let arg0, !arg0.isEmpty else { return nil }
+
+        // Resolve to absolute path if relative
+        if arg0.hasPrefix("/") {
+            return arg0
+        } else {
+            let url = URL(fileURLWithPath: arg0).standardized
+            return url.path
+        }
+    }
+
+    /// Find the path to the wendy binary using `which` (fallback method)
+    private static func findBinaryPathViaWhich() async -> String? {
+        do {
+            let result = try await Subprocess.run(
+                .name("which"),
+                arguments: ["wendy"],
+                output: .string(limit: 1024),
+                error: .discarded
+            )
+
+            guard result.terminationStatus.isSuccess,
+                let output = result.standardOutput?.trimmingCharacters(in: .whitespacesAndNewlines),
+                !output.isEmpty
+            else {
+                return nil
+            }
+
+            return output
+        } catch {
+            logger.debug("Failed to run 'which wendy'", metadata: ["error": "\(error)"])
+            return nil
+        }
+    }
+
+    /// Detect package manager based on the binary path
+    private static func detectFromPath(_ path: String) async -> PackageManagerType {
+        // Homebrew on macOS (Apple Silicon)
+        if path.hasPrefix("/opt/homebrew/") {
+            logger.debug("Detected package manager: brew (macOS ARM)")
+            return .brew
+        }
+
+        // Homebrew on macOS (Intel) or legacy Linuxbrew
+        if path.hasPrefix("/usr/local/Cellar/") || path.hasPrefix("/usr/local/bin/") {
+            // On macOS, /usr/local is typically Homebrew
+            // On Linux, could be manual install - check if Homebrew owns it
+            #if os(macOS)
+                logger.debug("Detected package manager: brew (macOS Intel)")
+                return .brew
+            #else
+                // On Linux, verify it's actually Homebrew
+                if await shellCommandSucceeds("brew", args: ["list", "wendy"]) {
+                    logger.debug("Detected package manager: brew (Linuxbrew)")
+                    return .brew
+                }
+            #endif
+        }
+
+        // Linuxbrew (common paths)
+        if path.contains("linuxbrew") || path.contains(".linuxbrew") {
+            logger.debug("Detected package manager: brew (Linuxbrew)")
+            return .brew
+        }
+
+        // System paths - need secondary detection
+        if path.hasPrefix("/usr/bin/") || path.hasPrefix("/bin/") {
+            return await detectSystemPackageManager()
+        }
+
+        // Windows paths
+        #if os(Windows)
+            if path.contains("Program Files") || path.contains("AppData") {
+                if await shellCommandSucceeds("winget", args: ["list", "--name", "wendy"]) {
+                    logger.debug("Detected package manager: winget")
+                    return .winget
+                }
+            }
+        #endif
+
+        logger.debug("Could not detect package manager from path", metadata: ["path": "\(path)"])
+        return .unknown
+    }
+
+    /// Detect which system package manager installed wendy (for /usr/bin paths)
+    private static func detectSystemPackageManager() async -> PackageManagerType {
+        #if os(Linux)
+            // Check apt (Debian/Ubuntu) - look for dpkg database entry
+            if FileManager.default.fileExists(atPath: "/var/lib/dpkg/info/wendy.list") {
+                logger.debug("Detected package manager: apt")
+                return .apt
+            }
+
+            // Check pacman (Arch Linux)
+            if await shellCommandSucceeds("pacman", args: ["-Q", "wendy"]) {
+                logger.debug("Detected package manager: pacman")
+                return .pacman
+            }
+
+            // Check rpm-based (Fedora/RHEL/CentOS)
+            if await shellCommandSucceeds("rpm", args: ["-q", "wendy"]) {
+                // Distinguish between dnf and yum
+                if FileManager.default.fileExists(atPath: "/usr/bin/dnf") {
+                    logger.debug("Detected package manager: dnf")
+                    return .dnf
+                } else {
+                    logger.debug("Detected package manager: yum")
+                    return .yum
+                }
+            }
+        #endif
+
+        logger.debug("Could not detect system package manager")
+        return .unknown
+    }
+
+    /// Get the update command for a given package manager.
+    static func updateCommand(for manager: PackageManagerType) -> String {
+        switch manager {
+        case .brew:
+            return "brew upgrade wendylabsinc/tap/wendy"
+        case .apt:
+            return "sudo apt update && sudo apt upgrade wendy"
+        case .pacman:
+            return "sudo pacman -Syu wendy"
+        case .dnf:
+            return "sudo dnf upgrade wendy"
+        case .yum:
+            return "sudo yum update wendy"
+        case .winget:
+            return "winget upgrade wendy"
+        case .unknown:
+            return "Please update using your package manager"
+        }
+    }
+
+    /// Execute a shell command and return whether it succeeded.
+    private static func shellCommandSucceeds(
+        _ executable: String,
+        args: [String]
+    ) async -> Bool {
+        do {
+            let result = try await Subprocess.run(
+                .name(executable),
+                arguments: Subprocess.Arguments(args),
+                output: .discarded,
+                error: .discarded
+            )
+            return result.terminationStatus.isSuccess
+        } catch {
+            logger.debug(
+                "Shell command failed",
+                metadata: [
+                    "executable": "\(executable)",
+                    "error": "\(error)",
+                ]
+            )
+            return false
+        }
+    }
+}

--- a/Sources/Wendy/utils/UpdateChecker.swift
+++ b/Sources/Wendy/utils/UpdateChecker.swift
@@ -4,9 +4,13 @@ import Noora
 import WendyShared
 
 /// Checks for CLI updates and prompts the user if a new version is available.
-/// Only checks once per day to avoid excessive API calls.
+/// - Checks once per 24 hours to avoid excessive API calls
+/// - Prompts user with a dialog to update
+/// - Respects user choice and doesn't re-prompt for 24 hours
+/// - Detects package manager used to install the CLI
 enum UpdateChecker {
-    private static let checkInterval: TimeInterval = 24 * 60 * 60  // 24 hours in seconds
+    private static let checkIntervalHours: Double = 24
+    private static let promptCooldownHours: Double = 24
     private static let logger = Logger(label: "sh.wendy.utils.updateChecker")
 
     /// Check for updates if enough time has passed since the last check.
@@ -22,25 +26,58 @@ enum UpdateChecker {
             return
         }
 
-        let config = getConfig()
+        var config = getConfig()
+        let state = config.updateCheck
 
-        // Check if enough time has passed since last check
-        if let lastCheck = config.lastUpdateCheck {
-            let timeSinceLastCheck = Date().timeIntervalSince(lastCheck)
-            guard timeSinceLastCheck >= checkInterval else {
-                logger.debug(
-                    "Skipping update check, last check was recent",
-                    metadata: ["hours_ago": "\(Int(timeSinceLastCheck / 3600))"]
-                )
-                return
+        // Check if enough time has passed since last network check
+        if !shouldCheckForUpdates(state: state) {
+            // Even if we don't need to check the network, we might still need to prompt
+            // if there's a known newer version
+            if let latestVersion = state?.latestKnownVersion,
+                isNewerVersion(latestVersion, than: Version.current),
+                shouldPromptUser(state: state)
+            {
+                await promptForUpdate(latestVersion: latestVersion, config: &config)
             }
+            return
         }
 
         // Perform the update check
-        await performUpdateCheck()
+        await performUpdateCheck(config: &config)
     }
 
-    private static func performUpdateCheck() async {
+    /// Force an update check, ignoring cooldowns.
+    /// Used by the `wendy update` command.
+    static func forceCheck() async {
+        // Skip update check in dev mode
+        guard Version.current != "dev" else {
+            Noora().info("Running in development mode - skipping update check")
+            return
+        }
+
+        var config = getConfig()
+        await performUpdateCheck(config: &config, forcePrompt: true)
+    }
+
+    /// Check if we should perform a network check for updates
+    private static func shouldCheckForUpdates(state: UpdateCheckState?) -> Bool {
+        guard let state = state, let lastCheck = state.lastCheckTime else {
+            return true  // Never checked before
+        }
+        let hoursSinceCheck = Date().timeIntervalSince(lastCheck) / 3600
+        return hoursSinceCheck >= checkIntervalHours
+    }
+
+    /// Check if we should prompt the user
+    private static func shouldPromptUser(state: UpdateCheckState?) -> Bool {
+        guard let state = state, let lastPrompt = state.lastPromptTime else {
+            return true  // Never prompted
+        }
+        let hoursSincePrompt = Date().timeIntervalSince(lastPrompt) / 3600
+        return hoursSincePrompt >= promptCooldownHours
+    }
+
+    private static func performUpdateCheck(config: inout Config, forcePrompt: Bool = false) async {
         do {
             logger.debug("Checking for updates...")
 
@@ -49,7 +86,7 @@ enum UpdateChecker {
             // Find the latest stable release
             guard let latestRelease = releases.first(where: { !$0.prerelease }) else {
                 logger.debug("No stable releases found")
-                updateLastCheckTime()
+                updateCheckTime(config: &config)
                 return
             }
 
@@ -59,9 +96,27 @@ enum UpdateChecker {
                 ? String(latestRelease.name.dropFirst())
                 : latestRelease.name
 
+            // Update the state with latest known version
+            var state = config.updateCheck ?? UpdateCheckState()
+            state.lastCheckTime = Date()
+            state.latestKnownVersion = latestVersion
+            config.updateCheck = state
+
             // Compare versions
             if isNewerVersion(latestVersion, than: Version.current) {
-                displayUpdatePrompt(newVersion: latestVersion)
+                // Should we prompt the user?
+                if forcePrompt || shouldPromptUser(state: config.updateCheck) {
+                    await promptForUpdate(latestVersion: latestVersion, config: &config)
+                } else {
+                    logger.debug(
+                        "Skipping prompt - user was recently prompted",
+                        metadata: [
+                            "current": "\(Version.current)",
+                            "latest": "\(latestVersion)",
+                        ]
+                    )
+                    try? config.save()
+                }
             } else {
                 logger.debug(
                     "CLI is up to date",
@@ -70,26 +125,79 @@ enum UpdateChecker {
                         "latest": "\(latestVersion)",
                     ]
                 )
+                if forcePrompt {
+                    Noora().success("You're up to date! (v\(Version.current))")
+                }
+                try? config.save()
             }
-
-            updateLastCheckTime()
         } catch {
             // Fail silently - update checks should never block the user
             logger.debug(
                 "Update check failed",
                 metadata: ["error": "\(error)"]
             )
+            if forcePrompt {
+                Noora().warning("Could not check for updates: \(error.localizedDescription)")
+            }
         }
     }
 
-    private static func updateLastCheckTime() {
-        var config = getConfig()
-        config.lastUpdateCheck = Date()
+    private static func updateCheckTime(config: inout Config) {
+        var state = config.updateCheck ?? UpdateCheckState()
+        state.lastCheckTime = Date()
+        config.updateCheck = state
+        try? config.save()
+    }
+
+    private static func promptForUpdate(latestVersion: String, config: inout Config) async {
+        // Display the update notification
+        Noora().info(
+            """
+
+            A new version of wendy is available!
+            Current: v\(Version.current)
+            Latest:  v\(latestVersion)
+            """
+        )
+
+        // Ask if the user wants to update
+        let shouldUpdate = Noora().yesOrNoChoicePrompt(
+            title: "",
+            question: "Would you like to see the update command?"
+        )
+
+        // Update the state with user's response
+        var state = config.updateCheck ?? UpdateCheckState()
+        state.lastPromptTime = Date()
+        state.lastPromptResponse = shouldUpdate
+        config.updateCheck = state
+
+        if shouldUpdate {
+            // Detect package manager (use cached value if available)
+            let packageManager: PackageManagerType
+            if let cached = state.detectedPackageManager {
+                packageManager = cached
+            } else {
+                packageManager = await PackageManagerDetector.detect()
+                state.detectedPackageManager = packageManager
+                config.updateCheck = state
+            }
+
+            let command = PackageManagerDetector.updateCommand(for: packageManager)
+
+            Noora().success(
+                """
+                Run this command to update:
+                  \(command)
+                """
+            )
+        }
+
         try? config.save()
     }
 
     /// Compare semantic versions. Returns true if `new` is greater than `current`.
-    private static func isNewerVersion(_ new: String, than current: String) -> Bool {
+    static func isNewerVersion(_ new: String, than current: String) -> Bool {
         let newComponents = new.split(separator: ".").compactMap { Int($0) }
         let currentComponents = current.split(separator: ".").compactMap { Int($0) }
 
@@ -105,51 +213,5 @@ enum UpdateChecker {
         }
 
         return false  // Versions are equal
-    }
-
-    private static func displayUpdatePrompt(newVersion: String) {
-        Noora().info(
-            """
-
-            A new version of wendy is available: \(newVersion) (current: \(Version.current))
-            Run: \(getUpdateCommand())
-            """
-        )
-    }
-
-    private static func getUpdateCommand() -> String {
-        #if os(macOS)
-            return "brew upgrade wendylabsinc/tap/wendy"
-        #elseif os(Linux)
-            // Detect Linux distribution and return appropriate command
-            if let osRelease = try? String(contentsOfFile: "/etc/os-release", encoding: .utf8) {
-                let lowercased = osRelease.lowercased()
-                if lowercased.contains("debian") || lowercased.contains("ubuntu") {
-                    return "sudo apt-get update && sudo apt-get upgrade wendy"
-                } else if lowercased.contains("fedora") {
-                    return "sudo dnf upgrade wendy"
-                } else if lowercased.contains("rhel") || lowercased.contains("centos")
-                    || lowercased.contains("rocky") || lowercased.contains("alma")
-                {
-                    return "sudo yum update wendy"
-                } else if lowercased.contains("arch") {
-                    return "yay -Syu wendy"
-                }
-            }
-            // Fallback: check for package manager binaries
-            if FileManager.default.fileExists(atPath: "/usr/bin/apt-get") {
-                return "sudo apt-get update && sudo apt-get upgrade wendy"
-            } else if FileManager.default.fileExists(atPath: "/usr/bin/dnf") {
-                return "sudo dnf upgrade wendy"
-            } else if FileManager.default.fileExists(atPath: "/usr/bin/yum") {
-                return "sudo yum update wendy"
-            } else if FileManager.default.fileExists(atPath: "/usr/bin/pacman") {
-                return "yay -Syu wendy"
-            }
-            // Generic fallback
-            return "Update using your package manager"
-        #else
-            return "Update using your package manager"
-        #endif
     }
 }


### PR DESCRIPTION
## Summary

- Adds intelligent CLI update notification system that checks once per 24 hours
- Prompts user with Noora dialog when update available, respects 24h cooldown after response
- Detects package manager via binary path detection (more reliable than probing installed package managers)
- Adds `wendy update` command for manual update checks
- Skips update checks in dev mode and when running from `.build/` directory

## Changes

| File | Description |
|------|-------------|
| `Config.swift` | Add `UpdateCheckState` struct and `PackageManagerType` enum |
| `PackageManagerDetector.swift` | New file - detects package manager from executable path |
| `UpdateChecker.swift` | Rewritten with prompt dialog, cooldowns, and PackageManagerDetector integration |
| `UpdateCommand.swift` | New `wendy update` command |
| `WendyCLI.swift` | Register UpdateCommand |

## Package Manager Detection

Uses binary path as primary detection method:

| Path | Package Manager |
|------|-----------------|
| `/opt/homebrew/*` | Homebrew (macOS ARM) |
| `/usr/local/*` | Homebrew (macOS Intel) |
| `*linuxbrew*` | Linuxbrew |
| `/usr/bin/*` | System package (apt/pacman/yum/dnf) |
| `*.build/*` | Development build (no update suggested) |

## Test plan

- [ ] Run `wendy update` on installed CLI - should show version info
- [ ] Run `wendy-dev update` - should show "Running in development mode"
- [ ] Verify update prompt appears only once per 24 hours
- [ ] Verify correct package manager detected on macOS (brew)

Closes WDY-698