### PR TITLE
Fix discover default device marker

### DIFF
--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -923,7 +923,11 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 func discoverPickerItems(items []discoverTableItem) []tui.PickerItem {
 	pickerItems := make([]tui.PickerItem, 0, len(items))
 	for _, item := range items {
-		pickerItems = append(pickerItems, item.picker)
+		pickerItem := item.picker
+		if item.defaultDevice != "" {
+			pickerItem.DefaultKeys = append(pickerItem.DefaultKeys, item.defaultDevice)
+		}
+		pickerItems = append(pickerItems, pickerItem)
 	}
 	return pickerItems
 }

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -12,6 +12,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
 	"github.com/wendylabsinc/wendy/go/internal/shared/env"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
@@ -166,6 +167,31 @@ func TestDiscoverModel_TableNavigation(t *testing.T) {
 
 	if um.table.Cursor() != 1 {
 		t.Fatalf("expected cursor to move to row 1, got %d", um.table.Cursor())
+	}
+}
+
+func TestDiscoverModel_DKeySetsDefaultAndMarksSelectedDevice(t *testing.T) {
+	setTempConfig(t, &config.Config{})
+
+	m := newDiscoverModel(context.Background(), defaultOpts())
+	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{
+		DisplayName: "ubuntu",
+		Hostname:    "ubuntu.local",
+		Port:        defaultAgentPort,
+	}}})
+	m = updated.(discoverModel)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	um := updated.(discoverModel)
+
+	if um.flashMessage != "Default device set to: ubuntu.local" {
+		t.Fatalf("flash message = %q, want default device confirmation", um.flashMessage)
+	}
+	if cmd == nil {
+		t.Fatal("expected clearFlashAfter cmd")
+	}
+	if !strings.Contains(um.table.View(), "★") {
+		t.Fatalf("expected selected default device to show marker, got %q", um.table.View())
 	}
 }
 

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -22,6 +22,10 @@ type PickerItem struct {
 	// Items with the same DedupKey (case-insensitive) are merged via MergeItem.
 	DedupKey string
 
+	// DefaultKeys are optional alternate identities compared against
+	// PickerModel.DefaultKey when rendering the default marker.
+	DefaultKeys []string
+
 	// SortKey overrides the sort order when set. Items are sorted by SortKey
 	// first (when non-empty), then by name. Use this to pin items to a specific
 	// position (e.g. "0_first", "z_last") without affecting the display name.
@@ -408,11 +412,7 @@ func pickerRows(items []PickerItem, cols []pickerColumnDef, defaultKey string, h
 		var row bubbleTable.Row
 		// Always add the ★ column when default tracking is enabled.
 		if hasDefaultCol {
-			key := strings.ToLower(item.DedupKey)
-			if key == "" {
-				key = strings.ToLower(item.Name)
-			}
-			if defaultKey != "" && key == defaultKey {
+			if pickerItemMatchesDefaultKey(item, defaultKey) {
 				row = append(row, "★")
 			} else {
 				row = append(row, "")
@@ -428,6 +428,23 @@ func pickerRows(items []PickerItem, cols []pickerColumnDef, defaultKey string, h
 		rows = append(rows, row)
 	}
 	return rows
+}
+
+func pickerItemMatchesDefaultKey(item PickerItem, defaultKey string) bool {
+	defaultKey = strings.ToLower(strings.TrimSpace(defaultKey))
+	if defaultKey == "" {
+		return false
+	}
+	for _, key := range item.DefaultKeys {
+		if strings.ToLower(strings.TrimSpace(key)) == defaultKey {
+			return true
+		}
+	}
+	key := strings.ToLower(strings.TrimSpace(item.DedupKey))
+	if key == "" {
+		key = strings.ToLower(strings.TrimSpace(item.Name))
+	}
+	return key == defaultKey
 }
 
 func pickerColumns(rows []bubbleTable.Row, defs []pickerColumnDef, hasDefaultCol bool) []bubbleTable.Column {

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -116,6 +116,22 @@ func TestPickerModel_DefaultKeyShowsStar(t *testing.T) {
 	}
 }
 
+func TestPickerTableData_DefaultKeysShowStar(t *testing.T) {
+	_, rows := PickerTableData([]PickerItem{{
+		Name:        "ubuntu",
+		Type:        "LAN",
+		DedupKey:    "ubuntu",
+		DefaultKeys: []string{"ubuntu.local"},
+	}}, "ubuntu.local", true)
+
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0][0] != "★" {
+		t.Fatalf("default marker = %q, want ★", rows[0][0])
+	}
+}
+
 func TestPickerModel_DKeySetsDefault(t *testing.T) {
 	m := NewPickerWithTitle("Select a device")
 	var setItem PickerItem


### PR DESCRIPTION
## Summary

Fixes WDY-1253 by making the `wendy discover` default-device marker compare against the same saved device identity that pressing `d` writes to config.

The bug was that discover saved LAN defaults such as `ubuntu.local`, while the shared picker table only compared the saved default against the display/dedup key such as `ubuntu`. Picker rows now support alternate default identities, and `discover` passes the saved default identity into the table rows.

## Validation

- `gofmt`
- `go test ./internal/cli/tui ./internal/cli/commands`
- `go build ./cmd/wendy`
- `git diff --check`

Note: local macOS builds emit the existing duplicate `-lobjc` linker warning, but the build/tests pass.