### PR TITLE
[codex] Show elapsed time for default-device lookup failures

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -63,7 +63,8 @@ var runAgentConnectionSpinner = func(ctx context.Context, label string, fn func(
 	go func() {
 		defer close(doneCh)
 		conn, runErr = fn(ctx)
-		prog.Send(tui.SpinnerDoneMsg{Err: runErr})
+		// Keep spinner teardown quiet; callers handle the returned error.
+		prog.Send(tui.SpinnerDoneMsg{})
 	}()
 
 	finalModel, err := prog.Run()
@@ -360,9 +361,10 @@ func defaultDeviceSearchLabel(hostname string) string {
 }
 
 func formatElapsedSeconds(elapsed time.Duration) string {
-	seconds := elapsed.Seconds()
+	roundedElapsed := elapsed.Round(10 * time.Millisecond)
+	seconds := roundedElapsed.Seconds()
 	unit := "seconds"
-	if seconds == 1 {
+	if roundedElapsed == time.Second {
 		unit = "second"
 	}
 	return fmt.Sprintf("%.2f %s", seconds, unit)

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -45,6 +45,50 @@ var getAgentVersionAtAddress = func(ctx context.Context, address string) (bool, 
 	return conn.IsMTLS, resp, err
 }
 
+var isInteractiveTerminalFn = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+var runAgentConnectionSpinner = func(ctx context.Context, label string, fn func(context.Context) (*grpcclient.AgentConnection, error)) (*grpcclient.AgentConnection, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	prog := tea.NewProgram(tui.NewSpinner(label))
+
+	var (
+		conn   *grpcclient.AgentConnection
+		runErr error
+		doneCh = make(chan struct{})
+	)
+	go func() {
+		defer close(doneCh)
+		conn, runErr = fn(ctx)
+		prog.Send(tui.SpinnerDoneMsg{Err: runErr})
+	}()
+
+	finalModel, err := prog.Run()
+	if err != nil {
+		cancel()
+		<-doneCh
+		if conn != nil {
+			conn.Close()
+		}
+		return nil, fmt.Errorf("spinner TUI: %w", err)
+	}
+
+	if sm, ok := finalModel.(tui.SpinnerModel); ok && !sm.Done() {
+		cancel()
+		<-doneCh
+		if conn != nil {
+			conn.Close()
+		}
+		return nil, ErrUserCancelled
+	}
+
+	<-doneCh
+	return conn, runErr
+}
+
 // ErrUserCancelled is returned when the user cancels an interactive prompt (e.g. Ctrl+C).
 var ErrUserCancelled = errors.New("cancelled")
 
@@ -296,19 +340,60 @@ func promptDefaultDeviceRecovery(hostname string) recoveryChoice {
 // isInteractiveTerminal returns true when both stdin and stdout are TTYs,
 // meaning it is safe to show interactive Bubble Tea prompts.
 func isInteractiveTerminal() bool {
-	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+	return isInteractiveTerminalFn()
 }
 
 // handleDefaultDeviceRecovery runs the recovery flow after a default device
 // connection failure. Shows a warning and immediately opens the device picker
 // where the user can select a new device and optionally set/unset default
 // via 'd'/'x' shortcuts.
-func handleDefaultDeviceRecovery(ctx context.Context, hostname string, _ error, excludeProviders map[string]bool, excludeBluetooth bool) (*SelectedDevice, error) {
+func handleDefaultDeviceRecovery(ctx context.Context, hostname string, elapsed time.Duration, _ error, excludeProviders map[string]bool, excludeBluetooth bool) (*SelectedDevice, error) {
 	warnStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
-	fmt.Println(warnStyle.Render(fmt.Sprintf("⚠ Default device %q is unreachable.", hostname)))
+	fmt.Println(warnStyle.Render(fmt.Sprintf("⚠ Default device %q is unreachable after %s.", hostname, formatElapsedSeconds(elapsed))))
 	fmt.Println()
 
 	return pickDevice(ctx, excludeProviders, excludeBluetooth, false)
+}
+
+func defaultDeviceSearchLabel(hostname string) string {
+	return fmt.Sprintf("Searching for default device %q...", hostname)
+}
+
+func formatElapsedSeconds(elapsed time.Duration) string {
+	seconds := elapsed.Seconds()
+	unit := "seconds"
+	if seconds == 1 {
+		unit = "second"
+	}
+	return fmt.Sprintf("%.2f %s", seconds, unit)
+}
+
+func connectAgentAtAddress(ctx context.Context, addr string, probePlaintext bool) (*grpcclient.AgentConnection, error) {
+	conn, err := connectWithAutoTLS(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	if probePlaintext && !conn.IsMTLS {
+		// gRPC plaintext connections are lazy — probe to detect unreachable
+		// default devices early so recovery can be offered immediately.
+		probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
+		cancel()
+		if probeErr != nil {
+			conn.Close()
+			return nil, probeErr
+		}
+	}
+	return conn, nil
+}
+
+func connectResolvedAgent(ctx context.Context, hostname, addr string, isDefault bool) (*grpcclient.AgentConnection, error) {
+	if isDefault && !jsonOutput && isInteractiveTerminal() {
+		return runAgentConnectionSpinner(ctx, defaultDeviceSearchLabel(hostname), func(spinCtx context.Context) (*grpcclient.AgentConnection, error) {
+			return connectAgentAtAddress(spinCtx, addr, true)
+		})
+	}
+	return connectAgentAtAddress(ctx, addr, isDefault)
 }
 
 // connectToAgent establishes a gRPC connection to the target device.
@@ -324,25 +409,20 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 
 	addr, isDefault, err := resolveDeviceAddress()
 	if err == nil {
-		conn, connErr := connectWithAutoTLS(ctx, addr)
-		if connErr == nil && isDefault && !conn.IsMTLS {
-			// gRPC plaintext connections are lazy — probe to detect
-			// unreachable default devices early so the recovery menu
-			// can be shown instead of a cryptic error later.
-			// mTLS connections are already probed inside connectWithAutoTLS.
-			probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-			_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
-			cancel()
-			if probeErr != nil {
-				conn.Close()
-				connErr = probeErr
-			}
+		startedAt := time.Now()
+		hostname := addr
+		if host, _, splitErr := net.SplitHostPort(addr); splitErr == nil {
+			hostname = host
 		}
+		conn, connErr := connectResolvedAgent(ctx, hostname, addr, isDefault)
 		if connErr != nil {
+			if errors.Is(connErr, ErrUserCancelled) {
+				return nil, connErr
+			}
 			// Default device is unreachable — offer interactive recovery.
 			if isDefault && !jsonOutput && isInteractiveTerminal() {
 				hostname, _, _ := net.SplitHostPort(addr)
-				target, recErr := handleDefaultDeviceRecovery(ctx, hostname, connErr, cfg.excludeProviderKeys, cfg.excludeBluetooth)
+				target, recErr := handleDefaultDeviceRecovery(ctx, hostname, time.Since(startedAt), connErr, cfg.excludeProviderKeys, cfg.excludeBluetooth)
 				if recErr != nil {
 					return nil, recErr
 				}
@@ -693,20 +773,15 @@ func resolveTarget(ctx context.Context, opts ...resolveOption) (*SelectedDevice,
 	// If a device hostname was given, connect via gRPC (with mTLS if authenticated).
 	if device != "" {
 		addr := hostPort(device, defaultAgentPort)
-		conn, err := connectWithAutoTLS(ctx, addr)
-		if err == nil && isDefault && !conn.IsMTLS {
-			probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-			_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
-			cancel()
-			if probeErr != nil {
-				conn.Close()
-				err = probeErr
-			}
-		}
+		startedAt := time.Now()
+		conn, err := connectResolvedAgent(ctx, device, addr, isDefault)
 		if err != nil {
+			if errors.Is(err, ErrUserCancelled) {
+				return nil, err
+			}
 			// Default device is unreachable — offer interactive recovery.
 			if isDefault && !jsonOutput && !cfg.nonInteractive && isInteractiveTerminal() {
-				return handleDefaultDeviceRecovery(ctx, device, err, cfg.excludeProviderKeys, cfg.excludeBluetooth)
+				return handleDefaultDeviceRecovery(ctx, device, time.Since(startedAt), err, cfg.excludeProviderKeys, cfg.excludeBluetooth)
 			}
 			return nil, err
 		}

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -371,6 +371,7 @@ func TestFormatElapsedSeconds(t *testing.T) {
 		{name: "fractional seconds", elapsed: 3420 * time.Millisecond, want: "3.42 seconds"},
 		{name: "rounding", elapsed: 3449 * time.Millisecond, want: "3.45 seconds"},
 		{name: "singular", elapsed: time.Second, want: "1.00 second"},
+		{name: "rounds to singular", elapsed: 1004 * time.Millisecond, want: "1.00 second"},
 	}
 
 	for _, tt := range tests {

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -6,7 +6,9 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/wendylabsinc/wendy/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/internal/shared/config"
 	"github.com/wendylabsinc/wendy/internal/shared/models"
 	"github.com/wendylabsinc/wendy/proto/gen/agentpb"
@@ -349,5 +351,77 @@ func TestResolveLANVersionsKeepsDevicesWhenMetadataLookupFails(t *testing.T) {
 		if got[i].AgentVersion != "" {
 			t.Fatalf("resolveLANVersions()[%d].AgentVersion = %q, want empty", i, got[i].AgentVersion)
 		}
+	}
+}
+
+func TestDefaultDeviceSearchLabel(t *testing.T) {
+	got := defaultDeviceSearchLabel("wendyos-daring-razorbill.local")
+	want := `Searching for default device "wendyos-daring-razorbill.local"...`
+	if got != want {
+		t.Fatalf("defaultDeviceSearchLabel() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatElapsedSeconds(t *testing.T) {
+	tests := []struct {
+		name    string
+		elapsed time.Duration
+		want    string
+	}{
+		{name: "fractional seconds", elapsed: 3420 * time.Millisecond, want: "3.42 seconds"},
+		{name: "rounding", elapsed: 3449 * time.Millisecond, want: "3.45 seconds"},
+		{name: "singular", elapsed: time.Second, want: "1.00 second"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatElapsedSeconds(tt.elapsed); got != tt.want {
+				t.Fatalf("formatElapsedSeconds(%v) = %q, want %q", tt.elapsed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectResolvedAgent_UsesSpinnerForInteractiveDefaultDevice(t *testing.T) {
+	origInteractive := isInteractiveTerminalFn
+	origSpinner := runAgentConnectionSpinner
+	origJSON := jsonOutput
+	defer func() {
+		isInteractiveTerminalFn = origInteractive
+		runAgentConnectionSpinner = origSpinner
+		jsonOutput = origJSON
+	}()
+
+	isInteractiveTerminalFn = func() bool { return true }
+	jsonOutput = false
+
+	wantConn := &grpcclient.AgentConnection{Host: "wendyos-daring-razorbill.local"}
+	var (
+		gotLabel       string
+		spinnerInvoked bool
+	)
+	runAgentConnectionSpinner = func(_ context.Context, label string, _ func(context.Context) (*grpcclient.AgentConnection, error)) (*grpcclient.AgentConnection, error) {
+		spinnerInvoked = true
+		gotLabel = label
+		return wantConn, nil
+	}
+
+	gotConn, err := connectResolvedAgent(
+		context.Background(),
+		"wendyos-daring-razorbill.local",
+		hostPort("wendyos-daring-razorbill.local", defaultAgentPort),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("connectResolvedAgent() error = %v", err)
+	}
+	if !spinnerInvoked {
+		t.Fatal("expected interactive default-device connection to use spinner")
+	}
+	if gotLabel != `Searching for default device "wendyos-daring-razorbill.local"...` {
+		t.Fatalf("spinner label = %q, want %q", gotLabel, `Searching for default device "wendyos-daring-razorbill.local"...`)
+	}
+	if gotConn != wantConn {
+		t.Fatal("connectResolvedAgent() did not return spinner result")
 	}
 }


### PR DESCRIPTION
## Summary
- keep the default-device search spinner visible while `wendy run` probes the saved default device
- include the elapsed lookup time in the unreachable warning as human-readable seconds with 2 decimal places
- add unit coverage for the spinner label and elapsed-time formatter

## Why
The CLI already spends a few seconds probing the saved default device before showing the recovery UI. Including the elapsed time in the final warning makes that pause explicit instead of feeling like an unexplained stall.

## User Impact
Users now see output like `⚠ Default device "wendyos-daring-razorbill.local" is unreachable after 3.42 seconds.` before the recovery picker opens.

## Validation
- `go test ./internal/cli/commands`

Refs: WDY-956
Linear: https://linear.app/wendylabsinc/issue/WDY-956/show-elapsed-time-when-default-device-lookup-fails