### PR TITLE
WDY-957: Code-sign Windows MSI and embedded wendy.exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,9 @@ name: Build products and release
 on:
   push:
     branches: [main]
-    paths: ['go/**']
+    paths:
+      - 'go/**'
+      - '.github/workflows/build.yml'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,6 +415,9 @@ jobs:
     runs-on: windows-latest
     needs: [determine-version, build]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         include:
@@ -422,6 +425,10 @@ jobs:
             goarch: amd64
           - arch: arm64
             goarch: arm64
+    env:
+      SIGNING_ENDPOINT: https://eus.codesigning.azure.net/
+      SIGNING_ACCOUNT: wendy-signing
+      SIGNING_PROFILE: wendy-cli
     steps:
       - uses: actions/checkout@v6
 
@@ -436,6 +443,41 @@ jobs:
       - name: Extract artifact
         run: |
           Expand-Archive "wendy-cli-windows-${{ matrix.goarch }}-${{ needs.determine-version.outputs.version }}.zip" -DestinationPath .
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign wendy.exe
+        uses: azure/trusted-signing-action@v0.5.1
+        with:
+          endpoint: ${{ env.SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ env.SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ env.SIGNING_PROFILE }}
+          files-folder: wendy-cli-windows-${{ matrix.goarch }}
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Re-zip with signed exe
+        run: |
+          $VERSION = "${{ needs.determine-version.outputs.version }}"
+          $ARCHIVE = "wendy-cli-windows-${{ matrix.goarch }}-${VERSION}.zip"
+          Remove-Item $ARCHIVE
+          Compress-Archive -Path "wendy-cli-windows-${{ matrix.goarch }}" -DestinationPath $ARCHIVE
+
+      - name: Upload signed zip
+        uses: actions/upload-artifact@v7
+        with:
+          name: wendy-cli-windows-${{ matrix.goarch }}-${{ needs.determine-version.outputs.version }}.zip
+          path: wendy-cli-windows-${{ matrix.goarch }}-${{ needs.determine-version.outputs.version }}.zip
+          retention-days: 14
+          if-no-files-found: error
+          overwrite: true
 
       - name: Build MSI
         run: |
@@ -456,6 +498,17 @@ jobs:
             -arch $MSI_ARCH `
             -o "wendy-cli-windows-${{ matrix.goarch }}-${VERSION}.msi" `
             go/installer/windows/wendy.wxs
+
+      - name: Sign MSI
+        uses: azure/trusted-signing-action@v0.5.1
+        with:
+          endpoint: ${{ env.SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ env.SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ env.SIGNING_PROFILE }}
+          files: ${{ github.workspace }}\wendy-cli-windows-${{ matrix.goarch }}-${{ needs.determine-version.outputs.version }}.msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Upload MSI
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Authenticode-sign `wendy.exe` **before** WiX packages it, so the MSI-embedded exe is trusted.
- Re-zip and overwrite the `wendy-cli-windows-*.zip` artifact so the raw exe shipped in releases is also signed.
- Authenticode-sign the built MSI with an RFC 3161 timestamp.
- Auth to Azure via GitHub OIDC federated credentials — no long-lived secrets in the repo.

Users should stop seeing "Unknown publisher" SmartScreen / UAC warnings on install; once SmartScreen reputation builds up, prompts will go away entirely.

## Required repo secrets

Before merging, add these in repo Settings → Secrets and variables → Actions:

| Secret | Value |
|---|---|
| `AZURE_CLIENT_ID` | `ff7a1228-76fa-4530-92c5-0076abd93ad1` |
| `AZURE_TENANT_ID` | `0a4dd300-841b-4727-9e8b-b186b61ef0f3` |
| `AZURE_SUBSCRIPTION_ID` | `621401d0-e619-48fa-8a4e-d38c86e8ed9e` |

These point at the `github-wendy-agent-signing` Entra app, which has a federated credential for `refs/heads/main` and `refs/tags/v*` on this repo, and the `Artifact Signing Certificate Profile Signer` role on the `wendy-signing` account in the Wendy Labs Azure tenant.

## Azure side

All resources provisioned under subscription `Azure subscription 1`:

- **Artifact Signing account**: `wendy-signing` (eastus, endpoint `https://eus.codesigning.azure.net/`)
- **Identity validation**: `Wendy Labs Inc` — Validation Pass
- **Certificate profile**: `wendy-cli` (Public Trust, Active)

(Full details in WDY-957.)

## Why sign order matters

If we only sign the MSI, Windows still shows warnings on the extracted `wendy.exe` (because installers unpack the exe and re-launch it). Signing the exe before WiX embeds it, then signing the MSI around it, is the correct Authenticode pattern.

## Test plan

- [x] Add the three `AZURE_*` secrets to the repo
- [ ] Merge, let the next nightly run on `main`
- [ ] Download `wendy-cli-windows-amd64-*.msi` from the nightly release
- [ ] On a Windows machine: `signtool verify /pa /all wendy-cli-windows-amd64-*.msi` — expect "Successfully verified"
- [ ] Extract the `.zip`, run `signtool verify /pa /all wendy.exe` — expect "Successfully verified"
- [ ] Double-click the MSI — UAC should say "Verified publisher: Wendy Labs Inc"
- [ ] Install via `winget install WendyLabs.Wendy` once nightly promotes