### PR TITLE
Fire postStart hook and readiness probe on `wendy device apps start`

### DIFF
--- a/go/internal/cli/commands/apps.go
+++ b/go/internal/cli/commands/apps.go
@@ -7,18 +7,18 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/wendylabsinc/wendy/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/internal/cli/providers"
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/internal/shared/config"
 	"github.com/wendylabsinc/wendy/proto/gen/agentpb"
 )
@@ -233,7 +233,8 @@ func appsListProvider(ctx context.Context, cm providers.ContainerManager) error 
 }
 
 func newAppsStartCmd() *cobra.Command {
-	return &cobra.Command{
+	var configPath string
+	cmd := &cobra.Command{
 		Use:   "start [app-name]",
 		Short: "Start an application",
 		Args:  cobra.MaximumNArgs(1),
@@ -255,42 +256,17 @@ func newAppsStartCmd() *cobra.Command {
 				}
 			}
 
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("resolving working directory: %w", err)
+			}
+			appCfg, err := loadAppConfigForStart(cwd, configPath, appName)
+			if err != nil {
+				return err
+			}
+
 			if target.Agent != nil {
-				outStream, stdinAttempted, err := openContainerStream(ctx, target.Agent.ContainerService, appName, nil)
-				if err != nil {
-					return err
-				}
-				gotFirstResponse := false
-				for {
-					resp, err := outStream.Recv()
-					if err == io.EOF {
-						break
-					}
-					if err != nil {
-						if stdinAttempted && !gotFirstResponse && status.Code(err) == codes.Unimplemented {
-							cliNotice("Notice: stdin not attached (not supported by agent)")
-							startStream, startErr := target.Agent.ContainerService.StartContainer(ctx, &agentpb.StartContainerRequest{
-								AppName: appName,
-							})
-							if startErr != nil {
-								return fmt.Errorf("starting container: %w", startErr)
-							}
-							outStream = startStream
-							stdinAttempted = false
-							continue
-						}
-						return fmt.Errorf("receiving start response: %w", err)
-					}
-					gotFirstResponse = true
-					if out := resp.GetStdoutOutput(); out != nil {
-						os.Stdout.Write(out.GetData())
-					}
-					if out := resp.GetStderrOutput(); out != nil {
-						os.Stderr.Write(out.GetData())
-					}
-				}
-				fmt.Printf("Application %s stopped.\n", appName)
-				return nil
+				return streamContainerWithHooks(ctx, target.Agent, appName, appCfg)
 			}
 
 			if target.Provider != nil {
@@ -308,6 +284,38 @@ func newAppsStartCmd() *cobra.Command {
 			return fmt.Errorf("selected device does not support this command")
 		},
 	}
+	cmd.Flags().StringVar(&configPath, "config", "", "Path to wendy.json (defaults to ./wendy.json if present). Used to fire readiness probe and postStart hook.")
+	return cmd
+}
+
+// loadAppConfigForStart resolves the wendy.json used by `apps start` to fire
+// readiness probes and postStart hooks. --config is strict; <cwd>/wendy.json
+// is best-effort, returning (nil, nil) with a notice when found-but-unusable.
+func loadAppConfigForStart(cwd, configPath, appName string) (*appconfig.AppConfig, error) {
+	if configPath != "" {
+		cfg, err := appconfig.LoadFromFile(configPath)
+		if err != nil {
+			return nil, err
+		}
+		if cfg.AppID != appName {
+			return nil, fmt.Errorf("--config %s has appId %q, does not match app %q", configPath, cfg.AppID, appName)
+		}
+		return cfg, nil
+	}
+
+	path := filepath.Join(cwd, "wendy.json")
+	cfg, err := appconfig.LoadFromFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			cliNotice("Notice: %s present but unreadable (%v); postStart hook will not fire", path, err)
+		}
+		return nil, nil
+	}
+	if cfg.AppID != appName {
+		cliNotice("Notice: %s has appId %q, does not match %q; postStart hook will not fire", path, cfg.AppID, appName)
+		return nil, nil
+	}
+	return cfg, nil
 }
 
 func newAppsStopCmd() *cobra.Command {

--- a/go/internal/cli/commands/apps_test.go
+++ b/go/internal/cli/commands/apps_test.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -24,4 +26,89 @@ func TestDeviceAppsListCommand_HelpDescribesDeployedApps(t *testing.T) {
 	if strings.Contains(output, "List running applications") {
 		t.Fatalf("expected help output to avoid stale wording, got %q", output)
 	}
+}
+
+func TestLoadAppConfigForStart(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(t *testing.T, name, body string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+
+	t.Run("no wendy.json and no --config returns nil", func(t *testing.T) {
+		cfg, err := loadAppConfigForStart(dir, "", "anything")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if cfg != nil {
+			t.Fatalf("expected nil cfg, got %+v", cfg)
+		}
+	})
+
+	write(t, "wendy.json", `{"appId":"my-app","version":"0.1.0"}`)
+
+	t.Run("wendy.json in cwd with matching appId is loaded", func(t *testing.T) {
+		cfg, err := loadAppConfigForStart(dir, "", "my-app")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if cfg == nil || cfg.AppID != "my-app" {
+			t.Fatalf("expected cfg.AppID=my-app, got %+v", cfg)
+		}
+	})
+
+	t.Run("wendy.json in cwd with mismatched appId returns nil (with notice)", func(t *testing.T) {
+		cfg, err := loadAppConfigForStart(dir, "", "other-app")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if cfg != nil {
+			t.Fatalf("expected nil cfg on mismatch, got %+v", cfg)
+		}
+	})
+
+	other := write(t, "other.json", `{"appId":"other-app","version":"0.1.0"}`)
+
+	t.Run("--config with matching appId is loaded", func(t *testing.T) {
+		cfg, err := loadAppConfigForStart(dir, other, "other-app")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if cfg == nil || cfg.AppID != "other-app" {
+			t.Fatalf("expected cfg.AppID=other-app, got %+v", cfg)
+		}
+	})
+
+	t.Run("--config with mismatched appId returns error", func(t *testing.T) {
+		_, err := loadAppConfigForStart(dir, other, "my-app")
+		if err == nil {
+			t.Fatalf("expected error on appId mismatch")
+		}
+	})
+
+	t.Run("--config pointing at missing file returns error", func(t *testing.T) {
+		_, err := loadAppConfigForStart(dir, filepath.Join(dir, "nope.json"), "my-app")
+		if err == nil {
+			t.Fatalf("expected error for missing file")
+		}
+	})
+
+	t.Run("malformed wendy.json in cwd returns nil (with notice)", func(t *testing.T) {
+		bad := t.TempDir()
+		if err := os.WriteFile(filepath.Join(bad, "wendy.json"), []byte("{not json"), 0o644); err != nil {
+			t.Fatalf("write bad json: %v", err)
+		}
+		cfg, err := loadAppConfigForStart(bad, "", "anything")
+		if err != nil {
+			t.Fatalf("expected nil error for malformed implicit config, got %v", err)
+		}
+		if cfg != nil {
+			t.Fatalf("expected nil cfg for malformed implicit config, got %+v", cfg)
+		}
+	})
 }

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1135,18 +1135,9 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		return nil
 	}
 
-	// Start and stream output using AttachContainer so stdin is forwarded.
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
 
-	outStream, stdinAttempted, err := openContainerStream(runCtx, conn.ContainerService, appCfg.AppID, appCfg)
-	if err != nil {
-		return err
-	}
-
-	cliLogln("Application %s started.", appCfg.AppID)
-
-	// Set up Ctrl+C handler first so readiness polling is cancellable.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 	go func() {
@@ -1158,32 +1149,59 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		runCancel()
 	}()
 
