### PR TITLE
Validate persist mounts as container paths

### DIFF
--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -373,10 +374,11 @@ func applyPersist(spec *Spec, ent appconfig.Entitlement, appID string) {
 	if name == "." || name == ".." || name == "/" || name == "" {
 		return
 	}
-	// Validate the container destination: must be absolute with no dot-dot
-	// components. Check the original before cleaning so "a/../b" is rejected
-	// even though Clean would resolve it to a valid absolute path.
-	if !filepath.IsAbs(ent.Path) {
+	// Validate the container destination as a POSIX path: it must be
+	// absolute with no dot-dot components. Check the original before cleaning
+	// so "a/../b" is rejected even though Clean would resolve it to a valid
+	// absolute path.
+	if !path.IsAbs(ent.Path) {
 		return
 	}
 	for _, component := range strings.Split(ent.Path, "/") {
@@ -384,7 +386,7 @@ func applyPersist(spec *Spec, ent appconfig.Entitlement, appID string) {
 			return
 		}
 	}
-	dest := filepath.Clean(ent.Path)
+	dest := path.Clean(ent.Path)
 	hostPath := filepath.Join("/var/lib/wendy/volumes", name)
 	if err := os.MkdirAll(hostPath, 0o755); err != nil {
 		// Best-effort: the container will fail to start with a clear mount error

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 	"slices"
 	"sort"
 	"strings"
@@ -216,7 +216,9 @@ func (c *AppConfig) Validate() error {
 			if e.Path == "" {
 				return fmt.Errorf("entitlement[%d]: persist entitlement requires a path", i)
 			}
-			if !filepath.IsAbs(e.Path) {
+			// Persist paths are container destinations, so validate them as
+			// POSIX paths regardless of the host OS running the CLI.
+			if !path.IsAbs(e.Path) {
 				return fmt.Errorf("entitlement[%d]: persist path must be absolute, got %q", i, e.Path)
 			}
 			if containsDotDot(e.Path) {

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -156,6 +156,23 @@ func TestValidate_PersistMissingFields(t *testing.T) {
 	}
 }
 
+func TestValidate_PersistPathUsesContainerPathSemantics(t *testing.T) {
+	cfg := &AppConfig{
+		AppID: "com.example.app",
+		Entitlements: []Entitlement{
+			{Type: EntitlementPersist, Name: "vol1", Path: "/data"},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error for POSIX container path: %v", err)
+	}
+
+	cfg.Entitlements[0].Path = `C:\data`
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() expected error for host-style absolute path, got nil")
+	}
+}
+
 func TestValidate_GPIOWithoutPins(t *testing.T) {
 	cfg := &AppConfig{
 		AppID: "com.example.app",


### PR DESCRIPTION
## Summary
- Validate persist entitlement paths with POSIX container path semantics instead of host OS path semantics
- Clean OCI mount destinations as POSIX paths
- Add coverage that accepts `/data` and rejects host-style `C:\data` destinations

## Problem
Persist entitlement `path` values describe destinations inside the Linux container, not paths on the developer's host machine. The CLI was using Go's `filepath.IsAbs`, which follows the host OS. On Windows, `/models` is not considered absolute, so a valid generated `wendy.json` failed with:

```text
invalid wendy.json: entitlement[2]: persist path must be absolute, got "/models"
```

Using POSIX path validation matches the container namespace and keeps the behavior consistent across macOS, Linux, and Windows.

## Validation
- `go test ./internal/shared/appconfig ./internal/agent/oci`