### PR TITLE
HelloMLX — Little Fixes

### DIFF
--- a/Examples/HelloMLX/README.md
+++ b/Examples/HelloMLX/README.md
@@ -78,6 +78,7 @@ This demo runs a vision-language model on the target Mac and evaluates a prompt 
 By default, the app configuration includes:
 
 - a local model path: `gemma-3-27b-it-qat-4bit`
+- a square frame resolution of `256x256` (override with `--resolution Y`)
 - a web server on port `8080`
 - a prompt that asks the model to comment on the captured frames
 
@@ -92,7 +93,8 @@ Final app config:
   "interval" : 5,
   "modelPath" : "gemma-3-27b-it-qat-4bit",
   "port" : 8080,
-  "prompt" : "These frames were captured at a fixed interval from a webcam. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames."
+  "prompt" : "These frames were captured at a fixed interval from a webcam. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames.",
+  "resolution" : 256
 }
 HELLO_MLX_URL=http://konstantins-macbook-pro-m5.local:8080/
 HELLO_MLX_DATA_DIR=/Users/konstantinbe/Library/Application Support/sh.wendy.WendyAgentMac/apps/sh.wendy.examples.HelloMLX/Runs

--- a/Examples/HelloMLX/Resources/index.html
+++ b/Examples/HelloMLX/Resources/index.html
@@ -476,6 +476,11 @@
       return date.toLocaleString();
     }
 
+    function formatNumber(value) {
+      if (Number.isInteger(value)) return `${value}`;
+      return value.toFixed(3).replace(/\.0+$|0+$/g, '').replace(/\.$/, '');
+    }
+
     function formatSquareResolution(value) {
       return `${value}x${value}`;
     }
@@ -527,7 +532,7 @@
       elements.modelStatus.textContent = payload.model.name
         ? `${payload.model.status} · ${payload.model.name}`
         : payload.model.status;
-      elements.runConfig.textContent = `${payload.run.interval}s window · ${payload.run.fps} fps · ${formatSquareResolution(payload.run.resolution)}`;
+      elements.runConfig.textContent = `${formatNumber(payload.run.interval)}s window · ${formatNumber(payload.run.fps)} fps · ${formatSquareResolution(payload.run.resolution)}`;
       elements.latestRun.textContent = payload.run.latestRunID
         ? `${payload.run.latestRunID} · ${payload.run.isRunningInference ? 'running' : 'idle'}`
         : (payload.run.isRunningInference ? 'Running…' : 'None yet');
@@ -579,7 +584,7 @@
       card.dataset.runId = run.id;
       fragment.querySelector('.run-time').textContent = formatDate(run.timestamp);
       const resolution = run.resolution ?? 256;
-      fragment.querySelector('.run-frame-count').textContent = `${run.frameCount} frame${run.frameCount === 1 ? '' : 's'} · ${run.interval}s · ${run.fps} fps · ${formatSquareResolution(resolution)}`;
+      fragment.querySelector('.run-frame-count').textContent = `${run.frameCount} frame${run.frameCount === 1 ? '' : 's'} · ${formatNumber(run.interval)}s · ${formatNumber(run.fps)} fps · ${formatSquareResolution(resolution)}`;
       fragment.querySelector('.run-prompt').textContent = run.prompt;
       fragment.querySelector('.run-response').textContent = run.response;
 

--- a/Examples/HelloMLX/Resources/index.html
+++ b/Examples/HelloMLX/Resources/index.html
@@ -48,7 +48,7 @@
     .page-header {
       display: flex;
       justify-content: space-between;
-      align-items: baseline;
+      align-items: flex-start;
       gap: 16px;
     }
 
