### PR TITLE
perf(camera): reduce `device camera view` latency (stage 1/3)

### DIFF
--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -507,9 +507,26 @@ func listGSTElements(inspectPath string) (map[string]bool, error) {
 	return elements, nil
 }
 
+// keyframeIntervalFrames returns the GOP size (keyframe interval, in frames)
+// for the given framerate: a keyframe roughly every 0.5s. A short GOP bounds
+// how long the preview stays corrupted after a dropped frame and how long a
+// client waits to resync when joining or skipping mid-stream. A framerate of 0
+// (device default) is treated as 30fps.
+func keyframeIntervalFrames(fps uint32) int {
+	if fps == 0 {
+		fps = 30
+	}
+	gop := int(fps) / 2
+	if gop < 1 {
+		gop = 1
+	}
+	return gop
+}
+
 // buildGStreamerArgs constructs the gst-launch-1.0 argument list for V4L2 encode.
 func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequest, encoder string, hasH264Parse bool) []string {
 	src := fmt.Sprintf("v4l2src device=%s", devicePath)
+	gop := keyframeIntervalFrames(req.GetFramerate())
 
 	var capsParts []string
 	if req.GetWidth() > 0 {
@@ -525,9 +542,9 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 	var pipeline string
 	if len(capsParts) > 0 {
 		caps := "video/x-raw," + strings.Join(capsParts, ",")
-		pipeline = fmt.Sprintf("%s ! %s ! %s ! fdsink fd=1", src, caps, encoderSegment(encoder, hasH264Parse))
+		pipeline = fmt.Sprintf("%s ! %s ! %s ! fdsink fd=1", src, caps, encoderSegment(encoder, hasH264Parse, gop))
 	} else {
-		pipeline = fmt.Sprintf("%s ! %s ! fdsink fd=1", src, encoderSegment(encoder, hasH264Parse))
+		pipeline = fmt.Sprintf("%s ! %s ! fdsink fd=1", src, encoderSegment(encoder, hasH264Parse, gop))
 	}
 	// -q suppresses gst-launch's status messages (e.g. "Setting pipeline to PLAYING")
 	// from being written to stdout and corrupting the binary H264 stream.
@@ -546,6 +563,31 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 // repeated SPS/PPS also lets the client sync mid-stream.
 const h264ByteStream = " ! h264parse config-interval=-1 ! video/x-h264,stream-format=byte-stream,alignment=au"
 
+// keyframeArg returns the encoder-specific property string (with a leading
+// space) that caps the keyframe interval to gop frames, or "" for encoders
+// whose keyframe-interval property name is not known — those keep their
+// firmware/library default rather than risk a pipeline that will not launch.
+func keyframeArg(encoder string, gop int) string {
+	switch encoder {
+	case "x264enc":
+		// bframes=0 is implied by tune=zerolatency; set it explicitly so the
+		// decoder's frame-reorder depth is provably 0.
+		return fmt.Sprintf(" key-int-max=%d bframes=0", gop)
+	case "nvv4l2h264enc":
+		return fmt.Sprintf(" iframeinterval=%d", gop)
+	case "avenc_h264", "openh264enc":
+		return fmt.Sprintf(" gop-size=%d", gop)
+	case "v4l2h264enc":
+		// V4L2 M2M encoders take the I-frame period through the extra-controls
+		// GStreamer structure property; gst-launch parses the quotes itself.
+		// An unknown control name is warned-and-ignored by the v4l2 element,
+		// so this is safe even where the driver names the control differently.
+		return fmt.Sprintf(" extra-controls=\"controls,h264_i_frame_period=%d\"", gop)
+	default:
+		return ""
+	}
+}
+
 // encoderSegment returns the GStreamer pipeline segment for the given encoder element.
 // Most H.264 encoders force I420 (4:2:0) input to avoid 4:4:4 output paths that
 // can make encoders such as x264enc select profile 244 (High 4:4:4 Predictive),
@@ -555,28 +597,32 @@ const h264ByteStream = " ! h264parse config-interval=-1 ! video/x-h264,stream-fo
 // with h264ByteStream to normalize to Annex B byte-stream. When h264parse is absent
 // (gst-plugins-bad not installed), hardware encoders such as nvv4l2h264enc and
 // v4l2h264enc output byte-stream natively; x264enc may output AVC in that case.
-func encoderSegment(encoder string, hasH264Parse bool) string {
+// gop is the keyframe interval in frames (see keyframeIntervalFrames).
+func encoderSegment(encoder string, hasH264Parse bool, gop int) string {
 	if encoder == "vp8enc" {
 		// webmmux streamable=true writes headers that matroskademux can parse from a pipe.
-		return "videoconvert ! vp8enc deadline=1 ! webmmux streamable=true"
+		// keyframe-max-dist caps the GOP so a dropped frame self-heals quickly.
+		return fmt.Sprintf("videoconvert ! vp8enc deadline=1 keyframe-max-dist=%d ! webmmux streamable=true", gop)
 	}
+
+	kf := keyframeArg(encoder, gop)
 
 	var enc string
 	switch encoder {
 	case "nvv4l2h264enc":
 		// Jetson L4T hardware encoder; NV12 is its preferred input format.
-		enc = "videoconvert ! video/x-raw,format=NV12 ! nvv4l2h264enc"
+		enc = "videoconvert ! video/x-raw,format=NV12 ! nvv4l2h264enc" + kf
 	case "v4l2h264enc":
-		enc = "videoconvert ! video/x-raw,format=I420 ! v4l2h264enc ! video/x-h264,profile=baseline"
+		enc = "videoconvert ! video/x-raw,format=I420 ! v4l2h264enc" + kf + " ! video/x-h264,profile=baseline"
 	case "x264enc":
-		enc = "videoconvert ! video/x-raw,format=I420 ! x264enc tune=zerolatency ! video/x-h264,profile=high"
+		enc = "videoconvert ! video/x-raw,format=I420 ! x264enc tune=zerolatency" + kf + " ! video/x-h264,profile=high"
 	case "openh264enc":
-		enc = "videoconvert ! video/x-raw,format=I420 ! openh264enc"
+		enc = "videoconvert ! video/x-raw,format=I420 ! openh264enc" + kf
 	case "avenc_h264":
-		enc = "videoconvert ! video/x-raw,format=I420 ! avenc_h264"
+		enc = "videoconvert ! video/x-raw,format=I420 ! avenc_h264" + kf
 	default:
 		// For other H.264-family encoders, force I420 to avoid 4:4:4 profile selection.
-		enc = "videoconvert ! video/x-raw,format=I420 ! " + encoder
+		enc = "videoconvert ! video/x-raw,format=I420 ! " + encoder + kf
 	}
 	if hasH264Parse {
 		return enc + h264ByteStream

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -180,11 +180,82 @@ func TestBuildGStreamerArgs_X264ProfileIsCapsFilter(t *testing.T) {
 	req := &agentpb.StreamVideoRequest{}
 	args := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video0", req, "x264enc", true)
 	joined := strings.Join(args, " ")
-	if strings.Contains(joined, "x264enc tune=zerolatency profile=high") {
-		t.Fatalf("profile=high must be an output capsfilter, not an x264enc property: %v", args)
-	}
-	if !strings.Contains(joined, "x264enc tune=zerolatency ! video/x-h264,profile=high") {
+	// profile=high must be an output capsfilter (,profile=high), not an x264enc
+	// element property ( profile=high) — as a property x264enc may select a
+	// 4:4:4 High profile that hardware decoders reject. The capsfilter only
+	// constrains the negotiated output.
+	if !strings.Contains(joined, "! video/x-h264,profile=high") {
 		t.Fatalf("expected x264enc output capsfilter for high profile: %v", args)
+	}
+	if strings.Contains(joined, " profile=high") {
+		t.Fatalf("profile=high must be a capsfilter, not an x264enc property: %v", args)
+	}
+}
+
+func TestKeyframeIntervalFrames(t *testing.T) {
+	cases := []struct {
+		fps  uint32
+		want int
+	}{
+		{0, 15},  // device default is treated as 30fps
+		{30, 15}, // ~0.5s GOP
+		{60, 30},
+		{1, 1}, // never below 1
+	}
+	for _, c := range cases {
+		if got := keyframeIntervalFrames(c.fps); got != c.want {
+			t.Errorf("keyframeIntervalFrames(%d) = %d, want %d", c.fps, got, c.want)
+		}
+	}
+}
+
+func TestBuildGStreamerArgs_X264SetsShortKeyframeInterval(t *testing.T) {
+	req := &agentpb.StreamVideoRequest{}
+	args := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video0", req, "x264enc", true)
+	joined := strings.Join(args, " ")
+	// fps 0 -> default 30 -> a keyframe every ~0.5s -> 15 frames. A short GOP
+	// lets a client resync within ~0.5s after a dropped or skipped frame.
+	if !strings.Contains(joined, "key-int-max=15") {
+		t.Errorf("x264enc pipeline must cap the GOP via key-int-max: %v", args)
+	}
+	if !strings.Contains(joined, "bframes=0") {
+		t.Errorf("x264enc pipeline must disable B-frames so decoder reorder depth is 0: %v", args)
+	}
+}
+
+func TestBuildGStreamerArgs_KeyframeIntervalScalesWithFramerate(t *testing.T) {
+	req := &agentpb.StreamVideoRequest{Framerate: 60}
+	args := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video0", req, "x264enc", true)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "key-int-max=30") {
+		t.Errorf("at 60fps the GOP should be 30 frames (~0.5s): %v", args)
+	}
+}
+
+func TestBuildGStreamerArgs_VP8SetsShortKeyframeInterval(t *testing.T) {
+	req := &agentpb.StreamVideoRequest{}
+	args := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video0", req, "vp8enc", false)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "keyframe-max-dist=15") {
+		t.Errorf("vp8enc pipeline must cap the GOP via keyframe-max-dist: %v", args)
+	}
+}
+
+func TestBuildGStreamerArgs_NVV4L2SetsKeyframeInterval(t *testing.T) {
+	req := &agentpb.StreamVideoRequest{}
+	args := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video0", req, "nvv4l2h264enc", true)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "iframeinterval=15") {
+		t.Errorf("nvv4l2h264enc pipeline must set iframeinterval: %v", args)
+	}
+}
+
+func TestBuildGStreamerArgs_V4L2SetsKeyframeInterval(t *testing.T) {
+	req := &agentpb.StreamVideoRequest{}
+	args := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video0", req, "v4l2h264enc", true)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "h264_i_frame_period=15") {
+		t.Errorf("v4l2h264enc pipeline must set the I-frame period via extra-controls: %v", args)
 	}
 }
 

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -3,11 +3,12 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"time"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
@@ -183,16 +184,11 @@ func playVideoWithGStreamer(ctx context.Context, stream videoStream) error {
 	}
 }
 
-// recvResult carries one stream.Recv outcome from the receive goroutine to the
-// frame consumer.
-type recvResult struct {
-	frame *agentpb.VideoFrame
-	err   error
-}
-
 // feedGStreamer writes the codec byte stream to GStreamer's stdin until the
-// video stream ends. For H.264 it first drops the backlog that accumulated
-// while gst-launch was starting, so playback begins near real time. A VP8/WebM
+// video stream ends. For H.264 it continuously drops the backlog ahead of the
+// most recent keyframe whenever the writer falls behind — chiefly while
+// gst-launch is still starting and its stdin pipe back-pressures — so the
+// preview plays near real time instead of replaying stale video. A VP8/WebM
 // stream cannot be joined mid-container, so its frames are written verbatim.
 func feedGStreamer(ctx context.Context, stream videoStream, first *agentpb.VideoFrame, codec agentpb.VideoCodec, stdin io.Writer) error {
 	if codec == agentpb.VideoCodec_VIDEO_CODEC_VP8 {
@@ -213,93 +209,109 @@ func feedGStreamer(ctx context.Context, stream videoStream, first *agentpb.Video
 		}
 	}
 
-	// H.264: a dedicated receive goroutine feeds a channel so the startup
-	// drain can bound how long it waits for the next frame.
-	frames := make(chan recvResult, 8)
+	// H.264: receive frames into a buffer that keeps only the most recent
+	// keyframe onward while the writer is behind, then write the freshest
+	// available bytes to GStreamer.
+	feed := newH264FeedBuffer()
+	feed.push(first.GetData())
 	go func() {
 		for {
-			f, err := stream.Recv()
-			select {
-			case frames <- recvResult{frame: f, err: err}:
-			case <-ctx.Done():
-				return
-			}
+			frame, err := stream.Recv()
 			if err != nil {
+				feed.close(err)
 				return
 			}
+			feed.push(frame.GetData())
 		}
 	}()
 
-	pending, err := drainStartupBacklogH264(ctx, frames, first)
-	if err != nil {
-		return err
-	}
-	if _, err := stdin.Write(pending); err != nil {
-		return fmt.Errorf("writing to GStreamer: %w", err)
-	}
 	for {
-		select {
-		case <-ctx.Done():
+		data, err, done := feed.take(ctx)
+		if len(data) > 0 {
+			if _, werr := stdin.Write(data); werr != nil {
+				return fmt.Errorf("writing to GStreamer: %w", werr)
+			}
+		}
+		if done {
+			if err != nil && !errors.Is(err, io.EOF) {
+				return fmt.Errorf("receiving video: %w", err)
+			}
 			return nil
-		case r := <-frames:
-			if r.err == io.EOF {
-				return nil
-			}
-			if r.err != nil {
-				return fmt.Errorf("receiving video: %w", r.err)
-			}
-			if _, err := stdin.Write(r.frame.GetData()); err != nil {
-				return fmt.Errorf("writing to GStreamer: %w", err)
-			}
 		}
 	}
 }
 
-// startupBacklogGap bounds how long the H.264 startup drain waits for the next
-// frame before concluding the spawn-time backlog is exhausted. It must exceed
-// the sub-millisecond inter-arrival of buffered backlog frames and stay below
-// the real-time inter-frame interval at 60fps (~16.7ms). Declared as a var so
-// tests can shorten it.
-var startupBacklogGap = 12 * time.Millisecond
+// h264FeedBuffer holds H.264 Annex-B bytes received from the stream but not yet
+// written to the decoder. Whenever bytes go unconsumed — chiefly while
+// gst-launch is still starting and its stdin pipe back-pressures — the buffer
+// is trimmed to the most recent keyframe so stale video is dropped instead of
+// being committed to the decoder and replayed as latency. Bytes that the
+// consumer takes promptly are passed through untrimmed, so steady-state
+// playback is a contiguous stream.
+type h264FeedBuffer struct {
+	mu     sync.Mutex
+	buf    []byte
+	err    error
+	closed bool
+	signal chan struct{} // buffered (cap 1); a value means buf/closed changed
+}
 
-// drainStartupBacklogH264 consumes the H.264 frames that piled up while
-// gst-launch was starting and returns the bytes to feed the decoder first:
-// everything from the most recent keyframe onward. Backlog frames arrive in a
-// tight burst and are dropped up to that keyframe; the drain ends once a frame
-// takes longer than startupBacklogGap to arrive (the camera's real cadence) or
-// the stream ends. Ending early or late is graceful — the result always begins
-// at a keyframe, and the decoder's leaky queue drops any remaining backlog.
-func drainStartupBacklogH264(ctx context.Context, frames <-chan recvResult, first *agentpb.VideoFrame) ([]byte, error) {
-	var pending []byte
-	keep := func(data []byte) {
-		if off, ok := lastKeyframeOffset(data); ok {
-			pending = append(pending[:0], data[off:]...)
-		} else {
-			pending = append(pending, data...)
-		}
+func newH264FeedBuffer() *h264FeedBuffer {
+	return &h264FeedBuffer{signal: make(chan struct{}, 1)}
+}
+
+// wake delivers a non-blocking notification to a waiting take.
+func (b *h264FeedBuffer) wake() {
+	select {
+	case b.signal <- struct{}{}:
+	default:
 	}
-	keep(first.GetData())
+}
 
-	timer := time.NewTimer(startupBacklogGap)
-	defer timer.Stop()
+// push appends a frame's bytes, then drops any not-yet-taken backlog ahead of
+// the most recent keyframe so the consumer never receives stale video.
+func (b *h264FeedBuffer) push(data []byte) {
+	b.mu.Lock()
+	b.buf = append(b.buf, data...)
+	if off, ok := lastKeyframeOffset(b.buf); ok && off > 0 {
+		b.buf = b.buf[off:]
+	}
+	b.mu.Unlock()
+	b.wake()
+}
+
+// close marks the stream finished; err is the terminating error (io.EOF on a
+// clean end).
+func (b *h264FeedBuffer) close(err error) {
+	b.mu.Lock()
+	b.err, b.closed = err, true
+	b.mu.Unlock()
+	b.wake()
+}
+
+// take blocks until buffered bytes, stream termination, or context
+// cancellation. It returns the buffered bytes (clearing them from the buffer);
+// done is true once the stream has ended and all bytes have been taken, with
+// err the terminating error (nil or io.EOF on a clean end, nil on cancellation).
+func (b *h264FeedBuffer) take(ctx context.Context) (data []byte, err error, done bool) {
 	for {
+		b.mu.Lock()
+		if len(b.buf) > 0 {
+			data, b.buf = b.buf, nil
+			b.mu.Unlock()
+			return data, nil, false
+		}
+		if b.closed {
+			err = b.err
+			b.mu.Unlock()
+			return nil, err, true
+		}
+		b.mu.Unlock()
+
 		select {
+		case <-b.signal:
 		case <-ctx.Done():
-			return pending, nil
-		case <-timer.C:
-			return pending, nil
-		case r := <-frames:
-			if r.err == io.EOF {
-				return pending, nil
-			}
-			if r.err != nil {
-				return nil, fmt.Errorf("receiving video: %w", r.err)
-			}
-			keep(r.frame.GetData())
-			if !timer.Stop() {
-				<-timer.C
-			}
-			timer.Reset(startupBacklogGap)
+			return nil, nil, true
 		}
 	}
 }

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/internal/cli/tui"
@@ -115,10 +116,13 @@ func newCameraViewCmd() *cobra.Command {
 	return cmd
 }
 
-// pipeVideoToStdout writes VideoFrame data chunks to w until the stream ends.
-func pipeVideoToStdout(stream interface {
+// videoStream is the receive side of the StreamVideo gRPC stream.
+type videoStream interface {
 	Recv() (*agentpb.VideoFrame, error)
-}, w io.Writer) error {
+}
+
+// pipeVideoToStdout writes VideoFrame data chunks to w until the stream ends.
+func pipeVideoToStdout(stream videoStream, w io.Writer) error {
 	for {
 		frame, err := stream.Recv()
 		if err == io.EOF {
@@ -135,15 +139,13 @@ func pipeVideoToStdout(stream interface {
 
 // playVideoWithGStreamer spawns gst-launch-1.0 and feeds it the video stream via stdin.
 // It peeks the first frame to determine the codec, then starts the matching decoder pipeline.
-func playVideoWithGStreamer(ctx context.Context, stream interface {
-	Recv() (*agentpb.VideoFrame, error)
-}) error {
+func playVideoWithGStreamer(ctx context.Context, stream videoStream) error {
 	gstPath, err := resolveGSTLaunch()
 	if err != nil {
 		return err
 	}
 
-	// Peek first frame to learn the codec.
+	// Peek the first frame to learn the codec.
 	first, err := stream.Recv()
 	if err == io.EOF {
 		return nil
@@ -151,10 +153,9 @@ func playVideoWithGStreamer(ctx context.Context, stream interface {
 	if err != nil {
 		return fmt.Errorf("receiving video: %w", err)
 	}
+	codec := first.GetCodec()
 
-	gstArgs := playbackPipelineArgs(first.GetCodec())
-
-	gst := exec.CommandContext(ctx, gstPath, gstArgs...)
+	gst := exec.CommandContext(ctx, gstPath, playbackPipelineArgs(codec)...)
 	gst.Stderr = os.Stderr
 
 	stdin, err := gst.StdinPipe()
@@ -171,38 +172,188 @@ func playVideoWithGStreamer(ctx context.Context, stream interface {
 		gst.Wait()         //nolint:errcheck
 	}()
 
-	recvErr := make(chan error, 1)
-	writeErr := make(chan error, 1)
-	go func() {
-		// Write the already-received first frame before entering the loop.
+	done := make(chan error, 1)
+	go func() { done <- feedGStreamer(ctx, stream, first, codec, stdin) }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return nil
+	}
+}
+
+// recvResult carries one stream.Recv outcome from the receive goroutine to the
+// frame consumer.
+type recvResult struct {
+	frame *agentpb.VideoFrame
+	err   error
+}
+
+// feedGStreamer writes the codec byte stream to GStreamer's stdin until the
+// video stream ends. For H.264 it first drops the backlog that accumulated
+// while gst-launch was starting, so playback begins near real time. A VP8/WebM
+// stream cannot be joined mid-container, so its frames are written verbatim.
+func feedGStreamer(ctx context.Context, stream videoStream, first *agentpb.VideoFrame, codec agentpb.VideoCodec, stdin io.Writer) error {
+	if codec == agentpb.VideoCodec_VIDEO_CODEC_VP8 {
 		if _, err := stdin.Write(first.GetData()); err != nil {
-			writeErr <- fmt.Errorf("writing to GStreamer: %w", err)
-			return
+			return fmt.Errorf("writing to GStreamer: %w", err)
 		}
 		for {
 			frame, err := stream.Recv()
+			if err == io.EOF {
+				return nil
+			}
 			if err != nil {
-				recvErr <- err
-				return
+				return fmt.Errorf("receiving video: %w", err)
 			}
 			if _, err := stdin.Write(frame.GetData()); err != nil {
-				writeErr <- fmt.Errorf("writing to GStreamer: %w", err)
+				return fmt.Errorf("writing to GStreamer: %w", err)
+			}
+		}
+	}
+
+	// H.264: a dedicated receive goroutine feeds a channel so the startup
+	// drain can bound how long it waits for the next frame.
+	frames := make(chan recvResult, 8)
+	go func() {
+		for {
+			f, err := stream.Recv()
+			select {
+			case frames <- recvResult{frame: f, err: err}:
+			case <-ctx.Done():
+				return
+			}
+			if err != nil {
 				return
 			}
 		}
 	}()
 
-	select {
-	case err := <-recvErr:
-		if err == io.EOF {
-			return nil
-		}
-		return fmt.Errorf("receiving video: %w", err)
-	case err := <-writeErr:
+	pending, err := drainStartupBacklogH264(ctx, frames, first)
+	if err != nil {
 		return err
-	case <-ctx.Done():
-		return nil
 	}
+	if _, err := stdin.Write(pending); err != nil {
+		return fmt.Errorf("writing to GStreamer: %w", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case r := <-frames:
+			if r.err == io.EOF {
+				return nil
+			}
+			if r.err != nil {
+				return fmt.Errorf("receiving video: %w", r.err)
+			}
+			if _, err := stdin.Write(r.frame.GetData()); err != nil {
+				return fmt.Errorf("writing to GStreamer: %w", err)
+			}
+		}
+	}
+}
+
+// startupBacklogGap bounds how long the H.264 startup drain waits for the next
+// frame before concluding the spawn-time backlog is exhausted. It must exceed
+// the sub-millisecond inter-arrival of buffered backlog frames and stay below
+// the real-time inter-frame interval at 60fps (~16.7ms). Declared as a var so
+// tests can shorten it.
+var startupBacklogGap = 12 * time.Millisecond
+
+// drainStartupBacklogH264 consumes the H.264 frames that piled up while
+// gst-launch was starting and returns the bytes to feed the decoder first:
+// everything from the most recent keyframe onward. Backlog frames arrive in a
+// tight burst and are dropped up to that keyframe; the drain ends once a frame
+// takes longer than startupBacklogGap to arrive (the camera's real cadence) or
+// the stream ends. Ending early or late is graceful — the result always begins
+// at a keyframe, and the decoder's leaky queue drops any remaining backlog.
+func drainStartupBacklogH264(ctx context.Context, frames <-chan recvResult, first *agentpb.VideoFrame) ([]byte, error) {
+	var pending []byte
+	keep := func(data []byte) {
+		if off, ok := lastKeyframeOffset(data); ok {
+			pending = append(pending[:0], data[off:]...)
+		} else {
+			pending = append(pending, data...)
+		}
+	}
+	keep(first.GetData())
+
+	timer := time.NewTimer(startupBacklogGap)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return pending, nil
+		case <-timer.C:
+			return pending, nil
+		case r := <-frames:
+			if r.err == io.EOF {
+				return pending, nil
+			}
+			if r.err != nil {
+				return nil, fmt.Errorf("receiving video: %w", r.err)
+			}
+			keep(r.frame.GetData())
+			if !timer.Stop() {
+				<-timer.C
+			}
+			timer.Reset(startupBacklogGap)
+		}
+	}
+}
+
+// H.264 NAL unit types relevant to keyframe detection (ITU-T H.264 Table 7-1).
+const (
+	h264NalTypeIDR = 5 // coded slice of an IDR picture
+	h264NalTypeSPS = 7 // sequence parameter set
+)
+
+// nextStartCode returns the index of the next Annex-B start code (00 00 01,
+// with an immediately preceding 00 absorbed so a 4-byte code is reported whole)
+// at or after from, together with the index of the NAL header byte that
+// follows it. found is false when no start code remains.
+func nextStartCode(data []byte, from int) (codeStart, headerIdx int, found bool) {
+	for i := from; i+2 < len(data); i++ {
+		if data[i] == 0x00 && data[i+1] == 0x00 && data[i+2] == 0x01 {
+			cs := i
+			if cs > 0 && data[cs-1] == 0x00 {
+				cs--
+			}
+			return cs, i + 3, true
+		}
+	}
+	return 0, 0, false
+}
+
+// lastKeyframeOffset scans Annex-B H.264 data and returns the byte offset of
+// the start code that begins the most recent keyframe — the SPS preceding an
+// IDR slice (the agent repeats SPS/PPS before every keyframe via h264parse
+// config-interval=-1), or the IDR's own start code when no SPS precedes it in
+// this data. found is false when data contains no keyframe.
+func lastKeyframeOffset(data []byte) (offset int, found bool) {
+	spsStart := -1
+	for i := 0; ; {
+		codeStart, headerIdx, ok := nextStartCode(data, i)
+		if !ok || headerIdx >= len(data) {
+			break
+		}
+		switch data[headerIdx] & 0x1F {
+		case h264NalTypeSPS:
+			spsStart = codeStart
+		case h264NalTypeIDR:
+			if spsStart >= 0 {
+				offset = spsStart
+			} else {
+				offset = codeStart
+			}
+			found = true
+			spsStart = -1
+		}
+		i = headerIdx
+	}
+	return offset, found
 }
 
 // playbackPipelineArgs returns the gst-launch-1.0 element arguments for decoding
@@ -211,10 +362,15 @@ func playbackPipelineArgs(codec agentpb.VideoCodec) []string {
 	switch codec {
 	case agentpb.VideoCodec_VIDEO_CODEC_VP8:
 		// Server sends VP8 in a WebM container (webmmux streamable=true).
+		// The leaky queue after matroskademux drops whole frames when decode
+		// falls behind, draining an encoded-side backlog instead of playing
+		// through it; the queue after the decoder absorbs display-sink jitter.
 		return []string{
 			"fdsrc", "fd=0",
 			"!", "matroskademux",
+			"!", "queue", "max-size-buffers=2", "leaky=downstream",
 			"!", "vp8dec",
+			"!", "videoconvert",
 			"!", "queue", "max-size-buffers=1", "leaky=downstream",
 			"!", "autovideosink", "sync=false",
 		}
@@ -227,11 +383,17 @@ func playbackPipelineArgs(codec agentpb.VideoCodec) []string {
 		// typefind inspects the actual bytes, detects the H.264 start codes, and
 		// sets fixed content-derived caps; h264parse then auto-detects whether
 		// the stream is Annex B byte-stream or length-prefixed AVC.
+		//
+		// The leaky queue between h264parse and the decoder drops whole access
+		// units when decode cannot keep up, so an encoded-side backlog drains
+		// by dropping rather than playing through. max-threads=1 removes
+		// avdec_h264's frame-threading output delay (~thread-count frames).
 		return []string{
 			"fdsrc", "fd=0",
 			"!", "typefind",
 			"!", "h264parse",
-			"!", "avdec_h264",
+			"!", "queue", "max-size-buffers=2", "leaky=downstream",
+			"!", "avdec_h264", "max-threads=1",
 			"!", "videoconvert",
 			"!", "queue", "max-size-buffers=1", "leaky=downstream",
 			"!", "autovideosink", "sync=false",

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -340,28 +340,41 @@ func nextStartCode(data []byte, from int) (codeStart, headerIdx int, found bool)
 }
 
 // lastKeyframeOffset scans Annex-B H.264 data and returns the byte offset of
-// the start code that begins the most recent keyframe — the SPS preceding an
-// IDR slice (the agent repeats SPS/PPS before every keyframe via h264parse
-// config-interval=-1), or the IDR's own start code when no SPS precedes it in
-// this data. found is false when data contains no keyframe.
+// the start code that begins the most recent keyframe access unit — the SPS
+// preceding the IDR (the agent repeats SPS/PPS before every keyframe via
+// h264parse config-interval=-1), or the first IDR slice when no SPS precedes it
+// in this data. A keyframe picture is frequently coded as several IDR slices
+// (e.g. x264enc tune=zerolatency uses sliced threads); those slices form one
+// access unit, so only the first slice — not each one — marks a keyframe.
+// found is false when data contains no keyframe.
 func lastKeyframeOffset(data []byte) (offset int, found bool) {
-	spsStart := -1
+	sps := -1             // start code of an SPS not yet consumed by a keyframe
+	inIDRPicture := false // within a run of IDR slice NALs forming one picture
 	for i := 0; ; {
 		codeStart, headerIdx, ok := nextStartCode(data, i)
 		if !ok || headerIdx >= len(data) {
 			break
 		}
-		switch data[headerIdx] & 0x1F {
+		nalType := data[headerIdx] & 0x1F
+		switch nalType {
 		case h264NalTypeSPS:
-			spsStart = codeStart
+			sps = codeStart
 		case h264NalTypeIDR:
-			if spsStart >= 0 {
-				offset = spsStart
-			} else {
-				offset = codeStart
+			if !inIDRPicture {
+				// First slice of a keyframe access unit.
+				if sps >= 0 {
+					offset = sps
+				} else {
+					offset = codeStart
+				}
+				found = true
+				inIDRPicture = true
+				sps = -1
 			}
-			found = true
-			spsStart = -1
+		}
+		// A non-IDR NAL ends the current IDR picture's run of slices.
+		if nalType != h264NalTypeIDR {
+			inIDRPicture = false
 		}
 		i = headerIdx
 	}

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -233,6 +233,11 @@ func feedGStreamer(ctx context.Context, stream videoStream, first *agentpb.Video
 			}
 		}
 		if done {
+			// If our caller cancelled the context (Ctrl+C / shutdown), treat any
+			// resulting stream error as a clean exit.
+			if ctx.Err() != nil {
+				return nil
+			}
 			if err != nil && !errors.Is(err, io.EOF) {
 				return fmt.Errorf("receiving video: %w", err)
 			}

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -236,47 +236,106 @@ func TestLastKeyframeOffset_Empty(t *testing.T) {
 	}
 }
 
-func TestDrainStartupBacklogH264_SkipsToMostRecentKeyframe(t *testing.T) {
+func TestH264FeedBuffer_PushTakeRoundTrips(t *testing.T) {
+	feed := newH264FeedBuffer()
+	idr := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR, 0x11))
+	feed.push(idr)
+
+	data, err, done := feed.take(context.Background())
+	if err != nil || done {
+		t.Fatalf("take: err=%v done=%v", err, done)
+	}
+	if !bytes.Equal(data, idr) {
+		t.Errorf("take returned %v, want %v", data, idr)
+	}
+}
+
+func TestH264FeedBuffer_DropsBacklogAheadOfKeyframe(t *testing.T) {
+	feed := newH264FeedBuffer()
 	idr1 := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR, 0x11))
 	p1 := h264NAL(nalHdrP, 0x22)
 	idr2 := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR, 0x33))
 	p2 := h264NAL(nalHdrP, 0x44)
 
-	frames := make(chan recvResult, 4)
-	frames <- recvResult{frame: &agentpb.VideoFrame{Data: p1}}
-	frames <- recvResult{frame: &agentpb.VideoFrame{Data: idr2}}
-	frames <- recvResult{frame: &agentpb.VideoFrame{Data: p2}}
-	frames <- recvResult{err: io.EOF}
+	// The writer never takes between pushes — gst-launch still starting up.
+	feed.push(idr1)
+	feed.push(p1)
+	feed.push(idr2)
+	feed.push(p2)
 
-	pending, err := drainStartupBacklogH264(context.Background(), frames, &agentpb.VideoFrame{Data: idr1})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	data, _, _ := feed.take(context.Background())
 	want := joinBytes(idr2, p2)
-	if !bytes.Equal(pending, want) {
-		t.Errorf("drain kept %v, want %v (most recent keyframe onward)", pending, want)
+	if !bytes.Equal(data, want) {
+		t.Errorf("take returned %v, want %v (backlog before the latest keyframe dropped)", data, want)
 	}
 }
 
-func TestDrainStartupBacklogH264_NoBacklogKeepsFirstFrame(t *testing.T) {
-	idr := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR, 0x11))
-	frames := make(chan recvResult) // nothing arrives — drain ends on the idle gap
-
-	pending, err := drainStartupBacklogH264(context.Background(), frames, &agentpb.VideoFrame{Data: idr})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !bytes.Equal(pending, idr) {
-		t.Errorf("drain kept %v, want the first frame %v", pending, idr)
-	}
-}
-
-func TestDrainStartupBacklogH264_StreamError(t *testing.T) {
+func TestH264FeedBuffer_KeepsContiguousBytesWhenWriterKeepsUp(t *testing.T) {
+	feed := newH264FeedBuffer()
 	idr := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR))
-	frames := make(chan recvResult, 1)
-	frames <- recvResult{err: errors.New("boom")}
+	p1 := h264NAL(nalHdrP, 0x01)
+	p2 := h264NAL(nalHdrP, 0x02)
 
-	if _, err := drainStartupBacklogH264(context.Background(), frames, &agentpb.VideoFrame{Data: idr}); err == nil {
-		t.Fatal("expected the stream error to propagate, got nil")
+	feed.push(idr)
+	if d, _, _ := feed.take(context.Background()); !bytes.Equal(d, idr) {
+		t.Fatalf("first take = %v, want %v", d, idr)
+	}
+	// P-frames with no newer keyframe must not be dropped when taken promptly.
+	feed.push(p1)
+	if d, _, _ := feed.take(context.Background()); !bytes.Equal(d, p1) {
+		t.Errorf("take = %v, want %v", d, p1)
+	}
+	feed.push(p2)
+	if d, _, _ := feed.take(context.Background()); !bytes.Equal(d, p2) {
+		t.Errorf("take = %v, want %v", d, p2)
+	}
+}
+
+func TestH264FeedBuffer_TakeDrainsBufferedBytesBeforeReportingEnd(t *testing.T) {
+	feed := newH264FeedBuffer()
+	idr := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR))
+	feed.push(idr)
+	feed.close(io.EOF)
+
+	data, _, done := feed.take(context.Background())
+	if done || !bytes.Equal(data, idr) {
+		t.Fatalf("first take = %v done=%v, want the buffered bytes", data, done)
+	}
+	if _, _, done = feed.take(context.Background()); !done {
+		t.Error("expected done on the second take")
+	}
+}
+
+func TestH264FeedBuffer_TakePropagatesError(t *testing.T) {
+	feed := newH264FeedBuffer()
+	feed.close(errors.New("boom"))
+
+	_, err, done := feed.take(context.Background())
+	if !done || err == nil {
+		t.Fatalf("expected a terminal error, got err=%v done=%v", err, done)
+	}
+}
+
+func TestH264FeedBuffer_TakeUnblocksOnContextCancel(t *testing.T) {
+	feed := newH264FeedBuffer()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, _, done := feed.take(ctx); !done {
+		t.Error("expected take to report done when the context is cancelled")
+	}
+}
+
+func TestH264FeedBuffer_TakeBlocksUntilPush(t *testing.T) {
+	feed := newH264FeedBuffer()
+	idr := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR))
+	go feed.push(idr)
+
+	data, err, done := feed.take(context.Background())
+	if err != nil || done {
+		t.Fatalf("take: err=%v done=%v", err, done)
+	}
+	if !bytes.Equal(data, idr) {
+		t.Errorf("take = %v, want %v", data, idr)
 	}
 }

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,28 @@ import (
 
 	agentpb "github.com/wendylabsinc/wendy/proto/gen/agentpb"
 )
+
+// Annex-B NAL header bytes (forbidden_zero | nal_ref_idc | nal_unit_type).
+const (
+	nalHdrSPS = 0x67 // sequence parameter set (type 7)
+	nalHdrPPS = 0x68 // picture parameter set (type 8)
+	nalHdrIDR = 0x65 // IDR slice (type 5) — a keyframe
+	nalHdrP   = 0x41 // non-IDR slice (type 1)
+)
+
+// h264NAL builds an Annex-B NAL unit: a 4-byte start code, a header byte, then payload.
+func h264NAL(header byte, payload ...byte) []byte {
+	return append([]byte{0x00, 0x00, 0x00, 0x01, header}, payload...)
+}
+
+// joinBytes concatenates byte slices.
+func joinBytes(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
 
 type mockVideoStream struct {
 	frames []*agentpb.VideoFrame
@@ -72,8 +95,40 @@ func TestPlaybackPipelineArgs_H264UsesTypefindNotBareCaps(t *testing.T) {
 func TestPlaybackPipelineArgs_VP8UsesMatroskademux(t *testing.T) {
 	args := playbackPipelineArgs(agentpb.VideoCodec_VIDEO_CODEC_VP8)
 	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "fdsrc fd=0 ! matroskademux ! vp8dec") {
-		t.Errorf("VP8 pipeline must demux WebM via matroskademux into vp8dec, got: %v", args)
+	if !strings.Contains(joined, "fdsrc fd=0 ! matroskademux") {
+		t.Errorf("VP8 pipeline must demux the WebM container via matroskademux, got: %v", args)
+	}
+	if !strings.Contains(joined, "! vp8dec !") {
+		t.Errorf("VP8 pipeline must decode via vp8dec, got: %v", args)
+	}
+}
+
+func TestPlaybackPipelineArgs_H264DecodesSingleThreaded(t *testing.T) {
+	args := playbackPipelineArgs(agentpb.VideoCodec_VIDEO_CODEC_H264)
+	joined := strings.Join(args, " ")
+	// Frame-based multithreading in avdec_h264 delays output by ~thread-count
+	// frames; max-threads=1 removes that constant latency.
+	if !strings.Contains(joined, "avdec_h264 max-threads=1") {
+		t.Errorf("H264 pipeline must decode single-threaded to avoid frame-threading latency, got: %v", args)
+	}
+}
+
+func TestPlaybackPipelineArgs_H264LeakyQueueBeforeDecoder(t *testing.T) {
+	args := playbackPipelineArgs(agentpb.VideoCodec_VIDEO_CODEC_H264)
+	joined := strings.Join(args, " ")
+	// A leaky queue between h264parse and the decoder drops whole access units
+	// when decode falls behind, so an encoded-side backlog drains by dropping
+	// rather than playing through.
+	if !strings.Contains(joined, "h264parse ! queue max-size-buffers=2 leaky=downstream ! avdec_h264") {
+		t.Errorf("H264 pipeline must have a leaky queue before the decoder, got: %v", args)
+	}
+}
+
+func TestPlaybackPipelineArgs_VP8LeakyQueueBeforeDecoder(t *testing.T) {
+	args := playbackPipelineArgs(agentpb.VideoCodec_VIDEO_CODEC_VP8)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "matroskademux ! queue max-size-buffers=2 leaky=downstream ! vp8dec") {
+		t.Errorf("VP8 pipeline must have a leaky queue before the decoder, got: %v", args)
 	}
 }
 
@@ -131,5 +186,97 @@ func TestResolveGSTLaunch_IgnoresDirectories(t *testing.T) {
 
 	if _, err := resolveGSTLaunch(); err == nil {
 		t.Fatal("expected error when only a directory matches, got nil")
+	}
+}
+
+func TestLastKeyframeOffset_NoKeyframe(t *testing.T) {
+	data := joinBytes(h264NAL(nalHdrP, 0xAA), h264NAL(nalHdrP, 0xBB))
+	if off, ok := lastKeyframeOffset(data); ok {
+		t.Errorf("expected no keyframe in a P-slice-only stream, got offset %d", off)
+	}
+}
+
+func TestLastKeyframeOffset_SPSBeforeIDR(t *testing.T) {
+	data := joinBytes(h264NAL(nalHdrSPS, 0x01), h264NAL(nalHdrPPS, 0x02), h264NAL(nalHdrIDR, 0x03))
+	off, ok := lastKeyframeOffset(data)
+	if !ok || off != 0 {
+		t.Errorf("keyframe should start at the SPS (offset 0), got off=%d ok=%v", off, ok)
+	}
+}
+
+func TestLastKeyframeOffset_PicksMostRecent(t *testing.T) {
+	leading := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR), h264NAL(nalHdrP))
+	data := joinBytes(leading, h264NAL(nalHdrSPS), h264NAL(nalHdrPPS), h264NAL(nalHdrIDR))
+	off, ok := lastKeyframeOffset(data)
+	if !ok || off != len(leading) {
+		t.Errorf("expected the most recent keyframe at offset %d, got off=%d ok=%v", len(leading), off, ok)
+	}
+}
+
+func TestLastKeyframeOffset_IDRWithoutSPS(t *testing.T) {
+	leading := h264NAL(nalHdrP)
+	data := joinBytes(leading, h264NAL(nalHdrIDR))
+	off, ok := lastKeyframeOffset(data)
+	if !ok || off != len(leading) {
+		t.Errorf("a bare IDR should be reported at its own start code (offset %d), got off=%d ok=%v", len(leading), off, ok)
+	}
+}
+
+func TestLastKeyframeOffset_ThreeByteStartCode(t *testing.T) {
+	data := []byte{0x00, 0x00, 0x01, nalHdrSPS, 0x00, 0x00, 0x01, nalHdrIDR}
+	off, ok := lastKeyframeOffset(data)
+	if !ok || off != 0 {
+		t.Errorf("expected keyframe at offset 0 with 3-byte start codes, got off=%d ok=%v", off, ok)
+	}
+}
+
+func TestLastKeyframeOffset_Empty(t *testing.T) {
+	if _, ok := lastKeyframeOffset(nil); ok {
+		t.Error("expected no keyframe in empty data")
+	}
+}
+
+func TestDrainStartupBacklogH264_SkipsToMostRecentKeyframe(t *testing.T) {
+	idr1 := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR, 0x11))
+	p1 := h264NAL(nalHdrP, 0x22)
+	idr2 := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR, 0x33))
+	p2 := h264NAL(nalHdrP, 0x44)
+
+	frames := make(chan recvResult, 4)
+	frames <- recvResult{frame: &agentpb.VideoFrame{Data: p1}}
+	frames <- recvResult{frame: &agentpb.VideoFrame{Data: idr2}}
+	frames <- recvResult{frame: &agentpb.VideoFrame{Data: p2}}
+	frames <- recvResult{err: io.EOF}
+
+	pending, err := drainStartupBacklogH264(context.Background(), frames, &agentpb.VideoFrame{Data: idr1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := joinBytes(idr2, p2)
+	if !bytes.Equal(pending, want) {
+		t.Errorf("drain kept %v, want %v (most recent keyframe onward)", pending, want)
+	}
+}
+
+func TestDrainStartupBacklogH264_NoBacklogKeepsFirstFrame(t *testing.T) {
+	idr := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR, 0x11))
+	frames := make(chan recvResult) // nothing arrives — drain ends on the idle gap
+
+	pending, err := drainStartupBacklogH264(context.Background(), frames, &agentpb.VideoFrame{Data: idr})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(pending, idr) {
+		t.Errorf("drain kept %v, want the first frame %v", pending, idr)
+	}
+}
+
+func TestDrainStartupBacklogH264_StreamError(t *testing.T) {
+	idr := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR))
+	frames := make(chan recvResult, 1)
+	frames <- recvResult{err: errors.New("boom")}
+
+	if _, err := drainStartupBacklogH264(context.Background(), frames, &agentpb.VideoFrame{Data: idr}); err == nil {
+		t.Fatal("expected the stream error to propagate, got nil")
 	}
 }

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -236,6 +236,67 @@ func TestLastKeyframeOffset_Empty(t *testing.T) {
 	}
 }
 
+func TestLastKeyframeOffset_MultiSliceKeyframe(t *testing.T) {
+	// A keyframe picture is often coded as several IDR slices (e.g. x264enc
+	// tune=zerolatency uses sliced threads). They are one access unit, which
+	// begins at the SPS — not at the last slice.
+	data := joinBytes(
+		h264NAL(nalHdrSPS), h264NAL(nalHdrPPS),
+		h264NAL(nalHdrIDR, 0x01), h264NAL(nalHdrIDR, 0x02), h264NAL(nalHdrIDR, 0x03),
+	)
+	off, ok := lastKeyframeOffset(data)
+	if !ok || off != 0 {
+		t.Errorf("multi-slice keyframe must start at the SPS (offset 0), got off=%d ok=%v", off, ok)
+	}
+}
+
+func TestLastKeyframeOffset_PicksMostRecentMultiSlice(t *testing.T) {
+	leading := joinBytes(
+		h264NAL(nalHdrSPS), h264NAL(nalHdrPPS),
+		h264NAL(nalHdrIDR, 0x01), h264NAL(nalHdrIDR, 0x02),
+	)
+	data := joinBytes(leading,
+		h264NAL(nalHdrSPS), h264NAL(nalHdrPPS),
+		h264NAL(nalHdrIDR, 0x03), h264NAL(nalHdrIDR, 0x04),
+	)
+	off, ok := lastKeyframeOffset(data)
+	if !ok || off != len(leading) {
+		t.Errorf("expected the second multi-slice keyframe at offset %d, got off=%d ok=%v", len(leading), off, ok)
+	}
+}
+
+func TestLastKeyframeOffset_MultiSliceIDRWithoutSPS(t *testing.T) {
+	// IDR slices with no SPS in this data: the keyframe begins at the first
+	// slice, not the last.
+	leading := h264NAL(nalHdrP, 0x09)
+	data := joinBytes(leading, h264NAL(nalHdrIDR, 0x01), h264NAL(nalHdrIDR, 0x02))
+	off, ok := lastKeyframeOffset(data)
+	if !ok || off != len(leading) {
+		t.Errorf("expected the keyframe at the first IDR slice (offset %d), got off=%d ok=%v", len(leading), off, ok)
+	}
+}
+
+func TestH264FeedBuffer_RetainsSPSofMultiSliceKeyframes(t *testing.T) {
+	feed := newH264FeedBuffer()
+	keyframe := func(tag byte) []byte {
+		return joinBytes(
+			h264NAL(nalHdrSPS), h264NAL(nalHdrPPS),
+			h264NAL(nalHdrIDR, tag, 0x01), h264NAL(nalHdrIDR, tag, 0x02),
+		)
+	}
+	// Writer is behind: two multi-slice keyframes pile up before a take.
+	feed.push(keyframe(0xA1))
+	feed.push(keyframe(0xB2))
+
+	data, _, _ := feed.take(context.Background())
+	if len(data) < 5 || data[4]&0x1F != h264NalTypeSPS {
+		t.Fatalf("taken bytes must start with an SPS, not a bare IDR slice")
+	}
+	if off, ok := lastKeyframeOffset(data); !ok || off != 0 {
+		t.Errorf("taken bytes must begin at a keyframe, got off=%d ok=%v", off, ok)
+	}
+}
+
 func TestH264FeedBuffer_PushTakeRoundTrips(t *testing.T) {
 	feed := newH264FeedBuffer()
 	idr := joinBytes(h264NAL(nalHdrSPS), h264NAL(nalHdrIDR, 0x11))


### PR DESCRIPTION
## Summary

`wendy device camera view` lagged reality by several seconds. The pipeline buffered instead of dropping — long encoder GOPs, no frame-dropping, and a startup backlog decoded in order forever. This is **Stage 1 of 3**; it brings the preview to near real-time (device-tested with a USB camera).

## Changes

**Agent — `video_service.go`**
- Every GStreamer encoder now caps the GOP to ~0.5s: `x264enc key-int-max=N bframes=0`, `vp8enc keyframe-max-dist=N`, `nvv4l2h264enc iframeinterval=N`, `avenc_h264`/`openh264enc gop-size=N`, `v4l2h264enc extra-controls=…h264_i_frame_period=N`. Unknown encoders keep their default.

**CLI — `camera.go`**
- New `h264FeedBuffer`: the receive goroutine pushes frames in; the writer takes the freshest bytes. While the writer is behind — chiefly while `gst-launch` is starting and its stdin pipe back-pressures — the buffer is continuously trimmed to the most recent keyframe, so the spawn-time backlog is dropped instead of decoded as latency.
- `lastKeyframeOffset` scans Annex-B H.264 and handles multi-slice keyframes (e.g. `x264enc tune=zerolatency` sliced threads emit many IDR slices per picture — all one access unit).
- `avdec_h264 max-threads=1` (removes frame-threading output delay) and a `leaky=downstream` queue before the decoder.

## Not in this PR

- **Stage 2** — agent-side drop-at-source + V4L2-native keyframe interval (ioctl).
- **Stage 3** — dedicated low-latency gRPC connection for the video stream.

## Testing

- gofmt / build / vet / `go test` (incl. `-race`) — all green. Multi-slice keyframe parsing and `h264FeedBuffer` logic covered by unit tests; the feed path was also reproduced against a real `gst-launch` decoder during development.
- Device-tested end-to-end with a USB camera: preview is now near real-time (down from several seconds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)