### PR TITLE
Ramp refreshing poll intervals

### DIFF
--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -220,6 +220,9 @@ type discoverModel struct {
 	opts               discovery.DiscoveryOptions
 	collection         *models.DevicesCollection
 	bleSeen            map[string]time.Time // device ID -> time last seen in a BLE scan
+	usbInterval        increasingRefreshInterval
+	ethernetInterval   increasingRefreshInterval
+	externalInterval   increasingRefreshInterval
 	table              bubbleTable.Model
 	quitting           bool
 	hasResults         bool
@@ -415,12 +418,14 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.collection.USBDevices = msg.devices
 		m.hasResults = true
 		m.refreshTable()
-		return m, delayThen(env.DiscoverUSBInterval(), m.scanUSB())
+		delay := m.usbInterval.delay(env.DiscoverUSBInterval())
+		return m, delayThen(delay, m.scanUSB())
 	case ethScanMsg:
 		m.collection.EthernetInterfaces = msg.devices
 		m.hasResults = true
 		m.refreshTable()
-		return m, delayThen(env.DiscoverEthernetInterval(), m.scanEthernet())
+		delay := m.ethernetInterval.delay(env.DiscoverEthernetInterval())
+		return m, delayThen(delay, m.scanEthernet())
 	case lanScanMsg:
 		// Preserve last known AgentVersion and DeviceType when the gRPC probe
 		// failed. The probe uses a 1500 ms timeout, so transient latency can
@@ -490,7 +495,8 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.collection.ExternalDevices = msg.devices
 		m.hasResults = true
 		m.refreshTable()
-		return m, delayThen(env.DiscoverExternalInterval(), m.scanExternal())
+		delay := m.externalInterval.delay(env.DiscoverExternalInterval())
+		return m, delayThen(delay, m.scanExternal())
 	case flashClearMsg:
 		m.flashMessage = ""
 		m.flashIsError = false

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -78,7 +78,7 @@ func TestDelayThen_ActuallyDelays(t *testing.T) {
 }
 
 func TestDiscoverModel_UpdateReturnsDelayedCmd(t *testing.T) {
-	// Use tiny intervals so the test doesn't actually sleep.
+	// Use tiny intervals so the test doesn't actually sleep if a returned command runs.
 	t.Setenv("WENDY_DISCOVER_USB_INTERVAL", "1ms")
 	t.Setenv("WENDY_DISCOVER_ETHERNET_INTERVAL", "1ms")
 	t.Setenv("WENDY_DISCOVER_EXTERNAL_INTERVAL", "1ms")
@@ -106,6 +106,23 @@ func TestDiscoverModel_UpdateReturnsDelayedCmd(t *testing.T) {
 				t.Error("expected non-nil cmd (delayed rescan)")
 			}
 		})
