### PR TITLE
fix: use active Swift for macOS package discovery

### DIFF
--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -855,7 +855,7 @@ func runMacOSSwiftPMWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 		return fmt.Errorf("architecture mismatch: device is %s but host is %s", deviceArch, runtime.GOARCH)
 	}
 
-	product, err := swifttoolchain.FindSwiftProductWithOptions(cwd, opts.product, !opts.yes && isInteractiveTerminal())
+	product, err := swifttoolchain.FindSwiftProductWithActiveSwiftOptions(cwd, opts.product, !opts.yes && isInteractiveTerminal())
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/run_macos_test.go
+++ b/go/internal/cli/commands/run_macos_test.go
@@ -154,12 +154,8 @@ func TestRunMacOSSwiftPMWithAgent_UsesRunArgsFromAppConfig(t *testing.T) {
 		t.Fatalf("MkdirAll bin: %v", err)
 	}
 
-	swiftlyPath := filepath.Join(binDir, "swiftly")
 	swiftPath := filepath.Join(binDir, "swift")
-	if err := os.WriteFile(swiftlyPath, []byte("#!/bin/sh\necho '{\"products\":[{\"name\":\"MySwiftApp\",\"type\":{\"executable\":null}}]}'\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile swiftly: %v", err)
-	}
-	if err := os.WriteFile(swiftPath, []byte("#!/bin/sh\nif [ \"$1\" = \"build\" ] && [ \"$2\" = \"-c\" ] && [ \"$3\" = \"release\" ] && [ \"$4\" = \"--show-bin-path\" ]; then\n  echo \"$PWD/.build/release\"\n  exit 0\nfi\nif [ \"$1\" = \"build\" ] && [ \"$2\" = \"-c\" ] && [ \"$3\" = \"release\" ]; then\n  mkdir -p \"$PWD/.build/release/MySwiftApp.bundle\" \"$PWD/.build/release/MySwiftApp.resources\"\n  printf '#!/bin/sh\\n' > \"$PWD/.build/release/MySwiftApp\"\n  printf '<plist/>' > \"$PWD/.build/release/MySwiftApp.bundle/Info.plist\"\n  printf '{}' > \"$PWD/.build/release/MySwiftApp.resources/config.json\"\n  chmod +x \"$PWD/.build/release/MySwiftApp\"\n  exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"), 0o755); err != nil {
+	if err := os.WriteFile(swiftPath, []byte("#!/bin/sh\nif [ \"$1\" = \"package\" ] && [ \"$2\" = \"dump-package\" ]; then\n  echo '{\"products\":[{\"name\":\"MySwiftApp\",\"type\":{\"executable\":null}}]}'\n  exit 0\nfi\nif [ \"$1\" = \"build\" ] && [ \"$2\" = \"-c\" ] && [ \"$3\" = \"release\" ] && [ \"$4\" = \"--show-bin-path\" ]; then\n  echo \"$PWD/.build/release\"\n  exit 0\nfi\nif [ \"$1\" = \"build\" ] && [ \"$2\" = \"-c\" ] && [ \"$3\" = \"release\" ]; then\n  mkdir -p \"$PWD/.build/release/MySwiftApp.bundle\" \"$PWD/.build/release/MySwiftApp.resources\"\n  printf '#!/bin/sh\\n' > \"$PWD/.build/release/MySwiftApp\"\n  printf '<plist/>' > \"$PWD/.build/release/MySwiftApp.bundle/Info.plist\"\n  printf '{}' > \"$PWD/.build/release/MySwiftApp.resources/config.json\"\n  chmod +x \"$PWD/.build/release/MySwiftApp\"\n  exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile swift: %v", err)
 	}
 

--- a/go/internal/cli/swifttoolchain/toolchain.go
+++ b/go/internal/cli/swifttoolchain/toolchain.go
@@ -168,6 +168,10 @@ func SwiftCommand(args ...string) *exec.Cmd {
 	return execCommand("swiftly", append([]string{"run", "+" + DefaultVersion, "swift"}, args...)...)
 }
 
+func ActiveSwiftCommand(args ...string) *exec.Cmd {
+	return execCommand("swift", args...)
+}
+
 func FindSwiftSDK(ctx context.Context, architecture string, stdout, stderr io.Writer) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
@@ -340,12 +344,25 @@ func FindSwiftProduct(dir string) (string, error) {
 }
 
 func FindSwiftProductWithOptions(dir, productOverride string, interactive bool) (string, error) {
+	return findSwiftProductWithOptions(dir, productOverride, interactive, SwiftCommand)
+}
+
+func FindSwiftProductWithActiveSwiftOptions(dir, productOverride string, interactive bool) (string, error) {
+	return findSwiftProductWithOptions(dir, productOverride, interactive, ActiveSwiftCommand)
+}
+
+func findSwiftProductWithOptions(
+	dir string,
+	productOverride string,
+	interactive bool,
+	command func(args ...string) *exec.Cmd,
+) (string, error) {
 	var stderr bytes.Buffer
 	if productOverride != "" {
 		return productOverride, nil
 	}
 
-	cmd := SwiftCommand("package", "dump-package")
+	cmd := command("package", "dump-package")
 	cmd.Dir = dir
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()

--- a/go/internal/cli/swifttoolchain/toolchain_test.go
+++ b/go/internal/cli/swifttoolchain/toolchain_test.go
@@ -304,6 +304,28 @@ func TestEnsureSwiftVersion_Cancellation(t *testing.T) {
 	}
 }
 
+func TestActiveSwiftCommandUsesSwiftFromPath(t *testing.T) {
+	original := execCommand
+	t.Cleanup(func() { execCommand = original })
+
+	var gotName string
+	var gotArgs []string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return exec.Command("true")
+	}
+
+	_ = ActiveSwiftCommand("package", "dump-package")
+
+	if gotName != "swift" {
+		t.Fatalf("expected swift command, got %q", gotName)
+	}
+	if fmt.Sprint(gotArgs) != "[package dump-package]" {
+		t.Fatalf("unexpected args: %v", gotArgs)
+	}
+}
+
 func TestFindSwiftSDK_AlreadyInstalled(t *testing.T) {
 	original := execCommandContext
 	t.Cleanup(func() { execCommandContext = original })


### PR DESCRIPTION
## Summary
- Use the active host `swift` toolchain for macOS SwiftPM package inspection in `wendy run`.
- This keeps the macOS native path aligned with the actual `swift build` step, letting `Package.swift` declare the real compatibility requirement.
- Leave the Linux/WendyOS/WASM Swift build paths pinned to the existing Swiftly toolchain, since those SDK artifacts are versioned for that toolchain.

## Tests
- `cd go && go test ./internal/cli/swifttoolchain ./internal/cli/commands ./internal/cli/providers`
- `cd go && go build -o /tmp/wendy-unpin ./cmd/wendy`
- `/tmp/wendy-unpin run --yes --detach --prefix Examples/HelloMac --device Konstantins-MacBook-Pro-M5.local`
- `/tmp/wendy-unpin --device Konstantins-MacBook-Pro-M5.local device apps stop sh.wendy.examples.HelloMac`
