### PR TITLE
Run integration testing CI before releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -590,10 +590,17 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
+  integration-tests:
+    name: Hardware Integration Tests
+    needs: [determine-version]
+    if: needs.determine-version.outputs.is_release == 'true' && needs.determine-version.outputs.is_prerelease == 'false'
+    uses: ./.github/workflows/integration-tests.yml
+    secrets: inherit
+
   publish-linux-repos:
     name: Publish to GCP Artifact Registry
     runs-on: ubuntu-latest
-    needs: [determine-version, package-linux, test-templates]
+    needs: [determine-version, package-linux, test-templates, integration-tests]
     if: needs.determine-version.outputs.is_release == 'true' && needs.determine-version.outputs.is_prerelease == 'false'
     permissions:
       contents: read
@@ -647,7 +654,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [determine-version, build, build-go-macos, build-agent-macos-app, package-linux, package-windows, test-templates]
+    needs: [determine-version, build, build-go-macos, build-agent-macos-app, package-linux, package-windows, test-templates, integration-tests]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
     steps:
       - name: Download artifact

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,24 @@ on:
         description: 'Platform to run integration tests on: all, macos, linux (default: all)'
         required: false
         default: 'all'
+  workflow_call:
+    inputs:
+      hostname:
+        type: string
+        required: false
+        default: ''
+      tests:
+        type: string
+        required: false
+        default: ''
+      jobs:
+        type: string
+        required: false
+        default: 'all'
+      platform:
+        type: string
+        required: false
+        default: 'all'
 
 jobs:
   discover:


### PR DESCRIPTION
This PR updates the `Hardware Integration Tests` action to run before any non-nightly releases (when `is_release=true` and `publish=true`). The Integration Tests **must pass** for the release to continue. It can still be run manually as well from the already existing trigger. 

This PR resolves [WDY-929](https://linear.app/wendylabsinc/issue/WDY-929/make-ci-test-for-nvidia-gpu-acceleration-availability), as the Hardware Integration Tests includes a sample project with GPU availability checking. 