### PR TITLE
ci: dispatch docs deploy on release even when determine-version is skipped

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -967,7 +967,10 @@ jobs:
     name: Dispatch docs deployment
     runs-on: ubuntu-latest
     needs: [determine-version, release]
-    if: needs.release.result == 'success'
+    # `always()` is required: without it the job is skipped whenever any `needs`
+    # entry (e.g. determine-version) is itself skipped or non-success, even
+    # though we only care that `release` succeeded. Matches the publish-aur job.
+    if: always() && needs.release.result == 'success'
     permissions:
       actions: write
     steps:


### PR DESCRIPTION
## Summary

Release `2026.06.01-021827` published successfully but **`/latest` docs were never rebuilt**. Root cause: the `dispatch-docs` job in `build.yml` — which is what tells the Fumadocs workflow to deploy on a release — was **skipped**, so nothing updated `/latest`.

## Why it was skipped

```yaml
dispatch-docs:
  needs: [determine-version, release]
  if: needs.release.result == 'success'   # <-- missing always()
```

GitHub skips a job when **any** of its `needs` is skipped or non-success — *before* evaluating `if`. So when `determine-version` doesn't cleanly succeed, `dispatch-docs` is skipped even though `release` succeeded. Confirmed on the release build run: `Release: success`, `Dispatch docs deployment: skipped`.

The `release: published` event can't cover for this either — releases created with `GITHUB_TOKEN` don't re-trigger other workflows (the fumadocs workflow documents this, which is the whole reason this dispatch job exists).

## Fix

Add `always() &&` so the job runs whenever `release` succeeds, regardless of the other `needs` — exactly how the sibling `publish-aur` job is already written:

```yaml
if: always() && needs.release.result == 'success'
```

## Notes
- One-line behavioral change (plus an explanatory comment). YAML validated.
- The current release's `/latest` was already recovered manually via `gh workflow run fumadocs.yml --ref <tag> -f release_tag=<tag>`; this PR makes future releases deploy docs automatically without that manual step.

## Test plan
- Next release off `main` should produce a `dispatch-docs` job that **runs** (not skipped) and triggers a Fumadocs deploy to `release-<version>` + `latest`.
