### PR TITLE
Add direnv Wendy CLI wrapper

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+repo_root="$(pwd -P)"
+shim_dir="$repo_root/.direnv/bin"
+mkdir -p "$shim_dir"
+
+cat > "$shim_dir/wendy" <<'SHIM'
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+exe_ext=""
+
+if [[ "$(go env GOOS 2>/dev/null || true)" == "windows" ]]; then
+  exe_ext=".exe"
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  export CGO_LDFLAGS="${CGO_LDFLAGS:+$CGO_LDFLAGS }-Wl,-no_warn_duplicate_libraries"
+fi
+
+mkdir -p "$repo_root/go/bin"
+(cd "$repo_root/go" && go build -o "bin/wendy${exe_ext}" ./cmd/wendy)
+exec "$repo_root/go/bin/wendy${exe_ext}" "$@"
+SHIM
+chmod +x "$shim_dir/wendy"
+
+cat > "$shim_dir/wendy.cmd" <<'SHIM'
+@echo off
+setlocal
+set "REPO_ROOT=%~dp0..\.."
+if not exist "%REPO_ROOT%\go\bin" mkdir "%REPO_ROOT%\go\bin"
+pushd "%REPO_ROOT%\go" || exit /b 1
+go build -o "bin\wendy.exe" ./cmd/wendy
+set "BUILD_STATUS=%ERRORLEVEL%"
+popd
+if not "%BUILD_STATUS%" == "0" exit /b %BUILD_STATUS%
+"%REPO_ROOT%\go\bin\wendy.exe" %*
+exit /b %ERRORLEVEL%
+SHIM
+
+PATH_add "$shim_dir"

--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# direnv executes this file after `direnv allow`. Inspect changes to this file
+# before allowing them; it controls the repository-local `wendy` shim on PATH.
 
-repo_root="$(pwd -P)"
+repo_root="$(git rev-parse --show-toplevel)"
 shim_dir="$repo_root/.direnv/bin"
+
+# Keep the PATH entry scoped and reviewable: this directory should contain only
+# the shims generated below, and it is recreated on every direnv load.
+rm -rf "$shim_dir"
 mkdir -p "$shim_dir"
+chmod 700 "$repo_root/.direnv" "$shim_dir"
 
 cat > "$shim_dir/wendy" <<'SHIM'
 #!/usr/bin/env bash
@@ -11,32 +20,78 @@ set -euo pipefail
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 exe_ext=""
 
+if ! command -v go >/dev/null 2>&1; then
+  echo "wendy shim: go toolchain not found on PATH" >&2
+  exit 1
+fi
+
 if [[ "$(go env GOOS 2>/dev/null || true)" == "windows" ]]; then
   exe_ext=".exe"
 fi
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  export CGO_LDFLAGS="${CGO_LDFLAGS:+$CGO_LDFLAGS }-Wl,-no_warn_duplicate_libraries"
+  export CGO_LDFLAGS="-Wl,-no_warn_duplicate_libraries"
 fi
 
 mkdir -p "$repo_root/go/bin"
-(cd "$repo_root/go" && go build -o "bin/wendy${exe_ext}" ./cmd/wendy)
-exec "$repo_root/go/bin/wendy${exe_ext}" "$@"
+git_sha="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+if ! git -C "$repo_root" diff-index --quiet HEAD -- 2>/dev/null; then
+  git_sha="${git_sha}-dirty"
+fi
+
+target_bin="$repo_root/go/bin/wendy${exe_ext}"
+tmp_bin="$repo_root/go/bin/.wendy.tmp.$$${exe_ext}"
+trap 'rm -f "$tmp_bin"' EXIT
+
+echo "wendy shim: building from ${git_sha} with $(go version)" >&2
+if ! (cd "$repo_root/go" && go build -trimpath -o "$tmp_bin" ./cmd/wendy); then
+  echo "wendy shim: build failed" >&2
+  exit 1
+fi
+
+if [[ ! -f "$tmp_bin" ]]; then
+  echo "wendy shim: expected build output missing: $tmp_bin" >&2
+  exit 1
+fi
+
+mv "$tmp_bin" "$target_bin"
+chmod +x "$target_bin"
+exec "$target_bin" "$@"
 SHIM
-chmod +x "$shim_dir/wendy"
+chmod 700 "$shim_dir/wendy"
 
 cat > "$shim_dir/wendy.cmd" <<'SHIM'
 @echo off
-setlocal
+setlocal EnableExtensions
 set "REPO_ROOT=%~dp0..\.."
