### PR TITLE
fix: prevent discover clipboard hangs on Linux

### DIFF
--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -850,6 +850,48 @@ type clipboardCandidate struct {
 var execLookPath = exec.LookPath
 var execCommand = exec.Command
 
+func shouldCaptureClipboardStderr(goos string) bool {
+	// wl-copy, xclip, and xsel commonly fork into the background to keep owning
+	// the clipboard selection. If os/exec captures stderr through a pipe, the
+	// daemonized child can inherit that pipe and Cmd.Wait can block indefinitely.
+	return goos != "linux"
+}
+
+func runClipboardCommand(cmd *exec.Cmd, timeout time.Duration) error {
+	cmd.WaitDelay = 500 * time.Millisecond
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		select {
+		case <-done:
+		case <-time.After(cmd.WaitDelay + 100*time.Millisecond):
+		}
+		return fmt.Errorf("timed out after %s", timeout)
+	}
+}
+
+// clipboardCommandTimeout bounds clipboard helper execution. Some Linux clipboard
+// tools daemonize to own the selection; if they (or their child processes) keep
+// inherited file descriptors open, waiting on the command can otherwise hang the
+// interactive discover TUI.
+var clipboardCommandTimeout = 2 * time.Second
+
 // copyToClipboard writes text to the system clipboard using platform tools.
 func copyToClipboard(text string) error {
 	var candidates []clipboardCandidate
@@ -879,8 +921,10 @@ func copyToClipboard(text string) error {
 		var stderr bytes.Buffer
 		cmd := execCommand(c.name, c.args...)
 		cmd.Stdin = strings.NewReader(text)
-		cmd.Stderr = &stderr
-		if err := cmd.Run(); err != nil {
+		if shouldCaptureClipboardStderr(runtime.GOOS) {
+			cmd.Stderr = &stderr
+		}
+		if err := runClipboardCommand(cmd, clipboardCommandTimeout); err != nil {
 			detail := stderr.String()
 			if detail == "" {
 				detail = err.Error()

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -470,6 +470,35 @@ func TestCopyToClipboard_AllToolsFailReportsErrors(t *testing.T) {
 	}
 }
 
+func TestShouldCaptureClipboardStderr_DisablesLinuxPipes(t *testing.T) {
+	if shouldCaptureClipboardStderr("linux") {
+		t.Fatal("linux clipboard helpers should not capture stderr through pipes")
+	}
+	if !shouldCaptureClipboardStderr("darwin") {
+		t.Fatal("darwin clipboard helper should capture stderr")
+	}
+}
+
+func TestRunClipboardCommand_TimesOut(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell")
+	}
+
+	start := time.Now()
+	err := runClipboardCommand(exec.Command("sleep", "5"), 25*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("timeout took too long: %v", elapsed)
+	}
+}
+
 func TestCopyToClipboard_NoToolsFound(t *testing.T) {
 	origLookPath := execLookPath
 	origCommand := execCommand


### PR DESCRIPTION
## Summary
- Prevent `wendy discover` from freezing when Enter copies device details on Linux.
- Avoid capturing stderr through pipes for Linux clipboard helpers that may daemonize while owning the selection.
- Add a timeout around clipboard helper execution so the TUI remains responsive if a clipboard tool hangs.

## Tests
- `cd go && go test ./internal/cli/commands`