+	}
+}
+
+func TestDiscoverModel_UpdateRampsRescanIntervals(t *testing.T) {
+	t.Setenv("WENDY_DISCOVER_USB_INTERVAL", "3s")
+
+	m := newDiscoverModel(context.Background(), defaultOpts())
+	updated, _ := m.Update(usbScanMsg{devices: []models.USBDevice{{DisplayName: "test"}}})
+	m = updated.(discoverModel)
+	if m.usbInterval.next != time.Second {
+		t.Fatalf("next USB interval = %v, want 1s", m.usbInterval.next)
+	}
+
+	updated, _ = m.Update(usbScanMsg{devices: []models.USBDevice{{DisplayName: "test"}}})
+	m = updated.(discoverModel)
+	if m.usbInterval.next != 2*time.Second {
+		t.Fatalf("next USB interval = %v, want 2s", m.usbInterval.next)
 	}
 }
 

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -569,7 +569,7 @@ func pickManifestVersion(title string, manifest *deviceManifest) (string, error)
 const externalDrivePickerRefreshInterval = 2 * time.Second
 
 func pickExternalDrive(ctx context.Context) (drive, error) {
-	item, err := pickRefreshingItem(ctx, "Select target drive (refreshes every 2s)", externalDrivePickerRefreshInterval, func(context.Context) ([]tui.PickerItem, error) {
+	item, err := pickRefreshingItem(ctx, "Select target drive", externalDrivePickerRefreshInterval, func(context.Context) ([]tui.PickerItem, error) {
 		drives, err := listExternalDrives()
 		if err != nil {
 			return nil, fmt.Errorf("listing drives: %w", err)

--- a/go/internal/cli/commands/picker_refresh.go
+++ b/go/internal/cli/commands/picker_refresh.go
@@ -17,7 +17,8 @@ type refreshingPickerLoadMsg struct {
 type refreshingPickerModel struct {
 	picker   tui.PickerModel
 	ctx      context.Context
-	interval time.Duration
+	maxDelay time.Duration
+	interval increasingRefreshInterval
 	load     func(context.Context) ([]tui.PickerItem, error)
 	err      error
 }
@@ -31,7 +32,7 @@ func newRefreshingPickerModel(
 	return refreshingPickerModel{
 		picker:   tui.NewPickerWithTitle(title),
 		ctx:      ctx,
-		interval: interval,
+		maxDelay: interval,
 		load:     load,
 	}
 }
@@ -49,7 +50,8 @@ func (m refreshingPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		updated, _ := m.picker.Update(tui.PickerSetMsg{Items: msg.items})
 		m.picker = updated.(tui.PickerModel)
-		return m, delayThen(m.interval, m.loadCmd())
+		delay := m.interval.delay(m.maxDelay)
+		return m, delayThen(delay, m.loadCmd())
 	default:
 		updated, cmd := m.picker.Update(msg)
 		m.picker = updated.(tui.PickerModel)

--- a/go/internal/cli/commands/picker_refresh_test.go
+++ b/go/internal/cli/commands/picker_refresh_test.go
@@ -30,7 +30,7 @@ func TestRefreshingPickerModel_InitLoadsItems(t *testing.T) {
 }
 
 func TestRefreshingPickerModel_LoadResultReplacesItemsAndSchedulesRefresh(t *testing.T) {
-	m := newRefreshingPickerModel(context.Background(), "Select", time.Millisecond, func(context.Context) ([]tui.PickerItem, error) {
+	m := newRefreshingPickerModel(context.Background(), "Select", 3*time.Second, func(context.Context) ([]tui.PickerItem, error) {
 		return nil, nil
 	})
 
@@ -41,6 +41,9 @@ func TestRefreshingPickerModel_LoadResultReplacesItemsAndSchedulesRefresh(t *tes
 		t.Fatal("expected load result to schedule refresh")
 	}
 	rm := updated.(refreshingPickerModel)
+	if rm.interval.next != time.Second {
+		t.Fatalf("next interval = %v, want 1s", rm.interval.next)
+	}
 	if view := rm.View(); !strings.Contains(view, "alpha") {
 		t.Fatalf("expected view to contain refreshed item, got %q", view)
 	}
@@ -52,6 +55,9 @@ func TestRefreshingPickerModel_LoadResultReplacesItemsAndSchedulesRefresh(t *tes
 		t.Fatal("expected second load result to schedule refresh")
 	}
 	rm = updated.(refreshingPickerModel)
+	if rm.interval.next != 2*time.Second {
+		t.Fatalf("next interval = %v, want 2s", rm.interval.next)
+	}
 	view := rm.View()
 	if strings.Contains(view, "alpha") {
 		t.Fatalf("stale item remained after replacement: %q", view)

--- a/go/internal/cli/commands/poll_interval.go
+++ b/go/internal/cli/commands/poll_interval.go
@@ -1,0 +1,29 @@
+package commands
+
+import "time"
+
+const initialRefreshInterval = 500 * time.Millisecond
+
+type increasingRefreshInterval struct {
+	next time.Duration
+}
+
+func (i *increasingRefreshInterval) delay(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	if i.next <= 0 {
+		i.next = initialRefreshInterval
+	}
+
+	delay := i.next
+	if delay > max {
+		delay = max
+	}
+
+	i.next *= 2
+	if i.next > max {
+		i.next = max
+	}
+	return delay
+}

--- a/go/internal/cli/commands/poll_interval_test.go
+++ b/go/internal/cli/commands/poll_interval_test.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIncreasingRefreshIntervalRampsToLimit(t *testing.T) {
+	var interval increasingRefreshInterval
+	maxDelay := 3 * time.Second
+
+	want := []time.Duration{
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+		3 * time.Second,
+		3 * time.Second,
+	}
+
+	for i, expected := range want {
+		if got := interval.delay(maxDelay); got != expected {
+			t.Fatalf("delay %d = %v, want %v", i, got, expected)
+		}
+	}
+}
+
+func TestIncreasingRefreshIntervalCapsInitialDelay(t *testing.T) {
+	var interval increasingRefreshInterval
+	maxDelay := 100 * time.Millisecond
+
+	for i := 0; i < 3; i++ {
+		if got := interval.delay(maxDelay); got != maxDelay {
+			t.Fatalf("delay %d = %v, want %v", i, got, maxDelay)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Start refresh loops quickly at 500ms, then double the wait after each result until reaching the configured interval.
- This makes newly attached drives/devices appear sooner without keeping steady-state polling overly aggressive.
- Apply the ramp to the target-drive picker and to `wendy discover` USB, Ethernet, and external rescans. LAN and Bluetooth keep their existing scan-window behavior.

## Tests
- `go test ./internal/cli/commands ./internal/cli/tui`
