### PR TITLE
docs: refine Swift E2E README, part 2

### DIFF
--- a/go/internal/cli/assets/docs/development/testing.md
+++ b/go/internal/cli/assets/docs/development/testing.md
@@ -83,6 +83,27 @@ Pull requests from within the repository that modify files under `.github/` auto
 
 ---
 
+## Swift E2E Tests
+
+The `swift/WendyE2ETests` package runs the real `wendy` binary against isolated
+sandboxes, records every shell command, and writes artifacts for local
+debugging, CI, and AI review. It is separate from the `.github/ci-tests/`
+integration tests described above.
+
+Quick start from `swift/`:
+
+```sh
+make e2e-test      # build the CLI, run local E2E tests, write attempts
+make e2e-analyze   # aggregate attempts, run AI review, render the report
+make e2e-reference # render HTML reference documentation from test prose
+```
+
+See [`swift/WendyE2ETests/README.md`](../../swift/WendyE2ETests/README.md) for
+the full contributor reference, including sandbox isolation modes, artifact
+layouts, CI triggering, and test-writing guidance.
+
+---
+
 ## Automated Integration Test Coverage (CI)
 
 When a PR is merged into `main`, the workflow `.github/workflows/integration-test-coverage.yml` automatically checks whether the merged changes introduced new CLI features, device capabilities, entitlements, or deployment modes that are not yet covered by an integration test.

--- a/go/internal/cli/assets/docs/development/testing.md
+++ b/go/internal/cli/assets/docs/development/testing.md
@@ -1,10 +1,10 @@
 # Testing
 
-WendyOS uses both unit tests and integration tests to validate the CLI and agent behaviour.
+WendyOS uses unit tests and app integration tests to validate the CLI and agent behaviour.
 
-## Integration Tests
+## App Integration Tests
 
-Integration tests verify that specific features work end-to-end on a real (or simulated) Wendy device. They live under `.github/ci-tests/` in the repository.
+App integration tests verify that specific features work end-to-end on a real (or simulated) Wendy device. They live under `.github/ci-tests/` in the repository.
 
 ### Directory structure
 
@@ -57,7 +57,7 @@ Depending on the language, a test directory contains:
 - Negative/blocking tests (verifying a capability is absent) should exit `1` if the blocked capability accidentally succeeds.
 - Each test is single-purpose: it proves exactly one feature works.
 
-### Running integration tests locally
+### Running app integration tests locally
 
 Tests are driven by `go/scripts/test-ci.sh`. The script contains an `ALL_TESTS` array listing every registered test name.
 
@@ -69,13 +69,13 @@ Refer to the `usage()` block in that script for a full list of available test na
 
 ### CI execution
 
-Integration tests run in `.github/workflows/integration-tests.yml` on both macOS and Linux runners.
+App integration tests run in `.github/workflows/integration-tests.yml` on both macOS and Linux runners.
 
 > **Note:** Swift tests (`swift-*`) run only on the macOS job. The Linux job omits them.
 
 #### Stable release gate
 
-When a release build is triggered with `publish=true`, the full macOS integration test suite runs as a required gate before the `release` and `publish-linux-repos` jobs proceed. If integration tests fail, neither job runs. Nightly builds (triggered by a `push` event or `publish=false`) skip the integration-test gate and proceed directly to release.
+When a release build is triggered with `publish=true`, the full macOS app integration test suite runs as a required gate before the `release` and `publish-linux-repos` jobs proceed. If app integration tests fail, neither job runs. Nightly builds (triggered by a `push` event or `publish=false`) skip the integration-test gate and proceed directly to release.
 
 #### PR gate for CI config changes
 
@@ -83,30 +83,9 @@ Pull requests from within the repository that modify files under `.github/` auto
 
 ---
 
-## Swift E2E Tests
+## Automated App Integration Test Coverage (CI)
 
