### PR TITLE
fix: always CloseSend after AttachContainer Send in compose mode

### DIFF
--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -686,9 +686,8 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 				streamErr = stream.Send(&agentpb.AttachContainerRequest{
 					RequestType: &agentpb.AttachContainerRequest_AppName{AppName: appID},
 				})
-				if streamErr != nil {
-					_ = stream.CloseSend()
-				}
+				// Compose never forwards stdin; half-close so the server sees EOF.
+				_ = stream.CloseSend()
 			}
 			if streamErr != nil {
 				// Fall back to the server-streaming StartContainer when AttachContainer is unavailable.


### PR DESCRIPTION
## Summary
- `compose.go` called `AttachContainer` bidi stream and sent `app_name`, but only called `CloseSend()` on the error path, never on success
- This left the server's stdin-forwarding goroutine blocked on `Recv()` forever, causing stdin-reading containers started via `wendy run` with a `compose.yml` to hang indefinitely
- Fix: move `CloseSend()` outside the `if streamErr != nil` block so it's always called after `Send()`

## Test plan
- [ ] Run `wendy run` with a `compose.yml` containing a service that reads stdin (e.g. `cat`) — it should exit cleanly instead of hanging
- [ ] Verify compose runs with services that don't read stdin are unaffected

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)