### PR TITLE
feat(os install): implement Windows writeConfigPartition

### DIFF
--- a/go/internal/cli/commands/os_provision.go
+++ b/go/internal/cli/commands/os_provision.go
@@ -125,6 +125,62 @@ func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName st
 	return json.Marshal(state)
 }
 
+// psPartition is one row from the Windows partition-listing PowerShell
+// script. Pointer fields tolerate JSON nulls for partitions without a
+// drive letter or associated volume (e.g. EFI or reserved partitions).
+type psPartition struct {
+	PartitionNumber int     `json:"PartitionNumber"`
+	DriveLetter     *string `json:"DriveLetter"`
+	Label           *string `json:"Label"`
+	Size            int64   `json:"Size"`
+}
+
+// parseConfigPartition returns the partition number whose FAT32 filesystem
+// label is "config" from the JSON output of the Windows partition-listing
+// script. Lives in the platform-agnostic file so its tests run on the
+// Darwin/Linux host CI without a Windows runner.
+//
+// PowerShell emits a single object (not an array) when the pipeline yields
+// one row, so the parser accepts both shapes. Label matching ignores case
+// and FAT32's 11-char whitespace padding.
+func parseConfigPartition(jsonBytes []byte) (int, error) {
+	trimmed := strings.TrimSpace(string(jsonBytes))
+	if trimmed == "" {
+		return 0, fmt.Errorf("no partitions found on disk (is the image fully written?)")
+	}
+
+	var parts []psPartition
+	if strings.HasPrefix(trimmed, "[") {
+		if err := json.Unmarshal([]byte(trimmed), &parts); err != nil {
+			return 0, fmt.Errorf("parsing partition JSON: %w", err)
+		}
+	} else {
+		var single psPartition
+		if err := json.Unmarshal([]byte(trimmed), &single); err != nil {
+			return 0, fmt.Errorf("parsing partition JSON: %w", err)
+		}
+		parts = []psPartition{single}
+	}
+
+	var matches []int
+	for _, p := range parts {
+		if p.Label == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(*p.Label), "config") {
+			matches = append(matches, p.PartitionNumber)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return 0, fmt.Errorf("no partition labelled 'config' found on disk (is the image fully written?)")
+	case 1:
+		return matches[0], nil
+	default:
+		return 0, fmt.Errorf("multiple partitions labelled 'config' found (%v); refusing to guess which to mount", matches)
+	}
+}
+
 // provisioningRequired reports whether the user supplied provisioning data
 // that must reach the device's config partition. When this returns true, a
 // failure to write the config partition has dropped user-visible state on

--- a/go/internal/cli/commands/os_provision_test.go
+++ b/go/internal/cli/commands/os_provision_test.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +52,128 @@ func TestProvisioningRequired(t *testing.T) {
 				t.Errorf("provisioningRequired(%v, %q, %v) = false; want true (user-supplied data must not be silently dropped)", c.creds, c.deviceName, c.provisioningJSON)
 			}
 		})
