### PR TITLE
ci: normalize hardware device locking

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,17 @@
+self-hosted-runner:
+  labels:
+    - AI
+    - ARM64
+    - Linux
+    - X64
+    - macOS
+    - macos-26
+
+config-variables: null
+
+paths:
+  .github/workflows/swift-e2e-tests.yml:
+    ignore:
+      # GitHub Actions supports this queue mode, but actionlint v1.7.12 only
+      # recognizes the older concurrency.group/cancel-in-progress schema.
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -15,3 +15,15 @@ paths:
       # GitHub Actions supports this queue mode, but actionlint v1.7.12 only
       # recognizes the older concurrency.group/cancel-in-progress schema.
       - 'unexpected key "queue" for "concurrency" section'
+
+      # Keep repo-wide actionlint focused on workflow validity. These existing
+      # shellcheck findings are advisory and can be tightened separately.
+      - 'shellcheck reported issue in this script: SC2012:info:'
+      - 'shellcheck reported issue in this script: SC2016:info:'
+      - 'shellcheck reported issue in this script: SC2035:info:'
+      - 'shellcheck reported issue in this script: SC2086:info:'
+      - 'shellcheck reported issue in this script: SC2129:style:'
+
+      # Known intentional workflow patterns.
+      - 'shellcheck reported issue in this script: SC1012:warning:'
+      - 'constant expression "false" in condition'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,7 +10,7 @@ self-hosted-runner:
 config-variables: null
 
 paths:
-  .github/workflows/swift-e2e-tests.yml:
+  .github/workflows/**/*.yml:
     ignore:
       # GitHub Actions supports this queue mode, but actionlint v1.7.12 only
       # recognizes the older concurrency.group/cancel-in-progress schema.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -15,15 +15,3 @@ paths:
       # GitHub Actions supports this queue mode, but actionlint v1.7.12 only
       # recognizes the older concurrency.group/cancel-in-progress schema.
       - 'unexpected key "queue" for "concurrency" section'
-
-      # Keep repo-wide actionlint focused on workflow validity. These existing
-      # shellcheck findings are advisory and can be tightened separately.
-      - 'shellcheck reported issue in this script: SC2012:info:'
-      - 'shellcheck reported issue in this script: SC2016:info:'
-      - 'shellcheck reported issue in this script: SC2035:info:'
-      - 'shellcheck reported issue in this script: SC2086:info:'
-      - 'shellcheck reported issue in this script: SC2129:style:'
-
-      # Known intentional workflow patterns.
-      - 'shellcheck reported issue in this script: SC1012:warning:'
-      - 'constant expression "false" in condition'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,8 +10,17 @@ self-hosted-runner:
 config-variables: null
 
 paths:
-  .github/workflows/**/*.yml:
+  .github/workflows/swift-e2e-tests.yml:
     ignore:
       # GitHub Actions supports this queue mode, but actionlint v1.7.12 only
       # recognizes the older concurrency.group/cancel-in-progress schema.
+      - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/integration-tests.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/test-templates.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/nightly-os-update.yml:
+    ignore:
       - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,41 +44,69 @@ permissions:
 jobs:
   discover:
     name: Discover (${{ matrix.runner.name }})
-    if: inputs.jobs == 'all' || inputs.jobs == 'discover'
+    if: inputs.jobs == 'all' || inputs.jobs == 'discover' || inputs.jobs == 'integration'
     runs-on:
       group: wendy-developer
       labels: [self-hosted, '${{ matrix.runner.os }}', '${{ matrix.runner.arch }}']
     concurrency:
-      group: discover-${{ matrix.runner.name }}
+      group: device-pool-discover-${{ matrix.runner.name }}
       cancel-in-progress: false
     timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.explicit.outputs.matrix || steps.scan.outputs.matrix || '[]' }}
     strategy:
       fail-fast: false
       matrix:
         runner:
           - { name: macOS, os: macOS, arch: ARM64 }
     steps:
+      - name: Resolve explicit device
+        id: explicit
+        if: inputs.hostname != ''
+        env:
+          INPUT_HOSTNAME: ${{ inputs.hostname }}
+        run: |
+          set -euo pipefail
+          hostname="$INPUT_HOSTNAME"
+          # Match test-ci.sh normalization for bare mDNS hostnames.
+          if [[ "$hostname" != *.local && "$hostname" != *.* && "$hostname" != *:* ]]; then
+            hostname="${hostname}.local"
+          fi
+          matrix=$(jq -cn --arg h "$hostname" '[$h]')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Using explicit device: $hostname"
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: inputs.hostname == '' || inputs.jobs == 'all' || inputs.jobs == 'discover'
 
       - name: Set up Go
+        if: inputs.hostname == '' || inputs.jobs == 'all' || inputs.jobs == 'discover'
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Build CLI
+        if: inputs.hostname == '' || inputs.jobs == 'all' || inputs.jobs == 'discover'
         working-directory: go
         run: make build-cli
 
       - name: Run wendy discover
+        id: scan
+        if: inputs.hostname == '' || inputs.jobs == 'all' || inputs.jobs == 'discover'
+        env:
+          INPUT_HOSTNAME: ${{ inputs.hostname }}
+          INPUT_JOBS: ${{ inputs.jobs }}
         run: |
