### PR TITLE
Fix D-Bus proxy dying immediately after container creation

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -365,10 +365,17 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	}
 
 	// Start D-Bus proxy if bluetooth entitlement is present.
+	var dbusProxyStarted bool
 	if c.proxyManager != nil && hasBluetooth(appCfg) {
 		if _, err := c.proxyManager.Start(ctx, appName); err != nil {
 			return fmt.Errorf("starting D-Bus proxy for %q: %w", appName, err)
 		}
+		dbusProxyStarted = true
+		defer func() {
+			if dbusProxyStarted {
+				_ = c.proxyManager.Stop(appName)
+			}
+		}()
 	}
 
 	// For local-registry images, always pull from the embedded HTTP registry
@@ -503,6 +510,9 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	if err != nil {
 		return fmt.Errorf("creating container %q: %w", appName, err)
 	}
+
+	// Container created successfully; keep the D-Bus proxy running.
+	dbusProxyStarted = false
 
 	report(&agentpb.CreateContainerProgress{Phase: agentpb.CreateContainerProgress_COMPLETE})
 

--- a/go/internal/agent/dbusproxy/proc_linux.go
+++ b/go/internal/agent/dbusproxy/proc_linux.go
@@ -1,0 +1,14 @@
+package dbusproxy
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setPdeathsig configures the command to receive SIGTERM when the parent
+// process (the agent) dies, preventing orphaned proxy processes.
+func setPdeathsig(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+}

--- a/go/internal/agent/dbusproxy/proc_linux.go
+++ b/go/internal/agent/dbusproxy/proc_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package dbusproxy
 
 import (
@@ -8,7 +10,8 @@ import (
 // setPdeathsig configures the command to receive SIGTERM when the parent
 // process (the agent) dies, preventing orphaned proxy processes.
 func setPdeathsig(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGTERM,
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGTERM
 }

--- a/go/internal/agent/dbusproxy/proc_other.go
+++ b/go/internal/agent/dbusproxy/proc_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package dbusproxy
+
+import "os/exec"
+
+// setPdeathsig is a no-op on non-Linux platforms.
+func setPdeathsig(_ *exec.Cmd) {}

--- a/go/internal/agent/dbusproxy/proxy.go
+++ b/go/internal/agent/dbusproxy/proxy.go
@@ -78,13 +78,17 @@ func (m *Manager) Start(ctx context.Context, appID string) (string, error) {
 	}
 
 	// Launch xdg-dbus-proxy with a filter that only allows org.bluez.
-	cmd := exec.CommandContext(ctx,
+	// Use exec.Command (not CommandContext) so the proxy outlives the
+	// request context that started it. Pdeathsig ensures the proxy is
+	// cleaned up if the agent process crashes.
+	cmd := exec.Command(
 		"xdg-dbus-proxy",
 		"unix:path="+hostBusSocket,
 		socketPath,
 		"--filter",
 		"--talk=org.bluez",
 	)
+	setPdeathsig(cmd)
 
 	if err := cmd.Start(); err != nil {
 		os.RemoveAll(socketDir)


### PR DESCRIPTION
## Problem

While testing on an RPi4 (Raspberry Pi OS), the `xdg-dbus-proxy` process for the bluetooth entitlement was observed dying immediately after `CreateContainer()` returns, leaving the container without D-Bus access to `org.bluez`.

**Root cause:** `proxy.go` launches the proxy with `exec.CommandContext(ctx)`, where `ctx` is the gRPC request context from `CreateContainerWithProgress()`. When the RPC completes and the client disconnects, the context cancels and Go's `os/exec` sends SIGKILL to the proxy process.

```
Timeline:
  1. CreateContainer RPC arrives       → ctx is the gRPC request context
  2. proxyManager.Start(ctx, appName)  → exec.CommandContext(ctx, "xdg-dbus-proxy", ...)
  3. Proxy starts, socket appears      → container creation proceeds
  4. CreateContainer RPC returns       → ctx.Done() fires
  5. Go runtime kills the proxy        → socket goes dead
  6. Container tries to talk to bluez  → connection refused
```

The downstream effect was that BLE speakers couldn't connect, no PipeWire sink was created, and the container had nothing to route audio to — even though audio and bluetooth entitlements were both correctly configured.

## Fix

Two changes:

### 1. `exec.Command` instead of `exec.CommandContext`

The proxy must outlive the request that created it — it needs to stay alive for the entire container lifetime. Switching to `exec.Command()` decouples the proxy from the gRPC request context.

This follows the existing proxy lifecycle pattern already in place via `Manager`:
- **On container replace:** `proxyManager.Stop(appName)` before starting a new proxy (client.go:362-363)
- **On container stop:** `proxyManager.Stop(appName)` kills the proxy and cleans up the socket dir (client.go:888)
- **On container delete:** same cleanup path (client.go:932)
- **On agent shutdown:** `proxyManager.StopAll()` in `Client.Close()` (client.go:78)
- **On unexpected exit:** background goroutine in `Start()` calls `cmd.Wait()` and cleans up the map entry (proxy.go:122-136)

The `CommandContext` cancellation was redundant with this explicit lifecycle management and harmful because it fired at the wrong time.

### 2. `Pdeathsig` for orphan prevention (Linux only)

If the agent process crashes hard (SIGKILL, OOM, panic without cleanup), `StopAll()` never runs and the proxy would be orphaned. `Pdeathsig: syscall.SIGTERM` tells the kernel to signal the proxy when its parent dies, ensuring cleanup even in abnormal termination.

Implemented via build-tagged files (`proc_linux.go` / `proc_other.go`) since `Pdeathsig` is Linux-specific.

## Alternatives considered

The `exec.Command` + `Pdeathsig` approach was chosen as the smallest change that follows the existing `Manager` pattern. Other approaches that could solve this:

### Pass a longer-lived context (e.g., `context.Background()`)
Keep `CommandContext` but pass a context that doesn't cancel on RPC completion. Fixes the immediate bug but results in two competing cleanup mechanisms — context cancellation and explicit `Stop()`/`StopAll()` — which could race.

### Use OCI `prestart`/`poststop` hooks
Configure `xdg-dbus-proxy` as an OCI lifecycle hook managed by containerd/runc. Tradeoffs:
- OCI hooks run synchronously and block container start — would need a wrapper that backgrounds the proxy and exits
- Hook error handling is opaque (stdout/stderr go to the runtime log, not structured logging)
- The proxy socket must exist *before* the container spec is finalized (it's referenced in bind mounts), so the proxy needs to start during `CreateContainer`, not as a hook at container start time
- Would require reworking the existing `Manager` pattern

### Supervise via systemd transient units
Launch the proxy via `systemd-run --user` as a transient service. Tradeoffs:
- Hard dependency on systemd user sessions being available (not guaranteed on all target devices)
- IPC complexity for lifecycle management
- Would require reworking the existing `Manager` pattern

## Verified

Tested on RPi4, Raspberry Pi OS:
- Proxy stays alive after `CreateContainer` RPC completes
- `ps aux | grep dbus-proxy` confirms process persists
- BLE speaker connects via `org.bluez` through the proxy
- Proxy cleaned up on container stop/delete
- Proxy cleaned up when agent process is killed (Pdeathsig)