### PR TITLE
ci: fail security review check on HIGH or CRITICAL findings

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -149,30 +149,23 @@ jobs:
               }],
           )
 
+          import re
+
           report = message.content[0].text[:20000]
           pathlib.Path('review.md').write_text(report + '\n')
           print(report)
 
-          # Determine the highest severity via a separate isolated call that only
-          # sees the generated report — not the PR content. This prevents prompt
-          # injection in the diff from influencing the gate decision.
-          verdict_msg = client.messages.create(
-              model='claude-sonnet-4-6',
-              max_tokens=10,
-              system=(
-                  'You are a security report classifier. '
-                  'Read the provided security report and reply with exactly one word '
-                  'representing the highest severity finding present: '
-                  'CRITICAL, HIGH, MEDIUM, LOW, or CLEAN (if no findings). '
-                  'Output only that single word — no punctuation, no explanation.'
-              ),
-              messages=[{'role': 'user', 'content': report}],
+          # Deterministically parse the findings table the system prompt instructs
+          # Claude to emit (| Severity | ... |). Line-anchored and restricted to the
+          # five valid tokens so free-form prose cannot accidentally match.
+          severities = re.findall(
+              r'^\|\s*(CRITICAL|HIGH|MEDIUM|LOW|INFORMATIONAL)\s*\|',
+              report,
+              re.MULTILINE,
           )
+          has_high = any(s in ('CRITICAL', 'HIGH') for s in severities)
+          print(f'Severities found: {severities}')
 
-          verdict = verdict_msg.content[0].text.strip().upper()
-          print(f'Severity verdict: {verdict}')
-
-          has_high = verdict in ('HIGH', 'CRITICAL')
           github_env = os.environ.get('GITHUB_ENV', '')
           if github_env and has_high:
               with open(github_env, 'a') as genv:

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -54,6 +54,7 @@ jobs:
           python3 << 'PYEOF'
           import anthropic
           import json
+          import os
           import pathlib
 
           client = anthropic.Anthropic()
@@ -148,14 +149,30 @@ jobs:
               }],
           )
 
-          import os
-          import re
-
           report = message.content[0].text[:20000]
           pathlib.Path('review.md').write_text(report + '\n')
           print(report)
 
-          has_high = bool(re.search(r'\|\s*(?:CRITICAL|HIGH)\s*\|', report))
+          # Determine the highest severity via a separate isolated call that only
+          # sees the generated report — not the PR content. This prevents prompt
+          # injection in the diff from influencing the gate decision.
+          verdict_msg = client.messages.create(
+              model='claude-sonnet-4-6',
+              max_tokens=10,
+              system=(
+                  'You are a security report classifier. '
+                  'Read the provided security report and reply with exactly one word '
+                  'representing the highest severity finding present: '
+                  'CRITICAL, HIGH, MEDIUM, LOW, or CLEAN (if no findings). '
+                  'Output only that single word — no punctuation, no explanation.'
+              ),
+              messages=[{'role': 'user', 'content': report}],
+          )
+
+          verdict = verdict_msg.content[0].text.strip().upper()
+          print(f'Severity verdict: {verdict}')
+
+          has_high = verdict in ('HIGH', 'CRITICAL')
           github_env = os.environ.get('GITHUB_ENV', '')
           if github_env and has_high:
               with open(github_env, 'a') as genv:

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -148,9 +148,18 @@ jobs:
               }],
           )
 
+          import os
+          import re
+
           report = message.content[0].text[:20000]
           pathlib.Path('review.md').write_text(report + '\n')
           print(report)
+
+          has_high = bool(re.search(r'\|\s*(?:CRITICAL|HIGH)\s*\|', report))
+          github_env = os.environ.get('GITHUB_ENV', '')
+          if github_env and has_high:
+              with open(github_env, 'a') as genv:
+                  genv.write('HAS_HIGH_SEVERITY=true\n')
           PYEOF
 
       - name: Post review as PR comment
@@ -204,3 +213,9 @@ jobs:
           else
             gh pr comment "${PR_NUM}" --repo "${REPO}" --body-file comment.md
           fi
+
+      - name: Fail on high or critical severity findings
+        if: env.HAS_HIGH_SEVERITY == 'true'
+        run: |
+          echo "Security review found HIGH or CRITICAL severity issues. Address them before merging."
+          exit 1


### PR DESCRIPTION
## Summary

- Parses the AI-generated security report for table rows with `HIGH` or `CRITICAL` severity
- Writes `HAS_HIGH_SEVERITY=true` to `GITHUB_ENV` when found
- Adds a final step that exits non-zero, blocking the PR from merging

The PR comment is still posted regardless, so reviewers can read the full report even when the check fails.

## Test plan

- [ ] Open a PR with no security issues — check passes, comment posted
- [ ] Open a PR where Claude flags a HIGH/CRITICAL finding — check fails, comment still posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)