### PR TITLE
ci: fix ai-pr-feedback authorization, deduplication, and pending-check handling

### DIFF
--- a/.github/workflows/agentic-ci-loop.yml
+++ b/.github/workflows/agentic-ci-loop.yml
@@ -82,8 +82,12 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
         run: |
-          CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
-            2>/dev/null || echo '{"check_runs":[]}')
+          # --paginate merges all pages; each page wraps check_runs in an object so
+          # jq --slurp collects those objects and we flatten the inner arrays.
+          CHECK_RUNS=$(gh api --paginate "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+            2>/dev/null \
+            | jq --slurp '{check_runs: [(.[].check_runs // [])[]]}' \
+            || echo '{"check_runs":[]}')
 
           FAILING=$(printf '%s' "$CHECK_RUNS" \
             | jq -r '[.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | .name] | join(",")')

--- a/.github/workflows/agentic-ci-loop.yml
+++ b/.github/workflows/agentic-ci-loop.yml
@@ -92,15 +92,18 @@ jobs:
             | jq -r '[.check_runs[] | select(.status == "in_progress" or .status == "queued") | .name] | join(",")')
 
           # Count active (non-outdated) inline bot comments; position is null when the diff moves on.
-          BOT_INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.position != null)] | length' \
-            2>/dev/null || echo "0")
+          # --paginate + jq --slurp ensures all pages are merged before counting.
+          BOT_INLINE=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/comments" \
+            2>/dev/null \
+            | jq --slurp '(add // []) | [.[] | select(.user.login == "github-actions[bot]") | select(.position != null)] | length' \
+            || echo "0")
 
           # Count bot reviews with CHANGES_REQUESTED or a non-empty COMMENTED body.
-          BOT_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]") |
+          BOT_REVIEWS=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            2>/dev/null \
+            | jq --slurp '(add // []) | [.[] | select(.user.login == "github-actions[bot]") |
                    select(.state == "CHANGES_REQUESTED" or (.state == "COMMENTED" and (.body // "") != ""))] | length' \
-            2>/dev/null || echo "0")
+            || echo "0")
 
           # Validate integers before arithmetic to avoid word-splitting on unexpected output.
           [[ "$BOT_INLINE"   =~ ^[0-9]+$ ]] || BOT_INLINE=0

--- a/.github/workflows/agentic-ci-loop.yml
+++ b/.github/workflows/agentic-ci-loop.yml
@@ -82,18 +82,35 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
         run: |
-          FAILING=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | .name] | join(",")' \
-            2>/dev/null || true)
+          CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+            2>/dev/null || echo '{"check_runs":[]}')
 
-          BOT_COMMENTS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]")] | length' \
+          FAILING=$(printf '%s' "$CHECK_RUNS" \
+            | jq -r '[.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | .name] | join(",")')
+
+          PENDING=$(printf '%s' "$CHECK_RUNS" \
+            | jq -r '[.check_runs[] | select(.status == "in_progress" or .status == "queued") | .name] | join(",")')
+
+          # Count active (non-outdated) inline bot comments; position is null when the diff moves on.
+          BOT_INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.position != null)] | length' \
             2>/dev/null || echo "0")
