### PR TITLE
fix: parse tls TXT record in Linux mDNS fallback discovery

### DIFF
--- a/go/internal/shared/discovery/discovery_linux.go
+++ b/go/internal/shared/discovery/discovery_linux.go
@@ -165,7 +165,8 @@ func avahiUnescape(s string) string {
 }
 
 // parseMDNSInfoFields parses hashicorp/mdns InfoFields (raw TXT records) into
-// a key→value map. This is used by the avahi-browse fallback path.
+// a key→value map. This is used by the hashicorp/mdns fallback path, which runs
+// when avahi-browse is unavailable.
 func parseMDNSInfoFields(fields []string) map[string]string {
 	records := make(map[string]string)
 	for _, txt := range fields {
@@ -225,6 +226,58 @@ func discoverLANMDNS(ctx context.Context, timeout time.Duration) ([]models.LANDe
 	return allDevices, nil
 }
 
+// lanDeviceFromMDNSEntry converts a hashicorp/mdns ServiceEntry into a
+// models.LANDevice. Returns false if the entry does not advertise the Wendy
+// service type. iface is used to scope IPv6 link-local addresses.
+func lanDeviceFromMDNSEntry(entry *mdns.ServiceEntry, iface *net.Interface) (models.LANDevice, bool) {
+	if entry == nil || !mdnsEntryMatchesServiceType(entry.Name, wendyServiceType) {
+		return models.LANDevice{}, false
+	}
+
+	hostname := strings.TrimSuffix(entry.Host, ".")
+
+	// Parse all TXT records into a map so we can read any key,
+	// including "tls" which determines whether mTLS is required.
+	txtRecords := parseMDNSInfoFields(entry.InfoFields)
+
+	displayName := strings.TrimSuffix(hostname, ".local")
+	if dn, ok := txtRecords["displayname"]; ok {
+		displayName = dn
+	}
+
+	ipAddr := ""
+	if entry.AddrV4 != nil {
+		ipAddr = entry.AddrV4.String()
+	} else if entry.AddrV6 != nil {
+		ipAddr = entry.AddrV6.String()
+		// IPv6 link-local addresses need a zone ID (%iface) to be routable.
+		if entry.AddrV6.IsLinkLocalUnicast() && iface != nil {
+			ipAddr = ipAddr + "%" + iface.Name
+		}
+	}
+
+	id := ""
+	if v, ok := txtRecords["wendyosdevice"]; ok {
+		id = v
+	} else if v, ok := txtRecords["id"]; ok {
+		id = v
+	}
+	if id == "" {
+		id = displayName
+	}
+
+	return models.LANDevice{
+		ID:            id,
+		DisplayName:   displayName,
+		Hostname:      hostname,
+		IPAddress:     ipAddr,
+		Port:          entry.Port,
+		IsMTLS:        txtRecords["tls"] == "true",
+		InterfaceType: string(models.InterfaceLAN),
+		IsWendyDevice: true,
+	}, true
+}
+
 // queryInterface runs a single mDNS query on a specific network interface.
 func queryInterface(ctx context.Context, iface *net.Interface, timeout time.Duration) []models.LANDevice {
 	entriesCh := make(chan *mdns.ServiceEntry, 16)
@@ -235,61 +288,19 @@ func queryInterface(ctx context.Context, iface *net.Interface, timeout time.Dura
 	go func() {
 		defer close(done)
 		for entry := range entriesCh {
-			// Filter out entries that don't match the queried service type.
-			// hashicorp/mdns can return unrelated mDNS responders (e.g. iPhones
-			// advertising _remotepairing._tcp).
-			if !mdnsEntryMatchesServiceType(entry.Name, wendyServiceType) {
+			dev, ok := lanDeviceFromMDNSEntry(entry, iface)
+			if !ok {
 				continue
 			}
 
 			hostname := strings.TrimSuffix(entry.Host, ".")
-
 			key := fmt.Sprintf("%s-%s-%d", entry.Name, hostname, entry.Port)
 			if seen[key] {
 				continue
 			}
 			seen[key] = true
 
-			// Parse all TXT records into a map so we can read any key,
-			// including "tls" which determines whether mTLS is required.
-			txtRecords := parseMDNSInfoFields(entry.InfoFields)
-
-			displayName := strings.TrimSuffix(hostname, ".local")
-			if dn, ok := txtRecords["displayname"]; ok {
-				displayName = dn
-			}
-
-			ipAddr := ""
-			if entry.AddrV4 != nil {
-				ipAddr = entry.AddrV4.String()
-			} else if entry.AddrV6 != nil {
-				ipAddr = entry.AddrV6.String()
-				// IPv6 link-local addresses need a zone ID (%iface) to be routable.
-				if entry.AddrV6.IsLinkLocalUnicast() {
-					ipAddr = ipAddr + "%" + iface.Name
-				}
-			}
-
-			id := ""
-			if v, ok := txtRecords["wendyosdevice"]; ok {
-				id = v
-			} else if v, ok := txtRecords["id"]; ok {
-				id = v
-			}
-			if id == "" {
-				id = displayName
-			}
-
-			devices = append(devices, models.LANDevice{
-				ID:            id,
-				DisplayName:   displayName,
-				Hostname:      hostname,
-				IPAddress:     ipAddr,
-				Port:          entry.Port,
-				IsMTLS:        txtRecords["tls"] == "true",
-				InterfaceType: string(models.InterfaceLAN),
-				IsWendyDevice: true,
-			})
+			devices = append(devices, dev)
 		}
 	}()
 

--- a/go/internal/shared/discovery/discovery_linux.go
+++ b/go/internal/shared/discovery/discovery_linux.go
@@ -164,6 +164,18 @@ func avahiUnescape(s string) string {
 	return b.String()
 }
 
+// parseMDNSInfoFields parses hashicorp/mdns InfoFields (raw TXT records) into
+// a key→value map. This is used by the avahi-browse fallback path.
+func parseMDNSInfoFields(fields []string) map[string]string {
+	records := make(map[string]string)
+	for _, txt := range fields {
+		if k, v, ok := strings.Cut(txt, "="); ok {
+			records[k] = v
+		}
+	}
+	return records
+}
+
 // parseAvahiTXT parses avahi's TXT record field.
 // Format: "key1=val1" "key2=val2" ...
 func parseAvahiTXT(field string) map[string]string {
@@ -238,7 +250,14 @@ func queryInterface(ctx context.Context, iface *net.Interface, timeout time.Dura
 			}
 			seen[key] = true
 
+			// Parse all TXT records into a map so we can read any key,
+			// including "tls" which determines whether mTLS is required.
+			txtRecords := parseMDNSInfoFields(entry.InfoFields)
+
 			displayName := strings.TrimSuffix(hostname, ".local")
+			if dn, ok := txtRecords["displayname"]; ok {
+				displayName = dn
+			}
 
 			ipAddr := ""
 			if entry.AddrV4 != nil {
@@ -252,10 +271,10 @@ func queryInterface(ctx context.Context, iface *net.Interface, timeout time.Dura
 			}
 
 			id := ""
-			for _, txt := range entry.InfoFields {
-				if k, v, ok := strings.Cut(txt, "="); ok && k == "id" {
-					id = v
-				}
+			if v, ok := txtRecords["wendyosdevice"]; ok {
+				id = v
+			} else if v, ok := txtRecords["id"]; ok {
+				id = v
 			}
 			if id == "" {
 				id = displayName
@@ -267,6 +286,7 @@ func queryInterface(ctx context.Context, iface *net.Interface, timeout time.Dura
 				Hostname:      hostname,
 				IPAddress:     ipAddr,
 				Port:          entry.Port,
+				IsMTLS:        txtRecords["tls"] == "true",
 				InterfaceType: string(models.InterfaceLAN),
 				IsWendyDevice: true,
 			})

--- a/go/internal/shared/discovery/discovery_linux_test.go
+++ b/go/internal/shared/discovery/discovery_linux_test.go
@@ -72,20 +72,31 @@ func TestParseAvahiTXT(t *testing.T) {
 
 func TestParseAvahiResolveLine(t *testing.T) {
 	tests := []struct {
-		name     string
-		line     string
-		wantOK   bool
-		wantID   string
-		wantIP   string
-		wantPort int
+		name       string
+		line       string
+		wantOK     bool
+		wantID     string
+		wantIP     string
+		wantPort   int
+		wantIsMTLS bool
 	}{
 		{
-			name:     "valid resolved line with link-local IPv6",
-			line:     `=;enp0s20f0u9;IPv6;WendyOS\032on\032wendyos-calm-zinnia;_wendyos._udp;local;wendyos-calm-zinnia.local;fe80::ffab:7cf6:ef:21c5;50051;"displayname=Calm Zinnia" "name=calm-zinnia" "wendyosdevice=769dc651-4eb2-49f3-b9f6-3e473f15694a" "id=WendyOS Device calm-zinnia"`,
-			wantOK:   true,
-			wantID:   "769dc651-4eb2-49f3-b9f6-3e473f15694a",
-			wantIP:   "fe80::ffab:7cf6:ef:21c5%enp0s20f0u9",
-			wantPort: 50051,
+			name:       "valid resolved line with link-local IPv6",
+			line:       `=;enp0s20f0u9;IPv6;WendyOS\032on\032wendyos-calm-zinnia;_wendyos._udp;local;wendyos-calm-zinnia.local;fe80::ffab:7cf6:ef:21c5;50051;"displayname=Calm Zinnia" "name=calm-zinnia" "wendyosdevice=769dc651-4eb2-49f3-b9f6-3e473f15694a" "id=WendyOS Device calm-zinnia"`,
+			wantOK:     true,
+			wantID:     "769dc651-4eb2-49f3-b9f6-3e473f15694a",
+			wantIP:     "fe80::ffab:7cf6:ef:21c5%enp0s20f0u9",
+			wantPort:   50051,
+			wantIsMTLS: false,
+		},
+		{
+			name:       "provisioned device with tls=true sets IsMTLS",
+			line:       `=;eth0;IPv4;WendyOS\032provisioned;_wendyos._udp;local;wendyos-prov.local;192.168.1.20;50052;"wendyosdevice=prov-uuid" "tls=true"`,
+			wantOK:     true,
+			wantID:     "prov-uuid",
+			wantIP:     "192.168.1.20",
+			wantPort:   50052,
+			wantIsMTLS: true,
 		},
 		{
 			name:     "global IPv6 does not get zone ID",
@@ -138,8 +149,67 @@ func TestParseAvahiResolveLine(t *testing.T) {
 			if dev.Port != tt.wantPort {
 				t.Fatalf("Port = %d, want %d", dev.Port, tt.wantPort)
 			}
+			if dev.IsMTLS != tt.wantIsMTLS {
+				t.Fatalf("IsMTLS = %v, want %v", dev.IsMTLS, tt.wantIsMTLS)
+			}
 			if !dev.IsWendyDevice {
 				t.Fatal("IsWendyDevice = false, want true")
+			}
+		})
+	}
+}
+
+// ── parseMDNSInfoFields ─────────────────────────────────────────────
+
+func TestParseMDNSInfoFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields []string
+		want   map[string]string
+	}{
+		{
+			name:   "empty",
+			fields: nil,
+			want:   map[string]string{},
+		},
+		{
+			name:   "no tls record",
+			fields: []string{"id=some-device", "name=my-device"},
+			want:   map[string]string{"id": "some-device", "name": "my-device"},
+		},
+		{
+			name:   "tls=true for provisioned device",
+			fields: []string{"wendyosdevice=prov-uuid", "tls=true"},
+			want:   map[string]string{"wendyosdevice": "prov-uuid", "tls": "true"},
+		},
+		{
+			name:   "tls=false is not treated as mTLS",
+			fields: []string{"wendyosdevice=some-uuid", "tls=false"},
+			want:   map[string]string{"wendyosdevice": "some-uuid", "tls": "false"},
+		},
+		{
+			name:   "entry without equals sign is skipped",
+			fields: []string{"noequals", "key=val"},
+			want:   map[string]string{"key": "val"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseMDNSInfoFields(tt.fields)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseMDNSInfoFields(%v) returned %d entries, want %d: got %v", tt.fields, len(got), len(tt.want), got)
+			}
+			for k, want := range tt.want {
+				if got[k] != want {
+					t.Fatalf("parseMDNSInfoFields()[%q] = %q, want %q", k, got[k], want)
+				}
+			}
+			// Verify tls→IsMTLS mapping works correctly.
+			isMTLS := got["tls"] == "true"
+			wantMTLS := tt.want["tls"] == "true"
+			if isMTLS != wantMTLS {
+				t.Fatalf("tls→IsMTLS = %v, want %v", isMTLS, wantMTLS)
 			}
 		})
 	}

--- a/go/internal/shared/discovery/discovery_linux_test.go
+++ b/go/internal/shared/discovery/discovery_linux_test.go
@@ -3,7 +3,11 @@
 package discovery
 
 import (
+	"net"
 	"testing"
+
+	"github.com/hashicorp/mdns"
+	"github.com/wendylabsinc/wendy/internal/shared/models"
 )
 
 // ── avahiUnescape ───────────────────────────────────────────────────
@@ -156,6 +160,91 @@ func TestParseAvahiResolveLine(t *testing.T) {
 				t.Fatal("IsWendyDevice = false, want true")
 			}
 		})
+	}
+}
+
+// ── lanDeviceFromMDNSEntry ──────────────────────────────────────────
+
+func TestLANDeviceFromMDNSEntrySetsMTLS(t *testing.T) {
+	entry := &mdns.ServiceEntry{
+		Name:       "wendyos-prov._wendyos._udp.local.",
+		Host:       "wendyos-prov.local.",
+		AddrV4:     net.ParseIP("192.168.1.20"),
+		Port:       50052,
+		InfoFields: []string{"wendyosdevice=prov-uuid", "tls=true"},
+	}
+
+	dev, ok := lanDeviceFromMDNSEntry(entry, nil)
+	if !ok {
+		t.Fatal("lanDeviceFromMDNSEntry returned false")
+	}
+	if !dev.IsMTLS {
+		t.Fatal("IsMTLS = false, want true for tls=true TXT record")
+	}
+	if dev.ID != "prov-uuid" {
+		t.Fatalf("ID = %q, want %q", dev.ID, "prov-uuid")
+	}
+	if dev.IPAddress != "192.168.1.20" {
+		t.Fatalf("IPAddress = %q, want %q", dev.IPAddress, "192.168.1.20")
+	}
+	if dev.Port != 50052 {
+		t.Fatalf("Port = %d, want %d", dev.Port, 50052)
+	}
+	if dev.InterfaceType != string(models.InterfaceLAN) {
+		t.Fatalf("InterfaceType = %q, want %q", dev.InterfaceType, models.InterfaceLAN)
+	}
+	if !dev.IsWendyDevice {
+		t.Fatal("IsWendyDevice = false, want true")
+	}
+}
+
+func TestLANDeviceFromMDNSEntryNoMTLSWithoutTLS(t *testing.T) {
+	entry := &mdns.ServiceEntry{
+		Name:       "wendyos-device._wendyos._udp.local.",
+		Host:       "wendyos-device.local.",
+		AddrV4:     net.ParseIP("192.168.1.10"),
+		Port:       50051,
+		InfoFields: []string{"wendyosdevice=some-uuid"},
+	}
+
+	dev, ok := lanDeviceFromMDNSEntry(entry, nil)
+	if !ok {
+		t.Fatal("lanDeviceFromMDNSEntry returned false")
+	}
+	if dev.IsMTLS {
+		t.Fatal("IsMTLS = true, want false when tls TXT record is absent")
+	}
+}
+
+func TestLANDeviceFromMDNSEntryAddsIPv6LinkLocalZone(t *testing.T) {
+	iface := &net.Interface{Name: "usb0"}
+	entry := &mdns.ServiceEntry{
+		Name:   "wendyos-device._wendyos._udp.local.",
+		Host:   "wendyos-device.local.",
+		AddrV6: net.ParseIP("fe80::1"),
+		Port:   50051,
+	}
+
+	dev, ok := lanDeviceFromMDNSEntry(entry, iface)
+	if !ok {
+		t.Fatal("lanDeviceFromMDNSEntry returned false")
+	}
+	want := "fe80::1%usb0"
+	if dev.IPAddress != want {
+		t.Fatalf("IPAddress = %q, want %q", dev.IPAddress, want)
+	}
+}
+
+func TestLANDeviceFromMDNSEntryFiltersWrongService(t *testing.T) {
+	entry := &mdns.ServiceEntry{
+		Name: "phone._remotepairing._tcp.local.",
+		Host: "phone.local.",
+		Port: 1234,
+	}
+
+	_, ok := lanDeviceFromMDNSEntry(entry, nil)
+	if ok {
+		t.Fatal("lanDeviceFromMDNSEntry returned true for wrong service type")
 	}
 }
 

--- a/go/internal/shared/discovery/mdns_linux.go
+++ b/go/internal/shared/discovery/mdns_linux.go
@@ -182,12 +182,7 @@ func queryInterfaceMDNS(_ context.Context, iface *net.Interface, serviceType str
 				}
 			}
 
-			txtRecords := make(map[string]string)
-			for _, txt := range entry.InfoFields {
-				if k, v, ok := strings.Cut(txt, "="); ok {
-					txtRecords[k] = v
-				}
-			}
+			txtRecords := parseMDNSInfoFields(entry.InfoFields)
 
 			services = append(services, MDNSService{
 				InstanceName: entry.Name,


### PR DESCRIPTION
## Summary

- The `queryInterface` fallback (used when `avahi-browse` is unavailable on Linux) only parsed the `id` TXT record and ignored all others, including `tls`.
- This caused `IsMTLS=false` for all provisioned devices, which advertise `tls=true` and listen on the mTLS port (50052). The CLI then tried the wrong port and all connections failed.
- Fix: introduce `parseMDNSInfoFields` to build a full key→value map from `entry.InfoFields` (mirroring `parseMDNSTXTRecords` on Windows), use it in `queryInterface`, and set `IsMTLS: txtRecords["tls"] == "true"`. Also bring `displayname` and `wendyosdevice` resolution in line with the avahi-browse primary path.

Fixes #698

## Test plan

- [ ] `go build ./...` passes with no new errors
- [ ] `go test ./internal/shared/discovery/ -v` passes
- [ ] New `TestParseMDNSInfoFields` tests verify TXT map parsing, including `tls=true` → `IsMTLS=true` and `tls=false` / absent → `IsMTLS=false`
- [ ] New `parseAvahiResolveLine` test case with `tls=true` confirms the primary avahi-browse path also sets `IsMTLS` correctly
- [ ] On a Linux machine without `avahi-browse`, running `wendy device list` with a provisioned device present now discovers it successfully via the mDNS fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)