### PR TITLE
Hold a containerd lease while unpacking image layers

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -433,7 +433,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	}
 	if !unpacked {
 		c.logger.Info("Unpacking image", zap.String("image", imageName))
-		if _, err := c.UnpackImage(ctx, imageName, func(progress UnpackProgress) {
+		if err := c.UnpackImage(ctx, imageName, func(progress UnpackProgress) {
 			if mapped := toCreateContainerProgress(progress); mapped != nil {
 				report(mapped)
 			}

--- a/go/internal/agent/containerd/unpack.go
+++ b/go/internal/agent/containerd/unpack.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/errdefs"
+	"github.com/google/uuid"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/zap"
 )
@@ -46,27 +47,26 @@ type UnpackProgress struct {
 //
 // The unpack runs inside a containerd lease and tags each committed snapshot
 // with a `containerd.io/gc.root` label. These work as a pair: the lease pins
-// content and snapshots while the unpack is in progress, and the gc.root
-// labels keep committed chain-ID snapshots alive after the lease releases.
-// Without both, containerd's metadata GC could reap a freshly committed
-// chain-ID snapshot before the next layer's `Prepare` references it as a
-// parent — surfacing as a random-layer "parent snapshot does not exist"
-// failure.
+// content and active snapshots while the unpack is in progress, and the
+// gc.root label on each committed chain-ID snapshot keeps it alive after the
+// lease releases. Without both, containerd's metadata GC could reap a
+// freshly committed chain-ID snapshot before the next layer's `Prepare`
+// references it as a parent — surfacing as a random-layer "parent snapshot
+// does not exist" failure.
 func (c *Client) UnpackImage(ctx context.Context, imageName string, progress func(UnpackProgress)) error {
 	ctx = c.withNamespace(ctx)
+
+	// cleanupCtx is used for best-effort `Remove` calls so a cancelled caller
+	// doesn't also cancel cleanup. The namespace is required by containerd
+	// services even off the happy path.
+	cleanupCtx := c.withNamespace(context.Background())
 
 	ctx, doneLease, err := c.client.WithLease(ctx, leases.WithExpiration(unpackLeaseExpiration))
 	if err != nil {
 		return fmt.Errorf("creating unpack lease: %w", err)
 	}
 	defer func() {
-		// Release on a fresh context so a cancelled caller still tears the
-		// lease down. The namespace is preserved because containerd's lease
-		// service requires it on every request — Background() alone would
-		// fail the NamespaceRequired check and silently leave the lease
-		// pinned until expiration.
-		releaseCtx := c.withNamespace(context.Background())
-		if err := doneLease(releaseCtx); err != nil {
+		if err := doneLease(cleanupCtx); err != nil {
 			c.logger.Warn("Failed to release unpack lease; relying on expiration backstop",
 				zap.Duration("expiration", unpackLeaseExpiration),
 				zap.Error(err),
@@ -122,28 +122,26 @@ func (c *Client) UnpackImage(ctx context.Context, imageName string, progress fun
 			return fmt.Errorf("stat snapshot %q: %w", chainID, err)
 		}
 
-		gcRootOpt := snapshots.WithLabels(map[string]string{
-			labelKeyGCRoot: gcTimestamp(),
-		})
-
-		activeKey := fmt.Sprintf("extract-%s-%d", imageName, i)
-		mounts, err := sn.Prepare(ctx, activeKey, parentChainID, gcRootOpt)
-		if errdefs.IsAlreadyExists(err) {
-			// Stale active key from a prior failed attempt; remove and retry once.
-			c.removeActiveSnapshot(ctx, sn, activeKey, "stale active snapshot before retry", i)
-			mounts, err = sn.Prepare(ctx, activeKey, parentChainID, gcRootOpt)
-			if err != nil {
-				return fmt.Errorf("preparing snapshot for layer %d after retry: %w", i, err)
-			}
-		} else if err != nil {
+		// Unique per-attempt active key so concurrent unpacks of the same
+		// image (or a stale key from a crashed prior attempt) can't collide
+		// on the AlreadyExists path and clobber each other's in-progress
+		// snapshot. The lease pins the active snapshot during this loop
+		// iteration; only the committed chain-ID snapshot needs gc.root
+		// to survive lease release.
+		activeKey := fmt.Sprintf("extract-%s-%d-%s", imageName, i, uuid.NewString())
+		mounts, err := sn.Prepare(ctx, activeKey, parentChainID)
+		if err != nil {
 			return fmt.Errorf("preparing snapshot for layer %d: %w", i, err)
 		}
 
 		if _, err := c.client.DiffService().Apply(ctx, layerDesc, mounts); err != nil {
-			c.removeActiveSnapshot(ctx, sn, activeKey, "active snapshot after apply failure", i)
+			c.removeActiveSnapshot(cleanupCtx, sn, activeKey, "active snapshot after apply failure", i)
 			return fmt.Errorf("applying layer %d: %w", i, err)
 		}
 
+		gcRootOpt := snapshots.WithLabels(map[string]string{
+			labelKeyGCRoot: gcTimestamp(),
+		})
 		commitErr := sn.Commit(ctx, chainID, activeKey, gcRootOpt)
 		switch {
 		case commitErr == nil:
@@ -165,7 +163,7 @@ func (c *Client) UnpackImage(ctx context.Context, imageName string, progress fun
 			// A concurrent unpack committed the same chain ID first. Our
 			// active key still exists; clean it up and report the layer
 			// as reused rather than freshly unpacked.
-			c.removeActiveSnapshot(ctx, sn, activeKey, "active snapshot after concurrent commit", i)
+			c.removeActiveSnapshot(cleanupCtx, sn, activeKey, "active snapshot after concurrent commit", i)
 			if progress != nil {
 				progress(UnpackProgress{
 					Phase:       "layer",

--- a/go/internal/agent/containerd/unpack.go
+++ b/go/internal/agent/containerd/unpack.go
@@ -4,13 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/zap"
 )
+
+// unpackLeaseExpiration bounds how long the unpack lease keeps freshly created
+// snapshots and content alive. It must be long enough to apply the largest
+// expected image, but short enough that orphaned leases from a crashed agent
+// don't accumulate indefinitely.
+const unpackLeaseExpiration = 30 * time.Minute
 
 // UnpackProgress reports progress during the image unpack operation.
 type UnpackProgress struct {
@@ -26,30 +35,46 @@ type UnpackProgress struct {
 	Reused bool
 }
 
-// UnpackImage unpacks an image's layers into the snapshotter, returning the
-// snapshot key that should be used as the container's rootfs. It computes
-// chain IDs for each layer and creates snapshots incrementally, reusing
-// existing snapshots when possible.
+// UnpackImage unpacks an image's layers into the snapshotter so that the
+// resulting chain-ID snapshots are present for a subsequent
+// `WithNewSnapshot` call to build a container rootfs from. It computes chain
+// IDs for each layer and creates snapshots incrementally, reusing existing
+// snapshots when possible.
 //
 // The progress callback, if non-nil, is invoked for each phase of the unpack
 // operation to allow callers to report progress upstream.
-func (c *Client) UnpackImage(ctx context.Context, imageName string, progress func(UnpackProgress)) (string, error) {
+//
+// The unpack runs inside a containerd lease and tags each committed snapshot
+// with a `containerd.io/gc.root` label. Without this, containerd's metadata
+// GC can reap a chain-ID snapshot between iterations of the loop — the
+// snapshot has no inbound references until the next layer is committed on
+// top of it — which surfaces as a random-layer "parent snapshot does not
+// exist" failure during `Prepare`.
+func (c *Client) UnpackImage(ctx context.Context, imageName string, progress func(UnpackProgress)) error {
 	ctx = c.withNamespace(ctx)
+
+	ctx, doneLease, err := c.client.WithLease(ctx, leases.WithExpiration(unpackLeaseExpiration))
+	if err != nil {
+		return fmt.Errorf("creating unpack lease: %w", err)
+	}
+	defer func() {
+		// Release on a fresh context so a cancelled caller still tears the
+		// lease down. The lease's expiration is the ultimate backstop.
+		_ = doneLease(context.Background())
+	}()
+
 	cs := c.client.ContentStore()
 	sn := c.client.SnapshotService("")
 
-	// Look up the image to get the manifest descriptor.
 	img, err := c.client.GetImage(ctx, imageName)
 	if err != nil {
-		return "", fmt.Errorf("getting image %q: %w", imageName, err)
+		return fmt.Errorf("getting image %q: %w", imageName, err)
 	}
 
-	target := img.Target()
-
 	// Resolve through index if needed (platform selection).
-	manifest, err := images.Manifest(ctx, cs, target, img.Platform())
+	manifest, err := images.Manifest(ctx, cs, img.Target(), img.Platform())
 	if err != nil {
-		return "", fmt.Errorf("reading manifest for %q: %w", imageName, err)
+		return fmt.Errorf("reading manifest for %q: %w", imageName, err)
 	}
 
 	totalLayers := len(manifest.Layers)
@@ -57,21 +82,16 @@ func (c *Client) UnpackImage(ctx context.Context, imageName string, progress fun
 		progress(UnpackProgress{Phase: "start", TotalLayers: totalLayers})
 	}
 
-	// For each layer, compute the chain ID and ensure a committed snapshot exists.
 	var parentChainID string
 	for i, layerDesc := range manifest.Layers {
 		diffID, err := layerDiffID(ctx, cs, layerDesc)
 		if err != nil {
-			return "", fmt.Errorf("getting diff ID for layer %d: %w", i, err)
+			return fmt.Errorf("getting diff ID for layer %d: %w", i, err)
 		}
 
 		chainID := computeChainID(parentChainID, diffID)
-		snapshotKey := chainID
 
-		// Check if the snapshot already exists (committed).
-		_, err = sn.Stat(ctx, snapshotKey)
-		if err == nil {
-			// Snapshot exists, reuse it.
+		if _, err := sn.Stat(ctx, chainID); err == nil {
 			if progress != nil {
 				progress(UnpackProgress{
 					Phase:       "layer",
@@ -87,45 +107,34 @@ func (c *Client) UnpackImage(ctx context.Context, imageName string, progress fun
 			)
 			parentChainID = chainID
 			continue
+		} else if !errdefs.IsNotFound(err) {
+			return fmt.Errorf("stat snapshot %q: %w", chainID, err)
 		}
 
-		if !errdefs.IsNotFound(err) {
-			return "", fmt.Errorf("stat snapshot %q: %w", snapshotKey, err)
-		}
+		gcRootOpt := snapshots.WithLabels(map[string]string{
+			labelKeyGCRoot: gcTimestamp(),
+		})
 
-		// Snapshot does not exist; create it by preparing from parent.
-		parentKey := ""
-		if parentChainID != "" {
-			parentKey = parentChainID
-		}
-
-		// Prepare the active snapshot (this will be committed).
 		activeKey := fmt.Sprintf("extract-%s-%d", imageName, i)
-		mounts, err := sn.Prepare(ctx, activeKey, parentKey)
+		mounts, err := sn.Prepare(ctx, activeKey, parentChainID, gcRootOpt)
 		if err != nil {
-			// If the active key already exists (from a previous failed attempt), remove and retry.
 			if errdefs.IsAlreadyExists(err) {
 				_ = sn.Remove(ctx, activeKey)
-				mounts, err = sn.Prepare(ctx, activeKey, parentKey)
+				mounts, err = sn.Prepare(ctx, activeKey, parentChainID, gcRootOpt)
 			}
 			if err != nil {
-				return "", fmt.Errorf("preparing snapshot for layer %d: %w", i, err)
+				return fmt.Errorf("preparing snapshot for layer %d: %w", i, err)
 			}
 		}
 
-		// Apply the layer diff onto the snapshot mounts.
-		differ := c.client.DiffService()
-		_, err = differ.Apply(ctx, layerDesc, mounts)
-		if err != nil {
+		if _, err := c.client.DiffService().Apply(ctx, layerDesc, mounts); err != nil {
 			_ = sn.Remove(ctx, activeKey)
-			return "", fmt.Errorf("applying layer %d: %w", i, err)
+			return fmt.Errorf("applying layer %d: %w", i, err)
 		}
 
-		// Commit the snapshot with the chain ID as its key.
-		err = sn.Commit(ctx, snapshotKey, activeKey)
-		if err != nil {
+		if err := sn.Commit(ctx, chainID, activeKey, gcRootOpt); err != nil {
 			if !errdefs.IsAlreadyExists(err) {
-				return "", fmt.Errorf("committing snapshot for layer %d: %w", i, err)
+				return fmt.Errorf("committing snapshot for layer %d: %w", i, err)
 			}
 			// Another process committed it concurrently; clean up our active key.
 			_ = sn.Remove(ctx, activeKey)
@@ -150,30 +159,14 @@ func (c *Client) UnpackImage(ctx context.Context, imageName string, progress fun
 		parentChainID = chainID
 	}
 
-	// Create an ephemeral (active) snapshot for the container's rootfs.
-	ephemeralKey := fmt.Sprintf("wendy-%s-%d", imageName, len(manifest.Layers))
-	_, err = sn.Prepare(ctx, ephemeralKey, parentChainID)
-	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			// Remove stale ephemeral and retry.
-			_ = sn.Remove(ctx, ephemeralKey)
-			_, err = sn.Prepare(ctx, ephemeralKey, parentChainID)
-		}
-		if err != nil {
-			return "", fmt.Errorf("preparing ephemeral snapshot: %w", err)
-		}
-	}
-
 	if progress != nil {
 		progress(UnpackProgress{Phase: "complete", TotalLayers: totalLayers})
 	}
 
-	return ephemeralKey, nil
+	return nil
 }
 
 // layerDiffID resolves the uncompressed diff ID for a layer descriptor.
-// It first checks the image config's diff_ids via the content store label,
-// and falls back to using the images.GetDiffID helper.
 func layerDiffID(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (string, error) {
 	diffID, err := images.GetDiffID(ctx, cs, desc)
 	if err != nil {
@@ -182,8 +175,7 @@ func layerDiffID(ctx context.Context, cs content.Store, desc ocispec.Descriptor)
 	return diffID.String(), nil
 }
 
-// images.Manifest resolves a manifest from a descriptor, handling index lookups.
-// This is a thin helper to keep the unpack code clean.
+// readManifest reads and unmarshals an OCI manifest blob from the content store.
 func readManifest(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (*ocispec.Manifest, error) {
 	p, err := content.ReadBlob(ctx, cs, desc)
 	if err != nil {

--- a/go/internal/agent/containerd/unpack.go
+++ b/go/internal/agent/containerd/unpack.go
@@ -2,7 +2,6 @@ package containerd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -17,8 +16,9 @@ import (
 
 // unpackLeaseExpiration bounds how long the unpack lease keeps freshly created
 // snapshots and content alive. It must be long enough to apply the largest
-// expected image, but short enough that orphaned leases from a crashed agent
-// don't accumulate indefinitely.
+// expected image, but short enough that a lease orphaned by a crashed agent
+// doesn't pin disk for too long. The expiration is a backstop only — the
+// happy path releases the lease on return.
 const unpackLeaseExpiration = 30 * time.Minute
 
 // UnpackProgress reports progress during the image unpack operation.
@@ -45,11 +45,13 @@ type UnpackProgress struct {
 // operation to allow callers to report progress upstream.
 //
 // The unpack runs inside a containerd lease and tags each committed snapshot
-// with a `containerd.io/gc.root` label. Without this, containerd's metadata
-// GC can reap a chain-ID snapshot between iterations of the loop — the
-// snapshot has no inbound references until the next layer is committed on
-// top of it — which surfaces as a random-layer "parent snapshot does not
-// exist" failure during `Prepare`.
+// with a `containerd.io/gc.root` label. These work as a pair: the lease pins
+// content and snapshots while the unpack is in progress, and the gc.root
+// labels keep committed chain-ID snapshots alive after the lease releases.
+// Without both, containerd's metadata GC could reap a freshly committed
+// chain-ID snapshot before the next layer's `Prepare` references it as a
+// parent — surfacing as a random-layer "parent snapshot does not exist"
+// failure.
 func (c *Client) UnpackImage(ctx context.Context, imageName string, progress func(UnpackProgress)) error {
 	ctx = c.withNamespace(ctx)
 
@@ -59,8 +61,17 @@ func (c *Client) UnpackImage(ctx context.Context, imageName string, progress fun
 	}
 	defer func() {
 		// Release on a fresh context so a cancelled caller still tears the
-		// lease down. The lease's expiration is the ultimate backstop.
-		_ = doneLease(context.Background())
+		// lease down. The namespace is preserved because containerd's lease
+		// service requires it on every request — Background() alone would
+		// fail the NamespaceRequired check and silently leave the lease
+		// pinned until expiration.
+		releaseCtx := c.withNamespace(context.Background())
+		if err := doneLease(releaseCtx); err != nil {
+			c.logger.Warn("Failed to release unpack lease; relying on expiration backstop",
+				zap.Duration("expiration", unpackLeaseExpiration),
+				zap.Error(err),
+			)
+		}
 	}()
 
 	cs := c.client.ContentStore()
@@ -117,44 +128,56 @@ func (c *Client) UnpackImage(ctx context.Context, imageName string, progress fun
 
 		activeKey := fmt.Sprintf("extract-%s-%d", imageName, i)
 		mounts, err := sn.Prepare(ctx, activeKey, parentChainID, gcRootOpt)
-		if err != nil {
-			if errdefs.IsAlreadyExists(err) {
-				_ = sn.Remove(ctx, activeKey)
-				mounts, err = sn.Prepare(ctx, activeKey, parentChainID, gcRootOpt)
-			}
+		if errdefs.IsAlreadyExists(err) {
+			// Stale active key from a prior failed attempt; remove and retry once.
+			c.removeActiveSnapshot(ctx, sn, activeKey, "stale active snapshot before retry", i)
+			mounts, err = sn.Prepare(ctx, activeKey, parentChainID, gcRootOpt)
 			if err != nil {
-				return fmt.Errorf("preparing snapshot for layer %d: %w", i, err)
+				return fmt.Errorf("preparing snapshot for layer %d after retry: %w", i, err)
 			}
+		} else if err != nil {
+			return fmt.Errorf("preparing snapshot for layer %d: %w", i, err)
 		}
 
 		if _, err := c.client.DiffService().Apply(ctx, layerDesc, mounts); err != nil {
-			_ = sn.Remove(ctx, activeKey)
+			c.removeActiveSnapshot(ctx, sn, activeKey, "active snapshot after apply failure", i)
 			return fmt.Errorf("applying layer %d: %w", i, err)
 		}
 
-		if err := sn.Commit(ctx, chainID, activeKey, gcRootOpt); err != nil {
-			if !errdefs.IsAlreadyExists(err) {
-				return fmt.Errorf("committing snapshot for layer %d: %w", i, err)
+		commitErr := sn.Commit(ctx, chainID, activeKey, gcRootOpt)
+		switch {
+		case commitErr == nil:
+			c.logger.Debug("Unpacked layer",
+				zap.Int("layer", i),
+				zap.String("chain_id", chainID),
+				zap.Int64("size", layerDesc.Size),
+			)
+			if progress != nil {
+				progress(UnpackProgress{
+					Phase:       "layer",
+					LayerIndex:  i,
+					TotalLayers: totalLayers,
+					LayerSize:   layerDesc.Size,
+					Reused:      false,
+				})
 			}
-			// Another process committed it concurrently; clean up our active key.
-			_ = sn.Remove(ctx, activeKey)
+		case errdefs.IsAlreadyExists(commitErr):
+			// A concurrent unpack committed the same chain ID first. Our
+			// active key still exists; clean it up and report the layer
+			// as reused rather than freshly unpacked.
+			c.removeActiveSnapshot(ctx, sn, activeKey, "active snapshot after concurrent commit", i)
+			if progress != nil {
+				progress(UnpackProgress{
+					Phase:       "layer",
+					LayerIndex:  i,
+					TotalLayers: totalLayers,
+					LayerSize:   layerDesc.Size,
+					Reused:      true,
+				})
+			}
+		default:
+			return fmt.Errorf("committing snapshot for layer %d: %w", i, commitErr)
 		}
-
-		if progress != nil {
-			progress(UnpackProgress{
-				Phase:       "layer",
-				LayerIndex:  i,
-				TotalLayers: totalLayers,
-				LayerSize:   layerDesc.Size,
-				Reused:      false,
-			})
-		}
-
-		c.logger.Debug("Unpacked layer",
-			zap.Int("layer", i),
-			zap.String("chain_id", chainID),
-			zap.Int64("size", layerDesc.Size),
-		)
 
 		parentChainID = chainID
 	}
@@ -166,6 +189,20 @@ func (c *Client) UnpackImage(ctx context.Context, imageName string, progress fun
 	return nil
 }
 
+// removeActiveSnapshot deletes an active snapshot key as part of error recovery,
+// logging at Warn for any failure other than NotFound (which is benign — the
+// key was never created or has already been swept).
+func (c *Client) removeActiveSnapshot(ctx context.Context, sn snapshots.Snapshotter, key, reason string, layer int) {
+	if err := sn.Remove(ctx, key); err != nil && !errdefs.IsNotFound(err) {
+		c.logger.Warn("Failed to remove active snapshot",
+			zap.String("active_key", key),
+			zap.String("reason", reason),
+			zap.Int("layer", layer),
+			zap.Error(err),
+		)
+	}
+}
+
 // layerDiffID resolves the uncompressed diff ID for a layer descriptor.
 func layerDiffID(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (string, error) {
 	diffID, err := images.GetDiffID(ctx, cs, desc)
@@ -173,17 +210,4 @@ func layerDiffID(ctx context.Context, cs content.Store, desc ocispec.Descriptor)
 		return "", err
 	}
 	return diffID.String(), nil
-}
-
-// readManifest reads and unmarshals an OCI manifest blob from the content store.
-func readManifest(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (*ocispec.Manifest, error) {
-	p, err := content.ReadBlob(ctx, cs, desc)
-	if err != nil {
-		return nil, err
-	}
-	var manifest ocispec.Manifest
-	if err := json.Unmarshal(p, &manifest); err != nil {
-		return nil, err
-	}
-	return &manifest, nil
 }


### PR DESCRIPTION
## Summary
- Wraps `UnpackImage` in `client.WithLease` and tags each `Prepare`/`Commit` with a `containerd.io/gc.root` label so freshly committed chain-ID snapshots aren't reaped by containerd's metadata GC mid-unpack.
- Drops the unused ephemeral active snapshot prepared at the end of the loop. The container's rootfs is built later by `containerd.WithNewSnapshot` in `CreateContainerWithProgress`, so the ephemeral key was leaked. `UnpackImage` now returns only `error`.

## Why
Running a Wendy app on a DGX Spark surfaced this:
```
Error: creating container: failed to create container: unpacking image
"localhost:5000/test:latest": preparing snapshot for layer 7: parent
snapshot sha256:3c5c… does not exist: not found
```
The failing layer index varied between runs (2, 5, 7, …), which is the classic signature of containerd GC running mid-loop and reaping a chain-ID snapshot that had no inbound references yet. The custom unpacker created snapshots without a lease and without GC labels — this PR matches the lease + label pattern containerd's own `image.Unpack` (and `registry.go` for blobs) already uses.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [ ] Run a `wendy run` deploy on a DGX Spark and verify image unpack completes without the random-layer "parent snapshot does not exist" error
- [ ] Confirm subsequent runs still hit the existing-snapshot reuse path (no regression in fast re-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)