### PR TITLE
Add explicit Swift build-type selection and default Dockerfile precedence

### DIFF
--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -176,16 +176,16 @@ func pickBuildOption(options []BuildOption) (*BuildOption, error) {
 }
 
 func preferredBuildOption(options []BuildOption) *BuildOption {
-	hasSwift := false
+	hasLanguageMarker := false
 	for i := range options {
 		switch {
-		case options[i].Type == "swift":
-			hasSwift = true
-		case hasSwift && options[i].Type == "docker" && options[i].File == "Dockerfile":
+		case options[i].Type == "swift" || options[i].Type == "python":
+			hasLanguageMarker = true
+		case hasLanguageMarker && options[i].Type == "docker" && options[i].File == "Dockerfile":
 			return &options[i]
 		}
 	}
-	if !hasSwift {
+	if !hasLanguageMarker {
 		return nil
 	}
 	for i := range options {

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -22,7 +22,13 @@ type BuildResult struct {
 	ProviderApp *providers.BuiltApp
 }
 
+type buildOptions struct {
+	buildType string
+}
+
 func newBuildCmd() *cobra.Command {
+	var opts buildOptions
+
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Build the application in the current directory",
@@ -76,7 +82,7 @@ func newBuildCmd() *cobra.Command {
 				return fmt.Errorf("no supported build type found for this target; check that the project contains the right files")
 			}
 
-			selected, err := pickBuildOption(options)
+			selected, err := resolveDetectedBuildOption(options, opts.buildType)
 			if err != nil {
 				return err
 			}
@@ -101,7 +107,21 @@ func newBuildCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type to use when multiple project markers are present: docker, swift, or python")
+
 	return cmd
+}
+
+func resolveDetectedBuildOption(options []BuildOption, requestedType string) (*BuildOption, error) {
+	if strings.TrimSpace(requestedType) != "" {
+		return buildOptionForType(options, requestedType)
+	}
+
+	if preferred := preferredBuildOption(options); preferred != nil {
+		return preferred, nil
+	}
+
+	return pickBuildOption(options)
 }
 
 // pickBuildOption presents an interactive picker when multiple build options
@@ -153,6 +173,74 @@ func pickBuildOption(options []BuildOption) (*BuildOption, error) {
 		return nil, fmt.Errorf("invalid selection")
 	}
 	return opt, nil
+}
+
+func preferredBuildOption(options []BuildOption) *BuildOption {
+	hasSwift := false
+	for i := range options {
+		switch {
+		case options[i].Type == "swift":
+			hasSwift = true
+		case hasSwift && options[i].Type == "docker" && options[i].File == "Dockerfile":
+			return &options[i]
+		}
+	}
+	if !hasSwift {
+		return nil
+	}
+	for i := range options {
+		if options[i].Type == "docker" && options[i].File == "Dockerfile" {
+			return &options[i]
+		}
+	}
+	return nil
+}
+
+func buildOptionForType(options []BuildOption, requestedType string) (*BuildOption, error) {
+	buildType := normalizeBuildType(requestedType)
+	if buildType == "" {
+		return nil, fmt.Errorf("build type must be one of docker, swift, or python")
+	}
+
+	var matches []BuildOption
+	for _, option := range options {
+		if option.Type == buildType {
+			matches = append(matches, option)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("build type %q is not available; detected %s", requestedType, strings.Join(buildOptionLabels(options), ", "))
+	}
+
+	if buildType == "docker" {
+		for i := range matches {
+			if matches[i].File == "Dockerfile" {
+				return &matches[i], nil
+			}
+		}
+		if len(matches) > 1 {
+			return nil, fmt.Errorf("multiple Dockerfiles detected (%s); keep only one Dockerfile or run in an interactive terminal to choose", strings.Join(buildOptionLabels(matches), ", "))
+		}
+	}
+
+	return &matches[0], nil
+}
+
+func buildOptionLabels(options []BuildOption) []string {
+	labels := make([]string, 0, len(options))
+	for _, option := range options {
+		labels = append(labels, option.Label)
+	}
+	return labels
+}
+
+func normalizeBuildType(buildType string) string {
+	switch strings.ToLower(strings.TrimSpace(buildType)) {
+	case "docker", "swift", "python":
+		return strings.ToLower(strings.TrimSpace(buildType))
+	default:
+		return ""
+	}
 }
 
 // filterBuildOptions removes options whose Type is not in the provider's

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -113,11 +113,13 @@ func newBuildCmd() *cobra.Command {
 }
 
 func resolveDetectedBuildOption(options []BuildOption, requestedType string) (*BuildOption, error) {
+	interactive := term.IsTerminal(int(os.Stdin.Fd()))
+
 	if strings.TrimSpace(requestedType) != "" {
-		return buildOptionForType(options, requestedType)
+		return buildOptionForType(options, requestedType, interactive)
 	}
 
-	if preferred := preferredBuildOption(options); preferred != nil {
+	if preferred := preferredBuildOption(options, interactive); preferred != nil {
 		return preferred, nil
 	}
 
@@ -127,6 +129,10 @@ func resolveDetectedBuildOption(options []BuildOption, requestedType string) (*B
 // pickBuildOption presents an interactive picker when multiple build options
 // are detected. If only one option exists, it is returned directly.
 func pickBuildOption(options []BuildOption) (*BuildOption, error) {
+	return pickBuildOptionWithTitle(options, "Select a build type")
+}
+
+func pickBuildOptionWithTitle(options []BuildOption, title string) (*BuildOption, error) {
 	if len(options) == 1 {
 		return &options[0], nil
 	}
@@ -139,7 +145,7 @@ func pickBuildOption(options []BuildOption) (*BuildOption, error) {
 		return nil, fmt.Errorf("multiple build types detected (%s); run in an interactive terminal or remove extra build markers so that only one remains", strings.Join(names, ", "))
 	}
 
-	picker := tui.NewPickerWithTitle("Select a build type")
+	picker := tui.NewPickerWithTitle(title)
 	p := tea.NewProgram(picker)
 
 	go func() {
@@ -175,28 +181,31 @@ func pickBuildOption(options []BuildOption) (*BuildOption, error) {
 	return opt, nil
 }
 
-func preferredBuildOption(options []BuildOption) *BuildOption {
+func preferredBuildOption(options []BuildOption, interactive bool) *BuildOption {
 	hasLanguageMarker := false
+	dockerCount := 0
+	dockerfile := (*BuildOption)(nil)
 	for i := range options {
 		switch {
 		case options[i].Type == "swift" || options[i].Type == "python":
 			hasLanguageMarker = true
-		case hasLanguageMarker && options[i].Type == "docker" && options[i].File == "Dockerfile":
-			return &options[i]
+		case options[i].Type == "docker":
+			dockerCount++
+			if options[i].File == "Dockerfile" {
+				dockerfile = &options[i]
+			}
 		}
 	}
-	if !hasLanguageMarker {
+	if !hasLanguageMarker || dockerfile == nil {
 		return nil
 	}
-	for i := range options {
-		if options[i].Type == "docker" && options[i].File == "Dockerfile" {
-			return &options[i]
-		}
+	if dockerCount == 1 || !interactive {
+		return dockerfile
 	}
 	return nil
 }
 
-func buildOptionForType(options []BuildOption, requestedType string) (*BuildOption, error) {
+func buildOptionForType(options []BuildOption, requestedType string, interactive bool) (*BuildOption, error) {
 	buildType := normalizeBuildType(requestedType)
 	if buildType == "" {
 		return nil, fmt.Errorf("build type must be one of docker, swift, or python")
@@ -213,13 +222,23 @@ func buildOptionForType(options []BuildOption, requestedType string) (*BuildOpti
 	}
 
 	if buildType == "docker" {
+		var dockerfile *BuildOption
 		for i := range matches {
 			if matches[i].File == "Dockerfile" {
-				return &matches[i], nil
+				dockerfile = &matches[i]
+				if !interactive {
+					return dockerfile, nil
+				}
 			}
 		}
 		if len(matches) > 1 {
+			if interactive {
+				return pickBuildOptionWithTitle(matches, "Select a Dockerfile")
+			}
 			return nil, fmt.Errorf("multiple Dockerfiles detected (%s); keep only one Dockerfile or omit --build-type to choose interactively", strings.Join(buildOptionLabels(matches), ", "))
+		}
+		if dockerfile != nil {
+			return dockerfile, nil
 		}
 	}
 

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -219,7 +219,7 @@ func buildOptionForType(options []BuildOption, requestedType string) (*BuildOpti
 			}
 		}
 		if len(matches) > 1 {
-			return nil, fmt.Errorf("multiple Dockerfiles detected (%s); keep only one Dockerfile or run in an interactive terminal to choose", strings.Join(buildOptionLabels(matches), ", "))
+			return nil, fmt.Errorf("multiple Dockerfiles detected (%s); keep only one Dockerfile or omit --build-type to choose interactively", strings.Join(buildOptionLabels(matches), ", "))
 		}
 	}
 

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -67,7 +67,7 @@ func TestNewRunCmd(t *testing.T) {
 	}
 
 	// Verify expected flags exist.
-	expectedFlags := []string{"debug", "deploy", "detach", "restart-unless-stopped", "restart-on-failure", "no-restart", "prefix", "user-args"}
+	expectedFlags := []string{"build-type", "debug", "deploy", "detach", "restart-unless-stopped", "restart-on-failure", "no-restart", "prefix", "user-args"}
 	for _, name := range expectedFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("missing flag %q", name)
@@ -167,6 +167,9 @@ func TestNewBuildCmd(t *testing.T) {
 	}
 	if cmd.Short == "" {
 		t.Error("Short should not be empty")
+	}
+	if cmd.Flags().Lookup("build-type") == nil {
+		t.Error("missing flag \"build-type\"")
 	}
 }
 

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -88,6 +88,78 @@ func TestDetectProjectType_DockerfileTakesPrecedence(t *testing.T) {
 	}
 }
 
+func TestResolveDetectedBuildOption_PrefersDockerfileOverSwift(t *testing.T) {
+	options := []BuildOption{
+		{Label: "Dockerfile", Type: "docker", File: "Dockerfile"},
+		{Label: "Package.swift (Swift)", Type: "swift", File: "Package.swift"},
+	}
+
+	got, err := resolveDetectedBuildOption(options, "")
+	if err != nil {
+		t.Fatalf("resolveDetectedBuildOption: %v", err)
+	}
+	if got == nil || got.Type != "docker" || got.File != "Dockerfile" {
+		t.Fatalf("got %+v, want Dockerfile docker option", got)
+	}
+}
+
+func TestBuildOptionForType_DockerUsesExactDockerfile(t *testing.T) {
+	options := []BuildOption{
+		{Label: "Dockerfile.dev", Type: "docker", File: "Dockerfile.dev"},
+		{Label: "Dockerfile", Type: "docker", File: "Dockerfile"},
+		{Label: "Package.swift (Swift)", Type: "swift", File: "Package.swift"},
+	}
+
+	got, err := buildOptionForType(options, "docker")
+	if err != nil {
+		t.Fatalf("buildOptionForType: %v", err)
+	}
+	if got == nil || got.File != "Dockerfile" {
+		t.Fatalf("got %+v, want Dockerfile", got)
+	}
+}
+
+func TestResolveRunProjectType_DefaultPrefersDockerfile(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"Dockerfile", "Package.swift"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := resolveRunProjectType(dir, "")
+	if err != nil {
+		t.Fatalf("resolveRunProjectType: %v", err)
+	}
+	if got != "docker" {
+		t.Fatalf("got %q, want docker", got)
+	}
+}
+
+func TestResolveRunProjectType_SwiftOverride(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"Dockerfile", "Package.swift"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := resolveRunProjectType(dir, "swift")
+	if err != nil {
+		t.Fatalf("resolveRunProjectType: %v", err)
+	}
+	if got != "swift" {
+		t.Fatalf("got %q, want swift", got)
+	}
+}
+
+func TestResolveRunProjectType_InvalidOverride(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := resolveRunProjectType(dir, "python"); err == nil {
+		t.Fatal("expected error for invalid run build type override")
+	}
+}
+
 func TestGeneratePythonDockerfile_WithRequirements(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("flask"), 0o644); err != nil {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -118,6 +118,19 @@ func TestResolveDetectedBuildOption_PrefersDockerfileOverPython(t *testing.T) {
 	}
 }
 
+func TestPreferredBuildOption_InteractiveMultipleDockerfilesDoesNotAutoPrefer(t *testing.T) {
+	options := []BuildOption{
+		{Label: "Dockerfile", Type: "docker", File: "Dockerfile"},
+		{Label: "Dockerfile.dev", Type: "docker", File: "Dockerfile.dev"},
+		{Label: "Package.swift (Swift)", Type: "swift", File: "Package.swift"},
+	}
+
+	got := preferredBuildOption(options, true)
+	if got != nil {
+		t.Fatalf("got %+v, want nil so the picker can choose among Dockerfiles", got)
+	}
+}
+
 func TestBuildOptionForType_DockerUsesExactDockerfile(t *testing.T) {
 	options := []BuildOption{
 		{Label: "Dockerfile.dev", Type: "docker", File: "Dockerfile.dev"},
@@ -125,7 +138,7 @@ func TestBuildOptionForType_DockerUsesExactDockerfile(t *testing.T) {
 		{Label: "Package.swift (Swift)", Type: "swift", File: "Package.swift"},
 	}
 
-	got, err := buildOptionForType(options, "docker")
+	got, err := buildOptionForType(options, "docker", false)
 	if err != nil {
 		t.Fatalf("buildOptionForType: %v", err)
 	}
@@ -187,8 +200,12 @@ func TestResolveRunProjectType_PythonOverride(t *testing.T) {
 
 func TestResolveRunProjectType_InvalidOverride(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := resolveRunProjectType(dir, "ruby"); err == nil {
+	_, err := resolveRunProjectType(dir, "ruby")
+	if err == nil {
 		t.Fatal("expected error for invalid run build type override")
+	}
+	if !strings.Contains(err.Error(), `invalid value "ruby" for --build-type`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -103,6 +103,21 @@ func TestResolveDetectedBuildOption_PrefersDockerfileOverSwift(t *testing.T) {
 	}
 }
 
+func TestResolveDetectedBuildOption_PrefersDockerfileOverPython(t *testing.T) {
+	options := []BuildOption{
+		{Label: "Dockerfile", Type: "docker", File: "Dockerfile"},
+		{Label: "requirements.txt (Python)", Type: "python", File: "requirements.txt"},
+	}
+
+	got, err := resolveDetectedBuildOption(options, "")
+	if err != nil {
+		t.Fatalf("resolveDetectedBuildOption: %v", err)
+	}
+	if got == nil || got.Type != "docker" || got.File != "Dockerfile" {
+		t.Fatalf("got %+v, want Dockerfile docker option", got)
+	}
+}
+
 func TestBuildOptionForType_DockerUsesExactDockerfile(t *testing.T) {
 	options := []BuildOption{
 		{Label: "Dockerfile.dev", Type: "docker", File: "Dockerfile.dev"},
@@ -153,9 +168,26 @@ func TestResolveRunProjectType_SwiftOverride(t *testing.T) {
 	}
 }
 
+func TestResolveRunProjectType_PythonOverride(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"Dockerfile", "requirements.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := resolveRunProjectType(dir, "python")
+	if err != nil {
+		t.Fatalf("resolveRunProjectType: %v", err)
+	}
+	if got != "python" {
+		t.Fatalf("got %q, want python", got)
+	}
+}
+
 func TestResolveRunProjectType_InvalidOverride(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := resolveRunProjectType(dir, "python"); err == nil {
+	if _, err := resolveRunProjectType(dir, "ruby"); err == nil {
 		t.Fatal("expected error for invalid run build type override")
 	}
 }

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -160,6 +160,22 @@ func TestResolveRunProjectType_InvalidOverride(t *testing.T) {
 	}
 }
 
+func TestResolveRunProjectType_PropagatesMarkerStatErrors(t *testing.T) {
+	dir := t.TempDir()
+	notDir := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(notDir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := resolveRunProjectType(notDir, "docker")
+	if err == nil {
+		t.Fatal("expected stat error for invalid project path")
+	}
+	if !strings.Contains(err.Error(), "checking for") {
+		t.Fatalf("expected wrapped stat error, got %v", err)
+	}
+}
+
 func TestGeneratePythonDockerfile_WithRequirements(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("flask"), 0o644); err != nil {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -387,7 +387,7 @@ func resolveRunProjectType(dir, requestedType string) (string, error) {
 
 	buildType := normalizeBuildType(requestedType)
 	if buildType != "docker" && buildType != "swift" && buildType != "python" {
-		return "", fmt.Errorf("run build type must be one of docker, swift, or python")
+		return "", fmt.Errorf("invalid value %q for --build-type: must be one of docker, swift, or python", requestedType)
 	}
 
 	switch buildType {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -200,7 +200,7 @@ func newRunCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type to use when both Dockerfile and Package.swift are present: docker or swift")
+	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type to use when Dockerfile is present alongside Package.swift or Python project markers: docker, swift, or python")
 	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Enable debug logging")
 	cmd.Flags().BoolVar(&opts.deploy, "deploy", false, "Create container but do not start it")
 	cmd.Flags().BoolVar(&opts.detach, "detach", false, "Start container but do not stream logs")
@@ -386,8 +386,8 @@ func resolveRunProjectType(dir, requestedType string) (string, error) {
 	}
 
 	buildType := normalizeBuildType(requestedType)
-	if buildType != "docker" && buildType != "swift" {
-		return "", fmt.Errorf("run build type must be one of docker or swift")
+	if buildType != "docker" && buildType != "swift" && buildType != "python" {
+		return "", fmt.Errorf("run build type must be one of docker, swift, or python")
 	}
 
 	switch buildType {
@@ -404,6 +404,15 @@ func resolveRunProjectType(dir, requestedType string) (string, error) {
 			return "swift", nil
 		} else if !os.IsNotExist(err) {
 			return "", fmt.Errorf("checking for %s: %w", marker, err)
+		}
+	case "python":
+		for _, marker := range []string{"requirements.txt", "pyproject.toml", "setup.py"} {
+			path := filepath.Join(dir, marker)
+			if _, err := os.Stat(path); err == nil {
+				return "python", nil
+			} else if !os.IsNotExist(err) {
+				return "", fmt.Errorf("checking for %s: %w", path, err)
+			}
 		}
 	}
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -176,6 +176,7 @@ func createContainerWithProgress(ctx context.Context, svc agentpb.WendyContainer
 
 // runOptions holds the parsed flags for the run command.
 type runOptions struct {
+	buildType            string
 	debug                bool
 	deploy               bool
 	detach               bool
@@ -199,6 +200,7 @@ func newRunCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type to use when both Dockerfile and Package.swift are present: docker or swift")
 	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Enable debug logging")
 	cmd.Flags().BoolVar(&opts.deploy, "deploy", false, "Create container but do not start it")
 	cmd.Flags().BoolVar(&opts.detach, "detach", false, "Start container but do not stream logs")
@@ -378,9 +380,36 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	return startAndStreamContainer(ctx, conn, appCfg, createReq, opts)
 }
 
+func resolveRunProjectType(dir, requestedType string) (string, error) {
+	if strings.TrimSpace(requestedType) == "" {
+		return detectProjectType(dir), nil
+	}
+
+	buildType := normalizeBuildType(requestedType)
+	if buildType != "docker" && buildType != "swift" {
+		return "", fmt.Errorf("run build type must be one of docker or swift")
+	}
+
+	switch buildType {
+	case "docker":
+		if _, err := os.Stat(filepath.Join(dir, "Dockerfile")); err == nil {
+			return "docker", nil
+		}
+	case "swift":
+		if _, err := os.Stat(filepath.Join(dir, "Package.swift")); err == nil {
+			return "swift", nil
+		}
+	}
+
+	return "", fmt.Errorf("build type %q is not available in %s", requestedType, dir)
+}
+
 // runWithProvider builds and runs via an external device provider.
 func runWithProvider(ctx context.Context, p providers.DeviceProvider, device models.ExternalDevice, projectPath, product string, opts runOptions) error {
-	projectType := detectProjectType(projectPath)
+	projectType, err := resolveRunProjectType(projectPath, opts.buildType)
+	if err != nil {
+		return err
+	}
 
 	// Resolve Swift product name from Package.swift.
 	if projectType == "swift" {
@@ -478,11 +507,17 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 // runWithAgent is the existing gRPC agent pipeline.
 func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, opts runOptions) error {
 	// Detect project type and ensure a Dockerfile exists.
-	projectType := detectProjectType(cwd)
+	projectType, err := resolveRunProjectType(cwd, opts.buildType)
+	if err != nil {
+		return err
+	}
 
 	// Swift projects without a Dockerfile use swift-container-plugin to push
 	// directly to the device's registry, bypassing the Docker build pipeline.
 	if projectType == "swift" {
+		if normalizeBuildType(opts.buildType) == "swift" {
+			return runSwiftWithAgent(ctx, conn, cwd, appCfg, opts)
+		}
 		if _, err := os.Stat(filepath.Join(cwd, "Dockerfile")); os.IsNotExist(err) {
 			return runSwiftWithAgent(ctx, conn, cwd, appCfg, opts)
 		}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -392,12 +392,18 @@ func resolveRunProjectType(dir, requestedType string) (string, error) {
 
 	switch buildType {
 	case "docker":
-		if _, err := os.Stat(filepath.Join(dir, "Dockerfile")); err == nil {
+		marker := filepath.Join(dir, "Dockerfile")
+		if _, err := os.Stat(marker); err == nil {
 			return "docker", nil
+		} else if !os.IsNotExist(err) {
+			return "", fmt.Errorf("checking for %s: %w", marker, err)
 		}
 	case "swift":
-		if _, err := os.Stat(filepath.Join(dir, "Package.swift")); err == nil {
+		marker := filepath.Join(dir, "Package.swift")
+		if _, err := os.Stat(marker); err == nil {
 			return "swift", nil
+		} else if !os.IsNotExist(err) {
+			return "", fmt.Errorf("checking for %s: %w", marker, err)
 		}
 	}
 
@@ -512,8 +518,10 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		return err
 	}
 
-	// Swift projects without a Dockerfile use swift-container-plugin to push
-	// directly to the device's registry, bypassing the Docker build pipeline.
+	// Swift projects use swift-container-plugin to push directly to the
+	// device's registry, bypassing the Docker build pipeline, when
+	// --build-type=swift explicitly selects that path or when no Dockerfile
+	// is present.
 	if projectType == "swift" {
 		if normalizeBuildType(opts.buildType) == "swift" {
 			return runSwiftWithAgent(ctx, conn, cwd, appCfg, opts)


### PR DESCRIPTION
## What changed

- added `--build-type` to `wendy build` so Docker vs Swift selection can be forced non-interactively
- added `--build-type` to `wendy run` for Swift/Docker resolution when both `Dockerfile` and `Package.swift` are present
- changed the default ambiguous-case behavior to prefer `Dockerfile` when no explicit selector is provided
- added command tests covering the new flag wiring and resolution behavior

## Why

Swift projects can contain both `Dockerfile` and `Package.swift`, which made `wendy build` interactive in the ambiguous case and left no explicit override for `wendy run`. This change provides a non-interactive selector and makes the default behavior deterministic.

## Impact

- `wendy build` can now be scripted with `--build-type`
- `wendy run --build-type=swift` forces the Swift container-plugin path even when a `Dockerfile` exists
- omitting the flag now prefers `Dockerfile`

## Root cause

Build-type selection lived in separate code paths. `build` relied on an interactive picker for ambiguity, while `run` inferred behavior from the presence of files and had no shared explicit override.

## Validation

- `go test ./internal/cli/commands`

Related to: WDY-925