### PR TITLE
fix: restore go/ prefix for wendy.wxs path in Windows MSI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -568,7 +568,7 @@ jobs:
             -d ExePath="wendy-cli-windows-${{ matrix.goarch }}/wendy.exe" `
             -arch $MSI_ARCH `
             -o "wendy-cli-windows-${{ matrix.goarch }}-${VERSION}.msi" `
-            installer/windows/wendy.wxs
+            go/installer/windows/wendy.wxs
 
       - name: Sign MSI
         uses: azure/trusted-signing-action@v2.0.0


### PR DESCRIPTION
## Summary
- PR #773 accidentally stripped the `go/` prefix from the `installer/windows/wendy.wxs` path in the Windows MSI build step
- The file lives at `go/installer/windows/wendy.wxs` and was never moved
- This broke the `Build products and release` workflow on main immediately after the merge

## Test plan
- [ ] Windows MSI arm64 and amd64 packaging jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)