### PR TITLE
security: stream cloud discover output and cap asset results

### DIFF
--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -45,7 +45,8 @@ func newCloudDiscoverCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("listing devices: %w", err)
 			}
-			var assets []*cloudpb.Asset
+			var count int
+			var headerPrinted bool
 			for {
 				resp, err := stream.Recv()
 				if err == io.EOF {
@@ -54,22 +55,24 @@ func newCloudDiscoverCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("listing devices: %w", err)
 				}
-				assets = append(assets, resp.GetAsset())
+				if count >= maxCloudAssets {
+					return fmt.Errorf("cloud returned more than %d devices", maxCloudAssets)
+				}
+				if !headerPrinted {
+					fmt.Fprintf(cmd.OutOrStdout(), "%-8s  %s\n", "ID", "Name")
+					fmt.Fprintf(cmd.OutOrStdout(), "%-8s  %s\n", "--------", "----")
+					headerPrinted = true
+				}
+				a := resp.GetAsset()
+				fmt.Fprintf(cmd.OutOrStdout(), "%-8d  %s\n", a.GetId(), a.GetName())
+				count++
 			}
-
-			if len(assets) == 0 {
+			if !headerPrinted {
 				if all {
 					fmt.Fprintln(cmd.OutOrStdout(), "No enrolled devices found.")
 				} else {
 					fmt.Fprintln(cmd.OutOrStdout(), "No online devices found. Use --all to include offline devices.")
 				}
-				return nil
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "%-8s  %s\n", "ID", "Name")
-			fmt.Fprintf(cmd.OutOrStdout(), "%-8s  %s\n", "--------", "----")
-			for _, a := range assets {
-				fmt.Fprintf(cmd.OutOrStdout(), "%-8d  %s\n", a.GetId(), a.GetName())
 			}
 			return nil
 		},

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -22,7 +22,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-const defaultBrokerPort = "50052"
+const (
+	defaultBrokerPort = "50052"
+	maxCloudAssets    = 10_000
+)
 
 type closeFunc func()
 
@@ -256,6 +259,9 @@ func fetchCloudAssets(ctx context.Context, auth *config.AuthConfig) ([]*cloudpb.
 		}
 		if err != nil {
 			return nil, fmt.Errorf("listing devices: %w", err)
+		}
+		if len(assets) >= maxCloudAssets {
+			return nil, fmt.Errorf("cloud returned more than %d devices", maxCloudAssets)
 		}
 		assets = append(assets, resp.GetAsset())
 	}

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -501,6 +501,7 @@ func mcpListCloudAssets(ctx context.Context, auth *config.AuthConfig, filter str
 	if err != nil {
 		return nil, fmt.Errorf("listing devices: %w", err)
 	}
+	const maxAssets = 10_000
 	var assets []*cloudpb.Asset
 	for {
 		resp, err := stream.Recv()
@@ -509,6 +510,9 @@ func mcpListCloudAssets(ctx context.Context, auth *config.AuthConfig, filter str
 		}
 		if err != nil {
 			return nil, fmt.Errorf("listing devices: %w", err)
+		}
+		if len(assets) >= maxAssets {
+			return nil, fmt.Errorf("cloud returned more than %d devices", maxAssets)
 		}
 		assets = append(assets, resp.GetAsset())
 	}


### PR DESCRIPTION
## Summary

- Stream `cloud discover` output as assets arrive instead of buffering the full response
- Cap asset results at 10 000 across `cloud_discover`, `cloud_tunnel`, and MCP to prevent unbounded memory growth from a misbehaving backend

## Test plan

- [ ] `wendy cloud discover` prints rows immediately as they stream in
- [ ] `wendy cloud discover` with a backend returning >10 000 items returns an error
- [ ] `wendy cloud tunnel` device picker still works normally
- [ ] MCP `list_cloud_assets` still returns assets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)