-The `swift/WendyE2ETests` package runs the real `wendy` binary against isolated
-sandboxes, records every shell command, and writes artifacts for local
-debugging, CI, and AI review. It is separate from the `.github/ci-tests/`
-integration tests described above.
-
-Quick start from `swift/`:
-
-```sh
-make e2e-test      # build the CLI, run local E2E tests, write attempts
-make e2e-analyze   # aggregate attempts, run AI review, render the report
-make e2e-reference # render HTML reference documentation from test prose
-```
-
-See [`swift/WendyE2ETests/README.md`](../../swift/WendyE2ETests/README.md) for
-the full contributor reference, including sandbox isolation modes, artifact
-layouts, CI triggering, and test-writing guidance.
-
----
-
-## Automated Integration Test Coverage (CI)
-
-When a PR is merged into `main`, the workflow `.github/workflows/integration-test-coverage.yml` automatically checks whether the merged changes introduced new CLI features, device capabilities, entitlements, or deployment modes that are not yet covered by an integration test.
+When a PR is merged into `main`, the workflow `.github/workflows/integration-test-coverage.yml` automatically checks whether the merged changes introduced new CLI features, device capabilities, entitlements, or deployment modes that are not yet covered by an app integration test.
 
 ### How it works
 

--- a/go/internal/cli/assets/docs/development/testing.md
+++ b/go/internal/cli/assets/docs/development/testing.md
@@ -1,10 +1,10 @@
 # Testing
 
-WendyOS uses unit tests and app integration tests to validate the CLI and agent behaviour.
+WendyOS uses both unit tests and integration tests to validate the CLI and agent behaviour.
 
-## App Integration Tests
+## Integration Tests
 
-App integration tests verify that specific features work end-to-end on a real (or simulated) Wendy device. They live under `.github/ci-tests/` in the repository.
+Integration tests verify that specific features work end-to-end on a real (or simulated) Wendy device. They live under `.github/ci-tests/` in the repository.
 
 ### Directory structure
 
@@ -57,7 +57,7 @@ Depending on the language, a test directory contains:
 - Negative/blocking tests (verifying a capability is absent) should exit `1` if the blocked capability accidentally succeeds.
 - Each test is single-purpose: it proves exactly one feature works.
 
-### Running app integration tests locally
+### Running integration tests locally
 
 Tests are driven by `go/scripts/test-ci.sh`. The script contains an `ALL_TESTS` array listing every registered test name.
 
@@ -69,13 +69,13 @@ Refer to the `usage()` block in that script for a full list of available test na
 
 ### CI execution
 
-App integration tests run in `.github/workflows/integration-tests.yml` on both macOS and Linux runners.
+Integration tests run in `.github/workflows/integration-tests.yml` on both macOS and Linux runners.
 
 > **Note:** Swift tests (`swift-*`) run only on the macOS job. The Linux job omits them.
 
 #### Stable release gate
 
-When a release build is triggered with `publish=true`, the full macOS app integration test suite runs as a required gate before the `release` and `publish-linux-repos` jobs proceed. If app integration tests fail, neither job runs. Nightly builds (triggered by a `push` event or `publish=false`) skip the integration-test gate and proceed directly to release.
+When a release build is triggered with `publish=true`, the full macOS integration test suite runs as a required gate before the `release` and `publish-linux-repos` jobs proceed. If integration tests fail, neither job runs. Nightly builds (triggered by a `push` event or `publish=false`) skip the integration-test gate and proceed directly to release.
 
 #### PR gate for CI config changes
 
@@ -83,9 +83,9 @@ Pull requests from within the repository that modify files under `.github/` auto
 
 ---
 
-## Automated App Integration Test Coverage (CI)
+## Automated Integration Test Coverage (CI)
 
-When a PR is merged into `main`, the workflow `.github/workflows/integration-test-coverage.yml` automatically checks whether the merged changes introduced new CLI features, device capabilities, entitlements, or deployment modes that are not yet covered by an app integration test.
+When a PR is merged into `main`, the workflow `.github/workflows/integration-test-coverage.yml` automatically checks whether the merged changes introduced new CLI features, device capabilities, entitlements, or deployment modes that are not yet covered by an integration test.
 
 ### How it works
 

