### PR TITLE
Improve "wendy os install" for ESP32 devices

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -32,8 +32,8 @@ wendy os install path/to/image.img /dev/disk4 --force
 The CLI scans for a connected ESP32 by looking for the Espressif USB serial device (VID `0x303a`, PID `0x1001`):
 
 | Platform | Where it looks | Expected path |
-|----------|---------------|---------------|
-| macOS | `/dev/cu.usbmodem*` (most recently connected) | `/dev/cu.usbmodem*` |
+|----------|----------------|---------------|
+| macOS | `IOKit` framework | `/dev/cu.usbmodem*` |
 | Linux | `/sys/class/tty/ttyACM*` matching VID/PID via sysfs | `/dev/ttyACM0` (typical) |
 | Windows | `Win32_PnPEntity` via PowerShell, filtered by VID/PID and `Ports` class | `COMN` (e.g. `COM7`) |
 
@@ -60,26 +60,33 @@ The downloaded `.bin` is a merged firmware image (same format as the CI artifact
 
 The CLI implements the ESP32 ROM bootloader protocol directly over the USB serial port — no `esptool` dependency required.
 
-**Bootloader entry sequence** (DTR/RTS toggle):
+**Bootloader entry sequence**
 
-```
-Assert RTS  (EN pin low  — hold in reset)
-Assert DTR  (IO0 pin low — select download mode)
-Release RTS (EN pin high — release reset, boots into download mode)
-Release DTR
-```
+Historically, many ESP boards were equipped with a USB-to-serial chip, and the DTR and RTS signals were used to drive the ESP's reset and GPIO0 pins. This allowed the host to reset the ESP and put it into download mode. Today, we use the ESP's built-in USB port, so the chip appears directly as an ACM device. We still use virtual DTR and RTS, but with a slightly different sequence.
+
+This communication scheme is called `USB-JTAG` because it combines a CDC-ACM serial interface and a JTAG debug interface over a single USB connection.
+
+Documentation can be found [here](https://docs.espressif.com/projects/esptool/en/latest/esp32c6/advanced-topics/serial-protocol.html#32-bit-readwrite).
 
 **Flash sequence:**
 
 | Step | Command | Notes |
 |------|---------|-------|
 | 1 | Sync (`0x08`) | Sends 36-byte sync frame; retries up to 10×; 3 s timeout per attempt |
-| 2 | ChangeBaud (`0x0F`) | Negotiates 921600 baud (up from 115200); drains serial before switching |
-| 3 | SPI Attach (`0x0D`) | Attaches internal SPI flash with default config |
-| 4 | SPI Set Params (`0x0B`) | Declares 4 MB flash; 64 KB block, 4 KB sector, 256-byte page |
-| 5 | Flash Begin (`0x02`) | Erases the target region (up to 30 s timeout for large erases) |
-| 6 | Flash Data (`0x03`) | Sends firmware in 16 KiB blocks; each block XOR-checksummed (seed `0xEF`), padded with `0xFF` |
-| 7 | Flash End (`0x04`) | Signals completion; `reboot=true` resets the device |
+| 2 | ChangeBaud (`0x0F`) | Negotiates 921600 baud (up from 115200) |
+| 3 | GetSecurityInfo (`0x14`) | Reads chip security info, including the chip ID |
+| 4 | Init | Series of `ReadReg`/`WriteReg` calls for chip identification and configuration (disabling watchdog) |
+| 5 | SPI Attach (`0x0D`) | Attaches internal SPI flash |
+| 6 | Init flash chip | Issues JEDEC RDID (`0x9F`), RSTEN (`0x66`), and RST (`0x99`) via SPI register writes; returns the flash JEDEC ID |
+| 7 | SPI Set Params (`0x0B`) | Flash size derived automatically from the JEDEC capacity byte (`1 << capacity`); defaults to 4 MB if the capacity byte is 0 |
+| 8 | Pre-flash eFuse checks | `ReadReg` calls on eFuse and chip-ID registers (result ignored) |
+| 9 | Flash Begin (`0x02`) | Erases the target region (up to 30 s timeout); sends a 20-byte payload (extra 4-byte encryption flag = 0) |
+| 10 | Flash Data (`0x03`) | Sends firmware in **4 KiB** blocks; each block XOR-checksummed (seed `0xEF`), padded with `0xFF` |
+| 11 | USB-JTAG reset | Issues the USB-JTAG DTR/RTS sequence with `enterBootloader=false` to reboot the device normally |
+
+Some of these steps are not needed but have been kept to match the esptool sequence as closely as possible.
+
+When put in download mode via USB, the chip has a watchdog that resets it after 9 seconds. The Init step is crucial to disable it. This watchdog is not active when the chip is put into download mode manually (BOOT + RESET).
 
 All messages are SLIP-framed (`0xC0` delimiters, `0xDB` escape byte). The CLI drains stale frames between retries and skips responses whose command echo doesn't match the sent opcode.
 

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -389,6 +389,9 @@ func (f *espFlasher) getSecurityInfo() (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
+	// It is not yet clear if the relevant data is in resp[0:4] or resp[4:8].
+	// The doc is vague and AI sources are inconsistent.
+	// Keeping resp[4:8] for now since this value is discarded anyway.
 	if len(resp) < 8 {
 		return 0, fmt.Errorf("getSecurityInfo: response too short (%d bytes)", len(resp))
 	}

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -478,10 +478,24 @@ func (f *espFlasher) chipDetect() error {
 	return nil
 }
 
+// waitSPICmd polls regSPICmd until the SPI_USR bit (bit 18) is cleared,
+// indicating the hardware has finished executing the command.
+func (f *espFlasher) waitSPICmd() error {
+	for {
+		val, err := f.readReg(regSPICmd)
+		if err != nil {
+			return err
+		}
+		if val&0x00040000 == 0 {
+			return nil
+		}
+	}
+}
+
 // initFlashChip performs the SPI flash controller register sequence
 // observed in the esptool trace after SPI_ATTACH.
-// It retrives the JEDEC ID and resets the flash chip, in order to start
-// without depeding on previous usages.
+// It retrieves the JEDEC ID and resets the flash chip, in order to start
+// without depending on previous uses.
 func (f *espFlasher) initFlashChip() (JedecID, error) {
 	user0, err := f.readReg(regSPIUser)
 	if err != nil {
@@ -508,7 +522,7 @@ func (f *espFlasher) initFlashChip() (JedecID, error) {
 	if err := f.writeReg(regSPICmd, 0x00040000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if _, err := f.readReg(regSPICmd); err != nil { // poll until done
+	if err := f.waitSPICmd(); err != nil {
 		return JedecID{}, err
 	}
 	// W0 layout: bits 7:0 = Manufacturer, bits 15:8 = MemoryType, bits 23:16 = Capacity.
@@ -548,7 +562,7 @@ func (f *espFlasher) initFlashChip() (JedecID, error) {
 	if err := f.writeReg(regSPICmd, 0x00040000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if _, err := f.readReg(regSPICmd); err != nil {
+	if err := f.waitSPICmd(); err != nil {
 		return JedecID{}, err
 	}
 	if _, err := f.readReg(regSPIW0); err != nil {
@@ -581,7 +595,7 @@ func (f *espFlasher) initFlashChip() (JedecID, error) {
 	if err := f.writeReg(regSPICmd, 0x00040000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if _, err := f.readReg(regSPICmd); err != nil {
+	if err := f.waitSPICmd(); err != nil {
 		return JedecID{}, err
 	}
 	if _, err := f.readReg(regSPIW0); err != nil {
@@ -764,8 +778,8 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 	}
 
 	// Step 6: Set SPI params.
-	flashSize := flashSize(jedecId)
-	if err := f.spiSetParams(flashSize); err != nil {
+	detectedFlashSize := flashSize(jedecId)
+	if err := f.spiSetParams(detectedFlashSize); err != nil {
 		return fmt.Errorf("SPI set params: %w", err)
 	}
 
@@ -807,7 +821,7 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 
 	// Step 6: Reboot.
 	// Please note that we never succeeded in using flashEnd() here.
-	espResetViaUsbJtag(port, false)
+	espResetViaUsbJtag(f.port, false)
 
 	return nil
 }

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -830,7 +830,7 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 		}
 	}
 
-	// Step 6: Reboot.
+	// Step 9: Reboot.
 	// Please note that we never succeeded in using flashEnd() here.
 	espResetViaUsbJtag(f.port, false)
 

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -131,10 +131,18 @@ func espLoaderErrorMessage(code byte) string {
 
 func flashSize(id JedecID) uint32 {
 	const defaultSize = 4 * 1024 * 1024
+	const maxSize = 128 * 1024 * 1024 // 128 MiB, generous upper bound for NOR flash
 	if id.capacity == 0 {
 		return defaultSize
 	}
-	return uint32(1) << id.capacity
+	if id.capacity > 31 {
+		return maxSize
+	}
+	size := uint32(1) << id.capacity
+	if size > maxSize {
+		return maxSize
+	}
+	return size
 }
 
 func slipEncode(data []byte) []byte {

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -855,6 +855,14 @@ func espResetViaUsbJtag(port serial.Port, enterBootloader bool) {
 
 // flashFirmware is the main entry point: flash a .bin file to the ESP32.
 func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) error {
+	info, err := os.Stat(firmwarePath)
+	if err != nil {
+		return fmt.Errorf("reading firmware: %w", err)
+	}
+	if info.Size() > maxFlashSize {
+		return fmt.Errorf("firmware too large (%d bytes, max %d)", info.Size(), maxFlashSize)
+	}
+
 	firmware, err := os.ReadFile(firmwarePath)
 	if err != nil {
 		return fmt.Errorf("reading firmware: %w", err)
@@ -936,8 +944,8 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 
 	// Step 8: Flash the firmware.
 	totalSize := len(firmware)
-	if totalSize > maxFlashSize {
-		return fmt.Errorf("firmware too large (%d bytes, max %d)", totalSize, maxFlashSize)
+	if totalSize > int(detectedFlashSize) {
+		return fmt.Errorf("firmware too large (%d bytes, max %d)", totalSize, detectedFlashSize)
 	}
 	blockCount := (totalSize + espFlashBlockSize - 1) / espFlashBlockSize
 	dbgf("flash: totalSize=%d blockCount=%d", totalSize, blockCount)

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -55,7 +55,8 @@ const (
 )
 
 const (
-	espFlashBlockSize = 0x1000 // 4 KiB per flash data block
+	espFlashBlockSize = 0x1000            // 4 KiB per flash data block
+	maxFlashSize      = 128 * 1024 * 1024 // 128 MiB, generous upper bound for NOR flash
 	espSyncTimeout    = 3 * time.Second
 	espCmdTimeout     = 10 * time.Second
 	flashBaudRate     = 921600
@@ -131,16 +132,15 @@ func espLoaderErrorMessage(code byte) string {
 
 func flashSize(id JedecID) uint32 {
 	const defaultSize = 4 * 1024 * 1024
-	const maxSize = 128 * 1024 * 1024 // 128 MiB, generous upper bound for NOR flash
 	if id.capacity == 0 {
 		return defaultSize
 	}
 	if id.capacity > 31 {
-		return maxSize
+		return maxFlashSize
 	}
 	size := uint32(1) << id.capacity
-	if size > maxSize {
-		return maxSize
+	if size > maxFlashSize {
+		return maxFlashSize
 	}
 	return size
 }
@@ -813,6 +813,9 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 	}
 
 	// Step 8: Flash the firmware.
+	if len(firmware) > maxFlashSize {
+		return fmt.Errorf("firmware too large (%d bytes, max %d)", len(firmware), maxFlashSize)
+	}
 	totalSize := uint32(len(firmware))
 	blockCount := (totalSize + espFlashBlockSize - 1) / espFlashBlockSize
 	if err := f.flashBegin(totalSize, blockCount, espFlashBlockSize, 0); err != nil {

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -813,16 +813,16 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 	}
 
 	// Step 8: Flash the firmware.
-	if len(firmware) > maxFlashSize {
-		return fmt.Errorf("firmware too large (%d bytes, max %d)", len(firmware), maxFlashSize)
+	totalSize := len(firmware)
+	if totalSize > maxFlashSize {
+		return fmt.Errorf("firmware too large (%d bytes, max %d)", totalSize, maxFlashSize)
 	}
-	totalSize := uint32(len(firmware))
 	blockCount := (totalSize + espFlashBlockSize - 1) / espFlashBlockSize
-	if err := f.flashBegin(totalSize, blockCount, espFlashBlockSize, 0); err != nil {
+	if err := f.flashBegin(uint32(totalSize), uint32(blockCount), espFlashBlockSize, 0); err != nil {
 		return fmt.Errorf("flash begin: %w", err)
 	}
 
-	for seq := uint32(0); seq < blockCount; seq++ {
+	for seq := uint32(0); seq < uint32(blockCount); seq++ {
 		offset := int(seq) * espFlashBlockSize
 		end := offset + espFlashBlockSize
 		if end > len(firmware) {

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -26,25 +26,77 @@ const (
 	espCmdGetSecurityInfo = 0x14
 )
 
-// ESP32-C6 register addresses used during flash initialisation.
+// chipModel identifies the ESP32 variant detected from the bootloader.
+type chipModel int
+
 const (
-	regChipMagic = 0x4087f580 // chip magic/identification word
-	regChipID0   = 0x600b0850 // eFuse chip ID word 0
-	regChipID1   = 0x600b0854 // eFuse chip ID word 1
-	regMACLow    = 0x600b0844 // eFuse MAC address low word
-	regMACHigh   = 0x600b0848 // eFuse MAC address high word
-	regEfuseA    = 0x600b0830 // eFuse miscellaneous register A
-	regEfuseB    = 0x600b0838 // eFuse miscellaneous register B
-	regRTCCtrl00 = 0x600b1c00 // RTC control register 0x00
-	regRTCCtrl18 = 0x600b1c18 // RTC control register 0x18
-	regRTCCtrl1C = 0x600b1c1c // RTC control register 0x1c
-	regRTCCtrl20 = 0x600b1c20 // RTC control register 0x20
-	regSPICmd    = 0x60003000 // SPI_MEM_CMD_REG
-	regSPIUser   = 0x60003018 // SPI_MEM_USER_REG
-	regSPIUser1  = 0x60003020 // SPI_MEM_USER1_REG
-	regSPIClock  = 0x60003028 // SPI_MEM_CLOCK_REG
-	regSPIW0     = 0x60003058 // SPI_MEM_W0_REG (data buffer word 0)
+	chipUnknown chipModel = iota
+	chipESP32C6
+	chipESP32P4
 )
+
+// chipRegs holds chip-specific peripheral register addresses. Different ESP32
+// variants have incompatible memory maps, so all chip-sensitive code goes
+// through f.regs rather than hardcoded constants.
+type chipRegs struct {
+	name string
+	// Watchdog registers: MWDT and SWD are disabled before flashing.
+	wdtProtect uint32 // MWDT write-protect key register
+	wdtConfig0 uint32 // MWDT config0 (write 0 to disable)
+	swdProtect uint32 // SWD write-protect key register
+	swdConf    uint32 // SWD config register
+	// eFuse registers.
+	efuseA  uint32 // BLOCK0 misc register A
+	efuseB  uint32 // BLOCK0 misc register B
+	chipID0 uint32 // eFuse chip ID word 0
+	chipID1 uint32 // eFuse chip ID word 1
+	macLow  uint32 // eFuse MAC address low word
+	macHigh uint32 // eFuse MAC address high word
+	// SPI flash controller registers (register naming follows esptool offsets).
+	spiCmd   uint32 // SPI_MEM_CMD_REG   (offset +0x00)
+	spiUser  uint32 // SPI_MEM_USER_REG  (offset +0x18)
+	spiUser1 uint32 // SPI_MEM_USER1_REG (offset +0x20)
+	spiClock uint32 // SPI_MEM_CLOCK_REG (offset +0x28)
+	spiW0    uint32 // SPI_MEM_W0_REG    (offset +0x58)
+}
+
+var regsESP32C6 = chipRegs{
+	name:       "ESP32-C6",
+	wdtProtect: 0x600b1c18,
+	wdtConfig0: 0x600b1c00,
+	swdProtect: 0x600b1c20,
+	swdConf:    0x600b1c1c,
+	efuseA:     0x600b0830,
+	efuseB:     0x600b0838,
+	chipID0:    0x600b0850,
+	chipID1:    0x600b0854,
+	macLow:     0x600b0844,
+	macHigh:    0x600b0848,
+	spiCmd:     0x60003000,
+	spiUser:    0x60003018,
+	spiUser1:   0x60003020,
+	spiClock:   0x60003028,
+	spiW0:      0x60003058,
+}
+
+var regsESP32P4 = chipRegs{
+	name:       "ESP32-P4",
+	wdtProtect: 0x50116018,
+	wdtConfig0: 0x50116000,
+	swdProtect: 0x50116020,
+	swdConf:    0x5011601c,
+	efuseA:     0x5012d030,
+	efuseB:     0x5012d038,
+	chipID0:    0x5012d050,
+	chipID1:    0x5012d054,
+	macLow:     0x5012d044,
+	macHigh:    0x5012d048,
+	spiCmd:     0x5008d000,
+	spiUser:    0x5008d018,
+	spiUser1:   0x5008d020,
+	spiClock:   0x5008d028,
+	spiW0:      0x5008d058,
+}
 
 // SLIP framing bytes.
 const (
@@ -63,6 +115,14 @@ const (
 	initialBaudRate   = 115200
 )
 
+const espDebugEnabled = false
+
+func dbgf(format string, args ...any) {
+	if espDebugEnabled {
+		fmt.Printf("DEBUG "+format+"\r\n", args...)
+	}
+}
+
 // JedecID holds the three-byte JEDEC flash identification returned by the
 // RDID (0x9f) command.
 type JedecID struct {
@@ -74,6 +134,8 @@ type JedecID struct {
 // espFlasher handles serial communication with the ESP32 bootloader.
 type espFlasher struct {
 	port serial.Port
+	chip chipModel
+	regs *chipRegs
 }
 
 func isPermissionDenied(err error) bool {
@@ -382,20 +444,44 @@ func (f *espFlasher) changeBaudRate(newBaud int) error {
 	return nil
 }
 
-// getSecurityInfo queries the chip security info (opcode 0x14).
-func (f *espFlasher) getSecurityInfo() (uint32, error) {
+// detectChip sends GET_SECURITY_INFO (0x14), extracts the chip_id from the
+// response, and populates f.chip and f.regs. Must be called before any
+// chip-specific register access.
+//
+// Response layout (sendCommand returns frame[4:]):
+//
+//	[0:4]  value field (unused for this command)
+//	[4:]   security info payload (20 bytes), status bytes follow after:
+//	  [4:8]   flags
+//	  [8]     flash_crypt_cnt
+//	  [9:16]  key_purposes[7]
+//	  [16:20] chip_id (uint32 LE)
+//	  [20:24] api_version
+//	[24:26] status bytes (esptool places them after the data)
+func (f *espFlasher) detectChip() error {
 	f.port.SetReadTimeout(espCmdTimeout)
 	resp, err := f.sendCommand(espCmdGetSecurityInfo, nil, 0)
 	if err != nil {
-		return 0, err
+		return fmt.Errorf("get security info: %w", err)
 	}
-	// It is not yet clear if the relevant data is in resp[0:4] or resp[4:8].
-	// The doc is vague and AI sources are inconsistent.
-	// Keeping resp[4:8] for now since this value is discarded anyway.
-	if len(resp) < 8 {
-		return 0, fmt.Errorf("getSecurityInfo: response too short (%d bytes)", len(resp))
+	const chipIDOff = 4 + 12 // value(4) + flags(4) + flash_crypt_cnt(1) + key_purposes(7)
+	if len(resp) < chipIDOff+4 {
+		return fmt.Errorf("get security info: response too short (%d bytes)", len(resp))
 	}
-	return binary.LittleEndian.Uint32(resp[4:8]), nil
+	chipID := binary.LittleEndian.Uint32(resp[chipIDOff : chipIDOff+4])
+	dbgf("detectChip: chipID=0x%04x", chipID)
+	switch chipID {
+	case 0x000d:
+		f.chip = chipESP32C6
+		f.regs = &regsESP32C6
+	case 0x0012:
+		f.chip = chipESP32P4
+		f.regs = &regsESP32P4
+	default:
+		return fmt.Errorf("unsupported chip id 0x%04x", chipID)
+	}
+	dbgf("detectChip: chipName=%s", f.regs.name)
+	return nil
 }
 
 // readReg reads a 32-bit peripheral register at addr.
@@ -439,69 +525,76 @@ func (f *espFlasher) spiAttach() error {
 	return err
 }
 
-// chipDetect runs the register read/write sequence the ROM bootloader requires
-// for chip identification.  We target ESP32-C6 only, so results are discarded.
-func (f *espFlasher) chipDetect() error {
-	if _, err := f.readReg(regChipMagic); err != nil {
-		return err
-	}
+// initChip disables the hardware watchdogs (MWDT and SWD) using chip-specific
+// register addresses, then performs the eFuse debug reads observed in esptool
+// traces. f.regs must be set by detectChip before calling this.
+func (f *espFlasher) initChip() error {
+	r := f.regs
 
-	// RTC / JTAG power-domain initialisation sequence observed in esptool trace.
-	if err := f.writeReg(regRTCCtrl18, 0x50d83aa1, 0xffffffff, 0); err != nil {
+	// MWDT: unlock → disable → re-lock.
+	if err := f.writeReg(r.wdtProtect, 0x50d83aa1, 0xffffffff, 0); err != nil {
 		return err
 	}
-	if err := f.writeReg(regRTCCtrl00, 0x00000000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.wdtConfig0, 0x00000000, 0xffffffff, 0); err != nil {
 		return err
 	}
-	if err := f.writeReg(regRTCCtrl18, 0x00000000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.wdtProtect, 0x00000000, 0xffffffff, 0); err != nil {
 		return err
 	}
-	if err := f.writeReg(regRTCCtrl20, 0x50d83aa1, 0xffffffff, 0); err != nil {
-		return err
-	}
+	dbgf("initChip: MWDT disabled OK")
 
-	// Read-modify-write: write back the value currently in regRTCCtrl1C.
-	val, err := f.readReg(regRTCCtrl1C)
+	// SWD: unlock → read-modify-write config → re-lock.
+	if err := f.writeReg(r.swdProtect, 0x50d83aa1, 0xffffffff, 0); err != nil {
+		return err
+	}
+	val, err := f.readReg(r.swdConf)
 	if err != nil {
 		return err
 	}
-	if err := f.writeReg(regRTCCtrl1C, val, 0xffffffff, 0); err != nil {
+	dbgf("initChip: swdConf=0x%08x", val)
+	if err := f.writeReg(r.swdConf, val, 0xffffffff, 0); err != nil {
 		return err
 	}
-	if err := f.writeReg(regRTCCtrl20, 0x00000000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.swdProtect, 0x00000000, 0xffffffff, 0); err != nil {
 		return err
 	}
+	dbgf("initChip: SWD disabled OK")
 
-	// Chip-ID reads (x3 for regChipID0, x1 for regChipID1).
+	// Debug: eFuse chip-ID and MAC reads (x3 each, matching esptool trace cadence).
 	for i := 0; i < 3; i++ {
-		if _, err := f.readReg(regChipID0); err != nil {
+		v, err := f.readReg(r.chipID0)
+		if err != nil {
 			return err
 		}
+		dbgf("initChip: chipID0[%d]=0x%08x", i, v)
 	}
-	if _, err := f.readReg(regChipID1); err != nil {
+	v, err := f.readReg(r.chipID1)
+	if err != nil {
 		return err
 	}
-
-	// MAC address reads (three sets of low+high words).
+	dbgf("initChip: chipID1=0x%08x", v)
 	for i := 0; i < 3; i++ {
-		if _, err := f.readReg(regMACLow); err != nil {
+		lo, err := f.readReg(r.macLow)
+		if err != nil {
 			return err
 		}
-		if _, err := f.readReg(regMACHigh); err != nil {
+		hi, err := f.readReg(r.macHigh)
+		if err != nil {
 			return err
 		}
+		dbgf("initChip: MAC[%d] lo=0x%08x hi=0x%08x", i, lo, hi)
 	}
 
 	return nil
 }
 
-// waitSPICmd polls regSPICmd until the SPI_USR bit (bit 18) is cleared,
+// waitSPICmd polls SPI_MEM_CMD_REG until the SPI_USR bit (bit 18) is cleared,
 // indicating the hardware has finished executing the command.
 func (f *espFlasher) waitSPICmd() error {
 	const timeout = 4000 * time.Millisecond
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		val, err := f.readReg(regSPICmd)
+		val, err := f.readReg(f.regs.spiCmd)
 		if err != nil {
 			return err
 		}
@@ -518,36 +611,37 @@ func (f *espFlasher) waitSPICmd() error {
 // It retrieves the JEDEC ID and resets the flash chip, in order to start
 // without depending on previous uses.
 func (f *espFlasher) initFlashChip() (JedecID, error) {
-	user0, err := f.readReg(regSPIUser)
+	r := f.regs
+	user0, err := f.readReg(r.spiUser)
 	if err != nil {
 		return JedecID{}, err
 	}
-	user1, err := f.readReg(regSPIUser1)
+	user1, err := f.readReg(r.spiUser1)
 	if err != nil {
 		return JedecID{}, err
 	}
 
 	// Step 1: RDID (0x9f) — read JEDEC ID using a faster clock.
-	if err := f.writeReg(regSPIClock, 0x00000017, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiClock, 0x00000017, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIUser, 0x90000000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser, 0x90000000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIUser1, 0x7000009f, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser1, 0x7000009f, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIW0, 0x00000000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiW0, 0x00000000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPICmd, 0x00040000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiCmd, 0x00040000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
 	if err := f.waitSPICmd(); err != nil {
 		return JedecID{}, err
 	}
 	// W0 layout: bits 7:0 = Manufacturer, bits 15:8 = MemoryType, bits 23:16 = Capacity.
-	w0, err := f.readReg(regSPIW0)
+	w0, err := f.readReg(r.spiW0)
 	if err != nil {
 		return JedecID{}, err
 	}
@@ -557,76 +651,76 @@ func (f *espFlasher) initFlashChip() (JedecID, error) {
 		capacity:     byte(w0 >> 16),
 	}
 	// Restore and verify.
-	if err := f.writeReg(regSPIUser, user0, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser, user0, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIUser1, user1, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser1, user1, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if _, err := f.readReg(regSPIUser); err != nil {
+	if _, err := f.readReg(r.spiUser); err != nil {
 		return JedecID{}, err
 	}
-	if _, err := f.readReg(regSPIUser1); err != nil {
+	if _, err := f.readReg(r.spiUser1); err != nil {
 		return JedecID{}, err
 	}
 
 	// Step 2: RSTEN (0x66) — Reset Enable command.
-	if err := f.writeReg(regSPIUser, 0x80000000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser, 0x80000000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIUser1, 0x70000066, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser1, 0x70000066, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIW0, 0x00000000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiW0, 0x00000000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPICmd, 0x00040000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiCmd, 0x00040000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
 	if err := f.waitSPICmd(); err != nil {
 		return JedecID{}, err
 	}
-	if _, err := f.readReg(regSPIW0); err != nil {
+	if _, err := f.readReg(r.spiW0); err != nil {
 		return JedecID{}, err
 	}
 	// Restore and verify.
-	if err := f.writeReg(regSPIUser, user0, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser, user0, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIUser1, user1, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser1, user1, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if _, err := f.readReg(regSPIUser); err != nil {
+	if _, err := f.readReg(r.spiUser); err != nil {
 		return JedecID{}, err
 	}
-	if _, err := f.readReg(regSPIUser1); err != nil {
+	if _, err := f.readReg(r.spiUser1); err != nil {
 		return JedecID{}, err
 	}
 
 	// Step 3: RST (0x99) — Reset command.
-	if err := f.writeReg(regSPIUser, 0x80000000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser, 0x80000000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIUser1, 0x70000099, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser1, 0x70000099, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIW0, 0x00000000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiW0, 0x00000000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPICmd, 0x00040000, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiCmd, 0x00040000, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
 	if err := f.waitSPICmd(); err != nil {
 		return JedecID{}, err
 	}
-	if _, err := f.readReg(regSPIW0); err != nil {
+	if _, err := f.readReg(r.spiW0); err != nil {
 		return JedecID{}, err
 	}
 	// Final restore (no verify needed after the last attempt).
-	if err := f.writeReg(regSPIUser, user0, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser, user0, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
-	if err := f.writeReg(regSPIUser1, user1, 0xffffffff, 0); err != nil {
+	if err := f.writeReg(r.spiUser1, user1, 0xffffffff, 0); err != nil {
 		return JedecID{}, err
 	}
 
@@ -635,20 +729,21 @@ func (f *espFlasher) initFlashChip() (JedecID, error) {
 
 // preFlashChecks performs the eFuse/security register reads observed on the esptool trace.
 func (f *espFlasher) preFlashChecks() error {
-	if _, err := f.readReg(regEfuseB); err != nil {
+	r := f.regs
+	if _, err := f.readReg(r.efuseB); err != nil {
 		return err
 	}
-	if _, err := f.readReg(regChipID0); err != nil {
+	if _, err := f.readReg(r.chipID0); err != nil {
 		return err
 	}
-	if _, err := f.readReg(regChipID0); err != nil {
+	if _, err := f.readReg(r.chipID0); err != nil {
 		return err
 	}
-	if _, err := f.readReg(regEfuseA); err != nil {
+	if _, err := f.readReg(r.efuseA); err != nil {
 		return err
 	}
 	// Final check immediately before erase/flash-begin.
-	if _, err := f.readReg(regEfuseB); err != nil {
+	if _, err := f.readReg(r.efuseB); err != nil {
 		return err
 	}
 	return nil
@@ -782,14 +877,12 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 		return fmt.Errorf("change baud: %w", err)
 	}
 
-	// Step 3: Security info + chip detection register sequence.
-	// The responses are ignored, but we perform them to stay close to the
-	// classic ROM bootloader init sequence.
-	if _, err := f.getSecurityInfo(); err != nil {
-		return fmt.Errorf("get security info: %w", err)
+	// Step 3: Identify chip and disable watchdogs.
+	if err := f.detectChip(); err != nil {
+		return fmt.Errorf("detect chip: %w", err)
 	}
-	if err := f.chipDetect(); err != nil {
-		return fmt.Errorf("chip detect: %w", err)
+	if err := f.initChip(); err != nil {
+		return fmt.Errorf("init chip: %w", err)
 	}
 
 	// Step 4: Attach SPI flash.
@@ -805,6 +898,8 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 
 	// Step 6: Set SPI params.
 	detectedFlashSize := flashSize(jedecId)
+	dbgf("flash: JEDEC manufacturer=0x%02x type=0x%02x capacity=0x%02x size=%dKiB",
+		jedecId.manufacturer, jedecId.memoryType, jedecId.capacity, detectedFlashSize/1024)
 	if err := f.spiSetParams(detectedFlashSize); err != nil {
 		return fmt.Errorf("SPI set params: %w", err)
 	}
@@ -821,6 +916,7 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 		return fmt.Errorf("firmware too large (%d bytes, max %d)", totalSize, maxFlashSize)
 	}
 	blockCount := (totalSize + espFlashBlockSize - 1) / espFlashBlockSize
+	dbgf("flash: totalSize=%d blockCount=%d", totalSize, blockCount)
 	if err := f.flashBegin(uint32(totalSize), uint32(blockCount), espFlashBlockSize, 0); err != nil {
 		return fmt.Errorf("flash begin: %w", err)
 	}

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -72,6 +73,11 @@ type JedecID struct {
 // espFlasher handles serial communication with the ESP32 bootloader.
 type espFlasher struct {
 	port serial.Port
+}
+
+func isPermissionDenied(err error) bool {
+	var portErr *serial.PortError
+	return errors.As(err, &portErr) && portErr.Code() == serial.PermissionDenied
 }
 
 func espLoaderErrorMessage(code byte) string {
@@ -729,7 +735,12 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 
 	port, err := serial.Open(portPath, mode)
 	if err != nil {
-		return fmt.Errorf("opening serial port %s: %w", portPath, err)
+		if isPermissionDenied(err) {
+			if group := serialPortGroup(portPath); group != "" {
+				return fmt.Errorf("Permission denied to access USB device %s. To have access, you need to be part of the user group '%s'.", portPath, group)
+			}
+		}
+		return fmt.Errorf("opening USB device %s: %w", portPath, err)
 	}
 
 	f := &espFlasher{port: port}

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -31,6 +31,7 @@ type chipModel int
 
 const (
 	chipUnknown chipModel = iota
+	chipESP32C5
 	chipESP32C6
 	chipESP32P4
 )
@@ -58,6 +59,26 @@ type chipRegs struct {
 	spiUser1 uint32 // SPI_MEM_USER1_REG (offset +0x20)
 	spiClock uint32 // SPI_MEM_CLOCK_REG (offset +0x28)
 	spiW0    uint32 // SPI_MEM_W0_REG    (offset +0x58)
+}
+
+// ESP32-C5 shares WDT and SPI registers with C6; only the eFuse base differs.
+var regsESP32C5 = chipRegs{
+	name:       "ESP32-C5",
+	wdtProtect: 0x600b1c18,
+	wdtConfig0: 0x600b1c00,
+	swdProtect: 0x600b1c20,
+	swdConf:    0x600b1c1c,
+	efuseA:     0x600b4830,
+	efuseB:     0x600b4838,
+	chipID0:    0x600b4850,
+	chipID1:    0x600b4854,
+	macLow:     0x600b4844,
+	macHigh:    0x600b4848,
+	spiCmd:     0x60003000,
+	spiUser:    0x60003018,
+	spiUser1:   0x60003020,
+	spiClock:   0x60003028,
+	spiW0:      0x60003058,
 }
 
 var regsESP32C6 = chipRegs{
@@ -471,6 +492,9 @@ func (f *espFlasher) detectChip() error {
 	chipID := binary.LittleEndian.Uint32(resp[chipIDOff : chipIDOff+4])
 	dbgf("detectChip: chipID=0x%04x", chipID)
 	switch chipID {
+	case 0x0017:
+		f.chip = chipESP32C5
+		f.regs = &regsESP32C5
 	case 0x000d:
 		f.chip = chipESP32C6
 		f.regs = &regsESP32C6

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -13,13 +13,36 @@ import (
 
 // ESP32 bootloader command opcodes.
 const (
-	espCmdFlashBegin   = 0x02
-	espCmdFlashData    = 0x03
-	espCmdFlashEnd     = 0x04
-	espCmdSync         = 0x08
-	espCmdSPISetParams = 0x0B
-	espCmdSPIAttach    = 0x0D
-	espCmdChangeBaud   = 0x0F
+	espCmdFlashBegin      = 0x02
+	espCmdFlashData       = 0x03
+	espCmdFlashEnd        = 0x04
+	espCmdSync            = 0x08
+	espCmdWriteReg        = 0x09
+	espCmdReadReg         = 0x0A
+	espCmdSPISetParams    = 0x0B
+	espCmdSPIAttach       = 0x0D
+	espCmdChangeBaud      = 0x0F
+	espCmdGetSecurityInfo = 0x14
+)
+
+// ESP32-C6 register addresses used during flash initialisation.
+const (
+	regChipMagic = 0x4087f580 // chip magic/identification word
+	regChipID0   = 0x600b0850 // eFuse chip ID word 0
+	regChipID1   = 0x600b0854 // eFuse chip ID word 1
+	regMACLow    = 0x600b0844 // eFuse MAC address low word
+	regMACHigh   = 0x600b0848 // eFuse MAC address high word
+	regEfuseA    = 0x600b0830 // eFuse miscellaneous register A
+	regEfuseB    = 0x600b0838 // eFuse miscellaneous register B
+	regRTCCtrl00 = 0x600b1c00 // RTC control register 0x00
+	regRTCCtrl18 = 0x600b1c18 // RTC control register 0x18
+	regRTCCtrl1C = 0x600b1c1c // RTC control register 0x1c
+	regRTCCtrl20 = 0x600b1c20 // RTC control register 0x20
+	regSPICmd    = 0x60003000 // SPI_MEM_CMD_REG
+	regSPIUser   = 0x60003018 // SPI_MEM_USER_REG
+	regSPIUser1  = 0x60003020 // SPI_MEM_USER1_REG
+	regSPIClock  = 0x60003028 // SPI_MEM_CLOCK_REG
+	regSPIW0     = 0x60003058 // SPI_MEM_W0_REG (data buffer word 0)
 )
 
 // SLIP framing bytes.
@@ -37,6 +60,14 @@ const (
 	flashBaudRate     = 921600
 	initialBaudRate   = 115200
 )
+
+// JedecID holds the three-byte JEDEC flash identification returned by the
+// RDID (0x9f) command.
+type JedecID struct {
+	manufacturer byte // vendor code (e.g. 0xEF = Winbond, 0x20 = Micron)
+	memoryType   byte // memory technology and interface (e.g. 0x40 = SPI NOR)
+	capacity     byte // density code (e.g. 0x17 = 64 Mbit)
+}
 
 // espFlasher handles serial communication with the ESP32 bootloader.
 type espFlasher struct {
@@ -90,6 +121,14 @@ func espLoaderErrorMessage(code byte) string {
 	default:
 		return fmt.Sprintf("unknown error code 0x%02x", code)
 	}
+}
+
+func flashSize(id JedecID) uint32 {
+	const defaultSize = 4 * 1024 * 1024
+	if id.capacity == 0 {
+		return defaultSize
+	}
+	return uint32(1) << id.capacity
 }
 
 func slipEncode(data []byte) []byte {
@@ -329,13 +368,255 @@ func (f *espFlasher) changeBaudRate(newBaud int) error {
 	return nil
 }
 
+// getSecurityInfo queries the chip security info (opcode 0x14).
+func (f *espFlasher) getSecurityInfo() (uint32, error) {
+	f.port.SetReadTimeout(espCmdTimeout)
+	resp, err := f.sendCommand(espCmdGetSecurityInfo, nil, 0)
+	if err != nil {
+		return 0, err
+	}
+	if len(resp) < 4 {
+		return 0, fmt.Errorf("getSecurityInfo: response too short (%d bytes)", len(resp))
+	}
+	return binary.LittleEndian.Uint32(resp[:4]), nil
+}
+
+// readReg reads a 32-bit peripheral register at addr.
+// The ROM bootloader returns the value in the header value field (bytes 4–7
+// of the raw response), which sendCommand exposes as result[0:4].
+func (f *espFlasher) readReg(addr uint32) (uint32, error) {
+	data := make([]byte, 4)
+	binary.LittleEndian.PutUint32(data, addr)
+	f.port.SetReadTimeout(espCmdTimeout)
+	result, err := f.sendCommand(espCmdReadReg, data, 0)
+	if err != nil {
+		return 0, err
+	}
+	if len(result) < 4 {
+		return 0, fmt.Errorf("readReg 0x%08x: short response", addr)
+	}
+	return binary.LittleEndian.Uint32(result[0:4]), nil
+}
+
+// writeReg performs a masked write to a 32-bit peripheral register:
+//
+//	reg[addr] = (reg[addr] & ^mask) | (value & mask)
+//
+// delay is a post-write delay in microseconds (pass 0 for no delay).
+func (f *espFlasher) writeReg(addr, value, mask, delay uint32) error {
+	data := make([]byte, 16)
+	binary.LittleEndian.PutUint32(data[0:4], addr)
+	binary.LittleEndian.PutUint32(data[4:8], value)
+	binary.LittleEndian.PutUint32(data[8:12], mask)
+	binary.LittleEndian.PutUint32(data[12:16], delay)
+	f.port.SetReadTimeout(espCmdTimeout)
+	_, err := f.sendCommand(espCmdWriteReg, data, 0)
+	return err
+}
+
 // spiAttach attaches the SPI flash.
 func (f *espFlasher) spiAttach() error {
-	// ESP32-C6 ROM bootloader expects 4 bytes (SPI config = 0 for defaults).
-	data := make([]byte, 4)
+	data := make([]byte, 8)
 	f.port.SetReadTimeout(espCmdTimeout)
 	_, err := f.sendCommand(espCmdSPIAttach, data, 0)
 	return err
+}
+
+// chipDetect runs the register read/write sequence the ROM bootloader requires
+// for chip identification.  We target ESP32-C6 only, so results are discarded.
+func (f *espFlasher) chipDetect() error {
+	if _, err := f.readReg(regChipMagic); err != nil {
+		return err
+	}
+
+	// RTC / JTAG power-domain initialisation sequence observed in esptool trace.
+	if err := f.writeReg(regRTCCtrl18, 0x50d83aa1, 0xffffffff, 0); err != nil {
+		return err
+	}
+	if err := f.writeReg(regRTCCtrl00, 0x00000000, 0xffffffff, 0); err != nil {
+		return err
+	}
+	if err := f.writeReg(regRTCCtrl18, 0x00000000, 0xffffffff, 0); err != nil {
+		return err
+	}
+	if err := f.writeReg(regRTCCtrl20, 0x50d83aa1, 0xffffffff, 0); err != nil {
+		return err
+	}
+
+	// Read-modify-write: write back the value currently in regRTCCtrl1C.
+	val, err := f.readReg(regRTCCtrl1C)
+	if err != nil {
+		return err
+	}
+	if err := f.writeReg(regRTCCtrl1C, val, 0xffffffff, 0); err != nil {
+		return err
+	}
+	if err := f.writeReg(regRTCCtrl20, 0x00000000, 0xffffffff, 0); err != nil {
+		return err
+	}
+
+	// Chip-ID reads (x3 for regChipID0, x1 for regChipID1).
+	for i := 0; i < 3; i++ {
+		if _, err := f.readReg(regChipID0); err != nil {
+			return err
+		}
+	}
+	if _, err := f.readReg(regChipID1); err != nil {
+		return err
+	}
+
+	// MAC address reads (three sets of low+high words).
+	for i := 0; i < 3; i++ {
+		if _, err := f.readReg(regMACLow); err != nil {
+			return err
+		}
+		if _, err := f.readReg(regMACHigh); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// initFlashChip performs the SPI flash controller register sequence
+// observed in the esptool trace after SPI_ATTACH.
+// It retrives the JEDEC ID and resets the flash chip, in order to start
+// without depeding on previous usages.
+func (f *espFlasher) initFlashChip() (JedecID, error) {
+	user0, err := f.readReg(regSPIUser)
+	if err != nil {
+		return JedecID{}, err
+	}
+	user1, err := f.readReg(regSPIUser1)
+	if err != nil {
+		return JedecID{}, err
+	}
+
+	// Step 1: RDID (0x9f) — read JEDEC ID using a faster clock.
+	if err := f.writeReg(regSPIClock, 0x00000017, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIUser, 0x90000000, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIUser1, 0x7000009f, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIW0, 0x00000000, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPICmd, 0x00040000, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if _, err := f.readReg(regSPICmd); err != nil { // poll until done
+		return JedecID{}, err
+	}
+	// W0 layout: bits 7:0 = Manufacturer, bits 15:8 = MemoryType, bits 23:16 = Capacity.
+	w0, err := f.readReg(regSPIW0)
+	if err != nil {
+		return JedecID{}, err
+	}
+	id := JedecID{
+		manufacturer: byte(w0),
+		memoryType:   byte(w0 >> 8),
+		capacity:     byte(w0 >> 16),
+	}
+	// Restore and verify.
+	if err := f.writeReg(regSPIUser, user0, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIUser1, user1, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if _, err := f.readReg(regSPIUser); err != nil {
+		return JedecID{}, err
+	}
+	if _, err := f.readReg(regSPIUser1); err != nil {
+		return JedecID{}, err
+	}
+
+	// Step 2: RSTEN (0x66) — Reset Enable command.
+	if err := f.writeReg(regSPIUser, 0x80000000, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIUser1, 0x70000066, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIW0, 0x00000000, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPICmd, 0x00040000, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if _, err := f.readReg(regSPICmd); err != nil {
+		return JedecID{}, err
+	}
+	if _, err := f.readReg(regSPIW0); err != nil {
+		return JedecID{}, err
+	}
+	// Restore and verify.
+	if err := f.writeReg(regSPIUser, user0, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIUser1, user1, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if _, err := f.readReg(regSPIUser); err != nil {
+		return JedecID{}, err
+	}
+	if _, err := f.readReg(regSPIUser1); err != nil {
+		return JedecID{}, err
+	}
+
+	// Step 3: RST (0x99) — Reset command.
+	if err := f.writeReg(regSPIUser, 0x80000000, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIUser1, 0x70000099, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIW0, 0x00000000, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPICmd, 0x00040000, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if _, err := f.readReg(regSPICmd); err != nil {
+		return JedecID{}, err
+	}
+	if _, err := f.readReg(regSPIW0); err != nil {
+		return JedecID{}, err
+	}
+	// Final restore (no verify needed after the last attempt).
+	if err := f.writeReg(regSPIUser, user0, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+	if err := f.writeReg(regSPIUser1, user1, 0xffffffff, 0); err != nil {
+		return JedecID{}, err
+	}
+
+	return id, nil
+}
+
+// preFlashChecks performs the eFuse/security register reads observed on the esptool trace.
+func (f *espFlasher) preFlashChecks() error {
+	if _, err := f.readReg(regEfuseB); err != nil {
+		return err
+	}
+	if _, err := f.readReg(regChipID0); err != nil {
+		return err
+	}
+	if _, err := f.readReg(regChipID0); err != nil {
+		return err
+	}
+	if _, err := f.readReg(regEfuseA); err != nil {
+		return err
+	}
+	// Final check immediately before erase/flash-begin.
+	if _, err := f.readReg(regEfuseB); err != nil {
+		return err
+	}
+	return nil
 }
 
 // spiSetParams configures SPI flash parameters.
@@ -408,10 +689,10 @@ func espResetViaUsbJtag(port serial.Port, enterBootloader bool) {
 	port.SetDTR(false)
 	port.SetRTS(false)
 	time.Sleep(100 * time.Millisecond)
-	port.SetDTR(enterBootloader)  // GPIO0=LOW (download mode selected)
+	port.SetDTR(enterBootloader) // GPIO0=LOW (download mode selected)
 	port.SetRTS(false)
 	time.Sleep(100 * time.Millisecond)
-	port.SetRTS(true)  // EN=LOW (assert reset)
+	port.SetRTS(true) // EN=LOW (assert reset)
 	port.SetDTR(false)
 	time.Sleep(100 * time.Millisecond)
 	port.SetRTS(false) // EN=HIGH (release reset → boots into download mode)
@@ -461,17 +742,40 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 		return fmt.Errorf("change baud: %w", err)
 	}
 
-	// Step 3: Attach SPI flash.
+	// Step 3: Security info + chip detection register sequence.
+	// The responses are ignored, but we perform them to stay close to the
+	// classic ROM bootloader init sequence.
+	if _, err := f.getSecurityInfo(); err != nil {
+		return fmt.Errorf("get security info: %w", err)
+	}
+	if err := f.chipDetect(); err != nil {
+		return fmt.Errorf("chip detect: %w", err)
+	}
+
+	// Step 4: Attach SPI flash.
 	if err := f.spiAttach(); err != nil {
 		return fmt.Errorf("SPI attach: %w", err)
 	}
 
-	// Step 4: Set SPI params (4 MB flash).
-	if err := f.spiSetParams(4 * 1024 * 1024); err != nil {
+	// Step 5: Reset flash chip and retrieve its JEDEC ID.
+	jedecId, err := f.initFlashChip()
+	if err != nil {
+		return fmt.Errorf("init flash chip: %w", err)
+	}
+
+	// Step 6: Set SPI params.
+	flashSize := flashSize(jedecId)
+	if err := f.spiSetParams(flashSize); err != nil {
 		return fmt.Errorf("SPI set params: %w", err)
 	}
 
-	// Step 5: Flash the firmware.
+	// Step 7: Pre-flash eFuse/security checks.
+	// Again, something done just to stick to the classic bootloader sequence.
+	if err := f.preFlashChecks(); err != nil {
+		return fmt.Errorf("pre-flash checks: %w", err)
+	}
+
+	// Step 8: Flash the firmware.
 	totalSize := uint32(len(firmware))
 	blockCount := (totalSize + espFlashBlockSize - 1) / espFlashBlockSize
 	if err := f.flashBegin(totalSize, blockCount, espFlashBlockSize, 0); err != nil {

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -487,7 +487,9 @@ func (f *espFlasher) chipDetect() error {
 // waitSPICmd polls regSPICmd until the SPI_USR bit (bit 18) is cleared,
 // indicating the hardware has finished executing the command.
 func (f *espFlasher) waitSPICmd() error {
-	for {
+	const timeout = 4000 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
 		val, err := f.readReg(regSPICmd)
 		if err != nil {
 			return err
@@ -495,7 +497,9 @@ func (f *espFlasher) waitSPICmd() error {
 		if val&0x00040000 == 0 {
 			return nil
 		}
+		time.Sleep(time.Millisecond)
 	}
+	return fmt.Errorf("SPI command timeout")
 }
 
 // initFlashChip performs the SPI flash controller register sequence

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -389,10 +389,10 @@ func (f *espFlasher) getSecurityInfo() (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	if len(resp) < 4 {
+	if len(resp) < 8 {
 		return 0, fmt.Errorf("getSecurityInfo: response too short (%d bytes)", len(resp))
 	}
-	return binary.LittleEndian.Uint32(resp[:4]), nil
+	return binary.LittleEndian.Uint32(resp[4:8]), nil
 }
 
 // readReg reads a 32-bit peripheral register at addr.

--- a/go/internal/cli/commands/espflash.go
+++ b/go/internal/cli/commands/espflash.go
@@ -31,7 +31,7 @@ const (
 )
 
 const (
-	espFlashBlockSize = 0x4000 // 16 KiB per flash data block
+	espFlashBlockSize = 0x1000 // 4 KiB per flash data block
 	espSyncTimeout    = 3 * time.Second
 	espCmdTimeout     = 10 * time.Second
 	flashBaudRate     = 921600
@@ -41,6 +41,55 @@ const (
 // espFlasher handles serial communication with the ESP32 bootloader.
 type espFlasher struct {
 	port serial.Port
+}
+
+func espLoaderErrorMessage(code byte) string {
+	switch code {
+	case 0x00:
+		return "undefined error"
+	case 0x01:
+		return "invalid input parameter"
+	case 0x02:
+		return "failed to allocate memory"
+	case 0x03:
+		return "failed to send message"
+	case 0x04:
+		return "failed to receive message"
+	case 0x05:
+		return "invalid message format"
+	case 0x06:
+		return "bad execution result"
+	case 0x07:
+		return "checksum error"
+	case 0x08:
+		return "flash write error (CRC mismatch on readback)"
+	case 0x09:
+		return "flash read error"
+	case 0x0a:
+		return "flash read length error"
+	case 0x0b:
+		return "deflate error"
+	case 0x0c:
+		return "deflate Adler32 error"
+	case 0x0d:
+		return "deflate parameter error"
+	case 0x0e:
+		return "invalid RAM binary size"
+	case 0x0f:
+		return "invalid RAM binary address"
+	case 0x64:
+		return "invalid parameter"
+	case 0x65:
+		return "invalid format"
+	case 0x66:
+		return "description too long"
+	case 0x67:
+		return "bad encoding description"
+	case 0x69:
+		return "insufficient storage"
+	default:
+		return fmt.Sprintf("unknown error code 0x%02x", code)
+	}
 }
 
 func slipEncode(data []byte) []byte {
@@ -77,6 +126,18 @@ func (f *espFlasher) readByte() (byte, error) {
 		// n == 0: port timeout, but our deadline hasn't passed — retry.
 	}
 	return 0, fmt.Errorf("serial read timed out")
+}
+
+// Ensure that all bytes are sent.
+func (f *espFlasher) writeData(data []byte) error {
+	for len(data) > 0 {
+		n, err := f.port.Write(data)
+		if err != nil {
+			return fmt.Errorf("write data error: %w", err)
+		}
+		data = data[n:]
+	}
+	return nil
 }
 
 func (f *espFlasher) slipDecode() ([]byte, error) {
@@ -153,7 +214,7 @@ func (f *espFlasher) sendCommand(opcode byte, data []byte, checksum byte) ([]byt
 	pkt := buildCommand(opcode, data, checksum)
 	encoded := slipEncode(pkt)
 
-	if _, err := f.port.Write(encoded); err != nil {
+	if err := f.writeData(encoded); err != nil {
 		return nil, fmt.Errorf("writing command 0x%02x: %w", opcode, err)
 	}
 
@@ -180,12 +241,18 @@ func (f *espFlasher) sendCommand(opcode byte, data []byte, checksum byte) ([]byt
 			continue
 		}
 
-		// Bytes 2:4 = size, 4:8 = value/error.
-		// Check the status field: last 4 bytes of the 8-byte header encode
-		// the return value. For most commands, a non-zero "error" field at
-		// byte offset 8+size-1 (the status struct appended by ROM loader)
-		// indicates failure. We return the payload and let callers check.
-		return resp[8:], nil
+		// Check payload
+		payload := resp[8:]
+		if len(payload) < 2 {
+			return nil, fmt.Errorf("bad protocol: response for 0x%02x too short (%d bytes)", opcode, len(payload))
+		}
+		if payload[0] != 0 || payload[1] != 0 {
+			if payload[0] != 1 {
+				return nil, fmt.Errorf("bad protocol: unexpected status 0x%02x for command 0x%02x", payload[0], opcode)
+			}
+			return nil, fmt.Errorf("command 0x%02x rejected: %s", opcode, espLoaderErrorMessage(payload[1]))
+		}
+		return resp[4:], nil
 	}
 
 	return nil, fmt.Errorf("no valid response for 0x%02x after 10 frames", opcode)
@@ -288,11 +355,12 @@ func (f *espFlasher) spiSetParams(totalSize uint32) error {
 
 // flashBegin starts a flash write operation, erasing the target region.
 func (f *espFlasher) flashBegin(size, blockCount, blockSize, offset uint32) error {
-	data := make([]byte, 16)
+	data := make([]byte, 20)
 	binary.LittleEndian.PutUint32(data[0:4], size)
 	binary.LittleEndian.PutUint32(data[4:8], blockCount)
 	binary.LittleEndian.PutUint32(data[8:12], blockSize)
 	binary.LittleEndian.PutUint32(data[12:16], offset)
+	binary.LittleEndian.PutUint32(data[16:20], 0) // 0 = no encryption
 
 	f.port.SetReadTimeout(30 * time.Second) // erase can be slow
 	_, err := f.sendCommand(espCmdFlashBegin, data, 0)
@@ -332,6 +400,24 @@ func (f *espFlasher) flashEnd(reboot bool) error {
 	return err
 }
 
+// Reset the chip and eventually enter download mode.
+// It uses the ESP32 USB-Serial/JTAG peripheral. ESP-IDF's USB-JTAG driver watches for this
+// specific DTR/RTS pattern and triggers a software reset into download mode.
+// This matches esptool's USBJTAGSerialReset strategy.
+func espResetViaUsbJtag(port serial.Port, enterBootloader bool) {
+	port.SetDTR(false)
+	port.SetRTS(false)
+	time.Sleep(100 * time.Millisecond)
+	port.SetDTR(enterBootloader)  // GPIO0=LOW (download mode selected)
+	port.SetRTS(false)
+	time.Sleep(100 * time.Millisecond)
+	port.SetRTS(true)  // EN=LOW (assert reset)
+	port.SetDTR(false)
+	time.Sleep(100 * time.Millisecond)
+	port.SetRTS(false) // EN=HIGH (release reset → boots into download mode)
+	time.Sleep(50 * time.Millisecond)
+}
+
 // flashFirmware is the main entry point: flash a .bin file to the ESP32.
 func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) error {
 	firmware, err := os.ReadFile(firmwarePath)
@@ -350,25 +436,22 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 	if err != nil {
 		return fmt.Errorf("opening serial port %s: %w", portPath, err)
 	}
-	defer port.Close()
 
 	f := &espFlasher{port: port}
+	defer func() { f.port.Close() }()
 
-	// Enter bootloader: toggle DTR/RTS to reset into download mode.
-	// Sequence: assert RTS (EN low) → assert DTR (IO0 low) → release RTS → release DTR.
-	port.SetDTR(false)
-	port.SetRTS(true)
-	time.Sleep(100 * time.Millisecond)
-	port.SetDTR(true)
-	port.SetRTS(false)
-	time.Sleep(100 * time.Millisecond)
-	port.SetDTR(false)
-	time.Sleep(50 * time.Millisecond)
-
-	// Drain any boot output.
+	// Step 1: Enter bootloader.
+	espResetViaUsbJtag(port, true)
+	f.port.Close()
+	time.Sleep(1500 * time.Millisecond) // wait for USB re-enumeration
+	newPort, err := serial.Open(portPath, mode)
+	if err != nil {
+		return fmt.Errorf("reopening port after reset: %w", err)
+	}
+	f.port = newPort
 	f.drain()
 
-	// Step 1: Sync.
+	// Verify that the bootloader is responding
 	if err := f.sync(); err != nil {
 		return fmt.Errorf("sync: %w", err)
 	}
@@ -391,7 +474,6 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 	// Step 5: Flash the firmware.
 	totalSize := uint32(len(firmware))
 	blockCount := (totalSize + espFlashBlockSize - 1) / espFlashBlockSize
-
 	if err := f.flashBegin(totalSize, blockCount, espFlashBlockSize, 0); err != nil {
 		return fmt.Errorf("flash begin: %w", err)
 	}
@@ -419,10 +501,9 @@ func flashFirmware(portPath, firmwarePath string, progressFn func(pct float64)) 
 		}
 	}
 
-	// Step 6: Finish and reboot.
-	if err := f.flashEnd(true); err != nil {
-		return fmt.Errorf("flash end: %w", err)
-	}
+	// Step 6: Reboot.
+	// Please note that we never succeeded in using flashEnd() here.
+	espResetViaUsbJtag(port, false)
 
 	return nil
 }

--- a/go/internal/cli/commands/espflash_linux.go
+++ b/go/internal/cli/commands/espflash_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package commands
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+func serialPortGroup(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return ""
+	}
+	group, err := user.LookupGroupId(strconv.Itoa(int(stat.Gid)))
+	if err != nil {
+		return strconv.Itoa(int(stat.Gid))
+	}
+	return group.Name
+}

--- a/go/internal/cli/commands/espflash_nonlinux.go
+++ b/go/internal/cli/commands/espflash_nonlinux.go
@@ -1,0 +1,7 @@
+//go:build darwin || windows
+
+package commands
+
+func serialPortGroup(_ string) string {
+	return ""
+}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -553,7 +553,7 @@ func connectFromSelectedDevice(target *SelectedDevice, cfg resolveConfig) (*grpc
 	// The user picked a Bluetooth device — connectToAgent only supports gRPC.
 	// Callers that support BLE should use resolveTarget() instead.
 	if target.Bluetooth != nil {
-		return nil, fmt.Errorf("selected device (%s) is a Bluetooth device; this command requires a LAN connection. Use 'wendy wifi connect' which supports BLE", target.Bluetooth.DisplayName)
+		return nil, fmt.Errorf("selected device (%s) is a Bluetooth device; this command requires a LAN connection. Use 'wendy device wifi connect' which supports BLE", target.Bluetooth.DisplayName)
 	}
 
 	// The user picked a non-gRPC device (e.g. external provider) which

--- a/go/internal/shared/discovery/serial_darwin.go
+++ b/go/internal/shared/discovery/serial_darwin.go
@@ -80,7 +80,7 @@ static WendySerialList wendy_find_usb_serial(int wantVID, int wantPID) {
 				if (!tmp) {
 					free(path);
 					IOObjectRelease(svc);
-					break;
+					goto cleanup;
 				}
 				result.paths = tmp;
 			}
@@ -90,6 +90,7 @@ static WendySerialList wendy_find_usb_serial(int wantVID, int wantPID) {
 		}
 		IOObjectRelease(svc);
 	}
+cleanup:
 	IOObjectRelease(iter);
 	return result;
 }

--- a/go/internal/shared/discovery/serial_darwin.go
+++ b/go/internal/shared/discovery/serial_darwin.go
@@ -103,7 +103,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/wendylabsinc/wendy/internal/shared/models"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 )
 
 // SerialDevice holds a serial port path and its USB connection time.

--- a/go/internal/shared/discovery/serial_darwin.go
+++ b/go/internal/shared/discovery/serial_darwin.go
@@ -76,7 +76,13 @@ static WendySerialList wendy_find_usb_serial(int wantVID, int wantPID) {
 		if (matched) {
 			if (result.count >= cap) {
 				cap *= 2;
-				result.paths = (char**)realloc(result.paths, cap * sizeof(char*));
+				char **tmp = (char**)realloc(result.paths, cap * sizeof(char*));
+				if (!tmp) {
+					free(path);
+					IOObjectRelease(svc);
+					break;
+				}
+				result.paths = tmp;
 			}
 			result.paths[result.count++] = path;
 		} else {

--- a/go/internal/shared/discovery/serial_darwin.go
+++ b/go/internal/shared/discovery/serial_darwin.go
@@ -2,37 +2,167 @@
 
 package discovery
 
+/*
+#cgo LDFLAGS: -framework IOKit -framework CoreFoundation
+#include <IOKit/IOKitLib.h>
+#include <IOKit/serial/IOSerialKeys.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <stdlib.h>
+
+static char* stringProp(io_service_t svc, CFStringRef key) {
+	CFTypeRef v = IORegistryEntryCreateCFProperty(svc, key, kCFAllocatorDefault, 0);
+	if (!v || CFGetTypeID(v) != CFStringGetTypeID()) {
+		if (v) CFRelease(v);
+		return NULL;
+	}
+	CFIndex n = CFStringGetMaximumSizeForEncoding(
+		CFStringGetLength((CFStringRef)v), kCFStringEncodingUTF8) + 1;
+	char *buf = (char*)malloc(n);
+	if (!CFStringGetCString((CFStringRef)v, buf, n, kCFStringEncodingUTF8)) {
+		free(buf);
+		CFRelease(v);
+		return NULL;
+	}
+	CFRelease(v);
+	return buf;
+}
+
+static int intProp(io_service_t svc, CFStringRef key, int *out) {
+	CFTypeRef v = IORegistryEntryCreateCFProperty(svc, key, kCFAllocatorDefault, 0);
+	if (!v || CFGetTypeID(v) != CFNumberGetTypeID()) {
+		if (v) CFRelease(v);
+		return 0;
+	}
+	CFNumberGetValue((CFNumberRef)v, kCFNumberIntType, out);
+	CFRelease(v);
+	return 1;
+}
+
+typedef struct { char **paths; int count; } WendySerialList;
+
+static WendySerialList wendy_find_usb_serial(int wantVID, int wantPID) {
+	WendySerialList result = {NULL, 0};
+	int cap = 8;
+	result.paths = (char**)malloc(cap * sizeof(char*));
+
+	CFMutableDictionaryRef match = IOServiceMatching(kIOSerialBSDServiceValue);
+	if (!match) return result;
+
+	io_iterator_t iter = IO_OBJECT_NULL;
+	if (IOServiceGetMatchingServices(0, match, &iter) != KERN_SUCCESS)
+		return result;
+
+	io_service_t svc;
+	while ((svc = IOIteratorNext(iter)) != IO_OBJECT_NULL) {
+		char *path = stringProp(svc, CFSTR(kIOCalloutDeviceKey));
+		if (!path) { IOObjectRelease(svc); continue; }
+
+		// Walk up the registry tree to find the USB node with VID/PID.
+		int matched = 0;
+		io_service_t cur = svc;
+		IOObjectRetain(cur);
+		io_service_t parent;
+		while (IORegistryEntryGetParentEntry(cur, kIOServicePlane, &parent) == KERN_SUCCESS) {
+			IOObjectRelease(cur);
+			cur = parent;
+			int vid = 0, pid = 0;
+			if (intProp(cur, CFSTR("idVendor"), &vid) && intProp(cur, CFSTR("idProduct"), &pid)) {
+				matched = (vid == wantVID && pid == wantPID);
+				break;
+			}
+		}
+		IOObjectRelease(cur);
+
+		if (matched) {
+			if (result.count >= cap) {
+				cap *= 2;
+				result.paths = (char**)realloc(result.paths, cap * sizeof(char*));
+			}
+			result.paths[result.count++] = path;
+		} else {
+			free(path);
+		}
+		IOObjectRelease(svc);
+	}
+	IOObjectRelease(iter);
+	return result;
+}
+
+static void wendy_free_serial_list(WendySerialList list) {
+	for (int i = 0; i < list.count; i++) free(list.paths[i]);
+	free(list.paths);
+}
+*/
+import "C"
+
 import (
 	"fmt"
 	"os"
-	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
+	"unsafe"
+
+	"github.com/wendylabsinc/wendy/internal/shared/models"
 )
 
-// ResolveESP32SerialPort finds the serial port for an ESP32-C6 device on macOS.
-// It globs /dev/cu.usbmodem* and returns the most recently connected.
-func ResolveESP32SerialPort() (string, error) {
-	matches, err := filepath.Glob("/dev/cu.usbmodem*")
+// SerialDevice holds a serial port path and its USB connection time.
+type SerialDevice struct {
+	Port           string
+	ConnectionTime time.Time
+}
+
+// ResolveESP32SerialPorts returns all connected serial ports whose USB VID/PID
+// match the ESP32 constants, along with each device node's plug-in time.
+func ResolveESP32SerialPorts() ([]SerialDevice, error) {
+	vid, err := parseHexID(models.ESP32VendorID)
 	if err != nil {
-		return "", fmt.Errorf("globbing serial ports: %w", err)
+		return nil, fmt.Errorf("invalid ESP32VendorID %q: %w", models.ESP32VendorID, err)
+	}
+	pid, err := parseHexID(models.ESP32ProductID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ESP32ProductID %q: %w", models.ESP32ProductID, err)
 	}
 
-	if len(matches) == 0 {
-		return "", fmt.Errorf("no ESP32 serial port found (expected /dev/cu.usbmodem*)")
+	list := C.wendy_find_usb_serial(C.int(vid), C.int(pid))
+	defer C.wendy_free_serial_list(list)
+
+	count := int(list.count)
+	if count == 0 {
+		return nil, nil
 	}
 
-	best := matches[0]
-	bestMtime := time.Time{}
-	for _, m := range matches {
-		info, err := os.Stat(m)
+	paths := unsafe.Slice(list.paths, count)
+	result := make([]SerialDevice, 0, count)
+	for _, cp := range paths {
+		path := C.GoString(cp)
+		info, err := os.Stat(path)
 		if err != nil {
 			continue
 		}
-		if info.ModTime().After(bestMtime) {
-			bestMtime = info.ModTime()
-			best = m
+		result = append(result, SerialDevice{Port: path, ConnectionTime: info.ModTime()})
+	}
+	return result, nil
+}
+
+// ResolveESP32SerialPort returns the most recently connected ESP32 serial port.
+func ResolveESP32SerialPort() (string, error) {
+	devices, err := ResolveESP32SerialPorts()
+	if err != nil {
+		return "", err
+	}
+	if len(devices) == 0 {
+		return "", fmt.Errorf("no ESP32 serial port found")
+	}
+	best := devices[0]
+	for _, d := range devices[1:] {
+		if d.ConnectionTime.After(best.ConnectionTime) {
+			best = d
 		}
 	}
+	return best.Port, nil
+}
 
-	return best, nil
+func parseHexID(s string) (int64, error) {
+	return strconv.ParseInt(strings.TrimPrefix(s, "0x"), 16, 32)
 }

--- a/go/internal/shared/discovery/serial_linux.go
+++ b/go/internal/shared/discovery/serial_linux.go
@@ -28,6 +28,10 @@ func ResolveESP32SerialPort() (string, error) {
 		if err != nil {
 			continue
 		}
+		// Constrain resolved path to sysfs to prevent traversal via adversarial symlinks.
+		if !strings.HasPrefix(resolvedIface, "/sys/devices/") {
+			continue
+		}
 		usbDevPath := filepath.Dir(resolvedIface)
 		vidPath := filepath.Join(usbDevPath, "idVendor")
 		pidPath := filepath.Join(usbDevPath, "idProduct")

--- a/go/internal/shared/discovery/serial_linux.go
+++ b/go/internal/shared/discovery/serial_linux.go
@@ -23,8 +23,14 @@ func ResolveESP32SerialPort() (string, error) {
 	wantPID := strings.TrimPrefix(models.ESP32ProductID, "0x")
 
 	for _, entry := range entries {
-		vidPath := filepath.Join(entry, "device", "..", "idVendor")
-		pidPath := filepath.Join(entry, "device", "..", "idProduct")
+		deviceSymlink := filepath.Join(entry, "device")
+		resolvedIface, err := filepath.EvalSymlinks(deviceSymlink)
+		if err != nil {
+			continue
+		}
+		usbDevPath := filepath.Dir(resolvedIface)
+		vidPath := filepath.Join(usbDevPath, "idVendor")
+		pidPath := filepath.Join(usbDevPath, "idProduct")
 
 		vid, err := os.ReadFile(vidPath)
 		if err != nil {


### PR DESCRIPTION
This includes:
* detect ESP32 devices by vendor/device ID on Mac
* fix detection on Linux
* automatically switch the ESP32 into program mode before flashing the firmware
* automatically reset the ESP32 after having flashed the firmware
* automatically detect Flash size
* better detect and report errors when flashing the firmware