### PR TITLE
Handle Homebrew tap trust in CLI installer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,15 +7,15 @@ For most users, the recommended installation method is the install script docume
 ### macOS (Homebrew)
 
 ```sh
-brew tap wendylabsinc/tap
-brew install wendy
+brew trust --formula wendylabsinc/tap/wendy
+brew install wendylabsinc/tap/wendy
 ```
 
 For the nightly (prerelease) version:
 
 ```sh
-brew tap wendylabsinc/tap
-brew install wendy-nightly
+brew trust --formula wendylabsinc/tap/wendy-nightly
+brew install wendylabsinc/tap/wendy-nightly
 ```
 
 To update:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,16 +6,34 @@ For most users, the recommended installation method is the install script docume
 
 ### macOS (Homebrew)
 
+On Homebrew versions that support formula trust:
+
 ```sh
 brew trust --formula wendylabsinc/tap/wendy
 brew install wendylabsinc/tap/wendy
 ```
 
+On older Homebrew versions where `brew trust` is unavailable:
+
+```sh
+brew tap wendylabsinc/tap
+brew install wendy
+```
+
 For the nightly (prerelease) version:
+
+On Homebrew versions that support formula trust:
 
 ```sh
 brew trust --formula wendylabsinc/tap/wendy-nightly
 brew install wendylabsinc/tap/wendy-nightly
+```
+
+On older Homebrew versions where `brew trust` is unavailable:
+
+```sh
+brew tap wendylabsinc/tap
+brew install wendy-nightly
 ```
 
 To update:

--- a/go/internal/cli/assets/docs/cli.sh
+++ b/go/internal/cli/assets/docs/cli.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 REPO="wendylabsinc/wendy-agent"
 INSTALL_DIR="/usr/local/bin"
 BINARY_NAME="wendy"
+HOMEBREW_FORMULA="wendylabsinc/tap/wendy"
 YES=false
 
 usage() {
@@ -86,6 +87,29 @@ download() {
   fi
 }
 
+# --- Homebrew helper ---
+homebrew_supports_trust() {
+  brew help trust >/dev/null 2>&1
+}
+
+trust_homebrew_formula() {
+  local formula="$1"
+
+  if ! homebrew_supports_trust; then
+    return 0
+  fi
+
+  echo "Trusting Homebrew formula: ${formula}"
+  if brew trust --formula "$formula"; then
+    return 0
+  fi
+
+  echo "Error: Homebrew could not trust ${formula}." >&2
+  echo "Run this command, then re-run the installer:" >&2
+  echo "  brew trust --formula ${formula}" >&2
+  exit 1
+}
+
 # --- Prompt for confirmation ---
 confirm() {
   if [[ "$YES" == true ]]; then return 0; fi
@@ -131,9 +155,16 @@ echo ""
 # ===== macOS =====
 if [[ "$OS" == "darwin" ]]; then
   if command -v brew &>/dev/null; then
-    echo "Homebrew detected. Will install via: brew install wendylabsinc/tap/wendy"
+    if homebrew_supports_trust; then
+      echo "Homebrew detected. Will trust and install via:"
+      echo "  brew trust --formula ${HOMEBREW_FORMULA}"
+      echo "  brew install ${HOMEBREW_FORMULA}"
+    else
+      echo "Homebrew detected. Will install via: brew install ${HOMEBREW_FORMULA}"
+    fi
     confirm "Proceed?"
-    brew install wendylabsinc/tap/wendy
+    trust_homebrew_formula "$HOMEBREW_FORMULA"
+    brew install "$HOMEBREW_FORMULA"
   else
     ARTIFACT="wendy-cli-darwin-${ARCH}-${VERSION}.tar.gz"
     URL="https://github.com/${REPO}/releases/download/${TAG}/${ARTIFACT}"


### PR DESCRIPTION
## Summary
- Trust `wendylabsinc/tap/wendy` with `brew trust --formula` before the CLI installer runs `brew install` when the local Homebrew supports trust.
- Keep older Homebrew behavior by skipping the trust step if `brew trust` is unavailable, and print the manual recovery command if trust fails.
- Update package-specific Homebrew instructions to use trust-qualified formula installs for stable and nightly CLI packages.

## Validation
- `bash -n go/internal/cli/assets/docs/cli.sh`
- `git diff --check`
- Fake-Homebrew installer harness for trust-supported, trust-unsupported, and trust-failure paths with `WENDY_VERSION=v0.0.0`
- `go test ./go/internal/cli/assets`

Note: `shellcheck` is not installed in this environment.