### PR TITLE
Improve local macOS agent testing workflow

### DIFF
--- a/swift/AGENTS.md
+++ b/swift/AGENTS.md
@@ -1,0 +1,55 @@
+# Swift agent instructions
+
+## Local macOS agent workflow
+
+When you need to run the local macOS app-backed agent for testing:
+
+1. Start it with:
+
+   ```sh
+   make run
+   ```
+
+   This will:
+   - quit any existing `WendyAgentMac`
+   - build the dev app
+   - open `Build/WendyAgentMac.app`
+
+2. Wait for the app and agent to finish starting before running CLI tests.
+
+3. Run CLI tests against the local agent from `../go/`, for example:
+
+   ```sh
+   cd ../go
+   go build -o bin/wendy ./cmd/wendy
+   ./bin/wendy <command>
+   ```
+
+   If you only need an ad hoc invocation, this is also acceptable:
+
+   ```sh
+   cd ../go
+   go run ./cmd/wendy <command>
+   ```
+
+4. When finished, stop the macOS app with:
+
+   ```sh
+   make quit
+   ```
+
+## Expectations
+
+- Do not leave `WendyAgentMac` running after tests complete.
+- Prefer `make run` and `make quit` over launching or killing the app manually.
+- Prefer deterministic smoke-test commands over exploratory manual testing when possible.
+
+## Formatting
+
+- After making changes in `swift/`, always run:
+
+  ```sh
+  make format
+  ```
+
+- Do this before committing.

--- a/swift/Makefile
+++ b/swift/Makefile
@@ -47,12 +47,18 @@ reset-mac-app-tcc: ## Reset WendyAgentMac TCC permissions
 
 reset-mac-app: reset-mac-app-settings reset-mac-app-tcc ## Reset WendyAgentMac settings and TCC permissions
 
