### PR TITLE
buildx: remove fixed 3s proxy stabilization sleep (WDY-1018)

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -689,9 +689,6 @@ func updateBuilderConfig(ctx context.Context, builderName, config string) error 
 	if out, err := bootstrapAfterRestart.CombinedOutput(); err != nil {
 		return fmt.Errorf("waiting for builder after restart: %s: %w", string(out), err)
 	}
-	fmt.Fprintf(os.Stderr, "[buildx] buildkitd ready, sleeping 3s to stabilize proxy\n")
-
-	time.Sleep(3 * time.Second)
 	fmt.Fprintf(os.Stderr, "[buildx] builder ready\n")
 
 	return nil


### PR DESCRIPTION
## Summary

- Removes the unconditional `time.Sleep(3 * time.Second)` that ran after `docker buildx inspect --bootstrap` in `updateBuilderConfig`.
- `--bootstrap` already blocks until buildkitd is fully up and has loaded its `buildkitd.toml` config (registry/proxy settings included), so the extra sleep served no purpose.
- Every build that went through the config-injection + container-restart path was paying a 3-second delay with no benefit.

## Test plan

- [ ] Existing unit tests in `internal/cli/commands/` still pass (`go test ./internal/cli/commands/`)
- [ ] Manual `wendy run` on a device exercises the config-injection path and completes successfully without the delay

Fixes [WDY-1018](https://linear.app/wendylabsinc/issue/WDY-1018/remove-fixed-3s-buildx-proxy-stabilization-sleep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)