### PR TITLE
WDY-734 Bootstrap containerd for pacman fallback agent installs

### DIFF
--- a/docs/agent.sh
+++ b/docs/agent.sh
@@ -103,6 +103,45 @@ confirm() {
   esac
 }
 
+ensure_pacman_keyring() {
+  if ! command -v pacman-key &>/dev/null; then
+    return 0
+  fi
+  if $SUDO pacman-key --list-keys >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "Initializing pacman keyring..."
+  $SUDO pacman-key --init
+  if [[ -f /usr/share/pacman/keyrings/holo.gpg ]]; then
+    $SUDO pacman-key --populate archlinux holo
+  else
+    $SUDO pacman-key --populate archlinux
+  fi
+}
+
+install_pacman_dependencies() {
+  if ! command -v pacman &>/dev/null; then
+    return 0
+  fi
+
+  echo "Pacman detected. Installing Wendy Agent runtime dependencies..."
+  ensure_pacman_keyring
+  $SUDO pacman -Sy --noconfirm --needed containerd xdg-dbus-proxy ca-certificates
+}
+
+ensure_containerd_service() {
+  if [[ ! -d /run/systemd/system ]] || ! command -v systemctl &>/dev/null; then
+    return 0
+  fi
+  if ! systemctl list-unit-files containerd.service --no-legend 2>/dev/null | grep -q '^containerd\.service'; then
+    echo "Error: containerd.service was not found."
+    echo "  Wendy Agent requires containerd for app deployment."
+    echo "  Install containerd and rerun the installer."
+    exit 1
+  fi
+}
+
 ARCH=$(detect_arch)
 
 if [[ "$ARCH" == "unsupported" ]]; then
@@ -173,6 +212,10 @@ else
   echo "  and install '${BINARY_NAME}' with systemd services and dev container registry."
   confirm "Proceed?"
 
+  if command -v pacman &>/dev/null; then
+    install_pacman_dependencies
+  fi
+
   TMPDIR_DL=$(mktemp -d)
   trap 'rm -rf "$TMPDIR_DL"' EXIT
 
@@ -189,7 +232,6 @@ else
     $SUDO mkdir -p /etc/wendy-agent
     $SUDO mkdir -p /usr/lib/systemd/system
     $SUDO mkdir -p /usr/share/wendyos/offline-images
-
     # wendy-agent systemd unit (unquoted heredoc so INSTALL_DIR is expanded)
     $SUDO tee /usr/lib/systemd/system/wendy-agent.service >/dev/null <<EOF
 [Unit]
@@ -414,6 +456,12 @@ EOF
 
     # Enable and start services (mirrors wendy-agent-postinstall.sh)
     $SUDO systemctl daemon-reload >/dev/null 2>&1 || true
+    ensure_containerd_service
+    if ! $SUDO systemctl enable --now containerd >/dev/null 2>&1; then
+      echo "Error: Failed to enable or start containerd."
+      exit 1
+    fi
+
     if systemctl is-enabled wendy-agent >/dev/null 2>&1; then
       $SUDO systemctl try-restart wendy-agent >/dev/null 2>&1 || true
     else


### PR DESCRIPTION
## Summary
- initialize/populate the pacman keyring when the fallback installer runs on SteamOS/Arch-like systems
- install required runtime dependencies for the tarball path, including containerd
- fail clearly if containerd is still unavailable and start containerd before starting wendy-agent

## Verification
- `bash -n docs/agent.sh`
- verified on `steamdeck.local` that the pre-fix registry probe returned `500` with `dial unix:///run/containerd/containerd.sock: timeout`
- installed `containerd` on the device, started `containerd` + `wendy-agent`, and confirmed the same registry blob `HEAD` now returns `404` and `/readyz` returns `200`
- reran `wendy run --device steamdeck.local` from `/Users/maximilianalexander/wendylabsinc/samples/python/hello-world`; build and push succeeded, and the next failure was unrelated device disk exhaustion (`no space left on device`)

Linear: https://linear.app/wendylabsinc/issue/WDY-734/steam-deck-fallback-installer-skips-containerd-and-breaks-wendy-run
