### PR TITLE
fix: add Read+Bash to allowedTools; show claude output on failure

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -506,13 +506,13 @@ jobs:
               shred -u "$USER_PROMPT_FILE" 2>/dev/null || rm -f "$USER_PROMPT_FILE"
               unset USER_PROMPT_FILE
               exec claude --print \
-                --allowedTools "Edit,MultiEdit" \
-                --disallowedTools "Bash,Read,Write,WebFetch,WebSearch,computer_use,LS,Glob,ListFiles,SearchFiles,ReadFile,TodoWrite,TodoRead,Agent,AskFollowupQuestion,mcp__*" \
+                --allowedTools "Edit,MultiEdit,Read,Bash" \
+                --disallowedTools "Write,WebFetch,WebSearch,computer_use,TodoWrite,TodoRead,Agent,AskFollowupQuestion,mcp__*" \
                 "$_user_prompt"
             ' \
             > "$RUNNER_TEMP/claude-output.txt" \
-            2> "$RUNNER_TEMP/claude-stderr.txt"
-          # Scrub API key from artifact files. ::add-mask:: protects runner logs; this scrubs files.
+            2> "$RUNNER_TEMP/claude-stderr.txt" || CLAUDE_EXIT=$?
+          # Always show output so failures are diagnosable.
           for _sf in "$RUNNER_TEMP/claude-output.txt" "$RUNNER_TEMP/claude-stderr.txt"; do
             [ -f "$_sf" ] && [ -n "$_ANTHROPIC_KEY" ] && \
               printf '%s' "$_ANTHROPIC_KEY" | python3 -c \
@@ -526,6 +526,7 @@ jobs:
             echo "--- stderr ---"
             cat "$RUNNER_TEMP/claude-stderr.txt"
           fi
+          [ "${CLAUDE_EXIT:-0}" -eq 0 ] || exit "$CLAUDE_EXIT"
 
       - name: Verify Claude did not touch protected paths
         # Post-Claude enforcement gate — primary path-restriction control.


### PR DESCRIPTION
## Summary

- `--allowedTools "Edit,MultiEdit"` was an exclusive allowlist that left Claude completely blind to the codebase — no `Read` means it can't see any files, no `Bash` means it can't run tests
- Changed allowedTools to `Edit,MultiEdit,Read,Bash` so Claude can actually read and understand the code before editing
- Capture claude exit code with `|| CLAUDE_EXIT=$?` so stdout/stderr are always shown in the log before failing — previously a non-zero exit would silently swallow all output (making failures undiagnosable)

## Test plan

- [ ] Post `/implement` on an issue after merge — Claude should be able to read files and make changes
- [ ] Intentionally trigger a failure and confirm the claude output is now visible in the log

🤖 Generated with [Claude Code](https://claude.ai/claude-code)