### PR TITLE
Handle auth errors for provisioned devices

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -33,8 +33,15 @@ import (
 )
 
 const defaultAgentPort = 50051
+const agentMTLSPortOffset = 1
 
 const lanAddressProbeTimeout = 1500 * time.Millisecond
+const agentPlaintextProbeTimeout = 3 * time.Second
+const provisionedAgentMetadataDiscoveryTimeout = 500 * time.Millisecond
+
+const provisionedAgentUnauthorizedMessage = "Unauthorized. Run 'wendy auth login' with an account that can access this provisioned wendy-agent."
+
+var errProvisionedAgentUnauthorized = errors.New(provisionedAgentUnauthorizedMessage)
 
 var getAgentVersionAtAddress = func(ctx context.Context, address string) (bool, *agentpb.GetAgentVersionResponse, error) {
 	conn, err := connectWithAutoTLS(ctx, address)
@@ -46,6 +53,8 @@ var getAgentVersionAtAddress = func(ctx context.Context, address string) (bool, 
 	resp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
 	return conn.IsMTLS, resp, err
 }
+
+var discoverLANDevices = discovery.DiscoverLAN
 
 var isInteractiveTerminalFn = func() bool {
 	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
@@ -147,15 +156,16 @@ func resolveHostPreferIPv4(host string) string {
 // hostname resolution is unavailable on the host machine.
 //
 // For provisioned (mTLS) devices the Avahi advertisement carries the mTLS
-// port. connectWithAutoTLS derives the mTLS port as plaintext+1, so we
-// subtract 1 here to keep that convention working correctly.
+// port. connectWithAutoTLS derives the mTLS port as plaintext plus
+// agentMTLSPortOffset, so we subtract that offset here to keep that
+// convention working correctly.
 func lanAgentAddresses(dev models.LANDevice) []string {
 	port := dev.Port
 	if port == 0 {
 		port = defaultAgentPort
 	}
-	if dev.IsMTLS && dev.Port != 0 && port > 1 {
-		port-- // advertised port is mTLS; connectWithAutoTLS will add 1 back
+	if dev.IsMTLS && dev.Port != 0 && port > agentMTLSPortOffset {
+		port -= agentMTLSPortOffset // advertised port is mTLS; connectWithAutoTLS will add the offset back
 	}
 
 	var addresses []string
@@ -413,19 +423,30 @@ func formatElapsedSeconds(elapsed time.Duration) string {
 	return fmt.Sprintf("%.2f %s", seconds, unit)
 }
 
-func connectAgentAtAddress(ctx context.Context, addr string, probePlaintext bool) (*grpcclient.AgentConnection, error) {
+func connectAgentAtAddress(ctx context.Context, addr string) (*grpcclient.AgentConnection, error) {
+	return connectAgentAtAddressWithProvisionedHint(ctx, addr, false)
+}
+
+func connectAgentAtAddressWithProvisionedHint(ctx context.Context, addr string, knownProvisionedMTLS bool) (*grpcclient.AgentConnection, error) {
 	conn, err := connectWithAutoTLS(ctx, addr)
 	if err != nil {
 		return nil, err
 	}
-	if probePlaintext && !conn.IsMTLS {
-		// gRPC plaintext connections are lazy — probe to detect unreachable
-		// default devices early so recovery can be offered immediately.
-		probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	if !conn.IsMTLS {
+		// gRPC plaintext connections are lazy. Probe before returning so
+		// command UIs don't surface delayed transport errors, and so provisioned
+		// agents that only expose the mTLS port can report an auth error.
+		probeCtx, cancel := context.WithTimeout(ctx, agentPlaintextProbeTimeout)
 		_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
 		cancel()
 		if probeErr != nil {
 			conn.Close()
+			// Use only the caller's pre-connection metadata snapshot here.
+			// Running discovery after the failed probe would make the auth
+			// decision depend on a second, unrelated network observation.
+			if knownProvisionedMTLS {
+				return nil, errProvisionedAgentUnauthorized
+			}
 			return nil, probeErr
 		}
 	}
@@ -433,12 +454,16 @@ func connectAgentAtAddress(ctx context.Context, addr string, probePlaintext bool
 }
 
 func connectResolvedAgent(ctx context.Context, hostname, addr string, isDefault bool) (*grpcclient.AgentConnection, error) {
+	return connectResolvedAgentWithProvisionedHint(ctx, hostname, addr, isDefault, false)
+}
+
+func connectResolvedAgentWithProvisionedHint(ctx context.Context, hostname, addr string, isDefault bool, knownProvisionedMTLS bool) (*grpcclient.AgentConnection, error) {
 	if isDefault && !jsonOutput && isInteractiveTerminal() {
 		return runAgentConnectionSpinner(ctx, defaultDeviceSearchLabel(hostname), func(spinCtx context.Context) (*grpcclient.AgentConnection, error) {
-			return connectAgentAtAddress(spinCtx, addr, true)
+			return connectAgentAtAddressWithProvisionedHint(spinCtx, addr, knownProvisionedMTLS)
 		})
 	}
-	return connectAgentAtAddress(ctx, addr, isDefault)
+	return connectAgentAtAddressWithProvisionedHint(ctx, addr, knownProvisionedMTLS)
 }
 
 // connectToAgent establishes a gRPC connection to the target device.
@@ -470,9 +495,13 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 		if host, _, splitErr := net.SplitHostPort(addr); splitErr == nil {
 			hostname = host
 		}
-		conn, connErr := connectResolvedAgent(ctx, hostname, addr, isDefault)
+		knownProvisionedMTLS := provisionedAgentAdvertisedMTLS(ctx, addr)
+		conn, connErr := connectResolvedAgentWithProvisionedHint(ctx, hostname, addr, isDefault, knownProvisionedMTLS)
 		if connErr != nil {
 			if errors.Is(connErr, ErrUserCancelled) {
+				return nil, connErr
+			}
+			if errors.Is(connErr, errProvisionedAgentUnauthorized) {
 				return nil, connErr
 			}
 			// Default device is unreachable — offer interactive recovery.
@@ -548,7 +577,7 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 	if len(allCerts) > 0 {
 		host, portStr, _ := net.SplitHostPort(plaintextAddr)
 		if port, err := strconv.Atoi(portStr); err == nil {
-			mtlsAddr := hostPort(host, port+1)
+			mtlsAddr := hostPort(host, port+agentMTLSPortOffset)
 			for i := range allCerts {
 				conn, tlsErr := grpcclient.ConnectWithTLS(ctx, mtlsAddr, &allCerts[i])
 				if tlsErr != nil {
@@ -574,6 +603,48 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 		}
 	}
 	return grpcclient.Connect(ctx, plaintextAddr)
+}
+
+// provisionedAgentAdvertisedMTLS takes a short pre-connection LAN discovery
+// snapshot and checks whether the target address was already advertised as an
+// mTLS-only agent. Callers pass this result into the dial path; it is not
+// refreshed after a failed connection attempt.
+func provisionedAgentAdvertisedMTLS(ctx context.Context, plaintextAddr string) bool {
+	devices, err := discoverLANDevices(ctx, provisionedAgentMetadataDiscoveryTimeout)
+	if err != nil {
+		return false
+	}
+	return provisionedAgentAdvertisedMTLSInSnapshot(plaintextAddr, devices)
+}
+
+func provisionedAgentAdvertisedMTLSInSnapshot(plaintextAddr string, devices []models.LANDevice) bool {
+	for _, dev := range devices {
+		if !dev.IsMTLS {
+			continue
+		}
+		for _, candidate := range lanAgentAddresses(dev) {
+			if sameAgentAddress(plaintextAddr, candidate) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sameAgentAddress(a, b string) bool {
+	aHost, aPort, aErr := net.SplitHostPort(a)
+	bHost, bPort, bErr := net.SplitHostPort(b)
+	if aErr != nil || bErr != nil {
+		return a == b
+	}
+	return aPort == bPort && normalizeAgentHost(aHost) == normalizeAgentHost(bHost)
+}
+
+func normalizeAgentHost(host string) string {
+	if addr, err := netip.ParseAddr(host); err == nil {
+		return addr.Unmap().String()
+	}
+	return strings.TrimSuffix(strings.ToLower(host), ".")
 }
 
 // suggestProvisioning prints a hint when the connection is not using mTLS,
@@ -888,9 +959,13 @@ func resolveTarget(ctx context.Context, opts ...resolveOption) (*SelectedDevice,
 	if device != "" {
 		addr := hostPort(device, defaultAgentPort)
 		startedAt := time.Now()
-		conn, err := connectResolvedAgent(ctx, device, addr, isDefault)
+		knownProvisionedMTLS := provisionedAgentAdvertisedMTLS(ctx, addr)
+		conn, err := connectResolvedAgentWithProvisionedHint(ctx, device, addr, isDefault, knownProvisionedMTLS)
 		if err != nil {
 			if errors.Is(err, ErrUserCancelled) {
+				return nil, err
+			}
+			if errors.Is(err, errProvisionedAgentUnauthorized) {
 				return nil, err
 			}
 			// Default device is unreachable — offer interactive recovery.
@@ -1329,7 +1404,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 				}
 				return nil, fmt.Errorf("selected LAN device has no usable address")
 			}
-			conn, err := connectWithAutoTLS(ctx, addr)
+			conn, err := connectAgentAtAddressWithProvisionedHint(ctx, addr, d.LAN.IsMTLS)
 			if err == nil {
 				if !suppressUpdateCheck {
 					var updateErr error

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"context"
 	"errors"
+	"net"
 	"reflect"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -71,6 +73,48 @@ func TestLANAgentAddressesPrefersIPAddress(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("lanAgentAddresses() = %v, want %v", got, want)
+	}
+}
+
+func TestProvisionedAgentAdvertisedMTLSMatchesDiscoveredMTLSDevice(t *testing.T) {
+	stubDiscoverLANDevices(t, []models.LANDevice{
+		{
+			IPAddress: "127.0.0.1",
+			Port:      defaultAgentPort + agentMTLSPortOffset,
+			IsMTLS:    true,
+		},
+	}, nil)
+
+	if !provisionedAgentAdvertisedMTLS(context.Background(), "127.0.0.1:50051") {
+		t.Fatal("provisionedAgentAdvertisedMTLS() = false, want true")
+	}
+}
+
+func TestProvisionedAgentAdvertisedMTLSIgnoresPlaintextDevices(t *testing.T) {
+	stubDiscoverLANDevices(t, []models.LANDevice{
+		{
+			IPAddress: "127.0.0.1",
+			Port:      defaultAgentPort,
+			IsMTLS:    false,
+		},
+	}, nil)
+
+	if provisionedAgentAdvertisedMTLS(context.Background(), "127.0.0.1:50051") {
+		t.Fatal("provisionedAgentAdvertisedMTLS() = true, want false")
+	}
+}
+
+func TestProvisionedAgentAdvertisedMTLSMatchesHostnameCaseInsensitively(t *testing.T) {
+	stubDiscoverLANDevices(t, []models.LANDevice{
+		{
+			Hostname: "WENDYOS-OTTER.LOCAL.",
+			Port:     defaultAgentPort + agentMTLSPortOffset,
+			IsMTLS:   true,
+		},
+	}, nil)
+
+	if !provisionedAgentAdvertisedMTLS(context.Background(), "wendyos-otter.local:50051") {
+		t.Fatal("provisionedAgentAdvertisedMTLS() = false, want true")
 	}
 }
 
@@ -425,4 +469,86 @@ func TestConnectResolvedAgent_UsesSpinnerForInteractiveDefaultDevice(t *testing.
 	if gotConn != wantConn {
 		t.Fatal("connectResolvedAgent() did not return spinner result")
 	}
+}
+
+func TestConnectResolvedAgent_NoAuthProvisionedAgentRequiresLogin(t *testing.T) {
+	origInteractive := isInteractiveTerminalFn
+	origJSON := jsonOutput
+	defer func() {
+		isInteractiveTerminalFn = origInteractive
+		jsonOutput = origJSON
+	}()
+
+	isInteractiveTerminalFn = func() bool { return false }
+	jsonOutput = false
+	setTempConfig(t, &config.Config{})
+
+	plaintextAddr := startFailingPlaintextAgent(t)
+	host, portStr, err := net.SplitHostPort(plaintextAddr)
+	if err != nil {
+		t.Fatalf("split plaintext address: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse plaintext port: %v", err)
+	}
+	stubDiscoverLANDevices(t, []models.LANDevice{
+		{
+			IPAddress: host,
+			Port:      port + agentMTLSPortOffset,
+			IsMTLS:    true,
+		},
+	}, nil)
+	knownProvisionedMTLS := provisionedAgentAdvertisedMTLS(context.Background(), plaintextAddr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := connectResolvedAgentWithProvisionedHint(ctx, "127.0.0.1", plaintextAddr, false, knownProvisionedMTLS)
+	if conn != nil {
+		conn.Close()
+		t.Fatal("connectResolvedAgent() returned a connection for an auth-only agent")
+	}
+	if !errors.Is(err, errProvisionedAgentUnauthorized) {
+		t.Fatalf("connectResolvedAgent() error = %v, want %v", err, errProvisionedAgentUnauthorized)
+	}
+	if err.Error() != provisionedAgentUnauthorizedMessage {
+		t.Fatalf("connectResolvedAgent() message = %q, want %q", err.Error(), provisionedAgentUnauthorizedMessage)
+	}
+}
+
+func startFailingPlaintextAgent(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen plaintext candidate: %v", err)
+	}
+	go closeAcceptedConnections(listener)
+	t.Cleanup(func() {
+		listener.Close()
+	})
+	return listener.Addr().String()
+}
+
+func closeAcceptedConnections(listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		conn.Close()
+	}
+}
+
+func stubDiscoverLANDevices(t *testing.T, devices []models.LANDevice, err error) {
+	t.Helper()
+
+	orig := discoverLANDevices
+	discoverLANDevices = func(context.Context, time.Duration) ([]models.LANDevice, error) {
+		return devices, err
+	}
+	t.Cleanup(func() {
+		discoverLANDevices = orig
+	})
 }


### PR DESCRIPTION
## Summary
- probe plaintext agent connections before returning them so command UIs do not surface lazy gRPC transport errors
- detect provisioned agents that only expose the mTLS port and return the requested unauthorized/login message
- cover the logged-out provisioned-agent path with a regression test

Linear: WDY-1254

## Tests
- go test ./internal/cli/commands ./internal/agent/services
- go build ./cmd/wendy ./cmd/wendy-agent
- git diff --check