### PR TITLE
Fix Linux Swift container builds on WendyAgentMac

### DIFF
--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -262,3 +262,45 @@ func TestCheckELFArchitecture(t *testing.T) {
 		})
 	}
 }
+
+func TestDetectELFArchitecture(t *testing.T) {
+	arch, isELF := detectELFArchitecture(makeELFHeader(62))
+	if !isELF {
+		t.Fatal("expected ELF to be detected")
+	}
+	if arch != "amd64" {
+		t.Fatalf("arch = %q, want amd64", arch)
+	}
+
+	arch, isELF = detectELFArchitecture([]byte("#!/bin/sh\n"))
+	if isELF {
+		t.Fatal("expected script not to be detected as ELF")
+	}
+	if arch != "" {
+		t.Fatalf("arch = %q, want empty", arch)
+	}
+}
+
+func TestValidateELFFileArchitecture(t *testing.T) {
+	dir := t.TempDir()
+	amd64Path := filepath.Join(dir, "amd64-bin")
+	if err := os.WriteFile(amd64Path, makeELFHeader(62), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := validateELFFileArchitecture(amd64Path, "amd64"); err != nil {
+		t.Fatalf("validateELFFileArchitecture() unexpected error: %v", err)
+	}
+
+	if err := validateELFFileArchitecture(amd64Path, "arm64"); err == nil {
+		t.Fatal("expected architecture mismatch error, got nil")
+	}
+
+	scriptPath := filepath.Join(dir, "script")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := validateELFFileArchitecture(scriptPath, "amd64"); err == nil {
+		t.Fatal("expected non-ELF validation error, got nil")
+	}
+}

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -263,6 +263,36 @@ func TestCheckELFArchitecture(t *testing.T) {
 	}
 }
 
