### PR TITLE
ci: gate stable releases on macOS integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -593,8 +593,11 @@ jobs:
   publish-linux-repos:
     name: Publish to GCP Artifact Registry
     runs-on: ubuntu-latest
-    needs: [determine-version, package-linux, test-templates]
-    if: needs.determine-version.outputs.is_release == 'true' && needs.determine-version.outputs.is_prerelease == 'false'
+    needs: [determine-version, package-linux, test-templates, integration-tests]
+    if: |
+      needs.determine-version.outputs.is_release == 'true' &&
+      needs.determine-version.outputs.is_prerelease == 'false' &&
+      (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
     permissions:
       contents: read
       id-token: write
@@ -644,11 +647,21 @@ jobs:
               --source="$rpm"
           done
 
+  integration-tests:
+    name: Integration Tests (macOS, stable gate)
+    if: github.event_name == 'workflow_dispatch' && inputs.publish == true
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      platform: macos
+      jobs: integration
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [determine-version, build, build-go-macos, build-agent-macos-app, package-linux, package-windows, test-templates]
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+    needs: [determine-version, build, build-go-macos, build-agent-macos-app, package-linux, package-windows, test-templates, integration-tests]
+    if: |
+      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)) &&
+      (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,0 +1,18 @@
+name: PR Integration Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+
+concurrency:
+  group: pr-integration-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  integration-tests:
+    name: Integration Tests (macOS)
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      platform: macos
+      jobs: integration

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   integration-tests:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: Integration Tests (macOS)
     uses: ./.github/workflows/integration-tests.yml
     with:

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -248,3 +248,80 @@ for test_name in "${TESTS[@]}"; do
     # ── Compose tests (docker-compose.{yml,yaml}, compose.{yml,yaml}, no wendy.json) ──
     compose_file=""
     for cand in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
+        if [[ -f "$test_dir/$cand" ]]; then
+            compose_file="$test_dir/$cand"
+            break
+        fi
+    done
+    if [[ -n "$compose_file" ]]; then
+        # Derive project name from directory name (mirrors CLI logic).
+        project_name="$(basename "$test_dir")"
+
+        # Use docker compose itself to enumerate services so we don't depend
+        # on PyYAML (not in stdlib and not installed on most CI hosts).
+        service_names=$(docker compose -f "$compose_file" config --services 2>/dev/null | tr '\n' ' ')
+
+        # Pre-cleanup: remove leftover service containers.
+        for svc in $service_names; do
+            "$WENDY" apps remove "${project_name}-${svc}" --device "$HOSTNAME" --force &>/dev/null || true
+        done
+
+        # Deploy and run.
+        pushd "$test_dir" > /dev/null
+        run_test "$test_name" "$WENDY" run --device "$HOSTNAME"
+        popd > /dev/null
+
+        # Post-cleanup.
+        for svc in $service_names; do
+            "$WENDY" apps stop "${project_name}-${svc}" --device "$HOSTNAME" &>/dev/null || true
+            "$WENDY" apps remove "${project_name}-${svc}" --device "$HOSTNAME" --force &>/dev/null || true
+        done
+        docker buildx rm "${WENDY_BUILDX_BUILDER:-wendy}" --force &>/dev/null || true
+        continue
+    fi
+
+    # ── Standard single-container tests (wendy.json) ───────────────────
+    if [[ ! -f "$test_dir/wendy.json" ]]; then
+        skip_test "$test_name" "no wendy.json"
+        continue
+    fi
+
+    # Extract appId
+    app_id=$(jq -r '.appId' "$test_dir/wendy.json" 2>/dev/null)
+    if [[ -z "$app_id" || "$app_id" == "null" ]]; then
+        skip_test "$test_name" "no appId"
+        continue
+    fi
+
+    # Pre-cleanup: remove leftover container from previous runs
+    "$WENDY" apps remove "$app_id" --device "$HOSTNAME" --force &>/dev/null || true
+
+    # Deploy and run
+    pushd "$test_dir" > /dev/null
+    run_test "$test_name" "$WENDY" run --device "$HOSTNAME"
+    popd > /dev/null
+
+    # Post-cleanup: stop and remove
+    "$WENDY" apps stop "$app_id" --device "$HOSTNAME" &>/dev/null || true
+    "$WENDY" apps remove "$app_id" --device "$HOSTNAME" --force &>/dev/null || true
+    docker buildx rm "${WENDY_BUILDX_BUILDER:-wendy}" --force &>/dev/null || true
+done
+
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+echo -e "${BOLD}========================================${RESET}"
+echo -e "${BOLD}Results:${RESET} $TOTAL tests"
+echo -e "  ${GREEN}Passed:  $PASS_COUNT${RESET}"
+echo -e "  ${RED}Failed:  $FAIL_COUNT${RESET}"
+if [[ $SKIP_COUNT -gt 0 ]]; then
+    echo -e "  ${YELLOW}Skipped: $SKIP_COUNT${RESET}"
+fi
+echo -e "${BOLD}========================================${RESET}"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Adds a new `integration-tests` job to `build.yml` that calls the existing `integration-tests.yml` workflow (macOS only, full device suite) — runs only when `publish=true`
- Gates the `release` job on `integration-tests` passing; updates `if` condition to allow `skipped` so nightly builds are unaffected
- Gates `publish-linux-repos` independently (it runs parallel to `release`) with the same guard

## Test Plan
- [ ] Trigger `workflow_dispatch` with `publish=false` — verify `integration-tests` is skipped and `release` still runs
- [ ] Trigger `workflow_dispatch` with `publish=true` and hardware available — verify `integration-tests` runs and release proceeds on pass
- [ ] Verify `publish-aur` and `publish-winget` remain transitively gated via `release`