+	}
+}
+
+func TestParseConfigPartition_Empty(t *testing.T) {
+	_, err := parseConfigPartition([]byte(""))
+	if err == nil {
+		t.Fatal("empty input must return error")
+	}
+	if !strings.Contains(err.Error(), "no partitions found") {
+		t.Errorf("error should mention 'no partitions found': %v", err)
+	}
+}
+
+func TestParseConfigPartition_SingleObject(t *testing.T) {
+	// PowerShell emits a bare object (not an array) when the pipeline yields
+	// exactly one row. Defending against this is necessary even though the
+	// wendyOS image always has multiple partitions, because a malformed image
+	// or a `Where-Object`-narrowed pipeline could land here.
+	js := []byte(`{"PartitionNumber":2,"DriveLetter":null,"Label":"config","Size":67108864}`)
+	n, err := parseConfigPartition(js)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("partition number = %d; want 2", n)
+	}
+}
+
+func TestParseConfigPartition_NullLabelSkipped(t *testing.T) {
+	// EFI / reserved partitions have no FAT volume → Label is null. The
+	// parser must skip those rather than treat them as a missing-config
+	// signal.
+	js := []byte(`[
+		{"PartitionNumber":1,"DriveLetter":null,"Label":null,"Size":268435456},
+		{"PartitionNumber":2,"DriveLetter":null,"Label":"config","Size":67108864},
+		{"PartitionNumber":3,"DriveLetter":null,"Label":"rootfs","Size":2147483648}
+	]`)
+	n, err := parseConfigPartition(js)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("partition number = %d; want 2", n)
+	}
+}
+
+func TestParseConfigPartition_NullDriveLetterAccepted(t *testing.T) {
+	// At first online, Windows hasn't auto-mounted the partition yet so
+	// DriveLetter is null. That's the common case — we mustn't filter it out.
+	js := []byte(`[{"PartitionNumber":2,"DriveLetter":null,"Label":"config","Size":67108864}]`)
+	n, err := parseConfigPartition(js)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("partition number = %d; want 2", n)
+	}
+}
+
+func TestParseConfigPartition_MixedCaseAndPadding(t *testing.T) {
+	// FAT32 labels are case-preserved and historically space-padded to 11
+	// chars. Match case-insensitively and trim before comparing so a tool
+	// that wrote "Config" or "config     " still matches.
+	cases := map[string]string{
+		"lowercase": `"config"`,
+		"uppercase": `"CONFIG"`,
+		"titlecase": `"Config"`,
+		"padded":    `"config     "`,
+		"both":      `"  Config "`,
+	}
+	for name, label := range cases {
+		t.Run(name, func(t *testing.T) {
+			js := []byte(fmt.Sprintf(`[{"PartitionNumber":2,"DriveLetter":null,"Label":%s,"Size":67108864}]`, label))
+			n, err := parseConfigPartition(js)
+			if err != nil {
+				t.Fatalf("label %s: unexpected error: %v", label, err)
+			}
+			if n != 2 {
+				t.Errorf("label %s: partition number = %d; want 2", label, n)
+			}
+		})
+	}
+}
+
+func TestParseConfigPartition_NoMatch(t *testing.T) {
+	// No "config" label found at all — fail loudly so the user knows the
+	// image isn't fully written rather than silently mounting an arbitrary
+	// partition.
+	js := []byte(`[
+		{"PartitionNumber":1,"DriveLetter":null,"Label":null,"Size":268435456},
+		{"PartitionNumber":2,"DriveLetter":null,"Label":"rootfs","Size":2147483648}
+	]`)
+	_, err := parseConfigPartition(js)
+	if err == nil {
+		t.Fatal("expected error when no config-labelled partition exists")
+	}
+	if !strings.Contains(err.Error(), "config") {
+		t.Errorf("error should mention 'config': %v", err)
+	}
+}
+
+func TestParseConfigPartition_MultipleMatches(t *testing.T) {
+	// Malformed image with two partitions both labelled "config" — refuse
+	// to guess. Better to bail than to silently mount whichever PowerShell
+	// happened to list first.
+	js := []byte(`[
+		{"PartitionNumber":2,"DriveLetter":null,"Label":"config","Size":67108864},
+		{"PartitionNumber":4,"DriveLetter":null,"Label":"config","Size":67108864}
+	]`)
+	_, err := parseConfigPartition(js)
+	if err == nil {
+		t.Fatal("expected error when multiple config-labelled partitions exist")
+	}
+	if !strings.Contains(err.Error(), "multiple") {
+		t.Errorf("error should mention 'multiple': %v", err)
+	}
+}
+
+func TestParseConfigPartition_MalformedJSON(t *testing.T) {
+	_, err := parseConfigPartition([]byte("not json at all"))
+	if err == nil {
+		t.Fatal("expected error on malformed JSON")
 	}
 }
 

--- a/go/internal/cli/commands/os_provision_windows.go
+++ b/go/internal/cli/commands/os_provision_windows.go
@@ -4,21 +4,203 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
+	"time"
 
 	"github.com/wendylabsinc/wendy/internal/shared/wendyconf"
 )
 
-// configPartitionSupported is false on Windows: writeConfigPartition has no
-// implementation, so callers must skip the agent download and refuse to claim
-// success when --wifi/--device-name/--pre-enroll were requested.
-const configPartitionSupported = false
+// configPartitionSupported reports whether writeConfigPartition has a working
+// implementation on this OS. Callers gate the agent download + config write
+// on this so non-supported platforms don't pay the network cost just to fail.
+const configPartitionSupported = true
 
