### PR TITLE
fix: correct broken Unicode tag-block range stripping issue/PR body text

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -335,7 +335,7 @@ jobs:
               text = unicodedata.normalize('NFKC', text)
               # Strip Unicode direction-override, zero-width, soft-hyphen (U+00AD),
               # CGJ (U+034F), ZWJ (U+200D), Hangul filler (U+3164), tag block, BOM
-              text = re.sub(r'[\u00ad\u034f\u200b-\u200f\u200d\u202a-\u202e\u2066-\u2069\u3164\ue0000-\ue007f\ufeff]', '', text)
+              text = re.sub('[\u00ad\u034f\u200b-\u200f\u200d\u202a-\u202e\u2066-\u2069\u3164\U000E0000-\U000E007F\ufeff]', '', text)
               # Destructive fence stripping — prevents nested code-block injection
               text = re.sub(r'`{3,}', '[fence]', text)
               text = re.sub(r'~{3,}', '[fence]', text)
@@ -807,7 +807,7 @@ jobs:
                   prev = text
                   text = html.unescape(text)
               text = unicodedata.normalize('NFKC', text)
-              text = re.sub(r'[\u00ad\u034f\u200b-\u200f\u200d\u202a-\u202e\u2066-\u2069\u3164\ue0000-\ue007f\ufeff]', '', text)
+              text = re.sub('[\u00ad\u034f\u200b-\u200f\u200d\u202a-\u202e\u2066-\u2069\u3164\U000E0000-\U000E007F\ufeff]', '', text)
               text = re.sub(r'`{3,}', '[fence]', text)
               text = re.sub(r'~{3,}', '[fence]', text)
               text = re.sub(r'<[^>]{0,4000}>', '[tag]', text)


### PR DESCRIPTION
## Summary

- The `sanitize()` function used `r'[...0-f...]'` (raw string) intending to strip Unicode tag block characters (U+E0000–U+E007F)
- `\u` in Python only takes 4 hex digits, so `` parsed as U+E000 and the remaining `0-f` created a character-class range from `0` (U+0030) to U+E007 — covering **all ASCII letters and digits**
- This silently stripped almost all content from issue titles and bodies passed to Claude, leaving a ~184-char prompt with nothing useful
- Claude was receiving an issue title like `"         ,     ."` instead of the real title, so it produced no useful implementation

## Fix

Switch `r'...'` to a regular string so Python's string-literal parser handles `\U000E0000-\U000E007F` correctly (uppercase `\U` for supplementary plane characters). Applied to both `sanitize()` occurrences in the file.

## How to test

Re-trigger `/implement` on issue #788 — Claude should now receive the full issue body and produce a real implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)