### PR TITLE
ci: run Swift E2E tests for Go CLI changes

### DIFF
--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -3,7 +3,11 @@ name: Swift E2E Tests
 on:
   pull_request:
     paths:
+      # The Swift E2E suite builds and exercises the Go CLI against real agents.
+      - 'go/**'
+      # The suite, runner scripts, Swift agent app/core, and generated Swift APIs live here.
       - 'swift/**'
+      # Protocol changes can affect both the generated CLI clients and Swift agent APIs.
       - 'Proto/**'
       - '.github/actions/swift-e2e-run/**'
       - '.github/workflows/swift-e2e-tests.yml'


### PR DESCRIPTION
## Summary
- Trigger the Swift E2E workflow for Go CLI changes, not only Swift/proto changes.
- The Swift E2E runner builds the managed `wendy` CLI from `go/` and exercises it against real agents, so CLI changes should be covered by this workflow.
- Add short comments to the path filter explaining why each trigger path is included.

## Tests
- Not run; workflow trigger-only change.
