### PR TITLE
feat(agent): inject WENDY_APP_ID and OTel service identity into containers [WDY-1259]

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -776,6 +776,10 @@ func buildContainerBaseEnv(appID string) []string {
 	if h := deviceHostnameWithSuffix(); h != "" {
 		env = append(env, "WENDY_HOSTNAME="+h)
 	}
+	// WENDY_APP_ID is injected unconditionally (all network modes) so app code
+	// can always read its own identity. The OTel identity vars are injected only
+	// under host networking (in injectOTELEnvIfNeeded) because the OTLP receiver
+	// is only reachable in that mode.
 	if appID != "" {
 		env = append(env, "WENDY_APP_ID="+appID)
 	}
@@ -807,20 +811,24 @@ func injectOTELEnvIfNeeded(env []string, appCfg *appconfig.AppConfig) []string {
 			hasResourceAttrs = true
 		}
 	}
-	if hasEndpoint {
-		return env // image already configured the exporter; do not override
+	// Endpoint/protocol: only point the exporter at our receiver when the image
+	// hasn't already configured one.
+	if !hasEndpoint {
+		otelPort := os.Getenv("WENDY_OTEL_PORT")
+		if otelPort == "" {
+			otelPort = "4317"
+		}
+		if p, err := strconv.Atoi(otelPort); err != nil || p < 1 || p > 65535 {
+			otelPort = "4317"
+		}
+		env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:"+otelPort)
+		if !hasProtocol {
+			env = append(env, "OTEL_EXPORTER_OTLP_PROTOCOL=grpc")
+		}
 	}
-	otelPort := os.Getenv("WENDY_OTEL_PORT")
-	if otelPort == "" {
-		otelPort = "4317"
-	}
-	if p, err := strconv.Atoi(otelPort); err != nil || p < 1 || p > 65535 {
-		otelPort = "4317"
-	}
-	env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:"+otelPort)
-	if !hasProtocol {
-		env = append(env, "OTEL_EXPORTER_OTLP_PROTOCOL=grpc")
-	}
+	// Identity: set regardless of where the exporter points, so `wendy device
+	// logs --app <id>` can match even when the image preset its own endpoint.
+	// Image-set values still take precedence.
 	if appCfg.AppID != "" {
 		if !hasServiceName {
 			env = append(env, "OTEL_SERVICE_NAME="+appCfg.AppID)

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -499,7 +499,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	}
 
 	// Build environment variables: image env first, then our overrides.
-	env := buildContainerBaseEnv()
+	env := buildContainerBaseEnv(appCfg.AppID)
 	if specErr == nil {
 		env = append(imageSpec.Config.Env, env...)
 	}
@@ -765,9 +765,10 @@ var deviceHostnameWithSuffix = func() string {
 
 // buildContainerBaseEnv builds the wendy-injected env vars layered on top of
 // the image's own env. WENDY_HOSTNAME is the device's mDNS hostname
-// (omitted when unresolvable). OTEL_EXPORTER_OTLP_ENDPOINT points at the
+// (omitted when unresolvable) and WENDY_APP_ID is the app's wendy.json appId
+// (omitted when empty). OTEL_EXPORTER_OTLP_ENDPOINT points at the
 // agent's OTLP gRPC receiver so containers auto-configure their exporters.
-func buildContainerBaseEnv() []string {
+func buildContainerBaseEnv(appID string) []string {
 	env := []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"TERM=xterm",
@@ -775,24 +776,35 @@ func buildContainerBaseEnv() []string {
 	if h := deviceHostnameWithSuffix(); h != "" {
 		env = append(env, "WENDY_HOSTNAME="+h)
 	}
+	if appID != "" {
+		env = append(env, "WENDY_APP_ID="+appID)
+	}
 	return env
 }
 
 // injectOTELEnvIfNeeded appends OTEL exporter env vars to env when host
-// networking is in effect and the endpoint is not already configured.
-// It must be called after the image env has been merged so that image-set
-// values take precedence.
+// networking is in effect and the endpoint is not already configured. Besides
+// the endpoint and protocol, it sets OTEL_SERVICE_NAME and
+// OTEL_RESOURCE_ATTRIBUTES (wendy.app.name) to the appId so that telemetry
+// exported by the app matches `wendy device logs --app <id>`, which filters on
+// those resource attributes. It must be called after the image env has been
+// merged so that image-set values take precedence.
 func injectOTELEnvIfNeeded(env []string, appCfg *appconfig.AppConfig) []string {
 	if !hasHostNetworkEntitlement(appCfg) {
 		return env
 	}
 	hasEndpoint, hasProtocol := false, false
+	hasServiceName, hasResourceAttrs := false, false
 	for _, e := range env {
-		if strings.HasPrefix(e, "OTEL_EXPORTER_OTLP_ENDPOINT=") {
+		switch {
+		case strings.HasPrefix(e, "OTEL_EXPORTER_OTLP_ENDPOINT="):
 			hasEndpoint = true
-		}
-		if strings.HasPrefix(e, "OTEL_EXPORTER_OTLP_PROTOCOL=") {
+		case strings.HasPrefix(e, "OTEL_EXPORTER_OTLP_PROTOCOL="):
 			hasProtocol = true
+		case strings.HasPrefix(e, "OTEL_SERVICE_NAME="):
+			hasServiceName = true
+		case strings.HasPrefix(e, "OTEL_RESOURCE_ATTRIBUTES="):
+			hasResourceAttrs = true
 		}
 	}
 	if hasEndpoint {
@@ -808,6 +820,14 @@ func injectOTELEnvIfNeeded(env []string, appCfg *appconfig.AppConfig) []string {
 	env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:"+otelPort)
 	if !hasProtocol {
 		env = append(env, "OTEL_EXPORTER_OTLP_PROTOCOL=grpc")
+	}
+	if appCfg.AppID != "" {
+		if !hasServiceName {
+			env = append(env, "OTEL_SERVICE_NAME="+appCfg.AppID)
+		}
+		if !hasResourceAttrs {
+			env = append(env, "OTEL_RESOURCE_ATTRIBUTES=wendy.app.name="+appCfg.AppID)
+		}
 	}
 	return env
 }

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -259,6 +259,32 @@ func TestInjectOTELEnvSetsServiceNameAndResourceAttrs(t *testing.T) {
 	}
 }
 
+func TestInjectOTELEnvSetsIdentityWhenEndpointPreset(t *testing.T) {
+	// An image that presets only the endpoint should still get identity vars so
+	// its direct OTLP logs remain filterable by `wendy device logs --app <id>`.
+	existing := []string{"OTEL_EXPORTER_OTLP_ENDPOINT=http://custom-collector:4317"}
+
+	env := injectOTELEnvIfNeeded(existing, hostNetworkCfgWithID("my-app"))
+
+	endpointCount, wantService, wantAttrs := 0, false, false
+	for _, kv := range env {
+		switch {
+		case strings.HasPrefix(kv, "OTEL_EXPORTER_OTLP_ENDPOINT="):
+			endpointCount++
+		case kv == "OTEL_SERVICE_NAME=my-app":
+			wantService = true
+		case kv == "OTEL_RESOURCE_ATTRIBUTES=wendy.app.name=my-app":
+			wantAttrs = true
+		}
+	}
+	if endpointCount != 1 {
+		t.Errorf("expected image endpoint preserved (1 entry), got %d: %v", endpointCount, env)
+	}
+	if !wantService || !wantAttrs {
+		t.Errorf("expected identity vars injected alongside preset endpoint; got %v", env)
+	}
+}
+
 func TestInjectOTELEnvOmitsServiceNameWhenAppIDEmpty(t *testing.T) {
 	env := injectOTELEnvIfNeeded(nil, hostNetworkCfgWithID(""))
 

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -63,7 +63,7 @@ func TestBuildContainerBaseEnvIncludesWendyHostname(t *testing.T) {
 	t.Cleanup(func() { deviceHostnameWithSuffix = old })
 	deviceHostnameWithSuffix = func() string { return "wendyos-test-device.local" }
 
-	env := buildContainerBaseEnv()
+	env := buildContainerBaseEnv("demo-app")
 
 	want := "WENDY_HOSTNAME=wendyos-test-device.local"
 	for _, kv := range env {
@@ -79,11 +79,41 @@ func TestBuildContainerBaseEnvOmitsWendyHostnameWhenUnavailable(t *testing.T) {
 	t.Cleanup(func() { deviceHostnameWithSuffix = old })
 	deviceHostnameWithSuffix = func() string { return "" }
 
-	env := buildContainerBaseEnv()
+	env := buildContainerBaseEnv("demo-app")
 
 	for _, kv := range env {
 		if len(kv) >= len("WENDY_HOSTNAME=") && kv[:len("WENDY_HOSTNAME=")] == "WENDY_HOSTNAME=" {
 			t.Errorf("env unexpectedly contains %q when device hostname is unresolvable", kv)
+		}
+	}
+}
+
+func TestBuildContainerBaseEnvIncludesAppID(t *testing.T) {
+	old := deviceHostnameWithSuffix
+	t.Cleanup(func() { deviceHostnameWithSuffix = old })
+	deviceHostnameWithSuffix = func() string { return "" }
+
+	env := buildContainerBaseEnv("demo-app")
+
+	want := "WENDY_APP_ID=demo-app"
+	for _, kv := range env {
+		if kv == want {
+			return
+		}
+	}
+	t.Errorf("env missing %q; got %v", want, env)
+}
+
+func TestBuildContainerBaseEnvOmitsAppIDWhenEmpty(t *testing.T) {
+	old := deviceHostnameWithSuffix
+	t.Cleanup(func() { deviceHostnameWithSuffix = old })
+	deviceHostnameWithSuffix = func() string { return "" }
+
+	env := buildContainerBaseEnv("")
+
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "WENDY_APP_ID=") {
+			t.Errorf("env unexpectedly contains %q when appID is empty", kv)
 		}
 	}
 }
@@ -200,6 +230,71 @@ func TestInjectOTELEnvInvalidPortFallsBackToDefault(t *testing.T) {
 		}
 	}
 	t.Errorf("expected fallback to default port; got %v", env)
+}
+
+func hostNetworkCfgWithID(appID string) *appconfig.AppConfig {
+	cfg := hostNetworkCfg()
+	cfg.AppID = appID
+	return cfg
+}
+
+func TestInjectOTELEnvSetsServiceNameAndResourceAttrs(t *testing.T) {
+	env := injectOTELEnvIfNeeded(nil, hostNetworkCfgWithID("my-app"))
+
+	wantService := false
+	wantAttrs := false
+	for _, kv := range env {
+		switch kv {
+		case "OTEL_SERVICE_NAME=my-app":
+			wantService = true
+		case "OTEL_RESOURCE_ATTRIBUTES=wendy.app.name=my-app":
+			wantAttrs = true
+		}
+	}
+	if !wantService {
+		t.Errorf("env missing OTEL_SERVICE_NAME=my-app; got %v", env)
+	}
+	if !wantAttrs {
+		t.Errorf("env missing OTEL_RESOURCE_ATTRIBUTES=wendy.app.name=my-app; got %v", env)
+	}
+}
+
+func TestInjectOTELEnvOmitsServiceNameWhenAppIDEmpty(t *testing.T) {
+	env := injectOTELEnvIfNeeded(nil, hostNetworkCfgWithID(""))
+
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "OTEL_SERVICE_NAME=") ||
+			strings.HasPrefix(kv, "OTEL_RESOURCE_ATTRIBUTES=") {
+			t.Errorf("env unexpectedly contains %q when appID is empty", kv)
+		}
+	}
+}
+
+func TestInjectOTELEnvDoesNotOverrideExistingServiceName(t *testing.T) {
+	existing := []string{
+		"OTEL_SERVICE_NAME=custom",
+		"OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod",
+	}
+
+	env := injectOTELEnvIfNeeded(existing, hostNetworkCfgWithID("my-app"))
+
+	serviceCount, attrCount := 0, 0
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "OTEL_SERVICE_NAME=") {
+			serviceCount++
+		}
+		if strings.HasPrefix(kv, "OTEL_RESOURCE_ATTRIBUTES=") {
+			attrCount++
+		}
+	}
+	if serviceCount != 1 || attrCount != 1 {
+		t.Errorf("expected image-set OTEL_SERVICE_NAME/OTEL_RESOURCE_ATTRIBUTES to be preserved; got %v", env)
+	}
+	for _, kv := range env {
+		if kv == "OTEL_SERVICE_NAME=my-app" || kv == "OTEL_RESOURCE_ATTRIBUTES=wendy.app.name=my-app" {
+			t.Errorf("image-set OTel resource values were overridden; got %v", env)
+		}
+	}
 }
 
 func TestHasHostNetworkEntitlementEmptyModeIsHost(t *testing.T) {

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -862,5 +862,13 @@ func parseAppConfig(data []byte) (*appconfig.AppConfig, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+	// Reject unsafe app IDs at the RPC boundary so direct callers and generated
+	// compose configs can't push comma/'='/newline characters into the env vars
+	// and labels derived from appId. Empty appId is left to existing behaviour.
+	if cfg.AppID != "" {
+		if err := appconfig.ValidateAppID(cfg.AppID); err != nil {
+			return nil, err
+		}
+	}
 	return &cfg, nil
 }

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -1049,3 +1049,32 @@ func TestStreamMCP_ContainerNotRunning(t *testing.T) {
 		t.Fatalf("expected FailedPrecondition, got %v", err)
 	}
 }
+
+func TestParseAppConfigRejectsUnsafeAppID(t *testing.T) {
+	// A comma in appId would corrupt OTEL_RESOURCE_ATTRIBUTES once injected.
+	_, err := parseAppConfig([]byte(`{"appId":"bad,id"}`))
+	if err == nil {
+		t.Fatal("expected error for unsafe appId, got nil")
+	}
+}
+
+func TestParseAppConfigAcceptsValidAppID(t *testing.T) {
+	cfg, err := parseAppConfig([]byte(`{"appId":"com.example.app"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AppID != "com.example.app" {
+		t.Fatalf("appId = %q, want %q", cfg.AppID, "com.example.app")
+	}
+}
+
+func TestParseAppConfigEmptyDataStillAllowed(t *testing.T) {
+	// Empty config is a pre-existing path (no appId); must not start erroring.
+	cfg, err := parseAppConfig(nil)
+	if err != nil {
+		t.Fatalf("unexpected error for empty config: %v", err)
+	}
+	if cfg.AppID != "" {
+		t.Fatalf("appId = %q, want empty", cfg.AppID)
+	}
+}

--- a/go/internal/cli/assets/docs/cloud/telemetry.md
+++ b/go/internal/cli/assets/docs/cloud/telemetry.md
@@ -6,6 +6,39 @@ These logs are received by a local on-device collector, which forwards the strea
 
 The OTel spec is a standard wire protocol, also based on gRPC, that we can implement and codegen. Wendy Cloud then collects the OTel data, and "processes" it. Any queries over structured logs, visualisation and forwarding of data happens on these streams.
 
+## Environment variables injected into app containers
+
+When the agent starts an app container it injects a set of environment variables
+on top of the image's own env. Two are always present (all network modes):
+
+| Variable | Value |
+|---|---|
+| `WENDY_HOSTNAME` | The device's mDNS hostname (omitted when unresolvable). |
+| `WENDY_APP_ID` | The `appId` from `wendy.json` (omitted when empty). |
+
+The OpenTelemetry variables are injected **only when the app has the host
+`network` entitlement**, because the agent's local OTLP receiver listens on the
+device loopback and is reachable only from a host-networked container. Each is
+left untouched if the image already sets it, so image-provided values win:
+
+| Variable | Value | Notes |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://127.0.0.1:4317` (port from `WENDY_OTEL_PORT`, default `4317`) | Only set if the image hasn't configured an endpoint. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | Only set if absent. |
+| `OTEL_SERVICE_NAME` | `<appId>` | Only set if absent and `appId` is non-empty. |
+| `OTEL_RESOURCE_ATTRIBUTES` | `wendy.app.name=<appId>` | Only set if absent and `appId` is non-empty. |
+
+`OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` set the `service.name` and
+`wendy.app.name` resource attributes that `wendy device logs --app <id>` filters
+on, so telemetry an app exports directly via OTLP is attributed to its app id
+without the app having to hardcode it. (Container stdout/stderr is already
+stamped with these attributes by the agent's log bridge.) The identity variables
+are set even when the image preconfigured a custom endpoint, so an app pointing
+at its own collector still produces app-filterable logs.
+
+The agent uses the OTLP receiver port (`4317`, gRPC) for the injected endpoint;
+an HTTP/protobuf receiver is also available on `4318` for clients that prefer it.
+
 ## Processing (TODO: @martien)
 
 TODO

--- a/go/internal/cli/assets/docs/cloud/telemetry.md
+++ b/go/internal/cli/assets/docs/cloud/telemetry.md
@@ -24,7 +24,7 @@ left untouched if the image already sets it, so image-provided values win:
 | Variable | Value | Notes |
 |---|---|---|
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://127.0.0.1:4317` (port from `WENDY_OTEL_PORT`, default `4317`) | Only set if the image hasn't configured an endpoint. |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | Only set if absent. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | Only set together with the default endpoint above (i.e. when the image hasn't set an endpoint) and only if absent. An image that sets its own endpoint keeps full control of the protocol. |
 | `OTEL_SERVICE_NAME` | `<appId>` | Only set if absent and `appId` is non-empty. |
 | `OTEL_RESOURCE_ATTRIBUTES` | `wendy.app.name=<appId>` | Only set if absent and `appId` is non-empty. |
 

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -7,10 +7,17 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
 )
+
+// appIDPattern restricts appId to characters that are safe to embed in
+// container env vars, OTEL_RESOURCE_ATTRIBUTES (key=value,… format), container
+// labels, and the OTel service.name resource attribute. A stray comma, '=',
+// space, or newline in appId would otherwise corrupt those downstream uses.
+var appIDPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,253}$`)
 
 // EntitlementType enumerates the supported entitlement types.
 const (
@@ -274,6 +281,9 @@ func validateEntitlements(entitlements []Entitlement, prefix string) error {
 func (c *AppConfig) Validate() error {
 	if c.AppID == "" {
 		return fmt.Errorf("appId is required")
+	}
+	if !appIDPattern.MatchString(c.AppID) {
+		return fmt.Errorf("appId %q is invalid: only letters, digits, '.', '_', and '-' are allowed (max 253 chars)", c.AppID)
 	}
 
 	if err := validateEntitlements(c.Entitlements, "entitlement"); err != nil {

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -277,13 +277,24 @@ func validateEntitlements(entitlements []Entitlement, prefix string) error {
 	return nil
 }
 
-// Validate checks the AppConfig for required fields and valid entitlement types.
-func (c *AppConfig) Validate() error {
-	if c.AppID == "" {
+// ValidateAppID reports whether id is a well-formed appId. It is the appId
+// portion of Validate, exported so the agent can reject unsafe ids on the RPC
+// path before they are used to build container env vars (WENDY_APP_ID,
+// OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES) and labels.
+func ValidateAppID(id string) error {
+	if id == "" {
 		return fmt.Errorf("appId is required")
 	}
-	if !appIDPattern.MatchString(c.AppID) {
-		return fmt.Errorf("appId %q is invalid: only letters, digits, '.', '_', and '-' are allowed (max 253 chars)", c.AppID)
+	if !appIDPattern.MatchString(id) {
+		return fmt.Errorf("appId %q is invalid: only letters, digits, '.', '_', and '-' are allowed (max 253 chars)", id)
+	}
+	return nil
+}
+
+// Validate checks the AppConfig for required fields and valid entitlement types.
+func (c *AppConfig) Validate() error {
+	if err := ValidateAppID(c.AppID); err != nil {
+		return err
 	}
 
 	if err := validateEntitlements(c.Entitlements, "entitlement"); err != nil {

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -114,6 +114,35 @@ func TestValidate_MissingAppID(t *testing.T) {
 	}
 }
 
+func TestValidate_AppIDCharset(t *testing.T) {
+	valid := []string{
+		"my-app",
+		"com.example.app",
+		"sh.wendy.App",
+		"app_123",
+	}
+	for _, id := range valid {
+		cfg := &AppConfig{AppID: id}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error for valid appId %q: %v", id, err)
+		}
+	}
+
+	invalid := []string{
+		"app,with,commas",  // would corrupt OTEL_RESOURCE_ATTRIBUTES
+		"app=value",        // would corrupt env-var parsing
+		"app with spaces",  // disallowed
+		"app\nnewline",     // would inject an env entry
+		"emoji-\U0001F600", // non-ASCII
+	}
+	for _, id := range invalid {
+		cfg := &AppConfig{AppID: id}
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("Validate() expected error for invalid appId %q, got nil", id)
+		}
+	}
+}
+
 func TestValidate_UnknownEntitlementType(t *testing.T) {
 	cfg := &AppConfig{
 		AppID: "com.example.app",

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -14,7 +14,9 @@
     "appId": {
       "type": "string",
       "minLength": 1,
-      "description": "Unique application identifier."
+      "maxLength": 253,
+      "pattern": "^[a-zA-Z0-9._-]+$",
+      "description": "Unique application identifier. Only letters, digits, '.', '_', and '-' are allowed."
     },
     "version": {
       "type": "string",


### PR DESCRIPTION
## What

Inject the app's identity into its container environment so that telemetry **exported directly via OTLP** matches `wendy device logs --app <id>`.

- `WENDY_APP_ID=<appId>` — added in `buildContainerBaseEnv` alongside `WENDY_HOSTNAME` (set whenever the appId is non-empty).
- `OTEL_SERVICE_NAME=<appId>` and `OTEL_RESOURCE_ATTRIBUTES=wendy.app.name=<appId>` — added in `injectOTELEnvIfNeeded`, so any OTel SDK auto-populates the resource with **zero app code**.

Image-set values take precedence, matching the existing endpoint/protocol injection guards.

## Why

`wendy device logs --app <id>` filters telemetry on the OTel resource attributes `service.name` (Go agent, `matchResourceAttributes`) / `wendy.app.name` (Swift agent). Container **stdout** is already stamped by the agent (`container_log_manager.go` → `containerResource`), but apps that **export OTLP directly** to the injected receiver — the documented "log to OTel" path — had their records broadcast as-is, with no appId.

The appId was previously unavailable to the app:
- Not a runtime env var (`buildContainerBaseEnv` set only `PATH`, `TERM`, `WENDY_HOSTNAME`, + OTEL endpoint).
- Not a build arg (`wendy run` passes `WENDY_PLATFORM`, `WENDY_DEBUG`, `WENDY_DEVICE_TYPE`, GPU/CUDA only).
- `WENDY_APP_ID` existed only as a hook-expansion token.

So apps had to hardcode the id or parse `wendy.json` at runtime to populate `service.name`. After this change they don't.

## Testing

- `go test ./internal/agent/containerd/` — all pass, including new cases:
  - `WENDY_APP_ID` present / omitted when empty
  - `OTEL_SERVICE_NAME` + `OTEL_RESOURCE_ATTRIBUTES` set from appId
  - image-set OTel resource values are not overridden
- `go vet ./internal/agent/containerd/` clean; `gofmt` applied.

## Follow-ups (not in this PR)

- Docs/telemetry guides could mention the new injected env vars.
- The Swift agent path has an equivalent env-build site that could mirror this.

Closes #797
Linear: [WDY-1259](https://linear.app/wendylabsinc/issue/WDY-1259/print-statements-in-device-logs-omit-app-id)
