### PR TITLE
WDY-713: Bind gRPC server to dual-stack [::] for IPv6 reachability

### DIFF
--- a/Sources/WendyAgent/WendyAgent.swift
+++ b/Sources/WendyAgent/WendyAgent.swift
@@ -198,7 +198,7 @@ struct WendyAgent: AsyncParsableCommand {
             servers.append(
                 GRPCServer(
                     transport: HTTP2ServerTransport.Posix(
-                        address: .ipv4(host: "0.0.0.0", port: port + 1),
+                        address: .ipv6(host: "::", port: port + 1),
                         transportSecurity: mTLS
                     ),
                     services: authenticatedServices,
@@ -212,7 +212,7 @@ struct WendyAgent: AsyncParsableCommand {
         servers.append(
             GRPCServer(
                 transport: HTTP2ServerTransport.Posix(
-                    address: .ipv4(host: "0.0.0.0", port: port),
+                    address: .ipv6(host: "::", port: port),
                     transportSecurity: .plaintext
                 ),
                 services: plaintextServices,


### PR DESCRIPTION
## Summary
- Changes the agent's gRPC server bind address from `0.0.0.0` (IPv4-only) to `::` (dual-stack IPv4+IPv6)
- USB-connected devices may only have IPv6 link-local addresses on the USB gadget interface when no DHCP server is present, making the agent unreachable with the old IPv4-only binding
- Both plaintext (port 50051) and mTLS (port 50052) servers are updated

## Test plan
- [ ] Deploy updated agent to a USB-connected device with IPv6-only link
- [ ] Verify `ss -tlnp | grep 50051` shows `[::]:50051` (dual-stack) instead of `0.0.0.0:50051`
- [ ] Verify CLI can connect over IPv6 link-local
- [ ] Verify existing IPv4 connections still work (dual-stack accepts both)

Fixes WDY-713