### PR TITLE
Create testing script for Go cli

### DIFF
--- a/go/scripts/test-cli.sh
+++ b/go/scripts/test-cli.sh
@@ -4,11 +4,6 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Defaults
-DEFAULT_HOSTNAME="wendyos-jolly-cedar.local"
-DEFAULT_USER="edge"
-DEFAULT_PASSWORD="edge"
-
 usage() {
     cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
@@ -16,39 +11,51 @@ Usage: $(basename "$0") [OPTIONS]
 Integration test script for the Go wendy CLI.
 Exercises most CLI commands against a real WendyOS device.
 
+Device Selection:
+  If --hostname is not provided, the script auto-discovers a device on the
+  local network using 'wendy discover --json'. The first LAN device found
+  is used.
+
 Options:
-  -h, --hostname HOST    Device hostname (default: $DEFAULT_HOSTNAME)
-  -u, --user USER        SSH username (default: $DEFAULT_USER)
-  -p, --password PASS    SSH password (default: $DEFAULT_PASSWORD)
-  --skip-deploy          Skip build/run/remove tests (read-only mode)
-  --help                 Show this help message
+  -h, --hostname HOST       Device hostname (skips auto-discovery)
+  --wifi-ssid SSID          WiFi SSID for connect test
+  --wifi-password PASS      WiFi password for connect test
+  --skip-wifi               Skip WiFi tests entirely
+  --skip-deploy             Skip build/run/remove tests (read-only mode)
+  --help                    Show this help message
 
 Examples:
-  $(basename "$0")
-  $(basename "$0") -h wendyos-merry-aurora
-  $(basename "$0") -h wendyos-merry-aurora --skip-deploy
+  $(basename "$0")                                      # auto-discover, prompt for wifi
+  $(basename "$0") -h wendyos-merry-aurora              # explicit host, prompt for wifi
+  $(basename "$0") --skip-wifi                           # auto-discover, no wifi tests
+  $(basename "$0") -h wendyos-merry-aurora --skip-wifi   # explicit host, no wifi
+  $(basename "$0") --wifi-ssid MyNet --wifi-password secret  # non-interactive wifi
+  $(basename "$0") --skip-wifi --skip-deploy             # read-only mode
 EOF
     exit 0
 }
 
-HOSTNAME="$DEFAULT_HOSTNAME"
-SSH_USER="$DEFAULT_USER"
-SSH_PASS="$DEFAULT_PASSWORD"
+HOSTNAME=""
+HOSTNAME_PROVIDED=false
 SKIP_DEPLOY=false
+SKIP_WIFI=false
+WIFI_SSID=""
+WIFI_PASSWORD=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -h|--hostname) HOSTNAME="$2"; shift 2 ;;
-        -u|--user)     SSH_USER="$2"; shift 2 ;;
-        -p|--password) SSH_PASS="$2"; shift 2 ;;
-        --skip-deploy) SKIP_DEPLOY=true; shift ;;
-        --help)        usage ;;
-        *)             echo "Unknown option: $1"; usage ;;
+        -h|--hostname)      HOSTNAME="$2"; HOSTNAME_PROVIDED=true; shift 2 ;;
+        --wifi-ssid)        WIFI_SSID="$2"; shift 2 ;;
+        --wifi-password)    WIFI_PASSWORD="$2"; shift 2 ;;
+        --skip-wifi)        SKIP_WIFI=true; shift ;;
+        --skip-deploy)      SKIP_DEPLOY=true; shift ;;
+        --help)             usage ;;
+        *)                  echo "Unknown option: $1"; usage ;;
     esac
 done
 
-# Add .local suffix if missing.
-if [[ "$HOSTNAME" != *.local ]]; then
+# Add .local suffix if hostname was explicitly provided and missing it.
+if [[ "$HOSTNAME_PROVIDED" == true ]] && [[ "$HOSTNAME" != *.local ]]; then
     HOSTNAME="${HOSTNAME}.local"
 fi
 
@@ -139,6 +146,39 @@ if [[ ! -x "$WENDY" ]]; then
 fi
 echo ""
 
