### PR TITLE
chore: opt in to wendy-project-template sync

### DIFF
--- a/.github/wendy-template.yml
+++ b/.github/wendy-template.yml
@@ -1,0 +1,4 @@
+type: swift
+overrides:
+  swift_versions:
+    - "6.3"


### PR DESCRIPTION
Adds `.github/wendy-template.yml` to opt this repo into the central template sync from [`wendylabsinc/wendy-project-template`](https://github.com/wendylabsinc/wendy-project-template).

Once merged, the sync workflow will open PRs here whenever standard workflows are updated in the template repo.

**Config:**
- Type: `swift`
- Swift versions: `6.3` (matches `.swift-version`)