### PR TITLE
Add SPI entitlement

### DIFF
--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -3,7 +3,9 @@ package oci
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
@@ -64,6 +66,8 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 			applyI2C(spec, ent)
 		case appconfig.EntitlementGPIO:
 			applyGPIO(spec, ent)
+		case appconfig.EntitlementSPI:
+			applySPI(spec)
 		case appconfig.EntitlementInput:
 			applyInput(spec)
 		}
@@ -439,6 +443,40 @@ func applyGPIO(spec *Spec, ent appconfig.Entitlement) {
 	})
 
 	_ = ent.Pins // Pins are used for documentation/validation; access is chip-level.
+}
+
+// applySPI adds SPI device access.
+func applySPI(spec *Spec) {
+	// Mount SPI devices that exist on the host.
+	for i := 0; i < 4; i++ {
+		for j := 0; j < 4; j++ {
+			devPath := fmt.Sprintf("/dev/spidev%d.%d", i, j)
+			if _, err := os.Stat(devPath); err == nil {
+				spec.Mounts = append(spec.Mounts, Mount{
+					Destination: devPath,
+					Source:      devPath,
+					Type:        "bind",
+					Options:     []string{"rbind", "rw"},
+				})
+			}
+		}
+	}
+
+	// Add SPI group GID for device permissions (group name varies by distro).
+	if grp, err := user.LookupGroup("spi"); err == nil {
+		if gid, err := strconv.ParseUint(grp.Gid, 10, 32); err == nil {
+			spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, uint32(gid))
+		}
+	}
+
+	// Allow SPI devices (major 153).
+	spiMajor := int64(153)
+	spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, LinuxDeviceCgroup{
+		Allow:  true,
+		Type:   "c",
+		Major:  &spiMajor,
+		Access: "rwm",
+	})
 }
 
 // applyInput adds HID input device access (barcode scanners, keyboards, etc.).

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -3,7 +3,9 @@ package oci
 import (
 	"errors"
 	"os"
+	"os/user"
 	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
@@ -476,6 +478,97 @@ func TestApplyEntitlements_Input(t *testing.T) {
 	if !foundInputRule {
 		t.Error("input entitlement did not add cgroup device rule (major 13)")
 	}
+}
+
+func TestApplyEntitlements_GPIO(t *testing.T) {
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "test-app",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementGPIO, Pins: []int{5, 6, 13}},
+		},
+	}
+
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+
+	// Should add a cgroup rule for GPIO devices (major 254).
+	foundGPIORule := false
+	for _, d := range spec.Linux.Resources.Devices {
+		if d.Major != nil && *d.Major == 254 && d.Allow {
+			foundGPIORule = true
+			break
+		}
+	}
+	if !foundGPIORule {
+		t.Error("gpio entitlement did not add cgroup device rule (major 254)")
+	}
+
+	// Should mount /dev/gpiochip0 when it exists on the host.
+	t.Run("mounts /dev/gpiochip0 when present", func(t *testing.T) {
+		if _, err := os.Stat("/dev/gpiochip0"); err == nil {
+			if !hasMountDest(spec, "/dev/gpiochip0") {
+				t.Error("gpio entitlement did not add /dev/gpiochip0 mount")
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat /dev/gpiochip0: %v", err)
+		} else {
+			t.Skip("/dev/gpiochip0 not present on this host")
+		}
+	})
+}
+
+func TestApplyEntitlements_SPI(t *testing.T) {
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "test-app",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementSPI},
+		},
+	}
+
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+
+	foundSPIRule := false
+	for _, d := range spec.Linux.Resources.Devices {
+		if d.Major != nil && *d.Major == 153 && d.Allow {
+			foundSPIRule = true
+			break
+		}
+	}
+	if !foundSPIRule {
+		t.Error("spi entitlement did not add SPI cgroup device rule (major 153)")
+	}
+
+	// SPI group GID: if the "spi" group exists on this host, verify it was added.
+	// If not (e.g. macOS, ubuntu CI), verify we didn't add a bogus GID.
+	if grp, err := user.LookupGroup("spi"); err == nil {
+		gid, err := strconv.ParseUint(grp.Gid, 10, 32)
+		if err != nil {
+			t.Fatalf("failed to parse spi group GID %q: %v", grp.Gid, err)
+		}
+		if !hasGID(spec, uint32(gid)) {
+			t.Errorf("spi entitlement did not add spi group GID %d", gid)
+		}
+	} else if len(spec.Process.User.AdditionalGids) != 0 {
+		t.Errorf("spi group not present on host but AdditionalGids is not empty: %v", spec.Process.User.AdditionalGids)
+	}
+
+	// Should mount /dev/spidev0.0 when it exists on the host.
+	t.Run("mounts /dev/spidev0.0 when present", func(t *testing.T) {
+		if _, err := os.Stat("/dev/spidev0.0"); err == nil {
+			if !hasMountDest(spec, "/dev/spidev0.0") {
+				t.Error("spi entitlement did not add /dev/spidev0.0 mount")
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat /dev/spidev0.0: %v", err)
+		} else {
+			t.Skip("/dev/spidev0.0 not present on this host")
+		}
+	})
 }
 
 func TestApplyEntitlements_Empty(t *testing.T) {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -92,6 +92,7 @@ var wendyOSEntitlementQuestions = []entitlementQuestion{
 	{"Does your app need Bluetooth peripheral access?", appconfig.EntitlementBluetooth, "Bluetooth Low Energy peripherals"},
 	{"Does your app need USB peripheral access?", appconfig.EntitlementUSB, "USB device access"},
 	{"Does your app need GPIO pin access?", appconfig.EntitlementGPIO, "General-purpose I/O pins"},
+	{"Does your app need SPI bus access (displays, sensors, flash)?", appconfig.EntitlementSPI, "SPI bus access (may require GPIO access)"},
 	{"Does your app need I2C bus access?", appconfig.EntitlementI2C, "I2C bus devices"},
 	{"Does your app need audio input/output?", appconfig.EntitlementAudio, "Microphone and speaker access"},
 	{"Does your app need camera access?", appconfig.EntitlementCamera, "Camera device access"},

--- a/go/internal/cli/commands/project.go
+++ b/go/internal/cli/commands/project.go
@@ -27,6 +27,7 @@ var entitlementDescriptions = map[string]string{
 	appconfig.EntitlementUSB:       "Access USB peripherals",
 	appconfig.EntitlementI2C:       "Access I2C bus devices",
 	appconfig.EntitlementGPIO:      "Access GPIO pins",
+	appconfig.EntitlementSPI:       "Access SPI bus devices (displays, sensors, flash - may require GPIO access)",
 	appconfig.EntitlementInput:     "Access HID input devices (barcode scanners, keyboards)",
 }
 

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -22,6 +22,7 @@ const (
 	EntitlementUSB       = "usb"
 	EntitlementI2C       = "i2c"
 	EntitlementGPIO      = "gpio"
+	EntitlementSPI       = "spi"
 	EntitlementInput     = "input"
 )
 
@@ -37,6 +38,7 @@ var ValidEntitlementTypes = []string{
 	EntitlementUSB,
 	EntitlementI2C,
 	EntitlementGPIO,
+	EntitlementSPI,
 	EntitlementInput,
 }
 
@@ -52,6 +54,7 @@ var allowedKeys = map[string][]string{
 	EntitlementUSB:       {"type"},
 	EntitlementI2C:       {"type", "device"},
 	EntitlementGPIO:      {"type", "pins"},
+	EntitlementSPI:       {"type"},
 	EntitlementInput:     {"type"},
 }
 

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -177,6 +177,14 @@
         },
         {
           "properties": {
+            "type": { "const": "spi" }
+          },
+          "required": ["type"],
+          "additionalProperties": false,
+          "description": "SPI device access."
+        },
+        {
+          "properties": {
             "type": { "const": "input" }
           },
           "required": ["type"],


### PR DESCRIPTION
## Problem

The `gpio` entitlement mounts `/dev/gpiochip*` devices (major 254) but does not expose `/dev/spidev*` devices (major 153). SPI-connected peripherals — displays, sensors, ADCs — require both GPIO (for control pins like chip select, data/command, reset) and SPI (for the data bus). With the current implementation, apps requesting the `gpio` entitlement cannot access SPI devices inside the container.

Discovered on a Raspberry Pi 4 running RPi OS Bookworm with a Waveshare 1.3" LCD HAT (ST7789 controller, SPI0). The display needs GPIO pins for DC/RST/backlight and SPI for pixel data transfer.

## Changes

### Separate SPI entitlement

SPI is a standalone entitlement (`spi`) rather than part of the GPIO entitlement. While SPI commonly shares GPIO pins (e.g. on Raspberry Pi), some platforms use dedicated SPI pins, so the two are independent. GPIO provides general-purpose pin access while SPI provides bus communication with peripherals (displays, sensors, ADCs). Keeping them separate allows apps to declare exactly what hardware capabilities they need and maps cleanly to ESP32 where entitlements must be replicated.

**`go/internal/shared/appconfig/appconfig.go`**
- Add `EntitlementSPI = "spi"` constant, valid types, and allowed keys (type-only)

**`go/internal/shared/appconfig/wendy.schema.json`**
- Add SPI entitlement schema definition (type-only, no extra fields)

**`go/internal/agent/oci/entitlements.go`**
- New `applySPI(spec *Spec)` function:
  - SPI device mounts: probes `/dev/spidev{0..3}.{0..3}` and bind-mounts any that exist
  - SPI cgroup rule: allows character devices major 153 with `rwm` access
  - SPI group GID: runtime lookup via `user.LookupGroup("spi")` with `ParseUint` error guard — silently skipped if group doesn't exist
- Add dispatch case in `ApplyEntitlements` switch
- `applyGPIO` only handles gpiochip mounts, GPIO cgroup rule (major 254), and pins

**`go/internal/cli/commands/init_cmd.go`**
- Add SPI question to WendyOS entitlement checklist with device examples (displays, sensors, flash)
- SPI description notes GPIO dependency so users see the relationship at selection time

**`go/internal/cli/commands/project.go`**
- Add SPI to `entitlementDescriptions` map for the entitlements add/remove picker UI

### Copilot review fixes

- Use `strconv.ParseUint` instead of `strconv.Atoi` for SPI group GID to prevent appending invalid value (GID 0) on parse failure
- Fix gofmt formatting (trailing whitespace, line breaks)
- Test: fail explicitly on GID parse error instead of silently using 0
- Test: distinguish `ErrNotExist` from unexpected stat errors on device paths
- Test: assert no bogus GIDs when spi group is absent
- Test: wrap host-dependent mount checks in subtests so `t.Skip` doesn't skip cgroup/GID assertions

## Tests

- `TestApplyEntitlements_SPI` — cgroup rule (major 153), SPI group GID with `ParseUint` error handling, device mount subtest with `ErrNotExist`/`t.Skip`, bogus GID assertion
- `TestApplyEntitlements_GPIO` — only tests GPIO-specific behavior, mount check in subtest

## Verified on hardware

Tested on Raspberry Pi 4, RPi OS Bookworm (64-bit). Container reports `SPI available: true` — before this fix, `SPI available: false`.