### PR TITLE
[WDY-1082] Filter init template languages by availability

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -438,13 +438,28 @@ func pickTemplateOrSkipForTarget(target string, meta *repoMeta) (string, error) 
 }
 
 // resolveTemplateLanguage picks the language for the template flow.
-// Wendy Lite always uses Swift; WendyOS offers the full language picker.
-func resolveTemplateLanguage(target string, meta *repoMeta, opts initOptions) (string, error) {
+// Wendy Lite always uses Swift; WendyOS offers the languages available for the selected template.
+func resolveTemplateLanguage(target, tmpl string, meta *repoMeta, opts initOptions) (string, error) {
 	if target == targetWendyLite {
 		if opts.languageSet && normalizeInitChoice(opts.language) != langSwift {
 			return "", fmt.Errorf("%s templates require %s", targetWendyLite, langSwift)
 		}
+		languages, err := templateLanguagesForTemplate(context.Background(), meta, tmpl, opts.branch)
+		if err != nil {
+			return "", err
+		}
+		if !templateLanguageAvailable(langSwift, languages) {
+			return "", fmt.Errorf("template %q is not available for language %q (available: %s)", tmpl, langSwift, repoMetaLanguageKeys(languages))
+		}
 		return langSwift, nil
+	}
+
+	languages, err := templateLanguagesForTemplate(context.Background(), meta, tmpl, opts.branch)
+	if err != nil {
+		return "", err
+	}
+	if len(languages) == 0 {
+		return "", fmt.Errorf("template %q is not available for any registered language", tmpl)
 	}
 
 	if opts.languageSet {
@@ -456,18 +471,38 @@ func resolveTemplateLanguage(target string, meta *repoMeta, opts initOptions) (s
 			}
 			return "", fmt.Errorf("invalid language %q for templates (available: %s)", opts.language, strings.Join(names, ", "))
 		}
+		if !templateLanguageAvailable(lang, languages) {
+			return "", fmt.Errorf("template %q is not available for language %q (available: %s)", tmpl, opts.language, repoMetaLanguageKeys(languages))
+		}
 		return lang, nil
 	}
 
 	fmt.Println()
 	var items []tui.PickerItem
-	for _, l := range meta.Languages {
+	for _, l := range languages {
 		items = append(items, tui.PickerItem{
 			Name:  l.Name,
 			Value: l.Key,
 		})
 	}
 	return pickFromItems("What language will you use?", items)
+}
+
+func templateLanguageAvailable(language string, languages []repoMetaLanguage) bool {
+	for _, available := range languages {
+		if available.Key == language {
+			return true
+		}
+	}
+	return false
+}
+
+func repoMetaLanguageKeys(languages []repoMetaLanguage) string {
+	keys := make([]string, len(languages))
+	for i, language := range languages {
+		keys[i] = language.Key
+	}
+	return strings.Join(keys, ", ")
 }
 
 func metaTemplateNames(meta *repoMeta) string {
@@ -585,7 +620,7 @@ func downloadTemplateArchiveWithUI(language, tmpl, branch string) (map[string][]
 // runTemplateFlow handles init when a template is selected.
 // destDir is the resolved project directory (either cwd or a new subdir).
 func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, opts initOptions) error {
-	language, err := resolveTemplateLanguage(target, meta, opts)
+	language, err := resolveTemplateLanguage(target, tmpl, meta, opts)
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -135,6 +135,52 @@ func TestTemplateRunCommand(t *testing.T) {
 	}
 }
 
+func TestResolveTemplateLanguage_RejectsUnavailableTemplateLanguage(t *testing.T) {
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{
+			{Name: "realsense-camera", Languages: []string{langPython}},
+		},
+		Languages: []repoMetaLanguage{
+			{Key: langPython, Name: "Python"},
+			{Key: langSwift, Name: "Swift"},
+		},
+	}
+
+	_, err := resolveTemplateLanguage(targetWendyOS, "realsense-camera", meta, initOptions{
+		language:    langSwift,
+		languageSet: true,
+	})
+	if err == nil {
+		t.Fatal("expected unavailable template language to fail")
+	}
+	if got, want := err.Error(), `template "realsense-camera" is not available for language "swift" (available: python)`; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTemplateLanguage_AcceptsAvailableTemplateLanguage(t *testing.T) {
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{
+			{Name: "realsense-camera", Languages: []string{langPython}},
+		},
+		Languages: []repoMetaLanguage{
+			{Key: langPython, Name: "Python"},
+			{Key: langSwift, Name: "Swift"},
+		},
+	}
+
+	language, err := resolveTemplateLanguage(targetWendyOS, "realsense-camera", meta, initOptions{
+		language:    langPython,
+		languageSet: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveTemplateLanguage: %v", err)
+	}
+	if language != langPython {
+		t.Fatalf("language = %q, want %q", language, langPython)
+	}
+}
+
 func TestBuildInitEntitlementsFromFlags_RejectsEmptyEntitlementFlag(t *testing.T) {
 	_, err := buildInitEntitlementsFromFlags(targetWendyOS, initOptions{
 		entitlementsSet: true,

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -32,6 +32,8 @@ var (
 	templateArchiveAttemptTimeout = 2 * time.Minute
 	templateArchiveMaxAttempts    = 3
 	templateArchiveRetryDelay     = 750 * time.Millisecond
+	templateRawBaseURL            = "https://raw.githubusercontent.com"
+	templateLanguageProbeClient   = &http.Client{Timeout: 10 * time.Second}
 )
 
 // resolveTemplateBranch returns branch if non-empty, otherwise the default branch.
@@ -51,7 +53,8 @@ type repoMeta struct {
 type repoMetaTemplate struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
-	Targets     []string `json:"targets"` // optional; empty means all targets
+	Targets     []string `json:"targets"`   // optional; empty means all targets
+	Languages   []string `json:"languages"` // optional; empty means discover from repo layout
 }
 
 type repoMetaLanguage struct {
@@ -163,6 +166,99 @@ func isTemplateLanguage(language string, meta *repoMeta) bool {
 		}
 	}
 	return false
+}
+
+func templateByName(meta *repoMeta, templateName string) (*repoMetaTemplate, bool) {
+	if meta == nil {
+		return nil, false
+	}
+	for i := range meta.Templates {
+		if meta.Templates[i].Name == templateName {
+			return &meta.Templates[i], true
+		}
+	}
+	return nil, false
+}
+
+func templateLanguagesForTemplate(ctx context.Context, meta *repoMeta, templateName, branch string) ([]repoMetaLanguage, error) {
+	tmpl, ok := templateByName(meta, templateName)
+	if !ok {
+		return nil, fmt.Errorf("unknown template %q", templateName)
+	}
+
+	if len(tmpl.Languages) > 0 {
+		return repoMetaLanguagesForKeys(meta, tmpl.Languages), nil
+	}
+
+	return probeTemplateLanguages(ctx, meta.Languages, templateName, branch)
+}
+
+func repoMetaLanguagesForKeys(meta *repoMeta, keys []string) []repoMetaLanguage {
+	if meta == nil || len(keys) == 0 {
+		return nil
+	}
+
+	allowed := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		allowed[key] = struct{}{}
+	}
+
+	languages := make([]repoMetaLanguage, 0, len(keys))
+	for _, language := range meta.Languages {
+		if _, ok := allowed[language.Key]; ok {
+			languages = append(languages, language)
+		}
+	}
+	return languages
+}
+
+func probeTemplateLanguages(ctx context.Context, languages []repoMetaLanguage, templateName, branch string) ([]repoMetaLanguage, error) {
+	branch = resolveTemplateBranch(branch)
+
+	available := make([]repoMetaLanguage, 0, len(languages))
+	for _, language := range languages {
+		ok, err := probeTemplateLanguage(ctx, branch, language.Key, templateName)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			available = append(available, language)
+		}
+	}
+	return available, nil
+}
+
+func probeTemplateLanguage(ctx context.Context, branch, language, templateName string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, templateLanguageManifestURL(branch, language, templateName), nil)
+	if err != nil {
+		return false, fmt.Errorf("checking template language availability: %w", err)
+	}
+
+	resp, err := templateLanguageProbeClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("checking template language availability (branch %q): %w", branch, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("checking template language availability (branch %q): HTTP %d", branch, resp.StatusCode)
+	}
+}
+
+func templateLanguageManifestURL(branch, language, templateName string) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%s/%s/template.json",
+		strings.TrimRight(templateRawBaseURL, "/"),
+		templateRepoOwner,
+		templateRepoName,
+		resolveTemplateBranch(branch),
+		language,
+		templateName,
+	)
 }
 
 // progressCallback reports download progress. total is the expected content

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -152,6 +152,66 @@ func TestExtractTemplateArchive_IgnoresOtherLanguages(t *testing.T) {
 	}
 }
 
