### PR TITLE
fix(cli): mount Linux config partition with caller's uid/gid

### DIFF
--- a/go/internal/cli/commands/os_provision_linux.go
+++ b/go/internal/cli/commands/os_provision_linux.go
@@ -36,7 +36,13 @@ func writeConfigPartition(d drive, agentBinary []byte, creds []wendyconf.WifiCre
 	}
 	defer os.RemoveAll(tmpDir)
 
-	mountCmd := exec.Command("sudo", "mount", "-t", "vfat", partDev, tmpDir)
+	// vfat has no on-disk ownership; the kernel synthesizes each file's uid from
+	// the mounting process. Without uid=/gid=, sudo gives every file to root and
+	// the subsequent non-root WriteFile calls in writeConfigFiles fail with
+	// EACCES. The device applies its own uid when it boots, so this only
+	// affects the host-side view of the mount.
+	mountOpts := fmt.Sprintf("uid=%d,gid=%d", os.Getuid(), os.Getgid())
+	mountCmd := exec.Command("sudo", "mount", "-t", "vfat", "-o", mountOpts, partDev, tmpDir)
 	if out, err := mountCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("mounting config partition %s: %s: %w", partDev, strings.TrimSpace(string(out)), err)
 	}


### PR DESCRIPTION
## Summary

- `writeConfigPartition` (Linux) mounts the FAT32 config partition via `sudo` but writes its contents from the non-root CLI process. With no `uid=`/`gid=` mount option, vfat synthesizes `uid=0` for every file and the subsequent `os.WriteFile` calls in `writeConfigFiles` fail with `EACCES`.
- The image install then prints "Successfully installed" but silently drops the agent binary, `wendy.conf`, and `provisioning.json` (or fails fatally when `--wifi` / `--device-name` / `--pre-enroll` were requested). Devices boot with the agent baked into the image and can't auto-update on first boot.
- Fix: pass `uid=$(id -u),gid=$(id -g)` mount options so the caller owns the mounted view. vfat has no on-disk ownership, so the device applies its own uid when it boots — no impact on what daemons on the device see.

## Repro (before fix)

```
$ wendy os install
...
Writing provisioning data to config partition...
Downloading wendy-agent 2026.05.04-145708 for device...
[sudo] password for sem:
Warning: could not write config partition: writing wendy-agent to config partition: open /tmp/wendyos-config-3676017615/wendy-agent: permission denied
Device will boot but WiFi and agent auto-update will not be pre-configured.

Successfully installed Jetson Orin Nano 0.13.3 on sda.
```

## Why this is safe

FAT/vfat directory entries store filename, attributes, timestamps, and starting cluster — there is no UID/GID/mode field. `uid=`/`gid=` mount options synthesize `st_uid`/`st_gid`/`st_mode` for `stat()` in that mount instance only; nothing is persisted to disk. The Jetson kernel applies its own uid/gid when it mounts the partition at boot.

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go vet ./internal/cli/commands/...` — clean
- [ ] `go test ./internal/cli/commands/...` — passes
- [ ] Manual: `wendy os install` on Linux end-to-end with `--wifi` and `--pre-enroll` — verify config partition is populated and the device boots enrolled with WiFi.