### PR TITLE
docs(agent): tie remaining PATH workarounds to WendyOS-Builder PR #53

### DIFF
--- a/go/internal/agent/configpartition/apply.go
+++ b/go/internal/agent/configpartition/apply.go
@@ -279,9 +279,30 @@ func applyDeviceName(logger *zap.Logger, name string) error {
 	}
 	logger.Info("Wrote device name", zap.String("name", name), zap.String("path", deviceNamePath))
 
+	// Build an env with a full system PATH so that the shell script and any
+	// utilities it execs (mkdir, logger, sed, ...) resolve correctly even on
+	// pre-WendyOS-Builder-PR-53 images, where the agent's systemd unit can
+	// inherit a CUDA-only or literal "$PATH" environment.
+	env := os.Environ()
+	const systemPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	replaced := false
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + systemPath
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		env = append(env, "PATH="+systemPath)
+	}
+
 	// generate-hostname.sh reads /etc/wendyos/device-name (which we just wrote)
 	// and derives wendyos-<name>, updating /etc/hostname and the running hostname.
-	hostnameScript := exec.Command("generate-hostname.sh")
+	// Use the absolute path: bare names would be resolved from the agent's
+	// inherited PATH, which is unreliable on pre-PR-53 images.
+	hostnameScript := exec.Command("/usr/sbin/generate-hostname.sh")
+	hostnameScript.Env = env
 	if out, err := hostnameScript.CombinedOutput(); err != nil {
 		logger.Warn("generate-hostname.sh failed", zap.Error(err), zap.String("output", string(out)))
 	} else {
@@ -290,14 +311,14 @@ func applyDeviceName(logger *zap.Logger, name string) error {
 
 	// update-mdns-uuid.sh is a first-boot placeholder replacer and is a no-op
 	// on a running device. Update the avahi service file directly instead.
-	updateAvahiDeviceName(logger, name)
+	updateAvahiDeviceName(logger, name, env)
 
 	return nil
 }
 
 // updateAvahiDeviceName rewrites the name/displayname/fqdn TXT records in the
 // avahi service file and reloads avahi-daemon so mDNS picks up the new name.
-func updateAvahiDeviceName(logger *zap.Logger, name string) {
+func updateAvahiDeviceName(logger *zap.Logger, name string, env []string) {
 	const serviceFile = "/etc/avahi/services/wendyos-mdns.service"
 
 	data, err := os.ReadFile(serviceFile)
@@ -321,7 +342,11 @@ func updateAvahiDeviceName(logger *zap.Logger, name string) {
 	// --reload (SIGHUP) only refreshes service files; it does not re-read the
 	// hostname from gethostname(), so %h would stay stale. A full restart picks
 	// up both the new service file and the updated hostname.
-	restart := exec.Command("systemctl", "restart", "avahi-daemon")
+	// Use the absolute path: exec.Command resolves binaries from the calling
+	// process's PATH, not from cmd.Env, so bare "systemctl" would not be found
+	// on pre-PR-53 images where the inherited PATH is broken.
+	restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
+	restart.Env = env
 	if out, err := restart.CombinedOutput(); err != nil {
 		logger.Warn("systemctl restart avahi-daemon failed", zap.Error(err), zap.String("output", string(out)))
 	} else {
@@ -366,7 +391,7 @@ func UpdateAvahiForProvisioning(logger *zap.Logger, mtlsPort int) {
 			return
 		}
 
-		restart := exec.Command("systemctl", "restart", "avahi-daemon")
+		restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
 		if out, err := restart.CombinedOutput(); err != nil {
 			logger.Warn("systemctl restart avahi-daemon failed after provisioning",
 				zap.Error(err), zap.String("output", string(out)))

--- a/go/internal/agent/configpartition/apply.go
+++ b/go/internal/agent/configpartition/apply.go
@@ -279,27 +279,9 @@ func applyDeviceName(logger *zap.Logger, name string) error {
 	}
 	logger.Info("Wrote device name", zap.String("name", name), zap.String("path", deviceNamePath))
 
-	// Build an env with a full system PATH so scripts can find standard
-	// utilities (mkdir, logger, etc.) even when the agent runs under systemd
-	// with a restricted PATH.
-	env := os.Environ()
-	const systemPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	replaced := false
-	for i, e := range env {
-		if strings.HasPrefix(e, "PATH=") {
-			env[i] = "PATH=" + systemPath
-			replaced = true
-			break
-		}
-	}
-	if !replaced {
-		env = append(env, "PATH="+systemPath)
-	}
-
 	// generate-hostname.sh reads /etc/wendyos/device-name (which we just wrote)
 	// and derives wendyos-<name>, updating /etc/hostname and the running hostname.
-	hostnameScript := exec.Command("/usr/sbin/generate-hostname.sh")
-	hostnameScript.Env = env
+	hostnameScript := exec.Command("generate-hostname.sh")
 	if out, err := hostnameScript.CombinedOutput(); err != nil {
 		logger.Warn("generate-hostname.sh failed", zap.Error(err), zap.String("output", string(out)))
 	} else {
@@ -308,14 +290,14 @@ func applyDeviceName(logger *zap.Logger, name string) error {
 
 	// update-mdns-uuid.sh is a first-boot placeholder replacer and is a no-op
 	// on a running device. Update the avahi service file directly instead.
-	updateAvahiDeviceName(logger, name, env)
+	updateAvahiDeviceName(logger, name)
 
 	return nil
 }
 
 // updateAvahiDeviceName rewrites the name/displayname/fqdn TXT records in the
 // avahi service file and reloads avahi-daemon so mDNS picks up the new name.
-func updateAvahiDeviceName(logger *zap.Logger, name string, env []string) {
+func updateAvahiDeviceName(logger *zap.Logger, name string) {
 	const serviceFile = "/etc/avahi/services/wendyos-mdns.service"
 
 	data, err := os.ReadFile(serviceFile)
@@ -339,10 +321,7 @@ func updateAvahiDeviceName(logger *zap.Logger, name string, env []string) {
 	// --reload (SIGHUP) only refreshes service files; it does not re-read the
 	// hostname from gethostname(), so %h would stay stale. A full restart picks
 	// up both the new service file and the updated hostname.
-	// Use the absolute path: exec.Command resolves binaries from the calling
-	// process's PATH, not from cmd.Env, so bare "systemctl" would not be found.
-	restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
-	restart.Env = env
+	restart := exec.Command("systemctl", "restart", "avahi-daemon")
 	if out, err := restart.CombinedOutput(); err != nil {
 		logger.Warn("systemctl restart avahi-daemon failed", zap.Error(err), zap.String("output", string(out)))
 	} else {
@@ -387,7 +366,7 @@ func UpdateAvahiForProvisioning(logger *zap.Logger, mtlsPort int) {
 			return
 		}
 
-		restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
+		restart := exec.Command("systemctl", "restart", "avahi-daemon")
 		if out, err := restart.CombinedOutput(); err != nil {
 			logger.Warn("systemctl restart avahi-daemon failed after provisioning",
 				zap.Error(err), zap.String("output", string(out)))

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -681,6 +681,7 @@ func (s *AgentService) UpdateOS(req *agentpb.UpdateOSRequest, stream grpc.Server
 	}
 
 	cmd := exec.CommandContext(stream.Context(), cmdName, "install", req.GetArtifactUrl())
+	cmd.Env = envWithPath("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -807,6 +808,22 @@ func (s *AgentService) UpdateOS(req *agentpb.UpdateOSRequest, stream grpc.Server
 	return nil
 }
 
+// envWithPath returns os.Environ() with the PATH entry replaced by the given value.
+// This ensures PATH is set exactly once (not duplicated), which matters because
+// getenv on Linux returns the first match — appending would leave the original in place.
+// Used to give mender-update a sane PATH on pre-WendyOS-Builder-PR-53 images where
+// the agent's inherited PATH may be missing standard system bin directories.
+func envWithPath(path string) []string {
+	env := os.Environ()
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + path
+			return env
+		}
+	}
+	return append(env, "PATH="+path)
+}
+
 // resolveMenderBinary finds the mender-update binary. It checks PATH via
 // exec.LookPath and then probes absolute paths directly. The os.Stat fallback
 // is restricted to absolute paths to avoid accidentally executing a file from
@@ -850,6 +867,7 @@ func CommitMenderUpdate(logger *zap.Logger) {
 		return
 	}
 	cmd := exec.Command(binary, "commit")
+	cmd.Env = envWithPath("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -681,7 +681,6 @@ func (s *AgentService) UpdateOS(req *agentpb.UpdateOSRequest, stream grpc.Server
 	}
 
 	cmd := exec.CommandContext(stream.Context(), cmdName, "install", req.GetArtifactUrl())
-	cmd.Env = envWithPath("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -808,20 +807,6 @@ func (s *AgentService) UpdateOS(req *agentpb.UpdateOSRequest, stream grpc.Server
 	return nil
 }
 
-// envWithPath returns os.Environ() with the PATH entry replaced by the given value.
-// This ensures PATH is set exactly once (not duplicated), which matters because
-// getenv on Linux returns the first match — appending would leave the original in place.
-func envWithPath(path string) []string {
-	env := os.Environ()
-	for i, e := range env {
-		if strings.HasPrefix(e, "PATH=") {
-			env[i] = "PATH=" + path
-			return env
-		}
-	}
-	return append(env, "PATH="+path)
-}
-
 // resolveMenderBinary finds the mender-update binary. It checks PATH via
 // exec.LookPath and then probes absolute paths directly. The os.Stat fallback
 // is restricted to absolute paths to avoid accidentally executing a file from
@@ -865,7 +850,6 @@ func CommitMenderUpdate(logger *zap.Logger) {
 		return
 	}
 	cmd := exec.Command(binary, "commit")
-	cmd.Env = envWithPath("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/go/internal/agent/services/os_update_service.go
+++ b/go/internal/agent/services/os_update_service.go
@@ -64,7 +64,6 @@ func (s *OSUpdateService) UpdateOS(req *agentpbv2.UpdateOSRequest, stream grpc.S
 	}
 
 	cmd := exec.CommandContext(stream.Context(), cmdName, "install", req.GetArtifactUrl())
-	cmd.Env = envWithPath("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {

--- a/go/internal/agent/services/os_update_service.go
+++ b/go/internal/agent/services/os_update_service.go
@@ -64,6 +64,7 @@ func (s *OSUpdateService) UpdateOS(req *agentpbv2.UpdateOSRequest, stream grpc.S
 	}
 
 	cmd := exec.CommandContext(stream.Context(), cmdName, "install", req.GetArtifactUrl())
+	cmd.Env = envWithPath("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary

[WendyOS-Builder PR #53](https://github.com/wendylabsinc/WendyOS-Builder/pull/53) gave the `wendy-agent` systemd unit a real `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` (it had been the literal string `$PATH` after a CUDA setup file).

The original ambition of this PR was to clean up the PATH workarounds the agent grew in response to that bug. After review, the consensus is to **wait until pre-PR-53 images are explicitly unsupported** before stripping the safety nets, because:

- `generate-hostname.sh` and `systemctl` had no `LookPath → fallback` resolver, so making them bare names regressed pre-PR-53 availability and weakened the privileged-command boundary.
- `mender-update` has a resolver (`resolveMenderBinary`) for *finding* the binary, but once started it still needs a working PATH for its own sub-utilities — dropping `envWithPath(...)` on those callsites was a real OTA regression on older images.

### What this PR now is

Reduced to **comment-only** changes against `main`: each remaining absolute path and PATH override is now explicitly tied to WendyOS-Builder PR #53 so a future cleanup pass (after that PR is universally deployed) knows exactly what it's allowed to remove. No behavior changes.

### Files touched

- `go/internal/agent/configpartition/apply.go` — clarify why `systemPath` override exists, why `/usr/sbin/generate-hostname.sh` and `/usr/bin/systemctl` are absolute.
- `go/internal/agent/services/agent_service.go` — clarify `envWithPath` is for pre-PR-53 mender-update sub-utility resolution.

3 files, +10 / -4.

### What was kept (matches `main`)

- `resolveNMCLIPath`, `resolveGSTBinary`, `resolveMenderBinary` — still wrap `LookPath → fallback`, no change.
- All three `cmd.Env = envWithPath(...)` calls (legacy v1 mender install, v2 mender install, `CommitMenderUpdate`).
- Both `/usr/bin/systemctl` invocations and `/usr/sbin/generate-hostname.sh`.
- Container-side `PATH=...` defaults in `oci/spec.go` and `containerd/client.go` (unrelated to the host PATH fix).

### Review history

- **Security Review (automated):** flagged HIGH on bare-name `exec.Command` (correct), HIGH on inherited-env injection for mender (overstated — `envWithPath` already used `os.Environ()`), MEDIUM on missing resolvers for `systemctl`/`generate-hostname.sh` (correct), MEDIUM on no runtime PATH guard (correct).
- **Human verdict:** restore absolute paths for `systemctl`/`generate-hostname.sh`, restore `envWithPath` for mender until older images are dropped. Applied in 2nd commit.

## Test plan

- [x] `gofmt -l .` from `go/` clean.
- [x] `go build ./...` clean.
- [x] `go vet ./internal/agent/configpartition/... ./internal/agent/services/...` clean.
- [x] `go test ./internal/agent/configpartition/... ./internal/agent/services/...` passes.
- [ ] (Optional, since this is now a no-op behavior change) smoke test on a current WendyOS device that hostname update, mDNS restart, and `mender-update commit` continue to work.

## Future work

Once a minimum WendyOS-Builder version including PR #53 is enforced (e.g., a startup PATH check that hard-fails on older images, or a CI gate on image manifests), the resolvers and `envWithPath` calls can be removed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)