### PR TITLE
Fix CLI analytics: capture command name, exclude CI, expand schema (WDY-969)

### DIFF
--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -94,7 +94,13 @@ func errorClass(err error) string {
 	if errors.Is(err, commands.ErrUserCancelled) || errors.Is(err, commands.ErrDefaultCleared) {
 		return "user_cancelled"
 	}
-	if st, ok := status.FromError(err); ok && st.Code() != codes.OK && st.Code() != codes.Unknown {
+	// status.FromError returns ok=true only for real gRPC errors (those
+	// produced by the grpc package or implementing GRPCStatus()). For
+	// non-gRPC errors it returns ok=false with a synthesized Unknown code,
+	// which we don't want to claim as a gRPC failure. An explicit
+	// Unknown code from a real gRPC error, however, should still bucket
+	// under grpc_other.
+	if st, ok := status.FromError(err); ok && st.Code() != codes.OK {
 		switch st.Code() {
 		case codes.Canceled:
 			return "context_canceled"

--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -1,34 +1,25 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/internal/cli/analytics"
 	"github.com/wendylabsinc/wendy/internal/cli/commands"
+	"github.com/wendylabsinc/wendy/internal/shared/version"
 )
 
 func main() {
+	start := time.Now()
 	cmd := commands.NewRootCmd()
-	err := cmd.Execute()
-
-	// Track the executed command after it completes, so we know success/failure.
-	if activeCmd, _, findErr := cmd.Find(os.Args[1:]); findErr == nil && activeCmd != nil {
-		success := "true"
-		if err != nil {
-			success = "false"
-		}
-		props := map[string]string{
-			"command": activeCmd.CommandPath(),
-			"success": success,
-		}
-		analytics.Track("command_executed", props)
-		if err != nil {
-			analytics.Track("command_error", props)
-		}
-	}
+	executed, err := cmd.ExecuteC()
+	trackCommand(executed, err, time.Since(start))
 	analytics.Close()
 
 	if err != nil {
@@ -37,6 +28,81 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", formatError(err))
 		os.Exit(1)
+	}
+}
+
+// trackCommand emits a single command_executed analytics event describing the
+// invocation. The schema is documented in Documentation/Analytics.md; in short:
+//
+//   - command_name is the canonical cobra path (e.g. "wendy device wifi connect"),
+//     never flag values or positional args.
+//   - command_root is the top-level token (e.g. "device") to give dashboards a
+//     low-cardinality breakdown axis that survives PostHog's 25-row table cap.
+//   - duration_ms is the wall-clock time from process start.
+//   - On failure, error_class is a bounded enum derived from err — never the
+//     error message text, which can leak hostnames or paths.
+func trackCommand(executed *cobra.Command, err error, dur time.Duration) {
+	if executed == nil {
+		return
+	}
+	props := map[string]string{
+		"command_name": executed.CommandPath(),
+		"command_root": commandRoot(executed),
+		"duration_ms":  strconv.FormatInt(dur.Milliseconds(), 10),
+		"success":      strconv.FormatBool(err == nil),
+		"is_dev_build": strconv.FormatBool(version.Version == "dev"),
+	}
+	if err != nil {
+		props["error_class"] = errorClass(err)
+	}
+	analytics.Track("command_executed", props)
+}
+
+// commandRoot returns the top-level subcommand token under the root, e.g.
+// "device" for `wendy device wifi connect`. Returns the root's own name
+// (typically "wendy") when invoked without a subcommand.
+func commandRoot(c *cobra.Command) string {
+	if c == nil {
+		return ""
+	}
+	if !c.HasParent() {
+		return c.Name()
+	}
+	for c.Parent() != nil && c.Parent().HasParent() {
+		c = c.Parent()
+	}
+	return c.Name()
+}
+
+// errorClass maps an execution error to a bounded enum suitable for analytics.
+// It must never embed the error message, which can contain hostnames, paths,
+// or other user input.
+func errorClass(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, commands.ErrUserCancelled) || errors.Is(err, commands.ErrDefaultCleared) {
+		return "user_cancelled"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "context_canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "context_deadline"
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "rpc error: code = ") {
+		return "other"
+	}
+	switch {
+	case strings.Contains(msg, "code = Unavailable"):
+		return "grpc_unavailable"
+	case strings.Contains(msg, "code = DeadlineExceeded"):
+		return "grpc_deadline"
+	case strings.Contains(msg, "code = Unimplemented"):
+		return "grpc_unimplemented"
+	default:
+		return "grpc_other"
 	}
 }
 

--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/wendylabsinc/wendy/internal/cli/analytics"
 	"github.com/wendylabsinc/wendy/internal/cli/commands"
 	"github.com/wendylabsinc/wendy/internal/shared/version"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func main() {
@@ -32,15 +34,17 @@ func main() {
 }
 
 // trackCommand emits a single command_executed analytics event describing the
-// invocation. The schema is documented in Documentation/Analytics.md; in short:
+// invocation. Properties:
 //
-//   - command_name is the canonical cobra path (e.g. "wendy device wifi connect"),
+//   - command_name: canonical cobra path (e.g. "wendy device wifi connect"),
 //     never flag values or positional args.
-//   - command_root is the top-level token (e.g. "device") to give dashboards a
-//     low-cardinality breakdown axis that survives PostHog's 25-row table cap.
-//   - duration_ms is the wall-clock time from process start.
-//   - On failure, error_class is a bounded enum derived from err — never the
-//     error message text, which can leak hostnames or paths.
+//   - command_root: top-level token (e.g. "device") for low-cardinality
+//     breakdowns that survive PostHog's 25-row table cap.
+//   - duration_ms: wall-clock time from process start.
+//   - success: bool serialized as "true"/"false".
+//   - is_dev_build: true when version.Version == "dev".
+//   - error_class (only when err != nil): bounded enum derived from err —
+//     never the error message text, which can leak hostnames or paths.
 func trackCommand(executed *cobra.Command, err error, dur time.Duration) {
 	if executed == nil {
 		return
@@ -77,6 +81,12 @@ func commandRoot(c *cobra.Command) string {
 // errorClass maps an execution error to a bounded enum suitable for analytics.
 // It must never embed the error message, which can contain hostnames, paths,
 // or other user input.
+//
+// User-cancellation sentinels are checked first so an outer wrap never
+// reclassifies them. gRPC errors are extracted via status.FromError, which
+// walks the wrapped chain — substring matching on err.Error() would miss
+// errors wrapped via fmt.Errorf with a custom prefix or any future change to
+// grpc-go's stringification.
 func errorClass(err error) string {
 	if err == nil {
 		return ""
@@ -84,26 +94,27 @@ func errorClass(err error) string {
 	if errors.Is(err, commands.ErrUserCancelled) || errors.Is(err, commands.ErrDefaultCleared) {
 		return "user_cancelled"
 	}
+	if st, ok := status.FromError(err); ok && st.Code() != codes.OK && st.Code() != codes.Unknown {
+		switch st.Code() {
+		case codes.Canceled:
+			return "context_canceled"
+		case codes.DeadlineExceeded:
+			return "grpc_deadline"
+		case codes.Unavailable:
+			return "grpc_unavailable"
+		case codes.Unimplemented:
+			return "grpc_unimplemented"
+		default:
+			return "grpc_other"
+		}
+	}
 	if errors.Is(err, context.Canceled) {
 		return "context_canceled"
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return "context_deadline"
 	}
-	msg := err.Error()
-	if !strings.Contains(msg, "rpc error: code = ") {
-		return "other"
-	}
-	switch {
-	case strings.Contains(msg, "code = Unavailable"):
-		return "grpc_unavailable"
-	case strings.Contains(msg, "code = DeadlineExceeded"):
-		return "grpc_deadline"
-	case strings.Contains(msg, "code = Unimplemented"):
-		return "grpc_unimplemented"
-	default:
-		return "grpc_other"
-	}
+	return "other"
 }
 
 // formatError converts raw gRPC errors into human-readable messages.

--- a/go/cmd/wendy/main_test.go
+++ b/go/cmd/wendy/main_test.go
@@ -322,6 +322,7 @@ func TestErrorClass_Mapping(t *testing.T) {
 		{"grpc_deadline_status", status.Error(codes.DeadlineExceeded, "ctx done"), "grpc_deadline"},
 		{"grpc_unimplemented_status", status.Error(codes.Unimplemented, "nope"), "grpc_unimplemented"},
 		{"grpc_internal", status.Error(codes.Internal, "boom"), "grpc_other"},
+		{"grpc_unknown_explicit", status.Error(codes.Unknown, "vague"), "grpc_other"},
 		{"non_grpc", errors.New("some plain failure"), "other"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/cmd/wendy/main_test.go
+++ b/go/cmd/wendy/main_test.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/internal/cli/analytics"
+	"github.com/wendylabsinc/wendy/internal/cli/commands"
+	"github.com/wendylabsinc/wendy/internal/shared/env"
+	"github.com/wendylabsinc/wendy/internal/shared/version"
+)
+
+type capturedEvent struct {
+	event string
+	props map[string]string
+}
+
+func captureAnalytics(t *testing.T) *[]capturedEvent {
+	t.Helper()
+	var events []capturedEvent
+	analytics.SetTrackHookForTesting(func(event string, props map[string]string) {
+		copied := make(map[string]string, len(props))
+		for k, v := range props {
+			copied[k] = v
+		}
+		events = append(events, capturedEvent{event: event, props: copied})
+	})
+	t.Cleanup(func() { analytics.SetTrackHookForTesting(nil) })
+	return &events
+}
+
+func newTestRoot() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "wendy",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	root.PersistentFlags().String("device", "", "target device")
+
+	run := &cobra.Command{
+		Use:  "run [path]",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+
+	device := &cobra.Command{Use: "device"}
+	wifi := &cobra.Command{Use: "wifi"}
+	connect := &cobra.Command{
+		Use:  "connect SSID",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	wifi.AddCommand(connect)
+	device.AddCommand(wifi)
+
+	failing := &cobra.Command{
+		Use: "failing",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("boom")
+		},
+	}
+
+	root.AddCommand(run, device, failing)
+	return root
+}
+
+func runWithArgs(t *testing.T, args []string) (*cobra.Command, error) {
+	t.Helper()
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	os.Args = args
+	root := newTestRoot()
+	root.SetArgs(args[1:])
+	return root.ExecuteC()
+}
+
+// clearCIEnv neutralizes every CI env var so tests run as a "real user".
+// Without this, running the suite under GitHub Actions or any other CI
+// would silently disable analytics and make the hook-based assertions
+// in the rest of the file fail or no-op.
+func clearCIEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"CI",
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"BUILDKITE",
+		"CIRCLECI",
+		"JENKINS_HOME",
+		"TF_BUILD",
+		"TEAMCITY_VERSION",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestTrackCommand_TopLevelSubcommand(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	executed, err := runWithArgs(t, []string{"wendy", "run", "myfile.json"})
+	trackCommand(executed, err, 42*time.Millisecond)
+
+	if len(*events) != 1 {
+		t.Fatalf("expected exactly 1 event, got %d: %+v", len(*events), *events)
+	}
+	got := (*events)[0]
+	if got.event != "command_executed" {
+		t.Errorf("event = %q, want %q", got.event, "command_executed")
+	}
+	if got.props["command_name"] != "wendy run" {
+		t.Errorf("command_name = %q, want %q", got.props["command_name"], "wendy run")
+	}
+	if got.props["command_root"] != "run" {
+		t.Errorf("command_root = %q, want %q", got.props["command_root"], "run")
+	}
+	if got.props["success"] != "true" {
+		t.Errorf("success = %q, want %q", got.props["success"], "true")
+	}
+	if got.props["duration_ms"] != "42" {
+		t.Errorf("duration_ms = %q, want %q", got.props["duration_ms"], "42")
+	}
+	if _, present := got.props["error_class"]; present {
+		t.Errorf("error_class must be absent on success, got %q", got.props["error_class"])
+	}
+}
+
+func TestTrackCommand_NestedSubcommand(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	executed, err := runWithArgs(t, []string{"wendy", "device", "wifi", "connect", "MySSID"})
+	trackCommand(executed, err, time.Millisecond)
+
+	if len(*events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(*events))
+	}
+	got := (*events)[0].props
+	if got["command_name"] != "wendy device wifi connect" {
+		t.Errorf("command_name = %q, want %q", got["command_name"], "wendy device wifi connect")
+	}
+	if got["command_root"] != "device" {
+		t.Errorf("command_root = %q, want %q", got["command_root"], "device")
+	}
+}
+
+func TestTrackCommand_StripsFlagAndPositionalValues(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	executed, err := runWithArgs(t, []string{"wendy", "run", "--device", "secret-host.example.com", "/private/path/file.json"})
+	trackCommand(executed, err, time.Millisecond)
+
+	if len(*events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(*events))
+	}
+	got := (*events)[0].props
+	for prop, want := range map[string]string{
+		"command_name": "wendy run",
+		"command_root": "run",
+	} {
+		if got[prop] != want {
+			t.Errorf("%s = %q, want %q", prop, got[prop], want)
+		}
+	}
+	leakage := []string{"secret-host", "private", "file.json", "--device"}
+	for _, value := range got {
+		for _, leak := range leakage {
+			if strings.Contains(value, leak) {
+				t.Errorf("event property %q leaked: %q", value, leak)
+			}
+		}
+	}
+}
+
+func TestTrackCommand_SingleEventOnFailureWithErrorClass(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	executed, err := runWithArgs(t, []string{"wendy", "failing"})
+	if err == nil {
+		t.Fatal("expected runWithArgs to return an error")
+	}
+	trackCommand(executed, err, time.Millisecond)
+
+	if len(*events) != 1 {
+		t.Fatalf("expected exactly 1 event on failure (no separate command_error), got %d: %+v", len(*events), *events)
+	}
+	got := (*events)[0]
+	if got.event != "command_executed" {
+		t.Errorf("event = %q, want %q", got.event, "command_executed")
+	}
+	if got.props["success"] != "false" {
+		t.Errorf("success = %q, want %q", got.props["success"], "false")
+	}
+	if got.props["error_class"] != "other" {
+		t.Errorf("error_class = %q, want %q", got.props["error_class"], "other")
+	}
+	if got.props["command_name"] != "wendy failing" {
+		t.Errorf("command_name = %q, want %q", got.props["command_name"], "wendy failing")
+	}
+}
+
+func TestTrackCommand_RootOnlyInvocation(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	executed, err := runWithArgs(t, []string{"wendy"})
+	trackCommand(executed, err, time.Millisecond)
+
+	if len(*events) == 0 {
+		t.Fatal("expected at least one event for a bare invocation")
+	}
+	got := (*events)[0].props
+	if got["command_name"] != "wendy" {
+		t.Errorf("command_name = %q, want %q", got["command_name"], "wendy")
+	}
+	if got["command_root"] != "wendy" {
+		t.Errorf("command_root = %q, want %q", got["command_root"], "wendy")
+	}
+}
+
+func TestTrackCommand_NilCommandIsNoOp(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	trackCommand(nil, nil, time.Millisecond)
+	if len(*events) != 0 {
+		t.Fatalf("expected no events for nil cmd, got %d", len(*events))
+	}
+}
+
+func TestTrackCommand_IsDevBuildReflectsVersion(t *testing.T) {
+	clearCIEnv(t)
+	originalVersion := version.Version
+	t.Cleanup(func() { version.Version = originalVersion })
+
+	for _, tc := range []struct {
+		ver  string
+		want string
+	}{
+		{"dev", "true"},
+		{"2026.04.27-103045", "false"},
+		{"v0.10.0", "false"},
+	} {
+		t.Run(tc.ver, func(t *testing.T) {
+			version.Version = tc.ver
+			events := captureAnalytics(t)
+			executed, err := runWithArgs(t, []string{"wendy", "run"})
+			trackCommand(executed, err, time.Millisecond)
+
+			if len(*events) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(*events))
+			}
+			if got := (*events)[0].props["is_dev_build"]; got != tc.want {
+				t.Errorf("is_dev_build = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrackCommand_DurationIsSerializedMilliseconds(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	executed, err := runWithArgs(t, []string{"wendy", "run"})
+	trackCommand(executed, err, 1234*time.Millisecond)
+
+	if len(*events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(*events))
+	}
+	got := (*events)[0].props["duration_ms"]
+	if _, parseErr := strconv.ParseInt(got, 10, 64); parseErr != nil {
+		t.Errorf("duration_ms = %q, must be parseable int64: %v", got, parseErr)
+	}
+	if got != "1234" {
+		t.Errorf("duration_ms = %q, want %q", got, "1234")
+	}
+}
+
+func TestErrorClass_Mapping(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"user_cancelled", commands.ErrUserCancelled, "user_cancelled"},
+		{"default_cleared", commands.ErrDefaultCleared, "user_cancelled"},
+		{"context_canceled", context.Canceled, "context_canceled"},
+		{"context_deadline", context.DeadlineExceeded, "context_deadline"},
+		{
+			name: "grpc_unavailable",
+			err:  errors.New("connecting to cloud: rpc error: code = Unavailable desc = transport closing"),
+			want: "grpc_unavailable",
+		},
+		{
+			name: "grpc_deadline",
+			err:  errors.New("rpc error: code = DeadlineExceeded desc = ctx done"),
+			want: "grpc_deadline",
+		},
+		{
+			name: "grpc_unimplemented",
+			err:  errors.New("rpc error: code = Unimplemented desc = nope"),
+			want: "grpc_unimplemented",
+		},
+		{
+			name: "grpc_other_code",
+			err:  errors.New("rpc error: code = Internal desc = boom"),
+			want: "grpc_other",
+		},
+		{
+			name: "non_grpc",
+			err:  errors.New("some plain failure"),
+			want: "other",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := errorClass(tc.err); got != tc.want {
+				t.Errorf("errorClass(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrorClass_NeverLeaksMessageText(t *testing.T) {
+	// Sanity check: even when the error embeds sensitive substrings, only
+	// the bounded enum value is returned.
+	leaky := fmt.Errorf("rpc error: code = Unavailable desc = could not reach %s", "secret-host.example.com")
+	got := errorClass(leaky)
+	if got != "grpc_unavailable" {
+		t.Errorf("errorClass = %q, want %q", got, "grpc_unavailable")
+	}
+	if strings.Contains(got, "secret-host") {
+		t.Errorf("errorClass leaked sensitive text: %q", got)
+	}
+}
+
+func TestEnv_IsCITripsKillSwitch(t *testing.T) {
+	// Sanity check that env.IsCI() recognizes the CI variable. The deeper
+	// contract — that analytics.Init refuses to enable in CI — is covered
+	// in internal/cli/analytics/analytics_test.go where the config package
+	// is already wired up.
+	clearCIEnv(t)
+	if env.IsCI() {
+		t.Fatal("test setup: clearCIEnv should leave IsCI false")
+	}
+	t.Setenv("CI", "1")
+	if !env.IsCI() {
+		t.Error("env.IsCI() should be true when CI=1")
+	}
+}

--- a/go/cmd/wendy/main_test.go
+++ b/go/cmd/wendy/main_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/wendylabsinc/wendy/internal/cli/commands"
 	"github.com/wendylabsinc/wendy/internal/shared/env"
 	"github.com/wendylabsinc/wendy/internal/shared/version"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type capturedEvent struct {
@@ -86,16 +88,7 @@ func runWithArgs(t *testing.T, args []string) (*cobra.Command, error) {
 // in the rest of the file fail or no-op.
 func clearCIEnv(t *testing.T) {
 	t.Helper()
-	for _, key := range []string{
-		"CI",
-		"GITHUB_ACTIONS",
-		"GITLAB_CI",
-		"BUILDKITE",
-		"CIRCLECI",
-		"JENKINS_HOME",
-		"TF_BUILD",
-		"TEAMCITY_VERSION",
-	} {
+	for _, key := range env.CIEnvVars {
 		t.Setenv(key, "")
 	}
 }
@@ -209,8 +202,8 @@ func TestTrackCommand_RootOnlyInvocation(t *testing.T) {
 	executed, err := runWithArgs(t, []string{"wendy"})
 	trackCommand(executed, err, time.Millisecond)
 
-	if len(*events) == 0 {
-		t.Fatal("expected at least one event for a bare invocation")
+	if len(*events) != 1 {
+		t.Fatalf("expected exactly 1 event for a bare invocation, got %d", len(*events))
 	}
 	got := (*events)[0].props
 	if got["command_name"] != "wendy" {
@@ -218,6 +211,40 @@ func TestTrackCommand_RootOnlyInvocation(t *testing.T) {
 	}
 	if got["command_root"] != "wendy" {
 		t.Errorf("command_root = %q, want %q", got["command_root"], "wendy")
+	}
+}
+
+func TestCommandRoot_DepthAndNilCases(t *testing.T) {
+	root := newTestRoot()
+	device, _, err := root.Find([]string{"device"})
+	if err != nil || device == nil {
+		t.Fatalf("setup: find device subcommand: %v", err)
+	}
+	wifi, _, err := root.Find([]string{"device", "wifi"})
+	if err != nil || wifi == nil {
+		t.Fatalf("setup: find wifi subcommand: %v", err)
+	}
+	connect, _, err := root.Find([]string{"device", "wifi", "connect"})
+	if err != nil || connect == nil {
+		t.Fatalf("setup: find connect subcommand: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		cmd  *cobra.Command
+		want string
+	}{
+		{"nil", nil, ""},
+		{"depth0_root", root, "wendy"},
+		{"depth1_device", device, "device"},
+		{"depth2_wifi", wifi, "device"},
+		{"depth3_connect", connect, "device"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commandRoot(tc.cmd); got != tc.want {
+				t.Errorf("commandRoot = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -286,33 +313,16 @@ func TestErrorClass_Mapping(t *testing.T) {
 		{"nil", nil, ""},
 		{"user_cancelled", commands.ErrUserCancelled, "user_cancelled"},
 		{"default_cleared", commands.ErrDefaultCleared, "user_cancelled"},
+		{"user_cancelled_wrapped", fmt.Errorf("aborted: %w", commands.ErrUserCancelled), "user_cancelled"},
 		{"context_canceled", context.Canceled, "context_canceled"},
 		{"context_deadline", context.DeadlineExceeded, "context_deadline"},
-		{
-			name: "grpc_unavailable",
-			err:  errors.New("connecting to cloud: rpc error: code = Unavailable desc = transport closing"),
-			want: "grpc_unavailable",
-		},
-		{
-			name: "grpc_deadline",
-			err:  errors.New("rpc error: code = DeadlineExceeded desc = ctx done"),
-			want: "grpc_deadline",
-		},
-		{
-			name: "grpc_unimplemented",
-			err:  errors.New("rpc error: code = Unimplemented desc = nope"),
-			want: "grpc_unimplemented",
-		},
-		{
-			name: "grpc_other_code",
-			err:  errors.New("rpc error: code = Internal desc = boom"),
-			want: "grpc_other",
-		},
-		{
-			name: "non_grpc",
-			err:  errors.New("some plain failure"),
-			want: "other",
-		},
+		{"grpc_canceled_status", status.Error(codes.Canceled, "client gone"), "context_canceled"},
+		{"grpc_unavailable_status", status.Error(codes.Unavailable, "transport closing"), "grpc_unavailable"},
+		{"grpc_unavailable_wrapped", fmt.Errorf("connecting to cloud: %w", status.Error(codes.Unavailable, "x")), "grpc_unavailable"},
+		{"grpc_deadline_status", status.Error(codes.DeadlineExceeded, "ctx done"), "grpc_deadline"},
+		{"grpc_unimplemented_status", status.Error(codes.Unimplemented, "nope"), "grpc_unimplemented"},
+		{"grpc_internal", status.Error(codes.Internal, "boom"), "grpc_other"},
+		{"non_grpc", errors.New("some plain failure"), "other"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := errorClass(tc.err); got != tc.want {
@@ -323,9 +333,9 @@ func TestErrorClass_Mapping(t *testing.T) {
 }
 
 func TestErrorClass_NeverLeaksMessageText(t *testing.T) {
-	// Sanity check: even when the error embeds sensitive substrings, only
-	// the bounded enum value is returned.
-	leaky := fmt.Errorf("rpc error: code = Unavailable desc = could not reach %s", "secret-host.example.com")
+	// Even when the error embeds sensitive substrings, only the bounded
+	// enum value is returned.
+	leaky := status.Error(codes.Unavailable, "could not reach secret-host.example.com")
 	got := errorClass(leaky)
 	if got != "grpc_unavailable" {
 		t.Errorf("errorClass = %q, want %q", got, "grpc_unavailable")

--- a/go/internal/cli/analytics/analytics.go
+++ b/go/internal/cli/analytics/analytics.go
@@ -45,16 +45,20 @@ func SetTrackHookForTesting(fn func(event string, properties map[string]string))
 // CI environments are hard-disabled here regardless of WENDY_ANALYTICS or the
 // stored config — there is no opt-in escape hatch. Real product signal must
 // come from human users, not automated runs.
+//
+// Each disabled-bailout path goes through Disable() so any state from a
+// prior Init call (client, distinctID) is cleared. In production Init runs
+// once per process, but tests reuse the package-level state across cases.
 func Init(cfg *config.Config) (firstRun bool) {
 	// Hard kill switch for CI: don't even consider WENDY_ANALYTICS.
 	if env.IsCI() {
-		enabled = false
+		Disable()
 		return false
 	}
 
 	// Env var overrides everything else.
 	if !env.Analytics() {
-		enabled = false
+		Disable()
 		return false
 	}
 
@@ -67,13 +71,14 @@ func Init(cfg *config.Config) (firstRun bool) {
 	}
 
 	if !enabled {
+		Disable()
 		return firstRun
 	}
 
 	var err error
 	distinctID, err = loadOrCreateID()
 	if err != nil {
-		enabled = false
+		Disable()
 		return firstRun
 	}
 
@@ -82,7 +87,7 @@ func Init(cfg *config.Config) (firstRun bool) {
 		Logger:   posthog.StdLogger(log.New(io.Discard, "", 0), false),
 	})
 	if err != nil {
-		enabled = false
+		Disable()
 		return firstRun
 	}
 

--- a/go/internal/cli/analytics/analytics.go
+++ b/go/internal/cli/analytics/analytics.go
@@ -26,13 +26,33 @@ var (
 	client     posthog.Client
 	enabled    bool
 	distinctID string
+
+	// trackHook is set by tests to intercept events before they would be
+	// enqueued to PostHog. It is never set in production code.
+	trackHook func(event string, properties map[string]string)
 )
+
+// SetTrackHookForTesting installs a hook that receives every Track call.
+// Pass nil to clear. Intended for tests only.
+func SetTrackHookForTesting(fn func(event string, properties map[string]string)) {
+	trackHook = fn
+}
 
 // Init initializes analytics. If disabled by env var, config, or missing API key,
 // tracking is a no-op. Returns true if this is the first run (config.Analytics
 // was nil) AND the env var does not override, so the caller can display a notice.
+//
+// CI environments are hard-disabled here regardless of WENDY_ANALYTICS or the
+// stored config — there is no opt-in escape hatch. Real product signal must
+// come from human users, not automated runs.
 func Init(cfg *config.Config) (firstRun bool) {
-	// Env var overrides everything
+	// Hard kill switch for CI: don't even consider WENDY_ANALYTICS.
+	if env.IsCI() {
+		enabled = false
+		return false
+	}
+
+	// Env var overrides everything else.
 	if !env.Analytics() {
 		enabled = false
 		return false
@@ -70,7 +90,17 @@ func Init(cfg *config.Config) (firstRun bool) {
 }
 
 // Track sends an analytics event. No-op if analytics is disabled.
+//
+// Privacy invariant: every value in `properties` must be anonymous. Allowed:
+// canonical command paths (e.g. "wendy device wifi connect"), the top-level
+// command token, success booleans, bounded error-class enums, build flags
+// (cli_version, is_dev_build), and platform metadata (os, arch). Forbidden:
+// flag values, positional arguments, file paths, hostnames, error message
+// text, or anything else derived from user input.
 func Track(event string, properties map[string]string) {
+	if trackHook != nil {
+		trackHook(event, properties)
+	}
 	if !enabled || client == nil {
 		return
 	}

--- a/go/internal/cli/analytics/analytics.go
+++ b/go/internal/cli/analytics/analytics.go
@@ -89,14 +89,19 @@ func Init(cfg *config.Config) (firstRun bool) {
 	return firstRun
 }
 
-// Track sends an analytics event. No-op if analytics is disabled.
+// Track sends an analytics event. The PostHog enqueue is a no-op when
+// analytics is disabled or uninitialized; the test hook (if any) always
+// fires so test assertions can observe the intended payload regardless of
+// initialization state.
 //
-// Privacy invariant: every value in `properties` must be anonymous. Allowed:
-// canonical command paths (e.g. "wendy device wifi connect"), the top-level
-// command token, success booleans, bounded error-class enums, build flags
-// (cli_version, is_dev_build), and platform metadata (os, arch). Forbidden:
-// flag values, positional arguments, file paths, hostnames, error message
-// text, or anything else derived from user input.
+// Caller contract (not enforced by this function): every value in
+// `properties` must be anonymous. Allowed: canonical command paths (e.g.
+// "wendy device wifi connect"), the top-level command token, success
+// booleans, bounded error-class enums, build flags (cli_version,
+// is_dev_build), and platform metadata (os, arch). Forbidden: flag values,
+// positional arguments, file paths, hostnames, error message text, or
+// anything else derived from user input. The function will happily forward
+// whatever it is given — reviewers must enforce this at call sites.
 func Track(event string, properties map[string]string) {
 	if trackHook != nil {
 		trackHook(event, properties)
@@ -113,6 +118,8 @@ func Track(event string, properties map[string]string) {
 		props.Set(k, v)
 	}
 
+	// Enqueue only errors when the buffer is full or the client is closed —
+	// neither is actionable from a CLI fire-and-forget path.
 	_ = client.Enqueue(posthog.Capture{
 		DistinctId: distinctID,
 		Event:      event,

--- a/go/internal/cli/analytics/analytics_test.go
+++ b/go/internal/cli/analytics/analytics_test.go
@@ -6,7 +6,29 @@ import (
 	"github.com/wendylabsinc/wendy/internal/shared/config"
 )
 
+// ciEnvVarKeys mirrors env.ciEnvVars; duplicated here to avoid coupling tests
+// across packages and to keep this test self-contained when the suite runs in
+// a real CI environment.
+var ciEnvVarKeys = []string{
+	"CI",
+	"GITHUB_ACTIONS",
+	"GITLAB_CI",
+	"BUILDKITE",
+	"CIRCLECI",
+	"JENKINS_HOME",
+	"TF_BUILD",
+	"TEAMCITY_VERSION",
+}
+
+func clearCIEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range ciEnvVarKeys {
+		t.Setenv(key, "")
+	}
+}
+
 func TestDisabledViaEnvVar(t *testing.T) {
+	clearCIEnv(t)
 	t.Setenv("WENDY_ANALYTICS", "false")
 	t.Setenv("HOME", t.TempDir())
 
@@ -21,6 +43,7 @@ func TestDisabledViaEnvVar(t *testing.T) {
 }
 
 func TestDisabledViaConfig(t *testing.T) {
+	clearCIEnv(t)
 	t.Setenv("WENDY_ANALYTICS", "")
 	t.Setenv("HOME", t.TempDir())
 
@@ -35,6 +58,7 @@ func TestDisabledViaConfig(t *testing.T) {
 }
 
 func TestEnabledByDefaultWhenNil(t *testing.T) {
+	clearCIEnv(t)
 	t.Setenv("WENDY_ANALYTICS", "")
 	t.Setenv("HOME", t.TempDir())
 
@@ -61,6 +85,7 @@ func TestEnvOverride(t *testing.T) {
 }
 
 func TestTrackNoOpWhenDisabled(t *testing.T) {
+	clearCIEnv(t)
 	t.Setenv("WENDY_ANALYTICS", "false")
 	t.Setenv("HOME", t.TempDir())
 
@@ -70,4 +95,31 @@ func TestTrackNoOpWhenDisabled(t *testing.T) {
 	// Should not panic
 	Track("test_event", map[string]string{"key": "value"})
 	Close()
+}
+
+// TestInitDisabledInCI is the load-bearing test for the "no analytics in CI,
+// ever" rule. Even when the user has explicitly opted in via env var AND has
+// an enabled stored config, the presence of any CI marker must hard-disable
+// the analytics client.
+func TestInitDisabledInCI(t *testing.T) {
+	for _, ciKey := range ciEnvVarKeys {
+		t.Run(ciKey, func(t *testing.T) {
+			clearCIEnv(t)
+			t.Setenv(ciKey, "1")
+			t.Setenv("WENDY_ANALYTICS", "true")
+			t.Setenv("HOME", t.TempDir())
+
+			cfg := &config.Config{
+				Analytics: &config.AnalyticsConfig{Enabled: true},
+			}
+			firstRun := Init(cfg)
+
+			if firstRun {
+				t.Errorf("Init must return firstRun=false in CI (%s set)", ciKey)
+			}
+			if Enabled() {
+				t.Errorf("analytics must not be enabled in CI (%s set), even with WENDY_ANALYTICS=true and config.enabled=true", ciKey)
+			}
+		})
+	}
 }

--- a/go/internal/cli/analytics/analytics_test.go
+++ b/go/internal/cli/analytics/analytics_test.go
@@ -4,25 +4,12 @@ import (
 	"testing"
 
 	"github.com/wendylabsinc/wendy/internal/shared/config"
+	"github.com/wendylabsinc/wendy/internal/shared/env"
 )
-
-// ciEnvVarKeys mirrors env.ciEnvVars; duplicated here to avoid coupling tests
-// across packages and to keep this test self-contained when the suite runs in
-// a real CI environment.
-var ciEnvVarKeys = []string{
-	"CI",
-	"GITHUB_ACTIONS",
-	"GITLAB_CI",
-	"BUILDKITE",
-	"CIRCLECI",
-	"JENKINS_HOME",
-	"TF_BUILD",
-	"TEAMCITY_VERSION",
-}
 
 func clearCIEnv(t *testing.T) {
 	t.Helper()
-	for _, key := range ciEnvVarKeys {
+	for _, key := range env.CIEnvVars {
 		t.Setenv(key, "")
 	}
 }
@@ -102,7 +89,7 @@ func TestTrackNoOpWhenDisabled(t *testing.T) {
 // an enabled stored config, the presence of any CI marker must hard-disable
 // the analytics client.
 func TestInitDisabledInCI(t *testing.T) {
-	for _, ciKey := range ciEnvVarKeys {
+	for _, ciKey := range env.CIEnvVars {
 		t.Run(ciKey, func(t *testing.T) {
 			clearCIEnv(t)
 			t.Setenv(ciKey, "1")
@@ -120,6 +107,43 @@ func TestInitDisabledInCI(t *testing.T) {
 			if Enabled() {
 				t.Errorf("analytics must not be enabled in CI (%s set), even with WENDY_ANALYTICS=true and config.enabled=true", ciKey)
 			}
+			// Structural invariant: the PostHog client must not exist when
+			// disabled. Without this, a future regression that flips the
+			// hook-vs-gate ordering inside Track could re-enable enqueue
+			// silently — `Enabled()` alone wouldn't catch it.
+			if client != nil {
+				t.Errorf("posthog client must be nil in CI; got %T", client)
+			}
 		})
+	}
+}
+
+// TestTrackHookFiresEvenWhenDisabled documents that the test hook is a
+// caller-visible seam: it fires on every Track call regardless of whether
+// analytics is enabled. The PostHog enqueue is the gated side effect, not
+// the hook. Tests rely on this to inspect intended payloads without having
+// to construct a real PostHog client.
+func TestTrackHookFiresEvenWhenDisabled(t *testing.T) {
+	clearCIEnv(t)
+	t.Setenv("WENDY_ANALYTICS", "false")
+	t.Setenv("HOME", t.TempDir())
+
+	Init(&config.Config{}) // disabled
+	if Enabled() {
+		t.Fatal("test setup: Init should have left analytics disabled")
+	}
+
+	var got []string
+	SetTrackHookForTesting(func(event string, _ map[string]string) {
+		got = append(got, event)
+	})
+	t.Cleanup(func() { SetTrackHookForTesting(nil) })
+
+	Track("synthetic", map[string]string{"k": "v"})
+	if len(got) != 1 || got[0] != "synthetic" {
+		t.Errorf("hook must fire when disabled; got %v", got)
+	}
+	if client != nil {
+		t.Error("client must remain nil when disabled")
 	}
 }

--- a/go/internal/shared/env/env.go
+++ b/go/internal/shared/env/env.go
@@ -32,6 +32,32 @@ func Analytics() bool {
 	}
 }
 
+// ciEnvVars are env vars whose presence (with any non-empty value) indicates
+// the process is running inside a CI system.
+var ciEnvVars = []string{
+	"CI",
+	"GITHUB_ACTIONS",
+	"GITLAB_CI",
+	"BUILDKITE",
+	"CIRCLECI",
+	"JENKINS_HOME",
+	"TF_BUILD",
+	"TEAMCITY_VERSION",
+}
+
+// IsCI reports whether the process is running inside a CI environment.
+// Wendy uses this as a hard analytics kill switch — CI runs are never useful
+// product signal and have historically inflated event volume by orders of
+// magnitude. There is no opt-in flag that re-enables analytics in CI.
+func IsCI() bool {
+	for _, key := range ciEnvVars {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func SystemdServiceName() string {
 	return stringOrDefault("WENDY_SYSTEMD_SERVICE_NAME", "edge-agent")
 }

--- a/go/internal/shared/env/env.go
+++ b/go/internal/shared/env/env.go
@@ -32,9 +32,9 @@ func Analytics() bool {
 	}
 }
 
-// CIEnvVars are env vars whose presence (with any non-empty value) indicates
-// the process is running inside a CI system. Exported so tests in other
-// packages can clear them without redefining the list.
+// CIEnvVars are env vars whose presence (with any non-empty, non-whitespace
+// value) indicates the process is running inside a CI system. Exported so
+// tests in other packages can clear them without redefining the list.
 var CIEnvVars = []string{
 	"CI",
 	"GITHUB_ACTIONS",

--- a/go/internal/shared/env/env.go
+++ b/go/internal/shared/env/env.go
@@ -32,9 +32,10 @@ func Analytics() bool {
 	}
 }
 
-// ciEnvVars are env vars whose presence (with any non-empty value) indicates
-// the process is running inside a CI system.
-var ciEnvVars = []string{
+// CIEnvVars are env vars whose presence (with any non-empty value) indicates
+// the process is running inside a CI system. Exported so tests in other
+// packages can clear them without redefining the list.
+var CIEnvVars = []string{
 	"CI",
 	"GITHUB_ACTIONS",
 	"GITLAB_CI",
@@ -50,7 +51,7 @@ var ciEnvVars = []string{
 // product signal and have historically inflated event volume by orders of
 // magnitude. There is no opt-in flag that re-enables analytics in CI.
 func IsCI() bool {
-	for _, key := range ciEnvVars {
+	for _, key := range CIEnvVars {
 		if strings.TrimSpace(os.Getenv(key)) != "" {
 			return true
 		}

--- a/go/internal/shared/env/env_test.go
+++ b/go/internal/shared/env/env_test.go
@@ -1,0 +1,36 @@
+package env
+
+import "testing"
+
+func TestIsCI_NoEnvVars(t *testing.T) {
+	for _, key := range ciEnvVars {
+		t.Setenv(key, "")
+	}
+	if IsCI() {
+		t.Error("IsCI should be false when no CI env vars are set")
+	}
+}
+
+func TestIsCI_DetectsEachKnownVar(t *testing.T) {
+	for _, key := range ciEnvVars {
+		t.Run(key, func(t *testing.T) {
+			for _, other := range ciEnvVars {
+				t.Setenv(other, "")
+			}
+			t.Setenv(key, "1")
+			if !IsCI() {
+				t.Errorf("IsCI should be true when %s is set", key)
+			}
+		})
+	}
+}
+
+func TestIsCI_IgnoresWhitespaceOnlyValues(t *testing.T) {
+	for _, key := range ciEnvVars {
+		t.Setenv(key, "")
+	}
+	t.Setenv("CI", "   ")
+	if IsCI() {
+		t.Error("IsCI should be false for whitespace-only CI value")
+	}
+}

--- a/go/internal/shared/env/env_test.go
+++ b/go/internal/shared/env/env_test.go
@@ -3,7 +3,7 @@ package env
 import "testing"
 
 func TestIsCI_NoEnvVars(t *testing.T) {
-	for _, key := range ciEnvVars {
+	for _, key := range CIEnvVars {
 		t.Setenv(key, "")
 	}
 	if IsCI() {
@@ -12,9 +12,9 @@ func TestIsCI_NoEnvVars(t *testing.T) {
 }
 
 func TestIsCI_DetectsEachKnownVar(t *testing.T) {
-	for _, key := range ciEnvVars {
+	for _, key := range CIEnvVars {
 		t.Run(key, func(t *testing.T) {
-			for _, other := range ciEnvVars {
+			for _, other := range CIEnvVars {
 				t.Setenv(other, "")
 			}
 			t.Setenv(key, "1")
@@ -26,7 +26,7 @@ func TestIsCI_DetectsEachKnownVar(t *testing.T) {
 }
 
 func TestIsCI_IgnoresWhitespaceOnlyValues(t *testing.T) {
-	for _, key := range ciEnvVars {
+	for _, key := range CIEnvVars {
 		t.Setenv(key, "")
 	}
 	t.Setenv("CI", "   ")


### PR DESCRIPTION
## Summary

- **WDY-969 fix:** rename the CLI's PostHog property `command` → `command_name` so the existing dashboard stops showing "None" for every event, and switch to canonical `cmd.ExecuteC()` so the matched command is always available for tracking.
- **Hard-disable analytics in CI** (no opt-in flag) — CI runs were inflating event volume by orders of magnitude. Detected via `CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `BUILDKITE`, `CIRCLECI`, `JENKINS_HOME`, `TF_BUILD`, `TEAMCITY_VERSION`.
- **Expanded schema:** add `command_root` (top-level token, low-cardinality breakdown axis), `duration_ms`, `is_dev_build`, and a bounded `error_class` enum on failures. Drop the duplicated `command_error` event in favor of a single `command_executed` per invocation.
- Add a test seam (`analytics.SetTrackHookForTesting`) so payload assertions don't touch PostHog.

## Privacy

The privacy invariant is unchanged: only canonical cobra command paths, bounded enum values, and platform metadata reach PostHog. No flag values, positional args, file paths, hostnames, or error message text. The new `error_class` is a fixed set: `user_cancelled`, `context_canceled`, `context_deadline`, `grpc_unavailable`, `grpc_deadline`, `grpc_unimplemented`, `grpc_other`, `other`.

## Test plan

- [x] `go test ./...` passes (full module)
- [x] `go vet ./...` clean
- [x] `gofmt -d` clean
- [x] `TestInitDisabledInCI` parametrized over every recognized CI env var
- [x] Tests assert no leakage of flag values into the event payload
- [x] Error-class mapping covered for each gRPC code and for `context.Canceled` / `context.DeadlineExceeded`
- [ ] After merge + release: confirm a new release's `command_name` and `duration_ms` columns populate in PostHog
- [ ] After merge: apply `is_dev_build != "true"` filter on the dashboard and confirm the "Other" bucket shrinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)