@@ -62,6 +62,38 @@
     .page-url {
       margin: 0;
       color: var(--muted);
+    }
+
+    .page-header-side {
+      display: grid;
+      gap: 10px;
+      justify-items: end;
+    }
+
+    .summary-metric {
+      min-width: 220px;
+      padding: 12px 14px;
+      border-radius: 14px;
+      border: 1px solid rgba(121, 168, 255, 0.28);
+      background: rgba(121, 168, 255, 0.09);
+      box-shadow: var(--shadow);
+    }
+
+    .summary-label {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      margin-bottom: 4px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .summary-value {
+      display: block;
+      font-size: 28px;
+      font-weight: 700;
+      line-height: 1.1;
+      color: var(--accent);
     }
 
     .top-grid {
@@ -259,15 +291,41 @@
     .run-meta {
       display: flex;
       justify-content: space-between;
-      gap: 12px;
-      align-items: baseline;
+      gap: 16px;
+      align-items: flex-start;
       flex-wrap: wrap;
+    }
+
+    .run-meta-main {
+      display: grid;
+      gap: 4px;
     }
 
     .run-time,
     .run-frame-count {
       color: var(--muted);
       font-size: 12px;
+    }
+
+    .run-duration-block {
+      text-align: right;
+    }
+
+    .run-duration-label {
+      display: block;
+      color: var(--muted);
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 2px;
+    }
+
+    .run-duration {
+      display: block;
+      font-size: 24px;
+      font-weight: 700;
+      line-height: 1.1;
+      color: var(--accent);
     }
 
     .run-section {
@@ -326,6 +384,15 @@
         padding: 16px;
       }
 
+      .page-header {
+        flex-direction: column;
+      }
+
+      .page-header-side {
+        width: 100%;
+        justify-items: stretch;
+      }
+
       .top-grid {
         grid-template-columns: 1fr;
       }
@@ -343,7 +410,13 @@
         <h1 class="page-title">HelloMLX</h1>
         <p class="page-subtitle">Live camera input, editable prompt, and persisted run history.</p>
       </div>
-      <p class="page-url" id="page-url">Waiting for server state…</p>
+      <div class="page-header-side">
+        <div class="summary-metric">
+          <span class="summary-label">Last run duration</span>
+          <span class="summary-value" id="last-run-duration">—</span>
+        </div>
+        <p class="page-url" id="page-url">Waiting for server state…</p>
+      </div>
     </header>
 
     <section class="top-grid" aria-label="Live view and prompt">
@@ -419,8 +492,14 @@
   <template id="run-template">
     <article class="run-card">
       <header class="run-meta">
-        <time class="run-time"></time>
-        <span class="run-frame-count"></span>
+        <div class="run-meta-main">
+          <time class="run-time"></time>
+          <span class="run-frame-count"></span>
+        </div>
+        <div class="run-duration-block">
+          <span class="run-duration-label">Duration</span>
+          <span class="run-duration"></span>
+        </div>
       </header>
       <section class="run-section">
         <span class="run-label">Prompt</span>
@@ -451,6 +530,7 @@
 
     const elements = {
       pageURL: document.getElementById('page-url'),
+      lastRunDuration: document.getElementById('last-run-duration'),
       liveFrame: document.getElementById('live-frame'),
       liveFramePlaceholder: document.getElementById('live-frame-placeholder'),
       liveFrameNote: document.getElementById('live-frame-note'),
@@ -483,6 +563,22 @@
 
     function formatSquareResolution(value) {
       return `${value}x${value}`;
+    }
+
+    function formatDuration(value) {
+      if (value == null || !Number.isFinite(value)) return '—';
+      if (value >= 3600) {
+        const hours = Math.floor(value / 3600);
+        const minutes = Math.floor((value % 3600) / 60);
+        const seconds = value % 60;
+        return `${hours}h ${minutes}m ${formatNumber(seconds)}s`;
+      }
+      if (value >= 60) {
+        const minutes = Math.floor(value / 60);
+        const seconds = value % 60;
+        return `${minutes}m ${formatNumber(seconds)}s`;
+      }
+      return `${formatNumber(value)}s`;
     }
 
     function updatePromptControls() {
@@ -533,6 +629,7 @@
         ? `${payload.model.status} · ${payload.model.name}`
         : payload.model.status;
       elements.runConfig.textContent = `${formatNumber(payload.run.interval)}s window · ${formatNumber(payload.run.fps)} fps · ${formatSquareResolution(payload.run.resolution)}`;
+      elements.lastRunDuration.textContent = formatDuration(payload.run.latestRunDuration);
       elements.latestRun.textContent = payload.run.latestRunID
         ? `${payload.run.latestRunID} · ${payload.run.isRunningInference ? 'running' : 'idle'}`
         : (payload.run.isRunningInference ? 'Running…' : 'None yet');
@@ -585,6 +682,7 @@
       fragment.querySelector('.run-time').textContent = formatDate(run.timestamp);
       const resolution = run.resolution ?? 256;
       fragment.querySelector('.run-frame-count').textContent = `${run.frameCount} frame${run.frameCount === 1 ? '' : 's'} · ${formatNumber(run.interval)}s · ${formatNumber(run.fps)} fps · ${formatSquareResolution(resolution)}`;
+      fragment.querySelector('.run-duration').textContent = formatDuration(run.duration);
       fragment.querySelector('.run-prompt').textContent = run.prompt;
       fragment.querySelector('.run-response').textContent = run.response;
 

--- a/Examples/HelloMLX/Resources/index.html
+++ b/Examples/HelloMLX/Resources/index.html
@@ -476,6 +476,10 @@
       return date.toLocaleString();
     }
 
+    function formatSquareResolution(value) {
+      return `${value}x${value}`;
+    }
+
     function updatePromptControls() {
       const hasChanges = elements.promptInput.value !== state.promptText;
       state.promptDirty = hasChanges;
@@ -523,7 +527,7 @@
       elements.modelStatus.textContent = payload.model.name
         ? `${payload.model.status} · ${payload.model.name}`
         : payload.model.status;
-      elements.runConfig.textContent = `${payload.run.interval}s window · ${payload.run.fps} fps`;
+      elements.runConfig.textContent = `${payload.run.interval}s window · ${payload.run.fps} fps · ${formatSquareResolution(payload.run.resolution)}`;
       elements.latestRun.textContent = payload.run.latestRunID
         ? `${payload.run.latestRunID} · ${payload.run.isRunningInference ? 'running' : 'idle'}`
         : (payload.run.isRunningInference ? 'Running…' : 'None yet');
@@ -574,7 +578,8 @@
       const card = fragment.querySelector('.run-card');
       card.dataset.runId = run.id;
       fragment.querySelector('.run-time').textContent = formatDate(run.timestamp);
-      fragment.querySelector('.run-frame-count').textContent = `${run.frameCount} frame${run.frameCount === 1 ? '' : 's'}`;
+      const resolution = run.resolution ?? 256;
+      fragment.querySelector('.run-frame-count').textContent = `${run.frameCount} frame${run.frameCount === 1 ? '' : 's'} · ${run.interval}s · ${run.fps} fps · ${formatSquareResolution(resolution)}`;
       fragment.querySelector('.run-prompt').textContent = run.prompt;
       fragment.querySelector('.run-response').textContent = run.response;
 

--- a/Examples/HelloMLX/Sources/AppState.swift
+++ b/Examples/HelloMLX/Sources/AppState.swift
@@ -36,8 +36,8 @@ struct PromptInfo: Codable {
 }
 
 struct RunInfo: Codable {
-    let interval: Int
-    let fps: Int
+    let interval: Double
+    let fps: Double
     let resolution: Int
     let isRunningInference: Bool
     let latestRunID: String?
@@ -65,8 +65,8 @@ struct PromptUpdateResponse: Codable {
 actor AppState {
     private let startedAt = Date()
     private let baseURL: String
-    private let interval: Int
-    private let fps: Int
+    private let interval: Double
+    private let fps: Double
     private let resolution: Int
 
     private var cameraStatus: CameraStatus = .starting

--- a/Examples/HelloMLX/Sources/AppState.swift
+++ b/Examples/HelloMLX/Sources/AppState.swift
@@ -41,6 +41,7 @@ struct RunInfo: Codable {
     let resolution: Int
     let isRunningInference: Bool
     let latestRunID: String?
+    let latestRunDuration: TimeInterval?
     let lastInferenceAt: Date?
 }
 
@@ -82,10 +83,11 @@ actor AppState {
 
     private var isRunningInference = false
     private var latestRunID: String?
+    private var latestRunDuration: TimeInterval?
     private var lastInferenceAt: Date?
     private var lastError: String?
 
-    init(config: AppConfig, baseURL: String, latestRunID: String?) {
+    init(config: AppConfig, baseURL: String, latestRun: PersistedRun?) {
         self.baseURL = baseURL
         self.interval = config.interval
         self.fps = config.fps
@@ -93,7 +95,9 @@ actor AppState {
         self.modelStatus = config.modelPath == nil ? .notConfigured : .loading
         self.modelName = config.modelPath.map { URL(fileURLWithPath: $0).lastPathComponent }
         self.promptText = config.prompt
-        self.latestRunID = latestRunID
+        self.latestRunID = latestRun?.id
+        self.latestRunDuration = latestRun?.duration
+        self.lastInferenceAt = latestRun?.timestamp
     }
 
     func snapshot() -> StateResponse {
@@ -116,6 +120,7 @@ actor AppState {
                 resolution: resolution,
                 isRunningInference: isRunningInference,
                 latestRunID: latestRunID,
+                latestRunDuration: latestRunDuration,
                 lastInferenceAt: lastInferenceAt
             ),
             error: lastError
@@ -180,8 +185,9 @@ actor AppState {
         isRunningInference = isRunning
     }
 
-    func recordRun(id: String, at date: Date) {
+    func recordRun(id: String, at date: Date, duration: TimeInterval) {
         latestRunID = id
+        latestRunDuration = duration
         lastInferenceAt = date
     }
 

--- a/Examples/HelloMLX/Sources/AppState.swift
+++ b/Examples/HelloMLX/Sources/AppState.swift
@@ -38,6 +38,7 @@ struct PromptInfo: Codable {
 struct RunInfo: Codable {
     let interval: Int
     let fps: Int
+    let resolution: Int
     let isRunningInference: Bool
     let latestRunID: String?
     let lastInferenceAt: Date?
@@ -66,6 +67,7 @@ actor AppState {
     private let baseURL: String
     private let interval: Int
     private let fps: Int
+    private let resolution: Int
 
     private var cameraStatus: CameraStatus = .starting
     private var cameraName: String?
@@ -87,6 +89,7 @@ actor AppState {
         self.baseURL = baseURL
         self.interval = config.interval
         self.fps = config.fps
+        self.resolution = config.resolution
         self.modelStatus = config.modelPath == nil ? .notConfigured : .loading
         self.modelName = config.modelPath.map { URL(fileURLWithPath: $0).lastPathComponent }
         self.promptText = config.prompt
@@ -110,6 +113,7 @@ actor AppState {
             run: RunInfo(
                 interval: interval,
                 fps: fps,
+                resolution: resolution,
                 isRunningInference: isRunningInference,
                 latestRunID: latestRunID,
                 lastInferenceAt: lastInferenceAt

--- a/Examples/HelloMLX/Sources/HelloMLX.swift
+++ b/Examples/HelloMLX/Sources/HelloMLX.swift
@@ -13,8 +13,8 @@ struct AppConfig: Encodable {
     var modelPath: String?
     var prompt: String
     var camera: String?
-    var interval: Int
-    var fps: Int
+    var interval: Double
+    var fps: Double
     var resolution: Int
     var port: Int
 }
@@ -49,10 +49,10 @@ struct CLIArguments: ParsableCommand {
     var prompt: String = ""
 
     @Option(name: .long, help: "Seconds of camera history to include in each inference pass.")
-    var interval: Int = 2
+    var interval: Double = 2
 
     @Option(name: .long, help: "Frames per second to sample into the buffer.")
-    var fps: Int = 1
+    var fps: Double = 1
 
     @Option(name: .long, help: "Square frame resolution. A value of Y produces YxY frames.")
     var resolution: Int = 512
@@ -279,7 +279,7 @@ final class Camera: NSObject {
     private func runInferenceLoop() async {
         guard let container = model else { return }
 
-        let interval = TimeInterval(config.interval)
+        let interval = config.interval
         print(
             "Sampling at \(config.fps) fps, evaluating last \(config.interval)s of frames at \(config.resolution)x\(config.resolution)."
         )
@@ -411,7 +411,7 @@ extension Camera: AVCaptureVideoDataOutputSampleBufferDelegate {
         guard let pixelBuffer = sampleBuffer.imageBuffer else { return }
 
         let now = Date()
-        let minGap = 1.0 / TimeInterval(config.fps)
+        let minGap = 1.0 / config.fps
 
         frameBufferLock.lock()
         let shouldSample = lastSampledAt == nil || now.timeIntervalSince(lastSampledAt!) >= minGap

--- a/Examples/HelloMLX/Sources/HelloMLX.swift
+++ b/Examples/HelloMLX/Sources/HelloMLX.swift
@@ -49,13 +49,13 @@ struct CLIArguments: ParsableCommand {
     var prompt: String = ""
 
     @Option(name: .long, help: "Seconds of camera history to include in each inference pass.")
-    var interval: Double = 20
+    var interval: Double = 5
 
     @Option(name: .long, help: "Frames per second to sample into the buffer.")
-    var fps: Double = 0.1
+    var fps: Double = 1
 
     @Option(name: .long, help: "Square frame resolution. A value of Y produces YxY frames.")
-    var resolution: Int = 512
+    var resolution: Int = 256
 
     @Option(name: .long, help: "Local port to serve the web UI on.")
     var port: Int = 8080

--- a/Examples/HelloMLX/Sources/HelloMLX.swift
+++ b/Examples/HelloMLX/Sources/HelloMLX.swift
@@ -49,10 +49,10 @@ struct CLIArguments: ParsableCommand {
     var prompt: String = ""
 
     @Option(name: .long, help: "Seconds of camera history to include in each inference pass.")
-    var interval: Double = 2
+    var interval: Double = 20
 
     @Option(name: .long, help: "Frames per second to sample into the buffer.")
-    var fps: Double = 1
+    var fps: Double = 0.1
 
     @Option(name: .long, help: "Square frame resolution. A value of Y produces YxY frames.")
     var resolution: Int = 512
@@ -123,7 +123,7 @@ struct HelloMLX {
             let dataDirectory = try AppDirectories.makeDataDirectory()
             let runStore = try RunStore(rootURL: dataDirectory)
             let baseURL = makeAdvertisedBaseURL(port: appConfig.port)
-            let state = AppState(config: appConfig, baseURL: baseURL, latestRunID: runStore.latestRunID())
+            let state = AppState(config: appConfig, baseURL: baseURL, latestRun: runStore.latestRun())
             let indexHTML = try loadIndexHTML()
             let webServer = try WebServer(
                 port: UInt16(appConfig.port),
@@ -309,6 +309,7 @@ final class Camera: NSObject {
             let resolution = CGFloat(config.resolution)
             userInput.processing.resize = CGSize(width: resolution, height: resolution)
 
+            let inferenceStartedAt = Date()
             var response = ""
             do {
                 let lmInput = try await container.prepare(input: userInput)
@@ -332,6 +333,7 @@ final class Camera: NSObject {
             }
             await state.setInferenceRunning(false)
 
+            let duration = Date().timeIntervalSince(inferenceStartedAt)
             let cleanedResponse = response.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !cleanedResponse.isEmpty else { continue }
 
@@ -344,9 +346,10 @@ final class Camera: NSObject {
                     modelName: modelName,
                     interval: config.interval,
                     fps: config.fps,
-                    resolution: config.resolution
+                    resolution: config.resolution,
+                    duration: duration
                 )
-                await state.recordRun(id: run.id, at: run.timestamp)
+                await state.recordRun(id: run.id, at: run.timestamp, duration: duration)
                 await state.setError(nil)
             } catch {
                 await state.setError("Failed to persist run: \(error.localizedDescription)")

--- a/Examples/HelloMLX/Sources/HelloMLX.swift
+++ b/Examples/HelloMLX/Sources/HelloMLX.swift
@@ -15,6 +15,7 @@ struct AppConfig: Encodable {
     var camera: String?
     var interval: Int
     var fps: Int
+    var resolution: Int
     var port: Int
 }
 
@@ -31,7 +32,7 @@ private func printFinalConfig(_ config: AppConfig) {
     }
 
     print(
-        "Final app config: modelPath=\(config.modelPath ?? "nil"), prompt=\(config.prompt), camera=\(config.camera ?? "nil"), interval=\(config.interval), fps=\(config.fps), port=\(config.port)"
+        "Final app config: modelPath=\(config.modelPath ?? "nil"), prompt=\(config.prompt), camera=\(config.camera ?? "nil"), interval=\(config.interval), fps=\(config.fps), resolution=\(config.resolution), port=\(config.port)"
     )
 }
 
@@ -53,6 +54,9 @@ struct CLIArguments: ParsableCommand {
     @Option(name: .long, help: "Frames per second to sample into the buffer.")
     var fps: Int = 2
 
+    @Option(name: .long, help: "Square frame resolution. A value of Y produces YxY frames.")
+    var resolution: Int = 256
+
     @Option(name: .long, help: "Local port to serve the web UI on.")
     var port: Int = 8080
 
@@ -67,6 +71,10 @@ struct CLIArguments: ParsableCommand {
 
         guard fps > 0 else {
             throw ValidationError("--fps must be greater than 0.")
+        }
+
+        guard resolution > 0 else {
+            throw ValidationError("--resolution must be greater than 0.")
         }
     }
 }
@@ -98,6 +106,7 @@ let appConfig: AppConfig = {
             camera: parsed.camera,
             interval: parsed.interval,
             fps: parsed.fps,
+            resolution: parsed.resolution,
             port: parsed.port
         )
         printFinalConfig(config)
@@ -271,7 +280,9 @@ final class Camera: NSObject {
         guard let container = model else { return }
 
         let interval = TimeInterval(config.interval)
-        print("Sampling at \(config.fps) fps, evaluating last \(config.interval)s of frames.")
+        print(
+            "Sampling at \(config.fps) fps, evaluating last \(config.interval)s of frames at \(config.resolution)x\(config.resolution)."
+        )
 
         while !Task.isCancelled {
             let prompt = await state.currentPrompt().trimmingCharacters(in: .whitespacesAndNewlines)
@@ -295,7 +306,8 @@ final class Camera: NSObject {
             var userInput = UserInput(
                 chat: [.user(prompt, images: frames.map { .ciImage(CIImage(cgImage: $0.image)) })]
             )
-            userInput.processing.resize = CGSize(width: 256, height: 256)
+            let resolution = CGFloat(config.resolution)
+            userInput.processing.resize = CGSize(width: resolution, height: resolution)
 
             var response = ""
             do {
@@ -359,6 +371,34 @@ final class Camera: NSObject {
             await state.setLiveFrame(jpeg: jpeg, at: frame.capturedAt)
         }
     }
+
+    private func makeSquareFrameImage(from ciImage: CIImage) -> CGImage? {
+        let extent = ciImage.extent.integral
+        let cropLength = min(extent.width, extent.height)
+        guard cropLength > 0 else { return nil }
+
+        let cropped = ciImage.cropped(
+            to: CGRect(
+                x: extent.origin.x + (extent.width - cropLength) / 2,
+                y: extent.origin.y + (extent.height - cropLength) / 2,
+                width: cropLength,
+                height: cropLength
+            )
+        )
+
+        let normalized = cropped.transformed(
+            by: CGAffineTransform(
+                translationX: -cropped.extent.origin.x,
+                y: -cropped.extent.origin.y
+            )
+        )
+
+        let resolution = CGFloat(config.resolution)
+        let scale = resolution / cropLength
+        let resized = normalized.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        let outputRect = CGRect(origin: .zero, size: CGSize(width: resolution, height: resolution))
+        return ciContext.createCGImage(resized, from: outputRect)
+    }
 }
 
 extension Camera: AVCaptureVideoDataOutputSampleBufferDelegate {
@@ -382,11 +422,8 @@ extension Camera: AVCaptureVideoDataOutputSampleBufferDelegate {
         guard shouldSample else { return }
 
         let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
-        let targetSize = CGSize(width: 256, height: 256)
-        let scale = min(targetSize.width / ciImage.extent.width, targetSize.height / ciImage.extent.height)
-        let scaled = ciImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
 
-        guard let image = ciContext.createCGImage(scaled, from: scaled.extent),
+        guard let image = makeSquareFrameImage(from: ciImage),
               let jpeg = jpegData(from: image)
         else {
             return

--- a/Examples/HelloMLX/Sources/HelloMLX.swift
+++ b/Examples/HelloMLX/Sources/HelloMLX.swift
@@ -49,13 +49,13 @@ struct CLIArguments: ParsableCommand {
     var prompt: String = ""
 
     @Option(name: .long, help: "Seconds of camera history to include in each inference pass.")
-    var interval: Int = 5
+    var interval: Int = 2
 
     @Option(name: .long, help: "Frames per second to sample into the buffer.")
-    var fps: Int = 2
+    var fps: Int = 1
 
     @Option(name: .long, help: "Square frame resolution. A value of Y produces YxY frames.")
-    var resolution: Int = 256
+    var resolution: Int = 512
 
     @Option(name: .long, help: "Local port to serve the web UI on.")
     var port: Int = 8080
@@ -343,7 +343,8 @@ final class Camera: NSObject {
                     cameraName: cameraName,
                     modelName: modelName,
                     interval: config.interval,
-                    fps: config.fps
+                    fps: config.fps,
+                    resolution: config.resolution
                 )
                 await state.recordRun(id: run.id, at: run.timestamp)
                 await state.setError(nil)

--- a/Examples/HelloMLX/Sources/HelloMLX.swift
+++ b/Examples/HelloMLX/Sources/HelloMLX.swift
@@ -291,7 +291,7 @@ final class Camera: NSObject {
                 continue
             }
 
-            while !Task.isCancelled && windowFrames(within: interval).count < 2 {
+            while !Task.isCancelled && windowFrames(within: interval).count < 1 {
                 try? await Task.sleep(for: .seconds(1))
             }
             if Task.isCancelled { return }

--- a/Examples/HelloMLX/Sources/RunStore.swift
+++ b/Examples/HelloMLX/Sources/RunStore.swift
@@ -13,8 +13,8 @@ struct PersistedRun: Codable, Sendable {
     let response: String
     let cameraName: String?
     let modelName: String?
-    let interval: Int
-    let fps: Int
+    let interval: Double
+    let fps: Double
     let resolution: Int?
     let frameCount: Int
     let frames: [PersistedFrame]
@@ -73,8 +73,8 @@ struct RunStore {
         frames: [FrameCapture],
         cameraName: String?,
         modelName: String?,
-        interval: Int,
-        fps: Int,
+        interval: Double,
+        fps: Double,
         resolution: Int
     ) throws -> PersistedRun {
         let id = RunID.make()

--- a/Examples/HelloMLX/Sources/RunStore.swift
+++ b/Examples/HelloMLX/Sources/RunStore.swift
@@ -16,6 +16,7 @@ struct PersistedRun: Codable, Sendable {
     let interval: Double
     let fps: Double
     let resolution: Int?
+    let duration: TimeInterval?
     let frameCount: Int
     let frames: [PersistedFrame]
 }
@@ -43,8 +44,12 @@ struct RunStore {
         try fileManager.createDirectory(at: runsURL, withIntermediateDirectories: true)
     }
 
+    func latestRun() -> PersistedRun? {
+        try? listRuns(limit: 1, before: nil).items.first
+    }
+
     func latestRunID() -> String? {
-        try? listRuns(limit: 1, before: nil).items.first?.id
+        latestRun()?.id
     }
 
     func listRuns(limit: Int, before cursor: String?) throws -> RunsResponse {
@@ -75,7 +80,8 @@ struct RunStore {
         modelName: String?,
         interval: Double,
         fps: Double,
-        resolution: Int
+        resolution: Int,
+        duration: TimeInterval
     ) throws -> PersistedRun {
         let id = RunID.make()
         let directoryURL = runsURL.appendingPathComponent(id, isDirectory: true)
@@ -109,6 +115,7 @@ struct RunStore {
             interval: interval,
             fps: fps,
             resolution: resolution,
+            duration: duration,
             frameCount: persistedFrames.count,
             frames: persistedFrames
         )

--- a/Examples/HelloMLX/Sources/RunStore.swift
+++ b/Examples/HelloMLX/Sources/RunStore.swift
@@ -15,6 +15,7 @@ struct PersistedRun: Codable, Sendable {
     let modelName: String?
     let interval: Int
     let fps: Int
+    let resolution: Int?
     let frameCount: Int
     let frames: [PersistedFrame]
 }
@@ -73,7 +74,8 @@ struct RunStore {
         cameraName: String?,
         modelName: String?,
         interval: Int,
-        fps: Int
+        fps: Int,
+        resolution: Int
     ) throws -> PersistedRun {
         let id = RunID.make()
         let directoryURL = runsURL.appendingPathComponent(id, isDirectory: true)
@@ -106,6 +108,7 @@ struct RunStore {
             modelName: modelName,
             interval: interval,
             fps: fps,
+            resolution: resolution,
             frameCount: persistedFrames.count,
             frames: persistedFrames
         )


### PR DESCRIPTION
## Summary
- allow fractional `--fps` / `--interval`, a configurable square `--resolution`, and inference with a single frame
- persist run resolution/duration metadata and surface it in the HelloMLX UI, including the last run duration
- update the README config docs to match