### PR TITLE
perf(camera): shrink gRPC flow-control windows for low-latency video (stage 3/3)

### DIFF
--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -22,8 +22,13 @@ import (
 )
 
 const (
-	grpcInitialStreamWindow = 8 * 1024 * 1024
-	grpcInitialConnWindow   = 16 * 1024 * 1024
+	// Stream/connection flow-control windows are intentionally small so that
+	// gRPC backpressure reaches the agent's Send() within ~250ms when the
+	// consumer falls behind, engaging the camera pipeline's agent-side
+	// frame-dropping. The floor (~128KB) keeps a single 1080p IDR (50–150KB)
+	// from stalling on the window.
+	grpcInitialStreamWindow = 256 * 1024
+	grpcInitialConnWindow   = 512 * 1024
 	grpcReadBufferSize      = 256 * 1024
 	grpcWriteBufferSize     = 256 * 1024
 	grpcKeepaliveTime       = 30 * time.Second


### PR DESCRIPTION
## Summary

Stage 3 (final) of the `wendy device camera view` latency work. Drops the shared agent gRPC connection's stream/connection flow-control windows from **8MB / 16MB → 256KB / 512KB** so backpressure reaches the agent's `Send()` within ~250ms when the preview consumer falls behind. That promptly engages the stage-2 agent-side frame-dropping. The 128KB floor keeps a 1080p IDR (50–150KB) from stalling on the window.

The previous revision of this PR added a dedicated `ConnectVideo` second connection with its own small windows so non-video RPCs were unaffected. Per reviewer feedback (#764#discussion_r3308643332), applied globally instead — simpler and avoids the second TCP connection / per-conn metadata plumbing.

## Test plan

Unit tests pass (CI).

On-device (needs a real camera — **not coverable in CI**):
- [ ] `wendy device camera view` against a device — glass-to-glass latency at the sub-500ms target on a LAN.
- [ ] Induce a network hiccup (briefly throttle WiFi); confirm the preview catches back up within ~0.5s instead of staying behind.
- [ ] Spot-check that other RPCs (image push, file sync) still work over the now-smaller windows — degraded throughput on high-RTT WiFi is the known tradeoff.
- [ ] Both encode paths (native-H.264 UVC camera and `streamGStreamer` fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)