### PR TITLE
perf(camera): drop-at-source on the agent (stage 2/3)

### DIFF
--- a/go/internal/agent/services/frame_slot.go
+++ b/go/internal/agent/services/frame_slot.go
@@ -1,0 +1,67 @@
+package services
+
+import (
+	"context"
+	"sync"
+)
+
+// frameSlot is a single-slot, drop-oldest hand-off between a producer (the V4L2
+// capture goroutine) and a consumer (the gRPC sender goroutine).
+//
+// put never blocks: it overwrites any frame the consumer has not yet taken, so a
+// slow sender (blocked on gRPC flow control) cannot stall the camera capture
+// loop. take always returns the freshest frame available; intermediate frames
+// produced while the sender was busy are dropped. This is what keeps the agent
+// from delivering a stale backlog late — it sends the newest frame and discards
+// the rest.
+type frameSlot struct {
+	mu     sync.Mutex
+	buf    []byte
+	have   bool
+	wakeup chan struct{} // capacity 1; signals take that a frame is available
+}
+
+func newFrameSlot() *frameSlot {
+	return &frameSlot{wakeup: make(chan struct{}, 1)}
+}
+
+// put stores frame as the latest available frame, dropping any frame the
+// consumer has not yet taken. It never blocks.
+func (s *frameSlot) put(frame []byte) {
+	s.mu.Lock()
+	s.buf = frame
+	s.have = true
+	s.mu.Unlock()
+
+	// Non-blocking signal: a full channel already means "frame available".
+	select {
+	case s.wakeup <- struct{}{}:
+	default:
+	}
+}
+
+// take blocks until a frame is available or ctx is cancelled. It returns the
+// freshest frame and true, or nil and false if ctx was cancelled before a frame
+// arrived. A buffered frame is delivered even if ctx is already cancelled, so no
+// captured frame is silently discarded.
+func (s *frameSlot) take(ctx context.Context) ([]byte, bool) {
+	for {
+		s.mu.Lock()
+		if s.have {
+			frame := s.buf
+			s.buf = nil
+			s.have = false
+			s.mu.Unlock()
+			return frame, true
+		}
+		s.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return nil, false
+		case <-s.wakeup:
+			// Re-check under lock: the wakeup may be stale (a frame already
+			// taken, or coalesced with a later put).
+		}
+	}
+}

