### PR TITLE
Small improvements: WiFi prompt on enroll, NVMe block size, Homebrew desc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -880,7 +880,7 @@ jobs:
 
             url "https://github.com/wendylabsinc/wendy-agent/releases/download/#{version}/wendy-agent-macos-arm64-#{version}.zip"
             name "Wendy Agent"
-            desc "Wendy Agent for macOS (nightly)"
+            desc "Manage your headless device (nightly)"
             homepage "https://github.com/wendylabsinc/wendy-agent"
 
             app "WendyAgentMac.app"
@@ -941,7 +941,7 @@ jobs:
 
             url "https://github.com/wendylabsinc/wendy-agent/releases/download/#{version}/wendy-agent-macos-arm64-#{version}.zip"
             name "Wendy Agent"
-            desc "Wendy Agent for macOS"
+            desc "Manage your headless device"
             homepage "https://github.com/wendylabsinc/wendy-agent"
 
             app "WendyAgentMac.app"

--- a/go/internal/cli/commands/cloud.go
+++ b/go/internal/cli/commands/cloud.go
@@ -91,6 +91,8 @@ func newCloudEnrollDeviceCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
+			promptWifiIfNeeded(ctx, conn)
+
 			auth, err := pickAuthEntry(cloudGRPC)
 			if err != nil {
 				return err

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -390,6 +390,8 @@ func newDeviceEnrollCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
+			promptWifiIfNeeded(ctx, conn)
+
 			auth, err := pickAuthEntry(cloudGRPC)
 			if err != nil {
 				return err
@@ -402,6 +404,61 @@ func newDeviceEnrollCmd() *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", "", "Device name")
 	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud/pki-core gRPC endpoint to use (required when multiple auth sessions exist)")
 	return cmd
+}
+
+// promptWifiIfNeeded checks whether the device is connected to WiFi, and if
+// not, offers an interactive flow to connect before enrollment. Errors from the
+// status check are silently ignored so the function degrades gracefully on
+// devices that don't support WiFi (e.g. local, docker).
+func promptWifiIfNeeded(ctx context.Context, conn *grpcclient.AgentConnection) {
+	if !isInteractiveTerminal() {
+		return
+	}
+
+	statusResp, err := conn.AgentService.GetWiFiStatus(ctx, &agentpb.GetWiFiStatusRequest{})
+	if err != nil || statusResp.GetConnected() {
+		return
+	}
+
+	fmt.Println("No WiFi connection detected on the device.")
+	fmt.Print("Set up WiFi before enrolling? [Y/n] ")
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	answer := strings.TrimSpace(strings.ToLower(line))
+	if answer != "" && answer != "y" && answer != "yes" {
+		return
+	}
+
+	target := &SelectedDevice{Agent: conn}
+	ssid, pickErr := pickWifiNetwork(ctx, target)
+	if pickErr != nil {
+		if !errors.Is(pickErr, ErrUserCancelled) {
+			fmt.Printf("WiFi setup failed: %v\n", pickErr)
+		}
+		return
+	}
+
+	fmt.Print("Password (leave empty for open networks): ")
+	passwordBytes, readErr := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+	if readErr != nil {
+		fmt.Printf("Failed to read password: %v\n", readErr)
+		return
+	}
+	password := strings.TrimSpace(string(passwordBytes))
+
+	fmt.Printf("Connecting to %s...\n", ssid)
+	wifiResp, connectErr := conn.AgentService.ConnectToWiFi(ctx, &agentpb.ConnectToWiFiRequest{
+		Ssid:     ssid,
+		Password: password,
+	})
+	if connectErr != nil {
+		fmt.Printf("WiFi connection failed: %v\n", connectErr)
+	} else if !wifiResp.GetSuccess() {
+		fmt.Printf("WiFi connection failed: %s\n", wifiResp.GetErrorMessage())
+	} else {
+		fmt.Printf("Connected to %s.\n", ssid)
+	}
 }
 
 // runEnrollDevice creates an enrollment token via the stored auth session and

--- a/go/internal/cli/commands/disklister_darwin.go
+++ b/go/internal/cli/commands/disklister_darwin.go
@@ -12,11 +12,11 @@ import (
 
 // drive represents an external disk suitable for image writing.
 type drive struct {
-	DevicePath  string      // e.g. /dev/disk4
-	RawPath     string      // e.g. /dev/rdisk4
-	Name        string      // human-readable name
-	Size        string      // human-readable size
-	SizeBytes   int64       // size in bytes
+	DevicePath  string // e.g. /dev/disk4
+	RawPath     string // e.g. /dev/rdisk4
+	Name        string // human-readable name
+	Size        string // human-readable size
+	SizeBytes   int64  // size in bytes
 	IsRemovable bool
 	StorageType StorageType // underlying storage protocol
 }
@@ -121,8 +121,8 @@ type diskInfo struct {
 	name      string
 	size      string
 	sizeBytes int64
-	removable bool // "Removable Media: Removable"
-	ejectable bool // "Ejectable: Yes"
+	removable bool   // "Removable Media: Removable"
+	ejectable bool   // "Ejectable: Yes"
 	protocol  string // "Protocol:" field, e.g. "NVMe", "USB"
 }
 

--- a/go/internal/cli/commands/disklister_darwin.go
+++ b/go/internal/cli/commands/disklister_darwin.go
@@ -12,12 +12,13 @@ import (
 
 // drive represents an external disk suitable for image writing.
 type drive struct {
-	DevicePath  string // e.g. /dev/disk4
-	RawPath     string // e.g. /dev/rdisk4
-	Name        string // human-readable name
-	Size        string // human-readable size
-	SizeBytes   int64  // size in bytes
+	DevicePath  string      // e.g. /dev/disk4
+	RawPath     string      // e.g. /dev/rdisk4
+	Name        string      // human-readable name
+	Size        string      // human-readable size
+	SizeBytes   int64       // size in bytes
 	IsRemovable bool
+	StorageType StorageType // underlying storage protocol
 }
 
 // listAllDrives lists external physical drives (NVMe, USB, SD cards) on macOS.
@@ -88,6 +89,7 @@ func parseDiskutilOutput(out []byte, seen map[string]bool, isExternal bool) []dr
 		size := ""
 		var sizeBytes int64
 		removable := isExternal
+		storageType := StorageUnknown
 		if infoErr == nil {
 			if info.name != "" {
 				name = info.name
@@ -96,6 +98,9 @@ func parseDiskutilOutput(out []byte, seen map[string]bool, isExternal bool) []dr
 			sizeBytes = info.sizeBytes
 			if !isExternal {
 				removable = info.removable || info.ejectable
+			}
+			if strings.EqualFold(info.protocol, "nvme") {
+				storageType = StorageNVMe
 			}
 		}
 
@@ -106,6 +111,7 @@ func parseDiskutilOutput(out []byte, seen map[string]bool, isExternal bool) []dr
 			Size:        size,
 			SizeBytes:   sizeBytes,
 			IsRemovable: removable,
+			StorageType: storageType,
 		})
 	}
 	return drives
@@ -117,6 +123,7 @@ type diskInfo struct {
 	sizeBytes int64
 	removable bool // "Removable Media: Removable"
 	ejectable bool // "Ejectable: Yes"
+	protocol  string // "Protocol:" field, e.g. "NVMe", "USB"
 }
 
 func getDiskInfo(devPath string) (*diskInfo, error) {
@@ -152,6 +159,9 @@ func getDiskInfo(devPath string) (*diskInfo, error) {
 			val := strings.TrimSpace(strings.TrimPrefix(line, "Ejectable:"))
 			info.ejectable = strings.EqualFold(val, "yes")
 		}
+		if strings.HasPrefix(line, "Protocol:") {
+			info.protocol = strings.TrimSpace(strings.TrimPrefix(line, "Protocol:"))
+		}
 	}
 	return info, nil
 }
