### PR TITLE
LLM discoverability: wendy_status, guide resource, run unification, mcp setup expansion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,11 @@ Configure the MCP server for your AI coding tool:
 wendy mcp setup
 ```
 
-Supports: Claude Code, Claude Desktop, Cursor, Windsurf, Codex.
+Supports: Claude Code, Claude Desktop.
 
 ## Quick Start (with MCP)
 
-1. Call `wendy_status` — returns connection state and a suggested next step.
+1. Call `device_list` to see available devices.
 2. Call `device_list` (optionally `scan: true`) to find available devices.
 3. Call `device_connect` or `cloud_connect` to connect.
 4. Use container, WiFi, hardware, telemetry, and OS tools.
@@ -32,12 +32,9 @@ To build and deploy a local project to any device (direct or cloud):
 wendy run --device <name>
 ```
 
-Or via the `run` MCP tool with `project_path`.
-
 ## Connection Model
 
-Most MCP tools require an active device connection. `wendy_status` always
-tells you where you are and what to do next. `run` and `cloud_run` work
+Most MCP tools require an active device connection. `cloud_run` works
 without a prior connection.
 
 ## Authentication

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,11 @@ Configure the MCP server for your AI coding tool:
 wendy mcp setup
 ```
 
-Supports: Claude Code, Claude Desktop.
+Supports: Claude Code, Claude Desktop, Cursor, Windsurf, Codex.
 
 ## Quick Start (with MCP)
 
-1. Call `device_list` to see available devices.
+1. Call `wendy_status` to see current connection state and a suggested next step.
 2. Call `device_list` (optionally `scan: true`) to find available devices.
 3. Call `device_connect` or `cloud_connect` to connect.
 4. Use container, WiFi, hardware, telemetry, and OS tools.
@@ -32,10 +32,12 @@ To build and deploy a local project to any device (direct or cloud):
 wendy run --device <name>
 ```
 
+Use the `run` MCP tool to deploy from within an AI session.
+
 ## Connection Model
 
-Most MCP tools require an active device connection. `cloud_run` works
-without a prior connection.
+Most MCP tools require an active device connection. The `run` tool works
+without a prior connection (it manages the cloud tunnel internally).
 
 ## Authentication
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Wendy Agent — AI Assistant Guide
+
+Wendy is a CLI and agent platform for developing and deploying applications on
+WendyOS edge devices (Raspberry Pi, NVIDIA Jetson, x86 SBCs, and more).
+
+## Setup
+
+Install the CLI:
+
+```sh
+curl -fsSL https://install.wendy.sh/cli.sh | bash
+```
+
+Configure the MCP server for your AI coding tool:
+
+```sh
+wendy mcp setup
+```
+
+Supports: Claude Code, Claude Desktop, Cursor, Windsurf, Codex.
+
+## Quick Start (with MCP)
+
+1. Call `wendy_status` — returns connection state and a suggested next step.
+2. Call `device_list` (optionally `scan: true`) to find available devices.
+3. Call `device_connect` or `cloud_connect` to connect.
+4. Use container, WiFi, hardware, telemetry, and OS tools.
+
+To build and deploy a local project to any device (direct or cloud):
+
+```sh
+wendy run --device <name>
+```
+
+Or via the `run` MCP tool with `project_path`.
+
+## Connection Model
+
+Most MCP tools require an active device connection. `wendy_status` always
+tells you where you are and what to do next. `run` and `cloud_run` work
+without a prior connection.
+
+## Authentication
+
+Log in to Wendy Cloud:
+
+```sh
+wendy auth login
+```
+
+Discover cloud-enrolled devices:
+
+```sh
+wendy cloud discover
+```

--- a/go/go.mod
+++ b/go/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20251212221603-3adeb8663819
+	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -4,6 +4,8 @@ cuelabs.dev/go/oci/ociregistry v0.0.0-20251212221603-3adeb8663819/go.mod h1:WjmQ
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 h1:0kQAzHq8vLs7Pptv+7TxjdETLf/nIqJpIB4oC6Ba4vY=
 github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29/go.mod h1:ZWa7ssZJT30CCDGJ7fk/2SBTq9BIQrrVjrcss0UW2s0=
 github.com/Microsoft/hcsshim v0.15.0-rc.1 h1:FbbwtQmiD+BVHynGkx5S65JkLyhkEiiTP8nrpmg2SZw=

