### PR TITLE
fix(cli): add Windows OS guard for Swift ImageBuilder and runWithProvider paths

### DIFF
--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -77,6 +77,9 @@ func newBuildCmd() *cobra.Command {
 				}
 				if projectType == "swift" {
 					if _, ok := target.Provider.(providers.ImageBuilder); ok {
+						if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+							return fmt.Errorf("`wendy build` for Swift packages is not supported on %s; provide a Dockerfile", runtime.GOOS)
+						}
 						if err := swifttoolchain.EnsureSwiftVersion(cmd.Context(), &dimWriter{}, os.Stderr); err != nil {
 							return err
 						}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -942,6 +942,9 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 
 	// Resolve Swift product name from Package.swift.
 	if projectType == "swift" {
+		if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+			return fmt.Errorf("`wendy build` for Swift packages is not supported on %s; provide a Dockerfile", runtime.GOOS)
+		}
 		if err := swifttoolchain.EnsureSwiftVersion(ctx, &dimWriter{}, os.Stderr); err != nil {
 			return err
 		}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -943,7 +943,7 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 	// Resolve Swift product name from Package.swift.
 	if projectType == "swift" {
 		if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-			return fmt.Errorf("`wendy build` for Swift packages is not supported on %s; provide a Dockerfile", runtime.GOOS)
+			return fmt.Errorf("`wendy run` for Swift packages is not supported on %s; provide a Dockerfile", runtime.GOOS)
 		}
 		if err := swifttoolchain.EnsureSwiftVersion(ctx, &dimWriter{}, os.Stderr); err != nil {
 			return err

--- a/go/internal/cli/commands/run_windows_test.go
+++ b/go/internal/cli/commands/run_windows_test.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/internal/shared/models"
+)
+
+// TestRunWithProvider_SwiftRejectedOnWindows verifies that `wendy run` for a
+// Swift project fails fast on Windows with an actionable message instead of
+// shelling out to a non-existent `swift` binary.
+func TestRunWithProvider_SwiftRejectedOnWindows(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Package.swift"), []byte("// swift-tools-version:5.9\n"), 0o644); err != nil {
+		t.Fatalf("creating Package.swift: %v", err)
+	}
+
+	err := runWithProvider(context.Background(), nil, models.ExternalDevice{}, dir, "", runOptions{})
+	if err == nil {
+		t.Fatal("runWithProvider(swift) on Windows: error = nil, want non-nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "not supported") {
+		t.Errorf("error message missing 'not supported': %q", msg)
+	}
+	if !strings.Contains(msg, "Dockerfile") {
+		t.Errorf("error message should suggest a Dockerfile alternative: %q", msg)
+	}
+}


### PR DESCRIPTION
## Summary
- The Swift ImageBuilder shortcut in `build.go` and the Swift branch in `runWithProvider` in `run.go` called `swifttoolchain.EnsureSwiftVersion()` without checking `runtime.GOOS`
- On Windows this produced a misleading "swiftly is required but not installed" error instead of the clear "not supported on windows; provide a Dockerfile" message
- Fix: added the same `runtime.GOOS` guard in both locations before `EnsureSwiftVersion()`

## Test plan
- [ ] On Windows, `wendy build` with a Swift project targeting Docker Desktop returns "not supported on windows; provide a Dockerfile"
- [ ] On macOS/Linux, Swift builds with Docker Desktop target are unaffected

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)