### PR TITLE
[codex] Fix WiFi keychain password prompts

### DIFF
--- a/go/internal/cli/commands/disklister_darwin.go
+++ b/go/internal/cli/commands/disklister_darwin.go
@@ -4,11 +4,13 @@ package commands
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // drive represents an external disk suitable for image writing.
@@ -21,6 +23,11 @@ type drive struct {
 	IsRemovable bool
 	StorageType StorageType // underlying storage protocol
 }
+
+const (
+	diskutilListTimeout = 10 * time.Second
+	diskutilInfoTimeout = 5 * time.Second
+)
 
 // listAllDrives lists external physical drives (NVMe, USB, SD cards) on macOS.
 func listAllDrives() ([]drive, error) {
@@ -37,7 +44,7 @@ func listExternalDrives() ([]drive, error) {
 // drives. It checks both external and internal physical disks because built-in
 // SD card readers present media as internal on macOS.
 func listDrivesText() ([]drive, error) {
-	out, err := exec.Command("diskutil", "list", "external", "physical").Output()
+	out, err := diskutilOutput(diskutilListTimeout, "list", "external", "physical")
 	if err != nil {
 		return nil, fmt.Errorf("running diskutil: %w", err)
 	}
@@ -47,7 +54,7 @@ func listDrivesText() ([]drive, error) {
 
 	// Also check internal physical disks for removable media
 	// (e.g., built-in SD card readers show as "internal" on macOS).
-	internalOut, err := exec.Command("diskutil", "list", "internal", "physical").CombinedOutput()
+	internalOut, err := diskutilCombinedOutput(diskutilListTimeout, "list", "internal", "physical")
 	if err != nil {
 		// Surface a warning instead of silently ignoring the failure so that
 		// users can diagnose missing drives (e.g., SD cards in built-in readers).
@@ -128,7 +135,7 @@ type diskInfo struct {
 }
 
 func getDiskInfo(devPath string) (*diskInfo, error) {
-	out, err := exec.Command("diskutil", "info", devPath).Output()
+	out, err := diskutilOutput(diskutilInfoTimeout, "info", devPath)
 	if err != nil {
 		return nil, err
 	}
@@ -165,6 +172,28 @@ func getDiskInfo(devPath string) (*diskInfo, error) {
 		}
 	}
 	return info, nil
+}
+
+func diskutilOutput(timeout time.Duration, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "diskutil", args...).Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("diskutil %q timed out after %s", args, timeout)
+	}
+	return out, err
+}
+
+func diskutilCombinedOutput(timeout time.Duration, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "diskutil", args...).CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("diskutil %q timed out after %s", args, timeout)
+	}
+	return out, err
 }
 
 // unmountDisk unmounts all volumes on a disk before writing.

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -567,9 +567,10 @@ func pickManifestVersion(title string, manifest *deviceManifest) (string, error)
 }
 
 const externalDrivePickerRefreshInterval = 2 * time.Second