-quit: ## Quit WendyAgentMac and fail if it is still running after 3 seconds
+quit: ## Quit WendyAgentMac and fail if it is still running after 10 seconds
 	@bundle_id="sh.wendy.WendyAgentMac"; \
 	if [[ "$$(osascript -e "application id \"$$bundle_id\" is running")" == "true" ]]; then \
 		osascript -e "tell application id \"$$bundle_id\" to quit"; \
+		for attempt in {1..10}; do \
+			if [[ "$$(osascript -e "application id \"$$bundle_id\" is running")" != "true" ]]; then \
+				exit 0; \
+			fi; \
+			echo "$$bundle_id is still running; waiting... ($$attempt/10)"; \
+			sleep 1; \
+		done; \
 	fi; \
-	sleep 3; \
 	if [[ "$$(osascript -e "application id \"$$bundle_id\" is running")" == "true" ]]; then \
 		echo "Error: $$bundle_id is still running after quit request." >&2; \
 		exit 1; \

--- a/swift/Makefile
+++ b/swift/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 
 SWIFT_FORMAT_TARGETS := WendyAgentCore/Sources WendyAgentCore/Tests WendyAgentMac/Sources
 
-.PHONY: help format lint test proto build build-dev reset-mac-app-settings reset-mac-app-tcc reset-mac-app clean
+.PHONY: help format lint test proto build build-dev reset-mac-app-settings reset-mac-app-tcc reset-mac-app quit clean
 
 help: ## Show this help message
 	@echo 'Usage:'
@@ -41,3 +41,14 @@ reset-mac-app-tcc: ## Reset WendyAgentMac TCC permissions
 	./Scripts/ResetMacAppTCC.sh
 
 reset-mac-app: reset-mac-app-settings reset-mac-app-tcc ## Reset WendyAgentMac settings and TCC permissions
+
+quit: ## Quit WendyAgentMac and fail if it is still running after 3 seconds
+	@bundle_id="sh.wendy.WendyAgentMac"; \
+	if [[ "$$(osascript -e "application id \"$$bundle_id\" is running")" == "true" ]]; then \
+		osascript -e "tell application id \"$$bundle_id\" to quit"; \
+	fi; \
+	sleep 3; \
+	if [[ "$$(osascript -e "application id \"$$bundle_id\" is running")" == "true" ]]; then \
+		echo "Error: $$bundle_id is still running after quit request." >&2; \
+		exit 1; \
+	fi

--- a/swift/Makefile
+++ b/swift/Makefile
@@ -48,18 +48,4 @@ reset-mac-app-tcc: ## Reset WendyAgentMac TCC permissions
 reset-mac-app: reset-mac-app-settings reset-mac-app-tcc ## Reset WendyAgentMac settings and TCC permissions
 
 quit: ## Quit WendyAgentMac and fail if it is still running after 10 seconds
-	@bundle_id="sh.wendy.WendyAgentMac"; \
-	if [[ "$$(osascript -e "application id \"$$bundle_id\" is running")" == "true" ]]; then \
-		osascript -e "tell application id \"$$bundle_id\" to quit"; \
-		for attempt in {1..10}; do \
-			if [[ "$$(osascript -e "application id \"$$bundle_id\" is running")" != "true" ]]; then \
-				exit 0; \
-			fi; \
-			echo "$$bundle_id is still running; waiting... ($$attempt/10)"; \
-			sleep 1; \
-		done; \
-	fi; \
-	if [[ "$$(osascript -e "application id \"$$bundle_id\" is running")" == "true" ]]; then \
-		echo "Error: $$bundle_id is still running after quit request." >&2; \
-		exit 1; \
-	fi
+	./Scripts/Quit.sh

--- a/swift/Makefile
+++ b/swift/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 
 SWIFT_FORMAT_TARGETS := WendyAgentCore/Sources WendyAgentCore/Tests WendyAgentMac/Sources
 
-.PHONY: help format lint test proto build build-dev reset-mac-app-settings reset-mac-app-tcc reset-mac-app quit clean
+.PHONY: help format lint test proto build build-dev run reset-mac-app-settings reset-mac-app-tcc reset-mac-app quit clean
 
 help: ## Show this help message
 	@echo 'Usage:'
@@ -33,6 +33,11 @@ build: ## Build, sign, notarize, and package the macOS app
 
 build-dev: ## Build and package a dev-signed macOS app without notarization
 	OUTPUT_DIR='$(OUTPUT_DIR)' bash ./Scripts/Build.sh --dev
+
+run: ## Quit, build, and open the WendyAgentMac app
+	@$(MAKE) quit
+	@$(MAKE) build-dev
+	open Build/WendyAgentMac.app
 
 reset-mac-app-settings: ## Reset WendyAgentMac preferences/defaults
 	./Scripts/ResetMacAppSettings.sh

--- a/swift/Makefile
+++ b/swift/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 
 SWIFT_FORMAT_TARGETS := WendyAgentCore/Sources WendyAgentCore/Tests WendyAgentMac/Sources
 
-.PHONY: help format lint test proto build reset-mac-app-settings reset-mac-app-tcc reset-mac-app clean
+.PHONY: help format lint test proto build build-dev reset-mac-app-settings reset-mac-app-tcc reset-mac-app clean
 
 help: ## Show this help message
 	@echo 'Usage:'
@@ -30,6 +30,9 @@ clean: ## Remove Build/
 
 build: ## Build, sign, notarize, and package the macOS app
 	VERSION='$(VERSION)' OUTPUT_DIR='$(OUTPUT_DIR)' bash ./Scripts/Build.sh
+
+build-dev: ## Build and package a dev-signed macOS app without notarization
+	OUTPUT_DIR='$(OUTPUT_DIR)' bash ./Scripts/Build.sh --dev
 
 reset-mac-app-settings: ## Reset WendyAgentMac preferences/defaults
 	./Scripts/ResetMacAppSettings.sh

--- a/swift/Scripts/Build.sh
+++ b/swift/Scripts/Build.sh
@@ -22,7 +22,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "$DEV_BUILD" -eq 1 ]]; then
-  VERSION="$(date -u '+%Y.%m.%d-%H%M%S-dev')"
+  VERSION="${VERSION:-0000.00.00-000000-dev}"
 else
   : "${VERSION:?VERSION is required}"
 fi

--- a/swift/Scripts/Build.sh
+++ b/swift/Scripts/Build.sh
@@ -36,6 +36,7 @@ else
 fi
 
 APP_NAME="WendyAgentMac.app"
+BUILD_CONFIGURATION="Release"
 OUTPUT_DIR="${OUTPUT_DIR:-$SWIFT_DIR/Build}"
 DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-$SWIFT_DIR/Build/Xcode}"
 TEMP_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
@@ -46,6 +47,10 @@ ARTIFACT_NAME="wendy-agent-macos-arm64-${VERSION}.zip"
 ARTIFACT_PATH="${OUTPUT_DIR}/${ARTIFACT_NAME}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-wendy-notary-profile}"
 ENTITLEMENTS_PATH="$SWIFT_DIR/WendyAgentMac/Support/WendyAgentMac.entitlements"
+
+if [[ "$DEV_BUILD" -eq 1 ]]; then
+  BUILD_CONFIGURATION="Debug"
+fi
 
 find_signing_identity() {
   if [ -n "${KEYCHAIN_PATH:-}" ]; then
@@ -134,7 +139,7 @@ fi
 xcodebuild archive \
   -workspace WendyAgent.xcworkspace \
   -scheme WendyAgentMac \
-  -configuration Release \
+  -configuration "$BUILD_CONFIGURATION" \
   -destination 'generic/platform=macOS' \
   -archivePath "$ARCHIVE_PATH" \
   -derivedDataPath "$DERIVED_DATA_PATH" \

--- a/swift/Scripts/Build.sh
+++ b/swift/Scripts/Build.sh
@@ -118,10 +118,18 @@ xcbeautify_or_cat() {
   fi
 }
 
-mkdir -p "$OUTPUT_DIR" "$DERIVED_DATA_PATH"
-rm -rf "$ARCHIVE_PATH" "$DERIVED_DATA_PATH" "$APP_PATH" "$NOTARY_ZIP"
-mkdir -p "$DERIVED_DATA_PATH"
+mkdir -p "$OUTPUT_DIR"
+
+rm -rf "$ARCHIVE_PATH"
+rm -rf "$APP_PATH"
+rm -rf "$NOTARY_ZIP"
 rm -f "$ARTIFACT_PATH"
+
+if [[ "$DEV_BUILD" -eq 1 ]]; then
+  echo "Preserving derived data for incremental dev build: $DERIVED_DATA_PATH"
+else
+  rm -rf "$DERIVED_DATA_PATH"
+fi
 
 xcodebuild archive \
   -workspace WendyAgent.xcworkspace \

--- a/swift/Scripts/Build.sh
+++ b/swift/Scripts/Build.sh
@@ -40,7 +40,6 @@ BUILD_CONFIGURATION="Release"
 OUTPUT_DIR="${OUTPUT_DIR:-$SWIFT_DIR/Build}"
 DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-$SWIFT_DIR/Build/Xcode}"
 TEMP_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
-ARCHIVE_PATH="${ARCHIVE_PATH:-$SWIFT_DIR/Build/WendyAgentMac.xcarchive}"
 APP_PATH="${OUTPUT_DIR}/${APP_NAME}"
 NOTARY_ZIP="${TEMP_DIR}/WendyAgentMac-notary.zip"
 ARTIFACT_NAME="wendy-agent-macos-arm64-${VERSION}.zip"
@@ -51,6 +50,8 @@ ENTITLEMENTS_PATH="$SWIFT_DIR/WendyAgentMac/Support/WendyAgentMac.entitlements"
 if [[ "$DEV_BUILD" -eq 1 ]]; then
   BUILD_CONFIGURATION="Debug"
 fi
+
+BUILT_APP_PATH="${DERIVED_DATA_PATH}/Build/Products/${BUILD_CONFIGURATION}/${APP_NAME}"
 
 find_signing_identity() {
   if [ -n "${KEYCHAIN_PATH:-}" ]; then
@@ -125,7 +126,6 @@ xcbeautify_or_cat() {
 
 mkdir -p "$OUTPUT_DIR"
 
-rm -rf "$ARCHIVE_PATH"
 rm -rf "$APP_PATH"
 rm -rf "$NOTARY_ZIP"
 rm -f "$ARTIFACT_PATH"
@@ -136,12 +136,11 @@ else
   rm -rf "$DERIVED_DATA_PATH"
 fi
 
-xcodebuild archive \
+xcodebuild build \
   -workspace WendyAgent.xcworkspace \
   -scheme WendyAgentMac \
   -configuration "$BUILD_CONFIGURATION" \
   -destination 'generic/platform=macOS' \
-  -archivePath "$ARCHIVE_PATH" \
   -derivedDataPath "$DERIVED_DATA_PATH" \
   MARKETING_VERSION="$APPLE_MARKETING_VERSION" \
   CURRENT_PROJECT_VERSION="$APPLE_CURRENT_PROJECT_VERSION" \
@@ -150,7 +149,7 @@ xcodebuild archive \
   -skipMacroValidation \
   | xcbeautify_or_cat
 
-ditto "$ARCHIVE_PATH/Products/Applications/$APP_NAME" "$APP_PATH"
+ditto "$BUILT_APP_PATH" "$APP_PATH"
 
 while IFS= read -r nested_code; do
   sign_path "$nested_code"

--- a/swift/Scripts/Build.sh
+++ b/swift/Scripts/Build.sh
@@ -5,7 +5,27 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SWIFT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$SWIFT_DIR"
 
-: "${VERSION:?VERSION is required}"
+DEV_BUILD=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dev)
+      DEV_BUILD=1
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--dev]" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ "$DEV_BUILD" -eq 1 ]]; then
+  VERSION="$(date -u '+%Y.%m.%d-%H%M%S-dev')"
+else
+  : "${VERSION:?VERSION is required}"
+fi
 
 if [[ "$VERSION" =~ ^([0-9]{4})\.([0-9]{2})\.([0-9]{2})(-([0-9]{6}))?([-.].*)?$ ]]; then
   APPLE_MARKETING_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
@@ -36,11 +56,19 @@ find_signing_identity() {
 }
 
 if [ -z "${SIGNING_IDENTITY:-}" ]; then
-  SIGNING_IDENTITY=$(find_signing_identity | awk -F '"' '/Developer ID Application/ { print $2; exit }')
+  if [[ "$DEV_BUILD" -eq 1 ]]; then
+    SIGNING_IDENTITY=$(find_signing_identity | awk -F '"' '/Apple Development/ { print $2; exit }')
+  else
+    SIGNING_IDENTITY=$(find_signing_identity | awk -F '"' '/Developer ID Application/ { print $2; exit }')
+  fi
 fi
 
 if [ -z "${SIGNING_IDENTITY:-}" ]; then
-  echo "Missing SIGNING_IDENTITY and could not auto-detect a Developer ID Application identity" >&2
+  if [[ "$DEV_BUILD" -eq 1 ]]; then
+    echo "Missing SIGNING_IDENTITY and could not auto-detect an Apple Development identity" >&2
+  else
+    echo "Missing SIGNING_IDENTITY and could not auto-detect a Developer ID Application identity" >&2
+  fi
   exit 1
 fi
 
@@ -62,10 +90,12 @@ sign_path() {
     command+=(--keychain "$KEYCHAIN_PATH")
   fi
 
-  command+=(
-    --options runtime
-    --timestamp
-  )
+  if [[ "$DEV_BUILD" -ne 1 ]]; then
+    command+=(
+      --options runtime
+      --timestamp
+    )
+  fi
 
   if [ -n "$entitlements_path" ]; then
     command+=(--entitlements "$entitlements_path")
@@ -119,15 +149,17 @@ sign_path "$APP_PATH" "$ENTITLEMENTS_PATH"
 
 codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 
-ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$NOTARY_ZIP"
+if [[ "$DEV_BUILD" -ne 1 ]]; then
+  ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$NOTARY_ZIP"
 
-xcrun notarytool submit "$NOTARY_ZIP" \
-  --keychain-profile "$NOTARY_PROFILE" \
-  --wait
+  xcrun notarytool submit "$NOTARY_ZIP" \
+    --keychain-profile "$NOTARY_PROFILE" \
+    --wait
 
-xcrun stapler staple -v "$APP_PATH"
-xcrun stapler validate "$APP_PATH"
-spctl -a -vv --type exec "$APP_PATH"
+  xcrun stapler staple -v "$APP_PATH"
+  xcrun stapler validate "$APP_PATH"
+  spctl -a -vv --type exec "$APP_PATH"
+fi
 
 ditto -c -k --sequesterRsrc --keepParent \
   "$APP_PATH" \

--- a/swift/Scripts/Quit.sh
+++ b/swift/Scripts/Quit.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle_id="sh.wendy.WendyAgentMac"
+
+if [[ "$(osascript -e "application id \"$bundle_id\" is running")" == "true" ]]; then
+  osascript -e "tell application id \"$bundle_id\" to quit"
+
+  for attempt in {1..10}; do
+    if [[ "$(osascript -e "application id \"$bundle_id\" is running")" != "true" ]]; then
+      exit 0
+    fi
+
+    echo "$bundle_id is still running; waiting... ($attempt/10)"
+    sleep 1
+  done
+fi
+
+if [[ "$(osascript -e "application id \"$bundle_id\" is running")" == "true" ]]; then
+  echo "Error: $bundle_id is still running after quit request." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a dev build mode for WendyAgentMac that uses ad hoc signing and skips notarization
- add Makefile run/quit helpers for starting and stopping the local macOS app-backed agent
- document the recommended local testing workflow in `swift/AGENTS.md`

## Testing
Verified the new local macOS app-backed agent workflow end to end:

```sh
cd swift
make run
```

```sh
cd go
go build -o bin/wendy ./cmd/wendy
./bin/wendy discover --json --timeout 5s
```

```json
{
  "usbDevices": null,
  "lanDevices": [
    {
      "id": "Konstantins-MacBook-Pro-M5",
      "displayName": "Konstantins-MacBook-Pro-M5",
      "hostname": "Konstantins-MacBook-Pro-M5.local",
      "port": 50051,
      "interfaceType": "lan",
      "isWendyDevice": true
    }
  ],
  "bluetoothDevices": null,
  "ethernetDevices": null,
  "externalDevices": [
    {
      "id": "local",
      "displayName": "Local Machine",
      "providerKey": "local",
      "isWendyDevice": false,
      "os": "darwin",
      "cpuArchitecture": "arm64"
    }
  ]
}
```

```sh
./bin/wendy device version --device Konstantins-MacBook-Pro-M5.local --json
```

```json
{
  "cliVersion": "dev",
  "cpuArchitecture": "arm64",
  "deviceType": "",
  "hasGpu": false,
  "os": "darwin",
  "osVersion": "26.4.1",
  "version": "0.0.0-dev"
}
```

```sh
./bin/wendy device apps list --device Konstantins-MacBook-Pro-M5.local --json
```

```json
[]
```

```sh
cd ../swift
make quit
```
