### PR TITLE
build: document `wendy completion install` post-install and `wendy mcp setup` in brew tap PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -904,6 +904,8 @@ jobs:
             desc "Manage your headless device (nightly)"
             homepage "https://github.com/wendylabsinc/wendy-agent"
 
+            depends_on :macos
+
             app "WendyAgentMac.app"
           end
           EOF
@@ -965,6 +967,8 @@ jobs:
             desc "Manage your headless device"
             homepage "https://github.com/wendylabsinc/wendy-agent"
 
+            depends_on :macos
+
             app "WendyAgentMac.app"
           end
           EOF
@@ -1009,7 +1013,13 @@ jobs:
           stable cask for the macOS agent app.
 
           The formula continues to use pre-built Go binaries, and the cask
-          points at the GitHub release app zip."
+          points at the GitHub release app zip.
+
+          Post-install: \`wendy completion install\` runs automatically to
+          configure shell completions for the current user.
+
+          Users are also notified about \`wendy mcp setup\` for AI tool
+          integration via the caveats message."
 
   publish-aur:
     name: Publish AUR Packages

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -382,12 +382,12 @@ func serviceOrder(cfg *composeConfig) ([]string, error) {
 
 // serviceLogPalette is the fixed color rotation for service name prefixes.
 var serviceLogPalette = []lipgloss.Color{
-	tui.Sky500,                     // cyan-ish
-	tui.Amber500,                   // yellow
-	tui.Emerald400,                 // green
-	lipgloss.Color("#c084fc"),      // magenta
-	lipgloss.Color("#60a5fa"),      // blue
-	tui.Red500,                     // red
+	tui.Sky500,                // cyan-ish
+	tui.Amber500,              // yellow
+	tui.Emerald400,            // green
+	lipgloss.Color("#c084fc"), // magenta
+	lipgloss.Color("#60a5fa"), // blue
+	tui.Red500,                // red
 }
 
 // serviceLogWriter buffers output for a single service and writes complete


### PR DESCRIPTION
## Summary

Updates the PR body generated by the stable Homebrew tap bump step in `build.yml` to document:

- `wendy completion install` runs as a `post_install` hook in the formulas, automatically wiring up shell completions for users.
- `wendy mcp setup` is surfaced in the formula caveats for AI tool integration.

This is the wendy-agent side of the pair of PRs; the actual formula changes live in the companion homebrew-tap PR (wendylabsinc/homebrew-tap#234).