### PR TITLE
fix(os install): accept .sdimg images inside zip archives

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -97,7 +97,7 @@ To provision WiFi after first boot, use `wendy device setup` or the BLE provisio
 
 1. **Resolve version** — `--version` if provided, otherwise latest (or nightly with `--nightly`).
 2. **Resolve drive** — `--drive` if provided, otherwise an interactive picker of external drives. Internal drives require `--yes-overwrite-internal` in non-interactive mode; in interactive mode the user must type the device path to confirm.
-3. **Download image** — fetched from GCS with a progress bar. Downloaded to `~/Library/Caches/wendy/os-images/` (macOS) or `~/.cache/wendy/os-images/` (Linux). Zip archives are streamed through to the first `.img`/`.raw`/`.wic` entry. Parallel download (8 workers) is used when the server supports HTTP range requests.
+3. **Download image** — fetched from GCS with a progress bar. Downloaded to `~/Library/Caches/wendy/os-images/` (macOS) or `~/.cache/wendy/os-images/` (Linux). Zip archives are streamed through to the first `.img`, `.raw`, `.wic`, or `.sdimg` entry. Parallel download (8 workers) is used when the server supports HTTP range requests.
 4. **Write image** — `dd`-equivalent write with elevated privileges (`sudo` on Unix, UAC on Windows), progress bar.
 5. **Write config partition** — downloads the latest stable `wendy-agent-linux-arm64` binary from GitHub, writes it along with any pre-seeded WiFi credentials and device name to the config partition on the newly written drive. Skipped silently on platforms that don't support config-partition writes; fails loudly if `--wifi`, `--device-name`, or `--pre-enroll` were requested but can't be applied.
 6. **Eject** — the drive is ejected automatically after writing.

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -880,8 +880,8 @@ func (z *zipReadCloser) Close() error {
 }
 
 // streamZipImageEntry opens a zip archive and returns a streaming reader over
-// the first .img, .raw, or .wic entry it finds, plus the uncompressed size.
-// The caller must Close the returned reader.
+// the first .img, .raw, .wic, or .sdimg entry it finds, plus the uncompressed
+// size. The caller must Close the returned reader.
 func streamZipImageEntry(zipPath string) (io.ReadCloser, int64, error) {
 	r, err := zip.OpenReader(zipPath)
 	if err != nil {
@@ -893,7 +893,8 @@ func streamZipImageEntry(zipPath string) (io.ReadCloser, int64, error) {
 			continue
 		}
 		ext := strings.ToLower(filepath.Ext(f.Name))
-		if ext != ".img" && ext != ".raw" && ext != ".wic" {
+		// .sdimg is the Mender A/B disk image RPi targets now produce.
+		if ext != ".img" && ext != ".raw" && ext != ".wic" && ext != ".sdimg" {
 			continue
 		}
 
@@ -917,7 +918,7 @@ func streamZipImageEntry(zipPath string) (io.ReadCloser, int64, error) {
 	}
 
 	r.Close()
-	return nil, 0, fmt.Errorf("no .img, .raw, or .wic file found in zip archive")
+	return nil, 0, fmt.Errorf("no .img, .raw, .wic, or .sdimg file found in zip archive")
 }
 
 func resolveOSImage(deviceKey string, img *imageInfo) (string, error) {

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -236,6 +236,15 @@ func TestStreamZipImageEntry(t *testing.T) {
 		r.Close()
 	})
 
+	t.Run("reads sdimg entry", func(t *testing.T) {
+		zipPath := makeTestZip(t, "wendyos.sdimg", content)
+		r, _, err := streamZipImageEntry(zipPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		r.Close()
+	})
+
 	t.Run("no image entry returns error", func(t *testing.T) {
 		zipPath := makeTestZip(t, "readme.txt", content)
 		_, _, err := streamZipImageEntry(zipPath)


### PR DESCRIPTION
RPi3/4/5 now ship Mender .sdimg disk images (A/B layout), but the zip-entry matcher only accepted .img/.raw/.wic, so `wendy os install` of a zipped RPi image failed with "no image found". Add .sdimg to the allowlist and cover it with a test.

Refs: WDY-983