+func TestLinuxTargetTriple(t *testing.T) {
+	cases := []struct {
+		arch       string
+		wantTriple string
+		wantErr    bool
+	}{
+		{arch: "arm64", wantTriple: "aarch64-unknown-linux-gnu"},
+		{arch: "amd64", wantTriple: "x86_64-unknown-linux-gnu"},
+		{arch: "riscv64", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.arch, func(t *testing.T) {
+			got, err := linuxTargetTriple(tc.arch)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("linuxTargetTriple() unexpected error: %v", err)
+			}
+			if got != tc.wantTriple {
+				t.Fatalf("linuxTargetTriple() = %q, want %q", got, tc.wantTriple)
+			}
+		})
+	}
+}
+
 func TestDetectELFArchitecture(t *testing.T) {
 	arch, isELF := detectELFArchitecture(makeELFHeader(62))
 	if !isELF {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1295,43 +1295,10 @@ func checkELFArchitecture(data []byte, deviceArch string) error {
 		return fmt.Errorf("device reports unsupported architecture %q; only amd64 and arm64 are supported", deviceArch)
 	}
 
-	// ELF magic + header fields up to e_machine occupy 20 bytes.
-	if len(data) < 20 {
-		return nil
+	binaryArch, isELF := detectELFArchitecture(data)
+	if !isELF || binaryArch == "" {
+		return nil // not an ELF binary or not one we recognise — skip check
 	}
-	if data[0] != 0x7f || data[1] != 'E' || data[2] != 'L' || data[3] != 'F' {
-		return nil // not an ELF binary — skip check
-	}
-
-	// Respect EI_DATA (byte 5) when reading the 2-byte e_machine field at offset 18.
-	const (
-		elfDataLittle = 1 // ELFDATA2LSB
-		elfDataBig    = 2 // ELFDATA2MSB
-
-		emX86_64  = 62  // EM_X86_64  → amd64
-		emAArch64 = 183 // EM_AARCH64 → arm64
-	)
-
-	var machine uint16
-	switch data[5] {
-	case elfDataLittle:
-		machine = uint16(data[18]) | uint16(data[19])<<8
-	case elfDataBig:
-		machine = uint16(data[18])<<8 | uint16(data[19])
-	default:
-		return nil // unknown ELF endianness — skip check
-	}
-
-	var binaryArch string
-	switch machine {
-	case emX86_64:
-		binaryArch = "amd64"
-	case emAArch64:
-		binaryArch = "arm64"
-	default:
-		return nil // unrecognised ELF machine type — let the device decide
-	}
-
 	if binaryArch != deviceArch {
 		return fmt.Errorf("binary is %s but device is %s; provide the correct binary with --binary", binaryArch, deviceArch)
 	}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -195,6 +195,34 @@ func generatePythonDockerfile(dir string) (string, error) {
 	return dockerfilePath, nil
 }
 
+func buildSwiftExecutable(ctx context.Context, dir, product, sdk, configuration string) (string, error) {
+	buildArgs := []string{"build"}
+	showBinArgs := []string{"build"}
+	if configuration != "" {
+		buildArgs = append(buildArgs, "-c", configuration)
+		showBinArgs = append(showBinArgs, "-c", configuration)
+	}
+	buildArgs = append(buildArgs, "--swift-sdk="+sdk, "--product", product)
+	showBinArgs = append(showBinArgs, "--swift-sdk="+sdk, "--show-bin-path")
+
+	buildCmd := swifttoolchain.SwiftCommandContext(ctx, buildArgs...)
+	buildCmd.Dir = dir
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+	if err := buildCmd.Run(); err != nil {
+		return "", fmt.Errorf("swift build: %w", err)
+	}
+
+	showBinCmd := swifttoolchain.SwiftCommandContext(ctx, showBinArgs...)
+	showBinCmd.Dir = dir
+	out, err := showBinCmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("swift build --show-bin-path: %w\n%s", err, string(out))
+	}
+
+	return filepath.Join(strings.TrimSpace(string(out)), product), nil
+}
+
 // buildSwiftContainerImage builds a Swift package and pushes the container image
 // directly to the device's registry using swift-container-plugin.
 // registryAddr is a pre-resolved host:port (e.g. "192.168.1.5:5000" or
@@ -209,6 +237,15 @@ func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, a
 		return err
 	}
 
+	cliLogln("Cross-compiling %s for linux/%s...", product, architecture)
+	binaryPath, err := buildSwiftExecutable(ctx, dir, product, sdk, "")
+	if err != nil {
+		return err
+	}
+	if err := validateELFFileArchitecture(binaryPath, architecture); err != nil {
+		return fmt.Errorf("validating Swift build output: %w", err)
+	}
+
 	swiftArgs := []string{
 		"package",
 		"--swift-sdk=" + sdk,
@@ -217,8 +254,11 @@ func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, a
 		"--from=swift:" + swifttoolchain.DefaultVersion + "-slim",
 		"--product=" + product,
 		"--repository=" + registryAddr + "/" + strings.ToLower(product),
-		"--architecture=" + architecture,
 	}
+
+	// Do not force --architecture here. The container plugin can detect the
+	// executable's actual ELF architecture, which avoids publishing an image
+	// whose metadata disagrees with the binary on disk.
 
 	// Use insecure HTTP when the connection is not mTLS; the registry only
 	// speaks TLS when the device is provisioned and the CLI connected via mTLS.
@@ -1169,25 +1209,13 @@ func buildSwiftDockerImage(ctx context.Context, dir, product string, toolchainSt
 	}
 
 	cliLogln("Cross-compiling %s for linux/%s...", product, arch)
-	buildCmd := swifttoolchain.SwiftCommandContext(ctx,
-		"build", "-c", "release", "--swift-sdk="+sdk, "--product", product)
-	buildCmd.Dir = dir
-	buildCmd.Stdout = os.Stdout
-	buildCmd.Stderr = os.Stderr
-	if err := buildCmd.Run(); err != nil {
-		return "", fmt.Errorf("swift build: %w", err)
-	}
-
-	// Determine the binary output path.
-	showBinCmd := swifttoolchain.SwiftCommandContext(ctx,
-		"build", "-c", "release", "--swift-sdk="+sdk, "--show-bin-path")
-	showBinCmd.Dir = dir
-	out, err := showBinCmd.CombinedOutput()
+	srcBin, err := buildSwiftExecutable(ctx, dir, product, sdk, "release")
 	if err != nil {
-		return "", fmt.Errorf("swift build --show-bin-path: %w\n%s", err, string(out))
+		return "", err
 	}
-	binDir := strings.TrimSpace(string(out))
-	srcBin := filepath.Join(binDir, product)
+	if err := validateELFFileArchitecture(srcBin, arch); err != nil {
+		return "", fmt.Errorf("validating Swift build output: %w", err)
+	}
 
 	// Create a temp directory with the binary and a minimal Dockerfile.
 	tmpDir, err := os.MkdirTemp("", "wendy-swift-docker-*")

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -195,15 +195,26 @@ func generatePythonDockerfile(dir string) (string, error) {
 	return dockerfilePath, nil
 }
 
-func buildSwiftExecutable(ctx context.Context, dir, product, sdk, configuration string) (string, error) {
+func linuxTargetTriple(architecture string) (string, error) {
+	switch architecture {
+	case "arm64":
+		return "aarch64-unknown-linux-gnu", nil
+	case "amd64":
+		return "x86_64-unknown-linux-gnu", nil
+	default:
+		return "", fmt.Errorf("unsupported linux target architecture %q", architecture)
+	}
+}
+
+func buildSwiftExecutable(ctx context.Context, dir, product, sdk, targetTriple, configuration string) (string, error) {
 	buildArgs := []string{"build"}
 	showBinArgs := []string{"build"}
 	if configuration != "" {
 		buildArgs = append(buildArgs, "-c", configuration)
 		showBinArgs = append(showBinArgs, "-c", configuration)
 	}
-	buildArgs = append(buildArgs, "--swift-sdk="+sdk, "--product", product)
-	showBinArgs = append(showBinArgs, "--swift-sdk="+sdk, "--show-bin-path")
+	buildArgs = append(buildArgs, "--swift-sdk="+sdk, "--triple="+targetTriple, "--product", product)
+	showBinArgs = append(showBinArgs, "--swift-sdk="+sdk, "--triple="+targetTriple, "--show-bin-path")
 
 	buildCmd := swifttoolchain.SwiftCommandContext(ctx, buildArgs...)
 	buildCmd.Dir = dir
@@ -237,8 +248,13 @@ func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, a
 		return err
 	}
 
-	cliLogln("Cross-compiling %s for linux/%s...", product, architecture)
-	binaryPath, err := buildSwiftExecutable(ctx, dir, product, sdk, "")
+	targetTriple, err := linuxTargetTriple(architecture)
+	if err != nil {
+		return err
+	}
+
+	cliLogln("Cross-compiling %s for linux/%s (%s)...", product, architecture, targetTriple)
+	binaryPath, err := buildSwiftExecutable(ctx, dir, product, sdk, targetTriple, "")
 	if err != nil {
 		return err
 	}
@@ -249,6 +265,7 @@ func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, a
 	swiftArgs := []string{
 		"package",
 		"--swift-sdk=" + sdk,
+		"--triple=" + targetTriple,
 		"--allow-network-connections=all",
 		"build-container-image",
 		"--from=swift:" + swifttoolchain.DefaultVersion + "-slim",
@@ -1208,8 +1225,13 @@ func buildSwiftDockerImage(ctx context.Context, dir, product string, toolchainSt
 		return "", fmt.Errorf("finding Swift SDK: %w", err)
 	}
 
-	cliLogln("Cross-compiling %s for linux/%s...", product, arch)
-	srcBin, err := buildSwiftExecutable(ctx, dir, product, sdk, "release")
+	targetTriple, err := linuxTargetTriple(arch)
+	if err != nil {
+		return "", err
+	}
+
+	cliLogln("Cross-compiling %s for linux/%s (%s)...", product, arch, targetTriple)
+	srcBin, err := buildSwiftExecutable(ctx, dir, product, sdk, targetTriple, "release")
 	if err != nil {
 		return "", err
 	}

--- a/go/internal/cli/commands/elf.go
+++ b/go/internal/cli/commands/elf.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	elfDataLittle = 1 // ELFDATA2LSB
+	elfDataBig    = 2 // ELFDATA2MSB
+
+	emX86_64  = 62  // EM_X86_64  → amd64
+	emAArch64 = 183 // EM_AARCH64 → arm64
+)
+
+// detectELFArchitecture returns the Go architecture name encoded in an ELF
+// header and whether the input looked like an ELF file at all.
+func detectELFArchitecture(data []byte) (arch string, isELF bool) {
+	// ELF magic + header fields up to e_machine occupy 20 bytes.
+	if len(data) < 20 {
+		return "", false
+	}
+	if data[0] != 0x7f || data[1] != 'E' || data[2] != 'L' || data[3] != 'F' {
+		return "", false
+	}
+
+	var machine uint16
+	switch data[5] {
+	case elfDataLittle:
+		machine = uint16(data[18]) | uint16(data[19])<<8
+	case elfDataBig:
+		machine = uint16(data[18])<<8 | uint16(data[19])
+	default:
+		return "", true
+	}
+
+	switch machine {
+	case emX86_64:
+		return "amd64", true
+	case emAArch64:
+		return "arm64", true
+	default:
+		return "", true
+	}
+}
+
+func validateELFFileArchitecture(path, expectedArch string) error {
+	switch expectedArch {
+	case "amd64", "arm64":
+		// supported, continue
+	default:
+		return fmt.Errorf("unsupported target architecture %q; only amd64 and arm64 are supported", expectedArch)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer file.Close()
+
+	header := make([]byte, 64)
+	n, err := io.ReadFull(file, header)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return fmt.Errorf("reading ELF header from %s: %w", path, err)
+	}
+	header = header[:n]
+
+	actualArch, isELF := detectELFArchitecture(header)
+	if !isELF {
+		return fmt.Errorf("swift build output %s is not an ELF executable; expected a linux/%s binary", path, expectedArch)
+	}
+	if actualArch == "" {
+		return fmt.Errorf("swift build output %s has an unsupported ELF architecture; expected linux/%s", path, expectedArch)
+	}
+	if actualArch != expectedArch {
+		return fmt.Errorf("swift build output %s is linux/%s, expected linux/%s", path, actualArch, expectedArch)
+	}
+	return nil
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -582,7 +582,7 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 // runSwiftWithAgent builds a Swift package using swift-container-plugin, which
 // pushes the image directly to the device's registry. Then it creates and
 // starts the container on the agent.
-func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, opts runOptions) error {
+func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, targetArchitecture string, opts runOptions) error {
 	// Verify auth certs are available if the device's registry requires mTLS.
 	if err := requireRegistryAuth(ctx, conn); err != nil {
 		return err
@@ -594,9 +594,11 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		return fmt.Errorf("querying device version: %w", err)
 	}
 	agentOS := versionResp.GetOs()
-	architecture := versionResp.GetCpuArchitecture()
-	if architecture == "" {
-		architecture = "arm64"
+	if targetArchitecture == "" {
+		targetArchitecture = versionResp.GetCpuArchitecture()
+		if targetArchitecture == "" {
+			targetArchitecture = "arm64"
+		}
 	}
 
 	regPort := registryPort(agentOS)
@@ -619,8 +621,8 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	}
 	defer proxyCleanup()
 
-	cliLogln("Building Swift container image for %s (%s)...", product, architecture)
-	if err := buildSwiftContainerImage(ctx, cwd, product, registryAddr, architecture, conn.IsMTLS, &dimWriter{}, os.Stderr); err != nil {
+	cliLogln("Building Swift container image for %s (%s)...", product, targetArchitecture)
+	if err := buildSwiftContainerImage(ctx, cwd, product, registryAddr, targetArchitecture, conn.IsMTLS, &dimWriter{}, os.Stderr); err != nil {
 		return fmt.Errorf("building Swift container image: %w", err)
 	}
 	cliLogln("Build and push completed.")
@@ -894,6 +896,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	}
 
 	platform := resolveAgentPlatform(appCfg.Platform, agentOS, architecture)
+	targetArchitecture := strings.TrimPrefix(platform, platformOS(platform)+"/")
 
 	// Xcode projects: always use the local-build + file-sync path (darwin only).
 	if projectType == "xcode" {
@@ -911,13 +914,13 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 			if platformOS(platform) == "darwin" {
 				return runMacOSSwiftPMWithAgent(ctx, conn, cwd, appCfg, opts)
 			}
-			return runSwiftWithAgent(ctx, conn, cwd, appCfg, opts)
+			return runSwiftWithAgent(ctx, conn, cwd, appCfg, targetArchitecture, opts)
 		}
 		if _, err := os.Stat(filepath.Join(cwd, "Dockerfile")); os.IsNotExist(err) {
 			if platformOS(platform) == "darwin" {
 				return runMacOSSwiftPMWithAgent(ctx, conn, cwd, appCfg, opts)
 			}
-			return runSwiftWithAgent(ctx, conn, cwd, appCfg, opts)
+			return runSwiftWithAgent(ctx, conn, cwd, appCfg, targetArchitecture, opts)
 		}
 	}
 

--- a/go/internal/cli/swifttoolchain/toolchain.go
+++ b/go/internal/cli/swifttoolchain/toolchain.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -149,9 +150,19 @@ func lookupSwiftSDK(ctx context.Context, sdkArch string, isWasm bool) (string, e
 		return "", nil
 	}
 
+	expectedTriple, err := expectedLinuxSDKTriple(sdkArch)
+	if err != nil {
+		return "", err
+	}
+
+	var validationErr error
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.Contains(line, "wendyos") && strings.Contains(line, sdkArch) && strings.Contains(line, DefaultVersion) {
+			if err := validateInstalledSwiftSDKVariant(line, expectedTriple); err != nil {
+				validationErr = err
+				continue
+			}
 			return line, nil
 		}
 	}
@@ -163,6 +174,9 @@ func lookupSwiftSDK(ctx context.Context, sdkArch string, isWasm bool) (string, e
 		}
 	}
 
