### PR TITLE
Show bubbletea progress bar / spinner for template downloads

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
@@ -337,7 +338,7 @@ func resolveInitTemplateForTarget(target string, opts initOptions) (string, *rep
 		tmpl := normalizeInitChoice(opts.template)
 
 		// Fetch meta.json to validate or show picker.
-		meta, err := fetchRepoMeta(opts.branch)
+		meta, err := fetchRepoMetaWithUI(opts.branch)
 		if err != nil {
 			return "", nil, err
 		}
@@ -368,7 +369,7 @@ func resolveInitTemplateForTarget(target string, opts initOptions) (string, *rep
 	}
 
 	// In interactive mode, fetch meta and offer templates for this target.
-	meta, err := fetchRepoMeta(opts.branch)
+	meta, err := fetchRepoMetaWithUI(opts.branch)
 	if err != nil {
 		return "", nil, err
 	}
@@ -476,6 +477,68 @@ func metaTemplateNames(meta *repoMeta) string {
 	return strings.Join(names, ", ")
 }
 
+// fetchRepoMetaWithUI wraps fetchRepoMeta with a bubbletea spinner when
+// stdout is a TTY. In non-interactive contexts it falls back to a plain
+// printf so logs stay readable.
+func fetchRepoMetaWithUI(branch string) (*repoMeta, error) {
+	if !isInteractiveTerminal() {
+		fmt.Println("Fetching template registry...")
+		return fetchRepoMeta(branch)
+	}
+
+	spin := tui.NewSpinner("Fetching template registry...")
+	prog := tea.NewProgram(spin)
+
+	var meta *repoMeta
+	var fetchErr error
+	go func() {
+		meta, fetchErr = fetchRepoMeta(branch)
+		prog.Send(tui.SpinnerDoneMsg{Err: fetchErr})
+	}()
+
+	if _, err := prog.Run(); err != nil {
+		return nil, fmt.Errorf("spinner TUI: %w", err)
+	}
+	return meta, fetchErr
+}
+
+// downloadTemplateArchiveWithUI wraps downloadTemplateArchive with a
+// bubbletea progress bar when stdout is a TTY. In non-interactive contexts
+// it falls back to plain text.
+func downloadTemplateArchiveWithUI(language, tmpl, branch string) (map[string][]byte, *templateManifest, error) {
+	title := fmt.Sprintf("Downloading template %q for %s (branch: %s)", tmpl, language, resolveTemplateBranch(branch))
+
+	if !isInteractiveTerminal() {
+		fmt.Printf("\n%s...\n", title)
+		return downloadTemplateArchive(language, tmpl, branch, nil)
+	}
+
+	prog := tea.NewProgram(tui.NewProgress(title))
+
+	var (
+		files    map[string][]byte
+		manifest *templateManifest
+		dlErr    error
+	)
+	go func() {
+		files, manifest, dlErr = downloadTemplateArchive(language, tmpl, branch, func(written, total int64) {
+			if total > 0 {
+				prog.Send(tui.ProgressUpdateMsg{
+					Percent: float64(written) / float64(total),
+					Written: written,
+					Total:   total,
+				})
+			}
+		})
+		prog.Send(tui.ProgressDoneMsg{Err: dlErr})
+	}()
+
+	if _, err := prog.Run(); err != nil {
+		return nil, nil, fmt.Errorf("progress TUI: %w", err)
+	}
+	return files, manifest, dlErr
+}
+
 // runTemplateFlow handles init when a template is selected.
 // destDir is the resolved project directory (either cwd or a new subdir).
 func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, opts initOptions) error {
@@ -490,9 +553,7 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 		return err
 	}
 
