### PR TITLE
Deprecate wendy device version

### DIFF
--- a/.github/workflows/nightly-os-update.yml
+++ b/.github/workflows/nightly-os-update.yml
@@ -94,7 +94,7 @@ jobs:
           WORKDIR="$(pwd)"
           SSH_ENV="export PATH='$PATH'"
 
-          INFO=$($SSH "$SSH_ENV && cd '$WORKDIR' && ./bin/wendy device version --json --device '$DEVICE_HOSTNAME'" || true)
+          INFO=$($SSH "$SSH_ENV && cd '$WORKDIR' && ./bin/wendy device info --json --device '$DEVICE_HOSTNAME'" || true)
           echo "$INFO" | jq '{osVersion, agentVersion: .version, deviceType}' || true
           DEVICE_TYPE=$(echo "$INFO" | jq -r '.deviceType // ""' 2>/dev/null || true)
           echo "device_type=$DEVICE_TYPE" >> "$GITHUB_OUTPUT"
@@ -113,7 +113,7 @@ jobs:
           # online, with a 5-minute internal timeout.
           $SSH "$SSH_ENV && cd '$WORKDIR' && ./bin/wendy os update --device '$DEVICE_HOSTNAME'"
 
-          $SSH "$SSH_ENV && cd '$WORKDIR' && ./bin/wendy device version --json --device '$DEVICE_HOSTNAME'" \
+          $SSH "$SSH_ENV && cd '$WORKDIR' && ./bin/wendy device info --json --device '$DEVICE_HOSTNAME'" \
             | jq '{osVersion, agentVersion: .version}'
 
           $SSH "$SSH_ENV && cd '$WORKDIR' && scripts/test-templates.sh -w ./bin/wendy -h '$DEVICE_HOSTNAME'"

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -189,11 +190,35 @@ func TestNewDeviceCmd(t *testing.T) {
 		subNames[c.Name()] = true
 	}
 
-	expectedSubs := []string{"version", "set-default", "unset-default", "setup", "update"}
+	expectedSubs := []string{"info", "version", "set-default", "unset-default", "setup", "update"}
 	for _, name := range expectedSubs {
 		if !subNames[name] {
 			t.Errorf("device command missing subcommand %q", name)
 		}
+	}
+	if !subNames["info"] || !subNames["version"] {
+		return
+	}
+	if infoCmd, _, err := cmd.Find([]string{"info"}); err != nil || infoCmd.Hidden {
+		t.Errorf("device info should be visible; cmd=%v err=%v", infoCmd, err)
+	}
+	if versionCmd, _, err := cmd.Find([]string{"version"}); err != nil || !versionCmd.Hidden {
+		t.Errorf("device version should be hidden; cmd=%v err=%v", versionCmd, err)
+	}
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("device help: %v", err)
+	}
+	help := buf.String()
+	if !strings.Contains(help, "info") {
+		t.Fatalf("device help missing info command: %s", help)
+	}
+	if strings.Contains(help, "\n  version") {
+		t.Fatalf("device help should not list deprecated version command: %s", help)
 	}
 }
 
@@ -218,7 +243,7 @@ func TestNewCloudDeviceCmd(t *testing.T) {
 		subNames[c.Name()] = true
 	}
 
