### PR TITLE
feat(WDY-892): parallel multi-service build in wendy run

### DIFF
--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -382,12 +382,12 @@ func serviceOrder(cfg *composeConfig) ([]string, error) {
 
 // serviceLogPalette is the fixed color rotation for service name prefixes.
 var serviceLogPalette = []lipgloss.Color{
-	tui.Sky500,                     // cyan-ish
-	tui.Amber500,                   // yellow
-	tui.Emerald400,                 // green
-	lipgloss.Color("#c084fc"),      // magenta
-	lipgloss.Color("#60a5fa"),      // blue
-	tui.Red500,                     // red
+	tui.Sky500,                // cyan-ish
+	tui.Amber500,              // yellow
+	tui.Emerald400,            // green
+	lipgloss.Color("#c084fc"), // magenta
+	lipgloss.Color("#60a5fa"), // blue
+	tui.Red500,                // red
 }
 
 // serviceLogWriter buffers output for a single service and writes complete

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -166,7 +166,7 @@ func detectBuildOptions(dir string) []BuildOption {
 }
 
 // injectDebugpy builds a wrapper image on top of the given image that installs debugpy.
-func injectDebugpy(ctx context.Context, registryAddr, registryImage, platform string, buildArgs map[string]string, streamOutput *os.File, useMTLS bool) error {
+func injectDebugpy(ctx context.Context, registryAddr, registryImage, platform string, buildArgs map[string]string, streamOutput io.Writer, useMTLS bool) error {
 	tmpDir, err := os.MkdirTemp("", "wendy-debugpy-*")
 	if err != nil {
 		return fmt.Errorf("creating temp dir: %w", err)
@@ -886,7 +886,7 @@ func updateBuilderConfig(ctx context.Context, builderName, config string) error 
 // it directly to the given registry using docker buildx. The registry transport
 // is conditional: plain HTTP for plaintext devices, and TLS/mTLS for provisioned
 // devices when useMTLS is enabled. buildArgs is passed as --build-arg KEY=VALUE flags.
-func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, platform string, buildArgs map[string]string, streamOutput *os.File, useMTLS bool) error {
+func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, platform string, buildArgs map[string]string, streamOutput io.Writer, useMTLS bool) error {
 	builder, effectiveAddr, err := ensureBuildxBuilder(ctx, registryAddr, useMTLS)
 	if err != nil {
 		return err

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -1,0 +1,395 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/wendylabsinc/wendy/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/proto/gen/agentpb"
+)
+
+const maxConcurrentBuilds = 4
+
+// resolveServiceSubset returns the services to build when --service is
+// specified. The named service and all transitive dependsOn entries are
+// included; if the name is empty all services are returned unchanged.
+func resolveServiceSubset(services map[string]*appconfig.ServiceConfig, only string) (map[string]*appconfig.ServiceConfig, error) {
+	if only == "" {
+		return services, nil
+	}
+
+	svc, ok := services[only]
+	if !ok {
+		return nil, fmt.Errorf("--service %q not found in services map", only)
+	}
+
+	subset := map[string]*appconfig.ServiceConfig{only: svc}
+	var walk func(name string)
+	walk = func(name string) {
+		for _, dep := range services[name].DependsOn {
+			if _, seen := subset[dep]; !seen {
+				subset[dep] = services[dep]
+				walk(dep)
+			}
+		}
+	}
+	walk(only)
+	return subset, nil
+}
+
+// serviceTopoOrder returns service names in topological order so that every
+// service appears after its dependsOn entries. Cycles are broken by appending
+// remaining names at the end (compose.go uses the same approach).
+func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) []string {
+	visited := make(map[string]bool, len(services))
+	ordered := make([]string, 0, len(services))
+
+	var visit func(name string)
+	visit = func(name string) {
+		if visited[name] {
+			return
+		}
+		visited[name] = true
+		if svc, ok := services[name]; ok {
+			for _, dep := range svc.DependsOn {
+				visit(dep)
+			}
+		}
+		ordered = append(ordered, name)
+	}
+
+	// Iterate in a stable order: collect names, sort, then visit.
+	names := make([]string, 0, len(services))
+	for n := range services {
+		names = append(names, n)
+	}
+	stableSort(names)
+	for _, n := range names {
+		visit(n)
+	}
+	return ordered
+}
+
+// stableSort sorts a string slice in place.
+func stableSort(ss []string) {
+	for i := 1; i < len(ss); i++ {
+		for j := i; j > 0 && ss[j] < ss[j-1]; j-- {
+			ss[j], ss[j-1] = ss[j-1], ss[j]
+		}
+	}
+}
+
+// runMultiServiceWithAgent orchestrates the full build → push → create →
+// stream pipeline for a multi-service wendy.json on a single agent.
+func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, opts runOptions) error {
+	services, err := resolveServiceSubset(appCfg.Services, opts.service)
+	if err != nil {
+		return err
+	}
+
+	if err := requireRegistryAuth(ctx, conn); err != nil {
+		return err
+	}
+
+	versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	if err != nil {
+		return fmt.Errorf("querying device version: %w", err)
+	}
+	agentOS := versionResp.GetOs()
+	architecture := versionResp.GetCpuArchitecture()
+	if architecture == "" {
+		architecture = "arm64"
+	}
+	platform := resolveAgentPlatform(appCfg.Platform, agentOS, architecture)
+
+	regPort := registryPort(agentOS)
+	registryAddr, proxyCleanup, err := resolveRegistryForAgent(ctx, conn, regPort)
+	if err != nil {
+		return err
+	}
+	defer proxyCleanup()
+
+	buildArgs := map[string]string{
+		"WENDY_PLATFORM": wendyPlatform(versionResp.GetDeviceType()),
+		"WENDY_DEBUG":    fmt.Sprintf("%t", opts.debug),
+	}
+	if dt := versionResp.GetDeviceType(); dt != "" {
+		buildArgs["WENDY_DEVICE_TYPE"] = dt
+	}
+	if versionResp.HasGpu != nil {
+		buildArgs["WENDY_HAS_GPU"] = fmt.Sprintf("%t", versionResp.GetHasGpu())
+	}
+	if v := versionResp.GetGpuVendor(); v != "" {
+		buildArgs["WENDY_GPU_VENDOR"] = v
+	}
+	if jv := versionResp.GetJetpackVersion(); jv != "" {
+		buildArgs["WENDY_JETPACK_VERSION"] = jv
+	}
+	if cv := versionResp.GetCudaVersion(); cv != "" {
+		buildArgs["WENDY_CUDA_VERSION"] = cv
+	}
+
+	// Build all service images in parallel, then create and start containers.
+	if err := buildServicesParallel(ctx, cwd, appCfg.AppID, services, registryAddr, platform, buildArgs, conn.IsMTLS); err != nil {
+		return err
+	}
+
+	// Create containers in dependency order.
+	ordered := serviceTopoOrder(services)
+	for _, name := range ordered {
+		svc := services[name]
+		deviceImage := fmt.Sprintf("localhost:%d/%s-%s:latest", regPort,
+			strings.ToLower(appCfg.AppID), strings.ToLower(name))
+
+		serviceCfg := &appconfig.AppConfig{
+			AppID:        fmt.Sprintf("%s-%s", appCfg.AppID, name),
+			Platform:     appCfg.Platform,
+			Entitlements: svc.Entitlements,
+		}
+		appConfigData, err := json.Marshal(serviceCfg)
+		if err != nil {
+			return fmt.Errorf("marshaling config for service %s: %w", name, err)
+		}
+
+		restartPolicy := resolveRestartPolicy(opts)
+		createReq := &agentpb.CreateContainerRequest{
+			ImageName:     deviceImage,
+			AppName:       serviceCfg.AppID,
+			AppConfig:     appConfigData,
+			RestartPolicy: restartPolicy,
+		}
+
+		cliLogln("Creating container for service %s...", name)
+		if err := createContainerWithProgress(ctx, conn.ContainerService, createReq); err != nil {
+			return fmt.Errorf("creating container for service %s: %w", name, err)
+		}
+		cliLogln("Service %s container created.", name)
+	}
+
+	if opts.deploy {
+		cliLogln("App group %s created (not started, --deploy).", appCfg.AppID)
+		return nil
+	}
+
+	// Start all containers and multiplex log output with per-service prefixes.
+	return startAndStreamServices(ctx, conn, appCfg.AppID, ordered, opts)
+}
+
+// buildServicesParallel builds all service images concurrently (up to
+// maxConcurrentBuilds at a time). Progress is shown via a Bubbletea multi-
+// spinner in interactive terminals and via plain log lines otherwise.
+func buildServicesParallel(
+	ctx context.Context,
+	cwd, appID string,
+	services map[string]*appconfig.ServiceConfig,
+	registryAddr, platform string,
+	buildArgs map[string]string,
+	useMTLS bool,
+) error {
+	names := make([]string, 0, len(services))
+	for n := range services {
+		names = append(names, n)
+	}
+	stableSort(names)
+
+	type result struct {
+		name string
+		err  error
+		dur  time.Duration
+	}
+
+	results := make(chan result, len(names))
+	sem := make(chan struct{}, maxConcurrentBuilds)
+
+	var prog *tea.Program
+	if isInteractiveTerminal() {
+		title := fmt.Sprintf("Building %d service(s)...", len(names))
+		m := tui.NewMultiSpinner(title, names)
+		prog = tea.NewProgram(m)
+	}
+
+	var wg sync.WaitGroup
+	for _, name := range names {
+		wg.Add(1)
+		go func(name string, svc *appconfig.ServiceConfig) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			if prog != nil {
+				prog.Send(tui.MultiSpinnerStartMsg{Name: name})
+			} else {
+				cliLogln("Building service %s...", name)
+			}
+
+			start := time.Now()
+			contextDir := filepath.Join(cwd, svc.Context)
+			imageName := fmt.Sprintf("%s/%s-%s:latest",
+				registryAddr, strings.ToLower(appID), strings.ToLower(name))
+
+			err := buildAndPushImage(ctx, contextDir, registryAddr, imageName, platform, buildArgs, os.Stdout, useMTLS)
+			dur := time.Since(start)
+
+			if prog != nil {
+				prog.Send(tui.MultiSpinnerDoneMsg{Name: name, Err: err, Dur: dur})
+			} else if err != nil {
+				cliLogln("Service %s build failed: %v", name, err)
+			} else {
+				cliLogln("Service %s built (%s).", name, dur.Round(time.Millisecond))
+			}
+
+			results <- result{name: name, err: err, dur: dur}
+		}(name, services[name])
+	}
+
+	// Wait for all goroutines, close the results channel, then signal TUI done.
+	go func() {
+		wg.Wait()
+		close(results)
+		if prog != nil {
+			prog.Send(tui.MultiSpinnerAllDoneMsg{})
+		}
+	}()
+
+	if prog != nil {
+		if _, runErr := prog.Run(); runErr != nil {
+			return fmt.Errorf("build progress TUI: %w", runErr)
+		}
+	}
+
+	// Collect errors from all builds.
+	var errs []error
+	for r := range results {
+		if r.err != nil {
+			errs = append(errs, fmt.Errorf("service %s: %w", r.name, r.err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+var serviceLogStyle = lipgloss.NewStyle().Foreground(tui.ColorInfo)
+
+// startAndStreamServices starts all service containers and streams their
+// combined output to stdout/stderr with a "[serviceName] " prefix per line.
+// This is a best-effort multiplexer; proper per-service log routing is handled
+// by WDY-893 (multiplexed AttachContainer).
+func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnection, appID string, ordered []string, opts runOptions) error {
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+
+	// Ctrl+C stops all services.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	go func() {
+		<-sigCh
+		cliLogln("\nStopping services...")
+		for _, name := range ordered {
+			_, _ = conn.ContainerService.StopContainer(context.Background(), &agentpb.StopContainerRequest{
+				AppName: fmt.Sprintf("%s-%s", appID, name),
+			})
+		}
+		runCancel()
+	}()
+
+	if opts.detach {
+		for _, name := range ordered {
+			containerName := fmt.Sprintf("%s-%s", appID, name)
+			stream, err := conn.ContainerService.StartContainer(runCtx, &agentpb.StartContainerRequest{
+				AppName: containerName,
+			})
+			if err != nil {
+				return fmt.Errorf("starting service %s: %w", name, err)
+			}
+			if _, err := stream.Recv(); err != nil && err != io.EOF {
+				return fmt.Errorf("waiting for service %s to start: %w", name, err)
+			}
+		}
+		cliLogln("App group %s running in detached mode.", appID)
+		return nil
+	}
+
+	type logLine struct {
+		service string
+		stdout  bool
+		data    []byte
+	}
+	lines := make(chan logLine, 256)
+
+	var wg sync.WaitGroup
+	for _, name := range ordered {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			containerName := fmt.Sprintf("%s-%s", appID, name)
+			stream, err := conn.ContainerService.StartContainer(runCtx, &agentpb.StartContainerRequest{
+				AppName: containerName,
+			})
+			if err != nil {
+				if runCtx.Err() == nil {
+					cliLogln("Warning: starting service %s: %v", name, err)
+				}
+				return
+			}
+			for {
+				resp, recvErr := stream.Recv()
+				if recvErr == io.EOF {
+					return
+				}
+				if recvErr != nil {
+					if runCtx.Err() == nil {
+						cliLogln("Warning: service %s stream: %v", name, recvErr)
+					}
+					return
+				}
+				if out := resp.GetStdoutOutput(); out != nil {
+					lines <- logLine{service: name, stdout: true, data: out.GetData()}
+				}
+				if out := resp.GetStderrOutput(); out != nil {
+					lines <- logLine{service: name, stdout: false, data: out.GetData()}
+				}
+			}
+		}(name)
+	}
+
+	go func() {
+		wg.Wait()
+		close(lines)
+	}()
+
+	cliLogln("App group %s started (%d services).", appID, len(ordered))
+
+	for line := range lines {
+		prefix := serviceLogStyle.Render(fmt.Sprintf("[%s] ", line.service))
+		if line.stdout {
+			fmt.Fprint(os.Stdout, prefix)
+			os.Stdout.Write(line.data)
+		} else {
+			fmt.Fprint(os.Stderr, prefix)
+			os.Stderr.Write(line.data)
+		}
+	}
+
+	if runCtx.Err() != nil {
+		cliLogln("\nApp group %s stopped.", appID)
+		return nil
+	}
+	cliLogln("\nApp group %s stopped.", appID)
+	return nil
+}

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -38,30 +39,39 @@ func resolveServiceSubset(services map[string]*appconfig.ServiceConfig, only str
 	}
 
 	subset := map[string]*appconfig.ServiceConfig{only: svc}
-	var walk func(name string)
-	walk = func(name string) {
+	var walk func(name string) error
+	walk = func(name string) error {
 		svc, ok := services[name]
 		if !ok || svc == nil {
-			return
+			return nil
 		}
 		for _, dep := range svc.DependsOn {
 			if _, seen := subset[dep]; !seen {
-				subset[dep] = services[dep]
-				walk(dep)
+				depSvc, ok := services[dep]
+				if !ok {
+					return fmt.Errorf("service %q depends on unknown service %q", name, dep)
+				}
+				subset[dep] = depSvc
+				if err := walk(dep); err != nil {
+					return err
+				}
 			}
 		}
+		return nil
 	}
-	walk(only)
+	if err := walk(only); err != nil {
+		return nil, err
+	}
 	return subset, nil
 }
 
 // serviceTopoOrder returns service names in topological order so that every
-// service appears after its dependsOn entries. Cycles are broken by appending
-// remaining names at the end (compose.go uses the same approach).
-// All deps must already be present in services (resolveServiceSubset guarantees
-// transitive closure); a missing dep returns an error.
+// service appears after its dependsOn entries. Returns an error for cyclic
+// graphs. All deps must already be present in services (resolveServiceSubset
+// guarantees transitive closure); a missing dep returns an error.
 func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) ([]string, error) {
 	visited := make(map[string]bool, len(services))
+	inStack := make(map[string]bool, len(services))
 	ordered := make([]string, 0, len(services))
 
 	var visit func(name string) error
@@ -69,7 +79,10 @@ func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) ([]string, e
 		if visited[name] {
 			return nil
 		}
-		visited[name] = true
+		if inStack[name] {
+			return fmt.Errorf("cycle detected in dependsOn graph involving service %q", name)
+		}
+		inStack[name] = true
 		if svc, ok := services[name]; ok {
 			for _, dep := range svc.DependsOn {
 				if _, present := services[dep]; !present {
@@ -80,6 +93,8 @@ func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) ([]string, e
 				}
 			}
 		}
+		delete(inStack, name)
+		visited[name] = true
 		ordered = append(ordered, name)
 		return nil
 	}
@@ -89,22 +104,13 @@ func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) ([]string, e
 	for n := range services {
 		names = append(names, n)
 	}
-	stableSort(names)
+	sort.Strings(names)
 	for _, n := range names {
 		if err := visit(n); err != nil {
 			return nil, err
 		}
 	}
 	return ordered, nil
-}
-
-// stableSort sorts a string slice in place.
-func stableSort(ss []string) {
-	for i := 1; i < len(ss); i++ {
-		for j := i; j > 0 && ss[j] < ss[j-1]; j-- {
-			ss[j], ss[j-1] = ss[j-1], ss[j]
-		}
-	}
 }
 
 // runMultiServiceWithAgent orchestrates the full build → push → create →
@@ -126,6 +132,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	agentOS := versionResp.GetOs()
 	architecture := versionResp.GetCpuArchitecture()
 	if architecture == "" {
+		cliLogln("Warning: agent did not report CPU architecture; assuming arm64.")
 		architecture = "arm64"
 	}
 	platform := resolveAgentPlatform(appCfg.Platform, agentOS, architecture)
@@ -194,7 +201,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 		}
 
 		cliLogln("Creating container for service %s...", name)
