### PR TITLE
feat(cli): interleaved color-coded log streaming per service

### DIFF
--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -414,10 +414,10 @@ func newServiceLogWriters(names []string) (stdout, stderr map[string]*serviceLog
 		color := serviceLogPalette[i%len(serviceLogPalette)]
 		style := lipgloss.NewStyle().Foreground(color).Bold(true)
 		errStyle := lipgloss.NewStyle().Foreground(color).Bold(true)
-		padded := name + strings.Repeat(" ", maxLen-len(name))
-		prefix := style.Render("["+padded+"]") + " "
+		padding := strings.Repeat(" ", maxLen-len(name)+1)
+		prefix := style.Render("["+name+"]") + padding
 		stdout[name] = &serviceLogWriter{mu: mu, dest: os.Stdout, prefix: prefix}
-		stderr[name] = &serviceLogWriter{mu: mu, dest: os.Stderr, prefix: errStyle.Render("["+padded+"]") + " "}
+		stderr[name] = &serviceLogWriter{mu: mu, dest: os.Stderr, prefix: errStyle.Render("["+name+"]") + padding}
 	}
 	return stdout, stderr
 }

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -427,8 +427,8 @@ func (w *serviceLogWriter) Write(p []byte) {
 		if b == '\n' {
 			w.mu.Lock()
 			fmt.Fprintln(w.dest, w.prefix+w.buf.String())
-			w.mu.Unlock()
 			w.buf.Reset()
+			w.mu.Unlock()
 		} else {
 			w.buf.WriteByte(b)
 		}
@@ -436,10 +436,10 @@ func (w *serviceLogWriter) Write(p []byte) {
 }
 
 func (w *serviceLogWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.buf.Len() > 0 {
-		w.mu.Lock()
 		fmt.Fprintln(w.dest, w.prefix+w.buf.String())
-		w.mu.Unlock()
 		w.buf.Reset()
 	}
 }

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/distribution/reference"
 	"gopkg.in/yaml.v3"
 
 	"github.com/wendylabsinc/wendy/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/proto/gen/agentpb"
 )
@@ -378,6 +380,70 @@ func serviceOrder(cfg *composeConfig) ([]string, error) {
 	return ordered, nil
 }
 
+// serviceLogPalette is the fixed color rotation for service name prefixes.
+var serviceLogPalette = []lipgloss.Color{
+	tui.Sky500,                     // cyan-ish
+	tui.Amber500,                   // yellow
+	tui.Emerald400,                 // green
+	lipgloss.Color("#c084fc"),      // magenta
+	lipgloss.Color("#60a5fa"),      // blue
+	tui.Red500,                     // red
+}
+
+// serviceLogWriter buffers output for a single service and writes complete
+// lines prefixed with a color-coded, column-aligned service name.
+// It is safe to call Write from a single goroutine; Flush drains any partial line.
+type serviceLogWriter struct {
+	mu     *sync.Mutex // shared with all writers so lines don't interleave
+	dest   *os.File
+	buf    strings.Builder
+	prefix string // pre-rendered "[name]  " with padding and color
+}
+
+func newServiceLogWriters(names []string) (stdout, stderr map[string]*serviceLogWriter) {
+	mu := &sync.Mutex{}
+	maxLen := 0
+	for _, n := range names {
+		if len(n) > maxLen {
+			maxLen = len(n)
+		}
+	}
+	stdout = make(map[string]*serviceLogWriter, len(names))
+	stderr = make(map[string]*serviceLogWriter, len(names))
+	for i, name := range names {
+		color := serviceLogPalette[i%len(serviceLogPalette)]
+		style := lipgloss.NewStyle().Foreground(color).Bold(true)
+		errStyle := lipgloss.NewStyle().Foreground(color).Bold(true)
+		padded := name + strings.Repeat(" ", maxLen-len(name))
+		prefix := style.Render("["+padded+"]") + " "
+		stdout[name] = &serviceLogWriter{mu: mu, dest: os.Stdout, prefix: prefix}
+		stderr[name] = &serviceLogWriter{mu: mu, dest: os.Stderr, prefix: errStyle.Render("["+padded+"]") + " "}
+	}
+	return stdout, stderr
+}
+
+func (w *serviceLogWriter) Write(p []byte) {
+	for _, b := range p {
+		if b == '\n' {
+			w.mu.Lock()
+			fmt.Fprintln(w.dest, w.prefix+w.buf.String())
+			w.mu.Unlock()
+			w.buf.Reset()
+		} else {
+			w.buf.WriteByte(b)
+		}
+	}
+}
+
+func (w *serviceLogWriter) Flush() {
+	if w.buf.Len() > 0 {
+		w.mu.Lock()
+		fmt.Fprintln(w.dest, w.prefix+w.buf.String())
+		w.mu.Unlock()
+		w.buf.Reset()
+	}
+}
+
 // runComposeWithAgent orchestrates a docker-compose project on a WendyOS device:
 // builds service images, pushes them to the device registry, creates containers,
 // and streams their combined output.
@@ -555,15 +621,21 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		case <-runCtx.Done():
 			return
 		}
