### PR TITLE
feat(completion): add --stdout flag for Homebrew completion staging

### DIFF
--- a/go/internal/cli/commands/completion.go
+++ b/go/internal/cli/commands/completion.go
@@ -70,6 +70,7 @@ func newCompletionInstallCmd() *cobra.Command {
 		shellOverride string
 		outputDir     string
 		printPath     bool
+		toStdout      bool
 	)
 
 	cmd := &cobra.Command{
@@ -77,12 +78,19 @@ func newCompletionInstallCmd() *cobra.Command {
 		Short: "Install shell completions into the user's standard config locations",
 		Long: "Detect the current shell and write its completion script to the conventional " +
 			"location, appending an idempotent sourcing line to your shell rc file when needed.\n\n" +
-			"Use --shell to override shell detection, or --print-path for a dry run.",
+			"Use --shell to override shell detection, --print-path for a dry run, or --stdout " +
+			"to print the script to stdout (useful for `brew install` completion staging).",
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
+			if toStdout && printPath {
+				return errors.New("--stdout and --print-path are mutually exclusive")
+			}
 			shell, err := detectShell(shellOverride, runtime.GOOS, os.Getenv)
 			if err != nil {
 				return err
+			}
+			if toStdout {
+				return writeShellScript(c.Root(), shell, c.OutOrStdout())
 			}
 			home, err := resolveHome(outputDir)
 			if err != nil {
@@ -108,6 +116,7 @@ func newCompletionInstallCmd() *cobra.Command {
 	cmd.Flags().StringVar(&shellOverride, "shell", "", "Override shell (bash|zsh|fish|powershell)")
 	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Use this directory as $HOME (for testing)")
 	cmd.Flags().BoolVar(&printPath, "print-path", false, "Print install paths without writing")
+	cmd.Flags().BoolVar(&toStdout, "stdout", false, "Print the completion script to stdout instead of installing")
 	// --output-dir is a test seam, not a user-facing knob; hide from --help.
 	_ = cmd.Flags().MarkHidden("output-dir")
 	return cmd

--- a/go/internal/cli/commands/completion_test.go
+++ b/go/internal/cli/commands/completion_test.go
@@ -262,6 +262,52 @@ func TestInstall_WritesFile(t *testing.T) {
 	}
 }
 
+func TestInstall_Stdout(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			tmp := t.TempDir()
+			stdout, _, err := executeCompletion(t,
+				"completion", "install",
+				"--shell", shell,
+				"--output-dir", tmp,
+				"--stdout",
+			)
+			if err != nil {
+				t.Fatalf("install --stdout: %v", err)
+			}
+			if stdout.Len() < 200 {
+				t.Errorf("stdout too short (%d bytes); got: %q", stdout.Len(), stdout.String())
+			}
+			// --stdout must not write any files or rc edits.
+			entries, err := os.ReadDir(tmp)
+			if err != nil {
+				t.Fatalf("readdir: %v", err)
+			}
+			if len(entries) != 0 {
+				names := make([]string, 0, len(entries))
+				for _, e := range entries {
+					names = append(names, e.Name())
+				}
+				t.Errorf("--stdout wrote into tmp dir: %v", names)
+			}
+		})
+	}
+}
+
+func TestInstall_StdoutAndPrintPathConflict(t *testing.T) {
+	tmp := t.TempDir()
+	_, _, err := executeCompletion(t,
+		"completion", "install",
+		"--shell", "bash",
+		"--output-dir", tmp,
+		"--stdout",
+		"--print-path",
+	)
+	if err == nil {
+		t.Fatal("expected error when both --stdout and --print-path are set")
+	}
+}
+
 func TestInstall_PrintPath(t *testing.T) {
 	tmp := t.TempDir()
 	stdout, _, err := executeCompletion(t,


### PR DESCRIPTION
## Summary
- Adds `--stdout` flag to `wendy completion install` that prints the completion script for the chosen shell to stdout without touching the filesystem or shell rc files.
- Unblocks Homebrew formulae using [`generate_completions_from_executable`](https://docs.brew.sh/Formula-Cookbook#completions), which expects the executable to emit completion scripts on stdout.
- Rejects `--stdout` combined with `--print-path` so the two dry-run modes can't be silently mixed.

## Why
`wendy completion install` writes scripts into the user's standard config locations and edits their shell rc files. That works great for end-user installs, but Homebrew's `generate_completions_from_executable` shells out to the binary expecting completion scripts on stdout so it can stage them under `bash_completion`, `zsh_completion`, and `fish_completion`. The existing `wendy completion bash|zsh|fish|powershell` subcommands already do that, but adding `--stdout` to `install` lets the formula use a single, intent-revealing invocation regardless of the path Homebrew chooses.

Example formula usage:

```ruby
generate_completions_from_executable(
  bin/"wendy",
  "completion", "install", "--stdout",
  shell_parameter_format: "--shell=%s",
)
```

## Test plan
- [x] `go test ./internal/cli/commands/...` — all green, including new `TestInstall_Stdout` (table over bash/zsh/fish/powershell) and `TestInstall_StdoutAndPrintPathConflict`.
- [x] `go vet ./...` and `gofmt -l -s .` clean.
- [x] Cross-compile clean for `darwin/arm64` (host), `linux/amd64`, and `windows/amd64`.
- [x] End-to-end smoke: `wendy completion install --shell bash --stdout | head` emits the bash completion script (16KB).
- [x] `wendy completion install --stdout --print-path` returns a clear error.

## Follow-ups (not in this PR)
- Update the Homebrew tap formula to call `generate_completions_from_executable` using the new flag.
- Mirror the change in the Linux `install.sh` if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)