### PR TITLE
feat(run): add hooks.postStart.openURL for portable browser opening (WDY-1119)

### DIFF
--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/wendylabsinc/wendy/internal/cli/swifttoolchain"
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/internal/shared/browseropen"
 	"github.com/wendylabsinc/wendy/internal/shared/models"
 	"github.com/wendylabsinc/wendy/proto/gen/agentpb"
 )
@@ -1262,36 +1263,72 @@ func waitForReadiness(ctx context.Context, cfg *appconfig.ReadinessConfig, hostn
 	}
 }
 
-// shellCommand returns the platform-appropriate shell and flag for running a
-// command string. On Windows it uses cmd.exe /C; everywhere else sh -c.
-func shellCommand() (string, string) {
+// shellCommand returns the shell binary and the argument prefix for running a
+// command string. On Windows it returns cmd.exe with /S /C: /S makes quote
+// stripping predictable when the command contains nested quotes (under the
+// default /C rules cmd.exe behavior depends on the count of `"` characters).
+// On Unix it returns sh -c.
+func shellCommand() (string, []string) {
 	if runtime.GOOS == "windows" {
-		return "cmd.exe", "/C"
+		return "cmd.exe", []string{"/S", "/C"}
 	}
-	return "sh", "-c"
+	return "sh", []string{"-c"}
 }
 
-// startPostStartHook expands environment variables in the postStart CLI hook
-// and spawns it as a child process. The returned *exec.Cmd can be used to wait
-// on or kill the process. Returns nil if there is no postStart CLI hook.
-func startPostStartHook(ctx context.Context, appCfg *appconfig.AppConfig, hostname string) *exec.Cmd {
-	if appCfg.Hooks == nil || appCfg.Hooks.PostStart == nil || appCfg.Hooks.PostStart.CLI == "" {
-		return nil
-	}
-
-	expanded := os.Expand(appCfg.Hooks.PostStart.CLI, func(key string) string {
+// expandHookEnv resolves Wendy's documented placeholders in s. Both Unix-style
+// (${VAR}, $VAR) and Windows-style (%WENDY_*%) forms are accepted for the two
+// Wendy-provided placeholders, so the same hook string parses identically in
+// sh and cmd.exe. Other ${VAR} forms fall through to os.Getenv; raw %VAR%
+// forms for non-Wendy variables are left for cmd.exe to expand natively.
+func expandHookEnv(s, hostname, appID string) string {
+	s = strings.ReplaceAll(s, "%WENDY_HOSTNAME%", hostname)
+	s = strings.ReplaceAll(s, "%WENDY_APP_ID%", appID)
+	return os.Expand(s, func(key string) string {
 		switch key {
 		case "WENDY_HOSTNAME":
 			return hostname
 		case "WENDY_APP_ID":
-			return appCfg.AppID
+			return appID
 		default:
 			return os.Getenv(key)
 		}
 	})
+}
 
-	shell, flag := shellCommand()
-	cmd := execCommandContext(ctx, shell, flag, expanded)
+// browserOpen is the cross-platform browser opener used by openURL hooks.
+// Indirected through a var so tests can swap it out.
+var browserOpen = browseropen.Open
+
+// startPostStartHook fires the postStart hook actions for appCfg.
+//
+// If openURL is set, it is expanded and opened in the developer's default
+// browser via the shared browseropen helper — no shell, no quoting. If cli
+// is set, it runs after, expanded for env vars and dispatched through the
+// platform shell; the returned *exec.Cmd is the cli child for the caller to
+// wait on or kill. Returns nil when no cli command is configured (regardless
+// of whether openURL was fired).
+func startPostStartHook(ctx context.Context, appCfg *appconfig.AppConfig, hostname string) *exec.Cmd {
+	if appCfg.Hooks == nil || appCfg.Hooks.PostStart == nil {
+		return nil
+	}
+	hook := appCfg.Hooks.PostStart
+
+	if hook.OpenURL != "" {
+		url := expandHookEnv(hook.OpenURL, hostname, appCfg.AppID)
+		if err := browserOpen(url); err != nil {
+			cliLogln("Warning: postStart openURL failed: %v", err)
+		} else {
+			cliLogln("Hook postStart: opened %s", url)
+		}
+	}
+
+	if hook.CLI == "" {
+		return nil
+	}
+
+	expanded := expandHookEnv(hook.CLI, hostname, appCfg.AppID)
+	shell, flags := shellCommand()
+	cmd := execCommandContext(ctx, shell, append(flags, expanded)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/go/internal/cli/commands/run_test.go
+++ b/go/internal/cli/commands/run_test.go
@@ -1,6 +1,13 @@
 package commands
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
+)
 
 func TestWendyPlatform(t *testing.T) {
 	cases := []struct {
@@ -19,5 +26,180 @@ func TestWendyPlatform(t *testing.T) {
 				t.Fatalf("wendyPlatform(%q) = %q, want %q", tc.deviceType, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestExpandHookEnv(t *testing.T) {
+	t.Setenv("WENDY_TEST_VAR", "from-env")
+
+	cases := []struct {
+		name     string
+		input    string
+		hostname string
+		appID    string
+		want     string
+	}{
+		{"unix style hostname", "http://${WENDY_HOSTNAME}:3001", "device.local", "app", "http://device.local:3001"},
+		{"unix style appid", "/var/lib/${WENDY_APP_ID}", "h", "com.example.app", "/var/lib/com.example.app"},
+		{"windows style hostname", "start http://%WENDY_HOSTNAME%:3001", "device.local", "app", "start http://device.local:3001"},
+		{"windows style appid", "echo %WENDY_APP_ID%", "h", "com.example.app", "echo com.example.app"},
+		{"mixed", "%WENDY_HOSTNAME% ${WENDY_APP_ID}", "host", "app", "host app"},
+		{"unknown unix var falls through to env", "${WENDY_TEST_VAR}", "h", "a", "from-env"},
+		{"unknown windows var left for cmd.exe", "%PATH_THAT_IS_NOT_WENDY%", "h", "a", "%PATH_THAT_IS_NOT_WENDY%"},
+		{"no expansion needed", "echo hello", "h", "a", "echo hello"},
+		{"repeated", "%WENDY_HOSTNAME% then %WENDY_HOSTNAME%", "h", "a", "h then h"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := expandHookEnv(tc.input, tc.hostname, tc.appID)
+			if got != tc.want {
+				t.Errorf("expandHookEnv(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShellCommandWindowsUsesS(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-specific behavior")
+	}
+	shell, flags := shellCommand()
+	if shell != "cmd.exe" {
+		t.Errorf("shellCommand() shell = %q, want cmd.exe", shell)
+	}
+	if len(flags) != 2 || flags[0] != "/S" || flags[1] != "/C" {
+		t.Errorf("shellCommand() flags = %v, want [/S /C]", flags)
+	}
+}
+
+func TestShellCommandUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-specific behavior")
+	}
+	shell, flags := shellCommand()
+	if shell != "sh" {
+		t.Errorf("shellCommand() shell = %q, want sh", shell)
+	}
+	if len(flags) != 1 || flags[0] != "-c" {
+		t.Errorf("shellCommand() flags = %v, want [-c]", flags)
+	}
+}
+
+func TestStartPostStartHook_OpenURL(t *testing.T) {
+	original := browserOpen
+	t.Cleanup(func() { browserOpen = original })
+
+	var got string
+	browserOpen = func(url string) error {
+		got = url
+		return nil
+	}
+
+	cfg := &appconfig.AppConfig{
+		AppID: "com.example.app",
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{
+				OpenURL: "http://${WENDY_HOSTNAME}:3001/${WENDY_APP_ID}",
+			},
+		},
+	}
+
+	cmd := startPostStartHook(context.Background(), cfg, "device.local")
+	if cmd != nil {
+		t.Errorf("startPostStartHook() returned non-nil cmd for openURL-only hook")
+	}
+	if got != "http://device.local:3001/com.example.app" {
+		t.Errorf("openURL = %q, want expanded URL", got)
+	}
+}
+
+func TestStartPostStartHook_OpenURLWindowsStyleVars(t *testing.T) {
+	original := browserOpen
+	t.Cleanup(func() { browserOpen = original })
+
+	var got string
+	browserOpen = func(url string) error {
+		got = url
+		return nil
+	}
+
+	cfg := &appconfig.AppConfig{
+		AppID: "com.example.app",
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{
+				OpenURL: "http://%WENDY_HOSTNAME%:3001",
+			},
+		},
+	}
+
+	startPostStartHook(context.Background(), cfg, "device.local")
+	if got != "http://device.local:3001" {
+		t.Errorf("openURL = %q, want %q", got, "http://device.local:3001")
+	}
+}
+
+func TestStartPostStartHook_OpenURLErrorDoesNotPropagate(t *testing.T) {
+	original := browserOpen
+	t.Cleanup(func() { browserOpen = original })
+
+	browserOpen = func(url string) error {
+		return errors.New("simulated browser failure")
+	}
+
+	cfg := &appconfig.AppConfig{
+		AppID: "com.example.app",
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{
+				OpenURL: "http://localhost:3001",
+			},
+		},
+	}
+
+	// Should not panic and should not block; CLI hook is not set so returns nil.
+	cmd := startPostStartHook(context.Background(), cfg, "h")
+	if cmd != nil {
+		t.Errorf("startPostStartHook() returned non-nil cmd")
+	}
+}
+
+func TestStartPostStartHook_OpenURLNotCalledWhenEmpty(t *testing.T) {
+	original := browserOpen
+	t.Cleanup(func() { browserOpen = original })
+
+	called := false
+	browserOpen = func(url string) error {
+		called = true
+		return nil
+	}
+
+	cfg := &appconfig.AppConfig{
+		AppID: "com.example.app",
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{
+				CLI: "echo hello",
+			},
+		},
+	}
+
+	startPostStartHook(context.Background(), cfg, "h")
+	if called {
+		t.Errorf("browserOpen was called for cli-only hook")
+	}
+}
+
+func TestStartPostStartHook_NoHookReturnsNil(t *testing.T) {
+	cfg := &appconfig.AppConfig{AppID: "com.example.app"}
+	if cmd := startPostStartHook(context.Background(), cfg, "h"); cmd != nil {
+		t.Errorf("startPostStartHook() = %v, want nil for missing hooks", cmd)
+	}
+
+	cfg.Hooks = &appconfig.HooksConfig{}
+	if cmd := startPostStartHook(context.Background(), cfg, "h"); cmd != nil {
+		t.Errorf("startPostStartHook() = %v, want nil for empty Hooks", cmd)
+	}
+
+	cfg.Hooks.PostStart = &appconfig.HookCommand{}
+	if cmd := startPostStartHook(context.Background(), cfg, "h"); cmd != nil {
+		t.Errorf("startPostStartHook() = %v, want nil for empty PostStart", cmd)
 	}
 }

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -128,9 +128,15 @@ type HooksConfig struct {
 const PostStartAgentHookMetadataKey = "wendy-post-start-agent-command"
 
 // HookCommand holds CLI and agent-side commands for a lifecycle hook.
+//
+// OpenURL is the portable way to open a URL in the developer's default browser
+// at hook time — the CLI dispatches it directly without a shell, so it works
+// uniformly on macOS, Linux, and Windows. Prefer it over `cli: "open …"` /
+// `cli: "xdg-open …"` / `cli: "start …"`, which are platform-specific.
 type HookCommand struct {
-	CLI   string `json:"cli,omitempty"`   // Command to run on the developer's machine
-	Agent string `json:"agent,omitempty"` // Command to run on the device
+	OpenURL string `json:"openURL,omitempty"` // URL to open in the developer's default browser
+	CLI     string `json:"cli,omitempty"`     // Command to run on the developer's machine
+	Agent   string `json:"agent,omitempty"`   // Command to run on the device
 }
 
 // PythonConfig holds Python-specific configuration.
@@ -310,16 +316,24 @@ func isValidI2CDevice(device string) bool {
 	return true
 }
 
-// ValidateJSON checks raw JSON data for unknown keys in entitlements and returns warnings.
-// Call this after decoding to detect potential typos or invalid configuration.
+// ValidateJSON checks raw JSON data for non-fatal issues that should surface
+// as user-visible warnings (unknown entitlement keys, deprecated entitlement
+// types, non-portable hook commands) and returns them. Call this after
+// decoding to detect potential typos or platform-specific configuration.
 func ValidateJSON(data []byte) []string {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
 	}
 
-	entRaw, ok := raw["entitlements"]
-	if !ok {
+	var warnings []string
+	warnings = append(warnings, validateEntitlementsJSON(raw["entitlements"])...)
+	warnings = append(warnings, validateHooksJSON(raw["hooks"])...)
+	return warnings
+}
+
+func validateEntitlementsJSON(entRaw json.RawMessage) []string {
+	if len(entRaw) == 0 {
 		return nil
 	}
 
@@ -378,4 +392,42 @@ func ValidateJSON(data []byte) []string {
 	}
 
 	return warnings
+}
+
+// nonPortableOpenerCommands maps the bare-binary prefix of a non-portable
+// URL-opening shell command to the platform on which it works. Detected at
+// the start of hooks.postStart.cli to suggest the portable openURL field.
+var nonPortableOpenerCommands = map[string]string{
+	"open":     "macOS",
+	"xdg-open": "Linux",
+	"start":    "Windows",
+}
+
+func validateHooksJSON(hooksRaw json.RawMessage) []string {
+	if len(hooksRaw) == 0 {
+		return nil
+	}
+
+	var hooks struct {
+		PostStart *struct {
+			CLI string `json:"cli"`
+		} `json:"postStart"`
+	}
+	if err := json.Unmarshal(hooksRaw, &hooks); err != nil {
+		return nil
+	}
+	if hooks.PostStart == nil || hooks.PostStart.CLI == "" {
+		return nil
+	}
+
+	cli := strings.TrimLeft(hooks.PostStart.CLI, " \t")
+	for opener, platform := range nonPortableOpenerCommands {
+		if cli == opener || strings.HasPrefix(cli, opener+" ") || strings.HasPrefix(cli, opener+"\t") {
+			return []string{fmt.Sprintf(
+				"hooks.postStart.cli starts with %q, which only works on %s; use \"openURL\" to open a URL portably across macOS, Linux, and Windows",
+				opener, platform,
+			)}
+		}
+	}
+	return nil
 }

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -358,6 +358,156 @@ func TestLoadFromFile_WithoutHooks(t *testing.T) {
 	}
 }
 
+func TestLoadFromFile_HooksPostStartOpenURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wendy.json")
+
+	content := `{
+		"appId": "com.example.webapp",
+		"hooks": {
+			"postStart": {
+				"openURL": "http://${WENDY_HOSTNAME}:3000"
+			}
+		}
+	}`
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	cfg, err := LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile() error = %v", err)
+	}
+	if cfg.Hooks == nil || cfg.Hooks.PostStart == nil {
+		t.Fatal("Hooks.PostStart is nil")
+	}
+	if got, want := cfg.Hooks.PostStart.OpenURL, "http://${WENDY_HOSTNAME}:3000"; got != want {
+		t.Errorf("Hooks.PostStart.OpenURL = %q, want %q", got, want)
+	}
+	if cfg.Hooks.PostStart.CLI != "" {
+		t.Errorf("Hooks.PostStart.CLI = %q, want empty", cfg.Hooks.PostStart.CLI)
+	}
+}
+
+func TestValidateJSON_PostStartCLILegacyOpener(t *testing.T) {
+	tests := []struct {
+		name       string
+		cli        string
+		wantOpener string
+		wantPlatfm string
+	}{
+		{"open", "open http://localhost:3000", "open", "macOS"},
+		{"xdg-open", "xdg-open http://localhost:3000", "xdg-open", "Linux"},
+		{"start", "start http://localhost:3000", "start", "Windows"},
+		{"open with leading whitespace", "  open http://localhost:3000", "open", "macOS"},
+		{"open with tab separator", "open\thttp://localhost:3000", "open", "macOS"},
+		{"bare open", "open", "open", "macOS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte(`{
+				"appId": "com.example.app",
+				"hooks": {
+					"postStart": {
+						"cli": ` + jsonString(tt.cli) + `
+					}
+				}
+			}`)
+
+			warnings := ValidateJSON(data)
+			if len(warnings) != 1 {
+				t.Fatalf("ValidateJSON() got %d warnings, want 1: %v", len(warnings), warnings)
+			}
+			if !strings.Contains(warnings[0], `"`+tt.wantOpener+`"`) {
+				t.Errorf("warning %q does not mention opener %q", warnings[0], tt.wantOpener)
+			}
+			if !strings.Contains(warnings[0], tt.wantPlatfm) {
+				t.Errorf("warning %q does not mention platform %q", warnings[0], tt.wantPlatfm)
+			}
+			if !strings.Contains(warnings[0], "openURL") {
+				t.Errorf("warning %q does not recommend openURL", warnings[0])
+			}
+		})
+	}
+}
+
+func TestValidateJSON_PostStartCLIPortableNoWarning(t *testing.T) {
+	tests := []struct {
+		name string
+		cli  string
+	}{
+		{"echo", "echo hello"},
+		{"openssl is not open", "openssl version"},
+		{"started is not start", "started --foo"},
+		{"empty", ""},
+		{"openURL only", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte(`{
+				"appId": "com.example.app",
+				"hooks": {
+					"postStart": {
+						"cli": ` + jsonString(tt.cli) + `
+					}
+				}
+			}`)
+
+			warnings := ValidateJSON(data)
+			for _, w := range warnings {
+				if strings.Contains(w, "hooks.postStart.cli") {
+					t.Errorf("unexpected warning: %q", w)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateJSON_PostStartOpenURLNoWarning(t *testing.T) {
+	data := []byte(`{
+		"appId": "com.example.app",
+		"hooks": {
+			"postStart": {
+				"openURL": "http://localhost:3000"
+			}
+		}
+	}`)
+
+	warnings := ValidateJSON(data)
+	for _, w := range warnings {
+		if strings.Contains(w, "hooks.postStart") {
+			t.Errorf("unexpected warning: %q", w)
+		}
+	}
+}
+
+func TestValidateJSON_NoEntitlementsStillValidatesHooks(t *testing.T) {
+	// Regression: ValidateJSON used to early-return when entitlements were
+	// missing, silently skipping hook validation.
+	data := []byte(`{
+		"appId": "com.example.app",
+		"hooks": {
+			"postStart": {
+				"cli": "open http://localhost:3000"
+			}
+		}
+	}`)
+
+	warnings := ValidateJSON(data)
+	if len(warnings) != 1 {
+		t.Fatalf("ValidateJSON() got %d warnings, want 1", len(warnings))
+	}
+}
+
+func jsonString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
 func TestLoadFromFile_HooksPostStartCLIOnly(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wendy.json")

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -260,9 +260,14 @@
       "description": "Commands to run at a lifecycle stage.",
       "additionalProperties": false,
       "properties": {
+        "openURL": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to open in the developer's default browser. Cross-platform; prefer this over a `cli` shell invocation of `open`/`xdg-open`/`start`. Supports ${WENDY_HOSTNAME} and ${WENDY_APP_ID} expansion."
+        },
         "cli": {
           "type": "string",
-          "description": "Command to run on the developer's machine."
+          "description": "Command to run on the developer's machine. Note: `open`/`xdg-open`/`start` are not portable across macOS/Linux/Windows — use `openURL` to open a URL instead."
         },
         "agent": {
           "type": "string",


### PR DESCRIPTION
Closes [WDY-1119](https://linear.app/wendylabsinc/issue/WDY-1119/wendy-run-portable-poststart-hooks-add-hookspoststartopenurl).

## Summary

A Windows user's `wendy run` printed `'open' is not recognized as an internal or external command` because their hand-written `wendy.json` hook was the literal `open http://...` (a macOS-only command). The CLI accepted arbitrary shell strings with no platform helper, no validation, and ignored the existing `browseropen` package designed for exactly this.

This adds a structured `hooks.postStart.openURL` field that bypasses the shell entirely — the CLI dispatches it via the shared `browseropen` helper. `cli` stays first-class as the free-form escape hatch but `appCfg.ValidateJSON` now warns when `cli` starts with `open`/`xdg-open`/`start`, catching this exact bug at config-load time.

```json
"hooks": {
  "postStart": {
    "openURL": "http://${WENDY_HOSTNAME}:3001",
    "cli": "...",
    "agent": "..."
  }
}
```

## Changes

- **`HookCommand.OpenURL string`** added to `appconfig.HookCommand`, surfaced in `wendy.schema.json` with a non-portability note on `cli`.
- **`startPostStartHook`** dispatches `openURL` via `browseropen.Open` (no shell, no quoting), then runs `cli` if also set. The returned `*exec.Cmd` continues to track the cli child for waiting/cancellation; openURL is fire-and-forget.
- **`ValidateJSON`** refactored into per-section helpers and extended with `validateHooksJSON`. Warns when `hooks.postStart.cli` begins with `open`/`xdg-open`/`start`, naming the originating platform and recommending `openURL`. Also fixes a latent bug where the function early-returned when `entitlements` was missing, silently skipping any other validation.

### Ride-along Windows hook fixes

- **`%VAR%` pre-substitution**: `expandHookEnv` now resolves Windows-style `%WENDY_HOSTNAME%` and `%WENDY_APP_ID%` in addition to `${VAR}`. Previously, a hook like `start %WENDY_HOSTNAME%:3001` would let `cmd.exe` try to expand `%WENDY_HOSTNAME%` from the (unset) process environment, producing `start :3001`.
- **`cmd.exe /S /C`**: `shellCommand` returns `/S /C` on Windows. `/S` makes quote stripping deterministic when the command contains nested quotes (under default `/C` rules `cmd.exe` behavior depends on the count of `\"` characters in the line).

The agent-side `startPostStartAgentHook` (`agent/containerd/client.go`) is left unchanged — agent hooks always run under Linux/`sh`, where `%VAR%` and `cmd.exe` quoting don't apply.

## Tests

- **`appconfig_test.go`** — round-trip parse with `openURL`; `ValidateJSON` warning matrix (open/xdg-open/start, leading whitespace, tab separator, bare opener); false-positive guards (`openssl version`, `started --foo`, `echo hello`); openURL config without `entitlements` still gets validated.
- **`run_test.go`** — `expandHookEnv` covering `\${VAR}` / `%VAR%` / mixed / unknown / repeated; `shellCommand` platform branches; `startPostStartHook` for openURL-only, openURL with Windows-style placeholders, browser failure does not propagate, openURL not called for cli-only hooks, missing-hook returns nil at each level.

## Test plan

- [x] `go test ./...` (darwin native) — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./cmd/wendy ./internal/cli/... ./internal/shared/...` — clean
- [x] `GOOS=windows GOARCH=386 go build ./cmd/wendy ./internal/cli/... ./internal/shared/...` — clean
- [x] `gofmt -l` and `go vet` — clean
- [ ] On a Windows machine: a `wendy.json` with `\"hooks\": { \"postStart\": { \"openURL\": \"http://\${WENDY_HOSTNAME}:3001\" } }` opens the device URL in the default browser via `wendy run`.
- [ ] On a Windows machine: a `wendy.json` with the legacy `\"cli\": \"open http://...\"` produces a `Warning: hooks.postStart.cli starts with \"open\", which only works on macOS; use \"openURL\" ...` at load time.

## Design notes

`cli` stays first-class with a validator warning rather than being deprecated immediately. We can revisit a deprecation timeline after this lands and users have had a release to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)