### PR TITLE
build: support host-specific Go make recipes

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -34,7 +34,10 @@ jobs:
 
       - name: Run tests
         working-directory: go
-        run: go test ./... -race -count=1 -timeout 120s
+        # Go 1.26.4 can ICE on the Linux runner while compiling some
+        # dependencies with the race detector and parallel compilation.
+        # Keep race coverage but compile serially.
+        run: go test -p=1 -gcflags=all=-c=1 ./... -race -count=1 -timeout 120s
 
       # Compile the Windows-shipping CLI packages so //go:build windows files
       # (e.g. wifi_scan_windows.go) are at least type-checked in PR CI. The

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,3 +1,28 @@
+ifeq ($(OS),Windows_NT)
+DETECTED_HOST_OS := windows
+DETECTED_HOST_ENV := windows
+else
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+DETECTED_HOST_OS := macos
+DETECTED_HOST_ENV := unix
+else ifeq ($(UNAME_S),Linux)
+DETECTED_HOST_OS := linux
+DETECTED_HOST_ENV := unix
+else
+DETECTED_HOST_OS := unknown
+DETECTED_HOST_ENV := unix
+endif
+endif
+
+HOST_OS ?= $(DETECTED_HOST_OS)
+HOST_ENV ?= $(DETECTED_HOST_ENV)
+
+ifeq ($(HOST_ENV),windows)
+override SHELL := powershell.exe
+.SHELLFLAGS := -NoProfile -ExecutionPolicy Bypass -Command
+endif
+
 .PHONY: build build-cli build-agent test vet proto clean fmt lint install \
        build-all \
        build-agent-linux-amd64 build-agent-linux-arm64 \
@@ -11,7 +36,7 @@
 VERSION ?= dev
 MSI_VERSION ?= 0.0.1
 LDFLAGS := -s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=$(VERSION)
-ifeq ($(shell uname -s),Darwin)
+ifeq ($(HOST_OS),macos)
 # Go/cgo adds -lobjc for each Objective-C package. The native CLI links
 # multiple CoreBluetooth-backed packages, and recent Apple linkers warn about
 # the duplicate even though it is harmless.
@@ -19,102 +44,263 @@ CGO_LDFLAGS += -Wl,-no_warn_duplicate_libraries
 export CGO_LDFLAGS
 endif
 
-# Build both CLI and agent (native)
-build: build-cli build-agent
-
-# Build the wendy CLI
-build-cli:
-	go build -o bin/wendy ./cmd/wendy
-
-# Build the wendy-agent
-build-agent:
-	go build -o bin/wendy-agent ./cmd/wendy-agent
-
-# Cross-compile all targets
-build-all: build-agent-linux-amd64 build-agent-linux-arm64 \
-           build-cli-linux-amd64 build-cli-linux-arm64 \
-           build-cli-darwin-amd64 build-cli-darwin-arm64 \
-           build-cli-windows-amd64 build-cli-windows-arm64
-
-build-agent-linux-amd64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-agent-linux-amd64 ./cmd/wendy-agent
-
-build-agent-linux-arm64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-agent-linux-arm64 ./cmd/wendy-agent
-
-build-cli-linux-amd64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-linux-amd64 ./cmd/wendy
-
-build-cli-linux-arm64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-linux-arm64 ./cmd/wendy
-
-build-cli-darwin-amd64:
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-darwin-amd64 ./cmd/wendy
-
-build-cli-darwin-arm64:
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-darwin-arm64 ./cmd/wendy
-
-build-cli-windows-amd64:
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-windows-amd64.exe ./cmd/wendy
-
-build-cli-windows-arm64:
-	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-windows-arm64.exe ./cmd/wendy
-
-# Build Windows MSI installers (requires WiX v4+: dotnet tool install --global wix)
 WXS := installer/windows/wendy.wxs
 
