### PR TITLE
[WDY-1255] Style device-name prompt with emerald TUI prompt

### DIFF
--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -6,6 +6,7 @@ import (
 	"archive/zip"
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -1273,6 +1274,10 @@ func optionalDeviceNameValidator(name string) error {
 	return validateDeviceName(name)
 }
 
+var promptDeviceName = func(prompt, hint string, validate tui.ValidateFunc) (string, error) {
+	return tui.PromptText(prompt, hint, validate)
+}
+
 // resolveDeviceName returns the device name to pre-configure on first boot.
 // If flagName is set it is validated and returned directly. In interactive mode
 // the user is prompted; an empty response skips naming (auto-generated on device).
@@ -1289,11 +1294,14 @@ func resolveDeviceName(flagName string) (string, error) {
 	}
 
 	fmt.Println()
-	name, err := tui.PromptText("Device name", "(leave empty to auto-generate)", optionalDeviceNameValidator)
+	name, err := promptDeviceName("Device name", "(leave empty to auto-generate)", optionalDeviceNameValidator)
 	if err != nil {
-		return "", err
+		if errors.Is(err, tui.ErrCancelled) {
+			return "", ErrUserCancelled
+		}
+		return "", fmt.Errorf("device-name prompt: %w", err)
 	}
-	return name, nil
+	return strings.TrimSpace(name), nil
 }
 
 // confirmOverwriteInternalDrive guards against accidentally wiping internal

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1248,30 +1248,37 @@ func nonEmptyValidator(v string) error {
 	return nil
 }
 
