### PR TITLE
Implement Windows WiFi scan via netsh (WDY-1122b)

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Run tests
         run: go test ./... -race -count=1 -timeout 120s
 
+      # Compile the Windows-shipping CLI packages so //go:build windows files
+      # (e.g. wifi_scan_windows.go) are at least type-checked in PR CI. The
+      # Linux runner can't execute Windows tests, but cross-compiling them
+      # catches build breaks that would otherwise only surface in the
+      # release workflow. The agent intentionally is not cross-compiled —
+      # it uses Linux-only syscalls and only the CLI ships to Windows.
+      - name: Cross-compile Windows CLI packages
+        env:
+          GOOS: windows
+          GOARCH: amd64
+        run: |
+          go build ./internal/cli/... ./cmd/wendy/
+          go test -c -o /dev/null ./internal/cli/commands
+
   vet:
     name: Vet
     runs-on: ubuntu-latest

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -678,6 +678,9 @@ func pickWifiNetwork(ctx context.Context, target *SelectedDevice) (string, error
 	}
 
 	if len(networks) == 0 {
+		if wifiScanCacheHint != "" {
+			return "", fmt.Errorf("no WiFi networks found (%s)", wifiScanCacheHint)
+		}
 		return "", fmt.Errorf("no WiFi networks found")
 	}
 
@@ -799,7 +802,11 @@ func wifiListFromHost() error {
 	}
 
 	if len(networks) == 0 {
-		cliNotice("No WiFi networks found.")
+		if wifiScanCacheHint != "" {
+			cliNotice("No WiFi networks found. %s.", wifiScanCacheHint)
+		} else {
+			cliNotice("No WiFi networks found.")
+		}
 		return nil
 	}
 

--- a/go/internal/cli/commands/wifi_scan_darwin.go
+++ b/go/internal/cli/commands/wifi_scan_darwin.go
@@ -12,10 +12,9 @@ import (
 	"time"
 )
 
