### PR TITLE
Disable hardware integration tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -590,17 +590,10 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
-  integration-tests:
-    name: Hardware Integration Tests
-    needs: [determine-version]
-    if: needs.determine-version.outputs.is_release == 'true' && needs.determine-version.outputs.is_prerelease == 'false'
-    uses: ./.github/workflows/integration-tests.yml
-    secrets: inherit
-
   publish-linux-repos:
     name: Publish to GCP Artifact Registry
     runs-on: ubuntu-latest
-    needs: [determine-version, package-linux, test-templates, integration-tests]
+    needs: [determine-version, package-linux, test-templates]
     if: needs.determine-version.outputs.is_release == 'true' && needs.determine-version.outputs.is_prerelease == 'false'
     permissions:
       contents: read
@@ -654,7 +647,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [determine-version, build, build-go-macos, build-agent-macos-app, package-linux, package-windows, test-templates, integration-tests]
+    needs: [determine-version, build, build-go-macos, build-agent-macos-app, package-linux, package-windows, test-templates]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
     steps:
       - name: Download artifact


### PR DESCRIPTION
Removes the hardware integration tests job from `build.yml` and drops it from the `needs` of the `release` and `publish-linux-repos` jobs, so releases can complete while the hardware runners are unavailable/failing.

The `integration-tests.yml` workflow file itself is left intact and can be re-wired when the runners are stable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)