### PR TITLE
Sync SwiftPM resource bundles on macOS

### DIFF
--- a/Examples/HelloMac/Package.swift
+++ b/Examples/HelloMac/Package.swift
@@ -7,12 +7,13 @@ let package = Package(
     platforms: [
         .macOS(.v26)
     ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-container-plugin", from: "1.3.0"),
-    ],
+    dependencies: [],
     targets: [
         .executableTarget(
-            name: "HelloMac"
+            name: "HelloMac",
+            resources: [
+                .process("Resources")
+            ]
         )
     ]
 )

--- a/Examples/HelloMac/Sources/Resources/Example.txt
+++ b/Examples/HelloMac/Sources/Resources/Example.txt
@@ -1,0 +1,1 @@
+Hello from a bundled text resource!

--- a/Examples/HelloMac/Sources/main.swift
+++ b/Examples/HelloMac/Sources/main.swift
@@ -1,18 +1,22 @@
 import Foundation
 
-@main
-struct HelloMac {
-    static func main() async throws {
-        var i = 0
-        while true {
-            try FileHandle.standardOutput.write(
-                contentsOf: Data("[\(Date())] Hello from Mac (stdout) #\(i)\n".utf8)
-            )
-            try FileHandle.standardError.write(
-                contentsOf: Data("[\(Date())] Hello from Mac (stderr) #\(i)\n".utf8)
-            )
-            i += 1
-            try await Task.sleep(for: .seconds(2))
-        }
-    }
+guard let resourceURL = Bundle.module.url(forResource: "Example", withExtension: "txt") else {
+    fatalError("Missing bundled resource: Example.txt")
+}
+
+let resourceContents = try String(contentsOf: resourceURL, encoding: .utf8)
+try FileHandle.standardOutput.write(
+    contentsOf: Data("Resources work too, here is the contents of the text file:\n\(resourceContents)\n".utf8)
+)
+
+var i = 0
+while true {
+    try FileHandle.standardOutput.write(
+        contentsOf: Data("[\(Date())] Hello from Mac (stdout) #\(i)\n".utf8)
+    )
+    try FileHandle.standardError.write(
+        contentsOf: Data("[\(Date())] Hello from Mac (stderr) #\(i)\n".utf8)
+    )
+    i += 1
+    try await Task.sleep(for: .seconds(2))
 }

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -742,33 +742,19 @@ func runMacOSSwiftPMWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 	cliLogln("Build completed.")
 
-	// Locate the binary.
-	binaryPath := filepath.Join(cwd, ".build", "debug", product)
+	binDir, err := swiftBuildBinPath(ctx, cwd)
+	if err != nil {
+		return err
+	}
+
+	binaryPath := filepath.Join(binDir, product)
 	if _, err := os.Stat(binaryPath); err != nil {
 		return fmt.Errorf("binary not found at %s: %w", binaryPath, err)
 	}
 
-	// Assemble file sync entries.
-	syncEntries := []fileSyncEntry{
-		{localPath: binaryPath, remotePath: product},
-	}
-
-	// Include sandbox.sb if present.
-	sandboxPath := filepath.Join(cwd, "sandbox.sb")
-	if _, err := os.Stat(sandboxPath); err == nil {
-		syncEntries = append(syncEntries, fileSyncEntry{
-			localPath:  sandboxPath,
-			remotePath: "sandbox.sb",
-		})
-	}
-
-	// Append user-declared files from wendy.json.
-	for _, f := range appCfg.Files {
-		localAbs := filepath.Join(cwd, f.Path)
-		syncEntries = append(syncEntries, fileSyncEntry{
-			localPath:  localAbs,
-			remotePath: effectiveRemotePath(f.Path, f.To),
-		})
+	syncEntries, err := assembleSwiftPMSyncEntries(binaryPath, cwd, appCfg)
+	if err != nil {
+		return err
 	}
 
 	// Sync files to the device.
@@ -786,6 +772,67 @@ func runMacOSSwiftPMWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 		UserArgs: runArgs,
 	}
 	return runMacOSNativeContainer(ctx, conn, appCfg, createReq, opts)
+}
+
+func swiftBuildBinPath(ctx context.Context, cwd string) (string, error) {
+	showBinCmd := exec.CommandContext(ctx, "swift", "build", "--show-bin-path")
+	showBinCmd.Dir = cwd
+	out, err := showBinCmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("swift build --show-bin-path: %w\n%s", err, string(out))
+	}
+
+	binDir := strings.TrimSpace(string(out))
+	if binDir == "" {
+		return "", fmt.Errorf("swift build --show-bin-path returned an empty path")
+	}
+	return binDir, nil
+}
+
+func assembleSwiftPMSyncEntries(binaryPath, cwd string, appCfg *appconfig.AppConfig) ([]fileSyncEntry, error) {
+	entries := []fileSyncEntry{{
+		localPath:  binaryPath,
+		remotePath: filepath.Base(binaryPath),
+	}}
+
+	buildDir := filepath.Dir(binaryPath)
+	siblings, err := os.ReadDir(buildDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading Swift build products directory %s: %w", buildDir, err)
+	}
+	for _, e := range siblings {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".bundle") && !strings.HasSuffix(name, ".resources") {
+			continue
+		}
+		entries = append(entries, fileSyncEntry{
+			localPath:  filepath.Join(buildDir, name),
+			remotePath: name,
+		})
+	}
+
+	// Include sandbox.sb if present.
+	sandboxPath := filepath.Join(cwd, "sandbox.sb")
+	if _, err := os.Stat(sandboxPath); err == nil {
+		entries = append(entries, fileSyncEntry{
+			localPath:  sandboxPath,
+			remotePath: "sandbox.sb",
+		})
+	}
+
+	// Append user-declared files from wendy.json.
+	for _, f := range appCfg.Files {
+		localAbs := filepath.Join(cwd, f.Path)
+		entries = append(entries, fileSyncEntry{
+			localPath:  localAbs,
+			remotePath: effectiveRemotePath(f.Path, f.To),
+		})
+	}
+
+	return entries, nil
 }
 
 func resolveRunProjectType(dir, requestedType string) (string, error) {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -731,9 +731,14 @@ func runMacOSSwiftPMWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 		return err
 	}
 