-	expectedSubs := []string{"version", "set-default", "unset-default", "setup", "update", "wifi", "apps"}
+	expectedSubs := []string{"info", "version", "set-default", "unset-default", "setup", "update", "wifi", "apps"}
 	for _, name := range expectedSubs {
 		if !subNames[name] {
 			t.Errorf("cloud device command missing mirrored subcommand %q", name)

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -197,7 +197,7 @@ func TestNewDeviceCmd(t *testing.T) {
 		}
 	}
 	if !subNames["info"] || !subNames["version"] {
-		return
+		t.Fatalf("prerequisite device info/version subcommands missing; cannot continue assertions")
 	}
 	if infoCmd, _, err := cmd.Find([]string{"info"}); err != nil || infoCmd.Hidden {
 		t.Errorf("device info should be visible; cmd=%v err=%v", infoCmd, err)
@@ -220,6 +220,49 @@ func TestNewDeviceCmd(t *testing.T) {
 	if strings.Contains(help, "\n  version") {
 		t.Fatalf("device help should not list deprecated version command: %s", help)
 	}
+}
+
+func TestDeprecatedDeviceVersionWarnsInHumanOutput(t *testing.T) {
+	stderr, err := executeDeprecatedDeviceVersion(t, []string{"--json=false", "--device", "local", "device", "version"})
+	if err == nil {
+		t.Fatal("expected device version against local provider to fail")
+	}
+	if !strings.Contains(stderr, "Warning: 'wendy device version' is deprecated; use 'wendy device info' instead.") {
+		t.Fatalf("expected deprecation warning on stderr, got %q", stderr)
+	}
+}
+
+func TestDeprecatedDeviceVersionDoesNotWarnInJSONOutput(t *testing.T) {
+	stderr, err := executeDeprecatedDeviceVersion(t, []string{"--json", "--device", "local", "device", "version"})
+	if err == nil {
+		t.Fatal("expected device version against local provider to fail")
+	}
+	if strings.Contains(stderr, "deprecated") {
+		t.Fatalf("--json output should not include deprecation warning on stderr, got %q", stderr)
+	}
+}
+
+func executeDeprecatedDeviceVersion(t *testing.T, args []string) (string, error) {
+	t.Helper()
+
+	origJSON := jsonOutput
+	origDevice := deviceFlag
+	t.Cleanup(func() {
+		jsonOutput = origJSON
+		deviceFlag = origDevice
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WENDY_ANALYTICS", "false")
+
+	root := NewRootCmd()
+	root.SetArgs(args)
+	root.SetOut(new(bytes.Buffer))
+	stderr := new(bytes.Buffer)
+	root.SetErr(stderr)
+
+	err := root.Execute()
+	return stderr.String(), err
 }
 
 func TestNewCloudDeviceCmd(t *testing.T) {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -55,7 +55,8 @@ func newDeviceCmd() *cobra.Command {
 	}
 
 	addToGroup("manage",
-		newDeviceVersionCmd(),
+		newDeviceInfoCmd(),
+		newDeprecatedDeviceVersionCmd(),
 		newDeviceSetDefaultCmd(),
 		newDeviceUnsetDefaultCmd(),
 		newDeviceSetupCmd(),
@@ -82,15 +83,27 @@ func newDeviceCmd() *cobra.Command {
 	return cmd
 }
 
-func newDeviceVersionCmd() *cobra.Command {
+func newDeviceInfoCmd() *cobra.Command {
+	return newDeviceInfoLikeCmd("info", false)
+}
+
+func newDeprecatedDeviceVersionCmd() *cobra.Command {
+	return newDeviceInfoLikeCmd("version", true)
+}
+
+func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 	var checkUpdates bool
 	var prerelease bool
 
 	cmd := &cobra.Command{
-		Use:     "version",
-		Aliases: []string{"info"},
-		Short:   "Show agent version, OS, architecture, GPU, and hardware info for the target device",
+		Use:    use,
+		Short:  "Show agent version, OS, architecture, GPU, and hardware info for the target device",
+		Hidden: deprecated,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if deprecated {
+				cmd.PrintErrln("Warning: 'wendy device version' is deprecated; use 'wendy device info' instead.")
+			}
+
 			ctx := cmd.Context()
 			target, err := resolveTarget(ctx)
 			if err != nil {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -100,7 +100,7 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 		Short:  "Show agent version, OS, architecture, GPU, and hardware info for the target device",
 		Hidden: deprecated,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if deprecated {
+			if deprecated && !jsonOutput {
 				cmd.PrintErrln("Warning: 'wendy device version' is deprecated; use 'wendy device info' instead.")
 			}
 

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -158,7 +158,7 @@ echo ""
 # ── Device capability detection ──────────────────────────────────────
 
 DEVICE_HAS_GPU=false
-VERSION_JSON=$("$WENDY" device version --json --device "$HOSTNAME" 2>/dev/null || true)
+VERSION_JSON=$("$WENDY" device info --json --device "$HOSTNAME" 2>/dev/null || true)
 if [[ -n "$VERSION_JSON" ]]; then
     GPU_VAL=$(echo "$VERSION_JSON" | jq -r '.hasGpu // false' 2>/dev/null || true)
     if [[ "$GPU_VAL" == "true" ]]; then

--- a/go/scripts/test-cli.sh
+++ b/go/scripts/test-cli.sh
@@ -231,11 +231,11 @@ echo -e "${BOLD}Phase 3: Device commands${RESET}"
 run_test "wendy device set-default" \
     "$WENDY" device set-default "$HOSTNAME"
 
-run_test "wendy device version" \
-    "$WENDY" device version --device "$HOSTNAME"
+run_test "wendy device info" \
+    "$WENDY" device info --device "$HOSTNAME"
 
-run_test_json "wendy device version --json" \
-    "$WENDY" device version --device "$HOSTNAME" --json
+run_test_json "wendy device info --json" \
+    "$WENDY" device info --device "$HOSTNAME" --json
 
 echo ""
 

--- a/go/scripts/test-cli.sh
+++ b/go/scripts/test-cli.sh
@@ -237,6 +237,10 @@ run_test "wendy device info" \
 run_test_json "wendy device info --json" \
     "$WENDY" device info --device "$HOSTNAME" --json
 
+# Backward compatibility: the hidden deprecated alias must remain machine-readable.
+run_test_json "wendy device version --json (deprecated)" \
+    "$WENDY" device version --device "$HOSTNAME" --json
+
 echo ""
 
 # ── Phase 4: Hardware / peripheral queries ──────────────────────────


### PR DESCRIPTION
## Summary
- Make `wendy device info` the visible device information command in help output.
- Keep `wendy device version` working as a hidden compatibility command and print a stderr deprecation warning when it runs.
- Update CLI smoke scripts to use `device info` so new automation avoids the deprecated command.

<img width="833" height="192" alt="Screenshot 2026-05-13 at 09 40 23" src="https://github.com/user-attachments/assets/26fcd7b4-3fb4-4d40-ae72-3f463b9352a7" />

## Tests
- `cd go && go test ./...`
- `cd go && go run ./cmd/wendy device --help | sed -n '/Device Management:/,/Monitoring:/p'`

