### PR TITLE
WDY-733 Add --prefix to wendy run

### DIFF
--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/proto/gen/agentpb"
@@ -64,12 +67,97 @@ func TestNewRunCmd(t *testing.T) {
 	}
 
 	// Verify expected flags exist.
-	expectedFlags := []string{"debug", "deploy", "detach", "restart-unless-stopped", "restart-on-failure", "no-restart", "user-args"}
+	expectedFlags := []string{"debug", "deploy", "detach", "restart-unless-stopped", "restart-on-failure", "no-restart", "prefix", "user-args"}
 	for _, name := range expectedFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("missing flag %q", name)
 		}
 	}
+}
+
+func TestResolveRunWorkingDir_Default(t *testing.T) {
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	tempDir := t.TempDir()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+
+	got, err := resolveRunWorkingDir(runOptions{})
+	if err != nil {
+		t.Fatalf("resolveRunWorkingDir: %v", err)
+	}
+	if canonicalPath(t, got) != canonicalPath(t, tempDir) {
+		t.Fatalf("got %q, want %q", got, tempDir)
+	}
+}
+
+func TestResolveRunWorkingDir_RelativePrefix(t *testing.T) {
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "apps", "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+
+	got, err := resolveRunWorkingDir(runOptions{prefix: filepath.Join("apps", "demo")})
+	if err != nil {
+		t.Fatalf("resolveRunWorkingDir: %v", err)
+	}
+	if canonicalPath(t, got) != canonicalPath(t, projectDir) {
+		t.Fatalf("got %q, want %q", got, projectDir)
+	}
+}
+
+func TestResolveRunWorkingDir_MissingPrefix(t *testing.T) {
+	_, err := resolveRunWorkingDir(runOptions{prefix: filepath.Join(t.TempDir(), "missing")})
+	if err == nil {
+		t.Fatal("expected error for missing directory")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "does not exist") {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
+func TestResolveRunWorkingDir_NotDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "wendy.json")
+	if err := os.WriteFile(filePath, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := resolveRunWorkingDir(runOptions{prefix: filePath})
+	if err == nil {
+		t.Fatal("expected error for file path")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "not a directory") {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
+func canonicalPath(t *testing.T, path string) string {
+	t.Helper()
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved
+	}
+
+	return filepath.Clean(path)
 }
 
 func TestNewBuildCmd(t *testing.T) {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -37,6 +37,7 @@ type runOptions struct {
 	restartUnlessStopped bool
 	restartOnFailure     bool
 	noRestart            bool
+	prefix               string
 	userArgs             []string
 }
 
@@ -46,7 +47,7 @@ func newRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Build and run application on a WendyOS device",
-		Long:  "Reads wendy.json from the current directory, builds a container image, and deploys it to the target device.",
+		Long:  "Reads wendy.json from the current directory or --prefix directory, builds a container image, and deploys it to the target device.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCommand(cmd.Context(), opts)
 		},
@@ -58,6 +59,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.restartUnlessStopped, "restart-unless-stopped", false, "Restart unless manually stopped")
 	cmd.Flags().BoolVar(&opts.restartOnFailure, "restart-on-failure", false, "Restart on failure")
 	cmd.Flags().BoolVar(&opts.noRestart, "no-restart", false, "Do not restart on exit")
+	cmd.Flags().StringVar(&opts.prefix, "prefix", "", "Project directory to run from instead of the current working directory")
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
 
 	return cmd
@@ -65,9 +67,9 @@ func newRunCmd() *cobra.Command {
 
 func runCommand(ctx context.Context, opts runOptions) error {
 	// Step 1: Load and validate wendy.json.
-	cwd, err := os.Getwd()
+	cwd, err := resolveRunWorkingDir(opts)
 	if err != nil {
-		return fmt.Errorf("getting working directory: %w", err)
+		return fmt.Errorf("resolving working directory: %w", err)
 	}
 
 	cfgPath := filepath.Join(cwd, "wendy.json")
@@ -118,6 +120,31 @@ func runCommand(ctx context.Context, opts runOptions) error {
 	// Agent-based run path (existing gRPC pipeline).
 	defer target.Agent.Close()
 	return runWithAgent(ctx, target.Agent, cwd, appCfg, opts)
+}
+
+func resolveRunWorkingDir(opts runOptions) (string, error) {
+	prefix := strings.TrimSpace(opts.prefix)
+	if prefix == "" {
+		return os.Getwd()
+	}
+
+	abs, err := filepath.Abs(prefix)
+	if err != nil {
+		return "", fmt.Errorf("resolving %q: %w", prefix, err)
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("%q does not exist", prefix)
+		}
+		return "", fmt.Errorf("checking %q: %w", prefix, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%q is not a directory", prefix)
+	}
+
+	return abs, nil
 }
 
 // runSwiftWithAgent builds a Swift package using swift-container-plugin, which


### PR DESCRIPTION
## Summary
- add a `--prefix` flag to `wendy run` so commands can target a project directory without changing the shell working directory
- resolve and validate the prefixed directory before loading `wendy.json` and building from that project root
- add coverage for default, relative, missing, and non-directory working directory resolution

## Testing
- go test ./internal/cli/...

Linear: WDY-733