### PR TITLE
feat(docs): add Google Analytics (shared GA4 with marketing site)

### DIFF
--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -193,6 +193,10 @@ jobs:
         env:
           DEPLOY_PATHS: ${{ steps.path.outputs.deploy_paths }}
           NEXT_PUBLIC_SITE_URL: https://docs.wendy.dev
+          # GA4 / Firebase Analytics — same measurement ID as the marketing site
+          # (wendy.dev). Public by design (it ships in client JS). Baked in at
+          # build time because the docs are a static export.
+          NEXT_PUBLIC_GA_MEASUREMENT_ID: G-7SMVRRYVW6
         run: |
           set -euo pipefail
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,14 @@ name: Security
 on:
   pull_request:
     branches: [main]
-    paths: ['go/**', 'Proto/**', 'go.mod', 'go.sum']
+    # The docs site lives under go/internal/cli/assets/docs but is a Next.js app,
+    # not Go. Exclude it so docs-only PRs don't run the Go vuln/security scans.
+    paths:
+      - 'go/**'
+      - '!go/internal/cli/assets/docs/**'
+      - 'Proto/**'
+      - 'go.mod'
+      - 'go.sum'
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:

--- a/go/internal/cli/assets/docs/app/layout.tsx
+++ b/go/internal/cli/assets/docs/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from '@/components/analytics';
 import { Provider } from '@/components/provider';
 import type { ReactNode } from 'react';
 import { ogImage } from '@/lib/shared';
@@ -32,6 +33,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en" suppressHydrationWarning>
       <body className="flex min-h-screen flex-col">
         <Provider>{children}</Provider>
+        <Analytics />
       </body>
     </html>
   );

--- a/go/internal/cli/assets/docs/components/analytics.tsx
+++ b/go/internal/cli/assets/docs/components/analytics.tsx
@@ -1,0 +1,18 @@
+import { GoogleAnalytics } from '@next/third-parties/google';
+
+// Google Analytics 4 / Firebase Analytics — shares the same measurement ID as
+// the marketing site (wendy.dev): the "marketing-website-wendy" Firebase web
+// app (project cloud-c7e56), so docs traffic lands in the same GA4 property.
+//
+// @next/third-parties injects gtag.js via next/script and tracks App Router
+// route changes automatically. Gated on the env var so local dev (where it is
+// unset) sends nothing; CI sets it at build time for deployed docs.
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+export function Analytics() {
+  if (!GA_MEASUREMENT_ID) {
+    return null;
+  }
+
+  return <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />;
+}

--- a/go/internal/cli/assets/docs/package-lock.json
+++ b/go/internal/cli/assets/docs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@wendy/wendyos-docs",
       "version": "0.0.0",
       "dependencies": {
+        "@next/third-parties": "16.2.6",
         "@orama/orama": "3.1.18",
         "fumadocs-core": "16.9.0",
         "fumadocs-mdx": "15.0.7",
@@ -1210,6 +1211,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.6.tgz",
+      "integrity": "sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@orama/orama": {
@@ -6657,6 +6671,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinyexec": {
       "version": "1.1.2",

--- a/go/internal/cli/assets/docs/package.json
+++ b/go/internal/cli/assets/docs/package.json
@@ -13,6 +13,7 @@
     "types:check": "fumadocs-mdx && next typegen && tsc --noEmit"
   },
   "dependencies": {
+    "@next/third-parties": "16.2.6",
     "@orama/orama": "3.1.18",
     "fumadocs-core": "16.9.0",
     "fumadocs-mdx": "15.0.7",


### PR DESCRIPTION
## Summary

Wire the docs into the **same Google Analytics 4 property as the marketing site** (wendy.dev), so docs traffic shows up in the same dashboard.

- Measurement ID **`G-7SMVRRYVW6`** — the "marketing-website-wendy" Firebase web app (project `cloud-c7e56`), identical to what wendy.dev uses (verified live on the marketing site and in its `apphosting.yaml`).

## Changes
- Add `@next/third-parties` (pinned to `next` 16.2.6) and a `components/analytics.tsx` that renders `<GoogleAnalytics gaId={...}>` **only when `NEXT_PUBLIC_GA_MEASUREMENT_ID` is set** — mirrors the marketing-website implementation. Mounted in the root `app/layout.tsx`.
- Set `NEXT_PUBLIC_GA_MEASUREMENT_ID: G-7SMVRRYVW6` in the fumadocs deploy build step. The docs are a **static export**, so the ID must be present at build time; it's public by design (it ships in client JS, same as on wendy.dev).

`@next/third-parties` injects `gtag.js` via `next/script` and tracks App Router route changes automatically (initial load + client-side navigations, no double counting).

## Verification
- Build **with** the var → `googletagmanager.com/gtag/js?id=G-7SMVRRYVW6` injected on the home page and sub-pages.
- Build **without** the var → no gtag, no googletagmanager (local dev sends nothing).

## Test plan
- After deploy, load `https://docs.wendy.dev/latest/`, confirm a `gtag/js?id=G-7SMVRRYVW6` request fires, and check GA4 Realtime shows the docs pageview.
