### PR TITLE
fix(docs): emit trailing slash on internal /docs links

### DIFF
--- a/go/internal/cli/assets/docs/scripts/prepare-content.mjs
+++ b/go/internal/cli/assets/docs/scripts/prepare-content.mjs
@@ -180,8 +180,13 @@ function normalizeMarkdown(raw, targetRelativePath) {
 function relativeFromPage(fromRelativePath, targetPath, hash = '') {
   const rootPrefix = routeSegments(fromRelativePath).length === 0 ? './' : '../'.repeat(routeSegments(fromRelativePath).length);
   const normalizedTarget = targetPath.replace(/^\/+/, '').replace(/\/$/, '');
+  // The site is exported with `trailingSlash: true`, so doc routes are canonical
+  // as `.../slug/`. Emit the trailing slash here too — without it a raw `<a href>`
+  // to a slugless path makes GCS 301 to `.../index.html`, which the fumadocs router
+  // can't match (sidebar stays collapsed / unhighlighted).
+  const targetWithSlash = normalizedTarget ? `${normalizedTarget}/` : '';
 
-  return `${rootPrefix}${normalizedTarget}${hash}`;
+  return `${rootPrefix}${targetWithSlash}${hash}`;
 }
 
 function relativeAssetImport(fromRelativePath, targetPath, hash = '') {


### PR DESCRIPTION
## Problem

On the deployed docs (e.g. https://docs.wendy.dev/latest/), clicking the **Get Started! → Developer Machine Setup** card navigates to `/installation/developer-machine-setup` (no trailing slash). On GCS website hosting that 301-redirects to `.../developer-machine-setup/index.html` (GCS appends the `index.html` MainPageSuffix literally). The fumadocs client router can't match an `index.html` URL, so the page loads with the **sidebar fully collapsed / unhighlighted**.

The same bug affects every `[Developer Machine Setup](/docs/...)` link across the guides (esp32, raspberry-pi, guides/swift/*, etc.).

## Root cause

The site is exported with `trailingSlash: true`, so routes are canonical as `.../slug/`. But `relativeFromPage` in `scripts/prepare-content.mjs` stripped the trailing slash when rewriting `/docs/...` links and raw `href="/docs/..."` attributes.

## Fix

Append the trailing slash (before any `#hash`) so links resolve to the canonical `.../slug/` and serve a clean `200`. Verified generated output:

- card: `href="./installation/developer-machine-setup/"`
- markdown link: `](../../installation/developer-machine-setup/)`
- anchor: `](../../installation/developer-machine-setup/#install-swift)` (slash before hash)
- deep page keeps correct depth: `](../../../installation/developer-machine-setup/#install-swift)`
- asset links (icons/images/videos) unchanged — they go through separate helpers.

Deploys to `/latest/` on the next full release.