### PR TITLE
fix: preserve symlink path in mcp setup to survive upgrades

### DIFF
--- a/go/internal/cli/commands/mcp_setup.go
+++ b/go/internal/cli/commands/mcp_setup.go
@@ -124,9 +124,6 @@ func claudeDesktopConfigPath() string {
 // binary, falling back to PATH lookup.
 func wendyBinaryPath() string {
 	if p, err := os.Executable(); err == nil {
-		if resolved, err := filepath.EvalSymlinks(p); err == nil {
-			return resolved
-		}
 		return p
 	}
 	if p, err := exec.LookPath("wendy"); err == nil {


### PR DESCRIPTION
## Summary

- `wendyBinaryPath()` was calling `filepath.EvalSymlinks`, which resolved the Homebrew symlink to the versioned Cellar path (e.g. `/opt/homebrew/Cellar/wendy/2026.05.03-215349/bin/wendy`)
- After `brew upgrade wendy`, this path points to the old binary and breaks the MCP integration
- Fix: drop `EvalSymlinks` so `os.Executable()` returns the stable symlink path (`/opt/homebrew/bin/wendy`) that always points to the current version

## Test plan

- [ ] Run `wendy mcp setup` on a Homebrew install and verify the config contains the symlink path, not the Cellar path
- [ ] Upgrade wendy and verify the MCP integration still works without re-running `mcp setup`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)