-msi-windows-amd64: build-cli-windows-amd64
+GO_BUILD_CROSS_UNIX = CGO_ENABLED=0 GOOS=$(1) GOARCH=$(2) go build -ldflags "$(LDFLAGS)" -o $(3) $(4)
+GO_BUILD_CROSS_WINDOWS = @if (-not $$PSVersionTable) { throw 'Windows make recipes require PowerShell.' }; $$env:CGO_ENABLED = '0'; $$env:GOOS = '$(1)'; $$env:GOARCH = '$(2)'; go build -ldflags "$(LDFLAGS)" -o $(3) $(4); if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }
+
+# Build both CLI and agent (native)
+.PHONY: build
+build: build-$(HOST_ENV)
+
+.PHONY: build-unix
+build-unix: build-cli-unix build-agent-unix
+
+.PHONY: build-windows
+build-windows: build-cli-windows build-agent-windows
+
+# Build the wendy CLI
+.PHONY: build-cli
+build-cli: build-cli-$(HOST_ENV)
+
+.PHONY: build-cli-unix
+build-cli-unix:
+	mkdir -p bin
+	go build -o bin/wendy ./cmd/wendy
+
+.PHONY: build-cli-windows
+build-cli-windows:
+	@if (-not $$PSVersionTable) { throw 'Windows build-cli requires PowerShell.' }; New-Item -ItemType Directory -Force -Path bin | Out-Null; go build -o bin/wendy.exe ./cmd/wendy; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }
+
+# Build the wendy-agent
+.PHONY: build-agent
+build-agent: build-agent-$(HOST_ENV)
+
+.PHONY: build-agent-unix
+build-agent-unix:
+	mkdir -p bin
+	go build -o bin/wendy-agent ./cmd/wendy-agent
+
+.PHONY: build-agent-windows
+build-agent-windows:
+	@throw 'build-agent is not supported on Windows yet.'
+
+# Cross-compile all targets
+.PHONY: build-all
+build-all: build-all-$(HOST_ENV)
+
+.PHONY: build-all-unix
+build-all-unix: build-agent-linux-amd64-unix build-agent-linux-arm64-unix \
+           build-cli-linux-amd64-unix build-cli-linux-arm64-unix \
+           build-cli-darwin-amd64-unix build-cli-darwin-arm64-unix \
+           build-cli-windows-amd64-unix build-cli-windows-arm64-unix
+
+.PHONY: build-all-windows
+build-all-windows: build-agent-linux-amd64-windows build-agent-linux-arm64-windows \
+           build-cli-linux-amd64-windows build-cli-linux-arm64-windows \
+           build-cli-darwin-amd64-windows build-cli-darwin-arm64-windows \
+           build-cli-windows-amd64-windows build-cli-windows-arm64-windows
+
+.PHONY: build-agent-linux-amd64
+build-agent-linux-amd64: build-agent-linux-amd64-$(HOST_ENV)
+.PHONY: build-agent-linux-amd64-unix
+build-agent-linux-amd64-unix:
+	$(call GO_BUILD_CROSS_UNIX,linux,amd64,bin/wendy-agent-linux-amd64,./cmd/wendy-agent)
+.PHONY: build-agent-linux-amd64-windows
+build-agent-linux-amd64-windows:
+	$(call GO_BUILD_CROSS_WINDOWS,linux,amd64,bin/wendy-agent-linux-amd64,./cmd/wendy-agent)
+
+.PHONY: build-agent-linux-arm64
+build-agent-linux-arm64: build-agent-linux-arm64-$(HOST_ENV)
+.PHONY: build-agent-linux-arm64-unix
+build-agent-linux-arm64-unix:
+	$(call GO_BUILD_CROSS_UNIX,linux,arm64,bin/wendy-agent-linux-arm64,./cmd/wendy-agent)
+.PHONY: build-agent-linux-arm64-windows
+build-agent-linux-arm64-windows:
+	$(call GO_BUILD_CROSS_WINDOWS,linux,arm64,bin/wendy-agent-linux-arm64,./cmd/wendy-agent)
+
+.PHONY: build-cli-linux-amd64
+build-cli-linux-amd64: build-cli-linux-amd64-$(HOST_ENV)
+.PHONY: build-cli-linux-amd64-unix
+build-cli-linux-amd64-unix:
+	$(call GO_BUILD_CROSS_UNIX,linux,amd64,bin/wendy-linux-amd64,./cmd/wendy)
+.PHONY: build-cli-linux-amd64-windows
+build-cli-linux-amd64-windows:
+	$(call GO_BUILD_CROSS_WINDOWS,linux,amd64,bin/wendy-linux-amd64,./cmd/wendy)
+
+.PHONY: build-cli-linux-arm64
+build-cli-linux-arm64: build-cli-linux-arm64-$(HOST_ENV)
+.PHONY: build-cli-linux-arm64-unix
+build-cli-linux-arm64-unix:
+	$(call GO_BUILD_CROSS_UNIX,linux,arm64,bin/wendy-linux-arm64,./cmd/wendy)
+.PHONY: build-cli-linux-arm64-windows
+build-cli-linux-arm64-windows:
+	$(call GO_BUILD_CROSS_WINDOWS,linux,arm64,bin/wendy-linux-arm64,./cmd/wendy)
+
+.PHONY: build-cli-darwin-amd64
+build-cli-darwin-amd64: build-cli-darwin-amd64-$(HOST_ENV)
+.PHONY: build-cli-darwin-amd64-unix
+build-cli-darwin-amd64-unix:
+	$(call GO_BUILD_CROSS_UNIX,darwin,amd64,bin/wendy-darwin-amd64,./cmd/wendy)
+.PHONY: build-cli-darwin-amd64-windows
+build-cli-darwin-amd64-windows:
+	$(call GO_BUILD_CROSS_WINDOWS,darwin,amd64,bin/wendy-darwin-amd64,./cmd/wendy)
+
+.PHONY: build-cli-darwin-arm64
+build-cli-darwin-arm64: build-cli-darwin-arm64-$(HOST_ENV)
+.PHONY: build-cli-darwin-arm64-unix
+build-cli-darwin-arm64-unix:
+	$(call GO_BUILD_CROSS_UNIX,darwin,arm64,bin/wendy-darwin-arm64,./cmd/wendy)
+.PHONY: build-cli-darwin-arm64-windows
+build-cli-darwin-arm64-windows:
+	$(call GO_BUILD_CROSS_WINDOWS,darwin,arm64,bin/wendy-darwin-arm64,./cmd/wendy)
+
+.PHONY: build-cli-windows-amd64
+build-cli-windows-amd64: build-cli-windows-amd64-$(HOST_ENV)
+.PHONY: build-cli-windows-amd64-unix
+build-cli-windows-amd64-unix:
+	$(call GO_BUILD_CROSS_UNIX,windows,amd64,bin/wendy-windows-amd64.exe,./cmd/wendy)
+.PHONY: build-cli-windows-amd64-windows
+build-cli-windows-amd64-windows:
+	$(call GO_BUILD_CROSS_WINDOWS,windows,amd64,bin/wendy-windows-amd64.exe,./cmd/wendy)
+
+.PHONY: build-cli-windows-arm64
+build-cli-windows-arm64: build-cli-windows-arm64-$(HOST_ENV)
+.PHONY: build-cli-windows-arm64-unix
+build-cli-windows-arm64-unix:
+	$(call GO_BUILD_CROSS_UNIX,windows,arm64,bin/wendy-windows-arm64.exe,./cmd/wendy)
+.PHONY: build-cli-windows-arm64-windows
+build-cli-windows-arm64-windows:
+	$(call GO_BUILD_CROSS_WINDOWS,windows,arm64,bin/wendy-windows-arm64.exe,./cmd/wendy)
+
+# Build Windows MSI installers (requires WiX v4+: dotnet tool install --global wix)
+.PHONY: msi-windows-amd64
+msi-windows-amd64: msi-windows-amd64-$(HOST_ENV)
+.PHONY: msi-windows-amd64-unix
+msi-windows-amd64-unix: build-cli-windows-amd64-unix
 	wix build -d Version=$(MSI_VERSION) -d ExePath=bin/wendy-windows-amd64.exe \
 	     -arch x64 -o bin/wendy-windows-amd64.msi $(WXS)
+.PHONY: msi-windows-amd64-windows
+msi-windows-amd64-windows: build-cli-windows-amd64-windows
+	wix build -d Version=$(MSI_VERSION) -d ExePath=bin/wendy-windows-amd64.exe -arch x64 -o bin/wendy-windows-amd64.msi $(WXS)
 
-msi-windows-arm64: build-cli-windows-arm64
+.PHONY: msi-windows-arm64
+msi-windows-arm64: msi-windows-arm64-$(HOST_ENV)
+.PHONY: msi-windows-arm64-unix
+msi-windows-arm64-unix: build-cli-windows-arm64-unix
 	wix build -d Version=$(MSI_VERSION) -d ExePath=bin/wendy-windows-arm64.exe \
 	     -arch arm64 -o bin/wendy-windows-arm64.msi $(WXS)
+.PHONY: msi-windows-arm64-windows
+msi-windows-arm64-windows: build-cli-windows-arm64-windows
+	wix build -d Version=$(MSI_VERSION) -d ExePath=bin/wendy-windows-arm64.exe -arch arm64 -o bin/wendy-windows-arm64.msi $(WXS)
 
 # Run all tests
-test:
+.PHONY: test
+test: test-$(HOST_ENV)
+.PHONY: test-unix
+test-unix:
+	go test ./... -v -count=1 -timeout 120s
+.PHONY: test-windows
+test-windows:
 	go test ./... -v -count=1 -timeout 120s
 
 # Run tests with race detector
