### PR TITLE
fix: return error from NewTLSConfig when chainPEM is empty

### DIFF
--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -19,6 +19,10 @@ import (
 // ML-DSA (post-quantum) signed certificates are handled via a custom VerifyPeerCertificate
 // callback because Go's crypto/x509 does not natively support ML-DSA signature verification.
 func NewTLSConfig(certPEM, chainPEM, keyPEM string) (*tls.Config, error) {
+	if chainPEM == "" {
+		return nil, fmt.Errorf("chainPEM is required for client certificate verification")
+	}
+
 	// Only include the leaf cert in the TLS certificate — not the chain.
 	// Go's TLS library calls x509.ParseCertificate on every cert sent in the
 	// handshake, and ML-DSA chain certs (from pki-core) cause parse failures

--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -20,7 +20,7 @@ import (
 // callback because Go's crypto/x509 does not natively support ML-DSA signature verification.
 func NewTLSConfig(certPEM, chainPEM, keyPEM string) (*tls.Config, error) {
 	if chainPEM == "" {
-		return nil, fmt.Errorf("chainPEM is required for client certificate verification")
+		return nil, fmt.Errorf("CA chain PEM is required to verify client certificates; device may need to be re-provisioned")
 	}
 
 	// Only include the leaf cert in the TLS certificate — not the chain.
@@ -37,16 +37,13 @@ func NewTLSConfig(certPEM, chainPEM, keyPEM string) (*tls.Config, error) {
 	}
 
 	caPool := x509.NewCertPool()
-	var caCerts []*x509.Certificate
-	if chainPEM != "" {
-		caPool.AppendCertsFromPEM([]byte(chainPEM))
-		caCerts, err = parseCertsFromPEM([]byte(chainPEM))
-		if err != nil {
-			return nil, fmt.Errorf("parsing chain PEM: %w", err)
-		}
-		if len(caCerts) == 0 {
-			return nil, fmt.Errorf("parsing chain PEM: no certificates found")
-		}
+	caPool.AppendCertsFromPEM([]byte(chainPEM))
+	caCerts, err := parseCertsFromPEM([]byte(chainPEM))
+	if err != nil {
+		return nil, fmt.Errorf("parsing chain PEM: %w", err)
+	}
+	if len(caCerts) == 0 {
+		return nil, fmt.Errorf("parsing chain PEM: no certificates found")
 	}
 	caPool.AppendCertsFromPEM([]byte(certPEM))
 

--- a/go/internal/agent/mtls/server_test.go
+++ b/go/internal/agent/mtls/server_test.go
@@ -45,6 +45,15 @@ func testCertificate(t *testing.T, commonName string) (certPEM, keyPEM string) {
 	return certPEM, keyPEM
 }
 
+func TestNewTLSConfigEmptyChainReturnsError(t *testing.T) {
+	certPEM, keyPEM := testCertificate(t, "leaf")
+
+	_, err := NewTLSConfig(certPEM, "", keyPEM)
+	if err == nil {
+		t.Fatal("NewTLSConfig() expected error for empty chainPEM, got nil")
+	}
+}
+
 func TestNewTLSConfigServesOnlyLeafCertificate(t *testing.T) {
 	leafPEM, keyPEM := testCertificate(t, "leaf")
 	chainPEM, _ := testCertificate(t, "chain")

--- a/go/internal/agent/mtls/server_test.go
+++ b/go/internal/agent/mtls/server_test.go
@@ -12,7 +12,42 @@ import (
 	"time"
 )
 
-func testCertificate(t *testing.T, commonName string) (certPEM, keyPEM string) {
+// testLeafCertificate generates a proper leaf (end-entity) certificate for testing.
+func testLeafCertificate(t *testing.T, commonName string) (certPEM, keyPEM string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshaling key: %v", err)
+	}
+	keyPEM = string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+	return certPEM, keyPEM
+}
+
+// testCACertificate generates a self-signed CA certificate for testing.
+func testCACertificate(t *testing.T, commonName string) (certPEM, keyPEM string) {
 	t.Helper()
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -46,7 +81,7 @@ func testCertificate(t *testing.T, commonName string) (certPEM, keyPEM string) {
 }
 
 func TestNewTLSConfigEmptyChainReturnsError(t *testing.T) {
-	certPEM, keyPEM := testCertificate(t, "leaf")
+	certPEM, keyPEM := testLeafCertificate(t, "leaf")
 
 	_, err := NewTLSConfig(certPEM, "", keyPEM)
 	if err == nil {
@@ -55,8 +90,8 @@ func TestNewTLSConfigEmptyChainReturnsError(t *testing.T) {
 }
 
 func TestNewTLSConfigServesOnlyLeafCertificate(t *testing.T) {
-	leafPEM, keyPEM := testCertificate(t, "leaf")
-	chainPEM, _ := testCertificate(t, "chain")
+	leafPEM, keyPEM := testLeafCertificate(t, "leaf")
+	chainPEM, _ := testCACertificate(t, "chain")
 
 	tlsConfig, err := NewTLSConfig(leafPEM+"\n"+chainPEM, chainPEM, keyPEM)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `NewTLSConfig` previously proceeded without error when `chainPEM == ""`, resulting in a CA pool containing only the server's leaf certificate — not a real CA
- `VerifyPeerCertificate` would then reject every client cert with "x509: certificate signed by unknown authority", making mTLS silently broken
- This PR adds an early return error when `chainPEM == ""` so callers get a clear, actionable error instead of a TLS config that rejects all clients

Closes #692

## Test plan

- [x] New test `TestNewTLSConfigEmptyChainReturnsError` verifies that passing an empty `chainPEM` returns a non-nil error
- [x] Existing test `TestNewTLSConfigServesOnlyLeafCertificate` continues to pass
- [x] `go build ./...` compiles successfully
- [x] All mTLS package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)