### PR TITLE
Add provider hints to device picker

### DIFF
--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -1006,6 +1006,16 @@ func externalProviderSortKey(providerKey, name string) string {
 	return ""
 }
 
+func externalProviderPickerHint(providerKey string) string {
+	switch providerKey {
+	case providers.ProviderKeyDocker:
+		return "Hint: Use Docker Desktop for local container or Compose runs when you do not need WendyOS hardware."
+	case providers.ProviderKeyLocal:
+		return "Hint: Use Local Machine for native Swift, Go, or Python apps that should run directly on this computer."
+	}
+	return ""
+}
+
 func firstNonEmpty(values ...string) string {
 	for _, value := range values {
 		if value != "" {

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1322,6 +1322,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 								OSVersion:    devices[i].OSVersion,
 								DedupKey:     devices[i].DisplayName,
 								SortKey:      externalProviderSortKey(prov.Key(), devices[i].DisplayName),
+								Hint:         externalProviderPickerHint(prov.Key()),
 								Value:        &pickerEntry{externalDevice: &devices[i], provider: prov},
 							})
 						}

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -6,11 +6,13 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -73,6 +75,45 @@ func TestLANAgentAddressesPrefersIPAddress(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("lanAgentAddresses() = %v, want %v", got, want)
+	}
+}
+
+func TestExternalProviderPickerHint(t *testing.T) {
+	tests := []struct {
+		name        string
+		providerKey string
+		want        string
+	}{
+		{
+			name:        "docker",
+			providerKey: providers.ProviderKeyDocker,
+			want:        "Docker Desktop",
+		},
+		{
+			name:        "local",
+			providerKey: providers.ProviderKeyLocal,
+			want:        "Local Machine",
+		},
+		{
+			name:        "other",
+			providerKey: "wendy-lite",
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := externalProviderPickerHint(tt.providerKey)
+			if tt.want == "" {
+				if got != "" {
+					t.Fatalf("hint = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("hint = %q, want it to mention %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -19,6 +19,7 @@ type PickerItem struct {
 	Address      string
 	AgentVersion string
 	OSVersion    string
+	Hint         string // optional footer text shown when this item is highlighted
 
 	// DedupKey is used for deduplication. If empty, Name is used.
 	// Items with the same DedupKey (case-insensitive) are merged via MergeItem.
@@ -261,7 +262,22 @@ func (m PickerModel) View() string {
 		sb.WriteString("\n" + m.viewLine(pickerScanning.Render("  Scanning for more results...")) + "\n")
 	}
 
+	if hint := m.selectedHint(); hint != "" {
+		if !m.scanning {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(m.viewLine(pickerHint.Render("  "+hint)) + "\n")
+	}
+
 	return sb.String()
+}
+
+func (m PickerModel) selectedHint() string {
+	cursor := m.table.Cursor()
+	if cursor < 0 || cursor >= len(m.items) {
+		return ""
+	}
+	return strings.TrimSpace(m.items[cursor].Hint)
 }
 
 func (m PickerModel) viewLine(line string) string {

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -279,6 +279,37 @@ func TestPickerModel_ShowsUSBInTypeColumn(t *testing.T) {
 	}
 }
 
+func TestPickerModel_ShowsSelectedHintAtBottom(t *testing.T) {
+	dockerHint := "Hint: Use Docker Desktop for local container or Compose runs when you do not need WendyOS hardware."
+	localHint := "Hint: Use Local Machine for native Swift, Go, or Python apps that should run directly on this computer."
+	m := NewPicker()
+
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "Docker Desktop", Type: "Docker Desktop", Hint: dockerHint, Value: "docker"},
+		{Name: "Local Machine", Type: "This Device", Hint: localHint, Value: "local"},
+	}})
+	pm := updated.(PickerModel)
+
+	plain := ansi.Strip(pm.View())
+	if got := lastNonEmptyLine(plain); got != dockerHint {
+		t.Fatalf("footer hint = %q, want %q", got, dockerHint)
+	}
+	if strings.Contains(plain, localHint) {
+		t.Fatalf("unexpected non-selected hint %q in view %q", localHint, plain)
+	}
+
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyDown})
+	pm = updated.(PickerModel)
+
+	plain = ansi.Strip(pm.View())
+	if got := lastNonEmptyLine(plain); got != localHint {
+		t.Fatalf("footer hint after moving cursor = %q, want %q", got, localHint)
+	}
+	if strings.Contains(plain, dockerHint) {
+		t.Fatalf("unexpected previous hint %q in view %q", dockerHint, plain)
+	}
+}
+
 func TestPickerModel_DefaultKeyShowsStar(t *testing.T) {
 	m := NewPickerWithTitle("Select a device")
 	m.DefaultKey = "alpha"
@@ -477,4 +508,12 @@ func columnWidth(cols []bubbleTable.Column, title string) int {
 		}
 	}
 	return 0
+}
+
+func lastNonEmptyLine(view string) string {
+	lines := strings.Split(strings.TrimSpace(view), "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(lines[len(lines)-1])
 }


### PR DESCRIPTION
Summary:
- Add selected-row footer hints to the shared picker
- Show Docker Desktop and Local Machine guidance in the device picker
- Cover hint rendering and provider hint mapping with tests

Tests:
- go test ./go/internal/cli/tui
- CC=/usr/bin/clang go test ./go/internal/cli/commands
- git diff --check