-test-race:
+.PHONY: test-race
+test-race: test-race-$(HOST_ENV)
+.PHONY: test-race-unix
+test-race-unix:
+	go test ./... -v -count=1 -race -timeout 120s
+.PHONY: test-race-windows
+test-race-windows:
 	go test ./... -v -count=1 -race -timeout 120s
 
 # Run go vet
-vet:
+.PHONY: vet
+vet: vet-$(HOST_ENV)
+.PHONY: vet-unix
+vet-unix:
+	go vet ./...
+.PHONY: vet-windows
+vet-windows:
 	go vet ./...
 
 # Generate protobuf code
-proto:
+.PHONY: proto
+proto: proto-$(HOST_ENV)
+.PHONY: proto-unix
+proto-unix:
 	bash scripts/generate-proto.sh
+.PHONY: proto-windows
+proto-windows:
+	@throw 'proto is not supported on Windows yet; use a unix host for scripts/generate-proto.sh.'
 
 # Clean build artifacts
-clean:
+.PHONY: clean
+clean: clean-$(HOST_ENV)
+.PHONY: clean-unix
+clean-unix:
 	rm -rf bin/
+.PHONY: clean-windows
+clean-windows:
+	Remove-Item -LiteralPath bin -Recurse -Force -ErrorAction SilentlyContinue
 
 # Install both binaries
-install:
+.PHONY: install
+install: install-$(HOST_ENV)
+.PHONY: install-unix
+install-unix:
 	go install ./cmd/wendy
 	go install ./cmd/wendy-agent
+.PHONY: install-windows
+install-windows:
+	@throw 'install is not supported on Windows yet because wendy-agent is not available there.'
 
 # Format code
-fmt:
+.PHONY: fmt
+fmt: fmt-$(HOST_ENV)
+.PHONY: fmt-unix
+fmt-unix:
+	gofmt -w -s .
+.PHONY: fmt-windows
+fmt-windows:
 	gofmt -w -s .
 
 # Lint (requires golangci-lint)
-lint:
+.PHONY: lint
+lint: lint-$(HOST_ENV)
+.PHONY: lint-unix
+lint-unix:
+	golangci-lint run ./...
+.PHONY: lint-windows
+lint-windows:
 	golangci-lint run ./...
 
 # Check that dependency licenses match the committed baseline (licenses.csv)
-licenses:
+.PHONY: licenses
+licenses: licenses-$(HOST_ENV)
+.PHONY: licenses-unix
+licenses-unix:
 	bash scripts/check-licenses.sh
+.PHONY: licenses-windows
+licenses-windows:
+	@throw 'licenses is not supported on Windows yet; use a unix host for scripts/check-licenses.sh.'
 
 # Regenerate licenses.csv from current dependencies
-licenses-update:
+.PHONY: licenses-update
+licenses-update: licenses-update-$(HOST_ENV)
+.PHONY: licenses-update-unix
+licenses-update-unix:
 	bash scripts/check-licenses.sh --update
+.PHONY: licenses-update-windows
+licenses-update-windows:
+	@throw 'licenses-update is not supported on Windows yet; use a unix host for scripts/check-licenses.sh.'
 
 # Sync embedded docs and skills from sibling repos (requires them checked out at ../../docs and ../claude-skills)
 # Note: go/ is a subdirectory; DOCS_SRC is two levels up, ASSETS is relative to go/
-sync-assets:
+.PHONY: sync-assets
+sync-assets: sync-assets-$(HOST_ENV)
+.PHONY: sync-assets-unix
+sync-assets-unix:
 	@DOCS_SRC=../../docs SKILLS_SRC=../claude-skills ASSETS=internal/cli/assets; \
 	if [ ! -d "$$DOCS_SRC" ]; then echo "Docs repo not found at $$DOCS_SRC — skipping"; else \
 	  rm -rf "$$ASSETS/docs" && mkdir -p "$$ASSETS/docs" && \
@@ -131,3 +317,6 @@ sync-assets:
 	    [ -d "$$SKILLS_SRC/$$skill" ] && rsync -a --exclude='.DS_Store' "$$SKILLS_SRC/$$skill/" "$$ASSETS/skills/$$skill/"; \
 	  done && \
 	  echo "Synced $$(find $$ASSETS/skills -type f | wc -l) skill files"; fi
+.PHONY: sync-assets-windows
+sync-assets-windows:
+	@throw 'sync-assets is not supported on Windows yet; use a unix host to sync embedded docs and skills.'

--- a/go/Makefile
+++ b/go/Makefile
@@ -21,22 +21,16 @@ HOST_ENV ?= $(DETECTED_HOST_ENV)
 VALID_HOST_OSES := macos linux windows unknown
 VALID_HOST_ENVS := unix windows
 
-ifneq ($(words $(HOST_OS)),1)
-$(error HOST_OS must be one of: $(VALID_HOST_OSES); got '$(HOST_OS)')
+ifeq ($(findstring |$(HOST_OS)|,$(foreach host_os,$(VALID_HOST_OSES),|$(host_os)|)),)
+$(error HOST_OS must be one of: $(VALID_HOST_OSES). Received an invalid value.)
 endif
-ifeq ($(filter $(VALID_HOST_OSES),$(HOST_OS)),)
-$(error HOST_OS must be one of: $(VALID_HOST_OSES); got '$(HOST_OS)')
-endif
-ifneq ($(words $(HOST_ENV)),1)
-$(error HOST_ENV must be one of: $(VALID_HOST_ENVS); got '$(HOST_ENV)')
-endif
-ifeq ($(filter $(VALID_HOST_ENVS),$(HOST_ENV)),)
-$(error HOST_ENV must be one of: $(VALID_HOST_ENVS); got '$(HOST_ENV)')
+ifeq ($(findstring |$(HOST_ENV)|,$(foreach host_env,$(VALID_HOST_ENVS),|$(host_env)|)),)
+$(error HOST_ENV must be one of: $(VALID_HOST_ENVS). Received an invalid value.)
 endif
 
 ifeq ($(HOST_ENV),windows)
-override SHELL := powershell.exe
-.SHELLFLAGS := -NoProfile -NonInteractive -Command
+SHELL := powershell.exe
+.SHELLFLAGS := -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command
 endif
 
 .PHONY: build build-cli build-agent test vet proto clean fmt lint install \
@@ -52,8 +46,6 @@ endif
 VERSION ?= dev
 MSI_VERSION ?= 0.0.1
 LDFLAGS := -s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=$(VERSION)
-override WENDY_GO_LDFLAGS := $(LDFLAGS)
-export WENDY_GO_LDFLAGS
 ifeq ($(HOST_OS),macos)
 # Go/cgo adds -lobjc for each Objective-C package. The native CLI links
 # multiple CoreBluetooth-backed packages, and recent Apple linkers warn about
