### PR TITLE
fix: surface clock-skew mTLS failures with actionable errors (WDY-1260)

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net"
 	"net/http"
@@ -190,7 +192,7 @@ func main() {
 
 	// Returns nil if the PEM data is invalid, which causes the registry to stay HTTP.
 	registryTLSConfig := func(certPEM, chainPEM, keyPEM string) *tls.Config {
-		tlsConfig, err := mtls.NewTLSConfig(certPEM, chainPEM, keyPEM)
+		tlsConfig, err := mtls.NewTLSConfig(certPEM, chainPEM, keyPEM, nil)
 		if err != nil {
 			logger.Error("Failed to build registry TLS config", zap.Error(err))
 			return nil
@@ -321,7 +323,12 @@ func main() {
 			return
 		}
 
-		srv, err := mtls.NewServer(certPEM, chainPEM, keyPEM,
+		// Warn if the device clock appears to predate the provisioning cert.
+		// This almost always means an unsynchronized RTC, which causes every
+		// client cert to appear "not yet valid" from the device's perspective.
+		warnClockSkewIfNeeded(logger, certPEM)
+
+		srv, err := mtls.NewServer(certPEM, chainPEM, keyPEM, logger,
 			grpc.UnaryInterceptor(interceptor.UnaryErrorInterceptor(logger)),
 			grpc.StreamInterceptor(interceptor.StreamErrorInterceptor(logger)),
 		)
@@ -361,7 +368,7 @@ func main() {
 
 	// Only called after provisioning so the cert is available.
 	startBLEPeripheral := func(certPEM, chainPEM, keyPEM string) {
-		tlsConfig, err := mtls.NewTLSConfig(certPEM, chainPEM, keyPEM)
+		tlsConfig, err := mtls.NewTLSConfig(certPEM, chainPEM, keyPEM, logger)
 		if err != nil {
 			logger.Error("Failed to build BLE TLS config", zap.Error(err))
 			return
@@ -525,6 +532,32 @@ func main() {
 	wg.Wait()
 
 	logger.Info("wendy-agent stopped")
+}
+
+// warnClockSkewIfNeeded parses the device's own provisioning cert and logs a
+// warning if the system clock predates the cert's NotBefore. A clock that is
+// behind the cert's issuance time will reject every legitimate client cert
+// ("not yet valid"), making the mTLS port effectively unusable — but silently.
+func warnClockSkewIfNeeded(logger *zap.Logger, certPEM string) {
+	if certPEM == "" {
+		return
+	}
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	if now.Before(cert.NotBefore) {
+		logger.Warn("Device clock appears to predate the provisioning certificate — mTLS client cert verification will fail until NTP synchronizes the clock",
+			zap.Time("deviceClock", now),
+			zap.Time("certNotBefore", cert.NotBefore),
+			zap.Duration("clockBehindBy", cert.NotBefore.Sub(now)),
+		)
+	}
 }
 
 func brokerURLForCloudHost(cloudHost string) string {

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"net"
@@ -546,7 +547,16 @@ func warnClockSkewIfNeeded(logger *zap.Logger, certPEM string) {
 	if block == nil {
 		return
 	}
+	// ML-DSA certs from pki-core have trailing ASN.1 bytes that cause
+	// x509.ParseCertificate to fail. Strip them with the same fallback
+	// used elsewhere in this repo (e.g. internal/agent/mtls/mldsa_verify.go).
 	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		var raw asn1.RawValue
+		if _, asn1Err := asn1.Unmarshal(block.Bytes, &raw); asn1Err == nil {
+			cert, err = x509.ParseCertificate(raw.FullBytes)
+		}
+	}
 	if err != nil {
 		return
 	}

--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -139,7 +139,14 @@ func formatError(err error) error {
 		strings.Contains(prefix, "creating enrollment token") ||
 		strings.Contains(prefix, "connecting to cloud")
 
+	isTLSError := strings.Contains(msg, "tls:") ||
+		strings.Contains(msg, "bad certificate") ||
+		strings.Contains(msg, "authentication handshake failed") ||
+		strings.Contains(msg, "certificate required")
+
 	switch {
+	case strings.Contains(msg, "code = Unavailable") && isTLSError:
+		return fmt.Errorf("%sTLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1", prefix)
 	case strings.Contains(msg, "code = Unavailable") && strings.Contains(msg, "connection refused"):
 		if isPKICoreCall {
 			return fmt.Errorf("%sCould not connect to local pki-core. Check that the gRPC endpoint is reachable from this machine.", prefix)

--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -145,7 +145,7 @@ func formatError(err error) error {
 		strings.Contains(msg, "certificate required")
 
 	switch {
-	case strings.Contains(msg, "code = Unavailable") && isTLSError:
+	case strings.Contains(msg, "code = Unavailable") && isTLSError && !isPKICoreCall && !isCloudCall:
 		return fmt.Errorf("%sTLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1", prefix)
 	case strings.Contains(msg, "code = Unavailable") && strings.Contains(msg, "connection refused"):
 		if isPKICoreCall {

--- a/go/internal/agent/mtls/mldsa_verify.go
+++ b/go/internal/agent/mtls/mldsa_verify.go
@@ -6,7 +6,6 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
-	"strings"
 	"time"
 
 	circlSign "github.com/cloudflare/circl/sign"
@@ -188,15 +187,10 @@ func logCertRejection(logger *zap.Logger, leaf *x509.Certificate, err error) {
 		zap.Error(err),
 	}
 	msg := "mTLS client certificate rejected"
-	// "not yet valid" comes from Go's x509 verifier (ECDSA path);
-	// "not valid at current time" comes from verifyMLDSAClientCert (ML-DSA path).
-	// Also check NotBefore directly so future error-message changes don't miss it.
-	errMsg := err.Error()
-	clockSkew := strings.Contains(errMsg, "not yet valid") ||
-		strings.Contains(errMsg, "not valid at current time") ||
-		strings.Contains(errMsg, "certificate has expired or is not yet valid") ||
-		time.Now().Before(leaf.NotBefore)
-	if clockSkew {
+	// Only hint at clock skew when the device clock is behind the cert's NotBefore.
+	// String-matching on the error text would also fire for expired certs, pointing
+	// operators at the wrong remediation (NTP sync won't help an expired cert).
+	if time.Now().Before(leaf.NotBefore) {
 		msg += ": certificate not yet valid — device clock may be skewed; check NTP sync with: timedatectl status"
 	}
 	logger.Warn(msg, fields...)

--- a/go/internal/agent/mtls/mldsa_verify.go
+++ b/go/internal/agent/mtls/mldsa_verify.go
@@ -188,7 +188,9 @@ func logCertRejection(logger *zap.Logger, leaf *x509.Certificate, err error) {
 		zap.Error(err),
 	}
 	msg := "mTLS client certificate rejected"
-	if strings.Contains(err.Error(), "not yet valid") || strings.Contains(err.Error(), "certificate has expired or is not yet valid") {
+	if strings.Contains(err.Error(), "not yet valid") ||
+		strings.Contains(err.Error(), "certificate has expired or is not yet valid") ||
+		(strings.Contains(err.Error(), "not valid at current time") && time.Now().Before(leaf.NotBefore)) {
 		msg += ": certificate not yet valid — device clock may be skewed; check NTP sync with: timedatectl status"
 	}
 	logger.Warn(msg, fields...)

--- a/go/internal/agent/mtls/mldsa_verify.go
+++ b/go/internal/agent/mtls/mldsa_verify.go
@@ -188,9 +188,15 @@ func logCertRejection(logger *zap.Logger, leaf *x509.Certificate, err error) {
 		zap.Error(err),
 	}
 	msg := "mTLS client certificate rejected"
-	if strings.Contains(err.Error(), "not yet valid") ||
-		strings.Contains(err.Error(), "certificate has expired or is not yet valid") ||
-		(strings.Contains(err.Error(), "not valid at current time") && time.Now().Before(leaf.NotBefore)) {
+	// "not yet valid" comes from Go's x509 verifier (ECDSA path);
+	// "not valid at current time" comes from verifyMLDSAClientCert (ML-DSA path).
+	// Also check NotBefore directly so future error-message changes don't miss it.
+	errMsg := err.Error()
+	clockSkew := strings.Contains(errMsg, "not yet valid") ||
+		strings.Contains(errMsg, "not valid at current time") ||
+		strings.Contains(errMsg, "certificate has expired or is not yet valid") ||
+		time.Now().Before(leaf.NotBefore)
+	if clockSkew {
 		msg += ": certificate not yet valid — device clock may be skewed; check NTP sync with: timedatectl status"
 	}
 	logger.Warn(msg, fields...)

--- a/go/internal/agent/mtls/mldsa_verify.go
+++ b/go/internal/agent/mtls/mldsa_verify.go
@@ -6,11 +6,13 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"time"
 
 	circlSign "github.com/cloudflare/circl/sign"
 	"github.com/cloudflare/circl/sign/mldsa/mldsa65"
 	"github.com/cloudflare/circl/sign/mldsa/mldsa87"
+	"go.uber.org/zap"
 )
 
 var (
@@ -120,7 +122,10 @@ func verifyMLDSASignature(issuer, cert *x509.Certificate) error {
 	return nil
 }
 
-func buildVerifyPeerCertificate(caPool *x509.CertPool, caCerts []*x509.Certificate) func([][]byte, [][]*x509.Certificate) error {
+// buildVerifyPeerCertificate returns a VerifyPeerCertificate callback that
+// handles both standard (RSA/ECDSA) and ML-DSA-signed certificate chains.
+// logger may be nil, in which case no logging is performed.
+func buildVerifyPeerCertificate(caPool *x509.CertPool, caCerts []*x509.Certificate, logger *zap.Logger) func([][]byte, [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if len(rawCerts) == 0 {
 			return fmt.Errorf("no client certificate presented")
@@ -154,14 +159,39 @@ func buildVerifyPeerCertificate(caPool *x509.CertPool, caCerts []*x509.Certifica
 		// signature algorithm; for all other failures return the standard error.
 		sigOID, oidErr := certSigAlgOID(leaf)
 		if oidErr != nil {
+			logCertRejection(logger, leaf, stdErr)
 			return stdErr
 		}
 		if _, schemeErr := mldsaScheme(sigOID); schemeErr != nil {
+			logCertRejection(logger, leaf, stdErr)
 			return stdErr
 		}
 
-		return verifyMLDSAClientCert(leaf, caCerts)
+		mldsaErr := verifyMLDSAClientCert(leaf, caCerts)
+		if mldsaErr != nil {
+			logCertRejection(logger, leaf, mldsaErr)
+		}
+		return mldsaErr
 	}
+}
+
+// logCertRejection logs a WARN when a client cert is rejected, with a clock
+// skew hint when the error indicates the cert is not yet valid.
+func logCertRejection(logger *zap.Logger, leaf *x509.Certificate, err error) {
+	if logger == nil {
+		return
+	}
+	fields := []zap.Field{
+		zap.String("subject", leaf.Subject.CommonName),
+		zap.Time("notBefore", leaf.NotBefore),
+		zap.Time("notAfter", leaf.NotAfter),
+		zap.Error(err),
+	}
+	msg := "mTLS client certificate rejected"
+	if strings.Contains(err.Error(), "not yet valid") || strings.Contains(err.Error(), "certificate has expired or is not yet valid") {
+		msg += ": certificate not yet valid — device clock may be skewed; check NTP sync with: timedatectl status"
+	}
+	logger.Warn(msg, fields...)
 }
 
 // verifyMLDSAClientCert verifies a client leaf cert against the trusted CA certs

--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -8,12 +8,19 @@ import (
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 )
 
-func NewTLSConfig(certPEM, chainPEM, keyPEM string) (*tls.Config, error) {
+// NewTLSConfig creates a TLS config from PEM-encoded certificate, chain, and private key.
+// The certificate and chain are concatenated to form the full server certificate chain.
+// Client certificates are required and verified against the chain as a CA pool.
+// ML-DSA (post-quantum) signed certificates are handled via a custom VerifyPeerCertificate
+// callback because Go's crypto/x509 does not natively support ML-DSA signature verification.
+// logger may be nil; when provided, rejected client certificates are logged at WARN level.
+func NewTLSConfig(certPEM, chainPEM, keyPEM string, logger *zap.Logger) (*tls.Config, error) {
 	if chainPEM == "" {
 		return nil, fmt.Errorf("CA chain PEM is required to verify client certificates; device may need to be re-provisioned")
 	}
@@ -56,12 +63,15 @@ func NewTLSConfig(certPEM, chainPEM, keyPEM string) (*tls.Config, error) {
 		// performs the actual ML-DSA-aware chain verification instead.
 		ClientCAs:             nil,
 		MinVersion:            tls.VersionTLS12,
-		VerifyPeerCertificate: buildVerifyPeerCertificate(caPool, caCerts),
+		VerifyPeerCertificate: buildVerifyPeerCertificate(caPool, caCerts, logger),
 	}, nil
 }
 
-func NewServer(certPEM, chainPEM, keyPEM string, extraOpts ...grpc.ServerOption) (*grpc.Server, error) {
-	tlsConfig, err := NewTLSConfig(certPEM, chainPEM, keyPEM)
+// NewServer creates a gRPC server with mTLS credentials.
+// Additional gRPC server options can be passed and will be applied alongside the TLS credentials.
+// logger may be nil; when provided, rejected client certificates are logged at WARN level.
+func NewServer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, extraOpts ...grpc.ServerOption) (*grpc.Server, error) {
+	tlsConfig, err := NewTLSConfig(certPEM, chainPEM, keyPEM, logger)
 	if err != nil {
 		return nil, fmt.Errorf("creating TLS config: %w", err)
 	}

--- a/go/internal/agent/mtls/server_test.go
+++ b/go/internal/agent/mtls/server_test.go
@@ -83,7 +83,7 @@ func testCACertificate(t *testing.T, commonName string) (certPEM, keyPEM string)
 func TestNewTLSConfigEmptyChainReturnsError(t *testing.T) {
 	certPEM, keyPEM := testLeafCertificate(t, "leaf")
 
-	_, err := NewTLSConfig(certPEM, "", keyPEM)
+	_, err := NewTLSConfig(certPEM, "", keyPEM, nil)
 	if err == nil {
 		t.Fatal("NewTLSConfig() expected error for empty chainPEM, got nil")
 	}
@@ -93,7 +93,7 @@ func TestNewTLSConfigServesOnlyLeafCertificate(t *testing.T) {
 	leafPEM, keyPEM := testLeafCertificate(t, "leaf")
 	chainPEM, _ := testCACertificate(t, "chain")
 
-	tlsConfig, err := NewTLSConfig(leafPEM+"\n"+chainPEM, chainPEM, keyPEM)
+	tlsConfig, err := NewTLSConfig(leafPEM+"\n"+chainPEM, chainPEM, keyPEM, nil)
 	if err != nil {
 		t.Fatalf("NewTLSConfig() error = %v", err)
 	}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -584,12 +584,20 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 			// point at the mTLS port), then fall back to port+1 (the normal case
 			// where discovery returns the plaintext port and mTLS is port+1).
 			mtlsAddrs := []string{plaintextAddr, hostPort(host, port+1)}
-			// Track TLS/non-TLS failures from index 1+ only (the dedicated mTLS port).
-			// Index 0 is plaintextAddr, which is probed speculatively; probing a plaintext
-			// port with TLS predictably gives a TLS-looking error ("error reading server
-			// preface: tls: ...") and a closed plaintext port gives connection refused.
-			// Neither is a reliable signal about whether the mTLS port rejected the cert.
-			var mtlsPortTLSFails, mtlsPortNonTLSFails int
+			// Two-bucket tracking per address index:
+			//
+			//   plaintextAddrCertReject — plaintextAddr itself was a TLS endpoint that
+			//   rejected our cert (tunnel/mTLS-only-discovery case where index 0 IS
+			//   already the mTLS port). isCertRejectionError only fires on server-sent
+			//   TLS alerts, not on "server sent non-TLS preface" errors from plaintext ports.
+			//
+			//   mtlsPortCertFails / mtlsPortNonCertFails — cert-rejection vs. other
+			//   failures at port+1 (the dedicated mTLS port in the normal case).
+			//
+			// Suppress the plaintext fallback if plaintextAddr itself was rejected, OR if
+			// all port+1 probe failures were cert rejections (none were just "unreachable").
+			var plaintextAddrCertReject bool
+			var mtlsPortCertFails, mtlsPortNonCertFails int
 			for addrIdx, mtlsAddr := range mtlsAddrs {
 				for i := range allCerts {
 					conn, tlsErr := grpcclient.ConnectWithTLS(ctx, mtlsAddr, &allCerts[i])
@@ -612,19 +620,20 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 						fmt.Fprintf(os.Stderr, "[tls-debug] GetAgentVersion(%s) error: %v\n", mtlsAddr, probeErr)
 					}
 					conn.Close()
-					if addrIdx > 0 {
-						if isTLSHandshakeError(probeErr) {
-							mtlsPortTLSFails++
+					if addrIdx == 0 {
+						if isCertRejectionError(probeErr) {
+							plaintextAddrCertReject = true
+						}
+					} else {
+						if isCertRejectionError(probeErr) {
+							mtlsPortCertFails++
 						} else {
-							mtlsPortNonTLSFails++
+							mtlsPortNonCertFails++
 						}
 					}
 				}
 			}
-			// Surface a TLS diagnostic only when every probe against the dedicated mTLS
-			// port (port+1) failed with a handshake error — no non-TLS failures that
-			// would indicate the port is simply unreachable.
-			if mtlsPortTLSFails > 0 && mtlsPortNonTLSFails == 0 {
+			if plaintextAddrCertReject || (mtlsPortCertFails > 0 && mtlsPortNonCertFails == 0) {
 				return nil, fmt.Errorf("TLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1")
 			}
 		}
@@ -632,15 +641,18 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 	return grpcclient.Connect(ctx, plaintextAddr)
 }
 
-// isTLSHandshakeError reports whether a gRPC probe error originates from a TLS
-// handshake failure rather than a plain TCP connectivity problem.
-func isTLSHandshakeError(err error) bool {
+// isCertRejectionError reports whether a gRPC probe error is a server-sent TLS
+// alert rejecting the client certificate, as distinct from the client failing to
+// complete the handshake because the server isn't a TLS endpoint at all.
+// Matches "remote error: tls:" (server sent an alert) and other cert-specific
+// signals; deliberately excludes "tls: first record does not look like a TLS
+// handshake" (plaintext server probed with TLS) and plain transport errors.
+func isCertRejectionError(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := err.Error()
-	return strings.Contains(msg, "tls:") ||
-		strings.Contains(msg, "bad certificate") ||
+	return strings.Contains(msg, "remote error: tls:") ||
 		strings.Contains(msg, "authentication handshake failed") ||
 		strings.Contains(msg, "certificate required")
 }

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -584,7 +584,7 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 			// point at the mTLS port), then fall back to port+1 (the normal case
 			// where discovery returns the plaintext port and mTLS is port+1).
 			mtlsAddrs := []string{plaintextAddr, hostPort(host, port+1)}
-			var lastTLSHandshakeErr error // non-nil when a handshake (not transport) error was seen
+			var tlsProbeFailures, nonTLSProbeFailures int
 			for _, mtlsAddr := range mtlsAddrs {
 				for i := range allCerts {
 					conn, tlsErr := grpcclient.ConnectWithTLS(ctx, mtlsAddr, &allCerts[i])
@@ -608,14 +608,17 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 					}
 					conn.Close()
 					if isTLSHandshakeError(probeErr) {
-						lastTLSHandshakeErr = probeErr
+						tlsProbeFailures++
+					} else {
+						nonTLSProbeFailures++
 					}
 				}
 			}
-			// A TLS handshake failure means the device rejected the cert — likely
-			// clock skew. Return a clear error instead of falling back to plaintext
-			// where "connection refused" would obscure the real cause.
-			if lastTLSHandshakeErr != nil {
+			// Only skip the plaintext fallback when every probe that reached a TLS
+			// handshake was rejected — i.e. no non-TLS failures (connection refused,
+			// timeout, etc.) that would indicate the mTLS port is simply unreachable.
+			// If any probe failed for a non-TLS reason, fall through to plaintext.
+			if tlsProbeFailures > 0 && nonTLSProbeFailures == 0 {
 				return nil, fmt.Errorf("TLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1")
 			}
 		}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -584,8 +584,13 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 			// point at the mTLS port), then fall back to port+1 (the normal case
 			// where discovery returns the plaintext port and mTLS is port+1).
 			mtlsAddrs := []string{plaintextAddr, hostPort(host, port+1)}
-			var tlsProbeFailures, nonTLSProbeFailures int
-			for _, mtlsAddr := range mtlsAddrs {
+			// Track TLS/non-TLS failures from index 1+ only (the dedicated mTLS port).
+			// Index 0 is plaintextAddr, which is probed speculatively; probing a plaintext
+			// port with TLS predictably gives a TLS-looking error ("error reading server
+			// preface: tls: ...") and a closed plaintext port gives connection refused.
+			// Neither is a reliable signal about whether the mTLS port rejected the cert.
+			var mtlsPortTLSFails, mtlsPortNonTLSFails int
+			for addrIdx, mtlsAddr := range mtlsAddrs {
 				for i := range allCerts {
 					conn, tlsErr := grpcclient.ConnectWithTLS(ctx, mtlsAddr, &allCerts[i])
 					if tlsErr != nil {
@@ -607,18 +612,19 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 						fmt.Fprintf(os.Stderr, "[tls-debug] GetAgentVersion(%s) error: %v\n", mtlsAddr, probeErr)
 					}
 					conn.Close()
-					if isTLSHandshakeError(probeErr) {
-						tlsProbeFailures++
-					} else {
-						nonTLSProbeFailures++
+					if addrIdx > 0 {
+						if isTLSHandshakeError(probeErr) {
+							mtlsPortTLSFails++
+						} else {
+							mtlsPortNonTLSFails++
+						}
 					}
 				}
 			}
-			// Only skip the plaintext fallback when every probe that reached a TLS
-			// handshake was rejected — i.e. no non-TLS failures (connection refused,
-			// timeout, etc.) that would indicate the mTLS port is simply unreachable.
-			// If any probe failed for a non-TLS reason, fall through to plaintext.
-			if tlsProbeFailures > 0 && nonTLSProbeFailures == 0 {
+			// Surface a TLS diagnostic only when every probe against the dedicated mTLS
+			// port (port+1) failed with a handshake error — no non-TLS failures that
+			// would indicate the port is simply unreachable.
+			if mtlsPortTLSFails > 0 && mtlsPortNonTLSFails == 0 {
 				return nil, fmt.Errorf("TLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1")
 			}
 		}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -569,6 +569,11 @@ func connectFromSelectedDevice(target *SelectedDevice, cfg resolveConfig) (*grpc
 // falling back to plaintext if no certs are available or all mTLS attempts fail.
 // It tries each stored certificate in order so that both production and local
 // pki-core certs are attempted.
+//
+// If every mTLS probe fails with a TLS handshake error, the plaintext fallback
+// is skipped and the TLS error is returned with a diagnostic hint. This prevents
+// the misleading "connection refused" from the plaintext port masking the real
+// cause (e.g. clock skew causing "certificate not yet valid").
 func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error) {
 	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
 	allCerts := loadAllCLICerts()
@@ -579,6 +584,7 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 			// point at the mTLS port), then fall back to port+1 (the normal case
 			// where discovery returns the plaintext port and mTLS is port+1).
 			mtlsAddrs := []string{plaintextAddr, hostPort(host, port+1)}
+			var lastTLSHandshakeErr error // non-nil when a handshake (not transport) error was seen
 			for _, mtlsAddr := range mtlsAddrs {
 				for i := range allCerts {
 					conn, tlsErr := grpcclient.ConnectWithTLS(ctx, mtlsAddr, &allCerts[i])
@@ -601,11 +607,33 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 						fmt.Fprintf(os.Stderr, "[tls-debug] GetAgentVersion(%s) error: %v\n", mtlsAddr, probeErr)
 					}
 					conn.Close()
+					if isTLSHandshakeError(probeErr) {
+						lastTLSHandshakeErr = probeErr
+					}
 				}
+			}
+			// A TLS handshake failure means the device rejected the cert — likely
+			// clock skew. Return a clear error instead of falling back to plaintext
+			// where "connection refused" would obscure the real cause.
+			if lastTLSHandshakeErr != nil {
+				return nil, fmt.Errorf("TLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1")
 			}
 		}
 	}
 	return grpcclient.Connect(ctx, plaintextAddr)
+}
+
+// isTLSHandshakeError reports whether a gRPC probe error originates from a TLS
+// handshake failure rather than a plain TCP connectivity problem.
+func isTLSHandshakeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "tls:") ||
+		strings.Contains(msg, "bad certificate") ||
+		strings.Contains(msg, "authentication handshake failed") ||
+		strings.Contains(msg, "certificate required")
 }
 
 // provisionedAgentAdvertisedMTLS takes a short pre-connection LAN discovery


### PR DESCRIPTION
## Summary

Fixes [WDY-1260](https://linear.app/wendylabsinc/issue/WDY-1260): device clock skew silently breaks mTLS — CLI shows "Could not connect to device" instead of the real cause.

Three layered fixes:

- **Agent now logs rejected client certs at WARN** (`internal/agent/mtls/mldsa_verify.go`): `buildVerifyPeerCertificate` emits a WARN with the leaf subject, `NotBefore`/`NotAfter`, and the error when a client cert is rejected. Includes an explicit clock-skew hint when the error is "not yet valid".

- **Agent warns at startup if device clock predates its own cert** (`cmd/wendy-agent/main.go`): `warnClockSkewIfNeeded()` compares `time.Now()` against the provisioning cert's `NotBefore` before the mTLS server starts. A dead RTC (clock = 1970) is caught immediately in the journal.

- **CLI surfaces TLS handshake errors instead of swallowing them** (`internal/cli/commands/helpers.go`, `cmd/wendy/main.go`): `connectWithAutoTLS` now tracks the last TLS handshake error across all mTLS probe attempts. When every probe fails with a TLS error it skips the plaintext fallback (which would produce the misleading "connection refused") and returns a clear message pointing to `timedatectl status` and `WENDY_TLS_DEBUG=1`. `formatError` also gains a TLS-specific `Unavailable` case.

## Test plan

- [x] `go test ./internal/agent/mtls/... ./internal/cli/commands/...` — all pass
- [x] `go build ./cmd/wendy-agent/... ./cmd/wendy/...` — no errors
- [ ] Manual: reproduce with a Jetson whose clock is behind its cert `NotBefore` and confirm the journal shows the WARN and the CLI shows the actionable message

🤖 Generated with [Claude Code](https://claude.com/claude-code)