### PR TITLE
Stream WiFi network picker results

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/wifi.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/wifi.md
@@ -22,27 +22,40 @@ wendy device wifi connect [--ssid <name>]
 
 Pass `--ssid` to skip the interactive network picker.
 
+The network picker opens immediately and refreshes every 3 seconds as new scan
+results arrive. Networks are sorted by signal strength, strongest first. If a
+refresh reorders the list, the cursor follows the previously selected SSID so
+the selection is not lost.
+
 ---
 
 ## Platform behavior
 
 ### macOS
 
-Uses CoreWLAN (`scanForNetworks`) to perform a synchronous, on-demand scan. Results are always current.
+Uses CoreWLAN (`scanForNetworks`) to perform a synchronous, on-demand scan on
+each refresh. Results reflect the most recent completed scan.
 
 Keychain lookup is supported: previously saved "AirPort network password" entries are read automatically, so the password prompt is often skipped.
 
 ### Linux
 
-Uses `nmcli device wifi rescan` followed by `nmcli device wifi list`. The rescan is triggered before listing, so results are always current.
+Uses `nmcli device wifi rescan` followed by `nmcli device wifi list` on each
+refresh.
 
 Keychain lookup is not supported. The password prompt is always shown when connecting to a network that requires a password.
 
 ### Windows
 
-Uses `netsh wlan show networks mode=bssid` to enumerate nearby networks. SSIDs are deduplicated; when a network is visible through multiple BSSIDs (roaming), the strongest signal observed across all BSSIDs is reported. Hidden networks (empty SSID) are skipped.
+Uses `netsh wlan show networks mode=bssid` to enumerate nearby networks on each
+refresh. SSIDs are deduplicated; when a network is visible through multiple
+BSSIDs (roaming), the strongest signal observed across all BSSIDs is reported.
+Hidden networks (empty SSID) are skipped.
 
