### PR TITLE
fix: close TCP conn on HalfClose to unblock relay goroutine

### DIFF
--- a/go/internal/agent/services/tunnel_broker_client.go
+++ b/go/internal/agent/services/tunnel_broker_client.go
@@ -246,6 +246,7 @@ func (c *TunnelBrokerClient) relay(ctx context.Context, cancel context.CancelFun
 	// gRPC -> TCP
 	go func() {
 		defer func() { done <- struct{}{} }()
+		defer tcpConn.Close()
 		for {
 			msg, err := stream.Recv()
 			if err != nil {
@@ -260,10 +261,9 @@ func (c *TunnelBrokerClient) relay(ctx context.Context, cancel context.CancelFun
 				if tc, ok := tcpConn.(*net.TCPConn); ok {
 					_ = tc.CloseWrite()
 				}
-				return
+				break
 			}
 		}
-		tcpConn.Close()
 	}()
 
 	// TCP -> gRPC


### PR DESCRIPTION
## Summary

- In `relay()`, the gRPC->TCP goroutine was calling `CloseWrite()` on HalfClose then returning without closing the TCP connection. This left the TCP->gRPC goroutine blocked forever on `Read()` if the remote peer kept the connection open, causing `relay()` to deadlock on `<-done`.
- Add `defer tcpConn.Close()` at the top of the gRPC->TCP goroutine so the TCP connection is always closed when the goroutine exits (both on error and on HalfClose).
- Change `return` to `break` on the HalfClose path so the deferred close actually runs.
- Remove the now-redundant explicit `tcpConn.Close()` that previously only ran on the error path.

Fixes #695

## Test plan

- [ ] `cd go && go build ./...` passes (no new compilation errors)
- [ ] `cd go && go test ./internal/agent/services/ -v` all pass
- [ ] Manual: verify a tunnel session where the client sends HalfClose terminates cleanly without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)