+set "TARGET_BIN=%REPO_ROOT%\go\bin\wendy.exe"
+set "TMP_BIN=%REPO_ROOT%\go\bin\.wendy.tmp.%RANDOM%%RANDOM%.exe"
+
+where go.exe >NUL 2>NUL
+if errorlevel 1 (
+  echo wendy shim: go toolchain not found on PATH 1>&2
+  exit /b 1
+)
+
 if not exist "%REPO_ROOT%\go\bin" mkdir "%REPO_ROOT%\go\bin"
 pushd "%REPO_ROOT%\go" || exit /b 1
-go build -o "bin\wendy.exe" ./cmd/wendy
+echo wendy shim: building with && go version
+go build -trimpath -o "%TMP_BIN%" ./cmd/wendy
 set "BUILD_STATUS=%ERRORLEVEL%"
 popd
-if not "%BUILD_STATUS%" == "0" exit /b %BUILD_STATUS%
-"%REPO_ROOT%\go\bin\wendy.exe" %*
+if %BUILD_STATUS% neq 0 (
+  if exist "%TMP_BIN%" del "%TMP_BIN%"
+  exit /b %BUILD_STATUS%
+)
+if not exist "%TMP_BIN%" (
+  echo wendy shim: expected build output missing: %TMP_BIN% 1>&2
+  exit /b 1
+)
+move /Y "%TMP_BIN%" "%TARGET_BIN%" >NUL
+if errorlevel 1 exit /b %ERRORLEVEL%
+endlocal & "%TARGET_BIN%" %*
 exit /b %ERRORLEVEL%
 SHIM
+chmod 700 "$shim_dir/wendy.cmd"
 
 PATH_add "$shim_dir"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.direnv
 build
 .worktrees
 .build
@@ -28,6 +29,7 @@ WendyCLI.app/
 *.resolved
 go/wendy-agent
 go/wendy
+go/bin/
 
 # Local settings
 *.local.*

--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ go build -o wendy-agent ./cmd/wendy-agent
 ### Repository-local Wendy CLI via direnv
 
 The repository includes a `.envrc` that creates a tiny local `wendy` shim in
-`.direnv/bin`. After allowing it once, `wendy` commands run from this checkout
-rebuild and execute the Go CLI without overwriting an installed `wendy`:
+`.direnv/bin`. Review `.envrc` changes before running `direnv allow`, because
+`direnv` executes allowed files in your shell context. After allowing it once,
+`wendy` commands run from this checkout rebuild and execute the Go CLI without
+overwriting an installed `wendy`:
 
 ```sh
 direnv allow
@@ -120,7 +122,9 @@ wendy run
 wendy discover --json
 ```
 
-Outside of this checkout, your normal installed `wendy` remains unchanged.
+The generated `.direnv/bin` directory is recreated on each `direnv` load and is
+ignored by git. Outside of this checkout, your normal installed `wendy` remains
+unchanged.
 
 You can still run the agent directly while developing it:
 

--- a/README.md
+++ b/README.md
@@ -108,26 +108,21 @@ cd go
 go build -o wendy-agent ./cmd/wendy-agent
 ```
 
-### Local Developer Tip
+### Repository-local Wendy CLI via direnv
 
-Add a `wendy-dev` shell function to your shell profile (`~/.zshrc` or
-`~/.bashrc`) so you can quickly iterate on CLI changes without overwriting your
-installed `wendy`:
-
-```sh
-wendy-dev() {
-  (cd /path/to/WendyOS/go && go run ./cmd/wendy "$@")
-}
-```
-
-Then use `wendy-dev` anywhere you would normally use `wendy`:
+The repository includes a `.envrc` that creates a tiny local `wendy` shim in
+`.direnv/bin`. After allowing it once, `wendy` commands run from this checkout
+rebuild and execute the Go CLI without overwriting an installed `wendy`:
 
 ```sh
-wendy-dev run
-wendy-dev discover --json
+direnv allow
+wendy run
+wendy discover --json
 ```
 
-You can do the same for the agent:
+Outside of this checkout, your normal installed `wendy` remains unchanged.
+
+You can still run the agent directly while developing it:
 
 ```sh
 wendy-agent-dev() {


### PR DESCRIPTION
## Summary

- Add a repo-local `.envrc` that generates `wendy` shims under `.direnv/bin`
- Keep generated direnv and Go build outputs ignored
- Replace the shell-function developer tip with the scoped direnv workflow

## Validation

- `direnv allow .`
- `direnv exec . sh -c 'command -v wendy && test -x .direnv/bin/wendy && test -f .direnv/bin/wendy.cmd'`
- `direnv exec . wendy --version`
