### PR TITLE
render init templates with text/template so {{if}} works

### DIFF
--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -570,18 +570,14 @@ func renderAndWriteTemplate(files map[string][]byte, destDir, appID, templateNam
 }
 
 // renderTemplateContent evaluates content as a Go text/template against vals.
-// If the file cannot be parsed as a Go template (e.g. it contains literal `{{`
-// for non-template purposes), it falls back to literal {{.VAR}} substitution so
-// existing simple templates keep working.
+// Parse errors are surfaced (scoped to path) so template-authoring mistakes
+// like a broken {{if}} don't silently produce files with unrendered actions.
+// missingkey=error causes references to undeclared variables to fail rather
+// than render as "<no value>".
 func renderTemplateContent(path string, content []byte, vals map[string]interface{}) ([]byte, error) {
-	tmpl, err := template.New(path).Parse(string(content))
+	tmpl, err := template.New(path).Option("missingkey=error").Parse(string(content))
 	if err != nil {
-		rendered := string(content)
-		for key, val := range vals {
-			token := fmt.Sprintf("{{.%s}}", key)
-			rendered = strings.ReplaceAll(rendered, token, fmt.Sprintf("%v", val))
-		}
-		return []byte(rendered), nil
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 
 	var buf bytes.Buffer

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -15,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
@@ -535,9 +537,9 @@ func validateVariable(v templateVariable, val interface{}) error {
 	return nil
 }
 
-// renderAndWriteTemplate takes the raw file map, replaces {{.VAR}} tokens
-// with collected values, and writes to destDir.
-// It renames directories named after the template to the app ID.
+// renderAndWriteTemplate takes the raw file map, evaluates each text file as a
+// Go text/template (so {{.VAR}}, {{if}}, {{range}}, etc. all work), and writes
+// to destDir. It renames directories named after the template to the app ID.
 func renderAndWriteTemplate(files map[string][]byte, destDir, appID, templateName string, vals map[string]interface{}) error {
 	for relPath, content := range files {
 		// Rename template-named directories to app ID.
@@ -549,16 +551,14 @@ func renderAndWriteTemplate(files map[string][]byte, destDir, appID, templateNam
 			return fmt.Errorf("creating directory for %s: %w", relPath, err)
 		}
 
-		// Only apply token replacement to text files. Binary files
-		// (images, fonts, wasm) are written as-is.
+		// Only render text files. Binary files (images, fonts, wasm) are written as-is.
 		output := content
 		if isTextFile(relPath) {
-			rendered := string(content)
-			for key, val := range vals {
-				token := fmt.Sprintf("{{.%s}}", key)
-				rendered = strings.ReplaceAll(rendered, token, fmt.Sprintf("%v", val))
+			rendered, err := renderTemplateContent(relPath, content, vals)
+			if err != nil {
+				return err
 			}
-			output = []byte(rendered)
+			output = rendered
 		}
 
 		if err := os.WriteFile(destPath, output, 0o644); err != nil {
@@ -567,6 +567,28 @@ func renderAndWriteTemplate(files map[string][]byte, destDir, appID, templateNam
 	}
 
 	return nil
+}
+
+// renderTemplateContent evaluates content as a Go text/template against vals.
+// If the file cannot be parsed as a Go template (e.g. it contains literal `{{`
+// for non-template purposes), it falls back to literal {{.VAR}} substitution so
+// existing simple templates keep working.
+func renderTemplateContent(path string, content []byte, vals map[string]interface{}) ([]byte, error) {
+	tmpl, err := template.New(path).Parse(string(content))
+	if err != nil {
+		rendered := string(content)
+		for key, val := range vals {
+			token := fmt.Sprintf("{{.%s}}", key)
+			rendered = strings.ReplaceAll(rendered, token, fmt.Sprintf("%v", val))
+		}
+		return []byte(rendered), nil
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, vals); err != nil {
+		return nil, fmt.Errorf("rendering %s: %w", path, err)
+	}
+	return buf.Bytes(), nil
 }
 
 // renameTemplatePath replaces occurrences of the template name in path

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -497,13 +497,6 @@ func TestRenderTemplateContent(t *testing.T) {
 			want: `FROM python:3.11-slim-bookworm
 `,
 		},
-		{
-			name:    "unparseable template falls back to literal substitution",
-			path:    "weird.txt",
-			content: "{{ not valid go template }} but {{.PORT}} should still work",
-			vals:    map[string]interface{}{"PORT": 8080},
-			want:    "{{ not valid go template }} but 8080 should still work",
-		},
 	}
 
 	for _, tc := range cases {
@@ -516,6 +509,38 @@ func TestRenderTemplateContent(t *testing.T) {
 				t.Errorf("got %q, want %q", string(got), tc.want)
 			}
 		})
+	}
+}
+
+func TestRenderTemplateContentParseError(t *testing.T) {
+	// An invalid template action must surface a path-scoped parse error rather
+	// than silently producing a file with unrendered actions.
+	_, err := renderTemplateContent(
+		"weird.txt",
+		[]byte("{{ not valid go template }} but {{.PORT}} should still work"),
+		map[string]interface{}{"PORT": 8080},
+	)
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), "weird.txt") {
+		t.Errorf("error should mention the file path, got: %v", err)
+	}
+}
+
+func TestRenderTemplateContentMissingKeyError(t *testing.T) {
+	// Referencing an undeclared variable must surface an error rather than
+	// silently rendering as "<no value>".
+	_, err := renderTemplateContent(
+		"Dockerfile",
+		[]byte("EXPOSE {{.MISSING}}\n"),
+		map[string]interface{}{"PORT": 3005},
+	)
+	if err == nil {
+		t.Fatal("expected error for missing key, got nil")
+	}
+	if !strings.Contains(err.Error(), "Dockerfile") {
+		t.Errorf("error should mention the file path, got: %v", err)
 	}
 }
 

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -461,3 +461,76 @@ func keys(m map[string][]byte) []string {
 	sort.Strings(out)
 	return out
 }
