### PR TITLE
Windows discovery + SSID parity (WDY-1122a)

### DIFF
--- a/go/internal/cli/commands/tour.go
+++ b/go/internal/cli/commands/tour.go
@@ -1796,6 +1796,33 @@ func detectCurrentWiFiSSID() string {
 				return ssid
 			}
 		}
+	case "windows":
+		out, err := exec.Command("netsh", "wlan", "show", "interfaces").Output()
+		if err != nil {
+			return ""
+		}
+		return parseNetshSSID(string(out))
+	}
+	return ""
+}
+
+// parseNetshSSID extracts the SSID value from the output of
+// `netsh wlan show interfaces`. The output contains many "<label> : <value>"
+// lines; we want the first one whose label is exactly "SSID" (the "BSSID" line
+// must not match). Returns "" if no SSID line is present or the value is empty.
+func parseNetshSSID(out string) string {
+	for _, raw := range strings.Split(out, "\n") {
+		line := strings.TrimSpace(raw)
+		if !strings.HasPrefix(line, "SSID") {
+			continue
+		}
+		rest := strings.TrimLeft(line[len("SSID"):], " \t")
+		if !strings.HasPrefix(rest, ":") {
+			continue
+		}
+		if ssid := strings.TrimSpace(rest[1:]); ssid != "" {
+			return ssid
+		}
 	}
 	return ""
 }

