### PR TITLE
Add multi-app deployment guide for Docker Compose

### DIFF
--- a/go/internal/cli/assets/docs/apps/compose.md
+++ b/go/internal/cli/assets/docs/apps/compose.md
@@ -74,7 +74,7 @@ Wendy honours the following compose fields. Fields not listed here are ignored.
 | `ports` | Port mappings (`host:container`). Adds a `network` entitlement when present. |
 | `network_mode: host` | Adds a `host` network entitlement. |
 | `volumes` | Named volumes are created as `persist` entitlements. Host bind mounts (paths starting with `.` or `/`) are silently skipped. |
-| `depends_on` | Dependency order: list or condition-map form. Services are created in dependency order; detached starts follow the same order. |
+| `depends_on` | Dependency order: list or condition-map form. Services are created in dependency order; detached starts follow the same order, but health checks and readiness conditions are not evaluated. |
 | `restart` | Restart policy: `no`, `on-failure`, `always`, `unless-stopped`. Overridden by CLI flags if specified. |
 
 ## Networking
@@ -123,5 +123,7 @@ All `wendy run` flags work with compose projects:
 ## Limitations
 
 - The `environment:` values are not forwarded to the container at runtime yet — set environment variables in the Dockerfile or via entrypoint scripts as a workaround.
+- Wendy-specific hardware access entitlements such as `gpu`, `camera`, `audio`, `bluetooth`, `usb`, `i2c`, `gpio`, `spi`, and `input` are not inferred from compose fields.
+- Host networking does not imply shared IPC or shared `/dev/shm`; ROS 2 shared-memory transport requires an app shape that can explicitly share namespaces.
 - Linux containers on macOS require a target WendyOS device; local Docker Desktop compose is used as a fallback when no device is targeted.
 - Compose `extends`, `profiles`, and `secrets` are not supported.

--- a/go/internal/cli/assets/docs/apps/compose.md
+++ b/go/internal/cli/assets/docs/apps/compose.md
@@ -124,6 +124,7 @@ All `wendy run` flags work with compose projects:
 
 - The `environment:` values are not forwarded to the container at runtime yet — set environment variables in the Dockerfile or via entrypoint scripts as a workaround.
 - Wendy-specific hardware access entitlements such as `gpu`, `camera`, `audio`, `bluetooth`, `usb`, `i2c`, `gpio`, `spi`, and `input` are not inferred from compose fields.
+- Service-specific lifecycle behavior is not supported yet: Compose services cannot declare Wendy readiness probes or `postStart` hooks, and top-level `wendy.json` hooks do not apply to generated Compose service apps.
 - Host networking does not imply shared IPC or shared `/dev/shm`; ROS 2 shared-memory transport requires an app shape that can explicitly share namespaces.
 - Linux containers on macOS require a target WendyOS device; local Docker Desktop compose is used as a fallback when no device is targeted.
 - Compose `extends`, `profiles`, and `secrets` are not supported.

--- a/go/internal/cli/assets/docs/apps/compose.md
+++ b/go/internal/cli/assets/docs/apps/compose.md
@@ -67,14 +67,14 @@ Wendy honours the following compose fields. Fields not listed here are ignored.
 
 | Field | Description |
 |-------|-------------|
-| `build` | Build context: a path string or a `{ context, dockerfile, args }` mapping. Services without `build` use a pre-built image via `image`. |
+| `build` | Build context: a path string or a `{ context, dockerfile, args }` mapping. Custom Dockerfile paths must resolve inside the build context. Services without `build` use a pre-built image via `image`. |
 | `image` | Pre-built image to pull and run on the device (e.g. `redis:7-alpine`). Public image names are normalised to their fully-qualified form automatically. |
 | `command` | Override the container's default command. Accepts a string (shell-split) or a YAML sequence. |
-| `environment` | Environment variables: key-value map or list of `KEY=VALUE` strings. Bare `KEY` entries inherit from the CLI environment. |
+| `environment` | Parsed from key-value maps or `KEY=VALUE` lists, but not forwarded to device containers yet. |
 | `ports` | Port mappings (`host:container`). Adds a `network` entitlement when present. |
 | `network_mode: host` | Adds a `host` network entitlement. |
 | `volumes` | Named volumes are created as `persist` entitlements. Host bind mounts (paths starting with `.` or `/`) are silently skipped. |
