### PR TITLE
ci: fix implement PR creation and ai-pr-feedback runner

### DIFF
--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -331,7 +331,7 @@ jobs:
   respond:
     name: Address PR feedback via Claude Code
     needs: gate
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Use PAT (`WENDY_AI_IMPLEMENT_TOKEN`/`WENDY_TEMPLATE_SYNC_TOKEN`) for PR creation in `implement.yml` — org policy blocks `GITHUB_TOKEN` from creating PRs
- Remove edit-only file guard in `implement.yml` (was blocking legitimate new file creation like tests)
- Remove exec-pattern scan in `implement.yml` (was blocking legitimate code like wifi scanning)
- Downgrade missing `ai/**` ruleset from hard error to warning in `implement.yml`
- Add explicit guard against pushing to protected branch names (`main`, `master`, `develop`, etc.)
- Fix `ai-pr-feedback.yml` respond job stuck in queue: `ubuntu-latest-4-cores` is unavailable for this repo; changed to `ubuntu-latest` to match `implement.yml` and `agentic-ci-loop.yml`

## Test plan
- [ ] Trigger an implement workflow run on an `ai/issue-*` branch and verify PR creation succeeds
- [ ] Verify `ai-pr-feedback.yml` respond job picks up a runner (no longer stuck in queue)
- [ ] Confirm pushes to protected branches are rejected with the new guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)