### PR TITLE
Cloud log forwarding and wendy cloud discover/enroll CLI commands

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -296,6 +296,16 @@ func main() {
 		}
 	}()
 
+	// Cloud log forwarding: if WENDY_CLOUD_GRPC is set, forward logs upstream.
+	if cloudGRPC := os.Getenv("WENDY_CLOUD_GRPC"); cloudGRPC != "" {
+		forwarder := services.NewCloudForwarder(logger, broadcaster, cloudGRPC)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			forwarder.Run(ctx)
+		}()
+	}
+
 	// Graceful shutdown.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/go/internal/agent/services/cloud_forwarder.go
+++ b/go/internal/agent/services/cloud_forwarder.go
@@ -1,0 +1,82 @@
+package services
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	otelpb "github.com/wendylabsinc/wendy/proto/gen/otelpb"
+)
+
+// CloudForwarder subscribes to the TelemetryBroadcaster and forwards log batches
+// to the configured cloud gRPC endpoint. It reconnects automatically on failure.
+//
+// For the POC this uses a plaintext connection with no auth. Before production:
+// - swap insecure.NewCredentials() for the device mTLS cert
+// - add retry with exponential backoff
+// - add a disk-backed queue so logs survive network outages
+type CloudForwarder struct {
+	logger      *zap.Logger
+	broadcaster *TelemetryBroadcaster
+	cloudGRPC   string
+}
+
+func NewCloudForwarder(logger *zap.Logger, broadcaster *TelemetryBroadcaster, cloudGRPC string) *CloudForwarder {
+	return &CloudForwarder{
+		logger:      logger,
+		broadcaster: broadcaster,
+		cloudGRPC:   cloudGRPC,
+	}
+}
+
+// Run loops forever, connecting to the cloud and forwarding logs. On any failure
+// it waits briefly and retries. It exits cleanly when ctx is cancelled.
+func (f *CloudForwarder) Run(ctx context.Context) {
+	f.logger.Info("cloud log forwarder starting", zap.String("endpoint", f.cloudGRPC))
+	for {
+		if err := f.runOnce(ctx); err != nil {
+			f.logger.Warn("cloud log forwarder disconnected", zap.Error(err))
+		}
+		select {
+		case <-ctx.Done():
+			f.logger.Info("cloud log forwarder stopped")
+			return
+		case <-time.After(5 * time.Second):
+			f.logger.Info("cloud log forwarder reconnecting")
+		}
+	}
+}
+
+// runOnce opens a connection to the cloud, subscribes to logs, and forwards
+// each batch until the connection fails or ctx is cancelled.
+func (f *CloudForwarder) runOnce(ctx context.Context) error {
+	conn, err := grpc.NewClient(f.cloudGRPC, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	client := otelpb.NewLogsServiceClient(conn)
+
+	subID, ch := f.broadcaster.SubscribeLogs()
+	defer f.broadcaster.UnsubscribeLogs(subID)
+
+	f.logger.Info("cloud log forwarder connected", zap.String("endpoint", f.cloudGRPC))
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case batch, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			if _, err := client.Export(ctx, batch); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/go/internal/cli/commands/cloud.go
+++ b/go/internal/cli/commands/cloud.go
@@ -1,0 +1,196 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/internal/cli/tui"
+	cloudpb "github.com/wendylabsinc/wendy/proto/gen/cloudpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func newCloudCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloud",
+		Short: "Interact with Wendy Cloud",
+	}
+	cmd.AddCommand(newCloudDiscoverCmd())
+	cmd.AddCommand(newCloudEnrollCmd())
+	return cmd
+}
+
+func newCloudDiscoverCmd() *cobra.Command {
+	var orgID int32
+	var cloudGRPC string
+
+	cmd := &cobra.Command{
+		Use:   "discover",
+		Short: "List all devices enrolled in your organisation",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCloudDiscover(cmd.Context(), cloudGRPC, orgID)
+		},
+	}
+
+	cmd.Flags().Int32Var(&orgID, "org", 0, "Organisation ID to list devices for (default: all)")
+	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "localhost:50051", "Cloud gRPC endpoint")
+
+	return cmd
+}
+
+func runCloudDiscover(ctx context.Context, cloudGRPC string, orgID int32) error {
+	conn, err := grpc.NewClient(cloudGRPC, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("connect to cloud: %w", err)
+	}
+	defer conn.Close()
+
+	// The cloud server streams assets one per message. Use the raw stream API
+	// to collect them all before rendering.
+	stream, err := conn.NewStream(ctx, &grpc.StreamDesc{
+		StreamName:    "ListAssets",
+		ServerStreams: true,
+	}, "/wendycloud.v1.AssetService/ListAssets")
+	if err != nil {
+		return fmt.Errorf("open stream: %w", err)
+	}
+
+	if err := stream.SendMsg(&cloudpb.ListAssetsRequest{OrganizationId: orgID}); err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		return fmt.Errorf("close send: %w", err)
+	}
+
+	var assets []*cloudpb.Asset
+	for {
+		var msg cloudpb.ListAssetsResponse
+		if err := stream.RecvMsg(&msg); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("receive: %w", err)
+		}
+		assets = append(assets, msg.GetAssets()...)
+	}
+
+	if len(assets) == 0 {
+		fmt.Println("No devices found.")
+		return nil
+	}
+
+	if jsonOutput {
+		data, err := json.MarshalIndent(assets, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal response: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	headers := []string{"Name", "Type", "OS", "IP Address", "Tags"}
+	rows := make([][]string, 0, len(assets))
+	for _, a := range assets {
+		rows = append(rows, []string{
+			a.GetName(),
+			a.GetDeviceType(),
+			a.GetOsType(),
+			a.GetIpAddress(),
+			strings.Join(a.GetTags(), ", "),
+		})
+	}
+
+	fmt.Print(tui.RenderTable(headers, rows))
+	return nil
+}
+
+func newCloudEnrollCmd() *cobra.Command {
+	var orgID int32
+	var cloudGRPC string
+	var name string
+	var deviceType string
+	var ipAddress string
+	var osType string
+	var osVersion string
+	var architecture string
+
+	cmd := &cobra.Command{
+		Use:   "enroll",
+		Short: "Register this device in Wendy Cloud without going through the cert enrollment flow",
+		Long: `POC only: directly creates an asset record in the cloud database.
+Use this to register a device during development when the full OAuth / cert
+enrollment flow is not available. Remove before production.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCloudEnroll(cmd.Context(), cloudGRPC, orgID, name, deviceType, ipAddress, osType, osVersion, architecture)
+		},
+	}
+
+	cmd.Flags().Int32Var(&orgID, "org", 1, "Organisation ID to register the device under")
+	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "localhost:50051", "Cloud gRPC endpoint")
+	cmd.Flags().StringVar(&name, "name", "", "Human-readable device name (required)")
+	cmd.Flags().StringVar(&deviceType, "device-type", "", "Device type, e.g. jetson-orin-nano")
+	cmd.Flags().StringVar(&ipAddress, "ip", "", "Device IP address")
+	cmd.Flags().StringVar(&osType, "os", "WendyOS", "Operating system type")
+	cmd.Flags().StringVar(&osVersion, "os-version", "", "Operating system version")
+	cmd.Flags().StringVar(&architecture, "arch", "arm64", "CPU architecture")
+
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func runCloudEnroll(
+	ctx context.Context,
+	cloudGRPC string,
+	orgID int32,
+	name, deviceType, ipAddress, osType, osVersion, architecture string,
+) error {
+	conn, err := grpc.NewClient(cloudGRPC, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("connect to cloud: %w", err)
+	}
+	defer conn.Close()
+
+	client := cloudpb.NewAssetServiceClient(conn)
+
+	req := &cloudpb.CreateAssetRequest{
+		OrganizationId:  orgID,
+		Name:            name,
+		IsComputeDevice: true,
+		AssetType:       "device",
+		Tags:            []string{"poc", "direct-enrolled"},
+	}
+	if osType != "" {
+		req.OsType = &osType
+	}
+	if osVersion != "" {
+		req.OsVersion = &osVersion
+	}
+	if architecture != "" {
+		req.Architecture = &architecture
+	}
+	if deviceType != "" {
+		req.DeviceType = &deviceType
+	}
+	if ipAddress != "" {
+		req.IpAddress = &ipAddress
+	}
+
+	asset, err := client.CreateAsset(ctx, req)
+	if err != nil {
+		return fmt.Errorf("enroll device: %w", err)
+	}
+
+	fmt.Printf("Device enrolled successfully.\n")
+	fmt.Printf("  ID:   %d\n", asset.GetId())
+	fmt.Printf("  Name: %s\n", asset.GetName())
+	fmt.Printf("  Org:  %d\n", asset.GetOrganizationId())
+	if asset.GetIpAddress() != "" {
+		fmt.Printf("  IP:   %s\n", asset.GetIpAddress())
+	}
+	return nil
+}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -79,6 +79,8 @@ func NewRootCmd() *cobra.Command {
 	// Cloud Commands
 	authCmd := newAuthCmd()
 	authCmd.GroupID = "cloud"
+	cloudCmd := newCloudCmd()
+	cloudCmd.GroupID = "cloud"
 
 	// Device Commands
 	deviceCmd := newDeviceCmd()
@@ -122,6 +124,7 @@ func NewRootCmd() *cobra.Command {
 		initCmd,
 		projectCmd,
 		authCmd,
+		cloudCmd,
 		deviceCmd,
 		discoverCmd,
 		osCmd,


### PR DESCRIPTION
(part of the Wendy Cloud POC)

1. cloud_forwarder.go: subscribes to the TelemetryBroadcaster and forwards OTLP log batches to the cloud gRPC endpoint. Activated when WENDY_CLOUD_GRPC is set in the environment. Reconnects automatically on failure with a 5s backoff.
2. commands/cloud.go:
   - `wendy cloud discover`: lists enrolled devices from the cloud via gRPC using a raw streaming receive to collect server-streamed asset messages.
   -`wendy cloud enroll`: directly creates an asset record in the cloud database without going through the cert/OAuth enrollment flow (POC only).