-| `depends_on` | Start order: list or condition-map form. Services start in dependency order. |
+| `depends_on` | Dependency order: list or condition-map form. Services are created in dependency order; detached starts follow the same order. |
 | `restart` | Restart policy: `no`, `on-failure`, `always`, `unless-stopped`. Overridden by CLI flags if specified. |
 
 ## Networking
@@ -122,7 +122,6 @@ All `wendy run` flags work with compose projects:
 
 ## Limitations
 
-- Custom Dockerfile paths (`dockerfile: path/to/Dockerfile`) are not yet supported. Rename the file to `Dockerfile` in its context directory.
 - The `environment:` values are not forwarded to the container at runtime yet — set environment variables in the Dockerfile or via entrypoint scripts as a workaround.
 - Linux containers on macOS require a target WendyOS device; local Docker Desktop compose is used as a fallback when no device is targeted.
 - Compose `extends`, `profiles`, and `secrets` are not supported.

--- a/go/internal/cli/assets/docs/guides/meta.json
+++ b/go/internal/cli/assets/docs/guides/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Guides & Tutorials",
   "description": "Learn how to build with Wendy through practical examples",
-  "pages": ["python", "swift", "cpp", "rust", "typescript", "device", "llm-integration"]
+  "pages": ["python", "swift", "cpp", "rust", "typescript", "device", "multi-app-deployments", "llm-integration"]
 }

