### PR TITLE
WDY-770: Add configurable WendyOS install payload support

### DIFF
--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -26,6 +26,7 @@ import (
 func newOSInstallCmd() *cobra.Command {
 	var nightly bool
 	var force bool
+	var cfgFlags osInstallConfigFlags
 
 	cmd := &cobra.Command{
 		Use:   "install [image] [drive]",
@@ -37,20 +38,28 @@ When called with positional arguments, skips interactive prompts:
 		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 2 {
-				return runOSInstallDirect(args[0], args[1], force)
+				return runOSInstallDirect(args[0], args[1], force, cfgFlags)
 			}
-			return runOSInstall(cmd.Context(), nightly)
+			return runOSInstall(cmd.Context(), nightly, cfgFlags)
 		},
 	}
 
 	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use nightly/prerelease builds")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
+	cmd.Flags().StringVar(&cfgFlags.Hostname, "hostname", "", "Set the installed device hostname (for example: wendyos-sunny-otter)")
+	cmd.Flags().StringArrayVar(&cfgFlags.WiFi, "wifi", nil, "Preconfigure Wi-Fi as SSID or SSID=password (repeatable)")
+	cmd.Flags().StringVar(&cfgFlags.AgentBinary, "agent-binary", "", "Inject a wendy-agent binary into the installed image")
+	cmd.Flags().StringVar(&cfgFlags.CertsZip, "certs-zip", "", "Inject provisioned wendy-agent certificate material from a zip file")
+	cmd.Flags().StringVar(&cfgFlags.SSHMode, "ssh", "", "Configure SSH: default, disable, password, or key")
+	cmd.Flags().StringVar(&cfgFlags.SSHUser, "ssh-user", "", "SSH username used with --ssh password or --ssh key")
+	cmd.Flags().StringVar(&cfgFlags.SSHPassword, "ssh-password", "", "SSH password used with --ssh password")
+	cmd.Flags().StringVar(&cfgFlags.SSHKeyFile, "ssh-key-file", "", "Public key file used with --ssh key")
 
 	return cmd
 }
 
 // runOSInstallDirect writes a local image file to the specified drive without interactive prompts.