@@ -64,8 +56,18 @@ endif
 
 WXS := installer/windows/wendy.wxs
 
-GO_BUILD_CROSS_UNIX = CGO_ENABLED=0 GOOS=$(1) GOARCH=$(2) go build -ldflags "$(LDFLAGS)" -o $(3) $(4)
-GO_BUILD_CROSS_WINDOWS = @if (-not $$PSVersionTable) { throw 'Windows make recipes require PowerShell.' }; $$env:CGO_ENABLED = '0'; $$env:GOOS = '$(1)'; $$env:GOARCH = '$(2)'; go build -ldflags $$env:WENDY_GO_LDFLAGS -o $(3) $(4); if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }
+VALID_CROSS_GOOS := linux darwin windows
+VALID_CROSS_GOARCHS := amd64 arm64
+VALID_CROSS_OUTPUTS := \
+       bin/wendy-agent-linux-amd64 bin/wendy-agent-linux-arm64 \
+       bin/wendy-linux-amd64 bin/wendy-linux-arm64 \
+       bin/wendy-darwin-amd64 bin/wendy-darwin-arm64 \
+       bin/wendy-windows-amd64.exe bin/wendy-windows-arm64.exe
+VALID_CROSS_PACKAGES := ./cmd/wendy ./cmd/wendy-agent
+ASSERT_GO_BUILD_CROSS_ARGS = $(if $(filter $(1),$(VALID_CROSS_GOOS)),,$(error GOOS must be one of: $(VALID_CROSS_GOOS)))$(if $(filter $(2),$(VALID_CROSS_GOARCHS)),,$(error GOARCH must be one of: $(VALID_CROSS_GOARCHS)))$(if $(filter $(3),$(VALID_CROSS_OUTPUTS)),,$(error output path is not an allowed cross-build artifact))$(if $(filter $(4),$(VALID_CROSS_PACKAGES)),,$(error package path is not an allowed cross-build package))
+
+GO_BUILD_CROSS_UNIX = $(call ASSERT_GO_BUILD_CROSS_ARGS,$(1),$(2),$(3),$(4))set -e; CGO_ENABLED=0 GOOS=$(1) GOARCH=$(2) go build -ldflags "$(LDFLAGS)" -o $(3) $(4)
+GO_BUILD_CROSS_WINDOWS = $(call ASSERT_GO_BUILD_CROSS_ARGS,$(1),$(2),$(3),$(4))@if (-not $$PSVersionTable) { throw 'Windows make recipes require PowerShell.' }; $$env:CGO_ENABLED = '0'; $$env:GOOS = '$(1)'; $$env:GOARCH = '$(2)'; go build -ldflags "$$env:WENDY_GO_LDFLAGS" -o '$(3)' '$(4)'; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }
 
 # Build both CLI and agent (native)
 .PHONY: build
@@ -118,6 +120,11 @@ build-all-windows: build-agent-linux-amd64-windows build-agent-linux-arm64-windo
            build-cli-linux-amd64-windows build-cli-linux-arm64-windows \
            build-cli-darwin-amd64-windows build-cli-darwin-arm64-windows \
            build-cli-windows-amd64-windows build-cli-windows-arm64-windows
+
+build-agent-linux-amd64-windows build-agent-linux-arm64-windows \
+        build-cli-linux-amd64-windows build-cli-linux-arm64-windows \
+        build-cli-darwin-amd64-windows build-cli-darwin-arm64-windows \
+        build-cli-windows-amd64-windows build-cli-windows-arm64-windows: export WENDY_GO_LDFLAGS := $(LDFLAGS)
 
 .PHONY: build-agent-linux-amd64
 build-agent-linux-amd64: build-agent-linux-amd64-$(HOST_ENV)

--- a/go/Makefile
+++ b/go/Makefile
@@ -2,7 +2,7 @@ ifeq ($(OS),Windows_NT)
 DETECTED_HOST_OS := windows
 DETECTED_HOST_ENV := windows
 else
-UNAME_S := $(shell uname -s)
+UNAME_S := $(shell uname -s 2>/dev/null)
 ifeq ($(UNAME_S),Darwin)
 DETECTED_HOST_OS := macos
 DETECTED_HOST_ENV := unix
@@ -18,9 +18,25 @@ endif
 HOST_OS ?= $(DETECTED_HOST_OS)
 HOST_ENV ?= $(DETECTED_HOST_ENV)
 
+VALID_HOST_OSES := macos linux windows unknown
+VALID_HOST_ENVS := unix windows
+
+ifneq ($(words $(HOST_OS)),1)
+$(error HOST_OS must be one of: $(VALID_HOST_OSES); got '$(HOST_OS)')
+endif
+ifeq ($(filter $(VALID_HOST_OSES),$(HOST_OS)),)
+$(error HOST_OS must be one of: $(VALID_HOST_OSES); got '$(HOST_OS)')
+endif
+ifneq ($(words $(HOST_ENV)),1)
+$(error HOST_ENV must be one of: $(VALID_HOST_ENVS); got '$(HOST_ENV)')
+endif
+ifeq ($(filter $(VALID_HOST_ENVS),$(HOST_ENV)),)
+$(error HOST_ENV must be one of: $(VALID_HOST_ENVS); got '$(HOST_ENV)')
+endif
+
 ifeq ($(HOST_ENV),windows)
 override SHELL := powershell.exe
-.SHELLFLAGS := -NoProfile -ExecutionPolicy Bypass -Command
+.SHELLFLAGS := -NoProfile -NonInteractive -Command
 endif
 
 .PHONY: build build-cli build-agent test vet proto clean fmt lint install \
@@ -36,6 +52,8 @@ endif
 VERSION ?= dev
 MSI_VERSION ?= 0.0.1
 LDFLAGS := -s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=$(VERSION)
+override WENDY_GO_LDFLAGS := $(LDFLAGS)
+export WENDY_GO_LDFLAGS
 ifeq ($(HOST_OS),macos)
 # Go/cgo adds -lobjc for each Objective-C package. The native CLI links
 # multiple CoreBluetooth-backed packages, and recent Apple linkers warn about
@@ -47,7 +65,7 @@ endif
 WXS := installer/windows/wendy.wxs
 
 GO_BUILD_CROSS_UNIX = CGO_ENABLED=0 GOOS=$(1) GOARCH=$(2) go build -ldflags "$(LDFLAGS)" -o $(3) $(4)
