### PR TITLE
fix(agent): WENDY_HOSTNAME must be the device mDNS hostname, not the app name

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -483,7 +483,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	}
 
 	// Build environment variables: image env first, then our overrides.
-	env := buildContainerBaseEnv(appName)
+	env := buildContainerBaseEnv()
 	if specErr == nil {
 		env = append(imageSpec.Config.Env, env...)
 	}
@@ -743,16 +743,15 @@ var deviceHostnameWithSuffix = func() string {
 }
 
 // buildContainerBaseEnv builds the wendy-injected env vars layered on top of
-// the image's own env. WENDY_HOSTNAME is the per-app mDNS name; WENDY_DEVICE_HOSTNAME
-// is the device's mDNS name (omitted when unresolvable).
-func buildContainerBaseEnv(appName string) []string {
+// the image's own env. WENDY_HOSTNAME is the device's mDNS hostname
+// (omitted when unresolvable).
+func buildContainerBaseEnv() []string {
 	env := []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"TERM=xterm",
-		fmt.Sprintf("WENDY_HOSTNAME=%s.local", appName),
 	}
 	if h := deviceHostnameWithSuffix(); h != "" {
-		env = append(env, "WENDY_DEVICE_HOSTNAME="+h)
+		env = append(env, "WENDY_HOSTNAME="+h)
 	}
 	return env
 }

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -56,41 +56,31 @@ func TestCreateContainerProgressMappingUsesUnpackingPhaseForStart(t *testing.T) 
 	}
 }
 
-func TestBuildContainerBaseEnvIncludesDeviceHostname(t *testing.T) {
+func TestBuildContainerBaseEnvIncludesWendyHostname(t *testing.T) {
 	old := deviceHostnameWithSuffix
 	t.Cleanup(func() { deviceHostnameWithSuffix = old })
 	deviceHostnameWithSuffix = func() string { return "wendyos-test-device.local" }
 
-	env := buildContainerBaseEnv("camera-app")
+	env := buildContainerBaseEnv()
 
-	wantApp := "WENDY_HOSTNAME=camera-app.local"
-	wantDevice := "WENDY_DEVICE_HOSTNAME=wendyos-test-device.local"
-	var sawApp, sawDevice bool
+	want := "WENDY_HOSTNAME=wendyos-test-device.local"
 	for _, kv := range env {
-		switch kv {
-		case wantApp:
-			sawApp = true
-		case wantDevice:
-			sawDevice = true
+		if kv == want {
+			return
 		}
 	}
-	if !sawApp {
-		t.Errorf("env missing %q; got %v", wantApp, env)
-	}
-	if !sawDevice {
-		t.Errorf("env missing %q; got %v", wantDevice, env)
-	}
+	t.Errorf("env missing %q; got %v", want, env)
 }
 
-func TestBuildContainerBaseEnvOmitsDeviceHostnameWhenUnavailable(t *testing.T) {
+func TestBuildContainerBaseEnvOmitsWendyHostnameWhenUnavailable(t *testing.T) {
 	old := deviceHostnameWithSuffix
 	t.Cleanup(func() { deviceHostnameWithSuffix = old })
 	deviceHostnameWithSuffix = func() string { return "" }
 
-	env := buildContainerBaseEnv("camera-app")
+	env := buildContainerBaseEnv()
 
 	for _, kv := range env {
-		if len(kv) >= len("WENDY_DEVICE_HOSTNAME=") && kv[:len("WENDY_DEVICE_HOSTNAME=")] == "WENDY_DEVICE_HOSTNAME=" {
+		if len(kv) >= len("WENDY_HOSTNAME=") && kv[:len("WENDY_HOSTNAME=")] == "WENDY_HOSTNAME=" {
 			t.Errorf("env unexpectedly contains %q when device hostname is unresolvable", kv)
 		}
 	}


### PR DESCRIPTION
## Summary

- `WENDY_HOSTNAME` now correctly carries the **device** mDNS hostname (e.g. `wendyos-mighty-kayak.local`), consistent with how `run.go` already expands `${WENDY_HOSTNAME}` in `postStart` CLI hooks
- Removes `WENDY_DEVICE_HOSTNAME` introduced by #633 — apps cannot be mDNS hostnames, so the naming in that PR was backwards
- `buildContainerBaseEnv` no longer takes `appName` (it was only used for the wrong env var)
- `WENDY_HOSTNAME` is omitted rather than set empty when `os.Hostname()` fails

## Test plan

- [x] `go test ./internal/agent/containerd/...` passes
- [x] `go build ./...` clean
- [ ] End-to-end: deploy to device, confirm `env | grep WENDY_HOSTNAME` shows the device mDNS name

🤖 Generated with [Claude Code](https://claude.com/claude-code)