### PR TITLE
docs(mcp): remove filesync_sync from guide's available-tools list

### DIFF
--- a/go/internal/cli/mcp/tools_guide.go
+++ b/go/internal/cli/mcp/tools_guide.go
@@ -34,7 +34,6 @@ Cloud-enrolled devices:
 - telemetry_logs / telemetry_metrics / telemetry_traces
 - hardware_capabilities
 - os_update
-- filesync_sync
 - provisioning_start / provisioning_status
 
 ## Deploying a workload


### PR DESCRIPTION
## Summary
- `tools_guide.go` listed `filesync_sync` under "Tools available once connected"
- The tool's handler unconditionally returns an error — it requires binary file transfer and cannot work via MCP
- Fix: removed the single `filesync_sync` line from the guide

## Test plan
- [ ] MCP guide no longer lists `filesync_sync` as available after connecting
- [ ] Other entries in the "available once connected" section are unchanged

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)