### PR TITLE
Auto Enter generated template project directory

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -700,7 +700,6 @@ func finishTemplateInitWithLauncher(cwd, destDir, appID string, enterProjectDir 
 			return err
 		}
 		cliLogln("Opening a shell in: %s", projectDir)
-		cliLogln("Shell: %s", shell)
 		cliLogln("Run `wendy run` to build and deploy.")
 		return launch(projectDir, shell)
 	}
@@ -730,11 +729,18 @@ func projectShellDir(cwd, destDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("checking project directory: %w", err)
 	}
-	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || !pathHasPrefix(cleanDest, cleanCwd) {
 		return "", fmt.Errorf("project directory %q is outside working directory %q", destDir, cwd)
 	}
 
 	return cleanDest, nil
+}
+
+func pathHasPrefix(path, prefix string) bool {
+	sep := string(filepath.Separator)
+	cleanPath := strings.TrimRight(filepath.Clean(path), sep) + sep
+	cleanPrefix := strings.TrimRight(filepath.Clean(prefix), sep) + sep
+	return strings.HasPrefix(cleanPath, cleanPrefix)
 }
 
 func canonicalProjectPath(path string) (string, error) {
@@ -746,8 +752,17 @@ func canonicalProjectPath(path string) (string, error) {
 }
 
 func startProjectShell(dir, shell string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("checking project directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("project directory %q is not a directory", dir)
+	}
+
 	cmd := exec.Command(shell)
-	cmd.Dir = filepath.Clean(dir)
+	cmd.Dir = dir
+	cmd.Env = projectShellEnv(shell)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -759,15 +774,22 @@ func startProjectShell(dir, shell string) error {
 
 func defaultInteractiveShell() (string, error) {
 	if runtime.GOOS == "windows" {
-		shell, err := exec.LookPath("cmd.exe")
-		if err == nil {
-			return shell, nil
+		systemRoot := strings.TrimSpace(os.Getenv("SystemRoot"))
+		if systemRoot == "" {
+			systemRoot = `C:\Windows`
 		}
-		return "", fmt.Errorf("finding interactive shell: %w", err)
+		shell := filepath.Join(systemRoot, "System32", "cmd.exe")
+		if valid, ok := validateInteractiveShell(shell); ok {
+			return valid, nil
+		}
+		return "", fmt.Errorf("finding interactive shell: %s not available", shell)
 	}
 
+	if shell, ok := validateInteractiveShell(os.Getenv("SHELL")); ok {
+		return shell, nil
+	}
 	for _, shell := range defaultUnixShellCandidates() {
-		if _, err := os.Stat(shell); err == nil {
+		if shell, ok := validateInteractiveShell(shell); ok {
 			return shell, nil
 		}
 	}
@@ -779,6 +801,71 @@ func defaultUnixShellCandidates() []string {
 		return []string{"/bin/zsh", "/bin/bash", "/bin/sh"}
 	}
 	return []string{"/bin/bash", "/usr/bin/bash", "/bin/sh", "/usr/bin/sh"}
+}
+
+func validateInteractiveShell(candidate string) (string, bool) {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" || !filepath.IsAbs(candidate) {
+		return "", false
+	}
+	candidate = filepath.Clean(candidate)
+	if !isKnownShellName(filepath.Base(candidate)) || isWorldWritableDir(filepath.Dir(candidate)) {
+		return "", false
+	}
+	info, err := os.Stat(candidate)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", false
+	}
+	mode := info.Mode().Perm()
+	if mode&0o111 == 0 || mode&0o002 != 0 {
+		return "", false
+	}
+	return candidate, true
+}
+
+func isKnownShellName(name string) bool {
+	switch strings.ToLower(name) {
+	case "sh", "bash", "zsh", "fish", "dash", "ksh", "cmd.exe", "powershell.exe", "pwsh.exe":
+		return true
+	default:
+		return false
+	}
+}
+
+func isWorldWritableDir(dir string) bool {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return true
+	}
+	return info.Mode().Perm()&0o002 != 0
+}
+
+func projectShellEnv(shell string) []string {
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, kv := range os.Environ() {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok || isSensitiveEnvKey(key) || key == "SHELL" {
+			continue
+		}
+		env = append(env, kv)
+	}
+	if runtime.GOOS != "windows" {
+		env = append(env, "SHELL="+shell)
+	}
+	return env
+}
+
+func isSensitiveEnvKey(key string) bool {
+	key = strings.ToUpper(strings.TrimSpace(key))
+	if key == "" {
+		return false
+	}
+	for _, marker := range []string{"TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "PRIVATE_KEY", "ACCESS_KEY", "API_KEY", "AUTH"} {
+		if strings.Contains(key, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func shellQuote(s string) string {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -702,7 +702,11 @@ func finishTemplateInitWithLauncher(cwd, destDir, appID string, enterProjectDir 
 		}
 		cliLogln("Opening a shell in: %s", projectDir)
 		cliLogln("Run `wendy run` to build and deploy.")
-		return launch(projectDir, shell)
+		if err := launch(projectDir, shell); err != nil {
+			cliLogln("Warning: failed to open project shell: %v", err)
+			return err
+		}
+		return nil
 	}
 
 	cliLogln("Next steps:")
@@ -840,7 +844,7 @@ func validateInteractiveShell(candidate string) (string, bool) {
 	}
 	if runtime.GOOS != "windows" {
 		mode := info.Mode().Perm()
-		if mode&0o111 == 0 || mode&0o022 != 0 || !isRootOwned(info) {
+		if mode&0o111 == 0 || mode&0o022 != 0 || !isRootOwned(resolved, info) {
 			return "", false
 		}
 	}
@@ -917,7 +921,7 @@ func isRootOwnedNonWritableDir(dir string) (bool, error) {
 	if !info.IsDir() {
 		return false, fmt.Errorf("checking shell directory %q: not a directory", dir)
 	}
-	return info.Mode().Perm()&0o022 == 0 && isRootOwned(info), nil
+	return info.Mode().Perm()&0o022 == 0 && isRootOwned(dir, info), nil
 }
 
 func projectShellEnv(shell string) ([]string, error) {
@@ -1034,7 +1038,7 @@ func isForbiddenProjectShellEnvKey(key string) bool {
 	switch upper {
 	case "GCONV_PATH",
 		"BASH_ENV", "ENV", "CDPATH", "IFS", "SHELLOPTS", "BASHOPTS", "PS4",
-		"PYTHONPATH", "RUBYLIB", "RUBYOPT", "NODE_PATH", "NODE_OPTIONS", "PERL5LIB", "PERL5OPT":
+		"ZDOTDIR", "PYTHONPATH", "RUBYLIB", "RUBYOPT", "NODE_PATH", "NODE_OPTIONS", "PERL5LIB", "PERL5OPT":
 		return true
 	default:
 		return false

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -820,7 +820,7 @@ func validateInteractiveShell(candidate string) (string, bool) {
 		return "", false
 	}
 	resolved = filepath.Clean(resolved)
-	if !isKnownShellName(filepath.Base(resolved)) || !isTrustedShellDir(filepath.Dir(resolved)) {
+	if !isKnownShellName(filepath.Base(resolved)) || !isTrustedShellPath(candidate, resolved) {
 		return "", false
 	}
 	writable, err := isWorldWritableDir(filepath.Dir(resolved))
@@ -838,9 +838,37 @@ func validateInteractiveShell(candidate string) (string, bool) {
 	return resolved, true
 }
 
+func isTrustedShellPath(candidate, resolved string) bool {
+	if runtime.GOOS == "windows" {
+		return isTrustedShellDir(filepath.Dir(resolved))
+	}
+	if shellListedInSystemShells(candidate) {
+		return true
+	}
+	return isTrustedShellDir(filepath.Dir(candidate)) && isTrustedShellDir(filepath.Dir(resolved))
+}
+
+func shellListedInSystemShells(shell string) bool {
+	data, err := os.ReadFile("/etc/shells")
+	if err != nil {
+		return false
+	}
+	shell = filepath.Clean(shell)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || !filepath.IsAbs(line) {
+			continue
+		}
+		if filepath.Clean(line) == shell {
+			return true
+		}
+	}
+	return false
+}
+
 func isTrustedShellDir(dir string) bool {
 	dir = filepath.Clean(dir)
-	for _, trusted := range trustedShellDirs() {
+	for _, trusted := range fallbackTrustedShellDirs() {
 		trusted = filepath.Clean(trusted)
 		if runtime.GOOS == "windows" {
 			if strings.EqualFold(dir, trusted) {
@@ -855,7 +883,7 @@ func isTrustedShellDir(dir string) bool {
 	return false
 }
 
-func trustedShellDirs() []string {
+func fallbackTrustedShellDirs() []string {
 	if runtime.GOOS == "windows" {
 		return []string{`C:\Windows\System32`}
 	}
@@ -896,6 +924,7 @@ func projectShellEnv(shell string) ([]string, error) {
 	if runtime.GOOS != "windows" {
 		env = append(env, "SHELL="+validated)
 	}
+	env = appendWithoutExistingEnv(env, "TERM", projectShellTerm(os.Getenv("TERM")))
 	env = appendWithoutExistingEnv(env, "PATH", projectShellPath())
 	return env, nil
 }
@@ -903,10 +932,10 @@ func projectShellEnv(shell string) ([]string, error) {
 func isProjectShellEnvKey(key string) bool {
 	key = strings.ToUpper(strings.TrimSpace(key))
 	switch key {
-	case "HOME", "TERM", "LANG", "LOGNAME", "USER", "USERNAME", "TMPDIR", "TMP", "TEMP", "COLORTERM", "CLICOLOR", "NO_COLOR":
+	case "HOME", "LOGNAME", "USER", "USERNAME", "TMPDIR", "TMP", "TEMP":
 		return true
 	default:
-		return strings.HasPrefix(key, "LC_")
+		return false
 	}
 }
 
@@ -914,11 +943,30 @@ func appendWithoutExistingEnv(env []string, key, value string) []string {
 	prefix := key + "="
 	out := make([]string, 0, len(env)+1)
 	for _, kv := range env {
-		if !strings.HasPrefix(kv, prefix) {
+		if !envKeyHasPrefix(kv, prefix) {
 			out = append(out, kv)
 		}
 	}
 	return append(out, prefix+value)
+}
+
+func envKeyHasPrefix(kv, prefix string) bool {
+	if len(kv) < len(prefix) {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(kv[:len(prefix)], prefix)
+	}
+	return strings.HasPrefix(kv, prefix)
+}
+
+func projectShellTerm(term string) string {
+	switch strings.TrimSpace(term) {
+	case "xterm", "xterm-256color", "screen", "screen-256color", "tmux", "tmux-256color", "vt100", "dumb":
+		return strings.TrimSpace(term)
+	default:
+		return "dumb"
+	}
 }
 
 func projectShellPath() string {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -741,7 +741,7 @@ func pathHasPrefix(path, prefix string) bool {
 	sep := string(filepath.Separator)
 	cleanPath := strings.TrimRight(filepath.Clean(path), sep) + sep
 	cleanPrefix := strings.TrimRight(filepath.Clean(prefix), sep) + sep
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" {
 		if len(cleanPath) < len(cleanPrefix) {
 			return false
 		}
@@ -806,7 +806,7 @@ func defaultInteractiveShell() (string, error) {
 }
 
 func defaultWindowsShellCandidates() []string {
-	return []string{filepath.Join(`C:\Windows`, "System32", "cmd.exe")}
+	return []string{filepath.Join(windowsRootDir(), "System32", "cmd.exe")}
 }
 
 func defaultUnixShellCandidates() []string {
@@ -901,7 +901,7 @@ func isTrustedShellDir(dir string) bool {
 
 func fallbackTrustedShellDirs() []string {
 	if runtime.GOOS == "windows" {
-		return []string{filepath.Join(`C:\Windows`, "System32")}
+		return []string{filepath.Join(windowsRootDir(), "System32")}
 	}
 	return []string{"/bin", "/usr/bin"}
 }
@@ -1047,7 +1047,7 @@ func projectShellPath() string {
 		for _, dir := range fallbackTrustedShellDirs() {
 			parts = appendProjectShellPathDir(parts, dir)
 		}
-		parts = appendProjectShellPathDir(parts, `C:\Windows`)
+		parts = appendProjectShellPathDir(parts, windowsRootDir())
 	} else {
 		parts = appendProjectShellPathDir(parts, "/usr/bin")
 		parts = appendProjectShellPathDir(parts, "/bin")
@@ -1146,12 +1146,7 @@ func resolveInitDestAndID(cwd string, args []string, opts initOptions) (string, 
 		}
 
 		fmt.Println()
-		appID, err := tui.PromptText("Project name", "directory name and app identifier", func(v string) error {
-			if strings.TrimSpace(v) == "" {
-				return fmt.Errorf("project name cannot be empty")
-			}
-			return nil
-		})
+		appID, err := tui.PromptText("Project name", "directory name and app identifier", validateNewProjectName)
 		if err != nil {
 			return "", "", false, err
 		}
@@ -1161,6 +1156,17 @@ func resolveInitDestAndID(cwd string, args []string, opts initOptions) (string, 
 
 	// Semi-interactive or non-interactive without explicit app ID: infer from cwd.
 	return cwd, strings.TrimSpace(filepath.Base(cwd)), false, nil
+}
+
+func validateNewProjectName(value string) error {
+	name := strings.TrimSpace(value)
+	if name == "" {
+		return fmt.Errorf("project name cannot be empty")
+	}
+	if filepath.IsAbs(name) || filepath.Clean(name) != name || name == "." || name == ".." || strings.ContainsAny(name, `/\:`) {
+		return fmt.Errorf("project name must be a single subdirectory name")
+	}
+	return nil
 }
 
 // maybeGitInit optionally runs git init in the project directory.

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -827,9 +827,11 @@ func validateInteractiveShell(candidate string) (string, bool) {
 		return "", false
 	}
 	if runtime.GOOS != "windows" {
-		trusted, err := isRootOwnedNonWritableDir(filepath.Dir(resolved))
-		if err != nil || !trusted {
-			return "", false
+		for _, dir := range shellValidationDirs(candidate, resolved) {
+			trusted, err := isRootOwnedNonWritableDir(dir)
+			if err != nil || !trusted {
+				return "", false
+			}
 		}
 	}
 	info, err := os.Lstat(resolved)
@@ -849,7 +851,29 @@ func isTrustedShellPath(candidate, resolved string) bool {
 	if runtime.GOOS == "windows" {
 		return isTrustedShellDir(filepath.Dir(resolved))
 	}
+	if runtime.GOOS == "darwin" {
+		return isDarwinSystemShellPath(candidate) && isDarwinSystemShellPath(resolved)
+	}
 	return isTrustedShellDir(filepath.Dir(candidate)) && isTrustedShellDir(filepath.Dir(resolved))
+}
+
+func shellValidationDirs(candidate, resolved string) []string {
+	dirs := []string{filepath.Dir(candidate)}
+	resolvedDir := filepath.Dir(resolved)
+	if resolvedDir != dirs[0] {
+		dirs = append(dirs, resolvedDir)
+	}
+	return dirs
+}
+
+func isDarwinSystemShellPath(path string) bool {
+	// Keep Darwin shell handoff limited to immutable SIP-protected system shells.
+	switch filepath.Clean(path) {
+	case "/bin/zsh", "/bin/bash", "/bin/sh":
+		return true
+	default:
+		return false
+	}
 }
 
 func isTrustedShellDir(dir string) bool {
@@ -908,7 +932,7 @@ func projectShellEnv(shell string) ([]string, error) {
 	}
 	env = appendWithoutExistingEnv(env, "TERM", projectShellTerm(os.Getenv("TERM")))
 	env = appendWithoutExistingEnv(env, "PATH", projectShellPath())
-	return env, nil
+	return scrubProjectShellEnv(env), nil
 }
 
 func projectShellUserEnv() []string {
@@ -989,7 +1013,37 @@ func appendWithoutExistingEnv(env []string, key, value string) []string {
 			out = append(out, kv)
 		}
 	}
+	if value == "" {
+		return out
+	}
 	return append(out, prefix+value)
+}
+
+func scrubProjectShellEnv(env []string) []string {
+	out := env[:0]
+	for _, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok || isForbiddenProjectShellEnvKey(key) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func isForbiddenProjectShellEnvKey(key string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(key))
+	if strings.HasPrefix(upper, "LD_") || strings.HasPrefix(upper, "DYLD_") {
+		return true
+	}
+	switch upper {
+	case "GCONV_PATH",
+		"BASH_ENV", "ENV", "CDPATH", "IFS", "SHELLOPTS", "BASHOPTS", "PS4",
+		"PYTHONPATH", "RUBYLIB", "RUBYOPT", "NODE_PATH", "NODE_OPTIONS", "PERL5LIB", "PERL5OPT":
+		return true
+	default:
+		return false
+	}
 }
 
 func envKeyHasPrefix(kv, prefix string) bool {
@@ -1138,6 +1192,12 @@ func validateNewProjectName(value string) error {
 	}
 	if filepath.IsAbs(name) || filepath.Clean(name) != name || name == "." || name == ".." || strings.ContainsAny(name, `/\:`) {
 		return fmt.Errorf("project name must be a single subdirectory name")
+	}
+	for _, r := range name {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '.' || r == '_' || r == '-' {
+			continue
+		}
+		return fmt.Errorf("project name may only contain letters, numbers, '.', '_' or '-'")
 	}
 	return nil
 }

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -849,7 +850,12 @@ func isTrustedShellPath(candidate, resolved string) bool {
 }
 
 func shellListedInSystemShells(shell string) bool {
-	data, err := os.ReadFile("/etc/shells")
+	f, err := os.Open("/etc/shells")
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, 64*1024))
 	if err != nil {
 		return false
 	}
@@ -900,7 +906,7 @@ func isKnownShellName(name string) bool {
 }
 
 func isWorldWritableDir(dir string) (bool, error) {
-	info, err := os.Stat(dir)
+	info, err := os.Lstat(dir)
 	if err != nil || !info.IsDir() {
 		return false, fmt.Errorf("checking shell directory %q: %w", dir, err)
 	}

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -781,24 +781,20 @@ func startProjectShell(dir, shell string) error {
 
 func defaultInteractiveShell() (string, error) {
 	if runtime.GOOS == "windows" {
-		systemRoot := strings.TrimSpace(os.Getenv("SystemRoot"))
-		if systemRoot == "" {
-			systemRoot = `C:\Windows`
-		}
-		shell := filepath.Join(systemRoot, "System32", "cmd.exe")
+		shell := filepath.Join(`C:\Windows`, "System32", "cmd.exe")
 		if valid, ok := validateInteractiveShell(shell); ok {
 			return valid, nil
 		}
 		return "", fmt.Errorf("finding interactive shell: %s not available", shell)
 	}
 
-	if shell, ok := validateInteractiveShell(os.Getenv("SHELL")); ok {
-		return shell, nil
-	}
 	for _, shell := range defaultUnixShellCandidates() {
 		if shell, ok := validateInteractiveShell(shell); ok {
 			return shell, nil
 		}
+	}
+	if shell, ok := validateInteractiveShell(os.Getenv("SHELL")); ok {
+		return shell, nil
 	}
 	return "", fmt.Errorf("finding interactive shell: no supported shell found")
 }
@@ -816,10 +812,19 @@ func validateInteractiveShell(candidate string) (string, bool) {
 		return "", false
 	}
 	candidate = filepath.Clean(candidate)
-	if !isKnownShellName(filepath.Base(candidate)) || !isTrustedShellDir(filepath.Dir(candidate)) || isWorldWritableDir(filepath.Dir(candidate)) {
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
 		return "", false
 	}
-	info, err := os.Stat(candidate)
+	resolved = filepath.Clean(resolved)
+	if !isKnownShellName(filepath.Base(resolved)) || !isTrustedShellDir(filepath.Dir(resolved)) {
+		return "", false
+	}
+	writable, err := isWorldWritableDir(filepath.Dir(resolved))
+	if err != nil || writable {
+		return "", false
+	}
+	info, err := os.Lstat(resolved)
 	if err != nil || !info.Mode().IsRegular() {
 		return "", false
 	}
@@ -827,7 +832,7 @@ func validateInteractiveShell(candidate string) (string, bool) {
 	if mode&0o111 == 0 || mode&0o002 != 0 {
 		return "", false
 	}
-	return candidate, true
+	return resolved, true
 }
 
 func isTrustedShellDir(dir string) bool {
@@ -857,12 +862,14 @@ func isKnownShellName(name string) bool {
 	}
 }
 
-func isWorldWritableDir(dir string) bool {
+func isWorldWritableDir(dir string) (bool, error) {
 	info, err := os.Stat(dir)
 	if err != nil || !info.IsDir() {
-		return true
+		return false, fmt.Errorf("checking shell directory %q: %w", dir, err)
 	}
-	return info.Mode().Perm()&0o002 != 0 && info.Mode()&os.ModeSticky == 0
+	// Sticky world-writable directories such as /tmp are not trusted shell
+	// directories, but this keeps the permission helper precise.
+	return info.Mode().Perm()&0o002 != 0 && info.Mode()&os.ModeSticky == 0, nil
 }
 
 func projectShellEnv(shell string) []string {
@@ -877,17 +884,35 @@ func projectShellEnv(shell string) []string {
 	if runtime.GOOS != "windows" {
 		env = append(env, "SHELL="+shell)
 	}
+	env = appendWithoutExistingEnv(env, "PATH", projectShellPath())
 	return env
 }
 
 func isProjectShellEnvKey(key string) bool {
 	key = strings.ToUpper(strings.TrimSpace(key))
 	switch key {
-	case "HOME", "PATH", "TERM", "LANG", "LOGNAME", "USER", "USERNAME", "TMPDIR", "TMP", "TEMP", "COLORTERM", "CLICOLOR", "NO_COLOR":
+	case "HOME", "TERM", "LANG", "LOGNAME", "USER", "USERNAME", "TMPDIR", "TMP", "TEMP", "COLORTERM", "CLICOLOR", "NO_COLOR":
 		return true
 	default:
 		return strings.HasPrefix(key, "LC_")
 	}
+}
+
+func appendWithoutExistingEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			env = append(env[:i], env[i+1:]...)
+		}
+	}
+	return append(env, prefix+value)
+}
+
+func projectShellPath() string {
+	if runtime.GOOS == "windows" {
+		return strings.Join([]string{`C:\Windows\System32`, `C:\Windows`}, string(os.PathListSeparator))
+	}
+	return strings.Join([]string{"/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"}, string(os.PathListSeparator))
 }
 
 func shellQuote(s string) string {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -887,8 +887,11 @@ func isKnownShellName(name string) bool {
 
 func isRootOwnedNonWritableDir(dir string) (bool, error) {
 	info, err := os.Stat(dir)
-	if err != nil || !info.IsDir() {
+	if err != nil {
 		return false, fmt.Errorf("checking shell directory %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("checking shell directory %q: not a directory", dir)
 	}
 	return info.Mode().Perm()&0o022 == 0 && isRootOwned(info), nil
 }

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -258,11 +259,11 @@ func runInitWizard(args []string, opts initOptions) error {
 	}
 
 	if tmpl != "" {
-		destDir, appID, err := resolveInitDestAndID(cwd, args, opts)
+		destDir, appID, enterProjectDir, err := resolveInitDestAndID(cwd, args, opts)
 		if err != nil {
 			return err
 		}
-		return runTemplateFlow(cwd, destDir, appID, tmpl, target, meta, opts)
+		return runTemplateFlow(cwd, destDir, appID, tmpl, target, meta, opts, enterProjectDir)
 	}
 
 	// Standard wizard flow (no template) — check wendy.json doesn't already exist.
@@ -619,7 +620,7 @@ func downloadTemplateArchiveWithUI(language, tmpl, branch string) (map[string][]
 
 // runTemplateFlow handles init when a template is selected.
 // destDir is the resolved project directory (either cwd or a new subdir).
-func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, opts initOptions) error {
+func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, opts initOptions, enterProjectDir bool) error {
 	language, err := resolveTemplateLanguage(target, tmpl, meta, opts)
 	if err != nil {
 		return err
@@ -679,7 +680,18 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 		return err
 	}
 
+	return finishTemplateInit(cwd, destDir, appID, enterProjectDir)
+}
+
+func finishTemplateInit(cwd, destDir, appID string, enterProjectDir bool) error {
 	cliSuccess("\nYour project is ready!")
+
+	if enterProjectDir && filepath.Clean(destDir) != filepath.Clean(cwd) {
+		cliLogln("Opening a shell in: %s", destDir)
+		cliLogln("Run `wendy run` to build and deploy.")
+		return startProjectShell(destDir)
+	}
+
 	cliLogln("Next steps:")
 	for _, step := range templateNextSteps(cwd, destDir, appID) {
 		cliLogln("  %s", step)
@@ -689,6 +701,33 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 	}
 
 	return nil
+}
+
+var startProjectShell = func(dir string) error {
+	shell := defaultInteractiveShell()
+	cmd := exec.Command(shell)
+	cmd.Dir = dir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("starting shell in project directory: %w", err)
+	}
+	return nil
+}
+
+func defaultInteractiveShell() string {
+	if runtime.GOOS == "windows" {
+		if shell := os.Getenv("COMSPEC"); shell != "" {
+			return shell
+		}
+		return "cmd.exe"
+	}
+
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell
+	}
+	return "/bin/sh"
 }
 
 func shellQuote(s string) string {
@@ -710,14 +749,14 @@ func templateNextSteps(cwd, destDir, appID string) []string {
 // resolveInitDestAndID determines the destination directory and app ID for template flow.
 // In fully interactive mode it asks whether to initialize in the current directory
 // or create a new project subdirectory.
-func resolveInitDestAndID(cwd string, args []string, opts initOptions) (string, string, error) {
+func resolveInitDestAndID(cwd string, args []string, opts initOptions) (string, string, bool, error) {
 	// Explicit app ID provided: always create a new subdirectory.
 	if len(args) > 0 || opts.appIDSet {
 		appID, err := resolveInitAppID(cwd, args, opts)
 		if err != nil {
-			return "", "", err
+			return "", "", false, err
 		}
-		return filepath.Join(cwd, appID), appID, nil
+		return filepath.Join(cwd, appID), appID, false, nil
 	}
 
 	// Fully interactive (no directive flags): ask where to set up the project.
@@ -725,10 +764,10 @@ func resolveInitDestAndID(cwd string, args []string, opts initOptions) (string, 
 		fmt.Println()
 		useCurrentDir, err := tui.ConfirmDefaultYes("Initialize in the current directory?")
 		if err != nil {
-			return "", "", err
+			return "", "", false, err
 		}
 		if useCurrentDir {
-			return cwd, strings.TrimSpace(filepath.Base(cwd)), nil
+			return cwd, strings.TrimSpace(filepath.Base(cwd)), false, nil
 		}
 
 		fmt.Println()
@@ -739,14 +778,14 @@ func resolveInitDestAndID(cwd string, args []string, opts initOptions) (string, 
 			return nil
 		})
 		if err != nil {
-			return "", "", err
+			return "", "", false, err
 		}
 		appID = strings.TrimSpace(appID)
-		return filepath.Join(cwd, appID), appID, nil
+		return filepath.Join(cwd, appID), appID, true, nil
 	}
 
 	// Semi-interactive or non-interactive without explicit app ID: infer from cwd.
-	return cwd, strings.TrimSpace(filepath.Base(cwd)), nil
+	return cwd, strings.TrimSpace(filepath.Base(cwd)), false, nil
 }
 
 // maybeGitInit optionally runs git init in the project directory.

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"os/user"
@@ -799,9 +798,6 @@ func defaultInteractiveShell() (string, error) {
 			return shell, nil
 		}
 	}
-	if shell, ok := validateInteractiveShell(os.Getenv("SHELL")); ok {
-		return shell, nil
-	}
 	return "", fmt.Errorf("finding interactive shell: no supported shell found")
 }
 
@@ -831,8 +827,8 @@ func validateInteractiveShell(candidate string) (string, bool) {
 		return "", false
 	}
 	if runtime.GOOS != "windows" {
-		writable, err := isWorldWritableDir(filepath.Dir(resolved))
-		if err != nil || writable {
+		trusted, err := isRootOwnedNonWritableDir(filepath.Dir(resolved))
+		if err != nil || !trusted {
 			return "", false
 		}
 	}
@@ -842,7 +838,7 @@ func validateInteractiveShell(candidate string) (string, bool) {
 	}
 	if runtime.GOOS != "windows" {
 		mode := info.Mode().Perm()
-		if mode&0o111 == 0 || mode&0o002 != 0 {
+		if mode&0o111 == 0 || mode&0o022 != 0 || !isRootOwned(info) {
 			return "", false
 		}
 	}
@@ -853,33 +849,7 @@ func isTrustedShellPath(candidate, resolved string) bool {
 	if runtime.GOOS == "windows" {
 		return isTrustedShellDir(filepath.Dir(resolved))
 	}
-	if shellListedInSystemShells(candidate) {
-		return true
-	}
 	return isTrustedShellDir(filepath.Dir(candidate)) && isTrustedShellDir(filepath.Dir(resolved))
-}
-
-func shellListedInSystemShells(shell string) bool {
-	f, err := os.Open("/etc/shells")
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-	data, err := io.ReadAll(io.LimitReader(f, 64*1024))
-	if err != nil {
-		return false
-	}
-	shell = filepath.Clean(shell)
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") || !filepath.IsAbs(line) {
-			continue
-		}
-		if filepath.Clean(line) == shell {
-			return true
-		}
-	}
-	return false
 }
 
 func isTrustedShellDir(dir string) bool {
@@ -915,12 +885,12 @@ func isKnownShellName(name string) bool {
 	}
 }
 
-func isWorldWritableDir(dir string) (bool, error) {
-	info, err := os.Lstat(dir)
+func isRootOwnedNonWritableDir(dir string) (bool, error) {
+	info, err := os.Stat(dir)
 	if err != nil || !info.IsDir() {
 		return false, fmt.Errorf("checking shell directory %q: %w", dir, err)
 	}
-	return info.Mode().Perm()&0o002 != 0, nil
+	return info.Mode().Perm()&0o022 == 0 && isRootOwned(info), nil
 }
 
 func projectShellEnv(shell string) ([]string, error) {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -779,19 +779,7 @@ func startProjectShell(dir, shell string) error {
 		return err
 	}
 
-	// Use a normal interactive shell so this handoff behaves like a user-run
-	// `cd`; user-owned startup files are intentionally honored.
-	cmd := exec.Command(validated)
-	cmd.Path = validated
-	cmd.Dir = dir
-	cmd.Env = env
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("starting shell in project directory: %w", err)
-	}
-	return nil
+	return runProjectShell(validated, dir, env)
 }
 
 func defaultInteractiveShell() (string, error) {
@@ -871,7 +859,7 @@ func trustedShellDirs() []string {
 	if runtime.GOOS == "windows" {
 		return []string{`C:\Windows\System32`}
 	}
-	return []string{"/bin", "/usr/bin", "/usr/local/bin", "/opt/homebrew/bin", "/opt/local/bin", "/run/current-system/sw/bin"}
+	return []string{"/bin", "/usr/bin"}
 }
 
 func isKnownShellName(name string) bool {
@@ -888,9 +876,7 @@ func isWorldWritableDir(dir string) (bool, error) {
 	if err != nil || !info.IsDir() {
 		return false, fmt.Errorf("checking shell directory %q: %w", dir, err)
 	}
-	// Sticky world-writable directories such as /tmp are not trusted shell
-	// directories, but this keeps the permission helper precise.
-	return info.Mode().Perm()&0o002 != 0 && info.Mode()&os.ModeSticky == 0, nil
+	return info.Mode().Perm()&0o002 != 0, nil
 }
 
 func projectShellEnv(shell string) ([]string, error) {
@@ -926,19 +912,20 @@ func isProjectShellEnvKey(key string) bool {
 
 func appendWithoutExistingEnv(env []string, key, value string) []string {
 	prefix := key + "="
-	for i := len(env) - 1; i >= 0; i-- {
-		if strings.HasPrefix(env[i], prefix) {
-			env = append(env[:i], env[i+1:]...)
+	out := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if !strings.HasPrefix(kv, prefix) {
+			out = append(out, kv)
 		}
 	}
-	return append(env, prefix+value)
+	return append(out, prefix+value)
 }
 
 func projectShellPath() string {
 	if runtime.GOOS == "windows" {
 		return strings.Join([]string{`C:\Windows\System32`, `C:\Windows`}, string(os.PathListSeparator))
 	}
-	return strings.Join([]string{"/opt/homebrew/bin", "/usr/local/bin", "/run/current-system/sw/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"}, string(os.PathListSeparator))
+	return strings.Join([]string{"/usr/bin", "/bin"}, string(os.PathListSeparator))
 }
 
 func shellQuote(s string) string {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -926,32 +926,32 @@ func projectShellEnv(shell string) ([]string, error) {
 		return nil, fmt.Errorf("interactive shell %q is no longer valid", shell)
 	}
 
-	env := projectShellUserEnv()
+	home, username := projectShellUserIdentity()
+	env := make([]string, 0, 6)
+	env = appendAllowedProjectShellEnv(env, "HOME", home)
 	if runtime.GOOS != "windows" {
-		env = append(env, "SHELL="+validated)
+		env = appendAllowedProjectShellEnv(env, "SHELL", validated)
+		env = appendAllowedProjectShellEnv(env, "LOGNAME", username)
+		env = appendAllowedProjectShellEnv(env, "USER", username)
+	} else {
+		env = appendAllowedProjectShellEnv(env, "USERNAME", username)
 	}
-	env = appendWithoutExistingEnv(env, "TERM", projectShellTerm(os.Getenv("TERM")))
-	env = appendWithoutExistingEnv(env, "PATH", projectShellPath())
-	return scrubProjectShellEnv(env), nil
+	env = appendAllowedProjectShellEnv(env, "TERM", projectShellTerm(os.Getenv("TERM")))
+	env = appendAllowedProjectShellEnv(env, "PATH", projectShellPath())
+	return env, nil
 }
 
-func projectShellUserEnv() []string {
+func projectShellUserIdentity() (string, string) {
 	current, err := user.Current()
 	if err != nil {
-		return nil
+		return "", ""
 	}
-	env := make([]string, 0, 3)
+	var home string
 	if isSafeEnvPathValue(current.HomeDir) {
-		env = append(env, "HOME="+filepath.Clean(current.HomeDir))
+		home = filepath.Clean(current.HomeDir)
 	}
 	username := safeCurrentUsername(current.Username)
-	if username == "" {
-		return env
-	}
-	if runtime.GOOS == "windows" {
-		return append(env, "USERNAME="+username)
-	}
-	return append(env, "LOGNAME="+username, "USER="+username)
+	return home, username
 }
 
 func safeCurrentUsername(username string) string {
@@ -1019,16 +1019,11 @@ func appendWithoutExistingEnv(env []string, key, value string) []string {
 	return append(out, prefix+value)
 }
 
-func scrubProjectShellEnv(env []string) []string {
-	out := env[:0]
-	for _, kv := range env {
-		key, _, ok := strings.Cut(kv, "=")
-		if !ok || isForbiddenProjectShellEnvKey(key) {
-			continue
-		}
-		out = append(out, kv)
+func appendAllowedProjectShellEnv(env []string, key, value string) []string {
+	if isForbiddenProjectShellEnvKey(key) {
+		return appendWithoutExistingEnv(env, key, "")
 	}
-	return out
+	return appendWithoutExistingEnv(env, key, value)
 }
 
 func isForbiddenProjectShellEnvKey(key string) bool {
@@ -1116,7 +1111,7 @@ func projectShellPathDir(dir string) (string, bool) {
 		return "", false
 	}
 	if runtime.GOOS != "windows" {
-		writable, err := isWorldWritablePathDir(dir)
+		writable, err := isGroupOrWorldWritablePathDir(dir)
 		if err != nil || writable {
 			return "", false
 		}
@@ -1124,12 +1119,12 @@ func projectShellPathDir(dir string) (string, bool) {
 	return dir, true
 }
 
-func isWorldWritablePathDir(dir string) (bool, error) {
+func isGroupOrWorldWritablePathDir(dir string) (bool, error) {
 	info, err := os.Stat(dir)
 	if err != nil || !info.IsDir() {
 		return false, fmt.Errorf("checking PATH directory %q: %w", dir, err)
 	}
-	return info.Mode().Perm()&0o002 != 0, nil
+	return info.Mode().Perm()&0o022 != 0, nil
 }
 
 func shellQuote(s string) string {
@@ -1192,6 +1187,9 @@ func validateNewProjectName(value string) error {
 	}
 	if filepath.IsAbs(name) || filepath.Clean(name) != name || name == "." || name == ".." || strings.ContainsAny(name, `/\:`) {
 		return fmt.Errorf("project name must be a single subdirectory name")
+	}
+	if strings.HasPrefix(name, "-") || strings.HasPrefix(name, ".") {
+		return fmt.Errorf("project name must not start with '-' or '.'")
 	}
 	for _, r := range name {
 		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '.' || r == '_' || r == '-' {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -684,12 +684,25 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 }
 
 func finishTemplateInit(cwd, destDir, appID string, enterProjectDir bool) error {
+	return finishTemplateInitWithLauncher(cwd, destDir, appID, enterProjectDir, defaultInteractiveShell, startProjectShell)
+}
+
+func finishTemplateInitWithLauncher(cwd, destDir, appID string, enterProjectDir bool, resolveShell func() (string, error), launch func(dir, shell string) error) error {
 	cliSuccess("\nYour project is ready!")
 
 	if enterProjectDir && filepath.Clean(destDir) != filepath.Clean(cwd) {
-		cliLogln("Opening a shell in: %s", destDir)
+		projectDir, err := projectShellDir(cwd, destDir)
+		if err != nil {
+			return err
+		}
+		shell, err := resolveShell()
+		if err != nil {
+			return err
+		}
+		cliLogln("Opening a shell in: %s", projectDir)
+		cliLogln("Shell: %s", shell)
 		cliLogln("Run `wendy run` to build and deploy.")
-		return startProjectShell(destDir)
+		return launch(projectDir, shell)
 	}
 
 	cliLogln("Next steps:")
@@ -703,10 +716,38 @@ func finishTemplateInit(cwd, destDir, appID string, enterProjectDir bool) error 
 	return nil
 }
 
-var startProjectShell = func(dir string) error {
-	shell := defaultInteractiveShell()
+func projectShellDir(cwd, destDir string) (string, error) {
+	cleanCwd, err := canonicalProjectPath(cwd)
+	if err != nil {
+		return "", fmt.Errorf("resolving working directory: %w", err)
+	}
+	cleanDest, err := canonicalProjectPath(destDir)
+	if err != nil {
+		return "", fmt.Errorf("resolving project directory: %w", err)
+	}
+
+	rel, err := filepath.Rel(cleanCwd, cleanDest)
+	if err != nil {
+		return "", fmt.Errorf("checking project directory: %w", err)
+	}
+	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("project directory %q is outside working directory %q", destDir, cwd)
+	}
+
+	return cleanDest, nil
+}
+
+func canonicalProjectPath(path string) (string, error) {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(abs)
+}
+
+func startProjectShell(dir, shell string) error {
 	cmd := exec.Command(shell)
-	cmd.Dir = dir
+	cmd.Dir = filepath.Clean(dir)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -716,18 +757,28 @@ var startProjectShell = func(dir string) error {
 	return nil
 }
 
-func defaultInteractiveShell() string {
+func defaultInteractiveShell() (string, error) {
 	if runtime.GOOS == "windows" {
-		if shell := os.Getenv("COMSPEC"); shell != "" {
-			return shell
+		shell, err := exec.LookPath("cmd.exe")
+		if err == nil {
+			return shell, nil
 		}
-		return "cmd.exe"
+		return "", fmt.Errorf("finding interactive shell: %w", err)
 	}
 
-	if shell := os.Getenv("SHELL"); shell != "" {
-		return shell
+	for _, shell := range defaultUnixShellCandidates() {
+		if _, err := os.Stat(shell); err == nil {
+			return shell, nil
+		}
 	}
-	return "/bin/sh"
+	return "", fmt.Errorf("finding interactive shell: no supported shell found")
+}
+
+func defaultUnixShellCandidates() []string {
+	if runtime.GOOS == "darwin" {
+		return []string{"/bin/zsh", "/bin/bash", "/bin/sh"}
+	}
+	return []string{"/bin/bash", "/usr/bin/bash", "/bin/sh", "/usr/bin/sh"}
 }
 
 func shellQuote(s string) string {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -928,14 +929,7 @@ func projectShellEnv(shell string) ([]string, error) {
 		return nil, fmt.Errorf("interactive shell %q is no longer valid", shell)
 	}
 
-	env := make([]string, 0, len(os.Environ())+1)
-	for _, kv := range os.Environ() {
-		key, value, ok := strings.Cut(kv, "=")
-		if !ok || !isProjectShellEnvKey(key) || key == "SHELL" || !isProjectShellEnvValueAllowed(key, value) {
-			continue
-		}
-		env = append(env, kv)
-	}
+	env := projectShellUserEnv()
 	if runtime.GOOS != "windows" {
 		env = append(env, "SHELL="+validated)
 	}
@@ -944,28 +938,34 @@ func projectShellEnv(shell string) ([]string, error) {
 	return env, nil
 }
 
-func isProjectShellEnvKey(key string) bool {
-	key = strings.ToUpper(strings.TrimSpace(key))
-	switch key {
-	case "HOME", "LOGNAME", "USER", "USERNAME", "TMPDIR", "TMP", "TEMP":
-		return true
-	default:
-		return false
+func projectShellUserEnv() []string {
+	current, err := user.Current()
+	if err != nil {
+		return nil
 	}
+	env := make([]string, 0, 3)
+	if isSafeEnvPathValue(current.HomeDir) {
+		env = append(env, "HOME="+filepath.Clean(current.HomeDir))
+	}
+	username := safeCurrentUsername(current.Username)
+	if username == "" {
+		return env
+	}
+	if runtime.GOOS == "windows" {
+		return append(env, "USERNAME="+username)
+	}
+	return append(env, "LOGNAME="+username, "USER="+username)
 }
 
-func isProjectShellEnvValueAllowed(key, value string) bool {
-	if value == "" || stringHasControlChars(value) {
-		return false
+func safeCurrentUsername(username string) string {
+	username = strings.TrimSpace(username)
+	if i := strings.LastIndex(username, `\`); i >= 0 {
+		username = username[i+1:]
 	}
-	switch strings.ToUpper(strings.TrimSpace(key)) {
-	case "HOME", "TMPDIR", "TMP", "TEMP":
-		return isSafeEnvPathValue(value)
-	case "LOGNAME", "USER", "USERNAME":
-		return isSafeEnvIdentityValue(value)
-	default:
-		return false
+	if !isSafeEnvIdentityValue(username) {
+		return ""
 	}
+	return username
 }
 
 func stringHasControlChars(value string) bool {
@@ -978,7 +978,7 @@ func stringHasControlChars(value string) bool {
 }
 
 func isSafeEnvPathValue(value string) bool {
-	if !filepath.IsAbs(value) || pathContainsParentReference(value) {
+	if value == "" || stringHasControlChars(value) || !filepath.IsAbs(value) || pathContainsParentReference(value) {
 		return false
 	}
 	return filepath.IsAbs(filepath.Clean(value))
@@ -996,7 +996,7 @@ func pathContainsParentReference(path string) bool {
 }
 
 func isSafeEnvIdentityValue(value string) bool {
-	if len(value) > 64 {
+	if value == "" || len(value) > 64 || stringHasControlChars(value) {
 		return false
 	}
 	for _, r := range value {
@@ -1089,12 +1089,20 @@ func projectShellPathDir(dir string) (string, bool) {
 		return "", false
 	}
 	if runtime.GOOS != "windows" {
-		writable, err := isWorldWritableDir(dir)
+		writable, err := isWorldWritablePathDir(dir)
 		if err != nil || writable {
 			return "", false
 		}
 	}
 	return dir, true
+}
+
+func isWorldWritablePathDir(dir string) (bool, error) {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return false, fmt.Errorf("checking PATH directory %q: %w", dir, err)
+	}
+	return info.Mode().Perm()&0o002 != 0, nil
 }
 
 func shellQuote(s string) string {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -785,11 +785,12 @@ func startProjectShell(dir, shell string) error {
 
 func defaultInteractiveShell() (string, error) {
 	if runtime.GOOS == "windows" {
-		shell := filepath.Join(`C:\Windows`, "System32", "cmd.exe")
-		if valid, ok := validateInteractiveShell(shell); ok {
-			return valid, nil
+		for _, shell := range defaultWindowsShellCandidates() {
+			if valid, ok := validateInteractiveShell(shell); ok {
+				return valid, nil
+			}
 		}
-		return "", fmt.Errorf("finding interactive shell: %s not available", shell)
+		return "", fmt.Errorf("finding interactive shell: cmd.exe not available")
 	}
 
 	for _, shell := range defaultUnixShellCandidates() {
@@ -801,6 +802,20 @@ func defaultInteractiveShell() (string, error) {
 		return shell, nil
 	}
 	return "", fmt.Errorf("finding interactive shell: no supported shell found")
+}
+
+func defaultWindowsShellCandidates() []string {
+	systemRoot := strings.TrimSpace(os.Getenv("SystemRoot"))
+	if systemRoot == "" || !filepath.IsAbs(systemRoot) {
+		systemRoot = `C:\Windows`
+	}
+	systemRoot = filepath.Clean(systemRoot)
+	candidates := []string{filepath.Join(systemRoot, "System32", "cmd.exe")}
+	fallback := filepath.Join(`C:\Windows`, "System32", "cmd.exe")
+	if !strings.EqualFold(candidates[0], fallback) {
+		candidates = append(candidates, fallback)
+	}
+	return candidates
 }
 
 func defaultUnixShellCandidates() []string {
@@ -824,17 +839,21 @@ func validateInteractiveShell(candidate string) (string, bool) {
 	if !isKnownShellName(filepath.Base(resolved)) || !isTrustedShellPath(candidate, resolved) {
 		return "", false
 	}
-	writable, err := isWorldWritableDir(filepath.Dir(resolved))
-	if err != nil || writable {
-		return "", false
+	if runtime.GOOS != "windows" {
+		writable, err := isWorldWritableDir(filepath.Dir(resolved))
+		if err != nil || writable {
+			return "", false
+		}
 	}
 	info, err := os.Lstat(resolved)
 	if err != nil || !info.Mode().IsRegular() {
 		return "", false
 	}
-	mode := info.Mode().Perm()
-	if mode&0o111 == 0 || mode&0o002 != 0 {
-		return "", false
+	if runtime.GOOS != "windows" {
+		mode := info.Mode().Perm()
+		if mode&0o111 == 0 || mode&0o002 != 0 {
+			return "", false
+		}
 	}
 	return resolved, true
 }
@@ -891,7 +910,16 @@ func isTrustedShellDir(dir string) bool {
 
 func fallbackTrustedShellDirs() []string {
 	if runtime.GOOS == "windows" {
-		return []string{`C:\Windows\System32`}
+		dirs := make([]string, 0, len(defaultWindowsShellCandidates()))
+		for _, shell := range defaultWindowsShellCandidates() {
+			dir := filepath.Dir(shell)
+			if !slices.ContainsFunc(dirs, func(existing string) bool {
+				return strings.EqualFold(existing, dir)
+			}) {
+				dirs = append(dirs, dir)
+			}
+		}
+		return dirs
 	}
 	return []string{"/bin", "/usr/bin"}
 }
@@ -976,10 +1004,28 @@ func projectShellTerm(term string) string {
 }
 
 func projectShellPath() string {
+	parts := []string{}
 	if runtime.GOOS == "windows" {
-		return strings.Join([]string{`C:\Windows\System32`, `C:\Windows`}, string(os.PathListSeparator))
+		parts = append(parts, fallbackTrustedShellDirs()...)
+		parts = append(parts, `C:\Windows`)
+	} else {
+		parts = append(parts, "/usr/bin", "/bin")
 	}
-	return strings.Join([]string{"/usr/bin", "/bin"}, string(os.PathListSeparator))
+	if exe, err := os.Executable(); err == nil {
+		exeDir := filepath.Clean(filepath.Dir(exe))
+		if filepath.IsAbs(exeDir) {
+			if runtime.GOOS == "windows" {
+				if !slices.ContainsFunc(parts, func(existing string) bool {
+					return strings.EqualFold(filepath.Clean(existing), exeDir)
+				}) {
+					parts = append(parts, exeDir)
+				}
+			} else if !slices.Contains(parts, exeDir) {
+				parts = append(parts, exeDir)
+			}
+		}
+	}
+	return strings.Join(parts, string(os.PathListSeparator))
 }
 
 func shellQuote(s string) string {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -725,11 +725,10 @@ func projectShellDir(cwd, destDir string) (string, error) {
 		return "", fmt.Errorf("resolving project directory: %w", err)
 	}
 
-	rel, err := filepath.Rel(cleanCwd, cleanDest)
-	if err != nil {
-		return "", fmt.Errorf("checking project directory: %w", err)
+	if cleanDest == cleanCwd {
+		return "", fmt.Errorf("project directory %q is the working directory %q", destDir, cwd)
 	}
-	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || !pathHasPrefix(cleanDest, cleanCwd) {
+	if !pathHasPrefix(cleanDest, cleanCwd) {
 		return "", fmt.Errorf("project directory %q is outside working directory %q", destDir, cwd)
 	}
 
@@ -748,10 +747,18 @@ func canonicalProjectPath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.EvalSymlinks(abs)
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("%q does not resolve to an existing path: %w", path, err)
+	}
+	return resolved, nil
 }
 
 func startProjectShell(dir, shell string) error {
+	if validated, ok := validateInteractiveShell(shell); !ok || validated != shell {
+		return fmt.Errorf("interactive shell %q is no longer valid", shell)
+	}
+
 	info, err := os.Stat(dir)
 	if err != nil {
 		return fmt.Errorf("checking project directory: %w", err)
@@ -809,7 +816,7 @@ func validateInteractiveShell(candidate string) (string, bool) {
 		return "", false
 	}
 	candidate = filepath.Clean(candidate)
-	if !isKnownShellName(filepath.Base(candidate)) || isWorldWritableDir(filepath.Dir(candidate)) {
+	if !isKnownShellName(filepath.Base(candidate)) || !isTrustedShellDir(filepath.Dir(candidate)) || isWorldWritableDir(filepath.Dir(candidate)) {
 		return "", false
 	}
 	info, err := os.Stat(candidate)
@@ -821,6 +828,24 @@ func validateInteractiveShell(candidate string) (string, bool) {
 		return "", false
 	}
 	return candidate, true
+}
+
+func isTrustedShellDir(dir string) bool {
+	dir = filepath.Clean(dir)
+	if runtime.GOOS == "windows" {
+		systemRoot := strings.TrimSpace(os.Getenv("SystemRoot"))
+		if systemRoot == "" {
+			systemRoot = `C:\Windows`
+		}
+		return strings.EqualFold(dir, filepath.Join(systemRoot, "System32"))
+	}
+
+	for _, trusted := range []string{"/bin", "/usr/bin", "/usr/local/bin", "/opt/homebrew/bin", "/opt/local/bin", "/run/current-system/sw/bin"} {
+		if dir == trusted {
+			return true
+		}
+	}
+	return false
 }
 
 func isKnownShellName(name string) bool {
@@ -837,14 +862,14 @@ func isWorldWritableDir(dir string) bool {
 	if err != nil || !info.IsDir() {
 		return true
 	}
-	return info.Mode().Perm()&0o002 != 0
+	return info.Mode().Perm()&0o002 != 0 && info.Mode()&os.ModeSticky == 0
 }
 
 func projectShellEnv(shell string) []string {
 	env := make([]string, 0, len(os.Environ())+1)
 	for _, kv := range os.Environ() {
 		key, _, ok := strings.Cut(kv, "=")
-		if !ok || isSensitiveEnvKey(key) || key == "SHELL" {
+		if !ok || !isProjectShellEnvKey(key) || key == "SHELL" {
 			continue
 		}
 		env = append(env, kv)
@@ -855,17 +880,14 @@ func projectShellEnv(shell string) []string {
 	return env
 }
 
-func isSensitiveEnvKey(key string) bool {
+func isProjectShellEnvKey(key string) bool {
 	key = strings.ToUpper(strings.TrimSpace(key))
-	if key == "" {
-		return false
+	switch key {
+	case "HOME", "PATH", "TERM", "LANG", "LOGNAME", "USER", "USERNAME", "TMPDIR", "TMP", "TEMP", "COLORTERM", "CLICOLOR", "NO_COLOR":
+		return true
+	default:
+		return strings.HasPrefix(key, "LC_")
 	}
-	for _, marker := range []string{"TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "PRIVATE_KEY", "ACCESS_KEY", "API_KEY", "AUTH"} {
-		if strings.Contains(key, marker) {
-			return true
-		}
-	}
-	return false
 }
 
 func shellQuote(s string) string {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -739,6 +739,12 @@ func pathHasPrefix(path, prefix string) bool {
 	sep := string(filepath.Separator)
 	cleanPath := strings.TrimRight(filepath.Clean(path), sep) + sep
 	cleanPrefix := strings.TrimRight(filepath.Clean(prefix), sep) + sep
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		if len(cleanPath) < len(cleanPrefix) {
+			return false
+		}
+		return strings.EqualFold(cleanPath[:len(cleanPrefix)], cleanPrefix)
+	}
 	return strings.HasPrefix(cleanPath, cleanPrefix)
 }
 
@@ -755,7 +761,8 @@ func canonicalProjectPath(path string) (string, error) {
 }
 
 func startProjectShell(dir, shell string) error {
-	if validated, ok := validateInteractiveShell(shell); !ok || validated != shell {
+	validated, ok := validateInteractiveShell(shell)
+	if !ok {
 		return fmt.Errorf("interactive shell %q is no longer valid", shell)
 	}
 
@@ -767,9 +774,17 @@ func startProjectShell(dir, shell string) error {
 		return fmt.Errorf("project directory %q is not a directory", dir)
 	}
 
-	cmd := exec.Command(shell)
+	env, err := projectShellEnv(validated)
+	if err != nil {
+		return err
+	}
+
+	// Use a normal interactive shell so this handoff behaves like a user-run
+	// `cd`; user-owned startup files are intentionally honored.
+	cmd := exec.Command(validated)
+	cmd.Path = validated
 	cmd.Dir = dir
-	cmd.Env = projectShellEnv(shell)
+	cmd.Env = env
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -837,15 +852,14 @@ func validateInteractiveShell(candidate string) (string, bool) {
 
 func isTrustedShellDir(dir string) bool {
 	dir = filepath.Clean(dir)
-	if runtime.GOOS == "windows" {
-		systemRoot := strings.TrimSpace(os.Getenv("SystemRoot"))
-		if systemRoot == "" {
-			systemRoot = `C:\Windows`
+	for _, trusted := range trustedShellDirs() {
+		trusted = filepath.Clean(trusted)
+		if runtime.GOOS == "windows" {
+			if strings.EqualFold(dir, trusted) {
+				return true
+			}
+			continue
 		}
-		return strings.EqualFold(dir, filepath.Join(systemRoot, "System32"))
-	}
-
-	for _, trusted := range []string{"/bin", "/usr/bin", "/usr/local/bin", "/opt/homebrew/bin", "/opt/local/bin", "/run/current-system/sw/bin"} {
 		if dir == trusted {
 			return true
 		}
@@ -853,9 +867,16 @@ func isTrustedShellDir(dir string) bool {
 	return false
 }
 
+func trustedShellDirs() []string {
+	if runtime.GOOS == "windows" {
+		return []string{`C:\Windows\System32`}
+	}
+	return []string{"/bin", "/usr/bin", "/usr/local/bin", "/opt/homebrew/bin", "/opt/local/bin", "/run/current-system/sw/bin"}
+}
+
 func isKnownShellName(name string) bool {
 	switch strings.ToLower(name) {
-	case "sh", "bash", "zsh", "fish", "dash", "ksh", "cmd.exe", "powershell.exe", "pwsh.exe":
+	case "sh", "bash", "zsh", "dash", "cmd.exe":
 		return true
 	default:
 		return false
@@ -872,7 +893,12 @@ func isWorldWritableDir(dir string) (bool, error) {
 	return info.Mode().Perm()&0o002 != 0 && info.Mode()&os.ModeSticky == 0, nil
 }
 
-func projectShellEnv(shell string) []string {
+func projectShellEnv(shell string) ([]string, error) {
+	validated, ok := validateInteractiveShell(shell)
+	if !ok {
+		return nil, fmt.Errorf("interactive shell %q is no longer valid", shell)
+	}
+
 	env := make([]string, 0, len(os.Environ())+1)
 	for _, kv := range os.Environ() {
 		key, _, ok := strings.Cut(kv, "=")
@@ -882,10 +908,10 @@ func projectShellEnv(shell string) []string {
 		env = append(env, kv)
 	}
 	if runtime.GOOS != "windows" {
-		env = append(env, "SHELL="+shell)
+		env = append(env, "SHELL="+validated)
 	}
 	env = appendWithoutExistingEnv(env, "PATH", projectShellPath())
-	return env
+	return env, nil
 }
 
 func isProjectShellEnvKey(key string) bool {
@@ -912,7 +938,7 @@ func projectShellPath() string {
 	if runtime.GOOS == "windows" {
 		return strings.Join([]string{`C:\Windows\System32`, `C:\Windows`}, string(os.PathListSeparator))
 	}
-	return strings.Join([]string{"/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"}, string(os.PathListSeparator))
+	return strings.Join([]string{"/opt/homebrew/bin", "/usr/local/bin", "/run/current-system/sw/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"}, string(os.PathListSeparator))
 }
 
 func shellQuote(s string) string {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -805,17 +805,7 @@ func defaultInteractiveShell() (string, error) {
 }
 
 func defaultWindowsShellCandidates() []string {
-	systemRoot := strings.TrimSpace(os.Getenv("SystemRoot"))
-	if systemRoot == "" || !filepath.IsAbs(systemRoot) {
-		systemRoot = `C:\Windows`
-	}
-	systemRoot = filepath.Clean(systemRoot)
-	candidates := []string{filepath.Join(systemRoot, "System32", "cmd.exe")}
-	fallback := filepath.Join(`C:\Windows`, "System32", "cmd.exe")
-	if !strings.EqualFold(candidates[0], fallback) {
-		candidates = append(candidates, fallback)
-	}
-	return candidates
+	return []string{filepath.Join(`C:\Windows`, "System32", "cmd.exe")}
 }
 
 func defaultUnixShellCandidates() []string {
@@ -910,16 +900,7 @@ func isTrustedShellDir(dir string) bool {
 
 func fallbackTrustedShellDirs() []string {
 	if runtime.GOOS == "windows" {
-		dirs := make([]string, 0, len(defaultWindowsShellCandidates()))
-		for _, shell := range defaultWindowsShellCandidates() {
-			dir := filepath.Dir(shell)
-			if !slices.ContainsFunc(dirs, func(existing string) bool {
-				return strings.EqualFold(existing, dir)
-			}) {
-				dirs = append(dirs, dir)
-			}
-		}
-		return dirs
+		return []string{filepath.Join(`C:\Windows`, "System32")}
 	}
 	return []string{"/bin", "/usr/bin"}
 }
@@ -949,8 +930,8 @@ func projectShellEnv(shell string) ([]string, error) {
 
 	env := make([]string, 0, len(os.Environ())+1)
 	for _, kv := range os.Environ() {
-		key, _, ok := strings.Cut(kv, "=")
-		if !ok || !isProjectShellEnvKey(key) || key == "SHELL" {
+		key, value, ok := strings.Cut(kv, "=")
+		if !ok || !isProjectShellEnvKey(key) || key == "SHELL" || !isProjectShellEnvValueAllowed(key, value) {
 			continue
 		}
 		env = append(env, kv)
@@ -971,6 +952,60 @@ func isProjectShellEnvKey(key string) bool {
 	default:
 		return false
 	}
+}
+
+func isProjectShellEnvValueAllowed(key, value string) bool {
+	if value == "" || stringHasControlChars(value) {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(key)) {
+	case "HOME", "TMPDIR", "TMP", "TEMP":
+		return isSafeEnvPathValue(value)
+	case "LOGNAME", "USER", "USERNAME":
+		return isSafeEnvIdentityValue(value)
+	default:
+		return false
+	}
+}
+
+func stringHasControlChars(value string) bool {
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+func isSafeEnvPathValue(value string) bool {
+	if !filepath.IsAbs(value) || pathContainsParentReference(value) {
+		return false
+	}
+	return filepath.IsAbs(filepath.Clean(value))
+}
+
+func pathContainsParentReference(path string) bool {
+	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func isSafeEnvIdentityValue(value string) bool {
+	if len(value) > 64 {
+		return false
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '.' || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func appendWithoutExistingEnv(env []string, key, value string) []string {
@@ -1004,28 +1039,62 @@ func projectShellTerm(term string) string {
 }
 
 func projectShellPath() string {
-	parts := []string{}
+	parts := make([]string, 0)
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		parts = appendProjectShellPathDir(parts, dir)
+	}
 	if runtime.GOOS == "windows" {
-		parts = append(parts, fallbackTrustedShellDirs()...)
-		parts = append(parts, `C:\Windows`)
+		for _, dir := range fallbackTrustedShellDirs() {
+			parts = appendProjectShellPathDir(parts, dir)
+		}
+		parts = appendProjectShellPathDir(parts, `C:\Windows`)
 	} else {
-		parts = append(parts, "/usr/bin", "/bin")
+		parts = appendProjectShellPathDir(parts, "/usr/bin")
+		parts = appendProjectShellPathDir(parts, "/bin")
 	}
 	if exe, err := os.Executable(); err == nil {
-		exeDir := filepath.Clean(filepath.Dir(exe))
-		if filepath.IsAbs(exeDir) {
-			if runtime.GOOS == "windows" {
-				if !slices.ContainsFunc(parts, func(existing string) bool {
-					return strings.EqualFold(filepath.Clean(existing), exeDir)
-				}) {
-					parts = append(parts, exeDir)
-				}
-			} else if !slices.Contains(parts, exeDir) {
-				parts = append(parts, exeDir)
-			}
-		}
+		parts = appendProjectShellPathDir(parts, filepath.Dir(exe))
 	}
 	return strings.Join(parts, string(os.PathListSeparator))
+}
+
+func appendProjectShellPathDir(parts []string, dir string) []string {
+	dir, ok := projectShellPathDir(dir)
+	if !ok {
+		return parts
+	}
+	if runtime.GOOS == "windows" {
+		if slices.ContainsFunc(parts, func(existing string) bool {
+			return strings.EqualFold(filepath.Clean(existing), dir)
+		}) {
+			return parts
+		}
+	} else if slices.Contains(parts, dir) {
+		return parts
+	}
+	return append(parts, dir)
+}
+
+func projectShellPathDir(dir string) (string, bool) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" || stringHasControlChars(dir) {
+		return "", false
+	}
+	dir = filepath.Clean(dir)
+	if !filepath.IsAbs(dir) {
+		return "", false
+	}
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	if runtime.GOOS != "windows" {
+		writable, err := isWorldWritableDir(dir)
+		if err != nil || writable {
+			return "", false
+		}
+	}
+	return dir, true
 }
 
 func shellQuote(s string) string {

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -289,13 +289,10 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 			t.Fatalf("projectShellEnv included disallowed key %q in %q", key, joined)
 		}
 	}
-	for _, key := range []string{"HOME", "USER"} {
-		if strings.Contains(joined, "\n"+key+"=") {
-			t.Fatalf("projectShellEnv included invalid value for %q in %q", key, joined)
+	for _, kv := range []string{"HOME=relative-home", "USER=bad user", "LOGNAME=safe-user"} {
+		if strings.Contains(joined, "\n"+kv+"\n") {
+			t.Fatalf("projectShellEnv forwarded parent environment value %q in %q", kv, joined)
 		}
-	}
-	if !strings.Contains(joined, "\nLOGNAME=safe-user\n") {
-		t.Fatalf("projectShellEnv missing valid environment value: %q", joined)
 	}
 	if !strings.Contains(joined, "\nTERM=xterm-256color\n") {
 		t.Fatalf("projectShellEnv missing allowed environment value: %q", joined)

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -100,7 +100,7 @@ func TestPathHasPrefix_IsCaseSensitiveOnUnix(t *testing.T) {
 }
 
 func TestValidateNewProjectName_RejectsNonSubdirectoryNames(t *testing.T) {
-	for _, value := range []string{"", "   ", ".", "..", "../outside", "nested/app", `nested\app`, "/tmp/app", "C:app"} {
+	for _, value := range []string{"", "   ", ".", "..", "../outside", "nested/app", `nested\app`, "/tmp/app", "C:app", "demo app", "demo'app"} {
 		t.Run(value, func(t *testing.T) {
 			if err := validateNewProjectName(value); err == nil {
 				t.Fatalf("validateNewProjectName(%q) = nil, want error", value)
@@ -110,7 +110,7 @@ func TestValidateNewProjectName_RejectsNonSubdirectoryNames(t *testing.T) {
 }
 
 func TestValidateNewProjectName_AcceptsPlainDirectoryNames(t *testing.T) {
-	for _, value := range []string{"demo-app", "demo app", "demo'app", "demo_app"} {
+	for _, value := range []string{"demo-app", "demo.app", "demo_app"} {
 		t.Run(value, func(t *testing.T) {
 			if err := validateNewProjectName(value); err != nil {
 				t.Fatalf("validateNewProjectName(%q): %v", value, err)
@@ -305,6 +305,14 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 	t.Setenv("HOME", "relative-home")
 	t.Setenv("USER", "bad user")
 	t.Setenv("LOGNAME", "safe-user")
+	for _, key := range []string{
+		"LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_TRACE_LOADED_OBJECTS",
+		"DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH", "DYLD_FALLBACK_LIBRARY_PATH",
+		"BASH_ENV", "ENV", "CDPATH", "IFS", "SHELLOPTS", "BASHOPTS", "PS4",
+		"GCONV_PATH", "PYTHONPATH", "RUBYLIB", "RUBYOPT", "NODE_PATH", "NODE_OPTIONS", "PERL5LIB", "PERL5OPT",
+	} {
+		t.Setenv(key, "injected")
+	}
 
 	shell := testInteractiveShell(t)
 	env, err := projectShellEnv(shell)
@@ -313,7 +321,13 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 	}
 	joined := "\n" + strings.Join(env, "\n") + "\n"
 
-	for _, key := range []string{"WENDY_TOKEN", "OPENAI_API_KEY", "NORMAL_ENV"} {
+	for _, key := range []string{
+		"WENDY_TOKEN", "OPENAI_API_KEY", "NORMAL_ENV",
+		"LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_TRACE_LOADED_OBJECTS",
+		"DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH", "DYLD_FALLBACK_LIBRARY_PATH",
+		"BASH_ENV", "ENV", "CDPATH", "IFS", "SHELLOPTS", "BASHOPTS", "PS4",
+		"GCONV_PATH", "PYTHONPATH", "RUBYLIB", "RUBYOPT", "NODE_PATH", "NODE_OPTIONS", "PERL5LIB", "PERL5OPT",
+	} {
 		if strings.Contains(joined, "\n"+key+"=") {
 			t.Fatalf("projectShellEnv included disallowed key %q in %q", key, joined)
 		}
@@ -372,6 +386,31 @@ func TestProjectShellPath_PreservesUsableParentPath(t *testing.T) {
 func TestProjectShellEnv_RejectsInvalidShell(t *testing.T) {
 	if _, err := projectShellEnv("test-shell"); err == nil {
 		t.Fatal("expected invalid shell to fail")
+	}
+}
+
+func TestScrubProjectShellEnv_DropsLinkerAndInterpreterVariables(t *testing.T) {
+	got := scrubProjectShellEnv([]string{
+		"PATH=/bin",
+		"LD_PRELOAD=/tmp/lib.so",
+		"DYLD_INSERT_LIBRARIES=/tmp/lib.dylib",
+		"BASH_ENV=/tmp/env",
+		"GCONV_PATH=/tmp/gconv",
+		"PYTHONPATH=/tmp/python",
+		"RUBYOPT=-r/tmp/ruby.rb",
+		"NODE_PATH=/tmp/node",
+		"NODE_OPTIONS=--require /tmp/node.js",
+	})
+
+	if strings.Join(got, "\n") != "PATH=/bin" {
+		t.Fatalf("scrubProjectShellEnv() = %#v, want only PATH", got)
+	}
+}
+
+func TestAppendWithoutExistingEnv_DropsEmptyValue(t *testing.T) {
+	got := appendWithoutExistingEnv([]string{"PATH=/bin", "TERM=xterm"}, "PATH", "")
+	if strings.Join(got, "\n") != "TERM=xterm" {
+		t.Fatalf("appendWithoutExistingEnv() = %#v, want existing PATH removed without adding empty PATH", got)
 	}
 }
 

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -90,6 +90,35 @@ func TestResolveInitAppID_TrimsExplicitFlag(t *testing.T) {
 	}
 }
 
+func TestPathHasPrefix_IsCaseSensitiveOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows paths are intentionally compared case-insensitively")
+	}
+	if pathHasPrefix("/tmp/Foo/app", "/tmp/foo") {
+		t.Fatal("pathHasPrefix should not case-fold Unix paths")
+	}
+}
+
+func TestValidateNewProjectName_RejectsNonSubdirectoryNames(t *testing.T) {
+	for _, value := range []string{"", "   ", ".", "..", "../outside", "nested/app", `nested\app`, "/tmp/app", "C:app"} {
+		t.Run(value, func(t *testing.T) {
+			if err := validateNewProjectName(value); err == nil {
+				t.Fatalf("validateNewProjectName(%q) = nil, want error", value)
+			}
+		})
+	}
+}
+
+func TestValidateNewProjectName_AcceptsPlainDirectoryNames(t *testing.T) {
+	for _, value := range []string{"demo-app", "demo app", "demo'app", "demo_app"} {
+		t.Run(value, func(t *testing.T) {
+			if err := validateNewProjectName(value); err != nil {
+				t.Fatalf("validateNewProjectName(%q): %v", value, err)
+			}
+		})
+	}
+}
+
 func TestTemplateRunCommand(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -100,7 +100,7 @@ func TestPathHasPrefix_IsCaseSensitiveOnUnix(t *testing.T) {
 }
 
 func TestValidateNewProjectName_RejectsNonSubdirectoryNames(t *testing.T) {
-	for _, value := range []string{"", "   ", ".", "..", "../outside", "nested/app", `nested\app`, "/tmp/app", "C:app", "demo app", "demo'app"} {
+	for _, value := range []string{"", "   ", ".", "..", "../outside", "nested/app", `nested\app`, "/tmp/app", "C:app", "demo app", "demo'app", "-demo", ".demo"} {
 		t.Run(value, func(t *testing.T) {
 			if err := validateNewProjectName(value); err == nil {
 				t.Fatalf("validateNewProjectName(%q) = nil, want error", value)
@@ -357,6 +357,13 @@ func TestProjectShellPath_PreservesUsableParentPath(t *testing.T) {
 	}
 
 	safeDir := t.TempDir()
+	groupWritableDir := filepath.Join(t.TempDir(), "group-writable")
+	if err := os.Mkdir(groupWritableDir, 0o775); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.Chmod(groupWritableDir, 0o775); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
 	worldWritableDir := filepath.Join(t.TempDir(), "world-writable")
 	if err := os.Mkdir(worldWritableDir, 0o777); err != nil {
 		t.Fatalf("Mkdir: %v", err)
@@ -365,13 +372,13 @@ func TestProjectShellPath_PreservesUsableParentPath(t *testing.T) {
 		t.Fatalf("Chmod: %v", err)
 	}
 
-	t.Setenv("PATH", strings.Join([]string{safeDir, "/tmp/does-not-exist", worldWritableDir, "relative-bin"}, string(os.PathListSeparator)))
+	t.Setenv("PATH", strings.Join([]string{safeDir, "/tmp/does-not-exist", groupWritableDir, worldWritableDir, "relative-bin"}, string(os.PathListSeparator)))
 
 	got := filepath.SplitList(projectShellPath())
 	if !slices.Contains(got, filepath.Clean(safeDir)) {
 		t.Fatalf("projectShellPath() = %q, want safe parent PATH directory %q", got, safeDir)
 	}
-	for _, disallowed := range []string{"/tmp/does-not-exist", worldWritableDir, "relative-bin"} {
+	for _, disallowed := range []string{"/tmp/does-not-exist", groupWritableDir, worldWritableDir, "relative-bin"} {
 		if slices.Contains(got, filepath.Clean(disallowed)) {
 			t.Fatalf("projectShellPath() = %q, did not expect %q", got, disallowed)
 		}
@@ -389,21 +396,26 @@ func TestProjectShellEnv_RejectsInvalidShell(t *testing.T) {
 	}
 }
 
-func TestScrubProjectShellEnv_DropsLinkerAndInterpreterVariables(t *testing.T) {
-	got := scrubProjectShellEnv([]string{
-		"PATH=/bin",
-		"LD_PRELOAD=/tmp/lib.so",
-		"DYLD_INSERT_LIBRARIES=/tmp/lib.dylib",
-		"BASH_ENV=/tmp/env",
-		"GCONV_PATH=/tmp/gconv",
-		"PYTHONPATH=/tmp/python",
-		"RUBYOPT=-r/tmp/ruby.rb",
-		"NODE_PATH=/tmp/node",
-		"NODE_OPTIONS=--require /tmp/node.js",
-	})
+func TestAppendAllowedProjectShellEnv_DropsLinkerAndInterpreterVariables(t *testing.T) {
+	env := []string{"PATH=/bin"}
+	for _, kv := range []struct {
+		key   string
+		value string
+	}{
+		{"LD_PRELOAD", "/tmp/lib.so"},
+		{"DYLD_INSERT_LIBRARIES", "/tmp/lib.dylib"},
+		{"BASH_ENV", "/tmp/env"},
+		{"GCONV_PATH", "/tmp/gconv"},
+		{"PYTHONPATH", "/tmp/python"},
+		{"RUBYOPT", "-r/tmp/ruby.rb"},
+		{"NODE_PATH", "/tmp/node"},
+		{"NODE_OPTIONS", "--require /tmp/node.js"},
+	} {
+		env = appendAllowedProjectShellEnv(env, kv.key, kv.value)
+	}
 
-	if strings.Join(got, "\n") != "PATH=/bin" {
-		t.Fatalf("scrubProjectShellEnv() = %#v, want only PATH", got)
+	if strings.Join(env, "\n") != "PATH=/bin" {
+		t.Fatalf("appendAllowedProjectShellEnv() = %#v, want only PATH", env)
 	}
 }
 

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -264,6 +264,40 @@ func TestProjectShellDir_RejectsDirectoryOutsideWorkingDirectory(t *testing.T) {
 	}
 }
 
+func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
+	t.Setenv("WENDY_TOKEN", "secret")
+	t.Setenv("OPENAI_API_KEY", "secret")
+	t.Setenv("NORMAL_ENV", "value")
+	t.Setenv("SHELL", "/tmp/evil")
+
+	env := projectShellEnv("/bin/sh")
+	joined := "\n" + strings.Join(env, "\n") + "\n"
+
+	for _, key := range []string{"WENDY_TOKEN", "OPENAI_API_KEY"} {
+		if strings.Contains(joined, "\n"+key+"=") {
+			t.Fatalf("projectShellEnv included sensitive key %q in %q", key, joined)
+		}
+	}
+	if !strings.Contains(joined, "\nNORMAL_ENV=value\n") {
+		t.Fatalf("projectShellEnv missing normal environment value: %q", joined)
+	}
+	if !strings.Contains(joined, "\nSHELL=/bin/sh\n") {
+		t.Fatalf("projectShellEnv did not override SHELL: %q", joined)
+	}
+}
+
+func TestValidateInteractiveShell_RejectsUnknownShellName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "not-a-shell")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if shell, ok := validateInteractiveShell(path); ok {
+		t.Fatalf("validateInteractiveShell(%q) = %q, true; want false", path, shell)
+	}
+}
+
 func TestResolveTemplateLanguage_RejectsUnavailableTemplateLanguage(t *testing.T) {
 	meta := &repoMeta{
 		Templates: []repoMetaTemplate{

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -192,7 +192,7 @@ func TestFinishTemplateInit_EntersProjectShellForInteractiveNewDirectory(t *test
 		return nil
 	}
 	resolveShell := func() (string, error) {
-		return "/bin/sh", nil
+		return "test-shell", nil
 	}
 
 	if err := finishTemplateInitWithLauncher(cwd, destDir, "demo-app", true, resolveShell, launch); err != nil {
@@ -205,8 +205,8 @@ func TestFinishTemplateInit_EntersProjectShellForInteractiveNewDirectory(t *test
 	if shellDir != wantDir {
 		t.Fatalf("project shell dir = %q, want %q", shellDir, wantDir)
 	}
-	if shellPath != "/bin/sh" {
-		t.Fatalf("project shell = %q, want %q", shellPath, "/bin/sh")
+	if shellPath != "test-shell" {
+		t.Fatalf("project shell = %q, want %q", shellPath, "test-shell")
 	}
 }
 
@@ -219,7 +219,7 @@ func TestFinishTemplateInit_DoesNotEnterProjectShellForCurrentDirectory(t *testi
 		return nil
 	}
 	resolveShell := func() (string, error) {
-		return "/bin/sh", nil
+		return "test-shell", nil
 	}
 
 	if err := finishTemplateInitWithLauncher(cwd, cwd, "demo-app", true, resolveShell, launch); err != nil {
@@ -242,7 +242,7 @@ func TestFinishTemplateInit_ReturnsProjectShellError(t *testing.T) {
 		return shellErr
 	}
 	resolveShell := func() (string, error) {
-		return "/bin/sh", nil
+		return "test-shell", nil
 	}
 
 	err := finishTemplateInitWithLauncher(cwd, destDir, "demo-app", true, resolveShell, launch)
@@ -268,20 +268,21 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 	t.Setenv("WENDY_TOKEN", "secret")
 	t.Setenv("OPENAI_API_KEY", "secret")
 	t.Setenv("NORMAL_ENV", "value")
+	t.Setenv("TERM", "xterm-256color")
 	t.Setenv("SHELL", "/tmp/evil")
 
-	env := projectShellEnv("/bin/sh")
+	env := projectShellEnv("test-shell")
 	joined := "\n" + strings.Join(env, "\n") + "\n"
 
-	for _, key := range []string{"WENDY_TOKEN", "OPENAI_API_KEY"} {
+	for _, key := range []string{"WENDY_TOKEN", "OPENAI_API_KEY", "NORMAL_ENV"} {
 		if strings.Contains(joined, "\n"+key+"=") {
-			t.Fatalf("projectShellEnv included sensitive key %q in %q", key, joined)
+			t.Fatalf("projectShellEnv included disallowed key %q in %q", key, joined)
 		}
 	}
-	if !strings.Contains(joined, "\nNORMAL_ENV=value\n") {
-		t.Fatalf("projectShellEnv missing normal environment value: %q", joined)
+	if !strings.Contains(joined, "\nTERM=xterm-256color\n") {
+		t.Fatalf("projectShellEnv missing allowed environment value: %q", joined)
 	}
-	if !strings.Contains(joined, "\nSHELL=/bin/sh\n") {
+	if !strings.Contains(joined, "\nSHELL=test-shell\n") {
 		t.Fatalf("projectShellEnv did not override SHELL: %q", joined)
 	}
 }

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -272,6 +273,9 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 	t.Setenv("TERM", "xterm-256color")
 	t.Setenv("PATH", "/tmp/evil")
 	t.Setenv("SHELL", "/tmp/evil")
+	t.Setenv("HOME", "relative-home")
+	t.Setenv("USER", "bad user")
+	t.Setenv("LOGNAME", "safe-user")
 
 	shell := testInteractiveShell(t)
 	env, err := projectShellEnv(shell)
@@ -285,6 +289,14 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 			t.Fatalf("projectShellEnv included disallowed key %q in %q", key, joined)
 		}
 	}
+	for _, key := range []string{"HOME", "USER"} {
+		if strings.Contains(joined, "\n"+key+"=") {
+			t.Fatalf("projectShellEnv included invalid value for %q in %q", key, joined)
+		}
+	}
+	if !strings.Contains(joined, "\nLOGNAME=safe-user\n") {
+		t.Fatalf("projectShellEnv missing valid environment value: %q", joined)
+	}
 	if !strings.Contains(joined, "\nTERM=xterm-256color\n") {
 		t.Fatalf("projectShellEnv missing allowed environment value: %q", joined)
 	}
@@ -296,6 +308,38 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 	}
 	if runtime.GOOS != "windows" && !strings.Contains(joined, "\nSHELL="+shell+"\n") {
 		t.Fatalf("projectShellEnv did not override SHELL with validated shell: %q", joined)
+	}
+}
+
+func TestProjectShellPath_PreservesUsableParentPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix path filtering semantics are covered on Unix")
+	}
+
+	safeDir := t.TempDir()
+	worldWritableDir := filepath.Join(t.TempDir(), "world-writable")
+	if err := os.Mkdir(worldWritableDir, 0o777); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.Chmod(worldWritableDir, 0o777); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	t.Setenv("PATH", strings.Join([]string{safeDir, "/tmp/does-not-exist", worldWritableDir, "relative-bin"}, string(os.PathListSeparator)))
+
+	got := filepath.SplitList(projectShellPath())
+	if !slices.Contains(got, filepath.Clean(safeDir)) {
+		t.Fatalf("projectShellPath() = %q, want safe parent PATH directory %q", got, safeDir)
+	}
+	for _, disallowed := range []string{"/tmp/does-not-exist", worldWritableDir, "relative-bin"} {
+		if slices.Contains(got, filepath.Clean(disallowed)) {
+			t.Fatalf("projectShellPath() = %q, did not expect %q", got, disallowed)
+		}
+	}
+	for _, fallback := range []string{"/usr/bin", "/bin"} {
+		if !slices.Contains(got, fallback) {
+			t.Fatalf("projectShellPath() = %q, want fallback directory %q", got, fallback)
+		}
 	}
 }
 

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -178,34 +178,51 @@ func TestTemplateNextSteps(t *testing.T) {
 }
 
 func TestFinishTemplateInit_EntersProjectShellForInteractiveNewDirectory(t *testing.T) {
-	origStartProjectShell := startProjectShell
-	t.Cleanup(func() { startProjectShell = origStartProjectShell })
+	cwd := t.TempDir()
+	destDir := filepath.Join(cwd, "demo-app")
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
 
 	var shellDir string
-	startProjectShell = func(dir string) error {
+	var shellPath string
+	launch := func(dir, shell string) error {
 		shellDir = dir
+		shellPath = shell
 		return nil
 	}
+	resolveShell := func() (string, error) {
+		return "/bin/sh", nil
+	}
 
-	if err := finishTemplateInit("/tmp/workspace", "/tmp/workspace/demo-app", "demo-app", true); err != nil {
+	if err := finishTemplateInitWithLauncher(cwd, destDir, "demo-app", true, resolveShell, launch); err != nil {
 		t.Fatalf("finishTemplateInit: %v", err)
 	}
-	if shellDir != "/tmp/workspace/demo-app" {
-		t.Fatalf("project shell dir = %q, want %q", shellDir, "/tmp/workspace/demo-app")
+	wantDir, err := projectShellDir(cwd, destDir)
+	if err != nil {
+		t.Fatalf("projectShellDir: %v", err)
+	}
+	if shellDir != wantDir {
+		t.Fatalf("project shell dir = %q, want %q", shellDir, wantDir)
+	}
+	if shellPath != "/bin/sh" {
+		t.Fatalf("project shell = %q, want %q", shellPath, "/bin/sh")
 	}
 }
 
 func TestFinishTemplateInit_DoesNotEnterProjectShellForCurrentDirectory(t *testing.T) {
-	origStartProjectShell := startProjectShell
-	t.Cleanup(func() { startProjectShell = origStartProjectShell })
+	cwd := t.TempDir()
 
 	called := false
-	startProjectShell = func(dir string) error {
+	launch := func(dir, shell string) error {
 		called = true
 		return nil
 	}
+	resolveShell := func() (string, error) {
+		return "/bin/sh", nil
+	}
 
-	if err := finishTemplateInit("/tmp/demo-app", "/tmp/demo-app", "demo-app", true); err != nil {
+	if err := finishTemplateInitWithLauncher(cwd, cwd, "demo-app", true, resolveShell, launch); err != nil {
 		t.Fatalf("finishTemplateInit: %v", err)
 	}
 	if called {
@@ -214,17 +231,36 @@ func TestFinishTemplateInit_DoesNotEnterProjectShellForCurrentDirectory(t *testi
 }
 
 func TestFinishTemplateInit_ReturnsProjectShellError(t *testing.T) {
-	origStartProjectShell := startProjectShell
-	t.Cleanup(func() { startProjectShell = origStartProjectShell })
-
-	shellErr := errors.New("shell failed")
-	startProjectShell = func(dir string) error {
-		return shellErr
+	cwd := t.TempDir()
+	destDir := filepath.Join(cwd, "demo-app")
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
 	}
 
-	err := finishTemplateInit("/tmp/workspace", "/tmp/workspace/demo-app", "demo-app", true)
+	shellErr := errors.New("shell failed")
+	launch := func(dir, shell string) error {
+		return shellErr
+	}
+	resolveShell := func() (string, error) {
+		return "/bin/sh", nil
+	}
+
+	err := finishTemplateInitWithLauncher(cwd, destDir, "demo-app", true, resolveShell, launch)
 	if !errors.Is(err, shellErr) {
 		t.Fatalf("finishTemplateInit error = %v, want %v", err, shellErr)
+	}
+}
+
+func TestProjectShellDir_RejectsDirectoryOutsideWorkingDirectory(t *testing.T) {
+	cwd := t.TempDir()
+	outside := t.TempDir()
+
+	_, err := projectShellDir(cwd, outside)
+	if err == nil {
+		t.Fatal("expected outside project directory to fail")
+	}
+	if !strings.Contains(err.Error(), "outside working directory") {
+		t.Fatalf("error = %q, want outside working directory", err)
 	}
 }
 

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -173,6 +174,57 @@ func TestTemplateNextSteps(t *testing.T) {
 				t.Fatalf("templateNextSteps(%q, %q, %q) = %#v, want %#v", tt.cwd, tt.destDir, tt.appID, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFinishTemplateInit_EntersProjectShellForInteractiveNewDirectory(t *testing.T) {
+	origStartProjectShell := startProjectShell
+	t.Cleanup(func() { startProjectShell = origStartProjectShell })
+
+	var shellDir string
+	startProjectShell = func(dir string) error {
+		shellDir = dir
+		return nil
+	}
+
+	if err := finishTemplateInit("/tmp/workspace", "/tmp/workspace/demo-app", "demo-app", true); err != nil {
+		t.Fatalf("finishTemplateInit: %v", err)
+	}
+	if shellDir != "/tmp/workspace/demo-app" {
+		t.Fatalf("project shell dir = %q, want %q", shellDir, "/tmp/workspace/demo-app")
+	}
+}
+
+func TestFinishTemplateInit_DoesNotEnterProjectShellForCurrentDirectory(t *testing.T) {
+	origStartProjectShell := startProjectShell
+	t.Cleanup(func() { startProjectShell = origStartProjectShell })
+
+	called := false
+	startProjectShell = func(dir string) error {
+		called = true
+		return nil
+	}
+
+	if err := finishTemplateInit("/tmp/demo-app", "/tmp/demo-app", "demo-app", true); err != nil {
+		t.Fatalf("finishTemplateInit: %v", err)
+	}
+	if called {
+		t.Fatal("startProjectShell called for current-directory init")
+	}
+}
+
+func TestFinishTemplateInit_ReturnsProjectShellError(t *testing.T) {
+	origStartProjectShell := startProjectShell
+	t.Cleanup(func() { startProjectShell = origStartProjectShell })
+
+	shellErr := errors.New("shell failed")
+	startProjectShell = func(dir string) error {
+		return shellErr
+	}
+
+	err := finishTemplateInit("/tmp/workspace", "/tmp/workspace/demo-app", "demo-app", true)
+	if !errors.Is(err, shellErr) {
+		t.Fatalf("finishTemplateInit error = %v, want %v", err, shellErr)
 	}
 }
 

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -269,6 +269,7 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "secret")
 	t.Setenv("NORMAL_ENV", "value")
 	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("PATH", "/tmp/evil")
 	t.Setenv("SHELL", "/tmp/evil")
 
 	env := projectShellEnv("test-shell")
@@ -282,8 +283,24 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 	if !strings.Contains(joined, "\nTERM=xterm-256color\n") {
 		t.Fatalf("projectShellEnv missing allowed environment value: %q", joined)
 	}
+	if strings.Contains(joined, "\nPATH=/tmp/evil\n") {
+		t.Fatalf("projectShellEnv forwarded parent PATH: %q", joined)
+	}
+	if !strings.Contains(joined, "\nPATH="+projectShellPath()+"\n") {
+		t.Fatalf("projectShellEnv missing safe PATH: %q", joined)
+	}
 	if !strings.Contains(joined, "\nSHELL=test-shell\n") {
 		t.Fatalf("projectShellEnv did not override SHELL: %q", joined)
+	}
+}
+
+func TestStartProjectShell_RejectsInvalidShell(t *testing.T) {
+	err := startProjectShell(t.TempDir(), "test-shell")
+	if err == nil {
+		t.Fatal("expected invalid shell to fail")
+	}
+	if !strings.Contains(err.Error(), "is no longer valid") {
+		t.Fatalf("error = %q, want shell validation failure", err)
 	}
 }
 

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -309,7 +309,7 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 		"LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_TRACE_LOADED_OBJECTS",
 		"DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH", "DYLD_FALLBACK_LIBRARY_PATH",
 		"BASH_ENV", "ENV", "CDPATH", "IFS", "SHELLOPTS", "BASHOPTS", "PS4",
-		"GCONV_PATH", "PYTHONPATH", "RUBYLIB", "RUBYOPT", "NODE_PATH", "NODE_OPTIONS", "PERL5LIB", "PERL5OPT",
+		"ZDOTDIR", "GCONV_PATH", "PYTHONPATH", "RUBYLIB", "RUBYOPT", "NODE_PATH", "NODE_OPTIONS", "PERL5LIB", "PERL5OPT",
 	} {
 		t.Setenv(key, "injected")
 	}
@@ -326,7 +326,7 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 		"LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_TRACE_LOADED_OBJECTS",
 		"DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH", "DYLD_FALLBACK_LIBRARY_PATH",
 		"BASH_ENV", "ENV", "CDPATH", "IFS", "SHELLOPTS", "BASHOPTS", "PS4",
-		"GCONV_PATH", "PYTHONPATH", "RUBYLIB", "RUBYOPT", "NODE_PATH", "NODE_OPTIONS", "PERL5LIB", "PERL5OPT",
+		"ZDOTDIR", "GCONV_PATH", "PYTHONPATH", "RUBYLIB", "RUBYOPT", "NODE_PATH", "NODE_OPTIONS", "PERL5LIB", "PERL5OPT",
 	} {
 		if strings.Contains(joined, "\n"+key+"=") {
 			t.Fatalf("projectShellEnv included disallowed key %q in %q", key, joined)
@@ -405,6 +405,7 @@ func TestAppendAllowedProjectShellEnv_DropsLinkerAndInterpreterVariables(t *test
 		{"LD_PRELOAD", "/tmp/lib.so"},
 		{"DYLD_INSERT_LIBRARIES", "/tmp/lib.dylib"},
 		{"BASH_ENV", "/tmp/env"},
+		{"ZDOTDIR", "/tmp/zsh"},
 		{"GCONV_PATH", "/tmp/gconv"},
 		{"PYTHONPATH", "/tmp/python"},
 		{"RUBYOPT", "-r/tmp/ruby.rb"},

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -272,7 +273,11 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 	t.Setenv("PATH", "/tmp/evil")
 	t.Setenv("SHELL", "/tmp/evil")
 
-	env := projectShellEnv("test-shell")
+	shell := testInteractiveShell(t)
+	env, err := projectShellEnv(shell)
+	if err != nil {
+		t.Fatalf("projectShellEnv: %v", err)
+	}
 	joined := "\n" + strings.Join(env, "\n") + "\n"
 
 	for _, key := range []string{"WENDY_TOKEN", "OPENAI_API_KEY", "NORMAL_ENV"} {
@@ -289,8 +294,14 @@ func TestProjectShellEnv_FiltersSensitiveValues(t *testing.T) {
 	if !strings.Contains(joined, "\nPATH="+projectShellPath()+"\n") {
 		t.Fatalf("projectShellEnv missing safe PATH: %q", joined)
 	}
-	if !strings.Contains(joined, "\nSHELL=test-shell\n") {
-		t.Fatalf("projectShellEnv did not override SHELL: %q", joined)
+	if runtime.GOOS != "windows" && !strings.Contains(joined, "\nSHELL="+shell+"\n") {
+		t.Fatalf("projectShellEnv did not override SHELL with validated shell: %q", joined)
+	}
+}
+
+func TestProjectShellEnv_RejectsInvalidShell(t *testing.T) {
+	if _, err := projectShellEnv("test-shell"); err == nil {
+		t.Fatal("expected invalid shell to fail")
 	}
 }
 
@@ -314,6 +325,22 @@ func TestValidateInteractiveShell_RejectsUnknownShellName(t *testing.T) {
 	if shell, ok := validateInteractiveShell(path); ok {
 		t.Fatalf("validateInteractiveShell(%q) = %q, true; want false", path, shell)
 	}
+}
+
+func TestValidateInteractiveShell_AcceptsDefaultShell(t *testing.T) {
+	shell := testInteractiveShell(t)
+	if got, ok := validateInteractiveShell(shell); !ok || got != shell {
+		t.Fatalf("validateInteractiveShell(%q) = %q, %t; want %q, true", shell, got, ok, shell)
+	}
+}
+
+func testInteractiveShell(t *testing.T) string {
+	t.Helper()
+	shell, err := defaultInteractiveShell()
+	if err != nil {
+		t.Skipf("no supported interactive shell: %v", err)
+	}
+	return shell
 }
 
 func TestResolveTemplateLanguage_RejectsUnavailableTemplateLanguage(t *testing.T) {

--- a/go/internal/cli/commands/init_cmd_unix.go
+++ b/go/internal/cli/commands/init_cmd_unix.go
@@ -22,7 +22,7 @@ func windowsRootDir() string {
 	panic("windowsRootDir called on non-Windows")
 }
 
-func isRootOwned(info os.FileInfo) bool {
+func isRootOwned(_ string, info os.FileInfo) bool {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	return ok && stat.Uid == 0
 }

--- a/go/internal/cli/commands/init_cmd_unix.go
+++ b/go/internal/cli/commands/init_cmd_unix.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"os"
 	"os/exec"
+	"syscall"
 )
 
 // launchAssistantWithPrompt invokes the AI assistant with the prompt passed
@@ -19,4 +20,9 @@ func launchAssistantWithPrompt(choice, prompt string) error {
 
 func windowsRootDir() string {
 	return `C:\Windows`
+}
+
+func isRootOwned(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == 0
 }

--- a/go/internal/cli/commands/init_cmd_unix.go
+++ b/go/internal/cli/commands/init_cmd_unix.go
@@ -19,7 +19,7 @@ func launchAssistantWithPrompt(choice, prompt string) error {
 }
 
 func windowsRootDir() string {
-	return `C:\Windows`
+	panic("windowsRootDir called on non-Windows")
 }
 
 func isRootOwned(info os.FileInfo) bool {

--- a/go/internal/cli/commands/init_cmd_unix.go
+++ b/go/internal/cli/commands/init_cmd_unix.go
@@ -16,3 +16,7 @@ func launchAssistantWithPrompt(choice, prompt string) error {
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
+
+func windowsRootDir() string {
+	return `C:\Windows`
+}

--- a/go/internal/cli/commands/init_cmd_windows.go
+++ b/go/internal/cli/commands/init_cmd_windows.go
@@ -68,5 +68,5 @@ func windowsRootDir() string {
 }
 
 func isRootOwned(_ os.FileInfo) bool {
-	return true
+	return false
 }

--- a/go/internal/cli/commands/init_cmd_windows.go
+++ b/go/internal/cli/commands/init_cmd_windows.go
@@ -67,6 +67,14 @@ func windowsRootDir() string {
 	return filepath.Clean(root)
 }
 
-func isRootOwned(_ os.FileInfo) bool {
-	return false
+func isRootOwned(path string, _ os.FileInfo) bool {
+	descriptor, err := windows.GetNamedSecurityInfo(filepath.Clean(path), windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+	if err != nil || descriptor == nil || !descriptor.IsValid() {
+		return false
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil || owner == nil || !owner.IsValid() {
+		return false
+	}
+	return owner.IsWellKnown(windows.WinLocalSystemSid) || owner.IsWellKnown(windows.WinBuiltinAdministratorsSid)
 }

--- a/go/internal/cli/commands/init_cmd_windows.go
+++ b/go/internal/cli/commands/init_cmd_windows.go
@@ -66,3 +66,7 @@ func windowsRootDir() string {
 	}
 	return filepath.Clean(root)
 }
+
+func isRootOwned(_ os.FileInfo) bool {
+	return true
+}

--- a/go/internal/cli/commands/init_cmd_windows.go
+++ b/go/internal/cli/commands/init_cmd_windows.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
 )
 
 // launchAssistantWithPrompt writes the full prompt to a temp file and asks the
@@ -53,4 +57,12 @@ func writePromptForAssistant(prompt string) (string, func(), error) {
 	}
 
 	return path, func() { os.Remove(path) }, nil
+}
+
+func windowsRootDir() string {
+	root, err := windows.GetWindowsDirectory()
+	if err != nil || strings.TrimSpace(root) == "" || !filepath.IsAbs(root) {
+		return `C:\Windows`
+	}
+	return filepath.Clean(root)
 }

--- a/go/internal/cli/commands/project_shell_darwin.go
+++ b/go/internal/cli/commands/project_shell_darwin.go
@@ -9,9 +9,9 @@ import (
 )
 
 func runProjectShell(shell, dir string, env []string) error {
-	shell, ok := validateDarwinSystemShell(shell)
-	if !ok {
-		return fmt.Errorf("interactive shell %q is no longer valid", shell)
+	shell, shellInfo, err := statDarwinSystemShell(shell)
+	if err != nil {
+		return err
 	}
 
 	dirFile, err := os.Open(dir)
@@ -41,16 +41,16 @@ func runProjectShell(shell, dir string, env []string) error {
 	if err := syscall.Fchdir(int(dirFile.Fd())); err != nil {
 		return fmt.Errorf("changing to project directory: %w", err)
 	}
-	revalidated, ok := validateDarwinSystemShell(shell)
-	if !ok {
+	revalidated, err := verifyDarwinSystemShell(shell, shellInfo)
+	if err != nil {
 		_ = syscall.Fchdir(int(originalDir.Fd()))
-		return fmt.Errorf("interactive shell %q is no longer valid", shell)
+		return err
 	}
 	shell = revalidated
 	// Darwin does not provide fd-based exec through Go. This path is limited to
-	// exact /bin shells on the SIP-protected system volume and is re-validated
-	// immediately before exec.
-	if err := syscall.Exec(shell, []string{shell}, env); err != nil {
+	// exact /bin shells on the SIP-protected system volume and is checked for
+	// the same inode immediately before exec.
+	if err := execDarwinSystemShell(shell, env); err != nil {
 		return restoreProjectShellDir(originalDir, err)
 	}
 	return nil
@@ -62,6 +62,42 @@ func validateDarwinSystemShell(shell string) (string, bool) {
 		return "", false
 	}
 	return validated, true
+}
+
+func statDarwinSystemShell(shell string) (string, os.FileInfo, error) {
+	validated, ok := validateDarwinSystemShell(shell)
+	if !ok {
+		return "", nil, fmt.Errorf("interactive shell %q is no longer valid", shell)
+	}
+	info, err := os.Lstat(validated)
+	if err != nil {
+		return "", nil, fmt.Errorf("checking interactive shell path: %w", err)
+	}
+	return validated, info, nil
+}
+
+func verifyDarwinSystemShell(shell string, before os.FileInfo) (string, error) {
+	validated, after, err := statDarwinSystemShell(shell)
+	if err != nil {
+		return "", err
+	}
+	if !os.SameFile(before, after) {
+		return "", fmt.Errorf("interactive shell changed before handoff")
+	}
+	return validated, nil
+}
+
+func execDarwinSystemShell(shell string, env []string) error {
+	switch shell {
+	case "/bin/zsh":
+		return syscall.Exec("/bin/zsh", []string{"/bin/zsh"}, env)
+	case "/bin/bash":
+		return syscall.Exec("/bin/bash", []string{"/bin/bash"}, env)
+	case "/bin/sh":
+		return syscall.Exec("/bin/sh", []string{"/bin/sh"}, env)
+	default:
+		return fmt.Errorf("interactive shell %q is no longer valid", shell)
+	}
 }
 
 func restoreProjectShellDir(originalDir *os.File, execErr error) error {

--- a/go/internal/cli/commands/project_shell_darwin.go
+++ b/go/internal/cli/commands/project_shell_darwin.go
@@ -1,0 +1,72 @@
+//go:build darwin
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func runProjectShell(shell, dir string, env []string) error {
+	shell, ok := validateDarwinSystemShell(shell)
+	if !ok {
+		return fmt.Errorf("interactive shell %q is no longer valid", shell)
+	}
+
+	dirFile, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("opening project directory: %w", err)
+	}
+	defer dirFile.Close()
+
+	fdInfo, err := dirFile.Stat()
+	if err != nil {
+		return fmt.Errorf("checking project directory handle: %w", err)
+	}
+	pathInfo, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("checking project directory path: %w", err)
+	}
+	if !os.SameFile(fdInfo, pathInfo) {
+		return fmt.Errorf("project directory changed before shell handoff")
+	}
+
+	originalDir, err := os.Open(".")
+	if err != nil {
+		return fmt.Errorf("opening current directory: %w", err)
+	}
+	defer originalDir.Close()
+
+	if err := syscall.Fchdir(int(dirFile.Fd())); err != nil {
+		return fmt.Errorf("changing to project directory: %w", err)
+	}
+	revalidated, ok := validateDarwinSystemShell(shell)
+	if !ok {
+		_ = syscall.Fchdir(int(originalDir.Fd()))
+		return fmt.Errorf("interactive shell %q is no longer valid", shell)
+	}
+	shell = revalidated
+	// Darwin does not provide fd-based exec through Go. This path is limited to
+	// exact /bin shells on the SIP-protected system volume and is re-validated
+	// immediately before exec.
+	if err := syscall.Exec(shell, []string{shell}, env); err != nil {
+		return restoreProjectShellDir(originalDir, err)
+	}
+	return nil
+}
+
+func validateDarwinSystemShell(shell string) (string, bool) {
+	validated, ok := validateInteractiveShell(shell)
+	if !ok || !isDarwinSystemShellPath(validated) {
+		return "", false
+	}
+	return validated, true
+}
+
+func restoreProjectShellDir(originalDir *os.File, execErr error) error {
+	if err := syscall.Fchdir(int(originalDir.Fd())); err != nil {
+		return fmt.Errorf("starting shell failed (%w) and restoring working directory failed: %v", execErr, err)
+	}
+	return fmt.Errorf("starting shell in project directory: %w", execErr)
+}

--- a/go/internal/cli/commands/project_shell_darwin.go
+++ b/go/internal/cli/commands/project_shell_darwin.go
@@ -41,6 +41,10 @@ func runProjectShell(shell, dir string, env []string) error {
 	if err := syscall.Fchdir(int(dirFile.Fd())); err != nil {
 		return fmt.Errorf("changing to project directory: %w", err)
 	}
+	if err := verifyProjectShellCWD(fdInfo); err != nil {
+		_ = syscall.Fchdir(int(originalDir.Fd()))
+		return err
+	}
 	revalidated, err := verifyDarwinSystemShell(shell, shellInfo)
 	if err != nil {
 		_ = syscall.Fchdir(int(originalDir.Fd()))
@@ -98,6 +102,17 @@ func execDarwinSystemShell(shell string, env []string) error {
 	default:
 		return fmt.Errorf("interactive shell %q is no longer valid", shell)
 	}
+}
+
+func verifyProjectShellCWD(want os.FileInfo) error {
+	got, err := os.Stat(".")
+	if err != nil {
+		return fmt.Errorf("checking project directory after handoff: %w", err)
+	}
+	if !os.SameFile(want, got) {
+		return fmt.Errorf("project directory changed before shell handoff")
+	}
+	return nil
 }
 
 func restoreProjectShellDir(originalDir *os.File, execErr error) error {

--- a/go/internal/cli/commands/project_shell_linux.go
+++ b/go/internal/cli/commands/project_shell_linux.go
@@ -50,6 +50,7 @@ func runProjectShell(shell, dir string, env []string) error {
 		_ = syscall.Fchdir(int(originalDir.Fd()))
 		return err
 	}
+	runtime.KeepAlive(shellFile)
 	if err := prepareOpenProjectShellForExec(shellFile); err != nil {
 		_ = syscall.Fchdir(int(originalDir.Fd()))
 		return err
@@ -75,6 +76,8 @@ func openProjectShellForExec(shell string) (*os.File, error) {
 }
 
 func prepareOpenProjectShellForExec(shellFile *os.File) error {
+	// Intentionally clear close-on-exec only for the validated shell fd so
+	// /proc/self/fd can execute it. Other Go-opened fds retain CLOEXEC.
 	if _, err := unix.FcntlInt(shellFile.Fd(), unix.F_SETFD, 0); err != nil {
 		return fmt.Errorf("preparing interactive shell handle: %w", err)
 	}

--- a/go/internal/cli/commands/project_shell_linux.go
+++ b/go/internal/cli/commands/project_shell_linux.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux
 
 package commands
 
@@ -12,11 +12,12 @@ import (
 )
 
 func runProjectShell(shell, dir string, env []string) error {
-	shellFile, shellExecPath, err := openProjectShellForExec(shell)
+	shellFile, err := openProjectShellForExec(shell)
 	if err != nil {
 		return err
 	}
 	defer shellFile.Close()
+	shellExecPath := shellFileExecPath(shellFile)
 
 	dirFile, err := os.Open(dir)
 	if err != nil {
@@ -49,37 +50,35 @@ func runProjectShell(shell, dir string, env []string) error {
 		_ = syscall.Fchdir(int(originalDir.Fd()))
 		return err
 	}
+	if err := prepareOpenProjectShellForExec(shellFile); err != nil {
+		_ = syscall.Fchdir(int(originalDir.Fd()))
+		return err
+	}
 	runtime.KeepAlive(shellFile)
 	if err := syscall.Exec(shellExecPath, []string{shell}, env); err != nil {
-		_ = syscall.Fchdir(int(originalDir.Fd()))
-		return fmt.Errorf("starting shell in project directory: %w", err)
+		return restoreProjectShellDir(originalDir, err)
 	}
 	return nil
 }
 
-func openProjectShellForExec(shell string) (*os.File, string, error) {
+func openProjectShellForExec(shell string) (*os.File, error) {
 	shellFile, err := os.Open(shell)
 	if err != nil {
-		return nil, "", fmt.Errorf("opening interactive shell: %w", err)
+		return nil, fmt.Errorf("opening interactive shell: %w", err)
 	}
 	if err := verifyOpenProjectShell(shellFile, shell); err != nil {
 		shellFile.Close()
-		return nil, "", err
-	}
-	// Linux can exec the validated descriptor through procfs. Darwin does not
-	// expose execveat/fexecve through Go, so the residual path-exec race is
-	// accepted there only after validateInteractiveShell restricts shells to
-	// root-owned, non-writable system locations and runProjectShell re-checks
-	// immediately before syscall.Exec.
-	if runtime.GOOS != "linux" {
-		return shellFile, shell, nil
-	}
-	if _, err := unix.FcntlInt(shellFile.Fd(), unix.F_SETFD, 0); err != nil {
-		shellFile.Close()
-		return nil, "", fmt.Errorf("preparing interactive shell handle: %w", err)
+		return nil, err
 	}
 
-	return shellFile, shellFileExecPath(shellFile), nil
+	return shellFile, nil
+}
+
+func prepareOpenProjectShellForExec(shellFile *os.File) error {
+	if _, err := unix.FcntlInt(shellFile.Fd(), unix.F_SETFD, 0); err != nil {
+		return fmt.Errorf("preparing interactive shell handle: %w", err)
+	}
+	return nil
 }
 
 func verifyOpenProjectShell(shellFile *os.File, shell string) error {
@@ -103,4 +102,11 @@ func verifyOpenProjectShell(shellFile *os.File, shell string) error {
 
 func shellFileExecPath(file *os.File) string {
 	return fmt.Sprintf("/proc/self/fd/%d", file.Fd())
+}
+
+func restoreProjectShellDir(originalDir *os.File, execErr error) error {
+	if err := syscall.Fchdir(int(originalDir.Fd())); err != nil {
+		return fmt.Errorf("starting shell failed (%w) and restoring working directory failed: %v", execErr, err)
+	}
+	return fmt.Errorf("starting shell in project directory: %w", execErr)
 }

--- a/go/internal/cli/commands/project_shell_unix.go
+++ b/go/internal/cli/commands/project_shell_unix.go
@@ -5,14 +5,47 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
 )
 
 func runProjectShell(shell, dir string, env []string) error {
-	if err := os.Chdir(dir); err != nil {
+	dirFile, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("opening project directory: %w", err)
+	}
+	defer dirFile.Close()
+
+	fdInfo, err := dirFile.Stat()
+	if err != nil {
+		return fmt.Errorf("checking project directory handle: %w", err)
+	}
+	pathInfo, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("checking project directory path: %w", err)
+	}
+	if !os.SameFile(fdInfo, pathInfo) {
+		return fmt.Errorf("project directory changed before shell handoff")
+	}
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return fmt.Errorf("resolving project directory before shell handoff: %w", err)
+	}
+	if filepath.Clean(resolved) != filepath.Clean(dir) {
+		return fmt.Errorf("project directory changed before shell handoff")
+	}
+
+	originalDir, err := os.Open(".")
+	if err != nil {
+		return fmt.Errorf("opening current directory: %w", err)
+	}
+	defer originalDir.Close()
+
+	if err := syscall.Fchdir(int(dirFile.Fd())); err != nil {
 		return fmt.Errorf("changing to project directory: %w", err)
 	}
 	if err := syscall.Exec(shell, []string{shell}, env); err != nil {
+		_ = syscall.Fchdir(int(originalDir.Fd()))
 		return fmt.Errorf("starting shell in project directory: %w", err)
 	}
 	return nil

--- a/go/internal/cli/commands/project_shell_unix.go
+++ b/go/internal/cli/commands/project_shell_unix.go
@@ -5,10 +5,19 @@ package commands
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func runProjectShell(shell, dir string, env []string) error {
+	shellFile, shellExecPath, err := openProjectShellForExec(shell)
+	if err != nil {
+		return err
+	}
+	defer shellFile.Close()
+
 	dirFile, err := os.Open(dir)
 	if err != nil {
 		return fmt.Errorf("opening project directory: %w", err)
@@ -36,9 +45,60 @@ func runProjectShell(shell, dir string, env []string) error {
 	if err := syscall.Fchdir(int(dirFile.Fd())); err != nil {
 		return fmt.Errorf("changing to project directory: %w", err)
 	}
-	if err := syscall.Exec(shell, []string{shell}, env); err != nil {
+	if shellExecPath == shell {
+		if err := verifyOpenProjectShell(shellFile, shell); err != nil {
+			_ = syscall.Fchdir(int(originalDir.Fd()))
+			return err
+		}
+	}
+	if err := syscall.Exec(shellExecPath, []string{shell}, env); err != nil {
 		_ = syscall.Fchdir(int(originalDir.Fd()))
 		return fmt.Errorf("starting shell in project directory: %w", err)
 	}
 	return nil
+}
+
+func openProjectShellForExec(shell string) (*os.File, string, error) {
+	shellFile, err := os.Open(shell)
+	if err != nil {
+		return nil, "", fmt.Errorf("opening interactive shell: %w", err)
+	}
+	if err := verifyOpenProjectShell(shellFile, shell); err != nil {
+		shellFile.Close()
+		return nil, "", err
+	}
+	// Linux can exec the validated descriptor through procfs. Other Unix
+	// targets keep the descriptor open and re-check it immediately before exec.
+	if runtime.GOOS != "linux" {
+		return shellFile, shell, nil
+	}
+	if _, err := unix.FcntlInt(shellFile.Fd(), unix.F_SETFD, 0); err != nil {
+		shellFile.Close()
+		return nil, "", fmt.Errorf("preparing interactive shell handle: %w", err)
+	}
+
+	return shellFile, shellFileExecPath(shellFile), nil
+}
+
+func verifyOpenProjectShell(shellFile *os.File, shell string) error {
+	fdInfo, err := shellFile.Stat()
+	if err != nil {
+		return fmt.Errorf("checking interactive shell handle: %w", err)
+	}
+	validated, ok := validateInteractiveShell(shell)
+	if !ok || validated != shell {
+		return fmt.Errorf("interactive shell %q is no longer valid", shell)
+	}
+	pathInfo, err := os.Lstat(validated)
+	if err != nil {
+		return fmt.Errorf("checking interactive shell path: %w", err)
+	}
+	if !os.SameFile(fdInfo, pathInfo) {
+		return fmt.Errorf("interactive shell changed before handoff")
+	}
+	return nil
+}
+
+func shellFileExecPath(file *os.File) string {
+	return fmt.Sprintf("/proc/self/fd/%d", file.Fd())
 }

--- a/go/internal/cli/commands/project_shell_unix.go
+++ b/go/internal/cli/commands/project_shell_unix.go
@@ -45,12 +45,11 @@ func runProjectShell(shell, dir string, env []string) error {
 	if err := syscall.Fchdir(int(dirFile.Fd())); err != nil {
 		return fmt.Errorf("changing to project directory: %w", err)
 	}
-	if shellExecPath == shell {
-		if err := verifyOpenProjectShell(shellFile, shell); err != nil {
-			_ = syscall.Fchdir(int(originalDir.Fd()))
-			return err
-		}
+	if err := verifyOpenProjectShell(shellFile, shell); err != nil {
+		_ = syscall.Fchdir(int(originalDir.Fd()))
+		return err
 	}
+	runtime.KeepAlive(shellFile)
 	if err := syscall.Exec(shellExecPath, []string{shell}, env); err != nil {
 		_ = syscall.Fchdir(int(originalDir.Fd()))
 		return fmt.Errorf("starting shell in project directory: %w", err)

--- a/go/internal/cli/commands/project_shell_unix.go
+++ b/go/internal/cli/commands/project_shell_unix.go
@@ -5,7 +5,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"syscall"
 )
 
@@ -25,13 +24,6 @@ func runProjectShell(shell, dir string, env []string) error {
 		return fmt.Errorf("checking project directory path: %w", err)
 	}
 	if !os.SameFile(fdInfo, pathInfo) {
-		return fmt.Errorf("project directory changed before shell handoff")
-	}
-	resolved, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		return fmt.Errorf("resolving project directory before shell handoff: %w", err)
-	}
-	if filepath.Clean(resolved) != filepath.Clean(dir) {
 		return fmt.Errorf("project directory changed before shell handoff")
 	}
 

--- a/go/internal/cli/commands/project_shell_unix.go
+++ b/go/internal/cli/commands/project_shell_unix.go
@@ -66,10 +66,11 @@ func openProjectShellForExec(shell string) (*os.File, string, error) {
 		shellFile.Close()
 		return nil, "", err
 	}
-	// Linux can exec the validated descriptor through procfs. Other Unix
-	// targets do not expose execveat/fexecve through Go; for those targets,
-	// validateInteractiveShell restricts shells to root-owned, non-writable
-	// system locations and runProjectShell re-checks immediately before exec.
+	// Linux can exec the validated descriptor through procfs. Darwin does not
+	// expose execveat/fexecve through Go, so the residual path-exec race is
+	// accepted there only after validateInteractiveShell restricts shells to
+	// root-owned, non-writable system locations and runProjectShell re-checks
+	// immediately before syscall.Exec.
 	if runtime.GOOS != "linux" {
 		return shellFile, shell, nil
 	}

--- a/go/internal/cli/commands/project_shell_unix.go
+++ b/go/internal/cli/commands/project_shell_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func runProjectShell(shell, dir string, env []string) error {
+	if err := os.Chdir(dir); err != nil {
+		return fmt.Errorf("changing to project directory: %w", err)
+	}
+	if err := syscall.Exec(shell, []string{shell}, env); err != nil {
+		return fmt.Errorf("starting shell in project directory: %w", err)
+	}
+	return nil
+}

--- a/go/internal/cli/commands/project_shell_unix.go
+++ b/go/internal/cli/commands/project_shell_unix.go
@@ -67,7 +67,9 @@ func openProjectShellForExec(shell string) (*os.File, string, error) {
 		return nil, "", err
 	}
 	// Linux can exec the validated descriptor through procfs. Other Unix
-	// targets keep the descriptor open and re-check it immediately before exec.
+	// targets do not expose execveat/fexecve through Go; for those targets,
+	// validateInteractiveShell restricts shells to root-owned, non-writable
+	// system locations and runProjectShell re-checks immediately before exec.
 	if runtime.GOOS != "linux" {
 		return shellFile, shell, nil
 	}

--- a/go/internal/cli/commands/project_shell_windows.go
+++ b/go/internal/cli/commands/project_shell_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func runProjectShell(shell, dir string, env []string) error {
+	cmd := exec.Command(shell)
+	cmd.Path = shell
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("starting shell in project directory: %w", err)
+	}
+	return nil
+}

--- a/go/internal/cli/commands/project_shell_windows.go
+++ b/go/internal/cli/commands/project_shell_windows.go
@@ -9,13 +9,14 @@ import (
 )
 
 func runProjectShell(shell, dir string, env []string) error {
-	cmd := exec.Command(shell)
-	cmd.Path = shell
-	cmd.Dir = dir
-	cmd.Env = env
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd := &exec.Cmd{
+		Path:   shell,
+		Dir:    dir,
+		Env:    env,
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("starting shell in project directory: %w", err)
 	}


### PR DESCRIPTION
## Summary

- make interactive `wendy init --template` enter a shell rooted in the generated project directory when the user chooses to create a new directory
- keep current-directory and scripted/non-interactive template init behavior on the existing next-step guidance path
- add focused tests for the new shell handoff behavior and error propagation

## Why

A standalone CLI process cannot change the parent shell's working directory after exit. For the interactive new-directory flow, handing control to a shell whose working directory is the generated project gives users the expected post-init experience without changing automation behavior.

Closes #794.

## Validation

- `CC="$(xcrun --find clang)" CXX="$(xcrun --find clang++)" SDKROOT="$(xcrun --show-sdk-path)" CGO_ENABLED=1 go -C go test ./internal/cli/commands`
- `CC="$(xcrun --find clang)" CXX="$(xcrun --find clang++)" SDKROOT="$(xcrun --show-sdk-path)" CGO_ENABLED=1 go -C go test ./...`
- `git diff --check`
- live PTY smoke test: `wendy init --template simple-api --language python --git-init no --assistant skip`, chose new directory `foo-auto-cd`, confirmed shell opened in `/tmp/wendy-init-auto-cd-smoke-3873/foo-auto-cd`
