### PR TITLE
Show USB-connected devices in discover

### DIFF
--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -113,6 +113,8 @@ func discoverJSON(ctx context.Context, opts discovery.DiscoveryOptions) error {
 	}
 
 	collection.LANDevices = resolveLANVersions(ctx, collection.LANDevices)
+	annotateLANUSBFromEthernet(collection)
+	sortLANDevicesForDiscover(collection.LANDevices)
 
 	if shouldIncludeExternal(opts) {
 		collection.ExternalDevices = discoverExternalDevices(ctx)
@@ -136,6 +138,8 @@ func discoverOnce(ctx context.Context, opts discovery.DiscoveryOptions) error {
 		collection, err := discovery.Discover(ctx, opts)
 		if err == nil {
 			collection.LANDevices = resolveLANVersions(ctx, collection.LANDevices)
+			annotateLANUSBFromEthernet(collection)
+			sortLANDevicesForDiscover(collection.LANDevices)
 			if includeExternal {
 				collection.ExternalDevices = discoverExternalDevices(ctx)
 			}
@@ -197,6 +201,7 @@ type extScanMsg struct{ devices []models.ExternalDevice }
 type discoverDeviceInfo struct {
 	Name    string `json:"name"`
 	Type    string `json:"type"`
+	USB     string `json:"usb,omitempty"`
 	Address string `json:"address"`
 	Version string `json:"version,omitempty"`
 }
@@ -279,6 +284,7 @@ func (m discoverModel) scanLAN() tea.Cmd {
 	return func() tea.Msg {
 		devices, _ := discovery.DiscoverLAN(m.ctx, m.opts.Timeout)
 		devices = resolveLANVersions(m.ctx, devices)
+		sortLANDevicesForDiscover(devices)
 		return lanScanMsg{devices: devices}
 	}
 }
@@ -362,31 +368,31 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			row := rows[cursor]
-			addr := lanDeviceAddr(m.collection, row[1])
+			addr := lanDeviceAddr(m.collection, row[rowNameIndex])
 			if addr == "" {
 				m.flashMessage = "Update is only supported for LAN devices."
 				m.flashIsError = true
 				return m, clearFlashAfter(3 * time.Second)
 			}
-			rowVer := strings.TrimPrefix(row[4], "* ")
+			rowVer := strings.TrimPrefix(row[rowVersionIndex], "* ")
 			if rowVer == "" || version.CompareVersions(version.Version, rowVer) <= 0 {
 				m.flashMessage = "Device is already up to date."
 				m.flashIsError = false
 				return m, clearFlashAfter(3 * time.Second)
 			}
-			m.updatingDeviceName = row[1]
-			m.flashMessage = "Updating " + row[1] + "..."
+			m.updatingDeviceName = row[rowNameIndex]
+			m.flashMessage = "Updating " + row[rowNameIndex] + "..."
 			m.flashIsError = false
-			return m, m.startDeviceUpdateCmd(addr, row[1])
+			return m, m.startDeviceUpdateCmd(addr, row[rowNameIndex])
 		case "d":
 			rows := discoverTableRows(m.collection)
 			cursor := m.table.Cursor()
 			if len(rows) > 0 && cursor >= 0 && cursor < len(rows) {
 				// Use the display name as the device identifier — for LAN devices
 				// this is the mDNS hostname which resolveDeviceAddress can resolve.
-				deviceID := rows[cursor][1]
+				deviceID := rows[cursor][rowNameIndex]
 				// For LAN devices, prefer the address column (hostname.local).
-				addr := rows[cursor][3]
+				addr := rows[cursor][rowAddressIndex]
 				if addr != "" && !strings.Contains(addr, ":") {
 					deviceID = addr
 				} else if host, _, err := net.SplitHostPort(addr); err == nil && host != "" {
@@ -687,9 +693,18 @@ func renderDeviceTable(collection *models.DevicesCollection) string {
 }
 
 var (
-	discoverTableHeaders   = []string{"", "Name", "Device Type", "Address", "Version"}
-	discoverTableMinWidths = []int{3, 12, 10, 14, 10}
-	discoverTableMaxWidths = []int{3, 33, 20, 28, 16}
+	discoverTableHeaders   = []string{"", "Name", "Device Type", "USB", "Address", "Version"}
+	discoverTableMinWidths = []int{3, 12, 10, 5, 14, 10}
+	discoverTableMaxWidths = []int{3, 33, 20, 24, 28, 16}
+)
+
+const (
+	rowDefaultIndex = iota
+	rowNameIndex
+	rowDeviceTypeIndex
+	rowUSBIndex
+	rowAddressIndex
+	rowVersionIndex
 )
 
 func newDiscoverTable(interactive bool) bubbleTable.Model {
@@ -712,8 +727,70 @@ func humanReadableDeviceType(dt string) string {
 	return dt
 }
 
+func sortLANDevicesForDiscover(devices []models.LANDevice) {
+	sort.SliceStable(devices, func(i, j int) bool {
+		iHasUSB := devices[i].USB != ""
+		jHasUSB := devices[j].USB != ""
+		if iHasUSB != jHasUSB {
+			return iHasUSB
+		}
+		return strings.ToLower(devices[i].DisplayName) < strings.ToLower(devices[j].DisplayName)
+	})
+}
+
+func annotateLANUSBFromEthernet(collection *models.DevicesCollection) {
+	if collection == nil || len(collection.EthernetInterfaces) == 0 {
+		return
+	}
+
+	byInterfaceName := make(map[string]models.EthernetInterface, len(collection.EthernetInterfaces))
+	for _, iface := range collection.EthernetInterfaces {
+		if iface.Name == "" {
+			continue
+		}
+		byInterfaceName[strings.ToLower(iface.Name)] = iface
+	}
+
+	for i := range collection.LANDevices {
+		dev := &collection.LANDevices[i]
+		if dev.USB != "" {
+			continue
+		}
+		interfaceName := dev.NetworkInterface
+		if interfaceName == "" {
+			interfaceName = interfaceNameFromScopedAddress(dev.IPAddress)
+		}
+		if interfaceName == "" {
+			continue
+		}
+		if iface, ok := byInterfaceName[strings.ToLower(interfaceName)]; ok {
+			dev.USB = ethernetInterfaceUSBSummary(iface)
+		}
+	}
+}
+
+func interfaceNameFromScopedAddress(addr string) string {
+	_, zone, ok := strings.Cut(addr, "%")
+	if !ok {
+		return ""
+	}
+	return zone
+}
+
+func ethernetInterfaceUSBSummary(iface models.EthernetInterface) string {
+	label := iface.Name
+	if iface.DisplayName != "" && !strings.EqualFold(iface.DisplayName, iface.Name) {
+		label = fmt.Sprintf("%s (%s)", iface.DisplayName, iface.Name)
+	}
+	if iface.LinkSpeed != "" {
+		return label + " " + iface.LinkSpeed
+	}
+	return label
+}
+
 func discoverTableRows(collection *models.DevicesCollection) []bubbleTable.Row {
 	var rows []bubbleTable.Row
+	annotateLANUSBFromEthernet(collection)
 
 	// Load default device to show ★ indicator.
 	var defaultDevice string
@@ -733,19 +810,23 @@ func discoverTableRows(collection *models.DevicesCollection) []bubbleTable.Row {
 		if d.IsESP32 {
 			deviceType = "ESP32"
 		}
-		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, deviceType, d.Hostname, markOutdated(d.AgentVersion)})
+		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, deviceType, d.USBVersion, d.Hostname, markOutdated(d.AgentVersion)})
 	}
 	for _, d := range collection.MergedDevices() {
 		deviceType := ""
+		usb := ""
 		if d.LAN != nil && d.LAN.DeviceType != "" {
 			deviceType = humanReadableDeviceType(d.LAN.DeviceType)
 		} else if d.Bluetooth != nil && !d.Bluetooth.IsWendyAgent() {
 			deviceType = "ESP32"
 		}
-		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, deviceType, d.Address(), markOutdated(d.AgentVersion)})
+		if d.LAN != nil {
+			usb = d.LAN.USB
+		}
+		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, deviceType, usb, d.Address(), markOutdated(d.AgentVersion)})
 	}
 	for _, d := range collection.EthernetInterfaces {
-		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, "", d.IPAddress, markOutdated(d.AgentVersion)})
+		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, "", "", d.IPAddress, markOutdated(d.AgentVersion)})
 	}
 	for _, d := range collection.ExternalDevices {
 		// Wendy Lite devices are merged with BLE Lite in MergedDevices().
@@ -753,14 +834,19 @@ func discoverTableRows(collection *models.DevicesCollection) []bubbleTable.Row {
 			continue
 		}
 		addr := fmt.Sprintf("%s: %s", d.ProviderKey, d.ID)
-		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, "", addr, markOutdated(d.AgentVersion)})
+		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, "", "", addr, markOutdated(d.AgentVersion)})
 	}
 
 	sort.Slice(rows, func(i, j int) bool {
-		if rows[i][2] != rows[j][2] { // Type column
-			return rows[i][2] < rows[j][2]
+		iHasUSB := rows[i][rowUSBIndex] != ""
+		jHasUSB := rows[j][rowUSBIndex] != ""
+		if iHasUSB != jHasUSB {
+			return iHasUSB
 		}
-		return strings.ToLower(rows[i][1]) < strings.ToLower(rows[j][1]) // Name column
+		if rows[i][rowDeviceTypeIndex] != rows[j][rowDeviceTypeIndex] {
+			return rows[i][rowDeviceTypeIndex] < rows[j][rowDeviceTypeIndex]
+		}
+		return strings.ToLower(rows[i][rowNameIndex]) < strings.ToLower(rows[j][rowNameIndex])
 	})
 
 	return rows
@@ -808,10 +894,11 @@ func discoverTableHeight(rowCount, windowHeight int, interactive bool) int {
 // deviceInfoFromRow converts a table row to a discoverDeviceInfo.
 func deviceInfoFromRow(row bubbleTable.Row) discoverDeviceInfo {
 	return discoverDeviceInfo{
-		Name:    row[1],
-		Type:    row[2],
-		Address: row[3],
-		Version: strings.TrimPrefix(row[4], "* "),
+		Name:    row[rowNameIndex],
+		Type:    row[rowDeviceTypeIndex],
+		USB:     row[rowUSBIndex],
+		Address: row[rowAddressIndex],
+		Version: strings.TrimPrefix(row[rowVersionIndex], "* "),
 	}
 }
 

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os/exec"
 	"runtime"
 	"sort"
@@ -206,6 +205,13 @@ type discoverDeviceInfo struct {
 	Version string `json:"version,omitempty"`
 }
 
+type discoverTableItem struct {
+	picker        tui.PickerItem
+	info          discoverDeviceInfo
+	lanName       string
+	defaultDevice string
+}
+
 // flashClearMsg is sent after a delay to clear the flash message.
 type flashClearMsg struct{}
 
@@ -335,21 +341,19 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			return m, tea.Quit
 		case "enter":
-			rows := discoverTableRows(m.collection)
+			items := discoverTableItems(m.collection)
 			cursor := m.table.Cursor()
-			if len(rows) > 0 && cursor >= 0 && cursor < len(rows) {
-				row := rows[cursor]
-				info := deviceInfoFromRow(row)
-				m.flashMessage, m.flashIsError = copyDeviceJSON(info)
+			if len(items) > 0 && cursor >= 0 && cursor < len(items) {
+				m.flashMessage, m.flashIsError = copyDeviceJSON(items[cursor].info)
 				return m, clearFlashAfter(5 * time.Second)
 			}
 			return m, nil
 		case "a":
-			rows := discoverTableRows(m.collection)
-			if len(rows) > 0 {
+			items := discoverTableItems(m.collection)
+			if len(items) > 0 {
 				var all []discoverDeviceInfo
-				for _, row := range rows {
-					all = append(all, deviceInfoFromRow(row))
+				for _, item := range items {
+					all = append(all, item.info)
 				}
 				m.flashMessage, m.flashIsError = copyDeviceJSON(all)
 				if !m.flashIsError {
@@ -362,42 +366,32 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.updatingDeviceName != "" {
 				return m, nil // already updating
 			}
-			rows := discoverTableRows(m.collection)
+			items := discoverTableItems(m.collection)
 			cursor := m.table.Cursor()
-			if len(rows) == 0 || cursor < 0 || cursor >= len(rows) {
+			if len(items) == 0 || cursor < 0 || cursor >= len(items) {
 				return m, nil
 			}
-			row := rows[cursor]
-			addr := lanDeviceAddr(m.collection, row[rowNameIndex])
+			item := items[cursor]
+			addr := lanDeviceAddr(m.collection, item.lanName)
 			if addr == "" {
 				m.flashMessage = "Update is only supported for LAN devices."
 				m.flashIsError = true
 				return m, clearFlashAfter(3 * time.Second)
 			}
-			rowVer := strings.TrimPrefix(row[rowVersionIndex], "* ")
-			if rowVer == "" || version.CompareVersions(version.Version, rowVer) <= 0 {
+			if item.info.Version == "" || version.CompareVersions(version.Version, item.info.Version) <= 0 {
 				m.flashMessage = "Device is already up to date."
 				m.flashIsError = false
 				return m, clearFlashAfter(3 * time.Second)
 			}
-			m.updatingDeviceName = row[rowNameIndex]
-			m.flashMessage = "Updating " + row[rowNameIndex] + "..."
+			m.updatingDeviceName = item.info.Name
+			m.flashMessage = "Updating " + item.info.Name + "..."
 			m.flashIsError = false
-			return m, m.startDeviceUpdateCmd(addr, row[rowNameIndex])
+			return m, m.startDeviceUpdateCmd(addr, item.info.Name)
 		case "d":
-			rows := discoverTableRows(m.collection)
+			items := discoverTableItems(m.collection)
 			cursor := m.table.Cursor()
-			if len(rows) > 0 && cursor >= 0 && cursor < len(rows) {
-				// Use the display name as the device identifier — for LAN devices
-				// this is the mDNS hostname which resolveDeviceAddress can resolve.
-				deviceID := rows[cursor][rowNameIndex]
-				// For LAN devices, prefer the address column (hostname.local).
-				addr := rows[cursor][rowAddressIndex]
-				if addr != "" && !strings.Contains(addr, ":") {
-					deviceID = addr
-				} else if host, _, err := net.SplitHostPort(addr); err == nil && host != "" {
-					deviceID = host
-				}
+			if len(items) > 0 && cursor >= 0 && cursor < len(items) {
+				deviceID := items[cursor].defaultDevice
 				if cfg, err := config.Load(); err == nil {
 					cfg.DefaultDevice = deviceID
 					_ = config.Save(cfg)
@@ -580,23 +574,16 @@ func (m discoverModel) View() string {
 }
 
 func (m *discoverModel) refreshTable() {
-	rows := discoverTableRows(m.collection)
-	m.table.SetColumns(discoverTableColumns(rows))
+	items := discoverTableItems(m.collection)
+	pickerItems := discoverPickerItems(items)
+	cols, rows := tui.PickerTableData(pickerItems, discoverDefaultKey(), true)
+	m.table.SetColumns(cols)
 	m.table.SetRows(rows)
 	if len(rows) > 0 && m.table.Cursor() < 0 {
 		m.table.SetCursor(0)
 	}
-	m.table.SetWidth(discoverTableWidth(m.table.Columns()))
-	m.table.SetHeight(discoverTableHeight(len(rows), m.windowHeight, true))
-}
-
-// markOutdated prefixes the version string with "* " when the agent is behind
-// the CLI, serving as a visible indicator in the discover table.
-func markOutdated(agentVer string) string {
-	if agentVer != "" && version.CompareVersions(version.Version, agentVer) > 0 {
-		return "* " + agentVer
-	}
-	return agentVer
+	m.table.SetWidth(tui.PickerTableWidth(m.table.Columns()))
+	m.table.SetHeight(tui.PickerTableHeight(len(rows), m.windowHeight))
 }
 
 // lanDeviceAddr returns the gRPC address for the first LAN device whose
@@ -678,38 +665,31 @@ func (m discoverModel) startDeviceUpdateCmd(addr, name string) tea.Cmd {
 // --- shared table rendering ---
 
 func renderDeviceTable(collection *models.DevicesCollection) string {
-	rows := discoverTableRows(collection)
+	items := discoverTableItems(collection)
+	pickerItems := discoverPickerItems(items)
+	cols, rows := tui.PickerTableData(pickerItems, discoverDefaultKey(), true)
 	if len(rows) == 0 {
 		return ""
 	}
 
 	t := newDiscoverTable(false)
-	t.SetColumns(discoverTableColumns(rows))
+	t.SetColumns(cols)
 	t.SetRows(rows)
-	t.SetWidth(discoverTableWidth(t.Columns()))
-	t.SetHeight(discoverTableHeight(len(rows), 0, false))
+	t.SetWidth(tui.PickerTableWidth(t.Columns()))
+	t.SetHeight(max(len(rows)+1, 1))
 
 	return t.View() + "\n"
 }
 
-var (
-	discoverTableHeaders   = []string{"", "Name", "Device Type", "USB", "Address", "Version"}
-	discoverTableMinWidths = []int{3, 12, 10, 5, 14, 10}
-	discoverTableMaxWidths = []int{3, 33, 20, 24, 28, 16}
-)
-
-const (
-	rowDefaultIndex = iota
-	rowNameIndex
-	rowDeviceTypeIndex
-	rowUSBIndex
-	rowAddressIndex
-	rowVersionIndex
-)
-
 func newDiscoverTable(interactive bool) bubbleTable.Model {
-	return tui.NewBubbleTable(interactive, discoverTableColumns(nil))
+	return tui.NewBubbleTable(interactive, nil)
 }
+
+var (
+	discoverTableHeaders   = []string{"", "Name", "Type", "Address", "Version"}
+	discoverTableMinWidths = []int{3, 12, 10, 14, 10}
+	discoverTableMaxWidths = []int{3, 33, 20, 28, 16}
+)
 
 var deviceTypeNames = map[string]string{
 	"raspberry-pi-3":   "Raspberry Pi 3",
@@ -725,6 +705,54 @@ func humanReadableDeviceType(dt string) string {
 		return name
 	}
 	return dt
+}
+
+// markOutdated prefixes the version string with "* " when the agent is behind
+// the CLI, serving as a visible indicator in discover-style tables.
+func markOutdated(agentVer string) string {
+	if agentVer != "" && version.CompareVersions(version.Version, agentVer) > 0 {
+		return "* " + agentVer
+	}
+	return agentVer
+}
+
+func discoverTableColumns(rows []bubbleTable.Row) []bubbleTable.Column {
+	cols := make([]bubbleTable.Column, len(discoverTableHeaders))
+	for i, title := range discoverTableHeaders {
+		width := lipgloss.Width(title)
+		for _, row := range rows {
+			if i >= len(row) {
+				continue
+			}
+			width = max(width, lipgloss.Width(row[i]))
+		}
+		width += 2
+		width = max(width, discoverTableMinWidths[i])
+		width = min(width, discoverTableMaxWidths[i])
+		cols[i] = bubbleTable.Column{Title: title, Width: width}
+	}
+	return cols
+}
+
+func discoverTableWidth(cols []bubbleTable.Column) int {
+	total := 0
+	for _, col := range cols {
+		total += col.Width + 2
+	}
+	return total
+}
+
+func discoverTableHeight(rowCount, windowHeight int, interactive bool) int {
+	height := rowCount + 1
+	if !interactive {
+		return max(height, 1)
+	}
+
+	height = max(height, 4)
+	if windowHeight > 0 {
+		return min(height, max(windowHeight-4, 4))
+	}
+	return min(height, 12)
 }
 
 func sortLANDevicesForDiscover(devices []models.LANDevice) {
@@ -788,45 +816,94 @@ func ethernetInterfaceUSBSummary(iface models.EthernetInterface) string {
 	return label
 }
 
-func discoverTableRows(collection *models.DevicesCollection) []bubbleTable.Row {
-	var rows []bubbleTable.Row
+func discoverDefaultKey() string {
+	if cfg, err := config.Load(); err == nil {
+		return strings.ToLower(cfg.DefaultDevice)
+	}
+	return ""
+}
+
+func discoverTableItems(collection *models.DevicesCollection) []discoverTableItem {
+	var items []discoverTableItem
+	if collection == nil {
+		return items
+	}
 	annotateLANUSBFromEthernet(collection)
 
-	// Load default device to show ★ indicator.
-	var defaultDevice string
-	if cfg, err := config.Load(); err == nil {
-		defaultDevice = strings.ToLower(cfg.DefaultDevice)
-	}
-
-	defaultMark := func(name string) string {
-		if defaultDevice != "" && strings.ToLower(name) == defaultDevice {
-			return "★"
-		}
-		return ""
-	}
-
 	for _, d := range collection.USBDevices {
-		deviceType := ""
+		deviceType := "USB"
 		if d.IsESP32 {
 			deviceType = "ESP32"
 		}
-		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, deviceType, d.USBVersion, d.Hostname, markOutdated(d.AgentVersion)})
+		items = append(items, discoverTableItem{
+			picker: tui.PickerItem{
+				Name:     discoverDisplayName(d.DisplayName, d.AgentVersion),
+				Type:     deviceType,
+				USB:      d.USBVersion,
+				Address:  d.Hostname,
+				DedupKey: d.DisplayName,
+				SortKey:  usbFirstSortKey(d.DisplayName, d.USBVersion),
+			},
+			info: discoverDeviceInfo{
+				Name:    d.DisplayName,
+				Type:    deviceType,
+				USB:     d.USBVersion,
+				Address: d.Hostname,
+				Version: d.AgentVersion,
+			},
+			defaultDevice: firstNonEmpty(d.Hostname, d.DisplayName),
+		})
 	}
 	for _, d := range collection.MergedDevices() {
-		deviceType := ""
+		deviceType := d.ConnectionTypes()
 		usb := ""
-		if d.LAN != nil && d.LAN.DeviceType != "" {
-			deviceType = humanReadableDeviceType(d.LAN.DeviceType)
-		} else if d.Bluetooth != nil && !d.Bluetooth.IsWendyAgent() {
-			deviceType = "ESP32"
-		}
 		if d.LAN != nil {
 			usb = d.LAN.USB
 		}
-		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, deviceType, usb, d.Address(), markOutdated(d.AgentVersion)})
+		address := d.Address()
+		defaultDevice := d.DisplayName
+		lanName := ""
+		if d.LAN != nil {
+			lanName = d.LAN.DisplayName
+			address = preferredLANAddress(*d.LAN)
+			defaultDevice = firstNonEmpty(d.LAN.Hostname, d.LAN.IPAddress, d.LAN.DisplayName)
+		}
+		items = append(items, discoverTableItem{
+			picker: tui.PickerItem{
+				Name:     discoverDisplayName(d.DisplayName, d.AgentVersion),
+				Type:     deviceType,
+				USB:      usb,
+				Address:  address,
+				DedupKey: d.DisplayName,
+				SortKey:  usbFirstSortKey(d.DisplayName, usb),
+			},
+			info: discoverDeviceInfo{
+				Name:    d.DisplayName,
+				Type:    deviceType,
+				USB:     usb,
+				Address: address,
+				Version: d.AgentVersion,
+			},
+			lanName:       lanName,
+			defaultDevice: defaultDevice,
+		})
 	}
 	for _, d := range collection.EthernetInterfaces {
-		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, "", "", d.IPAddress, markOutdated(d.AgentVersion)})
+		items = append(items, discoverTableItem{
+			picker: tui.PickerItem{
+				Name:     discoverDisplayName(d.DisplayName, d.AgentVersion),
+				Type:     "Ethernet",
+				Address:  d.IPAddress,
+				DedupKey: d.DisplayName,
+			},
+			info: discoverDeviceInfo{
+				Name:    d.DisplayName,
+				Type:    "Ethernet",
+				Address: d.IPAddress,
+				Version: d.AgentVersion,
+			},
+			defaultDevice: firstNonEmpty(d.IPAddress, d.DisplayName),
+		})
 	}
 	for _, d := range collection.ExternalDevices {
 		// Wendy Lite devices are merged with BLE Lite in MergedDevices().
@@ -834,72 +911,77 @@ func discoverTableRows(collection *models.DevicesCollection) []bubbleTable.Row {
 			continue
 		}
 		addr := fmt.Sprintf("%s: %s", d.ProviderKey, d.ID)
-		rows = append(rows, bubbleTable.Row{defaultMark(d.DisplayName), d.DisplayName, "", "", addr, markOutdated(d.AgentVersion)})
+		deviceType := externalProviderDisplayName(d.ProviderKey)
+		items = append(items, discoverTableItem{
+			picker: tui.PickerItem{
+				Name:     discoverDisplayName(d.DisplayName, d.AgentVersion),
+				Type:     deviceType,
+				Address:  addr,
+				DedupKey: d.DisplayName,
+			},
+			info: discoverDeviceInfo{
+				Name:    d.DisplayName,
+				Type:    deviceType,
+				Address: addr,
+				Version: d.AgentVersion,
+			},
+			defaultDevice: firstNonEmpty(d.ID, d.DisplayName),
+		})
 	}
 
-	sort.Slice(rows, func(i, j int) bool {
-		iHasUSB := rows[i][rowUSBIndex] != ""
-		jHasUSB := rows[j][rowUSBIndex] != ""
-		if iHasUSB != jHasUSB {
-			return iHasUSB
-		}
-		if rows[i][rowDeviceTypeIndex] != rows[j][rowDeviceTypeIndex] {
-			return rows[i][rowDeviceTypeIndex] < rows[j][rowDeviceTypeIndex]
-		}
-		return strings.ToLower(rows[i][rowNameIndex]) < strings.ToLower(rows[j][rowNameIndex])
+	sort.SliceStable(items, func(i, j int) bool {
+		return discoverSortKey(items[i].picker) < discoverSortKey(items[j].picker)
 	})
 
-	return rows
+	return items
 }
 
-func discoverTableColumns(rows []bubbleTable.Row) []bubbleTable.Column {
-	cols := make([]bubbleTable.Column, len(discoverTableHeaders))
-	for i, title := range discoverTableHeaders {
-		width := lipgloss.Width(title)
-		for _, row := range rows {
-			if i >= len(row) {
-				continue
-			}
-			width = max(width, lipgloss.Width(row[i]))
+func discoverPickerItems(items []discoverTableItem) []tui.PickerItem {
+	pickerItems := make([]tui.PickerItem, 0, len(items))
+	for _, item := range items {
+		pickerItems = append(pickerItems, item.picker)
+	}
+	return pickerItems
+}
+
+func discoverDisplayName(name, agentVer string) string {
+	if agentVer == "" {
+		return name
+	}
+	displayVersion := agentVer
+	if version.CompareVersions(version.Version, agentVer) > 0 {
+		displayVersion += " ⚠"
+	}
+	return name + " v" + displayVersion
+}
+
+func discoverSortKey(item tui.PickerItem) string {
+	if item.SortKey != "" {
+		return item.SortKey
+	}
+	key := item.DedupKey
+	if key == "" {
+		key = item.Name
+	}
+	return strings.ToLower(key)
+}
+
+func externalProviderDisplayName(key string) string {
+	for _, provider := range providers.AllProviders() {
+		if provider.Key() == key {
+			return provider.DisplayName()
 		}
-		width += 2
-		width = max(width, discoverTableMinWidths[i])
-		width = min(width, discoverTableMaxWidths[i])
-		cols[i] = bubbleTable.Column{Title: title, Width: width}
 	}
-	return cols
+	return key
 }
 
-func discoverTableWidth(cols []bubbleTable.Column) int {
-	total := 0
-	for _, col := range cols {
-		total += col.Width + 2
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
 	}
-	return total
-}
-
-func discoverTableHeight(rowCount, windowHeight int, interactive bool) int {
-	height := rowCount + 1
-	if !interactive {
-		return max(height, 1)
-	}
-
-	height = max(height, 4)
-	if windowHeight > 0 {
-		return min(height, max(windowHeight-4, 4))
-	}
-	return min(height, 12)
-}
-
-// deviceInfoFromRow converts a table row to a discoverDeviceInfo.
-func deviceInfoFromRow(row bubbleTable.Row) discoverDeviceInfo {
-	return discoverDeviceInfo{
-		Name:    row[rowNameIndex],
-		Type:    row[rowDeviceTypeIndex],
-		USB:     row[rowUSBIndex],
-		Address: row[rowAddressIndex],
-		Version: strings.TrimPrefix(row[rowVersionIndex], "* "),
-	}
+	return ""
 }
 
 // copyDeviceJSON marshals v as indented JSON, copies it to the clipboard,

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -929,10 +929,11 @@ func discoverPickerItems(items []discoverTableItem) []tui.PickerItem {
 }
 
 func discoverDisplayName(name, agentVer string) string {
+	name = discovery.SanitiseDisplayName(name)
 	if agentVer == "" {
 		return name
 	}
-	displayVersion := agentVer
+	displayVersion := discovery.SanitiseDisplayName(agentVer)
 	if version.CompareVersions(version.Version, agentVer) > 0 {
 		displayVersion += " ⚠"
 	}
@@ -961,9 +962,9 @@ func externalProviderDisplayName(key string) string {
 
 func externalProviderSortKey(providerKey, name string) string {
 	switch providerKey {
-	case "docker":
+	case providers.ProviderKeyDocker:
 		return "~0_" + strings.ToLower(name)
-	case "local":
+	case providers.ProviderKeyLocal:
 		return "~1_" + strings.ToLower(name)
 	}
 	return ""

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -888,23 +888,6 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 			defaultDevice: defaultDevice,
 		})
 	}
-	for _, d := range collection.EthernetInterfaces {
-		items = append(items, discoverTableItem{
-			picker: tui.PickerItem{
-				Name:     discoverDisplayName(d.DisplayName, d.AgentVersion),
-				Type:     "Ethernet",
-				Address:  d.IPAddress,
-				DedupKey: d.DisplayName,
-			},
-			info: discoverDeviceInfo{
-				Name:    d.DisplayName,
-				Type:    "Ethernet",
-				Address: d.IPAddress,
-				Version: d.AgentVersion,
-			},
-			defaultDevice: firstNonEmpty(d.IPAddress, d.DisplayName),
-		})
-	}
 	for _, d := range collection.ExternalDevices {
 		// Wendy Lite devices are merged with BLE Lite in MergedDevices().
 		if d.ProviderKey == "wendy-lite" {
@@ -918,6 +901,7 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 				Type:     deviceType,
 				Address:  addr,
 				DedupKey: d.DisplayName,
+				SortKey:  externalProviderSortKey(d.ProviderKey, d.DisplayName),
 			},
 			info: discoverDeviceInfo{
 				Name:    d.DisplayName,
@@ -973,6 +957,16 @@ func externalProviderDisplayName(key string) string {
 		}
 	}
 	return key
+}
+
+func externalProviderSortKey(providerKey, name string) string {
+	switch providerKey {
+	case "docker":
+		return "~0_" + strings.ToLower(name)
+	case "local":
+		return "~1_" + strings.ToLower(name)
+	}
+	return ""
 }
 
 func firstNonEmpty(values ...string) string {

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -224,10 +224,68 @@ func TestRenderDeviceTable_DeviceType(t *testing.T) {
 	}
 }
 
+func TestDiscoverTableRowsPrioritizesUSBDevices(t *testing.T) {
+	collection := &models.DevicesCollection{
+		LANDevices: []models.LANDevice{
+			{
+				DisplayName: "wendy-wifi",
+				IPAddress:   "192.168.1.20",
+			},
+			{
+				DisplayName: "wendy-usb",
+				IPAddress:   "169.254.20.30",
+				USB:         "enp0s20f0u9 480 Mbps",
+			},
+		},
+	}
+
+	rows := discoverTableRows(collection)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	if rows[0][rowNameIndex] != "wendy-usb" {
+		t.Fatalf("first row name = %q, want USB device first", rows[0][rowNameIndex])
+	}
+	if rows[0][rowUSBIndex] != "enp0s20f0u9 480 Mbps" {
+		t.Fatalf("USB column = %q, want interface summary", rows[0][rowUSBIndex])
+	}
+	if rows[1][rowUSBIndex] != "" {
+		t.Fatalf("non-USB row USB column = %q, want empty", rows[1][rowUSBIndex])
+	}
+}
+
+func TestDiscoverTableRowsAnnotatesLANUSBFromEthernetInterface(t *testing.T) {
+	collection := &models.DevicesCollection{
+		LANDevices: []models.LANDevice{{
+			DisplayName:      "wendy-usb",
+			IPAddress:        "169.254.20.30",
+			NetworkInterface: "Ethernet 3",
+		}},
+		EthernetInterfaces: []models.EthernetInterface{{
+			Name:        "Ethernet 3",
+			DisplayName: "Wendy Gadget Mode",
+			LinkSpeed:   "1 Gbps",
+		}},
+	}
+
+	rows := discoverTableRows(collection)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want LAN and Ethernet rows", len(rows))
+	}
+	if rows[0][rowNameIndex] != "wendy-usb" {
+		t.Fatalf("first row name = %q, want annotated LAN device first", rows[0][rowNameIndex])
+	}
+	wantUSB := "Wendy Gadget Mode (Ethernet 3) 1 Gbps"
+	if rows[0][rowUSBIndex] != wantUSB {
+		t.Fatalf("USB column = %q, want %q", rows[0][rowUSBIndex], wantUSB)
+	}
+}
+
 func TestDiscoverDeviceInfo_JSONSingleDevice(t *testing.T) {
 	info := discoverDeviceInfo{
 		Name:    "wendyos-brave-phoenix",
 		Type:    "LAN",
+		USB:     "en6 1 Gbps",
 		Address: "192.168.1.42",
 		Version: "2026.03.16-163942",
 	}
@@ -247,6 +305,9 @@ func TestDiscoverDeviceInfo_JSONSingleDevice(t *testing.T) {
 	}
 	if parsed["address"] != "192.168.1.42" {
 		t.Errorf("address = %v", parsed["address"])
+	}
+	if parsed["usb"] != "en6 1 Gbps" {
+		t.Errorf("usb = %v", parsed["usb"])
 	}
 }
 

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/internal/shared/discovery"
 	"github.com/wendylabsinc/wendy/internal/shared/env"
 	"github.com/wendylabsinc/wendy/internal/shared/models"
@@ -179,52 +180,14 @@ func TestRenderDeviceTable(t *testing.T) {
 	}
 
 	output := renderDeviceTable(collection)
-	for _, want := range []string{"Name", "Device Type", "Address", "Version", "wendy-alpha", "192.168.1.10", "1.2.3"} {
+	for _, want := range []string{"Name", "Type", "Address", "wendy-alpha v1.2.3", "LAN", "192.168.1.10:8443"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, output)
 		}
 	}
 }
 
-func TestHumanReadableDeviceType(t *testing.T) {
-	cases := []struct {
-		input string
-		want  string
-	}{
-		{"raspberry-pi-4", "Raspberry Pi 4"},
-		{"raspberry-pi-5", "Raspberry Pi 5"},
-		{"raspberry-pi-3", "Raspberry Pi 3"},
-		{"jetson-agx-orin", "Jetson AGX Orin"},
-		{"jetson-orin-nano", "Jetson Orin Nano"},
-		{"x86_64", "x86-64"},
-		{"unknown-board", "unknown-board"},
-		{"", ""},
-	}
-	for _, tc := range cases {
-		if got := humanReadableDeviceType(tc.input); got != tc.want {
-			t.Errorf("humanReadableDeviceType(%q) = %q; want %q", tc.input, got, tc.want)
-		}
-	}
-}
-
-func TestRenderDeviceTable_DeviceType(t *testing.T) {
-	collection := &models.DevicesCollection{
-		LANDevices: []models.LANDevice{{
-			DisplayName:  "wendy-pi",
-			IPAddress:    "192.168.1.20",
-			Port:         8443,
-			AgentVersion: "1.0.0",
-			DeviceType:   "raspberry-pi-4",
-		}},
-	}
-
-	output := renderDeviceTable(collection)
-	if !strings.Contains(output, "Raspberry Pi 4") {
-		t.Fatalf("expected output to contain %q, got %q", "Raspberry Pi 4", output)
-	}
-}
-
-func TestDiscoverTableRowsPrioritizesUSBDevices(t *testing.T) {
+func TestDiscoverTableItemsPrioritizesUSBDevices(t *testing.T) {
 	collection := &models.DevicesCollection{
 		LANDevices: []models.LANDevice{
 			{
@@ -239,22 +202,27 @@ func TestDiscoverTableRowsPrioritizesUSBDevices(t *testing.T) {
 		},
 	}
 
-	rows := discoverTableRows(collection)
-	if len(rows) != 2 {
-		t.Fatalf("got %d rows, want 2", len(rows))
+	items := discoverTableItems(collection)
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
 	}
-	if rows[0][rowNameIndex] != "wendy-usb" {
-		t.Fatalf("first row name = %q, want USB device first", rows[0][rowNameIndex])
+	if items[0].info.Name != "wendy-usb" {
+		t.Fatalf("first item name = %q, want USB device first", items[0].info.Name)
 	}
-	if rows[0][rowUSBIndex] != "enp0s20f0u9 480 Mbps" {
-		t.Fatalf("USB column = %q, want interface summary", rows[0][rowUSBIndex])
+	if items[0].picker.USB != "enp0s20f0u9 480 Mbps" {
+		t.Fatalf("USB detail = %q, want interface summary", items[0].picker.USB)
 	}
-	if rows[1][rowUSBIndex] != "" {
-		t.Fatalf("non-USB row USB column = %q, want empty", rows[1][rowUSBIndex])
+	if items[1].picker.USB != "" {
+		t.Fatalf("non-USB item USB detail = %q, want empty", items[1].picker.USB)
+	}
+
+	_, rows := tui.PickerTableData(discoverPickerItems(items), "", true)
+	if rows[0][3] != "Yes" {
+		t.Fatalf("USB display cell = %q, want Yes", rows[0][3])
 	}
 }
 
-func TestDiscoverTableRowsAnnotatesLANUSBFromEthernetInterface(t *testing.T) {
+func TestDiscoverTableItemsAnnotatesLANUSBFromEthernetInterface(t *testing.T) {
 	collection := &models.DevicesCollection{
 		LANDevices: []models.LANDevice{{
 			DisplayName:      "wendy-usb",
@@ -268,16 +236,21 @@ func TestDiscoverTableRowsAnnotatesLANUSBFromEthernetInterface(t *testing.T) {
 		}},
 	}
 
-	rows := discoverTableRows(collection)
-	if len(rows) != 2 {
-		t.Fatalf("got %d rows, want LAN and Ethernet rows", len(rows))
+	items := discoverTableItems(collection)
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want LAN and Ethernet rows", len(items))
 	}
-	if rows[0][rowNameIndex] != "wendy-usb" {
-		t.Fatalf("first row name = %q, want annotated LAN device first", rows[0][rowNameIndex])
+	if items[0].info.Name != "wendy-usb" {
+		t.Fatalf("first item name = %q, want annotated LAN device first", items[0].info.Name)
 	}
 	wantUSB := "Wendy Gadget Mode (Ethernet 3) 1 Gbps"
-	if rows[0][rowUSBIndex] != wantUSB {
-		t.Fatalf("USB column = %q, want %q", rows[0][rowUSBIndex], wantUSB)
+	if items[0].picker.USB != wantUSB {
+		t.Fatalf("USB detail = %q, want %q", items[0].picker.USB, wantUSB)
+	}
+
+	_, rows := tui.PickerTableData(discoverPickerItems(items), "", true)
+	if rows[0][3] != "Yes" {
+		t.Fatalf("USB display cell = %q, want Yes", rows[0][3])
 	}
 }
 

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -217,8 +217,8 @@ func TestDiscoverTableItemsPrioritizesUSBDevices(t *testing.T) {
 	}
 
 	_, rows := tui.PickerTableData(discoverPickerItems(items), "", true)
-	if rows[0][3] != "Yes" {
-		t.Fatalf("USB display cell = %q, want Yes", rows[0][3])
+	if rows[0][2] != "USB, LAN" {
+		t.Fatalf("Type display cell = %q, want \"USB, LAN\"", rows[0][2])
 	}
 }
 
@@ -237,8 +237,8 @@ func TestDiscoverTableItemsAnnotatesLANUSBFromEthernetInterface(t *testing.T) {
 	}
 
 	items := discoverTableItems(collection)
-	if len(items) != 2 {
-		t.Fatalf("got %d items, want LAN and Ethernet rows", len(items))
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1 (ethernet hidden)", len(items))
 	}
 	if items[0].info.Name != "wendy-usb" {
 		t.Fatalf("first item name = %q, want annotated LAN device first", items[0].info.Name)
@@ -249,8 +249,8 @@ func TestDiscoverTableItemsAnnotatesLANUSBFromEthernetInterface(t *testing.T) {
 	}
 
 	_, rows := tui.PickerTableData(discoverPickerItems(items), "", true)
-	if rows[0][3] != "Yes" {
-		t.Fatalf("USB display cell = %q, want Yes", rows[0][3])
+	if rows[0][2] != "USB, LAN" {
+		t.Fatalf("Type display cell = %q, want \"USB, LAN\"", rows[0][2])
 	}
 }
 

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1056,6 +1056,14 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 		md.LAN = nd.LAN
 		existing.Address = incoming.Address
 	}
+	if nd.LAN != nil && md.LAN != nil && nd.LAN.USB != "" && md.LAN.USB == "" {
+		md.LAN.USB = nd.LAN.USB
+		md.LAN.NetworkInterface = nd.LAN.NetworkInterface
+	}
+	if nd.LAN != nil && nd.LAN.USB != "" && existing.USB == "" {
+		existing.USB = incoming.USB
+		existing.SortKey = incoming.SortKey
+	}
 	if nd.Bluetooth != nil && md.Bluetooth == nil {
 		md.Bluetooth = nd.Bluetooth
 	}
@@ -1092,6 +1100,13 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 	if nd.LAN != nil {
 		existing.Insecure = incoming.Insecure
 	}
+}
+
+func usbFirstSortKey(name, usb string) string {
+	if usb == "" {
+		return ""
+	}
+	return "0_" + strings.ToLower(name)
 }
 
 // pickDevice runs an interactive TUI that discovers devices across all
@@ -1143,8 +1158,10 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 		p.Send(tui.PickerAddMsg{Items: []tui.PickerItem{{
 			Name:     name,
 			Type:     "LAN",
+			USB:      dev.USB,
 			Address:  preferredLANAddress(dev),
 			DedupKey: dev.DisplayName,
+			SortKey:  usbFirstSortKey(dev.DisplayName, dev.USB),
 			Insecure: insecure,
 			Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
 				DisplayName:     dev.DisplayName,

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1061,8 +1061,12 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 		md.LAN.NetworkInterface = nd.LAN.NetworkInterface
 	}
 	if nd.LAN != nil && nd.LAN.USB != "" && existing.USB == "" {
-		existing.USB = incoming.USB
-		existing.SortKey = incoming.SortKey
+		existing.USB = nd.LAN.USB
+		key := existing.DedupKey
+		if key == "" {
+			key = existing.Name
+		}
+		existing.SortKey = usbFirstSortKey(key, nd.LAN.USB)
 	}
 	if nd.Bluetooth != nil && md.Bluetooth == nil {
 		md.Bluetooth = nd.Bluetooth

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1224,10 +1224,12 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 							})
 						} else {
 							items = append(items, tui.PickerItem{
-								Name:    devices[i].DisplayName,
-								Type:    prov.DisplayName(),
-								Address: fmt.Sprintf("%s: %s", devices[i].ProviderKey, devices[i].ID),
-								Value:   &pickerEntry{externalDevice: &devices[i], provider: prov},
+								Name:     devices[i].DisplayName,
+								Type:     prov.DisplayName(),
+								Address:  fmt.Sprintf("%s: %s", devices[i].ProviderKey, devices[i].ID),
+								DedupKey: devices[i].DisplayName,
+								SortKey:  externalProviderSortKey(prov.Key(), devices[i].DisplayName),
+								Value:    &pickerEntry{externalDevice: &devices[i], provider: prov},
 							})
 						}
 					}

--- a/go/internal/cli/commands/json_schemas_test.go
+++ b/go/internal/cli/commands/json_schemas_test.go
@@ -440,6 +440,7 @@ func TestDiscoverCollectionJSON_AllArraysPresent(t *testing.T) {
 				IPAddress:     "192.168.1.10",
 				Port:          50051,
 				InterfaceType: "lan",
+				USB:           "enp0s20f0u9 480 Mbps",
 				IsWendyDevice: true,
 				AgentVersion:  "2026.01.01-120000",
 			},
@@ -498,13 +499,16 @@ func TestDiscoverCollectionJSON_AllArraysPresent(t *testing.T) {
 	// Verify LAN device fields.
 	lanArr := parsed["lanDevices"].([]interface{})
 	lan0 := lanArr[0].(map[string]interface{})
-	for _, f := range []string{"id", "displayName", "hostname", "ipAddress", "port", "isWendyDevice"} {
+	for _, f := range []string{"id", "displayName", "hostname", "ipAddress", "port", "usb", "isWendyDevice"} {
 		if _, ok := lan0[f]; !ok {
 			t.Errorf("lanDevices[0] missing field %q", f)
 		}
 	}
 	if lan0["ipAddress"] != "192.168.1.10" {
 		t.Errorf("lanDevices[0].ipAddress = %v; want 192.168.1.10", lan0["ipAddress"])
+	}
+	if lan0["usb"] != "enp0s20f0u9 480 Mbps" {
+		t.Errorf("lanDevices[0].usb = %v; want enp0s20f0u9 480 Mbps", lan0["usb"])
 	}
 
 	// Verify Bluetooth device fields.

--- a/go/internal/cli/providers/docker.go
+++ b/go/internal/cli/providers/docker.go
@@ -39,7 +39,7 @@ func composeFile(dir string) string {
 // DockerProvider builds and runs applications in Docker Desktop containers.
 type DockerProvider struct{}
 
-func (p *DockerProvider) Key() string         { return "docker" }
+func (p *DockerProvider) Key() string         { return ProviderKeyDocker }
 func (p *DockerProvider) DisplayName() string { return "Docker Desktop" }
 
 func (p *DockerProvider) IsAvailable(ctx context.Context) bool {

--- a/go/internal/cli/providers/local.go
+++ b/go/internal/cli/providers/local.go
@@ -22,7 +22,7 @@ type localBuildContext struct {
 // LocalProvider builds and runs applications on the local machine.
 type LocalProvider struct{}
 
-func (p *LocalProvider) Key() string         { return "local" }
+func (p *LocalProvider) Key() string         { return ProviderKeyLocal }
 func (p *LocalProvider) DisplayName() string { return "This Device" }
 
 func (p *LocalProvider) IsAvailable(_ context.Context) bool { return true }

--- a/go/internal/cli/providers/local.go
+++ b/go/internal/cli/providers/local.go
@@ -23,7 +23,7 @@ type localBuildContext struct {
 type LocalProvider struct{}
 
 func (p *LocalProvider) Key() string         { return "local" }
-func (p *LocalProvider) DisplayName() string { return "Local (This Device)" }
+func (p *LocalProvider) DisplayName() string { return "This Device" }
 
 func (p *LocalProvider) IsAvailable(_ context.Context) bool { return true }
 

--- a/go/internal/cli/providers/provider.go
+++ b/go/internal/cli/providers/provider.go
@@ -45,6 +45,12 @@ type BuiltApp struct {
 // RunOutputType classifies a line of output from a running app.
 type RunOutputType int
 
+// Provider key constants for the built-in providers.
+const (
+	ProviderKeyDocker = "docker"
+	ProviderKeyLocal  = "local"
+)
+
 const (
 	RunOutputStarted RunOutputType = iota
 	RunOutputStdout

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -15,6 +15,7 @@ type PickerItem struct {
 	Name        string
 	Description string // optional secondary text rendered dimmed
 	Type        string // "LAN", "Bluetooth", "External", etc.
+	USB         string // non-empty when the device is connected over USB
 	Address     string
 
 	// DedupKey is used for deduplication. If empty, Name is used.
@@ -284,6 +285,17 @@ var pickerColumnDefs = []pickerColumnDef{
 		},
 	},
 	{
+		title:    "USB",
+		minWidth: 5,
+		maxWidth: 5,
+		value: func(item PickerItem) string {
+			if item.USB == "" {
+				return ""
+			}
+			return "Yes"
+		},
+	},
+	{
 		title:    "Address",
 		minWidth: 14,
 		maxWidth: 28,
@@ -341,29 +353,7 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 	}
 
 	hasDefaultCol := m.OnSetDefault != nil
-	activeCols := pickerActiveColumns(m.items)
-	rows := pickerRows(m.items, activeCols, m.DefaultKey, hasDefaultCol)
-
-	var cols []bubbleTable.Column
-	if hasDefaultCol {
-		// Leading ★ column, then the data columns (offset by 1 in rows).
-		cols = append(cols, bubbleTable.Column{Title: "", Width: 3})
-		for i, def := range activeCols {
-			colIdx := i + 1 // rows have the star column at index 0
-			width := lipgloss.Width(def.title)
-			for _, row := range rows {
-				if colIdx < len(row) {
-					width = max(width, lipgloss.Width(row[colIdx]))
-				}
-			}
-			width += 2
-			width = max(width, def.minWidth)
-			width = min(width, def.maxWidth)
-			cols = append(cols, bubbleTable.Column{Title: def.title, Width: width})
-		}
-	} else {
-		cols = pickerColumns(rows, activeCols)
-	}
+	cols, rows := PickerTableData(m.items, m.DefaultKey, hasDefaultCol)
 	m.table.SetRows(nil)
 	m.table.SetColumns(cols)
 	m.table.SetRows(rows)
@@ -384,8 +374,8 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 		}
 	}
 
-	m.table.SetWidth(pickerTableWidth(m.table.Columns()))
-	m.table.SetHeight(pickerTableHeight(len(rows), m.height))
+	m.table.SetWidth(PickerTableWidth(m.table.Columns()))
+	m.table.SetHeight(PickerTableHeight(len(rows), m.height))
 }
 
 // pickerItemKey returns the dedup key for an item (DedupKey, or Name if empty).
@@ -411,6 +401,13 @@ func pickerActiveColumns(items []PickerItem) []pickerColumnDef {
 		}
 	}
 	return active
+}
+
+// PickerTableData builds the shared picker table columns and rows for items.
+func PickerTableData(items []PickerItem, defaultKey string, hasDefaultCol bool) ([]bubbleTable.Column, []bubbleTable.Row) {
+	activeCols := pickerActiveColumns(items)
+	rows := pickerRows(items, activeCols, defaultKey, hasDefaultCol)
+	return pickerColumns(rows, activeCols, hasDefaultCol), rows
 }
 
 func pickerRows(items []PickerItem, cols []pickerColumnDef, defaultKey string, hasDefaultCol bool) []bubbleTable.Row {
@@ -441,25 +438,32 @@ func pickerRows(items []PickerItem, cols []pickerColumnDef, defaultKey string, h
 	return rows
 }
 
-func pickerColumns(rows []bubbleTable.Row, defs []pickerColumnDef) []bubbleTable.Column {
-	cols := make([]bubbleTable.Column, len(defs))
+func pickerColumns(rows []bubbleTable.Row, defs []pickerColumnDef, hasDefaultCol bool) []bubbleTable.Column {
+	cols := make([]bubbleTable.Column, 0, len(defs)+1)
+	offset := 0
+	if hasDefaultCol {
+		cols = append(cols, bubbleTable.Column{Title: "", Width: 3})
+		offset = 1
+	}
 	for i, def := range defs {
 		width := lipgloss.Width(def.title)
 		for _, row := range rows {
-			if i >= len(row) {
+			rowIdx := i + offset
+			if rowIdx >= len(row) {
 				continue
 			}
-			width = max(width, lipgloss.Width(row[i]))
+			width = max(width, lipgloss.Width(row[rowIdx]))
 		}
 		width += 2
 		width = max(width, def.minWidth)
 		width = min(width, def.maxWidth)
-		cols[i] = bubbleTable.Column{Title: def.title, Width: width}
+		cols = append(cols, bubbleTable.Column{Title: def.title, Width: width})
 	}
 	return cols
 }
 
-func pickerTableWidth(cols []bubbleTable.Column) int {
+// PickerTableWidth returns the rendered width for picker table columns.
+func PickerTableWidth(cols []bubbleTable.Column) int {
 	total := 0
 	for _, col := range cols {
 		total += col.Width + 2
@@ -467,7 +471,8 @@ func pickerTableWidth(cols []bubbleTable.Column) int {
 	return total
 }
 
-func pickerTableHeight(rowCount, windowHeight int) int {
+// PickerTableHeight returns the picker table height for the row count/window.
+func PickerTableHeight(rowCount, windowHeight int) int {
 	height := max(rowCount+1, 4)
 	if windowHeight > 0 {
 		return min(height, max(windowHeight-5, 4))

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -279,20 +279,12 @@ var pickerColumnDefs = []pickerColumnDef{
 	{
 		title:    "Type",
 		minWidth: 12,
-		maxWidth: 18,
+		maxWidth: 28,
 		value: func(item PickerItem) string {
-			return item.Type
-		},
-	},
-	{
-		title:    "USB",
-		minWidth: 5,
-		maxWidth: 5,
-		value: func(item PickerItem) string {
-			if item.USB == "" {
-				return ""
+			if item.USB != "" && !strings.Contains(item.Type, "USB") {
+				return "USB, " + item.Type
 			}
-			return "Yes"
+			return item.Type
 		},
 	},
 	{

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -78,6 +78,25 @@ func TestPickerModel_ShowsDescriptionColumnWhenPresent(t *testing.T) {
 	}
 }
 
+func TestPickerModel_ShowsUSBColumnAsYes(t *testing.T) {
+	m := NewPickerWithTitle("Select a device")
+
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "Sunny Daisy", Type: "LAN", USB: "WendyOS Device sunny-daisy (en40)", Address: "wendyos-sunny-daisy.local:50052", Value: "sunny"},
+	}})
+	pm := updated.(PickerModel)
+
+	view := pm.View()
+	for _, want := range []string{"USB", "Yes"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected picker view to contain %q, got %q", want, view)
+		}
+	}
+	if strings.Contains(view, "WendyOS Device sunny-daisy") {
+		t.Fatalf("expected picker USB cell to hide long detail, got %q", view)
+	}
+}
+
 func TestPickerModel_DefaultKeyShowsStar(t *testing.T) {
 	m := NewPickerWithTitle("Select a device")
 	m.DefaultKey = "alpha"

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -78,7 +78,7 @@ func TestPickerModel_ShowsDescriptionColumnWhenPresent(t *testing.T) {
 	}
 }
 
-func TestPickerModel_ShowsUSBColumnAsYes(t *testing.T) {
+func TestPickerModel_ShowsUSBInTypeColumn(t *testing.T) {
 	m := NewPickerWithTitle("Select a device")
 
 	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
@@ -87,13 +87,8 @@ func TestPickerModel_ShowsUSBColumnAsYes(t *testing.T) {
 	pm := updated.(PickerModel)
 
 	view := pm.View()
-	for _, want := range []string{"USB", "Yes"} {
-		if !strings.Contains(view, want) {
-			t.Fatalf("expected picker view to contain %q, got %q", want, view)
-		}
-	}
-	if strings.Contains(view, "WendyOS Device sunny-daisy") {
-		t.Fatalf("expected picker USB cell to hide long detail, got %q", view)
+	if !strings.Contains(view, "USB, LAN") {
+		t.Fatalf("expected picker view to contain %q, got %q", "USB, LAN", view)
 	}
 }
 

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,7 +33,7 @@ func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice
 	}
 
 	var devices []models.LANDevice
-	seen := make(map[string]bool)
+	indexes := make(map[string]int)
 
 	for _, inst := range instances {
 		resolveCtx, resolveCancel := context.WithTimeout(ctx, 2*time.Second)
@@ -45,19 +46,16 @@ func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice
 		}
 
 		key := fmt.Sprintf("%s-%s-%d", dev.DisplayName, dev.Hostname, dev.Port)
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		devices = append(devices, dev)
+		devices = appendPreferredLANDevice(devices, indexes, key, dev)
 	}
 
 	return devices, nil
 }
 
 type browseResult struct {
-	instanceName string
-	domain       string
+	instanceName  string
+	domain        string
+	interfaceName string
 }
 
 // dnssdBrowse runs dns-sd -B and returns as soon as results stop arriving.
@@ -92,10 +90,17 @@ func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error
 			if len(fields) < 7 {
 				continue
 			}
+			interfaceName := ""
+			if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
+				if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
+					interfaceName = iface.Name
+				}
+			}
 			lineCh <- parsedLine{
 				result: browseResult{
-					instanceName: strings.Join(fields[6:], " "),
-					domain:       fields[4],
+					instanceName:  strings.Join(fields[6:], " "),
+					domain:        fields[4],
+					interfaceName: interfaceName,
 				},
 				ok: true,
 			}
@@ -119,8 +124,9 @@ func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error
 				_ = cmd.Wait()
 				return results, nil
 			}
-			if pl.ok && !seen[pl.result.instanceName] {
-				seen[pl.result.instanceName] = true
+			key := pl.result.instanceName + "%" + pl.result.interfaceName
+			if pl.ok && !seen[key] {
+				seen[key] = true
 				results = append(results, pl.result)
 				// Reset settle timer: wait 500ms for more results.
 				settle = time.After(500 * time.Millisecond)
@@ -231,7 +237,7 @@ func dnssdResolve(ctx context.Context, inst browseResult) (models.LANDevice, err
 		id = displayName
 	}
 
-	return models.LANDevice{
+	dev := models.LANDevice{
 		ID:            id,
 		DisplayName:   displayName,
 		Hostname:      hostname,
@@ -239,7 +245,9 @@ func dnssdResolve(ctx context.Context, inst browseResult) (models.LANDevice, err
 		IsMTLS:        txtRecords["tls"] == "true",
 		InterfaceType: string(models.InterfaceLAN),
 		IsWendyDevice: true,
-	}, nil
+	}
+	setLANNetworkInterface(&dev, inst.interfaceName, darwinInterfaceDisplayName(ctx, inst.interfaceName), getInterfaceLinkSpeed(ctx, inst.interfaceName))
+	return dev, nil
 }
 
 // deviceFromBrowse builds a LANDevice from browse results alone, without
@@ -280,7 +288,7 @@ func deviceFromBrowse(inst browseResult) models.LANDevice {
 		port = 50051
 	}
 
-	return models.LANDevice{
+	dev := models.LANDevice{
 		ID:            id,
 		DisplayName:   displayName,
 		Hostname:      hostname,
@@ -288,6 +296,8 @@ func deviceFromBrowse(inst browseResult) models.LANDevice {
 		InterfaceType: string(models.InterfaceLAN),
 		IsWendyDevice: true,
 	}
+	setLANNetworkInterface(&dev, inst.interfaceName, "", "")
+	return dev
 }
 
 // discoverLANContinuous keeps dns-sd -B running and sends each newly

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -326,15 +326,23 @@ func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 			continue
 		}
 
+		interfaceName := ""
+		if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
+			if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
+				interfaceName = iface.Name
+			}
+		}
 		inst := browseResult{
-			instanceName: strings.Join(fields[6:], " "),
-			domain:       fields[4],
+			instanceName:  strings.Join(fields[6:], " "),
+			domain:        fields[4],
+			interfaceName: interfaceName,
 		}
 
-		if seen[inst.instanceName] {
+		key := inst.instanceName + "%" + inst.interfaceName
+		if seen[key] {
 			continue
 		}
-		seen[inst.instanceName] = true
+		seen[key] = true
 
 		resolveCtx, resolveCancel := context.WithTimeout(ctx, 2*time.Second)
 		dev, err := dnssdResolve(resolveCtx, inst)

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -94,6 +94,9 @@ func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error
 			}
 			interfaceName := ""
 			if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
+				// Silently falls through with empty interfaceName when the
+				// interface disappears between browse and resolve; USB detection
+				// will be skipped for that device rather than returning an error.
 				if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
 					interfaceName = iface.Name
 				}
@@ -316,6 +319,9 @@ func deviceFromBrowse(inst browseResult, interfaceDisplayNames map[string]string
 
 // discoverLANContinuous keeps dns-sd -B running and sends each newly
 // discovered device to ch as it's resolved. Runs until ctx is cancelled.
+// linkSpeeds is intentionally not shared across goroutines — each call to
+// discoverLANContinuous owns its own map, and dnssdResolve is called
+// synchronously within the same goroutine, so no mutex is required.
 func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 	defer close(ch)
 	interfaceDisplayNames := darwinInterfaceDisplayNameMap(ctx)

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -31,18 +31,20 @@ func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice
 	if err != nil {
 		return nil, err
 	}
+	interfaceDisplayNames := darwinInterfaceDisplayNameMap(ctx)
+	linkSpeeds := make(map[string]string)
 
 	var devices []models.LANDevice
 	indexes := make(map[string]int)
 
 	for _, inst := range instances {
 		resolveCtx, resolveCancel := context.WithTimeout(ctx, 2*time.Second)
-		dev, err := dnssdResolve(resolveCtx, inst)
+		dev, err := dnssdResolve(resolveCtx, inst, interfaceDisplayNames, linkSpeeds)
 		resolveCancel()
 		if err != nil {
 			// Resolve failed (e.g. could not parse hostname) — fall back to
 			// a device derived from the browse instance name.
-			dev = deviceFromBrowse(inst)
+			dev = deviceFromBrowse(inst, interfaceDisplayNames)
 		}
 
 		key := fmt.Sprintf("%s-%s-%d", dev.DisplayName, dev.Hostname, dev.Port)
@@ -142,7 +144,7 @@ func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error
 
 // dnssdResolve runs dns-sd -L to resolve an instance to hostname, port, and TXT records.
 // Returns as soon as the "can be reached at" line is parsed.
-func dnssdResolve(ctx context.Context, inst browseResult) (models.LANDevice, error) {
+func dnssdResolve(ctx context.Context, inst browseResult, interfaceDisplayNames map[string]string, linkSpeeds map[string]string) (models.LANDevice, error) {
 	cmd := exec.CommandContext(ctx, "dns-sd", "-L", inst.instanceName, wendyServiceType, inst.domain)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -246,8 +248,20 @@ func dnssdResolve(ctx context.Context, inst browseResult) (models.LANDevice, err
 		InterfaceType: string(models.InterfaceLAN),
 		IsWendyDevice: true,
 	}
-	setLANNetworkInterface(&dev, inst.interfaceName, darwinInterfaceDisplayName(ctx, inst.interfaceName), getInterfaceLinkSpeed(ctx, inst.interfaceName))
+	setLANNetworkInterface(&dev, inst.interfaceName, interfaceDisplayNames[inst.interfaceName], darwinCachedInterfaceLinkSpeed(ctx, inst.interfaceName, linkSpeeds))
 	return dev, nil
+}
+
+func darwinCachedInterfaceLinkSpeed(ctx context.Context, interfaceName string, linkSpeeds map[string]string) string {
+	if interfaceName == "" {
+		return ""
+	}
+	if linkSpeed, ok := linkSpeeds[interfaceName]; ok {
+		return linkSpeed
+	}
+	linkSpeed := getInterfaceLinkSpeed(ctx, interfaceName)
+	linkSpeeds[interfaceName] = linkSpeed
+	return linkSpeed
 }
 
 // deviceFromBrowse builds a LANDevice from browse results alone, without
@@ -270,7 +284,7 @@ func unescapeDNSSDName(s string) string {
 	return strings.ReplaceAll(s, `\ `, " ")
 }
 
-func deviceFromBrowse(inst browseResult) models.LANDevice {
+func deviceFromBrowse(inst browseResult, interfaceDisplayNames map[string]string) models.LANDevice {
 	displayName := unescapeDNSSDName(inst.instanceName)
 
 	var (
@@ -296,7 +310,7 @@ func deviceFromBrowse(inst browseResult) models.LANDevice {
 		InterfaceType: string(models.InterfaceLAN),
 		IsWendyDevice: true,
 	}
-	setLANNetworkInterface(&dev, inst.interfaceName, "", "")
+	setLANNetworkInterface(&dev, inst.interfaceName, interfaceDisplayNames[inst.interfaceName], "")
 	return dev
 }
 
@@ -304,6 +318,8 @@ func deviceFromBrowse(inst browseResult) models.LANDevice {
 // discovered device to ch as it's resolved. Runs until ctx is cancelled.
 func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 	defer close(ch)
+	interfaceDisplayNames := darwinInterfaceDisplayNameMap(ctx)
+	linkSpeeds := make(map[string]string)
 
 	cmd := exec.CommandContext(ctx, "dns-sd", "-B", wendyServiceType, "local")
 	stdout, err := cmd.StdoutPipe()
@@ -345,10 +361,10 @@ func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 		seen[key] = true
 
 		resolveCtx, resolveCancel := context.WithTimeout(ctx, 2*time.Second)
-		dev, err := dnssdResolve(resolveCtx, inst)
+		dev, err := dnssdResolve(resolveCtx, inst, interfaceDisplayNames, linkSpeeds)
 		resolveCancel()
 		if err != nil {
-			dev = deviceFromBrowse(inst)
+			dev = deviceFromBrowse(inst, interfaceDisplayNames)
 		}
 
 		select {

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -31,6 +31,8 @@ func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice
 	if err != nil {
 		return nil, err
 	}
+	// darwinInterfaceDisplayNameMap shells out to networksetup once per scan and
+	// returns a map reused across all dnssdResolve calls below — not per instance.
 	interfaceDisplayNames := darwinInterfaceDisplayNameMap(ctx)
 	linkSpeeds := make(map[string]string)
 

--- a/go/internal/shared/discovery/discovery_linux.go
+++ b/go/internal/shared/discovery/discovery_linux.go
@@ -57,7 +57,7 @@ func discoverLANAvahi(ctx context.Context, timeout time.Duration) ([]models.LAND
 	}
 
 	var devices []models.LANDevice
-	seen := make(map[string]bool)
+	indexes := make(map[string]int)
 
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
@@ -66,11 +66,7 @@ func discoverLANAvahi(ctx context.Context, timeout time.Duration) ([]models.LAND
 			continue
 		}
 		key := fmt.Sprintf("%s-%s-%d", dev.DisplayName, dev.Hostname, dev.Port)
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		devices = append(devices, dev)
+		devices = appendPreferredLANDevice(devices, indexes, key, dev)
 	}
 
 	scanErr := scanner.Err()
@@ -135,7 +131,7 @@ func parseAvahiResolveLine(line string) (models.LANDevice, bool) {
 		id = instanceName
 	}
 
-	return models.LANDevice{
+	dev := models.LANDevice{
 		ID:            id,
 		DisplayName:   displayName,
 		Hostname:      hostname,
@@ -144,7 +140,9 @@ func parseAvahiResolveLine(line string) (models.LANDevice, bool) {
 		IsMTLS:        txtRecords["tls"] == "true",
 		InterfaceType: string(models.InterfaceLAN),
 		IsWendyDevice: true,
-	}, true
+	}
+	setLANNetworkInterface(&dev, ifaceName, "", linuxInterfaceLinkSpeed(ifaceName))
+	return dev, true
 }
 
 // avahiUnescape replaces avahi's \NNN decimal escape sequences with the
@@ -201,7 +199,7 @@ func discoverLANMDNS(ctx context.Context, timeout time.Duration) ([]models.LANDe
 	}
 
 	var allDevices []models.LANDevice
-	seen := make(map[string]bool)
+	indexes := make(map[string]int)
 
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagMulticast == 0 {
@@ -215,11 +213,7 @@ func discoverLANMDNS(ctx context.Context, timeout time.Duration) ([]models.LANDe
 		devices := queryInterface(ctx, &iface, timeout)
 		for _, dev := range devices {
 			key := fmt.Sprintf("%s-%s-%d", dev.DisplayName, dev.Hostname, dev.Port)
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-			allDevices = append(allDevices, dev)
+			allDevices = appendPreferredLANDevice(allDevices, indexes, key, dev)
 		}
 	}
 
@@ -266,7 +260,7 @@ func lanDeviceFromMDNSEntry(entry *mdns.ServiceEntry, iface *net.Interface) (mod
 		id = displayName
 	}
 
-	return models.LANDevice{
+	dev := models.LANDevice{
 		ID:            id,
 		DisplayName:   displayName,
 		Hostname:      hostname,
@@ -275,7 +269,11 @@ func lanDeviceFromMDNSEntry(entry *mdns.ServiceEntry, iface *net.Interface) (mod
 		IsMTLS:        txtRecords["tls"] == "true",
 		InterfaceType: string(models.InterfaceLAN),
 		IsWendyDevice: true,
-	}, true
+	}
+	if iface != nil {
+		setLANNetworkInterface(&dev, iface.Name, "", linuxInterfaceLinkSpeed(iface.Name))
+	}
+	return dev, true
 }
 
 // queryInterface runs a single mDNS query on a specific network interface.

--- a/go/internal/shared/discovery/discovery_linux_test.go
+++ b/go/internal/shared/discovery/discovery_linux_test.go
@@ -4,6 +4,7 @@ package discovery
 
 import (
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/mdns"
@@ -83,6 +84,8 @@ func TestParseAvahiResolveLine(t *testing.T) {
 		wantIP     string
 		wantPort   int
 		wantIsMTLS bool
+		wantIface  string
+		wantUSB    string
 	}{
 		{
 			name:       "valid resolved line with link-local IPv6",
@@ -92,6 +95,8 @@ func TestParseAvahiResolveLine(t *testing.T) {
 			wantIP:     "fe80::ffab:7cf6:ef:21c5%enp0s20f0u9",
 			wantPort:   50051,
 			wantIsMTLS: false,
+			wantIface:  "enp0s20f0u9",
+			wantUSB:    "enp0s20f0u9",
 		},
 		{
 			name:       "provisioned device with tls=true sets IsMTLS",
@@ -101,22 +106,25 @@ func TestParseAvahiResolveLine(t *testing.T) {
 			wantIP:     "192.168.1.20",
 			wantPort:   50052,
 			wantIsMTLS: true,
+			wantIface:  "eth0",
 		},
 		{
-			name:     "global IPv6 does not get zone ID",
-			line:     `=;eth0;IPv6;WendyOS\032device;_wendyos._udp;local;wendyos.local;2001:db8::1;50051;"wendyosdevice=abc123"`,
-			wantOK:   true,
-			wantID:   "abc123",
-			wantIP:   "2001:db8::1",
-			wantPort: 50051,
+			name:      "global IPv6 does not get zone ID",
+			line:      `=;eth0;IPv6;WendyOS\032device;_wendyos._udp;local;wendyos.local;2001:db8::1;50051;"wendyosdevice=abc123"`,
+			wantOK:    true,
+			wantID:    "abc123",
+			wantIP:    "2001:db8::1",
+			wantPort:  50051,
+			wantIface: "eth0",
 		},
 		{
-			name:     "IPv4 does not get zone ID",
-			line:     `=;eth0;IPv4;WendyOS\032device;_wendyos._udp;local;wendyos.local;192.168.1.10;50051;"wendyosdevice=abc123"`,
-			wantOK:   true,
-			wantID:   "abc123",
-			wantIP:   "192.168.1.10",
-			wantPort: 50051,
+			name:      "IPv4 does not get zone ID",
+			line:      `=;eth0;IPv4;WendyOS\032device;_wendyos._udp;local;wendyos.local;192.168.1.10;50051;"wendyosdevice=abc123"`,
+			wantOK:    true,
+			wantID:    "abc123",
+			wantIP:    "192.168.1.10",
+			wantPort:  50051,
+			wantIface: "eth0",
 		},
 		{
 			name:   "browse line (not resolved)",
@@ -155,6 +163,12 @@ func TestParseAvahiResolveLine(t *testing.T) {
 			}
 			if dev.IsMTLS != tt.wantIsMTLS {
 				t.Fatalf("IsMTLS = %v, want %v", dev.IsMTLS, tt.wantIsMTLS)
+			}
+			if dev.NetworkInterface != tt.wantIface {
+				t.Fatalf("NetworkInterface = %q, want %q", dev.NetworkInterface, tt.wantIface)
+			}
+			if tt.wantUSB != "" && !strings.HasPrefix(dev.USB, tt.wantUSB) {
+				t.Fatalf("USB = %q, want prefix %q", dev.USB, tt.wantUSB)
 			}
 			if !dev.IsWendyDevice {
 				t.Fatal("IsWendyDevice = false, want true")

--- a/go/internal/shared/discovery/discovery_windows.go
+++ b/go/internal/shared/discovery/discovery_windows.go
@@ -126,7 +126,7 @@ func lanDeviceFromMDNSEntry(entry *mdns.ServiceEntry, iface *net.Interface) (mod
 		id = displayName
 	}
 
-	return models.LANDevice{
+	dev := models.LANDevice{
 		ID:            id,
 		DisplayName:   displayName,
 		Hostname:      hostname,
@@ -135,7 +135,11 @@ func lanDeviceFromMDNSEntry(entry *mdns.ServiceEntry, iface *net.Interface) (mod
 		IsMTLS:        txtRecords["tls"] == "true",
 		InterfaceType: string(models.InterfaceLAN),
 		IsWendyDevice: true,
-	}, true
+	}
+	if iface != nil {
+		setLANNetworkInterface(&dev, iface.Name, "", "")
+	}
+	return dev, true
 }
 
 func parseMDNSTXTRecords(fields []string) map[string]string {
@@ -198,6 +202,9 @@ func lanDeviceDedupKey(dev models.LANDevice) string {
 }
 
 func preferLANDevice(candidate, existing models.LANDevice) bool {
+	if (candidate.USB != "") != (existing.USB != "") {
+		return candidate.USB != ""
+	}
 	if existing.IPAddress == "" && candidate.IPAddress != "" {
 		return true
 	}
@@ -234,6 +241,12 @@ func lanDeviceMetadataScore(dev models.LANDevice) int {
 	}
 	if dev.IsMTLS {
 		score++
+	}
+	if dev.NetworkInterface != "" {
+		score++
+	}
+	if dev.USB != "" {
+		score += 2
 	}
 	return score
 }

--- a/go/internal/shared/discovery/discovery_windows.go
+++ b/go/internal/shared/discovery/discovery_windows.go
@@ -31,10 +31,9 @@ func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice
 			queries = append(queries, &iface)
 		}
 	}
-	adapterLookup := windowsNetworkAdapterLookup{}
-	if len(queries) > 1 {
-		adapterLookup = newWindowsNetworkAdapterLookup(ctx)
-	}
+	// Always build the adapter lookup so USB detection works whether devices are
+	// found via the nil (all-interface) query or an interface-scoped query.
+	adapterLookup := newWindowsNetworkAdapterLookup(ctx)
 
 	resultsCh := make(chan []models.LANDevice, len(queries))
 	var wg sync.WaitGroup

--- a/go/internal/shared/discovery/discovery_windows.go
+++ b/go/internal/shared/discovery/discovery_windows.go
@@ -31,6 +31,10 @@ func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice
 			queries = append(queries, &iface)
 		}
 	}
+	adapterLookup := windowsNetworkAdapterLookup{}
+	if len(queries) > 1 {
+		adapterLookup = newWindowsNetworkAdapterLookup(ctx)
+	}
 
 	resultsCh := make(chan []models.LANDevice, len(queries))
 	var wg sync.WaitGroup
@@ -38,7 +42,7 @@ func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice
 		wg.Add(1)
 		go func(iface *net.Interface) {
 			defer wg.Done()
-			resultsCh <- queryLANMDNS(ctx, iface, timeout)
+			resultsCh <- queryLANMDNS(ctx, iface, timeout, adapterLookup)
 		}(iface)
 	}
 
@@ -62,7 +66,7 @@ func isMDNSInterfaceEligible(iface net.Interface) bool {
 
 // queryLANMDNS runs a single mDNS query. If iface is nil, hashicorp/mdns uses
 // its default all-interface behavior. Otherwise, the query is scoped to iface.
-func queryLANMDNS(ctx context.Context, iface *net.Interface, timeout time.Duration) []models.LANDevice {
+func queryLANMDNS(ctx context.Context, iface *net.Interface, timeout time.Duration, adapterLookup windowsNetworkAdapterLookup) []models.LANDevice {
 	if ctx.Err() != nil {
 		return nil
 	}
@@ -75,7 +79,7 @@ func queryLANMDNS(ctx context.Context, iface *net.Interface, timeout time.Durati
 		defer close(done)
 		seen := make(map[string]bool)
 		for entry := range entriesCh {
-			dev, ok := lanDeviceFromMDNSEntry(entry, iface)
+			dev, ok := lanDeviceFromMDNSEntry(entry, iface, adapterLookup)
 			if !ok {
 				continue
 			}
@@ -103,7 +107,7 @@ func queryLANMDNS(ctx context.Context, iface *net.Interface, timeout time.Durati
 	return devices
 }
 
-func lanDeviceFromMDNSEntry(entry *mdns.ServiceEntry, iface *net.Interface) (models.LANDevice, bool) {
+func lanDeviceFromMDNSEntry(entry *mdns.ServiceEntry, iface *net.Interface, adapterLookup windowsNetworkAdapterLookup) (models.LANDevice, bool) {
 	if entry == nil || !mdnsEntryMatchesServiceType(entry.Name, wendyServiceType) {
 		return models.LANDevice{}, false
 	}
@@ -137,9 +141,52 @@ func lanDeviceFromMDNSEntry(entry *mdns.ServiceEntry, iface *net.Interface) (mod
 		IsWendyDevice: true,
 	}
 	if iface != nil {
-		setLANNetworkInterface(&dev, iface.Name, "", "")
+		displayName, linkSpeed := adapterLookup.details(iface)
+		setLANNetworkInterface(&dev, iface.Name, displayName, linkSpeed)
 	}
 	return dev, true
+}
+
+type windowsNetworkAdapterLookup struct {
+	byIndex map[int]netAdapterEntry
+	byName  map[string]netAdapterEntry
+}
+
+func newWindowsNetworkAdapterLookup(ctx context.Context) windowsNetworkAdapterLookup {
+	entries, err := readNetAdapterEntries(ctx)
+	if err != nil {
+		return windowsNetworkAdapterLookup{}
+	}
+	return windowsNetworkAdapterLookupFromEntries(entries)
+}
+
+func windowsNetworkAdapterLookupFromEntries(entries []netAdapterEntry) windowsNetworkAdapterLookup {
+	lookup := windowsNetworkAdapterLookup{
+		byIndex: make(map[int]netAdapterEntry),
+		byName:  make(map[string]netAdapterEntry),
+	}
+	for _, entry := range entries {
+		if entry.InterfaceIndex > 0 {
+			lookup.byIndex[entry.InterfaceIndex] = entry
+		}
+		if entry.Name != "" {
+			lookup.byName[strings.ToLower(entry.Name)] = entry
+		}
+	}
+	return lookup
+}
+
+func (l windowsNetworkAdapterLookup) details(iface *net.Interface) (string, string) {
+	if iface == nil {
+		return "", ""
+	}
+	if entry, ok := l.byIndex[iface.Index]; ok {
+		return entry.InterfaceDescription, entry.LinkSpeed
+	}
+	if entry, ok := l.byName[strings.ToLower(iface.Name)]; ok {
+		return entry.InterfaceDescription, entry.LinkSpeed
+	}
+	return "", ""
 }
 
 func parseMDNSTXTRecords(fields []string) map[string]string {

--- a/go/internal/shared/discovery/discovery_windows_test.go
+++ b/go/internal/shared/discovery/discovery_windows_test.go
@@ -20,7 +20,7 @@ func TestLANDeviceFromMDNSEntryPrefersIPv4AndParsesTXT(t *testing.T) {
 		InfoFields: []string{"id=agent-id", "displayname=Prudent Lark", "tls=true"},
 	}
 
-	dev, ok := lanDeviceFromMDNSEntry(entry, nil)
+	dev, ok := lanDeviceFromMDNSEntry(entry, nil, windowsNetworkAdapterLookup{})
 	if !ok {
 		t.Fatal("lanDeviceFromMDNSEntry returned false")
 	}
@@ -59,7 +59,7 @@ func TestLANDeviceFromMDNSEntryUsesWendyOSDeviceID(t *testing.T) {
 		InfoFields: []string{"id=display-id", "wendyosdevice=device-id"},
 	}
 
-	dev, ok := lanDeviceFromMDNSEntry(entry, nil)
+	dev, ok := lanDeviceFromMDNSEntry(entry, nil, windowsNetworkAdapterLookup{})
 	if !ok {
 		t.Fatal("lanDeviceFromMDNSEntry returned false")
 	}
@@ -77,7 +77,7 @@ func TestLANDeviceFromMDNSEntryAddsIPv6LinkLocalZone(t *testing.T) {
 		Port:   50051,
 	}
 
-	dev, ok := lanDeviceFromMDNSEntry(entry, iface)
+	dev, ok := lanDeviceFromMDNSEntry(entry, iface, windowsNetworkAdapterLookup{})
 	if !ok {
 		t.Fatal("lanDeviceFromMDNSEntry returned false")
 	}
@@ -96,7 +96,7 @@ func TestLANDeviceFromMDNSEntryDoesNotZoneGlobalIPv6(t *testing.T) {
 		Port:   50051,
 	}
 
-	dev, ok := lanDeviceFromMDNSEntry(entry, iface)
+	dev, ok := lanDeviceFromMDNSEntry(entry, iface, windowsNetworkAdapterLookup{})
 	if !ok {
 		t.Fatal("lanDeviceFromMDNSEntry returned false")
 	}
@@ -112,7 +112,7 @@ func TestLANDeviceFromMDNSEntryFiltersWrongService(t *testing.T) {
 		Port: 1234,
 	}
 
-	_, ok := lanDeviceFromMDNSEntry(entry, nil)
+	_, ok := lanDeviceFromMDNSEntry(entry, nil, windowsNetworkAdapterLookup{})
 	if ok {
 		t.Fatal("lanDeviceFromMDNSEntry returned true for wrong service")
 	}
@@ -163,6 +163,35 @@ func TestParseNetAdapterJSONFiltersWendyByName(t *testing.T) {
 	}
 	if got[0] != want {
 		t.Fatalf("got %#v, want %#v", got[0], want)
+	}
+}
+
+func TestLANDeviceFromMDNSEntryUsesWindowsAdapterMetadataForUSB(t *testing.T) {
+	iface := &net.Interface{Index: 12, Name: "Ethernet 3"}
+	entry := &mdns.ServiceEntry{
+		Name:       "wendyos-prudent-lark._wendyos._udp.local.",
+		Host:       "wendyos-prudent-lark.local.",
+		AddrV4:     net.ParseIP("169.254.249.48"),
+		Port:       50051,
+		InfoFields: []string{"id=agent-id", "displayname=Prudent Lark"},
+	}
+	adapterLookup := windowsNetworkAdapterLookupFromEntries([]netAdapterEntry{{
+		InterfaceIndex:       12,
+		Name:                 "Ethernet 3",
+		InterfaceDescription: "Remote NDIS Compatible Device",
+		LinkSpeed:            "425 Mbps",
+	}})
+
+	dev, ok := lanDeviceFromMDNSEntry(entry, iface, adapterLookup)
+	if !ok {
+		t.Fatal("lanDeviceFromMDNSEntry returned false")
+	}
+	if dev.NetworkInterface != "Ethernet 3" {
+		t.Fatalf("NetworkInterface = %q, want Ethernet 3", dev.NetworkInterface)
+	}
+	wantUSB := "Remote NDIS Compatible Device (Ethernet 3) 425 Mbps"
+	if dev.USB != wantUSB {
+		t.Fatalf("USB = %q, want %q", dev.USB, wantUSB)
 	}
 }
 

--- a/go/internal/shared/discovery/ethernet_darwin.go
+++ b/go/internal/shared/discovery/ethernet_darwin.go
@@ -97,6 +97,33 @@ func getInterfaceIP(ctx context.Context, bsdName string) string {
 	return ""
 }
 
+func darwinInterfaceDisplayName(ctx context.Context, bsdName string) string {
+	if bsdName == "" {
+		return ""
+	}
+
+	cmd := exec.CommandContext(ctx, "networksetup", "-listallhardwareports")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	var currentDisplayName string
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "Hardware Port:"):
+			currentDisplayName = strings.TrimSpace(strings.TrimPrefix(line, "Hardware Port:"))
+		case strings.HasPrefix(line, "Device:"):
+			if strings.TrimSpace(strings.TrimPrefix(line, "Device:")) == bsdName {
+				return currentDisplayName
+			}
+		}
+	}
+	return ""
+}
+
 // linkSpeedRe matches speed values in ifconfig media lines, e.g. "1000baseT", "10Gbase-T".
 var linkSpeedRe = regexp.MustCompile(`(\d+\.?\d*)(G)?base`)
 

--- a/go/internal/shared/discovery/ethernet_darwin.go
+++ b/go/internal/shared/discovery/ethernet_darwin.go
@@ -81,6 +81,10 @@ func parseDarwinHardwarePorts(output string) []darwinHardwarePort {
 			current = darwinHardwarePort{}
 		}
 	}
+	if scanner.Err() != nil {
+		// Return whatever was successfully parsed before the error.
+		return ports
+	}
 	return ports
 }
 

--- a/go/internal/shared/discovery/ethernet_darwin.go
+++ b/go/internal/shared/discovery/ethernet_darwin.go
@@ -16,40 +16,9 @@ import (
 // discoverEthernet enumerates network interfaces on macOS and returns those
 // whose display name or BSD name contains "Wendy" (USB-Ethernet gadget mode).
 func discoverEthernet(ctx context.Context) ([]models.EthernetInterface, error) {
-	// networksetup -listallhardwareports gives us display names mapped to BSD names.
-	// Output format:
-	//   Hardware Port: <display name>
-	//   Device: <bsd name>
-	//   Ethernet Address: <mac>
-	cmd := exec.CommandContext(ctx, "networksetup", "-listallhardwareports")
-	out, err := cmd.Output()
+	ports, err := darwinHardwarePorts(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("running networksetup: %w", err)
-	}
-
-	type hwPort struct {
-		displayName string
-		bsdName     string
-		macAddress  string
-	}
-
-	var ports []hwPort
-	var current hwPort
-	scanner := bufio.NewScanner(strings.NewReader(string(out)))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		switch {
-		case strings.HasPrefix(line, "Hardware Port:"):
-			current = hwPort{displayName: strings.TrimPrefix(line, "Hardware Port: ")}
-		case strings.HasPrefix(line, "Device:"):
-			current.bsdName = strings.TrimSpace(strings.TrimPrefix(line, "Device:"))
-		case strings.HasPrefix(line, "Ethernet Address:"):
-			current.macAddress = strings.TrimSpace(strings.TrimPrefix(line, "Ethernet Address:"))
-			if current.bsdName != "" {
-				ports = append(ports, current)
-			}
-			current = hwPort{}
-		}
+		return nil, err
 	}
 
 	// Filter for Wendy interfaces.
@@ -78,6 +47,61 @@ func discoverEthernet(ctx context.Context) ([]models.EthernetInterface, error) {
 	return devices, nil
 }
 
+type darwinHardwarePort struct {
+	displayName string
+	bsdName     string
+	macAddress  string
+}
+
+func darwinHardwarePorts(ctx context.Context) ([]darwinHardwarePort, error) {
+	cmd := exec.CommandContext(ctx, "networksetup", "-listallhardwareports")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("running networksetup: %w", err)
+	}
+	return parseDarwinHardwarePorts(string(out)), nil
+}
+
+func parseDarwinHardwarePorts(output string) []darwinHardwarePort {
+	var ports []darwinHardwarePort
+	var current darwinHardwarePort
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "Hardware Port:"):
+			current = darwinHardwarePort{displayName: strings.TrimSpace(strings.TrimPrefix(line, "Hardware Port:"))}
+		case strings.HasPrefix(line, "Device:"):
+			current.bsdName = strings.TrimSpace(strings.TrimPrefix(line, "Device:"))
+		case strings.HasPrefix(line, "Ethernet Address:"):
+			current.macAddress = strings.TrimSpace(strings.TrimPrefix(line, "Ethernet Address:"))
+			if current.bsdName != "" {
+				ports = append(ports, current)
+			}
+			current = darwinHardwarePort{}
+		}
+	}
+	return ports
+}
+
+func darwinInterfaceDisplayNameMap(ctx context.Context) map[string]string {
+	ports, err := darwinHardwarePorts(ctx)
+	if err != nil {
+		return nil
+	}
+	return darwinDisplayNamesByInterface(ports)
+}
+
+func darwinDisplayNamesByInterface(ports []darwinHardwarePort) map[string]string {
+	names := make(map[string]string, len(ports))
+	for _, port := range ports {
+		if port.bsdName != "" {
+			names[port.bsdName] = port.displayName
+		}
+	}
+	return names
+}
+
 func getInterfaceIP(ctx context.Context, bsdName string) string {
 	cmd := exec.CommandContext(ctx, "ifconfig", bsdName)
 	out, err := cmd.Output()
@@ -91,33 +115,6 @@ func getInterfaceIP(ctx context.Context, bsdName string) string {
 			fields := strings.Fields(line)
 			if len(fields) >= 2 {
 				return fields[1]
-			}
-		}
-	}
-	return ""
-}
-
-func darwinInterfaceDisplayName(ctx context.Context, bsdName string) string {
-	if bsdName == "" {
-		return ""
-	}
-
-	cmd := exec.CommandContext(ctx, "networksetup", "-listallhardwareports")
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-
-	var currentDisplayName string
-	scanner := bufio.NewScanner(strings.NewReader(string(out)))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		switch {
-		case strings.HasPrefix(line, "Hardware Port:"):
-			currentDisplayName = strings.TrimSpace(strings.TrimPrefix(line, "Hardware Port:"))
-		case strings.HasPrefix(line, "Device:"):
-			if strings.TrimSpace(strings.TrimPrefix(line, "Device:")) == bsdName {
-				return currentDisplayName
 			}
 		}
 	}

--- a/go/internal/shared/discovery/ethernet_darwin_test.go
+++ b/go/internal/shared/discovery/ethernet_darwin_test.go
@@ -1,0 +1,25 @@
+//go:build darwin
+
+package discovery
+
+import "testing"
+
+func TestParseDarwinHardwarePortsBuildsDisplayNameMap(t *testing.T) {
+	out := `Hardware Port: USB 10/100/1000 LAN
+Device: en6
+Ethernet Address: aa:bb:cc:dd:ee:ff
+
+Hardware Port: Wi-Fi
+Device: en0
+Ethernet Address: 11:22:33:44:55:66
+`
+
+	ports := parseDarwinHardwarePorts(out)
+	names := darwinDisplayNamesByInterface(ports)
+	if names["en6"] != "USB 10/100/1000 LAN" {
+		t.Fatalf("en6 display name = %q, want USB 10/100/1000 LAN", names["en6"])
+	}
+	if names["en0"] != "Wi-Fi" {
+		t.Fatalf("en0 display name = %q, want Wi-Fi", names["en0"])
+	}
+}

--- a/go/internal/shared/discovery/ethernet_linux.go
+++ b/go/internal/shared/discovery/ethernet_linux.go
@@ -49,18 +49,7 @@ func discoverEthernet(_ context.Context) ([]models.EthernetInterface, error) {
 			}
 		}
 
-		// Read link speed (in Mbps, -1 if link is down).
-		if data, err := os.ReadFile(filepath.Join(sysClassNet, name, "speed")); err == nil {
-			speedStr := strings.TrimSpace(string(data))
-			var mbps int
-			if _, scanErr := fmt.Sscanf(speedStr, "%d", &mbps); scanErr == nil && mbps > 0 {
-				if mbps >= 1000 {
-					iface.LinkSpeed = fmt.Sprintf("%d Gbps", mbps/1000)
-				} else {
-					iface.LinkSpeed = fmt.Sprintf("%d Mbps", mbps)
-				}
-			}
-		}
+		iface.LinkSpeed = linuxInterfaceLinkSpeed(name)
 
 		// Read IP address via Go's net package.
 		if netIface, err := net.InterfaceByName(name); err == nil {
@@ -77,4 +66,21 @@ func discoverEthernet(_ context.Context) ([]models.EthernetInterface, error) {
 		devices = append(devices, iface)
 	}
 	return devices, nil
+}
+
+func linuxInterfaceLinkSpeed(name string) string {
+	data, err := os.ReadFile(filepath.Join(sysClassNet, name, "speed"))
+	if err != nil {
+		return ""
+	}
+
+	speedStr := strings.TrimSpace(string(data))
+	var mbps int
+	if _, scanErr := fmt.Sscanf(speedStr, "%d", &mbps); scanErr != nil || mbps <= 0 {
+		return ""
+	}
+	if mbps >= 1000 {
+		return fmt.Sprintf("%d Gbps", mbps/1000)
+	}
+	return fmt.Sprintf("%d Mbps", mbps)
 }

--- a/go/internal/shared/discovery/ethernet_windows.go
+++ b/go/internal/shared/discovery/ethernet_windows.go
@@ -20,6 +20,7 @@ const netAdapterPowershell = `Get-NetAdapter | ForEach-Object {
   $adapter = $_
   $ip = (Get-NetIPAddress -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue | Select-Object -First 1).IPAddress
   [PSCustomObject]@{
+    InterfaceIndex = $adapter.ifIndex
     Name = $adapter.Name
     InterfaceDescription = $adapter.InterfaceDescription
     MacAddress = $adapter.MacAddress
@@ -29,6 +30,7 @@ const netAdapterPowershell = `Get-NetAdapter | ForEach-Object {
 } | ConvertTo-Json -Compress`
 
 type netAdapterEntry struct {
+	InterfaceIndex       int    `json:"InterfaceIndex"`
 	Name                 string `json:"Name"`
 	InterfaceDescription string `json:"InterfaceDescription"`
 	MacAddress           string `json:"MacAddress"`
@@ -40,18 +42,30 @@ type netAdapterEntry struct {
 // and returns those whose Name or InterfaceDescription contains "Wendy"
 // (case-insensitive), matching the linux/darwin filter convention.
 func discoverEthernet(ctx context.Context) ([]models.EthernetInterface, error) {
+	entries, err := readNetAdapterEntries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ethernetInterfacesFromNetAdapterEntries(entries), nil
+}
+
+func readNetAdapterEntries(ctx context.Context) ([]netAdapterEntry, error) {
 	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", netAdapterPowershell)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("running Get-NetAdapter: %w", err)
 	}
-	return parseNetAdapterJSON(string(out)), nil
+	return parseNetAdapterEntriesJSON(string(out)), nil
 }
 
 // parseNetAdapterJSON parses the ConvertTo-Json output produced by
 // netAdapterPowershell and filters for Wendy interfaces. PowerShell omits the
 // outer array when there is exactly one result, so we normalize.
 func parseNetAdapterJSON(jsonOut string) []models.EthernetInterface {
+	return ethernetInterfacesFromNetAdapterEntries(parseNetAdapterEntriesJSON(jsonOut))
+}
+
+func parseNetAdapterEntriesJSON(jsonOut string) []netAdapterEntry {
 	trimmed := strings.TrimSpace(jsonOut)
 	if trimmed == "" {
 		return nil
@@ -64,7 +78,10 @@ func parseNetAdapterJSON(jsonOut string) []models.EthernetInterface {
 	if err := json.Unmarshal([]byte(trimmed), &entries); err != nil {
 		return nil
 	}
+	return entries
+}
 
+func ethernetInterfacesFromNetAdapterEntries(entries []netAdapterEntry) []models.EthernetInterface {
 	var devices []models.EthernetInterface
 	for _, e := range entries {
 		nameL := strings.ToLower(e.Name + " " + e.InterfaceDescription)

--- a/go/internal/shared/discovery/usb_connection.go
+++ b/go/internal/shared/discovery/usb_connection.go
@@ -1,0 +1,117 @@
+package discovery
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/internal/shared/models"
+)
+
+var linuxUSBInterfaceNameRE = regexp.MustCompile(`^en[a-z0-9]*u[0-9]+`)
+
+func setLANNetworkInterface(dev *models.LANDevice, interfaceName, displayName, linkSpeed string) {
+	interfaceName = strings.TrimSpace(interfaceName)
+	if interfaceName == "" {
+		return
+	}
+
+	dev.NetworkInterface = interfaceName
+	if dev.USB == "" {
+		dev.USB = usbConnectionSummary(interfaceName, displayName, linkSpeed)
+	}
+}
+
+func usbConnectionSummary(interfaceName, displayName, linkSpeed string) string {
+	if !looksLikeUSBConnection(interfaceName, displayName) {
+		return ""
+	}
+
+	label := interfaceName
+	if displayName != "" && !strings.EqualFold(displayName, interfaceName) {
+		label = fmt.Sprintf("%s (%s)", displayName, interfaceName)
+	}
+	if linkSpeed != "" {
+		return label + " " + linkSpeed
+	}
+	return label
+}
+
+func looksLikeUSBConnection(interfaceName, displayName string) bool {
+	name := strings.ToLower(strings.TrimSpace(interfaceName))
+	display := strings.ToLower(strings.TrimSpace(displayName))
+	combined := name + " " + display
+
+	switch {
+	case strings.Contains(combined, "wendy"):
+		return true
+	case strings.Contains(combined, "usb"):
+		return true
+	case strings.Contains(combined, "rndis"):
+		return true
+	case strings.Contains(combined, "ecm"):
+		return true
+	case strings.Contains(combined, "gadget"):
+		return true
+	case strings.HasPrefix(name, "enx"):
+		return true
+	case linuxUSBInterfaceNameRE.MatchString(name):
+		return true
+	default:
+		return false
+	}
+}
+
+func appendPreferredLANDevice(devices []models.LANDevice, indexes map[string]int, key string, dev models.LANDevice) []models.LANDevice {
+	if idx, ok := indexes[key]; ok {
+		if preferDiscoveredLANDevice(dev, devices[idx]) {
+			devices[idx] = dev
+		}
+		return devices
+	}
+
+	indexes[key] = len(devices)
+	return append(devices, dev)
+}
+
+func preferDiscoveredLANDevice(candidate, existing models.LANDevice) bool {
+	if (candidate.USB != "") != (existing.USB != "") {
+		return candidate.USB != ""
+	}
+	if existing.IPAddress == "" && candidate.IPAddress != "" {
+		return true
+	}
+	if existing.NetworkInterface == "" && candidate.NetworkInterface != "" {
+		return true
+	}
+	return lanDeviceDiscoveryScore(candidate) > lanDeviceDiscoveryScore(existing)
+}
+
+func lanDeviceDiscoveryScore(dev models.LANDevice) int {
+	score := 0
+	if dev.ID != "" {
+		score++
+	}
+	if dev.DisplayName != "" {
+		score++
+	}
+	if dev.Hostname != "" {
+		score++
+	}
+	if dev.IPAddress != "" {
+		score++
+	}
+	if dev.Port != 0 {
+		score++
+	}
+	if dev.NetworkInterface != "" {
+		score++
+	}
+	if dev.USB != "" {
+		score += 2
+	}
+	if dev.IsMTLS {
+		score++
+	}
+	return score
+}

--- a/go/internal/shared/discovery/usb_connection.go
+++ b/go/internal/shared/discovery/usb_connection.go
@@ -49,6 +49,8 @@ func looksLikeUSBConnection(interfaceName, displayName string) bool {
 		return true
 	case strings.Contains(combined, "rndis"):
 		return true
+	case strings.Contains(combined, "ndis"):
+		return true
 	case strings.Contains(combined, "ecm"):
 		return true
 	case strings.Contains(combined, "gadget"):

--- a/go/internal/shared/discovery/usb_connection.go
+++ b/go/internal/shared/discovery/usb_connection.go
@@ -15,20 +15,23 @@ var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 // the network (mDNS, TXT records) before it is rendered in the terminal.
 func SanitiseDisplayName(s string) string { return sanitiseNetworkString(s, 64) }
 
-// sanitiseNetworkString strips ANSI escape sequences and ASCII control
-// characters from a string sourced from the network, then truncates to maxLen.
-// This prevents terminal injection from rogue mDNS/DNS-SD advertisers.
+// sanitiseNetworkString strips ANSI escape sequences and C0/C1/DEL control
+// characters from a string sourced from the network, then truncates to maxLen
+// runes. This prevents terminal injection from rogue mDNS/DNS-SD advertisers.
 func sanitiseNetworkString(s string, maxLen int) string {
 	s = ansiEscapeRE.ReplaceAllString(s, "")
 	var b strings.Builder
 	for _, r := range s {
-		if r >= 0x20 {
+		if r >= 0x20 && r != 0x7f {
 			b.WriteRune(r)
 		}
 	}
 	s = strings.TrimSpace(b.String())
-	if maxLen > 0 && len(s) > maxLen {
-		s = s[:maxLen]
+	if maxLen > 0 {
+		runes := []rune(s)
+		if len(runes) > maxLen {
+			s = string(runes[:maxLen])
+		}
 	}
 	return s
 }

--- a/go/internal/shared/discovery/usb_connection.go
+++ b/go/internal/shared/discovery/usb_connection.go
@@ -8,17 +8,42 @@ import (
 	"github.com/wendylabsinc/wendy/internal/shared/models"
 )
 
+// ansiEscapeRE matches ANSI/VT100 escape sequences (e.g. colour codes).
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// SanitiseDisplayName sanitises a device name or version string sourced from
+// the network (mDNS, TXT records) before it is rendered in the terminal.
+func SanitiseDisplayName(s string) string { return sanitiseNetworkString(s, 64) }
+
+// sanitiseNetworkString strips ANSI escape sequences and ASCII control
+// characters from a string sourced from the network, then truncates to maxLen.
+// This prevents terminal injection from rogue mDNS/DNS-SD advertisers.
+func sanitiseNetworkString(s string, maxLen int) string {
+	s = ansiEscapeRE.ReplaceAllString(s, "")
+	var b strings.Builder
+	for _, r := range s {
+		if r >= 0x20 {
+			b.WriteRune(r)
+		}
+	}
+	s = strings.TrimSpace(b.String())
+	if maxLen > 0 && len(s) > maxLen {
+		s = s[:maxLen]
+	}
+	return s
+}
+
 var linuxUSBInterfaceNameRE = regexp.MustCompile(`^en[a-z0-9]*u[0-9]+`)
 
 func setLANNetworkInterface(dev *models.LANDevice, interfaceName, displayName, linkSpeed string) {
-	interfaceName = strings.TrimSpace(interfaceName)
+	interfaceName = strings.TrimSpace(sanitiseNetworkString(interfaceName, 64))
 	if interfaceName == "" {
 		return
 	}
 
 	dev.NetworkInterface = interfaceName
 	if dev.USB == "" {
-		dev.USB = usbConnectionSummary(interfaceName, displayName, linkSpeed)
+		dev.USB = usbConnectionSummary(interfaceName, sanitiseNetworkString(displayName, 64), sanitiseNetworkString(linkSpeed, 32))
 	}
 }
 

--- a/go/internal/shared/models/devices.go
+++ b/go/internal/shared/models/devices.go
@@ -50,19 +50,21 @@ func (d USBDevice) HumanReadable() string {
 
 // LANDevice represents a device discovered via mDNS on the local network.
 type LANDevice struct {
-	ID              string `json:"id"`
-	DisplayName     string `json:"displayName"`
-	Hostname        string `json:"hostname"`
-	IPAddress       string `json:"ipAddress,omitempty"`
-	Port            int    `json:"port"`
-	IsMTLS          bool   `json:"isMTLS,omitempty"`
-	InterfaceType   string `json:"interfaceType"`
-	IsWendyDevice   bool   `json:"isWendyDevice"`
-	AgentVersion    string `json:"agentVersion,omitempty"`
-	DeviceType      string `json:"deviceType,omitempty"`
-	OS              string `json:"os,omitempty"`
-	OSVersion       string `json:"osVersion,omitempty"`
-	CPUArchitecture string `json:"cpuArchitecture,omitempty"`
+	ID               string `json:"id"`
+	DisplayName      string `json:"displayName"`
+	Hostname         string `json:"hostname"`
+	IPAddress        string `json:"ipAddress,omitempty"`
+	Port             int    `json:"port"`
+	IsMTLS           bool   `json:"isMTLS,omitempty"`
+	InterfaceType    string `json:"interfaceType"`
+	NetworkInterface string `json:"-"`
+	USB              string `json:"usb,omitempty"`
+	IsWendyDevice    bool   `json:"isWendyDevice"`
+	AgentVersion     string `json:"agentVersion,omitempty"`
+	DeviceType       string `json:"deviceType,omitempty"`
+	OS               string `json:"os,omitempty"`
+	OSVersion        string `json:"osVersion,omitempty"`
+	CPUArchitecture  string `json:"cpuArchitecture,omitempty"`
 }
 
 // HumanReadable returns a human-friendly string describing this LAN device.


### PR DESCRIPTION
## Summary
- Detect USB-connected LAN devices via DNS-SD interface metadata and annotate them in the discovery pipeline
- Surface USB in the **Type** column (e.g. \"USB, LAN\") rather than a separate column, keeping the table compact
- Sort USB-connected devices first; Docker and Local (\"This Device\") sort to the bottom
- Hide Ethernet-only rows from the discover table
- Carry macOS DNS-SD interface metadata through continuous discovery
- Rename \"Local (This Device)\" provider display name to \"This Device\"
- Strip ANSI/control characters from mDNS/DNS-SD strings before terminal rendering
- Add ProviderKeyDocker/ProviderKeyLocal constants to avoid hard-coded key strings

Closes #737

## Validation
- \`gofmt\`
- \`go test -count=1 ./internal/cli/tui ./internal/cli/commands ./internal/agent/services ./internal/shared/models ./internal/shared/discovery\`
- \`go build -o ./wendy ./cmd/wendy\`
- \`GOOS=linux GOARCH=amd64 go test -c ./internal/shared/discovery -o /tmp/wendy-discovery-linux.test\`
- \`GOOS=windows GOARCH=amd64 go test -c ./internal/shared/discovery -o /tmp/wendy-discovery-windows.test.exe\`
- live TTY check: \`wendy discover\` shows USB-connected devices first with \"USB, LAN\" in the Type column