### PR TITLE
security: sanitize I2C device path and persist mount destination

### DIFF
--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -375,6 +375,18 @@ func applyPersist(spec *Spec, ent appconfig.Entitlement, appID string) {
 	if name == "." || name == ".." || name == "/" || name == "" {
 		return
 	}
+	// Validate the container destination: must be absolute with no dot-dot
+	// components. Check the original before cleaning so "a/../b" is rejected
+	// even though Clean would resolve it to a valid absolute path.
+	if !filepath.IsAbs(ent.Path) {
+		return
+	}
+	for _, component := range strings.Split(ent.Path, "/") {
+		if component == ".." {
+			return
+		}
+	}
+	dest := filepath.Clean(ent.Path)
 	hostPath := filepath.Join("/var/lib/wendy/volumes", name)
 	if err := os.MkdirAll(hostPath, 0o755); err != nil {
 		// Best-effort: the container will fail to start with a clear mount error
@@ -382,7 +394,7 @@ func applyPersist(spec *Spec, ent appconfig.Entitlement, appID string) {
 		_ = err
 	}
 	spec.Mounts = append(spec.Mounts, Mount{
-		Destination: ent.Path,
+		Destination: dest,
 		Source:      hostPath,
 		Type:        "bind",
 		Options:     []string{"rbind", "nosuid", "noexec"},
@@ -437,7 +449,20 @@ func applyUSB(spec *Spec) {
 
 // applyI2C adds I2C device access for a specific bus.
 func applyI2C(spec *Spec, ent appconfig.Entitlement) {
-	devPath := fmt.Sprintf("/dev/%s", ent.Device)
+	// Validate device name is i2c-N before constructing a path from it.
+	if !strings.HasPrefix(ent.Device, "i2c-") {
+		return
+	}
+	suffix := ent.Device[len("i2c-"):]
+	if suffix == "" {
+		return
+	}
+	for _, c := range suffix {
+		if c < '0' || c > '9' {
+			return
+		}
+	}
+	devPath := filepath.Clean(fmt.Sprintf("/dev/%s", ent.Device))
 	spec.Mounts = append(spec.Mounts, Mount{
 		Destination: devPath,
 		Source:      devPath,

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -704,3 +704,110 @@ func TestApplyEntitlements_Empty(t *testing.T) {
 			originalNSCount, len(spec.Linux.Namespaces))
 	}
 }
+
+// TestApplyI2C_PathTraversal verifies that a crafted device name cannot escape /dev/i2c-
+// (WDY-1015).
+func TestApplyI2C_PathTraversal(t *testing.T) {
+	traversalCases := []string{
+		"../sda",
+		"../mem",
+		"../../etc/passwd",
+		"i2c-1/../sda",
+		"sda",
+		"i2c-",
+		"i2c-1a",
+	}
+	for _, device := range traversalCases {
+		t.Run(device, func(t *testing.T) {
+			spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+			cfg := &appconfig.AppConfig{
+				AppID: "test-app",
+				Entitlements: []appconfig.Entitlement{
+					{Type: appconfig.EntitlementI2C, Device: device},
+				},
+			}
+			if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+				t.Fatalf("ApplyEntitlements() error = %v", err)
+			}
+			for _, m := range spec.Mounts {
+				if !slices.Contains([]string{"/dev/snd", "/dev/input", "/dev/bus/usb"}, m.Destination) &&
+					len(m.Destination) >= 9 && m.Destination[:9] != "/dev/i2c-" {
+					if m.Destination == "/dev/sda" || m.Destination == "/dev/mem" ||
+						m.Destination == "/etc/passwd" {
+						t.Errorf("path traversal via device=%q mounted %q", device, m.Destination)
+					}
+				}
+				if m.Destination == "/dev/"+device {
+					t.Errorf("unsanitized device=%q was mounted as %q", device, m.Destination)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyI2C_ValidDevice verifies that a legitimate i2c-N device is still mounted.
+func TestApplyI2C_ValidDevice(t *testing.T) {
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "test-app",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementI2C, Device: "i2c-1"},
+		},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+	if !hasMountDest(spec, "/dev/i2c-1") {
+		t.Error("valid i2c-1 device was not mounted")
+	}
+}
+
+// TestApplyPersist_PathTraversalDestination verifies that a crafted mount destination
+// cannot escape the container path validation (WDY-1016).
+func TestApplyPersist_PathTraversalDestination(t *testing.T) {
+	traversalCases := []string{
+		"relative/path",
+		"../escape",
+		"data",
+	}
+	for _, path := range traversalCases {
+		t.Run(path, func(t *testing.T) {
+			spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+			cfg := &appconfig.AppConfig{
+				AppID: "test-app",
+				Entitlements: []appconfig.Entitlement{
+					{Type: appconfig.EntitlementPersist, Name: "vol", Path: path},
+				},
+			}
+			if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+				t.Fatalf("ApplyEntitlements() error = %v", err)
+			}
+			if hasMountDest(spec, path) {
+				t.Errorf("relative/traversal path=%q was added as a mount destination", path)
+			}
+		})
+	}
+}
+
+// TestApplyPersist_DotDotInDestination verifies that dot-dot components in the
+// mount destination are rejected (WDY-1016).
+func TestApplyPersist_DotDotInDestination(t *testing.T) {
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "test-app",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementPersist, Name: "vol", Path: "/data/../etc"},
+		},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+	// filepath.Clean resolves /data/../etc → /etc, so the cleaned path must not
+	// be added as a mount destination when the original contained dot-dot.
+	if hasMountDest(spec, "/etc") {
+		t.Error("dot-dot in persist destination was silently resolved to /etc and mounted")
+	}
+	if hasMountDest(spec, "/data/../etc") {
+		t.Error("raw dot-dot persist destination was mounted unchanged")
+	}
+}

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -215,9 +216,18 @@ func (c *AppConfig) Validate() error {
 			if e.Path == "" {
 				return fmt.Errorf("entitlement[%d]: persist entitlement requires a path", i)
 			}
+			if !filepath.IsAbs(e.Path) {
+				return fmt.Errorf("entitlement[%d]: persist path must be absolute, got %q", i, e.Path)
+			}
+			if containsDotDot(e.Path) {
+				return fmt.Errorf("entitlement[%d]: persist path must not contain '..' components", i)
+			}
 		case EntitlementI2C:
 			if e.Device == "" {
 				return fmt.Errorf("entitlement[%d]: i2c entitlement requires a device", i)
+			}
+			if !isValidI2CDevice(e.Device) {
+				return fmt.Errorf("entitlement[%d]: i2c device must be in i2c-N format, got %q", i, e.Device)
 			}
 		case EntitlementGPIO:
 			// Pins are optional; omitting them grants access to all GPIO chips.
@@ -281,6 +291,23 @@ func containsDotDot(p string) bool {
 		}
 	}
 	return false
+}
+
+// isValidI2CDevice reports whether device is a safe I2C device name (i2c-N).
+func isValidI2CDevice(device string) bool {
+	if !strings.HasPrefix(device, "i2c-") {
+		return false
+	}
+	suffix := device[len("i2c-"):]
+	if suffix == "" {
+		return false
+	}
+	for _, c := range suffix {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // ValidateJSON checks raw JSON data for unknown keys in entitlements and returns warnings.


### PR DESCRIPTION
## Summary

- **WDY-1015**: `applyI2C` now validates `ent.Device` matches `i2c-N` (digits only after the hyphen) before constructing the `/dev/` path, blocking traversal to arbitrary host devices like `/dev/sda` or `/dev/mem`
- **WDY-1016**: `applyPersist` now validates `ent.Path` is absolute and contains no `..` components *before* calling `filepath.Clean`, preventing silent resolution of `/data/../etc` to `/etc` as the container mount destination
- Both validations are enforced at `Validate()` parse time (primary gate) and defensively in the apply functions (belt-and-suspenders)

## Test Plan

- [ ] `go test ./internal/agent/oci/... ./internal/shared/appconfig/...` passes
- [ ] `TestApplyI2C_PathTraversal` confirms traversal devices (`../sda`, `i2c-1a`, etc.) produce no mounts
- [ ] `TestApplyI2C_ValidDevice` confirms `i2c-1` still mounts correctly
- [ ] `TestApplyPersist_PathTraversalDestination` confirms relative paths are rejected
- [ ] `TestApplyPersist_DotDotInDestination` confirms `/data/../etc` is not mounted as `/etc`

Fixes https://linear.app/wendylabsinc/issue/WDY-1015
Fixes https://linear.app/wendylabsinc/issue/WDY-1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)