### PR TITLE
test(e2e): preserve scoped IPv6 default devices

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceInfoTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceInfoTests.swift
@@ -39,7 +39,7 @@ struct `'wendy device info'` {
             try await cli.sh(
                 """
                 mkdir -p "$HOME/.wendy"
-                printf '{"defaultDevice":"default-device-that-should-not-be-used.invalid"}\n' > "$HOME/.wendy/config.json"
+                printf '%s\n' '{"defaultDevice":"default-device-that-should-not-be-used.invalid"}' > "$HOME/.wendy/config.json"
                 """
             )
             try await cli.sh("wendy --device \(agentAddress) device info --json") {
@@ -71,7 +71,7 @@ struct `'wendy device info'` {
             try await cli.sh(
                 """
                 mkdir -p "$HOME/.wendy"
-                printf '{"defaultDevice":"\(agentAddress)"}\n' > "$HOME/.wendy/config.json"
+                printf '%s\n' '{"defaultDevice":"\(agentAddress)"}' > "$HOME/.wendy/config.json"
                 """
             )
 
@@ -209,7 +209,7 @@ struct `'wendy device info'` {
             try await cli.sh(
                 """
                 mkdir -p "$HOME/.wendy"
-                printf '{"defaultDevice":"\(agentAddress)"}\n' > "$HOME/.wendy/config.json"
+                printf '%s\n' '{"defaultDevice":"\(agentAddress)"}' > "$HOME/.wendy/config.json"
                 """
             )
 


### PR DESCRIPTION
## Summary
- Fix the E2E tests for devices that are reached over a link-local IPv6 address.
- While testing the Jetson from Ubuntu, discovery found the device at an address that contains a `%`, which identifies the network interface to use.
- Some tests wrote that address into a temporary Wendy config file using `printf` incorrectly. `printf` treated the `%` as formatting syntax and changed the address, so the test failed with a bad address instead of testing the CLI behavior.
- This changes the fixture-writing command so the address is saved exactly as discovered.

## Tests
- `make format`
- `cd swift/WendyE2ETests && swift test --filter NoSuchTestToOnlyBuild`
- Ubuntu/Jetson: `bash Scripts/TestE2E.sh --agent-address "$device" --filter "uses the configured default device" --no-report`
