### PR TITLE
Fix static SDK install when curl is missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish artifacts and release"
+        type: boolean
+        default: false
 
 concurrency:
   group: build-${{ github.ref }}
@@ -643,7 +648,7 @@ jobs:
     name: Publish to GCP Artifact Registry
     runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/spot=${{ needs.check-bugfix.outputs.spot }}
     needs: [check-bugfix, determine-version, package-linux]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
     permissions:
       contents: read
       id-token: write
@@ -697,7 +702,7 @@ jobs:
     name: Release
     runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-arm64/spot=${{ needs.check-bugfix.outputs.spot }}
     needs: [check-bugfix, determine-version, build, build-windows, package-linux]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -824,7 +829,7 @@ jobs:
     name: Publish AUR Packages
     runs-on: ubuntu-latest
     needs: [determine-version, release]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- avoid hard dependency on curl during static Linux SDK install
- fallback to installing SDK directly from URL when curl is unavailable

## Testing
- swift build