### PR TITLE
fix(wifi): preserve non-ASCII bytes in SSIDs across agent and CLI

### DIFF
--- a/go/cmd/wendy/console_windows.go
+++ b/go/cmd/wendy/console_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package main
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// cpUTF8 is the Windows code page identifier for UTF-8. x/sys/windows does
+// not export this constant, so we use the literal value documented by
+// Microsoft (Win32 API: `CP_UTF8 = 65001`).
+const cpUTF8 = 65001
+
+// init switches the Windows console to UTF-8 for both stdin and stdout so SSIDs
+// (and any other non-ASCII text) round-trip without being transcoded to the
+// active OEM/ANSI codepage. Without this, an emoji-bearing SSID rendered to the
+// console becomes a literal `?` byte the moment Windows converts UTF-8 output
+// to cp437/cp850, and the same `?` is what the user types back when they
+// re-enter the SSID for `wendy device wifi connect` — at which point the
+// agent's nmcli scan can never match it.
+//
+// Failures here are non-fatal: if the process is not attached to a console
+// (e.g. piped, redirected, or running under a service host) the calls return
+// an error which we ignore — there is no console to fix in that case.
+func init() {
+	_ = windows.SetConsoleOutputCP(cpUTF8)
+	_ = windows.SetConsoleCP(cpUTF8)
+}

--- a/go/internal/agent/configpartition/apply_test.go
+++ b/go/internal/agent/configpartition/apply_test.go
@@ -143,6 +143,32 @@ func TestParseINI_Empty(t *testing.T) {
 	}
 }
 
+// TestParseINI_NonASCIISSID guards against byte-level corruption of UTF-8
+// values: emoji bytes (0xF0..0xF4 + 0x80-0xBF continuation) never overlap with
+// `=` (0x3D), `[` (0x5B), `]` (0x5D), `#` (0x23), or `;` (0x3B), so the parser
+// must return them verbatim.
+func TestParseINI_NonASCIISSID(t *testing.T) {
+	cases := []struct {
+		name, ssid string
+	}{
+		{"latin1", "café-wifi"},
+		{"cjk", "東京 Wi-Fi"},
+		{"emoji-4byte", "Read Only Internet \xf0\x9f\xab\xa5"},
+		{"home-emoji", "Home \xf0\x9f\x8f\xa0"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data := []byte("[wifi]\nssid = " + c.ssid + "\n")
+			got := parseINI(data)
+			if got["wifi"]["ssid"] != c.ssid {
+				t.Errorf("ssid = %q (% x); want %q (% x)",
+					got["wifi"]["ssid"], []byte(got["wifi"]["ssid"]),
+					c.ssid, []byte(c.ssid))
+			}
+		})
+	}
+}
+
 func TestApplyBinaryUpdate_ValidBinary(t *testing.T) {
 	dir := t.TempDir()
 	installDir := t.TempDir()

--- a/go/internal/agent/network/networkmanager.go
+++ b/go/internal/agent/network/networkmanager.go
@@ -13,6 +13,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/wendylabsinc/wendy/internal/shared/nmcli"
 	agentpb "github.com/wendylabsinc/wendy/proto/gen/agentpb"
 )
 
@@ -48,28 +49,11 @@ func resolveNMCLIPath() string {
 	return ""
 }
 
-// nmcli -t output escapes embedded colons as `\:` — we need to respect that
-// when splitting. splitNMCLI splits a single record into `fields` substrings,
-// undoing the backslash escaping that nmcli applies.
+// splitNMCLI is the legacy local alias for nmcli.Split. Kept so the rest of
+// this file reads the same; the underlying implementation also unescapes
+// `\n`/`\r`/`\t` and forces a UTF-8 locale on every nmcli invocation.
 func splitNMCLI(line string, fields int) []string {
-	out := make([]string, 0, fields)
-	var cur strings.Builder
-	for i := 0; i < len(line); i++ {
-		c := line[i]
-		if c == '\\' && i+1 < len(line) {
-			cur.WriteByte(line[i+1])
-			i++
-			continue
-		}
-		if c == ':' && len(out) < fields-1 {
-			out = append(out, cur.String())
-			cur.Reset()
-			continue
-		}
-		cur.WriteByte(c)
-	}
-	out = append(out, cur.String())
-	return out
+	return nmcli.Split(line, fields)
 }
 
 // classifySecurity converts an nmcli SECURITY string (e.g. "WPA2", "WPA1 WPA2",
