### PR TITLE
Fix device apps list wording

### DIFF
--- a/go/internal/cli/commands/apps.go
+++ b/go/internal/cli/commands/apps.go
@@ -48,7 +48,7 @@ func newAppsCmd() *cobra.Command {
 func newAppsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List running applications",
+		Short: "List deployed applications",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			target, err := resolveTarget(ctx)
@@ -123,7 +123,7 @@ func appsListAgent(ctx context.Context, conn *grpcclient.AgentConnection) error 
 	}
 
 	if len(containers) == 0 {
-		fmt.Println("No applications running.")
+		fmt.Println("No applications deployed.")
 		return nil
 	}
 	headers := []string{"", "Name", "Version", "Failures"}
@@ -219,7 +219,7 @@ func appsListProvider(ctx context.Context, cm providers.ContainerManager) error 
 	}
 
 	if len(containers) == 0 {
-		fmt.Println("No applications found.")
+		fmt.Println("No applications deployed.")
 		return nil
 	}
 

--- a/go/internal/cli/commands/apps_test.go
+++ b/go/internal/cli/commands/apps_test.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestDeviceAppsListCommand_HelpDescribesDeployedApps(t *testing.T) {
+	cmd := newDeviceCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"apps", "list", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "List deployed applications") {
+		t.Fatalf("expected help output to contain %q, got %q", "List deployed applications", output)
+	}
+	if strings.Contains(output, "List running applications") {
+		t.Fatalf("expected help output to avoid stale wording, got %q", output)
+	}
+}


### PR DESCRIPTION
## Summary
- update `wendy device apps list` help text to describe deployed apps
- align the empty-state message with the command behavior
- add a help test to lock in the wording

## Testing
- go test ./internal/cli/commands