### PR TITLE
Fix SDK install retry + update notification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,9 +408,23 @@ jobs:
       - name: Install Static Linux SDK
         if: ${{ matrix.swift-sdk-url != '' }}
         run: |
+          sdk_url="${{ matrix.swift-sdk-url }}"
+          sdk_checksum="${{ matrix.swift-sdk-checksum }}"
+          sdk_archive="${sdk_url##*/}"
+          sdk_bundle="${sdk_archive%.tar.gz}"
+          sdk_path="$HOME/.swiftpm/swift-sdks/$sdk_bundle"
+          sdk_tmp="${RUNNER_TEMP:-/tmp}/$sdk_archive"
+
+          if [ -d "$sdk_path" ]; then
+            echo "Swift SDK already installed at $sdk_path"
+            exit 0
+          fi
+
           for attempt in 1 2 3; do
             echo "Attempt $attempt of 3..."
-            if swift sdk install ${{ matrix.swift-sdk-url }} --checksum ${{ matrix.swift-sdk-checksum }}; then
+            rm -rf "$sdk_path"
+            curl -L --fail --retry 5 --retry-delay 2 -o "$sdk_tmp" "$sdk_url"
+            if swift sdk install "$sdk_tmp" --checksum "$sdk_checksum"; then
               echo "SDK installed successfully"
               exit 0
             fi