-		if err := createContainerWithProgress(ctx, conn.ContainerService, createReq); err != nil {
+		if err := createContainerWithoutProgress(ctx, conn.ContainerService, createReq); err != nil {
 			return fmt.Errorf("creating container for service %s: %w", name, err)
 		}
 		cliLogln("Service %s container created.", name)
@@ -224,7 +231,7 @@ func buildServicesParallel(
 	for n := range services {
 		names = append(names, n)
 	}
-	stableSort(names)
+	sort.Strings(names)
 
 	type result struct {
 		name string
@@ -261,7 +268,11 @@ func buildServicesParallel(
 			imageName := fmt.Sprintf("%s/%s-%s:latest",
 				registryAddr, strings.ToLower(appID), strings.ToLower(name))
 
-			err := buildAndPushImage(ctx, contextDir, registryAddr, imageName, platform, buildArgs, os.Stdout, useMTLS)
+			buildOut := io.Writer(os.Stdout)
+			if prog != nil {
+				buildOut = io.Discard
+			}
+			err := buildAndPushImage(ctx, contextDir, registryAddr, imageName, platform, buildArgs, buildOut, useMTLS)
 			dur := time.Since(start)
 
 			if prog != nil {
@@ -321,14 +332,20 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 	go func() {
 		<-sigCh
 		cliLogln("\nStopping services...")
+		runCancel()
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer stopCancel()
+		var stopWg sync.WaitGroup
 		for _, name := range ordered {
-			_, _ = conn.ContainerService.StopContainer(stopCtx, &agentpb.StopContainerRequest{
-				AppName: fmt.Sprintf("%s-%s", appID, name),
-			})
+			stopWg.Add(1)
+			go func(name string) {
+				defer stopWg.Done()
+				_, _ = conn.ContainerService.StopContainer(stopCtx, &agentpb.StopContainerRequest{
+					AppName: fmt.Sprintf("%s-%s", appID, name),
+				})
+			}(name)
 		}
-		runCancel()
+		stopWg.Wait()
 	}()
 
 	if opts.detach {
@@ -382,10 +399,18 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 					return
 				}
 				if out := resp.GetStdoutOutput(); out != nil {
-					lines <- logLine{service: name, stdout: true, data: out.GetData()}
+					select {
+					case lines <- logLine{service: name, stdout: true, data: out.GetData()}:
+					case <-runCtx.Done():
+						return
+					}
 				}
 				if out := resp.GetStderrOutput(); out != nil {
-					lines <- logLine{service: name, stdout: false, data: out.GetData()}
+					select {
+					case lines <- logLine{service: name, stdout: false, data: out.GetData()}:
+					case <-runCtx.Done():
+						return
+					}
 				}
 			}
 		}(name)

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -40,7 +40,11 @@ func resolveServiceSubset(services map[string]*appconfig.ServiceConfig, only str
 	subset := map[string]*appconfig.ServiceConfig{only: svc}
 	var walk func(name string)
 	walk = func(name string) {
-		for _, dep := range services[name].DependsOn {
+		svc, ok := services[name]
+		if !ok || svc == nil {
+			return
+		}
+		for _, dep := range svc.DependsOn {
 			if _, seen := subset[dep]; !seen {
 				subset[dep] = services[dep]
 				walk(dep)
@@ -54,22 +58,30 @@ func resolveServiceSubset(services map[string]*appconfig.ServiceConfig, only str
 // serviceTopoOrder returns service names in topological order so that every
 // service appears after its dependsOn entries. Cycles are broken by appending
 // remaining names at the end (compose.go uses the same approach).
-func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) []string {
+// All deps must already be present in services (resolveServiceSubset guarantees
+// transitive closure); a missing dep returns an error.
+func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) ([]string, error) {
 	visited := make(map[string]bool, len(services))
 	ordered := make([]string, 0, len(services))
 
-	var visit func(name string)
-	visit = func(name string) {
+	var visit func(name string) error
+	visit = func(name string) error {
 		if visited[name] {
-			return
+			return nil
 		}
 		visited[name] = true
 		if svc, ok := services[name]; ok {
 			for _, dep := range svc.DependsOn {
-				visit(dep)
+				if _, present := services[dep]; !present {
+					return fmt.Errorf("service %q depends on %q which is not in the build subset", name, dep)
+				}
+				if err := visit(dep); err != nil {
+					return err
+				}
 			}
 		}
 		ordered = append(ordered, name)
+		return nil
 	}
 
 	// Iterate in a stable order: collect names, sort, then visit.
@@ -79,9 +91,11 @@ func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) []string {
 	}
 	stableSort(names)
 	for _, n := range names {
-		visit(n)
+		if err := visit(n); err != nil {
+			return nil, err
+		}
 	}
-	return ordered
+	return ordered, nil
 }
 
 // stableSort sorts a string slice in place.
@@ -125,7 +139,10 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 
 	buildArgs := map[string]string{
 		"WENDY_PLATFORM": wendyPlatform(versionResp.GetDeviceType()),
-		"WENDY_DEBUG":    fmt.Sprintf("%t", opts.debug),
+	}
+	if opts.debug {
+		cliLogln("Warning: building with WENDY_DEBUG=true — do not deploy to production.")
+		buildArgs["WENDY_DEBUG"] = "true"
 	}
 	if dt := versionResp.GetDeviceType(); dt != "" {
 		buildArgs["WENDY_DEVICE_TYPE"] = dt
@@ -149,7 +166,10 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Create containers in dependency order.
-	ordered := serviceTopoOrder(services)
+	ordered, err := serviceTopoOrder(services)
+	if err != nil {
+		return err
+	}
 	for _, name := range ordered {
 		svc := services[name]
 		deviceImage := fmt.Sprintf("localhost:%d/%s-%s:latest", regPort,
@@ -297,11 +317,14 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 	// Ctrl+C stops all services.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
 	go func() {
 		<-sigCh
 		cliLogln("\nStopping services...")
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer stopCancel()
 		for _, name := range ordered {
-			_, _ = conn.ContainerService.StopContainer(context.Background(), &agentpb.StopContainerRequest{
+			_, _ = conn.ContainerService.StopContainer(stopCtx, &agentpb.StopContainerRequest{
 				AppName: fmt.Sprintf("%s-%s", appID, name),
 			})
 		}
@@ -378,11 +401,9 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 	for line := range lines {
 		prefix := serviceLogStyle.Render(fmt.Sprintf("[%s] ", line.service))
 		if line.stdout {
-			fmt.Fprint(os.Stdout, prefix)
-			os.Stdout.Write(line.data)
+			fmt.Fprintf(os.Stdout, "%s%s", prefix, line.data)
 		} else {
-			fmt.Fprint(os.Stderr, prefix)
-			os.Stderr.Write(line.data)
+			fmt.Fprintf(os.Stderr, "%s%s", prefix, line.data)
 		}
 	}
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -394,6 +394,7 @@ type runOptions struct {
 	noRestart            bool
 	prefix               string
 	product              string
+	service              string
 	userArgs             []string
 }
 
@@ -419,6 +420,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.noRestart, "no-restart", false, "Do not restart on exit")
 	cmd.Flags().StringVar(&opts.prefix, "prefix", "", "Project directory to run from instead of the current working directory")
 	cmd.Flags().StringVar(&opts.product, "product", "", "Swift Package Manager product to build and run")
+	cmd.Flags().StringVar(&opts.service, "service", "", "Build and run only the named service and its dependencies (multi-service projects)")
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
 
 	return cmd
@@ -1008,6 +1010,12 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 
 // runWithAgent is the existing gRPC agent pipeline.
 func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, opts runOptions) error {
+	// Multi-service path: when wendy.json has a services map, build all images
+	// in parallel and manage the app group lifecycle.
+	if len(appCfg.Services) > 0 {
+		return runMultiServiceWithAgent(ctx, conn, cwd, appCfg, opts)
+	}
+
 	// Detect project type and ensure a Dockerfile exists.
 	projectType, err := resolveRunProjectType(cwd, opts.buildType)
 	if err != nil {

--- a/go/internal/cli/tui/multispinner.go
+++ b/go/internal/cli/tui/multispinner.go
@@ -137,12 +137,12 @@ func (m MultiSpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 var (
-	msCheckStyle  = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true)
-	msCrossStyle  = lipgloss.NewStyle().Foreground(ColorError).Bold(true)
-	msNameStyle   = lipgloss.NewStyle().Width(12)
-	msDimStyle    = lipgloss.NewStyle().Foreground(ColorDim)
-	msErrorStyle  = lipgloss.NewStyle().Foreground(ColorError)
-	msTitleStyle  = lipgloss.NewStyle().Foreground(ColorPrimary)
+	msCheckStyle = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true)
+	msCrossStyle = lipgloss.NewStyle().Foreground(ColorError).Bold(true)
+	msNameStyle  = lipgloss.NewStyle().Width(12)
+	msDimStyle   = lipgloss.NewStyle().Foreground(ColorDim)
+	msErrorStyle = lipgloss.NewStyle().Foreground(ColorError)
+	msTitleStyle = lipgloss.NewStyle().Foreground(ColorPrimary)
 )
 
 // View implements tea.Model.

--- a/go/internal/cli/tui/multispinner.go
+++ b/go/internal/cli/tui/multispinner.go
@@ -1,0 +1,219 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// MultiSpinnerServiceStatus describes the build state of a single service row.
+type MultiSpinnerServiceStatus int
+
+const (
+	MultiSpinnerPending MultiSpinnerServiceStatus = iota
+	MultiSpinnerRunning
+	MultiSpinnerDone
+	MultiSpinnerFailed
+)
+
+// MultiSpinnerStartMsg signals that a service's build has begun.
+type MultiSpinnerStartMsg struct{ Name string }
+
+// MultiSpinnerDetailMsg updates the detail text shown next to a service row.
+type MultiSpinnerDetailMsg struct {
+	Name   string
+	Detail string
+}
+
+// MultiSpinnerDoneMsg signals that a service's build has finished.
+type MultiSpinnerDoneMsg struct {
+	Name string
+	Err  error
+	Dur  time.Duration
+}
+
+// MultiSpinnerAllDoneMsg signals that all service builds have completed.
+// Err is non-nil if any individual build failed.
+type MultiSpinnerAllDoneMsg struct{ Err error }
+
+type multiSpinnerRow struct {
+	name   string
+	status MultiSpinnerServiceStatus
+	detail string
+	dur    time.Duration
+	err    error
+}
+
+// MultiSpinnerModel is a Bubble Tea model that shows per-service build progress.
+//
+//	⠋ Building 3 services...
+//	  ✓ postgres   2.1s
+//	  ⠋ api        building...
+//	  ⠋ frontend   building...
+type MultiSpinnerModel struct {
+	title   string
+	rows    []multiSpinnerRow
+	byName  map[string]int
+	spinner spinner.Model
+	done    bool
+	err     error
+}
+
+// NewMultiSpinner creates a MultiSpinnerModel with the given title and service
+// names listed in display order.
+func NewMultiSpinner(title string, names []string) MultiSpinnerModel {
+	rows := make([]multiSpinnerRow, len(names))
+	byName := make(map[string]int, len(names))
+	for i, n := range names {
+		rows[i] = multiSpinnerRow{name: n, status: MultiSpinnerPending}
+		byName[n] = i
+	}
+
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(ColorPrimary)
+
+	return MultiSpinnerModel{
+		title:   title,
+		rows:    rows,
+		byName:  byName,
+		spinner: s,
+	}
+}
+
+// Init implements tea.Model.
+func (m MultiSpinnerModel) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+// Update implements tea.Model.
+func (m MultiSpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			m.done = true
+			m.err = ErrCancelled
+			return m, tea.Quit
+		}
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case MultiSpinnerStartMsg:
+		if i, ok := m.byName[msg.Name]; ok {
+			m.rows[i].status = MultiSpinnerRunning
+		}
+
+	case MultiSpinnerDetailMsg:
+		if i, ok := m.byName[msg.Name]; ok {
+			m.rows[i].detail = msg.Detail
+		}
+
+	case MultiSpinnerDoneMsg:
+		if i, ok := m.byName[msg.Name]; ok {
+			m.rows[i].dur = msg.Dur
+			if msg.Err != nil {
+				m.rows[i].status = MultiSpinnerFailed
+				m.rows[i].err = msg.Err
+			} else {
+				m.rows[i].status = MultiSpinnerDone
+				m.rows[i].detail = ""
+			}
+		}
+
+	case MultiSpinnerAllDoneMsg:
+		m.done = true
+		m.err = msg.Err
+		return m, tea.Quit
+	}
+
+	return m, nil
+}
+
+var (
+	msCheckStyle  = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true)
+	msCrossStyle  = lipgloss.NewStyle().Foreground(ColorError).Bold(true)
+	msNameStyle   = lipgloss.NewStyle().Width(12)
+	msDimStyle    = lipgloss.NewStyle().Foreground(ColorDim)
+	msErrorStyle  = lipgloss.NewStyle().Foreground(ColorError)
+	msTitleStyle  = lipgloss.NewStyle().Foreground(ColorPrimary)
+)
+
+// View implements tea.Model.
+func (m MultiSpinnerModel) View() string {
+	if m.done {
+		return ""
+	}
+
+	running := 0
+	for _, r := range m.rows {
+		if r.status == MultiSpinnerRunning || r.status == MultiSpinnerPending {
+			running++
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s %s\n", m.spinner.View(), msTitleStyle.Render(m.title)))
+
+	for _, r := range m.rows {
+		switch r.status {
+		case MultiSpinnerPending:
+			sb.WriteString(fmt.Sprintf("  %s %s\n",
+				msDimStyle.Render("·"),
+				msDimStyle.Render(msNameStyle.Render(r.name)+"waiting"),
+			))
+
+		case MultiSpinnerRunning:
+			detail := r.detail
+			if detail == "" {
+				detail = "building..."
+			}
+			sb.WriteString(fmt.Sprintf("  %s %s%s\n",
+				m.spinner.View(),
+				msNameStyle.Render(r.name),
+				msDimStyle.Render(detail),
+			))
+
+		case MultiSpinnerDone:
+			sb.WriteString(fmt.Sprintf("  %s %s%s\n",
+				msCheckStyle.Render("✓"),
+				msNameStyle.Render(r.name),
+				msDimStyle.Render(fmt.Sprintf("built (%s)", r.dur.Round(time.Millisecond))),
+			))
+
+		case MultiSpinnerFailed:
+			sb.WriteString(fmt.Sprintf("  %s %s%s\n",
+				msCrossStyle.Render("✗"),
+				msNameStyle.Render(r.name),
+				msErrorStyle.Render("failed"),
+			))
+		}
+	}
+
+	return sb.String()
+}
+
+// Err returns the first error recorded, if any.
+func (m MultiSpinnerModel) Err() error {
+	return m.err
+}
+
+// RunMultiSpinner runs a MultiSpinnerModel and returns when MultiSpinnerAllDoneMsg
+// is received. The returned error is the aggregate build error, if any.
+func RunMultiSpinner(m MultiSpinnerModel) error {
+	prog := tea.NewProgram(m)
+	final, runErr := prog.Run()
+	if runErr != nil {
+		return fmt.Errorf("multi-spinner TUI: %w", runErr)
+	}
+	if fm, ok := final.(MultiSpinnerModel); ok {
+		return fm.Err()
+	}
+	return nil
+}

--- a/go/internal/cli/tui/multispinner.go
+++ b/go/internal/cli/tui/multispinner.go
@@ -37,8 +37,7 @@ type MultiSpinnerDoneMsg struct {
 }
 
 // MultiSpinnerAllDoneMsg signals that all service builds have completed.
-// Err is non-nil if any individual build failed.
-type MultiSpinnerAllDoneMsg struct{ Err error }
+type MultiSpinnerAllDoneMsg struct{}
 
 type multiSpinnerRow struct {
 	name   string
@@ -129,7 +128,6 @@ func (m MultiSpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case MultiSpinnerAllDoneMsg:
 		m.done = true
-		m.err = msg.Err
 		return m, tea.Quit
 	}
 
@@ -164,9 +162,10 @@ func (m MultiSpinnerModel) View() string {
 	for _, r := range m.rows {
 		switch r.status {
 		case MultiSpinnerPending:
-			sb.WriteString(fmt.Sprintf("  %s %s\n",
+			sb.WriteString(fmt.Sprintf("  %s %s%s\n",
 				msDimStyle.Render("·"),
-				msDimStyle.Render(msNameStyle.Render(r.name)+"waiting"),
+				msDimStyle.Render(msNameStyle.Render(r.name)),
+				msDimStyle.Render("waiting"),
 			))
 
 		case MultiSpinnerRunning:
@@ -202,18 +201,4 @@ func (m MultiSpinnerModel) View() string {
 // Err returns the first error recorded, if any.
 func (m MultiSpinnerModel) Err() error {
 	return m.err
-}
-
-// RunMultiSpinner runs a MultiSpinnerModel and returns when MultiSpinnerAllDoneMsg
-// is received. The returned error is the aggregate build error, if any.
-func RunMultiSpinner(m MultiSpinnerModel) error {
-	prog := tea.NewProgram(m)
-	final, runErr := prog.Run()
-	if runErr != nil {
-		return fmt.Errorf("multi-spinner TUI: %w", runErr)
-	}
-	if fm, ok := final.(MultiSpinnerModel); ok {
-		return fm.Err()
-	}
-	return nil
 }

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -98,19 +98,19 @@ type ServiceConfig struct {
 
 // AppConfig represents the wendy.json application configuration.
 type AppConfig struct {
-	AppID        string                     `json:"appId"`
-	Version      string                     `json:"version,omitempty"`
-	Platform     string                     `json:"platform,omitempty"`
-	Language     string                     `json:"language,omitempty"`
-	Xcode        *XcodeConfig               `json:"xcode,omitempty"`
-	Run          *RunConfig                 `json:"run,omitempty"`
-	Entitlements []Entitlement              `json:"entitlements,omitempty"`
-	Readiness    *ReadinessConfig           `json:"readiness,omitempty"`
-	Hooks        *HooksConfig               `json:"hooks,omitempty"`
-	Python       *PythonConfig              `json:"python,omitempty"`
-	Debug        bool                       `json:"debug,omitempty"`
-	Files        []FileSyncEntry            `json:"files,omitempty"`
-	Services     map[string]*ServiceConfig  `json:"services,omitempty"`
+	AppID        string                    `json:"appId"`
+	Version      string                    `json:"version,omitempty"`
+	Platform     string                    `json:"platform,omitempty"`
+	Language     string                    `json:"language,omitempty"`
+	Xcode        *XcodeConfig              `json:"xcode,omitempty"`
+	Run          *RunConfig                `json:"run,omitempty"`
+	Entitlements []Entitlement             `json:"entitlements,omitempty"`
+	Readiness    *ReadinessConfig          `json:"readiness,omitempty"`
+	Hooks        *HooksConfig              `json:"hooks,omitempty"`
+	Python       *PythonConfig             `json:"python,omitempty"`
+	Debug        bool                      `json:"debug,omitempty"`
+	Files        []FileSyncEntry           `json:"files,omitempty"`
+	Services     map[string]*ServiceConfig `json:"services,omitempty"`
 }
 
 // XcodeConfig holds Xcode-specific build settings.

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -86,20 +86,30 @@ type RunConfig struct {
 	Args []string `json:"args,omitempty"`
 }
 
+// ServiceConfig holds the per-service build and runtime configuration for a
+// multi-service wendy.json (the services map).
+type ServiceConfig struct {
+	// Context is the build context directory, relative to wendy.json.
+	Context      string        `json:"context"`
+	Entitlements []Entitlement `json:"entitlements,omitempty"`
+	DependsOn    []string      `json:"dependsOn,omitempty"`
+}
+
 // AppConfig represents the wendy.json application configuration.
 type AppConfig struct {
-	AppID        string           `json:"appId"`
-	Version      string           `json:"version,omitempty"`
-	Platform     string           `json:"platform,omitempty"`
-	Language     string           `json:"language,omitempty"`
-	Xcode        *XcodeConfig     `json:"xcode,omitempty"`
-	Run          *RunConfig       `json:"run,omitempty"`
-	Entitlements []Entitlement    `json:"entitlements,omitempty"`
-	Readiness    *ReadinessConfig `json:"readiness,omitempty"`
-	Hooks        *HooksConfig     `json:"hooks,omitempty"`
-	Python       *PythonConfig    `json:"python,omitempty"`
-	Debug        bool             `json:"debug,omitempty"`
-	Files        []FileSyncEntry  `json:"files,omitempty"`
+	AppID        string                     `json:"appId"`
+	Version      string                     `json:"version,omitempty"`
+	Platform     string                     `json:"platform,omitempty"`
+	Language     string                     `json:"language,omitempty"`
+	Xcode        *XcodeConfig               `json:"xcode,omitempty"`
+	Run          *RunConfig                 `json:"run,omitempty"`
+	Entitlements []Entitlement              `json:"entitlements,omitempty"`
+	Readiness    *ReadinessConfig           `json:"readiness,omitempty"`
+	Hooks        *HooksConfig               `json:"hooks,omitempty"`
+	Python       *PythonConfig              `json:"python,omitempty"`
+	Debug        bool                       `json:"debug,omitempty"`
+	Files        []FileSyncEntry            `json:"files,omitempty"`
+	Services     map[string]*ServiceConfig  `json:"services,omitempty"`
 }
 
 // XcodeConfig holds Xcode-specific build settings.
@@ -285,6 +295,23 @@ func (c *AppConfig) Validate() error {
 		}
 		if c.Readiness.TimeoutSeconds < 0 {
 			return fmt.Errorf("readiness.timeoutSeconds must not be negative, got %d", c.Readiness.TimeoutSeconds)
+		}
+	}
+
+	for name, svc := range c.Services {
+		if svc == nil {
+			return fmt.Errorf("services[%q]: must not be null", name)
+		}
+		if svc.Context == "" {
+			return fmt.Errorf("services[%q]: context is required", name)
+		}
+		if containsDotDot(svc.Context) {
+			return fmt.Errorf("services[%q]: context must not contain '..' components", name)
+		}
+		for _, dep := range svc.DependsOn {
+			if _, ok := c.Services[dep]; !ok {
+				return fmt.Errorf("services[%q]: dependsOn references unknown service %q", name, dep)
+			}
 		}
 	}
 

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -304,6 +305,9 @@ func (c *AppConfig) Validate() error {
 		}
 		if svc.Context == "" {
 			return fmt.Errorf("services[%q]: context is required", name)
+		}
+		if filepath.IsAbs(svc.Context) {
+			return fmt.Errorf("services[%q]: context must be a relative path", name)
 		}
 		if containsDotDot(svc.Context) {
 			return fmt.Errorf("services[%q]: context must not contain '..' components", name)

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -309,7 +309,7 @@ func (c *AppConfig) Validate() error {
 		if filepath.IsAbs(svc.Context) {
 			return fmt.Errorf("services[%q]: context must be a relative path", name)
 		}
-		if containsDotDot(svc.Context) {
+		if cleaned := filepath.Clean(svc.Context); strings.HasPrefix(cleaned, "..") {
 			return fmt.Errorf("services[%q]: context must not contain '..' components", name)
 		}
 		for _, dep := range svc.DependsOn {

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -973,3 +973,90 @@ func TestMCPEntitlementPortOutOfRange(t *testing.T) {
 		t.Fatal("expected error for out-of-range port")
 	}
 }
+
+func TestServiceConfigValidation(t *testing.T) {
+	t.Run("valid services", func(t *testing.T) {
+		cfg := &AppConfig{
+			AppID: "com.example.app",
+			Services: map[string]*ServiceConfig{
+				"api":      {Context: "api", DependsOn: []string{"db"}},
+				"db":       {Context: "db"},
+				"frontend": {Context: "frontend", DependsOn: []string{"api"}},
+			},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing context", func(t *testing.T) {
+		cfg := &AppConfig{
+			AppID: "com.example.app",
+			Services: map[string]*ServiceConfig{
+				"api": {Context: ""},
+			},
+		}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for missing context")
+		}
+		if !strings.Contains(err.Error(), "context is required") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("unknown dependsOn", func(t *testing.T) {
+		cfg := &AppConfig{
+			AppID: "com.example.app",
+			Services: map[string]*ServiceConfig{
+				"api": {Context: "api", DependsOn: []string{"ghost"}},
+			},
+		}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for unknown dependsOn")
+		}
+		if !strings.Contains(err.Error(), "ghost") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("dotdot in context rejected", func(t *testing.T) {
+		cfg := &AppConfig{
+			AppID: "com.example.app",
+			Services: map[string]*ServiceConfig{
+				"svc": {Context: "../escape"},
+			},
+		}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for dotdot context")
+		}
+	})
+
+	t.Run("services parsed from JSON", func(t *testing.T) {
+		data := `{
+			"appId": "com.example.app",
+			"services": {
+				"api":  {"context": "api",  "dependsOn": ["db"]},
+				"db":   {"context": "db"}
+			}
+		}`
+		cfg, err := LoadFromBytes([]byte(data))
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if len(cfg.Services) != 2 {
+			t.Fatalf("want 2 services, got %d", len(cfg.Services))
+		}
+		if cfg.Services["api"].Context != "api" {
+			t.Errorf("api context = %q, want %q", cfg.Services["api"].Context, "api")
+		}
+		if len(cfg.Services["api"].DependsOn) != 1 || cfg.Services["api"].DependsOn[0] != "db" {
+			t.Errorf("api dependsOn = %v, want [db]", cfg.Services["api"].DependsOn)
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("validate error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **`appconfig`**: adds `ServiceConfig` type (`context`, `entitlements`, `dependsOn`) and a `Services map[string]*ServiceConfig` field on `AppConfig`; validates unknown `dependsOn` references and `..` in context paths
- **`tui`**: new `MultiSpinnerModel` — Bubbletea model that shows per-service build status (pending/building/done/failed) with elapsed times
- **`commands/multibuild.go`**: parallel build orchestration (max 4 concurrent via semaphore), topological container creation order, multiplexed log streaming with `[name]` prefix; `resolveServiceSubset` implements `--service` filtering with transitive deps
- **`commands/run.go`**: adds `--service` flag; auto-routes to the multi-service path when `appCfg.Services` is non-nil

## Design notes

**`CreateAppGroup` RPC** — the agent proto doesn't have `CreateAppGroup` yet. Containers are created individually via `CreateContainerWithProgress` in dependency order (same result from the device's perspective until the agent-side grouping is implemented). This PR ships the full CLI surface; the RPC migration is a follow-up.

**Multiplexed log streaming** — logs are prefixed with `[serviceName]` and interleaved. WDY-893 will replace this with proper per-service stream routing.

## Test plan

- [ ] `go test ./internal/shared/appconfig/... ./internal/cli/tui/...` — all pass
- [ ] Verify `wendy run` on a single-container project still works unchanged
- [ ] Create a `wendy.json` with `services` map (e.g. `api`+`db`), run `wendy run` — both images should build in parallel with spinner, containers created in dep order
- [ ] Run `wendy run --service api` — only `api` and its deps should build
- [ ] Run `wendy run --service ghost` — should return a clear error
- [ ] Non-interactive terminal (`wendy run 2>&1 | cat`) — plain log lines instead of TUI

Closes WDY-892

🤖 Generated with [Claude Code](https://claude.com/claude-code)