### PR TITLE
fix: bind OTEL receivers to 127.0.0.1 only (WDY-1097, WDY-1100)

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -409,7 +409,7 @@ func main() {
 	otelpb.RegisterMetricsServiceServer(otelServer, otelMetricReceiver)
 	otelpb.RegisterTraceServiceServer(otelServer, otelTraceReceiver)
 
-	otelLis, err := net.Listen("tcp", "[::]:"+otelPort)
+	otelLis, err := net.Listen("tcp", "127.0.0.1:"+otelPort)
 	if err != nil {
 		logger.Fatal("Failed to listen on OTEL port", zap.String("port", otelPort), zap.Error(err))
 	}
@@ -430,7 +430,7 @@ func main() {
 	}
 
 	otelHTTPReceiver := services.NewOTELHTTPReceiver(logger, broadcaster)
-	otelHTTPLis, err := net.Listen("tcp", "[::]:"+otelHTTPPort)
+	otelHTTPLis, err := net.Listen("tcp", "127.0.0.1:"+otelHTTPPort)
 	if err != nil {
 		logger.Fatal("Failed to listen on OTEL HTTP port", zap.String("port", otelHTTPPort), zap.Error(err))
 	}

--- a/go/integration_test.go
+++ b/go/integration_test.go
@@ -1095,3 +1095,46 @@ func TestRunContainer(t *testing.T) {
 		}
 	})
 }
+
+// TestOTELLocalhostBindProperty verifies that a 127.0.0.1-bound TCP listener
+// is not reachable from a non-loopback interface, confirming the security
+// property of the fix for WDY-1097/WDY-1100.
+func TestOTELLocalhostBindProperty(t *testing.T) {
+	// Find a non-loopback IPv4 address on this machine. If none exists (e.g.
+	// a stripped-down CI container with only lo), skip rather than fail.
+	var externalIP string
+	ifaces, _ := net.InterfaceAddrs()
+	for _, a := range ifaces {
+		ipNet, ok := a.(*net.IPNet)
+		if !ok || ipNet.IP.IsLoopback() || ipNet.IP.To4() == nil {
+			continue
+		}
+		externalIP = ipNet.IP.String()
+		break
+	}
+	if externalIP == "" {
+		t.Skip("no non-loopback IPv4 interface — cannot verify localhost-only property")
+	}
+
+	// Bind to 127.0.0.1 only, as the OTEL receivers do after the fix.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer lis.Close()
+	port := lis.Addr().(*net.TCPAddr).Port
+
+	// Localhost must be able to connect.
+	c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), time.Second)
+	if err != nil {
+		t.Fatalf("localhost connection refused: %v", err)
+	}
+	c.Close()
+
+	// External interface must NOT be able to connect to the same port.
+	c2, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", externalIP, port), 500*time.Millisecond)
+	if err == nil {
+		c2.Close()
+		t.Errorf("connection via external IP %s:%d succeeded — listener should be localhost-only", externalIP, port)
+	}
+}

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -25,6 +25,7 @@ Tests:
   python-no-bluetooth   Verify bluetooth is blocked WITHOUT entitlement
   compose-hello         docker-compose multi-service deployment with build: Dockerfiles
   compose-images        docker-compose multi-service deployment using public images
+  otel-localhost-only   Verify OTEL receivers (4317/4318) are not reachable from the network
 
 Device Selection:
   If --hostname is not provided, the script auto-discovers a device on the
@@ -186,6 +187,7 @@ ALL_TESTS=(
     python-no-bluetooth
     compose-hello
     compose-images
+    otel-localhost-only
 )
 
 # If specific tests were requested via -t, filter the list.
@@ -221,6 +223,15 @@ for test_name in "${TESTS[@]}"; do
     # Skip GPU tests on devices that don't have a GPU.
     if [[ "$test_name" == *"-gpu"* ]] && [[ "$DEVICE_HAS_GPU" != "true" ]]; then
         skip_test "$test_name" "no GPU"
+        continue
+    fi
+
+    # ── Security: OTEL ports must not be reachable from the network ──────
+    if [[ "$test_name" == "otel-localhost-only" ]]; then
+        otel_grpc_closed() { ! nc -z -w 3 "$HOSTNAME" 4317 2>/dev/null; }
+        otel_http_closed() { ! nc -z -w 3 "$HOSTNAME" 4318 2>/dev/null; }
+        run_test "otel-localhost-only (gRPC 4317 not reachable)" otel_grpc_closed
+        run_test "otel-localhost-only (HTTP 4318 not reachable)" otel_http_closed
         continue
     fi
 


### PR DESCRIPTION
## Summary
- Bind both OTEL receivers (gRPC 4317, HTTP 4318) to `127.0.0.1` instead of `[::]`, so only local processes on the device can submit telemetry
- Fixes WDY-1097 (unauthenticated data injection from any network source) and WDY-1100 (resource exhaustion via unauthenticated endpoints) — same root cause, same fix

## Test Plan
- [ ] `go test .` — `TestOTELLocalhostBindProperty` verifies a `127.0.0.1`-bound listener is not reachable via a non-loopback IP
- [ ] `scripts/test-ci.sh -t otel-localhost-only -h <device>` — hardware CI test that uses `nc` to assert ports 4317/4318 are not reachable from the developer machine

Closes [WDY-1097](https://linear.app/wendylabsinc/issue/WDY-1097) · Closes [WDY-1100](https://linear.app/wendylabsinc/issue/WDY-1100)