### PR TITLE
Factor out swifttoolchain module and use in microwendy

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -181,7 +181,7 @@ func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, a
 		return err
 	}
 
-	sdk, err := swifttoolchain.FindSwiftSDK(architecture)
+	sdk, err := swifttoolchain.FindSwiftSDK(ctx, architecture)
 	if err != nil {
 		return err
 	}
@@ -1025,7 +1025,7 @@ func findIPv4NeighborLinux(ctx context.Context, ipv6LinkLocal string) string {
 // supports pushing to registries).
 func buildSwiftDockerImage(ctx context.Context, dir, product string) (string, error) {
 	arch := runtime.GOARCH
-	sdk, err := swifttoolchain.FindSwiftSDK(arch)
+	sdk, err := swifttoolchain.FindSwiftSDK(ctx, arch)
 	if err != nil {
 		return "", fmt.Errorf("finding Swift SDK: %w", err)
 	}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -243,18 +242,6 @@ func ensureContainerPlugin(dir string) error {
 	}
 
 	return nil
-}
-
-func findSwiftProduct(dir, productOverride string, interactive bool) (string, error) {
-	product, err := swifttoolchain.FindSwiftProductWithOptions(dir, productOverride, interactive)
-	if err != nil {
-		if errors.Is(err, swifttoolchain.ErrUserCancelled) {
-			return "", ErrUserCancelled
-		}
-		return "", err
-	}
-
-	return product, nil
 }
 
 // ensureBuildxBuilder ensures a buildx builder with the docker-container driver

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -176,12 +176,12 @@ func generatePythonDockerfile(dir string) (string, error) {
 // directly to the device's registry using swift-container-plugin.
 // registryAddr is a pre-resolved host:port (e.g. "192.168.1.5:5000" or
 // "host.docker.internal:12345" when proxying).
-func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, architecture string, useMTLS bool) error {
+func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, architecture string, useMTLS bool, toolchainStdout, toolchainStderr io.Writer) error {
 	if err := ensureContainerPlugin(dir); err != nil {
 		return err
 	}
 
-	sdk, err := swifttoolchain.FindSwiftSDK(ctx, architecture)
+	sdk, err := swifttoolchain.FindSwiftSDK(ctx, architecture, toolchainStdout, toolchainStderr)
 	if err != nil {
 		return err
 	}
@@ -1023,9 +1023,9 @@ func findIPv4NeighborLinux(ctx context.Context, ipv6LinkLocal string) string {
 // This is used by the Docker Desktop provider for Swift projects that do not
 // have a Dockerfile, as an alternative to swift-container-plugin (which only
 // supports pushing to registries).
-func buildSwiftDockerImage(ctx context.Context, dir, product string) (string, error) {
+func buildSwiftDockerImage(ctx context.Context, dir, product string, toolchainStdout, toolchainStderr io.Writer) (string, error) {
 	arch := runtime.GOARCH
-	sdk, err := swifttoolchain.FindSwiftSDK(ctx, arch)
+	sdk, err := swifttoolchain.FindSwiftSDK(ctx, arch, toolchainStdout, toolchainStderr)
 	if err != nil {
 		return "", fmt.Errorf("finding Swift SDK: %w", err)
 	}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1,10 +1,7 @@
 package commands
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -22,6 +19,7 @@ import (
 	"strconv"
 
 	"github.com/wendylabsinc/wendy/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/internal/cli/swifttoolchain"
 	"github.com/wendylabsinc/wendy/proto/gen/agentpb"
 )
 
@@ -174,71 +172,6 @@ func generatePythonDockerfile(dir string) (string, error) {
 	return dockerfilePath, nil
 }
 
-const (
-	// defaultSwiftVersion is the Swift toolchain version used for container base images.
-	defaultSwiftVersion = "6.2.3"
-	// wendySDKRelease is the GitHub release tag for WendyOS Swift SDKs.
-	wendySDKRelease = "0.4.0"
-)
-
-// wendySDKChecksums maps architecture to the checksum for the WendyOS Swift SDK bundle.
-var wendySDKChecksums = map[string]string{
-	"x86_64":  "b5a4d08ad4d4841043727f6671c6aa004da3a2b7f12dc28101d6770c1dc57eb1",
-	"aarch64": "ef8fa5a2eda766e3b1df791dc175bbf87f570b9cc6f95ada1fe7643a327e087e",
-}
-
-// execCommandContext is the function used to create exec commands.
-// It can be overridden in tests.
-var execCommandContext = exec.CommandContext
-
-// ensureSwiftVersion makes sure the required Swift toolchain is installed via swiftly.
-// If the version is already present this is a no-op.
-func ensureSwiftVersion(ctx context.Context) error {
-	// Avoid starting any subprocesses if the context is already canceled.
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	// First, check whether the requested Swift toolchain is already installed.
-	checkCmd := execCommandContext(ctx, "swiftly", "which", defaultSwiftVersion)
-	// Discard output for the existence check; this is only used as a probe.
-	checkCmd.Stdout = io.Discard
-	checkCmd.Stderr = io.Discard
-	if err := checkCmd.Run(); err == nil {
-		// Toolchain is already installed; nothing to do.
-		return nil
-	} else {
-		// If swiftly itself is missing, surface a helpful error.
-		if errors.Is(err, exec.ErrNotFound) {
-			return fmt.Errorf("swiftly is required but not installed; see https://swiftlang.github.io/swiftly for installation instructions")
-		}
-		// If the context was canceled or expired during the check, propagate that rather than starting an install.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return err
-		}
-		// For other errors (e.g., version not installed), fall through and attempt installation.
-	}
-
-	// Re-check the context before starting installation.
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	out := &dimWriter{}
-	cmd := execCommandContext(ctx, "swiftly", "install", defaultSwiftVersion)
-	cmd.Stdout = out
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	out.Flush()
-	if err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			return fmt.Errorf("swiftly is required but not installed; see https://swiftlang.github.io/swiftly for installation instructions")
-		}
-		return fmt.Errorf("installing Swift %s via swiftly: %w", defaultSwiftVersion, err)
-	}
-	return nil
-}
-
 // buildSwiftContainerImage builds a Swift package and pushes the container image
 // directly to the device's registry using swift-container-plugin.
 // registryAddr is a pre-resolved host:port (e.g. "192.168.1.5:5000" or
@@ -248,7 +181,7 @@ func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, a
 		return err
 	}
 
-	sdk, err := findSwiftSDK(architecture)
+	sdk, err := swifttoolchain.FindSwiftSDK(architecture)
 	if err != nil {
 		return err
 	}
@@ -258,7 +191,7 @@ func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, a
 		"--swift-sdk=" + sdk,
 		"--allow-network-connections=all",
 		"build-container-image",
-		"--from=swift:" + defaultSwiftVersion + "-slim",
+		"--from=swift:" + swifttoolchain.DefaultVersion + "-slim",
 		"--product=" + product,
 		"--repository=" + registryAddr + "/" + strings.ToLower(product),
 		"--architecture=" + architecture,
@@ -270,7 +203,7 @@ func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, a
 		swiftArgs = append(swiftArgs, "--allow-insecure-http=destination")
 	}
 