+func TestTemplateLanguagesForTemplate_ProbesRepoLayout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("method = %s, want HEAD", r.Method)
+		}
+		switch r.URL.Path {
+		case "/wendylabsinc/templates/main/python/realsense-camera/template.json":
+			w.WriteHeader(http.StatusOK)
+		case "/wendylabsinc/templates/main/swift/realsense-camera/template.json":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected probe path %q", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	origBaseURL := templateRawBaseURL
+	origClient := templateLanguageProbeClient
+	templateRawBaseURL = srv.URL
+	templateLanguageProbeClient = srv.Client()
+	t.Cleanup(func() {
+		templateRawBaseURL = origBaseURL
+		templateLanguageProbeClient = origClient
+	})
+
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{{Name: "realsense-camera"}},
+		Languages: []repoMetaLanguage{
+			{Key: langPython, Name: "Python"},
+			{Key: langSwift, Name: "Swift"},
+		},
+	}
+
+	languages, err := templateLanguagesForTemplate(context.Background(), meta, "realsense-camera", "")
+	if err != nil {
+		t.Fatalf("templateLanguagesForTemplate: %v", err)
+	}
+	if len(languages) != 1 || languages[0].Key != langPython {
+		t.Fatalf("languages = %+v, want only python", languages)
+	}
+}
+
+func TestTemplateLanguagesForTemplate_UsesMetadataLanguages(t *testing.T) {
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{{Name: "realsense-camera", Languages: []string{langPython}}},
+		Languages: []repoMetaLanguage{
+			{Key: langPython, Name: "Python"},
+			{Key: langSwift, Name: "Swift"},
+		},
+	}
+
+	languages, err := templateLanguagesForTemplate(context.Background(), meta, "realsense-camera", "")
+	if err != nil {
+		t.Fatalf("templateLanguagesForTemplate: %v", err)
+	}
+	if len(languages) != 1 || languages[0].Key != langPython {
+		t.Fatalf("languages = %+v, want only python", languages)
+	}
+}
+
 func TestDownloadTemplateArchiveFromURL_InvokesProgressCallback(t *testing.T) {
 	archive := buildTestTarball(t, "templates-main", "rust", "simple-api", map[string]string{
 		"template.json": `{"name":"simple-api"}`,

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -153,9 +153,19 @@ func TestExtractTemplateArchive_IgnoresOtherLanguages(t *testing.T) {
 }
 
 func TestTemplateLanguagesForTemplate_ProbesRepoLayout(t *testing.T) {
+	handlerErrs := make(chan string, 2)
+	recordHandlerErr := func(msg string) {
+		select {
+		case handlerErrs <- msg:
+		default:
+		}
+	}
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodHead {
-			t.Fatalf("method = %s, want HEAD", r.Method)
+			recordHandlerErr("method = " + r.Method + ", want HEAD")
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
 		}
 		switch r.URL.Path {
 		case "/wendylabsinc/templates/main/python/realsense-camera/template.json":
@@ -163,7 +173,8 @@ func TestTemplateLanguagesForTemplate_ProbesRepoLayout(t *testing.T) {
 		case "/wendylabsinc/templates/main/swift/realsense-camera/template.json":
 			w.WriteHeader(http.StatusNotFound)
 		default:
-			t.Fatalf("unexpected probe path %q", r.URL.Path)
+			recordHandlerErr("unexpected probe path " + strconv.Quote(r.URL.Path))
+			http.Error(w, "unexpected path", http.StatusInternalServerError)
 		}
 	}))
 	t.Cleanup(srv.Close)
@@ -188,6 +199,11 @@ func TestTemplateLanguagesForTemplate_ProbesRepoLayout(t *testing.T) {
 	languages, err := templateLanguagesForTemplate(context.Background(), meta, "realsense-camera", "")
 	if err != nil {
 		t.Fatalf("templateLanguagesForTemplate: %v", err)
+	}
+	select {
+	case msg := <-handlerErrs:
+		t.Fatal(msg)
+	default:
 	}
 	if len(languages) != 1 || languages[0].Key != langPython {
 		t.Fatalf("languages = %+v, want only python", languages)


### PR DESCRIPTION
## Summary
- Filter `wendy init --template` language choices to languages that actually contain the selected template.
- Probe current `wendylabsinc/templates` repo layout through lightweight `template.json` checks when `meta.json` does not declare per-template languages.
- Keep support for a future template-level `languages` field in `meta.json` and fail early for invalid `--template` / `--language` combinations.

## Linear
- [WDY-1082](https://linear.app/wendylabsinc/issue/WDY-1082/filter-init-template-languages-by-selected-template-availability)

## Validation
- `gofmt -w internal/cli/commands/init_cmd.go internal/cli/commands/init_cmd_test.go internal/cli/commands/template.go internal/cli/commands/template_test.go`
- `go test ./internal/cli/commands -run 'Test(ResolveTemplateLanguage|TemplateLanguagesForTemplate)'`
- `go test ./internal/cli/commands`
- `go test ./...`
- Smoke: `wendy init --target wendyos --app-id demo-realsense --template realsense-camera --language swift --assistant skip --git-init no` now fails early with `available: python`.