### PR TITLE
fix: install claude to explicit local prefix instead of npm -g

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -318,13 +318,16 @@ jobs:
             rm -f "$TARBALL"
             exit 1
           fi
-          npm install -g --ignore-scripts "$TARBALL"
+          # Install to an explicit local prefix so the bin location is deterministic.
+          # npm install -g with setup-node@v4 puts the binary somewhere npm prefix -g
+          # doesn't reliably reflect; node_modules/.bin is always predictable.
+          CLAUDE_PREFIX="$RUNNER_TEMP/npm-claude"
+          mkdir -p "$CLAUDE_PREFIX"
+          npm install --prefix "$CLAUDE_PREFIX" --ignore-scripts "$TARBALL"
           rm -f "$TARBALL"
-          # setup-node@v4 uses a custom npm prefix; add its bin/ to PATH for this step
-          # and for all subsequent steps so the claude binary is findable.
-          NPM_BIN="$(npm prefix -g)/bin"
-          export PATH="$NPM_BIN:$PATH"
-          echo "$NPM_BIN" >> "$GITHUB_PATH"
+          CLAUDE_BIN_DIR="$CLAUDE_PREFIX/node_modules/.bin"
+          export PATH="$CLAUDE_BIN_DIR:$PATH"
+          echo "$CLAUDE_BIN_DIR" >> "$GITHUB_PATH"
           # Secondary verification: confirm installed binary reports expected version.
           # Provides an independent check beyond the sha512 tarball integrity test.
           INSTALLED_VERSION=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo '')


### PR DESCRIPTION
## Summary

- `npm install -g` with `setup-node@v4` puts the binary at an unpredictable location that `npm prefix -g` doesn't reliably reflect (even after #800 tried adding `$(npm prefix -g)/bin` to PATH, the binary still wasn't found)
- Switch to `npm install --prefix "$RUNNER_TEMP/npm-claude"` so the binary is always at `node_modules/.bin/claude` — completely deterministic regardless of npm global config
- This is the root cause fix; #800 was a workaround that didn't fully address it

## Test plan

- [ ] Post `/implement` on an issue after merge — `Install Claude Code CLI` step should pass the version check and proceed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)