@@ -107,7 +91,7 @@ type knownProfile struct {
 // so the cost is O(1) exec calls regardless of how many profiles exist.
 func (n *NMCLINetworkManager) listKnownProfiles(ctx context.Context) ([]knownProfile, error) {
 	// First pass: list wifi connections and their priorities.
-	cmd := exec.CommandContext(ctx, n.nmcliPath, "-t",
+	cmd := nmcli.Command(ctx, n.nmcliPath, "-t",
 		"-f", "NAME,UUID,TYPE,AUTOCONNECT-PRIORITY",
 		"connection", "show")
 	out, err := cmd.Output()
@@ -146,7 +130,7 @@ func (n *NMCLINetworkManager) listKnownProfiles(ctx context.Context) ([]knownPro
 	for _, p := range result {
 		args = append(args, p.UUID)
 	}
-	dcmd := exec.CommandContext(ctx, n.nmcliPath, args...)
+	dcmd := nmcli.Command(ctx, n.nmcliPath, args...)
 	dout, derr := dcmd.Output()
 	if derr != nil {
 		// Fall back to name-as-ssid if the detail fetch fails so callers
@@ -175,16 +159,7 @@ func (n *NMCLINetworkManager) listKnownProfiles(ctx context.Context) ([]knownPro
 }
 
 func unescapeNMCLI(s string) string {
-	var b strings.Builder
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\\' && i+1 < len(s) {
-			b.WriteByte(s[i+1])
-			i++
-			continue
-		}
-		b.WriteByte(s[i])
-	}
-	return b.String()
+	return nmcli.Unescape(s)
 }
 
 func classifyKeyMgmt(k string) agentpb.WiFiSecurityType {
@@ -204,10 +179,10 @@ func classifyKeyMgmt(k string) agentpb.WiFiSecurityType {
 // ListWiFiNetworks scans for and lists available WiFi networks, merging scan
 // results with saved profiles so the response carries is_known/priority/security.
 func (n *NMCLINetworkManager) ListWiFiNetworks(ctx context.Context) ([]*agentpb.ListWiFiNetworksResponse_WiFiNetwork, error) {
-	rescan := exec.CommandContext(ctx, n.nmcliPath, "device", "wifi", "rescan")
+	rescan := nmcli.Command(ctx, n.nmcliPath, "device", "wifi", "rescan")
 	_ = rescan.Run()
 
-	cmd := exec.CommandContext(ctx, n.nmcliPath, "-t",
+	cmd := nmcli.Command(ctx, n.nmcliPath, "-t",
 		"-f", "IN-USE,SSID,SIGNAL,SECURITY",
 		"device", "wifi", "list")
 	output, err := cmd.Output()
@@ -331,7 +306,7 @@ func addOrUpdateProfile(ctx context.Context, nmcliPath string, c SavedCredential
 // exists. Uses a single batched `nmcli connection show UUID1 UUID2 …` call
 // so the cost is O(1) exec calls in the number of saved profiles.
 func existingProfileUUID(ctx context.Context, nmcliPath, ssid string) (string, error) {
-	out, err := exec.CommandContext(ctx, nmcliPath, "-t",
+	out, err := nmcli.Command(ctx, nmcliPath, "-t",
 		"-f", "NAME,UUID,TYPE", "connection", "show").Output()
 	if err != nil {
 		return "", fmt.Errorf("nmcli connection show: %w", err)
@@ -349,7 +324,7 @@ func existingProfileUUID(ctx context.Context, nmcliPath, ssid string) (string, e
 		return "", nil
 	}
 	args := append([]string{"-t", "-g", "802-11-wireless.ssid", "connection", "show"}, uuids...)
-	dout, derr := exec.CommandContext(ctx, nmcliPath, args...).Output()
+	dout, derr := nmcli.Command(ctx, nmcliPath, args...).Output()
 	if derr != nil {
 		return "", fmt.Errorf("nmcli connection show (ssids): %w", derr)
 	}
@@ -381,7 +356,7 @@ func addProfile(ctx context.Context, nmcliPath string, c SavedCredential) error 
 			args = append(args, "802-11-wireless-security.psk", c.Password)
 		}
 	}
-	cmd := exec.CommandContext(ctx, nmcliPath, args...)
+	cmd := nmcli.Command(ctx, nmcliPath, args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("nmcli connection add %s: %s: %w", c.SSID, strings.TrimSpace(string(out)), err)
 	}
@@ -408,7 +383,7 @@ func modifyProfile(ctx context.Context, nmcliPath, uuid string, c SavedCredentia
 		// Nothing to change beyond the existing profile — still fine.
 		return nil
 	}
-	cmd := exec.CommandContext(ctx, nmcliPath, args...)
+	cmd := nmcli.Command(ctx, nmcliPath, args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("nmcli connection modify %s: %s: %w", c.SSID, strings.TrimSpace(string(out)), err)
 	}
@@ -433,7 +408,7 @@ func activateProfile(ctx context.Context, nmcliPath, ssid string) error {
 	if uuid == "" {
 		return fmt.Errorf("no saved profile for SSID %q", ssid)
 	}
-	cmd := exec.CommandContext(ctx, nmcliPath, "connection", "up", uuid)
+	cmd := nmcli.Command(ctx, nmcliPath, "connection", "up", uuid)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("nmcli connection up %s: %s: %w", ssid, strings.TrimSpace(string(out)), err)
 	}
@@ -530,7 +505,7 @@ func (n *NMCLINetworkManager) cleanupTransientProfile(ctx context.Context, ssid,
 	if err != nil || uuid == "" {
 		return
 	}
-	cmd := exec.CommandContext(ctx, n.nmcliPath, "connection", "delete", uuid)
+	cmd := nmcli.Command(ctx, n.nmcliPath, "connection", "delete", uuid)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		n.logger.Warn("failed to clean up profile after failed connect",
 			zap.String("ssid", ssid),
@@ -568,7 +543,7 @@ func runNMCLIConnect(ctx context.Context, nmcliPath, ssid, password string, hidd
 	if hidden {
 		args = append(args, "hidden", "yes")
 	}
-	cmd := exec.CommandContext(ctx, nmcliPath, args...)
+	cmd := nmcli.Command(ctx, nmcliPath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("nmcli connect: %s: %w", strings.TrimSpace(string(output)), err)
@@ -578,7 +553,7 @@ func runNMCLIConnect(ctx context.Context, nmcliPath, ssid, password string, hidd
 
 // GetWiFiStatus returns the current WiFi connection status.
 func (n *NMCLINetworkManager) GetWiFiStatus(ctx context.Context) (connected bool, ssid string, err error) {
-	cmd := exec.CommandContext(ctx, n.nmcliPath, "-t", "-f", "TYPE,STATE,CONNECTION", "device", "status")
+	cmd := nmcli.Command(ctx, n.nmcliPath, "-t", "-f", "TYPE,STATE,CONNECTION", "device", "status")
 	output, err := cmd.Output()
 	if err != nil {
 		return false, "", fmt.Errorf("nmcli device status: %w", err)
@@ -599,7 +574,7 @@ func (n *NMCLINetworkManager) GetWiFiStatus(ctx context.Context) (connected bool
 
 // DisconnectWiFi disconnects from the current WiFi network.
 func (n *NMCLINetworkManager) DisconnectWiFi(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, n.nmcliPath, "-t", "-f", "DEVICE,TYPE", "device", "status")
+	cmd := nmcli.Command(ctx, n.nmcliPath, "-t", "-f", "DEVICE,TYPE", "device", "status")
 	output, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("nmcli device status: %w", err)
@@ -619,7 +594,7 @@ func (n *NMCLINetworkManager) DisconnectWiFi(ctx context.Context) error {
 		return fmt.Errorf("no WiFi device found")
 	}
 
-	disconnCmd := exec.CommandContext(ctx, n.nmcliPath, "device", "disconnect", wifiDevice)
+	disconnCmd := nmcli.Command(ctx, n.nmcliPath, "device", "disconnect", wifiDevice)
 	if disconnOutput, err := disconnCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("nmcli disconnect: %s: %w", strings.TrimSpace(string(disconnOutput)), err)
 	}
@@ -668,7 +643,7 @@ func (n *NMCLINetworkManager) SetWiFiNetworkPriority(ctx context.Context, ssid s
 	if err != nil {
 		return err
 	}
-	cmd := exec.CommandContext(ctx, n.nmcliPath, "connection", "modify", uuid,
+	cmd := nmcli.Command(ctx, n.nmcliPath, "connection", "modify", uuid,
 		"connection.autoconnect-priority", strconv.Itoa(int(priority)))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("nmcli modify: %s: %w", strings.TrimSpace(string(out)), err)
@@ -703,7 +678,7 @@ func (n *NMCLINetworkManager) ReorderKnownWiFiNetworks(ctx context.Context, orde
 		if kp.Priority == newPrio {
 			continue
 		}
-		cmd := exec.CommandContext(ctx, n.nmcliPath, "connection", "modify", kp.UUID,
+		cmd := nmcli.Command(ctx, n.nmcliPath, "connection", "modify", kp.UUID,
 			"connection.autoconnect-priority", strconv.Itoa(int(newPrio)))
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("nmcli modify %s: %s: %w", ssid, strings.TrimSpace(string(out)), err)
@@ -719,7 +694,7 @@ func (n *NMCLINetworkManager) ForgetWiFiNetwork(ctx context.Context, ssid string
 	if err != nil {
 		return err
 	}
-	cmd := exec.CommandContext(ctx, n.nmcliPath, "connection", "delete", uuid)
+	cmd := nmcli.Command(ctx, n.nmcliPath, "connection", "delete", uuid)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("nmcli delete: %s: %w", strings.TrimSpace(string(out)), err)
 	}

--- a/go/internal/agent/network/networkmanager_test.go
+++ b/go/internal/agent/network/networkmanager_test.go
@@ -16,6 +16,11 @@ func TestSplitNMCLI(t *testing.T) {
 		{"My\\:Net:50:WPA2:", 4, []string{"My:Net", "50", "WPA2", ""}},
 		{"a:b:c", 3, []string{"a", "b", "c"}},
 		{"trailing::", 3, []string{"trailing", "", ""}},
+		// Emoji bytes (0xF0-0xF4 + 0x80-0xBF continuation bytes) never collide
+		// with `:` (0x3A) or `\` (0x5C), so they must round-trip verbatim.
+		{"Read Only Internet \xf0\x9f\xab\xa5:70:WPA2:", 4, []string{"Read Only Internet \xf0\x9f\xab\xa5", "70", "WPA2", ""}},
+		// Escaped colon adjacent to an emoji.
+		{"evil\\:ssid \xf0\x9f\x98\x88:90:WPA3:", 4, []string{"evil:ssid \xf0\x9f\x98\x88", "90", "WPA3", ""}},
 	}
 	for _, c := range cases {
 		got := splitNMCLI(c.in, c.n)

--- a/go/internal/cli/commands/wifi_scan_linux.go
+++ b/go/internal/cli/commands/wifi_scan_linux.go
@@ -4,10 +4,13 @@ package commands
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/wendylabsinc/wendy/internal/shared/nmcli"
 )
 
 type localWifiNetwork struct {
@@ -18,10 +21,15 @@ type localWifiNetwork struct {
 // scanLocalWifiNetworks uses nmcli on Linux to list WiFi networks visible to
 // the host machine.
 func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
-	// Trigger a rescan first (may fail if already scanning).
-	_ = exec.Command("nmcli", "device", "wifi", "rescan").Run()
+	nmcliPath, err := exec.LookPath("nmcli")
+	if err != nil {
+		return nil, fmt.Errorf("nmcli not found on PATH: %w", err)
+	}
 
-	cmd := exec.Command("nmcli", "-t", "-f", "SSID,SIGNAL", "device", "wifi", "list")
+	// Trigger a rescan first (may fail if already scanning).
+	_ = nmcli.Command(context.Background(), nmcliPath, "device", "wifi", "rescan").Run()
+
+	cmd := nmcli.Command(context.Background(), nmcliPath, "-t", "-f", "SSID,SIGNAL", "device", "wifi", "list")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("scanning WiFi networks: %w", err)
@@ -32,7 +40,10 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 	for scanner.Scan() {
-		fields := strings.SplitN(scanner.Text(), ":", 2)
+		// Use the shared nmcli parser so SSIDs containing literal `:` (escaped
+		// by nmcli as `\:`) and `\` survive intact, and so the parsing is
+		// consistent with the agent side.
+		fields := nmcli.Split(scanner.Text(), 2)
 		if len(fields) < 2 {
 			continue
 		}

--- a/go/internal/shared/nmcli/nmcli.go
+++ b/go/internal/shared/nmcli/nmcli.go
@@ -1,0 +1,107 @@
+// Package nmcli centralises invocation and output parsing of the `nmcli` CLI.
+//
+// The two responsibilities it owns:
+//
+//  1. Build *exec.Cmd values that force `LC_ALL=C.UTF-8`. The agent runs under
+//     systemd with no inherited locale, and on some nmcli builds an unset or C
+//     locale causes SSID bytes outside printable ASCII (notably emoji) to be
+//     rendered as literal `?` characters via iconv before they reach stdout.
+//     Once that conversion happens the SSID can never round-trip back to a
+//     scan match. Forcing C.UTF-8 keeps output byte-clean.
+//
+//  2. Parse the colon-delimited terse format. nmcli `-t` escapes embedded `:`
+//     as `\:` and literal `\` as `\\`; older builds also escape `\n`, `\r`,
+//     `\t`. UTF-8 multi-byte sequences never include `:` (0x3A) or `\` (0x5C),
+//     so byte-wise scanning is safe for emoji as long as the escape rules
+//     above are honoured.
+package nmcli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// LocaleEnv is the locale forced on every nmcli invocation. C.UTF-8 is part of
+// glibc since 2.13 and present in musl-based images; on the rare host that
+// lacks it nmcli falls back to its built-in default, which is also UTF-8 in
+// terse mode.
+const LocaleEnv = "LC_ALL=C.UTF-8"
+
+// Command returns an *exec.Cmd that runs `nmcliPath` with the given args under
+// a UTF-8 locale. The parent process's environment is preserved except for
+// LC_ALL, which is overwritten.
+func Command(ctx context.Context, nmcliPath string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, nmcliPath, args...)
+	cmd.Env = withUTF8Locale(os.Environ())
+	return cmd
+}
+
+// withUTF8Locale returns env with LC_ALL set/overridden to C.UTF-8.
+func withUTF8Locale(env []string) []string {
+	out := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if strings.HasPrefix(e, "LC_ALL=") {
+			continue
+		}
+		out = append(out, e)
+	}
+	return append(out, LocaleEnv)
+}
+
+// Split splits a single record from `nmcli -t` output into `fields` substrings,
+// undoing the backslash escaping that nmcli applies (`\:`, `\\`, and the less
+// common `\n`, `\r`, `\t`). The split honours escaping, so an SSID containing
+// `\:` is kept intact instead of being broken in two.
+func Split(line string, fields int) []string {
+	out := make([]string, 0, fields)
+	var cur strings.Builder
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		if c == '\\' && i+1 < len(line) {
+			cur.WriteByte(unescapeByte(line[i+1]))
+			i++
+			continue
+		}
+		if c == ':' && len(out) < fields-1 {
+			out = append(out, cur.String())
+			cur.Reset()
+			continue
+		}
+		cur.WriteByte(c)
+	}
+	out = append(out, cur.String())
+	return out
+}
+
+// Unescape reverses nmcli's terse-mode escaping for a value that has already
+// been split into a single field (e.g. output from `nmcli -g <prop>`).
+func Unescape(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			b.WriteByte(unescapeByte(s[i+1]))
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func unescapeByte(c byte) byte {
+	switch c {
+	case 'n':
+		return '\n'
+	case 'r':
+		return '\r'
+	case 't':
+		return '\t'
+	}
+	return c
+}

--- a/go/internal/shared/nmcli/nmcli_test.go
+++ b/go/internal/shared/nmcli/nmcli_test.go
@@ -1,0 +1,128 @@
+package nmcli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplit(t *testing.T) {
+	cases := []struct {
+		name   string
+		line   string
+		fields int
+		want   []string
+	}{
+		{
+			name:   "ascii four-field",
+			line:   " :HomeNet:70:WPA2",
+			fields: 4,
+			want:   []string{" ", "HomeNet", "70", "WPA2"},
+		},
+		{
+			name:   "emoji passes through unmodified",
+			line:   " :Read Only Internet \xf0\x9f\xab\xa5:70:WPA2",
+			fields: 4,
+			want:   []string{" ", "Read Only Internet \xf0\x9f\xab\xa5", "70", "WPA2"},
+		},
+		{
+			name:   "literal colon escaped",
+			line:   "*:cafe\\:1:80:WPA2",
+			fields: 4,
+			want:   []string{"*", "cafe:1", "80", "WPA2"},
+		},
+		{
+			name:   "literal backslash escaped",
+			line:   " :path\\\\name:60:WPA2",
+			fields: 4,
+			want:   []string{" ", "path\\name", "60", "WPA2"},
+		},
+		{
+			name:   "newline escape decoded",
+			line:   " :two\\nlines:50:WPA2",
+			fields: 4,
+			want:   []string{" ", "two\nlines", "50", "WPA2"},
+		},
+		{
+			name:   "trailing backslash kept literal",
+			line:   " :endsbackslash\\",
+			fields: 2,
+			want:   []string{" ", "endsbackslash\\"},
+		},
+		{
+			name:   "fewer separators than fields",
+			line:   "wifi:connected",
+			fields: 3,
+			want:   []string{"wifi", "connected"},
+		},
+		{
+			name:   "emoji and escaped colon together",
+			line:   " :evil\\:wifi \xf0\x9f\x98\x88:90:WPA3",
+			fields: 4,
+			want:   []string{" ", "evil:wifi \xf0\x9f\x98\x88", "90", "WPA3"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Split(tc.line, tc.fields)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d fields %q, want %d %q", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("field[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestUnescape(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"plain", "plain"},
+		{"with\\:colon", "with:colon"},
+		{"back\\\\slash", "back\\slash"},
+		{"new\\nline", "new\nline"},
+		{"tab\\there", "tab\there"},
+		// Emoji must round-trip verbatim — its bytes (0xF0..0xF4 followed by
+		// 0x80-0xBF continuation bytes) never overlap with `\` (0x5C).
+		{"emoji \xf0\x9f\xab\xa5", "emoji \xf0\x9f\xab\xa5"},
+	}
+	for _, tc := range cases {
+		got := Unescape(tc.in)
+		if got != tc.want {
+			t.Errorf("Unescape(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestWithUTF8Locale(t *testing.T) {
+	in := []string{"PATH=/bin", "LC_ALL=POSIX", "FOO=bar"}
+	out := withUTF8Locale(in)
+
+	var locales []string
+	hasFoo, hasPath := false, false
+	for _, e := range out {
+		if strings.HasPrefix(e, "LC_ALL=") {
+			locales = append(locales, e)
+		}
+		if e == "FOO=bar" {
+			hasFoo = true
+		}
+		if e == "PATH=/bin" {
+			hasPath = true
+		}
+	}
+
+	if len(locales) != 1 {
+		t.Errorf("expected exactly one LC_ALL entry, got %d: %v", len(locales), locales)
+	}
+	if locales[0] != "LC_ALL=C.UTF-8" {
+		t.Errorf("LC_ALL = %q, want LC_ALL=C.UTF-8", locales[0])
+	}
+	if !hasFoo || !hasPath {
+		t.Errorf("non-locale env vars dropped: out=%v", out)
+	}
+}

--- a/go/internal/shared/wendyconf/wendyconf_test.go
+++ b/go/internal/shared/wendyconf/wendyconf_test.go
@@ -59,6 +59,36 @@ func TestUnmarshalSkipsEmptySSID(t *testing.T) {
 	}
 }
 
+// TestMarshalRoundTripUnicode covers the imaging path used by `wendy os
+// install`: the CLI writes wendy.conf with the user's SSID; the agent reads it
+// on first boot and registers an nmcli profile. SSIDs with emoji bytes (or any
+// other non-ASCII UTF-8) must round-trip verbatim — otherwise the agent ends
+// up trying to connect to a different network than the user picked.
+func TestMarshalRoundTripUnicode(t *testing.T) {
+	cases := []WifiCredential{
+		{SSID: "café-wifi", Password: "p"},                  // 2-byte UTF-8 (Latin-1 supplement)
+		{SSID: "東京 Wi-Fi", Password: "p"},                   // 3-byte UTF-8 (CJK)
+		{SSID: "Read Only Internet \xf0\x9f\xab\xa5"},       // 4-byte UTF-8 (emoji), open
+		{SSID: "Home \xf0\x9f\x8f\xa0", Password: "secret"}, // emoji + password
+	}
+	data := Marshal(cases)
+	parsed := UnmarshalWiFi(parseINIForTest(data))
+	if len(parsed) != len(cases) {
+		t.Fatalf("parsed %d creds, want %d:\nfile:\n%s", len(parsed), len(cases), data)
+	}
+	// Marshal preserves declaration order; UnmarshalWiFi sorts by priority then
+	// section number, and all priorities are 0 here, so the order matches.
+	for i, want := range cases {
+		if parsed[i].SSID != want.SSID {
+			t.Errorf("creds[%d].SSID = %q (% x); want %q (% x)",
+				i, parsed[i].SSID, []byte(parsed[i].SSID), want.SSID, []byte(want.SSID))
+		}
+		if parsed[i].Password != want.Password {
+			t.Errorf("creds[%d].Password = %q; want %q", i, parsed[i].Password, want.Password)
+		}
+	}
+}
+
 // parseINIForTest replicates the minimal INI parser used by the agent so we
 // can exercise the full write → parse cycle without importing the agent package.
 func parseINIForTest(data []byte) map[string]map[string]string {


### PR DESCRIPTION
## Summary

Emoji-bearing SSIDs were rendering as `?` and the same `?` was round-tripping back into the connect path, so the agent's nmcli scan could never match them. Two distinct root causes — one per platform — fixed here.

- **Agent (Linux)**: the agent runs under systemd with no inherited locale. Older nmcli builds transcode SSID bytes through `iconv` and replace unmappable codepoints with literal `?` when the locale charset is not UTF-8. Forcing `LC_ALL=C.UTF-8` on every nmcli invocation keeps the byte stream clean regardless of the host's locale.
- **CLI (Windows)**: the Windows console defaults to OEM cp437/cp850. Valid UTF-8 written to stdout is rendered as `?`, and the same `?` is what comes back when the user types/pastes the SSID. A Windows-only `init` switches both stdin and stdout codepages to UTF-8 (`CP_UTF8` / 65001).

Both are bundled behind a new `internal/shared/nmcli` package, which also retires the duplicated `splitNMCLI` / `unescapeNMCLI` helpers (the agent had them; the CLI's `wifi_scan_linux.go` was using a naive `strings.SplitN(":", 2)` that didn't unescape `\:` / `\\` at all). The shared parser additionally decodes `\n` / `\r` / `\t` escapes that some nmcli builds emit.

## Test plan
- [x] `go test ./...` — all green, includes new emoji round-trip tests for `nmcli.Split`, `parseINI`, and the `wendyconf` Marshal -> parse pipeline used by `wendy os install`
- [x] `go build ./...` clean on linux/amd64, linux/arm64, windows/amd64
- [ ] Manual: scan an emoji-bearing AP from a Windows host with `wendy device wifi list` and verify the SSID renders correctly
- [ ] Manual: `wendy os install --wifi "ssid=Café 🫥,password=…"` and confirm the agent connects on first boot
- [ ] Manual: connect to an emoji-bearing AP via the BLE WendyOS path