@@ -177,16 +187,24 @@ func unmountDisk(devPath string) error {
 // on raw devices. Progress is driven by `status=progress`, which BSD dd
 // has supported since macOS Monterey (12.0); it prints a transfer-stats
 // line to stderr roughly once per second.
+// /dev/rdisk bypasses the filesystem buffer cache, so no explicit flush is
+// needed after dd exits. NVMe drives in USB enclosures benefit from larger
+// blocks (64 MiB) to reduce per-write overhead over the USB link.
 func writeImageToDisk(imagePath string, d drive, progressFn func(written int64)) error {
 	if err := unmountDisk(d.DevicePath); err != nil {
 		return err
+	}
+
+	bs := "8m"
+	if d.StorageType == StorageNVMe {
+		bs = "64m"
 	}
 
 	// Use rdisk for faster raw writes on macOS.
 	cmd := exec.Command("sudo", "dd",
 		fmt.Sprintf("if=%s", imagePath),
 		fmt.Sprintf("of=%s", d.RawPath),
-		"bs=8m",
+		"bs="+bs,
 		"status=progress",
 	)
 

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -34,11 +34,11 @@ func (f *flexBool) UnmarshalJSON(data []byte) error {
 
 // drive represents an external disk suitable for image writing.
 type drive struct {
-	DevicePath  string      // e.g. /dev/sdb
-	RawPath     string      // same as DevicePath on Linux
-	Name        string      // human-readable name
-	Size        string      // human-readable size
-	SizeBytes   int64       // size in bytes
+	DevicePath  string // e.g. /dev/sdb
+	RawPath     string // same as DevicePath on Linux
+	Name        string // human-readable name
+	Size        string // human-readable size
+	SizeBytes   int64  // size in bytes
 	IsRemovable bool
 	StorageType StorageType // underlying storage protocol
 }

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -34,12 +34,13 @@ func (f *flexBool) UnmarshalJSON(data []byte) error {
 
 // drive represents an external disk suitable for image writing.
 type drive struct {
-	DevicePath  string // e.g. /dev/sdb
-	RawPath     string // same as DevicePath on Linux
-	Name        string // human-readable name
-	Size        string // human-readable size
-	SizeBytes   int64  // size in bytes
+	DevicePath  string      // e.g. /dev/sdb
+	RawPath     string      // same as DevicePath on Linux
+	Name        string      // human-readable name
+	Size        string      // human-readable size
+	SizeBytes   int64       // size in bytes
 	IsRemovable bool
+	StorageType StorageType // underlying storage protocol
 }
 
 // lsblkOutput is the JSON output from lsblk.
@@ -99,6 +100,10 @@ func listDrivesLinux() ([]drive, error) {
 			sizeBytes = n
 		}
 
+		storageType := StorageUnknown
+		if dev.Transport == "nvme" {
+			storageType = StorageNVMe
+		}
 		drives = append(drives, drive{
 			DevicePath: devPath,
 			RawPath:    devPath,
@@ -108,6 +113,7 @@ func listDrivesLinux() ([]drive, error) {
 			// IsRemovable reflects our external-ness predicate so downstream code
 			// sees the same classification used to include this device.
 			IsRemovable: isExternal,
+			StorageType: storageType,
 		})
 	}
 
@@ -146,17 +152,30 @@ func unmountLsblkDevice(dev lsblkDevice) {
 // produces 4 MiB writes to the device — pipe input forces dd to issue a write
 // per pipe-buffer-sized read, which is dramatically slower on raw devices.
 // Progress is driven by parsing dd's status=progress output on stderr.
+//
+// For NVMe drives we use a 64 MiB block size and oflag=direct to bypass the
+// page cache; large buffered writes cause RAM pressure and a multi-second
+// global sync stall after dd exits. conv=fdatasync ensures dd flushes the
+// target device before exiting (runs as root, only flushes this device).
 func writeImageToDisk(imagePath string, d drive, progressFn func(written int64)) error {
 	if err := unmountDisk(d.DevicePath); err != nil {
 		return err
 	}
 
-	cmd := exec.Command("sudo", "dd",
+	ddArgs := []string{
+		"dd",
 		fmt.Sprintf("if=%s", imagePath),
 		fmt.Sprintf("of=%s", d.DevicePath),
 		"bs=4M",
 		"status=progress",
-	)
+		"conv=fdatasync",
+	}
+	if d.StorageType == StorageNVMe {
+		ddArgs[3] = "bs=64M"
+		ddArgs = append(ddArgs, "oflag=direct")
+	}
+
+	cmd := exec.Command("sudo", ddArgs...)
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return fmt.Errorf("creating stderr pipe: %w", err)
@@ -178,9 +197,6 @@ func writeImageToDisk(imagePath string, d drive, progressFn func(written int64))
 	if waitErr != nil {
 		return fmt.Errorf("writing image: %w", waitErr)
 	}
-
-	// Sync to flush writes.
-	exec.Command("sync").Run() //nolint:errcheck
 
 	return nil
 }

--- a/go/internal/cli/commands/disklister_storage.go
+++ b/go/internal/cli/commands/disklister_storage.go
@@ -1,0 +1,9 @@
+package commands
+
+// StorageType identifies the underlying storage protocol of a drive.
+type StorageType int
+
+const (
+	StorageUnknown StorageType = iota
+	StorageNVMe
+)


### PR DESCRIPTION
## Summary

- Prompt interactively for WiFi setup when enrolling a device that has no active WiFi connection (`device enroll` and `cloud enroll-device`)
- Use a larger dd block size (64 MiB) for NVMe drives in USB enclosures on Linux and macOS to reduce per-write overhead; falls back to standard 8M/4M for other storage types
- Update Homebrew cask descriptions from \"Wendy Agent for macOS\" to \"Manage your headless device\"

## Test Plan

- [ ] Run `wendy device enroll` on a device with no WiFi — verify the WiFi setup prompt appears
- [ ] Confirm enrolling skips the WiFi prompt when already connected or on a non-interactive terminal
- [ ] Flash an NVMe-in-USB enclosure and verify the larger block size is used
- [ ] Flash a regular USB drive and verify standard block size is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)