### PR TITLE
fix(os install): honest success on Windows + early elevation + internal-drive guard

### DIFF
--- a/go/internal/cli/commands/elevation_windows.go
+++ b/go/internal/cli/commands/elevation_windows.go
@@ -3,17 +3,119 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
-	"os/exec"
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
-// preAuthElevation checks that the current process is running with
-// Administrator privileges, which are required for raw disk access on Windows.
-func preAuthElevation() error {
-	// "net session" succeeds only when running as Administrator.
-	if err := exec.Command("net", "session").Run(); err != nil {
-		return fmt.Errorf("administrator privileges required — please re-run this command from an elevated (Administrator) terminal")
+// isElevated reports whether the current process holds an elevated access
+// token. Uses the documented OpenProcessToken + GetTokenInformation API
+// instead of probing `net session`, which suffers false negatives when the
+// Server service is stopped or in some domain configurations.
+func isElevated() (bool, error) {
+	var token windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
+		return false, fmt.Errorf("OpenProcessToken: %w", err)
 	}
+	defer token.Close()
+
+	var elevation struct {
+		TokenIsElevated uint32
+	}
+	var returned uint32
+	err := windows.GetTokenInformation(
+		token,
+		windows.TokenElevation,
+		(*byte)(unsafe.Pointer(&elevation)),
+		uint32(unsafe.Sizeof(elevation)),
+		&returned,
+	)
+	if err != nil {
+		return false, fmt.Errorf("GetTokenInformation: %w", err)
+	}
+	return elevation.TokenIsElevated != 0, nil
+}
+
+// relaunchElevated re-launches the current executable with the original
+// arguments through the shell's "runas" verb, which triggers a UAC consent
+// prompt. The elevated child runs in a new console window. Returns nil when
+// the child started, or an error when the user declined the UAC prompt or
+// the launch otherwise failed.
+func relaunchElevated() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving executable path: %w", err)
+	}
+
+	var quoted []string
+	for _, a := range os.Args[1:] {
+		quoted = append(quoted, syscall.EscapeArg(a))
+	}
+	params := strings.Join(quoted, " ")
+
+	verbPtr, err := syscall.UTF16PtrFromString("runas")
+	if err != nil {
+		return fmt.Errorf("encoding verb: %w", err)
+	}
+	exePtr, err := syscall.UTF16PtrFromString(exe)
+	if err != nil {
+		return fmt.Errorf("encoding exe path: %w", err)
+	}
+	var paramsPtr *uint16
+	if params != "" {
+		paramsPtr, err = syscall.UTF16PtrFromString(params)
+		if err != nil {
+			return fmt.Errorf("encoding parameters: %w", err)
+		}
+	}
+
+	const swNormal int32 = 1
+	if err := windows.ShellExecute(0, verbPtr, exePtr, paramsPtr, nil, swNormal); err != nil {
+		// User clicking "No" on the UAC consent prompt surfaces here.
+		if errors.Is(err, windows.ERROR_CANCELLED) {
+			return fmt.Errorf("user declined the elevation prompt")
+		}
+		return fmt.Errorf("ShellExecute runas: %w", err)
+	}
+	return nil
+}
+
+// preAuthElevation ensures the current process has Administrator privileges,
+// which raw disk writes require on Windows. When not elevated, it offers a
+// UAC re-launch and, on success, exits this non-elevated process so the user
+// only has one live wendy process. When the user declines or the re-launch
+// fails, it returns a clear error so callers can abort before paying for any
+// network or disk work.
+func preAuthElevation() error {
+	elevated, err := isElevated()
+	if err != nil {
+		// If the elevation check itself fails, don't block the caller —
+		// surface the warning and let the disk write fail with its own
+		// "Access denied" if we really were unprivileged.
+		fmt.Fprintf(os.Stderr, "warning: could not determine elevation state: %v\n", err)
+		return nil
+	}
+	if elevated {
+		return nil
+	}
+
+	fmt.Println("Administrator privileges are required to write to a raw disk.")
+	fmt.Println("Requesting elevation — Windows will show a UAC consent prompt.")
+	fmt.Println("If you accept, this command will continue in a new elevated console window.")
+
+	if err := relaunchElevated(); err != nil {
+		return fmt.Errorf("administrator privileges required: %w. Right-click your terminal and choose \"Run as administrator\", then re-run this command", err)
+	}
+
+	// Hand off to the elevated child and exit so the user isn't left with
+	// two wendy processes. The child runs in its own console window.
+	fmt.Println("Elevated process started in a new window. Continuing there.")
+	os.Exit(0)
 	return nil
 }
 

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -37,6 +37,7 @@ const (
 func newOSInstallCmd() *cobra.Command {
 	var nightly bool
 	var force bool
+	var yesOverwriteInternal bool
 	var preEnroll bool
 	var deviceType string
 	var versionFlag string
@@ -92,7 +93,7 @@ Flags can be provided progressively — omitted values trigger interactive picke
 			}
 
 			if len(args) == 2 {
-				return runOSInstallDirect(args[0], args[1], force)
+				return runOSInstallDirect(args[0], args[1], force, yesOverwriteInternal)
 			}
 			mode := preEnrollAuto
 			if cmd.Flags().Changed("pre-enroll") {
@@ -102,12 +103,13 @@ Flags can be provided progressively — omitted values trigger interactive picke
 					mode = preEnrollSkip
 				}
 			}