+# ── Device discovery ─────────────────────────────────────────────────
+
+if [[ -z "$HOSTNAME" ]]; then
+    echo -e "${BOLD}==> Auto-discovering device...${RESET}"
+    DISCOVER_JSON=$("$WENDY" discover --json --timeout 5s 2>&1)
+    DISCOVERED_HOST=$(echo "$DISCOVER_JSON" | jq -r '.lanDevices[0].hostname // empty' 2>/dev/null)
+    if [[ -z "$DISCOVERED_HOST" ]]; then
+        echo -e "${RED}ERROR: No LAN device found via 'wendy discover --json --timeout 5s'${RESET}"
+        echo "    Output: $(echo "$DISCOVER_JSON" | head -5)"
+        echo ""
+        echo "Hint: pass -h <hostname> to skip auto-discovery."
+        exit 1
+    fi
+    HOSTNAME="$DISCOVERED_HOST"
+fi
+
+echo -e "${BOLD}==> Target device: ${HOSTNAME}${RESET}"
+echo ""
+
+# ── Prompt for WiFi credentials if needed ────────────────────────────
+
+if [[ "$SKIP_WIFI" != true ]] && [[ -z "$WIFI_SSID" ]]; then
+    echo -e "${BOLD}WiFi test configuration:${RESET}"
+    read -p "  WiFi SSID (or press Enter to skip WiFi tests): " WIFI_SSID
+    if [[ -z "$WIFI_SSID" ]]; then
+        SKIP_WIFI=true
+    else
+        read -sp "  WiFi password: " WIFI_PASSWORD
+        echo ""
+    fi
+    echo ""
+fi
+
 # ── Phase 1: Local commands ─────────────────────────────────────────
 
 echo -e "${BOLD}Phase 1: Local commands${RESET}"
@@ -217,68 +257,100 @@ run_test "wendy bluetooth list" \
 
 echo ""
 
-# ── Phase 5: App lifecycle ──────────────────────────────────────────
+# ── Phase 5: WiFi ───────────────────────────────────────────────────
 
-echo -e "${BOLD}Phase 5: App lifecycle${RESET}"
+echo -e "${BOLD}Phase 5: WiFi${RESET}"
+
+if [[ "$SKIP_WIFI" == true ]]; then
+    skip_test "wendy wifi list"
+    skip_test "wendy wifi connect"
+    skip_test "wendy wifi status"
+    skip_test "wendy wifi disconnect"
+else
+    run_test "wendy wifi list" \
+        "$WENDY" wifi list --device "$HOSTNAME"
+
+    run_test "wendy wifi connect" \
+        "$WENDY" wifi connect --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD" --device "$HOSTNAME"
+
+    run_test_expect_output "wendy wifi status" "connected" \
+        "$WENDY" wifi status --device "$HOSTNAME"
+
+    run_test "wendy wifi disconnect" \
+        "$WENDY" wifi disconnect --device "$HOSTNAME"
+fi
+
+echo ""
+
+# ── Phase 6: App lifecycle ──────────────────────────────────────────
+
+echo -e "${BOLD}Phase 6: App lifecycle${RESET}"
 
 if [[ "$SKIP_DEPLOY" == true ]]; then
     skip_test "wendy build"
     skip_test "wendy run --detach"
-    skip_test "wendy device apps list (app present)"
-    skip_test "wendy device apps stop"
-    skip_test "wendy device apps start"
-    skip_test "wendy device apps remove"
-    skip_test "wendy device apps list (app gone)"
+    skip_test "wendy apps list (app present)"
+    skip_test "wendy apps stop"
+    skip_test "wendy apps start"
+    skip_test "wendy apps remove"
+    skip_test "wendy apps list (app gone)"
 else