--- a/go/internal/cli/commands/cloud_run.go
+++ b/go/internal/cli/commands/cloud_run.go
@@ -2,13 +2,9 @@ package commands
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
-
-	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
 )
 
 func newCloudRunCmd() *cobra.Command {
@@ -18,11 +14,16 @@ func newCloudRunCmd() *cobra.Command {
 	var brokerURL string
 
 	cmd := &cobra.Command{
-		Use:   "run",
-		Short: "Build and run application on a cloud-enrolled device",
-		Long:  "Same as 'wendy run' but connects to the device through the Wendy Cloud tunnel broker instead of a direct network path.",
+		Use:    "run",
+		Short:  "Deprecated: use 'wendy run' instead",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cloudRunCommand(cmd.Context(), opts, cloudGRPC, deviceName, brokerURL)
+			ctx := context.WithValue(cmd.Context(), cloudDeviceContextKey{}, cloudDeviceConfig{
+				CloudGRPC:  cloudGRPC,
+				DeviceName: deviceName,
+				BrokerURL:  brokerURL,
+			})
+			return runCommand(ctx, opts)
 		},
 	}
 
@@ -39,60 +40,7 @@ func newCloudRunCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
 	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (required when multiple auth sessions exist)")
 	cmd.Flags().StringVar(&deviceName, "device", "", "Device name (skips interactive picker)")
-	cmd.Flags().StringVar(&brokerURL, "broker-url", os.Getenv("WENDY_BROKER_URL"), "Tunnel broker host:port (default: cloud :443 endpoint, otherwise <cloud-host>:50052)")
+	cmd.Flags().StringVar(&brokerURL, "broker-url", os.Getenv("WENDY_BROKER_URL"), "Tunnel broker host:port")
 
 	return cmd
-}
-
-func cloudRunCommand(ctx context.Context, opts runOptions, cloudGRPC, deviceName, brokerURL string) error {
-	cwd, err := resolveRunWorkingDir(opts)
-	if err != nil {
-		return fmt.Errorf("resolving working directory: %w", err)
-	}
-
-	projectType, err := resolveRunProjectType(cwd, opts.buildType)
-	if err != nil {
-		return err
-	}
-	if projectType == "compose" {
-		return fmt.Errorf("compose projects are not supported by 'wendy cloud run'")
-	}
-
-	cfgPath := filepath.Join(cwd, "wendy.json")
-	appCfg, err := ensureAppConfig(cfgPath, opts.yes)
-	if err != nil {
-		return fmt.Errorf("loading wendy.json: %w", err)
-	}
-	if err := appCfg.Validate(); err != nil {
-		return fmt.Errorf("invalid wendy.json: %w", err)
-	}
-	if err := warnAppConfigFile(cfgPath); err != nil {
-		return fmt.Errorf("reading wendy.json warnings: %w", err)
-	}
-
-	if opts.debug {
-		appCfg.Debug = true
-		foundNetwork := false
-		for i, e := range appCfg.Entitlements {
-			if e.Type == appconfig.EntitlementNetwork {
-				appCfg.Entitlements[i].Mode = "host"
-				foundNetwork = true
-				break
-			}
-		}
-		if !foundNetwork {
-			appCfg.Entitlements = append(appCfg.Entitlements, appconfig.Entitlement{
-				Type: appconfig.EntitlementNetwork,
-				Mode: "host",
-			})
-		}
-	}
-
-	agentConn, err := connectToCloudAgent(ctx, cloudGRPC, deviceName, brokerURL)
-	if err != nil {
-		return err
-	}
-	defer agentConn.Close()
-
-	return runWithAgent(ctx, agentConn, cwd, appCfg, opts)
 }

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -382,12 +382,12 @@ func serviceOrder(cfg *composeConfig) ([]string, error) {
 
 // serviceLogPalette is the fixed color rotation for service name prefixes.
 var serviceLogPalette = []lipgloss.Color{
-	tui.Sky500,                     // cyan-ish
-	tui.Amber500,                   // yellow
-	tui.Emerald400,                 // green
-	lipgloss.Color("#c084fc"),      // magenta
-	lipgloss.Color("#60a5fa"),      // blue
-	tui.Red500,                     // red
+	tui.Sky500,                // cyan-ish
+	tui.Amber500,              // yellow
+	tui.Emerald400,            // green
+	lipgloss.Color("#c084fc"), // magenta
+	lipgloss.Color("#60a5fa"), // blue
+	tui.Red500,                // red
 }
 
 // serviceLogWriter buffers output for a single service and writes complete

--- a/go/internal/cli/commands/mcp.go
+++ b/go/internal/cli/commands/mcp.go
@@ -25,7 +25,7 @@ func newMCPServeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Start the MCP server on stdio",
-		Long:  "Start a Model Context Protocol server that exposes wendy device tools over stdio.\nConfigure Claude Desktop, Claude Code, or Codex to run: wendy mcp serve",
+		Long:  "Start a Model Context Protocol server that exposes wendy device tools over stdio.\nConfigure your AI tool to run: wendy mcp serve\nOr run 'wendy mcp setup' to configure automatically.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			cfg, err := config.Load()

--- a/go/internal/cli/commands/mcp_cmd_test.go
+++ b/go/internal/cli/commands/mcp_cmd_test.go
@@ -24,6 +24,53 @@ func TestWindsurfConfigPath_ReturnsDirBasedPath(t *testing.T) {
 	}
 }
 
+func TestAddMCPToYAMLConfig_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	entry := map[string]any{"type": "stdio", "command": "wendy", "args": []string{"mcp", "serve"}}
+	if err := addMCPToYAMLConfig(path, "mcpServers", "wendy", entry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	if !strings.Contains(string(data), "wendy") {
+		t.Fatalf("expected 'wendy' in output, got: %s", data)
+	}
+}
+
+func TestAddMCPToYAMLConfig_PreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	existing := "mcpServers:\n  other:\n    type: stdio\n    command: other\n"
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entry := map[string]any{"type": "stdio", "command": "wendy", "args": []string{"mcp", "serve"}}
+	if err := addMCPToYAMLConfig(path, "mcpServers", "wendy", entry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	if !strings.Contains(string(data), "other") {
+		t.Fatalf("expected 'other' to be preserved, got: %s", data)
+	}
+	if !strings.Contains(string(data), "wendy") {
+		t.Fatalf("expected 'wendy' entry, got: %s", data)
+	}
+}
+
+func TestCodexConfigPath_ReturnsDirBasedPath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".codex", "config.yaml")
+	if got := codexConfigPath(); got != "" && got != want {
+		t.Fatalf("codexConfigPath() = %q, want %q or empty", got, want)
+	}
+}
+
 func TestMCPCmd_HelpText(t *testing.T) {
 	cmd := newMCPCmd()
 	buf := new(bytes.Buffer)

--- a/go/internal/cli/commands/mcp_cmd_test.go
+++ b/go/internal/cli/commands/mcp_cmd_test.go
@@ -2,9 +2,27 @@ package commands
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestCursorConfigPath_ReturnsDirBasedPath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".cursor", "mcp.json")
+	if got := cursorConfigPath(); got != "" && got != want {
+		t.Fatalf("cursorConfigPath() = %q, want %q or empty", got, want)
+	}
+}
+
+func TestWindsurfConfigPath_ReturnsDirBasedPath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+	if got := windsurfConfigPath(); got != "" && got != want {
+		t.Fatalf("windsurfConfigPath() = %q, want %q or empty", got, want)
+	}
+}
 
 func TestMCPCmd_HelpText(t *testing.T) {
 	cmd := newMCPCmd()

--- a/go/internal/cli/commands/mcp_cmd_test.go
+++ b/go/internal/cli/commands/mcp_cmd_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestCursorConfigPath_ReturnsDirBasedPath(t *testing.T) {
@@ -35,8 +37,20 @@ func TestAddMCPToYAMLConfig_CreatesFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading file: %v", err)
 	}
-	if !strings.Contains(string(data), "wendy") {
-		t.Fatalf("expected 'wendy' in output, got: %s", data)
+	var out map[string]any
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("parsing YAML: %v", err)
+	}
+	servers, ok := out["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mcpServers map, got: %T", out["mcpServers"])
+	}
+	wendyEntry, ok := servers["wendy"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected wendy entry, got: %T %v", servers["wendy"], servers["wendy"])
+	}
+	if wendyEntry["command"] != "wendy" {
+		t.Errorf("expected command=wendy, got: %v", wendyEntry["command"])
 	}
 }
 
@@ -55,11 +69,19 @@ func TestAddMCPToYAMLConfig_PreservesExisting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading file: %v", err)
 	}
-	if !strings.Contains(string(data), "other") {
-		t.Fatalf("expected 'other' to be preserved, got: %s", data)
+	var out map[string]any
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("parsing YAML: %v", err)
 	}
-	if !strings.Contains(string(data), "wendy") {
-		t.Fatalf("expected 'wendy' entry, got: %s", data)
+	servers, ok := out["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mcpServers map, got %T", out["mcpServers"])
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Error("expected 'other' entry to be preserved")
+	}
+	if _, ok := servers["wendy"]; !ok {
+		t.Error("expected 'wendy' entry to be present")
 	}
 }
 