--- a/swift/WendyE2ETests/README.md
+++ b/swift/WendyE2ETests/README.md
@@ -80,7 +80,7 @@ The most useful environment variables are:
 | `WENDY_E2E_TEST_FILTERS` | Comma-separated test filters. |
 | `WENDY_E2E_CLI_RUN_DIR` / `WENDY_E2E_AGENT_RUN_DIR` | Role run directories consumed by scenarios. |
 | `WENDY_E2E_CLI_BIN_DIR` | Directory containing the managed `wendy` binary. |
-| `WENDY_E2E_CLI_AUTH_CONFIG_PATH` | Wendy CLI auth config fixture for authenticated tests. |
+| `WENDY_E2E_CLI_AUTH_CONFIG_PATH` | Dedicated Wendy CLI auth config fixture for authenticated tests. |
 | `WENDY_E2E_CLI_ADDRESS` | Optional SSH host for the CLI machine. |
 | `WENDY_E2E_AGENT_ADDRESS` | Optional SSH host for the agent/device machine. |
 | `WENDY_E2E_CLI_OS` / `WENDY_E2E_AGENT_OS` | Override machine OS metadata. |
@@ -98,8 +98,10 @@ Sandbox isolation modes:
   Existing machine state is used directly.
 
 Authenticated scenarios copy `WENDY_E2E_CLI_AUTH_CONFIG_PATH` into the test
-sandbox. If it is not set, the runner uses the current CLI user's
-`~/.wendy/config.json` where possible.
+sandbox. Prefer a dedicated E2E fixture config instead of your live
+`~/.wendy/config.json`; do not commit fixture configs, and avoid putting
+credential-related values directly in shell history. If the variable is not set,
+the runner uses the current CLI user's `~/.wendy/config.json` where possible.
 
 ## Artifacts
 
@@ -177,7 +179,8 @@ that can be posted as a CI comment. Attempt and AI review JSON schemas live in
 ### Reference directory
 
 `make e2e-reference` renders static reference documentation from the suite and
-test documentation comments, independent of any test run:
+test documentation comments, independent of any test run. It writes local files
+and opens `index.html`; it does not start a web server or network listener.
 
 ```text
 Build/Reference/
@@ -414,7 +417,8 @@ RUN_ID="current"
 RUN_DIR="$PWD/.build/e2e/$RUN_ID"
 CLI_RUN_DIR="$HOME/.wendy/e2e/$RUN_ID/cli"
 CLI_BIN_DIR="$PWD/../../go/bin"
-CLI_AUTH_CONFIG_PATH="$HOME/.wendy/config.json"
+# Use a dedicated E2E auth fixture, not your live ~/.wendy/config.json.
+CLI_AUTH_CONFIG_PATH="$HOME/.wendy/e2e-config.json"
 AGENT_RUN_DIR="$HOME/.wendy/e2e/$RUN_ID/agent"
 
 rm -rf "$RUN_DIR" "$CLI_RUN_DIR" "$AGENT_RUN_DIR"
@@ -432,4 +436,6 @@ swift test --filter WendyE2ETests
 ```
 
 Prefer the wrapper for normal development; use this only when debugging the
-harness itself.
+harness itself. Authenticated tests copy `CLI_AUTH_CONFIG_PATH` into sandbox
+directories, so keep the fixture out of version control and remove stale
+sandboxes when they are no longer needed.

--- a/swift/WendyE2ETests/README.md
+++ b/swift/WendyE2ETests/README.md
@@ -4,6 +4,11 @@ Swift end-to-end tests for the Wendy CLI and Wendy agent. This package runs the
 real `wendy` binary, records every shell command, and writes artifacts for local
 debugging, CI, and AI review.
 
+The harness is currently separate from the `.github/ci-tests/` app integration
+suite. Over time, overlapping app integration coverage is expected to move into
+Swift E2E specs so orchestration, assertions, artifacts, and reporting can live
+in one place.
+
 ## Quick start
 
 From `swift/`:


### PR DESCRIPTION
## Summary
- Open a follow-up PR thread for the next round of Swift E2E README cleanup.
- This branch starts from the merged README refactor and is ready for additional edits.

## Tests
- Not run; placeholder PR only.
