### PR TITLE
Refresh target drives during OS install

### DIFF
--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -377,35 +377,12 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 			return fmt.Errorf("drive %s not found", flagDrive)
 		}
 	} else {
-		drives, err := listExternalDrives()
-		if err != nil {
-			return fmt.Errorf("listing drives: %w", err)
-		}
-		if len(drives) == 0 {
-			return fmt.Errorf("no external drives found — insert an SD card or USB drive and try again")
-		}
-
-		var driveItems []tui.PickerItem
-		driveMap := make(map[string]drive)
-		for _, d := range drives {
-			desc := d.DevicePath
-			if d.Size != "" {
-				desc += "  " + d.Size
-			}
-			driveItems = append(driveItems, tui.PickerItem{
-				Name:        d.Name,
-				Description: desc,
-				Value:       d.DevicePath,
-			})
-			driveMap[d.DevicePath] = d
-		}
-
 		fmt.Println()
-		sel, err := pickFromItems("Select target drive", driveItems)
+		selectedDrive, err := pickExternalDrive(ctx)
 		if err != nil {
 			return err
 		}
-		targetDrive = driveMap[sel]
+		targetDrive = selectedDrive
 	}
 
 	// Step 3: Confirm destructive write (unless --force).
@@ -587,6 +564,43 @@ func pickManifestVersion(title string, manifest *deviceManifest) (string, error)
 
 	fmt.Println()
 	return pickFromItems(title, items)
+}
+
+const externalDrivePickerRefreshInterval = 2 * time.Second
+
+func pickExternalDrive(ctx context.Context) (drive, error) {
+	item, err := pickRefreshingItem(ctx, "Select target drive (refreshes every 2s)", externalDrivePickerRefreshInterval, func(context.Context) ([]tui.PickerItem, error) {
+		drives, err := listExternalDrives()
+		if err != nil {
+			return nil, fmt.Errorf("listing drives: %w", err)
+		}
+		return externalDrivePickerItems(drives), nil
+	})
+	if err != nil {
+		return drive{}, err
+	}
+	selected, ok := item.Value.(drive)
+	if !ok {
+		return drive{}, fmt.Errorf("invalid drive selection")
+	}
+	return selected, nil
+}
+
+func externalDrivePickerItems(drives []drive) []tui.PickerItem {
+	items := make([]tui.PickerItem, 0, len(drives))
+	for _, d := range drives {
+		desc := d.DevicePath
+		if d.Size != "" {
+			desc += "  " + d.Size
+		}
+		items = append(items, tui.PickerItem{
+			Name:        d.Name,
+			Description: desc,
+			DedupKey:    d.DevicePath,
+			Value:       d,
+		})
+	}
+	return items
 }
 
 // throttledProgress returns a sender that forwards ProgressUpdateMsg to p at

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -477,6 +477,38 @@ func TestOpenOSImageStream_LegacyImgCacheHit(t *testing.T) {
 	}
 }
 
