### PR TITLE
EXPERIMENTAL fix: resolve local device names through discovery

### DIFF
--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -741,7 +741,11 @@ func discoverTableRows(collection *models.DevicesCollection) []bubbleTable.Row {
 		} else if d.Bluetooth != nil && !d.Bluetooth.IsWendyAgent() {
 			deviceType = "ESP32"
 		}
-		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, deviceType, d.Address(), markOutdated(d.AgentVersion)})
+		addr := d.Address()
+		if d.LAN != nil {
+			addr = lanDisplayHost(*d.LAN)
+		}
+		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, deviceType, addr, markOutdated(d.AgentVersion)})
 	}
 	for _, d := range collection.EthernetInterfaces {
 		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, "", d.IPAddress, markOutdated(d.AgentVersion)})

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -186,6 +186,26 @@ func TestRenderDeviceTable(t *testing.T) {
 	}
 }
 
+func TestRenderDeviceTable_PrefersHostnameForLANDisplay(t *testing.T) {
+	collection := &models.DevicesCollection{
+		LANDevices: []models.LANDevice{{
+			DisplayName:  "Calm Zinnia",
+			Hostname:     "wendyos-calm-zinnia.local",
+			IPAddress:    "fe80::ffab:7cf6:ef:21c5%enp0s20f0u9",
+			Port:         50051,
+			AgentVersion: "1.2.3",
+		}},
+	}
+
+	output := renderDeviceTable(collection)
+	if !strings.Contains(output, "wendyos-calm-zinnia.local") {
+		t.Fatalf("expected output to contain hostname, got %q", output)
+	}
+	if strings.Contains(output, "fe80::ffab:7cf6:ef:21c5") {
+		t.Fatalf("expected output to prefer hostname over IPv6 address, got %q", output)
+	}
+}
+
 func TestHumanReadableDeviceType(t *testing.T) {
 	cases := []struct {
 		input string

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -36,6 +36,8 @@ const defaultAgentPort = 50051
 
 const lanAddressProbeTimeout = 1500 * time.Millisecond
 
+var discoverLANForAddress = discovery.DiscoverLAN
+
 var getAgentVersionAtAddress = func(ctx context.Context, address string) (bool, *agentpb.GetAgentVersionResponse, error) {
 	conn, err := connectWithAutoTLS(ctx, address)
 	if err != nil {
@@ -150,13 +152,7 @@ func resolveHostPreferIPv4(host string) string {
 // port. connectWithAutoTLS derives the mTLS port as plaintext+1, so we
 // subtract 1 here to keep that convention working correctly.
 func lanAgentAddresses(dev models.LANDevice) []string {
-	port := dev.Port
-	if port == 0 {
-		port = defaultAgentPort
-	}
-	if dev.IsMTLS && dev.Port != 0 && port > 1 {
-		port-- // advertised port is mTLS; connectWithAutoTLS will add 1 back
-	}
+	port := lanAgentPort(dev)
 
 	var addresses []string
 	seen := make(map[string]bool)
@@ -171,14 +167,85 @@ func lanAgentAddresses(dev models.LANDevice) []string {
 	return addresses
 }
 
-// preferredLANAddress returns the best available address for display and
-// follow-up connection attempts. It prefers IPs over mDNS hostnames.
+func lanAgentPort(dev models.LANDevice) int {
+	port := dev.Port
+	if port == 0 {
+		port = defaultAgentPort
+	}
+	if dev.IsMTLS && dev.Port != 0 && port > 1 {
+		port-- // advertised port is mTLS; connectWithAutoTLS will add 1 back
+	}
+	return port
+}
+
+func lanDisplayHost(dev models.LANDevice) string {
+	if host := strings.TrimSpace(dev.Hostname); host != "" {
+		return host
+	}
+	return strings.TrimSpace(dev.IPAddress)
+}
+
+func lanDisplayAddress(dev models.LANDevice) string {
+	host := lanDisplayHost(dev)
+	if host == "" {
+		return ""
+	}
+	return hostPort(host, lanAgentPort(dev))
+}
+
+// preferredLANAddress returns the best available address for follow-up
+// connection attempts. It prefers IPs over mDNS hostnames.
 func preferredLANAddress(dev models.LANDevice) string {
 	addresses := lanAgentAddresses(dev)
 	if len(addresses) == 0 {
 		return ""
 	}
 	return addresses[0]
+}
+
+func resolveDiscoveredLANAddress(ctx context.Context, address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	if _, err := netip.ParseAddr(host); err == nil {
+		return address
+	}
+
+	wanted := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	if wanted == "" {
+		return address
+	}
+	wantedShort := strings.TrimSuffix(wanted, ".local")
+	if wanted == wantedShort && strings.Contains(wanted, ".") {
+		return address
+	}
+
+	discoverCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	devices, err := discoverLANForAddress(discoverCtx, 3*time.Second)
+	if err != nil {
+		return address
+	}
+	for _, dev := range devices {
+		hostname := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(dev.Hostname), "."))
+		displayName := strings.ToLower(strings.TrimSpace(dev.DisplayName))
+		if hostname != wanted && strings.TrimSuffix(hostname, ".local") != wantedShort && displayName != wanted && displayName != wantedShort {
+			continue
+		}
+		if ip := strings.TrimSpace(dev.IPAddress); ip != "" {
+			return hostPort(ip, mustAtoi(port, defaultAgentPort))
+		}
+	}
+	return address
+}
+
+func mustAtoi(s string, fallback int) int {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return fallback
+	}
+	return v
 }
 
 // resolveLANAgentVersion tries the discovered LAN addresses in order and
@@ -543,6 +610,7 @@ func connectFromSelectedDevice(target *SelectedDevice, cfg resolveConfig) (*grpc
 // It tries each stored certificate in order so that both production and local
 // pki-core certs are attempted.
 func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error) {
+	plaintextAddr = resolveDiscoveredLANAddress(ctx, plaintextAddr)
 	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
 	allCerts := loadAllCLICerts()
 	if len(allCerts) > 0 {
@@ -1143,7 +1211,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 		p.Send(tui.PickerAddMsg{Items: []tui.PickerItem{{
 			Name:     name,
 			Type:     "LAN",
-			Address:  preferredLANAddress(dev),
+			Address:  lanDisplayAddress(dev),
 			DedupKey: dev.DisplayName,
 			Insecure: insecure,
 			Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -74,6 +74,37 @@ func TestLANAgentAddressesPrefersIPAddress(t *testing.T) {
 	}
 }
 
+func TestLANDisplayAddressPrefersHostname(t *testing.T) {
+	dev := models.LANDevice{
+		IPAddress: "fe80::8c13:12bf:4df8:b976%en24",
+		Hostname:  "wendyos-otter.local",
+		Port:      defaultAgentPort,
+	}
+
+	if got, want := lanDisplayAddress(dev), "wendyos-otter.local:50051"; got != want {
+		t.Fatalf("lanDisplayAddress() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDiscoveredLANAddressResolvesLocalHostname(t *testing.T) {
+	orig := discoverLANForAddress
+	t.Cleanup(func() { discoverLANForAddress = orig })
+	discoverLANForAddress = func(context.Context, time.Duration) ([]models.LANDevice, error) {
+		return []models.LANDevice{{
+			DisplayName: "Jetson Orin Nano",
+			Hostname:    "wendyos-jetson-orin-nano.local",
+			IPAddress:   "fe80::3409:bb8b:7708:e7e%enx9677c7691091",
+			Port:        defaultAgentPort,
+		}}, nil
+	}
+
+	got := resolveDiscoveredLANAddress(context.Background(), "wendyos-jetson-orin-nano.local:50051")
+	want := "[fe80::3409:bb8b:7708:e7e%enx9677c7691091]:50051"
+	if got != want {
+		t.Fatalf("resolveDiscoveredLANAddress() = %q, want %q", got, want)
+	}
+}
+
 func TestLANAgentAddressesDeduplicatesIdenticalHosts(t *testing.T) {
 	dev := models.LANDevice{
 		IPAddress: "192.168.1.23",


### PR DESCRIPTION
## Summary
- Show LAN devices by hostname in the discovery table and device picker when a hostname is available, instead of surfacing scoped IPv6 addresses as the primary identity.
- Resolve `.local`/local device names through Wendy discovery before dialing, so `--device wendyos-...local` can work on Linux even when the system DNS stub cannot resolve mDNS.
- Keep the existing IP-first connection behavior for discovered devices, so link-local USB connections still use the scoped address internally.

## Tests
- `cd go && go test ./...`