-func runOSInstallDirect(imagePath string, driveID string, force bool) error {
+func runOSInstallDirect(imagePath string, driveID string, force bool, cfgFlags osInstallConfigFlags) error {
 	// Verify the image file exists.
 	if _, err := os.Stat(imagePath); err != nil {
 		return fmt.Errorf("image file: %w", err)
@@ -73,8 +82,16 @@ func runOSInstallDirect(imagePath string, driveID string, force bool) error {
 		return fmt.Errorf("drive %s not found", driveID)
 	}
 
+	installCfg, err := resolveOSInstallConfig(cfgFlags, false)
+	if err != nil {
+		return err
+	}
+
 	if !force {
 		reader := bufio.NewReader(os.Stdin)
+		if installCfg != nil {
+			fmt.Println(renderOSInstallConfigSummary(installCfg))
+		}
 		fmt.Printf("Writing will ERASE ALL DATA on %s (%s). Continue? [y/N] ", targetDrive.Name, targetDrive.DevicePath)
 		line, err := reader.ReadString('\n')
 		if err != nil {
@@ -86,9 +103,15 @@ func runOSInstallDirect(imagePath string, driveID string, force bool) error {
 		}
 	}
 
+	preparedImagePath, cleanup, err := promptOSInstallImageCustomization(imagePath, installCfg)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
 	fmt.Printf("Writing image to %s...\n", targetDrive.DevicePath)
 	fmt.Println("You may be prompted for your password (sudo is required).")
-	if err := writeImageToDisk(imagePath, *targetDrive, nil); err != nil {
+	if err := writeImageToDisk(preparedImagePath, *targetDrive, nil); err != nil {
 		return fmt.Errorf("writing image: %w", err)
 	}
 
@@ -105,6 +128,31 @@ type pickerDevice struct {
 	IsESP32    bool
 	ESP32Chip  string          // e.g. "esp32c6", "esp32c5"
 	Manifest   *deviceManifest // cached manifest for Linux devices
+}
+
+func linuxDeviceRecommendation(deviceKey string) string {
+	switch deviceKey {
+	case "jetson-orin-nano":
+		return "NVMe recommended"
+	case "raspberry-pi-5":
+		return "microSD or NVMe"
+	default:
+		return ""
+	}
+}
+
+func renderLinuxImageAdvisory(deviceKey string, deviceName string, img *imageInfo) string {
+	switch deviceKey {
+	case "jetson-orin-nano":
+		if img != nil && strings.Contains(strings.ToLower(img.DownloadURL), "nvme") {
+			return fmt.Sprintf("%s install uses the current NVMe image. Wendy highly recommends NVMe on Jetson Orin Nano. Use the recovery tegraflash flow only for legacy SD or break-glass recovery.", deviceName)
+		}
+		return fmt.Sprintf("Wendy highly recommends NVMe on %s. Use the recovery tegraflash flow only for legacy SD or break-glass recovery.", deviceName)
+	case "raspberry-pi-5":
+		return fmt.Sprintf("%s images can be written to either microSD or NVMe. NVMe is recommended when available.", deviceName)
+	default:
+		return ""
+	}
 }
 
 // pickLinuxDevice fetches available Linux devices from the manifest and presents
@@ -125,9 +173,13 @@ func pickLinuxDevice() (string, deviceInfo, error) {
 			continue
 		}
 		deviceMap[dev.Key] = dev
+		description := fmt.Sprintf("(latest: %s)", dev.LatestVersion)
+		if note := linuxDeviceRecommendation(dev.Key); note != "" {
+			description = fmt.Sprintf("%s  %s", description, note)
+		}
 		items = append(items, tui.PickerItem{
 			Name:        dev.Name,
-			Description: fmt.Sprintf("(latest: %s)", dev.LatestVersion),
+			Description: description,
 			Value:       dev.Key,
 		})
 	}
@@ -144,7 +196,7 @@ func pickLinuxDevice() (string, deviceInfo, error) {
 	return key, deviceMap[key], nil
 }
 
-func runOSInstall(ctx context.Context, nightly bool) error {
+func runOSInstall(ctx context.Context, nightly bool, cfgFlags osInstallConfigFlags) error {
 	fmt.Println("Fetching available devices...")
 
 	// Fetch Linux devices from GCS manifest.
@@ -177,9 +229,13 @@ func runOSInstall(ctx context.Context, nightly bool) error {
 		}
 		deviceMap[dev.Key] = pd
 
+		description := fmt.Sprintf("%s    %s", displayVersion, pd.Category)
+		if note := linuxDeviceRecommendation(dev.Key); note != "" {
+			description = fmt.Sprintf("%s    %s", description, note)
+		}
 		items = append(items, tui.PickerItem{
 			Name:        dev.Name,
-			Description: fmt.Sprintf("%s    %s", displayVersion, pd.Category),
+			Description: description,
 			Value:       dev.Key,
 		})
 	}
@@ -221,11 +277,11 @@ func runOSInstall(ctx context.Context, nightly bool) error {
 	if device.IsESP32 {
 		return installESP32Firmware(ctx, nightly, device.ESP32Chip)
 	}
-	return installLinuxImage(ctx, selected, device)
+	return installLinuxImage(ctx, selected, device, cfgFlags)
 }
 
 // installLinuxImage handles the Linux device path: pick drive → download → write.
-func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice) error {
+func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, cfgFlags osInstallConfigFlags) error {
 	// List external drives.
 	drives, err := listExternalDrives()
 	if err != nil {
@@ -258,8 +314,25 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	}
 	targetDrive := driveMap[sel]
 
+	installCfg, err := resolveOSInstallConfig(cfgFlags, isInteractiveTerminal())
+	if err != nil {
+		return err
+	}
+	imgInfo, err := getImageInfo(device.Manifest, device.RawVersion)
+	if err != nil {
+		return fmt.Errorf("getting image info: %w", err)
+	}
+
 	// Confirm destructive write.
 	reader := bufio.NewReader(os.Stdin)
+	if advisory := renderLinuxImageAdvisory(deviceKey, device.Name, imgInfo); advisory != "" {
+		fmt.Println()
+		fmt.Println(advisory)
+	}
+	if installCfg != nil {
+		fmt.Println()
+		fmt.Println(renderOSInstallConfigSummary(installCfg))
+	}
 	fmt.Printf("\nWriting will ERASE ALL DATA on %s (%s). Continue? [y/N] ", targetDrive.Name, targetDrive.DevicePath)
 	line, err := reader.ReadString('\n')
 	if err != nil {
@@ -272,15 +345,15 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 
 	// Resolve image (cached or download).
 	fmt.Printf("\nPreparing %s image...\n", device.Name)
-	imgInfo, err := getImageInfo(device.Manifest, device.RawVersion)
-	if err != nil {
-		return fmt.Errorf("getting image info: %w", err)
-	}
-
 	imagePath, err := resolveOSImage(deviceKey, imgInfo)
 	if err != nil {
 		return fmt.Errorf("resolving OS image: %w", err)
 	}
+	imagePath, cleanup, err := promptOSInstallImageCustomization(imagePath, installCfg)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
 	// Get image size for progress tracking.
 	imgStat, err := os.Stat(imagePath)

--- a/go/internal/cli/commands/os_install_config.go
+++ b/go/internal/cli/commands/os_install_config.go
@@ -1,0 +1,791 @@
+//go:build darwin || linux
+
+package commands
+
+import (
+	"archive/zip"
+	"bufio"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/wendylabsinc/wendy/internal/cli/tui"
+	"golang.org/x/term"
+)
+
+const (
+	osInstallPayloadDirName = "wendy-install"
+	defaultSSHUser          = "wendy"
+)
+
+var (
+	osInstallHostnameRE = regexp.MustCompile(`^wendyos-[a-z0-9](?:[a-z0-9-]{0,53}[a-z0-9])?$`)
+	osInstallUserRE     = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,30}$`)
+)
+
+type osInstallConfigFlags struct {
+	Hostname    string
+	WiFi        []string
+	AgentBinary string
+	CertsZip    string
+	SSHMode     string
+	SSHUser     string
+	SSHPassword string
+	SSHKeyFile  string
+}
+
+type osInstallConfig struct {
+	Hostname    string
+	WiFi        []osInstallWiFiCredential
+	AgentBinary string
+	CertsZip    string
+	SSH         osInstallSSHConfig
+}
+
+type osInstallWiFiCredential struct {
+	SSID     string
+	Password string
+}
+
+type osInstallSSHConfig struct {
+	Mode          string
+	Username      string
+	Password      string
+	AuthorizedKey string
+}
+
+type osInstallPayload struct {
+	Version  int                  `json:"version"`
+	Hostname string               `json:"hostname,omitempty"`
+	SSH      *osInstallSSHPayload `json:"ssh,omitempty"`
+}
+
+type osInstallSSHPayload struct {
+	Mode     string `json:"mode"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+func resolveOSInstallConfig(flags osInstallConfigFlags, interactive bool) (*osInstallConfig, error) {
+	cfg, err := osInstallConfigFromFlags(flags)
+	if err != nil {
+		return nil, err
+	}
+
+	if interactive {
+		reader := bufio.NewReader(os.Stdin)
+
+		if cfg.Hostname == "" {
+			hostname, err := promptOSInstallHostname(reader)
+			if err != nil {
+				return nil, err
+			}
+			cfg.Hostname = hostname
+		}
+
+		if len(cfg.WiFi) == 0 {
+			wifi, err := promptOSInstallWiFi(reader)
+			if err != nil {
+				return nil, err
+			}
+			cfg.WiFi = wifi
+		} else {
+			addMore, err := osInstallPromptYesNo(reader, "Add more Wi-Fi networks?", false)
+			if err != nil {
+				return nil, err
+			}
+			if addMore {
+				wifi, err := promptOSInstallWiFi(reader)
+				if err != nil {
+					return nil, err
+				}
+				cfg.WiFi = append(cfg.WiFi, wifi...)
+			}
+		}
+
+		if !hasOSInstallAdvancedFlags(flags) {
+			advanced, err := osInstallPromptYesNo(reader, "Configure advanced install options?", false)
+			if err != nil {
+				return nil, err
+			}
+			if advanced {
+				if err := promptOSInstallAdvanced(reader, cfg); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	if err := validateOSInstallConfig(cfg); err != nil {
+		return nil, err
+	}
+	if cfg.IsZero() {
+		return nil, nil
+	}
+	return cfg, nil
+}
+
+func osInstallConfigFromFlags(flags osInstallConfigFlags) (*osInstallConfig, error) {
+	cfg := &osInstallConfig{
+		Hostname:    strings.TrimSpace(flags.Hostname),
+		AgentBinary: strings.TrimSpace(flags.AgentBinary),
+		CertsZip:    strings.TrimSpace(flags.CertsZip),
+	}
+
+	for _, entry := range flags.WiFi {
+		parsed, err := parseOSInstallWiFiFlag(entry)
+		if err != nil {
+			return nil, err
+		}
+		cfg.WiFi = append(cfg.WiFi, parsed)
+	}
+
+	if flags.SSHMode != "" {
+		cfg.SSH.Mode = normalizeOSInstallSSHMode(flags.SSHMode)
+		cfg.SSH.Username = strings.TrimSpace(flags.SSHUser)
+		cfg.SSH.Password = flags.SSHPassword
+		if flags.SSHKeyFile != "" {
+			keyData, err := os.ReadFile(flags.SSHKeyFile)
+			if err != nil {
+				return nil, fmt.Errorf("reading --ssh-key-file: %w", err)
+			}
+			cfg.SSH.AuthorizedKey = strings.TrimSpace(string(keyData))
+		}
+	} else if flags.SSHUser != "" || flags.SSHPassword != "" || flags.SSHKeyFile != "" {
+		return nil, fmt.Errorf("ssh settings require --ssh with one of: default, disable, password, key")
+	}
+
+	return cfg, nil
+}
+
+func hasOSInstallAdvancedFlags(flags osInstallConfigFlags) bool {
+	return flags.AgentBinary != "" ||
+		flags.CertsZip != "" ||
+		flags.SSHMode != "" ||
+		flags.SSHUser != "" ||
+		flags.SSHPassword != "" ||
+		flags.SSHKeyFile != ""
+}
+
+func (c *osInstallConfig) IsZero() bool {
+	if c == nil {
+		return true
+	}
+	return c.Hostname == "" &&
+		len(c.WiFi) == 0 &&
+		c.AgentBinary == "" &&
+		c.CertsZip == "" &&
+		c.SSH.Mode == ""
+}
+
+func validateOSInstallConfig(cfg *osInstallConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Hostname != "" && !osInstallHostnameRE.MatchString(cfg.Hostname) {
+		return fmt.Errorf("hostname must match %q, got %q", osInstallHostnameRE.String(), cfg.Hostname)
+	}
+	for i, wifi := range cfg.WiFi {
+		if err := validateOSInstallWiFiCredential(wifi); err != nil {
+			return fmt.Errorf("wifi entry %d: %w", i+1, err)
+		}
+	}
+	if cfg.AgentBinary != "" {
+		info, err := os.Stat(cfg.AgentBinary)
+		if err != nil {
+			return fmt.Errorf("agent binary: %w", err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("agent binary path %q is a directory", cfg.AgentBinary)
+		}
+	}
+	if cfg.CertsZip != "" {
+		reader, err := zip.OpenReader(cfg.CertsZip)
+		if err != nil {
+			return fmt.Errorf("certificates zip: %w", err)
+		}
+		reader.Close()
+	}
+
+	switch cfg.SSH.Mode {
+	case "", "default":
+		cfg.SSH = osInstallSSHConfig{}
+	case "disable":
+		cfg.SSH.Username = ""
+		cfg.SSH.Password = ""
+		cfg.SSH.AuthorizedKey = ""
+	case "password":
+		if cfg.SSH.Username == "" {
+			cfg.SSH.Username = defaultSSHUser
+		}
+		if !osInstallUserRE.MatchString(cfg.SSH.Username) {
+			return fmt.Errorf("ssh username %q is invalid", cfg.SSH.Username)
+		}
+		if strings.TrimSpace(cfg.SSH.Password) == "" {
+			return fmt.Errorf("ssh password mode requires a password")
+		}
+		if cfg.SSH.AuthorizedKey != "" {
+			return fmt.Errorf("ssh password mode cannot also include an authorized key")
+		}
+	case "key":
+		if cfg.SSH.Username == "" {
+			cfg.SSH.Username = defaultSSHUser
+		}
+		if !osInstallUserRE.MatchString(cfg.SSH.Username) {
+			return fmt.Errorf("ssh username %q is invalid", cfg.SSH.Username)
+		}
+		if strings.TrimSpace(cfg.SSH.AuthorizedKey) == "" {
+			return fmt.Errorf("ssh key mode requires an authorized key")
+		}
+		if cfg.SSH.Password != "" {
+			return fmt.Errorf("ssh key mode cannot also include a password")
+		}
+	default:
+		return fmt.Errorf("unsupported ssh mode %q", cfg.SSH.Mode)
+	}
+
+	return nil
+}
+
+func validateOSInstallWiFiCredential(wifi osInstallWiFiCredential) error {
+	if strings.TrimSpace(wifi.SSID) == "" {
+		return fmt.Errorf("ssid cannot be empty")
+	}
+	if strings.ContainsAny(wifi.SSID, "\r\n") {
+		return fmt.Errorf("ssid cannot contain newlines")
+	}
+	if strings.ContainsAny(wifi.Password, "\r\n") {
+		return fmt.Errorf("password cannot contain newlines")
+	}
+	return nil
+}
+
+func parseOSInstallWiFiFlag(raw string) (osInstallWiFiCredential, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return osInstallWiFiCredential{}, fmt.Errorf("wifi entries cannot be empty")
+	}
+	parts := strings.SplitN(raw, "=", 2)
+	wifi := osInstallWiFiCredential{SSID: strings.TrimSpace(parts[0])}
+	if len(parts) == 2 {
+		wifi.Password = parts[1]
+	}
+	if err := validateOSInstallWiFiCredential(wifi); err != nil {
+		return osInstallWiFiCredential{}, err
+	}
+	return wifi, nil
+}
+
+func promptOSInstallHostname(reader *bufio.Reader) (string, error) {
+	defaultHostname := randomFriendlyHostname()
+	for {
+		value, err := osInstallPromptLine(reader, "Hostname", defaultHostname)
+		if err != nil {
+			return "", err
+		}
+		if osInstallHostnameRE.MatchString(value) {
+			return value, nil
+		}
+		fmt.Printf("Hostname must start with \"wendyos-\" and contain only lowercase letters, digits, and hyphens.\n")
+	}
+}
+
+func promptOSInstallWiFi(reader *bufio.Reader) ([]osInstallWiFiCredential, error) {
+	var networks []osInstallWiFiCredential
+	addMore := true
+	for addMore {
+		shouldAdd, err := osInstallPromptYesNo(reader, "Add a Wi-Fi network?", len(networks) == 0)
+		if err != nil {
+			return nil, err
+		}
+		if !shouldAdd {
+			break
+		}
+
+		ssid, err := osInstallPromptLine(reader, "Wi-Fi SSID", "")
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(ssid) == "" {
+			fmt.Println("SSID cannot be empty.")
+			continue
+		}
+
+		fmt.Print("Wi-Fi password (leave empty for open network): ")
+		passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Println()
+		if err != nil {
+			return nil, fmt.Errorf("reading Wi-Fi password: %w", err)
+		}
+
+		wifi := osInstallWiFiCredential{
+			SSID:     strings.TrimSpace(ssid),
+			Password: string(passwordBytes),
+		}
+		if err := validateOSInstallWiFiCredential(wifi); err != nil {
+			fmt.Printf("%v\n", err)
+			continue
+		}
+		networks = append(networks, wifi)
+		addMore = true
+	}
+
+	return networks, nil
+}
+
+func promptOSInstallAdvanced(reader *bufio.Reader, cfg *osInstallConfig) error {
+	agentBinary, err := osInstallPromptLine(reader, "Inject wendy-agent binary from path (optional)", "")
+	if err != nil {
+		return err
+	}
+	cfg.AgentBinary = strings.TrimSpace(agentBinary)
+
+	certsZip, err := osInstallPromptLine(reader, "Provisioned certificates zip path (optional)", "")
+	if err != nil {
+		return err
+	}
+	cfg.CertsZip = strings.TrimSpace(certsZip)
+
+	fmt.Println()
+	sshMode, err := pickFromItems("SSH setup", []tui.PickerItem{
+		{Name: "Leave SSH as-is", Description: "Keep the image default", Value: "default"},
+		{Name: "Disable SSH", Description: "Turn off the SSH service", Value: "disable"},
+		{Name: "Enable SSH with password", Description: "Create or update a user password", Value: "password"},
+		{Name: "Enable SSH with public key", Description: "Install an authorized_keys file", Value: "key"},
+	})
+	if err != nil {
+		return err
+	}
+
+	cfg.SSH.Mode = sshMode
+	switch sshMode {
+	case "default", "disable":
+		return nil
+	case "password":
+		username, err := osInstallPromptLine(reader, "SSH username", defaultSSHUser)
+		if err != nil {
+			return err
+		}
+		fmt.Print("SSH password: ")
+		passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Println()
+		if err != nil {
+			return fmt.Errorf("reading SSH password: %w", err)
+		}
+		cfg.SSH.Username = username
+		cfg.SSH.Password = string(passwordBytes)
+	case "key":
+		username, err := osInstallPromptLine(reader, "SSH username", defaultSSHUser)
+		if err != nil {
+			return err
+		}
+		keyFile, err := osInstallPromptLine(reader, "Public key file", "")
+		if err != nil {
+			return err
+		}
+		keyData, err := os.ReadFile(strings.TrimSpace(keyFile))
+		if err != nil {
+			return fmt.Errorf("reading public key file: %w", err)
+		}
+		cfg.SSH.Username = username
+		cfg.SSH.AuthorizedKey = strings.TrimSpace(string(keyData))
+	}
+
+	return nil
+}
+
+func osInstallPromptYesNo(reader *bufio.Reader, prompt string, defaultYes bool) (bool, error) {
+	suffix := "[y/N]"
+	if defaultYes {
+		suffix = "[Y/n]"
+	}
+	for {
+		fmt.Printf("%s %s ", prompt, suffix)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return false, err
+		}
+		answer := strings.TrimSpace(strings.ToLower(line))
+		if answer == "" {
+			return defaultYes, nil
+		}
+		if answer == "y" || answer == "yes" {
+			return true, nil
+		}
+		if answer == "n" || answer == "no" {
+			return false, nil
+		}
+		fmt.Println("Please answer y or n.")
+	}
+}
+
+func osInstallPromptLine(reader *bufio.Reader, prompt string, defaultValue string) (string, error) {
+	if defaultValue != "" && !strings.Contains(prompt, "[") {
+		fmt.Printf("%s [%s]: ", prompt, defaultValue)
+	} else {
+		fmt.Printf("%s: ", prompt)
+	}
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(line)
+	if value == "" {
+		return defaultValue, nil
+	}
+	return value, nil
+}
+
+func renderOSInstallConfigSummary(cfg *osInstallConfig) string {
+	if cfg == nil || cfg.IsZero() {
+		return "No install-time configuration"
+	}
+
+	var lines []string
+	if cfg.Hostname != "" {
+		lines = append(lines, fmt.Sprintf("Hostname: %s", cfg.Hostname))
+	}
+	if len(cfg.WiFi) > 0 {
+		var ssids []string
+		for _, wifi := range cfg.WiFi {
+			ssids = append(ssids, wifi.SSID)
+		}
+		lines = append(lines, fmt.Sprintf("Wi-Fi: %s", strings.Join(ssids, ", ")))
+	}
+	if cfg.AgentBinary != "" {
+		lines = append(lines, fmt.Sprintf("Injected agent binary: %s", filepath.Base(cfg.AgentBinary)))
+	}
+	if cfg.CertsZip != "" {
+		lines = append(lines, fmt.Sprintf("Provisioned certs: %s", filepath.Base(cfg.CertsZip)))
+	}
+	switch cfg.SSH.Mode {
+	case "disable":
+		lines = append(lines, "SSH: disabled")
+	case "password":
+		lines = append(lines, fmt.Sprintf("SSH: enabled for %s with password auth", cfg.SSH.Username))
+	case "key":
+		lines = append(lines, fmt.Sprintf("SSH: enabled for %s with public key auth", cfg.SSH.Username))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func stageOSInstallPayload(cfg *osInstallConfig) (string, error) {
+	payloadRoot, err := os.MkdirTemp("", "wendy-os-install-payload-*")
+	if err != nil {
+		return "", fmt.Errorf("creating install payload temp dir: %w", err)
+	}
+	payloadDir := filepath.Join(payloadRoot, osInstallPayloadDirName)
+	if err := os.MkdirAll(payloadDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating payload directory: %w", err)
+	}
+
+	payload := osInstallPayload{Version: 1}
+	if cfg != nil {
+		payload.Hostname = cfg.Hostname
+		if cfg.SSH.Mode != "" {
+			payload.SSH = &osInstallSSHPayload{
+				Mode:     cfg.SSH.Mode,
+				Username: cfg.SSH.Username,
+				Password: cfg.SSH.Password,
+			}
+		}
+	}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshaling payload config: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(payloadDir, "config.json"), data, 0o644); err != nil {
+		return "", fmt.Errorf("writing payload config: %w", err)
+	}
+
+	if cfg != nil {
+		if err := stageOSInstallWiFiPayload(payloadDir, cfg.WiFi); err != nil {
+			return "", err
+		}
+		if err := stageOSInstallAgentPayload(payloadDir, cfg.AgentBinary); err != nil {
+			return "", err
+		}
+		if err := stageOSInstallCertsPayload(payloadDir, cfg.CertsZip); err != nil {
+			return "", err
+		}
+		if err := stageOSInstallSSHPayload(payloadDir, cfg.SSH); err != nil {
+			return "", err
+		}
+	}
+
+	return payloadRoot, nil
+}
+
+func stageOSInstallWiFiPayload(payloadDir string, networks []osInstallWiFiCredential) error {
+	if len(networks) == 0 {
+		return nil
+	}
+	networkDir := filepath.Join(payloadDir, "network")
+	if err := os.MkdirAll(networkDir, 0o755); err != nil {
+		return fmt.Errorf("creating network payload dir: %w", err)
+	}
+
+	for i, network := range networks {
+		filename := fmt.Sprintf("wifi-%02d-%s.nmconnection", i+1, sanitizeOSInstallFileComponent(network.SSID))
+		content := renderWiFiConnectionProfile(network)
+		if err := os.WriteFile(filepath.Join(networkDir, filename), []byte(content), 0o600); err != nil {
+			return fmt.Errorf("writing network profile: %w", err)
+		}
+	}
+	return nil
+}
+
+func renderWiFiConnectionProfile(network osInstallWiFiCredential) string {
+	var builder strings.Builder
+	builder.WriteString("[connection]\n")
+	builder.WriteString(fmt.Sprintf("id=%s\n", sanitizeOSInstallConnectionID(network.SSID)))
+	builder.WriteString(fmt.Sprintf("uuid=%s\n", uuid.NewString()))
+	builder.WriteString("type=wifi\n")
+	builder.WriteString("autoconnect=true\n\n")
+
+	builder.WriteString("[wifi]\n")
+	builder.WriteString("mode=infrastructure\n")
+	builder.WriteString(fmt.Sprintf("ssid=%s\n\n", network.SSID))
+
+	if network.Password != "" {
+		builder.WriteString("[wifi-security]\n")
+		builder.WriteString("key-mgmt=wpa-psk\n")
+		builder.WriteString(fmt.Sprintf("psk=%s\n\n", network.Password))
+	}
+
+	builder.WriteString("[ipv4]\n")
+	builder.WriteString("method=auto\n\n")
+	builder.WriteString("[ipv6]\n")
+	builder.WriteString("addr-gen-mode=default\n")
+	builder.WriteString("method=auto\n\n")
+	builder.WriteString("[proxy]\n")
+
+	return builder.String()
+}
+
+func stageOSInstallAgentPayload(payloadDir string, agentBinary string) error {
+	if agentBinary == "" {
+		return nil
+	}
+	assetsDir := filepath.Join(payloadDir, "assets")
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+		return fmt.Errorf("creating asset payload dir: %w", err)
+	}
+	dst := filepath.Join(assetsDir, "wendy-agent")
+	if err := copyFile(agentBinary, dst); err != nil {
+		return fmt.Errorf("copying agent binary into payload: %w", err)
+	}
+	if err := os.Chmod(dst, 0o755); err != nil {
+		return fmt.Errorf("chmod agent payload: %w", err)
+	}
+	return nil
+}
+
+func stageOSInstallCertsPayload(payloadDir string, certsZip string) error {
+	if certsZip == "" {
+		return nil
+	}
+	reader, err := zip.OpenReader(certsZip)
+	if err != nil {
+		return fmt.Errorf("opening certificates zip: %w", err)
+	}
+	defer reader.Close()
+
+	certsDir := filepath.Join(payloadDir, "certs")
+	if err := os.MkdirAll(certsDir, 0o755); err != nil {
+		return fmt.Errorf("creating cert payload dir: %w", err)
+	}
+
+	for _, f := range reader.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		rel := filepath.Clean(f.Name)
+		if rel == "." || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+			return fmt.Errorf("invalid path %q in certificates zip", f.Name)
+		}
+
+		src, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("opening %q in certificates zip: %w", f.Name, err)
+		}
+
+		dstPath := filepath.Join(certsDir, rel)
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+			src.Close()
+			return fmt.Errorf("creating certificate payload path: %w", err)
+		}
+		dst, err := os.Create(dstPath)
+		if err != nil {
+			src.Close()
+			return fmt.Errorf("creating certificate payload file: %w", err)
+		}
+		if _, err := io.Copy(dst, src); err != nil {
+			dst.Close()
+			src.Close()
+			return fmt.Errorf("copying certificate payload file: %w", err)
+		}
+		dst.Close()
+		src.Close()
+	}
+
+	return nil
+}
+
+func stageOSInstallSSHPayload(payloadDir string, ssh osInstallSSHConfig) error {
+	if ssh.Mode != "key" {
+		return nil
+	}
+	sshDir := filepath.Join(payloadDir, "ssh")
+	if err := os.MkdirAll(sshDir, 0o755); err != nil {
+		return fmt.Errorf("creating ssh payload dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "authorized_keys"), []byte(strings.TrimSpace(ssh.AuthorizedKey)+"\n"), 0o600); err != nil {
+		return fmt.Errorf("writing authorized_keys payload: %w", err)
+	}
+	return nil
+}
+
+func sanitizeOSInstallFileComponent(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '-':
+			builder.WriteRune(r)
+		default:
+			builder.WriteRune('-')
+		}
+	}
+	sanitized := strings.Trim(builder.String(), "-")
+	if sanitized == "" {
+		return "network"
+	}
+	return sanitized
+}
+
+func sanitizeOSInstallConnectionID(ssid string) string {
+	id := "wifi-" + sanitizeOSInstallFileComponent(ssid)
+	id = strings.Trim(id, "-")
+	if id == "" {
+		return "wifi"
+	}
+	return id
+}
+
+func normalizeOSInstallSSHMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", "default":
+		return "default"
+	case "disable", "disabled", "off":
+		return "disable"
+	case "password":
+		return "password"
+	case "key", "pubkey", "public-key":
+		return "key"
+	default:
+		return strings.ToLower(strings.TrimSpace(mode))
+	}
+}
+
+func promptOSInstallImageCustomization(imagePath string, cfg *osInstallConfig) (string, func(), error) {
+	if cfg == nil || cfg.IsZero() {
+		return imagePath, func() {}, nil
+	}
+
+	fmt.Println("\nPreparing install payload...")
+	tmpImage, err := os.CreateTemp("", "wendyos-configured-*.img")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating configured image temp file: %w", err)
+	}
+	tmpImage.Close()
+
+	if err := copyFile(imagePath, tmpImage.Name()); err != nil {
+		os.Remove(tmpImage.Name())
+		return "", nil, fmt.Errorf("copying source image: %w", err)
+	}
+
+	payloadRoot, err := stageOSInstallPayload(cfg)
+	if err != nil {
+		os.Remove(tmpImage.Name())
+		return "", nil, err
+	}
+
+	if err := writeOSInstallPayloadToImage(tmpImage.Name(), filepath.Join(payloadRoot, osInstallPayloadDirName)); err != nil {
+		os.RemoveAll(payloadRoot)
+		os.Remove(tmpImage.Name())
+		return "", nil, err
+	}
+
+	cleanup := func() {
+		os.RemoveAll(payloadRoot)
+		os.Remove(tmpImage.Name())
+	}
+	return tmpImage.Name(), cleanup, nil
+}
+
+func copyDir(srcDir, dstDir string) error {
+	return filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dstDir, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := copyFile(path, target); err != nil {
+			return err
+		}
+		return os.Chmod(target, info.Mode())
+	})
+}
+
+var hostnameAdjectives = []string{
+	"amber", "brisk", "calm", "cinder", "clear", "cool", "daring", "ember", "fresh", "glossy",
+	"golden", "hollow", "jolly", "kind", "lively", "merry", "nimble", "nova", "plucky", "quiet",
+	"rapid", "sandy", "sharp", "silver", "spry", "steady", "sunny", "swift", "tidy", "vivid",
+	"warm", "wavy", "wild", "zesty",
+}
+
+var hostnameNouns = []string{
+	"badger", "comet", "dolphin", "falcon", "fox", "gecko", "heron", "ibis", "koala", "lark",
+	"lynx", "maple", "meadow", "otter", "owl", "panda", "pebble", "pine", "quill", "raven",
+	"ridge", "river", "robin", "seal", "sparrow", "spruce", "stork", "swift", "tiger", "trail",
+	"valley", "willow", "wolf", "wren",
+}
+
+func randomFriendlyHostname() string {
+	first := hostnameAdjectives[randomIndex(len(hostnameAdjectives))]
+	second := hostnameNouns[randomIndex(len(hostnameNouns))]
+	return fmt.Sprintf("wendyos-%s-%s", first, second)
+}
+
+func randomIndex(limit int) int {
+	if limit <= 1 {
+		return 0
+	}
+	var b [1]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		return int(b[0]) % limit
+	}
+	return limit - 1
+}

