### PR TITLE
WDY-919 Deprecate video entitlement in favor of camera entitlement

### DIFF
--- a/Examples/HelloVideo/wendy.json
+++ b/Examples/HelloVideo/wendy.json
@@ -8,7 +8,7 @@
             "mode": "host"
         },
         {
-            "type": "video"
+            "type": "camera"
         }
     ]
 }

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -50,8 +50,8 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 				didSetDeviceCapabilities = true
 				SetDeviceCapabilities(spec, cfg.AppID)
 			}
-		case appconfig.EntitlementVideo:
-			applyVideo(spec)
+		case appconfig.EntitlementVideo, appconfig.EntitlementCamera:
+			applyCamera(spec)
 			if !didSetDeviceCapabilities {
 				didSetDeviceCapabilities = true
 				SetDeviceCapabilities(spec, cfg.AppID)
@@ -60,8 +60,6 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 			applyPersist(spec, ent, cfg.AppID)
 		case appconfig.EntitlementBluetooth:
 			applyBluetooth(spec, cfg.AppID, opts.DBusProxyAvailable)
-		case appconfig.EntitlementCamera:
-			applyCamera(spec)
 		case appconfig.EntitlementUSB:
 			applyUSB(spec)
 		case appconfig.EntitlementI2C:
@@ -294,8 +292,8 @@ func applyAudio(spec *Spec) {
 	)
 }
 
-// applyVideo adds video device access.
-func applyVideo(spec *Spec) {
+// applyCamera adds camera/V4L2 device access.
+func applyCamera(spec *Spec) {
 	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, videoGroupGID)
 
 	// Allow video4linux devices (major 81).
@@ -318,6 +316,11 @@ func applyVideo(spec *Spec) {
 		Type:        "bind",
 		Options:     []string{"rbind", "rw", "nosuid", "noexec"},
 	})
+}
+
+// applyVideo is a deprecated alias for camera/V4L2 device access.
+func applyVideo(spec *Spec) {
+	applyCamera(spec)
 }
 
 // applyPersist adds a persistent volume bind mount, creating the host
@@ -368,12 +371,6 @@ func applyBluetooth(spec *Spec, appID string, proxyAvailable bool) {
 	spec.Process.Env = append(spec.Process.Env,
 		"DBUS_SYSTEM_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket",
 	)
-}
-
-// applyCamera adds camera/V4L2 device access.
-func applyCamera(spec *Spec) {
-	// Camera uses the same V4L2 devices as video.
-	applyVideo(spec)
 }
 
 // applyUSB adds USB device access.

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -51,6 +51,13 @@ func hasEnv(spec *Spec, envPrefix string) bool {
 	return false
 }
 