-// writeConfigPartition is a stub on Windows. Callers gate on
-// configPartitionSupported and never invoke this; it exists only so the
-// cross-platform call site in provisionConfigPartition compiles.
-func writeConfigPartition(_ drive, _ []byte, _ []wendyconf.WifiCredential, _ string, _ []byte) error {
-	return fmt.Errorf("config partition provisioning is not supported on Windows")
+// writeConfigPartition brings the target disk online, locates the FAT32
+// partition labelled "config", assigns it a drive letter, populates it with
+// the agent binary and provisioning files via the shared writeConfigFiles
+// helper, then unmounts every partition on the disk and takes the disk
+// offline. The disk-wide unmount is what stops Windows from leaving phantom
+// drive letters for partitions Explorer auto-mounted during the online
+// window (EFI, rootfs, config, recovery — there are typically several).
+//
+// On entry the disk is expected to be offline — writeImageToDisk takes it
+// offline at the end of the raw-image phase to suppress auto-mount of every
+// partition Windows finds in the freshly-written table.
+func writeConfigPartition(d drive, agentBinary []byte, creds []wendyconf.WifiCredential, deviceName string, provisioningJSON []byte) error {
+	diskNum, err := parseDiskNumber(d.DevicePath)
+	if err != nil {
+		return err
+	}
+
+	if err := onlineAndRescanDisk(diskNum); err != nil {
+		return fmt.Errorf("bringing disk %d online: %w", diskNum, err)
+	}
+	// Always unmount and offline the disk before returning, even on panic.
+	// This is what stops Windows from leaving phantom drive letters between
+	// now and ejectDisk.
+	defer func() {
+		if err := unmountAndOfflineDisk(diskNum); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to unmount/offline disk %d: %v\n", diskNum, err)
+		}
+	}()
+
+	// The storage stack needs a moment after Update-Disk before partitions
+	// are reliably enumerable by Get-Volume; mirrors the partprobe sleep on
+	// Linux.
+	time.Sleep(500 * time.Millisecond)
+
+	partNum, err := findConfigPartitionNumber(diskNum)
+	if err != nil {
+		return err
+	}
+
+	mountPath, err := ensureConfigPartitionMounted(diskNum, partNum)
+	if err != nil {
+		return err
+	}
+
+	if err := writeConfigFiles(mountPath, agentBinary, creds, deviceName, provisioningJSON); err != nil {
+		return err
+	}
+
+	flushVolume(mountPath)
+	return nil
+}
+
+// onlineAndRescanDisk brings the disk online and rescans its partition table
+// so partitions written by the dd phase become enumerable. Set-Disk
+// -IsOffline does not prompt, so we don't pass -Confirm:$false (the legacy
+// Storage module rejects -Confirm as unknown — see WINDOWS_REGRESSION_REVIEW.md
+// section 1.1).
+func onlineAndRescanDisk(diskNum int) error {
+	script := fmt.Sprintf(
+		"Set-Disk -Number %d -IsOffline $false -ErrorAction Stop; "+
+			"Update-Disk -Number %d -ErrorAction Stop",
+		diskNum, diskNum,
+	)
+	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// unmountAndOfflineDisk removes drive letters from every partition on the
+// disk and then takes the disk offline. Mirrors the cleanup pattern in
+// writeImageToDisk (disklister_windows.go) — disk-wide rather than
+// partition-scoped because Windows may auto-assign letters to EFI / rootfs
+// / recovery partitions when we brought the disk online, and leaving any of
+// those in place results in phantom drives in Explorer after the install.
+//
+// SilentlyContinue on Remove-PartitionAccessPath: the access paths may
+// already be gone (e.g. user yanked the SD card) and we don't want a
+// secondary error to mask the upstream failure.
+func unmountAndOfflineDisk(diskNum int) error {
+	script := fmt.Sprintf(
+		"Get-Partition -DiskNumber %d -ErrorAction SilentlyContinue | "+
+			"Where-Object { $_.DriveLetter } | "+
+			"ForEach-Object { "+
+			"Remove-PartitionAccessPath -DiskNumber $_.DiskNumber -PartitionNumber $_.PartitionNumber -AccessPath \"$($_.DriveLetter):\\\" -ErrorAction SilentlyContinue "+
+			"}; "+
+			"Set-Disk -Number %d -IsOffline $true -ErrorAction Stop",
+		diskNum, diskNum,
+	)
+	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// findConfigPartitionNumber returns the partition number on diskNum whose
+// FAT32 filesystem label matches "config" (case-insensitive, FAT32 padding
+// tolerated). The PowerShell script casts DriveLetter to [string] because
+// PowerShell hands back a [char] when assigned, whose JSON encoding is the
+// integer codepoint — that would silently corrupt the parser. -Depth 3
+// suppresses the depth-exceeded warning on nested CIM objects.
+func findConfigPartitionNumber(diskNum int) (int, error) {
+	script := fmt.Sprintf(
+		"Get-Partition -DiskNumber %d -ErrorAction Stop | "+
+			"ForEach-Object { "+
+			"$vol = $_ | Get-Volume -ErrorAction SilentlyContinue; "+
+			"[PSCustomObject]@{ "+
+			"PartitionNumber = $_.PartitionNumber; "+
+			"DriveLetter = if ($_.DriveLetter) { [string]$_.DriveLetter } else { $null }; "+
+			"Label = if ($vol) { $vol.FileSystemLabel } else { $null }; "+
+			"Size = $_.Size "+
+			"} "+
+			"} | ConvertTo-Json -Compress -Depth 3",
+		diskNum,
+	)
+	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).Output()
+	if err != nil {
+		return 0, fmt.Errorf("enumerating partitions on disk %d: %w", diskNum, err)
+	}
+	return parseConfigPartition(out)
+}
+
+// ensureConfigPartitionMounted returns the mount path (e.g. "X:\") for the
+// given partition, assigning a drive letter if Windows hasn't already
+// auto-assigned one.
+func ensureConfigPartitionMounted(diskNum, partNum int) (string, error) {
+	letter, err := readPartitionDriveLetter(diskNum, partNum)
+	if err != nil {
+		return "", fmt.Errorf("reading drive letter for disk %d partition %d: %w", diskNum, partNum, err)
+	}
+	if letter == "" {
+		if err := assignPartitionDriveLetter(diskNum, partNum); err != nil {
+			return "", fmt.Errorf("assigning drive letter to disk %d partition %d: %w", diskNum, partNum, err)
+		}
+		letter, err = readPartitionDriveLetter(diskNum, partNum)
+		if err != nil {
+			return "", fmt.Errorf("re-reading drive letter for disk %d partition %d: %w", diskNum, partNum, err)
+		}
+		if letter == "" {
+			return "", fmt.Errorf("Windows assigned no drive letter to disk %d partition %d (Group Policy or letter exhaustion?)", diskNum, partNum)
+		}
+	}
+	return letter + `:\`, nil
+}
+
+// readPartitionDriveLetter returns the assigned drive letter (e.g. "X") or
+// empty string when none is assigned.
+func readPartitionDriveLetter(diskNum, partNum int) (string, error) {
+	script := fmt.Sprintf(
+		"$p = Get-Partition -DiskNumber %d -PartitionNumber %d -ErrorAction Stop; "+
+			"if ($p.DriveLetter) { [string]$p.DriveLetter }",
+		diskNum, partNum,
+	)
+	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func assignPartitionDriveLetter(diskNum, partNum int) error {
+	script := fmt.Sprintf(
+		"Add-PartitionAccessPath -DiskNumber %d -PartitionNumber %d -AssignDriveLetter -ErrorAction Stop",
+		diskNum, partNum,
+	)
+	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// flushVolume best-effort flushes outstanding FAT32 writes for the given
+// mount path. The driver also flushes when the access path is removed, but
+// belt-and-suspenders is cheap given the cost of a corrupted boot config.
+func flushVolume(mountPath string) {
+	if mountPath == "" {
+		return
+	}
+	letter := string(mountPath[0])
+	script := fmt.Sprintf("Write-VolumeCache -DriveLetter %s -ErrorAction SilentlyContinue", letter)
+	_ = exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).Run()
 }
 
 func ejectDisk(devPath string) {
@@ -26,8 +208,10 @@ func ejectDisk(devPath string) {
 	if err != nil {
 		return
 	}
-	// Ensure the disk is offline so Windows doesn't assign drive letters
-	// to the partitions in the newly written image.
+	// Idempotent: writeConfigPartition's deferred cleanup already took the
+	// disk offline. This catches the path where the user invoked something
+	// that bypassed writeConfigPartition (e.g. a future caller that imaged
+	// without provisioning, or an early bail before the online step).
 	script := fmt.Sprintf("Set-Disk -Number %d -IsOffline $true -Confirm:$false -ErrorAction SilentlyContinue", diskNum)
 	_ = exec.Command("powershell", "-NoProfile", "-Command", script).Run()
 }

--- a/go/internal/cli/commands/os_provision_windows.go
+++ b/go/internal/cli/commands/os_provision_windows.go
@@ -28,23 +28,35 @@ const configPartitionSupported = true
 // On entry the disk is expected to be offline — writeImageToDisk takes it
 // offline at the end of the raw-image phase to suppress auto-mount of every
 // partition Windows finds in the freshly-written table.
-func writeConfigPartition(d drive, agentBinary []byte, creds []wendyconf.WifiCredential, deviceName string, provisioningJSON []byte) error {
+func writeConfigPartition(d drive, agentBinary []byte, creds []wendyconf.WifiCredential, deviceName string, provisioningJSON []byte) (retErr error) {
 	diskNum, err := parseDiskNumber(d.DevicePath)
 	if err != nil {
 		return err
 	}
 
-	if err := onlineAndRescanDisk(diskNum); err != nil {
+	if err := setDiskOnline(diskNum); err != nil {
 		return fmt.Errorf("bringing disk %d online: %w", diskNum, err)
 	}
-	// Always unmount and offline the disk before returning, even on panic.
-	// This is what stops Windows from leaving phantom drive letters between
-	// now and ejectDisk.
+	// From here the disk is online — register cleanup BEFORE the partition
+	// rescan so a failure between online and rescan still triggers
+	// unmount + offline. If the main path succeeded, a cleanup failure must
+	// be promoted to the returned error: leaving the disk online with
+	// phantom letters is the bug this PR exists to prevent, and silently
+	// returning nil would let the caller print "Successfully installed"
+	// against a half-cleaned-up disk.
 	defer func() {
-		if err := unmountAndOfflineDisk(diskNum); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to unmount/offline disk %d: %v\n", diskNum, err)
+		if cleanupErr := unmountAndOfflineDisk(diskNum); cleanupErr != nil {
+			if retErr == nil {
+				retErr = fmt.Errorf("config partition write succeeded but cleanup failed (disk may still be online with phantom drive letters): %w", cleanupErr)
+			} else {
+				fmt.Fprintf(os.Stderr, "warning: failed to unmount/offline disk %d during cleanup: %v\n", diskNum, cleanupErr)
+			}
 		}
 	}()
+
+	if err := updateDisk(diskNum); err != nil {
+		return fmt.Errorf("rescanning disk %d: %w", diskNum, err)
+	}
 
 	// The storage stack needs a moment after Update-Disk before partitions
 	// are reliably enumerable by Get-Volume; mirrors the partprobe sleep on
@@ -69,17 +81,23 @@ func writeConfigPartition(d drive, agentBinary []byte, creds []wendyconf.WifiCre
 	return nil
 }
 
-// onlineAndRescanDisk brings the disk online and rescans its partition table
-// so partitions written by the dd phase become enumerable. Set-Disk
-// -IsOffline does not prompt, so we don't pass -Confirm:$false (the legacy
-// Storage module rejects -Confirm as unknown — see WINDOWS_REGRESSION_REVIEW.md
-// section 1.1).
-func onlineAndRescanDisk(diskNum int) error {
-	script := fmt.Sprintf(
-		"Set-Disk -Number %d -IsOffline $false -ErrorAction Stop; "+
-			"Update-Disk -Number %d -ErrorAction Stop",
-		diskNum, diskNum,
-	)
+// setDiskOnline brings the disk online. Set-Disk -IsOffline does not prompt,
+// so we don't pass -Confirm:$false (the legacy Storage module rejects
+// -Confirm as unknown — see WINDOWS_REGRESSION_REVIEW.md section 1.1).
+func setDiskOnline(diskNum int) error {
+	script := fmt.Sprintf("Set-Disk -Number %d -IsOffline $false -ErrorAction Stop", diskNum)
+	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// updateDisk rescans the disk's partition table so partitions written by
+// the dd phase become enumerable. Kept separate from setDiskOnline so a
+// rescan failure still triggers the deferred cleanup of the now-online disk.
+func updateDisk(diskNum int) error {
+	script := fmt.Sprintf("Update-Disk -Number %d -ErrorAction Stop", diskNum)
 	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
@@ -212,6 +230,24 @@ func ejectDisk(devPath string) {
 	// disk offline. This catches the path where the user invoked something
 	// that bypassed writeConfigPartition (e.g. a future caller that imaged
 	// without provisioning, or an early bail before the online step).
-	script := fmt.Sprintf("Set-Disk -Number %d -IsOffline $true -Confirm:$false -ErrorAction SilentlyContinue", diskNum)
-	_ = exec.Command("powershell", "-NoProfile", "-Command", script).Run()
+	//
+	// No -Confirm:$false: Set-Disk -IsOffline does not prompt, and the
+	// legacy Storage module rejects -Confirm as unknown (see
+	// WINDOWS_REGRESSION_REVIEW.md §1.1). On the failure paths from
+	// writeConfigPartition this is the last attempt to offline the disk —
+	// surfacing rather than silently swallowing failure means a stuck
+	// online disk is at least visible to the user.
+	//
+	// Check IsOffline first so the success path (where writeConfigPartition's
+	// deferred cleanup already offlined the disk) doesn't emit a spurious
+	// warning if the legacy module errors on a redundant Set-Disk.
+	script := fmt.Sprintf(
+		"$d = Get-Disk -Number %d -ErrorAction Stop; "+
+			"if (-not $d.IsOffline) { Set-Disk -Number %d -IsOffline $true -ErrorAction Stop }",
+		diskNum, diskNum,
+	)
+	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to take disk %d offline (it may still be online with assigned drive letters): %v: %s\n", diskNum, err, strings.TrimSpace(string(out)))
+	}
 }


### PR DESCRIPTION
Closes [WDY-1123](https://linear.app/wendylabsinc/issue/WDY-1123/windows-implement-real-writeconfigpartition-wi-fi-pre-enroll-on).

**Stacked on #628.** Base is `ed/wdy-1118-os-install-honest-success`; will rebase onto `main` once #628 merges.

## Summary
- Real Windows implementation of `writeConfigPartition`. Brings the disk online, locates the FAT32 partition labelled `config` (same approach Linux and Darwin use), assigns a drive letter, populates it via the shared `writeConfigFiles` helper, then unmounts every partition on the disk and offlines it so Explorer doesn't end up with phantom drive letters for EFI/rootfs/recovery.
- Flips `configPartitionSupported` on Windows to `true` so PR #628's gating logic exercises the real path. Addresses Joannis's review comment on #628 — `--wifi`, `--device-name`, and `--pre-enroll` start working from a Windows host without further changes to #628.
- Pure-Go `parseConfigPartition` for the partition-listing JSON, so eight unit tests run on the Darwin/Linux host CI without a Windows runner.

## Design notes
- Disk-wide unmount in the deferred cleanup, mirroring `writeImageToDisk`'s existing pattern. Partition-scoped cleanup would miss EFI/rootfs/recovery letters Windows auto-assigns when we bring the disk online.
- All new PowerShell scripts deliberately avoid `-Confirm:$false` — the legacy Storage module rejects it as unknown, per `WINDOWS_REGRESSION_REVIEW.md` §1.1. Code is robust whether or not the companion PowerShell-hardening ticket has landed.
- `DriveLetter` is cast to `[string]` in the enumeration script before `ConvertTo-Json`. PowerShell hands back a `[char]` when assigned, whose JSON encoding is the integer codepoint — that would silently corrupt the parser.

## Test plan
- [x] `go test -count=1 ./internal/cli/commands/` (darwin host) — passes; eight new `TestParseConfigPartition_*` cases cover empty input, single-object PowerShell output, null labels, null drive letters, mixed case + FAT32 padding, no-match, multiple matches, malformed JSON.
- [x] `GOOS=windows GOARCH=amd64 go build ./internal/cli/commands/ ./cmd/wendy` — clean.
- [x] `GOOS=windows GOARCH=amd64 go vet ./internal/cli/commands/` — clean.
- [x] `GOOS=linux GOARCH=amd64 go build ./internal/cli/commands/` — clean.
- [ ] **Draft until manual smoke test on a Windows host:**
  - [ ] `wendy os install --pre-enroll` produces a device that registers itself with Wendy Cloud on first boot.
  - [ ] `wendy os install --wifi 'ssid:password'` produces a device that joins that Wi-Fi on first boot.
  - [ ] After install, no phantom drive letters remain in Explorer.
  - [ ] On a machine with mapped network drives at `Z:` / `Y:`, the parser correctly recovers whichever letter Windows picked (no hardcoded `D:`).
  - [ ] Mid-write SD-card yank: command fails per #628's gating, no zombie drive letter remains.
  - [ ] Run with Windows Defender real-time scanning enabled (race-prone with `os.WriteFile` on freshly-mounted FAT32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)