-	fmt.Printf("\nDownloading template %q for %s (branch: %s)...\n", tmpl, language, resolveTemplateBranch(opts.branch))
-
-	files, manifest, err := downloadTemplateArchive(language, tmpl, opts.branch)
+	files, manifest, err := downloadTemplateArchiveWithUI(language, tmpl, opts.branch)
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -479,39 +480,63 @@ func metaTemplateNames(meta *repoMeta) string {
 
 // fetchRepoMetaWithUI wraps fetchRepoMeta with a bubbletea spinner when
 // stdout is a TTY. In non-interactive contexts it falls back to a plain
-// printf so logs stay readable.
+// printf so logs stay readable. If the user cancels (q / ctrl+c) the
+// in-flight HTTP request is aborted and ErrUserCancelled is returned.
 func fetchRepoMetaWithUI(branch string) (*repoMeta, error) {
 	if !isInteractiveTerminal() {
 		fmt.Println("Fetching template registry...")
-		return fetchRepoMeta(branch)
+		return fetchRepoMeta(context.Background(), branch)
 	}
 
-	spin := tui.NewSpinner("Fetching template registry...")
-	prog := tea.NewProgram(spin)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	var meta *repoMeta
-	var fetchErr error
+	prog := tea.NewProgram(tui.NewSpinner("Fetching template registry..."))
+
+	var (
+		meta     *repoMeta
+		fetchErr error
+		done     = make(chan struct{})
+	)
 	go func() {
-		meta, fetchErr = fetchRepoMeta(branch)
+		defer close(done)
+		meta, fetchErr = fetchRepoMeta(ctx, branch)
 		prog.Send(tui.SpinnerDoneMsg{Err: fetchErr})
 	}()
 
-	if _, err := prog.Run(); err != nil {
+	finalModel, err := prog.Run()
+	if err != nil {
+		cancel()
+		<-done
 		return nil, fmt.Errorf("spinner TUI: %w", err)
 	}
+
+	// If the user quit before the fetch completed, cancel the request and
+	// wait for the goroutine to finish so we don't leak it.
+	if sm, ok := finalModel.(tui.SpinnerModel); ok && !sm.Done() {
+		cancel()
+		<-done
+		return nil, ErrUserCancelled
+	}
+
+	<-done
 	return meta, fetchErr
 }
 
 // downloadTemplateArchiveWithUI wraps downloadTemplateArchive with a
 // bubbletea progress bar when stdout is a TTY. In non-interactive contexts
-// it falls back to plain text.
+// it falls back to plain text. If the user cancels (q / ctrl+c) the
+// in-flight HTTP request is aborted and ErrUserCancelled is returned.
 func downloadTemplateArchiveWithUI(language, tmpl, branch string) (map[string][]byte, *templateManifest, error) {
 	title := fmt.Sprintf("Downloading template %q for %s (branch: %s)", tmpl, language, resolveTemplateBranch(branch))
 
 	if !isInteractiveTerminal() {
 		fmt.Printf("\n%s...\n", title)
-		return downloadTemplateArchive(language, tmpl, branch, nil)
+		return downloadTemplateArchive(context.Background(), language, tmpl, branch, nil)
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	prog := tea.NewProgram(tui.NewProgress(title))
 
@@ -519,9 +544,11 @@ func downloadTemplateArchiveWithUI(language, tmpl, branch string) (map[string][]
 		files    map[string][]byte
 		manifest *templateManifest
 		dlErr    error
+		done     = make(chan struct{})
 	)
 	go func() {
-		files, manifest, dlErr = downloadTemplateArchive(language, tmpl, branch, func(written, total int64) {
+		defer close(done)
+		files, manifest, dlErr = downloadTemplateArchive(ctx, language, tmpl, branch, func(written, total int64) {
 			if total > 0 {
 				prog.Send(tui.ProgressUpdateMsg{
 					Percent: float64(written) / float64(total),
@@ -533,9 +560,25 @@ func downloadTemplateArchiveWithUI(language, tmpl, branch string) (map[string][]
 		prog.Send(tui.ProgressDoneMsg{Err: dlErr})
 	}()
 
-	if _, err := prog.Run(); err != nil {
+	finalModel, err := prog.Run()
+	if err != nil {
+		cancel()
+		<-done
 		return nil, nil, fmt.Errorf("progress TUI: %w", err)
 	}
+
+	// If the user quit via q / ctrl+c, ProgressModel.Err() returns
+	// context.Canceled. Cancel the in-flight request and surface
+	// ErrUserCancelled so the caller doesn't dereference nil manifest/files.
+	if pm, ok := finalModel.(tui.ProgressModel); ok {
+		if errors.Is(pm.Err(), context.Canceled) {
+			cancel()
+			<-done
+			return nil, nil, ErrUserCancelled
+		}
+	}
+
+	<-done
 	return files, manifest, dlErr
 }
 

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -105,15 +105,46 @@ func isTemplateLanguage(language string, meta *repoMeta) bool {
 	return false
 }
 
+// progressCallback reports download progress. total is the expected content
+// length in bytes (0 if unknown); written is the cumulative number of bytes
+// read from the response body so far.
+type progressCallback func(written, total int64)
+
+// progressReader wraps an io.Reader and invokes onProgress after each Read.
+type progressReader struct {
+	r          io.Reader
+	total      int64
+	written    int64
+	onProgress progressCallback
+}
+
+func (pr *progressReader) Read(p []byte) (int, error) {
+	n, err := pr.r.Read(p)
+	if n > 0 {
+		pr.written += int64(n)
+		if pr.onProgress != nil {
+			pr.onProgress(pr.written, pr.total)
+		}
+	}
+	return n, err
+}
+
 // downloadTemplateArchive fetches the templates repo tarball and extracts
 // the files for {language}/{templateName}/ into a map of relative path -> content.
 // It also returns the parsed template.json manifest.
 // If branch is empty, it defaults to templateRepoBranch ("main").
-func downloadTemplateArchive(language, templateName, branch string) (map[string][]byte, *templateManifest, error) {
+// If onProgress is non-nil, it is invoked as the response body is read.
+func downloadTemplateArchive(language, templateName, branch string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
 	branch = resolveTemplateBranch(branch)
 	url := fmt.Sprintf("https://github.com/%s/%s/archive/refs/heads/%s.tar.gz",
 		templateRepoOwner, templateRepoName, branch)
+	return downloadTemplateArchiveFromURL(url, branch, language, templateName, onProgress)
+}
 
+// downloadTemplateArchiveFromURL is the testable core of downloadTemplateArchive:
+// it performs the HTTP GET against the caller-supplied URL and delegates
+// tarball parsing to extractTemplateArchive.
+func downloadTemplateArchiveFromURL(url, branch, language, templateName string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
 	client := &http.Client{Timeout: 60 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {
@@ -129,7 +160,23 @@ func downloadTemplateArchive(language, templateName, branch string) (map[string]
 		return nil, nil, fmt.Errorf("downloading template (branch %q): HTTP %d", branch, resp.StatusCode)
 	}
 
-	gz, err := gzip.NewReader(resp.Body)
+	var reader io.Reader = resp.Body
+	if onProgress != nil {
+		reader = &progressReader{
+			r:          resp.Body,
+			total:      resp.ContentLength,
+			onProgress: onProgress,
+		}
+	}
+
+	return extractTemplateArchive(reader, language, templateName)
+}
+
+// extractTemplateArchive reads a gzipped tarball from r and extracts files
+// matching {language}/{templateName}/ into a map of relative path -> content.
+// It also returns the parsed template.json manifest.
+func extractTemplateArchive(r io.Reader, language, templateName string) (map[string][]byte, *templateManifest, error) {
+	gz, err := gzip.NewReader(r)
 	if err != nil {
 		return nil, nil, fmt.Errorf("decompressing template archive: %w", err)
 	}

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -68,13 +69,18 @@ type templateVariable struct {
 
 // fetchRepoMeta downloads and parses meta.json from the templates repo.
 // If branch is empty, it defaults to templateRepoBranch ("main").
-func fetchRepoMeta(branch string) (*repoMeta, error) {
+// If ctx is cancelled, the in-flight request is aborted.
+func fetchRepoMeta(ctx context.Context, branch string) (*repoMeta, error) {
 	branch = resolveTemplateBranch(branch)
 	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/meta.json",
 		templateRepoOwner, templateRepoName, branch)
 
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetching template registry (branch %q): %w", branch, err)
+	}
 	client := &http.Client{Timeout: 15 * time.Second}
-	resp, err := client.Get(url)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetching template registry (branch %q): %w", branch, err)
 	}
@@ -134,19 +140,24 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 // It also returns the parsed template.json manifest.
 // If branch is empty, it defaults to templateRepoBranch ("main").
 // If onProgress is non-nil, it is invoked as the response body is read.
-func downloadTemplateArchive(language, templateName, branch string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
+// If ctx is cancelled, the in-flight request is aborted.
+func downloadTemplateArchive(ctx context.Context, language, templateName, branch string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
 	branch = resolveTemplateBranch(branch)
 	url := fmt.Sprintf("https://github.com/%s/%s/archive/refs/heads/%s.tar.gz",
 		templateRepoOwner, templateRepoName, branch)
-	return downloadTemplateArchiveFromURL(url, branch, language, templateName, onProgress)
+	return downloadTemplateArchiveFromURL(ctx, url, branch, language, templateName, onProgress)
 }
 
 // downloadTemplateArchiveFromURL is the testable core of downloadTemplateArchive:
 // it performs the HTTP GET against the caller-supplied URL and delegates
 // tarball parsing to extractTemplateArchive.
-func downloadTemplateArchiveFromURL(url, branch, language, templateName string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
+func downloadTemplateArchiveFromURL(ctx context.Context, url, branch, language, templateName string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("downloading template (branch %q): %w", branch, err)
+	}
 	client := &http.Client{Timeout: 60 * time.Second}
-	resp, err := client.Get(url)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("downloading template (branch %q): %w", branch, err)
 	}
@@ -162,9 +173,15 @@ func downloadTemplateArchiveFromURL(url, branch, language, templateName string, 
 
 	var reader io.Reader = resp.Body
 	if onProgress != nil {
+		// Normalize ContentLength to the progressCallback contract:
+		// http.Response.ContentLength is -1 when unknown, but callers expect 0.
+		total := resp.ContentLength
+		if total < 0 {
+			total = 0
+		}
 		reader = &progressReader{
 			r:          resp.Body,
-			total:      resp.ContentLength,
+			total:      total,
 			onProgress: onProgress,
 		}
 	}

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -1,0 +1,283 @@
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// buildTestTarball constructs a minimal gzipped tarball that mirrors the
+// layout of wendylabsinc/templates. The top-level directory name is arbitrary
+// because extractTemplateArchive strips it; "templates-main/" matches what
+// GitHub's tarball endpoint emits for the main branch.
+func buildTestTarball(t *testing.T, topDir, language, templateName string, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	for relPath, content := range files {
+		name := topDir + "/" + language + "/" + templateName + "/" + relPath
+		hdr := &tar.Header{
+			Name:     name,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader: %v", err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tw.Close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz.Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractTemplateArchive_ReturnsFilesAndManifest(t *testing.T) {
+	manifest := `{"name":"simple-api","description":"Test template","variables":[{"name":"PORT","type":"integer","default":8080}]}`
+	files := map[string]string{
+		"template.json": manifest,
+		"main.go":       "package main\n",
+		"README.md":     "# {{.APP_ID}}\n",
+	}
+
+	archive := buildTestTarball(t, "templates-main", "rust", "simple-api", files)
+
+	got, gotManifest, err := extractTemplateArchive(bytes.NewReader(archive), "rust", "simple-api")
+	if err != nil {
+		t.Fatalf("extractTemplateArchive: %v", err)
+	}
+
+	if gotManifest == nil {
+		t.Fatal("expected manifest to be returned")
+	}
+	if gotManifest.Name != "simple-api" {
+		t.Errorf("manifest.Name = %q, want %q", gotManifest.Name, "simple-api")
+	}
+	if len(gotManifest.Variables) != 1 || gotManifest.Variables[0].Name != "PORT" {
+		t.Errorf("manifest.Variables = %+v, want one PORT variable", gotManifest.Variables)
+	}
+
+	if _, ok := got["template.json"]; ok {
+		t.Error("template.json should be stripped from the returned files map")
+	}
+	if string(got["main.go"]) != "package main\n" {
+		t.Errorf("main.go contents = %q", got["main.go"])
+	}
+	if string(got["README.md"]) != "# {{.APP_ID}}\n" {
+		t.Errorf("README.md contents = %q", got["README.md"])
+	}
+}
+
+func TestExtractTemplateArchive_MissingManifestErrors(t *testing.T) {
+	archive := buildTestTarball(t, "templates-main", "rust", "simple-api", map[string]string{
+		"main.go": "package main\n",
+	})
+
+	_, _, err := extractTemplateArchive(bytes.NewReader(archive), "rust", "simple-api")
+	if err == nil {
+		t.Fatal("expected error for tarball missing template.json")
+	}
+	if !strings.Contains(err.Error(), "no template.json") {
+		t.Errorf("error = %q, want error mentioning missing template.json", err.Error())
+	}
+}
+
+func TestExtractTemplateArchive_IgnoresOtherLanguages(t *testing.T) {
+	// Build a tarball containing two templates — rust/simple-api and
+	// python/other — and ensure only the rust files come back.
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	write := func(name, content string) {
+		hdr := &tar.Header{
+			Name:     name,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader: %v", err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	write("templates-main/rust/simple-api/template.json", `{"name":"simple-api"}`)
+	write("templates-main/rust/simple-api/main.rs", "fn main() {}\n")
+	write("templates-main/python/other/template.json", `{"name":"other"}`)
+	write("templates-main/python/other/app.py", "print('hi')\n")
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tw.Close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz.Close: %v", err)
+	}
+
+	files, manifest, err := extractTemplateArchive(bytes.NewReader(buf.Bytes()), "rust", "simple-api")
+	if err != nil {
+		t.Fatalf("extractTemplateArchive: %v", err)
+	}
+	if manifest == nil || manifest.Name != "simple-api" {
+		t.Errorf("got manifest %+v, want simple-api", manifest)
+	}
+	if _, ok := files["main.rs"]; !ok {
+		t.Errorf("expected main.rs in files map, got keys %v", keys(files))
+	}
+	if _, ok := files["app.py"]; ok {
+		t.Error("python template should not leak into rust files map")
+	}
+}
+
+func TestDownloadTemplateArchiveFromURL_InvokesProgressCallback(t *testing.T) {
+	archive := buildTestTarball(t, "templates-main", "rust", "simple-api", map[string]string{
+		"template.json": `{"name":"simple-api"}`,
+		"main.rs":       strings.Repeat("fn main() {}\n", 500),
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(len(archive)))
+		_, _ = w.Write(archive)
+	}))
+	t.Cleanup(srv.Close)
+
+	var (
+		mu       sync.Mutex
+		calls    int
+		lastSize int64
+		lastTot  int64
+	)
+	cb := func(written, total int64) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		lastSize = written
+		lastTot = total
+	}
+
+	files, manifest, err := downloadTemplateArchiveFromURL(srv.URL, "main", "rust", "simple-api", cb)
+	if err != nil {
+		t.Fatalf("downloadTemplateArchiveFromURL: %v", err)
+	}
+	if manifest == nil || manifest.Name != "simple-api" {
+		t.Errorf("manifest = %+v", manifest)
+	}
+	if _, ok := files["main.rs"]; !ok {
+		t.Error("main.rs missing from files map")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls == 0 {
+		t.Error("progress callback was never invoked")
+	}
+	if lastTot != int64(len(archive)) {
+		t.Errorf("final total = %d, want %d (Content-Length)", lastTot, len(archive))
+	}
+	if lastSize != int64(len(archive)) {
+		t.Errorf("final written = %d, want %d", lastSize, len(archive))
+	}
+}
+
+func TestDownloadTemplateArchiveFromURL_NilCallbackIsSafe(t *testing.T) {
+	archive := buildTestTarball(t, "templates-main", "rust", "simple-api", map[string]string{
+		"template.json": `{"name":"simple-api"}`,
+		"main.rs":       "fn main() {}\n",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archive)
+	}))
+	t.Cleanup(srv.Close)
+
+	files, manifest, err := downloadTemplateArchiveFromURL(srv.URL, "main", "rust", "simple-api", nil)
+	if err != nil {
+		t.Fatalf("downloadTemplateArchiveFromURL with nil callback: %v", err)
+	}
+	if manifest == nil {
+		t.Fatal("expected manifest")
+	}
+	if _, ok := files["main.rs"]; !ok {
+		t.Error("main.rs missing from files map")
+	}
+}
+
+func TestDownloadTemplateArchiveFromURL_404MentionsBranch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := downloadTemplateArchiveFromURL(srv.URL, "nonexistent-branch", "rust", "simple-api", nil)
+	if err == nil {
+		t.Fatal("expected 404 to return an error")
+	}
+	if !strings.Contains(err.Error(), "nonexistent-branch") {
+		t.Errorf("error = %q, want it to mention the branch name", err.Error())
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want it to mention 'not found'", err.Error())
+	}
+}
+
+func TestProgressReader_TracksBytes(t *testing.T) {
+	data := []byte("hello world from the progress reader")
+	var calls []int64
+
+	pr := &progressReader{
+		r:     bytes.NewReader(data),
+		total: int64(len(data)),
+		onProgress: func(written, total int64) {
+			calls = append(calls, written)
+		},
+	}
+
+	buf := make([]byte, 8)
+	var total int
+	for {
+		n, err := pr.Read(buf)
+		total += n
+		if err != nil {
+			break
+		}
+	}
+
+	if total != len(data) {
+		t.Errorf("read %d bytes, want %d", total, len(data))
+	}
+	if len(calls) == 0 {
+		t.Fatal("progress callback never invoked")
+	}
+	if calls[len(calls)-1] != int64(len(data)) {
+		t.Errorf("final written = %d, want %d", calls[len(calls)-1], len(data))
+	}
+}
+
+// keys returns the sorted keys of a map[string][]byte — used in test failure
+// messages so the output is deterministic.
+func keys(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -4,8 +4,10 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -174,7 +176,7 @@ func TestDownloadTemplateArchiveFromURL_InvokesProgressCallback(t *testing.T) {
 		lastTot = total
 	}
 
-	files, manifest, err := downloadTemplateArchiveFromURL(srv.URL, "main", "rust", "simple-api", cb)
+	files, manifest, err := downloadTemplateArchiveFromURL(context.Background(), srv.URL, "main", "rust", "simple-api", cb)
 	if err != nil {
 		t.Fatalf("downloadTemplateArchiveFromURL: %v", err)
 	}
@@ -198,6 +200,53 @@ func TestDownloadTemplateArchiveFromURL_InvokesProgressCallback(t *testing.T) {
 	}
 }
 
+// TestDownloadTemplateArchiveFromURL_UnknownContentLengthNormalized verifies
+// that when the server doesn't send Content-Length (chunked/unknown length),
+// the progress callback receives total=0 rather than -1. This is the
+// progressCallback doc contract.
+func TestDownloadTemplateArchiveFromURL_UnknownContentLengthNormalized(t *testing.T) {
+	archive := buildTestTarball(t, "templates-main", "rust", "simple-api", map[string]string{
+		"template.json": `{"name":"simple-api"}`,
+		"main.rs":       "fn main() {}\n",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Force chunked transfer encoding so ContentLength == -1 on the
+		// client side.
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		half := len(archive) / 2
+		_, _ = w.Write(archive[:half])
+		if flusher != nil {
+			flusher.Flush()
+		}
+		_, _ = w.Write(archive[half:])
+	}))
+	t.Cleanup(srv.Close)
+
+	var (
+		mu       sync.Mutex
+		sawTotal int64 = -99 // sentinel so we can tell if callback ran
+	)
+	cb := func(written, total int64) {
+		mu.Lock()
+		defer mu.Unlock()
+		sawTotal = total
+	}
+
+	_, _, err := downloadTemplateArchiveFromURL(context.Background(), srv.URL, "main", "rust", "simple-api", cb)
+	if err != nil {
+		t.Fatalf("downloadTemplateArchiveFromURL: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if sawTotal < 0 {
+		t.Errorf("progress callback received total = %d, want 0 (normalized from unknown)", sawTotal)
+	}
+}
+
 func TestDownloadTemplateArchiveFromURL_NilCallbackIsSafe(t *testing.T) {
 	archive := buildTestTarball(t, "templates-main", "rust", "simple-api", map[string]string{
 		"template.json": `{"name":"simple-api"}`,
@@ -209,7 +258,7 @@ func TestDownloadTemplateArchiveFromURL_NilCallbackIsSafe(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	files, manifest, err := downloadTemplateArchiveFromURL(srv.URL, "main", "rust", "simple-api", nil)
+	files, manifest, err := downloadTemplateArchiveFromURL(context.Background(), srv.URL, "main", "rust", "simple-api", nil)
 	if err != nil {
 		t.Fatalf("downloadTemplateArchiveFromURL with nil callback: %v", err)
 	}
@@ -221,13 +270,35 @@ func TestDownloadTemplateArchiveFromURL_NilCallbackIsSafe(t *testing.T) {
 	}
 }
 
+// TestDownloadTemplateArchiveFromURL_CancelledContext verifies that a
+// cancelled context aborts the HTTP request rather than blocking forever.
+func TestDownloadTemplateArchiveFromURL_CancelledContext(t *testing.T) {
+	// Server that hangs until the client disconnects. It never sends a
+	// response body, so only a cancelled context can unblock the client.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel before the call so it aborts immediately
+
+	_, _, err := downloadTemplateArchiveFromURL(ctx, srv.URL, "main", "rust", "simple-api", nil)
+	if err == nil {
+		t.Fatal("expected cancelled context to produce an error")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("error = %q, want it to mention cancellation", err.Error())
+	}
+}
+
 func TestDownloadTemplateArchiveFromURL_404MentionsBranch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
 	t.Cleanup(srv.Close)
 
-	_, _, err := downloadTemplateArchiveFromURL(srv.URL, "nonexistent-branch", "rust", "simple-api", nil)
+	_, _, err := downloadTemplateArchiveFromURL(context.Background(), srv.URL, "nonexistent-branch", "rust", "simple-api", nil)
 	if err == nil {
 		t.Fatal("expected 404 to return an error")
 	}
@@ -279,5 +350,6 @@ func keys(m map[string][]byte) []string {
 	for k := range m {
 		out = append(out, k)
 	}
+	sort.Strings(out)
 	return out
 }


### PR DESCRIPTION
## Summary

- `wendy init --template <name>` now shows a live bubbletea progress bar (with byte counter) while downloading the templates tarball, and a spinner while fetching `meta.json`
- Both TUIs are guarded by `isInteractiveTerminal()` so non-TTY/CI runs keep the current plain-text output (no ANSI garbage in logs)
- Refactors `downloadTemplateArchive` to accept an optional progress callback, and splits the tarball-parsing core into a pure `extractTemplateArchive(io.Reader, ...)` helper so it can be unit-tested without hitting GitHub

Closes WDY-858

## Why

On a slow network, the existing flow prints one `Downloading template...` line and then silently blocks in `http.Client.Get → gzip.NewReader → tar.NewReader`. Users couldn't tell if the CLI was hung or just slow. Every other download path in the CLI (`os install`, firmware flash) already uses `tui.ProgressModel`; template downloads should match.

## Design

Mirrors the pattern in `os_install.go`:

```go
prog := tea.NewProgram(tui.NewProgress(title))
go func() {
    files, manifest, err = downloadTemplateArchive(lang, tmpl, branch, func(written, total int64) {
        prog.Send(tui.ProgressUpdateMsg{Percent: ..., Written: written, Total: total})
    })
    prog.Send(tui.ProgressDoneMsg{Err: err})
}()
prog.Run()
```

A new `progressReader` wraps `resp.Body` and invokes the callback on each `Read`. `Content-Length` from GitHub's tarball endpoint drives the percentage.

## Test plan

- [x] `go test ./internal/cli/commands/ -run 'TestExtractTemplateArchive|TestDownloadTemplateArchiveFromURL|TestProgressReader'` — 7 new tests, all passing
- [x] Full `go test ./internal/cli/commands/` — passes
- [x] `go vet ./internal/cli/commands/...` — clean
- [x] `gofmt -l` — clean
- [ ] Manual smoke test: `wendy init --template simple-api` on a TTY shows the progress bar
- [ ] Manual smoke test: `wendy init --template simple-api > out.log` writes plain text (no escape codes)

## New test coverage

- `TestExtractTemplateArchive_ReturnsFilesAndManifest`
- `TestExtractTemplateArchive_MissingManifestErrors`
- `TestExtractTemplateArchive_IgnoresOtherLanguages`
- `TestDownloadTemplateArchiveFromURL_InvokesProgressCallback` — verifies `written == Content-Length` at completion
- `TestDownloadTemplateArchiveFromURL_NilCallbackIsSafe` — regression guard
- `TestDownloadTemplateArchiveFromURL_404MentionsBranch`
- `TestProgressReader_TracksBytes`