--- a/go/internal/cli/commands/mcp_cmd_test.go
+++ b/go/internal/cli/commands/mcp_cmd_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	toml "github.com/BurntSushi/toml"
 )
 
 func TestCursorConfigPath_ReturnsDirBasedPath(t *testing.T) {
@@ -26,11 +26,11 @@ func TestWindsurfConfigPath_ReturnsDirBasedPath(t *testing.T) {
 	}
 }
 
-func TestAddMCPToYAMLConfig_CreatesFile(t *testing.T) {
+func TestAddMCPToTOMLConfig_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	entry := map[string]any{"type": "stdio", "command": "wendy", "args": []string{"mcp", "serve"}}
-	if err := addMCPToYAMLConfig(path, "mcpServers", "wendy", entry); err != nil {
+	path := filepath.Join(dir, "config.toml")
+	entry := map[string]any{"command": "wendy", "args": []string{"mcp", "serve"}}
+	if err := addMCPToTOMLConfig(path, "mcp_servers", "wendy", entry); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	data, err := os.ReadFile(path)
@@ -38,12 +38,12 @@ func TestAddMCPToYAMLConfig_CreatesFile(t *testing.T) {
 		t.Fatalf("reading file: %v", err)
 	}
 	var out map[string]any
-	if err := yaml.Unmarshal(data, &out); err != nil {
-		t.Fatalf("parsing YAML: %v", err)
+	if _, err := toml.Decode(string(data), &out); err != nil {
+		t.Fatalf("parsing TOML: %v", err)
 	}
-	servers, ok := out["mcpServers"].(map[string]any)
+	servers, ok := out["mcp_servers"].(map[string]any)
 	if !ok {
-		t.Fatalf("expected mcpServers map, got: %T", out["mcpServers"])
+		t.Fatalf("expected mcp_servers map, got: %T", out["mcp_servers"])
 	}
 	wendyEntry, ok := servers["wendy"].(map[string]any)
 	if !ok {
@@ -54,15 +54,15 @@ func TestAddMCPToYAMLConfig_CreatesFile(t *testing.T) {
 	}
 }
 
-func TestAddMCPToYAMLConfig_PreservesExisting(t *testing.T) {
+func TestAddMCPToTOMLConfig_PreservesExisting(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	existing := "mcpServers:\n  other:\n    type: stdio\n    command: other\n"
+	path := filepath.Join(dir, "config.toml")
+	existing := "[mcp_servers.other]\ncommand = \"other\"\n"
 	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	entry := map[string]any{"type": "stdio", "command": "wendy", "args": []string{"mcp", "serve"}}
-	if err := addMCPToYAMLConfig(path, "mcpServers", "wendy", entry); err != nil {
+	entry := map[string]any{"command": "wendy", "args": []string{"mcp", "serve"}}
+	if err := addMCPToTOMLConfig(path, "mcp_servers", "wendy", entry); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	data, err := os.ReadFile(path)
@@ -70,12 +70,12 @@ func TestAddMCPToYAMLConfig_PreservesExisting(t *testing.T) {
 		t.Fatalf("reading file: %v", err)
 	}
 	var out map[string]any
-	if err := yaml.Unmarshal(data, &out); err != nil {
-		t.Fatalf("parsing YAML: %v", err)
+	if _, err := toml.Decode(string(data), &out); err != nil {
+		t.Fatalf("parsing TOML: %v", err)
 	}
-	servers, ok := out["mcpServers"].(map[string]any)
+	servers, ok := out["mcp_servers"].(map[string]any)
 	if !ok {
-		t.Fatalf("expected mcpServers map, got %T", out["mcpServers"])
+		t.Fatalf("expected mcp_servers map, got %T", out["mcp_servers"])
 	}
 	if _, ok := servers["other"]; !ok {
 		t.Error("expected 'other' entry to be preserved")
@@ -87,7 +87,7 @@ func TestAddMCPToYAMLConfig_PreservesExisting(t *testing.T) {
 
 func TestCodexConfigPath_ReturnsDirBasedPath(t *testing.T) {
 	home, _ := os.UserHomeDir()
-	want := filepath.Join(home, ".codex", "config.yaml")
+	want := filepath.Join(home, ".codex", "config.toml")
 	if got := codexConfigPath(); got != "" && got != want {
 		t.Fatalf("codexConfigPath() = %q, want %q or empty", got, want)
 	}

--- a/go/internal/cli/commands/mcp_setup.go
+++ b/go/internal/cli/commands/mcp_setup.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func newMCPSetupCmd() *cobra.Command {
@@ -83,6 +84,15 @@ func setupMCPForAllTools() []mcpSetupResult {
 			results = append(results, mcpSetupResult{tool: "Windsurf", path: windsurfPath, err: err})
 		} else {
 			results = append(results, mcpSetupResult{tool: "Windsurf", path: windsurfPath})
+		}
+	}
+
+	// Codex (~/.codex/config.yaml)
+	if codexPath := codexConfigPath(); codexPath != "" {
+		if err := addMCPToYAMLConfig(codexPath, "mcpServers", "wendy", entry); err != nil {
+			results = append(results, mcpSetupResult{tool: "Codex", path: codexPath, err: err})
+		} else {
+			results = append(results, mcpSetupResult{tool: "Codex", path: codexPath})
 		}
 	}
 
@@ -178,6 +188,54 @@ func windsurfConfigPath() string {
 	}
 	if _, err := exec.LookPath("windsurf"); err == nil {
 		return filepath.Join(dir, "mcp_config.json")
+	}
+	return ""
+}
+
+// addMCPToYAMLConfig reads a YAML config file, sets cfg[topKey][name] = entry,
+// and writes it back. Creates the file if it does not exist.
+func addMCPToYAMLConfig(path, topKey, name string, entry any) error {
+	var cfg map[string]any
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(data) > 0 {
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+	}
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	top, _ := cfg[topKey].(map[string]any)
+	if top == nil {
+		top = map[string]any{}
+	}
+	top[name] = entry
+	cfg[topKey] = top
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644)
+}
+
+// codexConfigPath returns ~/.codex/config.yaml if Codex is installed.
+func codexConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(home, ".codex")
+	if _, err := os.Stat(dir); err == nil {
+		return filepath.Join(dir, "config.yaml")
+	}
+	if _, err := exec.LookPath("codex"); err == nil {
+		return filepath.Join(dir, "config.yaml")
 	}
 	return ""
 }

--- a/go/internal/cli/commands/mcp_setup.go
+++ b/go/internal/cli/commands/mcp_setup.go
@@ -15,7 +15,7 @@ import (
 func newMCPSetupCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "setup",
-		Short: "Configure the Wendy MCP server in Claude Code and Claude Desktop",
+		Short: "Configure the Wendy MCP server in supported AI tools",
 		Long:  "Detects installed AI tools and adds the wendy MCP server to their configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			results := setupMCPForAllTools()

--- a/go/internal/cli/commands/mcp_setup.go
+++ b/go/internal/cli/commands/mcp_setup.go
@@ -68,6 +68,24 @@ func setupMCPForAllTools() []mcpSetupResult {
 		}
 	}
 
+	// Cursor (~/.cursor/mcp.json)
+	if cursorPath := cursorConfigPath(); cursorPath != "" {
+		if err := addMCPToJSONConfig(cursorPath, "mcpServers", "wendy", entry); err != nil {
+			results = append(results, mcpSetupResult{tool: "Cursor", path: cursorPath, err: err})
+		} else {
+			results = append(results, mcpSetupResult{tool: "Cursor", path: cursorPath})
+		}
+	}
+
+	// Windsurf (~/.codeium/windsurf/mcp_config.json)
+	if windsurfPath := windsurfConfigPath(); windsurfPath != "" {
+		if err := addMCPToJSONConfig(windsurfPath, "mcpServers", "wendy", entry); err != nil {
+			results = append(results, mcpSetupResult{tool: "Windsurf", path: windsurfPath, err: err})
+		} else {
+			results = append(results, mcpSetupResult{tool: "Windsurf", path: windsurfPath})
+		}
+	}
+
 	return results
 }
 
@@ -130,6 +148,38 @@ func wendyBinaryPath() string {
 		return p
 	}
 	return "wendy"
+}
+
+// cursorConfigPath returns ~/.cursor/mcp.json if Cursor is installed.
+func cursorConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(home, ".cursor")
+	if _, err := os.Stat(dir); err == nil {
+		return filepath.Join(dir, "mcp.json")
+	}
+	if _, err := exec.LookPath("cursor"); err == nil {
+		return filepath.Join(dir, "mcp.json")
+	}
+	return ""
+}
+
+// windsurfConfigPath returns ~/.codeium/windsurf/mcp_config.json if Windsurf is installed.
+func windsurfConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(home, ".codeium", "windsurf")
+	if _, err := os.Stat(dir); err == nil {
+		return filepath.Join(dir, "mcp_config.json")
+	}
+	if _, err := exec.LookPath("windsurf"); err == nil {
+		return filepath.Join(dir, "mcp_config.json")
+	}
+	return ""
 }
 
 // addMCPToJSONConfig reads a JSON config file, sets cfg[topKey][name] = entry,

--- a/go/internal/cli/commands/mcp_setup.go
+++ b/go/internal/cli/commands/mcp_setup.go
@@ -192,6 +192,39 @@ func windsurfConfigPath() string {
 	return ""
 }
 
+// addMCPToJSONConfig reads a JSON config file, sets cfg[topKey][name] = entry,
+// and writes it back. Creates the file if it does not exist.
+func addMCPToJSONConfig(path, topKey, name string, entry any) error {
+	var cfg map[string]any
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+	}
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	top, _ := cfg[topKey].(map[string]any)
+	if top == nil {
+		top = map[string]any{}
+	}
+	top[name] = entry
+	cfg[topKey] = top
+
+	out, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644)
+}
+
 // addMCPToYAMLConfig reads a YAML config file, sets cfg[topKey][name] = entry,
 // and writes it back. Creates the file if it does not exist.
 func addMCPToYAMLConfig(path, topKey, name string, entry any) error {
@@ -238,37 +271,4 @@ func codexConfigPath() string {
 		return filepath.Join(dir, "config.yaml")
 	}
 	return ""
-}
-
-// addMCPToJSONConfig reads a JSON config file, sets cfg[topKey][name] = entry,
-// and writes it back. Creates the file if it does not exist.
-func addMCPToJSONConfig(path, topKey, name string, entry any) error {
-	var cfg map[string]any
-	data, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("reading %s: %w", path, err)
-	}
-	if len(data) > 0 {
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			return fmt.Errorf("parsing %s: %w", path, err)
-		}
-	}
-	if cfg == nil {
-		cfg = map[string]any{}
-	}
-	top, _ := cfg[topKey].(map[string]any)
-	if top == nil {
-		top = map[string]any{}
-	}
-	top[name] = entry
-	cfg[topKey] = top
-
-	out, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, out, 0o644)
 }

