### PR TITLE
Fix Template CI to properly detect runners

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -96,18 +96,22 @@ jobs:
         run: make clean
 
   deploy-to-device:
-    name: Deploy (${{ matrix.os }})
+    name: Deploy (${{ matrix.runner.name }})
     if: inputs.deploy == true
     needs: [generate-validate]
-    runs-on: [self-hosted, wendy-developer, '${{ matrix.os }}']
+    runs-on:
+      group: wendy-developer
+      labels: ${{ matrix.runner.labels }}
     concurrency:
-      group: template-deploy-${{ matrix.os }}
+      group: template-deploy-${{ matrix.runner.name }}
       cancel-in-progress: false
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS, Linux]
+        runner:
+          - { name: macOS, labels: [self-hosted, macOS, ARM64] }
+          - { name: Linux, labels: [self-hosted, Linux, X64] }
     defaults:
       run:
         working-directory: go


### PR DESCRIPTION
This PR addresses [WDY-832](https://linear.app/wendylabsinc/issue/WDY-832/template-tests-are-failing-to-run) by properly configuring the Template Tests CI job to detect our self-hosted runners.

This PR was tested on a manually triggered action, and did properly detect the runners but failed running the projects due to an unrelated issue: https://github.com/wendylabsinc/wendy-agent/actions/runs/24940046567/job/73032175072