-	cmd := exec.CommandContext(ctx, "swiftly", append([]string{"run", "+" + defaultSwiftVersion, "swift"}, swiftArgs...)...)
+	cmd := swifttoolchain.SwiftCommandContext(ctx, swiftArgs...)
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -287,7 +220,7 @@ const containerPluginMinVersion = "1.3.0"
 // package plugin in the given project directory. If not, it automatically adds
 // the dependency using `swift package add-dependency`.
 func ensureContainerPlugin(dir string) error {
-	cmd := exec.Command("swiftly", "run", "+"+defaultSwiftVersion, "swift", "package", "plugin", "--list")
+	cmd := swifttoolchain.SwiftCommand("package", "plugin", "--list")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
@@ -299,7 +232,7 @@ func ensureContainerPlugin(dir string) error {
 	}
 
 	fmt.Println("Adding swift-container-plugin dependency...")
-	add := exec.Command("swiftly", "run", "+"+defaultSwiftVersion, "swift", "package", "add-dependency",
+	add := swifttoolchain.SwiftCommand("package", "add-dependency",
 		"https://github.com/apple/swift-container-plugin", "--from", containerPluginMinVersion)
 	add.Dir = dir
 	add.Stdout = os.Stdout
@@ -309,197 +242,6 @@ func ensureContainerPlugin(dir string) error {
 	}
 
 	return nil
-}
-
-// findSwiftSDK looks for an installed Swift SDK for the given architecture.
-// It prefers WendyOS-specific SDKs, installing one automatically if not present.
-// For WASM targets (Wendy Lite), it installs the official Swift WASM SDK.
-func findSwiftSDK(architecture string) (string, error) {
-	// Normalize: swift-container-plugin uses "arm64"/"amd64" but SDKs use "aarch64"/"x86_64".
-	sdkArch := architecture
-	switch sdkArch {
-	case "arm64":
-		sdkArch = "aarch64"
-	case "amd64":
-		sdkArch = "x86_64"
-	}
-
-	isWasm := sdkArch == "wasm" || sdkArch == "wasm32"
-
-	sdk, err := lookupSwiftSDK(sdkArch, isWasm)
-	if err != nil {
-		return "", err
-	}
-	if sdk != "" {
-		return sdk, nil
-	}
-
-	// No suitable SDK found — install the appropriate one.
-	if isWasm {
-		if err := installWasmSwiftSDK(); err != nil {
-			return "", err
-		}
-	} else {
-		if err := installWendySwiftSDK(sdkArch); err != nil {
-			return "", err
-		}
-	}
-
-	// Look up again after install.
-	sdk, err = lookupSwiftSDK(sdkArch, isWasm)
-	if err != nil {
-		return "", err
-	}
-	if sdk == "" {
-		return "", fmt.Errorf("Swift SDK installed but not found; run 'swift sdk list' to verify")
-	}
-	return sdk, nil
-}
-
-// lookupSwiftSDK checks installed Swift SDKs for one matching the target architecture.
-func lookupSwiftSDK(sdkArch string, isWasm bool) (string, error) {
-	out, err := exec.Command("swiftly", "run", "+"+defaultSwiftVersion, "swift", "sdk", "list").Output()
-	if err != nil {
-		return "", fmt.Errorf("running 'swift sdk list': %w (is swiftly installed?)", err)
-	}
-
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-
-	if isWasm {
-		for _, line := range lines {
-			line = strings.TrimSpace(line)
-			if strings.Contains(line, "wasm") {
-				return line, nil
-			}
-		}
-		return "", nil
-	}
-
-	// Prefer a wendyos SDK matching the current Swift version.
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.Contains(line, "wendyos") && strings.Contains(line, sdkArch) && strings.Contains(line, defaultSwiftVersion) {
-			return line, nil
-		}
-	}
-
-	// Fall back to any matching linux SDK for the current Swift version.
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.Contains(line, sdkArch) && strings.Contains(line, "linux") && strings.Contains(line, defaultSwiftVersion) {
-			return line, nil
-		}
-	}
-
-	return "", nil
-}
-
-// installWendySwiftSDK downloads and installs the WendyOS Swift SDK for the given architecture.
-func installWendySwiftSDK(sdkArch string) error {
-	sdkName := fmt.Sprintf("%s-RELEASE_wendyos_%s", defaultSwiftVersion, sdkArch)
-	url := fmt.Sprintf(
-		"https://github.com/wendylabsinc/wendy-swift-tools/releases/download/%s/%s.artifactbundle.zip",
-		wendySDKRelease, sdkName,
-	)
-
-	fmt.Printf("Installing WendyOS Swift SDK (%s)...\n", sdkName)
-
-	checksum, ok := wendySDKChecksums[sdkArch]
-	if !ok {
-		return fmt.Errorf("no checksum available for architecture %s", sdkArch)
-	}
-
-	cmd := exec.Command("swiftly", "run", "+"+defaultSwiftVersion, "swift", "sdk", "install", url, "--checksum", checksum)
-	cmd.Stdout = os.Stdout
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
-
-	if err := cmd.Run(); err != nil {
-		if out := strings.TrimSpace(stderrBuf.String()); out != "" {
-			return fmt.Errorf("installing Swift SDK from %s: %w\n%s", url, err, out)
-		}
-		return fmt.Errorf("installing Swift SDK from %s: %w", url, err)
-	}
-
-	fmt.Println("Swift SDK installed.")
-	return nil
-}
-
-// installWasmSwiftSDK downloads and installs the official Swift WASM SDK for Wendy Lite targets.
-func installWasmSwiftSDK() error {
-	sdkName := fmt.Sprintf("swift-%s-RELEASE", defaultSwiftVersion)
-	url := fmt.Sprintf(
-		"https://download.swift.org/swift-%s-release/wasm-sdk/%s/%s_wasm.artifactbundle.tar.gz",
-		defaultSwiftVersion, sdkName, sdkName,
-	)
-
-	fmt.Printf("Installing Swift WASM SDK (%s)...\n", sdkName)
-
-	cmd := exec.Command("swiftly", "run", "+"+defaultSwiftVersion, "swift", "sdk", "install", url, "--checksum", "394040ecd5260e68bb02f6c20aeede733b9b90702c2204e178f3e42413edad2a")
-	cmd.Stdout = os.Stdout
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
-
-	if err := cmd.Run(); err != nil {
-		if out := strings.TrimSpace(stderrBuf.String()); out != "" {
-			return fmt.Errorf("installing Swift WASM SDK from %s: %w\n%s", url, err, out)
-		}
-		return fmt.Errorf("installing Swift WASM SDK from %s: %w", url, err)
-	}
-
-	fmt.Println("Swift WASM SDK installed.")
-	return nil
-}
-
-// findSwiftProduct determines the product name from Package.swift using
-// `swift package dump-package`. Returns an error with a suggestion when
-// no executable product can be determined.
-func findSwiftProduct(dir string) (string, error) {
-	cmd := exec.Command("swiftly", "run", "+"+defaultSwiftVersion, "swift", "package", "dump-package")
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("swift package dump-package failed: %s: %w", strings.TrimSpace(string(out)), err)
-	}
-
-	var manifest struct {
-		Products []struct {
-			Name string `json:"name"`
-		} `json:"products"`
-		Targets []struct {
-			Name string `json:"name"`
-			Type string `json:"type"`
-		} `json:"targets"`
-	}
-	if err := json.Unmarshal(out, &manifest); err != nil {
-		return "", fmt.Errorf("could not parse Package.swift manifest: %w", err)
-	}
-
-	if len(manifest.Products) == 1 {
-		return manifest.Products[0].Name, nil
-	}
-	if len(manifest.Products) > 1 {
-		var productNames []string
-		for _, p := range manifest.Products {
-			productNames = append(productNames, p.Name)
-		}
-		return "", fmt.Errorf("Package.swift declares multiple products (%s); wendy run requires a single executable product", strings.Join(productNames, ", "))
-	}
-
-	// No products — look for executable targets.
-	var execTargets []string
-	for _, t := range manifest.Targets {
-		if t.Type == "executable" {
-			execTargets = append(execTargets, t.Name)
-		}
-	}
-	if len(execTargets) == 1 {
-		return execTargets[0], nil
-	}
-	if len(execTargets) > 1 {
-		return "", fmt.Errorf("Package.swift has multiple executable targets but no products; add an executable product for the target you want to run")
-	}
-	return "", fmt.Errorf("Package.swift has no executable targets or products")
 }
 
 // ensureBuildxBuilder ensures a buildx builder with the docker-container driver
