### PR TITLE
Add wendy ssh commands

### DIFF
--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -105,6 +105,8 @@ func NewRootCmd() *cobra.Command {
 	bluetoothCmd.GroupID = "devices"
 	hardwareCmd := newHardwareCmd()
 	hardwareCmd.GroupID = "devices"
+	sshCmd := newSSHCmd()
+	sshCmd.GroupID = "devices"
 	// Misc Commands
 	cacheCmd := newCacheCmd()
 	cacheCmd.GroupID = "misc"
@@ -138,6 +140,7 @@ func NewRootCmd() *cobra.Command {
 		audioCmd,
 		bluetoothCmd,
 		hardwareCmd,
+		sshCmd,
 		cacheCmd,
 		infoCmd,
 		analyticsCmd,

--- a/go/internal/cli/commands/ssh.go
+++ b/go/internal/cli/commands/ssh.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
+)
+
+func newSSHCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ssh",
+		Short: "SSH utilities for the target device",
+	}
+	cmd.AddCommand(newSSHShellCmd(), newSSHExecCmd())
+	return cmd
+}
+
+func newSSHShellCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "shell",
+		Short: "Open an interactive SSH session to the target device",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSSH(cmd, nil)
+		},
+	}
+}
+
+func newSSHExecCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "exec <cmd> [args...]",
+		Short: "Run a command on the device over SSH and stream output",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSSH(cmd, args)
+		},
+	}
+}
+
+// sshUser reads the SSH username from wendy.json in the current directory,
+// falling back to "root" if the file is absent or has no ssh.user set.
+func sshUser() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "root"
+	}
+	cfg, err := appconfig.LoadFromFile(filepath.Join(cwd, "wendy.json"))
+	if err != nil || cfg.SSH == nil || cfg.SSH.User == "" {
+		return "root"
+	}
+	return cfg.SSH.User
+}
+
+// runSSH resolves the target device, derives the SSH user, then execs
+// ssh <user>@<host> [remoteArgs...]. Pass nil remoteArgs for an interactive shell.
+func runSSH(cmd *cobra.Command, remoteArgs []string) error {
+	ctx := cmd.Context()
+
+	target, err := resolveTarget(ctx, SuppressUpdateCheck(), SuppressProvisioningHint())
+	if err != nil {
+		return err
+	}
+
+	if target.Agent == nil {
+		target.Close()
+		return fmt.Errorf("wendy ssh requires a LAN-connected WendyOS device")
+	}
+
+	host := target.Agent.Host
+	target.Close()
+
+	user := sshUser()
+
+	sshArgs := []string{fmt.Sprintf("%s@%s", user, host)}
+	sshArgs = append(sshArgs, remoteArgs...)
+
+	c := exec.CommandContext(ctx, "ssh", sshArgs...)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -61,6 +61,11 @@ const (
 	PlatformWendyLite = "wendy-lite"
 )
 
+// SSHConfig holds SSH connection options read from wendy.json.
+type SSHConfig struct {
+	User string `json:"user,omitempty"`
+}
+
 // AppConfig represents the wendy.json application configuration.
 type AppConfig struct {
 	AppID        string           `json:"appId"`
@@ -71,6 +76,7 @@ type AppConfig struct {
 	Readiness    *ReadinessConfig `json:"readiness,omitempty"`
 	Hooks        *HooksConfig     `json:"hooks,omitempty"`
 	Python       *PythonConfig    `json:"python,omitempty"`
+	SSH          *SSHConfig       `json:"ssh,omitempty"`
 	Debug        bool             `json:"debug,omitempty"`
 }
 


### PR DESCRIPTION
Adds SSH support to the Wendy CLI:

- Add `SSHConfig` to `AppConfig` for `ssh.user` support
- Add `wendy ssh shell` and `wendy ssh exec` commands
- Register `wendy ssh` under the devices command group