### PR TITLE
fix: add npm global bin to PATH after setup-node so claude is found

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -320,6 +320,11 @@ jobs:
           fi
           npm install -g --ignore-scripts "$TARBALL"
           rm -f "$TARBALL"
+          # setup-node@v4 uses a custom npm prefix; add its bin/ to PATH for this step
+          # and for all subsequent steps so the claude binary is findable.
+          NPM_BIN="$(npm prefix -g)/bin"
+          export PATH="$NPM_BIN:$PATH"
+          echo "$NPM_BIN" >> "$GITHUB_PATH"
           # Secondary verification: confirm installed binary reports expected version.
           # Provides an independent check beyond the sha512 tarball integrity test.
           INSTALLED_VERSION=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo '')


### PR DESCRIPTION
## Summary

- After `npm install -g`, `claude` binary wasn't found because `setup-node@v4` configures a custom npm prefix whose `bin/` dir isn't automatically in `$PATH` within the same step
- Adds `$(npm prefix -g)/bin` to both the current step's `PATH` (via `export`) and to `$GITHUB_PATH` for subsequent steps
- Fixes the `claude --version` secondary verification check that was returning empty string and aborting the install step

Follows #799 (YAML parse fix that got the workflow trigger working again).

## Test plan

- [ ] Post `/implement` comment on an issue after this merges — the install step should pass and the workflow should proceed to run Claude

🤖 Generated with [Claude Code](https://claude.ai/claude-code)