### PR TITLE
[codex] WDY-933 stream unpack progress in wendy run

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -320,6 +320,26 @@ func (c *Client) CreateContainer(ctx context.Context, req *agentpb.CreateContain
 	return c.CreateContainerWithProgress(ctx, req, appCfg, nil)
 }
 
+func toCreateContainerProgress(progress UnpackProgress) *agentpb.CreateContainerProgress {
+	switch progress.Phase {
+	case "start":
+		return &agentpb.CreateContainerProgress{
+			Phase:       agentpb.CreateContainerProgress_UNPACKING,
+			TotalLayers: int32(progress.TotalLayers),
+		}
+	case "layer":
+		return &agentpb.CreateContainerProgress{
+			Phase:          agentpb.CreateContainerProgress_APPLYING_LAYER,
+			LayerIndex:     int32(progress.LayerIndex),
+			TotalLayers:    int32(progress.TotalLayers),
+			LayerSize:      progress.LayerSize,
+			ReusedSnapshot: progress.Reused,
+		}
+	default:
+		return nil
+	}
+}
+
 func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.CreateContainerRequest, appCfg *appconfig.AppConfig, onProgress services.ProgressFunc) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -406,7 +426,11 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	}
 	if !unpacked {
 		c.logger.Info("Unpacking image", zap.String("image", imageName))
-		if err := image.Unpack(ctx, ""); err != nil {
+		if _, err := c.UnpackImage(ctx, imageName, func(progress UnpackProgress) {
+			if mapped := toCreateContainerProgress(progress); mapped != nil {
+				report(mapped)
+			}
+		}); err != nil {
 			return fmt.Errorf("unpacking image %q: %w", imageName, err)
 		}
 	}

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -1,0 +1,54 @@
+package containerd
+
+import (
+	"testing"
+
+	agentpb "github.com/wendylabsinc/wendy/proto/gen/agentpb"
+)
+
+func TestCreateContainerProgressMappingUsesApplyPhase(t *testing.T) {
+	progress := UnpackProgress{
+		Phase:       "layer",
+		LayerIndex:  2,
+		TotalLayers: 5,
+		LayerSize:   1234,
+		Reused:      true,
+	}
+
+	got := toCreateContainerProgress(progress)
+
+	if got.GetPhase() != agentpb.CreateContainerProgress_APPLYING_LAYER {
+		t.Fatalf("phase = %v; want APPLYING_LAYER", got.GetPhase())
+	}
+	if got.GetLayerIndex() != 2 {
+		t.Fatalf("layer index = %d; want 2", got.GetLayerIndex())
+	}
+	if got.GetTotalLayers() != 5 {
+		t.Fatalf("total layers = %d; want 5", got.GetTotalLayers())
+	}
+	if got.GetLayerSize() != 1234 {
+		t.Fatalf("layer size = %d; want 1234", got.GetLayerSize())
+	}
+	if !got.GetReusedSnapshot() {
+		t.Fatal("expected reused snapshot to be true")
+	}
+}
+
+func TestCreateContainerProgressMappingUsesUnpackingPhaseForStart(t *testing.T) {
+	progress := UnpackProgress{
+		Phase:       "start",
+		TotalLayers: 3,
+	}
+
+	got := toCreateContainerProgress(progress)
+
+	if got.GetPhase() != agentpb.CreateContainerProgress_UNPACKING {
+		t.Fatalf("phase = %v; want UNPACKING", got.GetPhase())
+	}
+	if got.GetTotalLayers() != 3 {
+		t.Fatalf("total layers = %d; want 3", got.GetTotalLayers())
+	}
+	if got.GetLayerIndex() != 0 {
+		t.Fatalf("layer index = %d; want 0", got.GetLayerIndex())
+	}
+}

--- a/go/internal/agent/containerd/unpack.go
+++ b/go/internal/agent/containerd/unpack.go
@@ -47,7 +47,7 @@ func (c *Client) UnpackImage(ctx context.Context, imageName string, progress fun
 	target := img.Target()
 
 	// Resolve through index if needed (platform selection).
-	manifest, err := images.Manifest(ctx, cs, target, nil)
+	manifest, err := images.Manifest(ctx, cs, target, img.Platform())
 	if err != nil {
 		return "", fmt.Errorf("reading manifest for %q: %w", imageName, err)
 	}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -199,7 +198,12 @@ func createContainerWithProgressPlain(stream agentpb.WendyContainerService_Creat
 	return nil
 }
 
-func createContainerWithProgressTUI(ctx context.Context, stream agentpb.WendyContainerService_CreateContainerWithProgressClient) error {
+func progressModelUserCancelled(model tea.Model) bool {
+	pm, ok := model.(tui.ProgressModel)
+	return ok && pm.Err() == context.Canceled
+}
+
+func createContainerWithProgressTUI(cancel context.CancelFunc, stream agentpb.WendyContainerService_CreateContainerWithProgressClient) error {
 	prog := tea.NewProgram(tui.NewProgress("Pulling image on device..."))
 
 	var (
@@ -268,11 +272,13 @@ func createContainerWithProgressTUI(ctx context.Context, stream agentpb.WendyCon
 
 	finalModel, err := prog.Run()
 	if err != nil {
+		cancel()
 		<-done
 		return fmt.Errorf("progress TUI: %w", err)
 	}
 
-	if pm, ok := finalModel.(tui.ProgressModel); ok && errors.Is(pm.Err(), context.Canceled) {
+	if progressModelUserCancelled(finalModel) {
+		cancel()
 		<-done
 		return ErrUserCancelled
 	}
@@ -305,11 +311,7 @@ func createContainerWithProgress(ctx context.Context, svc agentpb.WendyContainer
 	if err != nil {
 		return fmt.Errorf("creating container: %w", err)
 	}
-	err = createContainerWithProgressTUI(progressCtx, stream)
-	if errors.Is(err, ErrUserCancelled) {
-		cancel()
-	}
-	return err
+	return createContainerWithProgressTUI(cancel, stream)
 }
 
 // runOptions holds the parsed flags for the run command.

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -14,9 +15,9 @@ import (
 	"strings"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -121,23 +122,48 @@ func cliNotice(format string, args ...any) {
 	fmt.Fprintln(os.Stderr, cliNoticeStyle.Render(fmt.Sprintf(format, args...)))
 }
 
-// createContainerWithProgress calls CreateContainerWithProgress and prints
-// phase updates so the user sees feedback during long image pulls/unpacks.
-func createContainerWithProgress(ctx context.Context, svc agentpb.WendyContainerServiceClient, req *agentpb.CreateContainerRequest) error {
-	stream, err := svc.CreateContainerWithProgress(ctx, req)
-	if err != nil {
-		return fmt.Errorf("creating container: %w", err)
+func unpackProgressTitle(progress *agentpb.CreateContainerProgress) string {
+	total := progress.GetTotalLayers()
+	if total <= 0 {
+		return "Pulling image on device..."
 	}
 
-	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
-	clearLine := func() {
-		if isTTY {
-			fmt.Print("\033[2K\r")
-		} else {
-			fmt.Println()
-		}
+	completed := progress.GetLayerIndex()
+	if progress.GetPhase() == agentpb.CreateContainerProgress_APPLYING_LAYER {
+		completed++
+	}
+	if completed > total {
+		completed = total
 	}
 
+	title := fmt.Sprintf("Unpacking image on device... (%d/%d layers", completed, total)
+	if progress.GetPhase() == agentpb.CreateContainerProgress_APPLYING_LAYER && progress.GetReusedSnapshot() {
+		title += ", reused snapshot"
+	}
+	return title + ")"
+}
+
+func unpackProgressPercent(progress *agentpb.CreateContainerProgress) float64 {
+	total := progress.GetTotalLayers()
+	if total <= 0 {
+		return 0
+	}
+
+	completed := progress.GetLayerIndex()
+	if progress.GetPhase() == agentpb.CreateContainerProgress_APPLYING_LAYER {
+		completed++
+	}
+	if completed < 0 {
+		completed = 0
+	}
+	if completed > total {
+		completed = total
+	}
+
+	return float64(completed) / float64(total)
+}
+
+func createContainerWithProgressPlain(stream agentpb.WendyContainerService_CreateContainerWithProgressClient) error {
 	completed := false
 	for {
 		resp, recvErr := stream.Recv()
@@ -152,12 +178,11 @@ func createContainerWithProgress(ctx context.Context, svc agentpb.WendyContainer
 		case *agentpb.CreateContainerProgressResponse_Progress:
 			switch r.Progress.GetPhase() {
 			case agentpb.CreateContainerProgress_UNPACKING:
-				cliLog("Pulling and unpacking image on device...")
+				cliLogln("%s", unpackProgressTitle(r.Progress))
+			case agentpb.CreateContainerProgress_APPLYING_LAYER:
+				cliLogln("%s", unpackProgressTitle(r.Progress))
 			case agentpb.CreateContainerProgress_CREATING_CONTAINER:
-				clearLine()
-				cliLog("Creating container...")
-			case agentpb.CreateContainerProgress_COMPLETE:
-				clearLine()
+				cliLogln("Creating container...")
 			}
 		case *agentpb.CreateContainerProgressResponse_Completed:
 			completed = true
@@ -172,6 +197,119 @@ func createContainerWithProgress(ctx context.Context, svc agentpb.WendyContainer
 		return fmt.Errorf("creating container: progress stream ended without completion")
 	}
 	return nil
+}
+
+func createContainerWithProgressTUI(ctx context.Context, stream agentpb.WendyContainerService_CreateContainerWithProgressClient) error {
+	prog := tea.NewProgram(tui.NewProgress("Pulling image on device..."))
+
+	var (
+		createErr error
+		done      = make(chan struct{})
+		creating  = make(chan struct{}, 1)
+		completed bool
+	)
+
+	go func() {
+		defer close(done)
+		progressDone := false
+		for {
+			resp, recvErr := stream.Recv()
+			if recvErr == io.EOF {
+				if !completed && createErr == nil {
+					createErr = fmt.Errorf("creating container: progress stream ended without completion")
+				}
+				if !progressDone {
+					prog.Send(tui.ProgressDoneMsg{Err: createErr})
+				}
+				return
+			}
+			if recvErr != nil {
+				createErr = fmt.Errorf("creating container: %w", recvErr)
+				if !progressDone {
+					prog.Send(tui.ProgressDoneMsg{Err: createErr})
+				}
+				return
+			}
+
+			switch r := resp.GetResponseType().(type) {
+			case *agentpb.CreateContainerProgressResponse_Progress:
+				switch r.Progress.GetPhase() {
+				case agentpb.CreateContainerProgress_UNPACKING, agentpb.CreateContainerProgress_APPLYING_LAYER:
+					prog.Send(tui.ProgressUpdateMsg{
+						Percent: unpackProgressPercent(r.Progress),
+						Title:   unpackProgressTitle(r.Progress),
+					})
+				case agentpb.CreateContainerProgress_CREATING_CONTAINER:
+					if !progressDone {
+						progressDone = true
+						select {
+						case creating <- struct{}{}:
+						default:
+						}
+						prog.Send(tui.ProgressDoneMsg{})
+					}
+				case agentpb.CreateContainerProgress_COMPLETE:
+					completed = true
+					if !progressDone {
+						progressDone = true
+						prog.Send(tui.ProgressDoneMsg{})
+					}
+				}
+			case *agentpb.CreateContainerProgressResponse_Completed:
+				completed = true
+				if !progressDone {
+					progressDone = true
+					prog.Send(tui.ProgressDoneMsg{})
+				}
+				return
+			}
+		}
+	}()
+
+	finalModel, err := prog.Run()
+	if err != nil {
+		<-done
+		return fmt.Errorf("progress TUI: %w", err)
+	}
+
+	if pm, ok := finalModel.(tui.ProgressModel); ok && errors.Is(pm.Err(), context.Canceled) {
+		<-done
+		return ErrUserCancelled
+	}
+
+	select {
+	case <-creating:
+		cliLogln("Creating container...")
+	default:
+	}
+
+	<-done
+	return createErr
+}
+
+// createContainerWithProgress calls CreateContainerWithProgress and prints
+// phase updates so the user sees feedback during long image pulls/unpacks.
+func createContainerWithProgress(ctx context.Context, svc agentpb.WendyContainerServiceClient, req *agentpb.CreateContainerRequest) error {
+	if !isInteractiveTerminal() {
+		stream, err := svc.CreateContainerWithProgress(ctx, req)
+		if err != nil {
+			return fmt.Errorf("creating container: %w", err)
+		}
+		return createContainerWithProgressPlain(stream)
+	}
+
+	progressCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := svc.CreateContainerWithProgress(progressCtx, req)
+	if err != nil {
+		return fmt.Errorf("creating container: %w", err)
+	}
+	err = createContainerWithProgressTUI(progressCtx, stream)
+	if errors.Is(err, ErrUserCancelled) {
+		cancel()
+	}
+	return err
 }
 
 // runOptions holds the parsed flags for the run command.

--- a/go/internal/cli/commands/run_progress_test.go
+++ b/go/internal/cli/commands/run_progress_test.go
@@ -1,8 +1,12 @@
 package commands
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/internal/cli/tui"
 	agentpb "github.com/wendylabsinc/wendy/proto/gen/agentpb"
 )
 
@@ -30,5 +34,21 @@ func TestUnpackProgressTitleAndPercentForLayerUpdates(t *testing.T) {
 
 	if got := unpackProgressPercent(progress); got != 0.5 {
 		t.Fatalf("percent = %v; want 0.5", got)
+	}
+}
+
+func TestProgressModelUserCancelled(t *testing.T) {
+	model, _ := tui.NewProgress("Unpacking...").Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if !progressModelUserCancelled(model) {
+		t.Fatal("expected direct ctrl+c cancellation to be treated as user cancellation")
+	}
+}
+
+func TestProgressModelUserCancelledIgnoresWrappedContextCanceled(t *testing.T) {
+	model, _ := tui.NewProgress("Unpacking...").Update(tui.ProgressDoneMsg{
+		Err: fmt.Errorf("creating container: %w", context.Canceled),
+	})
+	if progressModelUserCancelled(model) {
+		t.Fatal("expected wrapped context cancellation to not be treated as direct user cancellation")
 	}
 }

--- a/go/internal/cli/commands/run_progress_test.go
+++ b/go/internal/cli/commands/run_progress_test.go
@@ -1,0 +1,34 @@
+package commands
+
+import (
+	"testing"
+
+	agentpb "github.com/wendylabsinc/wendy/proto/gen/agentpb"
+)
+
+func TestUnpackProgressTitleForPullingPhase(t *testing.T) {
+	progress := &agentpb.CreateContainerProgress{
+		Phase: agentpb.CreateContainerProgress_UNPACKING,
+	}
+
+	if got := unpackProgressTitle(progress); got != "Pulling image on device..." {
+		t.Fatalf("title = %q; want pull title", got)
+	}
+}
+
+func TestUnpackProgressTitleAndPercentForLayerUpdates(t *testing.T) {
+	progress := &agentpb.CreateContainerProgress{
+		Phase:          agentpb.CreateContainerProgress_APPLYING_LAYER,
+		LayerIndex:     1,
+		TotalLayers:    4,
+		ReusedSnapshot: true,
+	}
+
+	if got := unpackProgressTitle(progress); got != "Unpacking image on device... (2/4 layers, reused snapshot)" {
+		t.Fatalf("title = %q; want layer detail title", got)
+	}
+
+	if got := unpackProgressPercent(progress); got != 0.5 {
+		t.Fatalf("percent = %v; want 0.5", got)
+	}
+}

--- a/go/internal/cli/tui/progress.go
+++ b/go/internal/cli/tui/progress.go
@@ -15,6 +15,7 @@ type ProgressUpdateMsg struct {
 	Percent float64
 	Written int64
 	Total   int64
+	Title   string
 }
 
 // ProgressDoneMsg signals that the progress operation is complete.
@@ -63,6 +64,9 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.percent = msg.Percent
 		m.written = msg.Written
 		m.total = msg.Total
+		if msg.Title != "" {
+			m.title = msg.Title
+		}
 		cmd := m.progress.SetPercent(msg.Percent)
 		return m, cmd
 


### PR DESCRIPTION
## Summary
This PR wires agent-side unpack progress into `CreateContainerWithProgress` and renders it in `wendy run` as a Bubble Tea progress bar when the CLI is running in an interactive terminal.

It preserves a plain streamed output path for non-interactive sessions so CLI coding agents and other headless callers do not require a TTY.

Linear issue: [WDY-933](https://linear.app/wendylabsinc/issue/WDY-933/stream-unpack-progress-in-wendy-run-with-bubble-tea-fallback-safe)

## What Changed
- mapped containerd unpack callbacks to `CreateContainerProgress` layer updates
- switched `run` to use Bubble Tea progress rendering only for interactive terminals
- kept non-interactive progress output as plain text
- added focused tests for unpack progress mapping and run progress helpers
- updated the unpack manifest lookup to use the image platform matcher

## Why
Previously the unpack stage was mostly an opaque wait in `wendy run`, even though the agent already had layer-level progress information available.

## Impact
Interactive users get better feedback during unpack, while non-TTY environments continue to work through the existing streaming RPC without Bubble Tea requirements.

## Validation
- `gofmt -w go/internal/cli/tui/progress.go go/internal/cli/commands/run.go go/internal/agent/containerd/client.go go/internal/agent/containerd/unpack.go go/internal/agent/containerd/client_test.go go/internal/cli/commands/run_progress_test.go`
- `go test ./internal/cli/tui ./internal/cli/commands ./internal/agent/containerd ./internal/agent/services`