--- a/go/internal/agent/services/frame_slot_test.go
+++ b/go/internal/agent/services/frame_slot_test.go
@@ -1,0 +1,97 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestFrameSlot_PutThenTake(t *testing.T) {
+	s := newFrameSlot()
+	s.put([]byte{0x42})
+	frame, ok := s.take(context.Background())
+	if !ok {
+		t.Fatal("take returned ok=false")
+	}
+	if len(frame) != 1 || frame[0] != 0x42 {
+		t.Errorf("expected frame [0x42], got %v", frame)
+	}
+}
+
+func TestFrameSlot_DropsOldestUnconsumedFrame(t *testing.T) {
+	s := newFrameSlot()
+	// Three frames produced before the consumer takes any: only the freshest
+	// must survive — the older two are dropped.
+	s.put([]byte{0x01})
+	s.put([]byte{0x02})
+	s.put([]byte{0x03})
+
+	frame, ok := s.take(context.Background())
+	if !ok {
+		t.Fatal("take returned ok=false")
+	}
+	if len(frame) != 1 || frame[0] != 0x03 {
+		t.Errorf("expected freshest frame [0x03], got %v", frame)
+	}
+
+	// Nothing stale remains after the freshest frame is consumed.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, ok := s.take(ctx); ok {
+		t.Error("expected no second frame after consuming the freshest")
+	}
+}
+
+func TestFrameSlot_TakeBlocksUntilPut(t *testing.T) {
+	s := newFrameSlot()
+	got := make(chan []byte, 1)
+	go func() {
+		frame, ok := s.take(context.Background())
+		if ok {
+			got <- frame
+		}
+	}()
+
+	// take must still be blocked: nothing has been produced yet.
+	select {
+	case <-got:
+		t.Fatal("take returned before any frame was put")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	s.put([]byte{0xAB})
+	select {
+	case frame := <-got:
+		if len(frame) != 1 || frame[0] != 0xAB {
+			t.Errorf("take returned wrong frame: %v", frame)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("take did not return after put")
+	}
+}
+
+func TestFrameSlot_TakeReturnsFalseOnContextCancel(t *testing.T) {
+	s := newFrameSlot()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan bool, 1)
+	go func() {
+		_, ok := s.take(ctx)
+		done <- ok
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("take returned before context was cancelled")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case ok := <-done:
+		if ok {
+			t.Error("take returned ok=true after context cancel; want false")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("take did not return after context cancel")
+	}
+}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -3,11 +3,13 @@ package services
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -36,6 +38,13 @@ const (
 	vidiocDqbuf     = 0xC0585611
 	vidiocStreamon  = 0x40045612
 	vidiocStreamoff = 0x40045613
+	vidiocSExtCtrls = 0xC0205648 // _IOWR('V', 72, struct v4l2_ext_controls), 32 bytes
+
+	// Encoder control IDs and class. V4L2_CID_CODEC_BASE = V4L2_CTRL_CLASS_CODEC
+	// (0x00990000) | 0x900; the keyframe controls are fixed offsets from it.
+	v4l2CtrlClassCodec = 0x00990000 // V4L2_CTRL_CLASS_CODEC
+	v4l2CIDGOPSize     = 0x009909CB // V4L2_CID_MPEG_VIDEO_GOP_SIZE (base+203)
+	v4l2CIDH264IPeriod = 0x00990A66 // V4L2_CID_MPEG_VIDEO_H264_I_PERIOD (base+358)
 )
 
 // v4l2Format matches struct v4l2_format (208 bytes) for V4L2_BUF_TYPE_VIDEO_CAPTURE.
@@ -75,6 +84,23 @@ func (b *v4l2Buf) setType(t uint32)   { *(*uint32)(unsafe.Pointer(&b[4])) = t }
 func (b *v4l2Buf) bytesUsed() uint32  { return *(*uint32)(unsafe.Pointer(&b[8])) }
 func (b *v4l2Buf) setMemory(m uint32) { *(*uint32)(unsafe.Pointer(&b[60])) = m }
 func (b *v4l2Buf) offset() uint32     { return *(*uint32)(unsafe.Pointer(&b[64])) }
+
+// v4l2ExtControl is a fixed-size array matching the __packed struct
+// v4l2_ext_control (20 bytes): id@0, size@4, reserved2@8, then an 8-byte union
+// whose __s32 value member sits at offset 12.
+type v4l2ExtControl [20]byte
+
+func (c *v4l2ExtControl) setID(id uint32)  { *(*uint32)(unsafe.Pointer(&c[0])) = id }
+func (c *v4l2ExtControl) setValue(v int32) { *(*int32)(unsafe.Pointer(&c[12])) = v }
+
+// v4l2ExtControls is a fixed-size array matching struct v4l2_ext_controls
+// (32 bytes): which@0, count@4, error_idx@8, request_fd@12, reserved@16, and a
+// pointer to the v4l2_ext_control array@24.
+type v4l2ExtControls [32]byte
+
+func (c *v4l2ExtControls) setWhich(w uint32)        { *(*uint32)(unsafe.Pointer(&c[0])) = w }
+func (c *v4l2ExtControls) setCount(n uint32)        { *(*uint32)(unsafe.Pointer(&c[4])) = n }
+func (c *v4l2ExtControls) setControlsPtr(p uintptr) { *(*uintptr)(unsafe.Pointer(&c[24])) = p }
 
 // nativeH264NotSupported is returned when the V4L2 device does not expose H.264 output.
 type nativeH264NotSupported struct{ msg string }
@@ -190,6 +216,10 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, stream grpc.ServerS
 		return nativeH264NotSupported{msg: "device switched pixel format away from H264"}
 	}
 
+	// Best-effort: cap the camera encoder's keyframe interval. Non-fatal — many
+	// UVC cameras reject this and keep their firmware default.
+	s.setV4L2KeyframeInterval(fd, keyframeIntervalFrames(req.GetFramerate()))
+
 	// Two buffers: one dequeued/in-flight, one queued for the camera to fill.
 	// More buffers increase kernel-side lag when the gRPC send lags the camera.
 	const numBuffers = 2
@@ -206,10 +236,7 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, stream grpc.ServerS
 	}
 
 	// Map and queue each buffer.
