### PR TITLE
fix: preserve user CN during cert refresh (WDY-1261)

### DIFF
--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -470,8 +470,15 @@ func newAuthRefreshCertsCmd() *cobra.Command {
 }
 
 // certCommonName extracts the Subject CN from a PEM-encoded certificate.
+// It normalizes the input with certs.LeafCertificatePEM first because
+// pki-core certificates can contain trailing ASN.1 bytes that cause
+// x509.ParseCertificate to fail on the raw stored PEM.
 func certCommonName(pemCertificate string) (string, error) {
-	block, _ := pem.Decode([]byte(pemCertificate))
+	leafPEM, err := certs.LeafCertificatePEM(pemCertificate)
+	if err != nil {
+		return "", fmt.Errorf("normalizing certificate PEM: %w", err)
+	}
+	block, _ := pem.Decode([]byte(leafPEM))
 	if block == nil {
 		return "", fmt.Errorf("decoding certificate PEM")
 	}

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -469,6 +469,19 @@ func newAuthRefreshCertsCmd() *cobra.Command {
 	}
 }
 
+// certCommonName extracts the Subject CN from a PEM-encoded certificate.
+func certCommonName(pemCertificate string) (string, error) {
+	block, _ := pem.Decode([]byte(pemCertificate))
+	if block == nil {
+		return "", fmt.Errorf("decoding certificate PEM")
+	}
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("parsing certificate: %w", err)
+	}
+	return parsed.Subject.CommonName, nil
+}
+
 // refreshCertsForAuth generates a new CSR and refreshes certificates for a single auth entry.
 func refreshCertsForAuth(ctx context.Context, auth *config.AuthConfig) error {
 	if len(auth.Certificates) == 0 {
@@ -477,13 +490,18 @@ func refreshCertsForAuth(ctx context.Context, auth *config.AuthConfig) error {
 
 	existingCert := auth.Certificates[0]
 
+	cn, err := certCommonName(existingCert.PemCertificate)
+	if err != nil {
+		return fmt.Errorf("reading existing cert CN: %w", err)
+	}
+
 	// Generate new key pair.
 	newKeyPEM, err := certs.GenerateKeyPair()
 	if err != nil {
 		return fmt.Errorf("generating key pair: %w", err)
 	}
 
-	csrPEM, err := certs.GenerateCSR(newKeyPEM, "wendy-cli-user")
+	csrPEM, err := certs.GenerateCSR(newKeyPEM, cn)
 	if err != nil {
 		return fmt.Errorf("generating CSR: %w", err)
 	}

--- a/go/internal/cli/commands/auth_test.go
+++ b/go/internal/cli/commands/auth_test.go
@@ -1,8 +1,16 @@
 package commands
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 )
 
 func testEnrollmentToken(t *testing.T, payload string) string {
@@ -37,5 +45,43 @@ func TestEnrollmentTokenCommonName_AssetEnrollment(t *testing.T) {
 func TestEnrollmentTokenCommonName_InvalidToken(t *testing.T) {
 	if _, err := enrollmentTokenCommonName("not-a-jwt"); err == nil {
 		t.Fatal("expected invalid token error")
+	}
+}
+
+func selfSignedCertPEM(t *testing.T, cn string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func TestCertCommonName(t *testing.T) {
+	const wantCN = "wendy/user/3VBQnKRlcFMOFjnjyw8ca7Rk6jR2"
+	certPEM := selfSignedCertPEM(t, wantCN)
+
+	got, err := certCommonName(certPEM)
+	if err != nil {
+		t.Fatalf("certCommonName() error = %v", err)
+	}
+	if got != wantCN {
+		t.Fatalf("certCommonName() = %q, want %q", got, wantCN)
+	}
+}
+
+func TestCertCommonName_InvalidPEM(t *testing.T) {
+	if _, err := certCommonName("not-a-pem"); err == nil {
+		t.Fatal("expected error for invalid PEM")
 	}
 }


### PR DESCRIPTION
## Summary

- `refreshCertsForAuth` was hardcoding `"wendy-cli-user"` as the CSR common name on every cert refresh
- After any refresh, the user cert's CN changed from `wendy/user/<uid>` to `wendy-cli-user`
- Cloud services that identify callers by CN (e.g. `ListAssets`) would return empty results, surfaced as misleading `"no enrolled devices found"` errors
- Full `wendy auth login` was the only recovery path

## Fix

Added `certCommonName` helper that parses the existing cert PEM and extracts its Subject CN. `refreshCertsForAuth` now passes that CN to `GenerateCSR` instead of the hardcoded string. Both `encoding/pem` and `crypto/x509` were already imported.

Works for both user certs (`wendy/user/<uid>`) and device certs (`wendy/<org>/<asset>`).

## Tests

- `TestCertCommonName` — round-trips a self-signed cert with `wendy/user/...` CN through the helper
- `TestCertCommonName_InvalidPEM` — error path for bad PEM input
- `go test ./internal/cli/commands/...` ✓

Fixes [WDY-1261](https://linear.app/wendylabsinc/issue/WDY-1261)

🤖 Generated with [Claude Code](https://claude.com/claude-code)