### PR TITLE
Support agent-side browser opening on Linux desktops

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -610,7 +610,7 @@ func handleUtilityCommand(args []string) (bool, int) {
 	if err := browseropen.Open(rawURL); err != nil {
 		fmt.Fprintf(os.Stderr, "Could not open browser: %v\n", err)
 		fmt.Println(rawURL)
-		return true, 0
+		return true, 1
 	}
 
 	fmt.Printf("Opening %s in default browser...\n", rawURL)

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -846,11 +846,10 @@ var startPostStartHookCommand = func(shell, flag, command string) (func() error,
 		if err == nil {
 			return nil
 		}
-		output := sanitizeHookDiagnosticOutput(stderr.String())
-		if output == "" {
+		if strings.TrimSpace(stderr.String()) == "" {
 			return err
 		}
-		return fmt.Errorf("%w: %s", err, output)
+		return fmt.Errorf("%w: hook wrote stderr", err)
 	}, nil
 }
 
@@ -884,28 +883,6 @@ func (b *limitedBuffer) String() string {
 		output += "[stderr truncated]"
 	}
 	return output
-}
-
-func sanitizeHookDiagnosticOutput(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-
-	const maxOutput = 512
-	var b strings.Builder
-	for _, r := range value {
-		switch {
-		case r == '\n' || r == '\r' || r == '\t':
-			b.WriteByte(' ')
-		case r >= 32 && r <= 126:
-			b.WriteRune(r)
-		}
-		if b.Len() >= maxOutput {
-			break
-		}
-	}
-	return strings.TrimSpace(b.String())
 }
 
 func (c *Client) startPostStartAgentHook(command, appName string) bool {

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -846,7 +846,7 @@ var startPostStartHookCommand = func(shell, flag, command string) (func() error,
 		if err == nil {
 			return nil
 		}
-		output := strings.TrimSpace(stderr.String())
+		output := sanitizeHookDiagnosticOutput(stderr.String())
 		if output == "" {
 			return err
 		}
@@ -884,6 +884,28 @@ func (b *limitedBuffer) String() string {
 		output += "[stderr truncated]"
 	}
 	return output
+}
+
+func sanitizeHookDiagnosticOutput(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	const maxOutput = 512
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteByte(' ')
+		case r >= 32 && r <= 126:
+			b.WriteRune(r)
+		}
+		if b.Len() >= maxOutput {
+			break
+		}
+	}
+	return strings.TrimSpace(b.String())
 }
 
 func (c *Client) startPostStartAgentHook(command, appName string) bool {

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -836,10 +836,54 @@ func expandAgentHook(command, appName string) string {
 
 var startPostStartHookCommand = func(shell, flag, command string) (func() error, error) {
 	cmd := exec.Command(shell, flag, command)
+	stderr := &limitedBuffer{limit: 4096}
+	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
-	return cmd.Wait, nil
+	return func() error {
+		err := cmd.Wait()
+		if err == nil {
+			return nil
+		}
+		output := strings.TrimSpace(stderr.String())
+		if output == "" {
+			return err
+		}
+		return fmt.Errorf("%w: %s", err, output)
+	}, nil
+}
+
+type limitedBuffer struct {
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	if b.limit > b.buf.Len() {
+		remaining := b.limit - b.buf.Len()
+		if len(p) > remaining {
+			_, _ = b.buf.Write(p[:remaining])
+			b.truncated = true
+		} else {
+			_, _ = b.buf.Write(p)
+		}
+	} else if len(p) > 0 {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *limitedBuffer) String() string {
+	output := b.buf.String()
+	if b.truncated {
+		if output != "" {
+			output += "\n"
+		}
+		output += "[stderr truncated]"
+	}
+	return output
 }
 
 func (c *Client) startPostStartAgentHook(command, appName string) bool {

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"errors"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -305,6 +306,25 @@ func TestStartPostStartAgentHookStartErrorDoesNotLogCommand(t *testing.T) {
 		if field.Key == "command" {
 			t.Fatal("hook command leaked into warning fields")
 		}
+	}
+}
+
+func TestStartPostStartHookCommandReportsStderrOnExitError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command shape is platform-specific")
+	}
+
+	wait, err := startPostStartHookCommand("/bin/sh", "-c", "printf 'Could not open browser: no display' >&2; exit 7")
+	if err != nil {
+		t.Fatalf("startPostStartHookCommand start error: %v", err)
+	}
+
+	err = wait()
+	if err == nil {
+		t.Fatal("expected wait error")
+	}
+	if !strings.Contains(err.Error(), "Could not open browser: no display") {
+		t.Fatalf("wait error = %q; want stderr output included", err)
 	}
 }
 

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -328,6 +328,13 @@ func TestStartPostStartHookCommandReportsStderrOnExitError(t *testing.T) {
 	}
 }
 
+func TestSanitizeHookDiagnosticOutput(t *testing.T) {
+	got := sanitizeHookDiagnosticOutput("bad\x1b[31m\nnext\tline")
+	if got != "bad[31m next line" {
+		t.Fatalf("sanitizeHookDiagnosticOutput = %q; want printable single-line output", got)
+	}
+}
+
 func TestLayerMediaType_Zstd(t *testing.T) {
 	got := layerMediaType(agentpb.RunContainerLayerHeader_COMPRESSION_ZSTD, false)
 	want := "application/vnd.oci.image.layer.v1.tar+zstd"

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -323,15 +323,11 @@ func TestStartPostStartHookCommandReportsStderrOnExitError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected wait error")
 	}
-	if !strings.Contains(err.Error(), "Could not open browser: no display") {
-		t.Fatalf("wait error = %q; want stderr output included", err)
+	if !strings.Contains(err.Error(), "hook wrote stderr") {
+		t.Fatalf("wait error = %q; want stderr presence included", err)
 	}
-}
-
-func TestSanitizeHookDiagnosticOutput(t *testing.T) {
-	got := sanitizeHookDiagnosticOutput("bad\x1b[31m\nnext\tline")
-	if got != "bad[31m next line" {
-		t.Fatalf("sanitizeHookDiagnosticOutput = %q; want printable single-line output", got)
+	if strings.Contains(err.Error(), "no display") {
+		t.Fatalf("wait error = %q; stderr content should not be logged", err)
 	}
 }
 

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -92,6 +92,8 @@ Lifecycle commands to run at specific points during the app lifecycle.
 | `hooks.postStart.cli` | Command run on the developer's machine after the app starts |
 | `hooks.postStart.agent` | Command run on the device after the app starts |
 
+If an agent-side hook exits with an error, bounded stderr from the hook may be included in agent logs to make failures diagnosable. Do not print secrets or credentials from lifecycle hooks.
+
 ### `python`
 
 Python-specific settings.

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -92,7 +92,7 @@ Lifecycle commands to run at specific points during the app lifecycle.
 | `hooks.postStart.cli` | Command run on the developer's machine after the app starts |
 | `hooks.postStart.agent` | Command run on the device after the app starts |
 
-If an agent-side hook exits with an error, bounded stderr from the hook may be included in agent logs to make failures diagnosable. Do not print secrets or credentials from lifecycle hooks.
+If an agent-side hook exits with an error after writing to stderr, agent logs note that stderr was emitted without logging the stderr content.
 
 ### `python`
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -81,7 +81,7 @@ When a `postStart` hook is configured in `wendy.json`, `wendy run` fires it afte
 }
 ```
 
-If the browser cannot be opened, a warning is printed and `wendy run` continues normally. `openURL` waits for the opener command to report success or failure, bounded by a short timeout; browser processes the opener may itself spawn are not tracked after that point.
+If the browser cannot be opened, a warning is printed and `wendy run` continues normally. `openURL` waits for the opener command to report success or failure, bounded by a short timeout; browser processes that the opener itself spawns are not tracked after that point.
 
 ### `cli`
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -81,7 +81,7 @@ When a `postStart` hook is configured in `wendy.json`, `wendy run` fires it afte
 }
 ```
 
-If the browser cannot be opened, a warning is printed and `wendy run` continues normally. `openURL` is fire-and-forget and does not affect the process tracked by `wendy run`.
+If the browser cannot be opened, a warning is printed and `wendy run` continues normally. `openURL` waits for the opener command to report success or failure, bounded by a short timeout; browser processes the opener may itself spawn are not tracked after that point.
 
 ### `cli`
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
@@ -4,7 +4,7 @@ This is useful for `wendy.json` postRun scripts that want to open your (web) app
 
 ## Accepted URLs
 
-Only `http` and `https` URLs are accepted. The URL must include a host and must not begin with `-`. Any other scheme, a missing host, or a URL starting with `-` is rejected immediately with a non-zero exit code.
+Only `http` and `https` URLs are accepted. The URL must include a host, must not include credentials, and must not begin with `-`. Any other scheme, embedded credentials, a missing host, or a URL starting with `-` is rejected immediately with a non-zero exit code.
 
 ## Exit codes
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
@@ -2,13 +2,13 @@ Opens a URL using the preferred mechanism on the current OS.
 
 This is useful for `wendy.json` postRun scripts that want to open your (web) app in a web-browser.
 
-## Accepted URLs
+## Automatic opening
 
-Only `http` and `https` URLs are accepted. The URL must include a host, must not include credentials, and must not begin with `-`. Any other scheme, embedded credentials, a missing host, or a URL starting with `-` is rejected immediately with a non-zero exit code.
+The underlying browser opener automatically opens only `http` and `https` URLs. The URL must include a host, must not include credentials, and must not begin with `-`. If the browser opener cannot open the URL, the command prints the URL to stdout and a diagnostic to stderr so it can be opened manually.
 
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
-| `0` | The browser was opened successfully. |
-| `1` | The browser could not be opened, or the URL was rejected as invalid. The URL is printed to stdout and a diagnostic is written to stderr. |
+| `0` | The browser was opened successfully, or the browser could not be opened and the URL was printed to stdout with a diagnostic on stderr. |
+| Non-zero | The command arguments were invalid, such as a missing URL, malformed URL, missing scheme, or missing host for an `http`/`https` URL. |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
@@ -2,9 +2,13 @@ Opens a URL using the preferred mechanism on the current OS.
 
 This is useful for `wendy.json` postRun scripts that want to open your (web) app in a web-browser.
 
+## Accepted URLs
+
+Only `http` and `https` URLs are accepted. The URL must include a host and must not begin with `-`. Any other scheme, a missing host, or a URL starting with `-` is rejected immediately with a non-zero exit code.
+
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
 | `0` | The browser was opened successfully. |
-| `1` | The browser could not be opened. The URL is printed to stdout and a diagnostic is written to stderr. |
+| `1` | The browser could not be opened, or the URL was rejected as invalid. The URL is printed to stdout and a diagnostic is written to stderr. |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
@@ -10,5 +10,5 @@ The underlying browser opener automatically opens only `http` and `https` URLs. 
 
 | Code | Meaning |
 |------|---------|