-GO_BUILD_CROSS_WINDOWS = @if (-not $$PSVersionTable) { throw 'Windows make recipes require PowerShell.' }; $$env:CGO_ENABLED = '0'; $$env:GOOS = '$(1)'; $$env:GOARCH = '$(2)'; go build -ldflags "$(LDFLAGS)" -o $(3) $(4); if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }
+GO_BUILD_CROSS_WINDOWS = @if (-not $$PSVersionTable) { throw 'Windows make recipes require PowerShell.' }; $$env:CGO_ENABLED = '0'; $$env:GOOS = '$(1)'; $$env:GOARCH = '$(2)'; go build -ldflags $$env:WENDY_GO_LDFLAGS -o $(3) $(4); if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }
 
 # Build both CLI and agent (native)
 .PHONY: build

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,36 +1,9 @@
 ifeq ($(OS),Windows_NT)
-DETECTED_HOST_OS := windows
-DETECTED_HOST_ENV := windows
+HOST_ENV ?= windows
+UNAME_S :=
 else
+HOST_ENV ?= unix
 UNAME_S := $(shell uname -s 2>/dev/null)
-ifeq ($(UNAME_S),Darwin)
-DETECTED_HOST_OS := macos
-DETECTED_HOST_ENV := unix
-else ifeq ($(UNAME_S),Linux)
-DETECTED_HOST_OS := linux
-DETECTED_HOST_ENV := unix
-else
-DETECTED_HOST_OS := unknown
-DETECTED_HOST_ENV := unix
-endif
-endif
-
-HOST_OS ?= $(DETECTED_HOST_OS)
-HOST_ENV ?= $(DETECTED_HOST_ENV)
-
-VALID_HOST_OSES := macos linux windows unknown
-VALID_HOST_ENVS := unix windows
-
-ifeq ($(findstring |$(HOST_OS)|,$(foreach host_os,$(VALID_HOST_OSES),|$(host_os)|)),)
-$(error HOST_OS must be one of: $(VALID_HOST_OSES). Received an invalid value.)
-endif
-ifeq ($(findstring |$(HOST_ENV)|,$(foreach host_env,$(VALID_HOST_ENVS),|$(host_env)|)),)
-$(error HOST_ENV must be one of: $(VALID_HOST_ENVS). Received an invalid value.)
-endif
-
-ifeq ($(HOST_ENV),windows)
-SHELL := powershell.exe
-.SHELLFLAGS := -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command
 endif
 
 .PHONY: build build-cli build-agent test vet proto clean fmt lint install \
@@ -46,7 +19,7 @@ endif
 VERSION ?= dev
 MSI_VERSION ?= 0.0.1
 LDFLAGS := -s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=$(VERSION)
-ifeq ($(HOST_OS),macos)
+ifeq ($(UNAME_S),Darwin)
 # Go/cgo adds -lobjc for each Objective-C package. The native CLI links
 # multiple CoreBluetooth-backed packages, and recent Apple linkers warn about
 # the duplicate even though it is harmless.
@@ -54,278 +27,108 @@ CGO_LDFLAGS += -Wl,-no_warn_duplicate_libraries
 export CGO_LDFLAGS
 endif
 
-WXS := installer/windows/wendy.wxs
-
-VALID_CROSS_GOOS := linux darwin windows
-VALID_CROSS_GOARCHS := amd64 arm64
-VALID_CROSS_OUTPUTS := \
-       bin/wendy-agent-linux-amd64 bin/wendy-agent-linux-arm64 \
-       bin/wendy-linux-amd64 bin/wendy-linux-arm64 \
-       bin/wendy-darwin-amd64 bin/wendy-darwin-arm64 \
-       bin/wendy-windows-amd64.exe bin/wendy-windows-arm64.exe
-VALID_CROSS_PACKAGES := ./cmd/wendy ./cmd/wendy-agent
-ASSERT_GO_BUILD_CROSS_ARGS = $(if $(filter $(1),$(VALID_CROSS_GOOS)),,$(error GOOS must be one of: $(VALID_CROSS_GOOS)))$(if $(filter $(2),$(VALID_CROSS_GOARCHS)),,$(error GOARCH must be one of: $(VALID_CROSS_GOARCHS)))$(if $(filter $(3),$(VALID_CROSS_OUTPUTS)),,$(error output path is not an allowed cross-build artifact))$(if $(filter $(4),$(VALID_CROSS_PACKAGES)),,$(error package path is not an allowed cross-build package))
-
-GO_BUILD_CROSS_UNIX = $(call ASSERT_GO_BUILD_CROSS_ARGS,$(1),$(2),$(3),$(4))set -e; CGO_ENABLED=0 GOOS=$(1) GOARCH=$(2) go build -ldflags "$(LDFLAGS)" -o $(3) $(4)
-GO_BUILD_CROSS_WINDOWS = $(call ASSERT_GO_BUILD_CROSS_ARGS,$(1),$(2),$(3),$(4))@if (-not $$PSVersionTable) { throw 'Windows make recipes require PowerShell.' }; $$env:CGO_ENABLED = '0'; $$env:GOOS = '$(1)'; $$env:GOARCH = '$(2)'; go build -ldflags "$$env:WENDY_GO_LDFLAGS" -o '$(3)' '$(4)'; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }
-
 # Build both CLI and agent (native)
-.PHONY: build
-build: build-$(HOST_ENV)
-
-.PHONY: build-unix
-build-unix: build-cli-unix build-agent-unix
-
-.PHONY: build-windows
-build-windows: build-cli-windows build-agent-windows
+build: build-cli build-agent
 
 # Build the wendy CLI
-.PHONY: build-cli
-build-cli: build-cli-$(HOST_ENV)
-
-.PHONY: build-cli-unix
-build-cli-unix:
+build-cli:
+ifeq ($(HOST_ENV),windows)
+	powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "New-Item -ItemType Directory -Force -Path bin | Out-Null; go build -o bin/wendy.exe ./cmd/wendy; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }"
+else
 	mkdir -p bin
 	go build -o bin/wendy ./cmd/wendy
-
-.PHONY: build-cli-windows
-build-cli-windows:
-	@if (-not $$PSVersionTable) { throw 'Windows build-cli requires PowerShell.' }; New-Item -ItemType Directory -Force -Path bin | Out-Null; go build -o bin/wendy.exe ./cmd/wendy; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }
+endif
 
 # Build the wendy-agent
-.PHONY: build-agent
-build-agent: build-agent-$(HOST_ENV)
-
-.PHONY: build-agent-unix
-build-agent-unix:
+build-agent:
 	mkdir -p bin
 	go build -o bin/wendy-agent ./cmd/wendy-agent
 
-.PHONY: build-agent-windows
-build-agent-windows:
-	@throw 'build-agent is not supported on Windows yet.'
-
 # Cross-compile all targets
-.PHONY: build-all
-build-all: build-all-$(HOST_ENV)
+build-all: build-agent-linux-amd64 build-agent-linux-arm64 \
+           build-cli-linux-amd64 build-cli-linux-arm64 \
+           build-cli-darwin-amd64 build-cli-darwin-arm64 \
+           build-cli-windows-amd64 build-cli-windows-arm64
 