+
+func TestRenderTemplateContent(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		content string
+		vals    map[string]interface{}
+		want    string
+	}{
+		{
+			name:    "simple variable substitution",
+			path:    "Dockerfile",
+			content: "EXPOSE {{.PORT}}\n",
+			vals:    map[string]interface{}{"PORT": 3005},
+			want:    "EXPOSE 3005\n",
+		},
+		{
+			name: "if/else branches on variable (jetson)",
+			path: "Dockerfile",
+			content: `{{if eq .TARGET "jetson"}}FROM dustynv/pytorch:latest
+{{else}}FROM python:3.11-slim-bookworm
+{{end}}`,
+			vals: map[string]interface{}{"TARGET": "jetson"},
+			want: `FROM dustynv/pytorch:latest
+`,
+		},
+		{
+			name: "if/else branches on variable (generic)",
+			path: "Dockerfile",
+			content: `{{if eq .TARGET "jetson"}}FROM dustynv/pytorch:latest
+{{else}}FROM python:3.11-slim-bookworm
+{{end}}`,
+			vals: map[string]interface{}{"TARGET": "generic"},
+			want: `FROM python:3.11-slim-bookworm
+`,
+		},
+		{
+			name:    "unparseable template falls back to literal substitution",
+			path:    "weird.txt",
+			content: "{{ not valid go template }} but {{.PORT}} should still work",
+			vals:    map[string]interface{}{"PORT": 8080},
+			want:    "{{ not valid go template }} but 8080 should still work",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := renderTemplateContent(tc.path, []byte(tc.content), tc.vals)
+			if err != nil {
+				t.Fatalf("renderTemplateContent: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %q, want %q", string(got), tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderTemplateContentExecuteError(t *testing.T) {
+	// Parse succeeds but Execute fails — calling a method that doesn't exist
+	// on the data map. The error must be surfaced so the user sees it.
+	_, err := renderTemplateContent(
+		"Dockerfile",
+		[]byte(`{{.PORT.NonExistentMethod}}`),
+		map[string]interface{}{"PORT": 3005},
+	)
+	if err == nil {
+		t.Fatal("expected error from Execute, got nil")
+	}
+	if !strings.Contains(err.Error(), "Dockerfile") {
+		t.Errorf("error should mention the file path, got: %v", err)
+	}
+}


### PR DESCRIPTION
`wendy init` previously rendered template files via `strings.ReplaceAll` per `{{.VAR}}` token, so any `{{if}}` / `{{else}}` / `{{end}}` block passed through verbatim and broke the resulting file 

Switches rendering to `text/template.Parse` + `Execute`, unlocking full Go template actions (`if`, `range`, etc.). Files that aren't valid Go templates fall back to the old literal substitution so existing simple templates keep working. 