+
+          # Count bot reviews with CHANGES_REQUESTED or a non-empty COMMENTED body.
+          BOT_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]") |
+                   select(.state == "CHANGES_REQUESTED" or (.state == "COMMENTED" and (.body // "") != ""))] | length' \
+            2>/dev/null || echo "0")
+
+          BOT_COMMENTS=$(( BOT_INLINE + BOT_REVIEWS ))
 
           echo "failing_checks=$FAILING" >> "$GITHUB_OUTPUT"
           echo "bot_comments=$BOT_COMMENTS" >> "$GITHUB_OUTPUT"
 
-          if [ -z "$FAILING" ] && [ "$BOT_COMMENTS" = "0" ]; then
+          if [ -n "$PENDING" ]; then
+            echo "needs_work=false" >> "$GITHUB_OUTPUT"
+            echo "Checks still in progress ($PENDING) — deferring until they complete"
+          elif [ -z "$FAILING" ] && [ "$BOT_COMMENTS" = "0" ]; then
             echo "needs_work=false" >> "$GITHUB_OUTPUT"
             echo "All checks pass and no bot comments — nothing to do"
           else

--- a/.github/workflows/agentic-ci-loop.yml
+++ b/.github/workflows/agentic-ci-loop.yml
@@ -102,7 +102,15 @@ jobs:
                    select(.state == "CHANGES_REQUESTED" or (.state == "COMMENTED" and (.body // "") != ""))] | length' \
             2>/dev/null || echo "0")
 
+          # Validate integers before arithmetic to avoid word-splitting on unexpected output.
+          [[ "$BOT_INLINE"   =~ ^[0-9]+$ ]] || BOT_INLINE=0
+          [[ "$BOT_REVIEWS"  =~ ^[0-9]+$ ]] || BOT_REVIEWS=0
           BOT_COMMENTS=$(( BOT_INLINE + BOT_REVIEWS ))
+
+          # Strip newlines from check names before writing to GITHUB_OUTPUT to prevent
+          # key=value injection via crafted check names containing newline characters.
+          FAILING=$(printf '%s' "$FAILING" | tr -d '\n\r')
+          PENDING=$(printf '%s' "$PENDING" | tr -d '\n\r')
 
           echo "failing_checks=$FAILING" >> "$GITHUB_OUTPUT"
           echo "bot_comments=$BOT_COMMENTS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -90,6 +90,12 @@ on:
 # the most recent arrival, keeping the loop count bounded to one per PR.
 # For interactive triggers (review comments), the latest run always sees the full
 # accumulated feedback anyway, so cancelling a stale in-flight run is safe.
+# RISK ACCEPTANCE (adversarial cancellation): only OWNER/MEMBER actors can trigger
+# this workflow (enforced by the gate job's if: conditions and live API re-check).
+# An adversary outside the org cannot land a new event in this concurrency group,
+# so the cancellation surface is limited to trusted org members. The circuit
+# breaker (BOT_STREAK >= 3) and SHA re-verification in respond provide additional
+# protection if a member were to act maliciously.
 # DoS bound: each run is capped at timeout-minutes: 30 (respond job) and the
 # circuit breaker (BOT_STREAK >= 3) prevents unbounded AI commit chains.
 concurrency:
@@ -120,6 +126,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      administration: read  # required for rulesets API (gh api .../rulesets) in guard step
     outputs:
       pr_number:   ${{ steps.resolve.outputs.pr_number }}
       head_sha:    ${{ steps.guard.outputs.head_sha }}
@@ -320,6 +327,19 @@ jobs:
             exit 0
           fi
 
+          # Verify a server-side ruleset covers ai/** before provisioning write tokens.
+          # Checked here (gate, no AI, no write tokens) rather than in respond to limit
+          # the blast radius of the administration:read permission to this minimal job.
+          MATCHING_RULESETS=$(gh api "repos/$REPO/rulesets" \
+            --jq '[.[] | select(.enforcement == "active") | select(any((.conditions.ref_name.include // [])[]?; . == "~ALL" or startswith("refs/heads/ai/") or . == "refs/heads/**" or . == "refs/heads/*"))] | length' \
+            2>/dev/null || echo '0')
+          if [ "$MATCHING_RULESETS" = "0" ]; then
+            echo "::error::No active ruleset covers ai/** branches — server-side push restrictions not configured"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Matching active rulesets for ai/**: $MATCHING_RULESETS found"
+
           echo "proceed=true" >> "$GITHUB_OUTPUT"
 
       - name: Fail if not authorized
@@ -341,7 +361,6 @@ jobs:
       checks: read
       actions: read
       issues: write
-      administration: read
     # SECURITY NOTE — step-level secrets:
     #   ANTHROPIC_API_KEY is injected only in the "Run Claude Code" step env.
     #   WENDY_TEMPLATE_SYNC_TOKEN (PAT for git push) is scoped to the "Push changes" step.
@@ -424,7 +443,7 @@ jobs:
           # gh api --jq runs per-page and would emit multiple timestamps with --paginate.
           CONTINUE_TS=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
             | jq --slurp '
-              add |
+              (add // []) |
               [ .[]
                 | select(.body | test("(?m)^\\r?/continue(\\s|$)"))
                 | select(.author_association as $a |
@@ -441,7 +460,7 @@ jobs:
           # Reversing the array ensures we count unbroken bot commits at HEAD.
           BOT_STREAK=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits?per_page=100" \
             | jq --arg ts "$CONTINUE_TS" --slurp '
-              add |
+              (add // []) |
               [
                 reverse[] |
                 if ((.author?.login // "") == "github-actions[bot]" and
@@ -1261,19 +1280,8 @@ jobs:
             exit 1
           fi
           echo "Branch protection confirmed: main is protected"
-          # Secondary check: verify an active ruleset covers the ai/** branch pattern.
-          # Fail closed: any error or no matching ruleset aborts the push.
-          # Checks for rulesets whose include patterns contain ~ALL (all branches),
-          # refs/heads/ai/ prefix, refs/heads/**, or refs/heads/* to ensure server-side
-          # push restrictions are actually in scope for the branch we will push to.
-          MATCHING_RULESETS=$(gh api "repos/${GITHUB_REPOSITORY}/rulesets" \
-            --jq '[.[] | select(.enforcement == "active") | select(any((.conditions.ref_name.include // [])[]?; . == "~ALL" or startswith("refs/heads/ai/") or . == "refs/heads/**" or . == "refs/heads/*"))] | length' \
-            2>/dev/null || echo '0')
-          if [ "$MATCHING_RULESETS" = "0" ]; then
-            echo "::error::No active ruleset covers ai/** branches — server-side push restrictions not configured"
-            exit 1
-          fi
-          echo "Matching active rulesets for ai/**: $MATCHING_RULESETS found"
+          # Ruleset check was moved to the gate job's guard step (runs under administration:read
+          # in a job with no AI and no write tokens) to minimise the scope of that permission.
           # Move token out of named env var immediately so it is absent from the
           # shell's /proc/self/environ for the rest of this step's child processes.
           PUSH_TOKEN="$TOKEN"

--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -330,9 +330,10 @@ jobs:
           # Verify a server-side ruleset covers ai/** before provisioning write tokens.
           # Checked here (gate, no AI, no write tokens) rather than in respond to limit
           # the blast radius of the administration:read permission to this minimal job.
-          MATCHING_RULESETS=$(gh api "repos/$REPO/rulesets" \
-            --jq '[.[] | select(.enforcement == "active") | select(any((.conditions.ref_name.include // [])[]?; . == "~ALL" or startswith("refs/heads/ai/") or . == "refs/heads/**" or . == "refs/heads/*"))] | length' \
-            2>/dev/null || echo '0')
+          MATCHING_RULESETS=$(gh api --paginate "repos/$REPO/rulesets" \
+            2>/dev/null \
+            | jq --slurp '(add // []) | [.[] | select(.enforcement == "active") | select(any((.conditions.ref_name.include // [])[]?; . == "~ALL" or startswith("refs/heads/ai/") or . == "refs/heads/**" or . == "refs/heads/*"))] | length' \
+            || echo '0')
           if [ "$MATCHING_RULESETS" = "0" ]; then
             echo "::error::No active ruleset covers ai/** branches — server-side push restrictions not configured"
             echo "proceed=false" >> "$GITHUB_OUTPUT"
@@ -436,6 +437,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
         run: |
+          set -o pipefail
           # Fail-safe: if either gh api call fails, abort rather than defaulting to
           # epoch (which could incorrectly reset the circuit breaker to zero streak).
           # Timestamp of the most recent /continue comment by a maintainer (or epoch).

--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -442,7 +442,7 @@ jobs:
           # Use piped jq with --slurp so all paginated pages are merged before filtering;
           # gh api --jq runs per-page and would emit multiple timestamps with --paginate.
           CONTINUE_TS=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
-            | jq --slurp '
+            | jq -r --slurp '
               (add // []) |
               [ .[]
                 | select(.body | test("(?m)^\\r?/continue(\\s|$)"))

--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -83,16 +83,18 @@ on:
     branches:
       - 'ai/**'
 
-# CONCURRENCY: cancel-in-progress: false serializes runs per PR rather than
-# cancelling the in-flight run. A new review comment trigger queues rather than
-# cancels, so the current edit cycle completes before the next begins.
+# CONCURRENCY: cancel-in-progress: true ensures at most one run is active per PR
+# at any time. When multiple CI workflows fail on the same commit (e.g. Build,
+# Go Tests, Swift Tests all fail at once), they each trigger this workflow and
+# land in the same concurrency group — cancel-in-progress: true discards all but
+# the most recent arrival, keeping the loop count bounded to one per PR.
+# For interactive triggers (review comments), the latest run always sees the full
+# accumulated feedback anyway, so cancelling a stale in-flight run is safe.
 # DoS bound: each run is capped at timeout-minutes: 30 (respond job) and the
 # circuit breaker (BOT_STREAK >= 3) prevents unbounded AI commit chains.
-# Accepted risk: a maintainer posting many comments quickly can queue multiple
-# runs; the 30-min timeout and Anthropic rate limits constrain the blast radius.
 concurrency:
   group: ai-pr-feedback-${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # Gate job: minimal permissions, no write tokens. Performs all authorization
@@ -339,6 +341,7 @@ jobs:
       checks: read
       actions: read
       issues: write
+      administration: read
     # SECURITY NOTE — step-level secrets:
     #   ANTHROPIC_API_KEY is injected only in the "Run Claude Code" step env.
     #   WENDY_TEMPLATE_SYNC_TOKEN (PAT for git push) is scoped to the "Push changes" step.
@@ -416,9 +419,12 @@ jobs:
         run: |
           # Fail-safe: if either gh api call fails, abort rather than defaulting to
           # epoch (which could incorrectly reset the circuit breaker to zero streak).
-          # Timestamp of the most recent /continue comment by a maintainer (or epoch)
+          # Timestamp of the most recent /continue comment by a maintainer (or epoch).
+          # Use piped jq with --slurp so all paginated pages are merged before filtering;
+          # gh api --jq runs per-page and would emit multiple timestamps with --paginate.
           CONTINUE_TS=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
-            --jq '
+            | jq --slurp '
+              add |
               [ .[]
                 | select(.body | test("(?m)^\\r?/continue(\\s|$)"))
                 | select(.author_association as $a |
@@ -434,7 +440,8 @@ jobs:
           # commit, giving a wrong count if humans/bots interleave earlier in history.
           # Reversing the array ensures we count unbroken bot commits at HEAD.
           BOT_STREAK=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits?per_page=100" \
-            --jq --arg ts "$CONTINUE_TS" '
+            | jq --arg ts "$CONTINUE_TS" --slurp '
+              add |
               [
                 reverse[] |
                 if ((.author?.login // "") == "github-actions[bot]" and


### PR DESCRIPTION
## Summary

- **`administration: read` permission** added to the `respond` job — the `gh api .../rulesets` call requires this scope; without it the check always returns 0 results and aborts the push with "No active ruleset covers ai/** branches."
- **`cancel-in-progress: true`** — when multiple CI workflows fail on the same commit (Build, Go Tests, Swift Tests, etc.) they each trigger `ai-pr-feedback` into the same concurrency group. Previously they serialized and all executed; now only the most recent arrival runs, bounding active loops to one per PR. For review-comment triggers the latest run always sees the full accumulated feedback, so cancelling a stale in-flight run is safe.
- **Circuit-breaker pagination fix** — pipe `gh api --paginate` output to `jq --slurp 'add | ...'` so all pages are merged before filtering; the previous `--jq` flag ran per-page and could miss the last `/continue` timestamp or miscount the bot streak across page boundaries.
- **`agentic-ci-loop` pending-check guard** — skip iteration when any check is still `in_progress` or `queued` to avoid racing a running check; also split bot-comment count into active inline comments (`position != null`) plus substantive bot reviews, ignoring outdated inline threads that have moved off the diff.

## Test plan

- [ ] Confirm `ai-pr-feedback` push step no longer aborts with "No active ruleset" once `administration: read` is in place
- [ ] Trigger multiple CI failures on an `ai/**` branch simultaneously; verify only one `ai-pr-feedback` run executes (others cancelled)
- [ ] Verify circuit-breaker `/continue` detection works correctly on PRs with >100 comments (pagination boundary)
- [ ] Confirm `agentic-ci-loop` defers when a check is still queued/in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)