### PR TITLE
Allow wendy os install to install older WendyOS versions

### DIFF
--- a/go/internal/cli/commands/os_download.go
+++ b/go/internal/cli/commands/os_download.go
@@ -5,11 +5,9 @@ package commands
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
-	"github.com/wendylabsinc/wendy/internal/shared/version"
 )
 
 func newOSDownloadCmd() *cobra.Command {
@@ -40,7 +38,7 @@ func runOSDownload(flagVersion string, overwrite bool) error {
 	// Resolve version — use flag, or pick interactively from available versions.
 	version := flagVersion
 	if version == "" {
-		version, err = pickVersion(dev)
+		version, err = pickManifestVersion("Select a version", dev.Manifest)
 		if err != nil {
 			return err
 		}
@@ -87,39 +85,4 @@ func runOSDownload(flagVersion string, overwrite bool) error {
 
 	fmt.Printf("\nCached at: %s\n", path)
 	return nil
-}
-
-// pickVersion presents an interactive picker for available versions of a device.
-func pickVersion(dev deviceInfo) (string, error) {
-	if dev.Manifest == nil || len(dev.Manifest.Versions) == 0 {
-		return "", fmt.Errorf("no versions available for %s", dev.Name)
-	}
-
-	// Collect and sort versions newest-first using semantic comparison.
-	var versions []string
-	for v := range dev.Manifest.Versions {
-		versions = append(versions, v)
-	}
-	sort.Slice(versions, func(i, j int) bool {
-		return version.CompareVersions(versions[i], versions[j]) > 0
-	})
-
-	var items []tui.PickerItem
-	for _, v := range versions {
-		ver := dev.Manifest.Versions[v]
-		desc := ""
-		if ver.IsLatest {
-			desc = "latest"
-		} else if ver.IsNightly {
-			desc = "nightly"
-		}
-		items = append(items, tui.PickerItem{
-			Name:        v,
-			Description: desc,
-			Value:       v,
-		})
-	}
-
-	fmt.Println()
-	return pickFromItems("Select a version", items)
 }

--- a/go/internal/cli/commands/os_download.go
+++ b/go/internal/cli/commands/os_download.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/internal/shared/version"
 )
 
 func newOSDownloadCmd() *cobra.Command {
@@ -94,12 +95,14 @@ func pickVersion(dev deviceInfo) (string, error) {
 		return "", fmt.Errorf("no versions available for %s", dev.Name)
 	}
 
-	// Collect and sort versions (newest first by string sort, reversed).
+	// Collect and sort versions newest-first using semantic comparison.
 	var versions []string
 	for v := range dev.Manifest.Versions {
 		versions = append(versions, v)
 	}
-	sort.Sort(sort.Reverse(sort.StringSlice(versions)))
+	sort.Slice(versions, func(i, j int) bool {
+		return version.CompareVersions(versions[i], versions[j]) > 0
+	})
 
 	var items []tui.PickerItem
 	for _, v := range versions {

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -42,7 +42,16 @@ When called with manifest-backed flags, installs a specific version:
   wendy os install --device-type raspberry-pi-5 --version 0.10.4 --drive /dev/disk4 --force
 
 Flags can be provided progressively — omitted values trigger interactive pickers.`,
-		Args: cobra.MaximumNArgs(2),
+		Args: func(cmd *cobra.Command, args []string) error {
+			switch len(args) {
+			case 0, 2:
+				return nil
+			case 1:
+				return fmt.Errorf("positional arguments must be provided as [image] [drive]; got 1 argument")
+			default:
+				return cobra.MaximumNArgs(2)(cmd, args)
+			}
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Positional direct-install mode is incompatible with manifest-backed flags.
 			if len(args) > 0 && (deviceType != "" || versionFlag != "" || driveFlag != "") {
@@ -231,6 +240,10 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	// Resolve device — use flag or interactive picker.
 	var selected string
 	if flagDeviceType != "" {
+		// --device-type is only supported for Linux devices, not ESP32/Wendy Lite.
+		if flagDeviceType == "esp32-c6" || flagDeviceType == "esp32-c5" {
+			return fmt.Errorf("--device-type does not support ESP32 targets; use the interactive picker for Wendy Lite devices")
+		}
 		if _, ok := deviceMap[flagDeviceType]; !ok {
 			var available []string
 			for k, d := range deviceMap {
@@ -238,6 +251,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 					available = append(available, k)
 				}
 			}
+			sort.Strings(available)
 			return fmt.Errorf("device type %q not found in manifest; available: %s", flagDeviceType, strings.Join(available, ", "))
 		}
 		selected = flagDeviceType
@@ -258,13 +272,13 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	if device.IsESP32 {
 		return installESP32Firmware(ctx, nightly, device.ESP32Chip)
 	}
-	return installLinuxImage(ctx, selected, device, flagVersion, flagDrive, force)
+	return installLinuxImage(ctx, selected, device, nightly, flagVersion, flagDrive, force)
 }
 
 // installLinuxImage handles the Linux device path: pick version → pick drive → download → write.
-// flagVersion, flagDrive, and force allow skipping the corresponding interactive prompts.
-func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, flagVersion, flagDrive string, force bool) error {
-	// Step 1: Resolve version — use flag, or pick interactively from manifest.
+// nightly, flagVersion, flagDrive, and force allow skipping the corresponding interactive prompts.
+func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, nightly bool, flagVersion, flagDrive string, force bool) error {
+	// Step 1: Resolve version — use flag, nightly shortcut, or pick interactively.
 	selectedVersion := device.RawVersion // default from device picker (latest or nightly)
 	if flagVersion != "" {
 		// Validate the requested version exists in the manifest.
@@ -272,14 +286,12 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 			return fmt.Errorf("version %q not found for %s", flagVersion, device.Name)
 		}
 		selectedVersion = flagVersion
+	} else if nightly {
+		// --nightly: use the nightly version directly, skip the version picker.
+		selectedVersion = device.RawVersion
 	} else {
 		// Show version picker.
-		devInfo := deviceInfo{
-			Key:      deviceKey,
-			Name:     device.Name,
-			Manifest: device.Manifest,
-		}
-		picked, err := pickInstallVersion(devInfo)
+		picked, err := pickManifestVersion("Select a version", device.Manifest)
 		if err != nil {
 			return err
 		}
@@ -407,16 +419,17 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	return nil
 }
 
-// pickInstallVersion presents an interactive picker for available versions of a
-// device, sorted newest-first using semantic version comparison. It marks
-// "latest" and "nightly" versions in the picker description.
-func pickInstallVersion(dev deviceInfo) (string, error) {
-	if dev.Manifest == nil || len(dev.Manifest.Versions) == 0 {
-		return "", fmt.Errorf("no versions available for %s", dev.Name)
+// pickManifestVersion presents an interactive picker for available versions in a
+// device manifest, sorted newest-first using semantic version comparison. It
+// marks "latest" and "nightly" versions in the picker description.
+// This is shared by both os install and os download flows.
+func pickManifestVersion(title string, manifest *deviceManifest) (string, error) {
+	if manifest == nil || len(manifest.Versions) == 0 {
+		return "", fmt.Errorf("no versions available")
 	}
 
 	var versionKeys []string
-	for v := range dev.Manifest.Versions {
+	for v := range manifest.Versions {
 		versionKeys = append(versionKeys, v)
 	}
 	sort.Slice(versionKeys, func(i, j int) bool {
@@ -425,7 +438,7 @@ func pickInstallVersion(dev deviceInfo) (string, error) {
 
 	var items []tui.PickerItem
 	for _, v := range versionKeys {
-		ver := dev.Manifest.Versions[v]
+		ver := manifest.Versions[v]
 		desc := ""
 		if ver.IsLatest {
 			desc = "latest"
@@ -440,7 +453,7 @@ func pickInstallVersion(dev deviceInfo) (string, error) {
 	}
 
 	fmt.Println()
-	return pickFromItems("Select a version", items)
+	return pickFromItems(title, items)
 }
 
 // downloadImage downloads an OS image to a temp file with a progress bar.

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -19,11 +20,15 @@ import (
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/internal/shared/config"
 	"github.com/wendylabsinc/wendy/internal/shared/discovery"
+	"github.com/wendylabsinc/wendy/internal/shared/version"
 )
 
 func newOSInstallCmd() *cobra.Command {
 	var nightly bool
 	var force bool
+	var deviceType string
+	var versionFlag string
+	var driveFlag string
 
 	cmd := &cobra.Command{
 		Use:   "install [image] [drive]",
@@ -31,18 +36,37 @@ func newOSInstallCmd() *cobra.Command {
 		Long: `Interactively select a supported device, download the latest OS image or firmware, and write it to the target.
 
 When called with positional arguments, skips interactive prompts:
-  wendy os install <image-path> <drive-id> --force`,
+  wendy os install <image-path> <drive-id> --force
+
+When called with manifest-backed flags, installs a specific version:
+  wendy os install --device-type raspberry-pi-5 --version 0.10.4 --drive /dev/disk4 --force
+
+Flags can be provided progressively — omitted values trigger interactive pickers.`,
 		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Positional direct-install mode is incompatible with manifest-backed flags.
+			if len(args) > 0 && (deviceType != "" || versionFlag != "" || driveFlag != "") {
+				return fmt.Errorf("positional [image] [drive] arguments cannot be combined with --device-type, --version, or --drive")
+			}
+
+			// --nightly and --version are mutually exclusive.
+			if nightly && versionFlag != "" {
+				return fmt.Errorf("--nightly and --version are mutually exclusive")
+			}
+
 			if len(args) == 2 {
 				return runOSInstallDirect(args[0], args[1], force)
 			}
-			return runOSInstall(cmd.Context(), nightly)
+
+			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force)
 		},
 	}
 
 	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use nightly/prerelease builds")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
+	cmd.Flags().StringVar(&deviceType, "device-type", "", "Device type from manifest (e.g. raspberry-pi-5)")
+	cmd.Flags().StringVar(&versionFlag, "version", "", "WendyOS version to install (interactive if omitted)")
+	cmd.Flags().StringVar(&driveFlag, "drive", "", "Target drive path (e.g. /dev/disk4)")
 
 	return cmd
 }
