### PR TITLE
With multiple /dev/cu-modem*, just pick the most recently connected one

### DIFF
--- a/go/internal/shared/discovery/serial_darwin.go
+++ b/go/internal/shared/discovery/serial_darwin.go
@@ -4,11 +4,13 @@ package discovery
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"time"
 )
 
 // ResolveESP32SerialPort finds the serial port for an ESP32-C6 device on macOS.
-// It globs /dev/cu.usbmodem* and returns the first match.
+// It globs /dev/cu.usbmodem* and returns the most recently connected.
 func ResolveESP32SerialPort() (string, error) {
 	matches, err := filepath.Glob("/dev/cu.usbmodem*")
 	if err != nil {
@@ -19,5 +21,18 @@ func ResolveESP32SerialPort() (string, error) {
 		return "", fmt.Errorf("no ESP32 serial port found (expected /dev/cu.usbmodem*)")
 	}
 
-	return matches[0], nil
+	best := matches[0]
+	bestMtime := time.Time{}
+	for _, m := range matches {
+		info, err := os.Stat(m)
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(bestMtime) {
+			bestMtime = info.ModTime()
+			best = m
+		}
+	}
+
+	return best, nil
 }


### PR DESCRIPTION
When, on Mac, you have several /dev/cu-modem* (EPS32), and some of them cannot be disconnected, it's very useful to just pick the last connected device by default.