### PR TITLE
Wendy for Mac — About Panel

### DIFF
--- a/swift/WendyAgentMac/Sources/AppDelegate.swift
+++ b/swift/WendyAgentMac/Sources/AppDelegate.swift
@@ -46,6 +46,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate,
         }
     }
 
+    func statusMenuControllerDidSelectAbout(_ controller: StatusMenuController) {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        NSApplication.shared.orderFrontStandardAboutPanel(options: [
+            .applicationName: AppDisplayName.current
+        ])
+    }
+
     func statusMenuControllerDidSelectWelcomeAndPermissions(_ controller: StatusMenuController) {
         self.showWelcomeAndPermissionsWindow()
     }

--- a/swift/WendyAgentMac/Sources/StatusMenuController.swift
+++ b/swift/WendyAgentMac/Sources/StatusMenuController.swift
@@ -3,6 +3,7 @@ import WendyAgentCore
 
 @MainActor
 protocol StatusMenuControllerDelegate: AnyObject {
+    func statusMenuControllerDidSelectAbout(_ controller: StatusMenuController)
     func statusMenuControllerDidSelectWelcomeAndPermissions(_ controller: StatusMenuController)
     func statusMenuControllerDidSelectQuit(_ controller: StatusMenuController)
 }
@@ -69,17 +70,13 @@ final class StatusMenuController: NSObject {
     private func rebuildMenu() {
         self.menu.removeAllItems()
 
-        let statusItem = self.makeDisabledMenuItem(title: self.currentStatus.menuTitle)
-        statusItem.image = self.makeStatusImage(for: self.currentStatus)
-        self.menu.addItem(statusItem)
-
-        for detail in self.currentStatus.menuFailureDetails {
-            self.menu.addItem(self.makeDisabledMenuItem(title: detail))
-        }
-
-        self.menu.addItem(.separator())
-        self.addRunningAppsSection()
-        self.menu.addItem(.separator())
+        let aboutItem = NSMenuItem(
+            title: "About \(self.bundleDisplayName)",
+            action: #selector(self.aboutSelected),
+            keyEquivalent: ""
+        )
+        aboutItem.target = self
+        self.menu.addItem(aboutItem)
 
         let welcomeItem = NSMenuItem(
             title: "Welcome & Permissions…",
@@ -88,6 +85,19 @@ final class StatusMenuController: NSObject {
         )
         welcomeItem.target = self
         self.menu.addItem(welcomeItem)
+
+        self.menu.addItem(.separator())
+
+        let statusItem = self.makeDisabledMenuItem(title: self.currentStatus.menuTitle)
+        statusItem.image = self.makeStatusImage(for: self.currentStatus)
+        self.menu.addItem(statusItem)
+
+        for detail in self.currentStatus.menuFailureDetails {
+            self.menu.addItem(self.makeDisabledMenuItem(title: detail))
+        }
+
+        self.addRunningAppsSection()
+        self.menu.addItem(.separator())
 
         let quitItem = NSMenuItem(
             title: "Quit \(self.bundleDisplayName)",
@@ -99,13 +109,7 @@ final class StatusMenuController: NSObject {
     }
 
     private func addRunningAppsSection() {
-        self.menu.addItem(self.makeDisabledMenuItem(title: "Apps:"))
-
         let runningApps = self.runningApps
-        guard !runningApps.isEmpty else {
-            self.menu.addItem(self.makeDisabledMenuItem(title: "—"))
-            return
-        }
 
         for app in runningApps {
             let appItem = NSMenuItem(title: app.id, action: nil, keyEquivalent: "")
@@ -214,6 +218,11 @@ final class StatusMenuController: NSObject {
 
     func invalidate() async {
         await self.cancelObservations()
+    }
+
+    @objc
+    private func aboutSelected() {
+        self.delegate?.statusMenuControllerDidSelectAbout(self)
     }
 
     @objc


### PR DESCRIPTION
## Summary
- add a standard About action to the WendyAgentMac status menu
- show the built-in macOS About panel from the app delegate
- simplify the menu layout around app-level actions and quit

## Testing
- xcodebuild -project WendyAgentMac/WendyAgentMac.xcodeproj -scheme WendyAgentMac -configuration Debug -sdk macosx CODE_SIGNING_ALLOWED=NO build
