### PR TITLE
Clarify Local Machine provider runtime behavior

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
@@ -18,3 +18,45 @@ mDNS and BLE discover nearby [WendyOS](../../wendyos/), [Wendy-Agent](../../wend
 
 > **TODO (test)**: If the target device is outdated, and `--json` is not specified, a warning will be printed to indicate an update is available.
 > If the terminal is interactive, a prompt will be made to update the device right now.
+
+## Local Targets
+
+The picker can also show local provider targets when the host supports them.
+These are not WendyOS devices.
+
+### Docker Desktop
+
+Use Docker Desktop for local container runs. Dockerfile and Compose projects run
+through the local Docker daemon. On macOS and Windows, Docker Desktop runs Linux
+containers inside Docker's Linux environment rather than as native macOS or
+Windows processes.
+
+Use this target when you want to test container build and runtime behavior
+without deploying to WendyOS hardware. Hardware-specific WendyOS behavior, device
+entitlements, and target filesystem assumptions still need a real WendyOS target.
+
+You can select it directly with:
+
+```sh
+wendy run --device docker
+```
+
+### Local Machine
+
+Use Local Machine for host-native apps. The app runs directly on the computer
+that is running the `wendy` CLI:
+
+- On macOS, it runs as a macOS process.
+- On Windows, it runs as a Windows process.
+- On Linux, it runs as a Linux process.
+
+Local Machine is intended for native Swift, Go, and Python projects. It does not
+run inside Docker's Linux environment, does not emulate WendyOS, and does not
+provide WendyOS container semantics, hardware entitlements, or device filesystem
+layout.
+
+You can select it directly with:
+
+```sh
+wendy run --device local
+```

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -88,12 +88,16 @@ func newBuildCmd() *cobra.Command {
 					}
 				}
 
+				projectType, ptErr := resolveRunProjectType(cwd, opts.buildType)
+				if ptErr != nil {
+					return ptErr
+				}
+				if err := ensureProviderSupportsProjectType(target.Provider, projectType, cwd); err != nil {
+					return err
+				}
+
 				// Swift projects without a Dockerfile: cross-compile on the host and
 				// build a Docker image, bypassing the provider's normal Build method.
