### PR TITLE
Dispatch docs deployment after releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ concurrency:
 
 # Add permissions needed for creating releases
 permissions:
-  actions: write
   contents: write
 
 env:
@@ -661,6 +660,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # contents: write to create the release; actions: write to dispatch the docs workflow
+    permissions:
+      contents: write
+      actions: write
     needs: [determine-version, build, build-go-macos, build-agent-macos-app, package-linux, package-windows, test-templates, integration-tests]
     if: |
       always() &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -660,10 +660,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # contents: write to create the release; actions: write to dispatch the docs workflow
-    permissions:
-      contents: write
-      actions: write
     needs: [determine-version, build, build-go-macos, build-agent-macos-app, package-linux, package-windows, test-templates, integration-tests]
     if: |
       always() &&
@@ -704,19 +700,6 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Dispatch docs deployment
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IS_PRERELEASE: ${{ needs.determine-version.outputs.is_prerelease }}
-          REPO: ${{ github.repository }}
-          VERSION: ${{ needs.determine-version.outputs.tag_name }}
-        run: |
-          gh workflow run fumadocs.yml \
-            --repo "${REPO}" \
-            --ref "${VERSION}" \
-            -f "release_tag=${VERSION}" \
-            -f "release_prerelease=${IS_PRERELEASE}"
 
       # Update floating 'latest' tag for nightly prereleases
       - name: Checkout repo
