### PR TITLE
Improve winget publish errors for missing workflow scope

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -962,7 +962,10 @@ jobs:
               if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
                 $statusCode = $_.Exception.Response.StatusCode.value__
               }
-              $errorMessage = $_.ErrorDetails.Message
+              $errorMessage = $null
+              if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+                $errorMessage = $_.ErrorDetails.Message
+              }
               if ([string]::IsNullOrWhiteSpace($errorMessage)) {
                 $errorMessage = $_.Exception.Message
               }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -958,10 +958,27 @@ jobs:
                 Write-Host $response.message
               }
             } catch {
-              $statusCode = $_.Exception.Response.StatusCode.value__
+              $statusCode = $null
+              if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+                $statusCode = $_.Exception.Response.StatusCode.value__
+              }
+              $errorMessage = $_.ErrorDetails.Message
+              if ([string]::IsNullOrWhiteSpace($errorMessage)) {
+                $errorMessage = $_.Exception.Message
+              }
+
               if ($statusCode -eq 409) {
                 Write-Host "winget-pkgs fork is already up to date."
                 return
+              }
+
+              if (
+                $statusCode -eq 422 -and (
+                  $errorMessage -match "refusing to allow a Personal Access Token to create or update workflow" -or
+                  $errorMessage -match "workflow scope"
+                )
+              ) {
+                throw "WINGET_GITHUB_TOKEN cannot sync $($viewer.login)/winget-pkgs because GitHub rejected workflow file updates in the fork. Update the secret to a token with workflow scope (for a classic PAT) or equivalent workflow-file write permission, then rerun the release workflow. GitHub API response: $errorMessage"
               }
 
               throw


### PR DESCRIPTION
## Summary
- detect the GitHub 422 error when fork sync fails because the configured token cannot update workflow files
- surface an explicit `WINGET_GITHUB_TOKEN` remediation message instead of a raw `Invoke-RestMethod` exception

## Context
The release workflow run `24315420642` failed in the `Publish to Winget` job after `wingetcreate` correctly detected an out-of-date fork. The retry path then attempted to sync the token owner fork via `merge-upstream`, but GitHub rejected that request because the configured token could not update workflow files in the fork.

## Validation
- workflow YAML parsed locally with Ruby `YAML.load_file`
- `git diff --check`