### PR TITLE
Fix Template Tests CI regressions

### DIFF
--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -600,12 +600,15 @@ func renameTemplatePath(relPath, templateName, appID string) string {
 }
 
 // isTextFile returns true if a file path looks like a text file that should
-// have template tokens replaced. Binary files are left as-is.
+// have template tokens replaced. Binary files are left as-is. JSX/TSX files
+// are excluded because they routinely contain `{{ … }}` object expressions
+// (e.g. `icons={{ success: ... }}`) that collide with Go template syntax;
+// they don't need variable interpolation in practice.
 func isTextFile(path string) bool {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
 	case ".json", ".toml", ".yaml", ".yml", ".md", ".txt", ".html", ".css",
-		".js", ".ts", ".tsx", ".jsx", ".py", ".rs", ".swift", ".go",
+		".js", ".ts", ".py", ".rs", ".swift", ".go",
 		".cpp", ".c", ".h", ".hpp", ".cmake", ".sh", ".bash", ".zsh",
 		".dockerfile", ".gitignore", ".env", ".cfg", ".ini", ".xml",
 		".svg", ".lock":

--- a/go/scripts/test-templates.sh
+++ b/go/scripts/test-templates.sh
@@ -170,6 +170,14 @@ for lang in "${LANGUAGES[@]}"; do
         app_id="test-${lang}-${tmpl}"
         test_name="${lang}/${tmpl}"
 
+        # Some templates only exist for a subset of languages (e.g.
+        # camera-feed-yolo is python-only). Skip combinations that aren't in
+        # the templates repo rather than counting them as failures.
+        if [[ ! -f "$TEMPLATES_DIR/$lang/$tmpl/template.json" ]]; then
+            skip_test "init $test_name (not available for $lang)"
+            continue
+        fi
+
         run_test "init $test_name" \
             bash -c "cd '$WORK_DIR/$lang' && '$WENDY' init \
                 --app-id '$app_id' \
@@ -191,6 +199,11 @@ for lang in "${LANGUAGES[@]}"; do
         app_id="test-${lang}-${tmpl}"
         project_dir="$WORK_DIR/$lang/$app_id"
         test_name="${lang}/${tmpl}"
+
+        if [[ ! -f "$TEMPLATES_DIR/$lang/$tmpl/template.json" ]]; then
+            skip_test "validate $test_name (not available for $lang)"
+            continue
+        fi
 
         if [[ ! -f "$project_dir/wendy.json" ]]; then
             skip_test "validate $test_name (no wendy.json)"


### PR DESCRIPTION
## Summary
Two fixes for the post-merge failure on main ([run 24689545755](https://github.com/wendylabsinc/wendy-agent/actions/runs/24689545755/job/72207609614)):

- **Stop running `.tsx`/`.jsx` through `text/template`.** The shadcn/Vite frontend files in the `fullstack` template contain JSX object expressions like `icons={{ success: ... }}`, which the strict parser landed in #515 rejects as `function "success" not defined`. These files never contain `{{.VAR}}` tokens in the `wendylabsinc/templates` repo, so copy them verbatim.
- **Skip template/language combinations missing from the templates repo** instead of failing them. `camera-feed-yolo` only ships for `python` today; the other four languages now surface as SKIP rather than FAIL.

Local run against `~/wendylabsinc/templates`: **42 passed, 0 failed, 8 skipped** (was 33/9/8).

## Test plan
- [x] `go test ./internal/cli/commands/ -run Template`
- [x] `./scripts/test-templates.sh -w ./bin/wendy --skip-run --templates-dir ~/wendylabsinc/templates`
- [ ] Template Tests CI job on this PR goes green