@@ -975,6 +958,40 @@ jobs:
 
           Users are also notified about \`wendy mcp setup\` for AI tool
           integration via the caveats message."
+
+  # Releases created with GITHUB_TOKEN do not re-trigger other workflows, so we
+  # dispatch the docs deploy explicitly. This lives in its own job scoped to
+  # actions: write only, so the cross-workflow dispatch token never also carries
+  # contents: write.
+  dispatch-docs:
+    name: Dispatch docs deployment
+    runs-on: ubuntu-latest
+    needs: [determine-version, release]
+    if: needs.release.result == 'success'
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch docs deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_PRERELEASE: ${{ needs.determine-version.outputs.is_prerelease }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ needs.determine-version.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+
+          # Validate the tag matches the release timestamp format before using it
+          # as a workflow ref and deploy-path component.
+          if [[ ! "${VERSION}" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9]{6}(-dev)?$ ]]; then
+            echo "::error::Refusing to dispatch docs: unexpected release tag format '${VERSION}'"
+            exit 1
+          fi
+
+          gh workflow run fumadocs.yml \
+            --repo "${REPO}" \
+            --ref "${VERSION}" \
+            -f "release_tag=${VERSION}" \
+            -f "release_prerelease=${IS_PRERELEASE}"
 
   publish-aur:
     name: Publish AUR Packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ concurrency:
 
 # Add permissions needed for creating releases
 permissions:
+  actions: write
   contents: write
 
 env:
@@ -700,6 +701,19 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dispatch docs deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_PRERELEASE: ${{ needs.determine-version.outputs.is_prerelease }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ needs.determine-version.outputs.tag_name }}
+        run: |
+          gh workflow run fumadocs.yml \
+            --repo "${REPO}" \
+            --ref main \
+            -f "release_tag=${VERSION}" \
+            -f "release_prerelease=${IS_PRERELEASE}"
 
       # Update floating 'latest' tag for nightly prereleases
       - name: Checkout repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -711,7 +711,7 @@ jobs:
         run: |
           gh workflow run fumadocs.yml \
             --repo "${REPO}" \
-            --ref main \
+            --ref "${VERSION}" \
             -f "release_tag=${VERSION}" \
             -f "release_prerelease=${IS_PRERELEASE}"
 

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -268,11 +268,31 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! gcloud storage buckets update "gs://${DOCS_BUCKET}" \
+          # Prefer to enable object versioning so latest/ alias overwrites stay
+          # recoverable. If the deploy identity lacks bucket-update IAM, fall
+          # back to verifying the current state: abort only when we can
+          # positively confirm versioning is OFF (the one case where an
+          # overwrite would be unrecoverable). If we can neither set nor read
+          # the bucket config, continue best-effort with a warning rather than
+          # blocking the deploy on a missing bucket-level permission.
+          if gcloud storage buckets update "gs://${DOCS_BUCKET}" \
             --versioning \
             --quiet \
             --project="${GCP_PROJECT_ID}"; then
-            echo "::warning::Unable to enable bucket versioning; continuing with docs deployment"
+            echo "Bucket object versioning is enabled."
+          else
+            echo "::warning::Unable to enable bucket versioning; verifying current state"
+            if VERSIONING="$(gcloud storage buckets describe "gs://${DOCS_BUCKET}" \
+              --format='value(versioning.enabled)' \
+              --project="${GCP_PROJECT_ID}" 2>/dev/null)"; then
+              if [[ "${VERSIONING}" != "True" ]]; then
+                echo "::error::Bucket object versioning is disabled and could not be enabled; aborting release alias update to keep latest/ overwrites recoverable"
+                exit 1
+              fi
+              echo "Bucket object versioning already enabled (managed out-of-band)."
+            else
+              echo "::warning::Unable to verify bucket versioning state; continuing with docs deployment"
+            fi
           fi
 
       - name: Upload to Cloud Storage

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -102,6 +102,7 @@ jobs:
         id: path
         env:
           DOCS_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          DISPATCH_REF_NAME: ${{ github.ref_name }}
           DISPATCH_RELEASE_PRERELEASE: ${{ inputs.release_prerelease || 'false' }}
           DISPATCH_RELEASE_TAG: ${{ inputs.release_tag || '' }}
           RELEASE_PRERELEASE: ${{ github.event.release.prerelease || 'false' }}
@@ -129,6 +130,14 @@ jobs:
             IS_RELEASE_DEPLOY="true"
             RAW_VERSION="${RELEASE_TAG_NAME}"
             if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+              # The docs are built from the checked-out ref, but deployed under
+              # release-<release_tag>/. Require the dispatch ref to match the
+              # release_tag so we never publish docs built from a different ref
+              # (e.g. main) under a release path.
+              if [[ "${DISPATCH_REF_NAME}" != "${DISPATCH_RELEASE_TAG}" ]]; then
+                echo "::error::workflow_dispatch ref '${DISPATCH_REF_NAME}' does not match release_tag '${DISPATCH_RELEASE_TAG}'; dispatch with --ref \"${DISPATCH_RELEASE_TAG}\" so the built docs match the release"
+                exit 1
+              fi
               RAW_VERSION="${DISPATCH_RELEASE_TAG}"
               RELEASE_PRERELEASE="${DISPATCH_RELEASE_PRERELEASE}"
             fi

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -226,7 +226,7 @@ jobs:
     needs: build
     if: >-
       github.event_name == 'release' ||
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && inputs.release_tag != '') ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -18,6 +18,16 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Optional release tag to deploy docs for"
+        required: false
+        type: string
+      release_prerelease:
+        description: "Deploy as nightly prerelease docs"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -37,6 +47,7 @@ jobs:
     outputs:
       deploy_path: ${{ steps.path.outputs.deploy_path }}
       deploy_paths: ${{ steps.path.outputs.deploy_paths }}
+      is_release_deploy: ${{ steps.path.outputs.is_release_deploy }}
       url: ${{ steps.path.outputs.url }}
     steps:
       - name: Check out repository
@@ -91,6 +102,8 @@ jobs:
         id: path
         env:
           DOCS_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          DISPATCH_RELEASE_PRERELEASE: ${{ inputs.release_prerelease || 'false' }}
+          DISPATCH_RELEASE_TAG: ${{ inputs.release_tag || '' }}
           RELEASE_PRERELEASE: ${{ github.event.release.prerelease || 'false' }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name || '' }}
         shell: bash
@@ -110,9 +123,15 @@ jobs:
           }
 
           DEPLOY_PATHS=()
+          IS_RELEASE_DEPLOY="false"
 
-          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "release" || ( "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${DISPATCH_RELEASE_TAG}" ) ]]; then
+            IS_RELEASE_DEPLOY="true"
             RAW_VERSION="${RELEASE_TAG_NAME}"
+            if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+              RAW_VERSION="${DISPATCH_RELEASE_TAG}"
+              RELEASE_PRERELEASE="${DISPATCH_RELEASE_PRERELEASE}"
+            fi
             if [[ -z "${RAW_VERSION}" ]]; then
               echo "::error::Missing release tag in GitHub event context"
               exit 1
@@ -158,6 +177,7 @@ jobs:
             printf '%s\n' "${DEPLOY_PATHS[@]}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+          echo "is_release_deploy=${IS_RELEASE_DEPLOY}" >> "$GITHUB_OUTPUT"
           echo "url=https://docs.wendy.dev/${DEPLOY_PATH}/" >> "$GITHUB_OUTPUT"
 
       - name: Build static site exports
@@ -206,6 +226,7 @@ jobs:
     needs: build
     if: >-
       github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:
@@ -231,17 +252,19 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
 
       - name: Ensure release alias rollback support
-        if: github.event_name == 'release'
+        if: needs.build.outputs.is_release_deploy == 'true'
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           DOCS_BUCKET: wendy-docs-public
         run: |
           set -euo pipefail
 
-          gcloud storage buckets update "gs://${DOCS_BUCKET}" \
+          if ! gcloud storage buckets update "gs://${DOCS_BUCKET}" \
             --versioning \
             --quiet \
-            --project="${GCP_PROJECT_ID}"
+            --project="${GCP_PROJECT_ID}"; then
+            echo "::warning::Unable to enable bucket versioning; continuing with docs deployment"
+          fi
 
       - name: Upload to Cloud Storage
         env:

--- a/go/internal/cli/assets/docs/development/docs-site.md
+++ b/go/internal/cli/assets/docs/development/docs-site.md
@@ -77,7 +77,7 @@ The `.github/workflows/fumadocs.yml` workflow runs when `docs`,
 | Published stable release | Deploys `release-<version>/` and updates `latest/` |
 | Published prerelease/nightly | Deploys `release-nightly-<version>/` and updates `latest-nightly/` |
 | Manual dispatch (no inputs) | Builds a branch-style preview artifact without deploying |
-| Manual dispatch with `release_tag` input | Deploys `release-<version>/` (or `release-nightly-<version>/`) and updates the appropriate `latest` alias, identical to a published-release trigger |
+| Manual dispatch with `release_tag` input | Deploys `release-<version>/` (or `release-nightly-<version>/`) and updates the appropriate `latest` alias, identical to a published-release trigger. The dispatch ref must match `release_tag` (dispatch with `--ref "<release_tag>"`), otherwise the deploy fails fast so docs built from one ref are never published under a different release path. |
 
 The deploy job authenticates to GCP with Workload Identity Federation and syncs
 static files to `gs://wendy-docs-public/<deploy-path>`. Static exports include

