### PR TITLE
fix: only set in-memory provisioning state after successful persistence

### DIFF
--- a/go/internal/agent/services/provisioning_service.go
+++ b/go/internal/agent/services/provisioning_service.go
@@ -186,19 +186,15 @@ func (s *ProvisioningService) StartProvisioning(ctx context.Context, req *agentp
 	certPEM := cert.GetPemCertificate()
 	chainPEM := cert.GetPemCertificateChain()
 
-	s.enrolled = true
-	s.cloudHost = req.GetCloudHost()
-	s.orgID = req.GetOrganizationId()
-	s.assetID = req.GetAssetId()
-	s.keyPEM = keyPEM
-	s.certPEM = certPEM
-	s.chainPEM = chainPEM
-
+	// Build the state struct from the request/cert values WITHOUT first mutating
+	// s.* fields. Only apply the state to s.* after saveState succeeds so that a
+	// disk-write failure does not leave the agent permanently stuck as "already
+	// provisioned".
 	state := &provisioningState{
 		Enrolled:  true,
-		CloudHost: s.cloudHost,
-		OrgID:     s.orgID,
-		AssetID:   s.assetID,
+		CloudHost: req.GetCloudHost(),
+		OrgID:     req.GetOrganizationId(),
+		AssetID:   req.GetAssetId(),
 		KeyPEM:    keyPEM,
 		CertPEM:   certPEM,
 		ChainPEM:  chainPEM,
@@ -207,6 +203,15 @@ func (s *ProvisioningService) StartProvisioning(ctx context.Context, req *agentp
 		s.logger.Error("Failed to persist provisioning state", zap.Error(err))
 		return nil, status.Errorf(codes.Internal, "failed to save provisioning state: %v", err)
 	}
+
+	// Persist succeeded — now it is safe to update in-memory state.
+	s.enrolled = true
+	s.cloudHost = state.CloudHost
+	s.orgID = state.OrgID
+	s.assetID = state.AssetID
+	s.keyPEM = keyPEM
+	s.certPEM = certPEM
+	s.chainPEM = chainPEM
 
 	// Write individual PEM files so the container registry can mount and use them.
 	if err := s.writePEMFiles(keyPEM, certPEM, chainPEM); err != nil {

--- a/go/internal/agent/services/save_state_failure_test.go
+++ b/go/internal/agent/services/save_state_failure_test.go
@@ -15,27 +15,29 @@ import (
 // other fields were set before saveState was called, leaving the agent
 // permanently stuck as "already provisioned" even though nothing was persisted.
 func TestStartProvisioning_SaveStateFailure(t *testing.T) {
-	// Create a temp dir for config, then make it read-only so saveState fails.
+	// Create a temp dir for config.
 	tmpDir, err := os.MkdirTemp("", "wendy-prov-savestate-*")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Pre-create the config dir as read-only so os.WriteFile inside saveState fails.
-	if err := os.Chmod(tmpDir, 0o500); err != nil {
-		t.Fatalf("Chmod: %v", err)
-	}
-
 	logger := zap.NewNop()
 	svc := NewProvisioningService(logger, tmpDir)
+
+	// Block saveState by creating a directory at the state file path. When the
+	// code tries to open that path for writing it gets EISDIR, which fails
+	// deterministically on all platforms and regardless of the running user.
+	if err := os.Mkdir(svc.statePath(), 0o755); err != nil {
+		t.Fatalf("Mkdir(statePath): %v", err)
+	}
 
 	// Attach a fake cloud dialer so the network call succeeds.
 	dialer, cleanup := startFakeCloudServer(t, "cert-pem", "chain-pem")
 	t.Cleanup(cleanup)
 	svc.CloudDialer = dialer
 
-	// First provisioning attempt — saveState will fail because the dir is read-only.
+	// First provisioning attempt — saveState will fail because the state path is a directory.
 	_, err = svc.StartProvisioning(context.Background(), &agentpb.StartProvisioningRequest{
 		OrganizationId: 7,
 		CloudHost:      "fail.wendy.io",
@@ -45,9 +47,9 @@ func TestStartProvisioning_SaveStateFailure(t *testing.T) {
 		t.Fatal("expected StartProvisioning to return an error when saveState fails")
 	}
 
-	// Restore write permission so the second attempt can succeed.
-	if err := os.Chmod(tmpDir, 0o700); err != nil {
-		t.Fatalf("Chmod restore: %v", err)
+	// Remove the blocking directory so the second attempt can write the state file.
+	if err := os.Remove(svc.statePath()); err != nil {
+		t.Fatalf("Remove(statePath): %v", err)
 	}
 
 	// Second provisioning attempt — must NOT be rejected as "already provisioned".

--- a/go/internal/agent/services/save_state_failure_test.go
+++ b/go/internal/agent/services/save_state_failure_test.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+
+	agentpb "github.com/wendylabsinc/wendy/proto/gen/agentpb"
+)
+
+// TestStartProvisioning_SaveStateFailure verifies that when saveState fails,
+// the in-memory provisioning state is NOT mutated. Previously, s.enrolled and
+// other fields were set before saveState was called, leaving the agent
+// permanently stuck as "already provisioned" even though nothing was persisted.
+func TestStartProvisioning_SaveStateFailure(t *testing.T) {
+	// Create a temp dir for config, then make it read-only so saveState fails.
+	tmpDir, err := os.MkdirTemp("", "wendy-prov-savestate-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Pre-create the config dir as read-only so os.WriteFile inside saveState fails.
+	if err := os.Chmod(tmpDir, 0o500); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	logger := zap.NewNop()
+	svc := NewProvisioningService(logger, tmpDir)
+
+	// Attach a fake cloud dialer so the network call succeeds.
+	dialer, cleanup := startFakeCloudServer(t, "cert-pem", "chain-pem")
+	t.Cleanup(cleanup)
+	svc.CloudDialer = dialer
+
+	// First provisioning attempt — saveState will fail because the dir is read-only.
+	_, err = svc.StartProvisioning(context.Background(), &agentpb.StartProvisioningRequest{
+		OrganizationId: 7,
+		CloudHost:      "fail.wendy.io",
+		AssetId:        77,
+	})
+	if err == nil {
+		t.Fatal("expected StartProvisioning to return an error when saveState fails")
+	}
+
+	// Restore write permission so the second attempt can succeed.
+	if err := os.Chmod(tmpDir, 0o700); err != nil {
+		t.Fatalf("Chmod restore: %v", err)
+	}
+
+	// Second provisioning attempt — must NOT be rejected as "already provisioned".
+	_, err = svc.StartProvisioning(context.Background(), &agentpb.StartProvisioningRequest{
+		OrganizationId: 7,
+		CloudHost:      "fail.wendy.io",
+		AssetId:        77,
+	})
+	if err != nil {
+		t.Fatalf("second StartProvisioning after saveState-failure should succeed, got: %v", err)
+	}
+
+	// Confirm the agent is now genuinely provisioned.
+	resp, err := svc.IsProvisioned(context.Background(), &agentpb.IsProvisionedRequest{})
+	if err != nil {
+		t.Fatalf("IsProvisioned: %v", err)
+	}
+	if resp.GetProvisioned() == nil {
+		t.Fatal("expected agent to be provisioned after successful second attempt")
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes bug where `s.enrolled` and related in-memory fields were mutated **before** `saveState()` was called in `StartProvisioning`
- If `saveState()` failed (disk full, bad permissions, etc.), the agent was permanently stuck reporting "already provisioned" on every subsequent retry until restarted
- Fix: build `provisioningState` from request/cert values first, persist it to disk, and only assign the values to `s.*` fields **after** the write succeeds
- Adds `TestStartProvisioning_SaveStateFailure` to prevent regression

Closes #697

## Test plan

- [ ] `go test ./internal/agent/services/ -run TestStartProvisioning_SaveStateFailure -v` passes
- [ ] `go test ./internal/agent/services/ -v` — all tests pass
- [ ] `go build ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)