-| `0` | The browser was opened successfully, or the browser could not be opened and the URL was printed to stdout with a diagnostic on stderr. |
-| Non-zero | The command arguments were invalid, such as a missing URL, malformed URL, missing scheme, or missing host for an `http`/`https` URL. |
+| `0` | The browser was opened successfully. |
+| Non-zero | The browser could not be opened, or the command arguments were invalid. When opening fails after URL validation, the URL is printed to stdout and a diagnostic is written to stderr. |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/utils/open-browser.md
@@ -1,3 +1,10 @@
 Opens a URL using the preferred mechanism on the current OS.
 
 This is useful for `wendy.json` postRun scripts that want to open your (web) app in a web-browser.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | The browser was opened successfully. |
+| `1` | The browser could not be opened. The URL is printed to stdout and a diagnostic is written to stderr. |

--- a/go/internal/shared/browseropen/browseropen.go
+++ b/go/internal/shared/browseropen/browseropen.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	openCommandTimeout      = 10 * time.Second
-	maxDiagnosticOutputSize = 512
+	openCommandTimeout           = 10 * time.Second
+	maxDiagnosticOutputSize      = 512
+	maxLoginctlPropertyValueSize = 256
 	// Browser session bridging targets normal interactive Linux users, not
 	// root or system accounts.
 	minGraphicalSessionUID = 1000
