### PR TITLE
Harden template archive downloads

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -538,7 +538,7 @@ func downloadTemplateArchiveWithUI(language, tmpl, branch string) (map[string][]
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	prog := tea.NewProgram(tui.NewProgress(title))
+	prog := tea.NewProgram(tui.NewProgress(title).WithoutErrorView())
 
 	var (
 		files    map[string][]byte

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -175,9 +175,6 @@ func downloadTemplateArchiveFromURL(ctx context.Context, url, branch, language, 
 		}
 
 		if err := waitForTemplateArchiveRetry(ctx, templateArchiveRetryDelay); err != nil {
-			if lastErr != nil {
-				return nil, nil, lastErr
-			}
 			return nil, nil, err
 		}
 	}

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -5,8 +5,10 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -22,6 +24,12 @@ const (
 	templateRepoOwner  = "wendylabsinc"
 	templateRepoName   = "templates"
 	templateRepoBranch = "main"
+)
+
+var (
+	templateArchiveAttemptTimeout = 2 * time.Minute
+	templateArchiveMaxAttempts    = 3
+	templateArchiveRetryDelay     = 750 * time.Millisecond
 )
 
 // resolveTemplateBranch returns branch if non-empty, otherwise the default branch.
@@ -143,7 +151,9 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 // If ctx is cancelled, the in-flight request is aborted.
 func downloadTemplateArchive(ctx context.Context, language, templateName, branch string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
 	branch = resolveTemplateBranch(branch)
-	url := fmt.Sprintf("https://github.com/%s/%s/archive/refs/heads/%s.tar.gz",
+	// Use codeload directly to avoid an extra redirect through github.com for the
+	// repository archive download.
+	url := fmt.Sprintf("https://codeload.github.com/%s/%s/tar.gz/refs/heads/%s",
 		templateRepoOwner, templateRepoName, branch)
 	return downloadTemplateArchiveFromURL(ctx, url, branch, language, templateName, onProgress)
 }
@@ -152,11 +162,38 @@ func downloadTemplateArchive(ctx context.Context, language, templateName, branch
 // it performs the HTTP GET against the caller-supplied URL and delegates
 // tarball parsing to extractTemplateArchive.
 func downloadTemplateArchiveFromURL(ctx context.Context, url, branch, language, templateName string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	var lastErr error
+	for attempt := 1; attempt <= templateArchiveMaxAttempts; attempt++ {
+		files, manifest, err := downloadTemplateArchiveAttempt(ctx, url, branch, language, templateName, onProgress)
+		if err == nil {
+			return files, manifest, nil
+		}
+		lastErr = err
+
+		if ctx.Err() != nil || attempt == templateArchiveMaxAttempts || !shouldRetryTemplateArchiveError(err) {
+			return nil, nil, err
+		}
+
+		if err := waitForTemplateArchiveRetry(ctx, templateArchiveRetryDelay); err != nil {
+			if lastErr != nil {
+				return nil, nil, lastErr
+			}
+			return nil, nil, err
+		}
+	}
+
+	return nil, nil, lastErr
+}
+
+func downloadTemplateArchiveAttempt(ctx context.Context, url, branch, language, templateName string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, templateArchiveAttemptTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("downloading template (branch %q): %w", branch, err)
 	}
-	client := &http.Client{Timeout: 60 * time.Second}
+	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("downloading template (branch %q): %w", branch, err)
@@ -187,6 +224,35 @@ func downloadTemplateArchiveFromURL(ctx context.Context, url, branch, language, 
 	}
 
 	return extractTemplateArchive(reader, language, templateName)
+}
+
+func shouldRetryTemplateArchiveError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "Client.Timeout") || strings.Contains(msg, "while reading body")
+}
+
+func waitForTemplateArchiveRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // extractTemplateArchive reads a gzipped tarball from r and extracts files

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // buildTestTarball constructs a minimal gzipped tarball that mirrors the
@@ -307,6 +308,69 @@ func TestDownloadTemplateArchiveFromURL_404MentionsBranch(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error = %q, want it to mention 'not found'", err.Error())
+	}
+}
+
+func TestDownloadTemplateArchiveFromURL_RetriesTransientTimeout(t *testing.T) {
+	archive := buildTestTarball(t, "templates-main", "python", "simple-api", map[string]string{
+		"template.json": `{"name":"simple-api"}`,
+		"app.py":        "print('hi')\n",
+	})
+
+	origTimeout := templateArchiveAttemptTimeout
+	origAttempts := templateArchiveMaxAttempts
+	origDelay := templateArchiveRetryDelay
+	templateArchiveAttemptTimeout = 50 * time.Millisecond
+	templateArchiveMaxAttempts = 2
+	templateArchiveRetryDelay = 10 * time.Millisecond
+	t.Cleanup(func() {
+		templateArchiveAttemptTimeout = origTimeout
+		templateArchiveMaxAttempts = origAttempts
+		templateArchiveRetryDelay = origDelay
+	})
+
+	var (
+		mu       sync.Mutex
+		attempts int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attempts++
+		attempt := attempts
+		mu.Unlock()
+
+		if attempt == 1 {
+			flusher, _ := w.(http.Flusher)
+			w.Header().Set("Content-Type", "application/gzip")
+			w.Header().Set("Content-Length", strconv.Itoa(len(archive)))
+			_, _ = w.Write(archive[:len(archive)/2])
+			if flusher != nil {
+				flusher.Flush()
+			}
+			time.Sleep(2 * templateArchiveAttemptTimeout)
+			_, _ = w.Write(archive[len(archive)/2:])
+			return
+		}
+
+		_, _ = w.Write(archive)
+	}))
+	t.Cleanup(srv.Close)
+
+	files, manifest, err := downloadTemplateArchiveFromURL(context.Background(), srv.URL, "main", "python", "simple-api", nil)
+	if err != nil {
+		t.Fatalf("downloadTemplateArchiveFromURL after retry: %v", err)
+	}
+	if manifest == nil || manifest.Name != "simple-api" {
+		t.Fatalf("manifest = %+v, want simple-api", manifest)
+	}
+	if string(files["app.py"]) != "print('hi')\n" {
+		t.Fatalf("app.py = %q", files["app.py"])
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
 	}
 }
 

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -371,6 +372,48 @@ func TestDownloadTemplateArchiveFromURL_RetriesTransientTimeout(t *testing.T) {
 	defer mu.Unlock()
 	if attempts != 2 {
 		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestDownloadTemplateArchiveFromURL_CancelledDuringRetryWaitReturnsContextError(t *testing.T) {
+	origTimeout := templateArchiveAttemptTimeout
+	origAttempts := templateArchiveMaxAttempts
+	origDelay := templateArchiveRetryDelay
+	templateArchiveAttemptTimeout = 20 * time.Millisecond
+	templateArchiveMaxAttempts = 3
+	templateArchiveRetryDelay = 200 * time.Millisecond
+	t.Cleanup(func() {
+		templateArchiveAttemptTimeout = origTimeout
+		templateArchiveMaxAttempts = origAttempts
+		templateArchiveRetryDelay = origDelay
+	})
+
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		time.Sleep(2 * templateArchiveAttemptTimeout)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := downloadTemplateArchiveFromURL(ctx, srv.URL, "main", "python", "simple-api", nil)
+		errCh <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
 	}
 }
 

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -388,9 +389,9 @@ func TestDownloadTemplateArchiveFromURL_CancelledDuringRetryWaitReturnsContextEr
 		templateArchiveRetryDelay = origDelay
 	})
 
