### PR TITLE
fix(windows): harden powershell + raw-disk in `wendy os install` (WDY-1117)

### DIFF
--- a/go/internal/cli/commands/disklister_windows.go
+++ b/go/internal/cli/commands/disklister_windows.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -22,6 +24,35 @@ const (
 	fsctlAllowExtendedDASDIO = 0x00090083
 	ioctlDiskGetDriveLayout  = 0x00070050
 )
+
+// powershellExe is the absolute path to powershell.exe, resolved once at
+// package init time. Looking it up via PATH is unsafe: in a 32-bit wendy.exe
+// process running on 64-bit Windows, PATH-resolved `powershell` lands in
+// SysWOW64, which ships a legacy Storage module that rejects modern parameters
+// like -Confirm on Set-Disk. Resolving through System32 (or Sysnative when
+// running under WoW64) ensures we always invoke the host-architecture
+// PowerShell with the current Storage module.
+var powershellExe = resolvePowershellExe()
+
+func resolvePowershellExe() string {
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	// Sysnative is a virtual alias that exists only inside a 32-bit (WoW64)
+	// process and points at the real System32. Prefer it so 32-bit builds of
+	// wendy.exe still launch 64-bit PowerShell.
+	candidates := []string{
+		filepath.Join(systemRoot, "Sysnative", "WindowsPowerShell", "v1.0", "powershell.exe"),
+		filepath.Join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return "powershell"
+}
 
 // drive represents an external disk suitable for image writing.
 type drive struct {
@@ -63,7 +94,7 @@ func listDrivesWindows(externalOnly bool) ([]drive, error) {
 		"[PSCustomObject]@{ Number=$_.Number; FriendlyName=$_.FriendlyName; Size=$_.Size; " +
 		"BusType=$_.BusType; IsSystem=$_.IsSystem; IsReadOnly=$_.IsReadOnly; MediaType=$mt } " +
 		"} | ConvertTo-Json -Compress"
-	out, err := exec.Command("powershell", "-NoProfile", "-Command", script).Output()
+	out, err := exec.Command(powershellExe, "-NoProfile", "-Command", script).Output()
 	if err != nil {
 		return nil, fmt.Errorf("running Get-Disk: %w", err)
 	}
@@ -157,7 +188,7 @@ func getVolumesForDisk(diskNumber int) ([]string, error) {
 			"Select-Object -ExpandProperty DriveLetter",
 		diskNumber,
 	)
-	out, err := exec.Command("powershell", "-NoProfile", "-Command", script).Output()
+	out, err := exec.Command(powershellExe, "-NoProfile", "-Command", script).Output()
 	if err != nil {
 		return nil, nil // no partitions is fine
 	}
@@ -213,11 +244,20 @@ func lockAndDismountVolume(letter string) (syscall.Handle, error) {
 	return h, nil
 }
 
+// physicalDrivePathRE matches a Windows physical-drive path with the disk
+// number captured. The end anchor matters: fmt.Sscanf with %d would silently
+// accept `\\.\PhysicalDrive1abc` as disk 1, picking up a path the user almost
+// certainly didn't intend.
+var physicalDrivePathRE = regexp.MustCompile(`^\\\\\.\\PhysicalDrive(\d+)$`)
+
 // parseDiskNumber extracts the disk number from a \\.\PhysicalDriveN path.
 func parseDiskNumber(devPath string) (int, error) {
+	m := physicalDrivePathRE.FindStringSubmatch(devPath)
+	if m == nil {
+		return 0, fmt.Errorf("parsing disk number from %q: not a physical drive path", devPath)
+	}
 	var n int
-	_, err := fmt.Sscanf(devPath, `\\.\PhysicalDrive%d`, &n)
-	if err != nil {
+	if _, err := fmt.Sscanf(m[1], "%d", &n); err != nil {
 		return 0, fmt.Errorf("parsing disk number from %q: %w", devPath, err)
 	}
 	return n, nil
@@ -227,19 +267,20 @@ func parseDiskNumber(devPath string) (int, error) {
 // volumes, and OEM recovery data from the disk. This releases Windows' hold
 // on volumes that have no drive letter (e.g. EFI, recovery, or Jetson
 // partitions) which would otherwise block raw disk writes with "Access denied".
+//
+// We first inspect Get-Disk's PartitionStyle: an uninitialized disk reports
+// "RAW" and Clear-Disk has nothing to do. Skipping in that case avoids a
+// non-terminating error whose message text is locale-dependent.
 func clearDiskPartitions(diskNum int) error {
 	script := fmt.Sprintf(
-		"Clear-Disk -Number %d -RemoveData -RemoveOEM -Confirm:$false",
-		diskNum,
+		"$d = Get-Disk -Number %d -ErrorAction Stop; "+
+			"if ($d.PartitionStyle -ne 'RAW') { "+
+			"Clear-Disk -Number %d -RemoveData -RemoveOEM -Confirm:$false "+
+			"}",
+		diskNum, diskNum,
 	)
-	out, err := exec.Command("powershell", "-NoProfile", "-Command", script).CombinedOutput()
+	out, err := exec.Command(powershellExe, "-NoProfile", "-Command", script).CombinedOutput()
 	if err != nil {
-		// "not been initialized" means the disk already has no partition
-		// table (e.g. from a previous Clear-Disk). That's the state we
-		// want, so treat it as success.
-		if strings.Contains(string(out), "not been initialized") {
-			return nil
-		}
 		return fmt.Errorf("clearing disk %d: %s: %w", diskNum, strings.TrimSpace(string(out)), err)
 	}
 	return nil
@@ -256,9 +297,11 @@ func writeImageToDisk(imagePath string, d drive, progressFn func(written int64))
 	}
 
 	// Ensure the disk is online before clearing partitions — a previous
-	// write may have left it offline.
-	onlineScript := fmt.Sprintf("Set-Disk -Number %d -IsOffline $false -Confirm:$false", diskNum)
-	_ = exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", onlineScript).Run()
+	// write may have left it offline. Set-Disk -IsOffline doesn't prompt, so
+	// no -Confirm switch is required (and the legacy Storage module rejects
+	// it outright).
+	onlineScript := fmt.Sprintf("Set-Disk -Number %d -IsOffline $false", diskNum)
+	_ = exec.Command(powershellExe, "-NoProfile", "-NonInteractive", "-Command", onlineScript).Run()
 
 	// Clear all partitions on the disk first. This is necessary because
 	// disks (e.g. from a prior Jetson flash) may contain many partitions
@@ -369,20 +412,34 @@ func writeImageToDisk(imagePath string, d drive, progressFn func(written int64))
 	// rescans the partition table and auto-assigns drive letters to every
 	// partition it finds (EFI, rootfs, recovery, etc.), flooding Explorer
 	// with phantom drives. Setting the disk offline right after prevents this.
-	syscall.CloseHandle(handle)
+	//
+	// os.NewFile took ownership of the underlying Windows HANDLE (it installs
+	// a finalizer that calls CloseHandle), so we close exclusively through
+	// diskFile.Close() — calling syscall.CloseHandle separately would
+	// double-close once the finalizer ran, with undefined behavior if Windows
+	// reused the handle value.
+	if cerr := diskFile.Close(); cerr != nil {
+		fmt.Fprintf(os.Stderr, "warning: closing %s: %v\n", d.DevicePath, cerr)
+	}
 	closeAllHandles()
 
 	// Remove any auto-assigned drive letters, then take the disk offline.
 	// Set-Disk -IsOffline alone doesn't remove letters that Windows already
 	// assigned during the brief window between releasing locks and going offline.
+	//
+	// Get-Partition -ErrorAction SilentlyContinue: right after Clear-Disk the
+	// partition table re-read may not have completed and the cmdlet emits a
+	// non-terminating "no MSFT_Partition objects" error we don't want fatal.
+	// Set-Disk: no -Confirm (legacy Storage module rejects it; -IsOffline
+	// doesn't prompt) and no -ErrorAction Stop (we log exit status below).
 	cleanupScript := fmt.Sprintf(
-		"Get-Partition -DiskNumber %d | "+
+		"Get-Partition -DiskNumber %d -ErrorAction SilentlyContinue | "+
 			"Where-Object { $_.DriveLetter } | "+
 			"ForEach-Object { Remove-PartitionAccessPath -DiskNumber $_.DiskNumber -PartitionNumber $_.PartitionNumber -AccessPath \"$($_.DriveLetter):\\\" -ErrorAction SilentlyContinue }; "+
-			"Set-Disk -Number %d -IsOffline $true -Confirm:$false -ErrorAction Stop",
+			"Set-Disk -Number %d -IsOffline $true",
 		diskNum, diskNum,
 	)
-	if output, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", cleanupScript).CombinedOutput(); err != nil {
+	if output, err := exec.Command(powershellExe, "-NoProfile", "-NonInteractive", "-Command", cleanupScript).CombinedOutput(); err != nil {
 		msg := strings.TrimSpace(string(output))
 		if msg != "" {
 			fmt.Fprintf(os.Stderr, "warning: failed to set disk %d offline: %v: %s\n", diskNum, err, msg)

--- a/go/internal/cli/commands/disklister_windows_test.go
+++ b/go/internal/cli/commands/disklister_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package commands
+
+import "testing"
+
+func TestParseDiskNumber(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{name: "single digit", input: `\\.\PhysicalDrive1`, want: 1},
+		{name: "multi digit", input: `\\.\PhysicalDrive42`, want: 42},
+		{name: "zero", input: `\\.\PhysicalDrive0`, want: 0},
+		{name: "trailing junk rejected", input: `\\.\PhysicalDrive1abc`, wantErr: true},
+		{name: "trailing space rejected", input: `\\.\PhysicalDrive1 `, wantErr: true},
+		{name: "missing prefix", input: `PhysicalDrive1`, wantErr: true},
+		{name: "wrong prefix case", input: `\\.\physicaldrive1`, wantErr: true},
+		{name: "empty", input: ``, wantErr: true},
+		{name: "no digits", input: `\\.\PhysicalDrive`, wantErr: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseDiskNumber(c.input)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("parseDiskNumber(%q) = %d, want error", c.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDiskNumber(%q) error: %v", c.input, err)
+			}
+			if got != c.want {
+				t.Fatalf("parseDiskNumber(%q) = %d, want %d", c.input, got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolvePowershellExe(t *testing.T) {
+	got := resolvePowershellExe()
+	if got == "" {
+		t.Fatal("resolvePowershellExe() returned empty string")
+	}
+	// The fallback "powershell" or an absolute path are both valid; we just
+	// require a non-empty string so misconfigured callers can't end up
+	// invoking exec.Command("") and getting a confusing error.
+}

--- a/go/internal/cli/commands/os_provision_windows.go
+++ b/go/internal/cli/commands/os_provision_windows.go
@@ -4,7 +4,9 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/wendylabsinc/wendy/internal/shared/wendyconf"
 )
@@ -16,10 +18,23 @@ func writeConfigPartition(d drive, agentBinary []byte, creds []wendyconf.WifiCre
 func ejectDisk(devPath string) {
 	diskNum, err := parseDiskNumber(devPath)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: cannot eject %s: %v\n", devPath, err)
 		return
 	}
-	// Ensure the disk is offline so Windows doesn't assign drive letters
-	// to the partitions in the newly written image.
-	script := fmt.Sprintf("Set-Disk -Number %d -IsOffline $true -Confirm:$false -ErrorAction SilentlyContinue", diskNum)
-	_ = exec.Command("powershell", "-NoProfile", "-Command", script).Run()
+	// Take the disk offline so Windows doesn't auto-assign drive letters to
+	// the partitions in the freshly written image. -Confirm:$false is omitted
+	// because Set-Disk -IsOffline doesn't prompt and the legacy Storage
+	// module rejects -Confirm.
+	script := fmt.Sprintf("Set-Disk -Number %d -IsOffline $true -ErrorAction SilentlyContinue", diskNum)
+	if out, err := exec.Command(powershellExe, "-NoProfile", "-Command", script).CombinedOutput(); err != nil {
+		msg := strings.TrimSpace(string(out))
+		// If eject fails the user will see Explorer flooded with
+		// auto-mounted phantom drive letters from the new image — surface
+		// the cause so they know what to clean up.
+		if msg != "" {
+			fmt.Fprintf(os.Stderr, "warning: failed to set disk %d offline: %v: %s\n", diskNum, err, msg)
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: failed to set disk %d offline: %v\n", diskNum, err)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

A Windows user reported `wendy os install` failing right after the image write with:

```
warning: failed to set disk 1 offline: exit status 1: Get-Partition : No MSFT_Partition objects found with property 'DiskNumber' equal to '1'.
Set-Disk : A parameter cannot be found that matches parameter name 'Confirm'.
```

Root causes and ride-along Windows hardening per [WDY-1117](https://linear.app/wendylabsinc/issue/WDY-1117) and §1 of `WINDOWS_REGRESSION_REVIEW.md`. Scope kept tight to `disklister_windows.go` + `os_provision_windows.go`.

### Fixes

- **`Set-Disk -Confirm:$false` rejected.** Resolve `powershell.exe` through `%SystemRoot%\System32` (or `Sysnative` when running under WoW64) once at startup so a 32-bit `wendy.exe` doesn't pick up the legacy SysWOW64 Storage module. Drop `-Confirm:$false` from every `Set-Disk` call (`-IsOffline` doesn't prompt; legacy modules reject the parameter outright).
- **`Get-Partition` errors on freshly cleared disk.** Add `-ErrorAction SilentlyContinue` to the cleanup `Get-Partition`; drop `-ErrorAction Stop` from the trailing `Set-Disk` so a soft Get-Partition error doesn't fail the whole script.
- **Locale-fragile error match.** Replace the `"not been initialized"` substring check with a structured `Get-Disk`/`PartitionStyle` pre-check — Clear-Disk is now skipped when the disk is already RAW.
- **Double-close on physical-drive handle.** `os.NewFile` takes finalizer ownership of the Windows HANDLE; the explicit `syscall.CloseHandle` would close the same handle twice (UB if Windows reused the value). Now we close through `diskFile.Close()`.
- **`parseDiskNumber` not anchored.** `\\.\PhysicalDrive1abc` was being parsed as disk 1; switched to an anchored regex.
- **`ejectDisk` swallowed errors.** Now logs a warning so users understand why phantom drive letters appear when eject fails.

### Tests

New `disklister_windows_test.go` covering `parseDiskNumber` (single/multi digit, trailing-junk rejection, missing prefix) and a smoke test for `resolvePowershellExe`.

## Test plan

- [x] `GOOS=windows GOARCH=amd64 go build ./internal/cli/...`
- [x] `GOOS=windows GOARCH=386 go build ./internal/cli/...`
- [x] `GOOS=windows GOARCH=amd64 go vet ./internal/cli/commands/...`
- [x] `go test ./internal/cli/commands/...` (native)
- [ ] Live re-run of `wendy os install` on the reporter's Windows machine, with both 64-bit and 32-bit `wendy.exe` if possible — confirm error from issue no longer appears and disk goes offline cleanly.
- [ ] Sanity-check a fresh/uninitialized USB disk (RAW partition style) — Clear-Disk pre-check should skip and the install should still succeed.

## Out of scope (separate tickets)

- Don't print "Successfully installed" when provisioning was skipped
- Real Windows `writeConfigPartition` implementation
- 4Kn drive sector alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)