### PR TITLE
Skip empty buildx cache imports

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -786,9 +786,11 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 		"buildx", "build",
 		"--builder", builder,
 		"--platform", platform,
-		"--cache-from", "type=local,src=" + cacheDirSlash,
-		"--cache-to", "type=local,dest=" + cacheDirSlash,
 	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "index.json")); err == nil {
+		args = append(args, "--cache-from", "type=local,src="+cacheDirSlash)
+	}
+	args = append(args, "--cache-to", "type=local,dest="+cacheDirSlash)
 	// Sort keys so the argument order is stable across runs, which keeps
 	// build logs reproducible and avoids flakiness in tests that assert args.
 	keys := make([]string, 0, len(buildArgs))


### PR DESCRIPTION
## Summary
- Only pass `--cache-from type=local` to Docker buildx once Wendy has a local cache manifest
- Keep writing `--cache-to` so the first build still populates the cache

## Problem
On a fresh Windows install, Wendy creates the buildx cache directory and immediately passes it as a cache source. Docker buildx then tries to read `index.json`, which does not exist before the first successful build, and prints a warning like:

```text
WARNING: local cache import at .../wendy/buildx skipped due to err: could not read .../index.json: The system cannot find the file specified.
```

The warning is harmless, but it looks like something went wrong during the first build. Skipping the cache import until `index.json` exists keeps first-run output clean while preserving cache writes.

## Validation
- `go test ./internal/cli/commands`