### PR TITLE
Add unpack progress detail lines

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -331,6 +331,13 @@ func toCreateContainerProgress(progress UnpackProgress) *agentpb.CreateContainer
 			Phase:       agentpb.CreateContainerProgress_UNPACKING,
 			TotalLayers: int32(progress.TotalLayers),
 		}
+	case "layer-start":
+		return &agentpb.CreateContainerProgress{
+			Phase:       agentpb.CreateContainerProgress_UNPACKING,
+			LayerIndex:  int32(progress.LayerIndex),
+			TotalLayers: int32(progress.TotalLayers),
+			LayerSize:   progress.LayerSize,
+		}
 	case "layer":
 		return &agentpb.CreateContainerProgress{
 			Phase:          agentpb.CreateContainerProgress_APPLYING_LAYER,

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -58,6 +58,30 @@ func TestCreateContainerProgressMappingUsesUnpackingPhaseForStart(t *testing.T) 
 	}
 }
 
+func TestCreateContainerProgressMappingUsesUnpackingPhaseForLayerStart(t *testing.T) {
+	progress := UnpackProgress{
+		Phase:       "layer-start",
+		LayerIndex:  1,
+		TotalLayers: 4,
+		LayerSize:   2048,
+	}
+
+	got := toCreateContainerProgress(progress)
+
+	if got.GetPhase() != agentpb.CreateContainerProgress_UNPACKING {
+		t.Fatalf("phase = %v; want UNPACKING", got.GetPhase())
+	}
+	if got.GetLayerIndex() != 1 {
+		t.Fatalf("layer index = %d; want 1", got.GetLayerIndex())
+	}
+	if got.GetTotalLayers() != 4 {
+		t.Fatalf("total layers = %d; want 4", got.GetTotalLayers())
+	}
+	if got.GetLayerSize() != 2048 {
+		t.Fatalf("layer size = %d; want 2048", got.GetLayerSize())
+	}
+}
+
 func TestBuildContainerBaseEnvIncludesWendyHostname(t *testing.T) {
 	old := deviceHostnameWithSuffix
 	t.Cleanup(func() { deviceHostnameWithSuffix = old })

--- a/go/internal/agent/containerd/unpack.go
+++ b/go/internal/agent/containerd/unpack.go
@@ -24,7 +24,7 @@ const unpackLeaseExpiration = 30 * time.Minute
 
 // UnpackProgress reports progress during the image unpack operation.
 type UnpackProgress struct {
-	// Phase is one of "start", "layer", "complete".
+	// Phase is one of "start", "layer-start", "layer", "complete".
 	Phase string
 	// LayerIndex is the zero-based index of the current layer being unpacked.
 	LayerIndex int
@@ -169,6 +169,15 @@ func (c *Client) UnpackImage(ctx context.Context, img containerd.Image, progress
 			)
 			parentChainID = chainID
 			continue
+		}
+
+		if progress != nil {
+			progress(UnpackProgress{
+				Phase:       "layer-start",
+				LayerIndex:  i,
+				TotalLayers: totalLayers,
+				LayerSize:   layerDesc.Size,
+			})
 		}
 
 		// Unique per-attempt active key so concurrent unpacks of the same

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -175,6 +175,58 @@ func unpackProgressTitle(progress *agentpb.CreateContainerProgress) string {
 	return title + ")"
 }
 
+func unpackProgressDetail(progress *agentpb.CreateContainerProgress) string {
+	total := progress.GetTotalLayers()
+	if total <= 0 {
+		return ""
+	}
+
+	switch progress.GetPhase() {
+	case agentpb.CreateContainerProgress_UNPACKING:
+		if progress.GetLayerSize() > 0 {
+			return fmt.Sprintf("Layer %d/%d applying%s", unpackLayerNumber(progress, total), total, unpackLayerSizeSuffix(progress))
+		}
+		return fmt.Sprintf("Unpack plan: %d %s", total, pluralize(total, "layer", "layers"))
+	case agentpb.CreateContainerProgress_APPLYING_LAYER:
+		status := "unpacked"
+		if progress.GetReusedSnapshot() {
+			status = "reused snapshot"
+		}
+		return fmt.Sprintf("Layer %d/%d %s%s", unpackLayerNumber(progress, total), total, status, unpackLayerSizeSuffix(progress))
+	default:
+		return ""
+	}
+}
+
+func unpackLayerNumber(progress *agentpb.CreateContainerProgress, total int32) int32 {
+	if total <= 0 {
+		return 0
+	}
+	index := progress.GetLayerIndex()
+	if index < 0 {
+		index = 0
+	}
+	if index >= total {
+		index = total - 1
+	}
+	return index + 1
+}
+
+func unpackLayerSizeSuffix(progress *agentpb.CreateContainerProgress) string {
+	size := progress.GetLayerSize()
+	if size <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (%s)", tui.FormatBytes(size))
+}
+
+func pluralize(n int32, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
 func unpackProgressPercent(progress *agentpb.CreateContainerProgress) float64 {
 	total := progress.GetTotalLayers()
 	if total <= 0 {
@@ -209,10 +261,12 @@ func createContainerWithProgressPlain(stream agentpb.WendyContainerService_Creat
 		switch r := resp.GetResponseType().(type) {
 		case *agentpb.CreateContainerProgressResponse_Progress:
 			switch r.Progress.GetPhase() {
-			case agentpb.CreateContainerProgress_UNPACKING:
-				cliLogln("%s", unpackProgressTitle(r.Progress))
-			case agentpb.CreateContainerProgress_APPLYING_LAYER:
-				cliLogln("%s", unpackProgressTitle(r.Progress))
+			case agentpb.CreateContainerProgress_UNPACKING, agentpb.CreateContainerProgress_APPLYING_LAYER:
+				if detail := unpackProgressDetail(r.Progress); detail != "" {
+					cliLogln("%s", detail)
+				} else {
+					cliLogln("%s", unpackProgressTitle(r.Progress))
+				}
 			case agentpb.CreateContainerProgress_CREATING_CONTAINER:
 				cliLogln("Creating container...")
 			}
@@ -296,6 +350,7 @@ func createContainerWithProgressTUI(cancel context.CancelFunc, stream agentpb.We
 					prog.Send(tui.ProgressUpdateMsg{
 						Percent: unpackProgressPercent(r.Progress),
 						Title:   unpackProgressTitle(r.Progress),
+						Detail:  unpackProgressDetail(r.Progress),
 					})
 				case agentpb.CreateContainerProgress_CREATING_CONTAINER:
 					if !progressDone {

--- a/go/internal/cli/commands/run_progress_test.go
+++ b/go/internal/cli/commands/run_progress_test.go
@@ -37,6 +37,48 @@ func TestUnpackProgressTitleAndPercentForLayerUpdates(t *testing.T) {
 	}
 }
 
+func TestUnpackProgressDetailForPlan(t *testing.T) {
+	progress := &agentpb.CreateContainerProgress{
+		Phase:       agentpb.CreateContainerProgress_UNPACKING,
+		TotalLayers: 4,
+	}
+
+	if got := unpackProgressDetail(progress); got != "Unpack plan: 4 layers" {
+		t.Fatalf("detail = %q; want unpack plan", got)
+	}
+}
+
+func TestUnpackProgressDetailForApplyingLayer(t *testing.T) {
+	progress := &agentpb.CreateContainerProgress{
+		Phase:       agentpb.CreateContainerProgress_UNPACKING,
+		LayerIndex:  1,
+		TotalLayers: 4,
+		LayerSize:   2 * 1024 * 1024,
+	}
+
+	if got := unpackProgressDetail(progress); got != "Layer 2/4 applying (2.0 MiB)" {
+		t.Fatalf("detail = %q; want applying layer detail", got)
+	}
+
+	if got := unpackProgressPercent(progress); got != 0.25 {
+		t.Fatalf("percent = %v; want 0.25", got)
+	}
+}
+
+func TestUnpackProgressDetailForReusedLayer(t *testing.T) {
+	progress := &agentpb.CreateContainerProgress{
+		Phase:          agentpb.CreateContainerProgress_APPLYING_LAYER,
+		LayerIndex:     1,
+		TotalLayers:    4,
+		LayerSize:      512,
+		ReusedSnapshot: true,
+	}
+
+	if got := unpackProgressDetail(progress); got != "Layer 2/4 reused snapshot (512 B)" {
+		t.Fatalf("detail = %q; want reused layer detail", got)
+	}
+}
+
 func TestProgressModelUserCancelled(t *testing.T) {
 	model, _ := tui.NewProgress("Unpacking...").Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	if !progressModelUserCancelled(model) {

--- a/go/internal/cli/tui/progress.go
+++ b/go/internal/cli/tui/progress.go
@@ -3,10 +3,13 @@ package tui
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/progress"
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+const maxProgressDetailLines = 4
 
 // ProgressUpdateMsg updates the progress bar percentage.
 // Written and Total are optional; when both are non-zero the view renders
@@ -16,6 +19,7 @@ type ProgressUpdateMsg struct {
 	Written int64
 	Total   int64
 	Title   string
+	Detail  string
 }
 
 // ProgressDoneMsg signals that the progress operation is complete.
@@ -27,6 +31,7 @@ type ProgressDoneMsg struct {
 type ProgressModel struct {
 	progress progress.Model
 	title    string
+	details  []string
 	percent  float64
 	written  int64
 	total    int64
@@ -76,6 +81,9 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Title != "" {
 			m.title = msg.Title
 		}
+		if msg.Detail != "" {
+			m.details = appendProgressDetail(m.details, msg.Detail)
+		}
 		cmd := m.progress.SetPercent(msg.Percent)
 		return m, cmd
 
@@ -98,8 +106,9 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m ProgressModel) View() string {
 	byteInfo := ""
 	if m.written > 0 && m.total > 0 {
-		byteInfo = fmt.Sprintf("  (%s / %s)", formatBytes(m.written), formatBytes(m.total))
+		byteInfo = fmt.Sprintf("  (%s / %s)", FormatBytes(m.written), FormatBytes(m.total))
 	}
+	details := m.detailView()
 
 	if m.done && m.err != nil {
 		if !m.showErr {
@@ -107,7 +116,7 @@ func (m ProgressModel) View() string {
 			if percent >= 1.0 {
 				percent = 0.99
 			}
-			return fmt.Sprintf("%s (failed)\n%s%s\n", m.title, m.progress.ViewAs(percent), byteInfo)
+			return fmt.Sprintf("%s (failed)\n%s%s%s\n", m.title, details, m.progress.ViewAs(percent), byteInfo)
 		}
 		return fmt.Sprintf("Error: %v\n", m.err)
 	}
@@ -116,14 +125,33 @@ func (m ProgressModel) View() string {
 		// Render at 100% directly — the animation may not have caught up
 		// before tea.Quit was processed.
 		if m.total > 0 {
-			byteInfo = fmt.Sprintf("  (%s / %s)", formatBytes(m.total), formatBytes(m.total))
+			byteInfo = fmt.Sprintf("  (%s / %s)", FormatBytes(m.total), FormatBytes(m.total))
 		}
-		return fmt.Sprintf("%s\n%s%s\n", m.title, m.progress.ViewAs(1.0), byteInfo)
+		return fmt.Sprintf("%s\n%s%s%s\n", m.title, details, m.progress.ViewAs(1.0), byteInfo)
 	}
-	return fmt.Sprintf("%s\n%s%s\n", m.title, m.progress.ViewAs(m.percent), byteInfo)
+	return fmt.Sprintf("%s\n%s%s%s\n", m.title, details, m.progress.ViewAs(m.percent), byteInfo)
 }
 
-func formatBytes(b int64) string {
+func appendProgressDetail(details []string, detail string) []string {
+	if len(details) > 0 && details[len(details)-1] == detail {
+		return details
+	}
+	details = append(details, detail)
+	if len(details) > maxProgressDetailLines {
+		details = details[len(details)-maxProgressDetailLines:]
+	}
+	return details
+}
+
+func (m ProgressModel) detailView() string {
+	if len(m.details) == 0 {
+		return ""
+	}
+	return strings.Join(m.details, "\n") + "\n"
+}
+
+// FormatBytes formats a byte count using binary units for progress displays.
+func FormatBytes(b int64) string {
 	const (
 		kib = 1024
 		mib = 1024 * kib

--- a/go/internal/cli/tui/spinner_test.go
+++ b/go/internal/cli/tui/spinner_test.go
@@ -257,6 +257,54 @@ func TestProgressModel_ViewByteCounter(t *testing.T) {
 	}
 }
 
+func TestProgressModel_ViewDetailsAboveProgressBar(t *testing.T) {
+	p := NewProgress("Unpacking...")
+
+	model, _ := p.Update(ProgressUpdateMsg{
+		Percent: 0.5,
+		Detail:  "Layer 1/2 unpacked (1.0 MiB)",
+	})
+	p = model.(ProgressModel)
+	model, _ = p.Update(ProgressUpdateMsg{
+		Percent: 0.5,
+		Detail:  "Layer 2/2 applying (2.0 MiB)",
+	})
+	updated := model.(ProgressModel)
+
+	view := updated.View()
+	firstDetail := strings.Index(view, "Layer 1/2 unpacked")
+	secondDetail := strings.Index(view, "Layer 2/2 applying")
+	percent := strings.Index(view, "50.00%")
+	if firstDetail == -1 || secondDetail == -1 {
+		t.Fatalf("view missing progress detail lines: %q", view)
+	}
+	if !(firstDetail < secondDetail && secondDetail < percent) {
+		t.Fatalf("details should render above progress bar; got view: %q", view)
+	}
+}
+
+func TestProgressModel_ViewDetailsAreRolling(t *testing.T) {
+	p := NewProgress("Unpacking...")
+
+	for i := 1; i <= maxProgressDetailLines+2; i++ {
+		model, _ := p.Update(ProgressUpdateMsg{
+			Percent: 0.5,
+			Detail:  fmt.Sprintf("detail %d", i),
+		})
+		p = model.(ProgressModel)
+	}
+
+	view := p.View()
+	if strings.Contains(view, "detail 1") || strings.Contains(view, "detail 2") {
+		t.Fatalf("view should omit old details after rolling limit, got: %q", view)
+	}
+	for i := 3; i <= maxProgressDetailLines+2; i++ {
+		if !strings.Contains(view, fmt.Sprintf("detail %d", i)) {
+			t.Fatalf("view should keep recent detail %d, got: %q", i, view)
+		}
+	}
+}
+
 func TestProgressModel_ViewNoByteCounterWhenZero(t *testing.T) {
 	p := NewProgress("Flashing...")
 
@@ -314,7 +362,7 @@ func TestFormatBytes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := formatBytes(tt.input)
+		got := FormatBytes(tt.input)
 		if got != tt.want {
 			t.Errorf("formatBytes(%d) = %q; want %q", tt.input, got, tt.want)
 		}


### PR DESCRIPTION
## Summary
- add rolling detail lines above the shared CLI progress bar
- show unpack plan, per-layer applying/unpacked/reused snapshot details, and layer sizes during `wendy run`
- emit a pre-apply unpack progress event from the agent using the existing progress stream fields

## Validation
- `go test ./internal/cli/tui ./internal/cli/commands ./internal/agent/containerd ./internal/agent/services`
- `go build ./cmd/wendy ./cmd/wendy-agent`
- `git diff --check`