### PR TITLE
fix: stream WriteLayer blob directly to content store (WDY-824)

### DIFF
--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -88,7 +88,6 @@ func (s *ContainerService) WriteLayer(stream grpc.BidiStreamingServer[agentpb.Wr
 	sr := &layerStreamReader{stream: stream, pending: first.GetData()}
 
 	if err := s.containerd.WriteLayer(ctx, digest, sr, 0); err != nil {
-		sr.drain()
 		return status.Errorf(codes.Internal, "failed to write layer: %v", err)
 	}
 

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -68,11 +67,11 @@ func (s *ContainerService) ListLayers(_ *agentpb.ListLayersRequest, stream grpc.
 }
 
 // WriteLayer receives a streaming layer upload and writes it to the containerd
-// content store. Chunks are buffered in memory before writing.
+// content store. Chunks are streamed directly to the content store without
+// buffering the entire blob in memory.
 func (s *ContainerService) WriteLayer(stream grpc.BidiStreamingServer[agentpb.WriteLayerRequest, agentpb.WriteLayerResponse]) error {
 	ctx := stream.Context()
 
-	// Receive the first message to get the digest.
 	first, err := stream.Recv()
 	if err == io.EOF {
 		return status.Error(codes.InvalidArgument, "empty layer upload stream")
@@ -86,37 +85,61 @@ func (s *ContainerService) WriteLayer(stream grpc.BidiStreamingServer[agentpb.Wr
 		return status.Error(codes.InvalidArgument, "no digest provided in layer upload")
 	}
 
-	// Buffer all chunks.
-	var data []byte
-	if chunk := first.GetData(); len(chunk) > 0 {
-		data = append(data, chunk...)
-	}
+	sr := &layerStreamReader{stream: stream, pending: first.GetData()}
 
-	for {
-		msg, recvErr := stream.Recv()
-		if recvErr == io.EOF {
-			break
-		}
-		if recvErr != nil {
-			return status.Errorf(codes.Internal, "error receiving layer data: %v", recvErr)
-		}
-		if chunk := msg.GetData(); len(chunk) > 0 {
-			data = append(data, chunk...)
-		}
-	}
-
-	s.logger.Info("Received layer data",
-		zap.String("digest", digest),
-		zap.Int("bytes", len(data)),
-	)
-
-	// Write to containerd content store.
-	if err := s.containerd.WriteLayer(ctx, digest, bytes.NewReader(data), int64(len(data))); err != nil {
+	if err := s.containerd.WriteLayer(ctx, digest, sr, 0); err != nil {
+		sr.drain()
 		return status.Errorf(codes.Internal, "failed to write layer: %v", err)
 	}
 
-	s.logger.Info("Layer written", zap.String("digest", digest), zap.Int("size", len(data)))
+	// Drain any messages not consumed by WriteLayer (e.g. blob already existed).
+	sr.drain()
+
+	s.logger.Info("Layer written", zap.String("digest", digest))
 	return stream.Send(&agentpb.WriteLayerResponse{})
+}
+
+// layerStreamReader adapts a WriteLayer gRPC request stream to io.Reader so
+// the blob can be piped directly to the content store without buffering.
+type layerStreamReader struct {
+	stream  grpc.BidiStreamingServer[agentpb.WriteLayerRequest, agentpb.WriteLayerResponse]
+	pending []byte
+	done    bool
+}
+
+func (r *layerStreamReader) Read(p []byte) (int, error) {
+	for len(r.pending) == 0 {
+		if r.done {
+			return 0, io.EOF
+		}
+		msg, err := r.stream.Recv()
+		if err == io.EOF {
+			r.done = true
+			return 0, io.EOF
+		}
+		if err != nil {
+			return 0, err
+		}
+		r.pending = msg.GetData()
+	}
+	n := copy(p, r.pending)
+	r.pending = r.pending[n:]
+	return n, nil
+}
+
+// drain consumes any remaining messages from the stream without processing them.
+// This is needed when WriteLayer returns early (e.g. blob already exists) so
+// the gRPC stream is not left in a half-read state.
+func (r *layerStreamReader) drain() {
+	if r.done {
+		return
+	}
+	for {
+		if _, err := r.stream.Recv(); err != nil {
+			r.done = true
+			return
+		}
+	}
 }
 
 // CreateContainer creates a container from an image with entitlements.

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -305,29 +305,17 @@ func TestWriteLayer(t *testing.T) {
 	data := []byte("layer-data-part1")
 	data2 := []byte("layer-data-part2")
 
-	// Send first chunk with digest.
-	if err := stream.Send(&agentpb.WriteLayerRequest{
-		Digest: digest,
-		Data:   data,
-	}); err != nil {
+	if err := stream.Send(&agentpb.WriteLayerRequest{Digest: digest, Data: data}); err != nil {
 		t.Fatalf("send chunk1: %v", err)
 	}
-
-	// Send second chunk.
-	if err := stream.Send(&agentpb.WriteLayerRequest{
-		Digest: digest,
-		Data:   data2,
-	}); err != nil {
+	if err := stream.Send(&agentpb.WriteLayerRequest{Data: data2}); err != nil {
 		t.Fatalf("send chunk2: %v", err)
 	}
-
-	// Close send and receive response.
 	if err := stream.CloseSend(); err != nil {
 		t.Fatalf("CloseSend: %v", err)
 	}
 
-	_, err = stream.Recv()
-	if err != nil {
+	if _, err = stream.Recv(); err != nil {
 		t.Fatalf("recv response: %v", err)
 	}
 
@@ -338,6 +326,49 @@ func TestWriteLayer(t *testing.T) {
 	if string(mock.writtenData) != string(expectedData) {
 		t.Errorf("writtenData = %q; want %q", mock.writtenData, expectedData)
 	}
+}
+
+// TestWriteLayerAlreadyExists verifies that WriteLayer succeeds and drains the
+// gRPC stream even when the content store returns without consuming the reader
+// (e.g. the blob already exists).
+func TestWriteLayerAlreadyExists(t *testing.T) {
+	// drainlessMock returns nil without reading from the reader, simulating
+	// the AlreadyExists fast-path in the containerd content store.
+	mock := &drainlessMockContainerdClient{mockContainerdClient: mockContainerdClient{}}
+	client, cleanup := startContainerServer(t, mock)
+	defer cleanup()
+
+	stream, err := client.WriteLayer(context.Background())
+	if err != nil {
+		t.Fatalf("WriteLayer: %v", err)
+	}
+
+	digest := "sha256:alreadyexists"
+	if err := stream.Send(&agentpb.WriteLayerRequest{Digest: digest, Data: []byte("chunk1")}); err != nil {
+		t.Fatalf("send chunk1: %v", err)
+	}
+	if err := stream.Send(&agentpb.WriteLayerRequest{Data: []byte("chunk2")}); err != nil {
+		t.Fatalf("send chunk2: %v", err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("CloseSend: %v", err)
+	}
+
+	// RPC must succeed without deadlock even though the reader was not consumed.
+	if _, err = stream.Recv(); err != nil {
+		t.Fatalf("recv response: %v", err)
+	}
+}
+
+// drainlessMockContainerdClient overrides WriteLayer to return without reading
+// the reader, simulating the content-store AlreadyExists path.
+type drainlessMockContainerdClient struct {
+	mockContainerdClient
+}
+
+func (m *drainlessMockContainerdClient) WriteLayer(_ context.Context, digest string, _ io.Reader, _ int64) error {
+	m.writtenDigest = digest
+	return nil
 }
 
 func TestCreateContainerWithProgress(t *testing.T) {

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -338,7 +339,10 @@ func TestWriteLayerAlreadyExists(t *testing.T) {
 	client, cleanup := startContainerServer(t, mock)
 	defer cleanup()
 
-	stream, err := client.WriteLayer(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.WriteLayer(ctx)
 	if err != nil {
 		t.Fatalf("WriteLayer: %v", err)
 	}

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -382,12 +382,12 @@ func serviceOrder(cfg *composeConfig) ([]string, error) {
 
 // serviceLogPalette is the fixed color rotation for service name prefixes.
 var serviceLogPalette = []lipgloss.Color{
-	tui.Sky500,                     // cyan-ish
-	tui.Amber500,                   // yellow
-	tui.Emerald400,                 // green
-	lipgloss.Color("#c084fc"),      // magenta
-	lipgloss.Color("#60a5fa"),      // blue
-	tui.Red500,                     // red
+	tui.Sky500,                // cyan-ish
+	tui.Amber500,              // yellow
+	tui.Emerald400,            // green
+	lipgloss.Color("#c084fc"), // magenta
+	lipgloss.Color("#60a5fa"), // blue
+	tui.Red500,                // red
 }
 
 // serviceLogWriter buffers output for a single service and writes complete


### PR DESCRIPTION
## Summary

- Replaces the in-memory `[]byte` accumulation in `WriteLayer` with a `layerStreamReader` that adapts the gRPC request stream to an `io.Reader`
- Chunks are now piped directly to containerd's content store — memory usage is proportional to chunk size, not full layer size
- Drains any unconsumed stream messages when the content store returns early (e.g. blob already exists in the store), preventing the gRPC stream from being left in a half-read state

## Test plan

- [ ] Existing `TestWriteLayer` still passes — verifies multi-chunk data is assembled and passed to the content store correctly
- [ ] New `TestWriteLayerAlreadyExists` — verifies no deadlock when the content store returns without consuming the reader (fast-path for already-existing blobs)
- [ ] `go test ./internal/agent/services/...` passes green

Closes [WDY-824](https://linear.app/wendylabsinc/issue/WDY-824)

🤖 Generated with [Claude Code](https://claude.com/claude-code)