--- a/go/internal/cli/assets/docs/development/docs-site.md
+++ b/go/internal/cli/assets/docs/development/docs-site.md
@@ -77,7 +77,7 @@ The `.github/workflows/fumadocs.yml` workflow runs when `docs`,
 | Published stable release | Deploys `release-<version>/` and updates `latest/` |
 | Published prerelease/nightly | Deploys `release-nightly-<version>/` and updates `latest-nightly/` |
 | Manual dispatch (no inputs) | Builds a branch-style preview artifact without deploying |
-| Manual dispatch with `release_tag` input | Deploys `release-<version>/` (or `release-nightly-<version>/`) and updates the appropriate `latest` alias, identical to a published-release trigger. The dispatch ref must match `release_tag` (dispatch with `--ref "<release_tag>"`), otherwise the deploy fails fast so docs built from one ref are never published under a different release path. |
+| Manual dispatch with `release_tag` input | Deploys a release, identical to a published-release trigger. The `release_prerelease` input selects the target: `false` (default) deploys `release-<version>/` and updates `latest/`; `true` deploys `release-nightly-<version>/` and updates `latest-nightly/`. The dispatch ref must match `release_tag` (dispatch with `--ref "<release_tag>"`), otherwise the deploy fails fast so docs built from one ref are never published under a different release path. |
 
 The deploy job authenticates to GCP with Workload Identity Federation and syncs
 static files to `gs://wendy-docs-public/<deploy-path>`. Static exports include