-type localWifiNetwork struct {
-	SSID           string
-	SignalStrength int32 // 0–100 percentage, or 0 if unknown
-}
+// wifiScanCacheHint is empty on macOS: CoreWLAN's scanForNetworks performs
+// a synchronous fresh scan, so the returned set is current.
+const wifiScanCacheHint = ""
 
 const corewlanScanScript = `
 import CoreWLAN

--- a/go/internal/cli/commands/wifi_scan_linux.go
+++ b/go/internal/cli/commands/wifi_scan_linux.go
@@ -13,10 +13,9 @@ import (
 	"github.com/wendylabsinc/wendy/internal/shared/nmcli"
 )
 
-type localWifiNetwork struct {
-	SSID           string
-	SignalStrength int32 // 0–100 percentage, or 0 if unknown
-}
+// wifiScanCacheHint is empty on Linux: nmcli's `device wifi rescan` triggers
+// a fresh scan before the list call, so the returned set is current.
+const wifiScanCacheHint = ""
 
 // scanLocalWifiNetworks uses nmcli on Linux to list WiFi networks visible to
 // the host machine.

--- a/go/internal/cli/commands/wifi_scan_netsh.go
+++ b/go/internal/cli/commands/wifi_scan_netsh.go
@@ -1,0 +1,77 @@
+package commands
+
+import (
+	"bufio"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// localWifiNetwork is the host-side scan result type shared across platforms.
+type localWifiNetwork struct {
+	SSID           string
+	SignalStrength int32 // 0–100 percentage, or 0 if unknown
+}
+
+// ssidLine matches `SSID 1 : MyNetwork`. The `\d+` between `SSID` and the
+// colon rejects `BSSID` lines, which would otherwise match `^.SSID`.
+var ssidLine = regexp.MustCompile(`^SSID\s+\d+\s*:\s*(.*)$`)
+
+// signalLine matches `         Signal             : 78%`.
+var signalLine = regexp.MustCompile(`^\s*Signal\s*:\s*(\d+)%`)
+
+// parseNetshNetworks parses the localized text output of
+// `netsh wlan show networks mode=bssid` into a deduplicated list of SSIDs,
+// each annotated with the strongest signal strength observed across all of
+// its BSSIDs. Hidden networks (empty SSID after the colon) are skipped.
+//
+// Lives in a non-OS-tagged file so its tests run under the standard PR CI
+// `go test ./...` job on Linux even though the only caller is the Windows
+// `scanLocalWifiNetworks` implementation.
+func parseNetshNetworks(output string) []localWifiNetwork {
+	type entry struct {
+		index  int
+		signal int32
+	}
+	entries := make(map[string]*entry)
+	order := 0
+
+	var currentSSID string
+	var haveSSID bool
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if m := ssidLine.FindStringSubmatch(line); m != nil {
+			currentSSID = strings.TrimSpace(m[1])
+			haveSSID = currentSSID != ""
+			if haveSSID {
+				if _, ok := entries[currentSSID]; !ok {
+					entries[currentSSID] = &entry{index: order}
+					order++
+				}
+			}
+			continue
+		}
+
+		if !haveSSID {
+			continue
+		}
+
+		if m := signalLine.FindStringSubmatch(line); m != nil {
+			if v, err := strconv.Atoi(m[1]); err == nil {
+				signal := int32(v)
+				if e := entries[currentSSID]; e != nil && signal > e.signal {
+					e.signal = signal
+				}
+			}
+		}
+	}
+
+	out := make([]localWifiNetwork, len(entries))
+	for ssid, e := range entries {
+		out[e.index] = localWifiNetwork{SSID: ssid, SignalStrength: e.signal}
+	}
+	return out
+}

--- a/go/internal/cli/commands/wifi_scan_netsh_test.go
+++ b/go/internal/cli/commands/wifi_scan_netsh_test.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package commands
 
 import (

--- a/go/internal/cli/commands/wifi_scan_windows.go
+++ b/go/internal/cli/commands/wifi_scan_windows.go
@@ -2,20 +2,96 @@
 
 package commands
 
-import "fmt"
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
 
 type localWifiNetwork struct {
 	SSID           string
-	SignalStrength int32
+	SignalStrength int32 // 0–100 percentage, or 0 if unknown
 }
 
+// scanLocalWifiNetworks uses `netsh wlan show networks mode=bssid` to list
+// WiFi networks visible to the host machine.
 func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
-	return nil, fmt.Errorf("local WiFi scanning is not yet supported on Windows; use --ssid to specify the network")
+	cmd := exec.Command("netsh", "wlan", "show", "networks", "mode=bssid")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("scanning WiFi networks: %w", err)
+	}
+	return parseNetshNetworks(string(output)), nil
+}
+
+// ssidLine matches `SSID 1 : MyNetwork`. It is anchored with a leading
+// boundary that rejects `BSSID` (which would otherwise match `^.SSID`).
+var ssidLine = regexp.MustCompile(`^SSID\s+\d+\s*:\s*(.*)$`)
+
+// signalLine matches `         Signal             : 78%`.
+var signalLine = regexp.MustCompile(`^\s*Signal\s*:\s*(\d+)%`)
+
+// parseNetshNetworks parses the localized text output of
+// `netsh wlan show networks mode=bssid` into a deduplicated list of SSIDs,
+// each annotated with the strongest signal strength observed across all of
+// its BSSIDs. Hidden networks (empty SSID after the colon) are skipped.
+func parseNetshNetworks(output string) []localWifiNetwork {
+	type entry struct {
+		index  int
+		signal int32
+	}
+	entries := make(map[string]*entry)
+	order := 0
+
+	var currentSSID string
+	var haveSSID bool
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if m := ssidLine.FindStringSubmatch(line); m != nil {
+			currentSSID = strings.TrimSpace(m[1])
+			haveSSID = currentSSID != ""
+			if haveSSID {
+				if _, ok := entries[currentSSID]; !ok {
+					entries[currentSSID] = &entry{index: order}
+					order++
+				}
+			}
+			continue
+		}
+
+		if !haveSSID {
+			continue
+		}
+
+		if m := signalLine.FindStringSubmatch(line); m != nil {
+			if v, err := strconv.Atoi(m[1]); err == nil {
+				signal := int32(v)
+				if e := entries[currentSSID]; e != nil && signal > e.signal {
+					e.signal = signal
+				}
+			}
+		}
+	}
+
+	out := make([]localWifiNetwork, len(entries))
+	for ssid, e := range entries {
+		out[e.index] = localWifiNetwork{SSID: ssid, SignalStrength: e.signal}
+	}
+	return out
 }
 
 const supportsKeychainLookup = false
 
-// lookupKeychainPassword is not supported on Windows.
+// lookupKeychainPassword is not supported on Windows. Windows has no
+// equivalent of macOS's auto-stored "AirPort network password" Keychain
+// entry; lookup would require a paired write path under a Wendy-owned
+// Credential Manager target. Matches the Linux behavior.
 func lookupKeychainPassword(_ string) (string, error) {
 	return "", nil
 }

--- a/go/internal/cli/commands/wifi_scan_windows.go
+++ b/go/internal/cli/commands/wifi_scan_windows.go
@@ -3,21 +3,24 @@
 package commands
 
 import (
-	"bufio"
 	"fmt"
 	"os/exec"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
-type localWifiNetwork struct {
-	SSID           string
-	SignalStrength int32 // 0–100 percentage, or 0 if unknown
-}
-
-// scanLocalWifiNetworks uses `netsh wlan show networks mode=bssid` to list
-// WiFi networks visible to the host machine.
+// scanLocalWifiNetworks lists WiFi networks visible to the host using
+// `netsh wlan show networks mode=bssid`.
+//
+// Important: netsh reads the Windows WLAN service's *cached* scan list.
+// The service asks the driver to rescan periodically and, per Microsoft's
+// docs, may not scan at all while already associated to a network. This
+// command therefore does not guarantee a fresh, on-demand scan the way the
+// macOS CoreWLAN and Linux `nmcli device wifi rescan` paths do.
+//
+// A proper fix is to call Native Wifi's WlanScan API
+// (https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlanscan)
+// via syscall — that work is intentionally deferred while this implementation
+// is the near-term fallback. Callers should treat empty results as "possibly
+// stale cache" and surface the retry hint defined by wifiScanCacheHint.
 func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	cmd := exec.Command("netsh", "wlan", "show", "networks", "mode=bssid")
 	output, err := cmd.Output()
@@ -27,64 +30,9 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	return parseNetshNetworks(string(output)), nil
 }
 
-// ssidLine matches `SSID 1 : MyNetwork`. It is anchored with a leading
-// boundary that rejects `BSSID` (which would otherwise match `^.SSID`).
-var ssidLine = regexp.MustCompile(`^SSID\s+\d+\s*:\s*(.*)$`)
-
-// signalLine matches `         Signal             : 78%`.
-var signalLine = regexp.MustCompile(`^\s*Signal\s*:\s*(\d+)%`)
-
-// parseNetshNetworks parses the localized text output of
-// `netsh wlan show networks mode=bssid` into a deduplicated list of SSIDs,
-// each annotated with the strongest signal strength observed across all of
-// its BSSIDs. Hidden networks (empty SSID after the colon) are skipped.
-func parseNetshNetworks(output string) []localWifiNetwork {
-	type entry struct {
-		index  int
-		signal int32
-	}
-	entries := make(map[string]*entry)
-	order := 0
-
-	var currentSSID string
-	var haveSSID bool
-
-	scanner := bufio.NewScanner(strings.NewReader(output))
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if m := ssidLine.FindStringSubmatch(line); m != nil {
-			currentSSID = strings.TrimSpace(m[1])
-			haveSSID = currentSSID != ""
-			if haveSSID {
-				if _, ok := entries[currentSSID]; !ok {
-					entries[currentSSID] = &entry{index: order}
-					order++
-				}
-			}
-			continue
-		}
-
-		if !haveSSID {
-			continue
-		}
-
-		if m := signalLine.FindStringSubmatch(line); m != nil {
-			if v, err := strconv.Atoi(m[1]); err == nil {
-				signal := int32(v)
-				if e := entries[currentSSID]; e != nil && signal > e.signal {
-					e.signal = signal
-				}
-			}
-		}
-	}
-
-	out := make([]localWifiNetwork, len(entries))
-	for ssid, e := range entries {
-		out[e.index] = localWifiNetwork{SSID: ssid, SignalStrength: e.signal}
-	}
-	return out
-}
+// wifiScanCacheHint is appended to empty-scan messages on Windows because
+// netsh reads cached results — see scanLocalWifiNetworks for details.
+const wifiScanCacheHint = "Windows scans for nearby networks periodically; if your network is missing, wait a few seconds and try again, or pass --ssid to specify it directly"
 
 const supportsKeychainLookup = false
 

--- a/go/internal/cli/commands/wifi_scan_windows_test.go
+++ b/go/internal/cli/commands/wifi_scan_windows_test.go
@@ -1,0 +1,152 @@
+//go:build windows
+
+package commands
+
+import (
+	"testing"
+)
+
+func TestParseNetshNetworks(t *testing.T) {
+	t.Run("single network with one BSSID", func(t *testing.T) {
+		input := "Interface name : Wi-Fi\r\n" +
+			"There are 1 networks currently visible.\r\n" +
+			"\r\n" +
+			"SSID 1 : HomeNet\r\n" +
+			"    Network type            : Infrastructure\r\n" +
+			"    Authentication          : WPA2-Personal\r\n" +
+			"    Encryption              : CCMP\r\n" +
+			"    BSSID 1                 : aa:bb:cc:dd:ee:ff\r\n" +
+			"         Signal             : 78%\r\n" +
+			"         Radio type         : 802.11n\r\n"
+		got := parseNetshNetworks(input)
+		if len(got) != 1 {
+			t.Fatalf("got %d networks, want 1: %+v", len(got), got)
+		}
+		if got[0].SSID != "HomeNet" {
+			t.Errorf("SSID = %q, want HomeNet", got[0].SSID)
+		}
+		if got[0].SignalStrength != 78 {
+			t.Errorf("SignalStrength = %d, want 78", got[0].SignalStrength)
+		}
+	})
+
+	t.Run("multiple networks preserve order", func(t *testing.T) {
+		input := "SSID 1 : Alpha\r\n" +
+			"    BSSID 1 : aa:aa:aa:aa:aa:aa\r\n" +
+			"         Signal : 50%\r\n" +
+			"\r\n" +
+			"SSID 2 : Bravo\r\n" +
+			"    BSSID 1 : bb:bb:bb:bb:bb:bb\r\n" +
+			"         Signal : 90%\r\n" +
+			"\r\n" +
+			"SSID 3 : Charlie\r\n" +
+			"    BSSID 1 : cc:cc:cc:cc:cc:cc\r\n" +
+			"         Signal : 25%\r\n"
+		got := parseNetshNetworks(input)
+		if len(got) != 3 {
+			t.Fatalf("got %d networks, want 3: %+v", len(got), got)
+		}
+		wantSSIDs := []string{"Alpha", "Bravo", "Charlie"}
+		wantSignals := []int32{50, 90, 25}
+		for i, n := range got {
+			if n.SSID != wantSSIDs[i] {
+				t.Errorf("got[%d].SSID = %q, want %q", i, n.SSID, wantSSIDs[i])
+			}
+			if n.SignalStrength != wantSignals[i] {
+				t.Errorf("got[%d].SignalStrength = %d, want %d", i, n.SignalStrength, wantSignals[i])
+			}
+		}
+	})
+
+	t.Run("hidden SSID is skipped", func(t *testing.T) {
+		input := "SSID 1 : \r\n" +
+			"    BSSID 1 : aa:aa:aa:aa:aa:aa\r\n" +
+			"         Signal : 60%\r\n" +
+			"\r\n" +
+			"SSID 2 : Visible\r\n" +
+			"    BSSID 1 : bb:bb:bb:bb:bb:bb\r\n" +
+			"         Signal : 40%\r\n"
+		got := parseNetshNetworks(input)
+		if len(got) != 1 {
+			t.Fatalf("got %d networks, want 1: %+v", len(got), got)
+		}
+		if got[0].SSID != "Visible" {
+			t.Errorf("SSID = %q, want Visible", got[0].SSID)
+		}
+	})
+
+	t.Run("missing Signal line yields zero", func(t *testing.T) {
+		input := "SSID 1 : NoSig\r\n" +
+			"    BSSID 1 : aa:aa:aa:aa:aa:aa\r\n" +
+			"         Radio type : 802.11n\r\n"
+		got := parseNetshNetworks(input)
+		if len(got) != 1 {
+			t.Fatalf("got %d networks, want 1: %+v", len(got), got)
+		}
+		if got[0].SSID != "NoSig" {
+			t.Errorf("SSID = %q, want NoSig", got[0].SSID)
+		}
+		if got[0].SignalStrength != 0 {
+			t.Errorf("SignalStrength = %d, want 0", got[0].SignalStrength)
+		}
+	})
+
+	t.Run("multiple BSSIDs take strongest signal", func(t *testing.T) {
+		input := "SSID 1 : Roaming\r\n" +
+			"    BSSID 1 : aa:aa:aa:aa:aa:aa\r\n" +
+			"         Signal : 45%\r\n" +
+			"    BSSID 2 : aa:aa:aa:aa:aa:bb\r\n" +
+			"         Signal : 88%\r\n" +
+			"    BSSID 3 : aa:aa:aa:aa:aa:cc\r\n" +
+			"         Signal : 60%\r\n"
+		got := parseNetshNetworks(input)
+		if len(got) != 1 {
+			t.Fatalf("got %d networks, want 1: %+v", len(got), got)
+		}
+		if got[0].SignalStrength != 88 {
+			t.Errorf("SignalStrength = %d, want 88 (strongest of 45/88/60)", got[0].SignalStrength)
+		}
+	})
+
+	t.Run("BSSID prefix does not match SSID pattern", func(t *testing.T) {
+		input := "SSID 1 : Net\r\n" +
+			"    BSSID 1 : aa:aa:aa:aa:aa:aa\r\n" +
+			"         Signal : 50%\r\n"
+		got := parseNetshNetworks(input)
+		if len(got) != 1 {
+			t.Fatalf("got %d networks, want 1 (BSSID line must not be parsed as SSID): %+v", len(got), got)
+		}
+		if got[0].SSID != "Net" {
+			t.Errorf("SSID = %q, want Net (BSSID value bled into SSID)", got[0].SSID)
+		}
+	})
+
+	t.Run("empty output", func(t *testing.T) {
+		got := parseNetshNetworks("")
+		if len(got) != 0 {
+			t.Errorf("got %d networks, want 0", len(got))
+		}
+	})
+
+	t.Run("output with no networks", func(t *testing.T) {
+		input := "Interface name : Wi-Fi\r\n" +
+			"There are 0 networks currently visible.\r\n"
+		got := parseNetshNetworks(input)
+		if len(got) != 0 {
+			t.Errorf("got %d networks, want 0", len(got))
+		}
+	})
+
+	t.Run("SSID containing colon is preserved", func(t *testing.T) {
+		input := "SSID 1 : Café: Wi-Fi\r\n" +
+			"    BSSID 1 : aa:aa:aa:aa:aa:aa\r\n" +
+			"         Signal : 70%\r\n"
+		got := parseNetshNetworks(input)
+		if len(got) != 1 {
+			t.Fatalf("got %d networks, want 1", len(got))
+		}
+		if got[0].SSID != "Café: Wi-Fi" {
+			t.Errorf("SSID = %q, want %q", got[0].SSID, "Café: Wi-Fi")
+		}
+	})
+}


### PR DESCRIPTION
Implements PR b of the WDY-1122 Windows-parity epic. Companion to PR a (#681), which lands Windows ethernet discovery and SSID detection. The two PRs touch disjoint files and merge in either order.

## Summary
- Replace the `scanLocalWifiNetworks` hard-error stub on Windows with a real `netsh wlan show networks mode=bssid` parser. SSIDs are deduplicated and annotated with the strongest signal observed across their BSSIDs; hidden networks are skipped.
- Keep `lookupKeychainPassword` as a `("", nil)` stub. Windows has no equivalent of macOS's auto-stored "AirPort network password" Keychain entry, `golang.org/x/sys/windows` (v0.44.0 vendored here) does not expose `CredRead`, and there is no paired save-password path planned. End-user behavior now matches Linux: keychain lookup is a quiet no-op and the prompt path in `wifi.go:384` is gated off (`supportsKeychainLookup == false`).

This corresponds to §3.3 of `WINDOWS_REGRESSION_REVIEW.md`. The keychain decision matches the alternative path explicitly called out in the plan (`/Users/ethan/.claude/plans/i-d-like-to-start-linear-shamir.md`, "Open decisions to resolve before / during PR b").

## Test plan
- [x] `gofmt -l .` from `go/` — clean
- [x] `go test ./...` from `go/` on macOS — pass (no regressions)
- [x] `GOOS=windows go test -c -o /dev/null ./internal/cli/commands/` — compiles
- [x] `GOOS=windows go build ./internal/cli/... ./cmd/wendy/` — clean
- [x] Pure-parser unit tests cover: single network, multiple networks, hidden SSID, missing Signal line, multi-BSSID roaming (strongest wins), BSSID prefix non-match, SSID containing colon, empty output
- [ ] Manual on Windows: `wendy device wifi scan` lists nearby networks with signal %
- [ ] Manual on Windows: `wendy device wifi connect` (interactive) flow no longer hits the previous hard-error

🤖 Generated with [Claude Code](https://claude.com/claude-code)