-		cliLogln("\nStopping all services...")
+		// Stop in reverse dependency order.
 		stopCtx := context.Background()
-		for _, name := range ordered {
+		stopped := 0
+		fmt.Println()
+		for i := len(ordered) - 1; i >= 0; i-- {
+			name := ordered[i]
 			svc := cfg.Services[name]
 			appCfg := composeAppConfig(projectName, name, svc)
+			cliLogln("Stopping %s...", name)
 			_, _ = conn.ContainerService.StopContainer(stopCtx, &agentpb.StopContainerRequest{
 				AppName: appCfg.AppID,
 			})
+			stopped++
 		}
+		cliLogln("Stopped %d service(s).", stopped)
 		runCancel()
 	}()
 
@@ -583,10 +655,17 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			cliLogln("Service %s started.", name)
 		}
 		cliLogln("All services running in detached mode.")
+		projectID := strings.ToLower(filepath.Base(projectDir))
+		cliLogln("Run 'wendy logs %s' to stream logs.", projectID)
 		return nil
 	}
 
-	// Attached mode: stream output from all containers concurrently, prefixed by service name.
+	// Attached mode: stream output from all containers concurrently with
+	// color-coded, column-aligned service name prefixes.
+	serviceNames := make([]string, len(ordered))
+	copy(serviceNames, ordered)
+	stdoutWriters, stderrWriters := newServiceLogWriters(serviceNames)
+
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(ordered))
 
@@ -597,16 +676,50 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		wg.Add(1)
 		go func(serviceName, appID string) {
 			defer wg.Done()
+			outW := stdoutWriters[serviceName]
+			errW := stderrWriters[serviceName]
+			defer outW.Flush()
+			defer errW.Flush()
 
-			stream, err := conn.ContainerService.StartContainer(runCtx, &agentpb.StartContainerRequest{
-				AppName: appID,
-			})
-			if err != nil {
-				errCh <- fmt.Errorf("starting service %s: %w", serviceName, err)
-				return
+			stream, streamErr := conn.ContainerService.AttachContainer(runCtx)
+			if streamErr == nil {
+				streamErr = stream.Send(&agentpb.AttachContainerRequest{
+					RequestType: &agentpb.AttachContainerRequest_AppName{AppName: appID},
+				})
+				if streamErr != nil {
+					_ = stream.CloseSend()
+				}
+			}
+			if streamErr != nil {
+				// Fall back to the server-streaming StartContainer when AttachContainer is unavailable.
+				startStream, startErr := conn.ContainerService.StartContainer(runCtx, &agentpb.StartContainerRequest{
+					AppName: appID,
+				})
+				if startErr != nil {
+					errCh <- fmt.Errorf("starting service %s: %w", serviceName, startErr)
+					return
+				}
+				for {
+					resp, recvErr := startStream.Recv()
+					if recvErr == io.EOF {
+						return
+					}
+					if recvErr != nil {
+						if runCtx.Err() != nil {
+							return
+						}
+						errCh <- fmt.Errorf("service %s: %w", serviceName, recvErr)
+						return
+					}
+					if out := resp.GetStdoutOutput(); out != nil {
+						outW.Write(out.GetData())
+					}
+					if out := resp.GetStderrOutput(); out != nil {
+						errW.Write(out.GetData())
+					}
+				}
 			}
 
-			prefix := "[" + serviceName + "] "
 			for {
 				resp, recvErr := stream.Recv()
 				if recvErr == io.EOF {
@@ -620,10 +733,10 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 					return
 				}
 				if out := resp.GetStdoutOutput(); out != nil {
-					_, _ = fmt.Fprint(os.Stdout, prefix+string(out.GetData()))
+					outW.Write(out.GetData())
 				}
 				if out := resp.GetStderrOutput(); out != nil {
-					_, _ = fmt.Fprint(os.Stderr, prefix+string(out.GetData()))
+					errW.Write(out.GetData())
 				}
 			}
 		}(name, appCfg.AppID)


### PR DESCRIPTION
Resolves [WDY-893](https://linear.app/wendylabsinc/issue/WDY-893/cli-interleaved-color-coded-log-streaming-per-service)

## Summary

- **Color-coded prefixes** — each service gets a unique ANSI color rotating through cyan, yellow, green, magenta, blue, red
- **Column alignment** — service name column is left-padded to the longest name so log lines align vertically
- **No mid-line interleaving** — a shared mutex and per-service line-buffer guarantee complete lines are written atomically
- **AttachContainer** — uses the bidi stream per service with a fallback to `StartContainer` for older agents
- **Ctrl+C** — stops in reverse dependency order, prints `Stopping <name>...` per service, then `Stopped N service(s).`
- **--detach hint** — prints `wendy logs <projectId>` after all services start in detached mode

## Test plan

- [ ] `wendy run` against a multi-service compose project — verify each service line is prefixed with its color-coded name
- [ ] Confirm alignment when service names differ in length (e.g. `api`, `postgres`, `frontend`)
- [ ] Press Ctrl+C — verify reverse-order stop messages and final count
- [ ] `wendy run --detach` — verify hint message appears
- [ ] `go test ./internal/cli/commands/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)