@@ -1283,13 +1025,13 @@ func findIPv4NeighborLinux(ctx context.Context, ipv6LinkLocal string) string {
 // supports pushing to registries).
 func buildSwiftDockerImage(ctx context.Context, dir, product string) (string, error) {
 	arch := runtime.GOARCH
-	sdk, err := findSwiftSDK(arch)
+	sdk, err := swifttoolchain.FindSwiftSDK(arch)
 	if err != nil {
 		return "", fmt.Errorf("finding Swift SDK: %w", err)
 	}
 
 	cliLogln("Cross-compiling %s for linux/%s...", product, arch)
-	buildCmd := exec.CommandContext(ctx, "swiftly", "run", "+"+defaultSwiftVersion, "swift",
+	buildCmd := swifttoolchain.SwiftCommandContext(ctx,
 		"build", "-c", "release", "--swift-sdk="+sdk, "--product", product)
 	buildCmd.Dir = dir
 	buildCmd.Stdout = os.Stdout
@@ -1299,7 +1041,7 @@ func buildSwiftDockerImage(ctx context.Context, dir, product string) (string, er
 	}
 
 	// Determine the binary output path.
-	showBinCmd := exec.CommandContext(ctx, "swiftly", "run", "+"+defaultSwiftVersion, "swift",
+	showBinCmd := swifttoolchain.SwiftCommandContext(ctx,
 		"build", "-c", "release", "--swift-sdk="+sdk, "--show-bin-path")
 	showBinCmd.Dir = dir
 	out, err := showBinCmd.CombinedOutput()
@@ -1325,7 +1067,7 @@ func buildSwiftDockerImage(ctx context.Context, dir, product string) (string, er
 
 	// Write a minimal Dockerfile using the fixed binary name.
 	dockerfile := fmt.Sprintf("FROM swift:%s-slim\nCOPY app /usr/local/bin/app\nCMD [\"app\"]\n",
-		defaultSwiftVersion)
+		swifttoolchain.DefaultVersion)
 	if err := os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
 		return "", fmt.Errorf("writing Dockerfile: %w", err)
 	}

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -456,108 +455,4 @@ func TestFindIPv4ViaNeighborTable_UnknownAddress(t *testing.T) {
 	// commands and read the host's neighbor tables, making it environment-dependent.
 	// Skip it to avoid flakiness/timeouts in unit test environments.
 	t.Skip("disabled: findIPv4ViaNeighborTable depends on host neighbor tables and OS commands")
-}
-
-func TestEnsureSwiftVersion_AlreadyInstalled(t *testing.T) {
-	original := execCommandContext
-	t.Cleanup(func() { execCommandContext = original })
-
-	var calls [][]string
-	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		calls = append(calls, append([]string{name}, args...))
-		return exec.CommandContext(ctx, "true")
-	}
-
-	if err := ensureSwiftVersion(context.Background()); err != nil {
-		t.Fatalf("ensureSwiftVersion() unexpected error: %v", err)
-	}
-
-	// When "swiftly which" succeeds, no install should happen.
-	if len(calls) != 1 {
-		t.Fatalf("expected 1 call (which), got %d: %v", len(calls), calls)
-	}
-	if calls[0][0] != "swiftly" || calls[0][1] != "which" || calls[0][2] != defaultSwiftVersion {
-		t.Errorf("expected [swiftly which %s], got %v", defaultSwiftVersion, calls[0])
-	}
-}
-
-func TestEnsureSwiftVersion_InstallsWhenMissing(t *testing.T) {
-	original := execCommandContext
-	t.Cleanup(func() { execCommandContext = original })
-
-	var calls [][]string
-	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		call := append([]string{name}, args...)
-		calls = append(calls, call)
-		// "swiftly which" fails (version not installed), "swiftly install" succeeds.
-		if len(args) > 0 && args[0] == "which" {
-			return exec.CommandContext(ctx, "false")
-		}
-		return exec.CommandContext(ctx, "true")
-	}
-
-	if err := ensureSwiftVersion(context.Background()); err != nil {
-		t.Fatalf("ensureSwiftVersion() unexpected error: %v", err)
-	}
-
-	if len(calls) != 2 {
-		t.Fatalf("expected 2 calls (which + install), got %d: %v", len(calls), calls)
-	}
-	if calls[0][1] != "which" {
-		t.Errorf("first call should be which, got %v", calls[0])
-	}
-	if calls[1][1] != "install" || calls[1][2] != defaultSwiftVersion {
-		t.Errorf("expected [swiftly install %s], got %v", defaultSwiftVersion, calls[1])
-	}
-}
-
-func TestEnsureSwiftVersion_SwiftlyNotFound(t *testing.T) {
-	original := execCommandContext
-	t.Cleanup(func() { execCommandContext = original })
-
-	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "nonexistent-binary-that-does-not-exist")
-	}
-
-	err := ensureSwiftVersion(context.Background())
-	if err == nil {
-		t.Fatal("ensureSwiftVersion() expected error when swiftly not found, got nil")
-	}
-	if !strings.Contains(err.Error(), "swiftly is required but not installed") {
-		t.Errorf("expected actionable error message, got: %v", err)
-	}
-}
-
-func TestEnsureSwiftVersion_InstallFails(t *testing.T) {
-	original := execCommandContext
-	t.Cleanup(func() { execCommandContext = original })
-
-	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "false")
-	}
-
-	err := ensureSwiftVersion(context.Background())
-	if err == nil {
-		t.Fatal("ensureSwiftVersion() expected error on install failure, got nil")
-	}
-	if !strings.Contains(err.Error(), "installing Swift") {
-		t.Errorf("expected install error message, got: %v", err)
-	}
-}
-
-func TestEnsureSwiftVersion_Cancellation(t *testing.T) {
-	original := execCommandContext
-	t.Cleanup(func() { execCommandContext = original })
-
-	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "true")
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	err := ensureSwiftVersion(ctx)
-	if err == nil {
-		t.Fatal("ensureSwiftVersion() expected error on cancelled context, got nil")
-	}
 }

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -485,8 +486,11 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		return err
 	}
 
