### PR TITLE
build: bump Go toolchain to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wendylabsinc/wendy
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20251212221603-3adeb8663819

--- a/go/internal/cli/assets/docs/development/setup.md
+++ b/go/internal/cli/assets/docs/development/setup.md
@@ -4,10 +4,10 @@
 
 ### Go
 
-The module requires **Go 1.26.2** or later. The exact version is pinned in `go.mod` at the repo root. The CI workflows use `actions/setup-go` with `go-version-file: go.mod`, so the version is always read from that file — follow the same practice locally.
+The module requires **Go 1.26.4** or later. The exact version is pinned in `go.mod` at the repo root. The CI workflows use `actions/setup-go` with `go-version-file: go.mod`, so the version is always read from that file — follow the same practice locally.
 
 ```sh
-go version   # should report go1.26 or later
+go version   # should report go1.26.4 or later
 ```
 
 ### System Dependencies


### PR DESCRIPTION
## Summary
- Bump the pinned Go toolchain to 1.26.4 so CI uses the patched standard library.
- This clears reachable `govulncheck` findings for `net/textproto` and `crypto/x509` reported against Go 1.26.3.
- Update the bundled development setup docs to match the new minimum version.

## Tests
- `cd go && go run golang.org/x/vuln/cmd/govulncheck@v1.2.0 ./...`
- `cd go && go test ./...`