+	buildConfig := "release"
+	if opts.debug {
+		buildConfig = "debug"
+	}
+
 	// Build locally.
 	cliLogln("Building Swift project locally...")
-	buildCmd := exec.CommandContext(ctx, "swift", "build")
+	buildCmd := exec.CommandContext(ctx, "swift", "build", "-c", buildConfig)
 	buildCmd.Dir = cwd
 	buildCmd.Stdout = os.Stdout
 	buildCmd.Stderr = os.Stderr
@@ -742,7 +747,7 @@ func runMacOSSwiftPMWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 	cliLogln("Build completed.")
 
-	binDir, err := swiftBuildBinPath(ctx, cwd)
+	binDir, err := swiftBuildBinPath(ctx, cwd, buildConfig)
 	if err != nil {
 		return err
 	}
@@ -774,12 +779,12 @@ func runMacOSSwiftPMWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	return runMacOSNativeContainer(ctx, conn, appCfg, createReq, opts)
 }
 
-func swiftBuildBinPath(ctx context.Context, cwd string) (string, error) {
-	showBinCmd := exec.CommandContext(ctx, "swift", "build", "--show-bin-path")
+func swiftBuildBinPath(ctx context.Context, cwd, buildConfig string) (string, error) {
+	showBinCmd := exec.CommandContext(ctx, "swift", "build", "-c", buildConfig, "--show-bin-path")
 	showBinCmd.Dir = cwd
 	out, err := showBinCmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("swift build --show-bin-path: %w\n%s", err, string(out))
+		return "", fmt.Errorf("swift build -c %s --show-bin-path: %w\n%s", buildConfig, err, string(out))
 	}
 
 	binDir := strings.TrimSpace(string(out))

--- a/go/internal/cli/commands/run_macos_test.go
+++ b/go/internal/cli/commands/run_macos_test.go
@@ -159,7 +159,7 @@ func TestRunMacOSSwiftPMWithAgent_UsesRunArgsFromAppConfig(t *testing.T) {
 	if err := os.WriteFile(swiftlyPath, []byte("#!/bin/sh\necho '{\"products\":[{\"name\":\"MySwiftApp\",\"type\":{\"executable\":null}}]}'\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile swiftly: %v", err)
 	}
-	if err := os.WriteFile(swiftPath, []byte("#!/bin/sh\nif [ \"$1\" = \"build\" ] && [ \"$2\" = \"--show-bin-path\" ]; then\n  echo \"$PWD/.build/debug\"\n  exit 0\nfi\nif [ \"$1\" = \"build\" ]; then\n  mkdir -p \"$PWD/.build/debug/MySwiftApp.bundle\" \"$PWD/.build/debug/MySwiftApp.resources\"\n  printf '#!/bin/sh\\n' > \"$PWD/.build/debug/MySwiftApp\"\n  printf '<plist/>' > \"$PWD/.build/debug/MySwiftApp.bundle/Info.plist\"\n  printf '{}' > \"$PWD/.build/debug/MySwiftApp.resources/config.json\"\n  chmod +x \"$PWD/.build/debug/MySwiftApp\"\n  exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"), 0o755); err != nil {
+	if err := os.WriteFile(swiftPath, []byte("#!/bin/sh\nif [ \"$1\" = \"build\" ] && [ \"$2\" = \"-c\" ] && [ \"$3\" = \"release\" ] && [ \"$4\" = \"--show-bin-path\" ]; then\n  echo \"$PWD/.build/release\"\n  exit 0\nfi\nif [ \"$1\" = \"build\" ] && [ \"$2\" = \"-c\" ] && [ \"$3\" = \"release\" ]; then\n  mkdir -p \"$PWD/.build/release/MySwiftApp.bundle\" \"$PWD/.build/release/MySwiftApp.resources\"\n  printf '#!/bin/sh\\n' > \"$PWD/.build/release/MySwiftApp\"\n  printf '<plist/>' > \"$PWD/.build/release/MySwiftApp.bundle/Info.plist\"\n  printf '{}' > \"$PWD/.build/release/MySwiftApp.resources/config.json\"\n  chmod +x \"$PWD/.build/release/MySwiftApp\"\n  exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile swift: %v", err)
 	}
 

--- a/go/internal/cli/commands/run_macos_test.go
+++ b/go/internal/cli/commands/run_macos_test.go
@@ -159,7 +159,7 @@ func TestRunMacOSSwiftPMWithAgent_UsesRunArgsFromAppConfig(t *testing.T) {
 	if err := os.WriteFile(swiftlyPath, []byte("#!/bin/sh\necho '{\"products\":[{\"name\":\"MySwiftApp\",\"type\":{\"executable\":null}}]}'\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile swiftly: %v", err)
 	}
-	if err := os.WriteFile(swiftPath, []byte("#!/bin/sh\nif [ \"$1\" = \"build\" ]; then\n  mkdir -p \"$PWD/.build/debug\"\n  printf '#!/bin/sh\\n' > \"$PWD/.build/debug/MySwiftApp\"\n  chmod +x \"$PWD/.build/debug/MySwiftApp\"\n  exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"), 0o755); err != nil {
+	if err := os.WriteFile(swiftPath, []byte("#!/bin/sh\nif [ \"$1\" = \"build\" ] && [ \"$2\" = \"--show-bin-path\" ]; then\n  echo \"$PWD/.build/debug\"\n  exit 0\nfi\nif [ \"$1\" = \"build\" ]; then\n  mkdir -p \"$PWD/.build/debug/MySwiftApp.bundle\" \"$PWD/.build/debug/MySwiftApp.resources\"\n  printf '#!/bin/sh\\n' > \"$PWD/.build/debug/MySwiftApp\"\n  printf '<plist/>' > \"$PWD/.build/debug/MySwiftApp.bundle/Info.plist\"\n  printf '{}' > \"$PWD/.build/debug/MySwiftApp.resources/config.json\"\n  chmod +x \"$PWD/.build/debug/MySwiftApp\"\n  exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile swift: %v", err)
 	}
 
@@ -200,6 +200,60 @@ func TestRunMacOSSwiftPMWithAgent_UsesRunArgsFromAppConfig(t *testing.T) {
 	}
 	if len(got.UserArgs) != 2 || got.UserArgs[0] != "--port" || got.UserArgs[1] != "8080" {
 		t.Fatalf("UserArgs = %v, want %v", got.UserArgs, appCfg.Run.Args)
+	}
+
+	acked := make(map[string]bool)
+	for _, path := range state.ackedPaths {
+		acked[path] = true
+	}
+	if !acked["MySwiftApp"] {
+		t.Fatalf("missing ack for MySwiftApp; got %v", state.ackedPaths)
+	}
+	if !acked["MySwiftApp.bundle/Info.plist"] {
+		t.Fatalf("missing ack for MySwiftApp.bundle/Info.plist; got %v", state.ackedPaths)
+	}
+	if !acked["MySwiftApp.resources/config.json"] {
+		t.Fatalf("missing ack for MySwiftApp.resources/config.json; got %v", state.ackedPaths)
+	}
+}
+
+func TestAssembleSwiftPMSyncEntries_IncludesSiblingResourceDirectories(t *testing.T) {
+	binDir := t.TempDir()
+	binaryPath := filepath.Join(binDir, "MySwiftApp")
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile binary: %v", err)
+	}
+
+	bundleDir := filepath.Join(binDir, "MySwiftApp.bundle")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll bundle: %v", err)
+	}
+
+	resourcesDir := filepath.Join(binDir, "MySwiftApp.resources")
+	if err := os.MkdirAll(resourcesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll resources: %v", err)
+	}
+
+	cwd := t.TempDir()
+	cfg := &appconfig.AppConfig{AppID: "sh.wendy.MySwiftApp"}
+
+	entries, err := assembleSwiftPMSyncEntries(binaryPath, cwd, cfg)
+	if err != nil {
+		t.Fatalf("assembleSwiftPMSyncEntries: %v", err)
+	}
+
+	remotes := make(map[string]bool)
+	for _, entry := range entries {
+		remotes[entry.remotePath] = true
+	}
+	if !remotes["MySwiftApp"] {
+		t.Fatalf("expected binary entry with remotePath MySwiftApp")
+	}
+	if !remotes["MySwiftApp.bundle"] {
+		t.Fatalf("expected bundle entry with remotePath MySwiftApp.bundle")
+	}
+	if !remotes["MySwiftApp.resources"] {
+		t.Fatalf("expected resources entry with remotePath MySwiftApp.resources")
 	}
 }
 


### PR DESCRIPTION
- Closes: https://linear.app/wendylabsinc/issue/WDY-963/properly-sync-swiftpm-resource-bundles

## Summary
- resolve the SwiftPM build products directory via `swift build --show-bin-path`
- sync sibling `.bundle` and `.resources` directories on the macOS SwiftPM run path
- update HelloMac to include and load a bundled SwiftPM resource
- add coverage for both sync entry assembly and end-to-end file sync behavior

## Testing
- tested manually with the HelloMac app to verify bundled SwiftPM resources are synced and loaded
- `cd go && go test ./internal/cli/commands -run 'TestRunMacOSSwiftPMWithAgent|TestAssembleSwiftPMSyncEntries|TestRunMacOSXcodeWithAgent|TestRunWithAgent_RejectsLinuxContainersOnMacs|TestStartAndStreamContainer_FallsBackWhenCreateProgressIsUnimplemented'`
