### PR TITLE
ci: remove workflow_run branches filter (broken for pull_request triggers)

### DIFF
--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -77,11 +77,9 @@ on:
       - Docs Review
       - Integration Test Review
     types: [completed]
-    # Scope to ai/* branches only: narrows the confused-deputy surface by ensuring
-    # this workflow only fires when CI ran on an AI-managed branch, not on arbitrary
-    # branches that happen to trigger the listed workflows.
-    branches:
-      - 'ai/**'
+    # branches filter removed: it only works for push-triggered upstream workflows,
+    # not pull_request-triggered ones, so it silently prevented the loop from firing.
+    # The guard step's head-branch check (^ai/[a-z0-9]) provides the same scoping.
 
 # CONCURRENCY: cancel-in-progress: true ensures at most one run is active per PR
 # at any time. When multiple CI workflows fail on the same commit (e.g. Build,

--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -77,9 +77,6 @@ on:
       - Docs Review
       - Integration Test Review
     types: [completed]
-    # branches filter removed: it only works for push-triggered upstream workflows,
-    # not pull_request-triggered ones, so it silently prevented the loop from firing.
-    # The guard step's head-branch check (^ai/[a-z0-9]) provides the same scoping.
 
 # CONCURRENCY: cancel-in-progress: true ensures at most one run is active per PR
 # at any time. When multiple CI workflows fail on the same commit (e.g. Build,


### PR DESCRIPTION
## Summary

- The `branches: ['ai/**']` filter on the `workflow_run` trigger only works when the upstream workflow was triggered by a `push` event
- When CI runs via `pull_request` (the common case for PRs), GitHub ignores the filter and the `workflow_run` event never fires
- This silently prevented the AI PR Feedback Loop from running for all PR #817 CI failures
- Removed the filter — the guard step's `^ai/[a-z0-9]` head-branch check already provides the same scoping

## Test plan

- [ ] Merge to main
- [ ] Re-run Go Tests on PR #817 — `AI PR Feedback Loop` should now be triggered via `workflow_run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)