### PR TITLE
Add --all flag to apps start, stop, and remove commands

### DIFF
--- a/Sources/Wendy/cli/commands/AppsCommand.swift
+++ b/Sources/Wendy/cli/commands/AppsCommand.swift
@@ -15,20 +15,32 @@ struct AppsCommand: AsyncParsableCommand {
         ]
     )
 
+    struct Apps: ParsableArguments {
+        @Argument(help: "Name of the application to select")
+        var appName: String?
+
+        @Flag(
+            name: .customLong("all"),
+            help: "Select all applications for the operation"
+        )
+        var all: Bool = false
+
+        func resolve(client: AgentClient) async throws -> [String] {
+            if all {
+                return try await client.listApps().map(\.name)
+            } else if let appName {
+                return [appName]
+            } else {
+                return []
+            }
+        }
+    }
+
     struct Remove: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "remove",
             abstract: "Stop and remove an application from the device"
         )
-
-        @Argument(help: "Application name used when the app was created")
-        var appName: String?
-
-        @Flag(
-            name: .customLong("all"),
-            help: "Remove all applications from the device"
-        )
-        var all: Bool = false
 
         @Flag(
             name: .customLong("purge-image"),
@@ -38,30 +50,17 @@ struct AppsCommand: AsyncParsableCommand {
 
         @OptionGroup var agentConnectionOptions: AgentConnectionOptions
 
-        func validate() throws {
-            if !all && appName == nil {
-                throw ValidationError("Please provide an app name or use --all")
-            }
-            if all && appName != nil {
-                throw ValidationError("Cannot specify both app name and --all")
-            }
-        }
+        @OptionGroup var apps: Apps
 
         func run() async throws {
             try await withAgentClientAndHostname(
                 agentConnectionOptions,
                 title: "Removing application"
             ) { client, hostname in
-                let appsToRemove: [String]
-                if all {
-                    let apps = try await client.listApps()
-                    appsToRemove = apps.map(\.name)
-                    guard !appsToRemove.isEmpty else {
-                        cliOutput.info("No applications to remove on \(hostname)")
-                        return
-                    }
-                } else {
-                    appsToRemove = [appName!]
+                let appsToRemove = try await apps.resolve(client: client)
+                guard !appsToRemove.isEmpty else {
+                    cliOutput.info("No applications to remove on \(hostname)")
+                    return
                 }
 
                 for name in appsToRemove {
@@ -82,41 +81,18 @@ struct AppsCommand: AsyncParsableCommand {
             abstract: "Start an application"
         )
 
-        @Argument(help: "Application name used when the app was created")
-        var appName: String?
-
-        @Flag(
-            name: .customLong("all"),
-            help: "Start all applications on the device"
-        )
-        var all: Bool = false
-
         @OptionGroup var agentConnectionOptions: AgentConnectionOptions
-
-        func validate() throws {
-            if !all && appName == nil {
-                throw ValidationError("Please provide an app name or use --all")
-            }
-            if all && appName != nil {
-                throw ValidationError("Cannot specify both app name and --all")
-            }
-        }
+        @OptionGroup var apps: Apps
 
         func run() async throws {
             try await withAgentClientAndHostname(
                 agentConnectionOptions,
                 title: "Starting application"
             ) { client, hostname in
-                let appsToStart: [String]
-                if all {
-                    let apps = try await client.listApps()
-                    appsToStart = apps.map(\.name)
-                    guard !appsToStart.isEmpty else {
-                        cliOutput.info("No applications to start on \(hostname)")
-                        return
-                    }
-                } else {
-                    appsToStart = [appName!]
+                let appsToStart = try await apps.resolve(client: client)
+                guard !appsToStart.isEmpty else {
+                    cliOutput.info("No applications to start on \(hostname)")
+                    return
                 }
 
                 for name in appsToStart {
@@ -133,41 +109,18 @@ struct AppsCommand: AsyncParsableCommand {
             abstract: "Stop a running application"
         )
 
-        @Argument(help: "Application name used when the app was created")
-        var appName: String?
-
-        @Flag(
-            name: .customLong("all"),
-            help: "Stop all running applications on the device"
-        )
-        var all: Bool = false
-
         @OptionGroup var agentConnectionOptions: AgentConnectionOptions
-
-        func validate() throws {
-            if !all && appName == nil {
-                throw ValidationError("Please provide an app name or use --all")
-            }
-            if all && appName != nil {
-                throw ValidationError("Cannot specify both app name and --all")
-            }
-        }
+        @OptionGroup var apps: Apps
 
         func run() async throws {
             try await withAgentClientAndHostname(
                 agentConnectionOptions,
                 title: "Stopping application"
             ) { client, hostname in
-                let appsToStop: [String]
-                if all {
-                    let apps = try await client.listApps()
-                    appsToStop = apps.map(\.name)
-                    guard !appsToStop.isEmpty else {
-                        cliOutput.info("No applications to stop on \(hostname)")
-                        return
-                    }
-                } else {
-                    appsToStop = [appName!]
+                let appsToStop = try await apps.resolve(client: client)
+                guard !appsToStop.isEmpty else {
+                    cliOutput.info("No applications to stop on \(hostname)")
+                    return
                 }
 
                 for name in appsToStop {


### PR DESCRIPTION
## Summary

Adds `--all` flag to device apps commands for batch operations:

- `wendy device apps start --all` - Start all applications
- `wendy device apps stop --all` - Stop all running applications
- `wendy device apps remove --all` - Remove all applications

## Changes

Each command now:
- Accepts optional `appName` argument instead of required
- Adds `--all` flag
- Validates that either `appName` or `--all` is provided (but not both)
- Iterates over all apps when `--all` is specified

## Test plan

- [ ] `wendy device apps start --all` starts all apps
- [ ] `wendy device apps stop --all` stops all apps
- [ ] `wendy device apps remove --all` removes all apps
- [ ] `wendy device apps start` (no args) shows validation error
- [ ] `wendy device apps start myapp --all` shows validation error

Closes WDY-697