### PR TITLE
docs: clarify PowerShell bypass guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ On Windows:
 winget install WendyLabs.Wendy
 ```
 
-If you are running a local, trusted PowerShell setup script and script execution is disabled, use a one-time bypass only after reviewing the script:
+Some local setup scripts are unsigned, so Windows may block them even when you trust the repository. If you need to run a local, trusted PowerShell setup script, use a one-time bypass only after reviewing the script:
 
 ```powershell
 Get-Content .\set-up-windows.ps1
 powershell -ExecutionPolicy Bypass -File .\set-up-windows.ps1
 ```
 
-The bypass applies only to that PowerShell invocation. Run it from a non-elevated PowerShell window unless the script explicitly requires administrator privileges.
+The bypass applies only to that PowerShell invocation. Run it from a non-elevated (standard-user) PowerShell window. If a specific step fails with an access-denied error, review that section of the script before re-running as Administrator.
 
 Package-specific options are available via
 [Homebrew, .deb, .rpm, and AUR](INSTALL.md).

--- a/go/internal/cli/assets/docs/development/setup.md
+++ b/go/internal/cli/assets/docs/development/setup.md
@@ -35,6 +35,19 @@ sudo apt-get install -y libasound2-dev
 sudo dnf install -y alsa-lib-devel
 ```
 
+#### Windows
+
+No additional system packages are required for a standard CLI build on Windows.
+
+Some local setup scripts are unsigned, so Windows may block them even when you trust the repository. If you need to run a local, trusted PowerShell setup script, use a one-time bypass only after reviewing the script:
+
+```powershell
+Get-Content .\set-up-windows.ps1
+powershell -ExecutionPolicy Bypass -File .\set-up-windows.ps1
+```
+
+The bypass applies only to that PowerShell invocation. Run it from a non-elevated (standard-user) PowerShell window. If a specific step fails with an access-denied error, review that section of the script before re-running as Administrator.
+
 ### Additional Tools
 
 | Tool | Purpose | Install |


### PR DESCRIPTION
## Summary
- Clarify why a one-time PowerShell execution-policy bypass may be needed for trusted local setup scripts.
- Strengthen the least-privilege guidance before re-running setup scripts as Administrator.
- Mirror the Windows setup note in the developer setup docs so it is not only in the top-level README.

## Tests
- Not run; docs-only change.
