### PR TITLE
Detect GPU platforms by family + vendor, not exact device-type match

### DIFF
--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -426,23 +426,26 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		}
 
 		imageName := fmt.Sprintf("%s/%s-%s:latest", registryAddr, projectName, name)
+		deviceType := versionResp.GetDeviceType()
+		gpuVendor := versionResp.GetGpuVendor()
+		jetpackVersion := versionResp.GetJetpackVersion()
 		allBuildArgs := map[string]string{
-			"WENDY_PLATFORM": wendyPlatform(versionResp.GetDeviceType()),
+			"WENDY_PLATFORM": wendyPlatform(deviceType, gpuVendor, jetpackVersion),
 			"WENDY_DEBUG":    fmt.Sprintf("%t", opts.debug),
 		}
 		// Mirror the single-container build path so compose-built Dockerfiles
 		// see the same WendyOS device hints (e.g. for GPU base-image selection).
-		if deviceType := versionResp.GetDeviceType(); deviceType != "" {
+		if deviceType != "" {
 			allBuildArgs["WENDY_DEVICE_TYPE"] = deviceType
 		}
 		if versionResp.HasGpu != nil {
 			allBuildArgs["WENDY_HAS_GPU"] = fmt.Sprintf("%t", versionResp.GetHasGpu())
 		}
-		if vendor := versionResp.GetGpuVendor(); vendor != "" {
-			allBuildArgs["WENDY_GPU_VENDOR"] = vendor
+		if gpuVendor != "" {
+			allBuildArgs["WENDY_GPU_VENDOR"] = gpuVendor
 		}
-		if jv := versionResp.GetJetpackVersion(); jv != "" {
-			allBuildArgs["WENDY_JETPACK_VERSION"] = jv
+		if jetpackVersion != "" {
+			allBuildArgs["WENDY_JETPACK_VERSION"] = jetpackVersion
 		}
 		if cv := versionResp.GetCudaVersion(); cv != "" {
 			allBuildArgs["WENDY_CUDA_VERSION"] = cv

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1001,8 +1001,10 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	}
 
 	deviceType := versionResp.GetDeviceType()
+	gpuVendor := versionResp.GetGpuVendor()
+	jetpackVersion := versionResp.GetJetpackVersion()
 	buildArgs := map[string]string{
-		"WENDY_PLATFORM": wendyPlatform(deviceType),
+		"WENDY_PLATFORM": wendyPlatform(deviceType, gpuVendor, jetpackVersion),
 		"WENDY_DEBUG":    fmt.Sprintf("%t", opts.debug),
 	}
 	// Only set WENDY_DEVICE_TYPE / GPU args when the agent reports them so
@@ -1016,11 +1018,11 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		buildArgs["WENDY_HAS_GPU"] = fmt.Sprintf("%t", versionResp.GetHasGpu())
 	}
 	// Remaining GPU build args — only set when the agent reports them.
-	if vendor := versionResp.GetGpuVendor(); vendor != "" {
-		buildArgs["WENDY_GPU_VENDOR"] = vendor
+	if gpuVendor != "" {
+		buildArgs["WENDY_GPU_VENDOR"] = gpuVendor
 	}
-	if jv := versionResp.GetJetpackVersion(); jv != "" {
-		buildArgs["WENDY_JETPACK_VERSION"] = jv
+	if jetpackVersion != "" {
+		buildArgs["WENDY_JETPACK_VERSION"] = jetpackVersion
 	}
 	if cv := versionResp.GetCudaVersion(); cv != "" {
 		buildArgs["WENDY_CUDA_VERSION"] = cv
@@ -1279,17 +1281,45 @@ func startPostStartHook(ctx context.Context, appCfg *appconfig.AppConfig, hostna
 	return cmd
 }
 
-// wendyPlatform maps a WendyOS device type to a platform tier used for
-// Dockerfile base stage selection. Adding a new device only requires adding
-// a case here; templates need no changes until a new platform tier is introduced.
-// Unknown device types fall back to "generic" (CPU-only).
-func wendyPlatform(deviceType string) string {
-	switch deviceType {
-	case "jetson-agx-orin", "jetson-orin-nano":
+// wendyPlatform classifies the host into a Dockerfile base-stage tier so
+// templates can pick the right runtime libraries (e.g. NVIDIA CUDA bases vs
+// CPU-only). Tiers, in priority order:
+//
+//  1. "nvidia-jetson" — Tegra/Jetson devices. Recognized either by a
+//     "jetson-" board prefix (so future Jetson SKUs work without code
+//     changes) or by the agent reporting a JetPack version (covers
+//     non-WendyOS Jetson hosts and any board-name format we haven't seen).
+//  2. "nvidia-cuda" — any other host with an NVIDIA GPU. Covers DGX Spark,
+//     x86_64 workstations, and any plain-Ubuntu host running wendy-agent
+//     where /etc/wendyos/device-type is missing.
+//  3. "generic" — no recognizable GPU; CPU-only base.
+func wendyPlatform(deviceType, gpuVendor, jetpackVersion string) string {
+	board := parseDeviceBoard(deviceType)
+	if strings.HasPrefix(board, "jetson-") || jetpackVersion != "" {
 		return "nvidia-jetson"
-	default:
-		return "generic"
 	}
+	if strings.EqualFold(gpuVendor, "nvidia") {
+		return "nvidia-cuda"
+	}
+	return "generic"
+}
+
+// parseDeviceBoard normalizes the device-type string the agent reports.
+// On WendyOS the file is multi-line ("BOARD=foo\nMACHINE=bar"); off-WendyOS
+// (DGX Spark on plain Ubuntu, dev boxes, etc.) it may be empty or a plain
+// identifier. Returns the lower-cased BOARD value when present, otherwise
+// the trimmed-and-lowered raw input.
+func parseDeviceBoard(deviceType string) string {
+	if deviceType == "" {
+		return ""
+	}
+	for _, line := range strings.Split(deviceType, "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "BOARD="); ok {
+			return strings.ToLower(strings.TrimSpace(rest))
+		}
+	}
+	return strings.ToLower(strings.TrimSpace(deviceType))
 }
 
 // resolveRestartPolicy converts the flag options into a protobuf RestartPolicy.

--- a/go/internal/cli/commands/run_test.go
+++ b/go/internal/cli/commands/run_test.go
@@ -4,19 +4,82 @@ import "testing"
 
 func TestWendyPlatform(t *testing.T) {
 	cases := []struct {
+		name       string
 		deviceType string
+		gpuVendor  string
+		jetpack    string
 		want       string
 	}{
-		{"jetson-agx-orin", "nvidia-jetson"},
-		{"jetson-orin-nano", "nvidia-jetson"},
-		{"raspberrypi5", "generic"},
-		{"unknown-device", "generic"},
-		{"", "generic"},
+		// Canonical single-token Jetson identifiers (back-compat).
+		{"jetson-orin-nano canonical", "jetson-orin-nano", "nvidia", "6.1", "nvidia-jetson"},
+		{"jetson-agx-orin canonical", "jetson-agx-orin", "nvidia", "6.1", "nvidia-jetson"},
+
+		// Real WendyOS file format on Orin Nano NVMe — multi-line BOARD/MACHINE.
+		{
+			"orin nano nvme BOARD/MACHINE blob",
+			"BOARD=jetson-orin-nano-nvme\nMACHINE=jetson-orin-nano-devkit-nvme-wendyos",
+			"nvidia", "6.1",
+			"nvidia-jetson",
+		},
+
+		// Future Jetson SKU recognized by prefix even without an entry.
+		{"future jetson by prefix", "jetson-thor", "nvidia", "7.0", "nvidia-jetson"},
+		{"future jetson via BOARD blob", "BOARD=jetson-future-sku\nMACHINE=irrelevant", "nvidia", "7.0", "nvidia-jetson"},
+
+		// JetPack present but board name unrecognized — still treat as Jetson.
+		{"jetpack fallback overrides board mismatch", "weirdo-board", "nvidia", "6.1", "nvidia-jetson"},
+
+		// Non-Jetson NVIDIA: DGX Spark / x86_64 workstation running plain
+		// Ubuntu with wendy-agent. /etc/wendyos/device-type may be missing.
+		{"empty device type with nvidia GPU", "", "nvidia", "", "nvidia-cuda"},
+		{"vendor case-insensitive", "", "Nvidia", "", "nvidia-cuda"},
+		{"non-jetson nvidia with cuda", "dgx-spark", "nvidia", "", "nvidia-cuda"},
+
+		// Raspberry Pi via WendyOS BOARD blob — no GPU vendor reported.
+		{"pi5 BOARD blob", "BOARD=raspberry-pi-5\nMACHINE=raspberrypi5-wendyos", "", "", "generic"},
+		{"raspberrypi5 canonical", "raspberrypi5", "", "", "generic"},
+
+		// Truly unknown / generic.
+		{"unknown device no gpu", "unknown-device", "", "", "generic"},
+		{"all empty", "", "", "", "generic"},
+
+		// Vendor we don't classify yet (AMD/Intel) falls to generic.
+		{"amd gpu unsupported tier", "", "amd", "", "generic"},
 	}
 	for _, tc := range cases {
-		t.Run(tc.deviceType, func(t *testing.T) {
-			if got := wendyPlatform(tc.deviceType); got != tc.want {
-				t.Fatalf("wendyPlatform(%q) = %q, want %q", tc.deviceType, got, tc.want)
+		t.Run(tc.name, func(t *testing.T) {
+			got := wendyPlatform(tc.deviceType, tc.gpuVendor, tc.jetpack)
+			if got != tc.want {
+				t.Fatalf("wendyPlatform(%q, %q, %q) = %q, want %q",
+					tc.deviceType, tc.gpuVendor, tc.jetpack, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseDeviceBoard(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain token", "jetson-orin-nano", "jetson-orin-nano"},
+		{"plain token uppercased", "Jetson-Orin-Nano", "jetson-orin-nano"},
+		{
+			"BOARD/MACHINE blob",
+			"BOARD=jetson-orin-nano-nvme\nMACHINE=jetson-orin-nano-devkit-nvme-wendyos",
+			"jetson-orin-nano-nvme",
+		},
+		{"BOARD only", "BOARD=raspberry-pi-5", "raspberry-pi-5"},
+		{"MACHINE first", "MACHINE=foo\nBOARD=bar", "bar"},
+		{"surrounding whitespace", "  BOARD=jetson-thor  \n  MACHINE=baz  ", "jetson-thor"},
+		{"no BOARD line", "MACHINE=foo", "machine=foo"}, // no BOARD= → fall back to lowercased input
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseDeviceBoard(tc.in); got != tc.want {
+				t.Fatalf("parseDeviceBoard(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Fix \`wendyPlatform\` so Jetson Orin Nano NVMe (and any \`BOARD=jetson-*\` board) correctly maps to \`nvidia-jetson\` instead of falling through to \`generic\`. The agent reports \`/etc/wendyos/device-type\` as a multi-line \`BOARD=…\nMACHINE=…\` blob and the previous literal switch never matched it, so Dockerfile build args got \`WENDY_PLATFORM=generic\` and the CPU-only base stage was selected.
- Add a new \`nvidia-cuda\` tier so non-Jetson NVIDIA hosts (DGX Spark on plain Ubuntu, x86_64 workstations, any host running just \`wendy-agent\` without WendyOS) also pick a CUDA-capable base. Selection is driven by the agent's \`gpu_vendor\` / \`jetpack_version\` fields, so it works even when \`/etc/wendyos/device-type\` is missing entirely.
- Match Jetson by \`jetson-*\` prefix and by JetPack-version presence so future Jetson SKUs (Thor, etc.) and Jetson-on-plain-Ubuntu both work without code changes.

### Tier table
| Tier | Trigger | Examples |
|------|---------|----------|
| \`nvidia-jetson\` | board prefix \`jetson-\` **or** JetPack reported | Orin Nano (with/without \`-nvme\`), AGX Orin, Thor, Jetson on plain Ubuntu |
| \`nvidia-cuda\` | \`gpu_vendor == \"nvidia\"\` (and not Jetson) | DGX Spark, dGPU workstations, any non-Jetson NVIDIA Linux host |
| \`generic\` | no recognizable NVIDIA GPU | Pi, AMD/Intel GPUs, CPU-only |

### Why apps were silently falling back to CPU
With \`WENDY_PLATFORM=generic\` selected, the auto-built image installed the CPU-only artifact for language-specific ONNX Runtime CUDA EPs (\`onnxruntime-node\`, Swift's onnxruntime SPM package). The CUDA libs were correctly bind-mounted into the container by the agent's CDI handling — but ORT's own provider plugin (\`libonnxruntime_providers_cuda.so\`) wasn't in the image rootfs. Hence \"removing requested execution provider 'cuda'… backend not found\" (Node) and \"CUDA EP unavailable — using CPU\" (Swift), even on a Jetson Orin Nano. Python templates escaped this because \`onnxruntime-gpu\` / PyTorch resolve CUDA at runtime rather than depending on a build-time base image swap.

## Test plan
- [x] \`go test ./internal/cli/commands/\` — all green, including 14 new \`wendyPlatform\` cases and 8 new \`parseDeviceBoard\` cases (covering the real \`BOARD=jetson-orin-nano-nvme\nMACHINE=…\` blob, future Jetson SKUs by prefix, JetPack-only fallback, empty-deviceType + nvidia, RPi BOARD format, AMD/unknown vendors).
- [x] \`go build ./...\` clean.
- [ ] Deploy a Swift YOLO app to Jetson Orin Nano NVMe; confirm \`platform=nvidia-jetson\` in startup log and that ORT loads the CUDA EP.
- [ ] Deploy a Node.js YOLO app to Jetson Orin Nano NVMe; confirm CUDA EP loads (no \"backend not found\" warning).
- [ ] Deploy a Python YOLO app to Jetson Orin Nano NVMe; confirm no regression.
- [ ] (Optional / once a \`nvidia-cuda\` base stage exists in the templates repo) Deploy to a DGX-style Ubuntu host running just \`wendy-agent\`; confirm \`WENDY_PLATFORM=nvidia-cuda\` is passed at build time.

## Follow-ups (not in this PR)
- Templates repo needs an \`nvidia-cuda\` base stage in the multi-stage Dockerfiles for Node.js / Swift / Python so DGX Spark and similar hosts have somewhere to land. Existing \`nvidia-jetson\` stages keep working unchanged.
- Wendy-agent install docs for non-WendyOS hosts should call out that \`nvidia-container-toolkit\` (provides \`nvidia-ctk\`) is a runtime prerequisite for CDI library mounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)