### PR TITLE
fix(docs): point static search client at basePath-prefixed index

### DIFF
--- a/go/internal/cli/assets/docs/components/search.tsx
+++ b/go/internal/cli/assets/docs/components/search.tsx
@@ -3,6 +3,7 @@
 import { create } from '@orama/orama';
 import { useDocsSearch } from 'fumadocs-core/search/client';
 import { useI18n } from 'fumadocs-ui/contexts/i18n';
+import { basePath } from '@/lib/shared';
 import {
   SearchDialog,
   SearchDialogClose,
@@ -28,6 +29,10 @@ export default function DefaultSearchDialog(props: SharedProps) {
     type: 'static',
     initOrama,
     locale,
+    // The static client fetches the exported index from `/api/search` by
+    // default, which omits the deploy basePath (e.g. `/latest`, `/release-x`,
+    // `/branch-main-<sha>`) and 404s on every non-root deploy. Prefix it.
+    from: `${basePath}/api/search`,
   });
 
   return (


### PR DESCRIPTION
## Summary

The docs **search bar returns no results** on deployed docs (`/latest`, and any `/release-<v>` or `/branch-main-<sha>` deploy).

## Root cause

We use the Fumadocs **static** search client (`type: 'static'`), which downloads a prebuilt index. Its `from` URL defaults to `/api/search` — with **no deploy basePath**. So on `/latest` the client fetches `https://docs.wendy.dev/api/search` (root) instead of `https://docs.wendy.dev/latest/api/search`, which 404s:

```
/latest/api/search       -> 200   (index exists here)
/api/search (root)       -> 404   (what the client actually requested)
```

Same class of bug as the `.tsx` asset paths fixed in #829: React components aren't processed by `prepare-content.mjs`, so the basePath has to be applied manually.

## Fix

In `components/search.tsx`, set the index URL explicitly:

```ts
useDocsSearch({
  type: 'static',
  initOrama,
  locale,
  from: `${basePath}/api/search`,   // basePath from lib/shared
});
```

## Verification

A `NEXT_PUBLIC_BASE_PATH=/branch-test` production build emits the call site as:
```js
type:"static", initOrama:a, locale:r, from:"/branch-test/api/search"
```
and the index exports to `out/api/search`. (The remaining bare `/api/search` strings in the bundle are just the library's internal default values, now overridden.)

## Test plan
- After deploy, open the search dialog on `https://docs.wendy.dev/latest/` and type a query — results should appear (index fetched from `/latest/api/search`).