--- a/go/internal/cli/assets/docs/development/docs-site.md
+++ b/go/internal/cli/assets/docs/development/docs-site.md
@@ -76,13 +76,16 @@ The `.github/workflows/fumadocs.yml` workflow runs when `docs`,
 | Pull request to `main` from this repository | Builds and deploys a branch preview |
 | Published stable release | Deploys `release-<version>/` and updates `latest/` |
 | Published prerelease/nightly | Deploys `release-nightly-<version>/` and updates `latest-nightly/` |
-| Manual dispatch | Builds a branch-style preview artifact without deploying |
+| Manual dispatch (no inputs) | Builds a branch-style preview artifact without deploying |
+| Manual dispatch with `release_tag` input | Deploys `release-<version>/` (or `release-nightly-<version>/`) and updates the appropriate `latest` alias, identical to a published-release trigger |
 
 The deploy job authenticates to GCP with Workload Identity Federation and syncs
 static files to `gs://wendy-docs-public/<deploy-path>`. Static exports include
 SHA-256 manifests that are verified before each deploy path is synced.
-Release deploys also ensure bucket object versioning is enabled before updating
-`latest/` or `latest-nightly/`, so alias overwrites remain recoverable.
+Release deploys attempt to enable bucket object versioning before updating
+`latest/` or `latest-nightly/` so alias overwrites remain recoverable; if the
+bucket-level update fails the deploy continues with a warning rather than
+aborting.
 
 Required GitHub environment variables:
 

--- a/go/internal/cli/assets/docs/development/docs-site.md
+++ b/go/internal/cli/assets/docs/development/docs-site.md
@@ -83,9 +83,11 @@ The deploy job authenticates to GCP with Workload Identity Federation and syncs
 static files to `gs://wendy-docs-public/<deploy-path>`. Static exports include
 SHA-256 manifests that are verified before each deploy path is synced.
 Release deploys attempt to enable bucket object versioning before updating
-`latest/` or `latest-nightly/` so alias overwrites remain recoverable; if the
-bucket-level update fails the deploy continues with a warning rather than
-aborting.
+`latest/` or `latest-nightly/` so alias overwrites remain recoverable. If the
+deploy identity lacks bucket-update permission, the deploy verifies the current
+state instead: it aborts only when versioning is confirmed disabled (an
+overwrite would be unrecoverable), and continues with a warning when versioning
+is already enabled out-of-band or cannot be read.
 
 Required GitHub environment variables:
 


### PR DESCRIPTION
## Summary
- add Fumadocs workflow_dispatch inputs for release tag/prerelease docs deploys
- dispatch Fumadocs from the release workflow after GitHub Release creation
- make bucket versioning setup best-effort so docs uploads are not blocked by bucket-level update failures

## Why
Releases created by Actions with GITHUB_TOKEN do not trigger the Fumadocs release workflow, so release docs/latest aliases were not deployed after the stable CLI/agent release.

## Validation
- ruby YAML parse for build.yml and fumadocs.yml
- git diff --check
- manually dispatched Fumadocs for 2026.05.23-190411 from this branch: https://github.com/wendylabsinc/WendyOS/actions/runs/26341515588
- verified https://docs.wendy.dev/latest/ and https://docs.wendy.dev/release-2026.05.23-190411/ return HTTP 200
