### PR TITLE
ci: pipe user prompt to claude via stdin instead of positional arg

### DIFF
--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -912,7 +912,8 @@ jobs:
           install -m 600 /dev/null "$RUNNER_TEMP/claude-stderr.txt"
           # Only file PATHS are passed via env -i — no secret values in cmdline or
           # parent-process environ. The bash subshell reads each value from its file,
-          # shreds the file, then exec-replaces itself with claude.
+          # shreds the file, then pipes the prompt to claude via stdin (more secure
+          # than a positional arg, which would appear in /proc/<pid>/cmdline).
           CLAUDE_EXIT=0
           env -i HOME="$HOME" PATH="$PATH" \
             ANTHROPIC_KEY_FILE="$RUNNER_TEMP/anthropic-key.txt" \
@@ -928,10 +929,9 @@ jobs:
               _user_prompt=$(< "$USER_PROMPT_FILE")
               shred -u "$USER_PROMPT_FILE" 2>/dev/null || rm -f "$USER_PROMPT_FILE"
               unset USER_PROMPT_FILE
-              exec claude --print \
+              printf "%s" "$_user_prompt" | claude --print \
                 --allowedTools "Edit,MultiEdit" \
-                --disallowedTools "Bash,Read,Write,WebFetch,WebSearch,computer_use,LS,Glob,ListFiles,SearchFiles,ReadFile,TodoWrite,TodoRead,Agent,AskFollowupQuestion,mcp__*" \
-                "$_user_prompt"
+                --disallowedTools "Bash,Read,Write,WebFetch,WebSearch,computer_use,LS,Glob,ListFiles,SearchFiles,ReadFile,TodoWrite,TodoRead,Agent,AskFollowupQuestion,mcp__*"
             ' \
             > "$RUNNER_TEMP/claude-output.txt" \
             2> "$RUNNER_TEMP/claude-stderr.txt" || CLAUDE_EXIT=$?


### PR DESCRIPTION
## Summary

`claude --print` expects the prompt via stdin but it was being passed as a positional argument (`exec claude --print ... "$_user_prompt"`), which the CLI ignores. The error (surfaced by the previous fix in #833) was:

> Input must be provided either through stdin or as a prompt argument when using --print

Switch to `printf "%s" "$_user_prompt" | claude --print ...` — stdin is the correct delivery path and is also more secure since the prompt content no longer appears in `/proc/<pid>/cmdline`.

## Test plan

- [ ] Trigger the ai-pr-feedback workflow on a PR with `/implement` — claude should receive the prompt and process the feedback
- [ ] Verify a successful run commits and pushes changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)