-    HELLO_DIR="$PROJECT_DIR/tmp/hello-python"
-    if [[ ! -d "$HELLO_DIR" ]]; then
-        echo -e "${RED}ERROR: Example project not found at $HELLO_DIR${RESET}"
-        skip_test "wendy build"
-        skip_test "wendy run --detach"
-        skip_test "wendy device apps list (app present)"
-        skip_test "wendy device apps stop"
-        skip_test "wendy device apps start"
-        skip_test "wendy device apps remove"
-        skip_test "wendy device apps list (app gone)"
+    # Create a temporary Python project for deployment testing
+    TEST_APP_DIR=$(mktemp -d)
+    APP_ID="sh.wendy.cli-test"
+    trap "rm -rf '$TEST_APP_DIR'" EXIT
+
+    cat > "$TEST_APP_DIR/main.py" <<'PYEOF'
+import http.server
+import socketserver
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+with socketserver.TCPServer(("", 8080), Handler) as httpd:
+    httpd.serve_forever()
+PYEOF
+
+    "$WENDY" init --language python --directory "$TEST_APP_DIR" --app-id "$APP_ID" >/dev/null 2>&1
+
+    run_test "wendy build" \
+        bash -c "cd '$TEST_APP_DIR' && '$WENDY' build"
+
+    run_test "wendy run --detach" \
+        bash -c "cd '$TEST_APP_DIR' && '$WENDY' run --device '$HOSTNAME' --detach"
+
+    run_test_expect_output "wendy apps list (app present)" "$APP_ID" \
+        "$WENDY" apps list --device "$HOSTNAME"
+
+    run_test "wendy apps stop" \
+        "$WENDY" apps stop "$APP_ID" --device "$HOSTNAME"
+
+    run_test "wendy apps start" \
+        "$WENDY" apps start "$APP_ID" --device "$HOSTNAME"
+
+    run_test "wendy apps remove" \
+        "$WENDY" apps remove "$APP_ID" --device "$HOSTNAME" --force
+
+    # Verify the app is gone
+    printf "  %-50s " "wendy apps list (app gone)"
+    LIST_OUTPUT=$("$WENDY" apps list --device "$HOSTNAME" 2>&1)
+    if echo "$LIST_OUTPUT" | grep -q "$APP_ID"; then
+        echo -e "${RED}FAIL${RESET} (app still present)"
+        ((FAIL_COUNT++))
     else
-        APP_ID="sh.wendy.examples.hello-python"
-
-        run_test "wendy build" \
-            bash -c "cd '$HELLO_DIR' && '$WENDY' build"
-
-        run_test "wendy run --detach" \
-            bash -c "cd '$HELLO_DIR' && '$WENDY' run --device '$HOSTNAME' --detach"
-
-        run_test_expect_output "wendy device apps list (app present)" "$APP_ID" \
-            "$WENDY" device device apps list --device "$HOSTNAME"
-
-        run_test "wendy device apps stop" \
-            "$WENDY" device apps stop "$APP_ID" --device "$HOSTNAME"
-
-        run_test "wendy device apps start" \
-            "$WENDY" device apps start "$APP_ID" --device "$HOSTNAME"
-
-        run_test "wendy device apps remove" \
-            "$WENDY" device apps remove "$APP_ID" --device "$HOSTNAME" --force
-
-        # Verify the app is gone
-        printf "  %-50s " "wendy device apps list (app gone)"
-        LIST_OUTPUT=$("$WENDY" device apps list --device "$HOSTNAME" 2>&1)
-        if echo "$LIST_OUTPUT" | grep -q "$APP_ID"; then
-            echo -e "${RED}FAIL${RESET} (app still present)"
-            ((FAIL_COUNT++))
-        else
-            echo -e "${GREEN}PASS${RESET}"
-            ((PASS_COUNT++))
-        fi
+        echo -e "${GREEN}PASS${RESET}"
+        ((PASS_COUNT++))
     fi
 fi
 
 echo ""
 
-# ── Phase 6: Telemetry ──────────────────────────────────────────────
+# ── Phase 7: Telemetry ──────────────────────────────────────────────
 
-echo -e "${BOLD}Phase 6: Telemetry${RESET}"
+echo -e "${BOLD}Phase 7: Telemetry${RESET}"
 
 # Streaming command — run with a short timeout; both success and timeout are OK
 printf "  %-50s " "wendy telemetry logs (3s timeout)"
@@ -296,9 +368,9 @@ fi
 
 echo ""
 
-# ── Phase 7: Cleanup ────────────────────────────────────────────────
+# ── Phase 8: Cleanup ────────────────────────────────────────────────
 
-echo -e "${BOLD}Phase 7: Cleanup${RESET}"
+echo -e "${BOLD}Phase 8: Cleanup${RESET}"
 
 run_test "wendy device unset-default" \
     "$WENDY" device unset-default


### PR DESCRIPTION
This PR addresses [WDY-718](https://linear.app/wendylabsinc/issue/WDY-718/create-script-for-automatic-go-cli-testing) by creating a script to automatically test most of the CLI commands for the Go port. Some commands such as the wifi related commands are excluded. The script takes similar parameters to the agent uploader script, including hostname, username, and other relevant info, including a parameter to skip deployment testing if desired.