+func TestExternalDrivePickerItems(t *testing.T) {
+	drives := []drive{
+		{Name: "Sandisk USB", DevicePath: "/dev/disk4", Size: "32 GB", IsRemovable: true},
+		{Name: "USB SSD", DevicePath: "/dev/disk5", IsRemovable: true},
+	}
+
+	items := externalDrivePickerItems(drives)
+	if got := len(items); got != 2 {
+		t.Fatalf("items = %d, want 2", got)
+	}
+	if items[0].Name != "Sandisk USB" {
+		t.Errorf("Name = %q, want Sandisk USB", items[0].Name)
+	}
+	if items[0].Description != "/dev/disk4  32 GB" {
+		t.Errorf("Description = %q, want device path and size", items[0].Description)
+	}
+	if items[0].DedupKey != "/dev/disk4" {
+		t.Errorf("DedupKey = %q, want /dev/disk4", items[0].DedupKey)
+	}
+	if items[1].Description != "/dev/disk5" {
+		t.Errorf("Description without size = %q, want /dev/disk5", items[1].Description)
+	}
+
+	selected, ok := items[0].Value.(drive)
+	if !ok {
+		t.Fatalf("Value has type %T, want drive", items[0].Value)
+	}
+	if selected.DevicePath != drives[0].DevicePath {
+		t.Errorf("selected drive path = %q, want %q", selected.DevicePath, drives[0].DevicePath)
+	}
+}
+
 func TestConfirmOverwriteInternalDrive(t *testing.T) {
 	removable := drive{Name: "Sandisk USB", DevicePath: "/dev/disk4", IsRemovable: true}
 	internal := drive{Name: "Internal SSD", DevicePath: "/dev/disk1", IsRemovable: false}

--- a/go/internal/cli/commands/os_provision.go
+++ b/go/internal/cli/commands/os_provision.go
@@ -8,15 +8,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/metadata"
-
 	"github.com/wendylabsinc/wendy/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/internal/shared/config"
 	"github.com/wendylabsinc/wendy/internal/shared/wendyconf"
 	cloudpb "github.com/wendylabsinc/wendy/proto/gen/cloudpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // preProvisionedState is written to the config partition during imaging.
@@ -72,10 +70,7 @@ func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName st
 
 	certClient := cloudpb.NewCertificateServiceClient(cloudConn)
 
-	tokenCtx := ctx
-	if auth.APIKey != "" {
-		tokenCtx = metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer "+auth.APIKey))
-	}
+	tokenCtx := cloudContext(ctx, auth)
 
 	tokenResp, err := certClient.CreateAssetEnrollmentToken(tokenCtx, &cloudpb.CreateAssetEnrollmentTokenRequest{
 		OrganizationId: int32(cert.OrganizationID),

--- a/go/internal/cli/commands/picker_refresh.go
+++ b/go/internal/cli/commands/picker_refresh.go
@@ -1,0 +1,116 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/internal/cli/tui"
+)
+
+type refreshingPickerLoadMsg struct {
+	items []tui.PickerItem
+	err   error
+}
+
+type refreshingPickerModel struct {
+	picker   tui.PickerModel
+	ctx      context.Context
+	interval time.Duration
+	load     func(context.Context) ([]tui.PickerItem, error)
+	err      error
+}
+
+func newRefreshingPickerModel(
+	ctx context.Context,
+	title string,
+	interval time.Duration,
+	load func(context.Context) ([]tui.PickerItem, error),
+) refreshingPickerModel {
+	return refreshingPickerModel{
+		picker:   tui.NewPickerWithTitle(title),
+		ctx:      ctx,
+		interval: interval,
+		load:     load,
+	}
+}
+
+func (m refreshingPickerModel) Init() tea.Cmd {
+	return m.loadCmd()
+}
+
+func (m refreshingPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case refreshingPickerLoadMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			return m, tea.Quit
+		}
+		updated, _ := m.picker.Update(tui.PickerSetMsg{Items: msg.items})
+		m.picker = updated.(tui.PickerModel)
+		return m, delayThen(m.interval, m.loadCmd())
+	default:
+		updated, cmd := m.picker.Update(msg)
+		m.picker = updated.(tui.PickerModel)
+		return m, cmd
+	}
+}
+
+func (m refreshingPickerModel) View() string {
+	return m.picker.View()
+}
+
+func (m refreshingPickerModel) loadCmd() tea.Cmd {
+	return func() tea.Msg {
+		items, err := m.load(m.ctx)
+		return refreshingPickerLoadMsg{items: items, err: err}
+	}
+}
+
+func pickRefreshingItem(
+	ctx context.Context,
+	title string,
+	interval time.Duration,
+	load func(context.Context) ([]tui.PickerItem, error),
+) (tui.PickerItem, error) {
+	pollCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	model := newRefreshingPickerModel(pollCtx, title, interval, load)
+	p := tea.NewProgram(model)
+	finalModel, err := p.Run()
+	if err != nil {
+		return tui.PickerItem{}, fmt.Errorf("picker: %w", err)
+	}
+
+	rm := finalModel.(refreshingPickerModel)
+	if rm.err != nil {
+		return tui.PickerItem{}, rm.err
+	}
+	if rm.picker.Cancelled() {
+		return tui.PickerItem{}, ErrUserCancelled
+	}
+	sel := rm.picker.Selected()
+	if sel == nil {
+		return tui.PickerItem{}, fmt.Errorf("no item selected")
+	}
+	return *sel, nil
+}
+
+func pickRefreshingFromItems(
+	ctx context.Context,
+	title string,
+	interval time.Duration,
+	load func(context.Context) ([]tui.PickerItem, error),
+) (string, error) {
+	item, err := pickRefreshingItem(ctx, title, interval, load)
+	if err != nil {
+		return "", err
+	}
+	value, ok := item.Value.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid picker selection")
+	}
+	return value, nil
+}