--- a/go/internal/cli/commands/os_install_config_test.go
+++ b/go/internal/cli/commands/os_install_config_test.go
@@ -1,0 +1,176 @@
+package commands
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseOSInstallWiFiFlag(t *testing.T) {
+	t.Run("secured", func(t *testing.T) {
+		got, err := parseOSInstallWiFiFlag("HomeNet=secret")
+		if err != nil {
+			t.Fatalf("parseOSInstallWiFiFlag: %v", err)
+		}
+		if got.SSID != "HomeNet" || got.Password != "secret" {
+			t.Fatalf("unexpected wifi parse result: %+v", got)
+		}
+	})
+
+	t.Run("open", func(t *testing.T) {
+		got, err := parseOSInstallWiFiFlag("CafeWiFi")
+		if err != nil {
+			t.Fatalf("parseOSInstallWiFiFlag: %v", err)
+		}
+		if got.SSID != "CafeWiFi" || got.Password != "" {
+			t.Fatalf("unexpected wifi parse result: %+v", got)
+		}
+	})
+}
+
+func TestValidateOSInstallConfig(t *testing.T) {
+	cfg := &osInstallConfig{
+		Hostname: "wendyos-sunny-otter",
+		WiFi: []osInstallWiFiCredential{
+			{SSID: "HomeNet", Password: "secret"},
+		},
+		SSH: osInstallSSHConfig{
+			Mode:          "key",
+			Username:      "wendy",
+			AuthorizedKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey test@example.com",
+		},
+	}
+
+	if err := validateOSInstallConfig(cfg); err != nil {
+		t.Fatalf("validateOSInstallConfig: %v", err)
+	}
+}
+
+func TestRenderWiFiConnectionProfile(t *testing.T) {
+	profile := renderWiFiConnectionProfile(osInstallWiFiCredential{
+		SSID:     "HomeNet",
+		Password: "secret",
+	})
+
+	required := []string{
+		"[connection]",
+		"type=wifi",
+		"ssid=HomeNet",
+		"[wifi-security]",
+		"psk=secret",
+	}
+	for _, needle := range required {
+		if !strings.Contains(profile, needle) {
+			t.Fatalf("profile missing %q:\n%s", needle, profile)
+		}
+	}
+}
+
+func TestStageOSInstallPayload(t *testing.T) {
+	tempDir := t.TempDir()
+
+	agentPath := filepath.Join(tempDir, "wendy-agent")
+	if err := os.WriteFile(agentPath, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("WriteFile(agent): %v", err)
+	}
+
+	certsZip := filepath.Join(tempDir, "certs.zip")
+	if err := writeTestZip(certsZip, map[string]string{
+		"device.pem":     "cert",
+		"device-key.pem": "key",
+	}); err != nil {
+		t.Fatalf("writeTestZip: %v", err)
+	}
+
+	payloadRoot, err := stageOSInstallPayload(&osInstallConfig{
+		Hostname:    "wendyos-sunny-otter",
+		AgentBinary: agentPath,
+		CertsZip:    certsZip,
+		WiFi: []osInstallWiFiCredential{
+			{SSID: "HomeNet", Password: "secret"},
+		},
+		SSH: osInstallSSHConfig{
+			Mode:          "key",
+			Username:      "wendy",
+			AuthorizedKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey test@example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("stageOSInstallPayload: %v", err)
+	}
+	defer os.RemoveAll(payloadRoot)
+
+	payloadDir := filepath.Join(payloadRoot, osInstallPayloadDirName)
+	expectedFiles := []string{
+		filepath.Join(payloadDir, "config.json"),
+		filepath.Join(payloadDir, "network"),
+		filepath.Join(payloadDir, "assets", "wendy-agent"),
+		filepath.Join(payloadDir, "certs", "device.pem"),
+		filepath.Join(payloadDir, "ssh", "authorized_keys"),
+	}
+	for _, path := range expectedFiles {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected payload path %s: %v", path, err)
+		}
+	}
+}
+
+func TestRandomFriendlyHostname(t *testing.T) {
+	got := randomFriendlyHostname()
+	if !strings.HasPrefix(got, "wendyos-") {
+		t.Fatalf("randomFriendlyHostname() = %q; want prefix wendyos-", got)
+	}
+	if !osInstallHostnameRE.MatchString(got) {
+		t.Fatalf("randomFriendlyHostname() = %q; does not match hostname validator", got)
+	}
+}
+
+func TestLinuxDeviceRecommendation(t *testing.T) {
+	if got := linuxDeviceRecommendation("jetson-orin-nano"); !strings.Contains(got, "NVMe") {
+		t.Fatalf("linuxDeviceRecommendation(jetson-orin-nano) = %q; want NVMe note", got)
+	}
+	if got := linuxDeviceRecommendation("raspberry-pi-5"); !strings.Contains(got, "microSD") || !strings.Contains(got, "NVMe") {
+		t.Fatalf("linuxDeviceRecommendation(raspberry-pi-5) = %q; want microSD/NVMe note", got)
+	}
+	if got := linuxDeviceRecommendation("test-device"); got != "" {
+		t.Fatalf("linuxDeviceRecommendation(test-device) = %q; want empty string", got)
+	}
+}
+
+func TestRenderLinuxImageAdvisory(t *testing.T) {
+	jetson := renderLinuxImageAdvisory("jetson-orin-nano", "Jetson Orin Nano", &imageInfo{
+		DownloadURL: "https://example.com/wendyos-image-jetson-orin-nano-devkit-nvme-wendyos.img.zip",
+	})
+	if !strings.Contains(jetson, "NVMe") || !strings.Contains(jetson, "recovery tegraflash") {
+		t.Fatalf("renderLinuxImageAdvisory(jetson-orin-nano) = %q; want NVMe + recovery guidance", jetson)
+	}
+
+	pi := renderLinuxImageAdvisory("raspberry-pi-5", "Raspberry Pi 5", nil)
+	if !strings.Contains(pi, "microSD") || !strings.Contains(pi, "NVMe") {
+		t.Fatalf("renderLinuxImageAdvisory(raspberry-pi-5) = %q; want microSD/NVMe guidance", pi)
+	}
+}
+
+func writeTestZip(path string, files map[string]string) error {
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	writer := zip.NewWriter(out)
+	for name, contents := range files {
+		entry, err := writer.Create(name)
+		if err != nil {
+			writer.Close()
+			return err
+		}
+		if _, err := entry.Write([]byte(contents)); err != nil {
+			writer.Close()
+			return err
+		}
+	}
+	return writer.Close()
+}

--- a/go/internal/cli/commands/os_install_customize_darwin.go
+++ b/go/internal/cli/commands/os_install_customize_darwin.go
@@ -1,0 +1,112 @@
+//go:build darwin
+
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func writeOSInstallPayloadToImage(imagePath string, payloadDir string) error {
+	baseDevice, partitions, err := darwinAttachRawImage(imagePath)
+	if err != nil {
+		return err
+	}
+	defer darwinDetachDevice(baseDevice)
+
+	partition, err := darwinFindPayloadPartition(partitions)
+	if err != nil {
+		return err
+	}
+
+	mountPoint, err := darwinMountPartition(partition)
+	if err != nil {
+		return err
+	}
+	defer darwinUnmountPartition(partition)
+
+	dst := filepath.Join(mountPoint, osInstallPayloadDirName)
+	if err := os.RemoveAll(dst); err != nil {
+		return fmt.Errorf("clearing existing payload directory: %w", err)
+	}
+	if err := copyDir(payloadDir, dst); err != nil {
+		return fmt.Errorf("copying payload to image: %w", err)
+	}
+	return nil
+}
+
+func darwinAttachRawImage(imagePath string) (string, []string, error) {
+	out, err := exec.Command("hdiutil", "attach", "-nomount", imagePath).CombinedOutput()
+	if err != nil {
+		return "", nil, fmt.Errorf("attaching image: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	var base string
+	var parts []string
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 || !strings.HasPrefix(fields[0], "/dev/disk") {
+			continue
+		}
+		if base == "" {
+			base = fields[0]
+			continue
+		}
+		parts = append(parts, fields[0])
+	}
+	if base == "" {
+		return "", nil, fmt.Errorf("unable to determine mounted device for %s", imagePath)
+	}
+	return base, parts, nil
+}
+
+func darwinDetachDevice(baseDevice string) {
+	exec.Command("hdiutil", "detach", baseDevice).Run() //nolint:errcheck
+}
+
+func darwinFindPayloadPartition(partitions []string) (string, error) {
+	for _, part := range partitions {
+		out, err := exec.Command("diskutil", "info", part).CombinedOutput()
+		if err != nil {
+			continue
+		}
+		text := strings.ToLower(string(out))
+		if strings.Contains(text, "file system personality:  ms-dos") ||
+			strings.Contains(text, "type (bundle):  msdos") ||
+			strings.Contains(text, "volume name:               efi") {
+			return part, nil
+		}
+	}
+	return "", fmt.Errorf("no FAT/EFI partition found in image")
+}
+
+func darwinMountPartition(partition string) (string, error) {
+	if out, err := exec.Command("diskutil", "mount", partition).CombinedOutput(); err != nil {
+		return "", fmt.Errorf("mounting %s: %s: %w", partition, strings.TrimSpace(string(out)), err)
+	}
+
+	out, err := exec.Command("diskutil", "info", partition).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("reading mount info for %s: %s: %w", partition, strings.TrimSpace(string(out)), err)
+	}
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "Mount Point:") {
+			mountPoint := strings.TrimSpace(strings.TrimPrefix(line, "Mount Point:"))
+			if mountPoint != "" && mountPoint != "Not mounted" {
+				return mountPoint, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("could not determine mount point for %s", partition)
+}
+
+func darwinUnmountPartition(partition string) {
+	exec.Command("diskutil", "unmount", partition).Run() //nolint:errcheck
+}

--- a/go/internal/cli/commands/os_install_customize_linux.go
+++ b/go/internal/cli/commands/os_install_customize_linux.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type imageLSBLKOutput struct {
+	Blockdevices []imageLSBLKDevice `json:"blockdevices"`
+}
+
+type imageLSBLKDevice struct {
+	Path     string             `json:"path"`
+	FSType   string             `json:"fstype"`
+	Children []imageLSBLKDevice `json:"children"`
+}
+
+func writeOSInstallPayloadToImage(imagePath string, payloadDir string) error {
+	loopDevice, err := linuxAttachImage(imagePath)
+	if err != nil {
+		return err
+	}
+	defer linuxDetachImage(loopDevice)
+
+	partition, err := linuxFindPayloadPartition(loopDevice)
+	if err != nil {
+		return err
+	}
+
+	mountDir, err := os.MkdirTemp("", "wendy-image-mount-*")
+	if err != nil {
+		return fmt.Errorf("creating image mount dir: %w", err)
+	}
+	defer os.RemoveAll(mountDir)
+
+	if err := linuxMountPartition(partition, mountDir); err != nil {
+		return err
+	}
+	defer linuxUnmountPartition(mountDir)
+
+	dst := filepath.Join(mountDir, osInstallPayloadDirName)
+	if err := os.RemoveAll(dst); err != nil {
+		return fmt.Errorf("clearing existing payload directory: %w", err)
+	}
+	if err := copyDir(payloadDir, dst); err != nil {
+		return fmt.Errorf("copying payload to image: %w", err)
+	}
+
+	return nil
+}
+
+func linuxAttachImage(imagePath string) (string, error) {
+	out, err := exec.Command("sudo", "losetup", "--find", "--partscan", "--show", imagePath).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("attaching image loop device: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func linuxDetachImage(loopDevice string) {
+	exec.Command("sudo", "losetup", "-d", loopDevice).Run() //nolint:errcheck
+}
+
+func linuxFindPayloadPartition(loopDevice string) (string, error) {
+	out, err := exec.Command("lsblk", "--json", "-o", "PATH,FSTYPE", loopDevice).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("inspecting image partitions: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	var data imageLSBLKOutput
+	if err := json.Unmarshal(out, &data); err != nil {
+		return "", fmt.Errorf("parsing lsblk output: %w", err)
+	}
+	for _, device := range data.Blockdevices {
+		for _, child := range device.Children {
+			if strings.EqualFold(child.FSType, "vfat") {
+				return child.Path, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no FAT/EFI partition found in image")
+}
+
+func linuxMountPartition(partition string, mountDir string) error {
+	opts := fmt.Sprintf("uid=%d,gid=%d,umask=022", os.Getuid(), os.Getgid())
+	out, err := exec.Command("sudo", "mount", "-o", opts, partition, mountDir).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("mounting %s: %s: %w", partition, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func linuxUnmountPartition(mountDir string) {
+	exec.Command("sudo", "umount", mountDir).Run() //nolint:errcheck
+}


### PR DESCRIPTION
## Summary
- add install-time WendyOS configuration flags and interactive prompts for hostname, Wi-Fi, SSH, agent binary, and cert payloads
- stage a `wendy-install` payload and inject it into the image before flashing on macOS and Linux
- surface platform guidance in the installer so Jetson Orin Nano is treated as NVMe-first and Pi 5 is called out as microSD or NVMe capable

## Testing
- `GOCACHE=/tmp/wendy-go-cache GOTMPDIR=/tmp/wendy-go-tmp go test ./internal/cli/commands -run 'Test(ParseOSInstallWiFiFlag|ValidateOSInstallConfig|RenderWiFiConnectionProfile|StageOSInstallPayload|RandomFriendlyHostname|LinuxDeviceRecommendation|RenderLinuxImageAdvisory)$'`

## Notes
- verified the live WendyOS image manifests while checking the Jetson and Pi install paths
- hardware flashing was not run in this branch