### PR TITLE
Add model metadata columns to template schema picker

### DIFF
--- a/go/internal/cli/commands/project.go
+++ b/go/internal/cli/commands/project.go
@@ -342,7 +342,14 @@ func parsePins(input string) ([]int, error) {
 // pickFromItems shows an interactive picker with the given title and items,
 // returning the selected item's Value as a string.
 func pickFromItems(title string, items []tui.PickerItem) (string, error) {
+	return pickFromItemsWithColumns(title, items, nil)
+}
+
+func pickFromItemsWithColumns(title string, items []tui.PickerItem, columns []tui.PickerColumn) (string, error) {
 	picker := tui.NewPickerWithTitle(title)
+	if len(columns) > 0 {
+		picker = tui.NewPickerWithTitleAndColumns(title, columns)
+	}
 	p := tea.NewProgram(picker)
 
 	go func() {
@@ -358,6 +365,9 @@ func pickFromItems(title string, items []tui.PickerItem) (string, error) {
 	pm := finalModel.(tui.PickerModel)
 	if pm.Cancelled() {
 		return "", ErrUserCancelled
+	}
+	if pm.Selected() == nil {
+		return "", fmt.Errorf("no selection")
 	}
 
 	return pm.Selected().Value.(string), nil

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -99,8 +99,12 @@ type templateSchemaQuestion struct {
 
 // templateSchemaOption is a single selectable choice in a radio or checkbox question.
 type templateSchemaOption struct {
-	Value string `json:"value"`
-	Label string `json:"label"`
+	Value       string `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+	Size        string `json:"size,omitempty"`
+	Parameters  string `json:"parameters,omitempty"`
+	Comments    string `json:"comments,omitempty"`
 }
 
 // templateSchemaCondition controls whether a phase or question is shown,
@@ -901,11 +905,14 @@ func promptSchemaQuestion(q templateSchemaQuestion, vals map[string]interface{})
 
 	switch q.Type {
 	case "radio":
-		items := make([]tui.PickerItem, len(q.Options))
-		for i, opt := range q.Options {
-			items[i] = tui.PickerItem{Name: opt.Label, Value: opt.Value}
+		items := schemaOptionPickerItems(q.Options)
+		var val string
+		var err error
+		if schemaOptionsHaveModelMetadata(q.Options) {
+			val, err = pickFromItemsWithColumns(q.Label, items, schemaModelPickerColumns())
+		} else {
+			val, err = pickFromItems(q.Label, items)
 		}
-		val, err := pickFromItems(q.Label, items)
 		if err != nil {
 			return err
 		}
@@ -953,6 +960,71 @@ func promptSchemaQuestion(q templateSchemaQuestion, vals map[string]interface{})
 	}
 
 	return nil
+}
+
+func schemaOptionPickerItems(options []templateSchemaOption) []tui.PickerItem {
+	items := make([]tui.PickerItem, len(options))
+	for i, opt := range options {
+		name := opt.Label
+		if name == "" {
+			name = opt.Value
+		}
+		items[i] = tui.PickerItem{
+			Name:        name,
+			Description: opt.Description,
+			Size:        opt.Size,
+			Parameters:  opt.Parameters,
+			Comments:    opt.Comments,
+			Value:       opt.Value,
+		}
+	}
+	return items
+}
+
+func schemaOptionsHaveModelMetadata(options []templateSchemaOption) bool {
+	for _, opt := range options {
+		if opt.Size != "" || opt.Parameters != "" || opt.Comments != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func schemaModelPickerColumns() []tui.PickerColumn {
+	return []tui.PickerColumn{
+		{
+			Title:    "model",
+			MinWidth: 32,
+			Required: true,
+			Value: func(item tui.PickerItem) string {
+				return item.Name
+			},
+		},
+		{
+			Title:    "size",
+			MinWidth: 10,
+			Value: func(item tui.PickerItem) string {
+				return item.Size
+			},
+		},
+		{
+			Title:    "parameters",
+			MinWidth: 14,
+			Value: func(item tui.PickerItem) string {
+				return item.Parameters
+			},
+		},
+		{
+			Title:    "comments",
+			MinWidth: 44,
+			Value: func(item tui.PickerItem) string {
+				if item.Comments != "" {
+					return item.Comments
+				}
+				return item.Description
+			},
+		},
+	}
 }
 
 // parseVarFlags parses --var KEY=VALUE flags into a map.

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -533,7 +533,7 @@ func TestExtractTemplateArchive_ParsesSchema(t *testing.T) {
 			"id":"p1","title":"Phase 1",
 			"questions":[
 				{"id":"MODE","label":"Mode?","type":"radio","required":true,
-				 "options":[{"value":"local","label":"Local"},{"value":"cloud","label":"Cloud"}]}
+				 "options":[{"value":"local","label":"Local","size":"edge","parameters":"4B","comments":"small device"},{"value":"cloud","label":"Cloud"}]}
 			]
 		}]
 	}`
@@ -560,6 +560,10 @@ func TestExtractTemplateArchive_ParsesSchema(t *testing.T) {
 	}
 	if len(phase.Questions) != 1 || phase.Questions[0].ID != "MODE" {
 		t.Errorf("phase.Questions = %+v, want one MODE question", phase.Questions)
+	}
+	opt := phase.Questions[0].Options[0]
+	if opt.Size != "edge" || opt.Parameters != "4B" || opt.Comments != "small device" {
+		t.Errorf("schema option metadata = %+v, want size/parameters/comments", opt)
 	}
 }
 

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -15,6 +15,9 @@ type PickerItem struct {
 	Name         string
 	Description  string // optional secondary text rendered dimmed
 	Type         string // "LAN", "Bluetooth", "External", etc.
+	Size         string // optional picker-specific metadata column
+	Parameters   string // optional picker-specific metadata column
+	Comments     string // optional picker-specific metadata column
 	USB          string // non-empty when the device is connected over USB
 	Address      string
 	AgentVersion string
@@ -93,6 +96,14 @@ type PickerModel struct {
 	height       int
 }
 
+// PickerColumn defines a caller-provided picker table column.
+type PickerColumn struct {
+	Title    string
+	MinWidth int
+	Required bool
+	Value    func(PickerItem) string
+}
+
 func NewPicker() PickerModel {
 	m := PickerModel{
 		Title:        "Select a device",
@@ -113,6 +124,16 @@ func NewPickerWithTitle(title string) PickerModel {
 		table:    newPickerTable(),
 		scanning: true,
 	}
+	m.refreshTable()
+	return m
+}
+
+// NewPickerWithTitleAndColumns creates a picker with a custom title and stable
+// caller-provided table columns.
+func NewPickerWithTitleAndColumns(title string, columns []PickerColumn) PickerModel {
+	m := NewPickerWithTitle(title)
+	m.columns = pickerColumnDefsFromColumns(columns)
+	m.fixedColumns = true
 	m.refreshTable()
 	return m
 }
@@ -305,6 +326,26 @@ type pickerColumnDef struct {
 	minWidth int
 	value    func(PickerItem) string
 	required bool
+}
+
+func pickerColumnDefsFromColumns(columns []PickerColumn) []pickerColumnDef {
+	if len(columns) == 0 {
+		return nil
+	}
+	defs := make([]pickerColumnDef, 0, len(columns))
+	for _, col := range columns {
+		value := col.Value
+		if value == nil {
+			value = func(PickerItem) string { return "" }
+		}
+		defs = append(defs, pickerColumnDef{
+			title:    col.Title,
+			minWidth: col.MinWidth,
+			value:    value,
+			required: col.Required,
+		})
+	}
+	return defs
 }
 
 var pickerColumnDefs = []pickerColumnDef{

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -131,6 +131,9 @@ func NewPickerWithTitle(title string) PickerModel {
 // NewPickerWithTitleAndColumns creates a picker with a custom title and stable
 // caller-provided table columns.
 func NewPickerWithTitleAndColumns(title string, columns []PickerColumn) PickerModel {
+	if len(columns) == 0 {
+		return NewPickerWithTitle(title)
+	}
 	m := NewPickerWithTitle(title)
 	m.columns = pickerColumnDefsFromColumns(columns)
 	m.fixedColumns = true

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -129,6 +129,22 @@ func TestPickerModel_CustomColumns(t *testing.T) {
 	}
 }
 
+func TestPickerModel_CustomColumnsNilFallsBackToDefaultPicker(t *testing.T) {
+	m := NewPickerWithTitleAndColumns("Select", nil)
+
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "alpha", Description: "only show populated optional columns", Value: "alpha"},
+	}})
+	pm := updated.(PickerModel)
+
+	if hasColumn(pm.table.Columns(), "Type") {
+		t.Fatal("nil custom columns should not force the fixed default column layout")
+	}
+	if !hasColumn(pm.table.Columns(), "Description") {
+		t.Fatal("nil custom columns should preserve the default picker dynamic column behavior")
+	}
+}
+
 func TestPickerTableData_KeepsFullColumnContentForScrolling(t *testing.T) {
 	items := []PickerItem{{
 		Name:        "wendyos-sunny-daisy",

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -80,6 +80,55 @@ func TestPickerModel_ShowsDescriptionColumnWhenPresent(t *testing.T) {
 	}
 }
 
+func TestPickerModel_CustomColumns(t *testing.T) {
+	m := NewPickerWithTitleAndColumns("Select a model", []PickerColumn{
+		{
+			Title:    "model",
+			MinWidth: 16,
+			Required: true,
+			Value: func(item PickerItem) string {
+				return item.Name
+			},
+		},
+		{
+			Title: "size",
+			Value: func(item PickerItem) string {
+				return item.Size
+			},
+		},
+		{
+			Title: "parameters",
+			Value: func(item PickerItem) string {
+				return item.Parameters
+			},
+		},
+		{
+			Title: "comments",
+			Value: func(item PickerItem) string {
+				return item.Comments
+			},
+		},
+	})
+
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{
+			Name:       "gemma4:e2b",
+			Size:       "edge",
+			Parameters: "E2B",
+			Comments:   "default for small devices",
+			Value:      "gemma4:e2b",
+		},
+	}})
+	pm := updated.(PickerModel)
+
+	view := pm.View()
+	for _, want := range []string{"model", "size", "parameters", "comments", "gemma4:e2b", "default for small devices"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected picker view to contain %q, got %q", want, view)
+		}
+	}
+}
+
 func TestPickerTableData_KeepsFullColumnContentForScrolling(t *testing.T) {
 	items := []PickerItem{{
 		Name:        "wendyos-sunny-daisy",


### PR DESCRIPTION
## Summary
- Extend template schema radio options with optional `description`, `size`, `parameters`, and `comments` metadata.
- Add custom Bubble Tea picker columns so model choices can render as `model`, `size`, `parameters`, and `comments`.
- Preserve existing picker behavior for normal schema radio questions and other picker call sites.

## Validation
- `gofmt -w go/internal/cli/tui/picker.go go/internal/cli/tui/picker_test.go go/internal/cli/commands/project.go go/internal/cli/commands/template.go go/internal/cli/commands/template_test.go`
- `go test ./go/internal/cli/tui ./go/internal/cli/commands`
- `git diff --check`