### PR TITLE
fix: wire ContainerMonitor to ContainerService for restart policy support

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -55,7 +55,19 @@ type containerMonitorAdapter struct {
 }
 
 func (a *containerMonitorAdapter) Register(appName string, policy int, maxRetries int) {
-	a.m.Register(appName, container.RestartPolicy(policy), maxRetries)
+	var rp container.RestartPolicy
+	switch policy {
+	case services.RestartPolicyAlways:
+		rp = container.RestartAlways
+	case services.RestartPolicyUnlessStopped:
+		rp = container.RestartUnlessStopped
+	case services.RestartPolicyOnFailure:
+		rp = container.RestartOnFailure
+	default:
+		// Unknown or RestartPolicyNo — skip registration.
+		return
+	}
+	a.m.Register(appName, rp, maxRetries)
 }
 
 func (a *containerMonitorAdapter) Unregister(appName string) {

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -137,13 +137,21 @@ func main() {
 
 	logManager := services.NewContainerLogManager(logger, broadcaster)
 
-	// Start container monitor.
-	monitor := container.NewContainerMonitor(logger, containerdClient, 15*time.Second)
+	// Start container monitor only when containerd is available.
+	var monitor *container.ContainerMonitor
+	if containerdClient != nil {
+		monitor = container.NewContainerMonitor(logger, containerdClient, 15*time.Second)
+	}
 
 	agentSvc := services.NewAgentService(logger, networkMgr, hwDiscoverer, btManager)
-	containerSvc := services.NewContainerService(logger, containerdClient,
+	containerSvcOpts := []services.ContainerServiceOption{
 		services.WithLogManager(logManager),
-		services.WithMonitor(&containerMonitorAdapter{m: monitor}),
+	}
+	if monitor != nil {
+		containerSvcOpts = append(containerSvcOpts, services.WithMonitor(&containerMonitorAdapter{m: monitor}))
+	}
+	containerSvc := services.NewContainerService(logger, containerdClient,
+		containerSvcOpts...,
 	)
 	audioSvc := services.NewAudioService(logger)
 	videoSvc := services.NewVideoService(logger)
@@ -219,12 +227,14 @@ func main() {
 
 	var wg sync.WaitGroup
 
-	// Start container monitor in background.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		monitor.Run(ctx)
-	}()
+	// Start container monitor in background (only when containerd is available).
+	if monitor != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			monitor.Run(ctx)
+		}()
+	}
 
 	// Collect CPU/memory metrics for all running containers.
 	if containerdClient != nil {

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -45,6 +45,27 @@ const (
 	defaultOTELHTTPPort = "4318"
 )
 
+// containerMonitorAdapter wraps *container.ContainerMonitor so it satisfies
+// services.ContainerMonitorRegistrar without creating a circular import.
+// The services package cannot import the container package (container imports
+// services), so we use an adapter with plain-int policy values that mirror the
+// container.RestartPolicy iota.
+type containerMonitorAdapter struct {
+	m *container.ContainerMonitor
+}
+
+func (a *containerMonitorAdapter) Register(appName string, policy int, maxRetries int) {
+	a.m.Register(appName, container.RestartPolicy(policy), maxRetries)
+}
+
+func (a *containerMonitorAdapter) Unregister(appName string) {
+	a.m.Unregister(appName)
+}
+
+func (a *containerMonitorAdapter) MarkExplicitStop(appName string) {
+	a.m.MarkExplicitStop(appName)
+}
+
 func main() {
 	if handled, code := handleUtilityCommand(os.Args[1:]); handled {
 		os.Exit(code)
@@ -116,8 +137,14 @@ func main() {
 
 	logManager := services.NewContainerLogManager(logger, broadcaster)
 
+	// Start container monitor.
+	monitor := container.NewContainerMonitor(logger, containerdClient, 15*time.Second)
+
 	agentSvc := services.NewAgentService(logger, networkMgr, hwDiscoverer, btManager)
-	containerSvc := services.NewContainerService(logger, containerdClient, services.WithLogManager(logManager))
+	containerSvc := services.NewContainerService(logger, containerdClient,
+		services.WithLogManager(logManager),
+		services.WithMonitor(&containerMonitorAdapter{m: monitor}),
+	)
 	audioSvc := services.NewAudioService(logger)
 	videoSvc := services.NewVideoService(logger)
 
@@ -139,9 +166,6 @@ func main() {
 	otelLogReceiver := services.NewOTELLogsReceiver(broadcaster)
 	otelMetricReceiver := services.NewOTELMetricsReceiver(broadcaster)
 	otelTraceReceiver := services.NewOTELTraceReceiver(broadcaster)
-
-	// Start container monitor.
-	monitor := container.NewContainerMonitor(logger, containerdClient, 15*time.Second)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -66,6 +66,10 @@ func (a *containerMonitorAdapter) MarkExplicitStop(appName string) {
 	a.m.MarkExplicitStop(appName)
 }
 
+func (a *containerMonitorAdapter) ClearExplicitStop(appName string) {
+	a.m.ClearExplicitStop(appName)
+}
+
 func main() {
 	if handled, code := handleUtilityCommand(os.Args[1:]); handled {
 		os.Exit(code)

--- a/go/integration_test.go
+++ b/go/integration_test.go
@@ -208,6 +208,10 @@ func (s *statefulContainerdClient) GetContainerMCPPort(_ context.Context, _ stri
 	return 0, nil
 }
 
+func (m *statefulContainerdClient) GetContainerRestartPolicyLabel(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
 // getLayerData returns the data stored for a given digest, for test assertions.
 func (m *statefulContainerdClient) getLayerData(digest string) ([]byte, bool) {
 	m.mu.Lock()

--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -222,6 +222,10 @@ func (m *ContainerMonitor) shouldRestart(state *containerState) bool {
 	case RestartUnlessStopped:
 		return !state.ExplicitStop
 	case RestartOnFailure:
+		// The monitor detects only whether a container has stopped; it has no
+		// exit-code signal from containerd. Until exit-code detection is added,
+		// ON_FAILURE behaves like UNLESS_STOPPED: it restarts on any exit, not
+		// only non-zero ones. MaxRetries is still enforced.
 		if state.ExplicitStop {
 			return false
 		}

--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -123,6 +123,16 @@ func (m *ContainerMonitor) MarkExplicitStop(appName string) {
 	}
 }
 
+// ClearExplicitStop reverts a prior MarkExplicitStop, re-enabling automatic
+// restarts for the container. It is a no-op if appName is not registered.
+func (m *ContainerMonitor) ClearExplicitStop(appName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if state, ok := m.states[appName]; ok {
+		state.ExplicitStop = false
+	}
+}
+
 // Start begins the monitoring loop in a goroutine.
 func (m *ContainerMonitor) Start(ctx context.Context) {
 	go m.Run(ctx)

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1200,6 +1200,22 @@ func (c *Client) GetContainerMCPPort(ctx context.Context, appName string) (uint3
 	return uint32(p), nil
 }
 
+// GetContainerRestartPolicyLabel returns the raw restart policy label stored on
+// the container (e.g. "unless-stopped", "on-failure:5", "no"). An empty string
+// is returned when the container exists but has no restart policy label.
+func (c *Client) GetContainerRestartPolicyLabel(ctx context.Context, appName string) (string, error) {
+	ctx = c.withNamespace(ctx)
+	ctr, err := c.client.LoadContainer(ctx, appName)
+	if err != nil {
+		return "", fmt.Errorf("loading container %q: %w", appName, err)
+	}
+	info, err := ctr.Info(ctx)
+	if err != nil {
+		return "", fmt.Errorf("getting container info for %q: %w", appName, err)
+	}
+	return info.Labels[labelKeyRestartPolicy], nil
+}
+
 // GetContainerStats collects memory and image-size stats for all Wendy-managed containers.
 // Memory is read from cgroup metrics (only available for running tasks). Storage is the
 // image size from the content store. Both values are 0 if unavailable.

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -286,7 +286,7 @@ func monitorPolicyInt(rp *agentpb.RestartPolicy) (policy int, maxRetries int, ok
 		}
 		return RestartPolicyOnFailure, retries, true
 	default:
-		return RestartPolicyUnlessStopped, 0, true // default to unless-stopped
+		return 0, 0, false // unknown mode — treat as no policy
 	}
 }
 
@@ -559,14 +559,19 @@ func (s *ContainerService) StopContainer(ctx context.Context, req *agentpb.StopC
 
 // DeleteContainer deletes a container and optionally its image and volumes.
 func (s *ContainerService) DeleteContainer(ctx context.Context, req *agentpb.DeleteContainerRequest) (*agentpb.DeleteContainerResponse, error) {
-	if err := s.containerd.DeleteContainer(ctx, req.GetAppName(), req.GetDeleteImage()); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to delete container: %v", err)
+	// Unregister from the monitor BEFORE deletion to close the window where the
+	// monitor could attempt a restart while the container is being removed.
+	// MarkExplicitStop prevents a spurious restart attempt if the monitor fires
+	// between the two calls. Safe to call even if the app was never registered.
+	// If DeleteContainer subsequently fails, the container is left unregistered —
+	// that is acceptable: the caller will retry deletion.
+	if s.monitor != nil {
+		s.monitor.MarkExplicitStop(req.GetAppName())
+		s.monitor.Unregister(req.GetAppName())
 	}
 
-	// Unregister from the monitor to remove any stale restart entries.
-	// Safe to call even if the app was never registered.
-	if s.monitor != nil {
-		s.monitor.Unregister(req.GetAppName())
+	if err := s.containerd.DeleteContainer(ctx, req.GetAppName(), req.GetDeleteImage()); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete container: %v", err)
 	}
 
 	if req.GetDeleteVolumes() {

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -214,13 +215,7 @@ func (s *ContainerService) RunContainer(req *agentpb.RunContainerLayersRequest, 
 // StartContainer starts an existing container and streams output.
 func (s *ContainerService) StartContainer(req *agentpb.StartContainerRequest, stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse]) error {
 	appName := req.GetAppName()
-	err := s.streamContainerOutput(stream.Context(), appName, postStartAgentHookFromContext(stream.Context()), req.GetRestartPolicy(), stream)
-	if err == nil && s.monitor != nil {
-		// The container started successfully. If it was previously explicitly
-		// stopped, clear that mark so automatic restarts are re-enabled.
-		s.monitor.ClearExplicitStop(appName)
-	}
-	return err
+	return s.streamContainerOutput(stream.Context(), appName, postStartAgentHookFromContext(stream.Context()), req.GetRestartPolicy(), stream)
 }
 
 func postStartAgentHookFromContext(ctx context.Context) string {
@@ -238,32 +233,36 @@ func monitorPolicyIntFromLabel(label string) (policy int, maxRetries int, ok boo
 	if label == "" || label == "no" {
 		return RestartPolicyNo, 0, false
 	}
-	policyStr, retries := parseRestartPolicyLabel(label)
+	policyStr, retries, parseOK := parseRestartPolicyLabel(label)
+	if !parseOK {
+		return 0, 0, false
+	}
 	switch policyStr {
 	case "always":
 		return RestartPolicyAlways, 0, true
 	case "unless-stopped":
 		return RestartPolicyUnlessStopped, 0, true
 	case "on-failure":
-		if retries < 0 {
-			retries = 0
-		}
 		return RestartPolicyOnFailure, retries, true
 	default:
 		return 0, 0, false
 	}
 }
 
-// parseRestartPolicyLabel splits a label like "on-failure:5" into ("on-failure", 5).
-func parseRestartPolicyLabel(label string) (string, int) {
+// parseRestartPolicyLabel splits a label like "on-failure:5" into ("on-failure", 5, true).
+// Returns ok=false when the retry count portion cannot be parsed as a non-negative integer.
+func parseRestartPolicyLabel(label string) (policyStr string, retries int, ok bool) {
 	idx := strings.LastIndex(label, ":")
 	if idx < 0 {
-		return label, 0
+		return label, 0, true
 	}
 	policy := label[:idx]
-	var retries int
-	fmt.Sscanf(label[idx+1:], "%d", &retries)
-	return policy, retries
+	parts := strings.SplitN(label, ":", 2)
+	n, err := strconv.Atoi(parts[1])
+	if err != nil || n < 0 {
+		return "", 0, false
+	}
+	return policy, n, true
 }
 
 // monitorPolicyInt converts an agentpb.RestartPolicy to the integer constant
@@ -304,6 +303,15 @@ func (s *ContainerService) streamContainerOutput(
 	outputCh, err := s.containerd.StartContainer(ctx, appName, postStartAgentCommand, restartPolicy)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to start container: %v", err)
+	}
+
+	// The container started successfully. If it was previously explicitly
+	// stopped, clear that mark so automatic restarts are re-enabled.
+	// We clear it here (right after start succeeds) rather than after
+	// streaming completes so that stream errors (e.g. client disconnect)
+	// do not leave ExplicitStop set and suppress future automatic restarts.
+	if s.monitor != nil {
+		s.monitor.ClearExplicitStop(appName)
 	}
 
 	// Register the container with the monitor if a restart policy is in effect.

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -225,24 +225,27 @@ func postStartAgentHookFromContext(ctx context.Context) string {
 }
 
 // monitorPolicyInt converts an agentpb.RestartPolicy to the integer constant
-// used by ContainerMonitorRegistrar (which mirrors container.RestartPolicy):
-//
-//	0 = No, 1 = UnlessStopped, 2 = OnFailure, 3 = Always
+// used by ContainerMonitorRegistrar (which mirrors container.RestartPolicy).
+// Use the RestartPolicy* constants defined in interfaces.go.
 //
 // Returns ok=false when the policy should not be registered (nil or explicit NO).
 func monitorPolicyInt(rp *agentpb.RestartPolicy) (policy int, maxRetries int, ok bool) {
 	if rp == nil {
-		return 0, 0, false
+		return RestartPolicyNo, 0, false
 	}
 	switch rp.GetMode() {
 	case agentpb.RestartPolicyMode_NO:
-		return 0, 0, false
+		return RestartPolicyNo, 0, false
 	case agentpb.RestartPolicyMode_DEFAULT, agentpb.RestartPolicyMode_UNLESS_STOPPED:
-		return 1, 0, true // RestartUnlessStopped
+		return RestartPolicyUnlessStopped, 0, true
 	case agentpb.RestartPolicyMode_ON_FAILURE:
-		return 2, int(rp.GetOnFailureMaxRetries()), true // RestartOnFailure
+		retries := int(rp.GetOnFailureMaxRetries())
+		if retries < 0 {
+			retries = 0
+		}
+		return RestartPolicyOnFailure, retries, true
 	default:
-		return 1, 0, true // default to unless-stopped
+		return RestartPolicyUnlessStopped, 0, true // default to unless-stopped
 	}
 }
 

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -298,12 +298,13 @@ func (s *ContainerService) registerContainerWithMonitor(ctx context.Context, app
 	}
 	if policy, maxRetries, ok := monitorPolicyInt(restartPolicy); ok {
 		s.monitor.Register(appName, policy, maxRetries)
-	} else if restartPolicy != nil {
-		// restartPolicy is non-nil but monitorPolicyInt returned false,
-		// meaning the mode is explicitly NO — remove any existing entry.
+	} else if restartPolicy != nil && restartPolicy.GetMode() == agentpb.RestartPolicyMode_NO {
+		// Explicit NO — remove any existing registration.
 		s.monitor.Unregister(appName)
 	} else {
-		// restartPolicy is nil: look up the persisted label from containerd.
+		// nil restartPolicy or unrecognized/forward-compatible mode: fall back
+		// to the persisted label so we don't accidentally clear an existing
+		// registration when a newer client sends a mode this agent doesn't know.
 		if label, labelErr := s.containerd.GetContainerRestartPolicyLabel(ctx, appName); labelErr == nil {
 			if label == "" || label == "no" {
 				// No restart policy persisted — clear any stale registration.

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -290,6 +290,41 @@ func monitorPolicyInt(rp *agentpb.RestartPolicy) (policy int, maxRetries int, ok
 	}
 }
 
+// registerContainerWithMonitor registers appName with the monitor using the supplied
+// restart policy. When restartPolicy is nil the persisted containerd label is used.
+// This is factored out so that both streamContainerOutput and AttachContainer can
+// share the same registration logic without duplicating it.
+func (s *ContainerService) registerContainerWithMonitor(ctx context.Context, appName string, restartPolicy *agentpb.RestartPolicy) {
+	if s.monitor == nil {
+		return
+	}
+	if policy, maxRetries, ok := monitorPolicyInt(restartPolicy); ok {
+		s.monitor.Register(appName, policy, maxRetries)
+	} else if restartPolicy != nil {
+		// restartPolicy is non-nil but monitorPolicyInt returned false,
+		// meaning the mode is explicitly NO — remove any existing entry.
+		s.monitor.Unregister(appName)
+	} else {
+		// restartPolicy is nil: look up the persisted label from containerd.
+		if label, labelErr := s.containerd.GetContainerRestartPolicyLabel(ctx, appName); labelErr == nil {
+			if label == "" || label == "no" {
+				// No restart policy persisted — clear any stale registration.
+				s.monitor.Unregister(appName)
+			} else if policy, maxRetries, ok := monitorPolicyIntFromLabel(label); ok {
+				s.monitor.Register(appName, policy, maxRetries)
+			} else {
+				// Unknown label value — treat as no restart policy.
+				s.monitor.Unregister(appName)
+			}
+		} else {
+			s.logger.Warn("failed to read restart policy label; monitor registration skipped",
+				zap.String("app_name", appName),
+				zap.Error(labelErr),
+			)
+		}
+	}
+}
+
 // streamContainerOutput starts a container and streams its stdout/stderr to the client.
 // When a ContainerLogManager is configured, it reads from the log manager subscription
 // instead of directly from containerd, enabling multi-subscriber fan-out and telemetry bridging.
@@ -322,33 +357,7 @@ func (s *ContainerService) streamContainerOutput(
 	// registers the container correctly (e.g. after an agent restart or when the
 	// client does not re-supply the policy on start).
 	// Only unregister when the caller explicitly sets mode==NO.
-	if s.monitor != nil {
-		if policy, maxRetries, ok := monitorPolicyInt(restartPolicy); ok {
-			s.monitor.Register(appName, policy, maxRetries)
-		} else if restartPolicy != nil {
-			// restartPolicy is non-nil but monitorPolicyInt returned false,
-			// meaning the mode is explicitly NO — remove any existing entry.
-			s.monitor.Unregister(appName)
-		} else {
-			// restartPolicy is nil: look up the persisted label from containerd.
-			if label, labelErr := s.containerd.GetContainerRestartPolicyLabel(ctx, appName); labelErr == nil {
-				if label == "" || label == "no" {
-					// No restart policy persisted — clear any stale registration.
-					s.monitor.Unregister(appName)
-				} else if policy, maxRetries, ok := monitorPolicyIntFromLabel(label); ok {
-					s.monitor.Register(appName, policy, maxRetries)
-				} else {
-					// Unknown label value — treat as no restart policy.
-					s.monitor.Unregister(appName)
-				}
-			} else {
-				s.logger.Warn("failed to read restart policy label; monitor registration skipped",
-					zap.String("app_name", appName),
-					zap.Error(labelErr),
-				)
-			}
-		}
-	}
+	s.registerContainerWithMonitor(ctx, appName, restartPolicy)
 
 	// Send started notification.
 	if err := stream.Send(&agentpb.RunContainerLayersResponse{
@@ -459,6 +468,13 @@ func (s *ContainerService) AttachContainer(stream grpc.BidiStreamingServer[agent
 		stdinR.Close()
 		return status.Errorf(codes.Internal, "failed to start container: %v", err)
 	}
+
+	// Mirror the same monitor bookkeeping as streamContainerOutput: clear any
+	// prior explicit-stop mark and register with the persisted restart policy.
+	if s.monitor != nil {
+		s.monitor.ClearExplicitStop(appName)
+	}
+	s.registerContainerWithMonitor(ctx, appName, nil)
 
 	// Send started notification.
 	if err := stream.Send(&agentpb.RunContainerLayersResponse{

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -240,7 +240,9 @@ func monitorPolicyIntFromLabel(label string) (policy int, maxRetries int, ok boo
 	}
 	policyStr, retries := parseRestartPolicyLabel(label)
 	switch policyStr {
-	case "unless-stopped", "always":
+	case "always":
+		return RestartPolicyAlways, 0, true
+	case "unless-stopped":
 		return RestartPolicyUnlessStopped, 0, true
 	case "on-failure":
 		if retries < 0 {
@@ -248,7 +250,7 @@ func monitorPolicyIntFromLabel(label string) (policy int, maxRetries int, ok boo
 		}
 		return RestartPolicyOnFailure, retries, true
 	default:
-		return RestartPolicyUnlessStopped, 0, true
+		return 0, 0, false
 	}
 }
 
@@ -322,8 +324,14 @@ func (s *ContainerService) streamContainerOutput(
 		} else {
 			// restartPolicy is nil: look up the persisted label from containerd.
 			if label, labelErr := s.containerd.GetContainerRestartPolicyLabel(ctx, appName); labelErr == nil {
-				if policy, maxRetries, ok := monitorPolicyIntFromLabel(label); ok {
+				if label == "" || label == "no" {
+					// No restart policy persisted — clear any stale registration.
+					s.monitor.Unregister(appName)
+				} else if policy, maxRetries, ok := monitorPolicyIntFromLabel(label); ok {
 					s.monitor.Register(appName, policy, maxRetries)
+				} else {
+					// Unknown label value — treat as no restart policy.
+					s.monitor.Unregister(appName)
 				}
 			} else {
 				s.logger.Warn("failed to read restart policy label; monitor registration skipped",

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -252,17 +252,15 @@ func monitorPolicyIntFromLabel(label string) (policy int, maxRetries int, ok boo
 // parseRestartPolicyLabel splits a label like "on-failure:5" into ("on-failure", 5, true).
 // Returns ok=false when the retry count portion cannot be parsed as a non-negative integer.
 func parseRestartPolicyLabel(label string) (policyStr string, retries int, ok bool) {
-	idx := strings.LastIndex(label, ":")
-	if idx < 0 {
+	parts := strings.SplitN(label, ":", 2)
+	if len(parts) == 1 {
 		return label, 0, true
 	}
-	policy := label[:idx]
-	parts := strings.SplitN(label, ":", 2)
 	n, err := strconv.Atoi(parts[1])
 	if err != nil || n < 0 {
 		return "", 0, false
 	}
-	return policy, n, true
+	return parts[0], n, true
 }
 
 // monitorPolicyInt converts an agentpb.RestartPolicy to the integer constant

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -265,9 +265,13 @@ func (s *ContainerService) streamContainerOutput(
 	}
 
 	// Register the container with the monitor if a restart policy is in effect.
+	// If the policy is nil or explicitly NO, unregister to clear any previous
+	// registration that may have been set by a prior start.
 	if s.monitor != nil {
 		if policy, maxRetries, ok := monitorPolicyInt(restartPolicy); ok {
 			s.monitor.Register(appName, policy, maxRetries)
+		} else {
+			s.monitor.Unregister(appName)
 		}
 	}
 
@@ -443,13 +447,13 @@ func (s *ContainerService) AttachContainer(stream grpc.BidiStreamingServer[agent
 
 // StopContainer stops a running container.
 func (s *ContainerService) StopContainer(ctx context.Context, req *agentpb.StopContainerRequest) (*agentpb.StopContainerResponse, error) {
-	// Mark the container as explicitly stopped before calling containerd so the
-	// monitor does not race to restart it.
-	if s.monitor != nil {
-		s.monitor.MarkExplicitStop(req.GetAppName())
-	}
 	if err := s.containerd.StopContainer(ctx, req.GetAppName()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to stop container: %v", err)
+	}
+	// Mark the container as explicitly stopped only after a successful stop so
+	// that a failed stop does not prevent future restarts.
+	if s.monitor != nil {
+		s.monitor.MarkExplicitStop(req.GetAppName())
 	}
 	s.logger.Info("Container stopped", zap.String("app_name", req.GetAppName()))
 	return &agentpb.StopContainerResponse{}, nil
@@ -459,6 +463,12 @@ func (s *ContainerService) StopContainer(ctx context.Context, req *agentpb.StopC
 func (s *ContainerService) DeleteContainer(ctx context.Context, req *agentpb.DeleteContainerRequest) (*agentpb.DeleteContainerResponse, error) {
 	if err := s.containerd.DeleteContainer(ctx, req.GetAppName(), req.GetDeleteImage()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete container: %v", err)
+	}
+
+	// Unregister from the monitor to remove any stale restart entries.
+	// Safe to call even if the app was never registered.
+	if s.monitor != nil {
+		s.monitor.Unregister(req.GetAppName())
 	}
 
 	if req.GetDeleteVolumes() {

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -265,14 +265,18 @@ func (s *ContainerService) streamContainerOutput(
 	}
 
 	// Register the container with the monitor if a restart policy is in effect.
-	// If the policy is nil or explicitly NO, unregister to clear any previous
-	// registration that may have been set by a prior start.
+	// If the policy is nil, leave the existing monitor state unchanged — many
+	// callers omit restart_policy and we must not clear a prior registration.
+	// Only unregister when the caller explicitly sets mode==NO.
 	if s.monitor != nil {
 		if policy, maxRetries, ok := monitorPolicyInt(restartPolicy); ok {
 			s.monitor.Register(appName, policy, maxRetries)
-		} else {
+		} else if restartPolicy != nil {
+			// restartPolicy is non-nil but monitorPolicyInt returned false,
+			// meaning the mode is explicitly NO — remove any existing entry.
 			s.monitor.Unregister(appName)
 		}
+		// nil restartPolicy: leave existing registration unchanged.
 	}
 
 	// Send started notification.
@@ -447,15 +451,22 @@ func (s *ContainerService) AttachContainer(stream grpc.BidiStreamingServer[agent
 
 // StopContainer stops a running container.
 func (s *ContainerService) StopContainer(ctx context.Context, req *agentpb.StopContainerRequest) (*agentpb.StopContainerResponse, error) {
-	if err := s.containerd.StopContainer(ctx, req.GetAppName()); err != nil {
+	appName := req.GetAppName()
+	// Mark the container as explicitly stopped BEFORE issuing the stop so that
+	// the monitor cannot observe the container exit and restart it in the window
+	// between StopContainer returning and MarkExplicitStop being called.
+	// If the stop fails we revert the mark via ClearExplicitStop.
+	if s.monitor != nil {
+		s.monitor.MarkExplicitStop(appName)
+	}
+	if err := s.containerd.StopContainer(ctx, appName); err != nil {
+		// Revert the explicit-stop mark so future restarts are not suppressed.
+		if s.monitor != nil {
+			s.monitor.ClearExplicitStop(appName)
+		}
 		return nil, status.Errorf(codes.Internal, "failed to stop container: %v", err)
 	}
-	// Mark the container as explicitly stopped only after a successful stop so
-	// that a failed stop does not prevent future restarts.
-	if s.monitor != nil {
-		s.monitor.MarkExplicitStop(req.GetAppName())
-	}
-	s.logger.Info("Container stopped", zap.String("app_name", req.GetAppName()))
+	s.logger.Info("Container stopped", zap.String("app_name", appName))
 	return &agentpb.StopContainerResponse{}, nil
 }
 

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -229,7 +229,7 @@ func postStartAgentHookFromContext(ctx context.Context) string {
 //
 //	0 = No, 1 = UnlessStopped, 2 = OnFailure, 3 = Always
 //
-// Returns -1 when the policy should not be registered (nil or explicit NO).
+// Returns ok=false when the policy should not be registered (nil or explicit NO).
 func monitorPolicyInt(rp *agentpb.RestartPolicy) (policy int, maxRetries int, ok bool) {
 	if rp == nil {
 		return 0, 0, false

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -27,6 +27,7 @@ type ContainerService struct {
 	logger     *zap.Logger
 	containerd ContainerdClient
 	logManager *ContainerLogManager
+	monitor    ContainerMonitorRegistrar
 }
 
 // NewContainerService creates a new ContainerService.
@@ -48,6 +49,15 @@ type ContainerServiceOption func(*ContainerService)
 func WithLogManager(lm *ContainerLogManager) ContainerServiceOption {
 	return func(s *ContainerService) {
 		s.logManager = lm
+	}
+}
+
+// WithMonitor sets the ContainerMonitorRegistrar on the ContainerService so
+// that containers started with a restart policy are registered for automatic
+// restart monitoring.
+func WithMonitor(m ContainerMonitorRegistrar) ContainerServiceOption {
+	return func(s *ContainerService) {
+		s.monitor = m
 	}
 }
 
@@ -214,6 +224,28 @@ func postStartAgentHookFromContext(ctx context.Context) string {
 	return values[len(values)-1]
 }
 
+// monitorPolicyInt converts an agentpb.RestartPolicy to the integer constant
+// used by ContainerMonitorRegistrar (which mirrors container.RestartPolicy):
+//
+//	0 = No, 1 = UnlessStopped, 2 = OnFailure, 3 = Always
+//
+// Returns -1 when the policy should not be registered (nil or explicit NO).
+func monitorPolicyInt(rp *agentpb.RestartPolicy) (policy int, maxRetries int, ok bool) {
+	if rp == nil {
+		return 0, 0, false
+	}
+	switch rp.GetMode() {
+	case agentpb.RestartPolicyMode_NO:
+		return 0, 0, false
+	case agentpb.RestartPolicyMode_DEFAULT, agentpb.RestartPolicyMode_UNLESS_STOPPED:
+		return 1, 0, true // RestartUnlessStopped
+	case agentpb.RestartPolicyMode_ON_FAILURE:
+		return 2, int(rp.GetOnFailureMaxRetries()), true // RestartOnFailure
+	default:
+		return 1, 0, true // default to unless-stopped
+	}
+}
+
 // streamContainerOutput starts a container and streams its stdout/stderr to the client.
 // When a ContainerLogManager is configured, it reads from the log manager subscription
 // instead of directly from containerd, enabling multi-subscriber fan-out and telemetry bridging.
@@ -227,6 +259,13 @@ func (s *ContainerService) streamContainerOutput(
 	outputCh, err := s.containerd.StartContainer(ctx, appName, postStartAgentCommand, restartPolicy)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to start container: %v", err)
+	}
+
+	// Register the container with the monitor if a restart policy is in effect.
+	if s.monitor != nil {
+		if policy, maxRetries, ok := monitorPolicyInt(restartPolicy); ok {
+			s.monitor.Register(appName, policy, maxRetries)
+		}
 	}
 
 	// Send started notification.
@@ -401,6 +440,11 @@ func (s *ContainerService) AttachContainer(stream grpc.BidiStreamingServer[agent
 
 // StopContainer stops a running container.
 func (s *ContainerService) StopContainer(ctx context.Context, req *agentpb.StopContainerRequest) (*agentpb.StopContainerResponse, error) {
+	// Mark the container as explicitly stopped before calling containerd so the
+	// monitor does not race to restart it.
+	if s.monitor != nil {
+		s.monitor.MarkExplicitStop(req.GetAppName())
+	}
 	if err := s.containerd.StopContainer(ctx, req.GetAppName()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to stop container: %v", err)
 	}

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -213,7 +213,14 @@ func (s *ContainerService) RunContainer(req *agentpb.RunContainerLayersRequest, 
 
 // StartContainer starts an existing container and streams output.
 func (s *ContainerService) StartContainer(req *agentpb.StartContainerRequest, stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse]) error {
-	return s.streamContainerOutput(stream.Context(), req.GetAppName(), postStartAgentHookFromContext(stream.Context()), req.GetRestartPolicy(), stream)
+	appName := req.GetAppName()
+	err := s.streamContainerOutput(stream.Context(), appName, postStartAgentHookFromContext(stream.Context()), req.GetRestartPolicy(), stream)
+	if err == nil && s.monitor != nil {
+		// The container started successfully. If it was previously explicitly
+		// stopped, clear that mark so automatic restarts are re-enabled.
+		s.monitor.ClearExplicitStop(appName)
+	}
+	return err
 }
 
 func postStartAgentHookFromContext(ctx context.Context) string {
@@ -222,6 +229,39 @@ func postStartAgentHookFromContext(ctx context.Context) string {
 		return ""
 	}
 	return values[len(values)-1]
+}
+
+// monitorPolicyIntFromLabel converts a raw restart policy label string (e.g.
+// "unless-stopped", "on-failure:5", "no") to the integer constants used by
+// ContainerMonitorRegistrar. Returns ok=false for an empty or "no" label.
+func monitorPolicyIntFromLabel(label string) (policy int, maxRetries int, ok bool) {
+	if label == "" || label == "no" {
+		return RestartPolicyNo, 0, false
+	}
+	policyStr, retries := parseRestartPolicyLabel(label)
+	switch policyStr {
+	case "unless-stopped", "always":
+		return RestartPolicyUnlessStopped, 0, true
+	case "on-failure":
+		if retries < 0 {
+			retries = 0
+		}
+		return RestartPolicyOnFailure, retries, true
+	default:
+		return RestartPolicyUnlessStopped, 0, true
+	}
+}
+
+// parseRestartPolicyLabel splits a label like "on-failure:5" into ("on-failure", 5).
+func parseRestartPolicyLabel(label string) (string, int) {
+	idx := strings.LastIndex(label, ":")
+	if idx < 0 {
+		return label, 0
+	}
+	policy := label[:idx]
+	var retries int
+	fmt.Sscanf(label[idx+1:], "%d", &retries)
+	return policy, retries
 }
 
 // monitorPolicyInt converts an agentpb.RestartPolicy to the integer constant
@@ -265,8 +305,12 @@ func (s *ContainerService) streamContainerOutput(
 	}
 
 	// Register the container with the monitor if a restart policy is in effect.
-	// If the policy is nil, leave the existing monitor state unchanged — many
-	// callers omit restart_policy and we must not clear a prior registration.
+	//
+	// When the caller provides an explicit restart policy, use it directly.
+	// When the caller omits it (nil), look up the policy persisted as a containerd
+	// label during CreateContainer so that a plain StartContainer call still
+	// registers the container correctly (e.g. after an agent restart or when the
+	// client does not re-supply the policy on start).
 	// Only unregister when the caller explicitly sets mode==NO.
 	if s.monitor != nil {
 		if policy, maxRetries, ok := monitorPolicyInt(restartPolicy); ok {
@@ -275,8 +319,19 @@ func (s *ContainerService) streamContainerOutput(
 			// restartPolicy is non-nil but monitorPolicyInt returned false,
 			// meaning the mode is explicitly NO — remove any existing entry.
 			s.monitor.Unregister(appName)
+		} else {
+			// restartPolicy is nil: look up the persisted label from containerd.
+			if label, labelErr := s.containerd.GetContainerRestartPolicyLabel(ctx, appName); labelErr == nil {
+				if policy, maxRetries, ok := monitorPolicyIntFromLabel(label); ok {
+					s.monitor.Register(appName, policy, maxRetries)
+				}
+			} else {
+				s.logger.Warn("failed to read restart policy label; monitor registration skipped",
+					zap.String("app_name", appName),
+					zap.Error(labelErr),
+				)
+			}
 		}
-		// nil restartPolicy: leave existing registration unchanged.
 	}
 
 	// Send started notification.

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -473,6 +473,147 @@ func TestAttachContainer(t *testing.T) {
 	}
 }
 
+// ---------- mock monitor registrar ----------
+
+type mockMonitorRegistrar struct {
+	registerCalls     []registerCall
+	explicitStopCalls []string
+}
+
+type registerCall struct {
+	appName    string
+	policy     int
+	maxRetries int
+}
+
+func (m *mockMonitorRegistrar) Register(appName string, policy int, maxRetries int) {
+	m.registerCalls = append(m.registerCalls, registerCall{appName, policy, maxRetries})
+}
+
+func (m *mockMonitorRegistrar) Unregister(_ string) {}
+
+func (m *mockMonitorRegistrar) MarkExplicitStop(appName string) {
+	m.explicitStopCalls = append(m.explicitStopCalls, appName)
+}
+
+// startContainerServerWithMonitor starts a gRPC bufconn server for ContainerService
+// configured with the given ContainerdClient and ContainerMonitorRegistrar.
+func startContainerServerWithMonitor(t *testing.T, client ContainerdClient, mon ContainerMonitorRegistrar) (agentpb.WendyContainerServiceClient, func()) {
+	t.Helper()
+	lis := bufconn.Listen(bufSize)
+	srv := grpc.NewServer()
+	logger := zap.NewNop()
+	svc := NewContainerService(logger, client, WithMonitor(mon))
+	agentpb.RegisterWendyContainerServiceServer(srv, svc)
+
+	go func() { _ = srv.Serve(lis) }()
+
+	dialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+
+	cl := agentpb.NewWendyContainerServiceClient(conn)
+	cleanup := func() {
+		conn.Close()
+		srv.Stop()
+		lis.Close()
+	}
+	return cl, cleanup
+}
+
+// TestStartContainer_RegistersMonitor_UnlessStopped verifies that starting a
+// container with an UNLESS_STOPPED restart policy calls Register on the monitor.
+func TestStartContainer_RegistersMonitor_UnlessStopped(t *testing.T) {
+	outputCh := make(chan ContainerOutput, 1)
+	outputCh <- ContainerOutput{Done: true}
+	close(outputCh)
+
+	mc := &mockContainerdClient{startOutputCh: outputCh}
+	mon := &mockMonitorRegistrar{}
+	client, cleanup := startContainerServerWithMonitor(t, mc, mon)
+	defer cleanup()
+
+	stream, err := client.StartContainer(context.Background(), &agentpb.StartContainerRequest{
+		AppName: "my-app",
+		RestartPolicy: &agentpb.RestartPolicy{
+			Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED,
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartContainer: %v", err)
+	}
+	// Drain the stream.
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	if len(mon.registerCalls) != 1 {
+		t.Fatalf("Register call count = %d; want 1", len(mon.registerCalls))
+	}
+	got := mon.registerCalls[0]
+	if got.appName != "my-app" {
+		t.Errorf("Register appName = %q; want my-app", got.appName)
+	}
+	if got.policy != RestartPolicyUnlessStopped {
+		t.Errorf("Register policy = %d; want %d (UnlessStopped)", got.policy, RestartPolicyUnlessStopped)
+	}
+}
+
+// TestStopContainer_CallsMarkExplicitStop verifies that StopContainer calls
+// MarkExplicitStop on the monitor before stopping the container.
+func TestStopContainer_CallsMarkExplicitStop(t *testing.T) {
+	mc := &mockContainerdClient{}
+	mon := &mockMonitorRegistrar{}
+	client, cleanup := startContainerServerWithMonitor(t, mc, mon)
+	defer cleanup()
+
+	_, err := client.StopContainer(context.Background(), &agentpb.StopContainerRequest{
+		AppName: "my-app",
+	})
+	if err != nil {
+		t.Fatalf("StopContainer: %v", err)
+	}
+
+	if len(mon.explicitStopCalls) != 1 {
+		t.Fatalf("MarkExplicitStop call count = %d; want 1", len(mon.explicitStopCalls))
+	}
+	if mon.explicitStopCalls[0] != "my-app" {
+		t.Errorf("MarkExplicitStop appName = %q; want my-app", mon.explicitStopCalls[0])
+	}
+}
+
+// TestMonitorPolicyInt_NegativeRetries verifies that a negative OnFailureMaxRetries
+// value is clamped to zero and does not result in a negative maxRetries.
+func TestMonitorPolicyInt_NegativeRetries(t *testing.T) {
+	rp := &agentpb.RestartPolicy{
+		Mode:                agentpb.RestartPolicyMode_ON_FAILURE,
+		OnFailureMaxRetries: -5,
+	}
+	policy, maxRetries, ok := monitorPolicyInt(rp)
+	if !ok {
+		t.Fatal("monitorPolicyInt ok = false; want true")
+	}
+	if policy != RestartPolicyOnFailure {
+		t.Errorf("policy = %d; want %d (OnFailure)", policy, RestartPolicyOnFailure)
+	}
+	if maxRetries != 0 {
+		t.Errorf("maxRetries = %d; want 0 (clamped from -5)", maxRetries)
+	}
+}
+
 // ---------- volume tests ----------
 
 func TestListVolumes_Empty(t *testing.T) {

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -722,6 +722,8 @@ func TestMonitorPolicyIntFromLabel(t *testing.T) {
 		{"always", RestartPolicyAlways, true, 0},
 		{"on-failure", RestartPolicyOnFailure, true, 0},
 		{"on-failure:3", RestartPolicyOnFailure, true, 3},
+		{"on-failure:foo", 0, false, 0},
+		{"on-failure:-1", 0, false, 0},
 		{"unknown-policy", 0, false, 0},
 	}
 	for _, tc := range cases {

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -24,24 +24,24 @@ import (
 // ---------- mock containerd client ----------
 
 type mockContainerdClient struct {
-	containers          []*agentpb.AppContainer
-	listErr             error
-	stopErr             error
-	deleteErr           error
-	layers              []*agentpb.LayerHeader
-	listLayersErr       error
-	writeLayerErr       error
-	writtenDigest       string
-	writtenData         []byte
-	createErr           error
-	progressPhases      []agentpb.CreateContainerProgress_Phase
-	startOutputCh       chan ContainerOutput
-	startErr            error
-	statsResult         []*agentpb.ContainerStats
-	statsErr            error
-	mcpPort             uint32
-	mcpPortErr          error
-	restartPolicyLabel  string
+	containers            []*agentpb.AppContainer
+	listErr               error
+	stopErr               error
+	deleteErr             error
+	layers                []*agentpb.LayerHeader
+	listLayersErr         error
+	writeLayerErr         error
+	writtenDigest         string
+	writtenData           []byte
+	createErr             error
+	progressPhases        []agentpb.CreateContainerProgress_Phase
+	startOutputCh         chan ContainerOutput
+	startErr              error
+	statsResult           []*agentpb.ContainerStats
+	statsErr              error
+	mcpPort               uint32
+	mcpPortErr            error
+	restartPolicyLabel    string
 	restartPolicyLabelErr error
 }
 
@@ -482,9 +482,9 @@ func TestAttachContainer(t *testing.T) {
 // ---------- mock monitor registrar ----------
 
 type mockMonitorRegistrar struct {
-	registerCalls      []registerCall
-	explicitStopCalls  []string
-	clearStopCalls     []string
+	registerCalls     []registerCall
+	explicitStopCalls []string
+	clearStopCalls    []string
 }
 
 type registerCall struct {
@@ -711,9 +711,9 @@ func TestStartContainer_ClearsExplicitStop(t *testing.T) {
 // TestMonitorPolicyIntFromLabel covers the label-based policy parser.
 func TestMonitorPolicyIntFromLabel(t *testing.T) {
 	cases := []struct {
-		label      string
-		wantPolicy int
-		wantOK     bool
+		label       string
+		wantPolicy  int
+		wantOK      bool
 		wantRetries int
 	}{
 		{"", RestartPolicyNo, false, 0},

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -719,9 +719,10 @@ func TestMonitorPolicyIntFromLabel(t *testing.T) {
 		{"", RestartPolicyNo, false, 0},
 		{"no", RestartPolicyNo, false, 0},
 		{"unless-stopped", RestartPolicyUnlessStopped, true, 0},
-		{"always", RestartPolicyUnlessStopped, true, 0},
+		{"always", RestartPolicyAlways, true, 0},
 		{"on-failure", RestartPolicyOnFailure, true, 0},
 		{"on-failure:3", RestartPolicyOnFailure, true, 3},
+		{"unknown-policy", 0, false, 0},
 	}
 	for _, tc := range cases {
 		policy, maxRetries, ok := monitorPolicyIntFromLabel(tc.label)

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -476,8 +476,9 @@ func TestAttachContainer(t *testing.T) {
 // ---------- mock monitor registrar ----------
 
 type mockMonitorRegistrar struct {
-	registerCalls     []registerCall
-	explicitStopCalls []string
+	registerCalls      []registerCall
+	explicitStopCalls  []string
+	clearStopCalls     []string
 }
 
 type registerCall struct {
@@ -494,6 +495,10 @@ func (m *mockMonitorRegistrar) Unregister(_ string) {}
 
 func (m *mockMonitorRegistrar) MarkExplicitStop(appName string) {
 	m.explicitStopCalls = append(m.explicitStopCalls, appName)
+}
+
+func (m *mockMonitorRegistrar) ClearExplicitStop(appName string) {
+	m.clearStopCalls = append(m.clearStopCalls, appName)
 }
 
 // startContainerServerWithMonitor starts a gRPC bufconn server for ContainerService

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -556,7 +556,7 @@ func TestStartContainer_RegistersMonitor_UnlessStopped(t *testing.T) {
 			break
 		}
 		if err != nil {
-			break
+			t.Fatalf("unexpected recv error: %v", err)
 		}
 	}
 

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -24,23 +24,25 @@ import (
 // ---------- mock containerd client ----------
 
 type mockContainerdClient struct {
-	containers     []*agentpb.AppContainer
-	listErr        error
-	stopErr        error
-	deleteErr      error
-	layers         []*agentpb.LayerHeader
-	listLayersErr  error
-	writeLayerErr  error
-	writtenDigest  string
-	writtenData    []byte
-	createErr      error
-	progressPhases []agentpb.CreateContainerProgress_Phase
-	startOutputCh  chan ContainerOutput
-	startErr       error
-	statsResult    []*agentpb.ContainerStats
-	statsErr       error
-	mcpPort        uint32
-	mcpPortErr     error
+	containers          []*agentpb.AppContainer
+	listErr             error
+	stopErr             error
+	deleteErr           error
+	layers              []*agentpb.LayerHeader
+	listLayersErr       error
+	writeLayerErr       error
+	writtenDigest       string
+	writtenData         []byte
+	createErr           error
+	progressPhases      []agentpb.CreateContainerProgress_Phase
+	startOutputCh       chan ContainerOutput
+	startErr            error
+	statsResult         []*agentpb.ContainerStats
+	statsErr            error
+	mcpPort             uint32
+	mcpPortErr          error
+	restartPolicyLabel  string
+	restartPolicyLabelErr error
 }
 
 func (m *mockContainerdClient) ListContainers(_ context.Context) ([]*agentpb.AppContainer, error) {
@@ -101,6 +103,10 @@ func (m *mockContainerdClient) GetContainerMetrics(_ context.Context, _ string) 
 
 func (m *mockContainerdClient) GetContainerMCPPort(_ context.Context, _ string) (uint32, error) {
 	return m.mcpPort, m.mcpPortErr
+}
+
+func (m *mockContainerdClient) GetContainerRestartPolicyLabel(_ context.Context, _ string) (string, error) {
+	return m.restartPolicyLabel, m.restartPolicyLabelErr
 }
 
 // attachTestMock embeds mockContainerdClient and overrides StartContainerWithStdin
@@ -616,6 +622,118 @@ func TestMonitorPolicyInt_NegativeRetries(t *testing.T) {
 	}
 	if maxRetries != 0 {
 		t.Errorf("maxRetries = %d; want 0 (clamped from -5)", maxRetries)
+	}
+}
+
+// TestStartContainer_RegistersMonitor_FromPersistedLabel verifies that when
+// StartContainer is called without a restart policy, the service reads the
+// persisted policy label from containerd and still registers with the monitor.
+func TestStartContainer_RegistersMonitor_FromPersistedLabel(t *testing.T) {
+	outputCh := make(chan ContainerOutput, 1)
+	outputCh <- ContainerOutput{Done: true}
+	close(outputCh)
+
+	mc := &mockContainerdClient{
+		startOutputCh:      outputCh,
+		restartPolicyLabel: "unless-stopped",
+	}
+	mon := &mockMonitorRegistrar{}
+	client, cleanup := startContainerServerWithMonitor(t, mc, mon)
+	defer cleanup()
+
+	// StartContainer with no restart policy — should fall back to the label.
+	stream, err := client.StartContainer(context.Background(), &agentpb.StartContainerRequest{
+		AppName: "my-app",
+		// RestartPolicy intentionally omitted.
+	})
+	if err != nil {
+		t.Fatalf("StartContainer: %v", err)
+	}
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected recv error: %v", err)
+		}
+	}
+
+	if len(mon.registerCalls) != 1 {
+		t.Fatalf("Register call count = %d; want 1 (from persisted label)", len(mon.registerCalls))
+	}
+	got := mon.registerCalls[0]
+	if got.appName != "my-app" {
+		t.Errorf("Register appName = %q; want my-app", got.appName)
+	}
+	if got.policy != RestartPolicyUnlessStopped {
+		t.Errorf("Register policy = %d; want %d (UnlessStopped)", got.policy, RestartPolicyUnlessStopped)
+	}
+}
+
+// TestStartContainer_ClearsExplicitStop verifies that a successful StartContainer
+// call clears any prior ExplicitStop mark, re-enabling automatic restarts.
+func TestStartContainer_ClearsExplicitStop(t *testing.T) {
+	outputCh := make(chan ContainerOutput, 1)
+	outputCh <- ContainerOutput{Done: true}
+	close(outputCh)
+
+	mc := &mockContainerdClient{startOutputCh: outputCh}
+	mon := &mockMonitorRegistrar{}
+	client, cleanup := startContainerServerWithMonitor(t, mc, mon)
+	defer cleanup()
+
+	stream, err := client.StartContainer(context.Background(), &agentpb.StartContainerRequest{
+		AppName: "my-app",
+	})
+	if err != nil {
+		t.Fatalf("StartContainer: %v", err)
+	}
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected recv error: %v", err)
+		}
+	}
+
+	// ClearExplicitStop must have been called once.
+	if len(mon.clearStopCalls) != 1 {
+		t.Fatalf("ClearExplicitStop call count = %d; want 1", len(mon.clearStopCalls))
+	}
+	if mon.clearStopCalls[0] != "my-app" {
+		t.Errorf("ClearExplicitStop appName = %q; want my-app", mon.clearStopCalls[0])
+	}
+}
+
+// TestMonitorPolicyIntFromLabel covers the label-based policy parser.
+func TestMonitorPolicyIntFromLabel(t *testing.T) {
+	cases := []struct {
+		label      string
+		wantPolicy int
+		wantOK     bool
+		wantRetries int
+	}{
+		{"", RestartPolicyNo, false, 0},
+		{"no", RestartPolicyNo, false, 0},
+		{"unless-stopped", RestartPolicyUnlessStopped, true, 0},
+		{"always", RestartPolicyUnlessStopped, true, 0},
+		{"on-failure", RestartPolicyOnFailure, true, 0},
+		{"on-failure:3", RestartPolicyOnFailure, true, 3},
+	}
+	for _, tc := range cases {
+		policy, maxRetries, ok := monitorPolicyIntFromLabel(tc.label)
+		if ok != tc.wantOK {
+			t.Errorf("label=%q ok=%v want %v", tc.label, ok, tc.wantOK)
+		}
+		if ok && policy != tc.wantPolicy {
+			t.Errorf("label=%q policy=%d want %d", tc.label, policy, tc.wantPolicy)
+		}
+		if ok && maxRetries != tc.wantRetries {
+			t.Errorf("label=%q maxRetries=%d want %d", tc.label, maxRetries, tc.wantRetries)
+		}
 	}
 }
 

--- a/go/internal/agent/services/container_service_v2.go
+++ b/go/internal/agent/services/container_service_v2.go
@@ -2,12 +2,7 @@ package services
 
 import (
 	"context"
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
 
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -34,120 +29,45 @@ func (s *ContainerServiceV2) StartContainer(req *agentpbv2.StartContainerRequest
 	return s.v1.streamContainerOutput(stream.Context(), req.GetAppName(), postStartAgentHookFromContext(stream.Context()), nil, &containerStreamV1Adapter{v2stream: stream})
 }
 
-// AttachContainer starts a container with stdin support, forwarding I/O bidirectionally.
+// AttachContainer starts a container with stdin support, forwarding I/O
+// bidirectionally. It delegates to the v1 service via an adapter so that the
+// monitor bookkeeping (ClearExplicitStop / restart-policy registration) and
+// log-manager fan-out in the v1 path apply equally to v2 attach clients.
 func (s *ContainerServiceV2) AttachContainer(stream grpc.BidiStreamingServer[agentpbv2.AttachContainerRequest, agentpbv2.ContainerStreamResponse]) error {
-	first, err := stream.Recv()
-	if err == io.EOF {
-		return status.Error(codes.InvalidArgument, "missing first attach message")
-	}
-	if err != nil {
-		return err
-	}
-	appName := first.GetAppName()
-	if appName == "" {
-		return status.Error(codes.InvalidArgument, "app_name required as first message")
-	}
-
-	ctx := stream.Context()
-	stdinR, stdinW := io.Pipe()
-	defer stdinR.Close()
-
-	go func() {
-		defer stdinW.Close()
-		for {
-			msg, recvErr := stream.Recv()
-			if recvErr != nil {
-				return
-			}
-			if data := msg.GetStdinData(); len(data) > 0 {
-				if _, writeErr := stdinW.Write(data); writeErr != nil {
-					return
-				}
-			}
-		}
-	}()
-
-	outputCh, err := s.v1.containerd.StartContainerWithStdin(ctx, appName, stdinR, postStartAgentHookFromContext(ctx), nil)
-	if err != nil {
-		stdinR.Close()
-		return status.Errorf(codes.Internal, "failed to start container: %v", err)
-	}
-
-	if err := stream.Send(&agentpbv2.ContainerStreamResponse{
-		ResponseType: &agentpbv2.ContainerStreamResponse_Started_{
-			Started: &agentpbv2.ContainerStreamResponse_Started{},
-		},
-	}); err != nil {
-		return err
-	}
-
-	var readCh <-chan ContainerOutput
-	if s.v1.logManager != nil {
-		subID, subCh := s.v1.logManager.Subscribe(appName)
-		defer s.v1.logManager.Unsubscribe(appName, subID)
-		readCh = subCh
-		go func() {
-			for output := range outputCh {
-				s.v1.logManager.Publish(appName, output)
-			}
-			s.v1.logManager.Publish(appName, ContainerOutput{Done: true})
-		}()
-	} else {
-		readCh = outputCh
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case output, ok := <-readCh:
-			if !ok || output.Done {
-				return nil
-			}
-			if len(output.Stdout) > 0 {
-				if err := stream.Send(&agentpbv2.ContainerStreamResponse{
-					ResponseType: &agentpbv2.ContainerStreamResponse_StdoutOutput{
-						StdoutOutput: &agentpbv2.ContainerStreamResponse_ConsoleOutput{Data: output.Stdout},
-					},
-				}); err != nil {
-					return err
-				}
-			}
-			if len(output.Stderr) > 0 {
-				if err := stream.Send(&agentpbv2.ContainerStreamResponse{
-					ResponseType: &agentpbv2.ContainerStreamResponse_StderrOutput{
-						StderrOutput: &agentpbv2.ContainerStreamResponse_ConsoleOutput{Data: output.Stderr},
-					},
-				}); err != nil {
-					return err
-				}
-			}
-		}
-	}
+	return s.v1.AttachContainer(&attachStreamV1Adapter{
+		containerStreamV1Adapter: &containerStreamV1Adapter{v2stream: stream},
+		v2stream:                 stream,
+	})
 }
 
-// StopContainer stops a running container by name.
+// StopContainer stops a running container by name. It delegates to the v1
+// service so the monitor's explicit-stop bookkeeping is applied and an
+// unless-stopped container is not restarted out from under the caller.
 func (s *ContainerServiceV2) StopContainer(ctx context.Context, req *agentpbv2.StopContainerRequest) (*agentpbv2.StopContainerResponse, error) {
 	if s.v1.containerd == nil {
 		return nil, status.Error(codes.Internal, "containerd is not available")
 	}
-	if err := s.v1.containerd.StopContainer(ctx, req.GetAppName()); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to stop container: %v", err)
+	if _, err := s.v1.StopContainer(ctx, &agentpb.StopContainerRequest{
+		AppName: req.GetAppName(),
+	}); err != nil {
+		return nil, err
 	}
-	s.v1.logger.Info("Container stopped", zap.String("app_name", req.GetAppName()))
 	return &agentpbv2.StopContainerResponse{}, nil
 }
 
-// DeleteContainer deletes a container and optionally its image and volumes.
+// DeleteContainer deletes a container and optionally its image and volumes. It
+// delegates to the v1 service so the container is unregistered from the monitor
+// before removal, closing the delete/restart race.
 func (s *ContainerServiceV2) DeleteContainer(ctx context.Context, req *agentpbv2.DeleteContainerRequest) (*agentpbv2.DeleteContainerResponse, error) {
 	if s.v1.containerd == nil {
 		return nil, status.Error(codes.Internal, "containerd is not available")
 	}
-	if err := s.v1.containerd.DeleteContainer(ctx, req.GetAppName(), req.GetDeleteImage()); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to delete container: %v", err)
-	}
-	if req.GetDeleteVolumes() {
-		deleteVolumesByAppName(s.v1.logger, req.GetAppName())
+	if _, err := s.v1.DeleteContainer(ctx, &agentpb.DeleteContainerRequest{
+		AppName:       req.GetAppName(),
+		DeleteImage:   req.GetDeleteImage(),
+		DeleteVolumes: req.GetDeleteVolumes(),
+	}); err != nil {
+		return nil, err
 	}
 	return &agentpbv2.DeleteContainerResponse{}, nil
 }
@@ -218,33 +138,6 @@ func (s *ContainerServiceV2) ListContainerStats(ctx context.Context, _ *agentpbv
 	return &agentpbv2.ListContainerStatsResponse{Stats: v2stats}, nil
 }
 
-// deleteVolumesByAppName removes all volume directories belonging to the given app.
-func deleteVolumesByAppName(logger *zap.Logger, appName string) {
-	entries, err := os.ReadDir(volumesDir)
-	if err != nil {
-		logger.Warn("Failed to read volumes directory",
-			zap.String("base", volumesDir),
-			zap.String("app_name", appName),
-			zap.Error(err),
-		)
-		return
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if name == appName || strings.HasPrefix(name, appName+"-") {
-			path := filepath.Join(volumesDir, name)
-			if err := os.RemoveAll(path); err != nil {
-				logger.Warn("Failed to remove volume", zap.String("path", path), zap.Error(err))
-			} else {
-				logger.Info("Volume removed", zap.String("path", path))
-			}
-		}
-	}
-}
-
 // mapAppContainerToV2 converts a v1 AppContainer to its v2 equivalent,
 // mapping the running state enum explicitly (v1 STOPPED=0/RUNNING=1 vs v2 STOPPED=1/RUNNING=2).
 func mapAppContainerToV2(c *agentpb.AppContainer) *agentpbv2.AppContainer {
@@ -301,3 +194,32 @@ func (a *containerStreamV1Adapter) SetTrailer(md metadata.MD)       { a.v2stream
 func (a *containerStreamV1Adapter) Context() context.Context        { return a.v2stream.Context() }
 func (a *containerStreamV1Adapter) SendMsg(m any) error             { return a.v2stream.SendMsg(m) }
 func (a *containerStreamV1Adapter) RecvMsg(m any) error             { return a.v2stream.RecvMsg(m) }
+
+// attachStreamV1Adapter adapts a v2 bidirectional attach stream to the v1
+// grpc.BidiStreamingServer[agentpb.AttachContainerRequest, agentpb.RunContainerLayersResponse]
+// interface. The embedded containerStreamV1Adapter supplies Send (v1->v2
+// response translation) and the grpc.ServerStream methods; this type adds the
+// Recv direction, translating v2 attach requests to their v1 equivalents.
+type attachStreamV1Adapter struct {
+	*containerStreamV1Adapter
+	v2stream grpc.BidiStreamingServer[agentpbv2.AttachContainerRequest, agentpbv2.ContainerStreamResponse]
+}
+
+func (a *attachStreamV1Adapter) Recv() (*agentpb.AttachContainerRequest, error) {
+	msg, err := a.v2stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+	switch rt := msg.GetRequestType().(type) {
+	case *agentpbv2.AttachContainerRequest_AppName:
+		return &agentpb.AttachContainerRequest{
+			RequestType: &agentpb.AttachContainerRequest_AppName{AppName: rt.AppName},
+		}, nil
+	case *agentpbv2.AttachContainerRequest_StdinData:
+		return &agentpb.AttachContainerRequest{
+			RequestType: &agentpb.AttachContainerRequest_StdinData{StdinData: rt.StdinData},
+		}, nil
+	default:
+		return &agentpb.AttachContainerRequest{}, nil
+	}
+}

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -55,13 +55,22 @@ type ContainerdClient interface {
 	GetContainerMCPPort(ctx context.Context, appName string) (uint32, error)
 }
 
+// Restart policy constants mirror container.RestartPolicy values and are used
+// as the policy argument to ContainerMonitorRegistrar.Register.
+const (
+	RestartPolicyNo            = 0 // never restart
+	RestartPolicyUnlessStopped = 1 // restart unless explicitly stopped
+	RestartPolicyOnFailure     = 2 // restart only on non-zero exit
+	RestartPolicyAlways        = 3 // always restart
+)
+
 // ContainerMonitorRegistrar is the subset of container.ContainerMonitor used by
 // ContainerService. It is declared here (rather than importing the container
 // package) to avoid a circular dependency: container imports services.
 type ContainerMonitorRegistrar interface {
 	// Register adds appName to the monitor with the given restart policy.
-	// policy values mirror container.RestartPolicy: 0=No, 1=UnlessStopped,
-	// 2=OnFailure, 3=Always.
+	// policy values mirror container.RestartPolicy: use the RestartPolicy*
+	// constants defined in this package.
 	Register(appName string, policy int, maxRetries int)
 	// Unregister removes appName from the monitor.
 	Unregister(appName string)

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -77,6 +77,10 @@ type ContainerMonitorRegistrar interface {
 	// MarkExplicitStop marks appName as intentionally stopped so it won't be
 	// automatically restarted by an unless-stopped or on-failure policy.
 	MarkExplicitStop(appName string)
+	// ClearExplicitStop reverts a prior MarkExplicitStop call, re-enabling
+	// automatic restarts for appName. Used to undo a pre-emptive mark when the
+	// stop operation itself fails.
+	ClearExplicitStop(appName string)
 }
 
 // ContainerOutput represents a chunk of output from a running container.

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -53,6 +53,10 @@ type ContainerdClient interface {
 	GetContainerStats(ctx context.Context) ([]*agentpb.ContainerStats, error)
 	GetContainerMetrics(ctx context.Context, appName string) (ContainerMetrics, error)
 	GetContainerMCPPort(ctx context.Context, appName string) (uint32, error)
+	// GetContainerRestartPolicyLabel returns the raw restart policy label stored on
+	// the container (e.g. "unless-stopped", "on-failure:5", "no"). An empty string
+	// is returned when the container exists but has no restart policy label.
+	GetContainerRestartPolicyLabel(ctx context.Context, appName string) (string, error)
 }
 
 // Restart policy constants mirror container.RestartPolicy values and are used

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -55,6 +55,21 @@ type ContainerdClient interface {
 	GetContainerMCPPort(ctx context.Context, appName string) (uint32, error)
 }
 
+// ContainerMonitorRegistrar is the subset of container.ContainerMonitor used by
+// ContainerService. It is declared here (rather than importing the container
+// package) to avoid a circular dependency: container imports services.
+type ContainerMonitorRegistrar interface {
+	// Register adds appName to the monitor with the given restart policy.
+	// policy values mirror container.RestartPolicy: 0=No, 1=UnlessStopped,
+	// 2=OnFailure, 3=Always.
+	Register(appName string, policy int, maxRetries int)
+	// Unregister removes appName from the monitor.
+	Unregister(appName string)
+	// MarkExplicitStop marks appName as intentionally stopped so it won't be
+	// automatically restarted by an unless-stopped or on-failure policy.
+	MarkExplicitStop(appName string)
+}
+
 // ContainerOutput represents a chunk of output from a running container.
 type ContainerOutput struct {
 	Stdout []byte

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -382,12 +382,12 @@ func serviceOrder(cfg *composeConfig) ([]string, error) {
 
 // serviceLogPalette is the fixed color rotation for service name prefixes.
 var serviceLogPalette = []lipgloss.Color{
-	tui.Sky500,                     // cyan-ish
-	tui.Amber500,                   // yellow
-	tui.Emerald400,                 // green
-	lipgloss.Color("#c084fc"),      // magenta
-	lipgloss.Color("#60a5fa"),      // blue
-	tui.Red500,                     // red
+	tui.Sky500,                // cyan-ish
+	tui.Amber500,              // yellow
+	tui.Emerald400,            // green
+	lipgloss.Color("#c084fc"), // magenta
+	lipgloss.Color("#60a5fa"), // blue
+	tui.Red500,                // red
 }
 
 // serviceLogWriter buffers output for a single service and writes complete


### PR DESCRIPTION
## Summary

- `ContainerMonitor` was created and run in `main.go` but never passed to `ContainerService`, so restart policies (`--restart-unless-stopped`, `--restart-on-failure`) silently did nothing — containers were never registered with the monitor.
- Introduces `ContainerMonitorRegistrar` interface in the `services` package to avoid a circular import (`container` package imports `services`).
- Adds `WithMonitor(ContainerMonitorRegistrar)` option on `ContainerService` following the existing `WithLogManager` pattern.
- Registers containers with the monitor in `streamContainerOutput` when a non-NO restart policy is set.
- Calls `MarkExplicitStop` in `StopContainer` before stopping containerd so the monitor does not race to restart an intentionally stopped container.
- Wires everything up in `main.go` via a `containerMonitorAdapter` that adapts `*container.ContainerMonitor` to the interface.

Fixes #696

## Test plan

- [ ] `go build ./...` succeeds with no errors
- [ ] `go test ./internal/agent/services/ ./internal/agent/containerd/ ./internal/agent/container/ -v` all pass
- [ ] On device: start a container with `--restart-unless-stopped`, kill the process inside it, verify the monitor restarts it within ~15 s
- [ ] On device: start a container with `--restart-unless-stopped`, then `wendy container stop <app>`, verify it is NOT restarted

🤖 Generated with [Claude Code](https://claude.com/claude-code)