### PR TITLE
[codex] WDY-1084 clarify template init next steps

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -679,7 +679,14 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 		return err
 	}
 
-	cliSuccess("\nYour project is ready! Run `%s` to build and deploy.", templateRunCommand(cwd, destDir, appID))
+	cliSuccess("\nYour project is ready!")
+	cliLogln("Next steps:")
+	for _, step := range templateNextSteps(cwd, destDir, appID) {
+		cliLogln("  %s", step)
+	}
+	if filepath.Clean(destDir) != filepath.Clean(cwd) {
+		cliLogln("Note: run the cd command in your shell; a CLI process cannot change its parent shell directory.")
+	}
 
 	return nil
 }
@@ -689,11 +696,15 @@ func shellQuote(s string) string {
 }
 
 func templateRunCommand(cwd, destDir, appID string) string {
+	return strings.Join(templateNextSteps(cwd, destDir, appID), " && ")
+}
+
+func templateNextSteps(cwd, destDir, appID string) []string {
 	if filepath.Clean(destDir) == filepath.Clean(cwd) {
-		return "wendy run"
+		return []string{"wendy run"}
 	}
 
-	return "cd " + shellQuote(appID) + " && wendy run"
+	return []string{"cd " + shellQuote(appID), "wendy run"}
 }
 
 // resolveInitDestAndID determines the destination directory and app ID for template flow.

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -135,6 +135,47 @@ func TestTemplateRunCommand(t *testing.T) {
 	}
 }
 
+func TestTemplateNextSteps(t *testing.T) {
+	tests := []struct {
+		name    string
+		cwd     string
+		destDir string
+		appID   string
+		want    []string
+	}{
+		{
+			name:    "current directory",
+			cwd:     "/tmp/demo-app",
+			destDir: "/tmp/demo-app",
+			appID:   "demo-app",
+			want:    []string{"wendy run"},
+		},
+		{
+			name:    "new subdirectory",
+			cwd:     "/tmp/workspace",
+			destDir: "/tmp/workspace/demo-app",
+			appID:   "demo-app",
+			want:    []string{"cd 'demo-app'", "wendy run"},
+		},
+		{
+			name:    "new subdirectory with apostrophe",
+			cwd:     "/tmp/workspace",
+			destDir: "/tmp/workspace/demo'app",
+			appID:   "demo'app",
+			want:    []string{"cd 'demo'\"'\"'app'", "wendy run"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := templateNextSteps(tt.cwd, tt.destDir, tt.appID)
+			if strings.Join(got, "\n") != strings.Join(tt.want, "\n") {
+				t.Fatalf("templateNextSteps(%q, %q, %q) = %#v, want %#v", tt.cwd, tt.destDir, tt.appID, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveTemplateLanguage_RejectsUnavailableTemplateLanguage(t *testing.T) {
 	meta := &repoMeta{
 		Templates: []repoMetaTemplate{


### PR DESCRIPTION
## Summary
- replace the single `cd ... && wendy run` completion line with explicit next steps
- make it clear that `wendy init` cannot change the parent shell directory when it scaffolds a subdirectory
- add tests for the next-step command rendering

## Note
A CLI process cannot automatically `cd` the user's current shell into a generated directory. This PR implements the safe CLI-native alternative: precise next-step output.

## Validation
- `gofmt -w go/internal/cli/commands/init_cmd.go go/internal/cli/commands/init_cmd_test.go`
- `go test ./internal/cli/commands -count=1`
- `git diff --check`

Linear: https://linear.app/wendylabsinc/issue/WDY-1084/make-template-init-enter-the-created-project-directory