### PR TITLE
fix(cli/mcp): default agent port when --device omits it

### DIFF
--- a/go/internal/cli/commands/mcp.go
+++ b/go/internal/cli/commands/mcp.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -37,6 +38,9 @@ func newMCPServeCmd() *cobra.Command {
 				address = cfg.DefaultDevice
 			}
 			if address != "" {
+				if _, _, err := net.SplitHostPort(address); err != nil {
+					address = hostPort(address, defaultAgentPort)
+				}
 				if err := srv.ConnectTo(ctx, address); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: could not connect to %s: %v\n", address, err)
 				}


### PR DESCRIPTION
## Summary
- `wendy mcp serve --device <name>` (no port) was falling through to gRPC's default of `:443`, since unlike `wendy run` it bypasses `resolveTarget`. Append `defaultAgentPort` when the address parses without a port.

## Repro before this fix
\`\`\`
$ wendy mcp serve --device ubuntu.local
Warning: listing containers for MCP tools: rpc error: ... dial tcp <host>:443: i/o timeout
\`\`\`

## Test plan
- [x] \`wendy mcp serve --device 127.0.0.1:50051\` still works (port already present)
- [x] \`wendy mcp serve --device 127.0.0.1\` now connects on 50051 (port appended)
- [x] Verified end-to-end with the go2-mcp demo container — go2 tools register through the StreamMCP proxy.

## Note
Hit two other rough edges while testing #590, surfacing here for a follow-up:
1. The proxy's \`NewStreamableHttpClient\` POSTs to root path. FastMCP defaults to \`/mcp\`, and legacy SSE servers serve \`/sse\` — both fail with \`server returned 4xx for initialize POST, likely a legacy SSE server\`. Either auto-fall-back, or document the path/transport contract.
2. Long-term, \`mcp serve --device\` could go through \`resolveTarget\` for the full LAN/cloud-tunnel fallback that other commands get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)