### PR TITLE
fix(cli): preserve mTLS diagnostics for provisioned agents

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -43,6 +43,29 @@ const provisionedAgentUnauthorizedMessage = "Unauthorized. Run 'wendy auth login
 
 var errProvisionedAgentUnauthorized = errors.New(provisionedAgentUnauthorizedMessage)
 
+type provisionedAgentUnauthorizedError struct {
+	cause error
+}
+
+func newProvisionedAgentUnauthorizedError(cause error) error {
+	if cause == nil {
+		return errProvisionedAgentUnauthorized
+	}
+	return provisionedAgentUnauthorizedError{cause: cause}
+}
+
+func (e provisionedAgentUnauthorizedError) Error() string {
+	return fmt.Sprintf("%s\nLast mTLS error: %v", provisionedAgentUnauthorizedMessage, e.cause)
+}
+
+func (e provisionedAgentUnauthorizedError) Is(target error) bool {
+	return target == errProvisionedAgentUnauthorized
+}
+
+func (e provisionedAgentUnauthorizedError) Unwrap() error {
+	return e.cause
+}
+
 var getAgentVersionAtAddress = func(ctx context.Context, address string) (bool, *agentpb.GetAgentVersionResponse, error) {
 	conn, err := connectWithAutoTLS(ctx, address)
 	if err != nil {
@@ -426,7 +449,7 @@ func connectAgentAtAddress(ctx context.Context, addr string) (*grpcclient.AgentC
 }
 
 func connectAgentAtAddressWithProvisionedHint(ctx context.Context, addr string, knownProvisionedMTLS bool) (*grpcclient.AgentConnection, error) {
-	conn, err := connectWithAutoTLS(ctx, addr)
+	conn, mtlsErr, err := connectWithAutoTLSDiagnostics(ctx, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +466,7 @@ func connectAgentAtAddressWithProvisionedHint(ctx context.Context, addr string, 
 			// Running discovery after the failed probe would make the auth
 			// decision depend on a second, unrelated network observation.
 			if knownProvisionedMTLS {
-				return nil, errProvisionedAgentUnauthorized
+				return nil, newProvisionedAgentUnauthorizedError(mtlsErr)
 			}
 			return nil, probeErr
 		}
@@ -575,8 +598,19 @@ func connectFromSelectedDevice(target *SelectedDevice, cfg resolveConfig) (*grpc
 // the misleading "connection refused" from the plaintext port masking the real
 // cause (e.g. clock skew causing "certificate not yet valid").
 func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error) {
+	conn, _, err := connectWithAutoTLSDiagnostics(ctx, plaintextAddr)
+	return conn, err
+}
+
+func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error, error) {
 	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
 	allCerts := loadAllCLICerts()
+	var lastMTLSErr error
+	recordMTLSErr := func(addr string, err error) {
+		if err != nil {
+			lastMTLSErr = fmt.Errorf("%s: %w", addr, err)
+		}
+	}
 	if len(allCerts) > 0 {
 		host, portStr, _ := net.SplitHostPort(plaintextAddr)
 		if port, err := strconv.Atoi(portStr); err == nil {
@@ -602,6 +636,7 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 				for i := range allCerts {
 					conn, tlsErr := grpcclient.ConnectWithTLS(ctx, mtlsAddr, &allCerts[i])
 					if tlsErr != nil {
+						recordMTLSErr(mtlsAddr, tlsErr)
 						if tlsDebug {
 							fmt.Fprintf(os.Stderr, "[tls-debug] ConnectWithTLS(%s) error: %v\n", mtlsAddr, tlsErr)
 						}
@@ -614,8 +649,9 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 					_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
 					cancel()
 					if probeErr == nil {
-						return conn, nil
+						return conn, nil, nil
 					}
+					recordMTLSErr(mtlsAddr, probeErr)
 					if tlsDebug {
 						fmt.Fprintf(os.Stderr, "[tls-debug] GetAgentVersion(%s) error: %v\n", mtlsAddr, probeErr)
 					}
@@ -634,11 +670,12 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 				}
 			}
 			if plaintextAddrCertReject || (mtlsPortCertFails > 0 && mtlsPortNonCertFails == 0) {
-				return nil, fmt.Errorf("TLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1")
+				return nil, lastMTLSErr, fmt.Errorf("TLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1")
 			}
 		}
 	}
-	return grpcclient.Connect(ctx, plaintextAddr)
+	conn, err := grpcclient.Connect(ctx, plaintextAddr)
+	return conn, lastMTLSErr, err
 }
 
 // isCertRejectionError reports whether a gRPC probe error is a server-sent TLS

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -541,22 +541,7 @@ func TestConnectResolvedAgent_NoAuthProvisionedAgentRequiresLogin(t *testing.T) 
 	setTempConfig(t, &config.Config{})
 
 	plaintextAddr := startFailingPlaintextAgent(t)
-	host, portStr, err := net.SplitHostPort(plaintextAddr)
-	if err != nil {
-		t.Fatalf("split plaintext address: %v", err)
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		t.Fatalf("parse plaintext port: %v", err)
-	}
-	stubDiscoverLANDevices(t, []models.LANDevice{
-		{
-			IPAddress: host,
-			Port:      port + agentMTLSPortOffset,
-			IsMTLS:    true,
-		},
-	}, nil)
-	knownProvisionedMTLS := provisionedAgentAdvertisedMTLS(context.Background(), plaintextAddr)
+	knownProvisionedMTLS := stubProvisionedMTLSDiscovery(t, plaintextAddr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -572,6 +557,71 @@ func TestConnectResolvedAgent_NoAuthProvisionedAgentRequiresLogin(t *testing.T) 
 	if err.Error() != provisionedAgentUnauthorizedMessage {
 		t.Fatalf("connectResolvedAgent() message = %q, want %q", err.Error(), provisionedAgentUnauthorizedMessage)
 	}
+}
+
+func TestConnectResolvedAgent_ProvisionedAgentPreservesMTLSError(t *testing.T) {
+	origInteractive := isInteractiveTerminalFn
+	origJSON := jsonOutput
+	defer func() {
+		isInteractiveTerminalFn = origInteractive
+		jsonOutput = origJSON
+	}()
+
+	isInteractiveTerminalFn = func() bool { return false }
+	jsonOutput = false
+	setTempConfig(t, &config.Config{
+		Auth: []config.AuthConfig{
+			{
+				Certificates: []config.CertificateInfo{
+					{
+						PemCertificate: "not a certificate",
+						PemPrivateKey:  "not a private key",
+					},
+				},
+			},
+		},
+	})
+
+	plaintextAddr := startFailingPlaintextAgent(t)
+	knownProvisionedMTLS := stubProvisionedMTLSDiscovery(t, plaintextAddr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := connectResolvedAgentWithProvisionedHint(ctx, "127.0.0.1", plaintextAddr, false, knownProvisionedMTLS)
+	if conn != nil {
+		conn.Close()
+		t.Fatal("connectResolvedAgent() returned a connection for an auth-only agent")
+	}
+	if !errors.Is(err, errProvisionedAgentUnauthorized) {
+		t.Fatalf("connectResolvedAgent() error = %v, want %v", err, errProvisionedAgentUnauthorized)
+	}
+	if errors.Unwrap(err) == nil {
+		t.Fatalf("connectResolvedAgent() error = %v, want wrapped mTLS cause", err)
+	}
+	if !strings.Contains(err.Error(), "Last mTLS error:") || !strings.Contains(err.Error(), "loading TLS cert") {
+		t.Fatalf("connectResolvedAgent() message = %q, want mTLS diagnostic", err.Error())
+	}
+}
+
+func stubProvisionedMTLSDiscovery(t *testing.T, plaintextAddr string) bool {
+	t.Helper()
+	host, portStr, err := net.SplitHostPort(plaintextAddr)
+	if err != nil {
+		t.Fatalf("split plaintext address: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse plaintext port: %v", err)
+	}
+	stubDiscoverLANDevices(t, []models.LANDevice{
+		{
+			IPAddress: host,
+			Port:      port + agentMTLSPortOffset,
+			IsMTLS:    true,
+		},
+	}, nil)
+	return provisionedAgentAdvertisedMTLS(context.Background(), plaintextAddr)
 }
 
 func startFailingPlaintextAgent(t *testing.T) string {


### PR DESCRIPTION
## Summary
- Preserve the last mTLS failure when a provisioned LAN agent falls through to the generic unauthorized error.
- This makes flaky CI/device failures show whether mTLS timed out, failed TLS setup, or hit another handshake issue instead of only suggesting `wendy auth login`.
- Keep the no-auth path unchanged so users without certs still see the simple login guidance.

## Tests
- `go test ./go/internal/cli/...`
