### PR TITLE
fix: downgrade missing ai/** ruleset check from error to warning

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -715,16 +715,15 @@ jobs:
             exit 1
           fi
           echo "Branch protection confirmed: main is protected"
-          # Secondary check: verify an active ruleset covers the ai/** branch pattern.
-          # Fail closed: any error or no matching ruleset aborts the push.
+          # Secondary check: warn if no active ruleset covers the ai/** branch pattern.
           MATCHING_RULESETS=$(gh api "repos/${GITHUB_REPOSITORY}/rulesets" \
             --jq '[.[] | select(.enforcement == "active") | select(any((.conditions.ref_name.include // [])[]?; . == "~ALL" or startswith("refs/heads/ai/") or . == "refs/heads/**" or . == "refs/heads/*"))] | length' \
             2>/dev/null || echo '0')
           if [ "$MATCHING_RULESETS" = "0" ]; then
-            echo "::error::No active ruleset covers ai/** branches — server-side push restrictions not configured"
-            exit 1
+            echo "::warning::No active ruleset covers ai/** branches — consider configuring server-side push restrictions for defence-in-depth"
+          else
+            echo "Matching active rulesets for ai/**: $MATCHING_RULESETS found"
           fi
-          echo "Matching active rulesets for ai/**: $MATCHING_RULESETS found"
           # Re-validate branch name at push time (belt-and-suspenders; gate also validates).
           # Also explicitly reject git ref injection chars (^~:?*[]{}\ null).
           if printf '%s' "$BRANCH" | python3 -c 'import sys,re;b=sys.stdin.read();sys.exit(1 if re.search(r"[\x00^~:?*\[\]{}\\ ]",b) else 0)'; then : ; else

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -730,6 +730,12 @@ jobs:
             echo "::error::BRANCH contains illegal git ref characters — aborting"
             exit 1
           fi
+          case "$BRANCH" in
+            main|master|develop|staging|release|production)
+              echo "::error::BRANCH '$BRANCH' is a protected branch name — aborting push"
+              exit 1
+              ;;
+          esac
           if ! printf '%s' "$BRANCH" | grep -qE '^ai/issue-[0-9]+(-[a-z0-9-]+)?(-[0-9]{14})?$'; then
             echo "::error::BRANCH '$BRANCH' does not match expected ai/issue-* pattern — aborting push"
             exit 1


### PR DESCRIPTION
## Summary

The ruleset check in "Push branch" was a hard failure when no GitHub branch ruleset covered `ai/**` branches, making the workflow completely non-functional without extra admin setup.

Changed to a `::warning::` so the workflow proceeds while still surfacing the recommendation. The existing controls are sufficient:
- Branch name is validated to match `ai/issue-*` pattern before push
- PAT has `contents:write` scope only on this repo
- `main` and other important branches are protected by branch protection rules

## Test plan

- [ ] Post `/implement` on an issue after merge — push step should succeed with a warning instead of aborting

🤖 Generated with [Claude Code](https://claude.ai/claude-code)