-	var attempts int
+	var attempts atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attempts++
+		attempts.Add(1)
 		time.Sleep(2 * templateArchiveAttemptTimeout)
 	}))
 	t.Cleanup(srv.Close)
@@ -412,8 +413,8 @@ func TestDownloadTemplateArchiveFromURL_CancelledDuringRetryWaitReturnsContextEr
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want context.Canceled", err)
 	}
-	if attempts != 1 {
-		t.Fatalf("attempts = %d, want 1", attempts)
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
 	}
 }
 

--- a/go/internal/cli/tui/progress.go
+++ b/go/internal/cli/tui/progress.go
@@ -31,6 +31,7 @@ type ProgressModel struct {
 	total    int64
 	done     bool
 	err      error
+	showErr  bool
 }
 
 // NewProgress creates a new ProgressModel with the given title.
@@ -40,7 +41,16 @@ func NewProgress(title string) ProgressModel {
 	return ProgressModel{
 		progress: p,
 		title:    title,
+		showErr:  true,
 	}
+}
+
+// WithoutErrorView suppresses inline error rendering in View. This is useful
+// when the caller will surface the returned error separately and would
+// otherwise print it twice.
+func (m ProgressModel) WithoutErrorView() ProgressModel {
+	m.showErr = false
+	return m
 }
 
 // Init implements tea.Model.
