### PR TITLE
fix: preserve plaintext fallback after non-TLS probe

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -652,6 +652,9 @@ func isCertRejectionError(err error) bool {
 		return false
 	}
 	msg := err.Error()
+	if strings.Contains(msg, "tls: first record does not look like a TLS handshake") {
+		return false
+	}
 	return strings.Contains(msg, "remote error: tls:") ||
 		strings.Contains(msg, "authentication handshake failed") ||
 		strings.Contains(msg, "certificate required")

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -223,6 +223,22 @@ func TestLANAgentAddressesFallsBackToDefaultPort(t *testing.T) {
 	}
 }
 
+func TestIsCertRejectionErrorIgnoresPlaintextTLSProbe(t *testing.T) {
+	err := errors.New(`rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"`)
+
+	if isCertRejectionError(err) {
+		t.Fatal("isCertRejectionError() = true, want false for plaintext TLS probe")
+	}
+}
+
+func TestIsCertRejectionErrorDetectsTLSAlert(t *testing.T) {
+	err := errors.New("rpc error: code = Unavailable desc = remote error: tls: bad certificate")
+
+	if !isCertRejectionError(err) {
+		t.Fatal("isCertRejectionError() = false, want true for TLS alert")
+	}
+}
+
 func TestResolveLANAgentVersionFallsBackAcrossAddresses(t *testing.T) {
 	orig := getAgentVersionAtAddress
 	defer func() { getAgentVersionAtAddress = orig }()


### PR DESCRIPTION
## Summary
- Keep auto-TLS from treating a plaintext endpoint probe as an mTLS cert rejection.
- Restores plaintext fallback for unenrolled LAN devices like Raspberry Pis.
- Keeps the TLS rejection path for real certificate alerts.

## Tests
- `go test ./internal/cli/commands -run 'TestIsCertRejectionError|TestResolveLANAgentVersionFallsBackAcrossAddresses'`