-	product, err := findSwiftProduct(cwd, opts.product, !opts.yes && isInteractiveTerminal())
+	product, err := swifttoolchain.FindSwiftProductWithOptions(cwd, opts.product, !opts.yes && isInteractiveTerminal())
 	if err != nil {
+		if errors.Is(err, swifttoolchain.ErrUserCancelled) {
+			return ErrUserCancelled
+		}
 		return err
 	}
 
@@ -575,14 +579,17 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 		if err := swifttoolchain.EnsureSwiftVersion(ctx, &dimWriter{}, os.Stderr); err != nil {
 			return err
 		}
-		swiftProduct, err := findSwiftProduct(projectPath, opts.product, !opts.yes && isInteractiveTerminal())
+		swiftProduct, err := swifttoolchain.FindSwiftProductWithOptions(projectPath, opts.product, !opts.yes && isInteractiveTerminal())
 		if err != nil {
+			if errors.Is(err, swifttoolchain.ErrUserCancelled) {
+				return ErrUserCancelled
+			}
 			return fmt.Errorf("could not determine Swift product: %w", err)
 		}
 		product = swiftProduct
 	} else if p.CanBuild(projectPath) {
 		// Dockerfile exists — try to use Swift product name if Package.swift is also present.
-		if swiftProduct, err := findSwiftProduct(projectPath, opts.product, false); err == nil {
+		if swiftProduct, err := swifttoolchain.FindSwiftProductWithOptions(projectPath, opts.product, false); err == nil {
 			product = swiftProduct
 		}
 	}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -495,7 +495,7 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	defer proxyCleanup()
 
 	cliLogln("Building Swift container image for %s (%s)...", product, architecture)
-	if err := buildSwiftContainerImage(ctx, cwd, product, registryAddr, architecture, conn.IsMTLS); err != nil {
+	if err := buildSwiftContainerImage(ctx, cwd, product, registryAddr, architecture, conn.IsMTLS, &dimWriter{}, os.Stderr); err != nil {
 		return fmt.Errorf("building Swift container image: %w", err)
 	}
 	cliLogln("Build and push completed.")
@@ -592,7 +592,7 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 	if projectType == "swift" {
 		if ib, ok := p.(providers.ImageBuilder); ok {
 			cliLogln("Building Swift project for %s...", p.DisplayName())
-			imageName, err := buildSwiftDockerImage(ctx, projectPath, product)
+			imageName, err := buildSwiftDockerImage(ctx, projectPath, product, &dimWriter{}, os.Stderr)
 			if err != nil {
 				return fmt.Errorf("building Swift Docker image: %w", err)
 			}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/wendylabsinc/wendy/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/internal/cli/swifttoolchain"
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/internal/shared/models"
@@ -30,6 +31,7 @@ import (
 
 var cliStyle = lipgloss.NewStyle().Foreground(tui.ColorDim)
 var cliNoticeStyle = lipgloss.NewStyle().Foreground(tui.ColorNotice)
+var execCommandContext = exec.CommandContext
 
 // dimWriter writes each line rendered through cliStyle (dim/background).
 // Incomplete lines are buffered until a newline or Flush is called.
@@ -477,11 +479,11 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		architecture = "arm64"
 	}
 
-	if err := ensureSwiftVersion(ctx); err != nil {
+	if err := swifttoolchain.EnsureSwiftVersion(ctx, &dimWriter{}, os.Stderr); err != nil {
 		return err
 	}
 
-	product, err := findSwiftProduct(cwd)
+	product, err := swifttoolchain.FindSwiftProduct(cwd)
 	if err != nil {
 		return err
 	}
@@ -568,17 +570,17 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 
 	// Resolve Swift product name from Package.swift.
 	if projectType == "swift" {
-		if err := ensureSwiftVersion(ctx); err != nil {
+		if err := swifttoolchain.EnsureSwiftVersion(ctx, &dimWriter{}, os.Stderr); err != nil {
 			return err
 		}
-		swiftProduct, err := findSwiftProduct(projectPath)
+		swiftProduct, err := swifttoolchain.FindSwiftProduct(projectPath)
 		if err != nil {
 			return fmt.Errorf("could not determine Swift product: %w", err)
 		}
 		product = swiftProduct
 	} else if p.CanBuild(projectPath) {
 		// Dockerfile exists — try to use Swift product name if Package.swift is also present.
-		if swiftProduct, err := findSwiftProduct(projectPath); err == nil {
+		if swiftProduct, err := swifttoolchain.FindSwiftProduct(projectPath); err == nil {
 			product = swiftProduct
 		}
 	}

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -36,7 +37,7 @@ func (p *MicroWendyProvider) Key() string         { return "wendy-lite" }
 func (p *MicroWendyProvider) DisplayName() string { return "Micro Wendy (WASM)" }
 
 func (p *MicroWendyProvider) IsAvailable(ctx context.Context) bool {
-	cmd := swifttoolchain.ExecCommandContext(ctx, "swiftly", "--version")
+	cmd := exec.CommandContext(ctx, "swiftly", "--version")
 	return cmd.Run() == nil
 }
 

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -91,12 +91,7 @@ func (p *MicroWendyProvider) Build(ctx context.Context, device models.ExternalDe
 		return nil, err
 	}
 
-	sdk, err := swifttoolchain.FindSwiftSDK("wasm32")
-	if err != nil {
-		return nil, fmt.Errorf("finding Swift SDK: %w", err)
-	}
-
-	args := []string{"build", "--swift-sdk=" + sdk, "--triple", swifttoolchain.WasmTargetTriple}
+	args := []string{"build", "--triple", swifttoolchain.WasmTargetTriple}
 	if !debug {
 		args = append(args, "-c", "release")
 	}

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -6,10 +6,10 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
+	"github.com/wendylabsinc/wendy/internal/cli/swifttoolchain"
 	"github.com/wendylabsinc/wendy/internal/shared/discovery"
 	"github.com/wendylabsinc/wendy/internal/shared/models"
 )
@@ -36,7 +36,7 @@ func (p *MicroWendyProvider) Key() string         { return "wendy-lite" }
 func (p *MicroWendyProvider) DisplayName() string { return "Micro Wendy (WASM)" }
 
 func (p *MicroWendyProvider) IsAvailable(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "swiftly", "--version")
+	cmd := swifttoolchain.ExecCommandContext(ctx, "swiftly", "--version")
 	return cmd.Run() == nil
 }
 
@@ -87,14 +87,20 @@ func (p *MicroWendyProvider) CanBuild(projectPath string) bool {
 }
 
 func (p *MicroWendyProvider) Build(ctx context.Context, device models.ExternalDevice, projectPath, product string, debug bool) (*BuiltApp, error) {
-	args := []string{
-		"run", "+6.2.3", "swift", "build",
-		"--triple", "wasm32-unknown-none-wasm",
+	if err := swifttoolchain.EnsureSwiftVersion(ctx, os.Stdout, os.Stderr); err != nil {
+		return nil, err
 	}
+
+	sdk, err := swifttoolchain.FindSwiftSDK("wasm32")
+	if err != nil {
+		return nil, fmt.Errorf("finding Swift SDK: %w", err)
+	}
+
+	args := []string{"build", "--swift-sdk=" + sdk, "--triple", swifttoolchain.WasmTargetTriple}
 	if !debug {
 		args = append(args, "-c", "release")
 	}
-	cmd := exec.CommandContext(ctx, "swiftly", args...)
+	cmd := swifttoolchain.SwiftCommandContext(ctx, args...)
 	cmd.Dir = projectPath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -106,7 +112,7 @@ func (p *MicroWendyProvider) Build(ctx context.Context, device models.ExternalDe
 	if !debug {
 		config = "release"
 	}
-	wasmPath := filepath.Join(projectPath, ".build", "wasm32-unknown-none-wasm", config, product+".wasm")
+	wasmPath := filepath.Join(projectPath, ".build", swifttoolchain.WasmTargetTriple, config, product+".wasm")
 
 	// Collect IPs of all known devices for unicast delivery.
 	var targetIPs []string

--- a/go/internal/cli/swifttoolchain/toolchain.go
+++ b/go/internal/cli/swifttoolchain/toolchain.go
@@ -24,8 +24,8 @@ var wendySDKChecksums = map[string]string{
 	"aarch64": "ef8fa5a2eda766e3b1df791dc175bbf87f570b9cc6f95ada1fe7643a327e087e",
 }
 
-var ExecCommandContext = exec.CommandContext
-var ExecCommand = exec.Command
+var execCommandContext = exec.CommandContext
+var execCommand = exec.Command
 
 func EnsureSwiftVersion(ctx context.Context, stdout, stderr io.Writer) error {
 	if err := ctx.Err(); err != nil {
@@ -38,7 +38,7 @@ func EnsureSwiftVersion(ctx context.Context, stdout, stderr io.Writer) error {
 		stderr = io.Discard
 	}
 
-	checkCmd := ExecCommandContext(ctx, "swiftly", "which", DefaultVersion)
+	checkCmd := execCommandContext(ctx, "swiftly", "which", DefaultVersion)
 	checkCmd.Stdout = io.Discard
 	checkCmd.Stderr = io.Discard
 	if err := checkCmd.Run(); err == nil {
@@ -56,7 +56,7 @@ func EnsureSwiftVersion(ctx context.Context, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	cmd := ExecCommandContext(ctx, "swiftly", "install", DefaultVersion)
+	cmd := execCommandContext(ctx, "swiftly", "install", DefaultVersion)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	err := cmd.Run()
@@ -73,11 +73,11 @@ func EnsureSwiftVersion(ctx context.Context, stdout, stderr io.Writer) error {
 }
 
 func SwiftCommandContext(ctx context.Context, args ...string) *exec.Cmd {
-	return ExecCommandContext(ctx, "swiftly", append([]string{"run", "+" + DefaultVersion, "swift"}, args...)...)
+	return execCommandContext(ctx, "swiftly", append([]string{"run", "+" + DefaultVersion, "swift"}, args...)...)
 }
 
 func SwiftCommand(args ...string) *exec.Cmd {
-	return ExecCommand("swiftly", append([]string{"run", "+" + DefaultVersion, "swift"}, args...)...)
+	return execCommand("swiftly", append([]string{"run", "+" + DefaultVersion, "swift"}, args...)...)
 }
 
 func FindSwiftSDK(architecture string) (string, error) {

--- a/go/internal/cli/swifttoolchain/toolchain.go
+++ b/go/internal/cli/swifttoolchain/toolchain.go
@@ -80,7 +80,11 @@ func SwiftCommand(args ...string) *exec.Cmd {
 	return execCommand("swiftly", append([]string{"run", "+" + DefaultVersion, "swift"}, args...)...)
 }
 
-func FindSwiftSDK(architecture string) (string, error) {
+func FindSwiftSDK(ctx context.Context, architecture string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
 	sdkArch := architecture
 	switch sdkArch {
 	case "arm64":
@@ -91,7 +95,7 @@ func FindSwiftSDK(architecture string) (string, error) {
 
 	isWasm := sdkArch == "wasm" || sdkArch == "wasm32"
 
-	sdk, err := lookupSwiftSDK(sdkArch, isWasm)
+	sdk, err := lookupSwiftSDK(ctx, sdkArch, isWasm)
 	if err != nil {
 		return "", err
 	}
@@ -100,16 +104,16 @@ func FindSwiftSDK(architecture string) (string, error) {
 	}
 
 	if isWasm {
-		if err := installWasmSwiftSDK(); err != nil {
+		if err := installWasmSwiftSDK(ctx); err != nil {
 			return "", err
 		}
 	} else {
-		if err := installWendySwiftSDK(sdkArch); err != nil {
+		if err := installWendySwiftSDK(ctx, sdkArch); err != nil {
 			return "", err
 		}
 	}
 
-	sdk, err = lookupSwiftSDK(sdkArch, isWasm)
+	sdk, err = lookupSwiftSDK(ctx, sdkArch, isWasm)
 	if err != nil {
 		return "", err
 	}
@@ -119,8 +123,12 @@ func FindSwiftSDK(architecture string) (string, error) {
 	return sdk, nil
 }
 
-func lookupSwiftSDK(sdkArch string, isWasm bool) (string, error) {
-	out, err := SwiftCommand("sdk", "list").Output()
+func lookupSwiftSDK(ctx context.Context, sdkArch string, isWasm bool) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	out, err := SwiftCommandContext(ctx, "sdk", "list").Output()
 	if err != nil {
 		return "", fmt.Errorf("running 'swift sdk list': %w (is swiftly installed?)", err)
 	}
@@ -154,7 +162,11 @@ func lookupSwiftSDK(sdkArch string, isWasm bool) (string, error) {
 	return "", nil
 }
 
-func installWendySwiftSDK(sdkArch string) error {
+func installWendySwiftSDK(ctx context.Context, sdkArch string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	sdkName := fmt.Sprintf("%s-RELEASE_wendyos_%s", DefaultVersion, sdkArch)
 	url := fmt.Sprintf(
 		"https://github.com/wendylabsinc/wendy-swift-tools/releases/download/%s/%s.artifactbundle.zip",
@@ -168,7 +180,7 @@ func installWendySwiftSDK(sdkArch string) error {
 		return fmt.Errorf("no checksum available for architecture %s", sdkArch)
 	}
 
-	cmd := SwiftCommand("sdk", "install", url, "--checksum", checksum)
+	cmd := SwiftCommandContext(ctx, "sdk", "install", url, "--checksum", checksum)
 	cmd.Stdout = os.Stdout
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
@@ -184,7 +196,11 @@ func installWendySwiftSDK(sdkArch string) error {
 	return nil
 }
 
-func installWasmSwiftSDK() error {
+func installWasmSwiftSDK(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	sdkName := fmt.Sprintf("swift-%s-RELEASE", DefaultVersion)
 	url := fmt.Sprintf(
 		"https://download.swift.org/swift-%s-release/wasm-sdk/%s/%s_wasm.artifactbundle.tar.gz",
@@ -193,7 +209,7 @@ func installWasmSwiftSDK() error {
 
 	fmt.Printf("Installing Swift WASM SDK (%s)...\n", sdkName)
 
-	cmd := SwiftCommand("sdk", "install", url, "--checksum", wasmSDKChecksum)
+	cmd := SwiftCommandContext(ctx, "sdk", "install", url, "--checksum", wasmSDKChecksum)
 	cmd.Stdout = os.Stdout
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)

--- a/go/internal/cli/swifttoolchain/toolchain.go
+++ b/go/internal/cli/swifttoolchain/toolchain.go
@@ -65,6 +65,7 @@ func EnsureSwiftVersion(ctx context.Context, stdout, stderr io.Writer) error {
 	cmd.Stderr = stderr
 	err := cmd.Run()
 	flushWriter(stdout)
+	flushWriter(stderr)
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return fmt.Errorf("swiftly is required but not installed; see https://swiftlang.github.io/swiftly for installation instructions")

--- a/go/internal/cli/swifttoolchain/toolchain.go
+++ b/go/internal/cli/swifttoolchain/toolchain.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"strings"
 )
@@ -27,15 +26,15 @@ var wendySDKChecksums = map[string]string{
 var execCommandContext = exec.CommandContext
 var execCommand = exec.Command
 
+func flushWriter(writer io.Writer) {
+	if flusher, ok := writer.(interface{ Flush() }); ok {
+		flusher.Flush()
+	}
+}
+
 func EnsureSwiftVersion(ctx context.Context, stdout, stderr io.Writer) error {
 	if err := ctx.Err(); err != nil {
 		return err
-	}
-	if stdout == nil {
-		stdout = io.Discard
-	}
-	if stderr == nil {
-		stderr = io.Discard
 	}
 
 	checkCmd := execCommandContext(ctx, "swiftly", "which", DefaultVersion)
@@ -60,9 +59,7 @@ func EnsureSwiftVersion(ctx context.Context, stdout, stderr io.Writer) error {
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	err := cmd.Run()
-	if flusher, ok := stdout.(interface{ Flush() }); ok {
-		flusher.Flush()
-	}
+	flushWriter(stdout)
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return fmt.Errorf("swiftly is required but not installed; see https://swiftlang.github.io/swiftly for installation instructions")
@@ -80,7 +77,7 @@ func SwiftCommand(args ...string) *exec.Cmd {
 	return execCommand("swiftly", append([]string{"run", "+" + DefaultVersion, "swift"}, args...)...)
 }
 
-func FindSwiftSDK(ctx context.Context, architecture string) (string, error) {
+func FindSwiftSDK(ctx context.Context, architecture string, stdout, stderr io.Writer) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
@@ -104,11 +101,11 @@ func FindSwiftSDK(ctx context.Context, architecture string) (string, error) {
 	}
 
 	if isWasm {
-		if err := installWasmSwiftSDK(ctx); err != nil {
+		if err := installWasmSwiftSDK(ctx, stdout, stderr); err != nil {
 			return "", err
 		}
 	} else {
-		if err := installWendySwiftSDK(ctx, sdkArch); err != nil {
+		if err := installWendySwiftSDK(ctx, sdkArch, stdout, stderr); err != nil {
 			return "", err
 		}
 	}
@@ -162,7 +159,7 @@ func lookupSwiftSDK(ctx context.Context, sdkArch string, isWasm bool) (string, e
 	return "", nil
 }
 
-func installWendySwiftSDK(ctx context.Context, sdkArch string) error {
+func installWendySwiftSDK(ctx context.Context, sdkArch string, stdout, stderr io.Writer) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -173,7 +170,7 @@ func installWendySwiftSDK(ctx context.Context, sdkArch string) error {
 		WendySDKRelease, sdkName,
 	)
 
-	fmt.Printf("Installing WendyOS Swift SDK (%s)...\n", sdkName)
+	fmt.Fprintf(stdout, "Installing WendyOS Swift SDK (%s)...\n", sdkName)
 
 	checksum, ok := wendySDKChecksums[sdkArch]
 	if !ok {
@@ -181,22 +178,26 @@ func installWendySwiftSDK(ctx context.Context, sdkArch string) error {
 	}
 
 	cmd := SwiftCommandContext(ctx, "sdk", "install", url, "--checksum", checksum)
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = stdout
 	var stderrBuf bytes.Buffer
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	cmd.Stderr = io.MultiWriter(stderr, &stderrBuf)
 
-	if err := cmd.Run(); err != nil {
+	err := cmd.Run()
+	flushWriter(stdout)
+	flushWriter(stderr)
+	if err != nil {
 		if out := strings.TrimSpace(stderrBuf.String()); out != "" {
 			return fmt.Errorf("installing Swift SDK from %s: %w\n%s", url, err, out)
 		}
 		return fmt.Errorf("installing Swift SDK from %s: %w", url, err)
 	}
 
-	fmt.Println("Swift SDK installed.")
+	fmt.Fprintln(stdout, "Swift SDK installed.")
+	flushWriter(stdout)
 	return nil
 }
 
-func installWasmSwiftSDK(ctx context.Context) error {
+func installWasmSwiftSDK(ctx context.Context, stdout, stderr io.Writer) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -207,21 +208,25 @@ func installWasmSwiftSDK(ctx context.Context) error {
 		DefaultVersion, sdkName, sdkName,
 	)
 
-	fmt.Printf("Installing Swift WASM SDK (%s)...\n", sdkName)
+	fmt.Fprintf(stdout, "Installing Swift WASM SDK (%s)...\n", sdkName)
 
 	cmd := SwiftCommandContext(ctx, "sdk", "install", url, "--checksum", wasmSDKChecksum)
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = stdout
 	var stderrBuf bytes.Buffer
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	cmd.Stderr = io.MultiWriter(stderr, &stderrBuf)
 
-	if err := cmd.Run(); err != nil {
+	err := cmd.Run()
+	flushWriter(stdout)
+	flushWriter(stderr)
+	if err != nil {
 		if out := strings.TrimSpace(stderrBuf.String()); out != "" {
 			return fmt.Errorf("installing Swift WASM SDK from %s: %w\n%s", url, err, out)
 		}
 		return fmt.Errorf("installing Swift WASM SDK from %s: %w", url, err)
 	}
 
-	fmt.Println("Swift SDK installed.")
+	fmt.Fprintln(stdout, "Swift SDK installed.")
+	flushWriter(stdout)
 	return nil
 }
 

--- a/go/internal/cli/swifttoolchain/toolchain.go
+++ b/go/internal/cli/swifttoolchain/toolchain.go
@@ -1,0 +1,257 @@
+package swifttoolchain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	DefaultVersion   = "6.2.3"
+	WendySDKRelease  = "0.4.0"
+	WasmTargetTriple = "wasm32-unknown-none-wasm"
+	wasmSDKChecksum  = "394040ecd5260e68bb02f6c20aeede733b9b90702c2204e178f3e42413edad2a"
+)
+
+var wendySDKChecksums = map[string]string{
+	"x86_64":  "b5a4d08ad4d4841043727f6671c6aa004da3a2b7f12dc28101d6770c1dc57eb1",
+	"aarch64": "ef8fa5a2eda766e3b1df791dc175bbf87f570b9cc6f95ada1fe7643a327e087e",
+}
+
+var ExecCommandContext = exec.CommandContext
+var ExecCommand = exec.Command
+
+func EnsureSwiftVersion(ctx context.Context, stdout, stderr io.Writer) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+
+	checkCmd := ExecCommandContext(ctx, "swiftly", "which", DefaultVersion)
+	checkCmd.Stdout = io.Discard
+	checkCmd.Stderr = io.Discard
+	if err := checkCmd.Run(); err == nil {
+		return nil
+	} else {
+		if errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf("swiftly is required but not installed; see https://swiftlang.github.io/swiftly for installation instructions")
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	cmd := ExecCommandContext(ctx, "swiftly", "install", DefaultVersion)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	if flusher, ok := stdout.(interface{ Flush() }); ok {
+		flusher.Flush()
+	}
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf("swiftly is required but not installed; see https://swiftlang.github.io/swiftly for installation instructions")
+		}
+		return fmt.Errorf("installing Swift %s via swiftly: %w", DefaultVersion, err)
+	}
+	return nil
+}
+
+func SwiftCommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	return ExecCommandContext(ctx, "swiftly", append([]string{"run", "+" + DefaultVersion, "swift"}, args...)...)
+}
+
+func SwiftCommand(args ...string) *exec.Cmd {
+	return ExecCommand("swiftly", append([]string{"run", "+" + DefaultVersion, "swift"}, args...)...)
+}
+
+func FindSwiftSDK(architecture string) (string, error) {
+	sdkArch := architecture
+	switch sdkArch {
+	case "arm64":
+		sdkArch = "aarch64"
+	case "amd64":
+		sdkArch = "x86_64"
+	}
+
+	isWasm := sdkArch == "wasm" || sdkArch == "wasm32"
+
+	sdk, err := lookupSwiftSDK(sdkArch, isWasm)
+	if err != nil {
+		return "", err
+	}
+	if sdk != "" {
+		return sdk, nil
+	}
+
+	if isWasm {
+		if err := installWasmSwiftSDK(); err != nil {
+			return "", err
+		}
+	} else {
+		if err := installWendySwiftSDK(sdkArch); err != nil {
+			return "", err
+		}
+	}
+
+	sdk, err = lookupSwiftSDK(sdkArch, isWasm)
+	if err != nil {
+		return "", err
+	}
+	if sdk == "" {
+		return "", fmt.Errorf("Swift SDK installed but not found; run 'swift sdk list' to verify")
+	}
+	return sdk, nil
+}
+
+func lookupSwiftSDK(sdkArch string, isWasm bool) (string, error) {
+	out, err := SwiftCommand("sdk", "list").Output()
+	if err != nil {
+		return "", fmt.Errorf("running 'swift sdk list': %w (is swiftly installed?)", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+
+	if isWasm {
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.Contains(line, "wasm") {
+				return line, nil
+			}
+		}
+		return "", nil
+	}
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "wendyos") && strings.Contains(line, sdkArch) && strings.Contains(line, DefaultVersion) {
+			return line, nil
+		}
+	}
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, sdkArch) && strings.Contains(line, "linux") && strings.Contains(line, DefaultVersion) {
+			return line, nil
+		}
+	}
+
+	return "", nil
+}
+
+func installWendySwiftSDK(sdkArch string) error {
+	sdkName := fmt.Sprintf("%s-RELEASE_wendyos_%s", DefaultVersion, sdkArch)
+	url := fmt.Sprintf(
+		"https://github.com/wendylabsinc/wendy-swift-tools/releases/download/%s/%s.artifactbundle.zip",
+		WendySDKRelease, sdkName,
+	)
+
+	fmt.Printf("Installing WendyOS Swift SDK (%s)...\n", sdkName)
+
+	checksum, ok := wendySDKChecksums[sdkArch]
+	if !ok {
+		return fmt.Errorf("no checksum available for architecture %s", sdkArch)
+	}
+
+	cmd := SwiftCommand("sdk", "install", url, "--checksum", checksum)
+	cmd.Stdout = os.Stdout
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+
+	if err := cmd.Run(); err != nil {
+		if out := strings.TrimSpace(stderrBuf.String()); out != "" {
+			return fmt.Errorf("installing Swift SDK from %s: %w\n%s", url, err, out)
+		}
+		return fmt.Errorf("installing Swift SDK from %s: %w", url, err)
+	}
+
+	fmt.Println("Swift SDK installed.")
+	return nil
+}
+
+func installWasmSwiftSDK() error {
+	sdkName := fmt.Sprintf("swift-%s-RELEASE", DefaultVersion)
+	url := fmt.Sprintf(
+		"https://download.swift.org/swift-%s-release/wasm-sdk/%s/%s_wasm.artifactbundle.tar.gz",
+		DefaultVersion, sdkName, sdkName,
+	)
+
+	fmt.Printf("Installing Swift WASM SDK (%s)...\n", sdkName)
+
+	cmd := SwiftCommand("sdk", "install", url, "--checksum", wasmSDKChecksum)
+	cmd.Stdout = os.Stdout
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+
+	if err := cmd.Run(); err != nil {
+		if out := strings.TrimSpace(stderrBuf.String()); out != "" {
+			return fmt.Errorf("installing Swift WASM SDK from %s: %w\n%s", url, err, out)
+		}
+		return fmt.Errorf("installing Swift WASM SDK from %s: %w", url, err)
+	}
+
+	fmt.Println("Swift SDK installed.")
+	return nil
+}
+
+func FindSwiftProduct(dir string) (string, error) {
+	cmd := SwiftCommand("package", "dump-package")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("swift package dump-package failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	var manifest struct {
+		Products []struct {
+			Name string `json:"name"`
+		} `json:"products"`
+		Targets []struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		} `json:"targets"`
+	}
+	if err := json.Unmarshal(out, &manifest); err != nil {
+		return "", fmt.Errorf("could not parse Package.swift manifest: %w", err)
+	}
+
+	if len(manifest.Products) == 1 {
+		return manifest.Products[0].Name, nil
+	}
+	if len(manifest.Products) > 1 {
+		var productNames []string
+		for _, product := range manifest.Products {
+			productNames = append(productNames, product.Name)
+		}
+		return "", fmt.Errorf("Package.swift declares multiple products (%s); wendy run requires a single executable product", strings.Join(productNames, ", "))
+	}
+
+	var execTargets []string
+	for _, target := range manifest.Targets {
+		if target.Type == "executable" {
+			execTargets = append(execTargets, target.Name)
+		}
+	}
+	if len(execTargets) == 1 {
+		return execTargets[0], nil
+	}
+	if len(execTargets) > 1 {
+		return "", fmt.Errorf("Package.swift has multiple executable targets but no products; add an executable product for the target you want to run")
+	}
+	return "", fmt.Errorf("Package.swift has no executable targets or products")
+}

--- a/go/internal/cli/swifttoolchain/toolchain_test.go
+++ b/go/internal/cli/swifttoolchain/toolchain_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestEnsureSwiftVersion_AlreadyInstalled(t *testing.T) {
-	original := ExecCommandContext
-	t.Cleanup(func() { ExecCommandContext = original })
+	original := execCommandContext
+	t.Cleanup(func() { execCommandContext = original })
 
 	var calls [][]string
-	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		calls = append(calls, append([]string{name}, args...))
 		return exec.CommandContext(ctx, "true")
 	}
@@ -31,11 +31,11 @@ func TestEnsureSwiftVersion_AlreadyInstalled(t *testing.T) {
 }
 
 func TestEnsureSwiftVersion_InstallsWhenMissing(t *testing.T) {
-	original := ExecCommandContext
-	t.Cleanup(func() { ExecCommandContext = original })
+	original := execCommandContext
+	t.Cleanup(func() { execCommandContext = original })
 
 	var calls [][]string
-	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		call := append([]string{name}, args...)
 		calls = append(calls, call)
 		if len(args) > 0 && args[0] == "which" {
@@ -60,10 +60,10 @@ func TestEnsureSwiftVersion_InstallsWhenMissing(t *testing.T) {
 }
 
 func TestEnsureSwiftVersion_SwiftlyNotFound(t *testing.T) {
-	original := ExecCommandContext
-	t.Cleanup(func() { ExecCommandContext = original })
+	original := execCommandContext
+	t.Cleanup(func() { execCommandContext = original })
 
-	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "nonexistent-binary-that-does-not-exist")
 	}
 
@@ -77,10 +77,10 @@ func TestEnsureSwiftVersion_SwiftlyNotFound(t *testing.T) {
 }
 
 func TestEnsureSwiftVersion_InstallFails(t *testing.T) {
-	original := ExecCommandContext
-	t.Cleanup(func() { ExecCommandContext = original })
+	original := execCommandContext
+	t.Cleanup(func() { execCommandContext = original })
 
-	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "false")
 	}
 
@@ -94,10 +94,10 @@ func TestEnsureSwiftVersion_InstallFails(t *testing.T) {
 }
 
 func TestEnsureSwiftVersion_Cancellation(t *testing.T) {
-	original := ExecCommandContext
-	t.Cleanup(func() { ExecCommandContext = original })
+	original := execCommandContext
+	t.Cleanup(func() { execCommandContext = original })
 
-	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.CommandContext(ctx, "true")
 	}
 

--- a/go/internal/cli/swifttoolchain/toolchain_test.go
+++ b/go/internal/cli/swifttoolchain/toolchain_test.go
@@ -1,0 +1,111 @@
+package swifttoolchain
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestEnsureSwiftVersion_AlreadyInstalled(t *testing.T) {
+	original := ExecCommandContext
+	t.Cleanup(func() { ExecCommandContext = original })
+
+	var calls [][]string
+	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		calls = append(calls, append([]string{name}, args...))
+		return exec.CommandContext(ctx, "true")
+	}
+
+	if err := EnsureSwiftVersion(context.Background(), io.Discard, io.Discard); err != nil {
+		t.Fatalf("EnsureSwiftVersion() unexpected error: %v", err)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call (which), got %d: %v", len(calls), calls)
+	}
+	if calls[0][0] != "swiftly" || calls[0][1] != "which" || calls[0][2] != DefaultVersion {
+		t.Errorf("expected [swiftly which %s], got %v", DefaultVersion, calls[0])
+	}
+}
+
+func TestEnsureSwiftVersion_InstallsWhenMissing(t *testing.T) {
+	original := ExecCommandContext
+	t.Cleanup(func() { ExecCommandContext = original })
+
+	var calls [][]string
+	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		call := append([]string{name}, args...)
+		calls = append(calls, call)
+		if len(args) > 0 && args[0] == "which" {
+			return exec.CommandContext(ctx, "false")
+		}
+		return exec.CommandContext(ctx, "true")
+	}
+
+	if err := EnsureSwiftVersion(context.Background(), io.Discard, io.Discard); err != nil {
+		t.Fatalf("EnsureSwiftVersion() unexpected error: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (which + install), got %d: %v", len(calls), calls)
+	}
+	if calls[0][1] != "which" {
+		t.Errorf("first call should be which, got %v", calls[0])
+	}
+	if calls[1][1] != "install" || calls[1][2] != DefaultVersion {
+		t.Errorf("expected [swiftly install %s], got %v", DefaultVersion, calls[1])
+	}
+}
+
+func TestEnsureSwiftVersion_SwiftlyNotFound(t *testing.T) {
+	original := ExecCommandContext
+	t.Cleanup(func() { ExecCommandContext = original })
+
+	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "nonexistent-binary-that-does-not-exist")
+	}
+
+	err := EnsureSwiftVersion(context.Background(), io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("EnsureSwiftVersion() expected error when swiftly not found, got nil")
+	}
+	if !strings.Contains(err.Error(), "swiftly is required but not installed") {
+		t.Errorf("expected actionable error message, got: %v", err)
+	}
+}
+
+func TestEnsureSwiftVersion_InstallFails(t *testing.T) {
+	original := ExecCommandContext
+	t.Cleanup(func() { ExecCommandContext = original })
+
+	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "false")
+	}
+
+	err := EnsureSwiftVersion(context.Background(), io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("EnsureSwiftVersion() expected error on install failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "installing Swift") {
+		t.Errorf("expected install error message, got: %v", err)
+	}
+}
+
+func TestEnsureSwiftVersion_Cancellation(t *testing.T) {
+	original := ExecCommandContext
+	t.Cleanup(func() { ExecCommandContext = original })
+
+	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "true")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := EnsureSwiftVersion(ctx, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("EnsureSwiftVersion() expected error on cancelled context, got nil")
+	}
+}

--- a/go/internal/cli/swifttoolchain/toolchain_test.go
+++ b/go/internal/cli/swifttoolchain/toolchain_test.go
@@ -2,6 +2,7 @@ package swifttoolchain
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os/exec"
 	"strings"
@@ -107,5 +108,32 @@ func TestEnsureSwiftVersion_Cancellation(t *testing.T) {
 	err := EnsureSwiftVersion(ctx, io.Discard, io.Discard)
 	if err == nil {
 		t.Fatal("EnsureSwiftVersion() expected error on cancelled context, got nil")
+	}
+}
+
+func TestFindSwiftSDK_AlreadyInstalled(t *testing.T) {
+	original := execCommandContext
+	t.Cleanup(func() { execCommandContext = original })
+
+	installedSDK := fmt.Sprintf("%s-RELEASE_wendyos_aarch64", DefaultVersion)
+	var calls [][]string
+
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		calls = append(calls, append([]string{name}, args...))
+		return exec.CommandContext(ctx, "echo", installedSDK)
+	}
+
+	got, err := FindSwiftSDK(context.Background(), "arm64", io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("FindSwiftSDK() unexpected error: %v", err)
+	}
+	if got != installedSDK {
+		t.Fatalf("expected SDK %q, got %q", installedSDK, got)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 command (sdk list), got %d: %v", len(calls), calls)
+	}
+	if calls[0][0] != "swiftly" || calls[0][1] != "run" || calls[0][2] != "+"+DefaultVersion || calls[0][3] != "swift" || calls[0][4] != "sdk" || calls[0][5] != "list" {
+		t.Fatalf("unexpected command: %v", calls[0])
 	}
 }


### PR DESCRIPTION
Preparatory refactoring to simplify toolchain upgrades

* Move swift toolchain management out of `docker.go` and into a separate `swifttoolchain` module
* Use it consistently from both `docker.go` and `microwendy.go` - an immediate benefit is that automatic installation now works on the wendy-lite path
* (suggested by copilot) Propagate ctx through the toolchain installation commands