### PR TITLE
fix: pipe prompt via stdin instead of positional arg to claude --print

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -505,10 +505,9 @@ jobs:
               _user_prompt=$(< "$USER_PROMPT_FILE")
               shred -u "$USER_PROMPT_FILE" 2>/dev/null || rm -f "$USER_PROMPT_FILE"
               unset USER_PROMPT_FILE
-              exec claude --print \
+              printf '%s\n' "$_user_prompt" | claude --print \
                 --allowedTools "Edit,MultiEdit,Read,Bash" \
-                --disallowedTools "Write,WebFetch,WebSearch,computer_use,TodoWrite,TodoRead,Agent,AskFollowupQuestion,mcp__*" \
-                "$_user_prompt"
+                --disallowedTools "Write,WebFetch,WebSearch,computer_use,TodoWrite,TodoRead,Agent,AskFollowupQuestion,mcp__*"
             ' \
             > "$RUNNER_TEMP/claude-output.txt" \
             2> "$RUNNER_TEMP/claude-stderr.txt" || CLAUDE_EXIT=$?


### PR DESCRIPTION
## Summary

`claude --print "$_user_prompt"` was failing with:
```
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

The positional argument form wasn't being accepted by claude 2.1.150 in this context. Switched to piping via stdin:
```bash
printf '%s\n' "$_user_prompt" | claude --print --allowedTools ...
```

This is the reliable path the error message itself suggests.

## Test plan

- [ ] Post `/implement` on an issue — Claude should receive the prompt and start working

🤖 Generated with [Claude Code](https://claude.ai/claude-code)