### PR TITLE
Fix format-check checkout ref

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run Swift Format Check
         id: format_check


### PR DESCRIPTION
## Summary
- use the PR head SHA for checkout in format-check workflow so runs don’t fail after branch deletion

## Testing
- swift build (warnings about input verification from existing .build objects)