--- a/go/internal/cli/assets/docs/guides/multi-app-deployments.mdx
+++ b/go/internal/cli/assets/docs/guides/multi-app-deployments.mdx
@@ -1,0 +1,191 @@
+---
+title: Multi-App Deployments with Docker Compose
+description: Run ROS 2-style multi-container stacks on WendyOS with docker-compose.yml and wendy run
+---
+
+## Run a ROS 2-style stack as one deployment
+
+Use `docker-compose.yml` when your project is naturally split into cooperating containers. This is common for ROS 2 systems: one service can publish sensor data, another can run planning or inference, and a third can expose a dashboard or bridge.
+
+Wendy treats the compose file as the deployment plan. You do not need a `wendy.json` for the project root.
+
+### Prerequisites
+
+- Wendy CLI installed on your development machine
+- A WendyOS device reachable over USB, LAN, or Wendy Cloud
+- Docker installed locally so Wendy can build service images
+- A project directory that contains `docker-compose.yml`, `docker-compose.yaml`, `compose.yml`, or `compose.yaml`
+
+## How Wendy runs compose projects
+
+When you run `wendy run` in a directory with a compose file, Wendy uses the compose path before the single-Dockerfile path. You can also make this explicit:
+
+```bash
+wendy run --build-type compose
+```
+
+For a WendyOS device target, Wendy:
+
+1. Reads the compose file from the project root.
+2. Builds each service that has a `build:` directive for the target device platform.
+3. Pushes built images to the device's embedded registry.
+4. Uses declared `image:` references directly for services without `build:`.
+5. Generates one device app per service, named `<project-folder>-<service>`.
+6. Creates service containers in `depends_on` order.
+7. Starts all services and streams logs with a `[service]` prefix.
+
+<Callout type="info">
+For ROS 2, set `network_mode: host` on every service that needs DDS discovery, multicast, or direct host-network communication. Wendy converts that field into a host-network entitlement for the generated service app.
+</Callout>
+
+Wendy maps a focused subset of Compose into device runtime configuration:
+
+| Compose field | Wendy behavior |
+| --- | --- |
+| `build` | Builds a service image. Supports `build: ./path` and `{ context, dockerfile, args }`. |
+| `image` | Uses a prebuilt image. Short public image names are normalized before the device pulls them. |
+| `command` | Overrides the container command. Use YAML sequence form for shell scripts or ROS launch commands. |
+| `ports` | Adds a network entitlement with explicit port mappings. |
+| `network_mode: host` | Adds a host-network entitlement. Recommended for ROS 2 service discovery. |
+| `volumes` | Converts named volumes into persistent storage entitlements. Host bind mounts are skipped on device. |
+| `depends_on` | Creates dependencies before dependents. Detached starts follow the same order. Both list and map forms are accepted. |
+| `restart` | Applies `no`, `on-failure`, `always`, or `unless-stopped` unless a CLI restart flag overrides it. |
+
+<Callout type="warning">
+`environment:` entries are parsed from the compose file but are not forwarded to device containers yet. Put required ROS variables in the Dockerfile with `ENV`, bake them into an entrypoint script, or pass them through the service command.
+</Callout>
+
+## Example ROS 2 layout
+
+Start with one folder per service and keep the compose file at the project root:
+
+```text
+ros2-stack/
+  docker-compose.yml
+  talker/
+    Dockerfile
+  listener/
+    Dockerfile
+```
+
+Both example services can use the same Dockerfile shape:
+
+```dockerfile
+ARG ROS_DISTRO=jazzy
+FROM ros:${ROS_DISTRO}-ros-base
+
+ARG ROS_DISTRO=jazzy
+ENV ROS_DISTRO=${ROS_DISTRO}
+ENV ROS_DOMAIN_ID=42
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ros-${ROS_DISTRO}-demo-nodes-cpp \
+        ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+The compose file defines two ROS 2 nodes. The listener starts after the talker, and both services share the host network so DDS discovery works across containers:
+
+```yaml
+services:
+  talker:
+    build:
+      context: ./talker
+      args:
+        ROS_DISTRO: jazzy
+    network_mode: host
+    restart: unless-stopped
+    command:
+      - bash
+      - -lc
+      - |
+        source /opt/ros/${ROS_DISTRO}/setup.bash
+        ros2 run demo_nodes_cpp talker
+
+  listener:
+    build:
+      context: ./listener
+      args:
+        ROS_DISTRO: jazzy
+    network_mode: host
+    depends_on:
+      - talker
+    restart: unless-stopped
+    command:
+      - bash
+      - -lc
+      - |
+        source /opt/ros/${ROS_DISTRO}/setup.bash
+        ros2 run demo_nodes_cpp listener
+```
+
+Run the stack from the project root:
+
+```bash
+cd ros2-stack
+wendy run --build-type compose
+```
+
+Attached mode streams logs from all services:
+
+```text
+[talker]    Publishing: 'Hello World: 1'
+[listener]  I heard: [Hello World: 1]
+```
+
+Press **Ctrl-C** to stop the stack. Wendy stops services in reverse dependency order.
+
+## Add persistent data
+
+Use named volumes for data that should survive redeployments. This is useful for ROS bags, calibration files, and generated maps.
+
+```yaml
+services:
+  recorder:
+    build: ./recorder
+    network_mode: host
+    volumes:
+      - ros-bags:/bags
+    command:
+      - bash
+      - -lc
+      - |
+        source /opt/ros/${ROS_DISTRO}/setup.bash
+        ros2 bag record -o /bags/session /camera/image_raw
+
+volumes:
+  ros-bags:
+```
+
+Avoid host bind mounts such as `./bags:/bags` for device deployments. Wendy skips bind mounts because local development-machine paths do not exist on the device.
+
+## Run in the background
+
+For long-running robot stacks, start the services without attaching logs:
+
+```bash
+wendy run --build-type compose --detach
+```
+
+Generated app names use the project folder and service name. For the example above, the apps are `ros2-stack-talker` and `ros2-stack-listener`.
+
+Useful follow-up commands:
+
+```bash
+wendy device apps list
+wendy device logs --app ros2-stack-talker
+wendy device apps stop ros2-stack-listener
+wendy device apps stop ros2-stack-talker
+```
+
+## When to use `wendy.json` services instead
+
+Compose is best for networked multi-container stacks that need host networking, port mappings, restart policy, dependency order, and persistent named volumes.
+
+Use [multi-service `wendy.json`](/docs/advanced/apps/wendy-services) when individual services need Wendy-specific configuration that Compose does not express yet, such as direct camera, GPU, audio, Bluetooth, USB, I2C, GPIO, SPI, readiness probes, hooks, or service-specific files.
+
+For the full Compose field reference, see [Multi-Service Apps with Docker Compose](/docs/advanced/apps/compose).

--- a/go/internal/cli/assets/docs/guides/multi-app-deployments.mdx
+++ b/go/internal/cli/assets/docs/guides/multi-app-deployments.mdx
@@ -190,6 +190,8 @@ wendy device apps stop ros2-stack-talker
 
 Compose is best for networked multi-container stacks that need host networking, port mappings, restart policy, dependency order, and persistent named volumes.
 
-Use [multi-service `wendy.json`](/docs/advanced/apps/wendy-services) when individual services need Wendy-specific configuration that Compose does not express yet, such as direct camera, GPU, audio, Bluetooth, USB, I2C, GPIO, SPI, readiness probes, hooks, shared IPC, runtime presets, or service-specific files.
+Use [multi-service `wendy.json`](/docs/advanced/apps/wendy-services) when individual services need Wendy-specific configuration that Compose does not express yet, such as direct camera, GPU, audio, Bluetooth, USB, I2C, GPIO, SPI, shared IPC, runtime presets, or service-specific files.
+
+Service-specific readiness probes and `postStart` hooks are not available for Compose services yet. Today, `hooks.postStart` applies to single-container `wendy.json` apps, so a Compose stack cannot trigger a browser opener only after one `frontend` service becomes ready.
 
 For the full Compose field reference, see [Multi-Service Apps with Docker Compose](/docs/advanced/apps/compose).

--- a/go/internal/cli/assets/docs/guides/multi-app-deployments.mdx
+++ b/go/internal/cli/assets/docs/guides/multi-app-deployments.mdx
@@ -38,6 +38,10 @@ For a WendyOS device target, Wendy:
 For ROS 2, set `network_mode: host` on every service that needs DDS discovery, multicast, or direct host-network communication. Wendy converts that field into a host-network entitlement for the generated service app.
 </Callout>
 
+<Callout type="warning">
+Host networking helps ROS 2 discovery, but it does not join IPC namespaces or share `/dev/shm` between containers. If your stack depends on ROS 2 shared-memory transport, zero-copy camera frames, or other pod-style namespace sharing, use a single container today or the multi-service `wendy.json` path once shared-IPC support is available.
+</Callout>
+
 Wendy maps a focused subset of Compose into device runtime configuration:
 
 | Compose field | Wendy behavior |
@@ -48,7 +52,7 @@ Wendy maps a focused subset of Compose into device runtime configuration:
 | `ports` | Adds a network entitlement with explicit port mappings. |
 | `network_mode: host` | Adds a host-network entitlement. Recommended for ROS 2 service discovery. |
 | `volumes` | Converts named volumes into persistent storage entitlements. Host bind mounts are skipped on device. |
-| `depends_on` | Creates dependencies before dependents. Detached starts follow the same order. Both list and map forms are accepted. |
+| `depends_on` | Creates dependencies before dependents. Detached starts follow the same order, but Wendy does not wait for health checks or readiness conditions. Both list and map forms are accepted. |
 | `restart` | Applies `no`, `on-failure`, `always`, or `unless-stopped` unless a CLI restart flag overrides it. |
 
 <Callout type="warning">
@@ -186,6 +190,6 @@ wendy device apps stop ros2-stack-talker
 
 Compose is best for networked multi-container stacks that need host networking, port mappings, restart policy, dependency order, and persistent named volumes.
 
-Use [multi-service `wendy.json`](/docs/advanced/apps/wendy-services) when individual services need Wendy-specific configuration that Compose does not express yet, such as direct camera, GPU, audio, Bluetooth, USB, I2C, GPIO, SPI, readiness probes, hooks, or service-specific files.
+Use [multi-service `wendy.json`](/docs/advanced/apps/wendy-services) when individual services need Wendy-specific configuration that Compose does not express yet, such as direct camera, GPU, audio, Bluetooth, USB, I2C, GPIO, SPI, readiness probes, hooks, shared IPC, runtime presets, or service-specific files.
 
 For the full Compose field reference, see [Multi-Service Apps with Docker Compose](/docs/advanced/apps/compose).

--- a/go/internal/cli/assets/docs/guides/swift/audio.mdx
+++ b/go/internal/cli/assets/docs/guides/swift/audio.mdx
@@ -260,7 +260,7 @@ If audio isn't working:
 1.  **Check Hardware**: Ensure your microphone/speaker is selected in the system settings or properly connected via USB.
 2.  **Check Logs**: Docker logs will show GStreamer errors.
     ```bash
-    wendy logs
+    wendy device logs
     ```
 3.  **ALSA Devices**: The app attempts to auto-detect ALSA devices. You can override this by setting the `AUDIO_DEVICE` environment variable (e.g., `hw:1,0`).
 

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -646,8 +646,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			cliLogln("Service %s started.", name)
 		}
 		cliLogln("All services running in detached mode.")
-		projectID := strings.ToLower(filepath.Base(projectDir))
-		cliLogln("Run 'wendy logs %s' to stream logs.", projectID)
+		cliLogln("Run 'wendy device logs' to stream logs.")
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- add a Fumadocs guide for ROS 2-style multi-app deployments with `docker-compose.yml`
- document how Wendy maps Compose services into device apps, networking, volumes, dependencies, and restart policy
- correct stale log-command references to `wendy device logs` and align the compose reference with current behavior

## Validation
- `go test ./internal/cli/commands`
- `npm run types:check`
- `npm run build`
- `git diff --check`
- local browser pass on `/guides/multi-app-deployments/`
