### PR TITLE
feat(agent): expose WENDY_DEVICE_HOSTNAME env var to containers (WDY-1126)

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -483,11 +483,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	}
 
 	// Build environment variables: image env first, then our overrides.
-	env := []string{
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-		"TERM=xterm",
-		fmt.Sprintf("WENDY_HOSTNAME=%s.local", appName),
-	}
+	env := buildContainerBaseEnv(appName)
 	if specErr == nil {
 		env = append(imageSpec.Config.Env, env...)
 	}
@@ -733,6 +729,32 @@ func shellCommand() (string, string) {
 		return "cmd.exe", "/C"
 	}
 	return "sh", "-c"
+}
+
+// deviceHostnameWithSuffix returns the device's mDNS hostname with the ".local"
+// suffix (e.g. "wendyos-mighty-kayak.local"), or "" if the OS hostname is
+// unavailable. Indirected through a var so tests can override it.
+var deviceHostnameWithSuffix = func() string {
+	h, err := os.Hostname()
+	if err != nil || h == "" {
+		return ""
+	}
+	return h + ".local"
+}
+
+// buildContainerBaseEnv builds the wendy-injected env vars layered on top of
+// the image's own env. WENDY_HOSTNAME is the per-app mDNS name; WENDY_DEVICE_HOSTNAME
+// is the device's mDNS name (omitted when unresolvable).
+func buildContainerBaseEnv(appName string) []string {
+	env := []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"TERM=xterm",
+		fmt.Sprintf("WENDY_HOSTNAME=%s.local", appName),
+	}
+	if h := deviceHostnameWithSuffix(); h != "" {
+		env = append(env, "WENDY_DEVICE_HOSTNAME="+h)
+	}
+	return env
 }
 
 func expandAgentHook(command, appName string) string {

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -56,6 +56,46 @@ func TestCreateContainerProgressMappingUsesUnpackingPhaseForStart(t *testing.T) 
 	}
 }
 
+func TestBuildContainerBaseEnvIncludesDeviceHostname(t *testing.T) {
+	old := deviceHostnameWithSuffix
+	t.Cleanup(func() { deviceHostnameWithSuffix = old })
+	deviceHostnameWithSuffix = func() string { return "wendyos-test-device.local" }
+
+	env := buildContainerBaseEnv("camera-app")
+
+	wantApp := "WENDY_HOSTNAME=camera-app.local"
+	wantDevice := "WENDY_DEVICE_HOSTNAME=wendyos-test-device.local"
+	var sawApp, sawDevice bool
+	for _, kv := range env {
+		switch kv {
+		case wantApp:
+			sawApp = true
+		case wantDevice:
+			sawDevice = true
+		}
+	}
+	if !sawApp {
+		t.Errorf("env missing %q; got %v", wantApp, env)
+	}
+	if !sawDevice {
+		t.Errorf("env missing %q; got %v", wantDevice, env)
+	}
+}
+
+func TestBuildContainerBaseEnvOmitsDeviceHostnameWhenUnavailable(t *testing.T) {
+	old := deviceHostnameWithSuffix
+	t.Cleanup(func() { deviceHostnameWithSuffix = old })
+	deviceHostnameWithSuffix = func() string { return "" }
+
+	env := buildContainerBaseEnv("camera-app")
+
+	for _, kv := range env {
+		if len(kv) >= len("WENDY_DEVICE_HOSTNAME=") && kv[:len("WENDY_DEVICE_HOSTNAME=")] == "WENDY_DEVICE_HOSTNAME=" {
+			t.Errorf("env unexpectedly contains %q when device hostname is unresolvable", kv)
+		}
+	}
+}
+
 func TestExpandAgentHook(t *testing.T) {
 	t.Setenv("EXTRA_VALUE", "ok")
 


### PR DESCRIPTION
## Summary

- Adds a new `WENDY_DEVICE_HOSTNAME` runtime env var (e.g. `wendyos-mighty-kayak.local`) to every container started by the agent, alongside the existing per-app `WENDY_HOSTNAME=<app-id>.local`.
- Matches what the `${WENDY_HOSTNAME}` placeholder expands to in `postStart` cli hooks, so container entrypoints can build URLs the developer will actually visit (TLS cert CN/SANs, "now serving on …" banners, postcard/share links, etc.).
- Resolves [WDY-1126](https://linear.app/wendylabsinc/issue/WDY-1126/wendy-agent-expose-device-mdns-hostname-as-a-container-runtime-env-var). The immediate motivator is the `voice-ai-pipecat` template needing the right CN on its self-signed TLS cert so the React UI's `getUserMedia` doesn't trip a name-mismatch warning.

## Implementation notes

- New `deviceHostnameWithSuffix` package var (overridable in tests) reads `os.Hostname()` and appends `.local`.
- New `buildContainerBaseEnv(appName)` helper centralizes the wendy-injected env. If `os.Hostname()` fails, `WENDY_DEVICE_HOSTNAME` is **omitted** rather than set empty, so containers don't see a misleading value.
- `WENDY_HOSTNAME` semantics unchanged — keeping it backwards-compatible per the issue's recommendation (no rename).

## Test plan

- [x] `go test ./internal/agent/containerd/...` — passes (incl. two new tests)
- [x] `go vet`, `gofmt` clean
- [x] `go build ./...` clean
- [ ] **End-to-end on hardware** (next step, before un-drafting):
  - Cross-compile agent for linux/arm64, deploy to a Jetson running WendyOS
  - Start a container via `wendy run`
  - `sudo ctr -n default tasks exec --exec-id env <app> env | grep -i wendy` shows both `WENDY_HOSTNAME=<app-id>.local` and `WENDY_DEVICE_HOSTNAME=<device>.local`
- [ ] Confirm `voice-ai-pipecat` template entrypoint can swap `WENDY_HOSTNAME` → `WENDY_DEVICE_HOSTNAME` for cert CN and the browser warning goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)