### PR TITLE
Add responsive TUI tables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/cloudflare/circl v1.6.3
 	github.com/containerd/cgroups/v3 v3.1.3
 	github.com/containerd/containerd/api v1.11.0
@@ -42,7 +43,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -65,9 +65,7 @@ func (s *AgentService) GetAgentVersion(_ context.Context, _ *agentpb.GetAgentVer
 		Featureset:      detectFeatureset(),
 	}
 
-	// Read WendyOS version if available.
-	if data, err := os.ReadFile("/etc/wendy/version.txt"); err == nil {
-		v := strings.TrimSpace(string(data))
+	if v, ok := wendyOSVersion(); ok {
 		resp.OsVersion = &v
 	}
 
@@ -557,10 +555,10 @@ const osUpdateUnsupportedForHostMessage = "This setup cannot be updated with wen
 var menderProgressRe = regexp.MustCompile(`(\d{1,3})%`)
 
 func defaultIsWendyOSHost() bool {
-	// Older WendyOS builds did not write /etc/wendyos/device-type, so keep
-	// /etc/wendy/version.txt as the primary compatibility marker.
-	if data, err := os.ReadFile("/etc/wendy/version.txt"); err == nil {
-		return strings.HasPrefix(strings.TrimSpace(string(data)), "WendyOS-")
+	// Older WendyOS builds did not write /etc/wendyos/device-type, so keep the
+	// version file as a compatibility marker alongside the newer device type.
+	if v, ok := wendyOSVersion(); ok {
+		return strings.HasPrefix(v, "WendyOS-")
 	}
 	// Newer WendyOS images report a board/device type used for OTA artifact
 	// selection. This file is absent on generic Linux agent installs.
@@ -568,6 +566,23 @@ func defaultIsWendyOSHost() bool {
 		return true
 	}
 	return false
+}
+
+func wendyOSVersion() (string, bool) {
+	return readWendyOSVersionFrom("/etc/wendyos/version.txt", "/etc/wendy/version.txt")
+}
+
+func readWendyOSVersionFrom(paths ...string) (string, bool) {
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if v := strings.TrimSpace(string(data)); v != "" {
+			return v, true
+		}
+	}
+	return "", false
 }
 
 // enableJetsonRootfsAB ensures rootfs A/B redundancy is configured on NVIDIA

--- a/go/internal/agent/services/agent_service_test.go
+++ b/go/internal/agent/services/agent_service_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -134,6 +136,54 @@ func TestGetAgentVersion(t *testing.T) {
 	}
 	if resp.CpuArchitecture != runtime.GOARCH {
 		t.Errorf("arch = %q; want %q", resp.CpuArchitecture, runtime.GOARCH)
+	}
+}
+
+func TestReadWendyOSVersionFromPrefersCurrentPath(t *testing.T) {
+	dir := t.TempDir()
+	current := filepath.Join(dir, "etc", "wendyos", "version.txt")
+	legacy := filepath.Join(dir, "etc", "wendy", "version.txt")
+
+	if err := os.MkdirAll(filepath.Dir(current), 0o755); err != nil {
+		t.Fatalf("mkdir current: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	if err := os.WriteFile(current, []byte("WendyOS-0.13.2\n"), 0o644); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte("WendyOS-0.10.4\n"), 0o644); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	got, ok := readWendyOSVersionFrom(current, legacy)
+	if !ok {
+		t.Fatal("expected WendyOS version")
+	}
+	if got != "WendyOS-0.13.2" {
+		t.Fatalf("version = %q, want current version", got)
+	}
+}
+
+func TestReadWendyOSVersionFromFallsBackToLegacyPath(t *testing.T) {
+	dir := t.TempDir()
+	current := filepath.Join(dir, "etc", "wendyos", "version.txt")
+	legacy := filepath.Join(dir, "etc", "wendy", "version.txt")
+
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte("WendyOS-0.10.4\n"), 0o644); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	got, ok := readWendyOSVersionFrom(current, legacy)
+	if !ok {
+		t.Fatal("expected WendyOS version")
+	}
+	if got != "WendyOS-0.10.4" {
+		t.Fatalf("version = %q, want legacy version", got)
 	}
 }
 

--- a/go/internal/agent/services/device_info_service.go
+++ b/go/internal/agent/services/device_info_service.go
@@ -32,8 +32,7 @@ func (s *DeviceInfoService) GetDeviceInfo(_ context.Context, _ *agentpbv2.GetDev
 		Featureset:      detectFeatureset(),
 	}
 
-	if data, err := os.ReadFile("/etc/wendy/version.txt"); err == nil {
-		v := strings.TrimSpace(string(data))
+	if v, ok := wendyOSVersion(); ok {
 		resp.OsVersion = &v
 	}
 

--- a/go/internal/cli/commands/apps_dashboard.go
+++ b/go/internal/cli/commands/apps_dashboard.go
@@ -128,9 +128,10 @@ type appsDashboardModel struct {
 
 	// Current data.
 	rows  []dashboardRow
-	table bubbleTable.Model
+	table tui.BubbleTable
 
 	// UI state.
+	width  int
 	flash  string
 	height int
 
@@ -388,9 +389,12 @@ func (m *appsDashboardModel) refreshTable() {
 func (m appsDashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		m.width = msg.Width
 		m.height = msg.Height
+		var cmd tea.Cmd
+		m.table, cmd = m.table.Update(msg)
 		m.refreshTable()
-		return m, nil
+		return m, cmd
 
 	case appsDashContainersMsg:
 		if msg.err != nil {
@@ -572,11 +576,14 @@ func (m appsDashboardModel) View() string {
 
 	// Hint line
 	hint := "↑/↓ navigate  s start  x stop  r remove  R remove+vols  enter logs  d default  q quit"
-	sb.WriteString(dashDimStyle.Render(hint) + "\n\n")
+	if m.table.CanScroll() {
+		hint = "↑/↓ navigate  ←/→ scroll  s start  x stop  r remove  R remove+vols  enter logs  d default  q quit"
+	}
+	sb.WriteString(m.viewLine(dashDimStyle.Render(hint)) + "\n\n")
 
 	// Table or empty state
 	if len(m.rows) == 0 {
-		sb.WriteString(dashDimStyle.Render("  No applications found. Polling…") + "\n")
+		sb.WriteString(m.viewLine(dashDimStyle.Render("  No applications found. Polling…")) + "\n")
 	} else {
 		sb.WriteString(m.table.View() + "\n")
 	}
@@ -592,14 +599,21 @@ func (m appsDashboardModel) View() string {
 	}
 	status := fmt.Sprintf("\n  %d apps  ● %d running  ○ %d stopped  (refreshes every 2s)",
 		len(m.rows), running, stopped)
-	sb.WriteString(dashDimStyle.Render(status) + "\n")
+	sb.WriteString(m.viewLine(dashDimStyle.Render(status)) + "\n")
 
 	// Flash / confirm line
 	if m.confirming {
-		sb.WriteString(dashDimStyle.Render("  "+m.confirmText) + "\n")
+		sb.WriteString(m.viewLine(dashDimStyle.Render("  "+m.confirmText)) + "\n")
 	} else if m.flash != "" {
-		sb.WriteString(dashMetricVal.Render("  "+m.flash) + "\n")
+		sb.WriteString(m.viewLine(dashMetricVal.Render("  "+m.flash)) + "\n")
 	}
 
 	return sb.String()
+}
+
+func (m appsDashboardModel) viewLine(line string) string {
+	if m.width <= 0 {
+		return line
+	}
+	return tui.CropANSIView(line, 0, m.width)
 }

--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -14,6 +14,7 @@ import (
 	bubbleTable "github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -82,12 +83,13 @@ type cloudDiscoverModel struct {
 	versions       map[int32]*agentpb.GetAgentVersionResponse
 	versionPending map[int32]bool
 	versionSem     chan struct{}
-	table          bubbleTable.Model
+	table          tui.BubbleTable
 	quitting       bool
 	flashMessage   string
 	flashIsError   bool
 	updatingName   string
 	selected       *cloudpb.Asset
+	windowWidth    int
 	windowHeight   int
 	err            error
 	hasResults     bool
@@ -145,9 +147,12 @@ func (m cloudDiscoverModel) scanCmd() tea.Cmd {
 func (m cloudDiscoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		m.windowWidth = msg.Width
 		m.windowHeight = msg.Height
+		var cmd tea.Cmd
+		m.table, cmd = m.table.Update(msg)
 		m.refreshTable()
-		return m, nil
+		return m, cmd
 
 	case cloudScanMsg:
 		if msg.err != nil {
@@ -256,33 +261,41 @@ func (m cloudDiscoverModel) View() string {
 	var sb strings.Builder
 
 	if m.pickerMode {
-		sb.WriteString(scanStyle.Render("⟳ Fetching cloud devices...") + "\n")
-		sb.WriteString(dimStyle.Render("  ↑/↓ navigate, enter select, u update, q quit") + "\n")
+		sb.WriteString(m.viewLine(scanStyle.Render("⟳ Fetching cloud devices...")) + "\n")
+		hint := "  ↑/↓ navigate, enter select, u update, q quit"
+		if m.table.CanScroll() {
+			hint = "  ↑/↓ navigate, ←/→ scroll, enter select, u update, q quit"
+		}
+		sb.WriteString(m.viewLine(dimStyle.Render(hint)) + "\n")
 	} else {
-		sb.WriteString(scanStyle.Render("⟳ Scanning for cloud devices...") + "\n")
+		sb.WriteString(m.viewLine(scanStyle.Render("⟳ Scanning for cloud devices...")) + "\n")
 		if m.updatingName != "" {
-			sb.WriteString(dimStyle.Render("  updating "+m.updatingName+"... (q quit)") + "\n")
+			sb.WriteString(m.viewLine(dimStyle.Render("  updating "+m.updatingName+"... (q quit)")) + "\n")
 		} else {
-			sb.WriteString(dimStyle.Render("  ↑/↓ navigate, enter copy, a copy all, u update, q quit") + "\n")
+			hint := "  ↑/↓ navigate, enter copy, a copy all, u update, q quit"
+			if m.table.CanScroll() {
+				hint = "  ↑/↓ navigate, ←/→ scroll, enter copy, a copy all, u update, q quit"
+			}
+			sb.WriteString(m.viewLine(dimStyle.Render(hint)) + "\n")
 		}
 	}
 
 	sb.WriteString("\n")
 
 	if m.err != nil {
-		sb.WriteString(fmt.Sprintf("Error: %v\n", m.err))
+		sb.WriteString(m.viewLine(fmt.Sprintf("Error: %v", m.err)) + "\n")
 	}
 	if len(m.assets) > 0 {
 		sb.WriteString(m.table.View() + "\n")
 	} else if m.err == nil {
 		if m.hasResults {
 			if m.all {
-				sb.WriteString(dimStyle.Render("No enrolled devices found.") + "\n")
+				sb.WriteString(m.viewLine(dimStyle.Render("No enrolled devices found.")) + "\n")
 			} else {
-				sb.WriteString(dimStyle.Render("No online devices found. Use --all to include offline devices.") + "\n")
+				sb.WriteString(m.viewLine(dimStyle.Render("No online devices found. Use --all to include offline devices.")) + "\n")
 			}
 		} else {
-			sb.WriteString(dimStyle.Render("Fetching devices from cloud...") + "\n")
+			sb.WriteString(m.viewLine(dimStyle.Render("Fetching devices from cloud...")) + "\n")
 		}
 	}
 
@@ -293,7 +306,7 @@ func (m cloudDiscoverModel) View() string {
 		} else if m.updatingName != "" {
 			style = scanStyle
 		}
-		sb.WriteString("\n" + style.Render("  "+m.flashMessage) + "\n")
+		sb.WriteString("\n" + m.viewLine(style.Render("  "+m.flashMessage)) + "\n")
 	}
 
 	return sb.String()
@@ -308,6 +321,13 @@ func (m *cloudDiscoverModel) refreshTable() {
 	}
 	m.table.SetWidth(discoverTableWidth(m.table.Columns()))
 	m.table.SetHeight(discoverTableHeight(len(rows), m.windowHeight, true))
+}
+
+func (m cloudDiscoverModel) viewLine(line string) string {
+	if m.windowWidth <= 0 {
+		return line
+	}
+	return tui.CropANSIView(line, 0, m.windowWidth)
 }
 
 func cloudDiscoverTableRows(assets []*cloudpb.Asset, versions map[int32]*agentpb.GetAgentVersionResponse) []bubbleTable.Row {

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -235,11 +235,12 @@ type discoverModel struct {
 	usbInterval        increasingRefreshInterval
 	ethernetInterval   increasingRefreshInterval
 	externalInterval   increasingRefreshInterval
-	table              bubbleTable.Model
+	table              tui.BubbleTable
 	quitting           bool
 	hasResults         bool
 	err                error
 	includeExternal    bool
+	windowWidth        int
 	windowHeight       int
 	bleWarning         string
 	flashMessage       string
@@ -332,9 +333,12 @@ func (m discoverModel) Init() tea.Cmd {
 func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		m.windowWidth = msg.Width
 		m.windowHeight = msg.Height
+		var cmd tea.Cmd
+		m.table, cmd = m.table.Update(msg)
 		m.refreshTable()
-		return m, nil
+		return m, cmd
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c":
@@ -428,9 +432,9 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		delay := m.ethernetInterval.delay(env.DiscoverEthernetInterval())
 		return m, delayThen(delay, m.scanEthernet())
 	case lanScanMsg:
-		// Preserve last known AgentVersion and DeviceType when the gRPC probe
-		// failed. The probe uses a 1500 ms timeout, so transient latency can
-		// cause a blank for one scan cycle even though the device is still up.
+		// Preserve last known agent metadata when the gRPC probe failed. The
+		// probe uses a 1500 ms timeout, so transient latency can cause a blank
+		// for one scan cycle even though the device is still up.
 		for i := range msg.devices {
 			if msg.devices[i].AgentVersion != "" {
 				continue
@@ -439,6 +443,9 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if strings.EqualFold(prev.DisplayName, msg.devices[i].DisplayName) && prev.AgentVersion != "" {
 					msg.devices[i].AgentVersion = prev.AgentVersion
 					msg.devices[i].DeviceType = prev.DeviceType
+					msg.devices[i].OS = prev.OS
+					msg.devices[i].OSVersion = prev.OSVersion
+					msg.devices[i].CPUArchitecture = prev.CPUArchitecture
 					break
 				}
 			}
@@ -537,27 +544,31 @@ func (m discoverModel) View() string {
 
 	var sb strings.Builder
 
-	sb.WriteString(scanStyle.Render("⟳ Scanning for WendyOS devices...") + "\n")
+	sb.WriteString(m.viewLine(scanStyle.Render("⟳ Scanning for WendyOS devices...")) + "\n")
 	if m.updatingDeviceName != "" {
-		sb.WriteString(dimStyle.Render("  updating "+m.updatingDeviceName+"... (q quit)") + "\n")
+		sb.WriteString(m.viewLine(dimStyle.Render("  updating "+m.updatingDeviceName+"... (q quit)")) + "\n")
 	} else {
-		sb.WriteString(dimStyle.Render("  ↑/↓ navigate, enter copy, a copy all, u update, d set default, x unset default, q quit") + "\n")
+		scrollHint := ""
+		if m.canScrollTable() {
+			scrollHint = ", ←/→ scroll"
+		}
+		sb.WriteString(m.viewLine(dimStyle.Render("  ↑/↓ navigate"+scrollHint+", enter copy, a copy all, u update, d set default, x unset default, q quit")) + "\n")
 	}
 
 	if m.bleWarning != "" {
-		sb.WriteString(dimStyle.Render("  Bluetooth: "+m.bleWarning) + "\n")
+		sb.WriteString(m.viewLine(dimStyle.Render("  Bluetooth: "+m.bleWarning)) + "\n")
 	}
 
 	sb.WriteString("\n")
 
 	if m.err != nil {
-		sb.WriteString(fmt.Sprintf("Error: %v\n", m.err))
+		sb.WriteString(m.viewLine(fmt.Sprintf("Error: %v", m.err)) + "\n")
 	}
 
 	if !m.collection.IsEmpty() {
-		sb.WriteString(m.table.View() + "\n")
+		sb.WriteString(m.tableView() + "\n")
 	} else if m.hasResults {
-		sb.WriteString(dimStyle.Render("No devices found yet...") + "\n")
+		sb.WriteString(m.viewLine(dimStyle.Render("No devices found yet...")) + "\n")
 	}
 
 	if m.flashMessage != "" {
@@ -567,7 +578,7 @@ func (m discoverModel) View() string {
 		} else if m.updatingDeviceName != "" {
 			style = scanStyle
 		}
-		sb.WriteString("\n" + style.Render("  "+m.flashMessage) + "\n")
+		sb.WriteString("\n" + m.viewLine(style.Render("  "+m.flashMessage)) + "\n")
 	}
 
 	return sb.String()
@@ -576,7 +587,7 @@ func (m discoverModel) View() string {
 func (m *discoverModel) refreshTable() {
 	items := discoverTableItems(m.collection)
 	pickerItems := discoverPickerItems(items)
-	cols, rows := tui.PickerTableData(pickerItems, discoverDefaultKey(), true)
+	cols, rows := tui.PickerDeviceTableData(pickerItems, discoverDefaultKey(), true)
 	m.table.SetColumns(cols)
 	m.table.SetRows(rows)
 	if len(rows) > 0 && m.table.Cursor() < 0 {
@@ -584,6 +595,28 @@ func (m *discoverModel) refreshTable() {
 	}
 	m.table.SetWidth(tui.PickerTableWidth(m.table.Columns()))
 	m.table.SetHeight(tui.PickerTableHeight(len(rows), m.windowHeight))
+}
+
+func (m discoverModel) viewLine(line string) string {
+	if m.windowWidth <= 0 {
+		return line
+	}
+	return tui.CropANSIView(line, 0, m.windowWidth)
+}
+
+func (m discoverModel) tableView() string {
+	return m.table.View()
+}
+
+func (m discoverModel) canScrollTable() bool {
+	return m.table.CanScroll()
+}
+
+func (m discoverModel) tableViewportWidth() int {
+	if width := m.table.ViewportWidth(); width > 0 {
+		return width
+	}
+	return tui.PickerTableWidth(m.table.Columns())
 }
 
 // lanDeviceAddr returns the gRPC address for the first LAN device whose
@@ -667,7 +700,7 @@ func (m discoverModel) startDeviceUpdateCmd(addr, name string) tea.Cmd {
 func renderDeviceTable(collection *models.DevicesCollection) string {
 	items := discoverTableItems(collection)
 	pickerItems := discoverPickerItems(items)
-	cols, rows := tui.PickerTableData(pickerItems, discoverDefaultKey(), true)
+	cols, rows := tui.PickerDeviceTableData(pickerItems, discoverDefaultKey(), true)
 	if len(rows) == 0 {
 		return ""
 	}
@@ -681,7 +714,7 @@ func renderDeviceTable(collection *models.DevicesCollection) string {
 	return t.View() + "\n"
 }
 
-func newDiscoverTable(interactive bool) bubbleTable.Model {
+func newDiscoverTable(interactive bool) tui.BubbleTable {
 	return tui.NewBubbleTable(interactive, nil)
 }
 
@@ -837,12 +870,13 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 		}
 		items = append(items, discoverTableItem{
 			picker: tui.PickerItem{
-				Name:     discoverDisplayName(d.DisplayName, d.AgentVersion),
-				Type:     deviceType,
-				USB:      d.USBVersion,
-				Address:  d.Hostname,
-				DedupKey: d.DisplayName,
-				SortKey:  usbFirstSortKey(d.DisplayName, d.USBVersion),
+				Name:         discovery.SanitiseDisplayName(d.DisplayName),
+				Type:         deviceType,
+				USB:          d.USBVersion,
+				Address:      d.Hostname,
+				AgentVersion: discoverAgentVersionDisplay(d.AgentVersion),
+				DedupKey:     d.DisplayName,
+				SortKey:      usbFirstSortKey(d.DisplayName, d.USBVersion),
 			},
 			info: discoverDeviceInfo{
 				Name:    d.DisplayName,
@@ -870,12 +904,14 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 		}
 		items = append(items, discoverTableItem{
 			picker: tui.PickerItem{
-				Name:     discoverDisplayName(d.DisplayName, d.AgentVersion),
-				Type:     deviceType,
-				USB:      usb,
-				Address:  address,
-				DedupKey: d.DisplayName,
-				SortKey:  usbFirstSortKey(d.DisplayName, usb),
+				Name:         discovery.SanitiseDisplayName(d.DisplayName),
+				Type:         deviceType,
+				USB:          usb,
+				Address:      address,
+				AgentVersion: discoverAgentVersionDisplay(d.AgentVersion),
+				OSVersion:    d.OSVersion,
+				DedupKey:     d.DisplayName,
+				SortKey:      usbFirstSortKey(d.DisplayName, usb),
 			},
 			info: discoverDeviceInfo{
 				Name:    d.DisplayName,
@@ -897,11 +933,13 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 		deviceType := externalProviderDisplayName(d.ProviderKey)
 		items = append(items, discoverTableItem{
 			picker: tui.PickerItem{
-				Name:     discoverDisplayName(d.DisplayName, d.AgentVersion),
-				Type:     deviceType,
-				Address:  addr,
-				DedupKey: d.DisplayName,
-				SortKey:  externalProviderSortKey(d.ProviderKey, d.DisplayName),
+				Name:         discovery.SanitiseDisplayName(d.DisplayName),
+				Type:         deviceType,
+				Address:      addr,
+				AgentVersion: discoverAgentVersionDisplay(d.AgentVersion),
+				OSVersion:    d.OSVersion,
+				DedupKey:     d.DisplayName,
+				SortKey:      externalProviderSortKey(d.ProviderKey, d.DisplayName),
 			},
 			info: discoverDeviceInfo{
 				Name:    d.DisplayName,
@@ -932,16 +970,15 @@ func discoverPickerItems(items []discoverTableItem) []tui.PickerItem {
 	return pickerItems
 }
 
-func discoverDisplayName(name, agentVer string) string {
-	name = discovery.SanitiseDisplayName(name)
-	if agentVer == "" {
-		return name
-	}
+func discoverAgentVersionDisplay(agentVer string) string {
 	displayVersion := discovery.SanitiseDisplayName(agentVer)
+	if displayVersion == "" {
+		return ""
+	}
 	if version.CompareVersions(version.Version, agentVer) > 0 {
 		displayVersion += " ⚠"
 	}
-	return name + " v" + displayVersion
+	return displayVersion
 }
 
 func discoverSortKey(item tui.PickerItem) string {

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
@@ -170,6 +171,87 @@ func TestDiscoverModel_TableNavigation(t *testing.T) {
 	}
 }
 
+func TestDiscoverModel_WindowWidthCropsViewLines(t *testing.T) {
+	m := newDiscoverModel(context.Background(), defaultOpts())
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 20})
+	m = updated.(discoverModel)
+	updated, _ = m.Update(lanScanMsg{devices: []models.LANDevice{{
+		DisplayName:  "Ardent Cashew",
+		Hostname:     "wendyos-ardent-cashew.local",
+		Port:         defaultAgentPort,
+		AgentVersion: "2026.05.30-161141",
+		OSVersion:    "WendyOS-0.13.2",
+	}}})
+	m = updated.(discoverModel)
+
+	if !m.canScrollTable() {
+		t.Fatalf("expected table width %d to exceed viewport %d", tui.PickerTableWidth(m.table.Columns()), m.tableViewportWidth())
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "←/→ scroll") {
+		t.Fatalf("expected scroll hint in cropped view, got %q", view)
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if got := ansi.StringWidth(line); got > 60 {
+			t.Fatalf("view line width = %d, want <= 60: %q", got, line)
+		}
+	}
+}
+
+func TestDiscoverModel_LeftRightScrollsWithoutBreakingVerticalNavigation(t *testing.T) {
+	m := newDiscoverModel(context.Background(), defaultOpts())
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	m = updated.(discoverModel)
+	updated, _ = m.Update(lanScanMsg{devices: []models.LANDevice{
+		{
+			DisplayName:  "alpha",
+			Hostname:     "wendyos-alpha.local",
+			Port:         defaultAgentPort,
+			AgentVersion: "2026.05.30-161141",
+			OSVersion:    "WendyOS-0.13.2",
+		},
+		{
+			DisplayName:  "beta",
+			Hostname:     "wendyos-beta.local",
+			Port:         defaultAgentPort,
+			AgentVersion: "2026.05.30-161141",
+			OSVersion:    "WendyOS-0.13.2",
+		},
+	}})
+	m = updated.(discoverModel)
+
+	before := m.tableView()
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated.(discoverModel)
+
+	if m.table.ScrollOffset() == 0 {
+		t.Fatal("expected right arrow to advance horizontal offset")
+	}
+	if after := m.tableView(); after == before {
+		t.Fatal("expected scrolled table view to change")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(discoverModel)
+
+	if m.table.Cursor() != 1 {
+		t.Fatalf("expected down arrow to move cursor, got %d", m.table.Cursor())
+	}
+	if m.table.ScrollOffset() == 0 {
+		t.Fatal("expected vertical navigation to preserve horizontal offset")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(discoverModel)
+
+	if m.table.ScrollOffset() != 0 {
+		t.Fatalf("expected left arrow to return to zero offset, got %d", m.table.ScrollOffset())
+	}
+}
+
 func TestDiscoverModel_DKeySetsDefaultAndMarksSelectedDevice(t *testing.T) {
 	setTempConfig(t, &config.Config{})
 
@@ -202,14 +284,18 @@ func TestRenderDeviceTable(t *testing.T) {
 			IPAddress:    "192.168.1.10",
 			Port:         8443,
 			AgentVersion: "1.2.3",
+			OSVersion:    "WendyOS-0.10.4",
 		}},
 	}
 
 	output := renderDeviceTable(collection)
-	for _, want := range []string{"Name", "Type", "Address", "wendy-alpha v1.2.3", "LAN", "192.168.1.10:8443"} {
+	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "wendy-alpha", "1.2.3", "WendyOS-0.10.4", "LAN", "192.168.1.10:8443"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, output)
 		}
+	}
+	if strings.Contains(output, "wendy-alpha v1.2.3") {
+		t.Fatalf("expected version in dedicated column, got suffixed name in %q", output)
 	}
 }
 
@@ -242,7 +328,7 @@ func TestDiscoverTableItemsPrioritizesUSBDevices(t *testing.T) {
 		t.Fatalf("non-USB item USB detail = %q, want empty", items[1].picker.USB)
 	}
 
-	_, rows := tui.PickerTableData(discoverPickerItems(items), "", true)
+	_, rows := tui.PickerDeviceTableData(discoverPickerItems(items), "", true)
 	if rows[0][2] != "USB, LAN" {
 		t.Fatalf("Type display cell = %q, want \"USB, LAN\"", rows[0][2])
 	}
@@ -274,7 +360,7 @@ func TestDiscoverTableItemsAnnotatesLANUSBFromEthernetInterface(t *testing.T) {
 		t.Fatalf("USB detail = %q, want %q", items[0].picker.USB, wantUSB)
 	}
 
-	_, rows := tui.PickerTableData(discoverPickerItems(items), "", true)
+	_, rows := tui.PickerDeviceTableData(discoverPickerItems(items), "", true)
 	if rows[0][2] != "USB, LAN" {
 		t.Fatalf("Type display cell = %q, want \"USB, LAN\"", rows[0][2])
 	}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1167,19 +1167,27 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 
 	if md.AgentVersion == "" {
 		md.AgentVersion = nd.AgentVersion
+		existing.AgentVersion = incoming.AgentVersion
 	}
 	if md.OS == "" {
 		md.OS = nd.OS
 	}
 	if md.OSVersion == "" {
 		md.OSVersion = nd.OSVersion
+		existing.OSVersion = incoming.OSVersion
 	}
 	if md.CPUArchitecture == "" {
 		md.CPUArchitecture = nd.CPUArchitecture
 	}
 
-	// Prefer the name that includes the version suffix.
-	if len(incoming.Name) > len(existing.Name) {
+	if existing.AgentVersion == "" {
+		existing.AgentVersion = incoming.AgentVersion
+	}
+	if existing.OSVersion == "" {
+		existing.OSVersion = incoming.OSVersion
+	}
+
+	if existing.Name == "" {
 		existing.Name = incoming.Name
 	}
 
@@ -1241,19 +1249,17 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 	lanCh := make(chan models.LANDevice, 16)
 	go discovery.DiscoverLANContinuous(discoverCtx, lanCh)
 	sendLANItem := func(dev models.LANDevice, insecure bool) {
-		name := dev.DisplayName
-		if dev.AgentVersion != "" {
-			name += " v" + dev.AgentVersion
-		}
 		devCopy := dev
 		p.Send(tui.PickerAddMsg{Items: []tui.PickerItem{{
-			Name:     name,
-			Type:     "LAN",
-			USB:      dev.USB,
-			Address:  preferredLANAddress(dev),
-			DedupKey: dev.DisplayName,
-			SortKey:  usbFirstSortKey(dev.DisplayName, dev.USB),
-			Insecure: insecure,
+			Name:         dev.DisplayName,
+			Type:         "LAN",
+			USB:          dev.USB,
+			Address:      preferredLANAddress(dev),
+			AgentVersion: dev.AgentVersion,
+			OSVersion:    dev.OSVersion,
+			DedupKey:     dev.DisplayName,
+			SortKey:      usbFirstSortKey(dev.DisplayName, dev.USB),
+			Insecure:     insecure,
 			Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
 				DisplayName:     dev.DisplayName,
 				AgentVersion:    dev.AgentVersion,
@@ -1303,24 +1309,30 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 					for i := range devices {
 						if prov.Key() == "wendy-lite" {
 							items = append(items, tui.PickerItem{
-								Name:     devices[i].DisplayName,
-								DedupKey: devices[i].DisplayName,
-								Type:     "LAN (Lite)",
-								Address:  devices[i].ConnectionInfo["ip"],
+								Name:         devices[i].DisplayName,
+								DedupKey:     devices[i].DisplayName,
+								Type:         "LAN (Lite)",
+								Address:      devices[i].ConnectionInfo["ip"],
+								AgentVersion: devices[i].AgentVersion,
+								OSVersion:    devices[i].OSVersion,
 								Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
 									DisplayName:     devices[i].DisplayName,
+									AgentVersion:    devices[i].AgentVersion,
+									OSVersion:       devices[i].OSVersion,
 									CPUArchitecture: devices[i].CPUArchitecture,
 									External:        &devices[i],
 								}},
 							})
 						} else {
 							items = append(items, tui.PickerItem{
-								Name:     devices[i].DisplayName,
-								Type:     prov.DisplayName(),
-								Address:  fmt.Sprintf("%s: %s", devices[i].ProviderKey, devices[i].ID),
-								DedupKey: devices[i].DisplayName,
-								SortKey:  externalProviderSortKey(prov.Key(), devices[i].DisplayName),
-								Value:    &pickerEntry{externalDevice: &devices[i], provider: prov},
+								Name:         devices[i].DisplayName,
+								Type:         prov.DisplayName(),
+								Address:      fmt.Sprintf("%s: %s", devices[i].ProviderKey, devices[i].ID),
+								AgentVersion: devices[i].AgentVersion,
+								OSVersion:    devices[i].OSVersion,
+								DedupKey:     devices[i].DisplayName,
+								SortKey:      externalProviderSortKey(prov.Key(), devices[i].DisplayName),
+								Value:        &pickerEntry{externalDevice: &devices[i], provider: prov},
 							})
 						}
 					}
@@ -1351,10 +1363,12 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 							connType = "BLE (Lite)"
 						}
 						items = append(items, tui.PickerItem{
-							Name:     bleDevices[i].DisplayName,
-							DedupKey: bleDevices[i].DisplayName,
-							Type:     connType,
-							Address:  bleDevices[i].Address,
+							Name:         bleDevices[i].DisplayName,
+							DedupKey:     bleDevices[i].DisplayName,
+							Type:         connType,
+							Address:      bleDevices[i].Address,
+							AgentVersion: bleDevices[i].AgentVersion,
+							OSVersion:    bleDevices[i].OSVersion,
 							Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
 								DisplayName:     bleDevices[i].DisplayName,
 								AgentVersion:    bleDevices[i].AgentVersion,

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -12,11 +12,13 @@ import (
 // PickerItem represents a selectable row in the device picker.
 type PickerItem struct {
 	// Display columns rendered in the table.
-	Name        string
-	Description string // optional secondary text rendered dimmed
-	Type        string // "LAN", "Bluetooth", "External", etc.
-	USB         string // non-empty when the device is connected over USB
-	Address     string
+	Name         string
+	Description  string // optional secondary text rendered dimmed
+	Type         string // "LAN", "Bluetooth", "External", etc.
+	USB          string // non-empty when the device is connected over USB
+	Address      string
+	AgentVersion string
+	OSVersion    string
 
 	// DedupKey is used for deduplication. If empty, Name is used.
 	// Items with the same DedupKey (case-insensitive) are merged via MergeItem.
@@ -78,22 +80,27 @@ type PickerModel struct {
 	// Shown with a ★ indicator in the table.
 	DefaultKey string
 
-	items    []PickerItem
-	seenIdx  map[string]int // dedup key -> index in items
-	table    bubbleTable.Model
-	selected *PickerItem
-	scanning bool
-	quitting bool
-	height   int
+	items        []PickerItem
+	seenIdx      map[string]int // dedup key -> index in items
+	table        BubbleTable
+	columns      []pickerColumnDef
+	fixedColumns bool
+	selected     *PickerItem
+	scanning     bool
+	quitting     bool
+	width        int
+	height       int
 }
 
 // NewPicker creates a new picker model with the default "Select a device" title.
 func NewPicker() PickerModel {
 	m := PickerModel{
-		Title:    "Select a device",
-		seenIdx:  make(map[string]int),
-		table:    newPickerTable(),
-		scanning: true,
+		Title:        "Select a device",
+		seenIdx:      make(map[string]int),
+		table:        newPickerTable(),
+		columns:      pickerDeviceColumnDefs,
+		fixedColumns: true,
+		scanning:     true,
 	}
 	m.refreshTable()
 	return m
@@ -116,9 +123,12 @@ func (m PickerModel) Init() tea.Cmd { return nil }
 func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		m.width = msg.Width
 		m.height = msg.Height
+		var cmd tea.Cmd
+		m.table, cmd = m.table.Update(msg)
 		m.refreshTable()
-		return m, nil
+		return m, cmd
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "enter":
@@ -216,7 +226,11 @@ func (m PickerModel) View() string {
 
 	var sb strings.Builder
 
-	hint := " (↑/↓ navigate, enter select, q quit)"
+	scrollHint := ""
+	if m.canScrollTable() {
+		scrollHint = ", ←/→ scroll"
+	}
+	hint := " (↑/↓ navigate" + scrollHint + ", enter select, q quit)"
 	if m.OnSetDefault != nil || m.OnUnsetDefault != nil {
 		extras := ""
 		if m.OnSetDefault != nil {
@@ -225,31 +239,42 @@ func (m PickerModel) View() string {
 		if m.OnUnsetDefault != nil {
 			extras += ", x unset default"
 		}
-		hint = " (↑/↓ navigate, enter select" + extras + ", q quit)"
+		hint = " (↑/↓ navigate" + scrollHint + ", enter select" + extras + ", q quit)"
 	}
-	sb.WriteString(pickerTitle.Render(m.Title) + pickerHint.Render(hint) + "\n\n")
+	sb.WriteString(m.viewLine(pickerTitle.Render(m.Title)+pickerHint.Render(hint)) + "\n\n")
 
 	if len(m.items) == 0 {
 		if m.scanning {
-			sb.WriteString(pickerScanning.Render("  Scanning...") + "\n")
+			sb.WriteString(m.viewLine(pickerScanning.Render("  Scanning...")) + "\n")
 		} else {
-			sb.WriteString(pickerHint.Render("  No options found.") + "\n")
+			sb.WriteString(m.viewLine(pickerHint.Render("  No options found.")) + "\n")
 		}
 		return sb.String()
 	}
 
-	sb.WriteString(m.table.View() + "\n")
+	sb.WriteString(m.tableView() + "\n")
 
 	cursor := m.table.Cursor()
 	if cursor >= 0 && cursor < len(m.items) && m.items[cursor].Insecure {
-		sb.WriteString(pickerInsecure.Render("  ⚠  Connection is not secured with mTLS. PKI support is coming soon.") + "\n")
+		sb.WriteString(m.viewLine(pickerInsecure.Render("  ⚠  Connection is not secured with mTLS. PKI support is coming soon.")) + "\n")
 	}
 
 	if m.scanning {
-		sb.WriteString("\n" + pickerScanning.Render("  Scanning for more results...") + "\n")
+		sb.WriteString("\n" + m.viewLine(pickerScanning.Render("  Scanning for more results...")) + "\n")
 	}
 
 	return sb.String()
+}
+
+func (m PickerModel) viewLine(line string) string {
+	if m.width <= 0 {
+		return line
+	}
+	return CropANSIView(line, 0, m.width)
+}
+
+func (m PickerModel) tableView() string {
+	return m.table.View()
 }
 
 // Cancelled returns true if the user quit the picker without selecting (e.g. Ctrl+C).
@@ -265,7 +290,6 @@ func (m PickerModel) Selected() *PickerItem {
 type pickerColumnDef struct {
 	title    string
 	minWidth int
-	maxWidth int
 	value    func(PickerItem) string
 	required bool
 }
@@ -274,7 +298,6 @@ var pickerColumnDefs = []pickerColumnDef{
 	{
 		title:    "Name",
 		minWidth: 18,
-		maxWidth: 48,
 		value: func(item PickerItem) string {
 			return item.Name
 		},
@@ -283,7 +306,6 @@ var pickerColumnDefs = []pickerColumnDef{
 	{
 		title:    "Type",
 		minWidth: 12,
-		maxWidth: 28,
 		value: func(item PickerItem) string {
 			if item.USB != "" && !strings.Contains(item.Type, "USB") {
 				return "USB, " + item.Type
@@ -294,7 +316,6 @@ var pickerColumnDefs = []pickerColumnDef{
 	{
 		title:    "Address",
 		minWidth: 14,
-		maxWidth: 28,
 		value: func(item PickerItem) string {
 			return item.Address
 		},
@@ -302,14 +323,34 @@ var pickerColumnDefs = []pickerColumnDef{
 	{
 		title:    "Description",
 		minWidth: 20,
-		maxWidth: 48,
 		value: func(item PickerItem) string {
 			return item.Description
 		},
 	},
 }
 
-func newPickerTable() bubbleTable.Model {
+var pickerDeviceColumnDefs = []pickerColumnDef{
+	pickerColumnDefs[0],
+	pickerColumnDefs[1],
+	pickerColumnDefs[2],
+	{
+		title:    "wendy-agent version",
+		minWidth: 20,
+		value: func(item PickerItem) string {
+			return item.AgentVersion
+		},
+	},
+	{
+		title:    "WendyOS Version",
+		minWidth: 16,
+		value: func(item PickerItem) string {
+			return item.OSVersion
+		},
+	},
+	pickerColumnDefs[3],
+}
+
+func newPickerTable() BubbleTable {
 	return NewBubbleTable(true, nil)
 }
 
@@ -349,7 +390,7 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 	}
 
 	hasDefaultCol := m.OnSetDefault != nil
-	cols, rows := PickerTableData(m.items, m.DefaultKey, hasDefaultCol)
+	cols, rows := pickerTableDataForColumns(m.items, m.DefaultKey, hasDefaultCol, m.columns, m.fixedColumns)
 	m.table.SetRows(nil)
 	m.table.SetColumns(cols)
 	m.table.SetRows(rows)
@@ -382,9 +423,15 @@ func pickerItemKey(item PickerItem) string {
 	return item.Name
 }
 
-func pickerActiveColumns(items []PickerItem) []pickerColumnDef {
+func pickerActiveColumnsForDefs(items []PickerItem, defs []pickerColumnDef, fixed bool) []pickerColumnDef {
+	if len(defs) == 0 {
+		defs = pickerColumnDefs
+	}
+	if fixed {
+		return defs
+	}
 	var active []pickerColumnDef
-	for _, def := range pickerColumnDefs {
+	for _, def := range defs {
 		if def.required {
 			active = append(active, def)
 			continue
@@ -401,7 +448,17 @@ func pickerActiveColumns(items []PickerItem) []pickerColumnDef {
 
 // PickerTableData builds the shared picker table columns and rows for items.
 func PickerTableData(items []PickerItem, defaultKey string, hasDefaultCol bool) ([]bubbleTable.Column, []bubbleTable.Row) {
-	activeCols := pickerActiveColumns(items)
+	return pickerTableDataForColumns(items, defaultKey, hasDefaultCol, nil, false)
+}
+
+// PickerDeviceTableData builds the stable device table used by device pickers
+// and discover output.
+func PickerDeviceTableData(items []PickerItem, defaultKey string, hasDefaultCol bool) ([]bubbleTable.Column, []bubbleTable.Row) {
+	return pickerTableDataForColumns(items, defaultKey, hasDefaultCol, pickerDeviceColumnDefs, true)
+}
+
+func pickerTableDataForColumns(items []PickerItem, defaultKey string, hasDefaultCol bool, defs []pickerColumnDef, fixed bool) ([]bubbleTable.Column, []bubbleTable.Row) {
+	activeCols := pickerActiveColumnsForDefs(items, defs, fixed)
 	rows := pickerRows(items, activeCols, defaultKey, hasDefaultCol)
 	return pickerColumns(rows, activeCols, hasDefaultCol), rows
 }
@@ -465,7 +522,6 @@ func pickerColumns(rows []bubbleTable.Row, defs []pickerColumnDef, hasDefaultCol
 		}
 		width += 2
 		width = max(width, def.minWidth)
-		width = min(width, def.maxWidth)
 		cols = append(cols, bubbleTable.Column{Title: def.title, Width: width})
 	}
 	return cols
@@ -487,4 +543,15 @@ func PickerTableHeight(rowCount, windowHeight int) int {
 		return min(height, max(windowHeight-5, 4))
 	}
 	return min(height, 12)
+}
+
+func (m PickerModel) canScrollTable() bool {
+	return m.table.CanScroll()
+}
+
+func (m PickerModel) tableViewportWidth() int {
+	if width := m.table.ViewportWidth(); width > 0 {
+		return width
+	}
+	return PickerTableWidth(m.table.Columns())
 }

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -4,7 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	bubbleTable "github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestPickerModel_SelectsFromTable(t *testing.T) {
@@ -75,6 +77,191 @@ func TestPickerModel_ShowsDescriptionColumnWhenPresent(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected picker view to contain %q, got %q", want, view)
 		}
+	}
+}
+
+func TestPickerTableData_KeepsFullColumnContentForScrolling(t *testing.T) {
+	items := []PickerItem{{
+		Name:        "wendyos-sunny-daisy",
+		Type:        "USB, LAN",
+		Address:     "wendyos-sunny-daisy.local:50052",
+		Description: "Full Linux-based edge device",
+		Value:       "sunny",
+	}}
+
+	cols, rows := PickerTableData(items, "", false)
+
+	for _, want := range []string{"Name", "Type", "Address", "Description"} {
+		if !hasColumn(cols, want) {
+			t.Fatalf("expected %s column to remain scrollable", want)
+		}
+	}
+	if width := columnWidth(cols, "Address"); width < len("wendyos-sunny-daisy.local:50052") {
+		t.Fatalf("address column width = %d, want enough for full hostname", width)
+	}
+	if len(rows) != 1 || len(rows[0]) != len(cols) {
+		t.Fatalf("row/column mismatch: rows=%v cols=%v", rows, cols)
+	}
+}
+
+func TestPickerTableData_KeepsDefaultMarkerInNarrowWidth(t *testing.T) {
+	items := []PickerItem{{
+		Name:     "alpha",
+		Type:     "LAN",
+		DedupKey: "alpha",
+		Value:    "alpha",
+	}}
+
+	cols, rows := PickerTableData(items, "alpha", true)
+
+	if len(cols) < 2 || cols[0].Title != "" || cols[1].Title != "Name" {
+		t.Fatalf("columns = %v, want marker and Name columns", cols)
+	}
+	if len(rows) != 1 || len(rows[0]) < 1 || rows[0][0] != "★" {
+		t.Fatalf("default marker row = %v, want leading star", rows)
+	}
+}
+
+func TestPickerDeviceTableData_UsesStableDeviceSchema(t *testing.T) {
+	cols, rows := PickerDeviceTableData([]PickerItem{{
+		Name: "alpha",
+	}}, "", false)
+
+	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "Description"} {
+		if !hasColumn(cols, want) {
+			t.Fatalf("expected stable device column %q, got %v", want, cols)
+		}
+	}
+	if len(rows) != 1 || len(rows[0]) != len(cols) {
+		t.Fatalf("row/column mismatch: rows=%v cols=%v", rows, cols)
+	}
+}
+
+func TestNewPicker_UsesStableDeviceSchemaBeforeMetadataArrives(t *testing.T) {
+	m := NewPicker()
+
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{Name: "alpha", Value: "alpha"}}})
+	pm := updated.(PickerModel)
+
+	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "Description"} {
+		if !hasColumn(pm.table.Columns(), want) {
+			t.Fatalf("expected stable device column %q, got %v", want, pm.table.Columns())
+		}
+	}
+}
+
+func TestPickerDeviceTableData_ShowsAgentAndWendyOSVersions(t *testing.T) {
+	_, rows := PickerDeviceTableData([]PickerItem{{
+		Name:         "alpha",
+		Type:         "LAN",
+		Address:      "alpha.local:50052",
+		AgentVersion: "2026.05.30-161141",
+		OSVersion:    "WendyOS-0.10.4",
+	}}, "", false)
+
+	if len(rows) != 1 || len(rows[0]) < 5 {
+		t.Fatalf("rows = %v, want version cells", rows)
+	}
+	if rows[0][3] != "2026.05.30-161141" {
+		t.Fatalf("agent version cell = %q", rows[0][3])
+	}
+	if rows[0][4] != "WendyOS-0.10.4" {
+		t.Fatalf("WendyOS version cell = %q", rows[0][4])
+	}
+}
+
+func TestPickerModel_WindowWidthControlsColumns(t *testing.T) {
+	m := NewPickerWithTitle("Select a device")
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 24, Height: 20})
+	pm := updated.(PickerModel)
+	updated, _ = pm.Update(PickerAddMsg{Items: []PickerItem{{
+		Name:        "wendyos-sunny-daisy",
+		Type:        "USB, LAN",
+		Address:     "wendyos-sunny-daisy.local:50052",
+		Description: "Full Linux-based edge device",
+		Value:       "sunny",
+	}}})
+	pm = updated.(PickerModel)
+
+	for _, want := range []string{"Name", "Type", "Address", "Description"} {
+		if !hasColumn(pm.table.Columns(), want) {
+			t.Fatalf("expected narrow picker to keep %s column for scrolling", want)
+		}
+	}
+	for _, line := range strings.Split(pm.tableView(), "\n") {
+		if got := ansi.StringWidth(line); got > 24 {
+			t.Fatalf("cropped line width = %d, want <= 24: %q", got, line)
+		}
+	}
+	if table := pm.table.FullView(); !strings.Contains(table, "wendyos-sunny-daisy.local:50052") {
+		t.Fatalf("underlying table should preserve full address without ellipsis, got %q", table)
+	}
+
+	updated, _ = pm.Update(tea.WindowSizeMsg{Width: 120, Height: 20})
+	pm = updated.(PickerModel)
+
+	if !hasColumn(pm.table.Columns(), "Address") {
+		t.Fatal("expected wide picker to show Address column")
+	}
+	if !hasColumn(pm.table.Columns(), "Description") {
+		t.Fatal("expected wide picker to show Description column")
+	}
+}
+
+func TestPickerModel_LeftRightScrollsWithoutBreakingVerticalNavigation(t *testing.T) {
+	m := NewPickerWithTitle("Select a device")
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 24, Height: 20})
+	pm := updated.(PickerModel)
+	updated, _ = pm.Update(PickerAddMsg{Items: []PickerItem{
+		{
+			Name:        "wendyos-alpha",
+			Type:        "USB, LAN",
+			Address:     "wendyos-alpha.local:50052",
+			Description: "Full Linux-based edge device",
+			Value:       "alpha",
+		},
+		{
+			Name:        "wendyos-beta",
+			Type:        "LAN",
+			Address:     "wendyos-beta.local:50052",
+			Description: "Another device",
+			Value:       "beta",
+		},
+	}})
+	pm = updated.(PickerModel)
+
+	if !pm.canScrollTable() {
+		t.Fatalf("expected table width %d to exceed viewport %d", PickerTableWidth(pm.table.Columns()), pm.tableViewportWidth())
+	}
+	before := pm.tableView()
+
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyRight})
+	pm = updated.(PickerModel)
+
+	if pm.table.ScrollOffset() == 0 {
+		t.Fatal("expected right arrow to advance horizontal offset")
+	}
+	if after := pm.tableView(); after == before {
+		t.Fatal("expected scrolled table view to change")
+	}
+
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyDown})
+	pm = updated.(PickerModel)
+
+	if pm.table.Cursor() != 1 {
+		t.Fatalf("expected down arrow to move cursor, got %d", pm.table.Cursor())
+	}
+	if pm.table.ScrollOffset() == 0 {
+		t.Fatal("expected vertical navigation to preserve horizontal offset")
+	}
+
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	pm = updated.(PickerModel)
+
+	if pm.table.ScrollOffset() != 0 {
+		t.Fatalf("expected left arrow to return to zero offset, got %d", pm.table.ScrollOffset())
 	}
 }
 
@@ -272,4 +459,22 @@ func TestPickerModel_DXIgnoredWithoutCallbacks(t *testing.T) {
 	if strings.Contains(view, "d set default") {
 		t.Error("d/x hint should not appear without callbacks")
 	}
+}
+
+func hasColumn(cols []bubbleTable.Column, title string) bool {
+	for _, col := range cols {
+		if col.Title == title {
+			return true
+		}
+	}
+	return false
+}
+
+func columnWidth(cols []bubbleTable.Column, title string) int {
+	for _, col := range cols {
+		if col.Title == title {
+			return col.Width
+		}
+	}
+	return 0
 }

--- a/go/internal/cli/tui/spinner_test.go
+++ b/go/internal/cli/tui/spinner_test.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	bubbleTable "github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestSpinnerModel_Init(t *testing.T) {
@@ -117,6 +121,49 @@ func TestRenderTable_NoRows(t *testing.T) {
 	}
 	if !strings.Contains(output, "Name") {
 		t.Error("expected headers in output")
+	}
+}
+
+func TestBubbleTable_CropsWideViewAndScrolls(t *testing.T) {
+	table := NewBubbleTable(true, []bubbleTable.Column{
+		{Title: "Name", Width: 20},
+		{Title: "Address", Width: 32},
+	})
+	table.SetRows([]bubbleTable.Row{
+		{"alpha", "wendyos-alpha.local:50051"},
+		{"beta", "wendyos-beta.local:50051"},
+	})
+	table.SetWidth(58)
+	table.SetHeight(3)
+	updated, cmd := table.Update(tea.WindowSizeMsg{Width: 24, Height: 10})
+	table = updated
+	if cmd == nil {
+		t.Fatal("expected resize to request a screen clear")
+	}
+
+	before := table.View()
+	for _, line := range strings.Split(before, "\n") {
+		if got := ansi.StringWidth(line); got > 24 {
+			t.Fatalf("view line width = %d, want <= 24: %q", got, line)
+		}
+	}
+
+	updated, _ = table.Update(tea.KeyMsg{Type: tea.KeyRight})
+	table = updated
+	if table.ScrollOffset() == 0 {
+		t.Fatal("expected right arrow to advance horizontal offset")
+	}
+	if after := table.View(); after == before {
+		t.Fatal("expected scrolled table view to change")
+	}
+
+	updated, _ = table.Update(tea.KeyMsg{Type: tea.KeyDown})
+	table = updated
+	if table.Cursor() != 1 {
+		t.Fatalf("expected down arrow to move cursor, got %d", table.Cursor())
+	}
+	if table.ScrollOffset() == 0 {
+		t.Fatal("expected row navigation to preserve horizontal offset")
 	}
 }
 

--- a/go/internal/cli/tui/table.go
+++ b/go/internal/cli/tui/table.go
@@ -1,9 +1,13 @@
 package tui
 
 import (
+	"strings"
+
 	bubbleTable "github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+	"github.com/charmbracelet/x/ansi"
 )
 
 var (
@@ -70,13 +74,163 @@ func BubbleTableStyles(interactive bool) bubbleTable.Styles {
 	return styles
 }
 
+// BubbleTable wraps bubbles/table with shared styling and responsive viewport
+// behavior. Its View is ANSI-safe cropped to the configured viewport width so
+// terminals do not wrap wide tables during resizes.
+type BubbleTable struct {
+	model         bubbleTable.Model
+	viewportWidth int
+	x             int
+}
+
 // NewBubbleTable creates a Bubble Tea table using the shared emerald styling.
-func NewBubbleTable(interactive bool, columns []bubbleTable.Column) bubbleTable.Model {
+func NewBubbleTable(interactive bool, columns []bubbleTable.Column) BubbleTable {
 	opts := []bubbleTable.Option{bubbleTable.WithFocused(interactive)}
 	if len(columns) > 0 {
 		opts = append(opts, bubbleTable.WithColumns(columns))
 	}
 	t := bubbleTable.New(opts...)
 	t.SetStyles(BubbleTableStyles(interactive))
-	return t
+	return BubbleTable{model: t}
+}
+
+func (t BubbleTable) Update(msg tea.Msg) (BubbleTable, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		t.SetViewportWidth(msg.Width)
+		return t, tea.ClearScreen
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "left", "h":
+			t.ScrollLeft()
+			return t, nil
+		case "right", "l":
+			t.ScrollRight()
+			return t, nil
+		}
+	}
+
+	var cmd tea.Cmd
+	t.model, cmd = t.model.Update(msg)
+	return t, cmd
+}
+
+func (t BubbleTable) View() string {
+	view := t.model.View()
+	if t.viewportWidth <= 0 {
+		return view
+	}
+	return CropANSIView(view, t.x, t.viewportWidth)
+}
+
+func (t BubbleTable) FullView() string {
+	return t.model.View()
+}
+
+func (t *BubbleTable) SetViewportWidth(width int) {
+	t.viewportWidth = max(width, 0)
+	t.clampX()
+}
+
+func (t BubbleTable) ViewportWidth() int {
+	return t.viewportWidth
+}
+
+func (t *BubbleTable) ScrollLeft() {
+	if t.x <= 0 {
+		t.x = 0
+		return
+	}
+	t.x = max(0, t.x-BubbleTableHorizontalStep())
+}
+
+func (t *BubbleTable) ScrollRight() {
+	t.x = min(t.maxX(), t.x+BubbleTableHorizontalStep())
+}
+
+func (t *BubbleTable) ClampScroll() {
+	t.clampX()
+}
+
+func (t *BubbleTable) clampX() {
+	t.x = min(max(t.x, 0), t.maxX())
+}
+
+func (t BubbleTable) ScrollOffset() int {
+	return t.x
+}
+
+func (t BubbleTable) CanScroll() bool {
+	return t.maxX() > 0
+}
+
+func (t BubbleTable) maxX() int {
+	if t.viewportWidth <= 0 {
+		return 0
+	}
+	return max(0, t.model.Width()-t.viewportWidth)
+}
+
+func BubbleTableHorizontalStep() int {
+	return 8
+}
+
+func (t BubbleTable) Columns() []bubbleTable.Column {
+	return t.model.Columns()
+}
+
+func (t *BubbleTable) SetColumns(cols []bubbleTable.Column) {
+	t.model.SetColumns(cols)
+	t.clampX()
+}
+
+func (t BubbleTable) Rows() []bubbleTable.Row {
+	return t.model.Rows()
+}
+
+func (t *BubbleTable) SetRows(rows []bubbleTable.Row) {
+	t.model.SetRows(rows)
+}
+
+func (t BubbleTable) Cursor() int {
+	return t.model.Cursor()
+}
+
+func (t *BubbleTable) SetCursor(n int) {
+	t.model.SetCursor(n)
+}
+
+func (t BubbleTable) Width() int {
+	return t.model.Width()
+}
+
+func (t *BubbleTable) SetWidth(width int) {
+	t.model.SetWidth(width)
+	t.clampX()
+}
+
+func (t BubbleTable) Height() int {
+	return t.model.Height()
+}
+
+func (t *BubbleTable) SetHeight(height int) {
+	t.model.SetHeight(height)
+}
+
+func (t BubbleTable) SelectedRow() bubbleTable.Row {
+	return t.model.SelectedRow()
+}
+
+// CropANSIView cuts every rendered line to width columns from offset. This
+// prevents terminal wrapping while preserving ANSI escape sequences.
+func CropANSIView(view string, offset, width int) string {
+	if width <= 0 {
+		return view
+	}
+
+	lines := strings.Split(view, "\n")
+	for i, line := range lines {
+		lines[i] = ansi.Cut(line, offset, offset+width)
+	}
+	return strings.Join(lines, "\n")
 }

--- a/go/internal/cli/tui/wifitable/model.go
+++ b/go/internal/cli/tui/wifitable/model.go
@@ -84,7 +84,7 @@ const flashDuration = 4 * time.Second
 // Model is the Bubble Tea model for the interactive WiFi table.
 type Model struct {
 	networks []Network
-	table    bubbleTable.Model
+	table    tui.BubbleTable
 	mode     mode
 
 	handler Handler
@@ -208,8 +208,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		var cmd tea.Cmd
+		m.table, cmd = m.table.Update(msg)
 		m.refreshRows()
-		return m, nil
+		return m, cmd
 
 	case RefreshMsg:
 		if m.mode == modeBrowsing {
@@ -716,7 +718,7 @@ func (m Model) View() string {
 		return ""
 	}
 	var sb strings.Builder
-	sb.WriteString(titleStyle.Render("WiFi networks") + "\n\n")
+	sb.WriteString(m.viewLine(titleStyle.Render("WiFi networks")) + "\n\n")
 	sb.WriteString(m.table.View())
 	sb.WriteString("\n")
 
@@ -725,22 +727,33 @@ func (m Model) View() string {
 		if m.flashIsError {
 			style = flashErrorStyle
 		}
-		sb.WriteString(style.Render(m.flashMessage) + "\n")
+		sb.WriteString(m.viewLine(style.Render(m.flashMessage)) + "\n")
 	}
 
 	switch m.mode {
 	case modeBrowsing:
-		sb.WriteString(footerStyle.Render("↑/↓ move · enter connect · r rank · n new · f forget · q quit") + "\n")
+		hint := "↑/↓ move · enter connect · r rank · n new · f forget · q quit"
+		if m.table.CanScroll() {
+			hint = "↑/↓ move · ←/→ scroll · enter connect · r rank · n new · f forget · q quit"
+		}
+		sb.WriteString(m.viewLine(footerStyle.Render(hint)) + "\n")
 	case modeRanking:
-		sb.WriteString(footerStyle.Render("rank mode: ↑/↓ reorder · enter commit · esc cancel") + "\n")
+		sb.WriteString(m.viewLine(footerStyle.Render("rank mode: ↑/↓ reorder · enter commit · esc cancel")) + "\n")
 	case modePassword:
-		sb.WriteString(titleStyle.Render("Password for "+m.pwFor) + "\n")
-		sb.WriteString(m.passwordInput.View() + "\n")
-		sb.WriteString(footerStyle.Render("enter connect · esc cancel") + "\n")
+		sb.WriteString(m.viewLine(titleStyle.Render("Password for "+m.pwFor)) + "\n")
+		sb.WriteString(m.viewLine(m.passwordInput.View()) + "\n")
+		sb.WriteString(m.viewLine(footerStyle.Render("enter connect · esc cancel")) + "\n")
 	case modeUnlisted:
 		sb.WriteString(m.renderUnlistedModal() + "\n")
 	}
 	return sb.String()
+}
+
+func (m Model) viewLine(line string) string {
+	if m.width <= 0 {
+		return line
+	}
+	return tui.CropANSIView(line, 0, m.width)
 }
 
 func (m Model) renderUnlistedModal() string {


### PR DESCRIPTION
## Summary
- Wrap the shared Bubble table with ANSI-safe viewport cropping and left/right horizontal scrolling.
- Apply the responsive table behavior across device pickers, discover, cloud discover, app dashboard, and WiFi tables.
- Add wendy-agent and WendyOS version columns, including agent-side WendyOS version discovery with legacy fallback.
- Clear the inline TUI on resize to avoid ghosted table frames after terminal shrink events.

## Testing
- `go test ./go/internal/cli/...`
- `go test ./go/internal/agent/services`
- `go vet ./go/internal/cli/... ./go/internal/agent/services`
- `git diff --check`
- `zsh -ic 'wendy-dev --help >/tmp/wendy-dev-help.out'`