@@ -84,6 +94,9 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View implements tea.Model.
 func (m ProgressModel) View() string {
 	if m.done && m.err != nil {
+		if !m.showErr {
+			return ""
+		}
 		return fmt.Sprintf("Error: %v\n", m.err)
 	}
 

--- a/go/internal/cli/tui/progress.go
+++ b/go/internal/cli/tui/progress.go
@@ -93,16 +93,16 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View implements tea.Model.
 func (m ProgressModel) View() string {
-	if m.done && m.err != nil {
-		if !m.showErr {
-			return ""
-		}
-		return fmt.Sprintf("Error: %v\n", m.err)
-	}
-
 	byteInfo := ""
 	if m.written > 0 && m.total > 0 {
 		byteInfo = fmt.Sprintf("  (%s / %s)", formatBytes(m.written), formatBytes(m.total))
+	}
+
+	if m.done && m.err != nil {
+		if !m.showErr {
+			return fmt.Sprintf("%s\n%s%s\n", m.title, m.progress.ViewAs(m.percent), byteInfo)
+		}
+		return fmt.Sprintf("Error: %v\n", m.err)
 	}
 
 	if m.done {

--- a/go/internal/cli/tui/progress.go
+++ b/go/internal/cli/tui/progress.go
@@ -100,7 +100,11 @@ func (m ProgressModel) View() string {
 
 	if m.done && m.err != nil {
 		if !m.showErr {
-			return fmt.Sprintf("%s\n%s%s\n", m.title, m.progress.ViewAs(m.percent), byteInfo)
+			percent := m.percent
+			if percent >= 1.0 {
+				percent = 0.99
+			}
+			return fmt.Sprintf("%s (failed)\n%s%s\n", m.title, m.progress.ViewAs(percent), byteInfo)
 		}
 		return fmt.Sprintf("Error: %v\n", m.err)
 	}

--- a/go/internal/cli/tui/spinner_test.go
+++ b/go/internal/cli/tui/spinner_test.go
@@ -161,6 +161,22 @@ func TestProgressModel_ErrorDoneMsg(t *testing.T) {
 	}
 }
 
+func TestProgressModel_WithoutErrorViewSuppressesInlineError(t *testing.T) {
+	p := NewProgress("Uploading...").WithoutErrorView()
+
+	testErr := fmt.Errorf("upload failed")
+	model, _ := p.Update(ProgressDoneMsg{Err: testErr})
+	updated := model.(ProgressModel)
+
+	if updated.Err() != testErr {
+		t.Errorf("Err() = %v; want %v", updated.Err(), testErr)
+	}
+
+	if view := updated.View(); view != "" {
+		t.Errorf("suppressed error view = %q, want empty string", view)
+	}
+}
+
 func TestProgressModel_ViewByteCounter(t *testing.T) {
 	p := NewProgress("Extracting...")
 

--- a/go/internal/cli/tui/spinner_test.go
+++ b/go/internal/cli/tui/spinner_test.go
@@ -165,15 +165,25 @@ func TestProgressModel_WithoutErrorViewSuppressesInlineError(t *testing.T) {
 	p := NewProgress("Uploading...").WithoutErrorView()
 
 	testErr := fmt.Errorf("upload failed")
-	model, _ := p.Update(ProgressDoneMsg{Err: testErr})
+	model, _ := p.Update(ProgressUpdateMsg{
+		Percent: 0.5,
+		Written: 512,
+		Total:   1024,
+	})
+	p = model.(ProgressModel)
+	model, _ = p.Update(ProgressDoneMsg{Err: testErr})
 	updated := model.(ProgressModel)
 
 	if updated.Err() != testErr {
 		t.Errorf("Err() = %v; want %v", updated.Err(), testErr)
 	}
 
-	if view := updated.View(); view != "" {
-		t.Errorf("suppressed error view = %q, want empty string", view)
+	view := updated.View()
+	if strings.Contains(view, "Error") {
+		t.Errorf("suppressed error view should not contain inline error text, got: %q", view)
+	}
+	if !strings.Contains(view, "Uploading...") {
+		t.Errorf("suppressed error view should retain the title, got: %q", view)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fetch template tarballs directly from `codeload.github.com`
- add bounded retries for transient template archive timeout and body-read failures during `wendy init`
- suppress duplicate inline progress errors so init download failures are reported once

## Context
`wendy init --language python` could intermittently fail with:

`reading template archive: context deadline exceeded (Client.Timeout or context cancellation while reading body)`

This came from streaming the full templates tarball through a single 60-second timeout while untarring the response body.

## Validation
- `go test ./internal/cli/commands ./internal/cli/tui`