@@ -140,7 +164,7 @@ func pickLinuxDevice() (string, deviceInfo, error) {
 	return key, deviceMap[key], nil
 }
 
-func runOSInstall(ctx context.Context, nightly bool) error {
+func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool) error {
 	fmt.Println("Fetching available devices...")
 
 	// Fetch Linux devices from GCS manifest.
@@ -180,36 +204,53 @@ func runOSInstall(ctx context.Context, nightly bool) error {
 		})
 	}
 
-	// Add ESP32 entries.
-	espVersion := "(latest)"
-	for _, esp := range []struct {
-		key, name, chip string
-	}{
-		{"esp32-c6", "ESP32-C6", "esp32c6"},
-		{"esp32-c5", "ESP32-C5", "esp32c5"},
-	} {
-		deviceMap[esp.key] = pickerDevice{
-			Name:      esp.name,
-			Version:   espVersion,
-			Category:  "Wendy Lite",
-			IsESP32:   true,
-			ESP32Chip: esp.chip,
+	// When --device-type is not provided, also offer ESP32 entries in the picker.
+	if flagDeviceType == "" {
+		espVersion := "(latest)"
+		for _, esp := range []struct {
+			key, name, chip string
+		}{
+			{"esp32-c6", "ESP32-C6", "esp32c6"},
+			{"esp32-c5", "ESP32-C5", "esp32c5"},
+		} {
+			deviceMap[esp.key] = pickerDevice{
+				Name:      esp.name,
+				Version:   espVersion,
+				Category:  "Wendy Lite",
+				IsESP32:   true,
+				ESP32Chip: esp.chip,
+			}
+			items = append(items, tui.PickerItem{
+				Name:        esp.name,
+				Description: fmt.Sprintf("%s    %s", espVersion, "Wendy Lite"),
+				Value:       esp.key,
+			})
 		}
-		items = append(items, tui.PickerItem{
-			Name:        esp.name,
-			Description: fmt.Sprintf("%s    %s", espVersion, "Wendy Lite"),
-			Value:       esp.key,
-		})
 	}
 
-	if len(items) == 0 {
-		return fmt.Errorf("no devices available")
-	}
+	// Resolve device — use flag or interactive picker.
+	var selected string
+	if flagDeviceType != "" {
+		if _, ok := deviceMap[flagDeviceType]; !ok {
+			var available []string
+			for k, d := range deviceMap {
+				if !d.IsESP32 {
+					available = append(available, k)
+				}
+			}
+			return fmt.Errorf("device type %q not found in manifest; available: %s", flagDeviceType, strings.Join(available, ", "))
+		}
+		selected = flagDeviceType
+	} else {
+		if len(items) == 0 {
+			return fmt.Errorf("no devices available")
+		}
 
-	fmt.Println()
-	selected, err := pickFromItems("Select a device", items)
-	if err != nil {
-		return err
+		fmt.Println()
+		selected, err = pickFromItems("Select a device", items)
+		if err != nil {
+			return err
+		}
 	}
 
 	device := deviceMap[selected]
@@ -217,57 +258,100 @@ func runOSInstall(ctx context.Context, nightly bool) error {
 	if device.IsESP32 {
 		return installESP32Firmware(ctx, nightly, device.ESP32Chip)
 	}
-	return installLinuxImage(ctx, selected, device)
+	return installLinuxImage(ctx, selected, device, flagVersion, flagDrive, force)
 }
 
-// installLinuxImage handles the Linux device path: pick drive → download → write.
-func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice) error {
-	// List external drives.
-	drives, err := listExternalDrives()
-	if err != nil {
-		return fmt.Errorf("listing drives: %w", err)
-	}
-	if len(drives) == 0 {
-		return fmt.Errorf("no external drives found — insert an SD card or USB drive and try again")
-	}
-
-	// Drive picker.
-	var driveItems []tui.PickerItem
-	driveMap := make(map[string]drive)
-	for _, d := range drives {
-		desc := d.DevicePath
-		if d.Size != "" {
-			desc += "  " + d.Size
+// installLinuxImage handles the Linux device path: pick version → pick drive → download → write.
+// flagVersion, flagDrive, and force allow skipping the corresponding interactive prompts.
+func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, flagVersion, flagDrive string, force bool) error {
+	// Step 1: Resolve version — use flag, or pick interactively from manifest.
+	selectedVersion := device.RawVersion // default from device picker (latest or nightly)
+	if flagVersion != "" {
+		// Validate the requested version exists in the manifest.
+		if _, err := getImageInfo(device.Manifest, flagVersion); err != nil {
+			return fmt.Errorf("version %q not found for %s", flagVersion, device.Name)
 		}
-		driveItems = append(driveItems, tui.PickerItem{
-			Name:        d.Name,
-			Description: desc,
-			Value:       d.DevicePath,
-		})
-		driveMap[d.DevicePath] = d
+		selectedVersion = flagVersion
+	} else {
+		// Show version picker.
+		devInfo := deviceInfo{
+			Key:      deviceKey,
+			Name:     device.Name,
+			Manifest: device.Manifest,
+		}
+		picked, err := pickInstallVersion(devInfo)
+		if err != nil {
+			return err
+		}
+		selectedVersion = picked
 	}
 
-	fmt.Println()
-	sel, err := pickFromItems("Select target drive", driveItems)
-	if err != nil {
-		return err
-	}
-	targetDrive := driveMap[sel]
+	// Step 2: Resolve target drive — use flag or interactive picker.
+	var targetDrive drive
+	if flagDrive != "" {
+		drives, err := listAllDrives()
+		if err != nil {
+			return fmt.Errorf("listing drives: %w", err)
+		}
+		var found bool
+		for _, d := range drives {
+			if d.DevicePath == flagDrive {
+				targetDrive = d
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("drive %s not found", flagDrive)
+		}
+	} else {
+		drives, err := listExternalDrives()
+		if err != nil {
+			return fmt.Errorf("listing drives: %w", err)
+		}
+		if len(drives) == 0 {
+			return fmt.Errorf("no external drives found — insert an SD card or USB drive and try again")
+		}
 
-	// Confirm destructive write.
-	fmt.Println()
-	confirmed, err := tui.Confirm(fmt.Sprintf("Writing will ERASE ALL DATA on %s (%s). Continue?", targetDrive.Name, targetDrive.DevicePath))
-	if err != nil {
-		return err
-	}
-	if !confirmed {
-		fmt.Println("Cancelled.")
-		return nil
+		var driveItems []tui.PickerItem
+		driveMap := make(map[string]drive)
+		for _, d := range drives {
+			desc := d.DevicePath
+			if d.Size != "" {
+				desc += "  " + d.Size
+			}
+			driveItems = append(driveItems, tui.PickerItem{
+				Name:        d.Name,
+				Description: desc,
+				Value:       d.DevicePath,
+			})
+			driveMap[d.DevicePath] = d
+		}
+
+		fmt.Println()
+		sel, err := pickFromItems("Select target drive", driveItems)
+		if err != nil {
+			return err
+		}
+		targetDrive = driveMap[sel]
 	}
 
-	// Resolve image (cached or download).
-	fmt.Printf("\nPreparing %s image...\n", device.Name)
-	imgInfo, err := getImageInfo(device.Manifest, device.RawVersion)
+	// Step 3: Confirm destructive write (unless --force).
+	if !force {
+		fmt.Println()
+		confirmed, err := tui.Confirm(fmt.Sprintf("Writing will ERASE ALL DATA on %s (%s). Continue?", targetDrive.Name, targetDrive.DevicePath))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	// Step 4: Resolve image (cached or download).
+	fmt.Printf("\nPreparing %s %s image...\n", device.Name, selectedVersion)
+	imgInfo, err := getImageInfo(device.Manifest, selectedVersion)
 	if err != nil {
 		return fmt.Errorf("getting image info: %w", err)
 	}
@@ -290,7 +374,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		return err
 	}
 
-	// Write image to drive with progress bar.
+	// Step 5: Write image to drive with progress bar.
 	fmt.Printf("Writing image to %s...\n", targetDrive.DevicePath)
 	writeProg := tui.NewProgress(fmt.Sprintf("Writing to %s...", targetDrive.DevicePath))
 	wp := tea.NewProgram(writeProg)
@@ -321,6 +405,42 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	fmt.Printf("\nSuccessfully installed %s %s on %s.\n", device.Name, imgInfo.Version, targetDrive.Name)
 	fmt.Println("You can now insert the drive into your device and power it on.")
 	return nil
+}
+
+// pickInstallVersion presents an interactive picker for available versions of a
+// device, sorted newest-first using semantic version comparison. It marks
+// "latest" and "nightly" versions in the picker description.
+func pickInstallVersion(dev deviceInfo) (string, error) {
+	if dev.Manifest == nil || len(dev.Manifest.Versions) == 0 {
+		return "", fmt.Errorf("no versions available for %s", dev.Name)
+	}
+
+	var versionKeys []string
+	for v := range dev.Manifest.Versions {
+		versionKeys = append(versionKeys, v)
+	}
+	sort.Slice(versionKeys, func(i, j int) bool {
+		return version.CompareVersions(versionKeys[i], versionKeys[j]) > 0
+	})
+
+	var items []tui.PickerItem
+	for _, v := range versionKeys {
+		ver := dev.Manifest.Versions[v]
+		desc := ""
+		if ver.IsLatest {
+			desc = "latest"
+		} else if ver.IsNightly {
+			desc = "nightly"
+		}
+		items = append(items, tui.PickerItem{
+			Name:        v,
+			Description: desc,
+			Value:       v,
+		})
+	}
+
+	fmt.Println()
+	return pickFromItems("Select a version", items)
 }
 
 // downloadImage downloads an OS image to a temp file with a progress bar.

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -3,6 +3,7 @@
 package commands
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/internal/shared/version"
@@ -60,20 +61,48 @@ func TestNewOSInstallCmd_PositionalArgsIncompatibleWithFlags(t *testing.T) {
 	}
 }
 
-func TestPickInstallVersion_SemverOrdering(t *testing.T) {
+func TestNewOSInstallCmd_SinglePositionalArgRejected(t *testing.T) {
+	cmd := newOSInstallCmd()
+	cmd.SetArgs([]string{"image.img"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when exactly 1 positional arg is provided")
+	}
+	expected := "positional arguments must be provided as [image] [drive]; got 1 argument"
+	if got := err.Error(); got != expected {
+		t.Errorf("unexpected error: %q; want %q", got, expected)
+	}
+}
+
+func TestNewOSInstallCmd_ESP32DeviceTypeRejected(t *testing.T) {
+	for _, dt := range []string{"esp32-c6", "esp32-c5"} {
+		t.Run(dt, func(t *testing.T) {
+			cmd := newOSInstallCmd()
+			cmd.SetArgs([]string{"--device-type", dt})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error for ESP32 --device-type")
+			}
+			if !strings.Contains(err.Error(), "does not support ESP32") {
+				t.Errorf("unexpected error: %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestPickManifestVersion_SemverOrdering(t *testing.T) {
 	// Verify that version keys are sorted semantically, not lexicographically.
 	// "0.10.0" should come after "0.9.0" semantically but before it lexicographically.
 	versions := []string{"0.2.0", "0.10.0", "0.9.0", "0.1.0", "0.10.1"}
 
-	// Use the same sorting logic as pickInstallVersion.
+	// Use the same sorting logic as pickManifestVersion.
 	sorted := make([]string, len(versions))
 	copy(sorted, versions)
-	// Import sort inline since the test file uses testing directly.
 	sortFunc := func(i, j int) bool {
 		return version.CompareVersions(sorted[i], sorted[j]) > 0
 	}
 
-	// Manual sort to avoid importing "sort" — just use a simple bubble sort for testing.
+	// Simple bubble sort for testing.
 	for i := 0; i < len(sorted); i++ {
 		for j := i + 1; j < len(sorted); j++ {
 			if !sortFunc(i, j) {

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -1,0 +1,115 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/internal/shared/version"
+)
+
+func TestNewOSInstallCmd_Flags(t *testing.T) {
+	cmd := newOSInstallCmd()
+	if cmd.Use != "install [image] [drive]" {
+		t.Errorf("Use = %q; want %q", cmd.Use, "install [image] [drive]")
+	}
+
+	expectedFlags := []string{"nightly", "force", "device-type", "version", "drive"}
+	for _, name := range expectedFlags {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing flag %q", name)
+		}
+	}
+}
+
+func TestNewOSInstallCmd_NightlyVersionMutualExclusion(t *testing.T) {
+	cmd := newOSInstallCmd()
+	cmd.SetArgs([]string{"--nightly", "--version", "0.10.0"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --nightly and --version are both set")
+	}
+	if got := err.Error(); got != "--nightly and --version are mutually exclusive" {
+		t.Errorf("unexpected error: %q", got)
+	}
+}
+
+func TestNewOSInstallCmd_PositionalArgsIncompatibleWithFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"positional with --device-type", []string{"image.img", "/dev/disk4", "--device-type", "raspberry-pi-5", "--force"}},
+		{"positional with --version", []string{"image.img", "/dev/disk4", "--version", "0.10.0", "--force"}},
+		{"positional with --drive", []string{"image.img", "/dev/disk4", "--drive", "/dev/disk5", "--force"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newOSInstallCmd()
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error when positional args are combined with manifest flags")
+			}
+			expected := "positional [image] [drive] arguments cannot be combined with --device-type, --version, or --drive"
+			if got := err.Error(); got != expected {
+				t.Errorf("unexpected error: %q; want %q", got, expected)
+			}
+		})
+	}
+}
+
+func TestPickInstallVersion_SemverOrdering(t *testing.T) {
+	// Verify that version keys are sorted semantically, not lexicographically.
+	// "0.10.0" should come after "0.9.0" semantically but before it lexicographically.
+	versions := []string{"0.2.0", "0.10.0", "0.9.0", "0.1.0", "0.10.1"}
+
+	// Use the same sorting logic as pickInstallVersion.
+	sorted := make([]string, len(versions))
+	copy(sorted, versions)
+	// Import sort inline since the test file uses testing directly.
+	sortFunc := func(i, j int) bool {
+		return version.CompareVersions(sorted[i], sorted[j]) > 0
+	}
+
+	// Manual sort to avoid importing "sort" — just use a simple bubble sort for testing.
+	for i := 0; i < len(sorted); i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			if !sortFunc(i, j) {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+
+	expected := []string{"0.10.1", "0.10.0", "0.9.0", "0.2.0", "0.1.0"}
+	for i, v := range sorted {
+		if v != expected[i] {
+			t.Errorf("sorted[%d] = %q; want %q (full: %v)", i, v, expected[i], sorted)
+			break
+		}
+	}
+}
+
+func TestOsCachedImagePath_Sanitization(t *testing.T) {
+	// Valid inputs should produce a valid path.
+	path, err := osCachedImagePath("raspberry-pi-5", "0.10.4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+
+	// Path traversal in version should be rejected.
+	_, err = osCachedImagePath("raspberry-pi-5", "../../../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for path traversal in version")
+	}
+
+	// Path traversal in device key should be rejected.
+	_, err = osCachedImagePath("../evil", "0.10.4")
+	if err == nil {
+		t.Fatal("expected error for path traversal in device key")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--device-type`, `--version`, and `--drive` flags to `wendy os install` so users can install a specific WendyOS version for Mender update-path testing without manually downloading an image first
- Interactive flow now includes a version picker (device → version → drive → confirm → write); non-interactive flow skips all prompts when all flags + `--force` are provided
- Fixes version ordering in both `os install` and `os download` to use semantic comparison (`version.CompareVersions`) instead of lexicographic string sort

Closes WDY-924

## Test plan
- [x] New unit tests for flag validation, mutual exclusivity, semver ordering, and cache path sanitization
- [x] All 112 tests in the commands package pass
- [x] Full project test suite passes
- [x] Manual: `wendy os install` interactive flow shows version picker after device selection
- [x] Manual: `wendy os install --device-type raspberry-pi-5 --version <older> --drive /dev/diskN --force` installs without prompts
- [x] Manual: `wendy os install <image-path> <drive-id> --force` still works unchanged
- [ ] Manual: seed older version then validate `wendy os update` upgrade path