-	type mappedBuf struct {
-		data []byte
-	}
-	mapped := make([]mappedBuf, req4.Count)
+	mapped := make([][]byte, req4.Count)
 
 	for i := uint32(0); i < req4.Count; i++ {
 		var qbuf v4l2Buf
@@ -226,15 +253,15 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, stream grpc.ServerS
 		if err != nil {
 			return status.Errorf(codes.Internal, "mmap buffer %d: %v", i, err)
 		}
-		mapped[i].data = data
+		mapped[i] = data
 
 		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocQbuf, uintptr(unsafe.Pointer(&qbuf))); errno != 0 {
 			return status.Errorf(codes.Internal, "VIDIOC_QBUF[%d]: %v", i, errno)
 		}
 	}
 	defer func() {
-		for _, m := range mapped {
-			unix.Munmap(m.data) //nolint:errcheck
+		for _, data := range mapped {
+			unix.Munmap(data) //nolint:errcheck
 		}
 	}()
 
@@ -247,7 +274,59 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, stream grpc.ServerS
 		unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocStreamoff, uintptr(unsafe.Pointer(&bufType))) //nolint:errcheck
 	}()
 
-	var framesSent int
+	// Capture and send run on separate goroutines joined by a single-slot,
+	// drop-oldest hand-off. Capture runs at camera speed; the sender may stall
+	// on gRPC flow control. While the sender stalls, the slot keeps being
+	// overwritten, so the sender always transmits the freshest frame and the
+	// frames captured in between are dropped instead of delivered late.
+	slot := newFrameSlot()
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- s.captureV4L2Frames(runCtx, fd, mapped, slot) }()
+	go func() { errCh <- s.sendV4L2Frames(runCtx, stream, slot) }()
+
+	// Whichever goroutine exits first, cancel the other and collect both errors.
+	first := <-errCh
+	cancel()
+	second := <-errCh
+	return pickV4L2StreamError(first, second, ctx.Err())
+}
+
+// pickV4L2StreamError selects which of the capture/sender goroutine errors
+// streamV4L2Native returns. nativeH264NotSupported wins so StreamVideo can fall
+// back to the GStreamer encoder; otherwise the first non-cancellation error is
+// the root cause, since the other goroutine usually only reports the context
+// cancellation that the first one triggered.
+func pickV4L2StreamError(first, second, ctxErr error) error {
+	for _, err := range []error{first, second} {
+		if _, ok := err.(nativeH264NotSupported); ok {
+			return err
+		}
+	}
+	for _, err := range []error{first, second} {
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
+	}
+	if ctxErr != nil {
+		return ctxErr
+	}
+	return first
+}
+
+// captureV4L2Frames runs the V4L2 capture loop: dequeue a filled buffer, copy
+// the access unit into a fresh slice, hand it to slot (dropping any frame the
+// sender has not yet taken), and requeue the buffer. It runs as fast as the
+// camera delivers frames, decoupled from the gRPC sender.
+//
+// It returns nativeH264NotSupported if VIDIOC_DQBUF fails before any frame is
+// captured: the device accepted the H.264 format but never delivered a frame, so
+// the caller can fall back to the GStreamer software encoder. Because no frame
+// was captured, none was handed to the sender, so the fallback stream is clean.
+func (s *VideoService) captureV4L2Frames(ctx context.Context, fd int, mapped [][]byte, slot *frameSlot) error {
+	var framesCaptured int
 	for {
 		select {
 		case <-ctx.Done():
@@ -264,38 +343,24 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, stream grpc.ServerS
 				continue
 			}
 			// Device accepted H264 format but failed before delivering any frame —
-			// fall back to the GStreamer software encoder path.
-			if framesSent == 0 {
+			// signal the caller to fall back to the GStreamer software encoder.
+			if framesCaptured == 0 {
 				return nativeH264NotSupported{msg: fmt.Sprintf("VIDIOC_DQBUF failed before first frame: %v", errno)}
 			}
 			return status.Errorf(codes.Internal, "VIDIOC_DQBUF: %v", errno)
 		}
 
 		idx := dqbuf.index()
-		n := dqbuf.bytesUsed()
-		if n == 0 {
-			// Empty buffer — requeue and skip.
-			var qbuf v4l2Buf
-			qbuf.setIndex(idx)
-			qbuf.setType(v4l2BufTypeVideoCapture)
-			qbuf.setMemory(v4l2MemoryMmap)
-			if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocQbuf, uintptr(unsafe.Pointer(&qbuf))); errno != 0 {
-				return status.Errorf(codes.Internal, "VIDIOC_QBUF: %v", errno)
-			}
-			continue
+		if n := dqbuf.bytesUsed(); n > 0 {
+			// Copy out of the mmap region before requeuing: the slice handed to
+			// the sender must not alias a buffer the camera may refill.
+			frameData := make([]byte, n)
+			copy(frameData, mapped[idx][:n])
+			slot.put(frameData)
+			framesCaptured++
 		}
-		frameData := make([]byte, n)
-		copy(frameData, mapped[idx].data[:n])
 
-		if err := stream.Send(&agentpb.VideoFrame{
-			Data:        frameData,
-			TimestampNs: uint64(time.Now().UnixNano()),
-		}); err != nil {
-			return err
-		}
-		framesSent++
-
-		// Re-queue the buffer.
+		// Re-queue the buffer (including empty ones) so the camera can refill it.
 		var qbuf v4l2Buf
 		qbuf.setIndex(idx)
 		qbuf.setType(v4l2BufTypeVideoCapture)
@@ -304,6 +369,74 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, stream grpc.ServerS
 			return status.Errorf(codes.Internal, "VIDIOC_QBUF requeue[%d]: %v", idx, errno)
 		}
 	}