--- a/Sources/Wendy/utils/PackageManagerDetector.swift
+++ b/Sources/Wendy/utils/PackageManagerDetector.swift
@@ -83,51 +83,57 @@ enum PackageManagerDetector {
 
     /// Detect package manager based on the binary path
     private static func detectFromPath(_ path: String) async -> PackageManagerType {
-        // Homebrew on macOS (Apple Silicon)
-        if path.hasPrefix("/opt/homebrew/") {
-            logger.debug("Detected package manager: brew (macOS ARM)")
-            return .brew
-        }
-
-        // Homebrew on macOS (Intel) or legacy Linuxbrew
-        if path.hasPrefix("/usr/local/Cellar/") || path.hasPrefix("/usr/local/bin/") {
-            // On macOS, /usr/local is typically Homebrew
-            // On Linux, could be manual install - check if Homebrew owns it
-            #if os(macOS)
-                logger.debug("Detected package manager: brew (macOS Intel)")
-                return .brew
-            #else
-                // On Linux, verify it's actually Homebrew
-                if await shellCommandSucceeds("brew", args: ["list", "wendy"]) {
-                    logger.debug("Detected package manager: brew (Linuxbrew)")
-                    return .brew
-                }
-            #endif
-        }
-
-        // Linuxbrew (common paths)
-        if path.contains("linuxbrew") || path.contains(".linuxbrew") {
-            logger.debug("Detected package manager: brew (Linuxbrew)")
-            return .brew
-        }
-
-        // System paths - need secondary detection
-        if path.hasPrefix("/usr/bin/") || path.hasPrefix("/bin/") {
-            return await detectSystemPackageManager()
-        }
-
-        // Windows paths
         #if os(Windows)
-            if path.contains("Program Files") || path.contains("AppData") {
-                if await shellCommandSucceeds("winget", args: ["list", "--name", "wendy"]) {
-                    logger.debug("Detected package manager: winget")
-                    return .winget
-                }
+            if await shellCommandSucceeds("winget", args: ["list", "--name", "wendy"]) {
+                logger.debug("Detected package manager: winget")
+                return .winget
             }
-        #endif
 
-        logger.debug("Could not detect package manager from path", metadata: ["path": "\(path)"])
-        return .unknown
+            logger.debug(
+                "Could not detect package manager from Windows path",
+                metadata: ["path": "\(path)"]
+            )
+            return .unknown
+        #else
+            // Homebrew on macOS (Apple Silicon)
+            if path.hasPrefix("/opt/homebrew/") {
+                logger.debug("Detected package manager: brew (macOS ARM)")
+                return .brew
+            }
+
+            // Homebrew on macOS (Intel) or legacy Linuxbrew
+            if path.hasPrefix("/usr/local/Cellar/") || path.hasPrefix("/usr/local/bin/") {
+                // On macOS, /usr/local is typically Homebrew
+                // On Linux, could be manual install - check if Homebrew owns it
+                #if os(macOS)
+                    logger.debug("Detected package manager: brew (macOS Intel)")
+                    return .brew
+                #else
+                    // On Linux, verify it's actually Homebrew
+                    if await shellCommandSucceeds("brew", args: ["list", "wendy"]) {
+                        logger.debug("Detected package manager: brew (Linuxbrew)")
+                        return .brew
+                    }
+                #endif
+            }
+
+            // Linuxbrew (common paths)
+            if path.contains("linuxbrew") || path.contains(".linuxbrew") {
+                logger.debug("Detected package manager: brew (Linuxbrew)")
+                return .brew
+            }
+
+            // System paths - need secondary detection
+            if path.hasPrefix("/usr/bin/") || path.hasPrefix("/bin/") {
+                return await detectSystemPackageManager()
+            }
+
+            logger.debug(
+                "Could not detect package manager from path",
+                metadata: ["path": "\(path)"]
+            )
+            return .unknown
+        #endif
     }
 
     /// Detect which system package manager installed wendy (for /usr/bin paths)

--- a/Sources/Wendy/utils/UpdateChecker.swift
+++ b/Sources/Wendy/utils/UpdateChecker.swift
@@ -1,12 +1,11 @@
 import Foundation
 import Logging
-import Noora
 import WendyShared
 
-/// Checks for CLI updates and prompts the user if a new version is available.
+/// Checks for CLI updates and notifies the user if a new version is available.
 /// - Checks once per 24 hours to avoid excessive API calls
-/// - Prompts user with a dialog to update
-/// - Respects user choice and doesn't re-prompt for 24 hours
+/// - Notifies user with the update command when a new version is available
+/// - Doesn't re-notify for 24 hours
 /// - Detects package manager used to install the CLI
 enum UpdateChecker {
     private static let checkIntervalHours: Double = 24
@@ -51,7 +50,7 @@ enum UpdateChecker {
     static func forceCheck() async {
         // Skip update check in dev mode
         guard Version.current != "dev" else {
-            Noora().info("Running in development mode - skipping update check")
+            cliOutput.info("Running in development mode - skipping update check")
             return
         }
 
@@ -126,7 +125,7 @@ enum UpdateChecker {
                     ]
                 )
                 if forcePrompt {
-                    Noora().success("You're up to date! (v\(Version.current))")
+                    cliOutput.success("You're up to date! (v\(Version.current))")
                 }
                 try? config.save()
             }
@@ -137,7 +136,7 @@ enum UpdateChecker {
                 metadata: ["error": "\(error)"]
             )
             if forcePrompt {
-                Noora().warning("Could not check for updates: \(error.localizedDescription)")
+                cliOutput.warning("Could not check for updates: \(error.localizedDescription)")
             }
         }
     }
@@ -151,7 +150,7 @@ enum UpdateChecker {
 
     private static func promptForUpdate(latestVersion: String, config: inout Config) async {
         // Display the update notification
-        Noora().info(
+        cliOutput.info(
             """
 
             A new version of wendy is available!
@@ -160,38 +159,30 @@ enum UpdateChecker {
             """
         )
 
-        // Ask if the user wants to update
-        let shouldUpdate = Noora().yesOrNoChoicePrompt(
-            title: "",
-            question: "Would you like to see the update command?"
-        )
-
-        // Update the state with user's response
+        // Update the state with notification time
         var state = config.updateCheck ?? UpdateCheckState()
         state.lastPromptTime = Date()
-        state.lastPromptResponse = shouldUpdate
+        state.lastPromptResponse = nil
         config.updateCheck = state
 
-        if shouldUpdate {
-            // Detect package manager (use cached value if available)
-            let packageManager: PackageManagerType
-            if let cached = state.detectedPackageManager {
-                packageManager = cached
-            } else {
-                packageManager = await PackageManagerDetector.detect()
-                state.detectedPackageManager = packageManager
-                config.updateCheck = state
-            }
-
-            let command = PackageManagerDetector.updateCommand(for: packageManager)
-
-            Noora().success(
-                """
-                Run this command to update:
-                  \(command)
-                """
-            )
+        // Detect package manager (use cached value if available)
+        let packageManager: PackageManagerType
+        if let cached = state.detectedPackageManager {
+            packageManager = cached
+        } else {
+            packageManager = await PackageManagerDetector.detect()
+            state.detectedPackageManager = packageManager
+            config.updateCheck = state
         }
+
+        let command = PackageManagerDetector.updateCommand(for: packageManager)
+
+        cliOutput.success(
+            """
+            Run this command to update:
+              \(command)
+            """
+        )
 
         try? config.save()
     }


### PR DESCRIPTION
## Summary
- make static Swift SDK install idempotent and avoid `swift sdk install` segfaults by installing from a downloaded artifact
- make update notifications non-interactive and consistently use `cliOutput`
- refine package manager detection on Windows paths

## Testing
- swift build (warnings about input verification from existing .build objects)
