### PR TITLE
fix: schema questions non-interactive mode (fixes CI)

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -607,6 +607,14 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 		return err
 	}
 
+	// Pre-populate vals with any --var overrides not consumed by template
+	// variables, so they can answer schema questions.
+	for k, v := range varOverrides {
+		if _, exists := vals[k]; !exists {
+			vals[k] = v
+		}
+	}
+
 	// Collect schema-driven answers (multi-phase conditional questions).
 	if manifest.Schema != nil {
 		if err := collectSchemaAnswers(manifest.Schema, vals); err != nil {

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -689,7 +689,12 @@ func isTextFile(path string) bool {
 // For "input" questions, vals[q.ID] is set to the entered string.
 // For "checkbox" questions, vals[q.ID] is a comma-separated list of selected
 // values, and vals[q.ID+"_"+optionValue] is true/false for each option.
+//
+// In non-interactive mode, questions already answered in vals (e.g. via --var)
+// are skipped, and unanswered questions fall back to their defaults. Required
+// questions with no default and no pre-supplied value return an error.
 func collectSchemaAnswers(schema *templateSchema, vals map[string]interface{}) error {
+	interactive := isInteractiveTerminal()
 	for _, phase := range schema.Phases {
 		if !evaluateSchemaCondition(phase.When, vals) {
 			continue
@@ -703,9 +708,55 @@ func collectSchemaAnswers(schema *templateSchema, vals map[string]interface{}) e
 			if !evaluateSchemaCondition(q.When, vals) {
 				continue
 			}
+			if _, answered := vals[q.ID]; answered {
+				continue
+			}
+			if !interactive {
+				if err := applySchemaDefault(q, vals); err != nil {
+					return err
+				}
+				continue
+			}
 			if err := promptSchemaQuestion(q, vals); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+// applySchemaDefault sets a schema question's answer in vals using its declared
+// default. For radio questions with no default, the first option is used. For
+// required questions that have no fallback, an error is returned directing the
+// user to supply the answer via --var.
+func applySchemaDefault(q templateSchemaQuestion, vals map[string]interface{}) error {
+	switch q.Type {
+	case "radio":
+		if q.Default != "" {
+			vals[q.ID] = q.Default
+		} else if len(q.Options) > 0 {
+			vals[q.ID] = q.Options[0].Value
+		} else if q.Required {
+			return fmt.Errorf("schema question %q requires input in non-interactive mode (use --var %s=VALUE)", q.Label, q.ID)
+		}
+	case "checkbox":
+		selectedSet := map[string]bool{}
+		if q.Default != "" {
+			for _, p := range strings.Split(q.Default, ",") {
+				selectedSet[strings.TrimSpace(p)] = true
+			}
+		}
+		vals[q.ID] = q.Default
+		for _, opt := range q.Options {
+			vals[q.ID+"_"+opt.Value] = selectedSet[opt.Value]
+		}
+	default: // "input"
+		if q.Default != "" {
+			vals[q.ID] = q.Default
+		} else if q.Required {
+			return fmt.Errorf("schema question %q requires input in non-interactive mode (use --var %s=VALUE)", q.Label, q.ID)
+		} else {
+			vals[q.ID] = ""
 		}
 	}
 	return nil

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -644,3 +644,135 @@ func TestRenderTemplateContentExecuteError(t *testing.T) {
 		t.Errorf("error should mention the file path, got: %v", err)
 	}
 }
+
+// TestCollectSchemaAnswers_NonInteractiveDefaults verifies that in non-interactive
+// mode, schema questions are answered using their declared defaults without
+// launching TUI prompts.
+func TestCollectSchemaAnswers_NonInteractiveDefaults(t *testing.T) {
+	origFn := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = origFn })
+
+	schema := &templateSchema{
+		Phases: []templateSchemaPhase{
+			{
+				Title: "Project Type",
+				Questions: []templateSchemaQuestion{
+					{ID: "project_type", Label: "Project Type", Type: "radio", Default: "cloud", Options: []templateSchemaOption{
+						{Value: "cloud", Label: "Cloud"},
+						{Value: "edge", Label: "Edge"},
+					}},
+					{ID: "name", Label: "Name", Type: "input", Default: "my-app"},
+					{ID: "features", Label: "Features", Type: "checkbox", Default: "a,b", Options: []templateSchemaOption{
+						{Value: "a", Label: "A"},
+						{Value: "b", Label: "B"},
+						{Value: "c", Label: "C"},
+					}},
+				},
+			},
+		},
+	}
+
+	vals := map[string]interface{}{}
+	if err := collectSchemaAnswers(schema, vals); err != nil {
+		t.Fatalf("collectSchemaAnswers: %v", err)
+	}
+
+	if vals["project_type"] != "cloud" {
+		t.Errorf("project_type = %v, want cloud", vals["project_type"])
+	}
+	if vals["name"] != "my-app" {
+		t.Errorf("name = %v, want my-app", vals["name"])
+	}
+	if vals["features"] != "a,b" {
+		t.Errorf("features = %v, want a,b", vals["features"])
+	}
+	if vals["features_a"] != true {
+		t.Errorf("features_a = %v, want true", vals["features_a"])
+	}
+	if vals["features_b"] != true {
+		t.Errorf("features_b = %v, want true", vals["features_b"])
+	}
+	if vals["features_c"] != false {
+		t.Errorf("features_c = %v, want false", vals["features_c"])
+	}
+}
+
+// TestCollectSchemaAnswers_NonInteractiveNoDefaultUsesFirstOption verifies
+// that a radio question with no default falls back to the first option value.
+func TestCollectSchemaAnswers_NonInteractiveNoDefaultUsesFirstOption(t *testing.T) {
+	origFn := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = origFn })
+
+	schema := &templateSchema{
+		Phases: []templateSchemaPhase{
+			{Questions: []templateSchemaQuestion{
+				{ID: "mode", Label: "Mode", Type: "radio", Options: []templateSchemaOption{
+					{Value: "first", Label: "First"},
+					{Value: "second", Label: "Second"},
+				}},
+			}},
+		},
+	}
+
+	vals := map[string]interface{}{}
+	if err := collectSchemaAnswers(schema, vals); err != nil {
+		t.Fatalf("collectSchemaAnswers: %v", err)
+	}
+	if vals["mode"] != "first" {
+		t.Errorf("mode = %v, want first (first option fallback)", vals["mode"])
+	}
+}
+
+// TestCollectSchemaAnswers_SkipsPreAnswered verifies that questions already
+// present in vals (e.g. pre-supplied via --var) are not overwritten.
+func TestCollectSchemaAnswers_SkipsPreAnswered(t *testing.T) {
+	origFn := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = origFn })
+
+	schema := &templateSchema{
+		Phases: []templateSchemaPhase{
+			{Questions: []templateSchemaQuestion{
+				{ID: "project_type", Label: "Project Type", Type: "radio", Default: "cloud", Options: []templateSchemaOption{
+					{Value: "cloud", Label: "Cloud"},
+					{Value: "edge", Label: "Edge"},
+				}},
+			}},
+		},
+	}
+
+	vals := map[string]interface{}{"project_type": "edge"}
+	if err := collectSchemaAnswers(schema, vals); err != nil {
+		t.Fatalf("collectSchemaAnswers: %v", err)
+	}
+	if vals["project_type"] != "edge" {
+		t.Errorf("project_type = %v, want edge (pre-supplied value must not be overwritten)", vals["project_type"])
+	}
+}
+
+// TestCollectSchemaAnswers_RequiredNoDefaultErrors verifies that a required
+// input question with no default returns an error in non-interactive mode.
+func TestCollectSchemaAnswers_RequiredNoDefaultErrors(t *testing.T) {
+	origFn := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = origFn })
+
+	schema := &templateSchema{
+		Phases: []templateSchemaPhase{
+			{Questions: []templateSchemaQuestion{
+				{ID: "api_key", Label: "API Key", Type: "input", Required: true},
+			}},
+		},
+	}
+
+	vals := map[string]interface{}{}
+	err := collectSchemaAnswers(schema, vals)
+	if err == nil {
+		t.Fatal("expected error for required question with no default, got nil")
+	}
+	if !strings.Contains(err.Error(), "--var") {
+		t.Errorf("error = %q, want it to mention --var for supplying the value", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- `collectSchemaAnswers` was always launching bubbletea TUI prompts regardless of whether stdout is a TTY
- The `python/voice-assistant` template has a schema with a \"Project Type\" radio question that has no built-in default
- In CI (non-interactive), the TUI picker exits with code 1 → `init python/voice-assistant` fails → CI red

## Changes

- **`template.go`**: `collectSchemaAnswers` now checks `isInteractiveTerminal()`. In non-interactive mode, questions are answered using their declared `default` field; radio questions with no default fall back to the first option; required input questions with no default return an error directing the user to `--var`
- **`template.go`**: Added `applySchemaDefault` helper  
- **`init_cmd.go`**: `runTemplateFlow` now pre-populates `vals` with unused `--var` overrides before calling `collectSchemaAnswers`, so `--var project_type=edge` can answer schema questions too
- **`template_test.go`**: 4 new tests covering the non-interactive paths

## Test plan

- [ ] All new `TestCollectSchema*` unit tests pass
- [ ] Existing template tests pass (`go test ./internal/cli/commands/`)
- [ ] CI template test `init python/voice-assistant` passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)