--- a/go/internal/cli/commands/picker_refresh_test.go
+++ b/go/internal/cli/commands/picker_refresh_test.go
@@ -1,0 +1,118 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/internal/cli/tui"
+)
+
+func TestRefreshingPickerModel_InitLoadsItems(t *testing.T) {
+	m := newRefreshingPickerModel(context.Background(), "Select", time.Millisecond, func(context.Context) ([]tui.PickerItem, error) {
+		return []tui.PickerItem{{Name: "alpha", Value: "alpha"}}, nil
+	})
+
+	msg := m.Init()()
+	loadMsg, ok := msg.(refreshingPickerLoadMsg)
+	if !ok {
+		t.Fatalf("Init returned %T, want refreshingPickerLoadMsg", msg)
+	}
+	if loadMsg.err != nil {
+		t.Fatalf("load error = %v", loadMsg.err)
+	}
+	if got := len(loadMsg.items); got != 1 {
+		t.Fatalf("items = %d, want 1", got)
+	}
+}
+
+func TestRefreshingPickerModel_LoadResultReplacesItemsAndSchedulesRefresh(t *testing.T) {
+	m := newRefreshingPickerModel(context.Background(), "Select", time.Millisecond, func(context.Context) ([]tui.PickerItem, error) {
+		return nil, nil
+	})
+
+	updated, cmd := m.Update(refreshingPickerLoadMsg{items: []tui.PickerItem{
+		{Name: "alpha", Value: "alpha"},
+	}})
+	if cmd == nil {
+		t.Fatal("expected load result to schedule refresh")
+	}
+	rm := updated.(refreshingPickerModel)
+	if view := rm.View(); !strings.Contains(view, "alpha") {
+		t.Fatalf("expected view to contain refreshed item, got %q", view)
+	}
+
+	updated, cmd = rm.Update(refreshingPickerLoadMsg{items: []tui.PickerItem{
+		{Name: "beta", Value: "beta"},
+	}})
+	if cmd == nil {
+		t.Fatal("expected second load result to schedule refresh")
+	}
+	rm = updated.(refreshingPickerModel)
+	view := rm.View()
+	if strings.Contains(view, "alpha") {
+		t.Fatalf("stale item remained after replacement: %q", view)
+	}
+	if !strings.Contains(view, "beta") {
+		t.Fatalf("expected view to contain replacement item, got %q", view)
+	}
+}
+
+func TestRefreshingPickerModel_EmptyLoadKeepsPickerOpen(t *testing.T) {
+	m := newRefreshingPickerModel(context.Background(), "Select", time.Millisecond, func(context.Context) ([]tui.PickerItem, error) {
+		return nil, nil
+	})
+
+	updated, cmd := m.Update(refreshingPickerLoadMsg{})
+	if cmd == nil {
+		t.Fatal("expected empty load to schedule refresh")
+	}
+	rm := updated.(refreshingPickerModel)
+	if rm.err != nil {
+		t.Fatalf("unexpected error: %v", rm.err)
+	}
+	if !strings.Contains(rm.View(), "Scanning") {
+		t.Fatalf("expected empty refreshing picker to keep scanning, got %q", rm.View())
+	}
+}
+
+func TestRefreshingPickerModel_LoadErrorQuits(t *testing.T) {
+	wantErr := errors.New("boom")
+	m := newRefreshingPickerModel(context.Background(), "Select", time.Millisecond, func(context.Context) ([]tui.PickerItem, error) {
+		return nil, nil
+	})
+
+	updated, cmd := m.Update(refreshingPickerLoadMsg{err: wantErr})
+	if cmd == nil {
+		t.Fatal("expected load error to quit")
+	}
+	rm := updated.(refreshingPickerModel)
+	if !errors.Is(rm.err, wantErr) {
+		t.Fatalf("error = %v, want %v", rm.err, wantErr)
+	}
+}
+
+func TestRefreshingPickerModel_SelectsItem(t *testing.T) {
+	m := newRefreshingPickerModel(context.Background(), "Select", time.Millisecond, func(context.Context) ([]tui.PickerItem, error) {
+		return nil, nil
+	})
+	updated, _ := m.Update(refreshingPickerLoadMsg{items: []tui.PickerItem{
+		{Name: "alpha", Value: "alpha"},
+	}})
+	rm := updated.(refreshingPickerModel)
+
+	updated, cmd := rm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected enter to quit")
+	}
+	rm = updated.(refreshingPickerModel)
+	if rm.picker.Selected() == nil {
+		t.Fatal("expected selected item")
+	}
+	if got := rm.picker.Selected().Value.(string); got != "alpha" {
+		t.Fatalf("selected value = %q, want alpha", got)
+	}
+}

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -44,6 +44,12 @@ type PickerAddMsg struct {
 // interactive so the user can still select from the collected items.
 type PickerDoneMsg struct{}
 
+// PickerSetMsg replaces all items in the picker. It is intended for
+// authoritative refreshes where missing items should disappear from the list.
+type PickerSetMsg struct {
+	Items []PickerItem
+}
+
 // PickerModel is a Bubble Tea model that presents a live-updating list of
 // items and lets the user select one with arrow keys + Enter.
 type PickerModel struct {
@@ -169,6 +175,23 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case PickerDoneMsg:
 		m.scanning = false
+
+	case PickerSetMsg:
+		cursorKey := m.currentCursorKey()
+		m.items = nil
+		m.seenIdx = make(map[string]int, len(msg.Items))
+		for _, item := range msg.Items {
+			key := strings.ToLower(pickerItemKey(item))
+			if idx, ok := m.seenIdx[key]; ok {
+				if m.MergeItem != nil {
+					m.MergeItem(&m.items[idx], item)
+				}
+				continue
+			}
+			m.seenIdx[key] = len(m.items)
+			m.items = append(m.items, item)
+		}
+		m.refreshTableWithCursorKey(cursorKey)
 	}
 
 	return m, nil
@@ -282,13 +305,18 @@ func newPickerTable() bubbleTable.Model {
 	return NewBubbleTable(true, nil)
 }
 
-func (m *PickerModel) refreshTable() {
-	// Remember which item the cursor is on so we can restore it after sorting.
-	var cursorKey string
+func (m *PickerModel) currentCursorKey() string {
 	if cursor := m.table.Cursor(); cursor >= 0 && cursor < len(m.items) {
-		cursorKey = strings.ToLower(pickerItemKey(m.items[cursor]))
+		return strings.ToLower(pickerItemKey(m.items[cursor]))
 	}
+	return ""
+}
 
+func (m *PickerModel) refreshTable() {
+	m.refreshTableWithCursorKey(m.currentCursorKey())
+}
+
+func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 	// Sort items for a stable, predictable display order. When SortKey is set,
 	// it takes precedence; otherwise sort by name (using DedupKey if present).
 	sort.SliceStable(m.items, func(i, j int) bool {
@@ -339,13 +367,20 @@ func (m *PickerModel) refreshTable() {
 	m.table.SetColumns(cols)
 	m.table.SetRows(rows)
 
-	// Restore cursor to the same item, or default to 0 on first render.
-	if cursorKey != "" {
-		if idx, ok := m.seenIdx[cursorKey]; ok {
-			m.table.SetCursor(idx)
+	// Restore cursor to the same item when possible. If that item disappeared,
+	// keep the cursor near its previous position and clamp it into range.
+	if len(rows) > 0 {
+		if cursorKey != "" {
+			if idx, ok := m.seenIdx[cursorKey]; ok {
+				m.table.SetCursor(idx)
+			} else if m.table.Cursor() >= len(rows) {
+				m.table.SetCursor(len(rows) - 1)
+			}
+		} else if m.table.Cursor() < 0 {
+			m.table.SetCursor(0)
+		} else if m.table.Cursor() >= len(rows) {
+			m.table.SetCursor(len(rows) - 1)
 		}
-	} else if len(rows) > 0 && m.table.Cursor() < 0 {
-		m.table.SetCursor(0)
 	}
 
 	m.table.SetWidth(pickerTableWidth(m.table.Columns()))

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -374,7 +374,7 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 		if cursorKey != "" {
 			if idx, ok := m.seenIdx[cursorKey]; ok {
 				m.table.SetCursor(idx)
-			} else if m.table.Cursor() >= len(rows) {
+			} else if m.table.Cursor() < 0 || m.table.Cursor() >= len(rows) {
 				m.table.SetCursor(len(rows) - 1)
 			}
 		} else if m.table.Cursor() < 0 {

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -364,6 +364,7 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 	} else {
 		cols = pickerColumns(rows, activeCols)
 	}
+	m.table.SetRows(nil)
 	m.table.SetColumns(cols)
 	m.table.SetRows(rows)
 

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -150,6 +150,77 @@ func TestPickerModel_XKeyClearsDefault(t *testing.T) {
 	}
 }
 
+func TestPickerModel_SetMsgReplacesItems(t *testing.T) {
+	m := NewPicker()
+
+	updated, _ := m.Update(PickerSetMsg{Items: []PickerItem{
+		{Name: "alpha", Value: "alpha"},
+		{Name: "beta", Value: "beta"},
+	}})
+	pm := updated.(PickerModel)
+
+	updated, _ = pm.Update(PickerSetMsg{Items: []PickerItem{
+		{Name: "gamma", Value: "gamma"},
+	}})
+	pm = updated.(PickerModel)
+
+	if got := len(pm.items); got != 1 {
+		t.Fatalf("expected replacement to leave 1 item, got %d", got)
+	}
+	if got := pm.items[0].Name; got != "gamma" {
+		t.Fatalf("remaining item = %q, want gamma", got)
+	}
+	if _, ok := pm.seenIdx["alpha"]; ok {
+		t.Fatal("stale alpha key remained in seenIdx")
+	}
+}
+
+func TestPickerModel_SetMsgPreservesCursorByItem(t *testing.T) {
+	m := NewPicker()
+
+	updated, _ := m.Update(PickerSetMsg{Items: []PickerItem{
+		{Name: "alpha", Value: "alpha"},
+		{Name: "beta", Value: "beta"},
+	}})
+	pm := updated.(PickerModel)
+	pm.table.SetCursor(1)
+
+	updated, _ = pm.Update(PickerSetMsg{Items: []PickerItem{
+		{Name: "beta", Value: "beta"},
+		{Name: "alpha", Value: "alpha"},
+		{Name: "gamma", Value: "gamma"},
+	}})
+	pm = updated.(PickerModel)
+
+	cursor := pm.table.Cursor()
+	if cursor < 0 || cursor >= len(pm.items) {
+		t.Fatalf("cursor out of range: %d", cursor)
+	}
+	if got := pm.items[cursor].Name; got != "beta" {
+		t.Fatalf("cursor item = %q, want beta", got)
+	}
+}
+
+func TestPickerModel_SetMsgClampsCursorWhenItemRemoved(t *testing.T) {
+	m := NewPicker()
+
+	updated, _ := m.Update(PickerSetMsg{Items: []PickerItem{
+		{Name: "alpha", Value: "alpha"},
+		{Name: "beta", Value: "beta"},
+	}})
+	pm := updated.(PickerModel)
+	pm.table.SetCursor(1)
+
+	updated, _ = pm.Update(PickerSetMsg{Items: []PickerItem{
+		{Name: "alpha", Value: "alpha"},
+	}})
+	pm = updated.(PickerModel)
+
+	if got := pm.table.Cursor(); got != 0 {
+		t.Fatalf("cursor = %d, want 0", got)
+	}
+}
+
 func TestPickerModel_DXIgnoredWithoutCallbacks(t *testing.T) {
 	m := NewPickerWithTitle("Select")
 	// No OnSetDefault/OnUnsetDefault set.

--- a/kb.refresh-select-target-device.plan.md
+++ b/kb.refresh-select-target-device.plan.md
@@ -1,0 +1,196 @@
+# Refresh Select Target Drive
+
+## Problem
+
+During `wendy os install`, the interactive "Select target drive" screen is populated from a single call to `listExternalDrives()` before the picker opens. If a user inserts an SSD, SD card, or USB drive after the picker is already displayed, the view does not refresh and the newly inserted drive never appears.
+
+This is especially noticeable on Windows, but the current normal `os install` flow appears static on all platforms:
+
+- `installLinuxImage` calls `listExternalDrives()` once.
+- It converts those results into `tui.PickerItem`s.
+- It calls `pickFromItems("Select target drive", driveItems)`.
+- `pickFromItems` sends `PickerAddMsg` once, then immediately sends `PickerDoneMsg`.
+
+There is drive-refresh behavior elsewhere in the `tour` wizard: the drive selection phase rescans every 2 seconds and updates the view. The regular `wendy os install` flow should likely get similar behavior, or another explicit refresh mechanism.
+
+## Investigation Notes
+
+There are two existing refresh patterns worth comparing:
+
+### `tour` drive selection
+
+The `wendy tour` wizard has a custom drive-selection phase (`phaseDriveWait`) rather than using `tui.PickerModel`.
+
+Current behavior:
+
+- entering the phase calls `listExternalDrives()` once
+- the model schedules `rescanDrivesAfter(2 * time.Second)`
+- that timer emits `tourDriveRescanMsg`
+- `Update()` handles `tourDriveRescanMsg` by calling `listExternalDrives()` again
+- `m.drives` is replaced with the new list
+- another rescan is scheduled while the phase remains `phaseDriveWait`
+
+This gives the desired UX, including removed drives disappearing from the list, but the scan itself happens directly in `Update()`. That is less consistent with the rest of the Bubble Tea code because blocking work is normally done in `tea.Cmd`s.
+
+### `wendy discover`
+
+`wendy discover` uses a custom Bubble Tea table model with command-driven polling:
+
+- `Init()` starts scan commands via `tea.Batch(...)`
+- each scan command performs discovery asynchronously and returns a typed result message
+- `Update()` handles the result message by replacing the authoritative collection slice and calling `refreshTable()`
+- `Update()` returns the next scan command, optionally wrapped in `delayThen(...)`
+
+Examples:
+
+- USB, Ethernet, and External discovery use `delayThen(interval, scanCmd)`
+- LAN immediately starts another scan; the scan itself has a timeout
+- BLE has source-specific retention logic because BLE scans are lossy
+
+This pattern is preferable for time-based refresh: scan work lives in `tea.Cmd`s, result messages update model state, and the model schedules the next scan.
+
+### Generic picker limitation
+
+The normal `os install` path currently uses `pickFromItems(...)`, which creates `tui.PickerModel`, sends one `PickerAddMsg`, then sends `PickerDoneMsg`.
+
+`PickerModel` currently supports append/merge semantics:
+
+- `PickerAddMsg` adds unseen items and optionally merges duplicates
+- `PickerDoneMsg` stops the "scanning" indicator
+
+It does not currently support authoritative replacement of the whole item list. That matters for drives because inserted drives should appear and removed drives should disappear.
+
+## Recommendation
+
+Unify on the `wendy discover` **command-driven polling pattern** for time-based refreshes, but do not try to reuse the full `discoverModel` for drive selection.
+
+`discoverModel` is a dashboard with multiple scan sources, multiple intervals, source-specific reconciliation, copy/update/default actions, and a custom table. A target-drive selector is a simple picker with one scan source, one interval, and one terminal action: select a drive. The shared abstraction should be the polling mechanics, not the entire UI model.
+
+Recommended rules:
+
+- Static choices continue using `pickFromItems(...)`.
+- Time-refreshing picker choices use a new refreshing picker helper/model.
+- Custom dashboards like `wendy discover` keep custom models, but use the same command-driven polling shape.
+- Physical-resource lists, including drives, should use authoritative replacement rather than append-only merge.
+
+## Proposed Implementation Plan
+
+### 1. Add authoritative replacement support to `tui.PickerModel`
+
+Add a new message, for example:
+
+```go
+type PickerSetMsg struct {
+    Items []PickerItem
+}
+```
+
+`PickerSetMsg` should replace the picker contents wholesale:
+
+- rebuild `items`
+- rebuild `seenIdx`
+- preserve cursor position where possible
+- clamp cursor if the new list is shorter
+- call `refreshTable()`
+
+This differs from `PickerAddMsg`, which should remain append/merge-oriented for streaming discovery.
+
+### 2. Add a command-driven refreshing picker helper
+
+Add a helper for dynamic picker flows, for example:
+
+```go
+func pickRefreshingFromItems(
+    ctx context.Context,
+    title string,
+    interval time.Duration,
+    load func(context.Context) ([]tui.PickerItem, error),
+) (string, error)
+```
+
+or return the selected `tui.PickerItem` if callers need richer values.
+
+Internally, it should follow the `discover` pattern:
+
+```text
+Init / start
+  -> run load command
+
+load result message
+  -> send/handle PickerSetMsg
+  -> schedule delayThen(interval, load command)
+
+selection/cancel
+  -> quit and cancel polling context
+```
+
+Avoid a simple background goroutine that repeatedly calls `p.Send(...)` unless the existing picker architecture makes that much simpler. For time-based polling, prefer Bubble Tea commands and result messages.
+
+### 3. Use the refreshing picker for `wendy os install` drive selection
+
+Replace the current interactive target-drive flow:
+
+```text
+listExternalDrives once
+convert to PickerItem
+pickFromItems("Select target drive", items)
+```
+
+with a refreshing drive picker that:
+
+- rescans every ~2 seconds, matching the tour UX
+- shows an empty-state message while no external drives are present
+- lets newly inserted drives appear without restarting the command
+- removes drives that disappear before selection
+- returns the selected `drive`
+
+Because picker values currently return strings, maintain a `DevicePath -> drive` mapping from the latest scan. Prefer making the helper return the full selected item, or set `Value` to a `drive` if safe for this package-local usage.
+
+### 4. Share or centralize the delay helper
+
+`discover.go` already has:
+
+```go
+func delayThen(d time.Duration, cmd tea.Cmd) tea.Cmd
+```
+
+The tour has a separate `rescanDrivesAfter(...)`. Standardize on one helper for command-delay polling. It can remain in the `commands` package if only command models use it, or move to `tui` if it becomes broadly useful.
+
+### 5. Optional follow-up: clean up the tour drive refresh
+
+The tour already has the right UX but a less ideal implementation. After the regular `os install` picker is fixed, consider refactoring the tour drive phase to use the same command-driven shape:
+
+```text
+drive scan cmd -> drive scan result msg -> replace m.drives -> delayThen(2s, drive scan cmd)
+```
+
+This is optional for the initial bug fix, but it would align all time-based refresh code with the `discover` approach.
+
+## Expected Behavior
+
+- Starting `wendy os install` with no external drive should keep the picker open instead of failing immediately.
+- Inserting an SSD, SD card, or USB drive while the picker is open should make it appear automatically within the refresh interval.
+- Removing a drive while the picker is open should remove it from the list or prevent selecting a stale entry.
+- The UI should communicate that it is scanning/refreshing, ideally with copy similar to the tour: `Refreshes every 2 s` / `auto-refreshing`.
+- Cancel behavior should remain unchanged: `q` or `ctrl+c` returns `ErrUserCancelled`.
+- Non-interactive `--drive` behavior should remain unchanged.
+
+## Tests
+
+Add or update tests around:
+
+- `PickerSetMsg` replaces items instead of appending.
+- `PickerSetMsg` removes stale items.
+- Cursor is clamped/preserved sensibly after replacement.
+- Refreshing picker schedules another scan after a successful scan result.
+- Refreshing picker handles an initial empty result without quitting.
+- `os install` drive selection maps the selected picker item back to the correct `drive` from the latest scan.
+
+Use short test intervals or injectable delay functions to avoid slow tests, similar to the existing `discover` tests that override discovery intervals via environment variables.
+
+## Cross-Platform Considerations
+
+- Windows drive insertion/removal is the main reported pain point, so verify behavior there if possible.
+- `listExternalDrives()` differs by platform; the picker layer should not add platform-specific assumptions.
+- Refresh interval should be long enough to avoid hammering platform drive-listing commands. The tour currently uses 2 seconds, which is a reasonable starting point.
+- Treat scan errors carefully: transient listing failures should probably display an error state or warning without immediately exiting, but fatal errors can still abort. Match existing command conventions where practical.


### PR DESCRIPTION
## Summary
- add authoritative replacement updates to the shared picker
- add a command-driven refreshing picker model for time-based polling
- refresh target drive selection during `wendy os install` every 2 seconds

## Tests
- `cd go && go test ./...`