### PR TITLE
fix: cache registry proxy per connection to allow concurrent Docker pushes

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -903,16 +903,18 @@ var (
 // agent's registry. The proxy is started once per connection and cached so
 // concurrent pushes to the same device share a stable host:port address.
 func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), err error) {
-	// Fast path: return cached address from a previously started proxy.
+	// Hold the lock for the entire operation so concurrent callers block rather
+	// than each starting their own proxy. Proxy creation is just a local
+	// net.Listen call, so the lock is held only briefly.
 	dockerRegistryProxyCacheMu.Lock()
+	defer dockerRegistryProxyCacheMu.Unlock()
+
 	if addr, ok := dockerRegistryProxyAddrs[conn]; ok {
-		dockerRegistryProxyCacheMu.Unlock()
 		return addr, func() {}, nil
 	}
-	dockerRegistryProxyCacheMu.Unlock()
 
-	// Slow path: start a proxy. Use context.Background so the proxy outlives
-	// this particular push and is reused by concurrent or subsequent pushes.
+	// Start a proxy tied to context.Background so it outlives this push and is
+	// reused by subsequent pushes on the same connection.
 	var addr string
 	var stopProxy func()
 
@@ -936,14 +938,6 @@ func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnecti
 		}
 	}
 
-	// Store under lock. If another goroutine raced and stored first, discard
-	// our proxy and return theirs.
-	dockerRegistryProxyCacheMu.Lock()
-	if existing, ok := dockerRegistryProxyAddrs[conn]; ok {
-		dockerRegistryProxyCacheMu.Unlock()
-		stopProxy()
-		return existing, func() {}, nil
-	}
 	dockerRegistryProxyAddrs[conn] = addr
 	conn.ExtraClosers = append(conn.ExtraClosers, closeFunc(func() {
 		dockerRegistryProxyCacheMu.Lock()
@@ -951,7 +945,6 @@ func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnecti
 		dockerRegistryProxyCacheMu.Unlock()
 		stopProxy()
 	}))
-	dockerRegistryProxyCacheMu.Unlock()
 
 	return addr, func() {}, nil
 }

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -881,7 +881,7 @@ func resolveRegistry(ctx context.Context, host string, port int) (registryAddr s
 		target = net.JoinHostPort(resolved, strconv.Itoa(port))
 	}
 
-	proxy, err := startRegistryProxy(ctx, target)
+	proxy, err := startRegistryProxy(ctx, "0.0.0.0:0", target)
 	if err != nil {
 		return "", nil, fmt.Errorf("starting registry proxy: %w", err)
 	}