-.PHONY: build-all-unix
-build-all-unix: build-agent-linux-amd64-unix build-agent-linux-arm64-unix \
-           build-cli-linux-amd64-unix build-cli-linux-arm64-unix \
-           build-cli-darwin-amd64-unix build-cli-darwin-arm64-unix \
-           build-cli-windows-amd64-unix build-cli-windows-arm64-unix
+build-agent-linux-amd64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-agent-linux-amd64 ./cmd/wendy-agent
 
-.PHONY: build-all-windows
-build-all-windows: build-agent-linux-amd64-windows build-agent-linux-arm64-windows \
-           build-cli-linux-amd64-windows build-cli-linux-arm64-windows \
-           build-cli-darwin-amd64-windows build-cli-darwin-arm64-windows \
-           build-cli-windows-amd64-windows build-cli-windows-arm64-windows
+build-agent-linux-arm64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-agent-linux-arm64 ./cmd/wendy-agent
 
-build-agent-linux-amd64-windows build-agent-linux-arm64-windows \
-        build-cli-linux-amd64-windows build-cli-linux-arm64-windows \
-        build-cli-darwin-amd64-windows build-cli-darwin-arm64-windows \
-        build-cli-windows-amd64-windows build-cli-windows-arm64-windows: export WENDY_GO_LDFLAGS := $(LDFLAGS)
+build-cli-linux-amd64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-linux-amd64 ./cmd/wendy
 
-.PHONY: build-agent-linux-amd64
-build-agent-linux-amd64: build-agent-linux-amd64-$(HOST_ENV)
-.PHONY: build-agent-linux-amd64-unix
-build-agent-linux-amd64-unix:
-	$(call GO_BUILD_CROSS_UNIX,linux,amd64,bin/wendy-agent-linux-amd64,./cmd/wendy-agent)
-.PHONY: build-agent-linux-amd64-windows
-build-agent-linux-amd64-windows:
-	$(call GO_BUILD_CROSS_WINDOWS,linux,amd64,bin/wendy-agent-linux-amd64,./cmd/wendy-agent)
+build-cli-linux-arm64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-linux-arm64 ./cmd/wendy
 
-.PHONY: build-agent-linux-arm64
-build-agent-linux-arm64: build-agent-linux-arm64-$(HOST_ENV)
-.PHONY: build-agent-linux-arm64-unix
-build-agent-linux-arm64-unix:
-	$(call GO_BUILD_CROSS_UNIX,linux,arm64,bin/wendy-agent-linux-arm64,./cmd/wendy-agent)
-.PHONY: build-agent-linux-arm64-windows
-build-agent-linux-arm64-windows:
-	$(call GO_BUILD_CROSS_WINDOWS,linux,arm64,bin/wendy-agent-linux-arm64,./cmd/wendy-agent)
+build-cli-darwin-amd64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-darwin-amd64 ./cmd/wendy
 
-.PHONY: build-cli-linux-amd64
-build-cli-linux-amd64: build-cli-linux-amd64-$(HOST_ENV)
-.PHONY: build-cli-linux-amd64-unix
-build-cli-linux-amd64-unix:
-	$(call GO_BUILD_CROSS_UNIX,linux,amd64,bin/wendy-linux-amd64,./cmd/wendy)
-.PHONY: build-cli-linux-amd64-windows
-build-cli-linux-amd64-windows:
-	$(call GO_BUILD_CROSS_WINDOWS,linux,amd64,bin/wendy-linux-amd64,./cmd/wendy)
+build-cli-darwin-arm64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-darwin-arm64 ./cmd/wendy
 
-.PHONY: build-cli-linux-arm64
-build-cli-linux-arm64: build-cli-linux-arm64-$(HOST_ENV)
-.PHONY: build-cli-linux-arm64-unix
-build-cli-linux-arm64-unix:
-	$(call GO_BUILD_CROSS_UNIX,linux,arm64,bin/wendy-linux-arm64,./cmd/wendy)
-.PHONY: build-cli-linux-arm64-windows
-build-cli-linux-arm64-windows:
-	$(call GO_BUILD_CROSS_WINDOWS,linux,arm64,bin/wendy-linux-arm64,./cmd/wendy)
+build-cli-windows-amd64:
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-windows-amd64.exe ./cmd/wendy
 
-.PHONY: build-cli-darwin-amd64
-build-cli-darwin-amd64: build-cli-darwin-amd64-$(HOST_ENV)
-.PHONY: build-cli-darwin-amd64-unix
-build-cli-darwin-amd64-unix:
-	$(call GO_BUILD_CROSS_UNIX,darwin,amd64,bin/wendy-darwin-amd64,./cmd/wendy)
-.PHONY: build-cli-darwin-amd64-windows
-build-cli-darwin-amd64-windows:
-	$(call GO_BUILD_CROSS_WINDOWS,darwin,amd64,bin/wendy-darwin-amd64,./cmd/wendy)
-
-.PHONY: build-cli-darwin-arm64
-build-cli-darwin-arm64: build-cli-darwin-arm64-$(HOST_ENV)
-.PHONY: build-cli-darwin-arm64-unix
-build-cli-darwin-arm64-unix:
-	$(call GO_BUILD_CROSS_UNIX,darwin,arm64,bin/wendy-darwin-arm64,./cmd/wendy)
-.PHONY: build-cli-darwin-arm64-windows
-build-cli-darwin-arm64-windows:
-	$(call GO_BUILD_CROSS_WINDOWS,darwin,arm64,bin/wendy-darwin-arm64,./cmd/wendy)
-
-.PHONY: build-cli-windows-amd64
-build-cli-windows-amd64: build-cli-windows-amd64-$(HOST_ENV)
-.PHONY: build-cli-windows-amd64-unix
-build-cli-windows-amd64-unix:
-	$(call GO_BUILD_CROSS_UNIX,windows,amd64,bin/wendy-windows-amd64.exe,./cmd/wendy)
-.PHONY: build-cli-windows-amd64-windows
-build-cli-windows-amd64-windows:
-	$(call GO_BUILD_CROSS_WINDOWS,windows,amd64,bin/wendy-windows-amd64.exe,./cmd/wendy)
-
-.PHONY: build-cli-windows-arm64
-build-cli-windows-arm64: build-cli-windows-arm64-$(HOST_ENV)
-.PHONY: build-cli-windows-arm64-unix
-build-cli-windows-arm64-unix:
-	$(call GO_BUILD_CROSS_UNIX,windows,arm64,bin/wendy-windows-arm64.exe,./cmd/wendy)
-.PHONY: build-cli-windows-arm64-windows
-build-cli-windows-arm64-windows:
-	$(call GO_BUILD_CROSS_WINDOWS,windows,arm64,bin/wendy-windows-arm64.exe,./cmd/wendy)
+build-cli-windows-arm64:
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-windows-arm64.exe ./cmd/wendy
 
 # Build Windows MSI installers (requires WiX v4+: dotnet tool install --global wix)
