### PR TITLE
chore: rename macOS agent make targets

### DIFF
--- a/swift/AGENTS.md
+++ b/swift/AGENTS.md
@@ -7,7 +7,7 @@ When you need to run the local macOS app-backed agent for testing:
 1. Start it with:
 
    ```sh
-   make run
+   make agent-start
    ```
 
    This will:
@@ -35,13 +35,13 @@ When you need to run the local macOS app-backed agent for testing:
 4. When finished, stop the macOS app with:
 
    ```sh
-   make quit
+   make agent-stop
    ```
 
 ## Expectations
 
 - Do not leave `WendyAgentMac` running after tests complete.
-- Prefer `make run` and `make quit` over launching or killing the app manually.
+- Prefer `make agent-start` and `make agent-stop` over launching or killing the app manually.
 - Prefer deterministic smoke-test commands over exploratory manual testing when possible.
 
 ## Formatting

--- a/swift/Makefile
+++ b/swift/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 
 SWIFT_FORMAT_TARGETS := WendyAgentCore/Sources WendyAgentCore/Tests WendyAgentMac/Sources
 
-.PHONY: help format lint test proto build build-cli build-dev run reset-mac-app-settings reset-mac-app-tcc reset-mac-app quit clean
+.PHONY: help format lint test proto build build-cli build-dev agent-start reset-mac-app-settings reset-mac-app-tcc reset-mac-app agent-stop clean
 
 help: ## Show this help message
 	@echo 'Usage:'
@@ -37,8 +37,8 @@ build-cli: ## Build the Go CLI in ../go
 build-dev: ## Build and package a dev-signed macOS app without notarization
 	OUTPUT_DIR='$(OUTPUT_DIR)' bash ./Scripts/Build.sh --dev
 
-run: ## Quit, build, and open the WendyAgentMac app
-	@$(MAKE) quit
+agent-start: ## Stop, build, and open the WendyAgentMac app
+	@$(MAKE) agent-stop
 	@$(MAKE) build-dev
 	open Build/WendyAgentMac.app
 
@@ -50,5 +50,5 @@ reset-mac-app-tcc: ## Reset WendyAgentMac TCC permissions
 
 reset-mac-app: reset-mac-app-settings reset-mac-app-tcc ## Reset WendyAgentMac settings and TCC permissions
 
-quit: ## Quit WendyAgentMac and fail if it is still running after 10 seconds
+agent-stop: ## Quit WendyAgentMac and fail if it is still running after 10 seconds
 	./Scripts/Quit.sh


### PR DESCRIPTION
## Summary
- rename the local macOS agent make targets from run/quit to agent-start/agent-stop
- update the Swift agent workflow notes to use the new target names

## Testing
- Not run; factored out from the Swift E2E branch for focused review.