-			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, opts, deviceName, mode)
+			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, opts, deviceName, mode)
 		},
 	}
 
 	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use nightly/prerelease builds")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&yesOverwriteInternal, "yes-overwrite-internal", false, "Required to wipe an internal (non-removable) drive in non-interactive mode")
 	cmd.Flags().StringVar(&deviceType, "device-type", "", "Device type from manifest (e.g. raspberry-pi-5)")
 	cmd.Flags().StringVar(&versionFlag, "version", "", "WendyOS version to install (interactive if omitted)")
 	cmd.Flags().StringVar(&driveFlag, "drive", "", "Target drive path (e.g. /dev/disk4)")
@@ -122,10 +124,17 @@ Flags can be provided progressively — omitted values trigger interactive picke
 }
 
 // runOSInstallDirect writes a local image file to the specified drive without interactive prompts.
-func runOSInstallDirect(imagePath string, driveID string, force bool) error {
+func runOSInstallDirect(imagePath string, driveID string, force bool, yesOverwriteInternal bool) error {
 	// Verify the image file exists.
 	if _, err := os.Stat(imagePath); err != nil {
 		return fmt.Errorf("image file: %w", err)
+	}
+
+	// Authenticate elevation before any disk-listing or write work. On
+	// Windows this offers a UAC re-launch when the current process isn't
+	// elevated; on Unix it pre-caches the sudo timestamp.
+	if err := preAuthElevation(); err != nil {
+		return err
 	}
 
 	// Find the target drive.
@@ -145,6 +154,10 @@ func runOSInstallDirect(imagePath string, driveID string, force bool) error {
 		return fmt.Errorf("drive %s not found", driveID)
 	}
 
+	if err := confirmOverwriteInternalDrive(*targetDrive, force, yesOverwriteInternal); err != nil {
+		return err
+	}
+
 	if !force {
 		confirmed, err := tui.Confirm(fmt.Sprintf("Writing will ERASE ALL DATA on %s (%s). Continue?", targetDrive.Name, targetDrive.DevicePath))
 		if err != nil {
@@ -157,7 +170,6 @@ func runOSInstallDirect(imagePath string, driveID string, force bool) error {
 	}
 
 	fmt.Printf("Writing image to %s...\n", targetDrive.DevicePath)
-	fmt.Println(elevationHint())
 	if err := writeImageToDisk(imagePath, *targetDrive, nil); err != nil {
 		return fmt.Errorf("writing image: %w", err)
 	}
@@ -214,7 +226,7 @@ func pickLinuxDevice() (string, deviceInfo, error) {
 	return key, deviceMap[key], nil
 }
 
-func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, wifi wifiCLIOptions, deviceName string, mode preEnrollMode) error {
+func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, wifi wifiCLIOptions, deviceName string, mode preEnrollMode) error {
 	fmt.Println("Fetching available devices...")
 
 	// Fetch Linux devices from GCS manifest.
@@ -313,12 +325,20 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	if device.IsESP32 {
 		return installESP32Firmware(ctx, nightly, device.ESP32Chip)
 	}
-	return installLinuxImage(ctx, selected, device, nightly, flagVersion, flagDrive, force, wifi, deviceName, mode)
+	return installLinuxImage(ctx, selected, device, nightly, flagVersion, flagDrive, force, yesOverwriteInternal, wifi, deviceName, mode)
 }
 
 // installLinuxImage handles the Linux device path: pick version → pick drive → download → write.
 // nightly, flagVersion, flagDrive, and force allow skipping the corresponding interactive prompts.
-func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, nightly bool, flagVersion, flagDrive string, force bool, wifi wifiCLIOptions, deviceName string, mode preEnrollMode) error {
+func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, nightly bool, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, wifi wifiCLIOptions, deviceName string, mode preEnrollMode) error {
+	// Authenticate elevation up front so we don't pay for the multi-hundred-MB
+	// image download just to discover the user can't write to a raw disk. On
+	// Windows this offers a UAC re-launch when not elevated; on Unix it
+	// pre-caches the sudo timestamp.
+	if err := preAuthElevation(); err != nil {
+		return err
+	}
+
 	// Step 1: Resolve version — use flag, nightly shortcut, or pick interactively.
 	selectedVersion := device.RawVersion // default: latest (or nightly if --nightly)
 	if flagVersion != "" {
@@ -380,6 +400,9 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	}
 
 	// Step 3: Confirm destructive write (unless --force).
+	if err := confirmOverwriteInternalDrive(targetDrive, force, yesOverwriteInternal); err != nil {
+		return err
+	}
 	if !force {
 		fmt.Println()
 		confirmed, err := tui.Confirm(fmt.Sprintf("Writing will ERASE ALL DATA on %s (%s). Continue?", targetDrive.Name, targetDrive.DevicePath))
@@ -498,10 +521,31 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		return fmt.Errorf("writing image: %w", writeModel.Err())
 	}
 
-	fmt.Printf("\nWriting provisioning data to config partition...\n")
-	if err := provisionConfigPartition(targetDrive, provCreds, provDeviceName, provisioningJSON); err != nil {
-		fmt.Printf("Warning: could not write config partition: %v\n", err)
-		fmt.Println("Device will boot but WiFi and agent auto-update will not be pre-configured.")
+	hasProvisioningData := provisioningRequired(provCreds, provDeviceName, provisioningJSON)
+
+	if !configPartitionSupported {
+		// writeConfigPartition has no implementation on this OS (currently
+		// Windows). Skip the agent download — paying 5–30s of network for a
+		// guaranteed-skipped step is the bug from WDY-1118.
+		if hasProvisioningData {
+			ejectDisk(targetDrive.DevicePath)
+			return fmt.Errorf("the OS image was written to %s, but --wifi, --device-name, and --pre-enroll cannot be applied on this platform: writing to the device's config partition is not yet supported. Re-run on macOS or Linux to apply provisioning, or omit those flags to image without provisioning", targetDrive.Name)
+		}
+		fmt.Println("\nNote: config-partition provisioning is not yet supported on this platform; skipping. The device will run the agent baked into the image and fetch updates after first boot.")
+	} else {
+		fmt.Printf("\nWriting provisioning data to config partition...\n")
+		if err := provisionConfigPartition(targetDrive, provCreds, provDeviceName, provisioningJSON); err != nil {
+			if hasProvisioningData {
+				// User asked for --wifi / --device-name / --pre-enroll. Silently
+				// dropping their input and printing "Successfully installed"
+				// would be a lie — this is the user-visible failure mode the
+				// ticket calls out. Fail loudly so the user knows to retry.
+				ejectDisk(targetDrive.DevicePath)
+				return fmt.Errorf("could not write provisioning data to config partition (--wifi / --device-name / --pre-enroll were requested but not applied): %w", err)
+			}
+			fmt.Printf("Warning: could not write config partition: %v\n", err)
+			fmt.Println("Device will boot but agent auto-update will not be pre-configured.")
+		}
 	}
 
 	ejectDisk(targetDrive.DevicePath)
@@ -1081,6 +1125,34 @@ func resolveDeviceName(flagName string) (string, error) {
 		return "", fmt.Errorf("invalid device name: %w", err)
 	}
 	return name, nil
+}
+
+// confirmOverwriteInternalDrive guards against accidentally wiping internal
+// (non-removable) drives. The OS-level system disk is already filtered out by
+// listAllDrives, but a non-system internal drive (e.g. a secondary SATA SSD
+// on Windows) is still selectable via --drive — the existing y/n confirm is
+// too easy to autopilot through. For those drives we either require an
+// explicit --yes-overwrite-internal flag (non-interactive) or a typed device
+// path (interactive).
+func confirmOverwriteInternalDrive(d drive, force bool, yesOverwriteInternal bool) error {
+	if d.IsRemovable {
+		return nil
+	}
+	if yesOverwriteInternal {
+		return nil
+	}
+	if force {
+		return fmt.Errorf("refusing to wipe non-removable drive %s (%s) with --force; pass --yes-overwrite-internal to confirm you really want to overwrite an internal drive", d.Name, d.DevicePath)
+	}
+	fmt.Printf("\n%s (%s) is an internal (non-removable) drive.\n", d.Name, d.DevicePath)
+	fmt.Println("Typically WendyOS is installed to an SD card or USB drive — overwriting an internal drive will destroy whatever filesystem currently lives on it.")
+	fmt.Printf("To proceed, type the device path exactly:\n  %s\n> ", d.DevicePath)
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	if strings.TrimSpace(line) != d.DevicePath {
+		return fmt.Errorf("internal-drive overwrite cancelled (typed value did not match %s)", d.DevicePath)
+	}
+	return nil
 }
 
 // provisionConfigPartition downloads the latest stable arm64 wendy-agent binary

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -15,7 +15,7 @@ func TestNewOSInstallCmd_Flags(t *testing.T) {
 		t.Errorf("Use = %q; want %q", cmd.Use, "install [image] [drive]")
 	}
 
-	expectedFlags := []string{"nightly", "force", "device-type", "version", "drive", "wifi-ssid", "wifi-password", "wifi", "no-wifi", "device-name"}
+	expectedFlags := []string{"nightly", "force", "yes-overwrite-internal", "device-type", "version", "drive", "wifi-ssid", "wifi-password", "wifi", "no-wifi", "device-name"}
 	for _, name := range expectedFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("missing flag %q", name)
@@ -225,4 +225,47 @@ func TestResolveWiFiCredentialsListFlags(t *testing.T) {
 	if _, err := resolveWiFiCredentialsList(wifiCLIOptions{Password: "pw"}); err == nil {
 		t.Error("expected error when --wifi-password is passed alone")
 	}
+}
+
+func TestConfirmOverwriteInternalDrive(t *testing.T) {
+	removable := drive{Name: "Sandisk USB", DevicePath: "/dev/disk4", IsRemovable: true}
+	internal := drive{Name: "Internal SSD", DevicePath: "/dev/disk1", IsRemovable: false}
+
+	t.Run("removable + force is fine", func(t *testing.T) {
+		if err := confirmOverwriteInternalDrive(removable, true, false); err != nil {
+			t.Errorf("removable drive should always pass: %v", err)
+		}
+	})
+
+	t.Run("removable interactive is fine", func(t *testing.T) {
+		if err := confirmOverwriteInternalDrive(removable, false, false); err != nil {
+			t.Errorf("removable drive should always pass: %v", err)
+		}
+	})
+
+	t.Run("internal + force without override errors out", func(t *testing.T) {
+		err := confirmOverwriteInternalDrive(internal, true, false)
+		if err == nil {
+			t.Fatal("internal drive with --force and no --yes-overwrite-internal must be rejected")
+		}
+		if !strings.Contains(err.Error(), "yes-overwrite-internal") {
+			t.Errorf("error should mention --yes-overwrite-internal: %v", err)
+		}
+		if !strings.Contains(err.Error(), internal.DevicePath) {
+			t.Errorf("error should name the drive: %v", err)
+		}
+	})
+
+	t.Run("internal + force + override is allowed", func(t *testing.T) {
+		if err := confirmOverwriteInternalDrive(internal, true, true); err != nil {
+			t.Errorf("override flag should permit overwrite: %v", err)
+		}
+	})
+
+	t.Run("internal interactive + override skips typed prompt", func(t *testing.T) {
+		// yesOverwriteInternal = true means we never reach the stdin read.
+		if err := confirmOverwriteInternalDrive(internal, false, true); err != nil {
+			t.Errorf("override flag should bypass typed prompt: %v", err)
+		}
+	})
 }

--- a/go/internal/cli/commands/os_provision.go
+++ b/go/internal/cli/commands/os_provision.go
@@ -125,6 +125,16 @@ func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName st
 	return json.Marshal(state)
 }
 
+// provisioningRequired reports whether the user supplied provisioning data
+// that must reach the device's config partition. When this returns true, a
+// failure to write the config partition has dropped user-visible state on
+// the floor and must be treated as fatal — silently printing "successfully
+// installed" hides the lost data (--wifi never reaches the device, the
+// pre-enroll key/cert is discarded, etc.).
+func provisioningRequired(creds []wendyconf.WifiCredential, deviceName string, provisioningJSON []byte) bool {
+	return len(creds) > 0 || deviceName != "" || len(provisioningJSON) > 0
+}
+
 // writeConfigFiles writes the agent binary, optional wendy.conf, and optional
 // provisioning.json to mountPoint.
 func writeConfigFiles(mountPoint string, agentBinary []byte, creds []wendyconf.WifiCredential, deviceName string, provisioningJSON []byte) error {

--- a/go/internal/cli/commands/os_provision_darwin.go
+++ b/go/internal/cli/commands/os_provision_darwin.go
@@ -10,6 +10,11 @@ import (
 	"github.com/wendylabsinc/wendy/internal/shared/wendyconf"
 )
 
+// configPartitionSupported reports whether writeConfigPartition has a working
+// implementation on this OS. Callers gate the agent download + config write
+// on this so non-supported platforms don't pay the network cost just to fail.
+const configPartitionSupported = true
+
 // writeConfigPartition finds, mounts, populates, and unmounts the FAT32 config
 // partition on d after a dd write. agentBinary is the arm64 agent binary
 // content. creds and deviceName are written to wendy.conf when non-empty.

--- a/go/internal/cli/commands/os_provision_linux.go
+++ b/go/internal/cli/commands/os_provision_linux.go
@@ -12,6 +12,11 @@ import (
 	"github.com/wendylabsinc/wendy/internal/shared/wendyconf"
 )
 
+// configPartitionSupported reports whether writeConfigPartition has a working
+// implementation on this OS. Callers gate the agent download + config write
+// on this so non-supported platforms don't pay the network cost just to fail.
+const configPartitionSupported = true
+
 // writeConfigPartition finds, mounts, populates, and unmounts the FAT32 config
 // partition on d after a dd write. agentBinary is the arm64 agent binary
 // content. creds and deviceName are written to wendy.conf when non-empty.

--- a/go/internal/cli/commands/os_provision_test.go
+++ b/go/internal/cli/commands/os_provision_test.go
@@ -21,8 +21,38 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/wendylabsinc/wendy/internal/shared/config"
+	"github.com/wendylabsinc/wendy/internal/shared/wendyconf"
 	cloudpb "github.com/wendylabsinc/wendy/proto/gen/cloudpb"
 )
+
+func TestProvisioningRequired(t *testing.T) {
+	// Empty inputs: no provisioning data, agent download is the only thing
+	// that would have happened, and a config-partition write failure can
+	// safely degrade to a warning.
+	if provisioningRequired(nil, "", nil) {
+		t.Error("provisioningRequired(nil, \"\", nil) = true; want false")
+	}
+
+	cred := []wendyconf.WifiCredential{{SSID: "Home", Password: "x"}}
+	cases := []struct {
+		name             string
+		creds            []wendyconf.WifiCredential
+		deviceName       string
+		provisioningJSON []byte
+	}{
+		{"creds only", cred, "", nil},
+		{"deviceName only", nil, "brave-dolphin", nil},
+		{"provisioningJSON only", nil, "", []byte(`{"enrolled":true}`)},
+		{"all three", cred, "brave-dolphin", []byte(`{"enrolled":true}`)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if !provisioningRequired(c.creds, c.deviceName, c.provisioningJSON) {
+				t.Errorf("provisioningRequired(%v, %q, %v) = false; want true (user-supplied data must not be silently dropped)", c.creds, c.deviceName, c.provisioningJSON)
+			}
+		})
+	}
+}
 
 type fakePreEnrollCertService struct {
 	cloudpb.UnimplementedCertificateServiceServer

--- a/go/internal/cli/commands/os_provision_windows.go
+++ b/go/internal/cli/commands/os_provision_windows.go
@@ -9,7 +9,15 @@ import (
 	"github.com/wendylabsinc/wendy/internal/shared/wendyconf"
 )
 
-func writeConfigPartition(d drive, agentBinary []byte, creds []wendyconf.WifiCredential, deviceName string, _ []byte) error {
+// configPartitionSupported is false on Windows: writeConfigPartition has no
+// implementation, so callers must skip the agent download and refuse to claim
+// success when --wifi/--device-name/--pre-enroll were requested.
+const configPartitionSupported = false
+
+// writeConfigPartition is a stub on Windows. Callers gate on
+// configPartitionSupported and never invoke this; it exists only so the
+// cross-platform call site in provisionConfigPartition compiles.
+func writeConfigPartition(_ drive, _ []byte, _ []wendyconf.WifiCredential, _ string, _ []byte) error {
 	return fmt.Errorf("config partition provisioning is not supported on Windows")
 }
 


### PR DESCRIPTION
Closes [WDY-1118](https://linear.app/wendylabsinc/issue/WDY-1118/wendy-os-install-dont-claim-success-when-provisioning-was-skipped).

## Summary
- `wendy os install` no longer claims success when Windows silently drops `--wifi` / `--device-name` / `--pre-enroll` data — it now returns a fatal error naming what was lost. When no provisioning data was requested, the agent download is short-circuited entirely on platforms that can't write the config partition.
- Elevation is checked at the top of `runOSInstallDirect` and `installLinuxImage` (before the manifest fetch and image download), and the Windows path uses `OpenProcessToken` + `GetTokenInformation(TokenElevation)` instead of a `net session` probe. When non-elevated, the user is offered a UAC re-launch via `ShellExecute` with the `runas` verb instead of just being told to relaunch.
- A new `--yes-overwrite-internal` flag (plus a typed-path interactive confirmation) guards `!IsRemovable` drives selectable through `--drive`, so a stray `--force` against `\\.\\PhysicalDrive1` no longer wipes a secondary internal SSD without an extra speed bump.

The existing late `preAuthElevation()` call before the TUI starts is kept so Unix's sudo timestamp gets refreshed through long downloads.

## Test plan
- [x] `go test -count=1 ./internal/cli/commands/` (darwin host) — passes; new tests `TestProvisioningRequired` and `TestConfirmOverwriteInternalDrive` cover the helper logic, and `TestNewOSInstallCmd_Flags` is updated for the new flag.
- [x] `GOOS=windows GOARCH=amd64 go build ./internal/cli/commands/` and `./cmd/wendy` — clean.
- [x] `GOOS=linux GOARCH=amd64 go build ./internal/cli/commands/` — clean.
- [x] `go vet` clean for darwin and windows.
- [ ] On a Windows machine: confirm `wendy os install --pre-enroll` exits non-zero and surfaces "config partition is not yet supported" instead of "Successfully installed".
- [ ] On a Windows machine without admin: confirm UAC dialog appears at the start of `wendy os install` (before any download) and that declining the prompt yields a clear error.
- [ ] On a Windows machine with `--drive \\\\.\\PhysicalDriveN` pointing at a non-removable internal drive: confirm `--force` alone is rejected and `--force --yes-overwrite-internal` proceeds.

## Out of scope (separate tickets)
- A real Windows `writeConfigPartition` implementation — until that lands, this PR makes the failure loud.
- The PowerShell `-Confirm:\$false` / `-ErrorAction` papercuts called out in `WINDOWS_REGRESSION_REVIEW.md` § 1.1, 1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)