+          set -euo pipefail
           DISCOVER_STDERR=$(mktemp)
           RESULT=$(./go/bin/wendy discover --json --timeout 10s 2>"$DISCOVER_STDERR" || true)
           cat "$DISCOVER_STDERR" >&2 || true
           rm -f "$DISCOVER_STDERR"
-          if [[ -n "$RESULT" ]]; then
-            echo "$RESULT" | jq .
+          if [[ -z "$RESULT" ]]; then
+            RESULT='{"lanDevices":[]}'
           fi
+          echo "$RESULT" | jq .
 
           EXPECTED=(
             "wendyos-keen-channel.local"
@@ -90,7 +118,7 @@ jobs:
           FAIL=0
           for host in "${EXPECTED[@]}"; do
             if echo "$RESULT" | jq -e --arg h "$host" \
-              '.lanDevices[] | select(.hostname == $h)' > /dev/null 2>&1; then
+              '(.lanDevices // [])[] | select(.hostname == $h)' > /dev/null 2>&1; then
               echo "FOUND: $host"
             else
               echo "MISSING: $host"
@@ -102,18 +130,36 @@ jobs:
             echo "WARNING: Some expected devices were not found. They may be offline."
           fi
 
+          MATRIX=$(echo "$RESULT" | jq -c '[(.lanDevices // [])[].hostname // empty]')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+          COUNT=$(echo "$MATRIX" | jq 'length')
+          echo "Discovered $COUNT LAN device(s)."
+          if [[ "$INPUT_HOSTNAME" == '' && "$INPUT_JOBS" != 'discover' && "$COUNT" -eq 0 ]]; then
+            echo "ERROR: No LAN devices found via wendy discover"
+            exit 1
+          fi
+
   integration-test-macos:
-    name: Integration (macOS)
-    if: (inputs.jobs == 'all' || inputs.jobs == 'integration') && (inputs.platform == 'all' || inputs.platform == 'macos')
+    name: Integration (macOS → ${{ matrix.hostname }})
+    needs: discover
+    if: >-
+      needs.discover.outputs.matrix != '[]' &&
+      (inputs.jobs == 'all' || inputs.jobs == 'integration') &&
+      (inputs.platform == 'all' || inputs.platform == 'macos')
     runs-on:
       group: wendy-developer
       labels: [self-hosted, macOS, ARM64]
     concurrency:
-      group: integration-hw-macos
+      group: device-${{ matrix.hostname }}
       cancel-in-progress: false
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        hostname: ${{ fromJson(needs.discover.outputs.matrix) }}
     env:
-      INPUT_HOSTNAME: ${{ inputs.hostname }}
+      INPUT_HOSTNAME: ${{ matrix.hostname }}
       INPUT_TESTS: ${{ inputs.tests }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -139,7 +185,8 @@ jobs:
           elif [ -d "/Applications/Docker.app" ]; then
             echo "Starting Docker Desktop..."
             open -a Docker
-            for i in $(seq 1 30); do
+            for attempt in $(seq 1 30); do
+              echo "Waiting for Docker Desktop ($attempt/30)..."
               if docker info >/dev/null 2>&1; then DOCKER_READY=true; break; fi
               sleep 5
             done
@@ -150,10 +197,6 @@ jobs:
             DOCKER_READY=true
           else
             echo "WARNING: Neither Docker Desktop nor Colima found; integration tests will be skipped"
-          fi
-          if [[ "$DOCKER_READY" == "true" ]]; then
-            docker buildx ls 2>/dev/null | awk '/^wendy/{print $1}' | xargs -r docker buildx rm --force 2>/dev/null || true
-            docker system prune -f 2>/dev/null || true
           fi
           echo "docker_ready=$DOCKER_READY" >> "$GITHUB_OUTPUT"
 
@@ -167,7 +210,6 @@ jobs:
           # session to localhost runs under the logged-in user, which has that
           # permission. See nightly-os-update.yml for the same pattern.
           WORKDIR="$(pwd)"
-          SSH_ENV="export PATH='$PATH' DOCKER_HOST='${DOCKER_HOST:-}'"
           SSH="ssh -o StrictHostKeyChecking=no localhost"
 
           TEST_ARGS="-w $WORKDIR/go/bin/wendy"
@@ -190,63 +232,39 @@ jobs:
             done
           fi
 
-          if [[ -n "$INPUT_HOSTNAME" ]]; then
-            DEVICES=("$INPUT_HOSTNAME")
-          else
-            echo "==> Discovering LAN devices..."
-            DISCOVER_STDERR=$(mktemp)
-            DISCOVER_JSON=$($SSH "$SSH_ENV && cd '$WORKDIR' && ./go/bin/wendy discover --json --timeout 10s" 2>"$DISCOVER_STDERR")
-            cat "$DISCOVER_STDERR" >&2 || true
-            rm -f "$DISCOVER_STDERR"
-            DEVICES=()
-            while IFS= read -r line; do
-              [[ -n "$line" ]] && DEVICES+=("$line")
-            done < <(echo "$DISCOVER_JSON" | jq -r '.lanDevices[].hostname // empty' 2>/dev/null)
-            if [[ ${#DEVICES[@]} -eq 0 ]]; then
-              echo "ERROR: No LAN devices found via wendy discover"
-              exit 1
-            fi
-            echo "==> Found ${#DEVICES[@]} device(s): ${DEVICES[*]}"
-          fi
+          builder_slug="$(printf '%s' "$INPUT_HOSTNAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//')"
+          BUILDER="wendy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${builder_slug}"
+          BUILDER="${BUILDER:0:128}"
+          docker buildx rm "$BUILDER" --force 2>/dev/null || true
+          trap 'docker buildx rm "$BUILDER" --force 2>/dev/null || true' EXIT
 
-          declare -a PIDS
-          OVERALL_FAIL=0
-          for i in "${!DEVICES[@]}"; do
-            device="${DEVICES[$i]}"
-            BUILDER="wendy-$i"
-            echo "==> Starting tests on $device (builder: $BUILDER)"
-            (
-              $SSH "export PATH='$PATH' DOCKER_HOST='${DOCKER_HOST:-}' WENDY_BUILDX_BUILDER='$BUILDER' && cd '$WORKDIR' && go/scripts/test-ci.sh $TEST_ARGS -h '$device'"
-              rc=$?
-              docker buildx rm "$BUILDER" --force 2>/dev/null || true
-              exit $rc
-            ) &
-            PIDS[$i]=$!
-          done
-
-          for i in "${!PIDS[@]}"; do
-            device="${DEVICES[$i]}"
-            if wait "${PIDS[$i]}"; then
-              echo "==> $device: PASS"
-            else
-              echo "==> $device: FAIL"
-              OVERALL_FAIL=1
-            fi
-          done
-          exit $OVERALL_FAIL
+          echo "==> Starting tests on $INPUT_HOSTNAME (builder: $BUILDER)"
+          set +e
+          $SSH "export PATH='$PATH' DOCKER_HOST='${DOCKER_HOST:-}' WENDY_BUILDX_BUILDER='$BUILDER' && cd '$WORKDIR' && go/scripts/test-ci.sh $TEST_ARGS -h '$INPUT_HOSTNAME'"
+          rc=$?
+          set -e
+          exit $rc
 
   integration-test-linux:
-    name: Integration (Linux)
-    if: (inputs.jobs == 'all' || inputs.jobs == 'integration') && (inputs.platform == 'all' || inputs.platform == 'linux')
+    name: Integration (Linux → ${{ matrix.hostname }})
+    needs: discover
+    if: >-
+      needs.discover.outputs.matrix != '[]' &&
+      (inputs.jobs == 'all' || inputs.jobs == 'integration') &&
+      (inputs.platform == 'all' || inputs.platform == 'linux')
     runs-on:
       group: wendy-developer
       labels: [self-hosted, Linux]
     concurrency:
-      group: integration-hw-linux
+      group: device-${{ matrix.hostname }}
       cancel-in-progress: false
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        hostname: ${{ fromJson(needs.discover.outputs.matrix) }}
     env:
-      INPUT_HOSTNAME: ${{ inputs.hostname }}
+      INPUT_HOSTNAME: ${{ matrix.hostname }}
       INPUT_TESTS: ${{ inputs.tests }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -270,10 +288,6 @@ jobs:
             DOCKER_READY=true
           else
             echo "WARNING: Docker not available; integration tests will be skipped"
-          fi
-          if [[ "$DOCKER_READY" == "true" ]]; then
-            docker buildx ls 2>/dev/null | awk '/^wendy/{print $1}' | xargs -r docker buildx rm --force 2>/dev/null || true
-            docker system prune -f 2>/dev/null || true
           fi
           echo "docker_ready=$DOCKER_READY" >> "$GITHUB_OUTPUT"
 
@@ -311,47 +325,12 @@ jobs:
             done
           fi
 
-          if [[ -n "$INPUT_HOSTNAME" ]]; then
-            DEVICES=("$INPUT_HOSTNAME")
-          else
-            echo "==> Discovering LAN devices..."
-            DISCOVER_STDERR=$(mktemp)
-            DISCOVER_JSON=$(./go/bin/wendy discover --json --timeout 10s 2>"$DISCOVER_STDERR")
-            cat "$DISCOVER_STDERR" >&2 || true
-            rm -f "$DISCOVER_STDERR"
-            DEVICES=()
-            while IFS= read -r line; do
-              [[ -n "$line" ]] && DEVICES+=("$line")
-            done < <(echo "$DISCOVER_JSON" | jq -r '.lanDevices[].hostname // empty' 2>/dev/null)
-            if [[ ${#DEVICES[@]} -eq 0 ]]; then
-              echo "ERROR: No LAN devices found via wendy discover"
-              exit 1
-            fi
-            echo "==> Found ${#DEVICES[@]} device(s): ${DEVICES[*]}"
-          fi
+          builder_slug="$(printf '%s' "$INPUT_HOSTNAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//')"
+          BUILDER="wendy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${builder_slug}"
+          BUILDER="${BUILDER:0:128}"
+          docker buildx rm "$BUILDER" --force 2>/dev/null || true
+          trap 'docker buildx rm "$BUILDER" --force 2>/dev/null || true' EXIT
 
-          declare -a PIDS
-          OVERALL_FAIL=0
-          for i in "${!DEVICES[@]}"; do
-            device="${DEVICES[$i]}"
-            BUILDER="wendy-$i"
-            echo "==> Starting tests on $device (builder: $BUILDER)"
-            (
-              WENDY_BUILDX_BUILDER="$BUILDER" go/scripts/test-ci.sh $TEST_ARGS -h "$device"
-              rc=$?
-              docker buildx rm "$BUILDER" --force 2>/dev/null || true
-              exit $rc
-            ) &
-            PIDS[$i]=$!
-          done
-
-          for i in "${!PIDS[@]}"; do
-            device="${DEVICES[$i]}"
-            if wait "${PIDS[$i]}"; then
-              echo "==> $device: PASS"
-            else
-              echo "==> $device: FAIL"
-              OVERALL_FAIL=1
-            fi
-          done
-          exit $OVERALL_FAIL
+          echo "==> Starting tests on $INPUT_HOSTNAME (builder: $BUILDER)"
+          # shellcheck disable=SC2086 # TEST_ARGS is intentionally expanded into test-ci flags.
+          WENDY_BUILDX_BUILDER="$BUILDER" go/scripts/test-ci.sh $TEST_ARGS -h "$INPUT_HOSTNAME"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,9 +48,6 @@ jobs:
     runs-on:
       group: wendy-developer
       labels: [self-hosted, '${{ matrix.runner.os }}', '${{ matrix.runner.arch }}']
-    concurrency:
-      group: device-pool-discover-${{ matrix.runner.name }}
-      cancel-in-progress: false
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.explicit.outputs.matrix || steps.scan.outputs.matrix || '[]' }}
@@ -153,6 +150,7 @@ jobs:
     concurrency:
       group: device-${{ matrix.hostname }}
       cancel-in-progress: false
+      queue: max
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -258,6 +256,7 @@ jobs:
     concurrency:
       group: device-${{ matrix.hostname }}
       cancel-in-progress: false
+      queue: max
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,6 +65,21 @@ jobs:
         run: |
           set -euo pipefail
           hostname="$INPUT_HOSTNAME"
+          validate_device_hostname() {
+            local value="$1"
+            if [[ -z "$value" || ${#value} -gt 253 ]]; then
+              return 1
+            fi
+            if [[ "$value" == *:* ]]; then
+              [[ "$value" =~ ^[0-9A-Fa-f:.]+$ ]]
+            else
+              [[ "$value" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*\.?$ ]]
+            fi
+          }
+          if ! validate_device_hostname "$hostname"; then
+            echo "ERROR: invalid device hostname: $hostname" >&2
+            exit 1
+          fi
           # Match test-ci.sh normalization for bare mDNS hostnames.
           if [[ "$hostname" != *.local && "$hostname" != *.* && "$hostname" != *:* ]]; then
             hostname="${hostname}.local"
@@ -127,10 +142,32 @@ jobs:
             echo "WARNING: Some expected devices were not found. They may be offline."
           fi
 
-          MATRIX=$(echo "$RESULT" | jq -c '[(.lanDevices // [])[].hostname // empty]')
+          validate_device_hostname() {
+            local value="$1"
+            if [[ -z "$value" || ${#value} -gt 253 ]]; then
+              return 1
+            fi
+            if [[ "$value" == *:* ]]; then
+              [[ "$value" =~ ^[0-9A-Fa-f:.]+$ ]]
+            else
+              [[ "$value" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*\.?$ ]]
+            fi
+          }
+
+          HOSTS=()
+          while IFS= read -r host; do
+            [[ -z "$host" ]] && continue
+            if ! validate_device_hostname "$host"; then
+              echo "ERROR: invalid discovered device hostname: $host" >&2
+              exit 1
+            fi
+            HOSTS+=("$host")
+          done < <(echo "$RESULT" | jq -r '(.lanDevices // [])[].hostname // empty')
+
+          MATRIX=$(jq -cn --args '${ARGS.positional}' "${HOSTS[@]}")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
-          COUNT=$(echo "$MATRIX" | jq 'length')
+          COUNT=${#HOSTS[@]}
           echo "Discovered $COUNT LAN device(s)."
           if [[ "$INPUT_HOSTNAME" == '' && "$INPUT_JOBS" != 'discover' && "$COUNT" -eq 0 ]]; then
             echo "ERROR: No LAN devices found via wendy discover"
@@ -217,6 +254,10 @@ jobs:
             IFS=',' read -ra TEST_ARRAY <<< "$INPUT_TESTS"
             for t in "${TEST_ARRAY[@]}"; do
               t="$(echo "$t" | xargs)"
+              if [[ ! "$t" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+                echo "ERROR: invalid test name: $t" >&2
+                exit 1
+              fi
               TEST_ARGS="$TEST_ARGS -t $t"
               HAS_TESTS=true
             done
@@ -236,9 +277,15 @@ jobs:
           docker buildx rm "$BUILDER" --force 2>/dev/null || true
           trap 'docker buildx rm "$BUILDER" --force 2>/dev/null || true' EXIT
 
+          remote_path="$(printf '%q' "$PATH")"
+          remote_docker_host="$(printf '%q' "${DOCKER_HOST:-}")"
+          remote_builder="$(printf '%q' "$BUILDER")"
+          remote_workdir="$(printf '%q' "$WORKDIR")"
+          remote_hostname="$(printf '%q' "$INPUT_HOSTNAME")"
+
           echo "==> Starting tests on $INPUT_HOSTNAME (builder: $BUILDER)"
           set +e
-          $SSH "export PATH='$PATH' DOCKER_HOST='${DOCKER_HOST:-}' WENDY_BUILDX_BUILDER='$BUILDER' && cd '$WORKDIR' && go/scripts/test-ci.sh $TEST_ARGS -h '$INPUT_HOSTNAME'"
+          $SSH "export PATH=$remote_path DOCKER_HOST=$remote_docker_host WENDY_BUILDX_BUILDER=$remote_builder && cd $remote_workdir && go/scripts/test-ci.sh $TEST_ARGS -h $remote_hostname"
           rc=$?
           set -e
           exit $rc
@@ -306,6 +353,10 @@ jobs:
             IFS=',' read -ra TEST_ARRAY <<< "$INPUT_TESTS"
             for t in "${TEST_ARRAY[@]}"; do
               t="$(echo "$t" | xargs)"
+              if [[ ! "$t" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+                echo "ERROR: invalid test name: $t" >&2
+                exit 1
+              fi
               # Skip swift-* tests on Linux.
               if [[ "$t" == swift-* ]]; then
                 echo "Skipping Swift test $t on Linux"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -164,10 +164,16 @@ jobs:
             HOSTS+=("$host")
           done < <(echo "$RESULT" | jq -r '(.lanDevices // [])[].hostname // empty')
 
-          MATRIX=$(jq -cn --args '${ARGS.positional}' "${HOSTS[@]}")
+          COUNT=${#HOSTS[@]}
+          if [[ "$COUNT" -gt 10 ]]; then
+            echo "ERROR: refusing to create integration matrix for $COUNT discovered devices (max 10)" >&2
+            exit 1
+          fi
+
+          MATRIX=$(jq -cn --args '$ARGS.positional' "${HOSTS[@]}")
+          [[ -n "$MATRIX" && "$MATRIX" != "null" ]] || { echo "ERROR: failed to build device matrix" >&2; exit 1; }
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
-          COUNT=${#HOSTS[@]}
           echo "Discovered $COUNT LAN device(s)."
           if [[ "$INPUT_HOSTNAME" == '' && "$INPUT_JOBS" != 'discover' && "$COUNT" -eq 0 ]]; then
             echo "ERROR: No LAN devices found via wendy discover"
@@ -245,9 +251,9 @@ jobs:
           # session to localhost runs under the logged-in user, which has that
           # permission. See nightly-os-update.yml for the same pattern.
           WORKDIR="$(pwd)"
-          SSH="ssh -o StrictHostKeyChecking=no localhost"
+          SSH=(ssh -o StrictHostKeyChecking=no localhost)
 
-          TEST_ARGS="-w $WORKDIR/go/bin/wendy"
+          TEST_ARGS=(-w "$WORKDIR/go/bin/wendy")
 
           if [[ -n "$INPUT_TESTS" ]]; then
             HAS_TESTS=false
@@ -258,7 +264,7 @@ jobs:
                 echo "ERROR: invalid test name: $t" >&2
                 exit 1
               fi
-              TEST_ARGS="$TEST_ARGS -t $t"
+              TEST_ARGS+=(-t "$t")
               HAS_TESTS=true
             done
             if [[ "$HAS_TESTS" == false ]]; then
@@ -267,7 +273,7 @@ jobs:
             fi
           else
             for t in swift-hello swift-network swift-bluetooth swift-resources python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-multiservice otel-localhost-only; do
-              TEST_ARGS="$TEST_ARGS -t $t"
+              TEST_ARGS+=(-t "$t")
             done
           fi
 
@@ -277,18 +283,24 @@ jobs:
           docker buildx rm "$BUILDER" --force 2>/dev/null || true
           trap 'docker buildx rm "$BUILDER" --force 2>/dev/null || true' EXIT
 
-          remote_path="$(printf '%q' "$PATH")"
-          remote_docker_host="$(printf '%q' "${DOCKER_HOST:-}")"
-          remote_builder="$(printf '%q' "$BUILDER")"
-          remote_workdir="$(printf '%q' "$WORKDIR")"
-          remote_hostname="$(printf '%q' "$INPUT_HOSTNAME")"
-
           echo "==> Starting tests on $INPUT_HOSTNAME (builder: $BUILDER)"
-          set +e
-          $SSH "export PATH=$remote_path DOCKER_HOST=$remote_docker_host WENDY_BUILDX_BUILDER=$remote_builder && cd $remote_workdir && go/scripts/test-ci.sh $TEST_ARGS -h $remote_hostname"
-          rc=$?
-          set -e
-          exit $rc
+          if "${SSH[@]}" bash -s -- "$WORKDIR" "$BUILDER" "${DOCKER_HOST:-}" "$INPUT_HOSTNAME" "${TEST_ARGS[@]}" <<'REMOTE'
+          set -euo pipefail
+          WORKDIR="$1"; shift
+          BUILDER="$1"; shift
+          DOCKER_HOST_VALUE="$1"; shift
+          HOSTNAME="$1"; shift
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"
+          export DOCKER_HOST="$DOCKER_HOST_VALUE"
+          export WENDY_BUILDX_BUILDER="$BUILDER"
+          cd "$WORKDIR"
+          exec go/scripts/test-ci.sh "$@" -h "$HOSTNAME"
+          REMOTE
+          then
+            exit 0
+          else
+            exit $?
+          fi
 
   integration-test-linux:
     name: Integration (Linux → ${{ matrix.hostname }})
@@ -346,7 +358,7 @@ jobs:
         run: |
           WORKDIR="$(pwd)"
 
-          TEST_ARGS="-w $WORKDIR/go/bin/wendy"
+          TEST_ARGS=(-w "$WORKDIR/go/bin/wendy")
 
           if [[ -n "$INPUT_TESTS" ]]; then
             HAS_TESTS=false
@@ -362,7 +374,7 @@ jobs:
                 echo "Skipping Swift test $t on Linux"
                 continue
               fi
-              TEST_ARGS="$TEST_ARGS -t $t"
+              TEST_ARGS+=(-t "$t")
               HAS_TESTS=true
             done
             if [[ "$HAS_TESTS" == false ]]; then
@@ -371,7 +383,7 @@ jobs:
             fi
           else
             for t in python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-multiservice otel-localhost-only; do
-              TEST_ARGS="$TEST_ARGS -t $t"
+              TEST_ARGS+=(-t "$t")
             done
           fi
 
@@ -382,5 +394,4 @@ jobs:
           trap 'docker buildx rm "$BUILDER" --force 2>/dev/null || true' EXIT
 
           echo "==> Starting tests on $INPUT_HOSTNAME (builder: $BUILDER)"
-          # shellcheck disable=SC2086 # TEST_ARGS is intentionally expanded into test-ci flags.
-          WENDY_BUILDX_BUILDER="$BUILDER" go/scripts/test-ci.sh $TEST_ARGS -h "$INPUT_HOSTNAME"
+          WENDY_BUILDX_BUILDER="$BUILDER" go/scripts/test-ci.sh "${TEST_ARGS[@]}" -h "$INPUT_HOSTNAME"

--- a/.github/workflows/nightly-os-update.yml
+++ b/.github/workflows/nightly-os-update.yml
@@ -61,7 +61,7 @@ jobs:
       group: wendy-developer
       labels: [self-hosted, macOS, ARM64]
     concurrency:
-      group: update-${{ matrix.hostname }}
+      group: device-${{ matrix.hostname }}
       cancel-in-progress: false
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-os-update.yml
+++ b/.github/workflows/nightly-os-update.yml
@@ -63,6 +63,7 @@ jobs:
     concurrency:
       group: device-${{ matrix.hostname }}
       cancel-in-progress: false
+      queue: max
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -38,7 +38,7 @@ on:
 
 concurrency:
   group: swift-e2e-tests-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -54,7 +54,7 @@ jobs:
     name: ${{ matrix.target.name }}
     runs-on: ["self-hosted", "${{ matrix.target.runner_label }}"]
     concurrency:
-      group: swift-e2e-${{ matrix.target.device_id }}
+      group: device-${{ matrix.target.device_id }}
       cancel-in-progress: false
       queue: max
     timeout-minutes: 120

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -113,9 +113,6 @@ jobs:
     runs-on:
       group: wendy-developer
       labels: [self-hosted, macOS, ARM64]
-    concurrency:
-      group: device-pool-template-discover
-      cancel-in-progress: false
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.explicit.outputs.matrix || steps.scan.outputs.matrix || '[]' }}
@@ -190,6 +187,7 @@ jobs:
     concurrency:
       group: device-${{ matrix.hostname }}
       cancel-in-progress: false
+      queue: max
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -54,7 +54,7 @@ permissions:
 
 concurrency:
   group: template-tests-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   generate-validate:
@@ -107,15 +107,88 @@ jobs:
         working-directory: go
         run: make clean
 
-  deploy-to-device:
-    name: Deploy (${{ matrix.runner.name }})
+  resolve-deploy-devices:
+    name: Resolve deploy devices
     if: inputs.deploy == true
-    needs: [generate-validate]
+    runs-on:
+      group: wendy-developer
+      labels: [self-hosted, macOS, ARM64]
+    concurrency:
+      group: device-pool-template-discover
+      cancel-in-progress: false
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.explicit.outputs.matrix || steps.scan.outputs.matrix || '[]' }}
+    steps:
+      - name: Resolve explicit device
+        id: explicit
+        if: inputs.hostname != ''
+        env:
+          INPUT_HOSTNAME: ${{ inputs.hostname }}
+        run: |
+          set -euo pipefail
+          hostname="$INPUT_HOSTNAME"
+          # Match the deploy scripts for bare mDNS hostnames while leaving IPs
+          # and fully-qualified hostnames unchanged.
+          if [[ "$hostname" != *.local && "$hostname" != *.* && "$hostname" != *:* ]]; then
+            hostname="${hostname}.local"
+          fi
+          matrix=$(jq -cn --arg h "$hostname" '[$h]')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Using explicit deploy device: $hostname"
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: inputs.hostname == ''
+
+      - name: Set up Go
+        if: inputs.hostname == ''
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Build CLI
+        if: inputs.hostname == ''
+        working-directory: go
+        run: make build-cli
+
+      - name: Discover WendyOS devices
+        id: scan
+        if: inputs.hostname == ''
+        run: |
+          set -euo pipefail
+          SSH="ssh -o StrictHostKeyChecking=no localhost"
+          WORKDIR="$(pwd)"
+          SSH_ENV="export PATH='$PATH'"
+
+          DISCOVER_STDERR=$(mktemp)
+          RESULT=$($SSH "$SSH_ENV && cd '$WORKDIR' && ./go/bin/wendy discover --json --type lan --timeout 10s" 2>"$DISCOVER_STDERR" || true)
+          cat "$DISCOVER_STDERR" >&2 || true
+          rm -f "$DISCOVER_STDERR"
+          if [[ -z "$RESULT" ]]; then
+            RESULT='{"lanDevices":[]}'
+          fi
+          echo "$RESULT" | jq .
+
+          MATRIX=$(echo "$RESULT" | jq -c '[(.lanDevices // [])[] | select(.isWendyDevice and .hostname) | .hostname]')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+          COUNT=$(echo "$MATRIX" | jq 'length')
+          echo "Discovered $COUNT WendyOS device(s) for template deploy."
+          if [[ "$COUNT" -eq 0 ]]; then
+            echo "ERROR: No WendyOS devices found via wendy discover"
+            exit 1
+          fi
+
+  deploy-to-device:
+    name: Deploy (${{ matrix.runner.name }} → ${{ matrix.hostname }})
+    if: inputs.deploy == true && needs.resolve-deploy-devices.outputs.matrix != '[]'
+    needs: [generate-validate, resolve-deploy-devices]
     runs-on:
       group: wendy-developer
       labels: ${{ matrix.runner.labels }}
     concurrency:
-      group: template-deploy-${{ matrix.runner.name }}
+      group: device-${{ matrix.hostname }}
       cancel-in-progress: false
     timeout-minutes: 30
     strategy:
@@ -124,8 +197,9 @@ jobs:
         runner:
           - { name: macOS, labels: [self-hosted, macOS, ARM64] }
           - { name: Linux, labels: [self-hosted, Linux, X64] }
+        hostname: ${{ fromJson(needs.resolve-deploy-devices.outputs.matrix) }}
     env:
-      INPUT_HOSTNAME: ${{ inputs.hostname }}
+      INPUT_HOSTNAME: ${{ matrix.hostname }}
       INPUT_TEMPLATES_BRANCH: ${{ inputs.templates_branch }}
       INPUT_TEMPLATE: ${{ inputs.template }}
       INPUT_EXCLUDE_TEMPLATE: ${{ inputs.exclude_template }}
@@ -146,11 +220,7 @@ jobs:
       - name: Run template tests with deploy
         working-directory: go
         run: |
-          ARGS=(-w ./bin/wendy)
-
-          if [[ -n "$INPUT_HOSTNAME" ]]; then
-            ARGS+=(-h "$INPUT_HOSTNAME")
-          fi
+          ARGS=(-w ./bin/wendy -h "$INPUT_HOSTNAME")
 
           if [[ -n "$INPUT_TEMPLATES_BRANCH" && "$INPUT_TEMPLATES_BRANCH" != "main" ]]; then
             ARGS+=(--templates-branch "$INPUT_TEMPLATES_BRANCH")
@@ -168,7 +238,14 @@ jobs:
             ARGS+=(--language "$INPUT_LANGUAGE")
           fi
 
-          scripts/test-templates.sh "${ARGS[@]}"
+          builder_slug="$(printf '%s' "$INPUT_HOSTNAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//')"
+          BUILDER="wendy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${builder_slug}"
+          BUILDER="${BUILDER:0:128}"
+          docker buildx rm "$BUILDER" --force 2>/dev/null || true
+          cleanup() { docker buildx rm "$BUILDER" --force 2>/dev/null || true; }
+          trap cleanup EXIT
+
+          WENDY_BUILDX_BUILDER="$BUILDER" scripts/test-templates.sh "${ARGS[@]}"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -125,6 +125,21 @@ jobs:
         run: |
           set -euo pipefail
           hostname="$INPUT_HOSTNAME"
+          validate_device_hostname() {
+            local value="$1"
+            if [[ -z "$value" || ${#value} -gt 253 ]]; then
+              return 1
+            fi
+            if [[ "$value" == *:* ]]; then
+              [[ "$value" =~ ^[0-9A-Fa-f:.]+$ ]]
+            else
+              [[ "$value" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*\.?$ ]]
+            fi
+          }
+          if ! validate_device_hostname "$hostname"; then
+            echo "ERROR: invalid device hostname: $hostname" >&2
+            exit 1
+          fi
           # Match the deploy scripts for bare mDNS hostnames while leaving IPs
           # and fully-qualified hostnames unchanged.
           if [[ "$hostname" != *.local && "$hostname" != *.* && "$hostname" != *:* ]]; then
@@ -149,7 +164,7 @@ jobs:
         working-directory: go
         run: make build-cli
 
-      - name: Discover WendyOS devices
+      - name: Discover deploy device
         id: scan
         if: inputs.hostname == ''
         run: |
@@ -167,15 +182,31 @@ jobs:
           fi
           echo "$RESULT" | jq .
 
-          MATRIX=$(echo "$RESULT" | jq -c '[(.lanDevices // [])[] | select(.isWendyDevice and .hostname) | .hostname]')
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          validate_device_hostname() {
+            local value="$1"
+            if [[ -z "$value" || ${#value} -gt 253 ]]; then
+              return 1
+            fi
+            if [[ "$value" == *:* ]]; then
+              [[ "$value" =~ ^[0-9A-Fa-f:.]+$ ]]
+            else
+              [[ "$value" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*\.?$ ]]
+            fi
+          }
 
-          COUNT=$(echo "$MATRIX" | jq 'length')
-          echo "Discovered $COUNT WendyOS device(s) for template deploy."
-          if [[ "$COUNT" -eq 0 ]]; then
-            echo "ERROR: No WendyOS devices found via wendy discover"
+          HOSTNAME=$(echo "$RESULT" | jq -r '(.lanDevices // [])[0].hostname // empty')
+          if [[ -z "$HOSTNAME" ]]; then
+            echo "ERROR: No LAN devices found via wendy discover"
             exit 1
           fi
+          if ! validate_device_hostname "$HOSTNAME"; then
+            echo "ERROR: invalid discovered device hostname: $HOSTNAME" >&2
+            exit 1
+          fi
+
+          MATRIX=$(jq -cn --arg h "$HOSTNAME" '[$h]')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "Discovered deploy device: $HOSTNAME"
 
   deploy-to-device:
     name: Deploy (${{ matrix.runner.name }} → ${{ matrix.hostname }})

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -24,7 +24,7 @@ on:
         type: boolean
         default: true
       hostname:
-        description: 'Device hostname for deploy phase (empty = auto-discover)'
+        description: 'Device hostname for deploy phase (empty = first auto-discovered LAN device)'
         required: false
         default: ''
 
@@ -169,12 +169,18 @@ jobs:
         if: inputs.hostname == ''
         run: |
           set -euo pipefail
-          SSH="ssh -o StrictHostKeyChecking=no localhost"
+          SSH=(ssh -o StrictHostKeyChecking=no localhost)
           WORKDIR="$(pwd)"
-          SSH_ENV="export PATH='$PATH'"
 
           DISCOVER_STDERR=$(mktemp)
-          RESULT=$($SSH "$SSH_ENV && cd '$WORKDIR' && ./go/bin/wendy discover --json --type lan --timeout 10s" 2>"$DISCOVER_STDERR" || true)
+          RESULT=$("${SSH[@]}" bash -s -- "$WORKDIR" <<'REMOTE' 2>"$DISCOVER_STDERR" || true
+          set -euo pipefail
+          WORKDIR="$1"
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"
+          cd "$WORKDIR"
+          ./go/bin/wendy discover --json --type lan --timeout 10s
+          REMOTE
+          )
           cat "$DISCOVER_STDERR" >&2 || true
           rm -f "$DISCOVER_STDERR"
           if [[ -z "$RESULT" ]]; then

--- a/go/scripts/test-templates.sh
+++ b/go/scripts/test-templates.sh
@@ -66,8 +66,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Add .local suffix if hostname was explicitly provided and missing it.
-if [[ "$HOSTNAME_PROVIDED" == true ]] && [[ "$HOSTNAME" != *.local ]]; then
+# Add .local suffix only for bare mDNS hostnames (no dots or colons).
+# Leave IPs, FQDNs, and IPv6 addresses unchanged.
+if [[ "$HOSTNAME_PROVIDED" == true ]] && [[ "$HOSTNAME" != *.local ]] && [[ "$HOSTNAME" != *.* ]] && [[ "$HOSTNAME" != *:* ]]; then
     HOSTNAME="${HOSTNAME}.local"
 fi
 

--- a/go/scripts/test-wendyos.sh
+++ b/go/scripts/test-wendyos.sh
@@ -59,8 +59,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Add .local suffix if hostname was explicitly provided and missing it.
-if [[ "$HOSTNAME_PROVIDED" == true ]] && [[ "$HOSTNAME" != *.local ]]; then
+# Add .local suffix only for bare mDNS hostnames (no dots or colons).
+# Leave IPs, FQDNs, and IPv6 addresses unchanged.
+if [[ "$HOSTNAME_PROVIDED" == true ]] && [[ "$HOSTNAME" != *.local ]] && [[ "$HOSTNAME" != *.* ]] && [[ "$HOSTNAME" != *:* ]]; then
     HOSTNAME="${HOSTNAME}.local"
 fi
 


### PR DESCRIPTION
## Summary
- Standardize hardware workflow concurrency around `device-*` locks, with queued behavior preserved via `cancel-in-progress: false` and `queue: max`.
- Split integration runs into per-device matrix jobs so GitHub Actions can serialize access to the same physical host across workflows.
- Keep template deploy auto-discovery single-target: when no hostname is provided, the workflow resolves one discovered LAN device and locks that device explicitly.
- Validate explicit and discovered device hostnames before they enter job matrices or shell commands.

## Notes
- The actionlint config only adds custom self-hosted runner labels and the `queue: max` false-positive ignore for the installed actionlint version; it does not globally suppress ShellCheck findings.

## Tests
- `actionlint .github/workflows/swift-e2e-tests.yml .github/workflows/integration-tests.yml .github/workflows/test-templates.yml .github/workflows/nightly-os-update.yml`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "OK #{p}" }' .github/workflows/swift-e2e-tests.yml .github/workflows/integration-tests.yml .github/workflows/test-templates.yml .github/workflows/nightly-os-update.yml`
- `bash -n go/scripts/test-ci.sh`
- `bash -n go/scripts/test-templates.sh`
- `bash -n go/scripts/test-wendyos.sh`
- `git diff --check`
