### PR TITLE
fix: unmount nested partitions before disk imaging on Linux

### DIFF
--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -175,9 +175,12 @@ func unmountDisk(devPath string) error {
 
 func unmountLsblkDevice(dev lsblkDevice) error {
 	if dev.Mountpoint != "" {
-		partPath := "/dev/" + dev.Name
-		if out, err := umountCmd(partPath); err != nil {
-			return fmt.Errorf("unmounting %s: %w\n%s", partPath, err, out)
+		// Unmount by mountpoint rather than device path so that device-mapper
+		// entries (e.g. mapper/data → /dev/mapper/data) and dm-* nodes are
+		// handled correctly.  The mountpoint is always the right argument to
+		// pass to umount when it is known.
+		if out, err := umountCmd(dev.Mountpoint); err != nil {
+			return fmt.Errorf("unmounting %s: %w\n%s", dev.Mountpoint, err, out)
 		}
 	}
 	// Recurse into children for defence-in-depth: lsblk without -l returns

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -122,6 +122,20 @@ func listDrivesLinux() ([]drive, error) {
 	return drives, nil
 }
 
+// lsblkCmd is the function used to run lsblk for partition enumeration.
+// It is a package-level variable so tests can inject a fake implementation
+// without spawning a real process.
+var lsblkCmd = func(devPath string) ([]byte, error) {
+	return exec.Command("lsblk", "--json", "-l", "-o", "NAME,MOUNTPOINT", devPath).Output()
+}
+
+// umountCmd is the function used to unmount a single partition path.
+// It is a package-level variable so tests can inject a mock that records
+// calls without invoking privileged host commands.
+var umountCmd = func(partPath string) ([]byte, error) {
+	return exec.Command("sudo", "umount", partPath).CombinedOutput()
+}
+
 // unmountDisk unmounts all partitions on a disk before writing.
 func unmountDisk(devPath string) error {
 	// Enumerate partitions via lsblk and unmount each one.
@@ -131,7 +145,7 @@ func unmountDisk(devPath string) error {
 	// because older code did not recurse into children.  We also keep the
 	// Children field on lsblkDevice and recurse in unmountLsblkDevice as a
 	// defence-in-depth measure for lsblk versions that ignore -l.
-	out, err := exec.Command("lsblk", "--json", "-l", "-o", "NAME,MOUNTPOINT", devPath).Output()
+	out, err := lsblkCmd(devPath)
 	if err != nil {
 		// If lsblk fails, the disk may not be mounted at all.
 		return nil
@@ -154,7 +168,7 @@ func unmountDisk(devPath string) error {
 func unmountLsblkDevice(dev lsblkDevice) error {
 	if dev.Mountpoint != "" {
 		partPath := "/dev/" + dev.Name
-		if out, err := exec.Command("sudo", "umount", partPath).CombinedOutput(); err != nil {
+		if out, err := umountCmd(partPath); err != nil {
 			return fmt.Errorf("unmounting %s: %w\n%s", partPath, err, out)
 		}
 	}

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -50,13 +50,14 @@ type lsblkOutput struct {
 }
 
 type lsblkDevice struct {
-	Name       string      `json:"name"`
-	Size       json.Number `json:"size"`
-	Type       string      `json:"type"`
-	Removable  flexBool    `json:"rm"`
-	Hotplug    flexBool    `json:"hotplug"`
-	Transport  string      `json:"tran"`
-	Mountpoint string      `json:"mountpoint"`
+	Name       string        `json:"name"`
+	Size       json.Number   `json:"size"`
+	Type       string        `json:"type"`
+	Removable  flexBool      `json:"rm"`
+	Hotplug    flexBool      `json:"hotplug"`
+	Transport  string        `json:"tran"`
+	Mountpoint string        `json:"mountpoint"`
+	Children   []lsblkDevice `json:"children"`
 }
 
 // listAllDrives lists external physical drives (USB, SD, hotplug) on Linux.
@@ -124,7 +125,13 @@ func listDrivesLinux() ([]drive, error) {
 // unmountDisk unmounts all partitions on a disk before writing.
 func unmountDisk(devPath string) error {
 	// Enumerate partitions via lsblk and unmount each one.
-	out, err := exec.Command("lsblk", "--json", "-o", "NAME,MOUNTPOINT", devPath).Output()
+	// The -l flag requests flat (list) output so every partition appears as a
+	// top-level entry in blockdevices rather than being nested under a parent
+	// disk's "children" array.  Without -l, partitions are silently dropped
+	// because older code did not recurse into children.  We also keep the
+	// Children field on lsblkDevice and recurse in unmountLsblkDevice as a
+	// defence-in-depth measure for lsblk versions that ignore -l.
+	out, err := exec.Command("lsblk", "--json", "-l", "-o", "NAME,MOUNTPOINT", devPath).Output()
 	if err != nil {
 		// If lsblk fails, the disk may not be mounted at all.
 		return nil
@@ -145,6 +152,11 @@ func unmountLsblkDevice(dev lsblkDevice) {
 	if dev.Mountpoint != "" {
 		partPath := "/dev/" + dev.Name
 		exec.Command("sudo", "umount", partPath).Run() //nolint:errcheck
+	}
+	// Recurse into children for defence-in-depth: lsblk without -l returns
+	// partitions nested under the parent disk entry.
+	for _, child := range dev.Children {
+		unmountLsblkDevice(child)
 	}
 }
 

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -142,22 +142,30 @@ func unmountDisk(devPath string) error {
 		return nil
 	}
 
+	var firstErr error
 	for _, dev := range result.Blockdevices {
-		unmountLsblkDevice(dev)
+		if err := unmountLsblkDevice(dev); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
-	return nil
+	return firstErr
 }
 
-func unmountLsblkDevice(dev lsblkDevice) {
+func unmountLsblkDevice(dev lsblkDevice) error {
 	if dev.Mountpoint != "" {
 		partPath := "/dev/" + dev.Name
-		exec.Command("sudo", "umount", partPath).Run() //nolint:errcheck
+		if out, err := exec.Command("sudo", "umount", partPath).CombinedOutput(); err != nil {
+			return fmt.Errorf("unmounting %s: %w\n%s", partPath, err, out)
+		}
 	}
 	// Recurse into children for defence-in-depth: lsblk without -l returns
 	// partitions nested under the parent disk entry.
 	for _, child := range dev.Children {
-		unmountLsblkDevice(child)
+		if err := unmountLsblkDevice(child); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(written int64)) error {

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -159,13 +159,16 @@ func unmountLsblkDevice(dev lsblkDevice) error {
 		}
 	}
 	// Recurse into children for defence-in-depth: lsblk without -l returns
-	// partitions nested under the parent disk entry.
+	// partitions nested under the parent disk entry.  Collect the first error
+	// but continue visiting ALL siblings so that a single failure does not
+	// leave subsequent partitions mounted.
+	var firstErr error
 	for _, child := range dev.Children {
-		if err := unmountLsblkDevice(child); err != nil {
-			return err
+		if err := unmountLsblkDevice(child); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
-	return nil
+	return firstErr
 }
 
 func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(written int64)) error {

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"sort"
+	"strings"
 
 	"github.com/dustin/go-humanize"
 )
@@ -155,14 +157,22 @@ func unmountDisk(devPath string) error {
 	// defence-in-depth measure for lsblk versions that ignore -l.
 	out, err := lsblkCmd(devPath)
 	if err != nil {
-		// If lsblk fails, the disk may not be mounted at all.
-		return nil
+		return fmt.Errorf("lsblk %s: %w", devPath, err)
 	}
 
 	var result lsblkOutput
 	if err := json.Unmarshal(out, &result); err != nil {
 		return nil
 	}
+
+	// Sort devices so that deeper mountpoints are unmounted first.
+	// This prevents a parent mount from being busy when we try to unmount it
+	// because a child mountpoint beneath it is still active.
+	sort.Slice(result.Blockdevices, func(i, j int) bool {
+		di := strings.Count(result.Blockdevices[i].Mountpoint, "/")
+		dj := strings.Count(result.Blockdevices[j].Mountpoint, "/")
+		return di > dj // deeper first; empty mountpoints (di==0) sort last
+	})
 
 	var firstErr error
 	for _, dev := range result.Blockdevices {

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -189,6 +189,16 @@ func unmountLsblkDevice(dev lsblkDevice) error {
 	// unmount this node.  Collect the first error but continue visiting ALL
 	// siblings so that a single failure does not leave subsequent partitions
 	// mounted.
+	// Sort children so that deeper mountpoints are unmounted first.
+	// This mirrors the top-level sort in unmountDisk and prevents EBUSY when
+	// two sibling children have nested mountpoints (e.g. /mnt/disk and
+	// /mnt/disk/sub): the deeper one must be unmounted before the shallower.
+	sort.Slice(dev.Children, func(i, j int) bool {
+		di := strings.Count(dev.Children[i].Mountpoint, "/")
+		dj := strings.Count(dev.Children[j].Mountpoint, "/")
+		return di > dj // deeper first; empty mountpoints (di==0) sort last
+	})
+
 	var firstErr error
 	for _, child := range dev.Children {
 		if err := unmountLsblkDevice(child); err != nil && firstErr == nil {

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -122,11 +122,19 @@ func listDrivesLinux() ([]drive, error) {
 	return drives, nil
 }
 
+// buildLsblkArgs returns the full argument list (including the command name)
+// used by lsblkCmd.  Extracting it into its own variable gives tests a seam
+// to assert that the -l flag is present without running a real process.
+var buildLsblkArgs = func(devPath string) []string {
+	return []string{"lsblk", "--json", "-l", "-o", "NAME,MOUNTPOINT", devPath}
+}
+
 // lsblkCmd is the function used to run lsblk for partition enumeration.
 // It is a package-level variable so tests can inject a fake implementation
 // without spawning a real process.
 var lsblkCmd = func(devPath string) ([]byte, error) {
-	return exec.Command("lsblk", "--json", "-l", "-o", "NAME,MOUNTPOINT", devPath).Output()
+	args := buildLsblkArgs(devPath)
+	return exec.Command(args[0], args[1:]...).Output()
 }
 
 // umountCmd is the function used to unmount a single partition path.

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -176,7 +176,7 @@ func unmountDisk(devPath string) error {
 
 	var result lsblkOutput
 	if err := json.Unmarshal(out, &result); err != nil {
-		return nil
+		return fmt.Errorf("parsing lsblk output for %s: %w", devPath, err)
 	}
 
 	// Sort devices so that deeper mountpoints are unmounted first.

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -146,6 +146,20 @@ var umountCmd = func(mountpoint string) ([]byte, error) {
 	return exec.Command("sudo", "umount", mountpoint).CombinedOutput()
 }
 
+// maxMountpointDepth returns the maximum mountpoint depth (number of '/'
+// characters) across a device node and all of its descendants.  This is used
+// to sort devices so that the deepest subtree is always unmounted first, even
+// when a node has no mountpoint of its own but has deeply-mounted children.
+func maxMountpointDepth(dev lsblkDevice) int {
+	d := strings.Count(dev.Mountpoint, "/")
+	for _, child := range dev.Children {
+		if cd := maxMountpointDepth(child); cd > d {
+			d = cd
+		}
+	}
+	return d
+}
+
 // unmountDisk unmounts all partitions on a disk before writing.
 func unmountDisk(devPath string) error {
 	// Enumerate partitions via lsblk and unmount each one.
@@ -168,9 +182,11 @@ func unmountDisk(devPath string) error {
 	// Sort devices so that deeper mountpoints are unmounted first.
 	// This prevents a parent mount from being busy when we try to unmount it
 	// because a child mountpoint beneath it is still active.
+	// maxMountpointDepth is used so that a device with no mountpoint itself but
+	// with deeply-nested children is still sorted correctly.
 	sort.Slice(result.Blockdevices, func(i, j int) bool {
-		di := strings.Count(result.Blockdevices[i].Mountpoint, "/")
-		dj := strings.Count(result.Blockdevices[j].Mountpoint, "/")
+		di := maxMountpointDepth(result.Blockdevices[i])
+		dj := maxMountpointDepth(result.Blockdevices[j])
 		return di > dj // deeper first; empty mountpoints (di==0) sort last
 	})
 
@@ -194,8 +210,8 @@ func unmountLsblkDevice(dev lsblkDevice) error {
 	// two sibling children have nested mountpoints (e.g. /mnt/disk and
 	// /mnt/disk/sub): the deeper one must be unmounted before the shallower.
 	sort.Slice(dev.Children, func(i, j int) bool {
-		di := strings.Count(dev.Children[i].Mountpoint, "/")
-		dj := strings.Count(dev.Children[j].Mountpoint, "/")
+		di := maxMountpointDepth(dev.Children[i])
+		dj := maxMountpointDepth(dev.Children[j])
 		return di > dj // deeper first; empty mountpoints (di==0) sort last
 	})
 

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -137,11 +137,11 @@ var lsblkCmd = func(devPath string) ([]byte, error) {
 	return exec.Command(args[0], args[1:]...).Output()
 }
 
-// umountCmd is the function used to unmount a single partition path.
+// umountCmd is the function used to unmount a single mountpoint path.
 // It is a package-level variable so tests can inject a mock that records
 // calls without invoking privileged host commands.
-var umountCmd = func(partPath string) ([]byte, error) {
-	return exec.Command("sudo", "umount", partPath).CombinedOutput()
+var umountCmd = func(mountpoint string) ([]byte, error) {
+	return exec.Command("sudo", "umount", mountpoint).CombinedOutput()
 }
 
 // unmountDisk unmounts all partitions on a disk before writing.
@@ -174,23 +174,24 @@ func unmountDisk(devPath string) error {
 }
 
 func unmountLsblkDevice(dev lsblkDevice) error {
-	if dev.Mountpoint != "" {
-		// Unmount by mountpoint rather than device path so that device-mapper
-		// entries (e.g. mapper/data → /dev/mapper/data) and dm-* nodes are
-		// handled correctly.  The mountpoint is always the right argument to
-		// pass to umount when it is known.
-		if out, err := umountCmd(dev.Mountpoint); err != nil {
-			return fmt.Errorf("unmounting %s: %w\n%s", dev.Mountpoint, err, out)
-		}
-	}
-	// Recurse into children for defence-in-depth: lsblk without -l returns
-	// partitions nested under the parent disk entry.  Collect the first error
-	// but continue visiting ALL siblings so that a single failure does not
-	// leave subsequent partitions mounted.
+	// Children first: a parent mount cannot be unmounted until all child
+	// mounts beneath it are gone.  Recurse into children before attempting to
+	// unmount this node.  Collect the first error but continue visiting ALL
+	// siblings so that a single failure does not leave subsequent partitions
+	// mounted.
 	var firstErr error
 	for _, child := range dev.Children {
 		if err := unmountLsblkDevice(child); err != nil && firstErr == nil {
 			firstErr = err
+		}
+	}
+	// Then unmount self.  Unmount by mountpoint rather than device path so
+	// that device-mapper entries (e.g. mapper/data → /dev/mapper/data) and
+	// dm-* nodes are handled correctly.  The mountpoint is always the right
+	// argument to pass to umount when it is known.
+	if dev.Mountpoint != "" {
+		if out, err := umountCmd(dev.Mountpoint); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("unmounting %s: %w\n%s", dev.Mountpoint, err, out)
 		}
 	}
 	return firstErr

--- a/go/internal/cli/commands/disklister_linux_test.go
+++ b/go/internal/cli/commands/disklister_linux_test.go
@@ -239,30 +239,32 @@ func TestUnmountLsblkDeviceRecursesIntoChildren(t *testing.T) {
 		t.Fatal("expected an error (mock umountCmd always fails), got nil — recursive unmount may not have been attempted")
 	}
 
-	// Verify that /dev/sdb1 was attempted.
-	if !strings.Contains(err.Error(), "/dev/sdb1") {
-		t.Fatalf("error %q does not mention /dev/sdb1 — recursive unmount of the first child may not be working", err.Error())
+	// Verify that the first child's mountpoint (/boot/efi) was attempted.
+	// unmountLsblkDevice now unmounts by mountpoint rather than device path.
+	if !strings.Contains(err.Error(), "/boot/efi") {
+		t.Fatalf("error %q does not mention /boot/efi — recursive unmount of the first child may not be working", err.Error())
 	}
 
-	// Verify that /dev/sdb2 was also attempted: unmountLsblkDevice must
-	// continue through ALL siblings even after the first failure.
+	// Verify that /media/user/data (sdb2's mountpoint) was also attempted:
+	// unmountLsblkDevice must continue through ALL siblings even after the
+	// first failure.
 	foundSdb2 := false
 	for _, p := range attempted {
-		if p == "/dev/sdb2" {
+		if p == "/media/user/data" {
 			foundSdb2 = true
 			break
 		}
 	}
 	if !foundSdb2 {
-		t.Fatalf("unmount was not attempted for /dev/sdb2 (attempted: %v) — recursion stopped after first failure", attempted)
+		t.Fatalf("unmount was not attempted for /media/user/data (attempted: %v) — recursion stopped after first failure", attempted)
 	}
 }
 
-// TestUnmountDiskUsesLFlag verifies that unmountDisk passes the -l flag to
-// lsblk so partitions appear as flat top-level entries.  A mock lsblkCmd
-// captures the device path argument and returns a minimal JSON payload; a mock
-// umountCmd records which partitions were unmounted.
-func TestUnmountDiskUsesLFlag(t *testing.T) {
+// TestUnmountDiskCallsLsblkCmd verifies that unmountDisk calls the injected
+// lsblkCmd with the target device path and then unmounts the partitions
+// returned in the JSON payload via umountCmd.  The -l flag coverage (flat
+// output mode) is verified separately by TestLsblkArgsIncludeFlatFlag.
+func TestUnmountDiskCallsLsblkCmd(t *testing.T) {
 	const fakeJSON = `{
 		"blockdevices": [
 			{"name": "sdb",  "mountpoint": null},
@@ -271,12 +273,10 @@ func TestUnmountDiskUsesLFlag(t *testing.T) {
 		]
 	}`
 
-	// Capture the raw command arguments so we can assert -l is present.
+	// Capture the device path forwarded to lsblkCmd.
 	var capturedArgs []string
 	origLsblk := lsblkCmd
 	lsblkCmd = func(devPath string) ([]byte, error) {
-		// Record only the devPath; the flag check is done via the real
-		// implementation's call site, so here we just verify the path forwarded.
 		capturedArgs = append(capturedArgs, devPath)
 		return []byte(fakeJSON), nil
 	}
@@ -299,8 +299,8 @@ func TestUnmountDiskUsesLFlag(t *testing.T) {
 		t.Fatalf("lsblkCmd called with %v, want [\"/dev/sdb\"]", capturedArgs)
 	}
 
-	// Both mounted partitions must have been unmounted.
-	wantUnmounted := map[string]bool{"/dev/sdb1": false, "/dev/sdb2": false}
+	// Both mounted partitions must have been unmounted by mountpoint.
+	wantUnmounted := map[string]bool{"/boot/efi": false, "/media/user/data": false}
 	for _, p := range unmounted {
 		if _, ok := wantUnmounted[p]; ok {
 			wantUnmounted[p] = true
@@ -321,8 +321,11 @@ func TestLsblkArgsIncludeFlatFlag(t *testing.T) {
 	args := buildLsblkArgs("/dev/sdb")
 
 	// The first element must be the command name.
-	if len(args) == 0 || args[0] != "lsblk" {
-		t.Fatalf("buildLsblkArgs(%q)[0] = %q, want \"lsblk\"", "/dev/sdb", args[0])
+	if len(args) == 0 {
+		t.Fatal("buildLsblkArgs returned empty slice")
+	}
+	if args[0] != "lsblk" {
+		t.Errorf("buildLsblkArgs(%q)[0] = %q, want \"lsblk\"", "/dev/sdb", args[0])
 	}
 
 	// The device path must be forwarded as the last argument.

--- a/go/internal/cli/commands/disklister_linux_test.go
+++ b/go/internal/cli/commands/disklister_linux_test.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -195,6 +196,45 @@ func TestParseLsblkChildrenUnmarshaled(t *testing.T) {
 	}
 	if disk.Children[1].Mountpoint != "/media/user/data" {
 		t.Fatalf("Children[1].Mountpoint = %q, want \"/media/user/data\"", disk.Children[1].Mountpoint)
+	}
+}
+
+// TestUnmountLsblkDeviceRecursesIntoChildren verifies that unmountLsblkDevice
+// attempts to unmount nested child partitions, not just the top-level device.
+// The test builds a mock lsblkDevice with a mounted child and checks that an
+// unmount is attempted for the child's path (sudo umount will fail in the test
+// environment, so we expect a non-nil error containing the child's device path).
+func TestUnmountLsblkDeviceRecursesIntoChildren(t *testing.T) {
+	parent := lsblkDevice{
+		Name:       "sdb",
+		Type:       "disk",
+		Mountpoint: "", // parent disk itself is not mounted
+		Children: []lsblkDevice{
+			{
+				Name:       "sdb1",
+				Type:       "part",
+				Mountpoint: "/boot/efi",
+			},
+			{
+				Name:       "sdb2",
+				Type:       "part",
+				Mountpoint: "/media/user/data",
+			},
+		},
+	}
+
+	err := unmountLsblkDevice(parent)
+	// In a test environment sudo/umount will not succeed; what matters is that
+	// unmountLsblkDevice did NOT silently ignore the child mountpoints — it must
+	// have attempted the umount command and returned the failure rather than nil.
+	if err == nil {
+		t.Fatal("expected an error when unmounting children in a test environment (umount should fail), got nil — recursive unmount may not have been attempted")
+	}
+	// The error message must reference one of the child device paths to confirm
+	// that the recursion actually reached a mounted child.
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "/dev/sdb1") && !strings.Contains(errMsg, "/dev/sdb2") {
+		t.Fatalf("error %q does not mention a child device path — recursive unmount may not be working", errMsg)
 	}
 }
 

--- a/go/internal/cli/commands/disklister_linux_test.go
+++ b/go/internal/cli/commands/disklister_linux_test.go
@@ -313,6 +313,37 @@ func TestUnmountDiskUsesLFlag(t *testing.T) {
 	}
 }
 
+// TestLsblkArgsIncludeFlatFlag verifies that buildLsblkArgs produces an
+// argument list that contains the -l (flat/list) flag.  This test will fail
+// if -l is ever removed from buildLsblkArgs, making the primary bug fix
+// directly observable without requiring a real lsblk process.
+func TestLsblkArgsIncludeFlatFlag(t *testing.T) {
+	args := buildLsblkArgs("/dev/sdb")
+
+	// The first element must be the command name.
+	if len(args) == 0 || args[0] != "lsblk" {
+		t.Fatalf("buildLsblkArgs(%q)[0] = %q, want \"lsblk\"", "/dev/sdb", args[0])
+	}
+
+	// The device path must be forwarded as the last argument.
+	if args[len(args)-1] != "/dev/sdb" {
+		t.Fatalf("buildLsblkArgs(%q) last arg = %q, want \"/dev/sdb\"", "/dev/sdb", args[len(args)-1])
+	}
+
+	// The -l flag must be present so lsblk returns a flat list of partitions
+	// rather than a nested hierarchy.
+	found := false
+	for _, a := range args {
+		if a == "-l" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("buildLsblkArgs(%q) = %v — missing required -l flag (flat output flag is the primary fix for WDY-774)", "/dev/sdb", args)
+	}
+}
+
 // TestParseLsblkOutputMatchesLinuxReport reproduces the exact lsblk -J output
 // from the bug report (WDY-774) to verify it parses without error.
 func TestParseLsblkOutputMatchesLinuxReport(t *testing.T) {

--- a/go/internal/cli/commands/disklister_linux_test.go
+++ b/go/internal/cli/commands/disklister_linux_test.go
@@ -210,8 +210,8 @@ func TestUnmountLsblkDeviceRecursesIntoChildren(t *testing.T) {
 	// unmountLsblkDevice behaves as if umount failed (normal in unit tests).
 	var attempted []string
 	orig := umountCmd
-	umountCmd = func(partPath string) ([]byte, error) {
-		attempted = append(attempted, partPath)
+	umountCmd = func(mountpoint string) ([]byte, error) {
+		attempted = append(attempted, mountpoint)
 		return []byte("mock error"), fmt.Errorf("exit status 1")
 	}
 	defer func() { umountCmd = orig }()
@@ -284,8 +284,8 @@ func TestUnmountDiskCallsLsblkCmd(t *testing.T) {
 
 	var unmounted []string
 	origUmount := umountCmd
-	umountCmd = func(partPath string) ([]byte, error) {
-		unmounted = append(unmounted, partPath)
+	umountCmd = func(mountpoint string) ([]byte, error) {
+		unmounted = append(unmounted, mountpoint)
 		return nil, nil // success
 	}
 	defer func() { umountCmd = origUmount }()

--- a/go/internal/cli/commands/disklister_linux_test.go
+++ b/go/internal/cli/commands/disklister_linux_test.go
@@ -224,17 +224,22 @@ func TestUnmountLsblkDeviceRecursesIntoChildren(t *testing.T) {
 	}
 
 	err := unmountLsblkDevice(parent)
-	// In a test environment sudo/umount will not succeed; what matters is that
-	// unmountLsblkDevice did NOT silently ignore the child mountpoints — it must
-	// have attempted the umount command and returned the failure rather than nil.
+	// This is an integration-style test: sudo/umount will fail in the test
+	// environment because /dev/sdb1 and /dev/sdb2 do not exist.  The non-nil
+	// error is the desired signal — it proves that unmountLsblkDevice actually
+	// attempted the umount command rather than silently skipping child
+	// mountpoints.
 	if err == nil {
 		t.Fatal("expected an error when unmounting children in a test environment (umount should fail), got nil — recursive unmount may not have been attempted")
 	}
-	// The error message must reference one of the child device paths to confirm
-	// that the recursion actually reached a mounted child.
+	// The error message must reference the first child device path (/dev/sdb1)
+	// to confirm that the recursion reached it.  Because unmountLsblkDevice now
+	// continues through ALL siblings even after an error, the returned error is
+	// the first failure (sdb1); we also verify that sdb2 was attempted by
+	// checking that the error was not returned before sdb1 was tried.
 	errMsg := err.Error()
-	if !strings.Contains(errMsg, "/dev/sdb1") && !strings.Contains(errMsg, "/dev/sdb2") {
-		t.Fatalf("error %q does not mention a child device path — recursive unmount may not be working", errMsg)
+	if !strings.Contains(errMsg, "/dev/sdb1") {
+		t.Fatalf("error %q does not mention /dev/sdb1 — recursive unmount of the first child may not be working", errMsg)
 	}
 }
 

--- a/go/internal/cli/commands/disklister_linux_test.go
+++ b/go/internal/cli/commands/disklister_linux_test.go
@@ -141,6 +141,63 @@ func TestParseLsblkOutput(t *testing.T) {
 	}
 }
 
+// TestParseLsblkChildrenUnmarshaled verifies that the Children field is populated
+// when lsblk emits hierarchical JSON (without -l), so that unmountLsblkDevice
+// can recurse into nested partitions (fix for bug_2683497e).
+func TestParseLsblkChildrenUnmarshaled(t *testing.T) {
+	const hierarchical = `{
+		"blockdevices": [
+			{
+				"name": "sdb",
+				"size": "16000000000",
+				"type": "disk",
+				"rm": true,
+				"hotplug": true,
+				"tran": "usb",
+				"mountpoint": null,
+				"children": [
+					{
+						"name": "sdb1",
+						"size": "536870912",
+						"type": "part",
+						"rm": true,
+						"hotplug": true,
+						"tran": "usb",
+						"mountpoint": "/boot/efi"
+					},
+					{
+						"name": "sdb2",
+						"size": "15463129088",
+						"type": "part",
+						"rm": true,
+						"hotplug": true,
+						"tran": "usb",
+						"mountpoint": "/media/user/data"
+					}
+				]
+			}
+		]
+	}`
+
+	var result lsblkOutput
+	if err := json.Unmarshal([]byte(hierarchical), &result); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if len(result.Blockdevices) != 1 {
+		t.Fatalf("got %d top-level devices, want 1", len(result.Blockdevices))
+	}
+	disk := result.Blockdevices[0]
+	if len(disk.Children) != 2 {
+		t.Fatalf("got %d children, want 2 — Children field not unmarshaled (this is the root cause of bug_2683497e)", len(disk.Children))
+	}
+	if disk.Children[0].Name != "sdb1" {
+		t.Fatalf("Children[0].Name = %q, want \"sdb1\"", disk.Children[0].Name)
+	}
+	if disk.Children[1].Mountpoint != "/media/user/data" {
+		t.Fatalf("Children[1].Mountpoint = %q, want \"/media/user/data\"", disk.Children[1].Mountpoint)
+	}
+}
+
 // TestParseLsblkOutputMatchesLinuxReport reproduces the exact lsblk -J output
 // from the bug report (WDY-774) to verify it parses without error.
 func TestParseLsblkOutputMatchesLinuxReport(t *testing.T) {

--- a/go/internal/cli/commands/disklister_linux_test.go
+++ b/go/internal/cli/commands/disklister_linux_test.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -200,11 +201,21 @@ func TestParseLsblkChildrenUnmarshaled(t *testing.T) {
 }
 
 // TestUnmountLsblkDeviceRecursesIntoChildren verifies that unmountLsblkDevice
-// attempts to unmount nested child partitions, not just the top-level device.
-// The test builds a mock lsblkDevice with a mounted child and checks that an
-// unmount is attempted for the child's path (sudo umount will fail in the test
-// environment, so we expect a non-nil error containing the child's device path).
+// attempts to unmount ALL nested child partitions, not just the first one.
+// A mock umountCmd records every path that was passed to it, allowing the test
+// to assert that both sdb1 and sdb2 were attempted without invoking any
+// privileged host commands.
 func TestUnmountLsblkDeviceRecursesIntoChildren(t *testing.T) {
+	// Install a mock that records calls and returns a simulated error so
+	// unmountLsblkDevice behaves as if umount failed (normal in unit tests).
+	var attempted []string
+	orig := umountCmd
+	umountCmd = func(partPath string) ([]byte, error) {
+		attempted = append(attempted, partPath)
+		return []byte("mock error"), fmt.Errorf("exit status 1")
+	}
+	defer func() { umountCmd = orig }()
+
 	parent := lsblkDevice{
 		Name:       "sdb",
 		Type:       "disk",
@@ -224,22 +235,81 @@ func TestUnmountLsblkDeviceRecursesIntoChildren(t *testing.T) {
 	}
 
 	err := unmountLsblkDevice(parent)
-	// This is an integration-style test: sudo/umount will fail in the test
-	// environment because /dev/sdb1 and /dev/sdb2 do not exist.  The non-nil
-	// error is the desired signal — it proves that unmountLsblkDevice actually
-	// attempted the umount command rather than silently skipping child
-	// mountpoints.
 	if err == nil {
-		t.Fatal("expected an error when unmounting children in a test environment (umount should fail), got nil — recursive unmount may not have been attempted")
+		t.Fatal("expected an error (mock umountCmd always fails), got nil — recursive unmount may not have been attempted")
 	}
-	// The error message must reference the first child device path (/dev/sdb1)
-	// to confirm that the recursion reached it.  Because unmountLsblkDevice now
-	// continues through ALL siblings even after an error, the returned error is
-	// the first failure (sdb1); we also verify that sdb2 was attempted by
-	// checking that the error was not returned before sdb1 was tried.
-	errMsg := err.Error()
-	if !strings.Contains(errMsg, "/dev/sdb1") {
-		t.Fatalf("error %q does not mention /dev/sdb1 — recursive unmount of the first child may not be working", errMsg)
+
+	// Verify that /dev/sdb1 was attempted.
+	if !strings.Contains(err.Error(), "/dev/sdb1") {
+		t.Fatalf("error %q does not mention /dev/sdb1 — recursive unmount of the first child may not be working", err.Error())
+	}
+
+	// Verify that /dev/sdb2 was also attempted: unmountLsblkDevice must
+	// continue through ALL siblings even after the first failure.
+	foundSdb2 := false
+	for _, p := range attempted {
+		if p == "/dev/sdb2" {
+			foundSdb2 = true
+			break
+		}
+	}
+	if !foundSdb2 {
+		t.Fatalf("unmount was not attempted for /dev/sdb2 (attempted: %v) — recursion stopped after first failure", attempted)
+	}
+}
+
+// TestUnmountDiskUsesLFlag verifies that unmountDisk passes the -l flag to
+// lsblk so partitions appear as flat top-level entries.  A mock lsblkCmd
+// captures the device path argument and returns a minimal JSON payload; a mock
+// umountCmd records which partitions were unmounted.
+func TestUnmountDiskUsesLFlag(t *testing.T) {
+	const fakeJSON = `{
+		"blockdevices": [
+			{"name": "sdb",  "mountpoint": null},
+			{"name": "sdb1", "mountpoint": "/boot/efi"},
+			{"name": "sdb2", "mountpoint": "/media/user/data"}
+		]
+	}`
+
+	// Capture the raw command arguments so we can assert -l is present.
+	var capturedArgs []string
+	origLsblk := lsblkCmd
+	lsblkCmd = func(devPath string) ([]byte, error) {
+		// Record only the devPath; the flag check is done via the real
+		// implementation's call site, so here we just verify the path forwarded.
+		capturedArgs = append(capturedArgs, devPath)
+		return []byte(fakeJSON), nil
+	}
+	defer func() { lsblkCmd = origLsblk }()
+
+	var unmounted []string
+	origUmount := umountCmd
+	umountCmd = func(partPath string) ([]byte, error) {
+		unmounted = append(unmounted, partPath)
+		return nil, nil // success
+	}
+	defer func() { umountCmd = origUmount }()
+
+	if err := unmountDisk("/dev/sdb"); err != nil {
+		t.Fatalf("unmountDisk returned unexpected error: %v", err)
+	}
+
+	// lsblkCmd should have been called with the target device path.
+	if len(capturedArgs) == 0 || capturedArgs[0] != "/dev/sdb" {
+		t.Fatalf("lsblkCmd called with %v, want [\"/dev/sdb\"]", capturedArgs)
+	}
+
+	// Both mounted partitions must have been unmounted.
+	wantUnmounted := map[string]bool{"/dev/sdb1": false, "/dev/sdb2": false}
+	for _, p := range unmounted {
+		if _, ok := wantUnmounted[p]; ok {
+			wantUnmounted[p] = true
+		}
+	}
+	for path, seen := range wantUnmounted {
+		if !seen {
+			t.Errorf("expected unmount of %s but it was not attempted (unmounted: %v)", path, unmounted)
+		}
 	}
 }
 

--- a/go/internal/cli/commands/disklister_linux_test.go
+++ b/go/internal/cli/commands/disklister_linux_test.go
@@ -5,7 +5,6 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -239,24 +238,23 @@ func TestUnmountLsblkDeviceRecursesIntoChildren(t *testing.T) {
 		t.Fatal("expected an error (mock umountCmd always fails), got nil — recursive unmount may not have been attempted")
 	}
 
-	// Verify that the first child's mountpoint (/boot/efi) was attempted.
-	// unmountLsblkDevice now unmounts by mountpoint rather than device path.
-	if !strings.Contains(err.Error(), "/boot/efi") {
-		t.Fatalf("error %q does not mention /boot/efi — recursive unmount of the first child may not be working", err.Error())
+	// Verify that BOTH child mountpoints were attempted.  We check the
+	// recorded attempted slice rather than the error message because the depth
+	// sort may cause either child to be processed first, meaning only the
+	// deeper one's path ends up in firstErr.
+	if len(attempted) != 2 {
+		t.Fatalf("expected 2 unmount attempts, got %d (attempted: %v)", len(attempted), attempted)
 	}
-
-	// Verify that /media/user/data (sdb2's mountpoint) was also attempted:
-	// unmountLsblkDevice must continue through ALL siblings even after the
-	// first failure.
-	foundSdb2 := false
+	wantAttempted := map[string]bool{"/boot/efi": false, "/media/user/data": false}
 	for _, p := range attempted {
-		if p == "/media/user/data" {
-			foundSdb2 = true
-			break
+		if _, ok := wantAttempted[p]; ok {
+			wantAttempted[p] = true
 		}
 	}
-	if !foundSdb2 {
-		t.Fatalf("unmount was not attempted for /media/user/data (attempted: %v) — recursion stopped after first failure", attempted)
+	for path, seen := range wantAttempted {
+		if !seen {
+			t.Errorf("unmount was not attempted for %s (attempted: %v) — recursion stopped after first failure", path, attempted)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #699 — mounted partitions were silently skipped during the unmount step before writing a disk image on Linux.

**Root cause**: `unmountDisk` called `lsblk --json` without `-l`, which emits hierarchical JSON where partitions are nested under the parent disk entry in a `children` array. The `lsblkDevice` struct had no `Children` field, so JSON unmarshaling silently dropped all partition data. The loop iterated only over the top-level disk (which has no mountpoint itself), leaving all mounted partitions in place before `dd` ran.

**Fix (two-pronged for defence-in-depth)**:
- Add `-l` to the `lsblk` call so all block devices appear as flat top-level entries — this is the primary fix and works for all standard `lsblk` versions.
- Add `Children []lsblkDevice \`json:"children"\`` to `lsblkDevice` and recurse in `unmountLsblkDevice` — covers any `lsblk` version that ignores `-l`.

**Test**: `TestParseLsblkChildrenUnmarshaled` added to `disklister_linux_test.go`; it would have failed before this fix because `disk.Children` was always nil with the old struct.

## Test plan

- [ ] `GOOS=linux go vet ./internal/cli/commands/` passes
- [ ] On a Linux host: `go test ./internal/cli/commands/ -run TestParseLsblkChildren` passes
- [ ] Manual: attach a USB drive with at least one mounted partition and run `wendy disk write` — confirm no "device busy" error from `dd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)