@@ -924,7 +924,14 @@ func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnecti
 			return "", nil, err
 		}
 	} else {
-		proxy, proxyErr := startRegistryProxyWithDialer(context.Background(), func(ctx context.Context) (net.Conn, error) {
+		// On Linux buildkitd uses host networking so 127.0.0.1 is reachable.
+		// On macOS it runs inside the Docker Desktop VM and must connect via
+		// host.docker.internal, which requires the proxy to bind on all interfaces.
+		listenAddr := "0.0.0.0:0"
+		if runtime.GOOS == "linux" {
+			listenAddr = "127.0.0.1:0"
+		}
+		proxy, proxyErr := startRegistryProxyWithDialer(context.Background(), listenAddr, func(ctx context.Context) (net.Conn, error) {
 			return conn.RegistryDialer(ctx, port)
 		})
 		if proxyErr != nil {
@@ -965,9 +972,9 @@ func resolveRegistryForSwift(ctx context.Context, host string, port int) (regist
 		return fmt.Sprintf("%s:%d", addr, port), func() {}, nil
 	}
 
-	// Link-local: same proxy approach as resolveRegistry.
+	// Link-local: proxy via 127.0.0.1 — Swift runs on the host, not in a VM.
 	target := net.JoinHostPort(host, strconv.Itoa(port))
-	proxy, err := startRegistryProxy(ctx, target)
+	proxy, err := startRegistryProxy(ctx, "127.0.0.1:0", target)
 	if err != nil {
 		return "", nil, fmt.Errorf("starting registry proxy for link-local device: %w", err)
 	}
@@ -979,7 +986,7 @@ func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentCon
 		return resolveRegistryForSwift(ctx, conn.Host, port)
 	}
 
-	proxy, err := startRegistryProxyWithDialer(ctx, func(ctx context.Context) (net.Conn, error) {
+	proxy, err := startRegistryProxyWithDialer(ctx, "127.0.0.1:0", func(ctx context.Context) (net.Conn, error) {
 		return conn.RegistryDialer(ctx, port)
 	})
 	if err != nil {
@@ -1013,18 +1020,20 @@ type registryProxy struct {
 	done     chan struct{}
 }
 
-// startRegistryProxy creates a TCP proxy that listens on all interfaces
-// (required for Docker Desktop VM connectivity) and forwards connections to
-// the target address. The target should use the device's mDNS hostname (not a
-// bare link-local IP) so the host's resolver provides the zone ID.
-func startRegistryProxy(ctx context.Context, target string) (*registryProxy, error) {
-	return startRegistryProxyWithDialer(ctx, func(ctx context.Context) (net.Conn, error) {
+// startRegistryProxy creates a TCP proxy that listens on listenAddr and
+// forwards connections to the target address. Pass "0.0.0.0:0" when Docker
+// Desktop's VM must reach the proxy via host.docker.internal; pass
+// "127.0.0.1:0" everywhere else so the listener is not exposed on all
+// interfaces. The target should use the device's mDNS hostname (not a bare
+// link-local IP) so the host's resolver provides the zone ID.
+func startRegistryProxy(ctx context.Context, listenAddr string, target string) (*registryProxy, error) {
+	return startRegistryProxyWithDialer(ctx, listenAddr, func(ctx context.Context) (net.Conn, error) {
 		return (&net.Dialer{}).DialContext(ctx, "tcp", target)
 	}, target)
 }
 
-func startRegistryProxyWithDialer(ctx context.Context, dial func(context.Context) (net.Conn, error), target ...string) (*registryProxy, error) {
-	ln, err := net.Listen("tcp", "0.0.0.0:0")
+func startRegistryProxyWithDialer(ctx context.Context, listenAddr string, dial func(context.Context) (net.Conn, error), target ...string) (*registryProxy, error) {
+	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -14,11 +14,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
-
-	"strconv"
 
 	"github.com/wendylabsinc/wendy/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/internal/cli/swifttoolchain"
@@ -890,26 +890,70 @@ func resolveRegistry(ctx context.Context, host string, port int) (registryAddr s
 	return registryAddr, proxy.Close, nil
 }
 
+// dockerRegistryProxyAddrs caches one proxy address per AgentConnection. The
+// proxy is allocated once (port 0 → OS-assigned) and reused for all pushes on
+// that connection, so the buildx builder config never changes between concurrent
+// builds and no builder teardown races can kill an in-flight push.
+var (
+	dockerRegistryProxyCacheMu sync.Mutex
+	dockerRegistryProxyAddrs   = map[*grpcclient.AgentConnection]string{}
+)
+
 // resolveRegistryForAgent determines how Docker buildx should reach the
-// agent's registry. Cloud connections provide a RegistryDialer that opens a
-// fresh broker tunnel per TCP connection; local/LAN connections use the normal
-// host-to-device proxy path.
+// agent's registry. The proxy is started once per connection and cached so
+// concurrent pushes to the same device share a stable host:port address.
 func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), err error) {
+	// Fast path: return cached address from a previously started proxy.
+	dockerRegistryProxyCacheMu.Lock()
+	if addr, ok := dockerRegistryProxyAddrs[conn]; ok {
+		dockerRegistryProxyCacheMu.Unlock()
+		return addr, func() {}, nil
+	}
+	dockerRegistryProxyCacheMu.Unlock()
+
+	// Slow path: start a proxy. Use context.Background so the proxy outlives
+	// this particular push and is reused by concurrent or subsequent pushes.
+	var addr string
+	var stopProxy func()
+
 	if conn.RegistryDialer == nil {
-		return resolveRegistry(ctx, conn.Host, port)
+		addr, stopProxy, err = resolveRegistry(context.Background(), conn.Host, port)
+		if err != nil {
+			return "", nil, err
+		}
+	} else {
+		proxy, proxyErr := startRegistryProxyWithDialer(context.Background(), func(ctx context.Context) (net.Conn, error) {
+			return conn.RegistryDialer(ctx, port)
+		})
+		if proxyErr != nil {
+			return "", nil, fmt.Errorf("starting cloud registry proxy: %w", proxyErr)
+		}
+		stopProxy = proxy.Close
+		if runtime.GOOS == "linux" {
+			addr = fmt.Sprintf("127.0.0.1:%d", proxy.Port())
+		} else {
+			addr = fmt.Sprintf("host.docker.internal:%d", proxy.Port())
+		}
 	}
 
-	proxy, err := startRegistryProxyWithDialer(ctx, func(ctx context.Context) (net.Conn, error) {
-		return conn.RegistryDialer(ctx, port)
-	})
-	if err != nil {
-		return "", nil, fmt.Errorf("starting cloud registry proxy: %w", err)
+	// Store under lock. If another goroutine raced and stored first, discard
+	// our proxy and return theirs.
+	dockerRegistryProxyCacheMu.Lock()
+	if existing, ok := dockerRegistryProxyAddrs[conn]; ok {
+		dockerRegistryProxyCacheMu.Unlock()
+		stopProxy()
+		return existing, func() {}, nil
 	}
+	dockerRegistryProxyAddrs[conn] = addr
+	conn.ExtraClosers = append(conn.ExtraClosers, closeFunc(func() {
+		dockerRegistryProxyCacheMu.Lock()
+		delete(dockerRegistryProxyAddrs, conn)
+		dockerRegistryProxyCacheMu.Unlock()
+		stopProxy()
+	}))
+	dockerRegistryProxyCacheMu.Unlock()
 
-	if runtime.GOOS == "linux" {
-		return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), proxy.Close, nil
-	}
-	return fmt.Sprintf("host.docker.internal:%d", proxy.Port()), proxy.Close, nil
+	return addr, func() {}, nil
 }
 
 // resolveRegistryForSwift is like resolveRegistry but for the Swift container


### PR DESCRIPTION
## Summary

- Each concurrent `wendy run`/`wendy deploy` to the same device created a new TCP proxy on a fresh OS-assigned port, giving a different `host.docker.internal:PORT` registry address each time
- `ensureMTLSBuilder`/`ensurePlaintextBuilder` detected the address change as a config diff, tore down the shared `wendy-mtls` builder, and killed in-flight buildkitd connections → EOF errors on the active push
- Fix: allocate the proxy **once per `AgentConnection`** (port 0 → OS-assigned, stable for the life of the connection) and cache it; concurrent pushes share the same address so the builder config never changes mid-build

## Test plan

- [ ] Push a single container — still works
- [ ] Push two containers to the same device concurrently — both succeed without EOF
- [ ] Compose build with multiple services — still works (was already using one proxy; now explicitly stable)
- [ ] Cloud-tunneled device (mTLS) — proxy reused across pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)