### PR TITLE
WDY-705: Improve semver release visibility with source pre-release tag

### DIFF
--- a/.github/workflows/release-semver.yml
+++ b/.github/workflows/release-semver.yml
@@ -120,16 +120,16 @@ jobs:
           done
 
           # Write job summary for easy reference in GitHub Actions UI
-          cat >> $GITHUB_STEP_SUMMARY << SUMMARY_EOF
-          ## 🚀 Semver Release Created
-
-          | Field | Value |
-          |-------|-------|
-          | **Semver Version** | \`$VERSION\` |
-          | **Source Pre-release** | [\`$PRERELEASE_TAG\`]($PRERELEASE_URL) |
-          | **Release URL** | [View Release](https://github.com/${{ github.repository }}/releases/tag/$VERSION) |
-          | **Assets Uploaded** | ${#RENAMED_FILES[@]} |
-          SUMMARY_EOF
+          {
+            echo "## 🚀 Semver Release Created"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| **Semver Version** | \`$VERSION\` |"
+            echo "| **Source Pre-release** | [\`$PRERELEASE_TAG\`]($PRERELEASE_URL) |"
+            echo "| **Release URL** | [View Release](https://github.com/${{ github.repository }}/releases/tag/$VERSION) |"
+            echo "| **Assets Uploaded** | ${#RENAMED_FILES[@]} |"
+          } >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Discord
         if: inputs.promote_prerelease != ''


### PR DESCRIPTION
## Summary

When promoting a pre-release to a semver release, it was hard to tell which pre-release was used after the fact. This PR improves visibility by:

- Adding source pre-release tag to release title
- Moving promotion note to TOP of release body with a clickable link
- Adding GitHub Actions job summary table for easy reference
- Including source tag in Discord notification

## Changes

### Release Title
Before: `Release v0.2.0`
After: `Release v0.2.0 (from 2026.01.29-153042)`

### Release Body
Before: Promotion note buried at the bottom
After: Promotion note at the top with link:
> 📦 **Promoted from pre-release [`2026.01.29-153042`](link)**

### GitHub Actions Summary
New table in workflow summary for easy reference after the workflow completes.

## Test plan
- [ ] Trigger workflow with a test pre-release tag and verify title/body format
- [ ] Check GitHub Actions summary appears correctly
- [ ] Verify Discord notification includes source tag