-				projectType, ptErr := detectProjectType(cwd)
-				if ptErr != nil {
-					cliLogln("Warning: could not detect project type: %v", ptErr)
-				}
 				if projectType == "swift" {
 					if _, ok := target.Provider.(providers.ImageBuilder); ok {
 						if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
@@ -403,6 +407,40 @@ func filterBuildOptions(options []BuildOption, provider providers.DeviceProvider
 		}
 	}
 	return filtered
+}
+
+func ensureProviderSupportsProjectType(provider providers.DeviceProvider, projectType, projectPath string) error {
+	if projectType == "unknown" && provider.CanBuild(projectPath) {
+		return nil
+	}
+	if providerSupportsProjectType(provider, projectType) {
+		return nil
+	}
+
+	providerName := provider.DisplayName()
+	if provider.Key() == providers.ProviderKeyLocal {
+		providerName = "Local Machine"
+	}
+
+	if provider.Key() == providers.ProviderKeyLocal && (projectType == "docker" || projectType == "compose") {
+		return fmt.Errorf("%s runs host-native apps and does not support %s projects; choose Docker Desktop with --device docker for local container runs", providerName, projectType)
+	}
+
+	return fmt.Errorf("%s provider does not support %s projects; supported build types: %s", providerName, projectType, strings.Join(provider.SupportedBuildTypes(), ", "))
+}
+
+func providerSupportsProjectType(provider providers.DeviceProvider, projectType string) bool {
+	if projectType == "swift" {
+		if _, ok := provider.(providers.ImageBuilder); ok {
+			return true
+		}
+	}
+	for _, supported := range provider.SupportedBuildTypes() {
+		if supported == projectType {
+			return true
+		}
+	}
+	return false
 }
 
 // detectProjectTypeWithLanguage determines the project type using the wendy.json

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
 )
 
 func mustDetectProjectType(t *testing.T, dir string) string {
@@ -487,6 +488,59 @@ func TestResolveDetectedBuildOption_DockerfileFlagNotFound(t *testing.T) {
 	_, err := resolveDetectedBuildOption(options, "", "Dockerfile.missing")
 	if err == nil {
 		t.Fatal("expected error for missing dockerfile")
+	}
+}
+
+func TestFilterBuildOptions_LocalProviderKeepsNativeOnly(t *testing.T) {
+	options := []BuildOption{
+		{Label: "compose.yml (Compose)", Type: "compose", File: "compose.yml"},
+		{Label: "Dockerfile", Type: "docker", File: "Dockerfile"},
+		{Label: "Package.swift (Swift)", Type: "swift", File: "Package.swift"},
+		{Label: "requirements.txt (Python)", Type: "python", File: "requirements.txt"},
+	}
+
+	got := filterBuildOptions(options, &providers.LocalProvider{})
+	if len(got) != 2 {
+		t.Fatalf("filtered options = %+v, want swift and python only", got)
+	}
+	for _, option := range got {
+		if option.Type != "swift" && option.Type != "python" {
+			t.Fatalf("filtered options include %q, want only swift/python: %+v", option.Type, got)
+		}
+	}
+}
+
+func TestEnsureProviderSupportsProjectType_LocalRejectsContainerProjects(t *testing.T) {
+	for _, projectType := range []string{"docker", "compose"} {
+		t.Run(projectType, func(t *testing.T) {
+			err := ensureProviderSupportsProjectType(&providers.LocalProvider{}, projectType, t.TempDir())
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			msg := err.Error()
+			for _, want := range []string{"Local Machine", "host-native", "Docker Desktop", "--device docker"} {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("error = %q, want substring %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureProviderSupportsProjectType_DockerProviderAllowsSwiftImageBuilder(t *testing.T) {
+	if err := ensureProviderSupportsProjectType(&providers.DockerProvider{}, "swift", t.TempDir()); err != nil {
+		t.Fatalf("DockerProvider should support swift via ImageBuilder: %v", err)
+	}
+}
+
+func TestEnsureProviderSupportsProjectType_LocalAllowsUnknownGoProject(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/app\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureProviderSupportsProjectType(&providers.LocalProvider{}, "unknown", dir); err != nil {
+		t.Fatalf("LocalProvider should allow unknown project types it can build directly: %v", err)
 	}
 }
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -979,6 +979,9 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 	if err != nil {
 		return err
 	}
+	if err := ensureProviderSupportsProjectType(p, projectType, projectPath); err != nil {
+		return err
+	}
 
 	// Resolve Swift product name from Package.swift.
 	if projectType == "swift" {

--- a/go/internal/cli/providers/local.go
+++ b/go/internal/cli/providers/local.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 )
@@ -18,8 +17,6 @@ type localBuildContext struct {
 	BinaryPath string
 	cmd        *exec.Cmd
 }
-
-var _ DockerfileBuilder = (*LocalProvider)(nil)
 
 // LocalProvider builds and runs applications on the local machine.
 type LocalProvider struct{}
@@ -45,11 +42,11 @@ func (p *LocalProvider) DiscoverDevices(_ context.Context) ([]models.ExternalDev
 }
 
 func (p *LocalProvider) SupportedBuildTypes() []string {
-	return []string{"docker", "swift", "go", "python"}
+	return []string{"swift", "go", "python"}
 }
 
 func (p *LocalProvider) CanBuild(projectPath string) bool {
-	for _, marker := range []string{"Dockerfile", "Package.swift", "go.mod", "requirements.txt", "pyproject.toml", "setup.py"} {
+	for _, marker := range []string{"Package.swift", "go.mod", "requirements.txt", "pyproject.toml", "setup.py"} {
 		if _, err := os.Stat(filepath.Join(projectPath, marker)); err == nil {
 			return true
 		}
@@ -59,9 +56,6 @@ func (p *LocalProvider) CanBuild(projectPath string) bool {
 
 func (p *LocalProvider) Build(ctx context.Context, device models.ExternalDevice, projectPath, product string, debug bool) (*BuiltApp, error) {
 	// Determine build strategy based on project markers.
-	if _, err := os.Stat(filepath.Join(projectPath, "Dockerfile")); err == nil {
-		return p.buildDocker(ctx, projectPath, product, "", debug)
-	}
 	if _, err := os.Stat(filepath.Join(projectPath, "Package.swift")); err == nil {
 		return p.buildSwift(ctx, device, projectPath, product, debug)
 	}
@@ -75,32 +69,6 @@ func (p *LocalProvider) Build(ctx context.Context, device models.ExternalDevice,
 		}
 	}
 	return nil, fmt.Errorf("local provider: cannot determine build method for %s", projectPath)
-}
-
-func (p *LocalProvider) BuildWithDockerfile(ctx context.Context, device models.ExternalDevice, projectPath, product, buildType, dockerfile string, debug bool) (*BuiltApp, error) {
-	return p.buildDocker(ctx, projectPath, product, dockerfile, debug)
-}
-
-func (p *LocalProvider) buildDocker(ctx context.Context, projectPath, product, dockerfile string, debug bool) (*BuiltApp, error) {
-	imageName := strings.ToLower(product) + ":latest"
-	args := []string{"build", "-t", imageName}
-	if dockerfile != "" {
-		args = append(args, "-f", filepath.Join(projectPath, dockerfile))
-	}
-	args = append(args, ".")
-	cmd := exec.CommandContext(ctx, "docker", args...)
-	cmd.Dir = projectPath
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("docker build: %w", err)
-	}
-	return &BuiltApp{
-		ProviderKey: p.Key(),
-		Device:      models.ExternalDevice{ID: "local", ProviderKey: p.Key()},
-		AppName:     product,
-		Context:     &localBuildContext{BinaryPath: imageName},
-	}, nil
 }
 
 func (p *LocalProvider) buildSwift(ctx context.Context, device models.ExternalDevice, projectPath, product string, debug bool) (*BuiltApp, error) {
@@ -175,7 +143,6 @@ func (p *LocalProvider) Run(ctx context.Context, app *BuiltApp, detach bool, out
 		return fmt.Errorf("local provider: invalid build context")
 	}
 
-	// If built via docker, delegate to docker run.
 	if _, err := os.Stat(bc.BinaryPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("local provider: cannot stat binary: %w", err)
 	}

--- a/go/internal/cli/providers/local_test.go
+++ b/go/internal/cli/providers/local_test.go
@@ -1,0 +1,47 @@
+package providers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+func TestLocalProviderSupportsOnlyNativeBuildTypes(t *testing.T) {
+	p := &LocalProvider{}
+
+	for _, unsupported := range []string{"docker", "compose"} {
+		if slices.Contains(p.SupportedBuildTypes(), unsupported) {
+			t.Fatalf("LocalProvider supports %q, want only host-native build types", unsupported)
+		}
+	}
+	for _, supported := range []string{"swift", "go", "python"} {
+		if !slices.Contains(p.SupportedBuildTypes(), supported) {
+			t.Fatalf("LocalProvider does not support %q", supported)
+		}
+	}
+}
+
+func TestLocalProviderDoesNotClaimDockerfileProjects(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &LocalProvider{}
+	if p.CanBuild(dir) {
+		t.Fatal("LocalProvider.CanBuild() = true for Dockerfile-only project, want false")
+	}
+
+	_, err := p.Build(context.Background(), models.ExternalDevice{ID: "local", ProviderKey: p.Key()}, dir, "app", false)
+	if err == nil {
+		t.Fatal("LocalProvider.Build() succeeded for Dockerfile-only project, want error")
+	}
+	if !strings.Contains(err.Error(), "cannot determine build method") {
+		t.Fatalf("LocalProvider.Build() error = %q, want cannot determine build method", err)
+	}
+}


### PR DESCRIPTION
Summary:
- Remove Dockerfile/Docker build support from LocalProvider so Local Machine remains host-native
- Add provider/project-type compatibility checks for wendy build/run with clearer Docker Desktop guidance
- Document Docker Desktop vs Local Machine in CLI device selection docs

Linear: WDY-1267

Tests:
- CC=/usr/bin/clang go test ./go/internal/cli/providers
- CC=/usr/bin/clang go test ./go/internal/cli/commands
- git diff --check