+func validateDeviceName(name string) error {
+	if len(name) < 3 || len(name) > 64 {
+		return fmt.Errorf("device name must be 3–64 characters")
+	}
+	for i, c := range name {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case (c >= '0' && c <= '9') || c == '-':
+			if i == 0 {
+				return fmt.Errorf("device name must start with a lowercase letter")
+			}
+		default:
+			return fmt.Errorf("device name may only contain lowercase letters, digits, and hyphens")
+		}
+	}
+	return nil
+}
+
+func optionalDeviceNameValidator(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return nil
+	}
+	return validateDeviceName(name)
+}
+
 // resolveDeviceName returns the device name to pre-configure on first boot.
 // If flagName is set it is validated and returned directly. In interactive mode
 // the user is prompted; an empty response skips naming (auto-generated on device).
 func resolveDeviceName(flagName string) (string, error) {
-	validate := func(name string) error {
-		if len(name) < 3 || len(name) > 64 {
-			return fmt.Errorf("device name must be 3–64 characters")
-		}
-		for i, c := range name {
-			switch {
-			case c >= 'a' && c <= 'z':
-			case (c >= '0' && c <= '9') || c == '-':
-				if i == 0 {
-					return fmt.Errorf("device name must start with a lowercase letter")
-				}
-			default:
-				return fmt.Errorf("device name may only contain lowercase letters, digits, and hyphens")
-			}
-		}
-		return nil
-	}
-
 	if flagName != "" {
-		if err := validate(flagName); err != nil {
+		if err := validateDeviceName(flagName); err != nil {
 			return "", fmt.Errorf("--device-name: %w", err)
 		}
 		return flagName, nil
@@ -1281,15 +1288,10 @@ func resolveDeviceName(flagName string) (string, error) {
 		return "", nil
 	}
 
-	fmt.Print("\nDevice name (leave empty to auto-generate): ")
-	reader := bufio.NewReader(os.Stdin)
-	line, _ := reader.ReadString('\n')
-	name := strings.TrimSpace(line)
-	if name == "" {
-		return "", nil
-	}
-	if err := validate(name); err != nil {
-		return "", fmt.Errorf("invalid device name: %w", err)
+	fmt.Println()
+	name, err := tui.PromptText("Device name", "(leave empty to auto-generate)", optionalDeviceNameValidator)
+	if err != nil {
+		return "", err
 	}
 	return name, nil
 }

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 )
 
@@ -348,6 +350,45 @@ func TestResolveDeviceNameNoFlagNonInteractive(t *testing.T) {
 	origInteractive := isInteractiveTerminalFn
 	isInteractiveTerminalFn = func() bool { return false }
 	t.Cleanup(func() { isInteractiveTerminalFn = origInteractive })
+
+	got, err := resolveDeviceName("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("got %q; want empty device name", got)
+	}
+}
+
+func TestResolveDeviceNameInteractiveCancelled(t *testing.T) {
+	origInteractive := isInteractiveTerminalFn
+	origPrompt := promptDeviceName
+	isInteractiveTerminalFn = func() bool { return true }
+	promptDeviceName = func(_, _ string, _ tui.ValidateFunc) (string, error) {
+		return "", tui.ErrCancelled
+	}
+	t.Cleanup(func() {
+		isInteractiveTerminalFn = origInteractive
+		promptDeviceName = origPrompt
+	})
+
+	_, err := resolveDeviceName("")
+	if !errors.Is(err, ErrUserCancelled) {
+		t.Fatalf("expected ErrUserCancelled, got %v", err)
+	}
+}
+
+func TestResolveDeviceNameInteractiveBlankReturnsEmpty(t *testing.T) {
+	origInteractive := isInteractiveTerminalFn
+	origPrompt := promptDeviceName
+	isInteractiveTerminalFn = func() bool { return true }
+	promptDeviceName = func(_, _ string, _ tui.ValidateFunc) (string, error) {
+		return "   ", nil
+	}
+	t.Cleanup(func() {
+		isInteractiveTerminalFn = origInteractive
+		promptDeviceName = origPrompt
+	})
 
 	got, err := resolveDeviceName("")
 	if err != nil {

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -334,6 +334,73 @@ func TestResolveWiFiCredentialsListFlags(t *testing.T) {
 	}
 }
 
+func TestResolveDeviceNameFlag(t *testing.T) {
+	got, err := resolveDeviceName("wendy-pi-5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "wendy-pi-5" {
+		t.Fatalf("got %q; want %q", got, "wendy-pi-5")
+	}
+}
+
+func TestResolveDeviceNameNoFlagNonInteractive(t *testing.T) {
+	origInteractive := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = origInteractive })
+
+	got, err := resolveDeviceName("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("got %q; want empty device name", got)
+	}
+}
+
+func TestResolveDeviceNameFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr string
+	}{
+		{"too short", "ab", "3–64 characters"},
+		{"too long", strings.Repeat("a", 65), "3–64 characters"},
+		{"starts with number", "1device", "start with a lowercase letter"},
+		{"uppercase", "Wendy", "lowercase letters, digits, and hyphens"},
+		{"underscore", "wendy_pi", "lowercase letters, digits, and hyphens"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveDeviceName(tc.in)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), "--device-name") {
+				t.Fatalf("error should mention --device-name, got %q", err.Error())
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q should contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestOptionalDeviceNameValidatorAllowsAutoGenerate(t *testing.T) {
+	if err := optionalDeviceNameValidator(""); err != nil {
+		t.Fatalf("empty device name should allow auto-generation: %v", err)
+	}
+	if err := optionalDeviceNameValidator("   "); err != nil {
+		t.Fatalf("blank device name should allow auto-generation: %v", err)
+	}
+	if err := optionalDeviceNameValidator("wendy-pi"); err != nil {
+		t.Fatalf("valid device name should pass: %v", err)
+	}
+	if err := optionalDeviceNameValidator("pi"); err == nil {
+		t.Fatal("invalid non-empty device name should fail")
+	}
+}
+
 func TestResolveOSImage_ZipCacheHit(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())


### PR DESCRIPTION
## Summary

- route the interactive `wendy os install` device-name prompt through the shared `tui.PromptText` renderer
- keep blank input as the existing first-boot auto-generation fallback
- add focused tests for flag validation, non-interactive behavior, and optional blank input

## Linear

Closes WDY-1255

Follow-up DX proposal: WDY-1256

## Validation

- `gofmt -w go/internal/cli/commands/os_install.go go/internal/cli/commands/os_install_test.go`
- `git diff --check`
- `CC="$(xcrun --find clang)" CXX="$(xcrun --find clang++)" SDKROOT="$(xcrun --show-sdk-path)" go test ./go/internal/cli/commands -run 'TestResolveDeviceName|TestResolveWiFiCredentialsListFlags|TestNewOSInstallCmd_Flags'`
