### PR TITLE
Add demo GIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="docs/media/demo.gif" alt="Wendy on NVIDIA Jetson" width="360">
+</p>
+
 # Wendy Agent & Wendy CLI
 
 ## Installing the CLI


### PR DESCRIPTION
## Summary
- Adds a 360×640 / 12fps / 30s demo GIF (`docs/media/demo.gif`, ~9.4MB) generated from the Marketing "Quick Story NVIDIA Jetson" video
- Embeds it as a centered hero above the H1 in the README

## Test plan
- [ ] Confirm GIF renders on GitHub README at https://github.com/wendylabsinc/wendy-agent