### PR TITLE
Fix Windows wendy init assistant launch and implement ESP32 serial discovery (WDY-1122c)

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -1300,11 +1300,7 @@ func runAIAssistantChoice(choice, appID, target, language string, entitlements [
 
 	cliLogln("\nStarting %s with project context...", choice)
 
-	cmd := exec.Command(choice, prompt)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return launchAssistantWithPrompt(choice, prompt)
 }
 
 func buildAssistantPrompt(appID, target, language string, entitlements []appconfig.Entitlement) string {

--- a/go/internal/cli/commands/init_cmd_unix.go
+++ b/go/internal/cli/commands/init_cmd_unix.go
@@ -1,0 +1,18 @@
+//go:build darwin || linux
+
+package commands
+
+import (
+	"os"
+	"os/exec"
+)
+
+// launchAssistantWithPrompt invokes the AI assistant with the prompt passed
+// as a single argv element. On Unix shells this round-trips intact.
+func launchAssistantWithPrompt(choice, prompt string) error {
+	cmd := exec.Command(choice, prompt)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/go/internal/cli/commands/init_cmd_windows.go
+++ b/go/internal/cli/commands/init_cmd_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// launchAssistantWithPrompt writes the full prompt to a temp file and asks the
+// assistant to read it. On Windows the assistant binaries (claude, codex) are
+// shipped as `.cmd` shims whose `%*` forwarding re-parses arguments through
+// cmd.exe, which mangles multi-line prompts containing quotes or `%`. The short
+// "Read the file at %q ..." instruction contains no `%` and no embedded
+// newlines, so it survives that re-parsing intact regardless of prompt content.
+func launchAssistantWithPrompt(choice, prompt string) error {
+	tmpPath, cleanup, err := writePromptForAssistant(prompt)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	short := fmt.Sprintf("Read the file at %q for project context, then help me get started building this project.", tmpPath)
+
+	cmd := exec.Command(choice, short)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// writePromptForAssistant writes prompt to a temp .md file and returns its path
+// plus a cleanup func. Split out so the temp-file lifecycle is unit-testable
+// without invoking the real assistant binary.
+func writePromptForAssistant(prompt string) (string, func(), error) {
+	f, err := os.CreateTemp("", "wendy-init-prompt-*.md")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating prompt temp file: %w", err)
+	}
+	path := f.Name()
+
+	if _, err := f.WriteString(prompt); err != nil {
+		f.Close()
+		os.Remove(path)
+		return "", nil, fmt.Errorf("writing prompt temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(path)
+		return "", nil, fmt.Errorf("closing prompt temp file: %w", err)
+	}
+
+	return path, func() { os.Remove(path) }, nil
+}

--- a/go/internal/cli/commands/init_cmd_windows.go
+++ b/go/internal/cli/commands/init_cmd_windows.go
@@ -11,9 +11,11 @@ import (
 // launchAssistantWithPrompt writes the full prompt to a temp file and asks the
 // assistant to read it. On Windows the assistant binaries (claude, codex) are
 // shipped as `.cmd` shims whose `%*` forwarding re-parses arguments through
-// cmd.exe, which mangles multi-line prompts containing quotes or `%`. The short
-// "Read the file at %q ..." instruction contains no `%` and no embedded
-// newlines, so it survives that re-parsing intact regardless of prompt content.
+// cmd.exe, which mangles multi-line prompts containing embedded quotes, `%`,
+// or newlines. The short instruction interpolates the temp path with `%s` so
+// the argument contains no embedded quotes and no Go-escaped backslashes —
+// just plain text plus the raw filesystem path — which survives `.cmd` re-
+// parsing intact regardless of prompt content.
 func launchAssistantWithPrompt(choice, prompt string) error {
 	tmpPath, cleanup, err := writePromptForAssistant(prompt)
 	if err != nil {
@@ -21,7 +23,7 @@ func launchAssistantWithPrompt(choice, prompt string) error {
 	}
 	defer cleanup()
 
-	short := fmt.Sprintf("Read the file at %q for project context, then help me get started building this project.", tmpPath)
+	short := fmt.Sprintf("Read the Markdown file at this absolute path: %s for project context, then help me get started building this project.", tmpPath)
 
 	cmd := exec.Command(choice, short)
 	cmd.Stdin = os.Stdin

--- a/go/internal/cli/commands/init_cmd_windows_test.go
+++ b/go/internal/cli/commands/init_cmd_windows_test.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package commands
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWritePromptForAssistant_CreatesFileWithPromptAndCleansUp(t *testing.T) {
+	prompt := "multi-line prompt\nwith \"quotes\" and 100% percent signs"
+
+	path, cleanup, err := writePromptForAssistant(prompt)
+	if err != nil {
+		t.Fatalf("writePromptForAssistant: %v", err)
+	}
+	if path == "" {
+		t.Fatal("returned path is empty")
+	}
+	if filepath.Ext(path) != ".md" {
+		t.Fatalf("path %q does not end in .md", path)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading temp file: %v", err)
+	}
+	if string(content) != prompt {
+		t.Fatalf("file content = %q, want %q", string(content), prompt)
+	}
+
+	cleanup()
+
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expected temp file to be removed after cleanup, got err=%v", err)
+	}
+}
+
+func TestWritePromptForAssistant_CleanupIsIdempotent(t *testing.T) {
+	path, cleanup, err := writePromptForAssistant("anything")
+	if err != nil {
+		t.Fatalf("writePromptForAssistant: %v", err)
+	}
+
+	cleanup()
+	// Second call must not panic or surface an error to the caller — it is
+	// invoked via defer in launchAssistantWithPrompt and we may have already
+	// hit an error path that removed the file.
+	cleanup()
+
+	if strings.TrimSpace(path) == "" {
+		t.Fatal("path should not be empty")
+	}
+}

--- a/go/internal/shared/discovery/serial_windows.go
+++ b/go/internal/shared/discovery/serial_windows.go
@@ -2,9 +2,80 @@
 
 package discovery
 
-import "fmt"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
 
-// ResolveESP32SerialPort is not yet implemented on Windows.
+	"github.com/wendylabsinc/wendy/internal/shared/models"
+)
+
+// ResolveESP32SerialPort finds the serial port for an ESP32-C6 device on
+// Windows. It queries Win32_PnPEntity via PowerShell for Ports-class entries
+// matching the Espressif VID/PID and extracts the COMN identifier from the
+// device's Name or Caption field.
 func ResolveESP32SerialPort() (string, error) {
-	return "", fmt.Errorf("ESP32 serial port detection is not yet supported on Windows")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	vid := strings.ToUpper(strings.TrimPrefix(models.ESP32VendorID, "0x"))
+	pid := strings.ToUpper(strings.TrimPrefix(models.ESP32ProductID, "0x"))
+
+	script := fmt.Sprintf(
+		`Get-CimInstance Win32_PnPEntity | Where-Object { $_.PNPClass -eq 'Ports' -and $_.PNPDeviceID -like 'USB\VID_%s&PID_%s*' } | Select-Object Name, PNPDeviceID, Caption | ConvertTo-Json -Compress`,
+		vid, pid,
+	)
+
+	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("querying Win32_PnPEntity for ESP32 serial port: %w", err)
+	}
+
+	return parseESP32SerialPortJSON(string(out))
+}
+
+// serialPortRegex matches a parenthesized COM port suffix such as "(COM5)".
+var serialPortRegex = regexp.MustCompile(`\(COM\d+\)`)
+
+// parseESP32SerialPortJSON extracts the first COMN port name from a JSON blob
+// produced by `Get-CimInstance Win32_PnPEntity | Select-Object Name,
+// PNPDeviceID, Caption | ConvertTo-Json`. Returns the bare "COMN" string
+// (matching what os_install.go and esptool expect on Windows).
+func parseESP32SerialPortJSON(jsonOut string) (string, error) {
+	trimmed := strings.TrimSpace(jsonOut)
+	if trimmed == "" {
+		return "", noESP32SerialPortErr()
+	}
+	// PowerShell returns a single object (not an array) when there's one result.
+	if !strings.HasPrefix(trimmed, "[") {
+		trimmed = "[" + trimmed + "]"
+	}
+
+	var entries []struct {
+		Name        string `json:"Name"`
+		PNPDeviceID string `json:"PNPDeviceID"`
+		Caption     string `json:"Caption"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &entries); err != nil {
+		return "", fmt.Errorf("parsing PowerShell JSON output: %w", err)
+	}
+
+	for _, entry := range entries {
+		for _, field := range []string{entry.Name, entry.Caption} {
+			if match := serialPortRegex.FindString(field); match != "" {
+				return strings.Trim(match, "()"), nil
+			}
+		}
+	}
+
+	return "", noESP32SerialPortErr()
+}
+
+func noESP32SerialPortErr() error {
+	return fmt.Errorf("no ESP32 serial port found (expected COM port with VID %s)", models.ESP32VendorID)
 }

--- a/go/internal/shared/discovery/serial_windows_test.go
+++ b/go/internal/shared/discovery/serial_windows_test.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package discovery
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseESP32SerialPortJSON_SingleEntry(t *testing.T) {
+	in := `{"Name":"USB JTAG/serial debug unit (COM7)","PNPDeviceID":"USB\\VID_303A&PID_1001\\0123456789","Caption":"USB JTAG/serial debug unit (COM7)"}`
+	got, err := parseESP32SerialPortJSON(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "COM7" {
+		t.Fatalf("got %q, want %q", got, "COM7")
+	}
+}
+
+func TestParseESP32SerialPortJSON_ArrayPicksFirstWithCOM(t *testing.T) {
+	in := `[{"Name":"USB JTAG/serial debug unit (COM3)","PNPDeviceID":"USB\\VID_303A&PID_1001\\A","Caption":"USB JTAG/serial debug unit (COM3)"},` +
+		`{"Name":"USB-SERIAL CH340 (COM12)","PNPDeviceID":"USB\\VID_303A&PID_1001\\B","Caption":"USB-SERIAL CH340 (COM12)"}]`
+	got, err := parseESP32SerialPortJSON(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "COM3" {
+		t.Fatalf("got %q, want %q", got, "COM3")
+	}
+}
+
+func TestParseESP32SerialPortJSON_FallsBackToCaption(t *testing.T) {
+	// Name field empty; COMN only present on Caption.
+	in := `{"Name":"","PNPDeviceID":"USB\\VID_303A&PID_1001\\X","Caption":"USB JTAG/serial debug unit (COM21)"}`
+	got, err := parseESP32SerialPortJSON(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "COM21" {
+		t.Fatalf("got %q, want %q", got, "COM21")
+	}
+}
+
+func TestParseESP32SerialPortJSON_EmptyInput(t *testing.T) {
+	_, err := parseESP32SerialPortJSON("")
+	if err == nil {
+		t.Fatal("expected error for empty input")
+	}
+	if !strings.Contains(err.Error(), "no ESP32 serial port found") {
+		t.Fatalf("got %v, want a 'no ESP32 serial port found' error", err)
+	}
+}
+
+func TestParseESP32SerialPortJSON_NoCOMSuffix(t *testing.T) {
+	in := `{"Name":"USB JTAG/serial debug unit","PNPDeviceID":"USB\\VID_303A&PID_1001\\Y","Caption":"USB JTAG/serial debug unit"}`
+	_, err := parseESP32SerialPortJSON(in)
+	if err == nil {
+		t.Fatal("expected error when no COM port is present")
+	}
+}
+
+func TestParseESP32SerialPortJSON_MalformedJSON(t *testing.T) {
+	_, err := parseESP32SerialPortJSON(`{"Name":}`)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}


### PR DESCRIPTION
## Summary

PR c of the WDY-1122 Windows parity epic.

- Extracts the AI-assistant launch step from `runAIAssistantChoice` into a platform-specific `launchAssistantWithPrompt` helper. On Windows, the full prompt is written to a temp `.md` and the assistant is invoked with a short *"Read the file at <path>..."* instruction so cmd.exe `%*` re-parsing in `.cmd` shim wrappers can't mangle multi-line prompts containing quotes or `%` characters (§3.7).
- Implements `ResolveESP32SerialPort` on Windows by querying `Win32_PnPEntity` via PowerShell for `Ports`-class entries matching the Espressif VID/PID and extracting the `COMN` identifier from the `Name`/`Caption` field. Returns the bare `COMN` string that `os_install.go` and esptool expect on Windows. Mirrors the `usb_windows.go` PowerShell-JSON pattern (§3.6).
- Adds parser unit tests for the PowerShell JSON output and temp-file lifecycle tests for the Windows assistant launcher.

Unblocks `wendy init` AI-assistant launch and `wendy os install` for Wendy Lite on Windows.

## Test plan

- [x] `gofmt -l .` clean from `go/` root.
- [x] `go test ./...` passes on macOS.
- [x] `GOOS=windows go vet ./internal/cli/... ./internal/shared/...` clean.
- [x] `GOOS=windows go test -c` for `internal/shared/discovery` and `internal/cli/commands` builds cleanly.
- [ ] Manual on Windows: `wendy init` → pick Claude/Codex → assistant launches with the short "Read the file..." prompt and reads the temp file.
- [ ] Manual on Windows: `wendy os install` on a Wendy Lite target → ESP32 serial port resolves to a `COMN` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)