+func hasCapability(spec *Spec, cap string) bool {
+	if spec.Process.Capabilities == nil {
+		return false
+	}
+	return slices.Contains(spec.Process.Capabilities.Bounding, cap)
+}
+
 func hasAllowAllDeviceRule(spec *Spec) bool {
 	for _, d := range spec.Linux.Resources.Devices {
 		if d.Allow && d.Type == "" && d.Major == nil && d.Minor == nil {
@@ -374,6 +381,48 @@ func TestBluetoothEntitlementDoesNotExposeNetworkManager(t *testing.T) {
 	}
 }
 
+func assertCameraEntitlement(t *testing.T, spec *Spec, entType string) {
+	t.Helper()
+
+	if !hasGID(spec, 44) {
+		t.Errorf("%s entitlement did not add GID 44", entType)
+	}
+
+	foundV4L2Rule := false
+	for _, d := range spec.Linux.Resources.Devices {
+		if d.Major != nil && *d.Major == 81 && d.Allow {
+			foundV4L2Rule = true
+			break
+		}
+	}
+	if !foundV4L2Rule {
+		t.Errorf("%s entitlement did not add V4L2 cgroup device rule (major 81)", entType)
+	}
+	if hasAllowAllDeviceRule(spec) {
+		t.Errorf("%s entitlement should not add a generic allow-all device cgroup rule", entType)
+	}
+
+	devMount, ok := mountForDest(spec, "/dev")
+	if !ok {
+		t.Fatalf("%s entitlement did not define /dev mount", entType)
+	}
+	if devMount.Source != "/dev" || devMount.Type != "bind" {
+		t.Fatalf("%s entitlement /dev mount = %+v, want bind mount from host /dev", entType, devMount)
+	}
+	if !slices.Contains(devMount.Options, "rbind") {
+		t.Errorf("%s entitlement /dev mount missing rbind option", entType)
+	}
+	if !slices.Contains(devMount.Options, "rw") {
+		t.Errorf("%s entitlement /dev mount missing rw option", entType)
+	}
+	if !slices.Contains(devMount.Options, "noexec") {
+		t.Errorf("%s entitlement /dev mount missing noexec option", entType)
+	}
+	if !hasCapability(spec, "CAP_SYS_PTRACE") {
+		t.Errorf("%s entitlement did not add device capability wiring", entType)
+	}
+}
+
 func TestApplyEntitlements_Video(t *testing.T) {
 	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 	cfg := &appconfig.AppConfig{
@@ -387,42 +436,23 @@ func TestApplyEntitlements_Video(t *testing.T) {
 		t.Fatalf("ApplyEntitlements() error = %v", err)
 	}
 
-	// Should add video group GID 44.
-	if !hasGID(spec, 44) {
-		t.Error("video entitlement did not add GID 44")
+	assertCameraEntitlement(t, spec, "video")
+}
+
+func TestApplyEntitlements_Camera(t *testing.T) {
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "test-app",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementCamera},
+		},
 	}
 
-	// Should add a cgroup rule for V4L2 devices (major 81).
-	foundV4L2Rule := false
-	for _, d := range spec.Linux.Resources.Devices {
-		if d.Major != nil && *d.Major == 81 && d.Allow {
-			foundV4L2Rule = true
-			break
-		}
-	}
-	if !foundV4L2Rule {
-		t.Error("video entitlement did not add V4L2 cgroup device rule (major 81)")
-	}
-	if hasAllowAllDeviceRule(spec) {
-		t.Error("video entitlement should not add a generic allow-all device cgroup rule")
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
 	}
 
-	devMount, ok := mountForDest(spec, "/dev")
-	if !ok {
-		t.Fatal("video entitlement did not define /dev mount")
-	}
-	if devMount.Source != "/dev" || devMount.Type != "bind" {
-		t.Fatalf("/dev mount = %+v, want bind mount from host /dev", devMount)
-	}
-	if !slices.Contains(devMount.Options, "rbind") {
-		t.Error("video entitlement /dev mount missing rbind option")
-	}
-	if !slices.Contains(devMount.Options, "rw") {
-		t.Error("video entitlement /dev mount missing rw option")
-	}
-	if !slices.Contains(devMount.Options, "noexec") {
-		t.Error("video entitlement /dev mount missing noexec option")
-	}
+	assertCameraEntitlement(t, spec, "camera")
 }
 
 func TestApplyEntitlements_Multiple(t *testing.T) {

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -35,6 +35,14 @@ func newBuildCmd() *cobra.Command {
 
 			cfgPath := filepath.Join(cwd, "wendy.json")
 			appCfg, cfgErr := ensureAppConfig(cfgPath, false)
+			if cfgErr == nil {
+				if err := appCfg.Validate(); err != nil {
+					return fmt.Errorf("invalid wendy.json: %w", err)
+				}
+				if err := warnAppConfigFile(cfgPath); err != nil {
+					return fmt.Errorf("reading wendy.json warnings: %w", err)
+				}
+			}
 
 			target, _ := resolveTarget(cmd.Context())
 

--- a/go/internal/cli/commands/config_warnings.go
+++ b/go/internal/cli/commands/config_warnings.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
+)
+
+func appConfigWarningsFromFile(cfgPath string) ([]string, error) {
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading wendy.json: %w", err)
+	}
+	return appconfig.ValidateJSON(data), nil
+}
+
+func printAppConfigWarnings(w io.Writer, warnings []string) {
+	for _, warning := range warnings {
+		fmt.Fprintf(w, "Warning: %s\n", warning)
+	}
+}
+
+func warnAppConfigFile(cfgPath string) error {
+	warnings, err := appConfigWarningsFromFile(cfgPath)
+	if err != nil {
+		return err
+	}
+	printAppConfigWarnings(os.Stderr, warnings)
+	return nil
+}

--- a/go/internal/cli/commands/config_warnings_test.go
+++ b/go/internal/cli/commands/config_warnings_test.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAppConfigWarningsFromFile_DeprecatedVideoEntitlement(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "wendy.json")
+	data := []byte(`{
+		"appId": "com.example.app",
+		"entitlements": [
+			{"type": "video"}
+		]
+	}`)
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	warnings, err := appConfigWarningsFromFile(cfgPath)
+	if err != nil {
+		t.Fatalf("appConfigWarningsFromFile() error = %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("appConfigWarningsFromFile() got %d warnings, want 1", len(warnings))
+	}
+	if got := warnings[0]; got != `entitlement[0]: "video" is deprecated; use "camera" instead` {
+		t.Fatalf("appConfigWarningsFromFile() warning = %q", got)
+	}
+}
+
+func TestPrintAppConfigWarnings(t *testing.T) {
+	var buf bytes.Buffer
+
+	printAppConfigWarnings(&buf, []string{"first warning", "second warning"})
+
+	if got := buf.String(); got != "Warning: first warning\nWarning: second warning\n" {
+		t.Fatalf("printAppConfigWarnings() output = %q", got)
+	}
+}

--- a/go/internal/cli/commands/json_cmd.go
+++ b/go/internal/cli/commands/json_cmd.go
@@ -76,9 +76,7 @@ func newJSONValidateCmd() *cobra.Command {
 			}
 
 			warnings := appconfig.ValidateJSON(data)
-			for _, w := range warnings {
-				fmt.Fprintf(os.Stderr, "Warning: %s\n", w)
-			}
+			printAppConfigWarnings(os.Stderr, warnings)
 
 			if len(warnings) > 0 {
 				fmt.Println("wendy.json is valid (with warnings).")

--- a/go/internal/cli/commands/project.go
+++ b/go/internal/cli/commands/project.go
@@ -19,7 +19,7 @@ import (
 var entitlementDescriptions = map[string]string{
 	appconfig.EntitlementNetwork:   "Access network interfaces",
 	appconfig.EntitlementBluetooth: "Access Bluetooth peripherals",
-	appconfig.EntitlementVideo:     "Access video cameras",
+	appconfig.EntitlementVideo:     "Deprecated: use camera instead",
 	appconfig.EntitlementGPU:       "Access GPU for AI or compute workloads",
 	appconfig.EntitlementPersist:   "Persist data across restarts",
 	appconfig.EntitlementAudio:     "Access audio input/output devices",

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -228,6 +228,9 @@ func runCommand(ctx context.Context, opts runOptions) error {
 	if err := appCfg.Validate(); err != nil {
 		return fmt.Errorf("invalid wendy.json: %w", err)
 	}
+	if err := warnAppConfigFile(cfgPath); err != nil {
+		return fmt.Errorf("reading wendy.json warnings: %w", err)
+	}
 
 	// Debug mode requires host networking for remote debugger access
 	// (gdb/lldb for native apps, debugpy for Python apps).

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -54,7 +54,7 @@ var allowedKeys = map[string][]string{
 	EntitlementGPU:       {"type"},
 	EntitlementPersist:   {"type", "name", "path"},
 	EntitlementAudio:     {"type"},
-	EntitlementCamera:    {"type"},
+	EntitlementCamera:    {"type", "mode", "allowlist"},
 	EntitlementUSB:       {"type"},
 	EntitlementI2C:       {"type", "device"},
 	EntitlementGPIO:      {"type", "pins"},

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -42,6 +42,10 @@ var ValidEntitlementTypes = []string{
 	EntitlementInput,
 }
 
+var deprecatedEntitlementReplacements = map[string]string{
+	EntitlementVideo: EntitlementCamera,
+}
+
 // allowedKeys maps each entitlement type to the set of JSON keys that are valid for it.
 var allowedKeys = map[string][]string{
 	EntitlementNetwork:   {"type", "mode"},
@@ -112,6 +116,12 @@ type Entitlement struct {
 	Path   string `json:"path,omitempty"`   // Persist
 	Device string `json:"device,omitempty"` // I2C
 	Pins   []int  `json:"pins,omitempty"`   // GPIO
+}
+
+// DeprecatedEntitlementReplacement reports the preferred replacement for a deprecated entitlement type.
+func DeprecatedEntitlementReplacement(entType string) (string, bool) {
+	replacement, ok := deprecatedEntitlementReplacements[entType]
+	return replacement, ok
 }
 
 // HasEntitlement reports whether the config contains an entitlement of the given type.
@@ -219,6 +229,13 @@ func ValidateJSON(data []byte) []string {
 		var entType string
 		if err := json.Unmarshal(typeRaw, &entType); err != nil {
 			continue
+		}
+
+		if replacement, ok := DeprecatedEntitlementReplacement(entType); ok {
+			warnings = append(warnings, fmt.Sprintf(
+				"entitlement[%d]: %q is deprecated; use %q instead",
+				i, entType, replacement,
+			))
 		}
 
 		allowed, ok := allowedKeys[entType]

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -248,6 +248,24 @@ func TestValidateJSON_VideoEntitlementDeprecated(t *testing.T) {
 	}
 }
 
+func TestValidateJSON_CameraLegacyKeysNoWarnings(t *testing.T) {
+	data := []byte(`{
+		"appId": "com.example.app",
+		"entitlements": [
+			{
+				"type": "camera",
+				"mode": "legacy",
+				"allowlist": ["/dev/video0"]
+			}
+		]
+	}`)
+
+	warnings := ValidateJSON(data)
+	if len(warnings) != 0 {
+		t.Fatalf("ValidateJSON() got %d warnings, want 0", len(warnings))
+	}
+}
+
 func TestLoadFromFile_WithHooksPostStart(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wendy.json")

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -231,6 +231,23 @@ func TestValidateJSON_InputUnknownKeys(t *testing.T) {
 	}
 }
 
+func TestValidateJSON_VideoEntitlementDeprecated(t *testing.T) {
+	data := []byte(`{
+		"appId": "com.example.app",
+		"entitlements": [
+			{"type": "video"}
+		]
+	}`)
+
+	warnings := ValidateJSON(data)
+	if len(warnings) != 1 {
+		t.Fatalf("ValidateJSON() got %d warnings, want 1", len(warnings))
+	}
+	if got := warnings[0]; got != `entitlement[0]: "video" is deprecated; use "camera" instead` {
+		t.Fatalf("ValidateJSON() warning = %q", got)
+	}
+}
+
 func TestLoadFromFile_WithHooksPostStart(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wendy.json")

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -138,11 +138,20 @@
         },
         {
           "properties": {
-            "type": { "const": "camera" }
+            "type": { "const": "camera" },
+            "mode": {
+              "type": "string",
+              "description": "Camera access mode. Accepted for compatibility with the deprecated video entitlement."
+            },
+            "allowlist": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Allowed camera device paths. Accepted for compatibility with the deprecated video entitlement."
+            }
           },
           "required": ["type"],
           "additionalProperties": false,
-          "description": "Camera/V4L2 device access."
+          "description": "Camera/V4L2 device access. Legacy video entitlement keys remain accepted for compatibility."
         },
         {
           "properties": {

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -81,8 +81,14 @@
           "additionalProperties": false
         },
         {
+          "deprecated": true,
+          "description": "Deprecated: use the camera entitlement instead.",
           "properties": {
-            "type": { "const": "video" },
+            "type": {
+              "const": "video",
+              "deprecated": true,
+              "description": "Deprecated: use \"camera\" instead."
+            },
             "mode": {
               "type": "string",
               "description": "Video access mode."
@@ -136,7 +142,7 @@
           },
           "required": ["type"],
           "additionalProperties": false,
-          "description": "Camera device access."
+          "description": "Camera/V4L2 device access."
         },
         {
           "properties": {


### PR DESCRIPTION
## Summary

- add deprecation warnings for the `video` entitlement in config validation, `wendy build`, `wendy run`, and the JSON schema
- make `camera` the canonical fully wired V4L2 entitlement while keeping `video` as a backward-compatible alias
- update the HelloVideo example and add tests covering the warning path and camera/video runtime parity

## Why

The codebase currently treats `camera` and `video` as the same capability, but the implementation is inconsistent: `video` had the more complete runtime wiring while `camera` behaved like a partial alias. This change deprecates `video` in favor of `camera` without breaking existing configs.

## User impact

Projects using `video` continue to work, but they now receive a warning that points them to `camera`. New and updated configs should use `camera`.

## Validation

- `go test ./internal/shared/appconfig ./internal/agent/oci ./internal/cli/commands`