-.PHONY: msi-windows-amd64
-msi-windows-amd64: msi-windows-amd64-$(HOST_ENV)
-.PHONY: msi-windows-amd64-unix
-msi-windows-amd64-unix: build-cli-windows-amd64-unix
+WXS := installer/windows/wendy.wxs
+
+msi-windows-amd64: build-cli-windows-amd64
 	wix build -d Version=$(MSI_VERSION) -d ExePath=bin/wendy-windows-amd64.exe \
 	     -arch x64 -o bin/wendy-windows-amd64.msi $(WXS)
-.PHONY: msi-windows-amd64-windows
-msi-windows-amd64-windows: build-cli-windows-amd64-windows
-	wix build -d Version=$(MSI_VERSION) -d ExePath=bin/wendy-windows-amd64.exe -arch x64 -o bin/wendy-windows-amd64.msi $(WXS)
 
-.PHONY: msi-windows-arm64
-msi-windows-arm64: msi-windows-arm64-$(HOST_ENV)
-.PHONY: msi-windows-arm64-unix
-msi-windows-arm64-unix: build-cli-windows-arm64-unix
+msi-windows-arm64: build-cli-windows-arm64
 	wix build -d Version=$(MSI_VERSION) -d ExePath=bin/wendy-windows-arm64.exe \
 	     -arch arm64 -o bin/wendy-windows-arm64.msi $(WXS)
-.PHONY: msi-windows-arm64-windows
-msi-windows-arm64-windows: build-cli-windows-arm64-windows
-	wix build -d Version=$(MSI_VERSION) -d ExePath=bin/wendy-windows-arm64.exe -arch arm64 -o bin/wendy-windows-arm64.msi $(WXS)
 
 # Run all tests
-.PHONY: test
-test: test-$(HOST_ENV)
-.PHONY: test-unix
-test-unix:
-	go test ./... -v -count=1 -timeout 120s
-.PHONY: test-windows
-test-windows:
+test:
 	go test ./... -v -count=1 -timeout 120s
 
 # Run tests with race detector
-.PHONY: test-race
-test-race: test-race-$(HOST_ENV)
-.PHONY: test-race-unix
-test-race-unix:
-	go test ./... -v -count=1 -race -timeout 120s
-.PHONY: test-race-windows
-test-race-windows:
+test-race:
 	go test ./... -v -count=1 -race -timeout 120s
 
 # Run go vet
-.PHONY: vet
-vet: vet-$(HOST_ENV)
-.PHONY: vet-unix
-vet-unix:
-	go vet ./...
-.PHONY: vet-windows
-vet-windows:
+vet:
 	go vet ./...
 
 # Generate protobuf code
-.PHONY: proto
-proto: proto-$(HOST_ENV)
-.PHONY: proto-unix
-proto-unix:
+proto:
 	bash scripts/generate-proto.sh
-.PHONY: proto-windows
-proto-windows:
-	@throw 'proto is not supported on Windows yet; use a unix host for scripts/generate-proto.sh.'
 
 # Clean build artifacts
-.PHONY: clean
-clean: clean-$(HOST_ENV)
-.PHONY: clean-unix
-clean-unix:
+clean:
 	rm -rf bin/
-.PHONY: clean-windows
-clean-windows:
-	Remove-Item -LiteralPath bin -Recurse -Force -ErrorAction SilentlyContinue
 
 # Install both binaries
-.PHONY: install
-install: install-$(HOST_ENV)
-.PHONY: install-unix
-install-unix:
+install:
 	go install ./cmd/wendy
 	go install ./cmd/wendy-agent
-.PHONY: install-windows
-install-windows:
-	@throw 'install is not supported on Windows yet because wendy-agent is not available there.'
 
 # Format code
-.PHONY: fmt
-fmt: fmt-$(HOST_ENV)
-.PHONY: fmt-unix
-fmt-unix:
-	gofmt -w -s .
-.PHONY: fmt-windows
-fmt-windows:
+fmt:
 	gofmt -w -s .
 
 # Lint (requires golangci-lint)
-.PHONY: lint
-lint: lint-$(HOST_ENV)
-.PHONY: lint-unix
-lint-unix:
-	golangci-lint run ./...
-.PHONY: lint-windows
-lint-windows:
+lint:
 	golangci-lint run ./...
 
 # Check that dependency licenses match the committed baseline (licenses.csv)
-.PHONY: licenses
-licenses: licenses-$(HOST_ENV)
-.PHONY: licenses-unix
-licenses-unix:
+licenses:
 	bash scripts/check-licenses.sh
-.PHONY: licenses-windows
-licenses-windows:
-	@throw 'licenses is not supported on Windows yet; use a unix host for scripts/check-licenses.sh.'
 
 # Regenerate licenses.csv from current dependencies
-.PHONY: licenses-update
-licenses-update: licenses-update-$(HOST_ENV)
-.PHONY: licenses-update-unix
-licenses-update-unix:
+licenses-update:
 	bash scripts/check-licenses.sh --update
-.PHONY: licenses-update-windows
-licenses-update-windows:
-	@throw 'licenses-update is not supported on Windows yet; use a unix host for scripts/check-licenses.sh.'
 
 # Sync embedded docs and skills from sibling repos (requires them checked out at ../../docs and ../claude-skills)
 # Note: go/ is a subdirectory; DOCS_SRC is two levels up, ASSETS is relative to go/
-.PHONY: sync-assets
-sync-assets: sync-assets-$(HOST_ENV)
-.PHONY: sync-assets-unix
-sync-assets-unix:
+sync-assets:
 	@DOCS_SRC=../../docs SKILLS_SRC=../claude-skills ASSETS=internal/cli/assets; \
 	if [ ! -d "$$DOCS_SRC" ]; then echo "Docs repo not found at $$DOCS_SRC — skipping"; else \
 	  rm -rf "$$ASSETS/docs" && mkdir -p "$$ASSETS/docs" && \
@@ -342,6 +145,3 @@ sync-assets-unix:
 	    [ -d "$$SKILLS_SRC/$$skill" ] && rsync -a --exclude='.DS_Store' "$$SKILLS_SRC/$$skill/" "$$ASSETS/skills/$$skill/"; \
 	  done && \
 	  echo "Synced $$(find $$ASSETS/skills -type f | wc -l) skill files"; fi
-.PHONY: sync-assets-windows
-sync-assets-windows:
-	@throw 'sync-assets is not supported on Windows yet; use a unix host to sync embedded docs and skills.'