+}
+
+// sendV4L2Frames takes the freshest captured frame from slot and sends it over
+// the gRPC stream. While stream.Send blocks on flow control, the capture
+// goroutine keeps overwriting the slot, so every Send transmits the newest frame
+// available — frames captured during the stall are dropped.
+func (s *VideoService) sendV4L2Frames(ctx context.Context, stream grpc.ServerStreamingServer[agentpb.VideoFrame], slot *frameSlot) error {
+	for {
+		frame, ok := slot.take(ctx)
+		if !ok {
+			return ctx.Err()
+		}
+		if err := stream.Send(&agentpb.VideoFrame{
+			Data:        frame,
+			TimestampNs: uint64(time.Now().UnixNano()),
+		}); err != nil {
+			return err
+		}
+	}
+}
+
+// setV4L2KeyframeInterval caps the camera encoder's keyframe interval to gop
+// frames so a dropped frame self-heals quickly and a client can resync within
+// ~0.5s. It is best-effort: many UVC cameras do not expose these controls and
+// reject them with EINVAL — that is logged and ignored, leaving the firmware
+// default in place. The H.264-specific I-period control is tried first, then
+// the generic MPEG GOP-size control.
+func (s *VideoService) setV4L2KeyframeInterval(fd, gop int) {
+	for _, ctl := range []struct {
+		name string
+		id   uint32
+	}{
+		{"V4L2_CID_MPEG_VIDEO_H264_I_PERIOD", v4l2CIDH264IPeriod},
+		{"V4L2_CID_MPEG_VIDEO_GOP_SIZE", v4l2CIDGOPSize},
+	} {
+		errno := setV4L2ExtControl(fd, ctl.id, int32(gop))
+		if errno == 0 {
+			s.logger.Info("V4L2 keyframe interval set",
+				zap.String("control", ctl.name), zap.Int("frames", gop))
+			return
+		}
+		s.logger.Debug("V4L2 keyframe control rejected, trying next",
+			zap.String("control", ctl.name), zap.String("errno", errno.Error()))
+	}
+	s.logger.Info("V4L2 keyframe interval not configurable; using camera default",
+		zap.Int("requested_frames", gop))
+}
+
+// setV4L2ExtControl issues VIDIOC_S_EXT_CTRLS to set a single integer control,
+// returning the raw errno (0 on success). The inner v4l2_ext_control is reached
+// only through a uintptr stored inside the outer struct, where the garbage
+// collector cannot see it, so it is pinned for the duration of the syscall.
+func setV4L2ExtControl(fd int, controlID uint32, value int32) unix.Errno {
+	var ctrl v4l2ExtControl
+	ctrl.setID(controlID)
+	ctrl.setValue(value)
+
+	var pinner runtime.Pinner
+	pinner.Pin(&ctrl)
+	defer pinner.Unpin()
+
+	var ctrls v4l2ExtControls
+	ctrls.setWhich(v4l2CtrlClassCodec) // classic API: all controls share this class
+	ctrls.setCount(1)
+	ctrls.setControlsPtr(uintptr(unsafe.Pointer(&ctrl)))
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocSExtCtrls, uintptr(unsafe.Pointer(&ctrls)))
+	return errno
 }
 
 // gstFallbackDirs is the list of directories searched for GStreamer binaries