+const externalDrivePickerEmptyMessage = "No removable target drives found. Insert an SD card or USB drive, then wait for it to appear. Press q to cancel."
 
 func pickExternalDrive(ctx context.Context) (drive, error) {
-	item, err := pickRefreshingItem(ctx, "Select target drive", externalDrivePickerRefreshInterval, func(context.Context) ([]tui.PickerItem, error) {
+	item, err := pickRefreshingItemWithEmptyMessage(ctx, "Select target drive", externalDrivePickerEmptyMessage, externalDrivePickerRefreshInterval, func(context.Context) ([]tui.PickerItem, error) {
 		drives, err := listExternalDrives()
 		if err != nil {
 			return nil, fmt.Errorf("listing drives: %w", err)
@@ -1066,11 +1067,14 @@ func resolveWiFiCredentialsList(opts wifiCLIOptions) ([]wendyconf.WifiCredential
 	// --wifi-ssid shortcut folds into a single trailing entry.
 	if opts.SSID != "" {
 		c := wendyconf.WifiCredential{SSID: opts.SSID, Password: opts.Password}
-		if c.Password == "" {
-			if pw, kerr := lookupKeychainPassword(c.SSID); kerr == nil && pw != "" {
+		if c.Password == "" && isInteractiveTerminal() {
+			if pw, kerr := promptForSavedWiFiPassword(c.SSID); kerr != nil {
+				return nil, fmt.Errorf("reading WiFi password: %w", kerr)
+			} else if pw != "" {
 				c.Password = pw
-			} else if isInteractiveTerminal() {
-				pw, perr := tui.PromptText(fmt.Sprintf("WiFi password for %s", c.SSID), "(leave empty for open network)", nil)
+			}
+			if c.Password == "" {
+				pw, perr := tui.PromptText(fmt.Sprintf("WiFi password for %s", quoteSSIDForPrompt(c.SSID)), "(leave empty for open network)", nil)
 				if perr != nil {
 					return nil, fmt.Errorf("reading WiFi password: %w", perr)
 				}
@@ -1212,23 +1216,14 @@ func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 		c.SSID = ssid
 	}
 
-	if supportsKeychainLookup {
-		useKeychain, err := tui.ConfirmDefaultYes(fmt.Sprintf("Look up password for '%s' from keychain? (macOS will ask for permission)", c.SSID))
-		if err != nil {
-			return c, false, err
-		}
-		if useKeychain {
-			if pw, kerr := lookupKeychainPassword(c.SSID); kerr == nil && pw != "" {
-				fmt.Println("Using saved password from keychain.")
-				c.Password = pw
-			} else {
-				fmt.Println("Password not available from keychain.")
-			}
-		}
+	if pw, err := promptForSavedWiFiPassword(c.SSID); err != nil {
+		return c, false, err
+	} else if pw != "" {
+		c.Password = pw
 	}
 
 	if c.Password == "" {
-		pw, err := tui.PromptText(fmt.Sprintf("Password for %s", c.SSID), "(leave empty for open network)", nil)
+		pw, err := tui.PromptText(fmt.Sprintf("Password for %s", quoteSSIDForPrompt(c.SSID)), "(leave empty for open network)", nil)
 		if err != nil {
 			return c, false, err
 		}

--- a/go/internal/cli/commands/picker_refresh.go
+++ b/go/internal/cli/commands/picker_refresh.go
@@ -29,8 +29,23 @@ func newRefreshingPickerModel(
 	interval time.Duration,
 	load func(context.Context) ([]tui.PickerItem, error),
 ) refreshingPickerModel {
+	return newRefreshingPickerModelWithEmptyMessage(ctx, title, "", interval, load)
+}
+
+func newRefreshingPickerModelWithEmptyMessage(
+	ctx context.Context,
+	title string,
+	emptyMessage string,
+	interval time.Duration,
+	load func(context.Context) ([]tui.PickerItem, error),
+) refreshingPickerModel {
+	picker := tui.NewPickerWithTitle(title)
+	if emptyMessage != "" {
+		picker.EmptyMessage = emptyMessage
+	}
+
 	return refreshingPickerModel{
-		picker:   tui.NewPickerWithTitle(title),
+		picker:   picker,
 		ctx:      ctx,
 		maxDelay: interval,
 		load:     load,
@@ -76,10 +91,20 @@ func pickRefreshingItem(
 	interval time.Duration,
 	load func(context.Context) ([]tui.PickerItem, error),
 ) (tui.PickerItem, error) {
+	return pickRefreshingItemWithEmptyMessage(ctx, title, "", interval, load)
+}
+
+func pickRefreshingItemWithEmptyMessage(
+	ctx context.Context,
+	title string,
+	emptyMessage string,
+	interval time.Duration,
+	load func(context.Context) ([]tui.PickerItem, error),
+) (tui.PickerItem, error) {
 	pollCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	model := newRefreshingPickerModel(pollCtx, title, interval, load)
+	model := newRefreshingPickerModelWithEmptyMessage(pollCtx, title, emptyMessage, interval, load)
 	p := tea.NewProgram(model)
 	finalModel, err := p.Run()
 	if err != nil {

--- a/go/internal/cli/commands/picker_refresh_test.go
+++ b/go/internal/cli/commands/picker_refresh_test.go
@@ -80,8 +80,23 @@ func TestRefreshingPickerModel_EmptyLoadKeepsPickerOpen(t *testing.T) {
 	if rm.err != nil {
 		t.Fatalf("unexpected error: %v", rm.err)
 	}
-	if !strings.Contains(rm.View(), "Scanning") {
-		t.Fatalf("expected empty refreshing picker to keep scanning, got %q", rm.View())
+	if !strings.Contains(rm.View(), "No options found.") {
+		t.Fatalf("expected empty refreshing picker to show empty state, got %q", rm.View())
+	}
+}
+
+func TestRefreshingPickerModel_CustomEmptyMessage(t *testing.T) {
+	m := newRefreshingPickerModelWithEmptyMessage(context.Background(), "Select", "Insert a drive.", time.Millisecond, func(context.Context) ([]tui.PickerItem, error) {
+		return nil, nil
+	})
+
+	updated, cmd := m.Update(refreshingPickerLoadMsg{})
+	if cmd == nil {
+		t.Fatal("expected empty load to schedule refresh")
+	}
+	rm := updated.(refreshingPickerModel)
+	if !strings.Contains(rm.View(), "Insert a drive.") {
+		t.Fatalf("expected custom empty state, got %q", rm.View())
 	}
 }
 

--- a/go/internal/cli/commands/tour.go
+++ b/go/internal/cli/commands/tour.go
@@ -73,7 +73,7 @@ type (
 		devices []models.LANDevice
 		err     error
 	}
-	tourWifiDetectedMsg struct{ ssid, password string }
+	tourWifiDetectedMsg struct{ ssid string }
 	tourWifiScanDoneMsg struct {
 		networks []localWifiNetwork
 		err      error
@@ -196,7 +196,6 @@ type tourWizardModel struct {
 
 	// WiFi
 	detectedSSID string
-	detectedPass string
 	wifiSSID     string
 	wifiPass     string
 	wifiCursor   int                // options menu cursor
@@ -296,7 +295,6 @@ func (m tourWizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyc
 
 	case tourWifiDetectedMsg:
 		m.detectedSSID = msg.ssid
-		m.detectedPass = msg.password
 		m.phase = phaseWifiQuestion
 		m.wifiCursor = 0
 		return m, nil
@@ -593,16 +591,11 @@ func (m tourWizardModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				if m.detectedSSID != "" {
 					// "Yes, use [detectedSSID]"
 					m.wifiSSID = m.detectedSSID
-					if m.detectedPass != "" {
-						m.wifiPass = m.detectedPass
-						m.phase = phaseReadyToInstall
-					} else {
-						m.phase = phaseWifiPassword
-						m.input.Placeholder = "WiFi password (leave empty for open network)"
-						m.input.EchoMode = textinput.EchoPassword
-						m.input.SetValue("")
-						m.input.Focus()
-					}
+					m.phase = phaseWifiPassword
+					m.input.Placeholder = "WiFi password (leave empty for open network)"
+					m.input.EchoMode = textinput.EchoPassword
+					m.input.SetValue("")
+					m.input.Focus()
 				} else {
 					// "Scan for nearby networks"
 					m.phase = phaseWifiScanLoading
@@ -664,13 +657,6 @@ func (m tourWizardModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if len(m.scanNetworks) > 0 && m.scanCursor < len(m.scanNetworks) {
 				net := m.scanNetworks[m.scanCursor]
 				m.wifiSSID = net.SSID
-				if supportsKeychainLookup {
-					if pwd, err := lookupKeychainPassword(net.SSID); err == nil && pwd != "" {
-						m.wifiPass = pwd
-						m.phase = phaseReadyToInstall
-						return m, nil
-					}
-				}
 				m.phase = phaseWifiPassword
 				m.input.Placeholder = "WiFi password (leave empty for open network)"
 				m.input.EchoMode = textinput.EchoPassword
@@ -1241,7 +1227,7 @@ func (m tourWizardModel) viewTextInput(w int) string {
 	switch m.phase {
 	case phaseWifiPassword:
 		title = "WiFi Password"
-		hint = fmt.Sprintf("Password for \"%s\" (leave blank for open network)", m.wifiSSID)
+		hint = fmt.Sprintf("Password for %s (leave blank for open network)", quoteSSIDForPrompt(m.wifiSSID))
 	case phaseWifiManualSSID:
 		title = "WiFi Network"
 		hint = "Enter the name (SSID) of the network"
@@ -1541,11 +1527,7 @@ func scanWifiCmd() tea.Cmd {
 func detectWifiCmd() tea.Cmd {
 	return func() tea.Msg {
 		ssid := detectCurrentWiFiSSID()
-		password := ""
-		if ssid != "" && supportsKeychainLookup {
-			password, _ = lookupKeychainPassword(ssid)
-		}
-		return tourWifiDetectedMsg{ssid: ssid, password: password}
+		return tourWifiDetectedMsg{ssid: ssid}
 	}
 }
 

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -381,20 +380,10 @@ func newWifiConnectCmd() *cobra.Command {
 			}
 
 			if !cmd.Flags().Changed("password") && term.IsTerminal(int(os.Stdin.Fd())) {
-				if supportsKeychainLookup {
-					fmt.Printf("Look up password for '%s' from keychain? (macOS will ask for permission) [Y/n] ", ssid)
-					reader := bufio.NewReader(os.Stdin)
-					line, _ := reader.ReadString('\n')
-					answer := strings.TrimSpace(strings.ToLower(line))
-
-					if answer == "" || answer == "y" || answer == "yes" {
-						if kp, err := lookupKeychainPassword(ssid); err == nil && kp != "" {
-							cliLogln("Using saved password from keychain.")
-							password = kp
-						} else {
-							cliNotice("Password not available from keychain.")
-						}
-					}
+				if kp, err := promptForSavedWiFiPassword(ssid); err != nil {
+					return err
+				} else if kp != "" {
+					password = kp
 				}
 
 				if password == "" {

--- a/go/internal/cli/commands/wifi_keychain.go
+++ b/go/internal/cli/commands/wifi_keychain.go
@@ -1,0 +1,5 @@
+package commands
+
+func promptForSavedWiFiPassword(_ string) (string, error) {
+	return "", nil
+}

--- a/go/internal/cli/commands/wifi_scan_darwin.go
+++ b/go/internal/cli/commands/wifi_scan_darwin.go
@@ -4,12 +4,10 @@ package commands
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // wifiScanCacheHint is empty on macOS: CoreWLAN's scanForNetworks performs
@@ -83,26 +81,4 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	}
 
 	return networks, nil
-}
-
-const supportsKeychainLookup = true
-
-// lookupKeychainPassword attempts to retrieve a saved WiFi password from the
-// macOS System Keychain using the `security` command. Returns ("", nil) if the
-// SSID is not found or the user denies the authorization prompt.
-func lookupKeychainPassword(ssid string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "/usr/bin/security", "find-generic-password",
-		"-D", "AirPort network password",
-		"-a", ssid,
-		"-w",
-	)
-	output, err := cmd.Output()
-	if err != nil {
-		// Not found or user denied — not an error we need to surface.
-		return "", nil
-	}
-	return strings.TrimSpace(string(output)), nil
 }

--- a/go/internal/cli/commands/wifi_ssid_display.go
+++ b/go/internal/cli/commands/wifi_ssid_display.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+func quoteSSIDForPrompt(ssid string) string {
+	return strconv.Quote(sanitizeSSIDForDisplay(ssid))
+}
+
+func sanitizeSSIDForDisplay(ssid string) string {
+	var b strings.Builder
+	for _, r := range ssid {
+		if r == utf8.RuneError || r < 0x20 || r == 0x7f || isBidiControl(r) {
+			b.WriteByte('?')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func isBidiControl(r rune) bool {
+	return r == 0x200e || r == 0x200f || (r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069)
+}

--- a/go/internal/cli/commands/wifi_ssid_display_test.go
+++ b/go/internal/cli/commands/wifi_ssid_display_test.go
@@ -1,0 +1,19 @@
+package commands
+
+import "testing"
+
+func TestQuoteSSIDForPromptSanitizesControls(t *testing.T) {
+	got := quoteSSIDForPrompt("Home\nOffice\x1b[31m")
+	want := `"Home?Office?[31m"`
+	if got != want {
+		t.Fatalf("quoteSSIDForPrompt = %q; want %q", got, want)
+	}
+}
+
+func TestQuoteSSIDForPromptSanitizesBidiControls(t *testing.T) {
+	got := quoteSSIDForPrompt("abc\u202edef")
+	want := `"abc?def"`
+	if got != want {
+		t.Fatalf("quoteSSIDForPrompt = %q; want %q", got, want)
+	}
+}

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -60,6 +60,10 @@ type PickerSetMsg struct {
 type PickerModel struct {
 	Title string // header line, e.g. "Select a device"
 
+	// EmptyMessage is shown after discovery or an authoritative refresh
+	// completes without any selectable items.
+	EmptyMessage string
+
 	// MergeItem is called when a new item shares a DedupKey with an existing
 	// item. The caller can update existing in place (type, address, value, ...).
 	// If nil, duplicate items are silently dropped.
@@ -90,10 +94,11 @@ type PickerModel struct {
 // NewPicker creates a new picker model with the default "Select a device" title.
 func NewPicker() PickerModel {
 	m := PickerModel{
-		Title:    "Select a device",
-		seenIdx:  make(map[string]int),
-		table:    newPickerTable(),
-		scanning: true,
+		Title:        "Select a device",
+		EmptyMessage: "No options found.",
+		seenIdx:      make(map[string]int),
+		table:        newPickerTable(),
+		scanning:     true,
 	}
 	m.refreshTable()
 	return m
@@ -102,10 +107,11 @@ func NewPicker() PickerModel {
 // NewPickerWithTitle creates a new picker model with a custom title.
 func NewPickerWithTitle(title string) PickerModel {
 	m := PickerModel{
-		Title:    title,
-		seenIdx:  make(map[string]int),
-		table:    newPickerTable(),
-		scanning: true,
+		Title:        title,
+		EmptyMessage: "No options found.",
+		seenIdx:      make(map[string]int),
+		table:        newPickerTable(),
+		scanning:     true,
 	}
 	m.refreshTable()
 	return m
@@ -185,6 +191,7 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cursorKey := m.currentCursorKey()
 		m.items = nil
 		m.seenIdx = make(map[string]int, len(msg.Items))
+		m.scanning = false
 		for _, item := range msg.Items {
 			key := strings.ToLower(pickerItemKey(item))
 			if idx, ok := m.seenIdx[key]; ok {
@@ -233,7 +240,11 @@ func (m PickerModel) View() string {
 		if m.scanning {
 			sb.WriteString(pickerScanning.Render("  Scanning...") + "\n")
 		} else {
-			sb.WriteString(pickerHint.Render("  No options found.") + "\n")
+			message := m.EmptyMessage
+			if message == "" {
+				message = "No options found."
+			}
+			sb.WriteString(pickerHint.Render("  "+message) + "\n")
 		}
 		return sb.String()
 	}

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -205,6 +205,21 @@ func TestPickerModel_SetMsgReplacesItems(t *testing.T) {
 	}
 }
 
+func TestPickerModel_SetMsgEmptyStopsScanning(t *testing.T) {
+	m := NewPicker()
+	m.EmptyMessage = "Nothing here yet."
+
+	updated, _ := m.Update(PickerSetMsg{})
+	pm := updated.(PickerModel)
+	view := pm.View()
+	if strings.Contains(view, "Scanning") {
+		t.Fatalf("expected authoritative empty set to stop scanning: %q", view)
+	}
+	if !strings.Contains(view, "Nothing here yet.") {
+		t.Fatalf("expected custom empty message: %q", view)
+	}
+}
+
 func TestPickerModel_SetMsgPreservesCursorByItem(t *testing.T) {
 	m := NewPicker()
 


### PR DESCRIPTION
## Summary

Fixes #789.

- Stop `wendy os install` / `wendy device wifi connect` from invoking macOS System Keychain password reads during Wi-Fi setup.
- Avoid the `security wants to use the "System" keychain` administrator dialog with the blank username field.
- Keep Wi-Fi setup on the normal Wendy terminal password prompt unless the password is provided with `--wifi-password` / `--wifi`.
- Stop `wendy tour` from automatically opening Keychain while detecting or selecting Wi-Fi networks.
- Sanitize SSIDs before rendering password prompts.
- Improve the `wendy os install` target-drive picker so an empty scan shows an actionable no-drive message instead of looking stuck on `Scanning...`.
- Bound macOS `diskutil` list/info calls with timeouts so a stuck disk scan can fail instead of hanging indefinitely.
- Add tests for prompt sanitization and refreshing picker empty states.

## Validation

- `go test ./internal/cli/commands ./internal/cli/tui`
- `CGO_ENABLED=1 CC="$(xcrun --find clang)" CXX="$(xcrun --find clang++)" SDKROOT="$(xcrun --sdk macosx --show-sdk-path)" go build -o /tmp/wendy-local ./cmd/wendy`
- `git diff --check`
- `/tmp/wendy-local os install --help`
- `/tmp/wendy-local os list-drives`