-	// Wait for readiness before firing hook.
-	if err := waitForReadiness(runCtx, appCfg.Readiness, conn.Host); err != nil {
-		if runCtx.Err() == nil {
-			cliLogln("Warning: %v", err)
-		}
-	}
+	return streamContainerWithHooks(runCtx, conn, appCfg.AppID, appCfg)
+}
 
-	// Post-start hook tied to runCtx so Ctrl+C kills it.
-	postStartCmd := startPostStartHook(runCtx, appCfg, conn.Host)
+// streamContainerWithHooks attaches to a container's stdout/stderr, runs the
+// readiness probe and postStart CLI hook, and pumps output until the stream
+// ends. appCfg may be nil — readiness and hook are skipped in that case.
+func streamContainerWithHooks(ctx context.Context, conn *grpcclient.AgentConnection, appName string, appCfg *appconfig.AppConfig) (retErr error) {
+	svc := conn.ContainerService
+	outStream, stdinAttempted, err := openContainerStream(ctx, svc, appName, appCfg)
+	if err != nil {
+		return err
+	}
+	cliLogln("Application %s started.", appName)
+	defer func() {
+		if retErr == nil {
+			cliLogln("\nApplication %s stopped.", appName)
+		}
+	}()
+
+	if appCfg != nil {
+		if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
+			if ctx.Err() == nil {
+				cliLogln("Warning: %v", err)
+			}
+		}
+		hookCtx, cancelHook := context.WithCancel(ctx)
+		postStartCmd := startPostStartHook(hookCtx, appCfg, conn.Host)
+		// Cancel the hook's context before waiting so we don't block on a
+		// still-running child after the container's stream ends.
+		defer func() {
+			cancelHook()
+			if postStartCmd != nil {
+				_ = postStartCmd.Wait()
+			}
+		}()
+	}
 
 	gotFirstResponse := false
 	for {
 		resp, recvErr := outStream.Recv()
 		if recvErr == io.EOF {
-			break
+			return nil
 		}
 		if recvErr != nil {
-			if runCtx.Err() != nil {
-				break
+			if ctx.Err() != nil {
+				return nil
 			}
 			// If the bidi stream returned Unimplemented before any response,
 			// the container was never started — fall back silently to StartContainer.
 			if stdinAttempted && !gotFirstResponse && status.Code(recvErr) == codes.Unimplemented {
 				cliNotice("Notice: stdin not attached (not supported by agent)")
-				startStream, startErr := conn.ContainerService.StartContainer(contextWithPostStartAgentHook(runCtx, appCfg), &agentpb.StartContainerRequest{
-					AppName: appCfg.AppID,
+				startStream, startErr := svc.StartContainer(contextWithPostStartAgentHook(ctx, appCfg), &agentpb.StartContainerRequest{
+					AppName: appName,
 				})
 				if startErr != nil {
 					return fmt.Errorf("starting container: %w", startErr)
@@ -1202,15 +1220,6 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 			_, _ = os.Stderr.Write(out.GetData())
 		}
 	}
-
-	// Cancel runCtx to terminate the postStart hook if it's still running,
-	// then wait for it to exit so we don't leave orphan processes.
-	runCancel()
-	if postStartCmd != nil {
-		_ = postStartCmd.Wait()
-	}
-	cliLogln("\nApplication %s stopped.", appCfg.AppID)
-	return nil
 }
 
 // waitForReadiness polls the readiness probe until it passes or the context is


### PR DESCRIPTION
Fixes WDY-1017.

`apps start` now runs the readiness probe and postStart hook via a `streamContainerWithHooks` helper shared with `wendy run`. wendy.json is picked up from cwd, or via `--config <path>` for explicit override.