@@ -523,6 +656,16 @@ func keyframeIntervalFrames(fps uint32) int {
 	return gop
 }
 
+// leakyRawQueue is a GStreamer queue placed between the V4L2 source and the
+// encoder. The agent reads a continuous encoded byte stream from the encoder, so
+// arbitrary encoded bytes cannot be dropped; instead this queue drops *raw*
+// frames when capture outruns the encoder/gRPC send. leaky=downstream evicts the
+// oldest buffered frame, so the encoder always works on the freshest raw frame
+// and a capture backlog drains by skipping rather than encoding stale frames.
+// Dropping raw input never desyncs the encoded GOP. max-size-bytes/-time are
+// disabled so only the 2-buffer count bounds the queue.
+const leakyRawQueue = "queue max-size-buffers=2 max-size-bytes=0 max-size-time=0 leaky=downstream"
+
 // buildGStreamerArgs constructs the gst-launch-1.0 argument list for V4L2 encode.
 func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequest, encoder string, hasH264Parse bool) []string {
 	src := fmt.Sprintf("v4l2src device=%s", devicePath)
@@ -542,9 +685,9 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 	var pipeline string
 	if len(capsParts) > 0 {
 		caps := "video/x-raw," + strings.Join(capsParts, ",")
-		pipeline = fmt.Sprintf("%s ! %s ! %s ! fdsink fd=1", src, caps, encoderSegment(encoder, hasH264Parse, gop))
+		pipeline = fmt.Sprintf("%s ! %s ! %s ! %s ! fdsink fd=1", src, caps, leakyRawQueue, encoderSegment(encoder, hasH264Parse, gop))
 	} else {
-		pipeline = fmt.Sprintf("%s ! %s ! fdsink fd=1", src, encoderSegment(encoder, hasH264Parse, gop))
+		pipeline = fmt.Sprintf("%s ! %s ! %s ! fdsink fd=1", src, leakyRawQueue, encoderSegment(encoder, hasH264Parse, gop))
 	}
 	// -q suppresses gst-launch's status messages (e.g. "Setting pipeline to PLAYING")
 	// from being written to stdout and corrupting the binary H264 stream.

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"strings"
@@ -301,6 +302,41 @@ func TestBuildGStreamerArgs_VP8Encoder(t *testing.T) {
 	}
 }
 