--- a/go/internal/cli/commands/mcp_setup.go
+++ b/go/internal/cli/commands/mcp_setup.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	toml "github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 func newMCPSetupCmd() *cobra.Command {
@@ -87,9 +87,13 @@ func setupMCPForAllTools() []mcpSetupResult {
 		}
 	}
 
-	// Codex (~/.codex/config.yaml)
+	// Codex (~/.codex/config.toml)
 	if codexPath := codexConfigPath(); codexPath != "" {
-		if err := addMCPToYAMLConfig(codexPath, "mcpServers", "wendy", entry); err != nil {
+		codexEntry := map[string]any{
+			"command": wendyBin,
+			"args":    []string{"mcp", "serve"},
+		}
+		if err := addMCPToTOMLConfig(codexPath, "mcp_servers", "wendy", codexEntry); err != nil {
 			results = append(results, mcpSetupResult{tool: "Codex", path: codexPath, err: err})
 		} else {
 			results = append(results, mcpSetupResult{tool: "Codex", path: codexPath})
@@ -225,16 +229,16 @@ func addMCPToJSONConfig(path, topKey, name string, entry any) error {
 	return os.WriteFile(path, out, 0o644)
 }
 
-// addMCPToYAMLConfig reads a YAML config file, sets cfg[topKey][name] = entry,
+// addMCPToTOMLConfig reads a TOML config file, sets cfg[topKey][name] = entry,
 // and writes it back. Creates the file if it does not exist.
-func addMCPToYAMLConfig(path, topKey, name string, entry any) error {
+func addMCPToTOMLConfig(path, topKey, name string, entry any) error {
 	var cfg map[string]any
 	data, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("reading %s: %w", path, err)
 	}
 	if len(data) > 0 {
-		if err := yaml.Unmarshal(data, &cfg); err != nil {
+		if _, err := toml.Decode(string(data), &cfg); err != nil {
 			return fmt.Errorf("parsing %s: %w", path, err)
 		}
 	}
@@ -247,17 +251,18 @@ func addMCPToYAMLConfig(path, topKey, name string, entry any) error {
 	}
 	top[name] = entry
 	cfg[topKey] = top
-	out, err := yaml.Marshal(cfg)
-	if err != nil {
-		return err
-	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(path, out, 0o644)
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return toml.NewEncoder(f).Encode(cfg)
 }
 
-// codexConfigPath returns ~/.codex/config.yaml if Codex is installed.
+// codexConfigPath returns ~/.codex/config.toml if Codex is installed.
 func codexConfigPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -265,10 +270,10 @@ func codexConfigPath() string {
 	}
 	dir := filepath.Join(home, ".codex")
 	if _, err := os.Stat(dir); err == nil {
-		return filepath.Join(dir, "config.yaml")
+		return filepath.Join(dir, "config.toml")
 	}
 	if _, err := exec.LookPath("codex"); err == nil {
-		return filepath.Join(dir, "config.yaml")
+		return filepath.Join(dir, "config.toml")
 	}
 	return ""
 }

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -28,6 +28,7 @@ import (
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/internal/shared/browseropen"
+	"github.com/wendylabsinc/wendy/internal/shared/config"
 	"github.com/wendylabsinc/wendy/internal/shared/models"
 	"github.com/wendylabsinc/wendy/proto/gen/agentpb"
 )
@@ -424,6 +425,39 @@ func newRunCmd() *cobra.Command {
 	return cmd
 }
 
+// resolveRunTarget resolves the target device for the run command. It first
+// tries resolveTarget (direct/picker). If that fails and cloud auth entries
+// exist, it retries via the cloud tunnel using the device name from --device
+// or the configured default.
+func resolveRunTarget(ctx context.Context, opts ...resolveOption) (*SelectedDevice, error) {
+	target, err := resolveTarget(ctx, opts...)
+	if err == nil {
+		return target, nil
+	}
+	if errors.Is(err, ErrUserCancelled) {
+		return nil, err
+	}
+
+	cfg, loadErr := config.Load()
+	if loadErr != nil || len(cfg.Auth) == 0 {
+		return nil, err
+	}
+
+	deviceName := deviceFlag
+	if deviceName == "" {
+		deviceName = cfg.DefaultDevice
+	}
+	if deviceName == "" {
+		return nil, err
+	}
+
+	cloudConn, cloudErr := connectToCloudAgent(ctx, "", deviceName, "")
+	if cloudErr != nil {
+		return nil, err
+	}
+	return &SelectedDevice{Agent: cloudConn}, nil
+}
+
 func runCommand(ctx context.Context, opts runOptions) error {
 	// Step 1: Load and validate wendy.json.
 	cwd, err := resolveRunWorkingDir(opts)
@@ -481,7 +515,7 @@ func runCommand(ctx context.Context, opts runOptions) error {
 	if opts.yes {
 		resolveOpts = append(resolveOpts, NonInteractive())
 	}
-	target, err := resolveTarget(ctx, resolveOpts...)
+	target, err := resolveRunTarget(ctx, resolveOpts...)
 	if err != nil {
 		return err
 	}
@@ -522,7 +556,7 @@ func runComposeCommand(ctx context.Context, cwd string, opts runOptions) error {
 	if opts.yes {
 		resolveOpts = append(resolveOpts, NonInteractive())
 	}
-	target, err := resolveTarget(ctx, resolveOpts...)
+	target, err := resolveRunTarget(ctx, resolveOpts...)
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/run_test.go
+++ b/go/internal/cli/commands/run_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
@@ -201,5 +202,23 @@ func TestStartPostStartHook_NoHookReturnsNil(t *testing.T) {
 	cfg.Hooks.PostStart = &appconfig.HookCommand{}
 	if cmd := startPostStartHook(context.Background(), cfg, "h"); cmd != nil {
 		t.Errorf("startPostStartHook() = %v, want nil for empty PostStart", cmd)
+	}
+}
+
+func TestResolveRunTarget_DirectSucceeds_NoCloudFallback(t *testing.T) {
+	// When resolveTarget succeeds, resolveRunTarget returns same result.
+	// We can test this by checking that when deviceFlag is empty and no
+	// default device, we get the "no device" error (picker falls through).
+	// Since we can't test interactive picker in unit tests, test the
+	// non-interactive path.
+	ctx := context.Background()
+	// Non-interactive: resolveTarget will error "no device specified"
+	_, err := resolveRunTarget(ctx, NonInteractive())
+	if err == nil {
+		t.Fatal("expected error with no device in non-interactive mode")
+	}
+	// Should be the direct error, not a cloud error (no auth configured)
+	if !strings.Contains(err.Error(), "no device") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/go/internal/cli/mcp/server.go
+++ b/go/internal/cli/mcp/server.go
@@ -89,8 +89,10 @@ func (s *mcpServer) ConnectTo(ctx context.Context, address string) error {
 func (s *mcpServer) Start(ctx context.Context) error {
 	srv := server.NewMCPServer("wendy", version.Version,
 		server.WithToolCapabilities(true),
+		server.WithResourceCapabilities(false, false),
 	)
 	s.registerStatusTools(srv)
+	s.registerGuideResource(srv)
 	s.registerDeviceTools(srv)
 	s.registerContainerTools(srv)
 	s.registerTelemetryTools(srv)

--- a/go/internal/cli/mcp/server.go
+++ b/go/internal/cli/mcp/server.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/wendylabsinc/wendy/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/internal/shared/config"
+	"github.com/wendylabsinc/wendy/internal/shared/discovery"
+	"github.com/wendylabsinc/wendy/internal/shared/models"
 	"github.com/wendylabsinc/wendy/internal/shared/version"
 	agentpb "github.com/wendylabsinc/wendy/proto/gen/agentpb"
 	"google.golang.org/grpc/status"
@@ -23,18 +25,24 @@ type ConnectFunc func(ctx context.Context, address string) (*grpcclient.AgentCon
 
 // mcpServer holds active connection state and implements all MCP tool handlers.
 type mcpServer struct {
-	cfg          *config.Config
-	connectFn    ConnectFunc
-	conn         *grpcclient.AgentConnection
-	connType     string
-	cloudTunnels map[string]*mcpCloudTunnel
-	mu           sync.RWMutex
+	cfg           *config.Config
+	connectFn     ConnectFunc
+	conn          *grpcclient.AgentConnection
+	connType      string
+	cloudTunnels  map[string]*mcpCloudTunnel
+	discoverLANFn func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error)
+	mu            sync.RWMutex
 }
 
 // New creates a new mcpServer. connectFn is called by device_connect; pass nil
 // to disable dynamic connection (useful in tests that set conn directly).
 func New(cfg *config.Config, connectFn ConnectFunc) *mcpServer {
-	return &mcpServer{cfg: cfg, connectFn: connectFn, cloudTunnels: make(map[string]*mcpCloudTunnel)}
+	return &mcpServer{
+		cfg:           cfg,
+		connectFn:     connectFn,
+		cloudTunnels:  make(map[string]*mcpCloudTunnel),
+		discoverLANFn: discovery.DiscoverLAN,
+	}
 }
 
 // GetConn returns the current active connection (nil if not connected).

--- a/go/internal/cli/mcp/server.go
+++ b/go/internal/cli/mcp/server.go
@@ -26,6 +26,7 @@ type mcpServer struct {
 	cfg          *config.Config
 	connectFn    ConnectFunc
 	conn         *grpcclient.AgentConnection
+	connType     string
 	cloudTunnels map[string]*mcpCloudTunnel
 	mu           sync.RWMutex
 }
@@ -51,6 +52,23 @@ func (s *mcpServer) SetConn(conn *grpcclient.AgentConnection) {
 		_ = s.conn.Close()
 	}
 	s.conn = conn
+	if conn == nil {
+		s.connType = ""
+	}
+}
+
+// SetConnType records the transport type of the active connection ("direct" or "cloud").
+func (s *mcpServer) SetConnType(t string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.connType = t
+}
+
+// GetConnType returns the transport type of the active connection.
+func (s *mcpServer) GetConnType() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.connType
 }
 
 // ConnectTo connects to address and stores the result as the active connection.
@@ -72,6 +90,7 @@ func (s *mcpServer) Start(ctx context.Context) error {
 	srv := server.NewMCPServer("wendy", version.Version,
 		server.WithToolCapabilities(true),
 	)
+	s.registerStatusTools(srv)
 	s.registerDeviceTools(srv)
 	s.registerContainerTools(srv)
 	s.registerTelemetryTools(srv)

--- a/go/internal/cli/mcp/server_helpers_test.go
+++ b/go/internal/cli/mcp/server_helpers_test.go
@@ -100,8 +100,10 @@ func (s *mcpServer) callTool(ctx context.Context, name string, args map[string]a
 		return s.handleCloudEnrollDevice(ctx, req)
 	case "cloud_tunnel":
 		return s.handleCloudTunnel(ctx, req)
+	case "run":
+		return s.handleRun(ctx, req)
 	case "cloud_run":
-		return s.handleCloudRun(ctx, req)
+		return s.handleRun(ctx, req)
 	default:
 		return mcpgo.NewToolResultError("unknown tool: " + name), nil
 	}

--- a/go/internal/cli/mcp/server_helpers_test.go
+++ b/go/internal/cli/mcp/server_helpers_test.go
@@ -2,9 +2,31 @@ package mcp
 
 import (
 	"context"
+	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
+
+// callToolReq builds a minimal CallToolRequest for tests.
+func callToolReq(name string, args map[string]any) mcpgo.CallToolRequest {
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = name
+	req.Params.Arguments = any(args)
+	return req
+}
+
+// toolResultText extracts the text from the first content item of a CallToolResult.
+func toolResultText(t *testing.T, result *mcpgo.CallToolResult) string {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("result has no content")
+	}
+	tc, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	return tc.Text
+}
 
 // callTool invokes a registered tool handler by name. Used in tests only.
 func (s *mcpServer) callTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
@@ -12,6 +34,8 @@ func (s *mcpServer) callTool(ctx context.Context, name string, args map[string]a
 	req.Params.Name = name
 	req.Params.Arguments = any(args)
 	switch name {
+	case "wendy_status":
+		return s.handleWendyStatus(ctx, req)
 	case "device_list":
 		return s.handleDeviceList(ctx, req)
 	case "device_connect":

--- a/go/internal/cli/mcp/server_test.go
+++ b/go/internal/cli/mcp/server_test.go
@@ -1,8 +1,10 @@
 package mcp
 
 import (
+	"context"
 	"testing"
 
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/wendylabsinc/wendy/internal/shared/config"
 )
 
@@ -17,5 +19,29 @@ func TestGetConn_NilBeforeConnect(t *testing.T) {
 	srv := New(&config.Config{}, nil)
 	if srv.GetConn() != nil {
 		t.Fatal("expected nil connection before connect")
+	}
+}
+
+func TestGuideResource_ReturnsText(t *testing.T) {
+	srv := New(&config.Config{}, nil)
+	contents, err := srv.handleGuideResource(context.Background(), mcpgo.ReadResourceRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(contents))
+	}
+	tc, ok := contents[0].(mcpgo.TextResourceContents)
+	if !ok {
+		t.Fatalf("expected TextResourceContents, got %T", contents[0])
+	}
+	if tc.URI != "wendy://guide" {
+		t.Errorf("expected URI wendy://guide, got %q", tc.URI)
+	}
+	if tc.MIMEType != "text/plain" {
+		t.Errorf("expected MIME text/plain, got %q", tc.MIMEType)
+	}
+	if len(tc.Text) < 100 {
+		t.Errorf("expected guide text to be at least 100 chars, got %d", len(tc.Text))
 	}
 }

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -133,8 +133,37 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		),
 	), s.handleCloudTunnel)
 
+	srv.AddTool(mcpgo.NewTool("run",
+		mcpgo.WithDescription("Build and deploy a local project to a cloud-enrolled device. Runs 'wendy cloud run' with your configured cloud credentials."),
+		mcpgo.WithString("project_path",
+			mcpgo.Required(),
+			mcpgo.Description("Project directory containing wendy.json"),
+		),
+		mcpgo.WithString("device_name",
+			mcpgo.Description("Cloud device name"),
+		),
+		mcpgo.WithString("build_type",
+			mcpgo.Description("Build type: docker, swift, or python"),
+		),
+		mcpgo.WithString("product",
+			mcpgo.Description("Swift Package Manager product to build and run"),
+		),
+		mcpgo.WithBoolean("debug",
+			mcpgo.Description("Enable debug logging"),
+		),
+		mcpgo.WithBoolean("deploy",
+			mcpgo.Description("Create container but do not start it"),
+		),
+		mcpgo.WithBoolean("detach",
+			mcpgo.Description("Start container but do not stream logs (default true for MCP)"),
+		),
+		mcpgo.WithNumber("timeout_seconds",
+			mcpgo.Description("Maximum command runtime in seconds (default 300)"),
+		),
+	), s.handleRun)
+
 	srv.AddTool(mcpgo.NewTool("cloud_run",
-		mcpgo.WithDescription("Run 'wendy cloud run' for a local project and return bounded command output"),
+		mcpgo.WithDescription("Deprecated: use run instead. Run 'wendy cloud run' for a local project and return bounded command output"),
 		mcpgo.WithString("project_path",
 			mcpgo.Required(),
 			mcpgo.Description("Project directory containing wendy.json"),
@@ -166,7 +195,7 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("timeout_seconds",
 			mcpgo.Description("Maximum command runtime in seconds (default 300)"),
 		),
-	), s.handleCloudRun)
+	), s.handleRun)
 }
 
 func (s *mcpServer) handleCloudDiscover(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -291,7 +320,7 @@ func (s *mcpServer) handleCloudTunnel(ctx context.Context, req mcpgo.CallToolReq
 	return mcpgo.NewToolResultText(string(b)), nil
 }
 
-func (s *mcpServer) handleCloudRun(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+func (s *mcpServer) handleRun(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	projectPath := stringParam(req, "project_path")
 	if projectPath == "" {
 		return mcpgo.NewToolResultError("project_path is required"), nil

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -192,6 +192,7 @@ func (s *mcpServer) handleCloudConnect(ctx context.Context, req mcpgo.CallToolRe
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
 	s.SetConn(conn)
+	s.SetConnType("cloud")
 	return mcpgo.NewToolResultText(fmt.Sprintf("connected to %s via cloud", asset.GetName())), nil
 }
 

--- a/go/internal/cli/mcp/tools_cloud_test.go
+++ b/go/internal/cli/mcp/tools_cloud_test.go
@@ -126,3 +126,14 @@ func TestCloudRun_RequiresProjectPath(t *testing.T) {
 		t.Fatal("expected error result")
 	}
 }
+
+func TestRun_MissingProjectPath(t *testing.T) {
+	srv := New(&config.Config{}, nil)
+	result, err := srv.callTool(context.Background(), "run", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected IsError=true when project_path is missing")
+	}
+}

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -13,7 +14,10 @@ import (
 
 func (s *mcpServer) registerDeviceTools(srv *server.MCPServer) {
 	srv.AddTool(mcpgo.NewTool("device_list",
-		mcpgo.WithDescription("List wendy devices from config and known addresses"),
+		mcpgo.WithDescription("List wendy devices from config and known addresses. Pass scan=true to also run a live 3-second mDNS scan for devices on the local network."),
+		mcpgo.WithBoolean("scan",
+			mcpgo.Description("If true, run a live mDNS scan (3 s) in addition to returning configured devices"),
+		),
 	), s.handleDeviceList)
 
 	srv.AddTool(mcpgo.NewTool("device_connect",
@@ -41,13 +45,16 @@ func (s *mcpServer) registerDeviceTools(srv *server.MCPServer) {
 	), s.handleDeviceSetDefault)
 }
 
-func (s *mcpServer) handleDeviceList(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+func (s *mcpServer) handleDeviceList(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	scan := req.GetBool("scan", false)
+
 	var devices []map[string]any
 	for _, auth := range s.cfg.Auth {
 		if auth.CloudGRPC != "" {
 			devices = append(devices, map[string]any{
 				"address": auth.CloudGRPC,
 				"type":    "cloud",
+				"source":  "config",
 			})
 		}
 	}
@@ -55,8 +62,37 @@ func (s *mcpServer) handleDeviceList(_ context.Context, _ mcpgo.CallToolRequest)
 		devices = append(devices, map[string]any{
 			"address": s.cfg.DefaultDevice,
 			"type":    "default",
+			"source":  "config",
 		})
 	}
+
+	if scan {
+		found, err := s.discoverLANFn(ctx, 3*time.Second)
+		if err == nil {
+			for _, d := range found {
+				addr := d.Hostname
+				if d.IPAddress != "" {
+					addr = d.IPAddress
+				}
+				if d.Port > 0 {
+					addr = fmt.Sprintf("%s:%d", addr, d.Port)
+				}
+				entry := map[string]any{
+					"address": addr,
+					"type":    "lan",
+					"source":  "scan",
+				}
+				if d.DisplayName != "" {
+					entry["name"] = d.DisplayName
+				}
+				if d.AgentVersion != "" {
+					entry["agent_version"] = d.AgentVersion
+				}
+				devices = append(devices, entry)
+			}
+		}
+	}
+
 	if len(devices) == 0 {
 		devices = []map[string]any{}
 	}

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -72,6 +72,7 @@ func (s *mcpServer) handleDeviceConnect(ctx context.Context, req mcpgo.CallToolR
 	if err := s.ConnectTo(ctx, address); err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("connecting to %s: %s", address, err.Error())), nil
 	}
+	s.SetConnType("direct")
 	return mcpgo.NewToolResultText(fmt.Sprintf("connected to %s", address)), nil
 }
 

--- a/go/internal/cli/mcp/tools_device_test.go
+++ b/go/internal/cli/mcp/tools_device_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"net"
 	"testing"
+	"time"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/wendylabsinc/wendy/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/internal/shared/config"
+	"github.com/wendylabsinc/wendy/internal/shared/models"
 	"github.com/wendylabsinc/wendy/proto/gen/agentpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -107,6 +109,62 @@ func TestDeviceList_ReturnsConfiguredDevices(t *testing.T) {
 	}
 	if len(devices) == 0 {
 		t.Fatal("expected at least one device")
+	}
+}
+
+func TestDeviceList_SourceFieldOnConfigEntries(t *testing.T) {
+	cfg := &config.Config{
+		Auth: []config.AuthConfig{
+			{CloudGRPC: "mydevice.local:50051"},
+		},
+	}
+	srv := New(cfg, nil)
+	result, err := srv.callTool(context.Background(), "device_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result")
+	}
+	var devices []map[string]any
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &devices); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	for _, d := range devices {
+		if d["source"] != "config" {
+			t.Errorf("expected source=config, got %v (device: %v)", d["source"], d)
+		}
+	}
+}
+
+func TestDeviceList_ScanTrue_IncludesScanResults(t *testing.T) {
+	cfg := &config.Config{}
+	srv := New(cfg, nil)
+	srv.discoverLANFn = func(_ context.Context, _ time.Duration) ([]models.LANDevice, error) {
+		return []models.LANDevice{
+			{DisplayName: "test-device", Hostname: "test-device.local", Port: 50051, AgentVersion: "1.0.0"},
+		}, nil
+	}
+
+	result, err := srv.callTool(context.Background(), "device_list", map[string]any{"scan": true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result")
+	}
+	var devices []map[string]any
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &devices); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(devices))
+	}
+	if devices[0]["source"] != "scan" {
+		t.Errorf("expected source=scan, got %v", devices[0]["source"])
+	}
+	if devices[0]["type"] != "lan" {
+		t.Errorf("expected type=lan, got %v", devices[0]["type"])
 	}
 }
 

--- a/go/internal/cli/mcp/tools_guide.go
+++ b/go/internal/cli/mcp/tools_guide.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"context"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const guideText = `Wendy MCP Guide
+===============
+
+Wendy manages remote Linux devices (edge servers, embedded boards, cloud VMs).
+Every MCP session has at most one active device connection at a time.
+
+## Getting started
+
+Call wendy_status first — it tells you whether you are connected and what to do next.
+
+## Connecting to a device
+
+Local/direct devices:
+1. device_list          — lists devices from config (add scan=true for live mDNS scan)
+2. device_connect       — connect by address (host:port), e.g. "mydevice.local:50051"
+
+Cloud-enrolled devices:
+1. cloud_discover       — finds devices enrolled in your Wendy Cloud account
+2. cloud_connect        — opens a secure tunnel to a cloud device by name
+
+## Tools available once connected
+
+- container_list / container_start / container_stop / container_delete / container_attach / container_stats
+- wifi_list / wifi_connect / wifi_disconnect / wifi_status / wifi_known_networks
+- telemetry_logs / telemetry_metrics / telemetry_traces
+- hardware_capabilities
+- os_update
+- filesync_sync
+- provisioning_start / provisioning_status
+
+## Deploying a workload
+
+Use cloud_run to run a container image on a cloud-enrolled device:
+  cloud_run(device_name="mydevice", image="ghcr.io/myorg/myapp:latest")
+
+## Disconnecting
+
+device_disconnect — closes the active connection and frees resources.
+`
+
+func (s *mcpServer) registerGuideResource(srv *server.MCPServer) {
+	srv.AddResource(
+		mcpgo.NewResource("wendy://guide", "Wendy Guide",
+			mcpgo.WithResourceDescription("Overview of Wendy MCP tools, connection model, and common workflows. Read this first."),
+			mcpgo.WithMIMEType("text/plain"),
+		),
+		s.handleGuideResource,
+	)
+}
+
+func (s *mcpServer) handleGuideResource(_ context.Context, _ mcpgo.ReadResourceRequest) ([]mcpgo.ResourceContents, error) {
+	return []mcpgo.ResourceContents{
+		mcpgo.TextResourceContents{URI: "wendy://guide", MIMEType: "text/plain", Text: guideText},
+	}, nil
+}

--- a/go/internal/cli/mcp/tools_guide.go
+++ b/go/internal/cli/mcp/tools_guide.go
@@ -39,8 +39,8 @@ Cloud-enrolled devices:
 
 ## Deploying a workload
 
-Use cloud_run to run a container image on a cloud-enrolled device:
-  cloud_run(device_name="mydevice", image="ghcr.io/myorg/myapp:latest")
+Use the run tool to build and deploy a local project to a cloud-enrolled device:
+  run(project_path="/path/to/project", device_name="mydevice")
 
 ## Disconnecting
 

--- a/go/internal/cli/mcp/tools_status.go
+++ b/go/internal/cli/mcp/tools_status.go
@@ -1,0 +1,43 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func (s *mcpServer) registerStatusTools(srv *server.MCPServer) {
+	srv.AddTool(mcpgo.NewTool("wendy_status",
+		mcpgo.WithDescription("Return current MCP session connection state and a plain-English suggested next step. Call this first to orient yourself."),
+	), s.handleWendyStatus)
+}
+
+func (s *mcpServer) handleWendyStatus(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	connType := s.GetConnType()
+
+	if conn == nil {
+		out := map[string]any{
+			"connected":           false,
+			"suggested_next_step": "not connected — call device_list to see available devices then device_connect, or cloud_discover + cloud_connect for cloud-enrolled devices",
+		}
+		b, _ := json.Marshal(out)
+		return mcpgo.NewToolResultText(string(b)), nil
+	}
+
+	host := conn.Host
+	if host == "" {
+		host = "device"
+	}
+	out := map[string]any{
+		"connected":           true,
+		"device":              host,
+		"connection_type":     connType,
+		"suggested_next_step": fmt.Sprintf("connected to %s via %s — ready to use container, wifi, hardware, telemetry, and os tools", host, connType),
+	}
+	b, _ := json.Marshal(out)
+	return mcpgo.NewToolResultText(string(b)), nil
+}

--- a/go/internal/cli/mcp/tools_status_test.go
+++ b/go/internal/cli/mcp/tools_status_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/internal/shared/config"
+)
+
+func TestWendyStatus_NotConnected(t *testing.T) {
+	srv := New(&config.Config{}, nil)
+	result, err := srv.handleWendyStatus(context.Background(), callToolReq("wendy_status", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &out); err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+	if out["connected"] != false {
+		t.Errorf("expected connected=false, got %v", out["connected"])
+	}
+	if out["suggested_next_step"] == "" {
+		t.Error("expected non-empty suggested_next_step")
+	}
+}
+
+func TestWendyStatus_Connected_Direct(t *testing.T) {
+	conn, _ := startFakeAgentServer(t, &fakeAgentServer{})
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+	srv.SetConnType("direct")
+
+	result, err := srv.handleWendyStatus(context.Background(), callToolReq("wendy_status", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &out); err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+	if out["connected"] != true {
+		t.Errorf("expected connected=true, got %v", out["connected"])
+	}
+	if out["connection_type"] != "direct" {
+		t.Errorf("expected connection_type=direct, got %v", out["connection_type"])
+	}
+}


### PR DESCRIPTION
## Summary

- **AGENTS.md** — top-level onboarding doc for LLMs with repo access: setup steps, connection model, auth, and quick start
- **`wendy mcp setup` expansion** — auto-detects and configures Cursor (`~/.cursor/mcp.json`), Windsurf (`~/.codeium/windsurf/mcp_config.json`), and Codex (`~/.codex/config.toml`, TOML format with `[mcp_servers.wendy]`)
- **`wendy_status` MCP tool** — call-first tool that returns `connected`, `device`, `connection_type`, and a plain-English `suggested_next_step`
- **`wendy://guide` MCP resource** — static orientation doc registered at server startup; explains connection model and common tool workflows
- **`device_list` `scan` param** — optional `scan=true` runs a live 3-second mDNS scan; all results include a `source` field (`"config"` or `"scan"`)
- **`run` MCP tool** — replaces `cloud_run` as the canonical deploy tool (no `cloud_grpc`/`broker_url` noise); `cloud_run` kept as deprecated alias
- **`wendy run` cloud fallback** — `resolveRunTarget` tries direct connection first, then falls back to cloud tunnel if auth entries exist and the device isn't reachable directly
- **`wendy cloud run` deprecation** — now a hidden alias that injects cloud context and delegates to `runCommand`

## Test plan

- [ ] `wendy mcp setup` on a machine with Claude Code installed → confirms `✓ Claude Code: configured at ~/.claude.json`
- [ ] `wendy mcp setup` on a machine with Cursor installed → confirms `✓ Cursor: configured at ~/.cursor/mcp.json`
- [ ] `wendy mcp setup` on a machine with Codex installed → `~/.codex/config.toml` contains `[mcp_servers.wendy]` with `command` and `args`
- [ ] Start `wendy mcp serve` from Claude Desktop / Claude Code; call `wendy_status` → returns `connected: false` with next-step hint
- [ ] Read `wendy://guide` resource → returns orientation text
- [ ] `device_list` with `scan: true` → results include `source: "scan"` entries
- [ ] `wendy run --device mydevice` where device is only cloud-enrolled → connects via cloud automatically
- [ ] `wendy cloud run` still works (hidden but functional)
- [ ] `go test ./internal/cli/commands/... ./internal/cli/mcp/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)