### PR TITLE
feat: add E2E report target overview

### DIFF
--- a/swift/WendyE2ETests/Package.swift
+++ b/swift/WendyE2ETests/Package.swift
@@ -47,6 +47,12 @@ let package = Package(
             swiftSettings: swiftSettings
         ),
         .testTarget(
+            name: "SwiftE2ETestingCLITests",
+            dependencies: ["SwiftE2ETestingCLI"],
+            path: "Tests/SwiftE2ETestingCLITests",
+            swiftSettings: swiftSettings
+        ),
+        .testTarget(
             name: "WendyE2ETests",
             dependencies: ["WendyE2ETesting"],
             path: "Tests/WendyE2ETests",

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -291,6 +291,55 @@ private enum ReportTargetOutcome {
     case skipped
     case failed
     case unknown
+
+    var statusClass: String {
+        switch self {
+        case .passed:
+            return "pass"
+        case .flaked:
+            return "flaked"
+        case .skipped:
+            return "skipped"
+        case .failed:
+            return "fail"
+        case .unknown:
+            return "unknown"
+        }
+    }
+
+    var statusText: String {
+        switch self {
+        case .passed:
+            return "Passed"
+        case .flaked:
+            return "Flaked"
+        case .skipped:
+            return "Skipped"
+        case .failed:
+            return "Failed"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+}
+
+private struct ReportTargetOverviewRow {
+    var target: String
+    var route: TargetRoute
+    var attempts: Int
+    var tests: Int
+    var counts: ReportTargetOutcomeCounts
+
+    var outcome: ReportTargetOutcome {
+        targetOverviewOutcome(for: counts)
+    }
+}
+
+private struct ReportTargetOverviewAccumulator {
+    var route: TargetRoute?
+    var attempts: Set<String> = []
+    var tests = 0
+    var counts = ReportTargetOutcomeCounts()
 }
 
 private struct ReportTestCase {
@@ -633,6 +682,15 @@ private func targetOutcome(for statuses: [ReportTestStatus]) -> ReportTargetOutc
     if failed && !passed && !skipped && !unknown {
         return .failed
     }
+    return .unknown
+}
+
+private func targetOverviewOutcome(for counts: ReportTargetOutcomeCounts) -> ReportTargetOutcome {
+    if counts.failed > 0 { return .failed }
+    if counts.unknown > 0 { return .unknown }
+    if counts.flaked > 0 { return .flaked }
+    if counts.passed > 0 { return .passed }
+    if counts.skipped > 0 { return .skipped }
     return .unknown
 }
 
@@ -1000,6 +1058,33 @@ private func extractAIItems(from lines: [String]) -> [String] {
     return items
 }
 
+private func buildTargetOverview(files: [ReportTestFile]) -> [ReportTargetOverviewRow] {
+    var rowsByTarget: [String: ReportTargetOverviewAccumulator] = [:]
+
+    for test in files.flatMap(\.tests) {
+        let observationsByTarget = Dictionary(grouping: test.observations, by: \.target)
+        for (target, observations) in observationsByTarget {
+            var row = rowsByTarget[target] ?? ReportTargetOverviewAccumulator()
+            row.route = row.route ?? observations.first?.route
+            row.attempts.formUnion(observations.map(\.attempt))
+            row.tests += 1
+            row.counts.add(targetOutcome(for: observations.map(\.status)))
+            rowsByTarget[target] = row
+        }
+    }
+
+    return rowsByTarget.map { target, row in
+        ReportTargetOverviewRow(
+            target: target,
+            route: row.route ?? TargetRoute(cli: .unknown, agent: nil),
+            attempts: row.attempts.count,
+            tests: row.tests,
+            counts: row.counts
+        )
+    }
+    .sorted { $0.target < $1.target }
+}
+
 private func renderReport(
     templateURL: URL,
     runURL: URL,
@@ -1037,6 +1122,7 @@ private func renderReport(
     try renderReviewAggregateHTMLIfPresent(runURL: runURL)
 
     let reviewHTML = renderRunAIReview(aiReviews.root)
+    let targetOverview = renderTargetOverview(buildTargetOverview(files: files))
     let testCards = renderCards(files: files)
 
     template.replaceSubrange(
@@ -1051,6 +1137,7 @@ private func renderReport(
             "Generated from Swift E2E run results, Swift Testing results, and captured command recordings.",
         "{{RUN_ID}}": runID(outputURL: outputURL),
         "{{REVIEW_AGGREGATE_LINK}}": renderReviewAggregateLink(runURL: runURL),
+        "{{TARGET_OVERVIEW}}": targetOverview,
         "{{TESTS_PASSED_COUNT}}": String(passed),
         "{{TESTS_FLAKED_COUNT}}": String(flaked),
         "{{TESTS_SKIPPED_COUNT}}": String(skipped),
@@ -1072,6 +1159,7 @@ private func renderReport(
         "{{VISIBLE_TEST_COUNT}}",
         "{{TOTAL_TEST_COUNT}}",
         "{{REVIEW_AGGREGATE_LINK}}",
+        "{{TARGET_OVERVIEW}}",
     ]
 
     for (placeholder, value) in replacements {
@@ -1332,6 +1420,58 @@ private func renderCards(files: [ReportTestFile]) -> String {
 
 private func displayOutcomeCounts(for test: ReportTestCase) -> ReportTargetOutcomeCounts {
     test.targetOutcomes.isEmpty ? .fallback(for: test.status) : test.targetOutcomes
+}
+
+private func renderTargetOverview(_ rows: [ReportTargetOverviewRow]) -> String {
+    guard !rows.isEmpty else {
+        return ""
+    }
+
+    let tableRows = rows.map { row in
+        let outcome = row.outcome
+        return """
+            <tr>
+              <td><span class="target-overview-target">\(renderTargetRoute(row.route, title: row.target))<span>\(escapeHTML(row.target))</span></span></td>
+              <td><span class="badge \(outcome.statusClass)">\(outcome.statusText)</span></td>
+              <td class="numeric">\(row.attempts)</td>
+              <td class="numeric">\(row.tests)</td>
+              <td class="numeric">\(row.counts.passed)</td>
+              <td class="numeric">\(row.counts.flaked)</td>
+              <td class="numeric">\(row.counts.failed)</td>
+              <td class="numeric">\(row.counts.skipped)</td>
+              <td class="numeric">\(row.counts.unknown)</td>
+            </tr>
+            """
+    }.joined(separator: "\n")
+
+    return """
+        <section class="target-overview" aria-labelledby="target-overview-heading">
+          <div class="target-overview-header">
+            <h2 id="target-overview-heading">CLI → Agent run overview</h2>
+            <p>Target outcome is aggregated across all attempts for each CLI/agent combination. Individual test badges below keep their per-test semantics.</p>
+          </div>
+          <div class="target-overview-table-wrapper">
+            <table class="target-overview-table">
+              <thead>
+                <tr>
+                  <th scope="col">CLI → Agent</th>
+                  <th scope="col">Outcome</th>
+                  <th class="numeric" scope="col">Attempts</th>
+                  <th class="numeric" scope="col">Tests</th>
+                  <th class="numeric" scope="col">Passed</th>
+                  <th class="numeric" scope="col">Flaked</th>
+                  <th class="numeric" scope="col">Failed</th>
+                  <th class="numeric" scope="col">Skipped</th>
+                  <th class="numeric" scope="col">Unknown</th>
+                </tr>
+              </thead>
+              <tbody>
+        \(tableRows)
+              </tbody>
+            </table>
+          </div>
+        </section>
+        """
 }
 
 private func renderTargetOutcomeBadges(_ counts: ReportTargetOutcomeCounts) -> String {

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -1440,9 +1440,11 @@ private func renderTargetOverview(_ rows: [ReportTargetOverviewRow]) -> String {
 
     let tableRows = rows.map { row in
         let outcome = row.outcome
+        let escapedTarget = escapeHTML(row.target)
+        let route = renderTargetRoute(row.route, escapedTitle: escapedTarget)
         return """
             <tr>
-              <td><span class="target-overview-target">\(renderTargetRoute(row.route, title: row.target))<span>\(escapeHTML(row.target))</span></span></td>
+              <td><span class="target-overview-target">\(route)<span>\(escapedTarget)</span></span></td>
               <td><span class="badge \(outcome.statusClass)">\(outcome.statusText)</span></td>
               <td class="numeric">\(row.attempts)</td>
               <td class="numeric">\(row.tests)</td>
@@ -1515,9 +1517,10 @@ private func renderObservations(
     for observation in observations.sorted(by: observationSort) {
         let isFirstTargetRow = observation.target != previousTarget
         previousTarget = observation.target
-        let target = isFirstTargetRow ? escapeHTML(observation.target) : ""
+        let escapedTarget = isFirstTargetRow ? escapeHTML(observation.target) : ""
+        let target = escapedTarget
         let route =
-            isFirstTargetRow ? renderTargetRoute(observation.route, title: observation.target) : ""
+            isFirstTargetRow ? renderTargetRoute(observation.route, escapedTitle: escapedTarget) : ""
         let rowClass = isFirstTargetRow ? "observation-row" : "observation-row same-target"
         chunks.append(
             "<div class=\"\(rowClass)\"><span class=\"observation-route-cell\">\(route)</span><span class=\"observation-target\">\(target)</span><span class=\"observation-spacer\" aria-hidden=\"true\"></span>\(renderObservationLinks(observation))<span class=\"observation-attempt\">\(escapeHTML(observation.attempt))</span><span class=\"badge \(observation.status.statusClass)\">\(observation.status.statusText)</span>\(observationDurationBadge(observation.duration))</div>"
@@ -1543,13 +1546,15 @@ private func renderObservationLinks(_ observation: ReportTestObservation) -> Str
     return "<span class=\"observation-actions\">\(links.joined())</span>"
 }
 
-private func renderTargetRoute(_ route: TargetRoute, title: String) -> String {
+private func renderTargetRoute(_ route: TargetRoute, escapedTitle: String) -> String {
+    // Returns a trusted HTML fragment. Callers must pass an already-escaped title
+    // so untrusted target names are encoded before entering this fragment.
     let cli = "<span class=\"target-route-cli\">\(renderTargetLogo(route.cli))</span>"
     let arrow = "<span class=\"target-route-arrow\" aria-hidden=\"true\">›</span>"
     let agent =
         "<span class=\"target-route-agent\">\(route.agent.map(renderTargetLogo) ?? "")</span>"
     return
-        "<span class=\"target-route\" title=\"\(escapeHTML(title))\">\(cli)\(arrow)\(agent)</span>"
+        "<span class=\"target-route\" title=\"\(escapedTitle)\">\(cli)\(arrow)\(agent)</span>"
 }
 
 private func targetRoute(for target: String, attemptURL: URL) throws -> TargetRoute {
@@ -2184,4 +2189,5 @@ private func escapeHTML(_ value: String) -> String {
         .replacingOccurrences(of: "<", with: "&lt;")
         .replacingOccurrences(of: ">", with: "&gt;")
         .replacingOccurrences(of: "\"", with: "&quot;")
+        .replacingOccurrences(of: "'", with: "&#39;")
 }

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -1445,17 +1445,13 @@ private func renderTargetOverview(_ rows: [ReportTargetOverviewRow]) -> String {
     }.joined(separator: "\n")
 
     return """
-        <section class="target-overview" aria-labelledby="target-overview-heading">
-          <div class="target-overview-header">
-            <h2 id="target-overview-heading">CLI → Agent run overview</h2>
-            <p>Target outcome is aggregated across all attempts for each CLI/agent combination. Individual test badges below keep their per-test semantics.</p>
-          </div>
+        <section class="target-overview" aria-label="CLI to Agent run overview">
           <div class="target-overview-table-wrapper">
             <table class="target-overview-table">
               <thead>
                 <tr>
-                  <th scope="col">CLI → Agent</th>
-                  <th scope="col">Outcome</th>
+                  <th scope="col" aria-label="CLI to Agent"></th>
+                  <th scope="col" aria-label="Outcome"></th>
                   <th class="numeric" scope="col">Attempts</th>
                   <th class="numeric" scope="col">Tests</th>
                   <th class="numeric" scope="col">Passed</th>

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -610,9 +610,20 @@ private func runObservationStatus(
     }
 
     let results = try parseXUnitResults(at: resultURL)
-    return results.first { key, _ in
+    if let status = results.first(where: { key, _ in
         slug(key.suite) == suiteKey && slug(key.name) == testKey
-    }?.value ?? .unknown
+    })?.value {
+        return status
+    }
+
+    let matchingTestNames = results.filter { key, _ in
+        slug(key.name) == testKey
+    }
+    if matchingTestNames.count == 1, let status = matchingTestNames.first?.value {
+        return status
+    }
+
+    return .unknown
 }
 
 private func observationSort(_ lhs: ReportTestObservation, _ rhs: ReportTestObservation) -> Bool {

--- a/swift/WendyE2ETests/Support/e2e-report.template.html
+++ b/swift/WendyE2ETests/Support/e2e-report.template.html
@@ -250,6 +250,75 @@
       min-width: min(520px, 100%);
     }
 
+    .target-overview {
+      margin: 18px 0 20px;
+      padding: 16px;
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      box-shadow: 0 10px 28px var(--shadow);
+    }
+
+    .target-overview-header {
+      display: grid;
+      gap: 5px;
+      margin-bottom: 12px;
+    }
+
+    .target-overview h2 {
+      margin: 0;
+      font-size: 20px;
+      line-height: 1.2;
+      letter-spacing: -0.025em;
+    }
+
+    .target-overview p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    .target-overview-table-wrapper {
+      overflow-x: auto;
+    }
+
+    .target-overview-table {
+      width: 100%;
+      min-width: 760px;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+
+    .target-overview-table th,
+    .target-overview-table td {
+      padding: 9px 10px;
+      border-top: 1px solid var(--line);
+      text-align: left;
+      vertical-align: middle;
+      white-space: nowrap;
+    }
+
+    .target-overview-table th {
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 900;
+      letter-spacing: .07em;
+      text-transform: uppercase;
+    }
+
+    .target-overview-table .numeric {
+      text-align: right;
+    }
+
+    .target-overview-target {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      font-weight: 700;
+    }
+
     .filter-bar {
       position: sticky;
       top: 0;
@@ -1306,6 +1375,8 @@
         </section>
       </div>
     </header>
+
+    {{TARGET_OVERVIEW}}
 
     <section class="filter-bar" aria-label="Filter tests by status">
       <span class="filter-label">Filter</span>

--- a/swift/WendyE2ETests/Support/e2e-report.template.html
+++ b/swift/WendyE2ETests/Support/e2e-report.template.html
@@ -259,26 +259,6 @@
       box-shadow: 0 10px 28px var(--shadow);
     }
 
-    .target-overview-header {
-      display: grid;
-      gap: 5px;
-      margin-bottom: 12px;
-    }
-
-    .target-overview h2 {
-      margin: 0;
-      font-size: 20px;
-      line-height: 1.2;
-      letter-spacing: -0.025em;
-    }
-
-    .target-overview p {
-      margin: 0;
-      color: var(--muted);
-      font-size: 13px;
-      line-height: 1.45;
-    }
-
     .target-overview-table-wrapper {
       overflow-x: auto;
     }

--- a/swift/WendyE2ETests/Support/e2e-report.template.html
+++ b/swift/WendyE2ETests/Support/e2e-report.template.html
@@ -282,10 +282,6 @@
       border-top: 1px solid var(--line);
     }
 
-    .target-overview-table tbody tr:first-child td {
-      border-top: 0;
-    }
-
     .target-overview-table th {
       color: var(--muted);
       font-size: 11px;

--- a/swift/WendyE2ETests/Support/e2e-report.template.html
+++ b/swift/WendyE2ETests/Support/e2e-report.template.html
@@ -273,10 +273,17 @@
     .target-overview-table th,
     .target-overview-table td {
       padding: 9px 10px;
-      border-top: 1px solid var(--line);
       text-align: left;
       vertical-align: middle;
       white-space: nowrap;
+    }
+
+    .target-overview-table tbody td {
+      border-top: 1px solid var(--line);
+    }
+
+    .target-overview-table tbody tr:first-child td {
+      border-top: 0;
     }
 
     .target-overview-table th {

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
@@ -1,0 +1,88 @@
+import ArgumentParser
+import Foundation
+import Testing
+
+@testable import SwiftE2ETestingCLI
+
+@Suite
+struct `report command` {
+    @Test
+    func `escapes target names in overview HTML`() throws {
+        let rootURL = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let packageURL = rootURL.appendingPathComponent("Package", isDirectory: true)
+        let testsURL = packageURL.appendingPathComponent("Tests", isDirectory: true)
+        let supportURL = packageURL.appendingPathComponent("Support", isDirectory: true)
+        let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
+        let attemptURL = runURL
+            .appendingPathComponent("report-security", isDirectory: true)
+            .appendingPathComponent("escapes-malicious-target", isDirectory: true)
+            .appendingPathComponent("macos-to-<img src=x onerror=\"alert(1)\">", isDirectory: true)
+            .appendingPathComponent("attempt-1", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: testsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: supportURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: attemptURL, withIntermediateDirectories: true)
+
+        try """
+            import Testing
+
+            @Suite
+            struct `report security` {
+                @Test
+                func `escapes malicious target`() async throws {}
+            }
+            """.write(
+                to: testsURL.appendingPathComponent("ReportSecurityTests.swift"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+        try """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite tests="1" failures="0" skipped="0">
+              <testcase classname="WendyE2ETests.`report security`" name="escapes malicious target()" time="0.01" />
+            </testsuite>
+            """.write(
+                to: attemptURL.appendingPathComponent("test-results.xml"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+        try """
+            <!doctype html>
+            <html>
+              <body>
+                {{TARGET_OVERVIEW}}
+                <!-- Repeat this .card section once per test file. -->
+                <footer></footer>
+              </body>
+            </html>
+            """.write(
+                to: supportURL.appendingPathComponent("e2e-report.template.html"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+        var command = try ReportCommand.parse([
+            "--package-dir", packageURL.path,
+            "--run-dir", runURL.path,
+        ])
+        try command.run()
+
+        let html = try String(
+            contentsOf: runURL.appendingPathComponent("index.html"),
+            encoding: .utf8
+        )
+
+        #expect(!html.contains("<img src=x onerror="))
+        #expect(html.contains("macos-to-&lt;img src=x onerror=&quot;alert(1)&quot;&gt;"))
+        #expect(html.contains("title=\"macos-to-&lt;img src=x onerror=&quot;alert(1)&quot;&gt;\""))
+    }
+}
+
+private func temporaryDirectory() -> URL {
+    URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("wendy-e2e-cli-tests-\(UUID().uuidString)", isDirectory: true)
+}


### PR DESCRIPTION
## Summary
- Add a CLI → agent run overview near the top of the Swift E2E HTML report.
- Aggregate each target by per-test outcomes so deterministic failures, unknowns, flakes, passes, and skips are visible before reading individual test cards.
- Keep the existing individual test badge semantics unchanged.

## Tests
- `cd swift/WendyE2ETests && swift build`
- `cd swift/WendyE2ETests && swift test` *(fails: local E2E auth fixture is missing, `WENDY_E2E_CLI_AUTH_CONFIG_PATH` is unset)*
- Rendered a synthetic aggregate run with `swift run swift-e2e-testing report` and verified a mixed pass/fail target reports `Flaked` in the overview.