--- a/go/internal/cli/commands/tour_test.go
+++ b/go/internal/cli/commands/tour_test.go
@@ -1,0 +1,82 @@
+package commands
+
+import "testing"
+
+func TestParseNetshSSID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "typical connected interface",
+			in: `There is 1 interface on the system:
+
+    Name                   : Wi-Fi
+    Description            : Intel(R) Wi-Fi 6 AX201 160MHz
+    GUID                   : abcdef01-2345-6789-abcd-ef0123456789
+    Physical address       : 00:11:22:33:44:55
+    State                  : connected
+    SSID                   : MyHomeNetwork
+    BSSID                  : aa:bb:cc:dd:ee:ff
+    Network type           : Infrastructure
+`,
+			want: "MyHomeNetwork",
+		},
+		{
+			name: "BSSID line alone does not match",
+			in: `    Name                   : Wi-Fi
+    BSSID                  : aa:bb:cc:dd:ee:ff
+`,
+			want: "",
+		},
+		{
+			name: "SSID with spaces and punctuation",
+			in: `    SSID                   : My Coffee Shop - 5G
+    BSSID                  : aa:bb:cc:dd:ee:ff
+`,
+			want: "My Coffee Shop - 5G",
+		},
+		{
+			name: "disconnected interface (empty SSID)",
+			in: `    State                  : disconnected
+    SSID                   :
+`,
+			want: "",
+		},
+		{
+			name: "no SSID line",
+			in: `    State                  : disconnected
+`,
+			want: "",
+		},
+		{
+			name: "empty output",
+			in:   ``,
+			want: "",
+		},
+		{
+			name: "SSID label not followed by colon is skipped",
+			in: `    SSIDLike  not a real label
+    SSID                   : RealNetwork
+`,
+			want: "RealNetwork",
+		},
+		{
+			name: "first SSID wins when multiple present",
+			in: `    SSID                   : First
+    SSID                   : Second
+`,
+			want: "First",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseNetshSSID(c.in)
+			if got != c.want {
+				t.Fatalf("parseNetshSSID(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/go/internal/shared/discovery/discovery_windows.go
+++ b/go/internal/shared/discovery/discovery_windows.go
@@ -14,10 +14,6 @@ import (
 	"github.com/wendylabsinc/wendy/internal/shared/models"
 )
 
-func discoverEthernet(_ context.Context) ([]models.EthernetInterface, error) {
-	return nil, nil
-}
-
 // discoverLAN uses hashicorp/mdns to find WendyOS devices on Windows.
 func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
 	if timeout == 0 {

--- a/go/internal/shared/discovery/discovery_windows_test.go
+++ b/go/internal/shared/discovery/discovery_windows_test.go
@@ -145,6 +145,75 @@ func TestDeduplicateLANDevicesPrefersIPv4(t *testing.T) {
 	}
 }
 
+func TestParseNetAdapterJSONFiltersWendyByName(t *testing.T) {
+	// Single entry: PowerShell emits an object, not an array, in this case.
+	in := `{"Name":"Wendy USB Ethernet","InterfaceDescription":"Realtek USB GbE","MacAddress":"00-11-22-33-44-55","LinkSpeed":"1 Gbps","IPAddress":"169.254.1.5"}`
+
+	got := parseNetAdapterJSON(in)
+	if len(got) != 1 {
+		t.Fatalf("got %d devices, want 1", len(got))
+	}
+	want := models.EthernetInterface{
+		Name:          "Wendy USB Ethernet",
+		DisplayName:   "Realtek USB GbE",
+		MACAddress:    "00-11-22-33-44-55",
+		IPAddress:     "169.254.1.5",
+		LinkSpeed:     "1 Gbps",
+		IsWendyDevice: true,
+	}
+	if got[0] != want {
+		t.Fatalf("got %#v, want %#v", got[0], want)
+	}
+}
+
+func TestParseNetAdapterJSONFiltersWendyByDescription(t *testing.T) {
+	in := `[
+		{"Name":"Ethernet 3","InterfaceDescription":"Wendy Gadget Mode","MacAddress":"AA-BB-CC-DD-EE-FF","LinkSpeed":"100 Mbps","IPAddress":"169.254.2.7"},
+		{"Name":"Wi-Fi","InterfaceDescription":"Intel AX201","MacAddress":"11-22-33-44-55-66","LinkSpeed":"866 Mbps","IPAddress":"192.168.0.20"}
+	]`
+
+	got := parseNetAdapterJSON(in)
+	if len(got) != 1 {
+		t.Fatalf("got %d devices, want 1 (case-insensitive Wendy match on InterfaceDescription)", len(got))
+	}
+	if got[0].Name != "Ethernet 3" || got[0].DisplayName != "Wendy Gadget Mode" {
+		t.Fatalf("unexpected entry: %#v", got[0])
+	}
+}
+
+func TestParseNetAdapterJSONIsCaseInsensitive(t *testing.T) {
+	in := `{"Name":"WENDY ADAPTER","InterfaceDescription":"some vendor","MacAddress":"","LinkSpeed":"","IPAddress":""}`
+	got := parseNetAdapterJSON(in)
+	if len(got) != 1 {
+		t.Fatalf("got %d devices, want 1 (uppercase WENDY should match)", len(got))
+	}
+}
+
+func TestParseNetAdapterJSONEmpty(t *testing.T) {
+	if got := parseNetAdapterJSON(""); got != nil {
+		t.Fatalf("parseNetAdapterJSON(\"\") = %#v, want nil", got)
+	}
+	if got := parseNetAdapterJSON("   \n  "); got != nil {
+		t.Fatalf("parseNetAdapterJSON(whitespace) = %#v, want nil", got)
+	}
+}
+
+func TestParseNetAdapterJSONIgnoresNonWendy(t *testing.T) {
+	in := `[
+		{"Name":"Ethernet","InterfaceDescription":"Realtek PCIe","MacAddress":"00-00-00-00-00-00","LinkSpeed":"1 Gbps","IPAddress":"192.168.1.10"},
+		{"Name":"vEthernet (Default Switch)","InterfaceDescription":"Hyper-V Virtual Ethernet Adapter","MacAddress":"","LinkSpeed":"10 Gbps","IPAddress":"172.20.0.1"}
+	]`
+	if got := parseNetAdapterJSON(in); len(got) != 0 {
+		t.Fatalf("got %d devices, want 0 (no Wendy match)", len(got))
+	}
+}
+
+func TestParseNetAdapterJSONMalformedReturnsNil(t *testing.T) {
+	if got := parseNetAdapterJSON("{not json"); got != nil {
+		t.Fatalf("malformed JSON returned %#v, want nil", got)
+	}
+}
+
 func TestDeduplicateLANDevicesPrefersScopedIPv6(t *testing.T) {
 	devices := []models.LANDevice{
 		{

--- a/go/internal/shared/discovery/ethernet_windows.go
+++ b/go/internal/shared/discovery/ethernet_windows.go
@@ -1,0 +1,84 @@
+//go:build windows
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/internal/shared/models"
+)
+
+// netAdapterPowershell joins Get-NetAdapter with the first IPv4 address from
+// Get-NetIPAddress for each adapter and emits a compact JSON array. ifIndex is
+// the join key. SilentlyContinue prevents errors when an adapter has no IPv4
+// address (e.g., link is down).
+const netAdapterPowershell = `Get-NetAdapter | ForEach-Object {
+  $adapter = $_
+  $ip = (Get-NetIPAddress -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue | Select-Object -First 1).IPAddress
+  [PSCustomObject]@{
+    Name = $adapter.Name
+    InterfaceDescription = $adapter.InterfaceDescription
+    MacAddress = $adapter.MacAddress
+    LinkSpeed = $adapter.LinkSpeed
+    IPAddress = $ip
+  }
+} | ConvertTo-Json -Compress`
+
+type netAdapterEntry struct {
+	Name                 string `json:"Name"`
+	InterfaceDescription string `json:"InterfaceDescription"`
+	MacAddress           string `json:"MacAddress"`
+	LinkSpeed            string `json:"LinkSpeed"`
+	IPAddress            string `json:"IPAddress"`
+}
+
+// discoverEthernet uses PowerShell to enumerate network adapters on Windows
+// and returns those whose Name or InterfaceDescription contains "Wendy"
+// (case-insensitive), matching the linux/darwin filter convention.
+func discoverEthernet(ctx context.Context) ([]models.EthernetInterface, error) {
+	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", netAdapterPowershell)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("running Get-NetAdapter: %w", err)
+	}
+	return parseNetAdapterJSON(string(out)), nil
+}
+
+// parseNetAdapterJSON parses the ConvertTo-Json output produced by
+// netAdapterPowershell and filters for Wendy interfaces. PowerShell omits the
+// outer array when there is exactly one result, so we normalize.
+func parseNetAdapterJSON(jsonOut string) []models.EthernetInterface {
+	trimmed := strings.TrimSpace(jsonOut)
+	if trimmed == "" {
+		return nil
+	}
+	if !strings.HasPrefix(trimmed, "[") {
+		trimmed = "[" + trimmed + "]"
+	}
+
+	var entries []netAdapterEntry
+	if err := json.Unmarshal([]byte(trimmed), &entries); err != nil {
+		return nil
+	}
+
+	var devices []models.EthernetInterface
+	for _, e := range entries {
+		nameL := strings.ToLower(e.Name + " " + e.InterfaceDescription)
+		if !strings.Contains(nameL, "wendy") {
+			continue
+		}
+		devices = append(devices, models.EthernetInterface{
+			Name:          e.Name,
+			DisplayName:   e.InterfaceDescription,
+			MACAddress:    e.MacAddress,
+			IPAddress:     e.IPAddress,
+			LinkSpeed:     e.LinkSpeed,
+			IsWendyDevice: true,
+		})
+	}
+	return devices
+}


### PR DESCRIPTION
## Summary
- Implements `discoverEthernet` on Windows (§3.4 of `WINDOWS_REGRESSION_REVIEW.md`) — shells out to PowerShell, joins `Get-NetAdapter` with `Get-NetIPAddress`, and filters adapters whose `Name` or `InterfaceDescription` contains "Wendy" (case-insensitive). Matches the linux/darwin filter convention.
- Removes the silent `nil, nil` stub from `discovery_windows.go`.
- Adds a `case "windows":` branch to `detectCurrentWiFiSSID` (§3.5) that shells out to `netsh wlan show interfaces` and extracts the SSID via a pure `parseNetshSSID` helper — so `wendy tour` prefills the host SSID instead of asking the user to type it.

Part of the WDY-1122 epic. PR b (Wi-Fi scan + keychain) and PR c (`wendy init` assistant launch + ESP32 serial) will follow in separate branches.

## Test plan
- [x] `gofmt -l .` clean from `go/`
- [x] `go test ./...` passes on macOS host
- [x] `GOOS=windows go build ./cmd/wendy/... ./internal/cli/... ./internal/shared/...` succeeds
- [x] `GOOS=windows go test -c` builds the discovery test binary
- [x] New `TestParseNetshSSID` covers connected/disconnected/BSSID-only/multiple-SSID cases (runs on all platforms)
- [x] `parseNetAdapterJSON` tests cover Wendy-by-name, Wendy-by-description, case-insensitive matching, non-Wendy adapters filtered, empty input, malformed JSON (Windows-only build tag, like the existing `discovery_windows_test.go`)
- [ ] Manual on Windows: `wendy discover` lists a USB-attached Wendy device
- [ ] Manual on Windows: `wendy tour` prefills the current SSID in the Wi-Fi step

🤖 Generated with [Claude Code](https://claude.com/claude-code)