+	if validationErr != nil {
+		return "", validationErr
+	}
 	return "", nil
 }
 
@@ -182,6 +196,82 @@ func unzipOverwriteEnv() (env []string, cleanup func(), err error) {
 	}
 	env = append(os.Environ(), "PATH="+dir+":"+os.Getenv("PATH"))
 	return env, func() { os.RemoveAll(dir) }, nil
+}
+
+func expectedLinuxSDKTriple(sdkArch string) (string, error) {
+	switch sdkArch {
+	case "aarch64":
+		return "aarch64-unknown-linux-gnu", nil
+	case "x86_64":
+		return "x86_64-unknown-linux-gnu", nil
+	default:
+		return "", fmt.Errorf("unsupported linux SDK architecture %q", sdkArch)
+	}
+}
+
+type swiftSDKBundleInfo struct {
+	Artifacts map[string]struct {
+		Type     string `json:"type"`
+		Variants []struct {
+			Path string `json:"path"`
+		} `json:"variants"`
+	} `json:"artifacts"`
+}
+
+func validateInstalledSwiftSDKVariant(sdkName, expectedTriple string) error {
+	if !strings.Contains(sdkName, "wendyos") {
+		return nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	roots := []string{
+		filepath.Join(home, "Library", "org.swift.swiftpm", "swift-sdks"),
+		filepath.Join(home, ".swiftpm", "swift-sdks"),
+	}
+
+	var infoPath string
+	for _, root := range roots {
+		candidate := filepath.Join(root, sdkName+".artifactbundle", "info.json")
+		if _, err := os.Stat(candidate); err == nil {
+			infoPath = candidate
+			break
+		}
+	}
+	if infoPath == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(infoPath)
+	if err != nil {
+		return fmt.Errorf("reading Swift SDK metadata for %s: %w", sdkName, err)
+	}
+
+	var info swiftSDKBundleInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return fmt.Errorf("parsing Swift SDK metadata for %s: %w", sdkName, err)
+	}
+
+	artifact, ok := info.Artifacts[sdkName]
+	if !ok {
+		return nil
+	}
+
+	variants := make([]string, 0, len(artifact.Variants))
+	for _, variant := range artifact.Variants {
+		variants = append(variants, filepath.Base(variant.Path))
+		if filepath.Base(variant.Path) == expectedTriple {
+			return nil
+		}
+	}
+	if len(variants) == 0 {
+		return fmt.Errorf("Swift SDK %q does not declare any target variants in %s", sdkName, infoPath)
+	}
+	sort.Strings(variants)
+	return fmt.Errorf("Swift SDK %q provides %s, not %s; reinstall or fix the SDK artifact", sdkName, strings.Join(variants, ", "), expectedTriple)
 }
 
 func installWendySwiftSDK(ctx context.Context, sdkArch string, stdout, stderr io.Writer) error {

--- a/go/internal/cli/swifttoolchain/toolchain_test.go
+++ b/go/internal/cli/swifttoolchain/toolchain_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -115,9 +117,25 @@ func TestFindSwiftSDK_AlreadyInstalled(t *testing.T) {
 	original := execCommandContext
 	t.Cleanup(func() { execCommandContext = original })
 
-	installedSDK := fmt.Sprintf("%s-RELEASE_wendyos_aarch64", DefaultVersion)
-	var calls [][]string
+	home := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("Setenv HOME: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Setenv("HOME", originalHome) })
 
+	installedSDK := fmt.Sprintf("%s-RELEASE_wendyos_aarch64", DefaultVersion)
+	infoPath := filepath.Join(home, "Library", "org.swift.swiftpm", "swift-sdks", installedSDK+".artifactbundle", "info.json")
+	if err := os.MkdirAll(filepath.Dir(infoPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	info := fmt.Sprintf(`{"artifacts":{"%s":{"type":"swiftSDK","variants":[{"path":"%s/aarch64-unknown-linux-gnu"}],"version":"0.0.1"}},"schemaVersion":"1.0"}`,
+		installedSDK, installedSDK)
+	if err := os.WriteFile(infoPath, []byte(info), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var calls [][]string
 	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		calls = append(calls, append([]string{name}, args...))
 		return exec.CommandContext(ctx, "echo", installedSDK)
@@ -135,5 +153,40 @@ func TestFindSwiftSDK_AlreadyInstalled(t *testing.T) {
 	}
 	if calls[0][0] != "swiftly" || calls[0][1] != "run" || calls[0][2] != "+"+DefaultVersion || calls[0][3] != "swift" || calls[0][4] != "sdk" || calls[0][5] != "list" {
 		t.Fatalf("unexpected command: %v", calls[0])
+	}
+}
+
+func TestFindSwiftSDK_RejectsWendySDKWithWrongVariant(t *testing.T) {
+	original := execCommandContext
+	t.Cleanup(func() { execCommandContext = original })
+
+	home := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("Setenv HOME: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Setenv("HOME", originalHome) })
+
+	installedSDK := fmt.Sprintf("%s-RELEASE_wendyos_aarch64", DefaultVersion)
+	infoPath := filepath.Join(home, "Library", "org.swift.swiftpm", "swift-sdks", installedSDK+".artifactbundle", "info.json")
+	if err := os.MkdirAll(filepath.Dir(infoPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	info := fmt.Sprintf(`{"artifacts":{"%s":{"type":"swiftSDK","variants":[{"path":"%s/x86_64-unknown-linux-gnu"}],"version":"0.0.1"}},"schemaVersion":"1.0"}`,
+		installedSDK, installedSDK)
+	if err := os.WriteFile(infoPath, []byte(info), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "echo", installedSDK)
+	}
+
+	_, err := FindSwiftSDK(context.Background(), "arm64", io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("FindSwiftSDK() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "provides x86_64-unknown-linux-gnu, not aarch64-unknown-linux-gnu") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/kb.fix-linux-container-path.plan.md
+++ b/kb.fix-linux-container-path.plan.md
@@ -1,0 +1,343 @@
+# Plan: fix Linux container path on WendyAgentMac
+
+## Worktree
+
+- Worktree: `/Volumes/WendyLabs/wendy-agent/kb.fix-linux-container-path`
+- Branch: `kb.fix-linux-container-path`
+- Branched from: `kb/mac-prototype-fixes`
+- Starting point commit: `e03e0717` (`Find Docker Desktop CLI and soften progress fallback errors`)
+
+## Problem summary
+
+Running a Linux Swift example against the mac prototype agent now gets past the
+original `docker`-not-found issue, but still fails during container creation.
+The CLI falls back from `CreateContainerWithProgress` to legacy
+`CreateContainer`, then the mac agent starts the Linux-container Docker path,
+but the create call fails while pulling the image.
+
+Current user-visible CLI output:
+
+```text
+Pulling image on device... (failed)
+█████████████████████████████████ 99.00%
+Info: progress reporting is currently not available on this agent; continuing without progress
+Error: creating container: Service method threw an unknown error.
+```
+
+Agent log output shows the failure happens after `CreateContainer` enters the
+Linux Docker backend and starts the image pull:
+
+```text
+2026-04-24T09:00:49+0200 info sh.wendy.agent.container: app_name=engineer.edge.examples.helloworld image_name=localhost:5555/helloworld:latest [WendyAgentCore] CreateContainer called
+2026-04-24T09:00:49+0200 info sh.wendy.agent.docker-backend: image=localhost:5555/helloworld:latest [WendyAgentCore] Pulling image
+```
+
+No more detailed error is surfaced yet.
+
+## Relevant history already landed
+
+1. `f7dd1bf7` — CLI falls back from `CreateContainerWithProgress` to legacy
+   `CreateContainer` on older agents.
+2. `e03e0717` — mac agent now resolves `docker` from common locations and
+   reports searched paths when it cannot find Docker; CLI fallback message was
+   softened to an info message.
+
+Those changes fixed the earlier false-negative Docker detection issue, but did
+not fix the actual Linux container pull/start path.
+
+## Reproduction context
+
+User repro command:
+
+```bash
+cd Examples/HelloWorld
+(cd ../../go && make build) && ../../go/bin/wendy run
+```
+
+Relevant app config:
+
+- `Examples/HelloWorld/wendy.json`
+- `platform: "linux"`
+
+This means the mac agent takes the Linux container path, not the native darwin
+file-sync path.
+
+## What is already known
+
+### CLI side
+
+- Swift container builds are pushed to a local registry address returned by:
+  - `go/internal/cli/commands/run.go`
+  - `resolveRegistryForSwift(...)` in `go/internal/cli/commands/docker.go`
+- For the Swift local-build path, the CLI prints values like:
+  - `127.0.0.1:51599/helloworld:latest`
+- After the build/push completes, the CLI asks the agent to create from:
+  - `localhost:5555/helloworld:latest`
+- The intended model is: the device/agent should pull from its own local
+  registry on `localhost:<registryPort>`.
+
+### Agent side
+
+- `swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift`
+  calls `dockerBackend.pullImage(imageName)` for Linux targets.
+- `swift/WendyAgentCore/Sources/WendyAgent/Docker/DockerContainerBackend.swift`
+  currently does:
+
+  ```swift
+  try await docker.pull(image: imageName)
+  ```
+
+- `docker pull` errors currently escape as generic Swift errors and appear to
+  be turned into gRPC `Unknown`, which the CLI renders as:
+  - `Service method threw an unknown error.`
+
+### Host checks already performed
+
+- The host-side registry is reachable via plain HTTP:
+
+  ```bash
+  curl http://localhost:5555/v2/_catalog
+  curl http://localhost:5555/v2/helloworld/tags/list
+  ```
+
+  and it returned:
+
+  ```json
+  {"repositories":["helloworld"]}
+  {"name":"helloworld","tags":["latest"]}
+  ```
+
+- A shell check showed `docker` is not on `PATH` as `env docker`, which led to
+  the previous fix.
+- A direct call to Docker from this harness failed with:
+
+  ```text
+  failed to connect to the docker API at unix:///var/run/docker.sock
+  ```
+
+  That failure is from this harness environment and is not enough by itself to
+  diagnose the app-side agent behavior, because the GUI app may run with a
+  different Docker context/socket setup.
+
+## Primary hypothesis
+
+The mac agent is attempting:
+
+```bash
+docker pull localhost:5555/helloworld:latest
+```
+
+and that pull is failing for one of these reasons:
+
+1. `localhost:5555` is the wrong registry host from Docker Desktop's point of
+   view for this path.
+2. Docker is trying HTTPS and rejecting the local plaintext registry.
+3. The registry is reachable from the host but not from the Docker daemon path
+   used by `docker pull`.
+4. The error is ordinary and actionable, but we are losing it because the agent
+   does not wrap and surface the underlying Docker failure.
+
+## Findings after code inspection and implementation
+
+### Error surfacing gap confirmed
+
+The Swift mac agent was indeed allowing Docker/backend errors to escape as raw
+Swift errors, which GRPC Swift then surfaced to the CLI as generic
+`Unknown`/`Service method threw an unknown error.`
+
+That gap existed in two places:
+
+- `ContainerService.createContainer(...)` during Linux-image pull
+- `ContainerService.startContainer(...)` / `DockerContainerBackend.createAndStart(...)`
+
+### Most likely root cause: loopback registry + plain-HTTP handling on Docker Desktop
+
+After tracing the end-to-end flow, the most likely actual failure is not the
+CLI fallback anymore but the mac agent's `docker pull localhost:5555/...`
+path itself.
+
+Why this now looks like the primary issue:
+
+- The Swift CLI build path pushes to the mac agent's own local registry on port
+  `5555`.
+- The mac agent then shells out to plain `docker pull localhost:5555/...`.
+- Docker Desktop commonly treats `localhost:PORT` as a normal registry name,
+  which may go through HTTPS expectations.
+- Docker's default insecure loopback allowance is reliable for
+  `127.0.0.0/8`, not for a `localhost` hostname path.
+
+That makes the most plausible fix on the mac agent:
+
+- rewrite loopback registry references from `localhost:5555/...` or
+  `[::1]:5555/...` to `127.0.0.1:5555/...` before `docker pull` and
+  `docker run`
+- keep surfacing the exact Docker error if the pull still fails after rewrite
+
+This is a better fit than `host.docker.internal` for the current architecture,
+because the registry container is started by the same Docker daemon the mac
+agent is talking to.
+
+### Changes implemented
+
+1. Added explicit `RPCError(.internalError, ...)` wrapping/logging for Linux
+   Docker pull/start failures in:
+   - `swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift`
+   - `swift/WendyAgentCore/Sources/WendyAgent/Docker/DockerContainerBackend.swift`
+2. Added loopback-registry host rewriting in the mac Docker backend:
+   - `localhost[:port]/...` -> `127.0.0.1[:port]/...`
+   - `[::1][:port]/...` -> `127.0.0.1[:port]/...`
+3. Applied the same rewrite consistently to both:
+   - `docker pull ...`
+   - `docker run ...`
+4. Added Swift unit tests covering the rewrite behavior.
+
+### Remaining verification needed on the real mac-agent host
+
+This harness still cannot talk to the local Docker daemon (`/var/run/docker.sock`
+missing here), so the final end-to-end confirmation still needs to be done in
+WendyAgentMac itself with the normal repro command.
+
+## First fixes to make in this branch
+
+### 1. Surface the real Docker pull failure
+
+Make the agent wrap the Linux container pull/create/start failures in explicit
+`RPCError`s instead of letting them escape as generic unknown errors.
+
+Candidate locations:
+
+- `swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift`
+- `swift/WendyAgentCore/Sources/WendyAgent/Docker/DockerContainerBackend.swift`
+
+Expected outcome:
+
+- CLI should show the actual Docker failure message, such as:
+  - registry host not reachable
+  - insecure registry / HTTP vs HTTPS issue
+  - daemon connection issue
+  - image not found
+
+Also add structured logging on the agent side for the failure.
+
+### 2. Revisit the image reference used by the mac agent Docker path
+
+Investigate whether `localhost:5555/...` is the right image reference for the
+mac prototype's Docker-backed Linux container execution.
+
+Files to inspect:
+
+- `go/internal/cli/commands/run.go`
+- `go/internal/cli/commands/docker.go`
+- `swift/WendyAgentCore/Sources/WendyAgent/Docker/DockerContainerBackend.swift`
+- `swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift`
+- any older mac/legacy agent implementation if available elsewhere in the repo
+
+Possible outcomes:
+
+- keep `localhost:5555/...` but configure the mac agent Docker path correctly
+- translate to a different host such as `host.docker.internal:5555/...`
+- avoid `docker pull` entirely if the image should already exist locally under a
+  different name
+- add explicit local-registry/insecure-registry handling for the mac prototype
+
+### 3. Improve the progress fallback UX fully
+
+The inline progress UI still shows:
+
+```text
+Pulling image on device... (failed)
+...
+Info: progress reporting is currently not available...
+```
+
+That is better than the earlier hard error, but still misleading because the
+operation has not actually failed at that point.
+
+Investigate the TUI completion path so `Unimplemented` can bypass the failed
+progress rendering entirely when we know we are about to fall back.
+
+Files:
+
+- `go/internal/cli/commands/run.go`
+- `go/internal/cli/tui/progress.go`
+
+This is secondary to fixing the real Linux container pull failure.
+
+## Concrete implementation plan
+
+1. Add explicit error wrapping/logging around Linux-container `pullImage` in
+   `ContainerService.createContainer(...)`.
+2. If needed, add error wrapping in `DockerContainerBackend.pullImage(...)` so
+   the failing image name and Docker command are preserved.
+3. Reproduce again and capture the exact surfaced Docker error.
+4. Based on the real error, fix the image-reference path or registry handling:
+   - host mapping
+   - insecure/plain-HTTP handling
+   - registry bootstrap assumptions
+   - Docker Desktop-specific behavior
+5. Add regression tests for the newly exposed errors and for any host rewrite or
+   pull-path logic introduced.
+6. Optionally clean up the remaining fallback progress UI artifact.
+
+## Suggested verification steps
+
+### Agent-side manual checks
+
+Run on the machine hosting WendyAgentMac:
+
+```bash
+/Applications/Docker.app/Contents/Resources/bin/docker version
+/Applications/Docker.app/Contents/Resources/bin/docker pull localhost:5555/helloworld:latest
+/Applications/Docker.app/Contents/Resources/bin/docker pull host.docker.internal:5555/helloworld:latest
+```
+
+If one fails and the other succeeds, that will strongly suggest the needed host
+rewrite.
+
+Also useful:
+
+```bash
+/Applications/Docker.app/Contents/Resources/bin/docker info
+/Applications/Docker.app/Contents/Resources/bin/docker context show
+```
+
+### End-to-end verification
+
+From `Examples/HelloWorld`:
+
+```bash
+(cd ../../go && make build) && ../../go/bin/wendy run
+```
+
+Expected success path:
+
+- Swift image builds and pushes
+- CLI prints an info-level progress fallback message if the agent still does not
+  implement streaming progress
+- `CreateContainer` succeeds
+- container starts on the mac agent via Docker backend
+- output streams normally
+
+## Acceptance criteria
+
+- Linux container create failures on WendyAgentMac no longer surface as generic
+  `Service method threw an unknown error.`
+- The real Docker/registry failure is visible in both agent logs and CLI output.
+- The HelloWorld Linux example can successfully create and start on the mac
+  prototype, or the remaining blocker is at least reported clearly and
+  specifically.
+- If touched, progress fallback no longer shows a misleading failed progress bar
+  before the info message.
+
+## Notes
+
+The branch started as diagnosis-first work. After inspection, the best current
+fit is that the real bug is on the mac agent Docker path itself:
+
+- error details were being lost as gRPC `Unknown`
+- `localhost:5555/...` is likely the wrong loopback form for Docker Desktop's
+  plaintext local-registry pull path
+
+The implemented agent-side rewrite keeps the CLI/device protocol unchanged while
+making the mac Docker backend use the loopback form Docker Desktop is most
+likely to accept for a local insecure registry.

--- a/kb.fix-linux-container-path.plan.md
+++ b/kb.fix-linux-container-path.plan.md
@@ -253,6 +253,11 @@ Current fix direction now implemented in the CLI:
    target architecture
 4. stop forcing the plugin's `--architecture` flag so the published image
    cannot silently disagree with the executable's actual ELF architecture
+5. pass an explicit Linux target triple into Swift builds/plugin invocations so
+   SwiftPM does not silently fall back to host-default x86_64 Linux output when
+   targeting an arm64 agent
+6. validate installed Wendy Swift SDK bundle variants before selecting them, so
+   a misnamed or mispackaged SDK fails with a precise target-triple error
 
 This should turn the confusing runtime failure into either:
 

--- a/kb.fix-linux-container-path.plan.md
+++ b/kb.fix-linux-container-path.plan.md
@@ -197,6 +197,24 @@ This harness still cannot talk to the local Docker daemon (`/var/run/docker.sock
 missing here), so the final end-to-end confirmation still needs to be done in
 WendyAgentMac itself with the normal repro command.
 
+### New finding from live repro
+
+The first post-fix repro exposed the next real blocker cleanly:
+
+```text
+error getting credentials - err: exec: "docker-credential-desktop": executable file not found in $PATH
+```
+
+That means the mac app is successfully finding `docker` itself, but the
+subprocess environment still does not provide a `PATH` that lets the Docker CLI
+find its companion credential helper binaries inside Docker.app.
+
+Follow-up fix:
+
+- when `DockerCLI` launches subprocesses, augment `PATH` with the resolved
+  Docker executable directory (and fallback Docker binary directories) so
+  helper binaries like `docker-credential-desktop` are discoverable too
+
 ## First fixes to make in this branch
 
 ### 1. Surface the real Docker pull failure

--- a/kb.fix-linux-container-path.plan.md
+++ b/kb.fix-linux-container-path.plan.md
@@ -190,6 +190,13 @@ agent is talking to.
    - `docker pull ...`
    - `docker run ...`
 4. Added Swift unit tests covering the rewrite behavior.
+5. Added CLI-side ELF architecture validation for Swift Linux builds before
+   packaging/publishing them.
+6. Stopped forcing `--architecture` into `swift package build-container-image`;
+   the container plugin now gets to derive image architecture from the actual
+   built executable after CLI validation passes.
+7. Made the Swift container path use the resolved target platform architecture
+   instead of always re-deriving architecture directly from `GetAgentVersion`.
 
 ### Remaining verification needed on the real mac-agent host
 
@@ -214,6 +221,44 @@ Follow-up fix:
 - when `DockerCLI` launches subprocesses, augment `PATH` with the resolved
   Docker executable directory (and fallback Docker binary directories) so
   helper binaries like `docker-credential-desktop` are discoverable too
+
+### Latest finding: the Swift container path was masking ELF/image architecture mismatches
+
+The current runtime failure strongly suggests the CLI/container packaging path
+was creating an image whose declared/base architecture did not necessarily match
+the executable that Swift actually built.
+
+The key reason this could happen in our code:
+
+- the CLI always passed `--architecture=<target>` to
+  `swift package build-container-image`
+- but `swift-container-plugin` already knows how to inspect the built ELF and
+  derive the right container architecture from the executable itself
+- by forcing `--architecture`, the CLI could override that ELF-based detection
+  and publish an `arm64` image even when the built executable on disk was
+  actually `x86_64`
+
+That exactly fits the observed symptom cluster:
+
+- `.build/x86_64-unknown-linux-gnu/.../HelloWorld` exists
+- the agent/runtime sees `qemu-x86_64`
+- the container then fails looking for the x86_64 dynamic loader inside what
+  appears to be an arm64-oriented image/base selection
+
+Current fix direction now implemented in the CLI:
+
+1. explicitly build the Swift Linux executable first
+2. inspect the produced ELF header before packaging/publishing
+3. fail early if the built binary architecture does not match the requested
+   target architecture
+4. stop forcing the plugin's `--architecture` flag so the published image
+   cannot silently disagree with the executable's actual ELF architecture
+
+This should turn the confusing runtime failure into either:
+
+- a correct image when Swift really builds the requested target
+- or a precise build-time error when Swift/SDK selection still yields the wrong
+  ELF
 
 ## First fixes to make in this branch
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Docker/DockerCLI.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Docker/DockerCLI.swift
@@ -169,7 +169,7 @@ struct DockerCLI: Sendable {
         let process = Foundation.Process()
         process.executableURL = URL(fileURLWithPath: resolvedExecutable)
         process.arguments = allArgs
-        process.environment = self.environment
+        process.environment = self.makeProcessEnvironment(resolvedExecutable: resolvedExecutable)
         process.terminationHandler = terminationHandler
 
         let stdoutPipe = Pipe()
@@ -236,7 +236,7 @@ struct DockerCLI: Sendable {
         let process = Foundation.Process()
         process.executableURL = URL(fileURLWithPath: resolvedExecutable)
         process.arguments = arguments
-        process.environment = self.environment
+        process.environment = self.makeProcessEnvironment(resolvedExecutable: resolvedExecutable)
 
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
@@ -344,6 +344,10 @@ struct DockerCLI: Sendable {
         return (resolution.resolvedPath, resolution.searchedPaths)
     }
 
+    func processEnvironmentForTesting(resolvedExecutable: String) -> [String: String] {
+        self.makeProcessEnvironment(resolvedExecutable: resolvedExecutable)
+    }
+
     private func resolveExecutable() -> ExecutableResolution {
         if self.executable.contains("/") {
             let resolvedPath = FileManager.default.isExecutableFile(atPath: self.executable)
@@ -379,6 +383,33 @@ struct DockerCLI: Sendable {
             uniqueCandidates.append(candidate)
         }
         return uniqueCandidates
+    }
+
+    private func makeProcessEnvironment(resolvedExecutable: String) -> [String: String] {
+        var environment = self.environment
+
+        let existingPathEntries = (environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+
+        let helperDirectories = [
+            URL(fileURLWithPath: resolvedExecutable).deletingLastPathComponent().path
+        ] + Self.fallbackExecutablePaths(for: self.executable).map {
+            URL(fileURLWithPath: $0).deletingLastPathComponent().path
+        }
+
+        var seen = Set<String>()
+        var mergedPathEntries: [String] = []
+        for pathEntry in helperDirectories + existingPathEntries where seen.insert(pathEntry).inserted {
+            mergedPathEntries.append(pathEntry)
+        }
+
+        if !mergedPathEntries.isEmpty {
+            environment["PATH"] = mergedPathEntries.joined(separator: ":")
+        }
+
+        return environment
     }
 
     private static func fallbackExecutablePaths(for executable: String) -> [String] {

--- a/swift/WendyAgentCore/Sources/WendyAgent/Docker/DockerContainerBackend.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Docker/DockerContainerBackend.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRPCCore
 import Logging
 
 /// Manages the lifecycle of Linux containers running via Docker on a Mac agent.
@@ -6,14 +7,47 @@ import Logging
 /// When the agent receives a container request with `platform: "linux/..."`, it
 /// delegates to this backend. The image is already in the local Docker registry
 /// at `localhost:<registryPort>` (pushed by the CLI via the standard buildx pipeline).
+///
+/// On Docker Desktop, `docker pull localhost:...` may be treated as an HTTPS
+/// registry lookup, while `127.0.0.1:...` is part of Docker's default insecure
+/// loopback range. We therefore rewrite loopback registry references to
+/// `127.0.0.1` before pulling/running so the daemon can talk to the local
+/// plaintext registry without requiring manual daemon reconfiguration.
 actor DockerContainerBackend {
     private let docker = DockerCLI()
     private let logger = Logger(label: "sh.wendy.agent.docker-backend")
 
     /// Pull an image from the local registry into Docker.
     func pullImage(_ imageName: String) async throws {
-        logger.info("Pulling image", metadata: ["image": "\(imageName)"])
-        try await docker.pull(image: imageName)
+        let dockerImageName = Self.rewriteLoopbackRegistryHost(in: imageName)
+        self.logImageRewriteIfNeeded(original: imageName, effective: dockerImageName)
+
+        logger.info(
+            "Pulling image",
+            metadata: [
+                "image": "\(dockerImageName)",
+                "requested_image": "\(imageName)",
+            ]
+        )
+
+        do {
+            try await docker.pull(image: dockerImageName)
+        } catch {
+            logger.error(
+                "Docker image pull failed",
+                metadata: [
+                    "image": "\(dockerImageName)",
+                    "requested_image": "\(imageName)",
+                    "error": "\(String(describing: error))",
+                ]
+            )
+            throw Self.makeRPCError(
+                action: "pull Docker image",
+                requestedImageName: imageName,
+                effectiveImageName: dockerImageName,
+                error: error
+            )
+        }
     }
 
     /// Remove any stale container, then create and start a Docker container in
@@ -25,6 +59,8 @@ actor DockerContainerBackend {
         terminationHandler: (@Sendable (Foundation.Process) -> Void)? = nil
     ) async throws -> (process: Foundation.Process, stdout: Pipe, stderr: Pipe) {
         let containerName = "wendy-\(appName)"
+        let dockerImageName = Self.rewriteLoopbackRegistryHost(in: imageName)
+        self.logImageRewriteIfNeeded(original: imageName, effective: dockerImageName)
 
         // Remove any stale container with the same name.
         _ = try? await docker.rm(options: [.force], container: containerName)
@@ -45,15 +81,34 @@ actor DockerContainerBackend {
             "Starting Docker container",
             metadata: [
                 "container": "\(containerName)",
-                "image": "\(imageName)",
+                "image": "\(dockerImageName)",
+                "requested_image": "\(imageName)",
             ]
         )
 
-        return try docker.runAttached(
-            options: options,
-            image: imageName,
-            terminationHandler: terminationHandler
-        )
+        do {
+            return try docker.runAttached(
+                options: options,
+                image: dockerImageName,
+                terminationHandler: terminationHandler
+            )
+        } catch {
+            logger.error(
+                "Docker container start failed",
+                metadata: [
+                    "container": "\(containerName)",
+                    "image": "\(dockerImageName)",
+                    "requested_image": "\(imageName)",
+                    "error": "\(String(describing: error))",
+                ]
+            )
+            throw Self.makeRPCError(
+                action: "start Docker container from image",
+                requestedImageName: imageName,
+                effectiveImageName: dockerImageName,
+                error: error
+            )
+        }
     }
 
     /// Stop a running Docker container.
@@ -73,6 +128,57 @@ actor DockerContainerBackend {
     /// List Wendy-managed Docker containers.
     func listContainers() async throws -> [DockerCLI.ContainerInfo] {
         try await docker.ps(label: "wendy.managed=true")
+    }
+
+    static func rewriteLoopbackRegistryHostForTesting(_ imageName: String) -> String {
+        Self.rewriteLoopbackRegistryHost(in: imageName)
+    }
+
+    private func logImageRewriteIfNeeded(original: String, effective: String) {
+        guard original != effective else { return }
+
+        logger.info(
+            "Rewriting loopback registry host for Docker Desktop",
+            metadata: [
+                "requested_image": "\(original)",
+                "effective_image": "\(effective)",
+                "reason": "Docker treats 127.0.0.1 as a default insecure loopback registry, but localhost may be forced through HTTPS",
+            ]
+        )
+    }
+
+    private static func rewriteLoopbackRegistryHost(in imageName: String) -> String {
+        guard let separator = imageName.firstIndex(of: "/") else { return imageName }
+
+        let registry = String(imageName[..<separator])
+        let remainder = String(imageName[separator...])
+
+        switch registry.lowercased() {
+        case "localhost":
+            return "127.0.0.1\(remainder)"
+        case let registry where registry.hasPrefix("localhost:"):
+            return "127.0.0.1\(registry.dropFirst("localhost".count))\(remainder)"
+        case "[::1]":
+            return "127.0.0.1\(remainder)"
+        case let registry where registry.hasPrefix("[::1]:"):
+            return "127.0.0.1\(registry.dropFirst("[::1]".count))\(remainder)"
+        default:
+            return imageName
+        }
+    }
+
+    private static func makeRPCError(
+        action: String,
+        requestedImageName: String,
+        effectiveImageName: String,
+        error: Error
+    ) -> RPCError {
+        var message = "Failed to \(action) \(requestedImageName)"
+        if effectiveImageName != requestedImageName {
+            message += " (using \(effectiveImageName) inside Docker)"
+        }
+        message += ": \(String(describing: error))"
+        return RPCError(code: .internalError, message: message)
     }
 
     // MARK: - Entitlement mapping

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -417,7 +417,25 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             }
 
             // Pull the image from the local registry into Docker.
-            try await dockerBackend.pullImage(imageName)
+            do {
+                try await dockerBackend.pullImage(imageName)
+            } catch {
+                self.logger.error(
+                    "Linux container image pull failed",
+                    metadata: [
+                        "app_name": "\(appName)",
+                        "image_name": "\(imageName)",
+                        "error": "\(String(describing: error))",
+                    ]
+                )
+                if let rpcError = error as? RPCError {
+                    throw rpcError
+                }
+                throw RPCError(
+                    code: .internalError,
+                    message: "Failed to pull Docker image \(imageName): \(String(describing: error))"
+                )
+            }
             logger.info(
                 "Linux container image pulled via Docker",
                 metadata: ["app_name": "\(appName)"]
@@ -576,7 +594,21 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
                 )
             } catch {
                 self.cancelAppLaunch(id: appName, launchToken: launchToken)
-                throw error
+                self.logger.error(
+                    "Linux container start failed",
+                    metadata: [
+                        "app_name": "\(appName)",
+                        "image_name": "\(deviceImage)",
+                        "error": "\(String(describing: error))",
+                    ]
+                )
+                if let rpcError = error as? RPCError {
+                    throw rpcError
+                }
+                throw RPCError(
+                    code: .internalError,
+                    message: "Failed to start Docker container from image \(deviceImage): \(String(describing: error))"
+                )
             }
 
             try await self.markAppRunning(id: appName, process: process, launchToken: launchToken)

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/DockerCLITests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/DockerCLITests.swift
@@ -75,6 +75,23 @@ struct DockerCLITests {
         )
     }
 
+    @Test("docker commands inherit a PATH that includes Docker helper binaries")
+    func dockerCommandsInheritAPathThatIncludesDockerHelperBinaries() {
+        let docker = DockerCLI(
+            executable: "/Applications/Docker.app/Contents/Resources/bin/docker",
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let environment = docker.processEnvironmentForTesting(
+            resolvedExecutable: "/Applications/Docker.app/Contents/Resources/bin/docker"
+        )
+        let path = environment["PATH"] ?? ""
+
+        #expect(path.contains("/Applications/Docker.app/Contents/Resources/bin"))
+        #expect(path.contains("/usr/bin"))
+        #expect(path.contains("/bin"))
+    }
+
     @Test("DockerContainerBackend rewrites loopback registry hosts to 127.0.0.1")
     func dockerBackendRewritesLoopbackRegistryHosts() {
         #expect(

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/DockerCLITests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/DockerCLITests.swift
@@ -75,6 +75,39 @@ struct DockerCLITests {
         )
     }
 
+    @Test("DockerContainerBackend rewrites loopback registry hosts to 127.0.0.1")
+    func dockerBackendRewritesLoopbackRegistryHosts() {
+        #expect(
+            DockerContainerBackend.rewriteLoopbackRegistryHostForTesting(
+                "localhost:5555/helloworld:latest"
+            ) == "127.0.0.1:5555/helloworld:latest"
+        )
+        #expect(
+            DockerContainerBackend.rewriteLoopbackRegistryHostForTesting(
+                "[::1]:5555/helloworld:latest"
+            ) == "127.0.0.1:5555/helloworld:latest"
+        )
+        #expect(
+            DockerContainerBackend.rewriteLoopbackRegistryHostForTesting(
+                "localhost/library/alpine:latest"
+            ) == "127.0.0.1/library/alpine:latest"
+        )
+    }
+
+    @Test("DockerContainerBackend leaves non-loopback registry hosts unchanged")
+    func dockerBackendLeavesNonLoopbackRegistryHostsUnchanged() {
+        #expect(
+            DockerContainerBackend.rewriteLoopbackRegistryHostForTesting(
+                "host.docker.internal:5555/helloworld:latest"
+            ) == "host.docker.internal:5555/helloworld:latest"
+        )
+        #expect(
+            DockerContainerBackend.rewriteLoopbackRegistryHostForTesting(
+                "ghcr.io/wendylabsinc/helloworld:latest"
+            ) == "ghcr.io/wendylabsinc/helloworld:latest"
+        )
+    }
+
     private static func makeExecutableScript(name: String, contents: String) throws -> URL {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## Summary
- surface Docker Desktop pull/start failures more clearly and normalize loopback registry refs for the mac Linux-container path
- make Docker subprocesses inherit a PATH that can find Docker credential helper binaries
- validate Swift Linux build artifacts and SDK variants against the requested target triple before packaging container images

## Testing
- `cd go && go test ./internal/cli/commands -run TestLinuxTargetTriple`
- `cd go && go test ./internal/cli/swifttoolchain -run 'TestFindSwiftSDK_(AlreadyInstalled|RejectsWendySDKWithWrongVariant)'`
- `cd swift/WendyAgentCore && swift test --filter DockerCLITests`
