### PR TITLE
ci: guard GITHUB_TOKEN mask against empty string

### DIFF
--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -879,7 +879,7 @@ jobs:
         # (SYSTEM_PROMPT_FILE) read inside the bash subshell — not as an env var
         # value in the env -i invocation, so absent from /proc/<parent-pid>/environ.
         run: |
-          echo "::add-mask::$GITHUB_TOKEN"
+          [ -n "$GITHUB_TOKEN" ] && echo "::add-mask::$GITHUB_TOKEN" || true
           # Read prompts into shell vars, then delete the files so Claude's Read
           # tool cannot access them (or any other sensitive RUNNER_TEMP content)
           SYSTEM_PROMPT=$(cat "$RUNNER_TEMP/system-prompt.txt")


### PR DESCRIPTION
## Summary

Newer runner versions fail the step when `::add-mask::` receives an empty value. `GITHUB_TOKEN` is already masked in the `Mask long-lived PAT secret` step — this redundant re-mask in `Run Claude Code` just needs a guard so it's skipped when empty rather than crashing the step.

## Test plan

- [ ] Trigger the AI PR Feedback Loop via `/iterate` comment — `Run Claude Code` step should proceed past the mask line

🤖 Generated with [Claude Code](https://claude.com/claude-code)