+func TestBuildGStreamerArgs_LeakyRawQueueBeforeEncoder(t *testing.T) {
+	// No caps requested: the leaky raw queue must sit directly after v4l2src so
+	// the encoder always works on the freshest raw frame and a capture backlog
+	// drains by dropping raw frames rather than encoding stale ones.
+	req := &agentpb.StreamVideoRequest{}
+	args := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video0", req, "x264enc", true)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "queue max-size-buffers=2 max-size-bytes=0 max-size-time=0 leaky=downstream") {
+		t.Fatalf("pipeline must insert a leaky raw queue before the encoder: %v", args)
+	}
+	srcIdx := strings.Index(joined, "v4l2src")
+	queueIdx := strings.Index(joined, "queue ")
+	encIdx := strings.Index(joined, "x264enc")
+	if !(srcIdx < queueIdx && queueIdx < encIdx) {
+		t.Errorf("leaky queue must sit between v4l2src and the encoder: %v", args)
+	}
+}
+
+func TestBuildGStreamerArgs_LeakyRawQueueWithCaps(t *testing.T) {
+	// With raw caps requested, the leaky queue must come after the caps filter
+	// and before the encoder segment.
+	req := &agentpb.StreamVideoRequest{Width: 1280, Height: 720, Framerate: 30}
+	args := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video0", req, "x264enc", true)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "queue max-size-buffers=2 max-size-bytes=0 max-size-time=0 leaky=downstream") {
+		t.Fatalf("pipeline must insert a leaky raw queue before the encoder: %v", args)
+	}
+	capsIdx := strings.Index(joined, "video/x-raw,width=1280")
+	queueIdx := strings.Index(joined, "queue ")
+	encIdx := strings.Index(joined, "x264enc")
+	if !(capsIdx < queueIdx && queueIdx < encIdx) {
+		t.Errorf("leaky queue must sit between the raw caps and the encoder: %v", args)
+	}
+}
+
 func TestListGSTElements_ParsesElements(t *testing.T) {
 	input := `
 matroska:  matroskamux: Matroska muxer
@@ -429,6 +465,86 @@ func TestFindGStreamerEncoder_FallsBackToVP8WhenNoH264Encoder(t *testing.T) {
 	}
 	if result.codec != agentpb.VideoCodec_VIDEO_CODEC_VP8 {
 		t.Errorf("expected VP8 codec, got %v", result.codec)
+	}
+}
+
+func TestPickV4L2StreamError(t *testing.T) {
+	notSupported := nativeH264NotSupported{msg: "no h264"}
+	captureErr := status.Errorf(codes.Internal, "VIDIOC_DQBUF: boom")
+	sendErr := status.Errorf(codes.Unavailable, "client gone")
+
+	cases := []struct {
+		name          string
+		first, second error
+		ctxErr        error
+		want          error
+	}{
+		// nativeH264NotSupported must win regardless of position so StreamVideo
+		// falls back to GStreamer.
+		{"notSupported in first", notSupported, context.Canceled, nil, notSupported},
+		{"notSupported in second", context.Canceled, notSupported, nil, notSupported},
+		// The goroutine that failed first is the root cause; the other usually
+		// just reports the context cancellation it triggered.
+		{"real capture error over cancelled sender", captureErr, context.Canceled, nil, captureErr},
+		{"real send error over cancelled capture", context.Canceled, sendErr, context.Canceled, sendErr},
+		// Both goroutines stopped only because the parent context was cancelled.
+		{"both cancelled returns ctx error", context.Canceled, context.Canceled, context.Canceled, context.Canceled},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := pickV4L2StreamError(c.first, c.second, c.ctxErr); got != c.want {
+				t.Errorf("pickV4L2StreamError(%v, %v, %v) = %v, want %v", c.first, c.second, c.ctxErr, got, c.want)
+			}
+		})
+	}
+}
+
+func TestV4L2KeyframeControlIDs(t *testing.T) {
+	// V4L2_CID_CODEC_BASE = V4L2_CTRL_CLASS_CODEC | 0x900. The keyframe control
+	// IDs are fixed offsets from that base in the kernel uapi headers; pin them
+	// here so a transcription slip cannot silently turn the ioctl into a no-op.
+	const codecBase = 0x00990000 | 0x900
+	if v4l2CIDGOPSize != codecBase+203 {
+		t.Errorf("v4l2CIDGOPSize = %#x, want V4L2_CID_CODEC_BASE+203 = %#x", v4l2CIDGOPSize, codecBase+203)
+	}
+	if v4l2CIDH264IPeriod != codecBase+358 {
+		t.Errorf("v4l2CIDH264IPeriod = %#x, want V4L2_CID_CODEC_BASE+358 = %#x", v4l2CIDH264IPeriod, codecBase+358)
+	}
+}
+
+func TestV4L2ExtControlLayout(t *testing.T) {
+	// struct v4l2_ext_control is __packed: id@0, value (union __s32)@12, 20 bytes.
+	var ctrl v4l2ExtControl
+	if len(ctrl) != 20 {
+		t.Fatalf("v4l2_ext_control must be 20 bytes packed, got %d", len(ctrl))
+	}
+	ctrl.setID(0xAABBCCDD)
+	ctrl.setValue(0x11223344)
+	if got := binary.LittleEndian.Uint32(ctrl[0:4]); got != 0xAABBCCDD {
+		t.Errorf("id must be at offset 0, got %#x", got)
+	}
+	if got := binary.LittleEndian.Uint32(ctrl[12:16]); got != 0x11223344 {
+		t.Errorf("value must be at offset 12, got %#x", got)
+	}
+}
+
+func TestV4L2ExtControlsLayout(t *testing.T) {
+	// struct v4l2_ext_controls: which@0, count@4, controls pointer@24, 32 bytes.
+	var ctrls v4l2ExtControls
+	if len(ctrls) != 32 {
+		t.Fatalf("v4l2_ext_controls must be 32 bytes, got %d", len(ctrls))
+	}
+	ctrls.setWhich(0x00990000)
+	ctrls.setCount(1)
+	ctrls.setControlsPtr(0xDEADBEEF)
+	if got := binary.LittleEndian.Uint32(ctrls[0:4]); got != 0x00990000 {
+		t.Errorf("which must be at offset 0, got %#x", got)
+	}
+	if got := binary.LittleEndian.Uint32(ctrls[4:8]); got != 1 {
+		t.Errorf("count must be at offset 4, got %#x", got)
+	}
+	if got := binary.LittleEndian.Uint64(ctrls[24:32]); got != 0xDEADBEEF {
+		t.Errorf("controls pointer must be at offset 24, got %#x", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Stage 2 of the `wendy device camera view` latency work (3-stage plan, one PR per stage). The agent now **drops frames at the source** when it falls behind, instead of delivering a stale backlog late — this kills the steady-state latency drift.

- **2a — `streamV4L2Native` drop-oldest:** the capture loop is split into a capture goroutine and a sender goroutine joined by a single-slot, drop-oldest hand-off (`frameSlot`). Capture runs at camera speed; while the sender stalls on gRPC flow control the slot is overwritten, so every `Send` transmits the freshest frame and intermediate frames are dropped. `numBuffers` stays at 2; the `framesCaptured == 0 → nativeH264NotSupported` GStreamer fallback is preserved (decided capture-side, before any frame is sent).
- **2b — `streamGStreamer` leaky raw queue:** a `queue ... leaky=downstream` is inserted between the V4L2 source and the encoder. The agent reads a continuous encoded byte stream, so encoded bytes can't be dropped arbitrarily — raw frames are dropped instead, and the encoder always works on the freshest raw frame.
- **2c — V4L2-native keyframe interval:** best-effort `VIDIOC_S_EXT_CTRLS` after `VIDIOC_S_FMT` caps the camera encoder's keyframe interval (tries `H264_I_PERIOD`, falls back to `GOP_SIZE`). Any error (e.g. `EINVAL` from UVC cameras that don't expose the control) is logged and ignored — it never aborts the stream.

**Stacked on #762 (stage 1).** Base is `ed/camera-view-latency-stage1`; that PR should be reviewed/merged first. GitHub will retarget this PR to `main` once #762 merges.

> Plan correction: the planned `H264_I_PERIOD` constant (`0x00990e62`) was wrong. It is corrected to `0x00990A66` (`V4L2_CID_CODEC_BASE + 358`), verified against the kernel `v4l2-controls.h` uapi header. A unit test pins both control IDs to the kernel offset formula.

## Test plan

Unit tests (CI, no device — all passing, incl. `-race`):
- `frameSlot` drop-oldest / blocking-take / context-cancel behaviour.
- `pickV4L2StreamError` precedence (`nativeH264NotSupported` wins; root-cause selection).
- `buildGStreamerArgs` inserts the leaky raw queue before the encoder (caps + no-caps branches).
- `v4l2_ext_control` / `v4l2_ext_controls` packed-struct layout offsets and keyframe control IDs.

On-device (needs a real camera — **not coverable in CI**):
- [ ] `wendy device camera view` against a UVC camera with native H.264 (`streamV4L2Native`) — latency holds flat over several minutes (no drift).
- [ ] A camera without native H.264 (`streamGStreamer` fallback) — same.
- [ ] Confirm the `S_EXT_CTRLS` keyframe call logs success or a non-fatal skip — never aborts the stream.
- [ ] Induce a network hiccup (briefly throttle WiFi); confirm the preview catches back up within ~0.5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)