### PR TITLE
feat: add JSON output for cache list commands

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/cache/list.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/cache/list.md
@@ -33,6 +33,8 @@ Each element of the returned array represents one cached item:
 | `sizeBytes` | integer | Size in bytes |
 | `size` | string | Human-readable size string |
 
+> **Note:** `path` is a full local filesystem path and may include the current username or CI runner cache location. Redact it before forwarding command output to shared logs or support channels.
+
 Returns `[]` when the cache is empty.
 
 ### `wendy os cache list --json`

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/cache/list.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/cache/list.md
@@ -1,5 +1,58 @@
 Lists all local caches used by Wendy, mainly downloaded OS images.
 
-If ran **without** `--json`, and the terminal is interactive, an interactive picker is shown with all files and the option to remove them.
+Pass `--json` to receive a JSON array on stdout instead of the human-readable output described below.
 
-> **TODO**: --json is broken
+When `--json` is **not** passed:
+
+- In an **interactive terminal** (stdin and stdout are both TTYs), an interactive picker is shown listing all cached items with their sizes. Selected items can be removed.
+- In a **non-interactive** context (pipe, CI, etc.), a plain text list is printed, one entry per line in the format `  <name>  (<size>)`.
+
+When the cache is empty (or the cache directory does not exist), the command prints `Cache is empty.` in human-readable mode, or an empty JSON array (`[]`) with `--json`.
+
+## JSON output
+
+### `wendy cache list --json`
+
+Each element of the returned array represents one cached item:
+
+```json
+[
+  {
+    "name": "os-images/wendyos-raspberry-pi-5-0.10.4.img",
+    "path": "/Users/you/Library/Caches/wendy/os-images/wendyos-raspberry-pi-5-0.10.4.img",
+    "sizeBytes": 4831838208,
+    "size": "4.5 GB"
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name of the cache entry (OS images are prefixed with `os-images/`) |
+| `path` | string | Absolute path to the cached file or directory |
+| `sizeBytes` | integer | Size in bytes |
+| `size` | string | Human-readable size string |
+
+Returns `[]` when the cache is empty.
+
+### `wendy os cache list --json`
+
+Each element represents one cached OS image file:
+
+```json
+[
+  {
+    "name": "wendyos-raspberry-pi-5-0.10.4.img",
+    "sizeBytes": 4831838208,
+    "size": "4.5 GB"
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Filename of the cached OS image |
+| `sizeBytes` | integer | Size in bytes |
+| `size` | string | Human-readable size string |
+
+Returns `[]` when no cached OS images are found.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/cache.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/cache.md
@@ -1,1 +1,0 @@
-Alias to [`wendy cache`](../cache/).

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/cache/index.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/cache/index.md
@@ -1,0 +1,1 @@
+Alias to [`wendy cache`](../../cache/).

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/cache/list.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/cache/list.md
@@ -1,0 +1,66 @@
+# `wendy os cache list`
+
+Lists cached WendyOS OS images stored locally.
+
+## Usage
+
+```sh
+wendy os cache list [--json]
+```
+
+## Description
+
+`wendy os cache list` shows OS image files that have been downloaded to the local cache by `wendy os install` or `wendy os download`. Cached images are reused on subsequent installs to avoid re-downloading.
+
+Pass `--json` to receive a JSON array on stdout instead of the human-readable output described below.
+
+## Human-readable output
+
+When `--json` is **not** passed, each cached image is printed one per line with its size in MiB:
+
+```text
+  wendyos-raspberry-pi-5-0.10.4.img  (4608.0 MB)
+  ...
+
+Cache directory: /Users/you/Library/Caches/wendy/os-images
+```
+
+When no cached images are found (or the cache directory does not exist), the command prints:
+
+```text
+No cached OS images.
+```
+
+## JSON output (`--json`)
+
+Each element of the returned array represents one cached OS image file:
+
+```json
+[
+  {
+    "name": "wendyos-raspberry-pi-5-0.10.4.img",
+    "sizeBytes": 4831838208,
+    "size": "4.5 GB"
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Filename of the cached OS image |
+| `sizeBytes` | integer | Size in bytes |
+| `size` | string | Human-readable size string |
+
+Returns `[]` when no cached OS images are found.
+
+> **Note:** Unlike `wendy cache list --json`, this output does not include a `path` field.
+
+## Error handling
+
+If reading the metadata for a cache entry fails, the command exits with an error rather than silently skipping the entry.
+
+## Related
+
+- [`wendy cache list`](../../cache/list.md) — lists all cached items, including OS images
+- [`wendy os install`](../install.md) — installs WendyOS and populates the cache
+- [`wendy os download`](../download.md) — downloads WendyOS images into the cache

--- a/go/internal/cli/commands/cache.go
+++ b/go/internal/cli/commands/cache.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -29,10 +30,32 @@ func newCacheCmd() *cobra.Command {
 }
 
 func newCacheListCmd() *cobra.Command {
+	type cacheEntry struct {
+		Name      string `json:"name"`
+		Path      string `json:"path"`
+		SizeBytes int64  `json:"sizeBytes"`
+		Size      string `json:"size"`
+	}
+
+	printJSON := func(items []cacheEntry) error {
+		if items == nil {
+			items = []cacheEntry{}
+		}
+		data, err := json.MarshalIndent(items, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List cached items",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			explicitJSON := jsonOutput && cmd.Root().PersistentFlags().Changed("json")
+
 			cacheDir, err := config.CacheDir()
 			if err != nil {
 				return err
@@ -41,6 +64,9 @@ func newCacheListCmd() *cobra.Command {
 			entries, err := os.ReadDir(cacheDir)
 			if err != nil {
 				if os.IsNotExist(err) {
+					if explicitJSON {
+						return printJSON(nil)
+					}
 					fmt.Println("Cache is empty.")
 					return nil
 				}
@@ -48,17 +74,15 @@ func newCacheListCmd() *cobra.Command {
 			}
 
 			if len(entries) == 0 {
+				if explicitJSON {
+					return printJSON(nil)
+				}
 				fmt.Println("Cache is empty.")
 				return nil
 			}
 
 			// Compute sizes up front (needed for both modes).
 			// The os-images directory is expanded so each image is listed individually.
-			type cacheEntry struct {
-				name string
-				path string
-				size int64
-			}
 			var items []cacheEntry
 			for _, entry := range entries {
 				if isCacheDBFile(entry.Name()) {
@@ -80,9 +104,10 @@ func newCacheListCmd() *cobra.Command {
 							return fmt.Errorf("reading os-images cache entry info for %q: %w", img.Name(), err)
 						}
 						items = append(items, cacheEntry{
-							name: "os-images/" + img.Name(),
-							path: imgPath,
-							size: imgInfo.Size(),
+							Name:      "os-images/" + img.Name(),
+							Path:      imgPath,
+							SizeBytes: imgInfo.Size(),
+							Size:      formatSize(imgInfo.Size()),
 						})
 					}
 					continue
@@ -91,7 +116,16 @@ func newCacheListCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("determining cache entry size for %s: %w", entry.Name(), err)
 				}
-				items = append(items, cacheEntry{name: entry.Name(), path: path, size: size})
+				items = append(items, cacheEntry{
+					Name:      entry.Name(),
+					Path:      path,
+					SizeBytes: size,
+					Size:      formatSize(size),
+				})
+			}
+
+			if explicitJSON {
+				return printJSON(items)
 			}
 
 			// Interactive mode when stdin and stdout are both terminals.
@@ -99,9 +133,9 @@ func newCacheListCmd() *cobra.Command {
 				checkItems := make([]tui.ChecklistItem, len(items))
 				for i, item := range items {
 					checkItems[i] = tui.ChecklistItem{
-						Label:       item.name,
-						Description: formatSize(item.size),
-						Value:       item.path,
+						Label:       item.Name,
+						Description: item.Size,
+						Value:       item.Path,
 					}
 				}
 
@@ -141,7 +175,7 @@ func newCacheListCmd() *cobra.Command {
 
 			// Non-interactive (plain listing).
 			for _, item := range items {
-				fmt.Printf("  %s  (%s)\n", item.name, formatSize(item.size))
+				fmt.Printf("  %s  (%s)\n", item.Name, item.Size)
 			}
 			return nil
 		},

--- a/go/internal/cli/commands/cache.go
+++ b/go/internal/cli/commands/cache.go
@@ -54,6 +54,8 @@ func newCacheListCmd() *cobra.Command {
 		Short: "List cached items",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// jsonOutput is auto-enabled for non-interactive commands; cache list
+			// keeps plain text there unless --json was explicitly requested.
 			explicitJSON := jsonOutput && cmd.Root().PersistentFlags().Changed("json")
 
 			cacheDir, err := config.CacheDir()

--- a/go/internal/cli/commands/cache_json_test.go
+++ b/go/internal/cli/commands/cache_json_test.go
@@ -217,9 +217,19 @@ func captureCommandStdout(t *testing.T, fn func() error) (string, error) {
 
 	oldStdout := os.Stdout
 	os.Stdout = writer
+	restored := false
+	restoreStdout := func() {
+		if restored {
+			return
+		}
+		_ = writer.Close()
+		os.Stdout = oldStdout
+		restored = true
+	}
+	defer restoreStdout()
+
 	execErr := fn()
-	_ = writer.Close()
-	os.Stdout = oldStdout
+	restoreStdout()
 	defer reader.Close()
 
 	var buf bytes.Buffer

--- a/go/internal/cli/commands/cache_json_test.go
+++ b/go/internal/cli/commands/cache_json_test.go
@@ -1,0 +1,264 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+func TestCacheListJSONEmptyArray(t *testing.T) {
+	setupCacheListTestEnv(t)
+
+	output, err := executeCacheListCommand(t, []string{"--json", "cache", "list"})
+	if err != nil {
+		t.Fatalf("cache list --json: %v", err)
+	}
+
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(output), &items); err != nil {
+		t.Fatalf("unmarshal output: %v\nraw=%s", err, output)
+	}
+	if len(items) != 0 {
+		t.Fatalf("len(items) = %d, want 0", len(items))
+	}
+	if strings.TrimSpace(output) != "[]" {
+		t.Fatalf("empty JSON output = %q, want []", output)
+	}
+}
+
+func TestCacheListJSONIncludesEntries(t *testing.T) {
+	setupCacheListTestEnv(t)
+	cacheDir, err := config.CacheDir()
+	if err != nil {
+		t.Fatalf("cache dir: %v", err)
+	}
+	writeSizedFile(t, filepath.Join(cacheDir, "template.tar"), 1536)
+	writeSizedFile(t, filepath.Join(cacheDir, "os-images", "wendyos-test.img"), 2*1024*1024)
+
+	output, err := executeCacheListCommand(t, []string{"--json", "cache", "list"})
+	if err != nil {
+		t.Fatalf("cache list --json: %v", err)
+	}
+
+	var items []struct {
+		Name      string `json:"name"`
+		Path      string `json:"path"`
+		SizeBytes int64  `json:"sizeBytes"`
+		Size      string `json:"size"`
+	}
+	if err := json.Unmarshal([]byte(output), &items); err != nil {
+		t.Fatalf("unmarshal output: %v\nraw=%s", err, output)
+	}
+	if len(items) != 2 {
+		t.Fatalf("len(items) = %d, want 2; raw=%s", len(items), output)
+	}
+
+	byName := make(map[string]struct {
+		Path      string
+		SizeBytes int64
+		Size      string
+	}, len(items))
+	for _, item := range items {
+		byName[item.Name] = struct {
+			Path      string
+			SizeBytes int64
+			Size      string
+		}{Path: item.Path, SizeBytes: item.SizeBytes, Size: item.Size}
+	}
+
+	assertCacheItem(t, byName, "template.tar", filepath.Join(cacheDir, "template.tar"), 1536, "1.5 KB")
+	assertCacheItem(t, byName, "os-images/wendyos-test.img", filepath.Join(cacheDir, "os-images", "wendyos-test.img"), 2*1024*1024, "2.0 MB")
+}
+
+func TestCacheListNonInteractiveDefaultStaysPlainText(t *testing.T) {
+	setupCacheListTestEnv(t)
+	cacheDir, err := config.CacheDir()
+	if err != nil {
+		t.Fatalf("cache dir: %v", err)
+	}
+	writeSizedFile(t, filepath.Join(cacheDir, "template.tar"), 1536)
+
+	output, err := executeCacheListCommand(t, []string{"cache", "list"}, func() {
+		// Root command execution auto-enables jsonOutput in non-interactive
+		// contexts. The cache list command should still require explicit --json.
+		jsonOutput = true
+	})
+	if err != nil {
+		t.Fatalf("cache list: %v", err)
+	}
+	if !strings.Contains(output, "  template.tar  (1.5 KB)") {
+		t.Fatalf("plain-text output missing cache entry: %q", output)
+	}
+	if json.Valid([]byte(output)) {
+		t.Fatalf("cache list without explicit --json produced JSON: %q", output)
+	}
+}
+
+func TestOSCacheListJSONEmptyArray(t *testing.T) {
+	setupCacheListTestEnv(t)
+
+	output, err := executeCacheListCommand(t, []string{"--json", "os", "cache", "list"})
+	if err != nil {
+		t.Fatalf("os cache list --json: %v", err)
+	}
+
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(output), &items); err != nil {
+		t.Fatalf("unmarshal output: %v\nraw=%s", err, output)
+	}
+	if len(items) != 0 {
+		t.Fatalf("len(items) = %d, want 0", len(items))
+	}
+}
+
+func TestOSCacheListJSONUsesSharedSizeShape(t *testing.T) {
+	setupCacheListTestEnv(t)
+	cacheDir, err := osCacheDir()
+	if err != nil {
+		t.Fatalf("os cache dir: %v", err)
+	}
+	writeSizedFile(t, filepath.Join(cacheDir, "wendyos-test.img"), 2*1024*1024+512*1024)
+	writeSizedFile(t, filepath.Join(cacheDir, "ignored-dir", "nested.img"), 1024)
+
+	output, err := executeCacheListCommand(t, []string{"--json", "os", "cache", "list"})
+	if err != nil {
+		t.Fatalf("os cache list --json: %v", err)
+	}
+
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(output), &items); err != nil {
+		t.Fatalf("unmarshal output: %v\nraw=%s", err, output)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1; raw=%s", len(items), output)
+	}
+	item := items[0]
+	if item["name"] != "wendyos-test.img" {
+		t.Fatalf("name = %v, want wendyos-test.img", item["name"])
+	}
+	if item["sizeBytes"] != float64(2*1024*1024+512*1024) {
+		t.Fatalf("sizeBytes = %v, want %d", item["sizeBytes"], 2*1024*1024+512*1024)
+	}
+	if item["size"] != "2.5 MB" {
+		t.Fatalf("size = %v, want 2.5 MB", item["size"])
+	}
+	if _, ok := item["sizeMB"]; ok {
+		t.Fatalf("JSON output includes deprecated sizeMB field: %s", output)
+	}
+}
+
+func setupCacheListTestEnv(t *testing.T) {
+	t.Helper()
+
+	origJSON := jsonOutput
+	origDevice := deviceFlag
+	t.Cleanup(func() {
+		jsonOutput = origJSON
+		deviceFlag = origDevice
+	})
+	jsonOutput = false
+	deviceFlag = ""
+
+	base := t.TempDir()
+	t.Setenv("HOME", base)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(base, "xdg-cache"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(base, "local-app-data"))
+	t.Setenv("WENDY_ANALYTICS", "false")
+
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", base)
+	}
+}
+
+func executeCacheListCommand(t *testing.T, args []string, beforeExecute ...func()) (string, error) {
+	t.Helper()
+
+	root := &cobra.Command{
+		Use:           "wendy",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	root.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	root.AddCommand(newCacheCmd())
+
+	osCmd := &cobra.Command{Use: "os"}
+	addOSCacheCmd(osCmd)
+	root.AddCommand(osCmd)
+
+	root.SetArgs(args)
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+
+	for _, fn := range beforeExecute {
+		fn()
+	}
+
+	return captureCommandStdout(t, root.Execute)
+}
+
+func captureCommandStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	oldStdout := os.Stdout
+	os.Stdout = writer
+	execErr := fn()
+	_ = writer.Close()
+	os.Stdout = oldStdout
+	defer reader.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, reader); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return buf.String(), execErr
+}
+
+func writeSizedFile(t *testing.T, path string, size int) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := bytes.Repeat([]byte("x"), size)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func assertCacheItem(t *testing.T, items map[string]struct {
+	Path      string
+	SizeBytes int64
+	Size      string
+}, name, path string, sizeBytes int64, size string) {
+	t.Helper()
+
+	item, ok := items[name]
+	if !ok {
+		t.Fatalf("missing cache item %q", name)
+	}
+	if item.Path != path {
+		t.Fatalf("%s path = %q, want %q", name, item.Path, path)
+	}
+	if item.SizeBytes != sizeBytes {
+		t.Fatalf("%s sizeBytes = %d, want %d", name, item.SizeBytes, sizeBytes)
+	}
+	if item.Size != size {
+		t.Fatalf("%s size = %q, want %q", name, item.Size, size)
+	}
+}

--- a/go/internal/cli/commands/os_cache_supported.go
+++ b/go/internal/cli/commands/os_cache_supported.go
@@ -3,8 +3,10 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -22,10 +24,30 @@ func addOSCacheCmd(parent *cobra.Command) {
 }
 
 func newOSCacheListCmd() *cobra.Command {
+	type osCacheEntry struct {
+		Name      string  `json:"name"`
+		SizeBytes int64   `json:"sizeBytes"`
+		SizeMB    float64 `json:"sizeMB"`
+	}
+
+	printJSON := func(items []osCacheEntry) error {
+		if items == nil {
+			items = []osCacheEntry{}
+		}
+		data, err := json.MarshalIndent(items, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List cached OS images",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			explicitJSON := jsonOutput && cmd.Root().PersistentFlags().Changed("json")
 			dir, err := osCacheDir()
 			if err != nil {
 				return err
@@ -34,29 +56,46 @@ func newOSCacheListCmd() *cobra.Command {
 			entries, err := os.ReadDir(dir)
 			if err != nil {
 				if os.IsNotExist(err) {
+					if explicitJSON {
+						return printJSON(nil)
+					}
 					fmt.Println("No cached OS images.")
 					return nil
 				}
 				return fmt.Errorf("reading cache: %w", err)
 			}
 
-			var found bool
+			var items []osCacheEntry
 			for _, entry := range entries {
+				path := filepath.Join(dir, entry.Name())
 				if entry.IsDir() {
+					if _, err := entrySize(path); err != nil {
+						return fmt.Errorf("determining OS cache entry size for %s: %w", entry.Name(), err)
+					}
 					continue
 				}
 				info, err := entry.Info()
 				if err != nil {
-					continue
+					return fmt.Errorf("reading OS cache entry info for %s: %w", entry.Name(), err)
 				}
 				sizeMB := float64(info.Size()) / (1024 * 1024)
-				fmt.Printf("  %s  (%.1f MB)\n", entry.Name(), sizeMB)
-				found = true
+				items = append(items, osCacheEntry{
+					Name:      entry.Name(),
+					SizeBytes: info.Size(),
+					SizeMB:    sizeMB,
+				})
 			}
 
-			if !found {
+			if explicitJSON {
+				return printJSON(items)
+			}
+
+			if len(items) == 0 {
 				fmt.Println("No cached OS images.")
 			} else {
+				for _, item := range items {
+					fmt.Printf("  %s  (%.1f MB)\n", item.Name, item.SizeMB)
+				}
 				fmt.Printf("\nCache directory: %s\n", dir)
 			}
 

--- a/go/internal/cli/commands/os_cache_supported.go
+++ b/go/internal/cli/commands/os_cache_supported.go
@@ -27,10 +27,6 @@ func newOSCacheListCmd() *cobra.Command {
 		Name      string `json:"name"`
 		SizeBytes int64  `json:"sizeBytes"`
 		Size      string `json:"size"`
-
-		// Keep the existing human-readable output in MiB while exposing the
-		// same JSON shape as `wendy cache list --json`.
-		sizeMB float64
 	}
 
 	printJSON := func(items []osCacheEntry) error {
@@ -84,7 +80,6 @@ func newOSCacheListCmd() *cobra.Command {
 					Name:      entry.Name(),
 					SizeBytes: size,
 					Size:      formatSize(size),
-					sizeMB:    float64(size) / (1024 * 1024),
 				})
 			}
 
@@ -96,7 +91,8 @@ func newOSCacheListCmd() *cobra.Command {
 				fmt.Println("No cached OS images.")
 			} else {
 				for _, item := range items {
-					fmt.Printf("  %s  (%.1f MB)\n", item.Name, item.sizeMB)
+					sizeMB := float64(item.SizeBytes) / (1024 * 1024)
+					fmt.Printf("  %s  (%.1f MB)\n", item.Name, sizeMB)
 				}
 				fmt.Printf("\nCache directory: %s\n", dir)
 			}

--- a/go/internal/cli/commands/os_cache_supported.go
+++ b/go/internal/cli/commands/os_cache_supported.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -25,9 +24,13 @@ func addOSCacheCmd(parent *cobra.Command) {
 
 func newOSCacheListCmd() *cobra.Command {
 	type osCacheEntry struct {
-		Name      string  `json:"name"`
-		SizeBytes int64   `json:"sizeBytes"`
-		SizeMB    float64 `json:"sizeMB"`
+		Name      string `json:"name"`
+		SizeBytes int64  `json:"sizeBytes"`
+		Size      string `json:"size"`
+
+		// Keep the existing human-readable output in MiB while exposing the
+		// same JSON shape as `wendy cache list --json`.
+		sizeMB float64
 	}
 
 	printJSON := func(items []osCacheEntry) error {
@@ -47,6 +50,8 @@ func newOSCacheListCmd() *cobra.Command {
 		Short: "List cached OS images",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// jsonOutput is auto-enabled for non-interactive commands; os cache list
+			// keeps plain text there unless --json was explicitly requested.
 			explicitJSON := jsonOutput && cmd.Root().PersistentFlags().Changed("json")
 			dir, err := osCacheDir()
 			if err != nil {
@@ -67,22 +72,19 @@ func newOSCacheListCmd() *cobra.Command {
 
 			var items []osCacheEntry
 			for _, entry := range entries {
-				path := filepath.Join(dir, entry.Name())
 				if entry.IsDir() {
-					if _, err := entrySize(path); err != nil {
-						return fmt.Errorf("determining OS cache entry size for %s: %w", entry.Name(), err)
-					}
 					continue
 				}
 				info, err := entry.Info()
 				if err != nil {
 					return fmt.Errorf("reading OS cache entry info for %s: %w", entry.Name(), err)
 				}
-				sizeMB := float64(info.Size()) / (1024 * 1024)
+				size := info.Size()
 				items = append(items, osCacheEntry{
 					Name:      entry.Name(),
-					SizeBytes: info.Size(),
-					SizeMB:    sizeMB,
+					SizeBytes: size,
+					Size:      formatSize(size),
+					sizeMB:    float64(size) / (1024 * 1024),
 				})
 			}
 
@@ -94,7 +96,7 @@ func newOSCacheListCmd() *cobra.Command {
 				fmt.Println("No cached OS images.")
 			} else {
 				for _, item := range items {
-					fmt.Printf("  %s  (%.1f MB)\n", item.Name, item.SizeMB)
+					fmt.Printf("  %s  (%.1f MB)\n", item.Name, item.sizeMB)
 				}
 				fmt.Printf("\nCache directory: %s\n", dir)
 			}


### PR DESCRIPTION
## Summary
- add explicit JSON output for cache list and os cache list
- preserve existing human-readable output for non-JSON invocations
- make empty cache results deterministic for automation

## Testing
- Not run; factored out from the Swift E2E branch for focused review.