--- a/go/internal/cli/assets/docs/development/setup.md
+++ b/go/internal/cli/assets/docs/development/setup.md
@@ -69,7 +69,7 @@ You can override detection when needed:
 make build HOST_ENV=unix   # force Unix recipes on a misdetected host
 ```
 
-Allowed values are `HOST_ENV=unix|windows` and `HOST_OS=macos|linux|windows|unknown`.
+Allowed values are `HOST_ENV=unix|windows` and `HOST_OS=macos|linux|windows|unknown`. Any other value fails immediately; treat these as developer/CI overrides and do not derive them from untrusted input.
 
 ### Build both binaries (native architecture)
 

--- a/go/internal/cli/assets/docs/development/setup.md
+++ b/go/internal/cli/assets/docs/development/setup.md
@@ -56,6 +56,21 @@ All Go code lives under `go/`. Run every `make` target and `go` command from tha
 
 The `Makefile` lives in `go/`. All targets below are run from `go/`.
 
+### Host detection
+
+The Makefile auto-detects the host environment and dispatches each target through a host-specific recipe:
+
+- **Windows** (`%OS% == Windows_NT`): uses `powershell.exe` and `-windows` target variants.
+- **macOS / Linux / other Unix**: uses the default shell and `-unix` target variants.
+
+You can override detection when needed:
+
+```sh
+make build HOST_ENV=unix   # force Unix recipes on a misdetected host
+```
+
+Allowed values are `HOST_ENV=unix|windows` and `HOST_OS=macos|linux|windows|unknown`.
+
 ### Build both binaries (native architecture)
 
 ```sh
@@ -78,7 +93,7 @@ make build-agent   # bin/wendy-agent
 
 ### Cross-compile
 
-The Makefile contains pre-wired targets for every supported platform. All cross-compiled targets use `CGO_ENABLED=0`:
+The Makefile contains pre-wired targets for every supported platform. All cross-compiled targets use `CGO_ENABLED=0` and dispatch to the correct host-specific recipe automatically:
 
 ```sh
 make build-agent-linux-amd64    # bin/wendy-agent-linux-amd64
@@ -88,7 +103,24 @@ make build-cli-windows-amd64    # bin/wendy-windows-amd64.exe
 make build-all                  # all of the above in one shot
 ```
 
+On Windows, cross-compile recipes set `$env:CGO_ENABLED`, `$env:GOOS`, and `$env:GOARCH` through PowerShell before invoking `go build`.
+
 Note: macOS CLI builds in CI run on a macOS runner (`macos-15`) with `CGO_ENABLED=1` because CoreBluetooth is required for BLE support.
+
+### Windows limitations
+
+The following targets are not supported on Windows and fail with an explicit error:
+
+| Target | Reason |
+|---|---|
+| `build-agent` | Native Windows agent build is not implemented yet |
+| `install` | Depends on `wendy-agent`, which is unavailable on Windows |
+| `proto` | Uses `scripts/generate-proto.sh` |
+| `licenses` | Uses `scripts/check-licenses.sh` |
+| `licenses-update` | Uses `scripts/check-licenses.sh` |
+| `sync-assets` | Uses Unix shell and `rsync` |
+
+Use macOS, Linux, or WSL for these targets.
 
 ### Version embedding
 
@@ -137,6 +169,8 @@ cd go
 make install
 # installs both binaries to $(go env GOPATH)/bin
 ```
+
+> **Note:** `make install` is not supported on Windows because `wendy-agent` does not have a Windows build yet. Run this target on macOS, Linux, or WSL.
 
 ## Regenerating Protobuf Code
 

--- a/go/internal/cli/assets/docs/development/setup.md
+++ b/go/internal/cli/assets/docs/development/setup.md
@@ -56,21 +56,6 @@ All Go code lives under `go/`. Run every `make` target and `go` command from tha
 
 The `Makefile` lives in `go/`. All targets below are run from `go/`.
 
-### Host detection
-
-The Makefile auto-detects the host environment and dispatches each target through a host-specific recipe:
-
-- **Windows** (`%OS% == Windows_NT`): uses `powershell.exe` and `-windows` target variants.
-- **macOS / Linux / other Unix**: uses the default shell and `-unix` target variants.
-
-You can override detection when needed:
-
-```sh
-make build HOST_ENV=unix   # force Unix recipes on a misdetected host
-```
-
-Allowed values are `HOST_ENV=unix|windows` and `HOST_OS=macos|linux|windows|unknown`. Any other value fails immediately; treat these as developer/CI overrides and do not derive them from untrusted input.
-
 ### Build both binaries (native architecture)
 
 ```sh
@@ -82,8 +67,10 @@ make build
 ### Build just the CLI
 
 ```sh
-make build-cli   # bin/wendy
+make build-cli   # bin/wendy on Unix, bin/wendy.exe on Windows
 ```
+
+On Windows, `make build-cli` invokes PowerShell for the native Windows CLI build.
 
 ### Build just the agent
 
@@ -93,7 +80,7 @@ make build-agent   # bin/wendy-agent
 
 ### Cross-compile
 
-The Makefile contains pre-wired targets for every supported platform. All cross-compiled targets use `CGO_ENABLED=0` and dispatch to the correct host-specific recipe automatically:
+The Makefile contains pre-wired targets for every supported platform. All cross-compiled targets use `CGO_ENABLED=0`:
 
 ```sh
 make build-agent-linux-amd64    # bin/wendy-agent-linux-amd64
@@ -103,24 +90,7 @@ make build-cli-windows-amd64    # bin/wendy-windows-amd64.exe
 make build-all                  # all of the above in one shot
 ```
 
-On Windows, cross-compile recipes set `$env:CGO_ENABLED`, `$env:GOOS`, and `$env:GOARCH` through PowerShell before invoking `go build`.
-
 Note: macOS CLI builds in CI run on a macOS runner (`macos-15`) with `CGO_ENABLED=1` because CoreBluetooth is required for BLE support.
-
-### Windows limitations
-
-The following targets are not supported on Windows and fail with an explicit error:
-
-| Target | Reason |
-|---|---|
-| `build-agent` | Native Windows agent build is not implemented yet |
-| `install` | Depends on `wendy-agent`, which is unavailable on Windows |
-| `proto` | Uses `scripts/generate-proto.sh` |
-| `licenses` | Uses `scripts/check-licenses.sh` |
-| `licenses-update` | Uses `scripts/check-licenses.sh` |
-| `sync-assets` | Uses Unix shell and `rsync` |
-
-Use macOS, Linux, or WSL for these targets.
 
 ### Version embedding
 


### PR DESCRIPTION
## Summary
- dispatch Go make targets by detected host environment
- add PowerShell-safe Windows recipes for native and cross builds
- keep Unix build commands behind host-specific targets

## Testing
- Not run; factored out from the Swift E2E branch for focused review.