-**Important:** `netsh` reads the Windows WLAN service's cached scan list. The service asks the driver to rescan periodically and may not scan at all while the host is already associated to a network. Results may therefore be stale. If the expected network is missing, wait a few seconds and run the command again, or pass `--ssid` to specify the network directly.
+**Note:** `netsh` reads the Windows WLAN service's cached scan list. The service
+asks the driver to rescan periodically and may not scan at all while the host is
+already associated to a network. If the expected network does not appear after
+several refreshes, pass `--ssid` to specify the network directly.
 
 Keychain lookup is not supported. Windows has no equivalent of macOS's auto-stored "AirPort network password" Keychain entry. The password prompt is always shown when connecting to a network that requires a password.
 

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1187,21 +1187,10 @@ func splitEscaped(s string, sep byte) []string {
 func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 	var c wendyconf.WifiCredential
 
-	networks, scanErr := scanLocalWifiNetworks()
-	if scanErr == nil && len(networks) > 0 {
-		var items []tui.PickerItem
-		for _, n := range networks {
-			signal := ""
-			if n.SignalStrength > 0 {
-				signal = fmt.Sprintf("%d%%", n.SignalStrength)
-			}
-			items = append(items, tui.PickerItem{Name: n.SSID, Type: signal, Value: n.SSID})
-		}
-		fmt.Println()
-		picked, pickErr := pickFromItems("Select WiFi network (or Ctrl+C to type manually)", items)
-		if pickErr == nil {
-			c.SSID = picked
-		}
+	fmt.Println()
+	picked, pickErr := pickLocalWifiNetwork(context.Background(), "Select WiFi network (or Ctrl+C to type manually)")
+	if pickErr == nil {
+		c.SSID = picked
 	}
 
 	if c.SSID == "" {

--- a/go/internal/cli/commands/picker_refresh_test.go
+++ b/go/internal/cli/commands/picker_refresh_test.go
@@ -122,3 +122,36 @@ func TestRefreshingPickerModel_SelectsItem(t *testing.T) {
 		t.Fatalf("selected value = %q, want alpha", got)
 	}
 }
+
+func TestRefreshingWifiPickerPreservesSSIDCursorWhenOrderChanges(t *testing.T) {
+	m := newRefreshingPickerModel(context.Background(), "Select WiFi network", time.Millisecond, func(context.Context) ([]tui.PickerItem, error) {
+		return nil, nil
+	})
+
+	updated, _ := m.Update(refreshingPickerLoadMsg{items: []tui.PickerItem{
+		wifiPickerItem("alpha", 90, ""),
+		wifiPickerItem("beta", 80, ""),
+	}})
+	rm := updated.(refreshingPickerModel)
+
+	updated, _ = rm.Update(tea.KeyMsg{Type: tea.KeyDown})
+	rm = updated.(refreshingPickerModel)
+
+	updated, _ = rm.Update(refreshingPickerLoadMsg{items: []tui.PickerItem{
+		wifiPickerItem("beta", 99, ""),
+		wifiPickerItem("alpha", 90, ""),
+	}})
+	rm = updated.(refreshingPickerModel)
+
+	updated, cmd := rm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected enter to quit")
+	}
+	rm = updated.(refreshingPickerModel)
+	if rm.picker.Selected() == nil {
+		t.Fatal("expected selected item")
+	}
+	if got := rm.picker.Selected().Value.(string); got != "beta" {
+		t.Fatalf("selected value = %q, want beta", got)
+	}
+}

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -3,11 +3,14 @@ package commands
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -18,6 +21,8 @@ import (
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"golang.org/x/term"
 )
+
+const wifiNetworkPickerRefreshInterval = 3 * time.Second
 
 func newWifiCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -622,108 +627,145 @@ func newWifiForgetCmd() *cobra.Command {
 	return cmd
 }
 
-// ── WiFi network picker (legacy, still used by `connect`) ──────────
+// ── WiFi network picker ────────────────────────────────────────────
 
 func pickWifiNetwork(ctx context.Context, target *SelectedDevice) (string, error) {
-	type wifiEntry struct {
-		ssid           string
-		signalStrength int32
-	}
-
-	var networks []wifiEntry
+	var load func(context.Context) ([]tui.PickerItem, error)
 
 	switch {
 	case target.Bluetooth != nil && target.Bluetooth.IsWendyAgent():
-		cliLogln("Scanning for WiFi networks on %s...", target.Bluetooth.DisplayName)
-		tlsCfg, err := bleTLSConfig()
-		if err != nil {
-			return "", err
-		}
-		client, err := ble.ConnectAgent(target.Bluetooth, tlsCfg)
-		if err != nil {
-			return "", fmt.Errorf("connecting to device: %w", err)
-		}
-		defer client.Close()
+		device := *target.Bluetooth
+		load = func(context.Context) ([]tui.PickerItem, error) {
+			tlsCfg, err := bleTLSConfig()
+			if err != nil {
+				return nil, err
+			}
+			client, err := ble.ConnectAgent(&device, tlsCfg)
+			if err != nil {
+				return nil, fmt.Errorf("connecting to device: %w", err)
+			}
+			defer client.Close()
 
-		nets, err := client.WifiList()
-		if err != nil {
-			return "", fmt.Errorf("listing WiFi networks: %w", err)
-		}
-		for _, n := range nets {
-			networks = append(networks, wifiEntry{ssid: n.GetSsid(), signalStrength: n.GetSignalStrength()})
+			nets, err := client.WifiList()
+			if err != nil {
+				return nil, fmt.Errorf("listing WiFi networks: %w", err)
+			}
+			return wifiPickerItemsFromBluetooth(nets), nil
 		}
 
 	case target.Bluetooth != nil:
-		cliLogln("Scanning for WiFi networks on this computer...")
-		nets, err := scanLocalWifiNetworks()
-		if err != nil {
-			return "", fmt.Errorf("scanning local WiFi networks: %w", err)
-		}
-		for _, n := range nets {
-			networks = append(networks, wifiEntry{ssid: n.SSID, signalStrength: n.SignalStrength})
+		load = func(context.Context) ([]tui.PickerItem, error) {
+			return localWifiPickerItems()
 		}
 
 	case target.Agent != nil:
-		cliLogln("Scanning for WiFi networks...")
-		resp, err := target.Agent.AgentService.ListWiFiNetworks(ctx, &agentpb.ListWiFiNetworksRequest{})
-		if err != nil {
-			return "", fmt.Errorf("listing WiFi networks: %w", err)
-		}
-		for _, n := range resp.GetNetworks() {
-			networks = append(networks, wifiEntry{ssid: n.GetSsid(), signalStrength: n.GetSignalStrength()})
+		agentSvc := target.Agent.AgentService
+		load = func(loadCtx context.Context) ([]tui.PickerItem, error) {
+			resp, err := agentSvc.ListWiFiNetworks(loadCtx, &agentpb.ListWiFiNetworksRequest{})
+			if err != nil {
+				return nil, fmt.Errorf("listing WiFi networks: %w", err)
+			}
+			return wifiPickerItemsFromProto(resp.GetNetworks()), nil
 		}
 
 	default:
 		return "", fmt.Errorf("selected device does not support WiFi network scanning")
 	}
 
+	return pickRefreshingFromItems(ctx, "Select a WiFi network", wifiNetworkPickerRefreshInterval, load)
+}
+
+func localWifiPickerItems() ([]tui.PickerItem, error) {
+	networks, err := scanLocalWifiNetworks()
+	if err != nil {
+		return nil, fmt.Errorf("scanning local WiFi networks: %w", err)
+	}
 	if len(networks) == 0 {
 		if wifiScanCacheHint != "" {
-			return "", fmt.Errorf("no WiFi networks found (%s)", wifiScanCacheHint)
+			return nil, fmt.Errorf("no WiFi networks found (%s)", wifiScanCacheHint)
 		}
-		return "", fmt.Errorf("no WiFi networks found")
+		return nil, fmt.Errorf("no WiFi networks found")
 	}
+	return wifiPickerItemsFromLocal(networks), nil
+}
 
-	var items []tui.PickerItem
+func pickLocalWifiNetwork(ctx context.Context, title string) (string, error) {
+	return pickRefreshingFromItems(ctx, title, wifiNetworkPickerRefreshInterval, func(context.Context) ([]tui.PickerItem, error) {
+		return localWifiPickerItems()
+	})
+}
+
+func wifiPickerItemsFromLocal(networks []localWifiNetwork) []tui.PickerItem {
+	items := make([]tui.PickerItem, 0, len(networks))
 	for _, n := range networks {
-		signal := ""
-		if n.signalStrength > 0 {
-			signal = fmt.Sprintf("%d%%", n.signalStrength)
-		}
-		items = append(items, tui.PickerItem{
-			Name:  n.ssid,
-			Type:  signal,
-			Value: n.ssid,
-		})
+		items = append(items, wifiPickerItem(n.SSID, n.SignalStrength, ""))
 	}
+	return items
+}
 
-	picker := tui.NewPickerWithTitle("Select a WiFi network")
-	p := tea.NewProgram(picker)
-
-	go func() {
-		p.Send(tui.PickerAddMsg{Items: items})
-		p.Send(tui.PickerDoneMsg{})
-	}()
-
-	finalModel, err := p.Run()
-	if err != nil {
-		return "", fmt.Errorf("network picker: %w", err)
+func wifiPickerItemsFromProto(networks []*agentpb.ListWiFiNetworksResponse_WiFiNetwork) []tui.PickerItem {
+	items := make([]tui.PickerItem, 0, len(networks))
+	for _, n := range networks {
+		description := wifiPickerDescription(n.GetIsConnected(), n.GetIsKnown(), n.GetSecurity())
+		items = append(items, wifiPickerItem(n.GetSsid(), n.GetSignalStrength(), description))
 	}
+	return items
+}
 
-	pm := finalModel.(tui.PickerModel)
-	if pm.Cancelled() {
-		return "", ErrUserCancelled
+func wifiPickerItemsFromBluetooth(networks []*agentpb.WifiNetworkInfo) []tui.PickerItem {
+	items := make([]tui.PickerItem, 0, len(networks))
+	for _, n := range networks {
+		description := wifiPickerDescription(n.GetIsConnected(), n.GetIsKnown(), n.GetSecurity())
+		items = append(items, wifiPickerItem(n.GetSsid(), n.GetSignalStrength(), description))
 	}
-	sel := pm.Selected()
-	if sel == nil {
-		return "", fmt.Errorf("no network selected")
-	}
+	return items
+}
 
-	ssid, ok := sel.Value.(string)
-	if !ok {
-		return "", fmt.Errorf("invalid picker selection")
+func wifiPickerDescription(connected, known bool, security agentpb.WiFiSecurityType) string {
+	var parts []string
+	if connected {
+		parts = append(parts, "Connected")
 	}
-	return ssid, nil
+	if known {
+		parts = append(parts, "Known")
+	}
+	if sec := wifitable.SecurityLabel(security); sec != "" {
+		parts = append(parts, sec)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func wifiPickerItem(ssid string, signalStrength int32, description string) tui.PickerItem {
+	signalStrength = clampSignalStrength(signalStrength)
+	signal := ""
+	if signalStrength > 0 {
+		signal = fmt.Sprintf("%d%%", signalStrength)
+	}
+	return tui.PickerItem{
+		Name:        ssid,
+		Type:        signal,
+		Description: description,
+		DedupKey:    ssid,
+		SortKey:     wifiPickerSortKey(ssid, signalStrength),
+		Value:       ssid,
+	}
+}
+
+func wifiPickerSortKey(ssid string, signalStrength int32) string {
+	signalStrength = clampSignalStrength(signalStrength)
+	sum := sha256.Sum256([]byte(strings.ToLower(ssid)))
+	hashedSSID := hex.EncodeToString(sum[:8])
+	return fmt.Sprintf("%03d:%s", 100-signalStrength, hashedSSID)
+}
+
+func clampSignalStrength(signalStrength int32) int32 {
+	if signalStrength < 0 {
+		return 0
+	}
+	if signalStrength > 100 {
+		return 100
+	}
+	return signalStrength
 }
 
 // ── BLE WendyOS Agent / Lite helpers retained for status/disconnect ──


### PR DESCRIPTION
Fixes #788

## Summary
- route `wendy os install` WiFi selection through the refreshing picker so the table opens immediately while scans run
- use the same refreshing picker path for `wendy device wifi connect`, including BLE agent, local host, and gRPC device scans
- sort WiFi rows by signal strength while preserving the cursor by SSID when refreshes reorder the list
- document the new refresh behavior for `wendy device wifi connect`

## Testing
- `go test ./internal/cli/commands ./internal/cli/tui ./internal/cli/tui/wifitable`
- `go build ./cmd/wendy`