@@ -204,9 +205,26 @@ func parseLoginctlProperties(raw string) map[string]string {
 		if !ok {
 			continue
 		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || !validLoginctlPropertyValue(value) {
+			continue
+		}
 		props[key] = value
 	}
 	return props
+}
+
+func validLoginctlPropertyValue(value string) bool {
+	if len(value) > maxLoginctlPropertyValueSize {
+		return false
+	}
+	for _, r := range value {
+		if r <= 32 || r > 126 {
+			return false
+		}
+	}
+	return true
 }
 
 func (s loginSession) isGraphicalUserSession() bool {
@@ -242,17 +260,23 @@ func (o opener) openLinuxInLoginSession(session loginSession, url string) error 
 	var candidates []commandSpec
 	if uid == o.euid() {
 		candidates = append(candidates, commandSpec{name: xdgOpenPath, args: []string{url}, env: env, minimalEnv: true})
-	} else if validUsername(session.user) {
+	} else if session.user = strings.TrimSpace(session.user); validUsername(session.user) {
 		if o.euid() != 0 {
 			return fmt.Errorf("agent is not root; cannot open browser as graphical session user")
 		}
-		envArgs := append(append([]string{}, env...), xdgOpenPath, url)
+		envArgs := make([]string, 0, len(env)+2)
+		envArgs = append(envArgs, env...)
+		envArgs = append(envArgs, xdgOpenPath, url)
 		runuserCandidates := o.runuserCandidates()
 		if len(runuserCandidates) == 0 {
 			return fmt.Errorf("no supported runuser path configured")
 		}
 		for _, runuser := range runuserCandidates {
-			candidates = append(candidates, commandSpec{name: runuser, args: append([]string{"-u", session.user, "--", envPath, "-i"}, envArgs...), minimalEnv: true})
+			prefix := []string{"-u", session.user, "--", envPath, "-i"}
+			args := make([]string, len(prefix)+len(envArgs))
+			copy(args, prefix)
+			copy(args[len(prefix):], envArgs)
+			candidates = append(candidates, commandSpec{name: runuser, args: args, minimalEnv: true})
 		}
 	} else {
 		return fmt.Errorf("active graphical login session has invalid username")
@@ -310,7 +334,11 @@ func linuxRuntimeDir(uid string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid uid for graphical runtime directory")
 	}
-	return "/run/user/" + strconv.Itoa(parsedUID), nil
+	runtimeDir := "/run/user/" + strconv.Itoa(parsedUID)
+	if clean := filepath.Clean(runtimeDir); clean != runtimeDir {
+		return "", fmt.Errorf("invalid graphical runtime directory")
+	}
+	return runtimeDir, nil
 }
 
 func hasEnv(env []string, key string) bool {
@@ -410,7 +438,7 @@ func validateEnvAssignment(value string) error {
 	if !ok || name == "" || envValue == "" {
 		return fmt.Errorf("invalid environment assignment")
 	}
-	if strings.ContainsAny(name, "\x00\r\n=") || strings.ContainsAny(envValue, "\x00\r\n") {
+	if strings.ContainsAny(name, "\x00\r\n=") || strings.ContainsAny(envValue, "\x00\r\n\t ") {
 		return fmt.Errorf("invalid environment assignment")
 	}
 	return nil

--- a/go/internal/shared/browseropen/browseropen.go
+++ b/go/internal/shared/browseropen/browseropen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -14,17 +13,9 @@ import (
 	"time"
 )
 
-const openCommandTimeout = 10 * time.Second
-
-var (
-	goos           = runtime.GOOS
-	commandContext = exec.CommandContext
-	commandOutput  = commandOutputDefault
-	getEnv         = os.Getenv
-	getEUID        = os.Geteuid
-	glob           = filepath.Glob
-	runCommand     = runOpenCommandDefault
-	stat           = os.Stat
+const (
+	openCommandTimeout      = 10 * time.Second
+	maxDiagnosticOutputSize = 512
 )
 
 type commandSpec struct {
@@ -33,44 +24,69 @@ type commandSpec struct {
 	env  []string
 }
 
-// Open opens url in the platform default browser without waiting for the
-// browser process to exit.
-func Open(url string) error {
-	switch goos {
-	case "darwin":
-		return runCommand(commandSpec{name: "open", args: []string{url}})
-	case "linux":
-		return openLinux(url)
-	case "windows":
-		return runCommand(commandSpec{name: "rundll32", args: []string{"url.dll,FileProtocolHandler", url}})
-	default:
-		return fmt.Errorf("unsupported platform %q", goos)
+type opener struct {
+	runtimeGOOS    string
+	commandContext func(context.Context, string, ...string) *exec.Cmd
+	commandOutput  func(string, ...string) ([]byte, error)
+	getenv         func(string) string
+	geteuid        func() int
+	glob           func(string) ([]string, error)
+	runCommand     func(commandSpec) error
+}
+
+func newDefaultOpener() opener {
+	return opener{
+		runtimeGOOS:    runtime.GOOS,
+		commandContext: exec.CommandContext,
+		getenv:         os.Getenv,
+		geteuid:        os.Geteuid,
+		glob:           filepath.Glob,
 	}
 }
 
-func openLinux(url string) error {
-	if hasCurrentGraphicalSessionEnv() {
-		return runCommand(commandSpec{name: "xdg-open", args: []string{url}})
+// Open opens url in the platform default browser. It waits for the opener
+// command to report success or failure, bounded by a short timeout; browser
+// processes spawned by the opener are not tracked after that.
+func Open(url string) error {
+	return newDefaultOpener().open(url)
+}
+
+func (o opener) open(url string) error {
+	switch o.runtimeGOOS {
+	case "darwin":
+		return o.run(commandSpec{name: "open", args: []string{url}})
+	case "linux":
+		return o.openLinux(url)
+	case "windows":
+		return o.run(commandSpec{name: "rundll32", args: []string{"url.dll,FileProtocolHandler", url}})
+	default:
+		return fmt.Errorf("unsupported platform %q", o.runtimeGOOS)
+	}
+}
+
+func (o opener) openLinux(url string) error {
+	if o.hasCurrentGraphicalSessionEnv() {
+		return o.run(commandSpec{name: "xdg-open", args: []string{url}})
 	}
 
-	session, sessionErr := activeGraphicalLoginSession()
+	session, sessionErr := o.activeGraphicalLoginSession()
 	if sessionErr == nil {
-		if err := openLinuxInLoginSession(session, url); err == nil {
+		if err := o.openLinuxInLoginSession(session, url); err == nil {
 			return nil
 		} else {
 			return err
 		}
 	}
 
-	if err := runCommand(commandSpec{name: "xdg-open", args: []string{url}}); err != nil {
+	if err := o.run(commandSpec{name: "xdg-open", args: []string{url}}); err != nil {
 		return fmt.Errorf("xdg-open failed without a graphical session: %w; loginctl: %v", err, sessionErr)
 	}
 	return nil
 }
 
-func hasCurrentGraphicalSessionEnv() bool {
+func (o opener) hasCurrentGraphicalSessionEnv() bool {
 	for _, key := range []string{"DISPLAY", "WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS"} {
-		if getEnv(key) != "" {
+		if o.env(key) != "" {
 			return true
 		}
 	}
@@ -87,8 +103,8 @@ type loginSession struct {
 	active  bool
 }
 
-func activeGraphicalLoginSession() (loginSession, error) {
-	out, err := commandOutput("loginctl", "list-sessions", "--no-legend", "--no-pager")
+func (o opener) activeGraphicalLoginSession() (loginSession, error) {
+	out, err := o.output("loginctl", "list-sessions", "--no-legend", "--no-pager")
 	if err != nil {
 		return loginSession{}, fmt.Errorf("list login sessions: %w", err)
 	}
@@ -106,7 +122,7 @@ func activeGraphicalLoginSession() (loginSession, error) {
 			session.user = fields[2]
 		}
 
-		props, err := commandOutput(
+		props, err := o.output(
 			"loginctl",
 			"show-session",
 			session.id,
@@ -164,32 +180,30 @@ func (s loginSession) isGraphicalUserSession() bool {
 	case "x11", "wayland", "mir":
 		return true
 	default:
-		return s.display != ""
+		return validX11Display(s.display) || validWaylandDisplay(s.display)
 	}
 }
 
-func openLinuxInLoginSession(session loginSession, url string) error {
-	if session.uid == "" {
-		return fmt.Errorf("active graphical login session %q has no uid", session.id)
+func (o opener) openLinuxInLoginSession(session loginSession, url string) error {
+	uid, err := strconv.Atoi(session.uid)
+	if err != nil || uid < 0 {
+		return fmt.Errorf("active graphical login session %q has invalid uid", session.id)
 	}
 
-	env := sessionEnv(session)
+	env := o.sessionEnv(session)
 	var candidates []commandSpec
-	if uid, err := strconv.Atoi(session.uid); err == nil && uid == getEUID() {
+	if uid == o.euid() {
 		candidates = append(candidates, commandSpec{name: "xdg-open", args: []string{url}, env: env})
-	} else if session.user != "" {
+	} else if validUsername(session.user) {
 		envArgs := append(append([]string{}, env...), "xdg-open", url)
-		candidates = append(candidates,
-			commandSpec{name: "runuser", args: append([]string{"-u", session.user, "--", "env"}, envArgs...)},
-			commandSpec{name: "sudo", args: append([]string{"-n", "-u", session.user, "env"}, envArgs...)},
-		)
+		candidates = append(candidates, commandSpec{name: "runuser", args: append([]string{"-u", session.user, "--", "env"}, envArgs...)})
 	} else {
-		return fmt.Errorf("active graphical login session %q has no username", session.id)
+		return fmt.Errorf("active graphical login session %q has invalid username", session.id)
 	}
 
 	var failures []string
 	for _, candidate := range candidates {
-		if err := runCommand(candidate); err != nil {
+		if err := o.run(candidate); err != nil {
 			failures = append(failures, err.Error())
 			continue
 		}
@@ -204,29 +218,31 @@ func openLinuxInLoginSession(session loginSession, url string) error {
 	)
 }
 
-func sessionEnv(session loginSession) []string {
-	runtimeDir := path.Join("/run/user", session.uid)
+func (o opener) sessionEnv(session loginSession) []string {
+	runtimeDir := linuxRuntimeDir(session.uid)
 	env := []string{
 		"XDG_RUNTIME_DIR=" + runtimeDir,
-		"DBUS_SESSION_BUS_ADDRESS=unix:path=" + path.Join(runtimeDir, "bus"),
+		"DBUS_SESSION_BUS_ADDRESS=unix:path=" + runtimeDir + "/bus",
 	}
 
-	if strings.HasPrefix(session.display, ":") {
+	switch {
+	case validX11Display(session.display):
 		env = append(env, "DISPLAY="+session.display)
-	} else if session.display != "" {
+	case validWaylandDisplay(session.display):
 		env = append(env, "WAYLAND_DISPLAY="+session.display)
 	}
 
 	if session.typ == "wayland" && !hasEnv(env, "WAYLAND_DISPLAY") {
-		if display := firstWaylandDisplay(runtimeDir); display != "" {
+		if display := o.firstWaylandDisplay(runtimeDir); display != "" {
 			env = append(env, "WAYLAND_DISPLAY="+display)
 		}
 	}
-	if session.typ == "x11" && !hasEnv(env, "DISPLAY") && fileExists("/tmp/.X11-unix/X0") {
-		env = append(env, "DISPLAY=:0")
-	}
 
 	return env
+}
+
+func linuxRuntimeDir(uid string) string {
+	return "/run/user/" + uid
 }
 
 func hasEnv(env []string, key string) bool {
@@ -239,31 +255,95 @@ func hasEnv(env []string, key string) bool {
 	return false
 }
 
-func firstWaylandDisplay(runtimeDir string) string {
-	matches, err := glob(path.Join(runtimeDir, "wayland-*"))
+func (o opener) firstWaylandDisplay(runtimeDir string) string {
+	matches, err := o.globFiles(runtimeDir + "/wayland-*")
 	if err != nil || len(matches) == 0 {
 		return ""
 	}
-	return path.Base(matches[0])
+	display := matches[0]
+	if slash := strings.LastIndex(display, "/"); slash >= 0 {
+		display = display[slash+1:]
+	}
+	if !validWaylandDisplay(display) {
+		return ""
+	}
+	return display
 }
 
-func fileExists(path string) bool {
-	_, err := stat(path)
-	return err == nil
+func validUsername(value string) bool {
+	if value == "" || len(value) > 32 {
+		return false
+	}
+	for i, r := range value {
+		if i == 0 {
+			if (r >= 'a' && r <= 'z') || r == '_' {
+				continue
+			}
+			return false
+		}
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
-func runOpenCommandDefault(spec commandSpec) error {
+func validX11Display(value string) bool {
+	if !strings.HasPrefix(value, ":") {
+		return false
+	}
+	rest := strings.TrimPrefix(value, ":")
+	if rest == "" {
+		return false
+	}
+	parts := strings.Split(rest, ".")
+	if len(parts) > 2 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || !allDigits(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func validWaylandDisplay(value string) bool {
+	if !strings.HasPrefix(value, "wayland-") {
+		return false
+	}
+	return allDigits(strings.TrimPrefix(value, "wayland-"))
+}
+
+func allDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func (o opener) run(spec commandSpec) error {
+	if o.runCommand != nil {
+		return o.runCommand(spec)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
 	defer cancel()
 
-	cmd := commandContext(ctx, spec.name, spec.args...)
+	cmd := o.command(ctx, spec.name, spec.args...)
 	if len(spec.env) > 0 {
 		cmd.Env = append(os.Environ(), spec.env...)
 	}
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		message := strings.TrimSpace(stderr.String())
+		message := sanitizeDiagnosticOutput(stderr.String())
 		if ctx.Err() == context.DeadlineExceeded {
 			return fmt.Errorf("%s timed out", spec.name)
 		}
@@ -275,13 +355,66 @@ func runOpenCommandDefault(spec commandSpec) error {
 	return nil
 }
 
-func commandOutputDefault(name string, args ...string) ([]byte, error) {
+func (o opener) output(name string, args ...string) ([]byte, error) {
+	if o.commandOutput != nil {
+		return o.commandOutput(name, args...)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
 	defer cancel()
 
-	out, err := commandContext(ctx, name, args...).Output()
+	out, err := o.command(ctx, name, args...).Output()
 	if ctx.Err() == context.DeadlineExceeded {
 		return nil, fmt.Errorf("%s timed out", name)
 	}
 	return out, err
+}
+
+func (o opener) command(ctx context.Context, name string, args ...string) *exec.Cmd {
+	if o.commandContext != nil {
+		return o.commandContext(ctx, name, args...)
+	}
+	return exec.CommandContext(ctx, name, args...)
+}
+
+func (o opener) env(key string) string {
+	if o.getenv != nil {
+		return o.getenv(key)
+	}
+	return os.Getenv(key)
+}
+
+func (o opener) euid() int {
+	if o.geteuid != nil {
+		return o.geteuid()
+	}
+	return os.Geteuid()
+}
+
+func (o opener) globFiles(pattern string) ([]string, error) {
+	if o.glob != nil {
+		return o.glob(pattern)
+	}
+	return filepath.Glob(pattern)
+}
+
+func sanitizeDiagnosticOutput(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteByte(' ')
+		case r >= 32 && r <= 126:
+			b.WriteRune(r)
+		}
+		if b.Len() >= maxDiagnosticOutputSize {
+			break
+		}
+	}
+	return strings.TrimSpace(b.String())
 }

--- a/go/internal/shared/browseropen/browseropen.go
+++ b/go/internal/shared/browseropen/browseropen.go
@@ -84,7 +84,7 @@ func (o opener) open(url string) error {
 
 func (o opener) openLinux(url string) error {
 	if o.hasCurrentGraphicalSessionEnv() {
-		return o.run(commandSpec{name: xdgOpenPath, args: []string{url}, minimalEnv: true})
+		return o.run(commandSpec{name: xdgOpenPath, args: []string{url}, env: o.currentGraphicalSessionEnv(), minimalEnv: true})
 	}
 
 	session, sessionErr := o.activeGraphicalLoginSession()
@@ -109,6 +109,19 @@ func (o opener) hasCurrentGraphicalSessionEnv() bool {
 		}
 	}
 	return false
+}
+
+func (o opener) currentGraphicalSessionEnv() []string {
+	var env []string
+	for _, key := range []string{"DISPLAY", "WAYLAND_DISPLAY", "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS"} {
+		if value := o.env(key); value != "" {
+			kv := key + "=" + value
+			if validateEnvAssignment(kv) == nil {
+				env = append(env, kv)
+			}
+		}
+	}
+	return env
 }
 
 type loginSession struct {
@@ -488,11 +501,21 @@ func (o opener) output(name string, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
 	defer cancel()
 
-	out, err := o.command(ctx, name, args...).Output()
+	cmd := o.command(ctx, name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if ctx.Err() == context.DeadlineExceeded {
 		return nil, fmt.Errorf("%s timed out", name)
 	}
-	return out, err
+	if err != nil {
+		message := sanitizeDiagnosticOutput(stderr.String())
+		if message != "" {
+			return out, fmt.Errorf("%s failed: %w: %s", name, err, message)
+		}
+		return out, fmt.Errorf("%s failed: %w", name, err)
+	}
+	return out, nil
 }
 
 func (o opener) command(ctx context.Context, name string, args ...string) *exec.Cmd {

--- a/go/internal/shared/browseropen/browseropen.go
+++ b/go/internal/shared/browseropen/browseropen.go
@@ -18,10 +18,13 @@ import (
 const (
 	openCommandTimeout      = 10 * time.Second
 	maxDiagnosticOutputSize = 512
-	maxGraphicalSessionUID  = 65535
-	envPath                 = "/usr/bin/env"
-	loginctlPath            = "/usr/bin/loginctl"
-	xdgOpenPath             = "/usr/bin/xdg-open"
+	// Browser session bridging targets normal interactive Linux users, not
+	// root or system accounts.
+	minGraphicalSessionUID = 1000
+	maxGraphicalSessionUID = 65535
+	envPath                = "/usr/bin/env"
+	loginctlPath           = "/usr/bin/loginctl"
+	xdgOpenPath            = "/usr/bin/xdg-open"
 )
 
 var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
@@ -131,7 +134,7 @@ func (o opener) activeGraphicalLoginSession() (loginSession, error) {
 			continue
 		}
 		if !validSessionID(fields[0]) {
-			failures = append(failures, fmt.Sprintf("%q: invalid login session id", sanitizeIdentifier(fields[0])))
+			failures = append(failures, "invalid login session id")
 			continue
 		}
 		session := loginSession{id: fields[0]}
@@ -155,7 +158,7 @@ func (o opener) activeGraphicalLoginSession() (loginSession, error) {
 			"--no-pager",
 		)
 		if err != nil {
-			failures = append(failures, fmt.Sprintf("%q: %s", sanitizeIdentifier(session.id), sanitizeDiagnosticOutput(err.Error())))
+			failures = append(failures, fmt.Sprintf("session query failed: %s", sanitizeDiagnosticOutput(err.Error())))
 			continue
 		}
 		propsMap := parseLoginctlProperties(string(props))
@@ -215,7 +218,7 @@ func (o opener) openLinuxInLoginSession(session loginSession, url string) error 
 
 	uid, err := validGraphicalSessionUID(session.uid)
 	if err != nil {
-		return fmt.Errorf("active graphical login session %q has invalid uid", sanitizeIdentifier(session.id))
+		return fmt.Errorf("active graphical login session has invalid uid")
 	}
 
 	session.uid = strconv.Itoa(uid)
@@ -228,14 +231,18 @@ func (o opener) openLinuxInLoginSession(session loginSession, url string) error 
 		candidates = append(candidates, commandSpec{name: xdgOpenPath, args: []string{url}, env: env, minimalEnv: true})
 	} else if validUsername(session.user) {
 		if o.euid() != 0 {
-			return fmt.Errorf("agent is not root; cannot open browser as session user %q", sanitizeIdentifier(session.user))
+			return fmt.Errorf("agent is not root; cannot open browser as graphical session user")
 		}
 		envArgs := append(append([]string{}, env...), xdgOpenPath, url)
-		for _, runuser := range o.runuserCandidates() {
+		runuserCandidates := o.runuserCandidates()
+		if len(runuserCandidates) == 0 {
+			return fmt.Errorf("no supported runuser path configured")
+		}
+		for _, runuser := range runuserCandidates {
 			candidates = append(candidates, commandSpec{name: runuser, args: append([]string{"-u", session.user, "--", envPath, "-i"}, envArgs...), minimalEnv: true})
 		}
 	} else {
-		return fmt.Errorf("active graphical login session %q has invalid username", sanitizeIdentifier(session.id))
+		return fmt.Errorf("active graphical login session has invalid username")
 	}
 
 	var failures []string
@@ -248,9 +255,7 @@ func (o opener) openLinuxInLoginSession(session loginSession, url string) error 
 	}
 
 	return fmt.Errorf(
-		"open browser in graphical login session %q for user %q failed: %s",
-		sanitizeIdentifier(session.id),
-		sanitizeIdentifier(session.user),
+		"open browser in graphical login session failed: %s",
 		strings.Join(failures, "; "),
 	)
 }
@@ -326,12 +331,12 @@ func validUsername(value string) bool {
 	}
 	for i, r := range value {
 		if i == 0 {
-			if (r >= 'a' && r <= 'z') || r == '_' {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' {
 				continue
 			}
 			return false
 		}
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
 			continue
 		}
 		return false
@@ -381,7 +386,7 @@ func validSessionID(value string) bool {
 
 func validGraphicalSessionUID(value string) (int, error) {
 	uid, err := strconv.Atoi(value)
-	if err != nil || uid <= 0 || uid > maxGraphicalSessionUID {
+	if err != nil || uid < minGraphicalSessionUID || uid > maxGraphicalSessionUID {
 		return 0, fmt.Errorf("invalid graphical session uid")
 	}
 	return uid, nil
@@ -410,6 +415,9 @@ func validateOpenURL(raw string) error {
 	case "http", "https":
 		if parsed.Host == "" {
 			return fmt.Errorf("invalid URL %q: must include a host", raw)
+		}
+		if parsed.User != nil {
+			return fmt.Errorf("invalid URL %q: must not include credentials", raw)
 		}
 		return nil
 	default:
@@ -516,10 +524,29 @@ func (o opener) globFiles(pattern string) ([]string, error) {
 }
 
 func (o opener) runuserCandidates() []string {
+	var candidates []string
 	if len(o.runuserPaths) > 0 {
-		return o.runuserPaths
+		candidates = o.runuserPaths
+	} else {
+		candidates = []string{"/usr/sbin/runuser", "/sbin/runuser"}
 	}
-	return []string{"/usr/sbin/runuser", "/sbin/runuser"}
+
+	valid := candidates[:0]
+	for _, candidate := range candidates {
+		if validRunuserPath(candidate) {
+			valid = append(valid, candidate)
+		}
+	}
+	return valid
+}
+
+func validRunuserPath(value string) bool {
+	switch value {
+	case "/usr/sbin/runuser", "/sbin/runuser":
+		return true
+	default:
+		return false
+	}
 }
 
 func (o opener) minimalCommandEnv() []string {

--- a/go/internal/shared/browseropen/browseropen.go
+++ b/go/internal/shared/browseropen/browseropen.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -16,12 +18,16 @@ import (
 const (
 	openCommandTimeout      = 10 * time.Second
 	maxDiagnosticOutputSize = 512
+	xdgOpenPath             = "/usr/bin/xdg-open"
 )
 
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+
 type commandSpec struct {
-	name string
-	args []string
-	env  []string
+	name       string
+	args       []string
+	env        []string
+	minimalEnv bool
 }
 
 type opener struct {
@@ -31,6 +37,7 @@ type opener struct {
 	getenv         func(string) string
 	geteuid        func() int
 	glob           func(string) ([]string, error)
+	runuserPaths   []string
 	runCommand     func(commandSpec) error
 }
 
@@ -41,6 +48,7 @@ func newDefaultOpener() opener {
 		getenv:         os.Getenv,
 		geteuid:        os.Geteuid,
 		glob:           filepath.Glob,
+		runuserPaths:   []string{"/usr/sbin/runuser", "/sbin/runuser"},
 	}
 }
 
@@ -52,9 +60,13 @@ func Open(url string) error {
 }
 
 func (o opener) open(url string) error {
+	if err := validateOpenURL(url); err != nil {
+		return err
+	}
+
 	switch o.runtimeGOOS {
 	case "darwin":
-		return o.run(commandSpec{name: "open", args: []string{url}})
+		return o.run(commandSpec{name: "/usr/bin/open", args: []string{url}})
 	case "linux":
 		return o.openLinux(url)
 	case "windows":
@@ -66,7 +78,7 @@ func (o opener) open(url string) error {
 
 func (o opener) openLinux(url string) error {
 	if o.hasCurrentGraphicalSessionEnv() {
-		return o.run(commandSpec{name: "xdg-open", args: []string{url}})
+		return o.run(commandSpec{name: xdgOpenPath, args: []string{url}, minimalEnv: true})
 	}
 
 	session, sessionErr := o.activeGraphicalLoginSession()
@@ -78,7 +90,7 @@ func (o opener) openLinux(url string) error {
 		}
 	}
 
-	if err := o.run(commandSpec{name: "xdg-open", args: []string{url}}); err != nil {
+	if err := o.run(commandSpec{name: xdgOpenPath, args: []string{url}, minimalEnv: true}); err != nil {
 		return fmt.Errorf("xdg-open failed without a graphical session: %w; loginctl: %v", err, sessionErr)
 	}
 	return nil
@@ -109,6 +121,7 @@ func (o opener) activeGraphicalLoginSession() (loginSession, error) {
 		return loginSession{}, fmt.Errorf("list login sessions: %w", err)
 	}
 
+	var failures []string
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) == 0 {
@@ -135,6 +148,7 @@ func (o opener) activeGraphicalLoginSession() (loginSession, error) {
 			"--no-pager",
 		)
 		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %s", session.id, sanitizeDiagnosticOutput(err.Error())))
 			continue
 		}
 		propsMap := parseLoginctlProperties(string(props))
@@ -154,6 +168,9 @@ func (o opener) activeGraphicalLoginSession() (loginSession, error) {
 		}
 	}
 
+	if len(failures) > 0 {
+		return loginSession{}, fmt.Errorf("no active graphical login session found; loginctl show-session failures: %s", strings.Join(failures, "; "))
+	}
 	return loginSession{}, fmt.Errorf("no active graphical login session found")
 }
 
@@ -190,13 +207,19 @@ func (o opener) openLinuxInLoginSession(session loginSession, url string) error 
 		return fmt.Errorf("active graphical login session %q has invalid uid", session.id)
 	}
 
-	env := o.sessionEnv(session)
+	session.uid = strconv.Itoa(uid)
+	env, err := o.sessionEnv(session)
+	if err != nil {
+		return err
+	}
 	var candidates []commandSpec
 	if uid == o.euid() {
-		candidates = append(candidates, commandSpec{name: "xdg-open", args: []string{url}, env: env})
+		candidates = append(candidates, commandSpec{name: xdgOpenPath, args: []string{url}, env: env, minimalEnv: true})
 	} else if validUsername(session.user) {
-		envArgs := append(append([]string{}, env...), "xdg-open", url)
-		candidates = append(candidates, commandSpec{name: "runuser", args: append([]string{"-u", session.user, "--", "env"}, envArgs...)})
+		envArgs := append(append([]string{}, env...), xdgOpenPath, url)
+		for _, runuser := range o.runuserCandidates() {
+			candidates = append(candidates, commandSpec{name: runuser, args: append([]string{"-u", session.user, "--", "env", "-i"}, envArgs...), minimalEnv: true})
+		}
 	} else {
 		return fmt.Errorf("active graphical login session %q has invalid username", session.id)
 	}
@@ -218,8 +241,11 @@ func (o opener) openLinuxInLoginSession(session loginSession, url string) error 
 	)
 }
 
-func (o opener) sessionEnv(session loginSession) []string {
-	runtimeDir := linuxRuntimeDir(session.uid)
+func (o opener) sessionEnv(session loginSession) ([]string, error) {
+	runtimeDir, err := linuxRuntimeDir(session.uid)
+	if err != nil {
+		return nil, err
+	}
 	env := []string{
 		"XDG_RUNTIME_DIR=" + runtimeDir,
 		"DBUS_SESSION_BUS_ADDRESS=unix:path=" + runtimeDir + "/bus",
@@ -238,11 +264,14 @@ func (o opener) sessionEnv(session loginSession) []string {
 		}
 	}
 
-	return env
+	return env, nil
 }
 
-func linuxRuntimeDir(uid string) string {
-	return "/run/user/" + uid
+func linuxRuntimeDir(uid string) (string, error) {
+	if !allDigits(uid) {
+		return "", fmt.Errorf("invalid uid for graphical runtime directory")
+	}
+	return "/run/user/" + uid, nil
 }
 
 func hasEnv(env []string, key string) bool {
@@ -316,6 +345,25 @@ func validWaylandDisplay(value string) bool {
 	return allDigits(strings.TrimPrefix(value, "wayland-"))
 }
 
+func validateOpenURL(raw string) error {
+	if strings.HasPrefix(raw, "-") {
+		return fmt.Errorf("invalid URL %q: must not begin with '-'", raw)
+	}
+	parsed, err := url.ParseRequestURI(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", raw, err)
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+		if parsed.Host == "" {
+			return fmt.Errorf("invalid URL %q: must include a host", raw)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
+	}
+}
+
 func allDigits(value string) bool {
 	if value == "" {
 		return false
@@ -337,8 +385,8 @@ func (o opener) run(spec commandSpec) error {
 	defer cancel()
 
 	cmd := o.command(ctx, spec.name, spec.args...)
-	if len(spec.env) > 0 {
-		cmd.Env = append(os.Environ(), spec.env...)
+	if spec.minimalEnv || len(spec.env) > 0 {
+		cmd.Env = append(o.minimalCommandEnv(), spec.env...)
 	}
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -398,7 +446,25 @@ func (o opener) globFiles(pattern string) ([]string, error) {
 	return filepath.Glob(pattern)
 }
 
+func (o opener) runuserCandidates() []string {
+	if len(o.runuserPaths) > 0 {
+		return o.runuserPaths
+	}
+	return []string{"/usr/sbin/runuser", "/sbin/runuser"}
+}
+
+func (o opener) minimalCommandEnv() []string {
+	env := []string{"PATH=/usr/bin:/bin:/usr/sbin:/sbin"}
+	for _, key := range []string{"HOME", "USER", "LOGNAME"} {
+		if value := o.env(key); value != "" && !strings.ContainsAny(value, "\x00\r\n") {
+			env = append(env, key+"="+value)
+		}
+	}
+	return env
+}
+
 func sanitizeDiagnosticOutput(value string) string {
+	value = ansiEscapePattern.ReplaceAllString(value, "")
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return ""

--- a/go/internal/shared/browseropen/browseropen.go
+++ b/go/internal/shared/browseropen/browseropen.go
@@ -1,30 +1,287 @@
 package browseropen
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
+	"time"
 )
+
+const openCommandTimeout = 10 * time.Second
+
+var (
+	goos           = runtime.GOOS
+	commandContext = exec.CommandContext
+	commandOutput  = commandOutputDefault
+	getEnv         = os.Getenv
+	getEUID        = os.Geteuid
+	glob           = filepath.Glob
+	runCommand     = runOpenCommandDefault
+	stat           = os.Stat
+)
+
+type commandSpec struct {
+	name string
+	args []string
+	env  []string
+}
 
 // Open opens url in the platform default browser without waiting for the
 // browser process to exit.
 func Open(url string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
+	switch goos {
 	case "darwin":
-		cmd = exec.Command("open", url)
+		return runCommand(commandSpec{name: "open", args: []string{url}})
 	case "linux":
-		cmd = exec.Command("xdg-open", url)
+		return openLinux(url)
 	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+		return runCommand(commandSpec{name: "rundll32", args: []string{"url.dll,FileProtocolHandler", url}})
 	default:
-		return fmt.Errorf("unsupported platform %q", runtime.GOOS)
+		return fmt.Errorf("unsupported platform %q", goos)
 	}
-	if err := cmd.Start(); err != nil {
-		return err
+}
+
+func openLinux(url string) error {
+	if hasCurrentGraphicalSessionEnv() {
+		return runCommand(commandSpec{name: "xdg-open", args: []string{url}})
 	}
-	go func() {
-		_ = cmd.Wait()
-	}()
+
+	session, sessionErr := activeGraphicalLoginSession()
+	if sessionErr == nil {
+		if err := openLinuxInLoginSession(session, url); err == nil {
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	if err := runCommand(commandSpec{name: "xdg-open", args: []string{url}}); err != nil {
+		return fmt.Errorf("xdg-open failed without a graphical session: %w; loginctl: %v", err, sessionErr)
+	}
 	return nil
+}
+
+func hasCurrentGraphicalSessionEnv() bool {
+	for _, key := range []string{"DISPLAY", "WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS"} {
+		if getEnv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+type loginSession struct {
+	id      string
+	uid     string
+	user    string
+	class   string
+	typ     string
+	display string
+	active  bool
+}
+
+func activeGraphicalLoginSession() (loginSession, error) {
+	out, err := commandOutput("loginctl", "list-sessions", "--no-legend", "--no-pager")
+	if err != nil {
+		return loginSession{}, fmt.Errorf("list login sessions: %w", err)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		session := loginSession{id: fields[0]}
+		if len(fields) > 1 {
+			session.uid = fields[1]
+		}
+		if len(fields) > 2 {
+			session.user = fields[2]
+		}
+
+		props, err := commandOutput(
+			"loginctl",
+			"show-session",
+			session.id,
+			"--property=Active",
+			"--property=Class",
+			"--property=Display",
+			"--property=Name",
+			"--property=Type",
+			"--property=User",
+			"--no-pager",
+		)
+		if err != nil {
+			continue
+		}
+		propsMap := parseLoginctlProperties(string(props))
+		if user := propsMap["User"]; user != "" {
+			session.uid = user
+		}
+		if name := propsMap["Name"]; name != "" {
+			session.user = name
+		}
+		session.class = propsMap["Class"]
+		session.typ = propsMap["Type"]
+		session.display = propsMap["Display"]
+		session.active = propsMap["Active"] == "yes"
+
+		if session.isGraphicalUserSession() {
+			return session, nil
+		}
+	}
+
+	return loginSession{}, fmt.Errorf("no active graphical login session found")
+}
+
+func parseLoginctlProperties(raw string) map[string]string {
+	props := make(map[string]string)
+	for _, line := range strings.Split(raw, "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		props[key] = value
+	}
+	return props
+}
+
+func (s loginSession) isGraphicalUserSession() bool {
+	if !s.active {
+		return false
+	}
+	if s.class != "" && s.class != "user" {
+		return false
+	}
+	switch s.typ {
+	case "x11", "wayland", "mir":
+		return true
+	default:
+		return s.display != ""
+	}
+}
+
+func openLinuxInLoginSession(session loginSession, url string) error {
+	if session.uid == "" {
+		return fmt.Errorf("active graphical login session %q has no uid", session.id)
+	}
+
+	env := sessionEnv(session)
+	var candidates []commandSpec
+	if uid, err := strconv.Atoi(session.uid); err == nil && uid == getEUID() {
+		candidates = append(candidates, commandSpec{name: "xdg-open", args: []string{url}, env: env})
+	} else if session.user != "" {
+		envArgs := append(append([]string{}, env...), "xdg-open", url)
+		candidates = append(candidates,
+			commandSpec{name: "runuser", args: append([]string{"-u", session.user, "--", "env"}, envArgs...)},
+			commandSpec{name: "sudo", args: append([]string{"-n", "-u", session.user, "env"}, envArgs...)},
+		)
+	} else {
+		return fmt.Errorf("active graphical login session %q has no username", session.id)
+	}
+
+	var failures []string
+	for _, candidate := range candidates {
+		if err := runCommand(candidate); err != nil {
+			failures = append(failures, err.Error())
+			continue
+		}
+		return nil
+	}
+
+	return fmt.Errorf(
+		"open browser in graphical login session %s for user %s failed: %s",
+		session.id,
+		session.user,
+		strings.Join(failures, "; "),
+	)
+}
+
+func sessionEnv(session loginSession) []string {
+	runtimeDir := path.Join("/run/user", session.uid)
+	env := []string{
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"DBUS_SESSION_BUS_ADDRESS=unix:path=" + path.Join(runtimeDir, "bus"),
+	}
+
+	if strings.HasPrefix(session.display, ":") {
+		env = append(env, "DISPLAY="+session.display)
+	} else if session.display != "" {
+		env = append(env, "WAYLAND_DISPLAY="+session.display)
+	}
+
+	if session.typ == "wayland" && !hasEnv(env, "WAYLAND_DISPLAY") {
+		if display := firstWaylandDisplay(runtimeDir); display != "" {
+			env = append(env, "WAYLAND_DISPLAY="+display)
+		}
+	}
+	if session.typ == "x11" && !hasEnv(env, "DISPLAY") && fileExists("/tmp/.X11-unix/X0") {
+		env = append(env, "DISPLAY=:0")
+	}
+
+	return env
+}
+
+func hasEnv(env []string, key string) bool {
+	prefix := key + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstWaylandDisplay(runtimeDir string) string {
+	matches, err := glob(path.Join(runtimeDir, "wayland-*"))
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	return path.Base(matches[0])
+}
+
+func fileExists(path string) bool {
+	_, err := stat(path)
+	return err == nil
+}
+
+func runOpenCommandDefault(spec commandSpec) error {
+	ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
+	defer cancel()
+
+	cmd := commandContext(ctx, spec.name, spec.args...)
+	if len(spec.env) > 0 {
+		cmd.Env = append(os.Environ(), spec.env...)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("%s timed out", spec.name)
+		}
+		if message != "" {
+			return fmt.Errorf("%s failed: %w: %s", spec.name, err, message)
+		}
+		return fmt.Errorf("%s failed: %w", spec.name, err)
+	}
+	return nil
+}
+
+func commandOutputDefault(name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
+	defer cancel()
+
+	out, err := commandContext(ctx, name, args...).Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("%s timed out", name)
+	}
+	return out, err
 }

--- a/go/internal/shared/browseropen/browseropen.go
+++ b/go/internal/shared/browseropen/browseropen.go
@@ -18,6 +18,9 @@ import (
 const (
 	openCommandTimeout      = 10 * time.Second
 	maxDiagnosticOutputSize = 512
+	maxGraphicalSessionUID  = 65535
+	envPath                 = "/usr/bin/env"
+	loginctlPath            = "/usr/bin/loginctl"
 	xdgOpenPath             = "/usr/bin/xdg-open"
 )
 
@@ -116,7 +119,7 @@ type loginSession struct {
 }
 
 func (o opener) activeGraphicalLoginSession() (loginSession, error) {
-	out, err := o.output("loginctl", "list-sessions", "--no-legend", "--no-pager")
+	out, err := o.output(loginctlPath, "list-sessions", "--no-legend", "--no-pager")
 	if err != nil {
 		return loginSession{}, fmt.Errorf("list login sessions: %w", err)
 	}
@@ -125,6 +128,10 @@ func (o opener) activeGraphicalLoginSession() (loginSession, error) {
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) == 0 {
+			continue
+		}
+		if !validSessionID(fields[0]) {
+			failures = append(failures, fmt.Sprintf("%q: invalid login session id", sanitizeIdentifier(fields[0])))
 			continue
 		}
 		session := loginSession{id: fields[0]}
@@ -136,7 +143,7 @@ func (o opener) activeGraphicalLoginSession() (loginSession, error) {
 		}
 
 		props, err := o.output(
-			"loginctl",
+			loginctlPath,
 			"show-session",
 			session.id,
 			"--property=Active",
@@ -148,7 +155,7 @@ func (o opener) activeGraphicalLoginSession() (loginSession, error) {
 			"--no-pager",
 		)
 		if err != nil {
-			failures = append(failures, fmt.Sprintf("%s: %s", session.id, sanitizeDiagnosticOutput(err.Error())))
+			failures = append(failures, fmt.Sprintf("%q: %s", sanitizeIdentifier(session.id), sanitizeDiagnosticOutput(err.Error())))
 			continue
 		}
 		propsMap := parseLoginctlProperties(string(props))
@@ -202,9 +209,13 @@ func (s loginSession) isGraphicalUserSession() bool {
 }
 
 func (o opener) openLinuxInLoginSession(session loginSession, url string) error {
-	uid, err := strconv.Atoi(session.uid)
-	if err != nil || uid < 0 {
-		return fmt.Errorf("active graphical login session %q has invalid uid", session.id)
+	if err := validateOpenURL(url); err != nil {
+		return err
+	}
+
+	uid, err := validGraphicalSessionUID(session.uid)
+	if err != nil {
+		return fmt.Errorf("active graphical login session %q has invalid uid", sanitizeIdentifier(session.id))
 	}
 
 	session.uid = strconv.Itoa(uid)
@@ -216,12 +227,15 @@ func (o opener) openLinuxInLoginSession(session loginSession, url string) error 
 	if uid == o.euid() {
 		candidates = append(candidates, commandSpec{name: xdgOpenPath, args: []string{url}, env: env, minimalEnv: true})
 	} else if validUsername(session.user) {
+		if o.euid() != 0 {
+			return fmt.Errorf("agent is not root; cannot open browser as session user %q", sanitizeIdentifier(session.user))
+		}
 		envArgs := append(append([]string{}, env...), xdgOpenPath, url)
 		for _, runuser := range o.runuserCandidates() {
-			candidates = append(candidates, commandSpec{name: runuser, args: append([]string{"-u", session.user, "--", "env", "-i"}, envArgs...), minimalEnv: true})
+			candidates = append(candidates, commandSpec{name: runuser, args: append([]string{"-u", session.user, "--", envPath, "-i"}, envArgs...), minimalEnv: true})
 		}
 	} else {
-		return fmt.Errorf("active graphical login session %q has invalid username", session.id)
+		return fmt.Errorf("active graphical login session %q has invalid username", sanitizeIdentifier(session.id))
 	}
 
 	var failures []string
@@ -234,9 +248,9 @@ func (o opener) openLinuxInLoginSession(session loginSession, url string) error 
 	}
 
 	return fmt.Errorf(
-		"open browser in graphical login session %s for user %s failed: %s",
-		session.id,
-		session.user,
+		"open browser in graphical login session %q for user %q failed: %s",
+		sanitizeIdentifier(session.id),
+		sanitizeIdentifier(session.user),
 		strings.Join(failures, "; "),
 	)
 }
@@ -264,14 +278,21 @@ func (o opener) sessionEnv(session loginSession) ([]string, error) {
 		}
 	}
 
+	for _, kv := range env {
+		if err := validateEnvAssignment(kv); err != nil {
+			return nil, err
+		}
+	}
+
 	return env, nil
 }
 
 func linuxRuntimeDir(uid string) (string, error) {
-	if !allDigits(uid) {
+	parsedUID, err := validGraphicalSessionUID(uid)
+	if err != nil {
 		return "", fmt.Errorf("invalid uid for graphical runtime directory")
 	}
-	return "/run/user/" + uid, nil
+	return "/run/user/" + strconv.Itoa(parsedUID), nil
 }
 
 func hasEnv(env []string, key string) bool {
@@ -345,6 +366,38 @@ func validWaylandDisplay(value string) bool {
 	return allDigits(strings.TrimPrefix(value, "wayland-"))
 }
 
+func validSessionID(value string) bool {
+	if value == "" || len(value) > 64 {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validGraphicalSessionUID(value string) (int, error) {
+	uid, err := strconv.Atoi(value)
+	if err != nil || uid <= 0 || uid > maxGraphicalSessionUID {
+		return 0, fmt.Errorf("invalid graphical session uid")
+	}
+	return uid, nil
+}
+
+func validateEnvAssignment(value string) error {
+	name, envValue, ok := strings.Cut(value, "=")
+	if !ok || name == "" || envValue == "" {
+		return fmt.Errorf("invalid environment assignment")
+	}
+	if strings.ContainsAny(name, "\x00\r\n=") || strings.ContainsAny(envValue, "\x00\r\n") {
+		return fmt.Errorf("invalid environment assignment")
+	}
+	return nil
+}
+
 func validateOpenURL(raw string) error {
 	if strings.HasPrefix(raw, "-") {
 		return fmt.Errorf("invalid URL %q: must not begin with '-'", raw)
@@ -362,6 +415,22 @@ func validateOpenURL(raw string) error {
 	default:
 		return fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
 	}
+}
+
+func sanitizeIdentifier(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			b.WriteRune(r)
+			if b.Len() >= 64 {
+				break
+			}
+		}
+	}
+	if b.Len() == 0 {
+		return "unknown"
+	}
+	return b.String()
 }
 
 func allDigits(value string) bool {
@@ -477,6 +546,8 @@ func sanitizeDiagnosticOutput(value string) string {
 			b.WriteByte(' ')
 		case r >= 32 && r <= 126:
 			b.WriteRune(r)
+		default:
+			b.WriteByte('?')
 		}
 		if b.Len() >= maxDiagnosticOutputSize {
 			break

--- a/go/internal/shared/browseropen/browseropen_test.go
+++ b/go/internal/shared/browseropen/browseropen_test.go
@@ -52,13 +52,23 @@ func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
 	op.runuserPaths = []string{"/usr/sbin/runuser"}
 
 	op.commandOutput = func(name string, args ...string) ([]byte, error) {
-		if name != "loginctl" {
+		if name != loginctlPath {
 			t.Fatalf("unexpected command output request: %s %v", name, args)
 		}
-		switch args[0] {
-		case "list-sessions":
+		if reflect.DeepEqual(args, []string{"list-sessions", "--no-legend", "--no-pager"}) {
 			return []byte("2 1000 alice seat0 tty2\n"), nil
-		case "show-session":
+		}
+		if reflect.DeepEqual(args, []string{
+			"show-session",
+			"2",
+			"--property=Active",
+			"--property=Class",
+			"--property=Display",
+			"--property=Name",
+			"--property=Type",
+			"--property=User",
+			"--no-pager",
+		}) {
 			return []byte(strings.Join([]string{
 				"Active=yes",
 				"Class=user",
@@ -68,10 +78,9 @@ func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
 				"User=1000",
 				"",
 			}, "\n")), nil
-		default:
-			t.Fatalf("unexpected loginctl args: %v", args)
-			return nil, nil
 		}
+		t.Fatalf("unexpected loginctl args: %v", args)
+		return nil, nil
 	}
 	op.glob = func(pattern string) ([]string, error) {
 		if pattern != "/run/user/1000/wayland-*" {
@@ -91,7 +100,7 @@ func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
 	}
 
 	wantArgs := []string{
-		"-u", "alice", "--", "env", "-i",
+		"-u", "alice", "--", envPath, "-i",
 		"XDG_RUNTIME_DIR=/run/user/1000",
 		"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus",
 		"WAYLAND_DISPLAY=wayland-1",
@@ -109,7 +118,7 @@ func TestOpenLinuxRejectsInvalidSessionIdentity(t *testing.T) {
 	op := testOpener()
 
 	op.commandOutput = func(name string, args ...string) ([]byte, error) {
-		if name != "loginctl" {
+		if name != loginctlPath {
 			t.Fatalf("unexpected command output request: %s %v", name, args)
 		}
 		switch args[0] {
@@ -148,7 +157,7 @@ func TestOpenLinuxReportsMissingGraphicalSession(t *testing.T) {
 	op := testOpener()
 
 	op.commandOutput = func(name string, args ...string) ([]byte, error) {
-		if name != "loginctl" || args[0] != "list-sessions" {
+		if name != loginctlPath || args[0] != "list-sessions" {
 			t.Fatalf("unexpected command output request: %s %v", name, args)
 		}
 		return []byte("\n"), nil
@@ -181,11 +190,28 @@ func TestValidateSessionValues(t *testing.T) {
 	if !validUsername("alice_1") || validUsername("Alice") || validUsername("alice;bad") {
 		t.Fatal("validUsername did not enforce expected Linux username shape")
 	}
+	if !validSessionID("session-2") || validSessionID("../../bad") {
+		t.Fatal("validSessionID did not enforce expected session id shape")
+	}
 	if !validX11Display(":0") || !validX11Display(":0.0") || validX11Display(":bad") {
 		t.Fatal("validX11Display did not enforce expected display shape")
 	}
 	if !validWaylandDisplay("wayland-0") || validWaylandDisplay("wayland-main") {
 		t.Fatal("validWaylandDisplay did not enforce expected display shape")
+	}
+	if _, err := validGraphicalSessionUID("1000"); err != nil {
+		t.Fatalf("validGraphicalSessionUID returned error for normal uid: %v", err)
+	}
+	for _, uid := range []string{"0", "-1", "999999"} {
+		if _, err := validGraphicalSessionUID(uid); err == nil {
+			t.Fatalf("validGraphicalSessionUID(%q) unexpectedly succeeded", uid)
+		}
+	}
+	if err := validateEnvAssignment("DISPLAY=:0"); err != nil {
+		t.Fatalf("validateEnvAssignment returned error for DISPLAY: %v", err)
+	}
+	if err := validateEnvAssignment("DISPLAY=:0\nBAD=1"); err == nil {
+		t.Fatal("validateEnvAssignment unexpectedly accepted newline")
 	}
 }
 
@@ -222,8 +248,8 @@ func TestMinimalCommandEnvOmitsUnrelatedVariables(t *testing.T) {
 }
 
 func TestSanitizeDiagnosticOutput(t *testing.T) {
-	got := sanitizeDiagnosticOutput("bad\x1b[31m\nnext\tline")
-	if got != "bad next line" {
+	got := sanitizeDiagnosticOutput("bad\x1b[31m\nnext\tline\u202e")
+	if got != "bad next line?" {
 		t.Fatalf("sanitizeDiagnosticOutput = %q; want printable single-line output", got)
 	}
 }

--- a/go/internal/shared/browseropen/browseropen_test.go
+++ b/go/internal/shared/browseropen/browseropen_test.go
@@ -1,0 +1,152 @@
+package browseropen
+
+import (
+	"errors"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func withTestHooks(t *testing.T) {
+	t.Helper()
+
+	oldGOOS := goos
+	oldCommandOutput := commandOutput
+	oldGetEnv := getEnv
+	oldGetEUID := getEUID
+	oldGlob := glob
+	oldRunCommand := runCommand
+	oldStat := stat
+
+	t.Cleanup(func() {
+		goos = oldGOOS
+		commandOutput = oldCommandOutput
+		getEnv = oldGetEnv
+		getEUID = oldGetEUID
+		glob = oldGlob
+		runCommand = oldRunCommand
+		stat = oldStat
+	})
+
+	goos = "linux"
+	getEnv = func(string) string { return "" }
+	getEUID = func() int { return 0 }
+	glob = func(string) ([]string, error) { return nil, nil }
+	stat = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+}
+
+func TestOpenLinuxUsesCurrentGraphicalSessionEnv(t *testing.T) {
+	withTestHooks(t)
+
+	env := map[string]string{"DISPLAY": ":1"}
+	getEnv = func(key string) string { return env[key] }
+	commandOutput = func(string, ...string) ([]byte, error) {
+		t.Fatal("loginctl should not be queried when current process has a display")
+		return nil, nil
+	}
+
+	var got commandSpec
+	runCommand = func(spec commandSpec) error {
+		got = spec
+		return nil
+	}
+
+	if err := Open("https://example.com"); err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+
+	if got.name != "xdg-open" || !reflect.DeepEqual(got.args, []string{"https://example.com"}) {
+		t.Fatalf("command = %#v; want xdg-open URL", got)
+	}
+	if len(got.env) != 0 {
+		t.Fatalf("direct xdg-open env = %v; want no overrides", got.env)
+	}
+}
+
+func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
+	withTestHooks(t)
+
+	commandOutput = func(name string, args ...string) ([]byte, error) {
+		if name != "loginctl" {
+			t.Fatalf("unexpected command output request: %s %v", name, args)
+		}
+		switch args[0] {
+		case "list-sessions":
+			return []byte("2 1000 alice seat0 tty2\n"), nil
+		case "show-session":
+			return []byte(strings.Join([]string{
+				"Active=yes",
+				"Class=user",
+				"Display=",
+				"Name=alice",
+				"Type=wayland",
+				"User=1000",
+				"",
+			}, "\n")), nil
+		default:
+			t.Fatalf("unexpected loginctl args: %v", args)
+			return nil, nil
+		}
+	}
+	glob = func(pattern string) ([]string, error) {
+		if pattern != "/run/user/1000/wayland-*" {
+			t.Fatalf("glob pattern = %q; want wayland runtime socket pattern", pattern)
+		}
+		return []string{"/run/user/1000/wayland-1"}, nil
+	}
+
+	var got commandSpec
+	runCommand = func(spec commandSpec) error {
+		got = spec
+		return nil
+	}
+
+	if err := Open("http://wendy-ser9.local:3001"); err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+
+	wantArgs := []string{
+		"-u", "alice", "--", "env",
+		"XDG_RUNTIME_DIR=/run/user/1000",
+		"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus",
+		"WAYLAND_DISPLAY=wayland-1",
+		"xdg-open", "http://wendy-ser9.local:3001",
+	}
+	if got.name != "runuser" || !reflect.DeepEqual(got.args, wantArgs) {
+		t.Fatalf("command = %#v; want runuser session bridge", got)
+	}
+}
+
+func TestOpenLinuxReportsMissingGraphicalSession(t *testing.T) {
+	withTestHooks(t)
+
+	commandOutput = func(name string, args ...string) ([]byte, error) {
+		if name != "loginctl" || args[0] != "list-sessions" {
+			t.Fatalf("unexpected command output request: %s %v", name, args)
+		}
+		return []byte("\n"), nil
+	}
+	runCommand = func(spec commandSpec) error {
+		if spec.name != "xdg-open" {
+			t.Fatalf("command = %#v; want xdg-open fallback", spec)
+		}
+		return errors.New("exit status 3")
+	}
+
+	err := Open("https://example.com")
+	if err == nil {
+		t.Fatal("expected error when xdg-open fails and no graphical session exists")
+	}
+	if !strings.Contains(err.Error(), "no active graphical login session found") {
+		t.Fatalf("error = %q; want missing graphical session diagnostic", err)
+	}
+}
+
+func TestParseLoginctlProperties(t *testing.T) {
+	props := parseLoginctlProperties("Active=yes\nType=x11\nIgnoredLine\nDisplay=:0\n")
+
+	if props["Active"] != "yes" || props["Type"] != "x11" || props["Display"] != ":0" {
+		t.Fatalf("props = %#v; want parsed loginctl properties", props)
+	}
+}

--- a/go/internal/shared/browseropen/browseropen_test.go
+++ b/go/internal/shared/browseropen/browseropen_test.go
@@ -1,8 +1,11 @@
 package browseropen
 
 import (
+	"context"
 	"errors"
+	"os/exec"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -19,7 +22,12 @@ func testOpener() opener {
 func TestOpenLinuxUsesCurrentGraphicalSessionEnv(t *testing.T) {
 	op := testOpener()
 
-	env := map[string]string{"DISPLAY": ":1"}
+	env := map[string]string{
+		"DISPLAY":                  ":1",
+		"WAYLAND_DISPLAY":          "wayland-0",
+		"XDG_RUNTIME_DIR":          "/run/user/1000",
+		"DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/1000/bus",
+	}
 	op.getenv = func(key string) string { return env[key] }
 	op.commandOutput = func(string, ...string) ([]byte, error) {
 		t.Fatal("loginctl should not be queried when current process has a display")
@@ -42,8 +50,14 @@ func TestOpenLinuxUsesCurrentGraphicalSessionEnv(t *testing.T) {
 	if !got.minimalEnv {
 		t.Fatalf("command = %#v; want minimal environment", got)
 	}
-	if len(got.env) != 0 {
-		t.Fatalf("direct xdg-open env = %v; want no overrides", got.env)
+	wantEnv := []string{
+		"DISPLAY=:1",
+		"WAYLAND_DISPLAY=wayland-0",
+		"XDG_RUNTIME_DIR=/run/user/1000",
+		"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus",
+	}
+	if !reflect.DeepEqual(got.env, wantEnv) {
+		t.Fatalf("direct xdg-open env = %v; want current graphical session env", got.env)
 	}
 }
 
@@ -247,6 +261,28 @@ func TestMinimalCommandEnvOmitsUnrelatedVariables(t *testing.T) {
 		if strings.HasPrefix(kv, "API_TOKEN=") {
 			t.Fatalf("minimalCommandEnv leaked unrelated variable: %v", got)
 		}
+	}
+}
+
+func TestOutputIncludesSanitizedStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command shape is platform-specific")
+	}
+
+	op := testOpener()
+	op.commandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "printf '\\033[31mpermission denied\\n' >&2; exit 12")
+	}
+
+	_, err := op.output(loginctlPath, "show-session", "2")
+	if err == nil {
+		t.Fatal("expected command failure")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("error = %q; want sanitized stderr", err)
+	}
+	if strings.Contains(err.Error(), "\x1b") {
+		t.Fatalf("error = %q; want ANSI escapes stripped", err)
 	}
 }
 

--- a/go/internal/shared/browseropen/browseropen_test.go
+++ b/go/internal/shared/browseropen/browseropen_test.go
@@ -2,57 +2,37 @@ package browseropen
 
 import (
 	"errors"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
 )
 
-func withTestHooks(t *testing.T) {
-	t.Helper()
-
-	oldGOOS := goos
-	oldCommandOutput := commandOutput
-	oldGetEnv := getEnv
-	oldGetEUID := getEUID
-	oldGlob := glob
-	oldRunCommand := runCommand
-	oldStat := stat
-
-	t.Cleanup(func() {
-		goos = oldGOOS
-		commandOutput = oldCommandOutput
-		getEnv = oldGetEnv
-		getEUID = oldGetEUID
-		glob = oldGlob
-		runCommand = oldRunCommand
-		stat = oldStat
-	})
-
-	goos = "linux"
-	getEnv = func(string) string { return "" }
-	getEUID = func() int { return 0 }
-	glob = func(string) ([]string, error) { return nil, nil }
-	stat = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+func testOpener() opener {
+	return opener{
+		runtimeGOOS: "linux",
+		getenv:      func(string) string { return "" },
+		geteuid:     func() int { return 0 },
+		glob:        func(string) ([]string, error) { return nil, nil },
+	}
 }
 
 func TestOpenLinuxUsesCurrentGraphicalSessionEnv(t *testing.T) {
-	withTestHooks(t)
+	op := testOpener()
 
 	env := map[string]string{"DISPLAY": ":1"}
-	getEnv = func(key string) string { return env[key] }
-	commandOutput = func(string, ...string) ([]byte, error) {
+	op.getenv = func(key string) string { return env[key] }
+	op.commandOutput = func(string, ...string) ([]byte, error) {
 		t.Fatal("loginctl should not be queried when current process has a display")
 		return nil, nil
 	}
 
 	var got commandSpec
-	runCommand = func(spec commandSpec) error {
+	op.runCommand = func(spec commandSpec) error {
 		got = spec
 		return nil
 	}
 
-	if err := Open("https://example.com"); err != nil {
+	if err := op.open("https://example.com"); err != nil {
 		t.Fatalf("Open returned error: %v", err)
 	}
 
@@ -65,9 +45,9 @@ func TestOpenLinuxUsesCurrentGraphicalSessionEnv(t *testing.T) {
 }
 
 func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
-	withTestHooks(t)
+	op := testOpener()
 
-	commandOutput = func(name string, args ...string) ([]byte, error) {
+	op.commandOutput = func(name string, args ...string) ([]byte, error) {
 		if name != "loginctl" {
 			t.Fatalf("unexpected command output request: %s %v", name, args)
 		}
@@ -89,7 +69,7 @@ func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
 			return nil, nil
 		}
 	}
-	glob = func(pattern string) ([]string, error) {
+	op.glob = func(pattern string) ([]string, error) {
 		if pattern != "/run/user/1000/wayland-*" {
 			t.Fatalf("glob pattern = %q; want wayland runtime socket pattern", pattern)
 		}
@@ -97,12 +77,12 @@ func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
 	}
 
 	var got commandSpec
-	runCommand = func(spec commandSpec) error {
+	op.runCommand = func(spec commandSpec) error {
 		got = spec
 		return nil
 	}
 
-	if err := Open("http://wendy-ser9.local:3001"); err != nil {
+	if err := op.open("http://wendy-ser9.local:3001"); err != nil {
 		t.Fatalf("Open returned error: %v", err)
 	}
 
@@ -118,23 +98,62 @@ func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
 	}
 }
 
-func TestOpenLinuxReportsMissingGraphicalSession(t *testing.T) {
-	withTestHooks(t)
+func TestOpenLinuxRejectsInvalidSessionIdentity(t *testing.T) {
+	op := testOpener()
 
-	commandOutput = func(name string, args ...string) ([]byte, error) {
+	op.commandOutput = func(name string, args ...string) ([]byte, error) {
+		if name != "loginctl" {
+			t.Fatalf("unexpected command output request: %s %v", name, args)
+		}
+		switch args[0] {
+		case "list-sessions":
+			return []byte("2 1000 alice seat0 tty2\n"), nil
+		case "show-session":
+			return []byte(strings.Join([]string{
+				"Active=yes",
+				"Class=user",
+				"Display=wayland-0",
+				"Name=alice;bad",
+				"Type=wayland",
+				"User=1000",
+				"",
+			}, "\n")), nil
+		default:
+			t.Fatalf("unexpected loginctl args: %v", args)
+			return nil, nil
+		}
+	}
+	op.runCommand = func(commandSpec) error {
+		t.Fatal("runCommand should not be called for an invalid session identity")
+		return nil
+	}
+
+	err := op.open("https://example.com")
+	if err == nil {
+		t.Fatal("expected invalid username error")
+	}
+	if !strings.Contains(err.Error(), "invalid username") {
+		t.Fatalf("error = %q; want invalid username diagnostic", err)
+	}
+}
+
+func TestOpenLinuxReportsMissingGraphicalSession(t *testing.T) {
+	op := testOpener()
+
+	op.commandOutput = func(name string, args ...string) ([]byte, error) {
 		if name != "loginctl" || args[0] != "list-sessions" {
 			t.Fatalf("unexpected command output request: %s %v", name, args)
 		}
 		return []byte("\n"), nil
 	}
-	runCommand = func(spec commandSpec) error {
+	op.runCommand = func(spec commandSpec) error {
 		if spec.name != "xdg-open" {
 			t.Fatalf("command = %#v; want xdg-open fallback", spec)
 		}
 		return errors.New("exit status 3")
 	}
 
-	err := Open("https://example.com")
+	err := op.open("https://example.com")
 	if err == nil {
 		t.Fatal("expected error when xdg-open fails and no graphical session exists")
 	}
@@ -148,5 +167,24 @@ func TestParseLoginctlProperties(t *testing.T) {
 
 	if props["Active"] != "yes" || props["Type"] != "x11" || props["Display"] != ":0" {
 		t.Fatalf("props = %#v; want parsed loginctl properties", props)
+	}
+}
+
+func TestValidateSessionValues(t *testing.T) {
+	if !validUsername("alice_1") || validUsername("Alice") || validUsername("alice;bad") {
+		t.Fatal("validUsername did not enforce expected Linux username shape")
+	}
+	if !validX11Display(":0") || !validX11Display(":0.0") || validX11Display(":bad") {
+		t.Fatal("validX11Display did not enforce expected display shape")
+	}
+	if !validWaylandDisplay("wayland-0") || validWaylandDisplay("wayland-main") {
+		t.Fatal("validWaylandDisplay did not enforce expected display shape")
+	}
+}
+
+func TestSanitizeDiagnosticOutput(t *testing.T) {
+	got := sanitizeDiagnosticOutput("bad\x1b[31m\nnext\tline")
+	if got != "bad[31m next line" {
+		t.Fatalf("sanitizeDiagnosticOutput = %q; want printable single-line output", got)
 	}
 }

--- a/go/internal/shared/browseropen/browseropen_test.go
+++ b/go/internal/shared/browseropen/browseropen_test.go
@@ -36,8 +36,11 @@ func TestOpenLinuxUsesCurrentGraphicalSessionEnv(t *testing.T) {
 		t.Fatalf("Open returned error: %v", err)
 	}
 
-	if got.name != "xdg-open" || !reflect.DeepEqual(got.args, []string{"https://example.com"}) {
-		t.Fatalf("command = %#v; want xdg-open URL", got)
+	if got.name != xdgOpenPath || !reflect.DeepEqual(got.args, []string{"https://example.com"}) {
+		t.Fatalf("command = %#v; want absolute xdg-open URL", got)
+	}
+	if !got.minimalEnv {
+		t.Fatalf("command = %#v; want minimal environment", got)
 	}
 	if len(got.env) != 0 {
 		t.Fatalf("direct xdg-open env = %v; want no overrides", got.env)
@@ -46,6 +49,7 @@ func TestOpenLinuxUsesCurrentGraphicalSessionEnv(t *testing.T) {
 
 func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
 	op := testOpener()
+	op.runuserPaths = []string{"/usr/sbin/runuser"}
 
 	op.commandOutput = func(name string, args ...string) ([]byte, error) {
 		if name != "loginctl" {
@@ -87,14 +91,17 @@ func TestOpenLinuxBridgesIntoActiveWaylandSession(t *testing.T) {
 	}
 
 	wantArgs := []string{
-		"-u", "alice", "--", "env",
+		"-u", "alice", "--", "env", "-i",
 		"XDG_RUNTIME_DIR=/run/user/1000",
 		"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus",
 		"WAYLAND_DISPLAY=wayland-1",
-		"xdg-open", "http://wendy-ser9.local:3001",
+		xdgOpenPath, "http://wendy-ser9.local:3001",
 	}
-	if got.name != "runuser" || !reflect.DeepEqual(got.args, wantArgs) {
+	if got.name != "/usr/sbin/runuser" || !reflect.DeepEqual(got.args, wantArgs) {
 		t.Fatalf("command = %#v; want runuser session bridge", got)
+	}
+	if !got.minimalEnv {
+		t.Fatalf("command = %#v; want minimal environment", got)
 	}
 }
 
@@ -147,7 +154,7 @@ func TestOpenLinuxReportsMissingGraphicalSession(t *testing.T) {
 		return []byte("\n"), nil
 	}
 	op.runCommand = func(spec commandSpec) error {
-		if spec.name != "xdg-open" {
+		if spec.name != xdgOpenPath {
 			t.Fatalf("command = %#v; want xdg-open fallback", spec)
 		}
 		return errors.New("exit status 3")
@@ -182,9 +189,41 @@ func TestValidateSessionValues(t *testing.T) {
 	}
 }
 
+func TestValidateOpenURL(t *testing.T) {
+	for _, raw := range []string{"file:///etc/shadow", "javascript:alert(1)", "-https://example.com", "http://"} {
+		if err := validateOpenURL(raw); err == nil {
+			t.Fatalf("validateOpenURL(%q) unexpectedly succeeded", raw)
+		}
+	}
+	if err := validateOpenURL("https://example.com/path"); err != nil {
+		t.Fatalf("validateOpenURL returned error for https URL: %v", err)
+	}
+}
+
+func TestMinimalCommandEnvOmitsUnrelatedVariables(t *testing.T) {
+	op := testOpener()
+	env := map[string]string{
+		"HOME":      "/home/alice",
+		"USER":      "alice",
+		"LOGNAME":   "alice",
+		"API_TOKEN": "secret",
+	}
+	op.getenv = func(key string) string { return env[key] }
+
+	got := op.minimalCommandEnv()
+	if reflect.DeepEqual(got, []string{}) {
+		t.Fatal("minimalCommandEnv returned no environment")
+	}
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "API_TOKEN=") {
+			t.Fatalf("minimalCommandEnv leaked unrelated variable: %v", got)
+		}
+	}
+}
+
 func TestSanitizeDiagnosticOutput(t *testing.T) {
 	got := sanitizeDiagnosticOutput("bad\x1b[31m\nnext\tline")
-	if got != "bad[31m next line" {
+	if got != "bad next line" {
 		t.Fatalf("sanitizeDiagnosticOutput = %q; want printable single-line output", got)
 	}
 }

--- a/go/internal/shared/browseropen/browseropen_test.go
+++ b/go/internal/shared/browseropen/browseropen_test.go
@@ -193,10 +193,27 @@ func TestOpenLinuxReportsMissingGraphicalSession(t *testing.T) {
 }
 
 func TestParseLoginctlProperties(t *testing.T) {
-	props := parseLoginctlProperties("Active=yes\nType=x11\nIgnoredLine\nDisplay=:0\n")
+	props := parseLoginctlProperties("Active=yes\nType=x11\nIgnoredLine\nDisplay= :0 \n")
 
 	if props["Active"] != "yes" || props["Type"] != "x11" || props["Display"] != ":0" {
 		t.Fatalf("props = %#v; want parsed loginctl properties", props)
+	}
+}
+
+func TestParseLoginctlPropertiesRejectsUnsafeValues(t *testing.T) {
+	props := parseLoginctlProperties("Name=alice bad\nUser=1000\tbad\nType=" + strings.Repeat("x", maxLoginctlPropertyValueSize+1) + "\nActive=yes\n")
+
+	if _, ok := props["Name"]; ok {
+		t.Fatalf("props = %#v; want whitespace-bearing Name rejected", props)
+	}
+	if _, ok := props["User"]; ok {
+		t.Fatalf("props = %#v; want control-bearing User rejected", props)
+	}
+	if _, ok := props["Type"]; ok {
+		t.Fatalf("props = %#v; want overlong Type rejected", props)
+	}
+	if props["Active"] != "yes" {
+		t.Fatalf("props = %#v; want safe value retained", props)
 	}
 }
 
@@ -226,6 +243,9 @@ func TestValidateSessionValues(t *testing.T) {
 	}
 	if err := validateEnvAssignment("DISPLAY=:0\nBAD=1"); err == nil {
 		t.Fatal("validateEnvAssignment unexpectedly accepted newline")
+	}
+	if err := validateEnvAssignment("DISPLAY=:0 bad"); err == nil {
+		t.Fatal("validateEnvAssignment unexpectedly accepted space")
 	}
 	if !validRunuserPath("/usr/sbin/runuser") || validRunuserPath("/tmp/runuser") {
 		t.Fatal("validRunuserPath did not enforce expected allow-list")

--- a/go/internal/shared/browseropen/browseropen_test.go
+++ b/go/internal/shared/browseropen/browseropen_test.go
@@ -187,7 +187,7 @@ func TestParseLoginctlProperties(t *testing.T) {
 }
 
 func TestValidateSessionValues(t *testing.T) {
-	if !validUsername("alice_1") || validUsername("Alice") || validUsername("alice;bad") {
+	if !validUsername("alice_1") || !validUsername("Alice.Name") || validUsername("alice;bad") {
 		t.Fatal("validUsername did not enforce expected Linux username shape")
 	}
 	if !validSessionID("session-2") || validSessionID("../../bad") {
@@ -202,7 +202,7 @@ func TestValidateSessionValues(t *testing.T) {
 	if _, err := validGraphicalSessionUID("1000"); err != nil {
 		t.Fatalf("validGraphicalSessionUID returned error for normal uid: %v", err)
 	}
-	for _, uid := range []string{"0", "-1", "999999"} {
+	for _, uid := range []string{"0", "1", "999", "-1", "999999"} {
 		if _, err := validGraphicalSessionUID(uid); err == nil {
 			t.Fatalf("validGraphicalSessionUID(%q) unexpectedly succeeded", uid)
 		}
@@ -213,10 +213,13 @@ func TestValidateSessionValues(t *testing.T) {
 	if err := validateEnvAssignment("DISPLAY=:0\nBAD=1"); err == nil {
 		t.Fatal("validateEnvAssignment unexpectedly accepted newline")
 	}
+	if !validRunuserPath("/usr/sbin/runuser") || validRunuserPath("/tmp/runuser") {
+		t.Fatal("validRunuserPath did not enforce expected allow-list")
+	}
 }
 
 func TestValidateOpenURL(t *testing.T) {
-	for _, raw := range []string{"file:///etc/shadow", "javascript:alert(1)", "-https://example.com", "http://"} {
+	for _, raw := range []string{"file:///etc/shadow", "javascript:alert(1)", "-https://example.com", "http://", "https://user:pass@example.com"} {
 		if err := validateOpenURL(raw); err == nil {
 			t.Fatalf("validateOpenURL(%q) unexpectedly succeeded", raw)
 		}


### PR DESCRIPTION
## Summary
- Bridge Linux browser opening into the active graphical `loginctl` session when the agent process lacks display/session environment.
- Wait for opener command failures so `xdg-open`/`loginctl` errors are returned with bounded diagnostics instead of being hidden after process start.
- Return nonzero from `wendy-agent utils open-browser` on open failures and note when failed postStart hooks wrote stderr without logging stderr content.

Fixes #786

## Validation
- `go test ./go/internal/shared/browseropen`
- `go test ./go/internal/agent/containerd ./go/internal/agent/services ./go/cmd/wendy-agent`
- `CC="$(xcrun -f clang)" CXX="$(xcrun -f clang++)" SDKROOT="$(xcrun --sdk macosx --show-sdk-path)" go test -v ./go/internal/cli/commands -run TestOpenBrowserCmd`
- `GOOS=linux GOARCH=amd64 go test -c ./go/internal/shared/browseropen -o /tmp/browseropen-linux.test`
- `GOOS=windows GOARCH=amd64 go test -c ./go/internal/shared/browseropen -o /tmp/browseropen-windows.test.exe`
- `git diff --check`
