### PR TITLE
feat: shell tab completion for wendy CLI (WDY-694)

### DIFF
--- a/go/internal/cli/commands/completion.go
+++ b/go/internal/cli/commands/completion.go
@@ -278,7 +278,9 @@ func performInstall(root *cobra.Command, stderr io.Writer, shell string, plan in
 		return fmt.Errorf("creating %s: %w", plan.scriptPath, err)
 	}
 	if err := writeShellScript(root, shell, f); err != nil {
-		f.Close()
+		if cerr := f.Close(); cerr != nil {
+			return errors.Join(err, cerr)
+		}
 		return err
 	}
 	if err := f.Close(); err != nil {

--- a/go/internal/cli/commands/completion.go
+++ b/go/internal/cli/commands/completion.go
@@ -1,0 +1,344 @@
+// Package commands - shell completion script generation and installation.
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// completionRcSentinel marks Wendy-managed lines in a user's shell rc file so
+// repeat installs are idempotent.
+const completionRcSentinel = "# wendy-completion"
+
+type installPlan struct {
+	scriptPath string
+	rcPath     string
+	rcBlock    string
+	notes      []string
+}
+
+func newCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Generate or install shell completion scripts",
+		Long: "Generate shell completion scripts, or install them automatically for the current user " +
+			"with `wendy completion install`.\n\n" +
+			"Supported shells: bash, zsh, fish, powershell.",
+		Args: cobra.NoArgs,
+	}
+
+	cmd.AddCommand(
+		shellGenCmd("bash", "Print bash completion script", func(root *cobra.Command, w io.Writer) error {
+			return root.GenBashCompletionV2(w, true)
+		}),
+		shellGenCmd("zsh", "Print zsh completion script", func(root *cobra.Command, w io.Writer) error {
+			return root.GenZshCompletion(w)
+		}),
+		shellGenCmd("fish", "Print fish completion script", func(root *cobra.Command, w io.Writer) error {
+			return root.GenFishCompletion(w, true)
+		}),
+		shellGenCmd("powershell", "Print PowerShell completion script", func(root *cobra.Command, w io.Writer) error {
+			return root.GenPowerShellCompletionWithDesc(w)
+		}),
+		newCompletionInstallCmd(),
+	)
+
+	return cmd
+}
+
+func shellGenCmd(name, short string, fn func(*cobra.Command, io.Writer) error) *cobra.Command {
+	return &cobra.Command{
+		Use:   name,
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			return fn(c.Root(), c.OutOrStdout())
+		},
+	}
+}
+
+func newCompletionInstallCmd() *cobra.Command {
+	var (
+		shellOverride string
+		outputDir     string
+		printPath     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install shell completions into the user's standard config locations",
+		Long: "Detect the current shell and write its completion script to the conventional " +
+			"location, appending an idempotent sourcing line to your shell rc file when needed.\n\n" +
+			"Use --shell to override detection, --print-path for a dry run, or --output-dir to " +
+			"redirect writes (used by tests).",
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			shell, err := detectShell(shellOverride, runtime.GOOS, os.Getenv)
+			if err != nil {
+				return err
+			}
+			home, err := resolveHome(outputDir)
+			if err != nil {
+				return err
+			}
+			plan, err := computeInstallPlan(shell, runtime.GOOS, home, os.Getenv, fileExists)
+			if err != nil {
+				return err
+			}
+
+			if printPath {
+				fmt.Fprintln(c.OutOrStdout(), plan.scriptPath)
+				if plan.rcPath != "" {
+					fmt.Fprintln(c.OutOrStdout(), plan.rcPath)
+				}
+				return nil
+			}
+
+			return performInstall(c.Root(), c.ErrOrStderr(), shell, plan)
+		},
+	}
+
+	cmd.Flags().StringVar(&shellOverride, "shell", "", "Override shell (bash|zsh|fish|powershell)")
+	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Use this directory as $HOME (for testing)")
+	cmd.Flags().BoolVar(&printPath, "print-path", false, "Print install paths without writing")
+	return cmd
+}
+
+func detectShell(override, goos string, env func(string) string) (string, error) {
+	if override != "" {
+		return normalizeShell(override)
+	}
+	if goos == "windows" {
+		return "powershell", nil
+	}
+	s := env("SHELL")
+	if s == "" {
+		return "", errors.New("could not detect shell from $SHELL; pass --shell <bash|zsh|fish|powershell>")
+	}
+	return normalizeShell(filepath.Base(s))
+}
+
+func normalizeShell(name string) (string, error) {
+	switch name {
+	case "bash", "zsh", "fish", "powershell":
+		return name, nil
+	case "pwsh":
+		return "powershell", nil
+	default:
+		return "", fmt.Errorf("unsupported shell %q (supported: bash, zsh, fish, powershell)", name)
+	}
+}
+
+func resolveHome(override string) (string, error) {
+	if override != "" {
+		return filepath.Abs(override)
+	}
+	return os.UserHomeDir()
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func computeInstallPlan(shell, goos, home string, env func(string) string, exists func(string) bool) (installPlan, error) {
+	switch shell {
+	case "bash":
+		return bashPlan(goos, home, env, exists), nil
+	case "zsh":
+		return zshPlan(home, env), nil
+	case "fish":
+		return fishPlan(home, env), nil
+	case "powershell":
+		return powershellPlan(goos, home), nil
+	default:
+		return installPlan{}, fmt.Errorf("unsupported shell %q", shell)
+	}
+}
+
+func bashPlan(goos, home string, env func(string) string, exists func(string) bool) installPlan {
+	xdg := env("XDG_DATA_HOME")
+	if xdg == "" {
+		xdg = filepath.Join(home, ".local", "share")
+	}
+	standard := filepath.Join(xdg, "bash-completion", "completions", "wendy")
+
+	bcPresent := exists(filepath.Join(xdg, "bash-completion")) ||
+		exists("/etc/bash_completion") ||
+		exists("/usr/local/etc/bash_completion") ||
+		exists("/opt/homebrew/etc/bash_completion")
+
+	if bcPresent {
+		return installPlan{
+			scriptPath: standard,
+			notes:      []string{"bash-completion v2 detected; the script will be auto-loaded on next shell start."},
+		}
+	}
+
+	scriptPath := filepath.Join(home, ".wendy", "completions", "wendy.bash")
+	rcPath := filepath.Join(home, ".bashrc")
+	rcBlock := fmt.Sprintf("%s\n[ -f %q ] && source %q", completionRcSentinel, scriptPath, scriptPath)
+	notes := []string{
+		"bash-completion package not detected; using stand-alone install.",
+		"Restart your shell (or `source ~/.bashrc`) for completions to take effect.",
+	}
+	if goos == "darwin" {
+		notes = append(notes, "On macOS login shells, ensure ~/.bash_profile sources ~/.bashrc.")
+	}
+	return installPlan{
+		scriptPath: scriptPath,
+		rcPath:     rcPath,
+		rcBlock:    rcBlock,
+		notes:      notes,
+	}
+}
+
+func zshPlan(home string, env func(string) string) installPlan {
+	scriptDir := filepath.Join(home, ".zfunc")
+	scriptPath := filepath.Join(scriptDir, "_wendy")
+
+	rcDir := home
+	if zd := env("ZDOTDIR"); zd != "" {
+		rcDir = zd
+	}
+	rcPath := filepath.Join(rcDir, ".zshrc")
+	rcBlock := fmt.Sprintf("%s\nfpath=(%q $fpath)\nautoload -U compinit && compinit", completionRcSentinel, scriptDir)
+
+	return installPlan{
+		scriptPath: scriptPath,
+		rcPath:     rcPath,
+		rcBlock:    rcBlock,
+		notes:      []string{"Restart your shell (or `source ~/.zshrc`) for completions to take effect."},
+	}
+}
+
+func fishPlan(home string, env func(string) string) installPlan {
+	cfg := env("XDG_CONFIG_HOME")
+	if cfg == "" {
+		cfg = filepath.Join(home, ".config")
+	}
+	return installPlan{
+		scriptPath: filepath.Join(cfg, "fish", "completions", "wendy.fish"),
+		notes:      []string{"Fish auto-loads completions on next shell start."},
+	}
+}
+
+func powershellPlan(goos, home string) installPlan {
+	var profileDir string
+	switch goos {
+	case "windows":
+		profileDir = filepath.Join(home, "Documents", "PowerShell")
+	default:
+		profileDir = filepath.Join(home, ".config", "powershell")
+	}
+	scriptPath := filepath.Join(profileDir, "Completions", "wendy.ps1")
+	rcPath := filepath.Join(profileDir, "Microsoft.PowerShell_profile.ps1")
+	rcBlock := fmt.Sprintf("%s\n. %q", completionRcSentinel, scriptPath)
+	notes := []string{"Restart PowerShell for completions to take effect."}
+	if goos == "windows" {
+		notes = append(notes, "Windows PowerShell 5.1 users: dot-source the script from your WindowsPowerShell profile manually.")
+	}
+	return installPlan{
+		scriptPath: scriptPath,
+		rcPath:     rcPath,
+		rcBlock:    rcBlock,
+		notes:      notes,
+	}
+}
+
+func performInstall(root *cobra.Command, stderr io.Writer, shell string, plan installPlan) error {
+	if err := os.MkdirAll(filepath.Dir(plan.scriptPath), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(plan.scriptPath), err)
+	}
+	f, err := os.Create(plan.scriptPath)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", plan.scriptPath, err)
+	}
+	if err := writeShellScript(root, shell, f); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	fmt.Fprintf(stderr, "Wrote %s\n", plan.scriptPath)
+
+	if plan.rcPath != "" {
+		added, err := ensureBlockInFile(plan.rcPath, completionRcSentinel, plan.rcBlock)
+		if err != nil {
+			return fmt.Errorf("editing %s: %w", plan.rcPath, err)
+		}
+		if added {
+			fmt.Fprintf(stderr, "Updated %s\n", plan.rcPath)
+		} else {
+			fmt.Fprintf(stderr, "Already configured in %s\n", plan.rcPath)
+		}
+	}
+
+	for _, note := range plan.notes {
+		fmt.Fprintln(stderr, note)
+	}
+	return nil
+}
+
+func writeShellScript(root *cobra.Command, shell string, w io.Writer) error {
+	switch shell {
+	case "bash":
+		return root.GenBashCompletionV2(w, true)
+	case "zsh":
+		return root.GenZshCompletion(w)
+	case "fish":
+		return root.GenFishCompletion(w, true)
+	case "powershell":
+		return root.GenPowerShellCompletionWithDesc(w)
+	default:
+		return fmt.Errorf("unsupported shell %q", shell)
+	}
+}
+
+// ensureBlockInFile appends block to path unless sentinel is already present.
+// Returns true when the file was modified.
+func ensureBlockInFile(path, sentinel, block string) (bool, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, err
+	}
+
+	existing, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		existing = nil
+	case err != nil:
+		return false, err
+	}
+
+	if bytes.Contains(existing, []byte(sentinel)) {
+		return false, nil
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	var buf strings.Builder
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(block)
+	if !strings.HasSuffix(block, "\n") {
+		buf.WriteByte('\n')
+	}
+	if _, err := f.WriteString(buf.String()); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/go/internal/cli/commands/completion.go
+++ b/go/internal/cli/commands/completion.go
@@ -77,8 +77,7 @@ func newCompletionInstallCmd() *cobra.Command {
 		Short: "Install shell completions into the user's standard config locations",
 		Long: "Detect the current shell and write its completion script to the conventional " +
 			"location, appending an idempotent sourcing line to your shell rc file when needed.\n\n" +
-			"Use --shell to override detection, --print-path for a dry run, or --output-dir to " +
-			"redirect writes (used by tests).",
+			"Use --shell to override shell detection, or --print-path for a dry run.",
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			shell, err := detectShell(shellOverride, runtime.GOOS, os.Getenv)
@@ -109,7 +108,22 @@ func newCompletionInstallCmd() *cobra.Command {
 	cmd.Flags().StringVar(&shellOverride, "shell", "", "Override shell (bash|zsh|fish|powershell)")
 	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Use this directory as $HOME (for testing)")
 	cmd.Flags().BoolVar(&printPath, "print-path", false, "Print install paths without writing")
+	// --output-dir is a test seam, not a user-facing knob; hide from --help.
+	_ = cmd.Flags().MarkHidden("output-dir")
 	return cmd
+}
+
+// posixSingleQuote returns s wrapped in POSIX single quotes, suitable for
+// embedding in bash/zsh rc files. Inside single quotes only the quote
+// character itself is special; close-quote-literal-quote-open-quote escapes it.
+func posixSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// powershellSingleQuote returns s wrapped in PowerShell single quotes, where
+// single quotes are literal and embedded quotes are escaped by doubling.
+func powershellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 func detectShell(override, goos string, env func(string) string) (string, error) {
@@ -185,7 +199,8 @@ func bashPlan(goos, home string, env func(string) string, exists func(string) bo
 
 	scriptPath := filepath.Join(home, ".wendy", "completions", "wendy.bash")
 	rcPath := filepath.Join(home, ".bashrc")
-	rcBlock := fmt.Sprintf("%s\n[ -f %q ] && source %q", completionRcSentinel, scriptPath, scriptPath)
+	quoted := posixSingleQuote(scriptPath)
+	rcBlock := fmt.Sprintf("%s\n[ -f %s ] && source %s", completionRcSentinel, quoted, quoted)
 	notes := []string{
 		"bash-completion package not detected; using stand-alone install.",
 		"Restart your shell (or `source ~/.bashrc`) for completions to take effect.",
@@ -210,7 +225,7 @@ func zshPlan(home string, env func(string) string) installPlan {
 		rcDir = zd
 	}
 	rcPath := filepath.Join(rcDir, ".zshrc")
-	rcBlock := fmt.Sprintf("%s\nfpath=(%q $fpath)\nautoload -U compinit && compinit", completionRcSentinel, scriptDir)
+	rcBlock := fmt.Sprintf("%s\nfpath=(%s $fpath)\nautoload -U compinit && compinit", completionRcSentinel, posixSingleQuote(scriptDir))
 
 	return installPlan{
 		scriptPath: scriptPath,
@@ -241,7 +256,7 @@ func powershellPlan(goos, home string) installPlan {
 	}
 	scriptPath := filepath.Join(profileDir, "Completions", "wendy.ps1")
 	rcPath := filepath.Join(profileDir, "Microsoft.PowerShell_profile.ps1")
-	rcBlock := fmt.Sprintf("%s\n. %q", completionRcSentinel, scriptPath)
+	rcBlock := fmt.Sprintf("%s\n. %s", completionRcSentinel, powershellSingleQuote(scriptPath))
 	notes := []string{"Restart PowerShell for completions to take effect."}
 	if goos == "windows" {
 		notes = append(notes, "Windows PowerShell 5.1 users: dot-source the script from your WindowsPowerShell profile manually.")
@@ -258,7 +273,7 @@ func performInstall(root *cobra.Command, stderr io.Writer, shell string, plan in
 	if err := os.MkdirAll(filepath.Dir(plan.scriptPath), 0o755); err != nil {
 		return fmt.Errorf("creating %s: %w", filepath.Dir(plan.scriptPath), err)
 	}
-	f, err := os.Create(plan.scriptPath)
+	f, err := os.OpenFile(plan.scriptPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("creating %s: %w", plan.scriptPath, err)
 	}
@@ -305,29 +320,34 @@ func writeShellScript(root *cobra.Command, shell string, w io.Writer) error {
 }
 
 // ensureBlockInFile appends block to path unless sentinel is already present.
-// Returns true when the file was modified.
-func ensureBlockInFile(path, sentinel, block string) (bool, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+// Returns true when the file was modified. Surfaces close errors via a named
+// return so buffered-write failures on close aren't silently dropped.
+func ensureBlockInFile(path, sentinel, block string) (added bool, err error) {
+	if err = os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return false, err
 	}
 
-	existing, err := os.ReadFile(path)
+	existing, readErr := os.ReadFile(path)
 	switch {
-	case errors.Is(err, os.ErrNotExist):
+	case errors.Is(readErr, os.ErrNotExist):
 		existing = nil
-	case err != nil:
-		return false, err
+	case readErr != nil:
+		return false, readErr
 	}
 
 	if bytes.Contains(existing, []byte(sentinel)) {
 		return false, nil
 	}
 
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
-	if err != nil {
-		return false, err
+	f, openErr := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if openErr != nil {
+		return false, openErr
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
 
 	var buf strings.Builder
 	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
@@ -337,7 +357,7 @@ func ensureBlockInFile(path, sentinel, block string) (bool, error) {
 	if !strings.HasSuffix(block, "\n") {
 		buf.WriteByte('\n')
 	}
-	if _, err := f.WriteString(buf.String()); err != nil {
+	if _, err = f.WriteString(buf.String()); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/go/internal/cli/commands/completion_test.go
+++ b/go/internal/cli/commands/completion_test.go
@@ -329,6 +329,45 @@ func TestInstall_RcLineIdempotent(t *testing.T) {
 	}
 }
 
+func TestRcBlock_QuotesPathsWithSpecialChars(t *testing.T) {
+	// Paths containing $, backticks, single-quotes, or spaces must be safely
+	// quoted in rc blocks so the shell doesn't expand them.
+	awkward := "/h/u with $var and `cmd` and 'quote'"
+
+	bash, err := computeInstallPlan("bash", "linux", awkward,
+		func(string) string { return "" }, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("bash: %v", err)
+	}
+	for _, bad := range []string{"$var", "`cmd`"} {
+		// The dollar/backtick should appear only inside the literal path,
+		// never bare in shell-interpreted positions. POSIX single quotes
+		// escape everything except `'` itself, so the literal `$var` must
+		// remain in the block but bash treats it literally there.
+		if !strings.Contains(bash.rcBlock, bad) {
+			t.Errorf("bash rcBlock missing literal %q in path", bad)
+		}
+	}
+	// Single quotes must be POSIX-escaped as '\''.
+	if !strings.Contains(bash.rcBlock, `'\''`) {
+		t.Errorf("bash rcBlock did not POSIX-escape single quote; got: %q", bash.rcBlock)
+	}
+
+	ps, err := computeInstallPlan("powershell", "linux", awkward,
+		func(string) string { return "" }, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("powershell: %v", err)
+	}
+	// PowerShell single quotes are doubled.
+	if !strings.Contains(ps.rcBlock, "''") {
+		t.Errorf("powershell rcBlock did not double single quote; got: %q", ps.rcBlock)
+	}
+	// PowerShell rc must NOT use double quotes around the path (would interpolate $var).
+	if strings.Contains(ps.rcBlock, `. "`) {
+		t.Errorf("powershell rcBlock used double quotes (would interpolate $var); got: %q", ps.rcBlock)
+	}
+}
+
 func TestEnsureBlockInFile_AppendsLeadingNewline(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "rc")

--- a/go/internal/cli/commands/completion_test.go
+++ b/go/internal/cli/commands/completion_test.go
@@ -1,0 +1,374 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func executeCompletion(t *testing.T, args ...string) (stdout, stderr *bytes.Buffer, err error) {
+	t.Helper()
+	// Isolate from host env so --output-dir gives a self-contained sandbox.
+	// Without this, host ZDOTDIR/XDG_* would redirect rc and script paths
+	// outside the test's tmp dir and could clobber the developer's real config.
+	for _, k := range []string{"ZDOTDIR", "XDG_DATA_HOME", "XDG_CONFIG_HOME"} {
+		t.Setenv(k, "")
+	}
+	root := NewRootCmd()
+	root.PersistentPreRunE = nil
+	root.PersistentPostRunE = nil
+	stdout = new(bytes.Buffer)
+	stderr = new(bytes.Buffer)
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs(args)
+	err = root.Execute()
+	return stdout, stderr, err
+}
+
+func TestCompletion_GeneratesNonEmpty(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			stdout, _, err := executeCompletion(t, "completion", shell)
+			if err != nil {
+				t.Fatalf("completion %s: %v", shell, err)
+			}
+			if stdout.Len() < 200 {
+				t.Errorf("completion %s output too short (%d bytes); got: %q", shell, stdout.Len(), stdout.String())
+			}
+		})
+	}
+}
+
+func TestCompletion_HasInstallSubcommand(t *testing.T) {
+	root := NewRootCmd()
+	var compCmd *cobra.Command
+	for _, c := range root.Commands() {
+		if c.Name() == "completion" {
+			compCmd = c
+			break
+		}
+	}
+	if compCmd == nil {
+		t.Fatal("expected `completion` subcommand on root")
+	}
+	if compCmd.GroupID != "misc" {
+		t.Errorf("completion.GroupID = %q; want %q", compCmd.GroupID, "misc")
+	}
+	want := map[string]bool{"bash": true, "zsh": true, "fish": true, "powershell": true, "install": true}
+	have := []string{}
+	for _, c := range compCmd.Commands() {
+		have = append(have, c.Name())
+		delete(want, c.Name())
+	}
+	if len(want) > 0 {
+		t.Errorf("missing completion children: %v (have: %v)", want, have)
+	}
+}
+
+func TestDetectShell(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		goos     string
+		shellEnv string
+		want     string
+		wantErr  bool
+	}{
+		{name: "override bash", override: "bash", goos: "linux", want: "bash"},
+		{name: "override pwsh maps to powershell", override: "pwsh", goos: "linux", want: "powershell"},
+		{name: "override unsupported", override: "tcsh", goos: "linux", wantErr: true},
+		{name: "windows defaults to powershell", goos: "windows", want: "powershell"},
+		{name: "linux bash", goos: "linux", shellEnv: "/bin/bash", want: "bash"},
+		{name: "linux zsh", goos: "linux", shellEnv: "/usr/bin/zsh", want: "zsh"},
+		{name: "macos fish via brew", goos: "darwin", shellEnv: "/opt/homebrew/bin/fish", want: "fish"},
+		{name: "linux unknown", goos: "linux", shellEnv: "/bin/tcsh", wantErr: true},
+		{name: "linux empty SHELL", goos: "linux", shellEnv: "", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := func(k string) string {
+				if k == "SHELL" {
+					return tc.shellEnv
+				}
+				return ""
+			}
+			got, err := detectShell(tc.override, tc.goos, env)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v; wantErr = %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("got %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeInstallPlan(t *testing.T) {
+	tests := []struct {
+		name        string
+		shell       string
+		goos        string
+		home        string
+		env         map[string]string
+		exists      map[string]bool
+		wantScript  string
+		wantRC      string
+		wantBlockIn string // substring expected in rcBlock; empty if no rc edit
+	}{
+		{
+			name:       "bash with bash-completion present uses XDG path",
+			shell:      "bash",
+			goos:       "linux",
+			home:       "/h/u",
+			exists:     map[string]bool{"/h/u/.local/share/bash-completion": true},
+			wantScript: "/h/u/.local/share/bash-completion/completions/wendy",
+		},
+		{
+			name:        "bash without bash-completion uses fallback",
+			shell:       "bash",
+			goos:        "linux",
+			home:        "/h/u",
+			wantScript:  "/h/u/.wendy/completions/wendy.bash",
+			wantRC:      "/h/u/.bashrc",
+			wantBlockIn: "/h/u/.wendy/completions/wendy.bash",
+		},
+		{
+			name:        "bash darwin fallback notes bash_profile",
+			shell:       "bash",
+			goos:        "darwin",
+			home:        "/h/u",
+			wantScript:  "/h/u/.wendy/completions/wendy.bash",
+			wantRC:      "/h/u/.bashrc",
+			wantBlockIn: completionRcSentinel,
+		},
+		{
+			name:       "bash honors XDG_DATA_HOME",
+			shell:      "bash",
+			goos:       "linux",
+			home:       "/h/u",
+			env:        map[string]string{"XDG_DATA_HOME": "/x/data"},
+			exists:     map[string]bool{"/x/data/bash-completion": true},
+			wantScript: "/x/data/bash-completion/completions/wendy",
+		},
+		{
+			name:        "zsh default home",
+			shell:       "zsh",
+			home:        "/h/u",
+			wantScript:  "/h/u/.zfunc/_wendy",
+			wantRC:      "/h/u/.zshrc",
+			wantBlockIn: "fpath=",
+		},
+		{
+			name:        "zsh honors ZDOTDIR for rc",
+			shell:       "zsh",
+			home:        "/h/u",
+			env:         map[string]string{"ZDOTDIR": "/h/u/.config/zsh"},
+			wantScript:  "/h/u/.zfunc/_wendy",
+			wantRC:      "/h/u/.config/zsh/.zshrc",
+			wantBlockIn: "fpath=",
+		},
+		{
+			name:       "fish default config",
+			shell:      "fish",
+			home:       "/h/u",
+			wantScript: "/h/u/.config/fish/completions/wendy.fish",
+		},
+		{
+			name:       "fish honors XDG_CONFIG_HOME",
+			shell:      "fish",
+			home:       "/h/u",
+			env:        map[string]string{"XDG_CONFIG_HOME": "/x/cfg"},
+			wantScript: "/x/cfg/fish/completions/wendy.fish",
+		},
+		{
+			name:        "powershell on linux uses .config/powershell",
+			shell:       "powershell",
+			goos:        "linux",
+			home:        "/h/u",
+			wantScript:  "/h/u/.config/powershell/Completions/wendy.ps1",
+			wantRC:      "/h/u/.config/powershell/Microsoft.PowerShell_profile.ps1",
+			wantBlockIn: "/h/u/.config/powershell/Completions/wendy.ps1",
+		},
+		{
+			name:        "powershell on windows uses Documents/PowerShell",
+			shell:       "powershell",
+			goos:        "windows",
+			home:        `C:\Users\u`,
+			wantScript:  filepath.Join(`C:\Users\u`, "Documents", "PowerShell", "Completions", "wendy.ps1"),
+			wantRC:      filepath.Join(`C:\Users\u`, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1"),
+			wantBlockIn: completionRcSentinel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := func(k string) string { return tc.env[k] }
+			exists := func(p string) bool { return tc.exists[p] }
+			plan, err := computeInstallPlan(tc.shell, tc.goos, tc.home, env, exists)
+			if err != nil {
+				t.Fatalf("computeInstallPlan: %v", err)
+			}
+			if plan.scriptPath != tc.wantScript {
+				t.Errorf("scriptPath = %q; want %q", plan.scriptPath, tc.wantScript)
+			}
+			if plan.rcPath != tc.wantRC {
+				t.Errorf("rcPath = %q; want %q", plan.rcPath, tc.wantRC)
+			}
+			if tc.wantBlockIn != "" && !strings.Contains(plan.rcBlock, tc.wantBlockIn) {
+				t.Errorf("rcBlock = %q; want substring %q", plan.rcBlock, tc.wantBlockIn)
+			}
+		})
+	}
+}
+
+func TestComputeInstallPlan_UnsupportedShell(t *testing.T) {
+	_, err := computeInstallPlan("tcsh", "linux", "/h/u",
+		func(string) string { return "" },
+		func(string) bool { return false },
+	)
+	if err == nil {
+		t.Fatal("expected error for unsupported shell")
+	}
+}
+
+func TestInstall_WritesFile(t *testing.T) {
+	tmp := t.TempDir()
+	stdout, _, err := executeCompletion(t,
+		"completion", "install",
+		"--shell", "fish",
+		"--output-dir", tmp,
+	)
+	if err != nil {
+		t.Fatalf("install: %v\nstdout: %s", err, stdout.String())
+	}
+
+	scriptPath := filepath.Join(tmp, ".config", "fish", "completions", "wendy.fish")
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("expected file at %s: %v", scriptPath, err)
+	}
+	if len(data) < 200 {
+		t.Errorf("fish script too short (%d bytes)", len(data))
+	}
+	// Fish completion scripts use the `complete` builtin.
+	if !bytes.Contains(data, []byte("complete")) {
+		t.Errorf("fish script missing `complete` keyword; got: %s", data)
+	}
+}
+
+func TestInstall_PrintPath(t *testing.T) {
+	tmp := t.TempDir()
+	stdout, _, err := executeCompletion(t,
+		"completion", "install",
+		"--shell", "zsh",
+		"--output-dir", tmp,
+		"--print-path",
+	)
+	if err != nil {
+		t.Fatalf("install --print-path: %v", err)
+	}
+	out := stdout.String()
+	wantScript := filepath.Join(tmp, ".zfunc", "_wendy")
+	wantRC := filepath.Join(tmp, ".zshrc")
+	if !strings.Contains(out, wantScript) {
+		t.Errorf("output missing script path %q; got: %q", wantScript, out)
+	}
+	if !strings.Contains(out, wantRC) {
+		t.Errorf("output missing rc path %q; got: %q", wantRC, out)
+	}
+	// --print-path must not write anything.
+	if _, err := os.Stat(wantScript); err == nil {
+		t.Error("--print-path should not have created the script file")
+	}
+}
+
+func TestInstall_RcLineIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+
+	// First install: should add the sentinel block.
+	if _, _, err := executeCompletion(t,
+		"completion", "install",
+		"--shell", "zsh",
+		"--output-dir", tmp,
+	); err != nil {
+		t.Fatalf("install 1: %v", err)
+	}
+
+	rcPath := filepath.Join(tmp, ".zshrc")
+	first, err := os.ReadFile(rcPath)
+	if err != nil {
+		t.Fatalf("read rc: %v", err)
+	}
+	if c := bytes.Count(first, []byte(completionRcSentinel)); c != 1 {
+		t.Fatalf("after first install: sentinel count = %d; want 1", c)
+	}
+
+	// Second install: must not re-append.
+	if _, _, err := executeCompletion(t,
+		"completion", "install",
+		"--shell", "zsh",
+		"--output-dir", tmp,
+	); err != nil {
+		t.Fatalf("install 2: %v", err)
+	}
+	second, err := os.ReadFile(rcPath)
+	if err != nil {
+		t.Fatalf("read rc 2: %v", err)
+	}
+	if c := bytes.Count(second, []byte(completionRcSentinel)); c != 1 {
+		t.Errorf("after second install: sentinel count = %d; want 1", c)
+	}
+	if !bytes.Equal(first, second) {
+		t.Errorf("rc file changed between idempotent installs:\nbefore: %s\nafter: %s", first, second)
+	}
+}
+
+func TestEnsureBlockInFile_AppendsLeadingNewline(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "rc")
+	if err := os.WriteFile(path, []byte("existing-line-no-newline"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	added, err := ensureBlockInFile(path, "# sentinel", "# sentinel\nblock-line")
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if !added {
+		t.Error("expected added = true on first call")
+	}
+	got, _ := os.ReadFile(path)
+	want := "existing-line-no-newline\n# sentinel\nblock-line\n"
+	if string(got) != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}
+
+func TestResolveHome_Override(t *testing.T) {
+	got, err := resolveHome("/tmp/x")
+	if err != nil {
+		t.Fatalf("resolveHome: %v", err)
+	}
+	if got != "/tmp/x" {
+		t.Errorf("got %q; want %q", got, "/tmp/x")
+	}
+}
+
+func TestResolveHome_Default(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("UserHomeDir behavior on Windows depends on env not set in CI")
+	}
+	got, err := resolveHome("")
+	if err != nil {
+		t.Fatalf("resolveHome: %v", err)
+	}
+	if got == "" {
+		t.Error("expected non-empty home")
+	}
+}
+

--- a/go/internal/cli/commands/completion_test.go
+++ b/go/internal/cli/commands/completion_test.go
@@ -371,4 +371,3 @@ func TestResolveHome_Default(t *testing.T) {
 		t.Error("expected non-empty home")
 	}
 }
-

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -132,6 +132,8 @@ func NewRootCmd() *cobra.Command {
 	tourCmd.GroupID = "misc"
 	mcpCmd := newMCPCmd()
 	mcpCmd.GroupID = "misc"
+	completionCmd := newCompletionCmd()
+	completionCmd.GroupID = "misc"
 
 	// Hidden command used by a subprocess to test CoreBluetooth access.
 	// The main process spawns a child process that runs this command so
@@ -163,6 +165,7 @@ func NewRootCmd() *cobra.Command {
 		utilsCmd,
 		tourCmd,
 		mcpCmd,
+		completionCmd,
 	)
 
 	root.SetHelpCommandGroupID("misc")


### PR DESCRIPTION
## Summary

- Replace Cobra's auto-generated `completion` command with a custom one in `go/internal/cli/commands/completion.go`. Provides the same per-shell script emitters (`wendy completion bash|zsh|fish|powershell`) plus a new `install` subcommand.
- `wendy completion install` auto-detects the running shell (`$SHELL` on Unix, default `powershell` on Windows; `--shell <name>` overrides) and writes the script to the conventional location, appending an idempotent sentinel-marked (`# wendy-completion`) block to the shell rc file when needed.
- Closes WDY-694. The Linear ticket described the legacy Swift ArgumentParser CLI; the modern CLI is Cobra-based, so the implementation follows Cobra idioms instead of `--generate-completion-script`.

## Install paths

| Shell | Script path | rc edit |
|---|---|---|
| bash (`bash-completion` v2 detected) | `${XDG_DATA_HOME:-~/.local/share}/bash-completion/completions/wendy` | none |
| bash (fallback) | `~/.wendy/completions/wendy.bash` | sentinel-marked `source` line in `~/.bashrc` |
| zsh | `~/.zfunc/_wendy` | sentinel-marked `fpath` + `compinit` block in `${ZDOTDIR:-~}/.zshrc` |
| fish | `${XDG_CONFIG_HOME:-~/.config}/fish/completions/wendy.fish` | none (auto-loaded) |
| powershell (Unix) | `~/.config/powershell/Completions/wendy.ps1` | dot-source in `Microsoft.PowerShell_profile.ps1` |
| powershell (Windows) | `~/Documents/PowerShell/Completions/wendy.ps1` | dot-source in `Microsoft.PowerShell_profile.ps1` |

Flags on `install`:
- `--shell bash|zsh|fish|powershell` — override auto-detection
- `--print-path` — dry run; print computed paths and exit
- `--output-dir <dir>` — testing seam (overrides `$HOME` for the planner)

## Implementation notes

- Cobra's `InitDefaultCompletionCmd` skips creating its default when a `completion` command already exists (`vendor/.../cobra/completions.go:745-753`), so no `CompletionOptions.DisableDefaultCmd` toggle is needed; the existing `root.SetCompletionCommandGroupID("misc")` becomes a harmless no-op.
- Path computation lives in a pure function `computeInstallPlan(shell, goos, home, env, exists)` for table-driven testing.
- rc edits are appended through `ensureBlockInFile` keyed off the `# wendy-completion` sentinel — running `install` twice produces no duplicate lines.

## Test plan

- [x] `go build ./...` clean (darwin, linux/amd64, windows/amd64)
- [x] `go vet ./...` clean
- [x] `go test ./internal/cli/commands/` — all existing tests still pass plus the new ones below
- [x] `TestCompletion_GeneratesNonEmpty` — `wendy completion bash|zsh|fish|powershell` each produces > 200 bytes
- [x] `TestCompletion_HasInstallSubcommand` — root has `completion` cmd in the `misc` group with all five children
- [x] `TestDetectShell` — table-driven over `$SHELL` values, override flag, and `runtime.GOOS`
- [x] `TestComputeInstallPlan` — table-driven over all shells and the relevant env vars (`XDG_DATA_HOME`, `XDG_CONFIG_HOME`, `ZDOTDIR`)
- [x] `TestInstall_WritesFile` — `--shell fish --output-dir <tmp>` writes a valid fish script
- [x] `TestInstall_PrintPath` — `--print-path` reports paths and writes nothing
- [x] `TestInstall_RcLineIdempotent` — running install twice keeps exactly one sentinel block
- [x] Smoke test against the real binary: `wendy completion --help` lists all 5 subcommands; `wendy completion install --shell fish --output-dir /tmp/...` produces the expected file

## Next steps (follow-up issues, not in this PR)

- **Homebrew tap formula** — update `wendylabsinc/homebrew-tap` (or wherever the formula lives) to invoke `wendy completion install` post-install, or pre-stage the scripts so `brew install wendy` wires up completions automatically on macOS.
- **Linux install script** — update `https://install.wendy.sh/cli.sh` to run `wendy completion install` after copying the binary into place.
- **Dynamic flag completion** — add `RegisterFlagCompletionFunc` for `--device <TAB>` (complete discovered device hostnames) and similar dynamic completions for app/cloud subcommands. Larger scope — needs care around discovery timeouts in the completion path.
- **`pwsh` profile resolution** — current PowerShell paths assume the conventional pwsh layout; could optionally shell out to `pwsh -NoProfile -Command '$PROFILE'` to honor non-standard profile locations and Windows PowerShell 5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)