### PR TITLE
feat: generate E2E overview for AI review

### DIFF
--- a/swift/WendyAgentCore/Tests/WendyAgentTests/FileSyncServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/FileSyncServiceTests.swift
@@ -563,7 +563,7 @@ struct RunSessionTests {
                 sha256: digest
             )
         )
-        try await waitForFile(at: tempURL)
+        try await waitForFile(at: tempURL, size: content.count)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o000],
             ofItemAtPath: tempURL.path
@@ -1059,11 +1059,22 @@ private func temporaryURL(appsBase: URL, appID: String, path: String, digest: Da
     return destinationURL.deletingLastPathComponent().appendingPathComponent(temporaryName)
 }
 
-private func waitForFile(at url: URL, timeoutNanoseconds: UInt64 = 1_000_000_000) async throws {
+private func waitForFile(
+    at url: URL,
+    size expectedSize: Int? = nil,
+    timeoutNanoseconds: UInt64 = 1_000_000_000
+) async throws {
     let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
     while DispatchTime.now().uptimeNanoseconds < deadline {
         if FileManager.default.fileExists(atPath: url.path) {
-            return
+            if let expectedSize {
+                let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+                if attributes[.size] as? Int == expectedSize {
+                    return
+                }
+            } else {
+                return
+            }
         }
         try await Task.sleep(nanoseconds: 10_000_000)
     }

--- a/swift/WendyE2ETests/README.md
+++ b/swift/WendyE2ETests/README.md
@@ -178,8 +178,8 @@ directory:
 captured `sh()` calls in order for manual debugging.
 
 AI review files are Markdown. Top-level `review.md` is the compact aggregate
-that can be posted as a CI comment. Attempt and AI review JSON schemas live in
-`Support/Schemas/`.
+that can be posted as a CI comment. Attempt, overview, and AI review JSON
+schemas live in `Support/Schemas/`.
 
 ### Reference directory
 

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/AggregateCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/AggregateCommand.swift
@@ -54,7 +54,9 @@ struct AggregateCommand: ParsableCommand {
         }
 
         for root in runURLs.sorted(by: { $0.path < $1.path }) {
+            _ = try writeRunOverview(in: root)
             print("==> Wrote Swift E2E run: \(root.path)")
+            print("    Overview: \(runOverviewURL(in: root).path)")
         }
     }
 

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
@@ -2,7 +2,8 @@ import Foundation
 
 func writeE2EReviewAggregate(in runURL: URL) throws {
     let issues = try loadE2EReviewAggregateIssues(in: runURL)
-    let markdown = renderE2EReviewAggregate(issues: issues)
+    let overview = try loadRunOverview(in: runURL)
+    let markdown = renderE2EReviewAggregate(issues: issues, overview: overview)
     let outputURL = runURL.appendingPathComponent("review.md")
     try markdown.write(to: outputURL, atomically: true, encoding: .utf8)
     print("==> Wrote Swift E2E review aggregate")
@@ -94,15 +95,26 @@ private func loadE2EReviewAggregateIssues(in runURL: URL) throws -> [E2EReviewAg
     }
 }
 
-private func renderE2EReviewAggregate(issues: [E2EReviewAggregateIssue]) -> String {
+private func renderE2EReviewAggregate(
+    issues: [E2EReviewAggregateIssue],
+    overview: E2ERunOverview?
+) -> String {
     var lines: [String] = [
         "# Swift E2E Review",
         "",
     ]
 
+    let wroteOutcomeSummary = appendE2EReviewAggregateOutcomeSummary(
+        overview: overview,
+        issues: issues,
+        to: &lines
+    )
+
     guard !issues.isEmpty else {
-        lines.append("No Swift E2E review issues were generated for this run.")
-        lines.append("")
+        if !wroteOutcomeSummary {
+            lines.append("No Swift E2E review issues were generated for this run.")
+            lines.append("")
+        }
         return lines.joined(separator: "\n")
     }
 
@@ -110,6 +122,10 @@ private func renderE2EReviewAggregate(issues: [E2EReviewAggregateIssue]) -> Stri
         issues
         .filter { $0.scope == .report }
         .sorted(by: reviewAggregateIssueSort)
+    if wroteOutcomeSummary, !runIssues.isEmpty {
+        lines.append("---")
+        lines.append("")
+    }
     for issue in runIssues {
         appendE2EReviewAggregateIssue(issue, headingLevel: 2, to: &lines)
     }
@@ -126,7 +142,7 @@ private func renderE2EReviewAggregate(issues: [E2EReviewAggregateIssue]) -> Stri
             .filter { $0.scope == .test && $0.suiteKey == suiteKey }
         guard !suiteIssues.isEmpty || !testIssues.isEmpty else { continue }
 
-        if !runIssues.isEmpty || wroteSuite {
+        if wroteOutcomeSummary || !runIssues.isEmpty || wroteSuite {
             lines.append("---")
             lines.append("")
         }
@@ -159,6 +175,151 @@ private func reviewAggregateIssueSort(
     return lhs.review.path < rhs.review.path
 }
 
+@discardableResult
+private func appendE2EReviewAggregateOutcomeSummary(
+    overview: E2ERunOverview?,
+    issues: [E2EReviewAggregateIssue],
+    to lines: inout [String]
+) -> Bool {
+    guard let overview else { return false }
+
+    let failures = overview.noteworthy.deterministicFailures
+    let flakes = overview.noteworthy.flakes
+    guard !failures.isEmpty || !flakes.isEmpty else { return false }
+
+    lines.append("## Failed and flaked tests")
+    lines.append("")
+    lines.append(
+        "Every failed or flaked target outcome is listed here with the matching AI review evidence when one was recorded. Failed tests should identify the likely root cause and next action; flaked tests should explain why the outcome may be nondeterministic and what to do next."
+    )
+    lines.append("")
+
+    for issue in failures.sorted(by: reviewAggregateOverviewIssueSort) {
+        appendE2EReviewAggregateOutcome(
+            issue,
+            label: "Failed",
+            marker: "❤️",
+            relatedReviews: relatedReviews(for: issue, in: issues),
+            to: &lines
+        )
+    }
+    for issue in flakes.sorted(by: reviewAggregateOverviewIssueSort) {
+        appendE2EReviewAggregateOutcome(
+            issue,
+            label: "Flaked",
+            marker: "💛",
+            relatedReviews: relatedReviews(for: issue, in: issues),
+            to: &lines
+        )
+    }
+
+    return true
+}
+
+private func appendE2EReviewAggregateOutcome(
+    _ issue: E2ERunOverviewIssue,
+    label: String,
+    marker: String,
+    relatedReviews: [E2EReviewAggregateIssue],
+    to lines: inout [String]
+) {
+    let title = "`\(issue.suite)/\(issue.test)` on `\(issue.target)` \(label.lowercased())"
+    lines.append("### \(marker) \(title)")
+    lines.append("")
+    if relatedReviews.isEmpty {
+        lines.append(
+            "No AI review file was recorded for this \(label.lowercased()) target outcome. Add a review that explains the likely root cause and the next action."
+        )
+    } else {
+        for reviewIssue in relatedReviews {
+            let review = reviewIssue.review
+            lines.append("- AI review: **\(reviewAggregateSingleLine(review.title))**")
+            lines.append("")
+            lines.append(review.summaryMarkdown)
+            lines.append("")
+        }
+    }
+
+    lines.append("<details>")
+    lines.append("<summary>Outcome evidence</summary>")
+    lines.append("")
+    lines.append("- Outcome: `\(issue.outcome.rawValue)`")
+    lines.append("- Target: `\(issue.target)`")
+    lines.append("- Attempts: \(reviewAggregateAttemptSummary(issue.attempts))")
+    for attempt in issue.attempts where attempt.status != .passed || issue.outcome == .flaked {
+        lines.append("  - `\(attempt.attempt)`: `\(attempt.status.rawValue)`")
+        if let detail = attempt.detail, !detail.isEmpty {
+            lines.append("    - Detail: \(reviewAggregateSingleLine(detail))")
+        }
+        appendE2EReviewAggregateEvidence(attempt.artifacts, to: &lines)
+    }
+    if !relatedReviews.isEmpty {
+        lines.append("- Related review files:")
+        for reviewIssue in relatedReviews {
+            lines.append("  - `\(reviewIssue.review.path)`")
+        }
+    }
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+}
+
+private func reviewAggregateOverviewIssueSort(
+    _ lhs: E2ERunOverviewIssue,
+    _ rhs: E2ERunOverviewIssue
+) -> Bool {
+    if lhs.suite != rhs.suite { return lhs.suite < rhs.suite }
+    if lhs.test != rhs.test { return lhs.test < rhs.test }
+    return lhs.target < rhs.target
+}
+
+private func relatedReviews(
+    for issue: E2ERunOverviewIssue,
+    in reviews: [E2EReviewAggregateIssue]
+) -> [E2EReviewAggregateIssue] {
+    let exact = reviews.filter { review in
+        review.scope == .test && review.suiteKey == issue.suite && review.testKey == issue.test
+    }
+    if !exact.isEmpty {
+        return exact.sorted(by: reviewAggregateIssueSort)
+    }
+
+    return reviews.filter { review in
+        review.scope == .suite && review.suiteKey == issue.suite
+    }
+    .sorted(by: reviewAggregateIssueSort)
+}
+
+private func appendE2EReviewAggregateEvidence(
+    _ artifacts: E2ERunOverviewArtifacts,
+    to lines: inout [String]
+) {
+    if let recording = artifacts.recording {
+        lines.append("    - Recording: `\(recording)`")
+    }
+    if let shell = artifacts.shell {
+        lines.append("    - Shell: `\(shell)`")
+    }
+    if let testResults = artifacts.testResults {
+        lines.append("    - xUnit: `\(testResults)`")
+    }
+}
+
+private func reviewAggregateAttemptSummary(_ attempts: [E2ERunOverviewIssueAttempt]) -> String {
+    attempts.map { "`\($0.attempt):\($0.status.rawValue)`" }.joined(separator: ", ")
+}
+
+private func reviewAggregateSeverityMarker(_ severity: E2EReviewSeverity) -> String {
+    switch severity {
+    case .fail:
+        "❤️"
+    case .concern:
+        "💛"
+    case .info:
+        "💙"
+    }
+}
+
 private func appendE2EReviewAggregateIssue(
     _ issue: E2EReviewAggregateIssue,
     headingLevel: Int,
@@ -185,8 +346,8 @@ private func reviewAggregateTitleLine(
     headingLevel: Int
 ) -> String {
     let heading = String(repeating: "#", count: headingLevel)
-    return
-        "\(heading) \(issue.severity.displayName): \(reviewAggregateSingleLine(issue.review.title))"
+    let title = reviewAggregateSingleLine(issue.review.title)
+    return "\(heading) \(reviewAggregateSeverityMarker(issue.severity)) \(title)"
 }
 
 private func appendE2EReviewAggregateMetadata(

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
@@ -93,6 +93,7 @@ extension ReviewCommand {
         let resolvedModel = reviewHarness.modelName
         let reviewer = e2eReviewReviewer(model: resolvedModel)
         let reviewDirectoryName = e2eReviewDirectoryName(reviewer: reviewer)
+        let overview = try ensureRunOverview(in: runURL)
         let suites = try loadRunReviewSuites(
             testsURL: testsURL,
             runURL: runURL,
@@ -107,6 +108,7 @@ extension ReviewCommand {
         print("    Auth:           \(reviewHarness.authSummary)")
         print("    Repo:           \(repoURL.path)")
         print("    Run:            \(runURL.path)")
+        print("    Overview:       \(runOverviewURL(in: runURL).path)")
         print("    Mode:           \(reviewMode.name)")
         print("    Reviewer:       \(reviewer)")
         print("    Review dir:     \(reviewDirectoryName)")
@@ -140,6 +142,7 @@ extension ReviewCommand {
                             testsURL: testsURL,
                             runURL: runURL,
                             context: context,
+                            overview: overview,
                             reviewer: reviewer,
                             reviewDirectoryName: reviewDirectoryName,
                             overwrite: overwrite
@@ -169,6 +172,7 @@ extension ReviewCommand {
                 testsURL: testsURL,
                 runURL: runURL,
                 context: context,
+                overview: overview,
                 reviewer: reviewer,
                 reviewDirectoryName: reviewDirectoryName,
                 overwrite: overwrite
@@ -822,9 +826,20 @@ private func runReviewObservationResult(
     guard xmlParser.parse() else {
         throw ValidationError("Could not parse Swift Testing xUnit results: \(resultURL.path)")
     }
-    return parser.results.first { key, _ in
+    if let result = parser.results.first(where: { key, _ in
         reviewSlug(key.suite) == suiteKey && reviewSlug(key.name) == testKey
-    }?.value ?? ReviewTestObservation(status: .unknown, durationSeconds: nil)
+    })?.value {
+        return result
+    }
+
+    let matchingTestNames = parser.results.filter { key, _ in
+        reviewSlug(key.name) == testKey
+    }
+    if matchingTestNames.count == 1, let result = matchingTestNames.first?.value {
+        return result
+    }
+
+    return ReviewTestObservation(status: .unknown, durationSeconds: nil)
 }
 
 private func runReviewDirectoryChildren(of url: URL) throws -> [URL] {
@@ -856,6 +871,7 @@ private func runSuitePrompt(
     testsURL: URL,
     runURL: URL,
     context: ReviewContext,
+    overview: E2ERunOverview,
     reviewer: String,
     reviewDirectoryName: String,
     overwrite: Bool
@@ -867,7 +883,8 @@ private func runSuitePrompt(
         packageURL: packageURL,
         testsURL: testsURL,
         runURL: runURL,
-        context: context
+        context: context,
+        overviewURL: runOverviewURL(in: runURL)
     )
     lines.append("## Suite")
     lines.append("")
@@ -888,10 +905,16 @@ private func runSuitePrompt(
         overwrite: overwrite
     )
     lines.append("")
+    appendRunOverviewSuiteFocus(overview, suiteKey: suite.suiteKey, to: &lines)
     lines.append("## Tests in this suite")
     lines.append("")
     for test in suite.tests {
-        appendRunReviewTest(test, to: &lines, runURL: runURL)
+        appendRunReviewTest(
+            test,
+            to: &lines,
+            runURL: runURL,
+            reviewDirectoryName: reviewDirectoryName
+        )
     }
     return lines.joined(separator: "\n")
 }
@@ -904,6 +927,7 @@ private func runReportPrompt(
     testsURL: URL,
     runURL: URL,
     context: ReviewContext,
+    overview: E2ERunOverview,
     reviewer: String,
     reviewDirectoryName: String,
     overwrite: Bool
@@ -915,7 +939,8 @@ private func runReportPrompt(
         packageURL: packageURL,
         testsURL: testsURL,
         runURL: runURL,
-        context: context
+        context: context,
+        overviewURL: runOverviewURL(in: runURL)
     )
     lines.append("## Report scope")
     lines.append("")
@@ -933,6 +958,7 @@ private func runReportPrompt(
         "For report-level reviews, only create findings that are run-level or cross-suite. Do not repeat suite/test reviews already covered at lower scopes."
     )
     lines.append("")
+    appendRunOverviewReportFocus(overview, to: &lines)
     lines.append("## Run summary")
     lines.append("")
     for suite in suites {
@@ -963,7 +989,8 @@ private func runPromptHeader(
     packageURL: URL,
     testsURL: URL,
     runURL: URL,
-    context: ReviewContext
+    context: ReviewContext,
+    overviewURL: URL
 ) -> [String] {
     var lines = [
         "# \(title)",
@@ -976,6 +1003,7 @@ private func runPromptHeader(
         "- Swift package: `\(packageURL.path)`",
         "- Swift E2E tests: `\(testsURL.path)`",
         "- Run directory: `\(runURL.path)`",
+        "- Run overview JSON: `\(overviewURL.path)`",
         "",
         "Walk only the canonical run depth. Do not recursively scan copied `cli/` or `agent/` sandboxes unless you intentionally inspect a specific artifact referenced below.",
         "Print short `Progress:` lines while reviewing so CI shows activity.",
@@ -1055,6 +1083,183 @@ private func appendReviewOutputContract(
     )
 }
 
+private func appendRunOverviewSuiteFocus(
+    _ overview: E2ERunOverview,
+    suiteKey: String,
+    to lines: inout [String]
+) {
+    lines.append("## Failure and flake evidence from `\(e2eRunOverviewFileName)`")
+    lines.append("")
+    lines.append(
+        "Prioritize deterministic `FAILED` target outcomes first, then `FLAKED` target outcomes, then unresolved `UNKNOWN` outcomes. Cite the attempt artifacts listed here when writing reviews."
+    )
+    lines.append("")
+
+    guard let suite = overview.suites.first(where: { $0.key == suiteKey }) else {
+        lines.append("- No suite entry was found in `\(e2eRunOverviewFileName)` for `\(suiteKey)`.")
+        lines.append("")
+        return
+    }
+
+    var wrote = false
+    for test in suite.tests {
+        let notableOutcomes = test.targetOutcomes.filter { outcome in
+            outcome.outcome == .failed || outcome.outcome == .flaked || outcome.outcome == .unknown
+        }
+        guard !notableOutcomes.isEmpty else { continue }
+
+        wrote = true
+        lines.append("### `\(suite.key)/\(test.key)`")
+        for outcome in notableOutcomes {
+            appendRunOverviewTestTargetOutcome(outcome, prefix: "-", to: &lines)
+        }
+        lines.append("")
+    }
+
+    if !wrote {
+        lines.append("- No deterministic failures, flakes, or unknown target outcomes were recorded for this suite.")
+        lines.append("")
+    }
+}
+
+private func appendRunOverviewReportFocus(
+    _ overview: E2ERunOverview,
+    to lines: inout [String]
+) {
+    lines.append("## Run overview from `\(e2eRunOverviewFileName)`")
+    lines.append("")
+    lines.append(
+        "The overview is generated before AI review from xUnit results and per-attempt artifacts. Use it as the source of truth for target-level deterministic failures and flakes."
+    )
+    lines.append("")
+    lines.append(
+        "- Summary: tests=\(overview.summary.tests), test-targets=\(overview.summary.testTargets), attempts=\(overview.summary.attemptResults), passed=\(overview.summary.passed), flaked=\(overview.summary.flaked), failed=\(overview.summary.failed), skipped=\(overview.summary.skipped), unknown=\(overview.summary.unknown), commands=\(overview.summary.commands)"
+    )
+    lines.append("- Target overview:")
+    for target in overview.targets {
+        lines.append(
+            "  - `\(target.name)`: outcome=`\(target.outcome.rawValue)`, attempts=\(target.attempts), tests=\(target.tests), passed=\(target.passed), flaked=\(target.flaked), failed=\(target.failed), skipped=\(target.skipped), unknown=\(target.unknown)"
+        )
+    }
+    lines.append("")
+
+    appendRunOverviewIssues(
+        title: "Deterministic failures",
+        issues: overview.noteworthy.deterministicFailures,
+        to: &lines
+    )
+    appendRunOverviewIssues(
+        title: "Flakes",
+        issues: overview.noteworthy.flakes,
+        to: &lines
+    )
+    appendRunOverviewIssues(
+        title: "Unknown outcomes",
+        issues: overview.noteworthy.unknowns,
+        to: &lines
+    )
+}
+
+private func appendRunOverviewIssues(
+    title: String,
+    issues: [E2ERunOverviewIssue],
+    to lines: inout [String]
+) {
+    lines.append("### \(title)")
+    lines.append("")
+    guard !issues.isEmpty else {
+        lines.append("- None recorded.")
+        lines.append("")
+        return
+    }
+
+    for issue in issues {
+        lines.append(
+            "- `\(issue.suite)/\(issue.test)` target=`\(issue.target)` outcome=`\(issue.outcome.rawValue)` attempts=\(runOverviewIssueAttemptSummary(issue.attempts))"
+        )
+        for attempt in issue.attempts where attempt.status != .passed || issue.outcome == .flaked {
+            appendRunOverviewIssueAttempt(attempt, prefix: "  ", to: &lines)
+        }
+    }
+    lines.append("")
+}
+
+private func appendRunOverviewTestTargetOutcome(
+    _ outcome: E2ERunOverviewTestTargetOutcome,
+    prefix: String,
+    to lines: inout [String]
+) {
+    lines.append(
+        "\(prefix) target=`\(outcome.target)` outcome=`\(outcome.outcome.rawValue)` attempts=\(runOverviewObservationSummary(outcome.attempts))"
+    )
+    for attempt in outcome.attempts where attempt.status != .passed || outcome.outcome == .flaked {
+        appendRunOverviewObservation(attempt, prefix: "  ", to: &lines)
+    }
+}
+
+private func appendRunOverviewObservation(
+    _ observation: E2ERunOverviewObservation,
+    prefix: String,
+    to lines: inout [String]
+) {
+    let duration = observation.durationSeconds.map(formatSeconds) ?? "unknown"
+    lines.append(
+        "\(prefix)- attempt=`\(observation.attempt)` status=`\(observation.status.rawValue)` duration=`\(duration)`"
+    )
+    appendRunOverviewDetail(observation.detail, prefix: "\(prefix)  ", to: &lines)
+    appendRunOverviewArtifacts(observation.artifacts, prefix: "\(prefix)  ", to: &lines)
+}
+
+private func appendRunOverviewIssueAttempt(
+    _ attempt: E2ERunOverviewIssueAttempt,
+    prefix: String,
+    to lines: inout [String]
+) {
+    lines.append("\(prefix)- attempt=`\(attempt.attempt)` status=`\(attempt.status.rawValue)`")
+    appendRunOverviewDetail(attempt.detail, prefix: "\(prefix)  ", to: &lines)
+    appendRunOverviewArtifacts(attempt.artifacts, prefix: "\(prefix)  ", to: &lines)
+}
+
+private func appendRunOverviewDetail(
+    _ detail: String?,
+    prefix: String,
+    to lines: inout [String]
+) {
+    guard let detail, !detail.isEmpty else { return }
+    lines.append("\(prefix)detail: \(runOverviewSingleLine(detail, limit: 500))")
+}
+
+private func appendRunOverviewArtifacts(
+    _ artifacts: E2ERunOverviewArtifacts,
+    prefix: String,
+    to lines: inout [String]
+) {
+    if let recording = artifacts.recording {
+        lines.append("\(prefix)recording: `\(recording)`")
+    }
+    if let shell = artifacts.shell {
+        lines.append("\(prefix)shell: `\(shell)`")
+    }
+    if let testResults = artifacts.testResults {
+        lines.append("\(prefix)xunit: `\(testResults)`")
+    }
+}
+
+private func runOverviewObservationSummary(_ observations: [E2ERunOverviewObservation]) -> String {
+    observations.map { "\($0.attempt):\($0.status.rawValue)" }.joined(separator: ",")
+}
+
+private func runOverviewIssueAttemptSummary(_ attempts: [E2ERunOverviewIssueAttempt]) -> String {
+    attempts.map { "\($0.attempt):\($0.status.rawValue)" }.joined(separator: ",")
+}
+
+private func runOverviewSingleLine(_ value: String, limit: Int) -> String {
+    let singleLine = value.replacingOccurrences(of: "\n", with: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard singleLine.count > limit else { return singleLine }
+    return String(singleLine.prefix(limit)) + "…"
+}
+
 private func appendExistingReviews(
     _ reviews: [E2EReview],
     label: String,
@@ -1114,13 +1319,14 @@ private func appendReviewContext(_ context: ReviewContext, to lines: inout [Stri
 private func appendRunReviewTest(
     _ test: RunReviewTest,
     to lines: inout [String],
-    runURL: URL
+    runURL: URL,
+    reviewDirectoryName: String
 ) {
     lines.append("### \(test.test.suite) › \(test.test.name)")
     lines.append("- Test key: `\(test.suiteKey)/\(test.testKey)`")
     lines.append("- Source: `\(test.test.sourcePath):\(test.test.funcLine)`")
     lines.append(
-        "- Review directory: `\(runURL.appendingPathComponent(test.suiteKey).appendingPathComponent(test.testKey).appendingPathComponent("review").path)`"
+        "- Review directory: `\(runURL.appendingPathComponent(test.suiteKey).appendingPathComponent(test.testKey).appendingPathComponent(reviewDirectoryName).path)`"
     )
     appendExistingReviews(test.existingReviews, label: "Existing reviews", to: &lines)
     if !test.test.aiComments.isEmpty {

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
@@ -1095,31 +1095,21 @@ private func appendRunOverviewSuiteFocus(
     )
     lines.append("")
 
-    guard let suite = overview.suites.first(where: { $0.key == suiteKey }) else {
-        lines.append("- No suite entry was found in `\(e2eRunOverviewFileName)` for `\(suiteKey)`.")
-        lines.append("")
-        return
-    }
-
-    var wrote = false
-    for test in suite.tests {
-        let notableOutcomes = test.targetOutcomes.filter { outcome in
-            outcome.outcome == .failed || outcome.outcome == .flaked || outcome.outcome == .unknown
-        }
-        guard !notableOutcomes.isEmpty else { continue }
-
-        wrote = true
-        lines.append("### `\(suite.key)/\(test.key)`")
-        for outcome in notableOutcomes {
-            appendRunOverviewTestTargetOutcome(outcome, prefix: "-", to: &lines)
-        }
-        lines.append("")
-    }
-
-    if !wrote {
-        lines.append("- No deterministic failures, flakes, or unknown target outcomes were recorded for this suite.")
-        lines.append("")
-    }
+    appendRunOverviewIssues(
+        title: "Deterministic failures",
+        issues: overview.noteworthy.deterministicFailures.filter { $0.suite == suiteKey },
+        to: &lines
+    )
+    appendRunOverviewIssues(
+        title: "Flakes",
+        issues: overview.noteworthy.flakes.filter { $0.suite == suiteKey },
+        to: &lines
+    )
+    appendRunOverviewIssues(
+        title: "Unknown outcomes",
+        issues: overview.noteworthy.unknowns.filter { $0.suite == suiteKey },
+        to: &lines
+    )
 }
 
 private func appendRunOverviewReportFocus(
@@ -1184,38 +1174,15 @@ private func appendRunOverviewIssues(
     lines.append("")
 }
 
-private func appendRunOverviewTestTargetOutcome(
-    _ outcome: E2ERunOverviewTestTargetOutcome,
-    prefix: String,
-    to lines: inout [String]
-) {
-    lines.append(
-        "\(prefix) target=`\(outcome.target)` outcome=`\(outcome.outcome.rawValue)` attempts=\(runOverviewObservationSummary(outcome.attempts))"
-    )
-    for attempt in outcome.attempts where attempt.status != .passed || outcome.outcome == .flaked {
-        appendRunOverviewObservation(attempt, prefix: "  ", to: &lines)
-    }
-}
-
-private func appendRunOverviewObservation(
-    _ observation: E2ERunOverviewObservation,
-    prefix: String,
-    to lines: inout [String]
-) {
-    let duration = observation.durationSeconds.map(formatSeconds) ?? "unknown"
-    lines.append(
-        "\(prefix)- attempt=`\(observation.attempt)` status=`\(observation.status.rawValue)` duration=`\(duration)`"
-    )
-    appendRunOverviewDetail(observation.detail, prefix: "\(prefix)  ", to: &lines)
-    appendRunOverviewArtifacts(observation.artifacts, prefix: "\(prefix)  ", to: &lines)
-}
-
 private func appendRunOverviewIssueAttempt(
     _ attempt: E2ERunOverviewIssueAttempt,
     prefix: String,
     to lines: inout [String]
 ) {
-    lines.append("\(prefix)- attempt=`\(attempt.attempt)` status=`\(attempt.status.rawValue)`")
+    let duration = attempt.durationSeconds.map(formatSeconds) ?? "unknown"
+    lines.append(
+        "\(prefix)- attempt=`\(attempt.attempt)` status=`\(attempt.status.rawValue)` duration=`\(duration)`"
+    )
     appendRunOverviewDetail(attempt.detail, prefix: "\(prefix)  ", to: &lines)
     appendRunOverviewArtifacts(attempt.artifacts, prefix: "\(prefix)  ", to: &lines)
 }
@@ -1243,10 +1210,6 @@ private func appendRunOverviewArtifacts(
     if let testResults = artifacts.testResults {
         lines.append("\(prefix)xunit: `\(testResults)`")
     }
-}
-
-private func runOverviewObservationSummary(_ observations: [E2ERunOverviewObservation]) -> String {
-    observations.map { "\($0.attempt):\($0.status.rawValue)" }.joined(separator: ",")
 }
 
 private func runOverviewIssueAttemptSummary(_ attempts: [E2ERunOverviewIssueAttempt]) -> String {

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
@@ -955,7 +955,7 @@ private func runReportPrompt(
         overwrite: overwrite
     )
     lines.append(
-        "For report-level reviews, only create findings that are run-level or cross-suite. Do not repeat suite/test reviews already covered at lower scopes."
+        "For report-level reviews, create run-level or cross-suite findings. If the overview records failed or flaked target outcomes, include a top-level synthesis that covers each one and cites the lower-scope review or artifact evidence."
     )
     lines.append("")
     appendRunOverviewReportFocus(overview, to: &lines)

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
@@ -1,0 +1,679 @@
+import ArgumentParser
+import Foundation
+
+#if canImport(FoundationXML)
+    import FoundationXML
+#endif
+
+let e2eRunOverviewFileName = "overview.json"
+let e2eRunOverviewSchemaID = "wendy.e2e.overview.v1"
+
+struct E2ERunOverview: Codable, Sendable {
+    var schema: String
+    var generatedAt: String
+    var summary: E2ERunOverviewSummary
+    var targets: [E2ERunOverviewTarget]
+    var suites: [E2ERunOverviewSuite]
+    var noteworthy: E2ERunOverviewNoteworthy
+}
+
+struct E2ERunOverviewSummary: Codable, Sendable {
+    var tests: Int
+    var testTargets: Int
+    var attemptResults: Int
+    var commands: Int
+    var passed: Int
+    var flaked: Int
+    var failed: Int
+    var skipped: Int
+    var unknown: Int
+}
+
+struct E2ERunOverviewTarget: Codable, Sendable {
+    var name: String
+    var outcome: E2ERunOverviewOutcome
+    var attempts: Int
+    var tests: Int
+    var passed: Int
+    var flaked: Int
+    var failed: Int
+    var skipped: Int
+    var unknown: Int
+}
+
+struct E2ERunOverviewSuite: Codable, Sendable {
+    var key: String
+    var tests: [E2ERunOverviewTest]
+}
+
+struct E2ERunOverviewTest: Codable, Sendable {
+    var key: String
+    var targetOutcomes: [E2ERunOverviewTestTargetOutcome]
+}
+
+struct E2ERunOverviewTestTargetOutcome: Codable, Sendable {
+    var target: String
+    var outcome: E2ERunOverviewOutcome
+    var attempts: [E2ERunOverviewObservation]
+}
+
+struct E2ERunOverviewObservation: Codable, Sendable {
+    var attempt: String
+    var status: E2ERunOverviewStatus
+    var durationSeconds: Double?
+    var detail: String?
+    var artifacts: E2ERunOverviewArtifacts
+}
+
+struct E2ERunOverviewArtifacts: Codable, Sendable {
+    var recording: String?
+    var shell: String?
+    var testResults: String?
+}
+
+struct E2ERunOverviewNoteworthy: Codable, Sendable {
+    var deterministicFailures: [E2ERunOverviewIssue]
+    var flakes: [E2ERunOverviewIssue]
+    var unknowns: [E2ERunOverviewIssue]
+}
+
+struct E2ERunOverviewIssue: Codable, Sendable {
+    var suite: String
+    var test: String
+    var target: String
+    var outcome: E2ERunOverviewOutcome
+    var attempts: [E2ERunOverviewIssueAttempt]
+}
+
+struct E2ERunOverviewIssueAttempt: Codable, Sendable {
+    var attempt: String
+    var status: E2ERunOverviewStatus
+    var detail: String?
+    var artifacts: E2ERunOverviewArtifacts
+}
+
+enum E2ERunOverviewOutcome: String, Codable, Sendable {
+    case passed = "PASSED"
+    case flaked = "FLAKED"
+    case failed = "FAILED"
+    case skipped = "SKIPPED"
+    case unknown = "UNKNOWN"
+}
+
+enum E2ERunOverviewStatus: String, Codable, Sendable {
+    case passed = "PASSED"
+    case failed = "FAILED"
+    case skipped = "SKIPPED"
+    case unknown = "UNKNOWN"
+}
+
+@discardableResult
+func writeRunOverview(in runURL: URL) throws -> E2ERunOverview {
+    let overview = try makeRunOverview(in: runURL)
+    let outputURL = runOverviewURL(in: runURL)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(overview)
+    try data.write(to: outputURL, options: .atomic)
+    return overview
+}
+
+func loadRunOverview(in runURL: URL) throws -> E2ERunOverview? {
+    let url = runOverviewURL(in: runURL)
+    guard FileManager.default.fileExists(atPath: url.path) else {
+        return nil
+    }
+    let data = try Data(contentsOf: url)
+    let overview = try JSONDecoder().decode(E2ERunOverview.self, from: data)
+    guard overview.schema == e2eRunOverviewSchemaID else {
+        throw ValidationError("Run overview has unsupported schema: \(url.path)")
+    }
+    return overview
+}
+
+func ensureRunOverview(in runURL: URL) throws -> E2ERunOverview {
+    if let overview = try loadRunOverview(in: runURL) {
+        return overview
+    }
+    return try writeRunOverview(in: runURL)
+}
+
+func runOverviewURL(in runURL: URL) -> URL {
+    runURL.appendingPathComponent(e2eRunOverviewFileName)
+}
+
+private struct OverviewResultKey: Hashable {
+    var suite: String
+    var name: String
+}
+
+private struct OverviewObservationResult {
+    var status: E2ERunOverviewStatus
+    var durationSeconds: Double?
+    var detail: String?
+}
+
+private struct OverviewOutcomeCounts {
+    var passed = 0
+    var flaked = 0
+    var failed = 0
+    var skipped = 0
+    var unknown = 0
+
+    mutating func add(_ outcome: E2ERunOverviewOutcome) {
+        switch outcome {
+        case .passed:
+            passed += 1
+        case .flaked:
+            flaked += 1
+        case .failed:
+            failed += 1
+        case .skipped:
+            skipped += 1
+        case .unknown:
+            unknown += 1
+        }
+    }
+}
+
+private struct OverviewTargetAccumulator {
+    var attempts: Set<String> = []
+    var tests = 0
+    var counts = OverviewOutcomeCounts()
+}
+
+private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
+    var suites: [E2ERunOverviewSuite] = []
+    var targetAccumulators: [String: OverviewTargetAccumulator] = [:]
+    var summaryCounts = OverviewOutcomeCounts()
+    var uniqueTests = Set<String>()
+    var testTargetCount = 0
+    var attemptResultCount = 0
+    var commandCount = 0
+    var deterministicFailures: [E2ERunOverviewIssue] = []
+    var flakes: [E2ERunOverviewIssue] = []
+    var unknowns: [E2ERunOverviewIssue] = []
+
+    for suiteURL in try overviewDirectoryChildren(of: runURL) {
+        let suiteKey = suiteURL.lastPathComponent
+        guard !isE2EReviewDirectoryName(suiteKey) else { continue }
+        var tests: [E2ERunOverviewTest] = []
+
+        for testURL in try overviewDirectoryChildren(of: suiteURL) {
+            let testKey = testURL.lastPathComponent
+            guard !isE2EReviewDirectoryName(testKey) else { continue }
+            var targetOutcomes: [E2ERunOverviewTestTargetOutcome] = []
+
+            for targetURL in try overviewDirectoryChildren(of: testURL) {
+                let targetName = targetURL.lastPathComponent
+                guard !isE2EReviewDirectoryName(targetName) else { continue }
+                var observations: [E2ERunOverviewObservation] = []
+
+                for attemptURL in try overviewDirectoryChildren(of: targetURL) {
+                    let attemptName = attemptURL.lastPathComponent
+                    guard !isE2EReviewDirectoryName(attemptName) else { continue }
+                    let result = try overviewObservationResult(
+                        suiteKey: suiteKey,
+                        testKey: testKey,
+                        attemptURL: attemptURL
+                    )
+                    let artifacts = overviewArtifacts(attemptURL: attemptURL, runURL: runURL)
+                    observations.append(
+                        E2ERunOverviewObservation(
+                            attempt: attemptName,
+                            status: result.status,
+                            durationSeconds: result.durationSeconds,
+                            detail: result.detail,
+                            artifacts: artifacts
+                        )
+                    )
+                    attemptResultCount += 1
+                    commandCount += try overviewCommandCount(attemptURL: attemptURL)
+                }
+
+                observations.sort { $0.attempt < $1.attempt }
+                let outcome = overviewOutcome(for: observations.map(\.status))
+                targetOutcomes.append(
+                    E2ERunOverviewTestTargetOutcome(
+                        target: targetName,
+                        outcome: outcome,
+                        attempts: observations
+                    )
+                )
+
+                testTargetCount += 1
+                summaryCounts.add(outcome)
+                targetAccumulators[targetName, default: OverviewTargetAccumulator()].attempts
+                    .formUnion(observations.map(\.attempt))
+                targetAccumulators[targetName, default: OverviewTargetAccumulator()].tests += 1
+                targetAccumulators[targetName, default: OverviewTargetAccumulator()].counts.add(outcome)
+
+                let issue = E2ERunOverviewIssue(
+                    suite: suiteKey,
+                    test: testKey,
+                    target: targetName,
+                    outcome: outcome,
+                    attempts: observations.map {
+                        E2ERunOverviewIssueAttempt(
+                            attempt: $0.attempt,
+                            status: $0.status,
+                            detail: $0.detail,
+                            artifacts: $0.artifacts
+                        )
+                    }
+                )
+                switch outcome {
+                case .failed:
+                    deterministicFailures.append(issue)
+                case .flaked:
+                    flakes.append(issue)
+                case .unknown:
+                    unknowns.append(issue)
+                case .passed, .skipped:
+                    break
+                }
+            }
+
+            targetOutcomes.sort { $0.target < $1.target }
+            guard !targetOutcomes.isEmpty else { continue }
+            uniqueTests.insert("\(suiteKey)/\(testKey)")
+            tests.append(E2ERunOverviewTest(key: testKey, targetOutcomes: targetOutcomes))
+        }
+
+        tests.sort { $0.key < $1.key }
+        guard !tests.isEmpty else { continue }
+        suites.append(E2ERunOverviewSuite(key: suiteKey, tests: tests))
+    }
+
+    suites.sort { $0.key < $1.key }
+
+    let targets = targetAccumulators.map { targetName, accumulator in
+        E2ERunOverviewTarget(
+            name: targetName,
+            outcome: overviewTargetOutcome(for: accumulator.counts),
+            attempts: accumulator.attempts.count,
+            tests: accumulator.tests,
+            passed: accumulator.counts.passed,
+            flaked: accumulator.counts.flaked,
+            failed: accumulator.counts.failed,
+            skipped: accumulator.counts.skipped,
+            unknown: accumulator.counts.unknown
+        )
+    }.sorted { $0.name < $1.name }
+
+    return E2ERunOverview(
+        schema: e2eRunOverviewSchemaID,
+        generatedAt: ISO8601DateFormatter().string(from: Date()),
+        summary: E2ERunOverviewSummary(
+            tests: uniqueTests.count,
+            testTargets: testTargetCount,
+            attemptResults: attemptResultCount,
+            commands: commandCount,
+            passed: summaryCounts.passed,
+            flaked: summaryCounts.flaked,
+            failed: summaryCounts.failed,
+            skipped: summaryCounts.skipped,
+            unknown: summaryCounts.unknown
+        ),
+        targets: targets,
+        suites: suites,
+        noteworthy: E2ERunOverviewNoteworthy(
+            deterministicFailures: deterministicFailures.sorted(by: overviewIssueSort),
+            flakes: flakes.sorted(by: overviewIssueSort),
+            unknowns: unknowns.sorted(by: overviewIssueSort)
+        )
+    )
+}
+
+private func overviewObservationResult(
+    suiteKey: String,
+    testKey: String,
+    attemptURL: URL
+) throws -> OverviewObservationResult {
+    let resultURL = attemptURL.appendingPathComponent("test-results.xml")
+    guard FileManager.default.fileExists(atPath: resultURL.path) else {
+        return OverviewObservationResult(
+            status: .unknown,
+            durationSeconds: nil,
+            detail: "test-results.xml not found"
+        )
+    }
+
+    let results: [OverviewResultKey: OverviewObservationResult]
+    do {
+        results = try overviewParseXUnitResults(at: resultURL)
+    } catch {
+        return OverviewObservationResult(
+            status: .unknown,
+            durationSeconds: nil,
+            detail: "Could not parse test-results.xml: \(error)"
+        )
+    }
+
+    if let result = results.first(where: { key, _ in
+        overviewSlug(key.suite) == suiteKey && overviewSlug(key.name) == testKey
+    })?.value {
+        return result
+    }
+
+    let matchingTestNames = results.filter { key, _ in
+        overviewSlug(key.name) == testKey
+    }
+    if matchingTestNames.count == 1, let result = matchingTestNames.first?.value {
+        return result
+    }
+
+    return OverviewObservationResult(
+        status: .unknown,
+        durationSeconds: nil,
+        detail: "No Swift Testing result was found for this test in test-results.xml"
+    )
+}
+
+private func overviewParseXUnitResults(
+    at resultURL: URL
+) throws -> [OverviewResultKey: OverviewObservationResult] {
+    let data = try Data(contentsOf: resultURL)
+    let parser = OverviewXUnitResultParser()
+    let xmlParser = XMLParser(data: data)
+    xmlParser.delegate = parser
+    guard xmlParser.parse() else {
+        throw ValidationError("Could not parse Swift Testing xUnit results: \(resultURL.path)")
+    }
+    return parser.results
+}
+
+private func overviewArtifacts(attemptURL: URL, runURL: URL) -> E2ERunOverviewArtifacts {
+    E2ERunOverviewArtifacts(
+        recording: overviewRelativeFilePath(
+            fileName: "recording.md",
+            attemptURL: attemptURL,
+            runURL: runURL
+        ),
+        shell: overviewRelativeFilePath(
+            fileName: "recording.sh.txt",
+            attemptURL: attemptURL,
+            runURL: runURL
+        ),
+        testResults: overviewRelativeFilePath(
+            fileName: "test-results.xml",
+            attemptURL: attemptURL,
+            runURL: runURL
+        )
+    )
+}
+
+private func overviewRelativeFilePath(fileName: String, attemptURL: URL, runURL: URL) -> String? {
+    let url = attemptURL.appendingPathComponent(fileName)
+    guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+    return overviewRelativePath(from: runURL, to: url)
+}
+
+private func overviewRelativePath(from baseURL: URL, to url: URL) -> String {
+    let basePath = baseURL.standardizedFileURL.path
+    let path = url.standardizedFileURL.path
+    let prefix = basePath.hasSuffix("/") ? basePath : basePath + "/"
+    guard path.hasPrefix(prefix) else { return url.lastPathComponent }
+    return String(path.dropFirst(prefix.count))
+}
+
+private func overviewCommandCount(attemptURL: URL) throws -> Int {
+    let recordURL = attemptURL.appendingPathComponent("recording.md")
+    guard FileManager.default.fileExists(atPath: recordURL.path) else { return 0 }
+    let text = try String(contentsOf: recordURL, encoding: .utf8)
+    return text.components(separatedBy: "\n## Command").count - 1
+}
+
+private func overviewOutcome(for statuses: [E2ERunOverviewStatus]) -> E2ERunOverviewOutcome {
+    guard !statuses.isEmpty else { return .unknown }
+
+    let passed = statuses.contains(.passed)
+    let failed = statuses.contains(.failed)
+    let skipped = statuses.contains(.skipped)
+    let unknown = statuses.contains(.unknown)
+
+    if skipped && !passed && !failed && !unknown {
+        return .skipped
+    }
+    if passed && failed {
+        return .flaked
+    }
+    if passed && !failed && !skipped && !unknown {
+        return .passed
+    }
+    if failed && !passed && !skipped && !unknown {
+        return .failed
+    }
+    return .unknown
+}
+
+private func overviewTargetOutcome(for counts: OverviewOutcomeCounts) -> E2ERunOverviewOutcome {
+    if counts.failed > 0 { return .failed }
+    if counts.unknown > 0 { return .unknown }
+    if counts.flaked > 0 { return .flaked }
+    if counts.passed > 0 { return .passed }
+    if counts.skipped > 0 { return .skipped }
+    return .unknown
+}
+
+private func overviewIssueSort(
+    _ lhs: E2ERunOverviewIssue,
+    _ rhs: E2ERunOverviewIssue
+) -> Bool {
+    if lhs.suite != rhs.suite { return lhs.suite < rhs.suite }
+    if lhs.test != rhs.test { return lhs.test < rhs.test }
+    return lhs.target < rhs.target
+}
+
+private func overviewDirectoryChildren(of url: URL) throws -> [URL] {
+    guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+    return try FileManager.default.contentsOfDirectory(
+        at: url,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+    )
+    .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+    .sorted { $0.path < $1.path }
+}
+
+private final class OverviewXUnitResultParser: NSObject, XMLParserDelegate {
+    var results: [OverviewResultKey: OverviewObservationResult] = [:]
+
+    private var current:
+        (key: OverviewResultKey, failure: String?, skipped: String?, time: Double?)?
+    private var currentElement: String?
+    private var currentText = ""
+
+    func parser(
+        _: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?,
+        attributes attributeDict: [String: String]
+    ) {
+        switch elementName {
+        case "testcase":
+            guard let classname = attributeDict["classname"], let name = attributeDict["name"],
+                let key = overviewTestResultKey(classname: classname, name: name)
+            else {
+                current = nil
+                return
+            }
+            current = (
+                key: key,
+                failure: nil,
+                skipped: nil,
+                time: attributeDict["time"].flatMap(Double.init)
+            )
+        case "failure", "skipped":
+            currentElement = elementName
+            currentText = ""
+            guard var current else { return }
+            if elementName == "failure" {
+                current.failure = attributeDict["message"] ?? ""
+            } else {
+                current.skipped = attributeDict["message"] ?? ""
+            }
+            self.current = current
+        default:
+            break
+        }
+    }
+
+    func parser(_: XMLParser, foundCharacters string: String) {
+        if currentElement == "failure" || currentElement == "skipped" {
+            currentText.append(string)
+        }
+    }
+
+    func parser(
+        _: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?
+    ) {
+        switch elementName {
+        case "failure", "skipped":
+            guard var current else { return }
+            let text = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if elementName == "failure", current.failure?.isEmpty != false, !text.isEmpty {
+                current.failure = text
+            } else if elementName == "skipped", current.skipped?.isEmpty != false, !text.isEmpty {
+                current.skipped = text
+            }
+            self.current = current
+            currentElement = nil
+            currentText = ""
+        case "testcase":
+            guard let current else { return }
+            let result: OverviewObservationResult
+            if let skipped = current.skipped {
+                result = OverviewObservationResult(
+                    status: .skipped,
+                    durationSeconds: current.time,
+                    detail: skipped.isEmpty ? nil : skipped
+                )
+            } else if let failure = current.failure {
+                result = OverviewObservationResult(
+                    status: .failed,
+                    durationSeconds: current.time,
+                    detail: failure.isEmpty ? nil : failure
+                )
+            } else {
+                result = OverviewObservationResult(
+                    status: .passed,
+                    durationSeconds: current.time,
+                    detail: nil
+                )
+            }
+            results[current.key] = result
+            self.current = nil
+        default:
+            break
+        }
+    }
+}
+
+private func overviewTestResultKey(classname: String, name: String) -> OverviewResultKey? {
+    let suite = overviewNormalizedClassname(classname)
+    let testName = overviewNormalizedTestName(name)
+    guard !suite.isEmpty, !testName.isEmpty else { return nil }
+    return OverviewResultKey(suite: suite, name: testName)
+}
+
+private func overviewNormalizedClassname(_ classname: String) -> String {
+    if classname.last == "`", let start = classname.dropLast().lastIndex(of: "`") {
+        let suiteStart = classname.index(after: start)
+        return String(classname[suiteStart..<classname.index(before: classname.endIndex)])
+    }
+    return overviewStripBackticks(String(classname.split(separator: ".").last ?? ""))
+}
+
+private func overviewNormalizedTestName(_ name: String) -> String {
+    var value = name
+    if value.hasSuffix("()") {
+        value.removeLast(2)
+    }
+    return overviewStripBackticks(value)
+}
+
+private func overviewStripBackticks(_ value: String) -> String {
+    if value.first == "`", value.last == "`" {
+        return String(value.dropFirst().dropLast())
+    }
+    return value
+}
+
+private func overviewSlug(_ value: String) -> String {
+    var result = ""
+    var needsSeparator = false
+    var previousKind: OverviewSlugCharacterKind?
+    let scalars = Array(value.unicodeScalars)
+
+    for index in scalars.indices {
+        let scalar = scalars[index]
+        guard let kind = OverviewSlugCharacterKind(scalar) else {
+            needsSeparator = !result.isEmpty
+            previousKind = nil
+            continue
+        }
+        let nextKind =
+            scalars.index(after: index) < scalars.endIndex
+            ? OverviewSlugCharacterKind(scalars[scalars.index(after: index)]) : nil
+        if !result.isEmpty,
+            needsSeparator
+                || overviewNeedsCamelCaseSeparator(
+                    previousKind: previousKind,
+                    currentKind: kind,
+                    nextKind: nextKind
+                )
+        {
+            result.append("-")
+        }
+        result.append(Character(scalar).lowercased())
+        needsSeparator = false
+        previousKind = kind
+    }
+
+    return result
+}
+
+private enum OverviewSlugCharacterKind {
+    case uppercase
+    case lowercase
+    case digit
+
+    init?(_ scalar: UnicodeScalar) {
+        switch scalar.value {
+        case 48...57:
+            self = .digit
+        case 65...90:
+            self = .uppercase
+        case 97...122:
+            self = .lowercase
+        default:
+            return nil
+        }
+    }
+}
+
+private func overviewNeedsCamelCaseSeparator(
+    previousKind: OverviewSlugCharacterKind?,
+    currentKind: OverviewSlugCharacterKind,
+    nextKind: OverviewSlugCharacterKind?
+) -> Bool {
+    guard let previousKind else { return false }
+    if currentKind == .digit {
+        return previousKind != .digit
+    }
+    if previousKind == .digit {
+        return true
+    }
+    if currentKind == .uppercase, previousKind == .lowercase {
+        return true
+    }
+    if currentKind == .uppercase, previousKind == .uppercase, nextKind == .lowercase {
+        return true
+    }
+    return false
+}

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
@@ -13,7 +13,6 @@ struct E2ERunOverview: Codable, Sendable {
     var generatedAt: String
     var summary: E2ERunOverviewSummary
     var targets: [E2ERunOverviewTarget]
-    var suites: [E2ERunOverviewSuite]
     var noteworthy: E2ERunOverviewNoteworthy
 }
 
@@ -41,30 +40,6 @@ struct E2ERunOverviewTarget: Codable, Sendable {
     var unknown: Int
 }
 
-struct E2ERunOverviewSuite: Codable, Sendable {
-    var key: String
-    var tests: [E2ERunOverviewTest]
-}
-
-struct E2ERunOverviewTest: Codable, Sendable {
-    var key: String
-    var targetOutcomes: [E2ERunOverviewTestTargetOutcome]
-}
-
-struct E2ERunOverviewTestTargetOutcome: Codable, Sendable {
-    var target: String
-    var outcome: E2ERunOverviewOutcome
-    var attempts: [E2ERunOverviewObservation]
-}
-
-struct E2ERunOverviewObservation: Codable, Sendable {
-    var attempt: String
-    var status: E2ERunOverviewStatus
-    var durationSeconds: Double?
-    var detail: String?
-    var artifacts: E2ERunOverviewArtifacts
-}
-
 struct E2ERunOverviewArtifacts: Codable, Sendable {
     var recording: String?
     var shell: String?
@@ -88,6 +63,7 @@ struct E2ERunOverviewIssue: Codable, Sendable {
 struct E2ERunOverviewIssueAttempt: Codable, Sendable {
     var attempt: String
     var status: E2ERunOverviewStatus
+    var durationSeconds: Double?
     var detail: String?
     var artifacts: E2ERunOverviewArtifacts
 }
@@ -183,7 +159,6 @@ private struct OverviewTargetAccumulator {
 }
 
 private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
-    var suites: [E2ERunOverviewSuite] = []
     var targetAccumulators: [String: OverviewTargetAccumulator] = [:]
     var summaryCounts = OverviewOutcomeCounts()
     var uniqueTests = Set<String>()
@@ -197,17 +172,16 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
     for suiteURL in try overviewDirectoryChildren(of: runURL) {
         let suiteKey = suiteURL.lastPathComponent
         guard !isE2EReviewDirectoryName(suiteKey) else { continue }
-        var tests: [E2ERunOverviewTest] = []
 
         for testURL in try overviewDirectoryChildren(of: suiteURL) {
             let testKey = testURL.lastPathComponent
             guard !isE2EReviewDirectoryName(testKey) else { continue }
-            var targetOutcomes: [E2ERunOverviewTestTargetOutcome] = []
+            var hasTargetOutcome = false
 
             for targetURL in try overviewDirectoryChildren(of: testURL) {
                 let targetName = targetURL.lastPathComponent
                 guard !isE2EReviewDirectoryName(targetName) else { continue }
-                var observations: [E2ERunOverviewObservation] = []
+                var attempts: [E2ERunOverviewIssueAttempt] = []
 
                 for attemptURL in try overviewDirectoryChildren(of: targetURL) {
                     let attemptName = attemptURL.lastPathComponent
@@ -218,8 +192,8 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
                         attemptURL: attemptURL
                     )
                     let artifacts = overviewArtifacts(attemptURL: attemptURL, runURL: runURL)
-                    observations.append(
-                        E2ERunOverviewObservation(
+                    attempts.append(
+                        E2ERunOverviewIssueAttempt(
                             attempt: attemptName,
                             status: result.status,
                             durationSeconds: result.durationSeconds,
@@ -231,36 +205,27 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
                     commandCount += try overviewCommandCount(attemptURL: attemptURL)
                 }
 
-                observations.sort { $0.attempt < $1.attempt }
-                let outcome = overviewOutcome(for: observations.map(\.status))
-                targetOutcomes.append(
-                    E2ERunOverviewTestTargetOutcome(
-                        target: targetName,
-                        outcome: outcome,
-                        attempts: observations
-                    )
-                )
+                attempts.sort { $0.attempt < $1.attempt }
+                let outcome = overviewOutcome(for: attempts.map(\.status))
+                hasTargetOutcome = true
 
                 testTargetCount += 1
                 summaryCounts.add(outcome)
-                targetAccumulators[targetName, default: OverviewTargetAccumulator()].attempts
-                    .formUnion(observations.map(\.attempt))
-                targetAccumulators[targetName, default: OverviewTargetAccumulator()].tests += 1
-                targetAccumulators[targetName, default: OverviewTargetAccumulator()].counts.add(outcome)
+                var targetAccumulator = targetAccumulators[
+                    targetName,
+                    default: OverviewTargetAccumulator()
+                ]
+                targetAccumulator.attempts.formUnion(attempts.map(\.attempt))
+                targetAccumulator.tests += 1
+                targetAccumulator.counts.add(outcome)
+                targetAccumulators[targetName] = targetAccumulator
 
                 let issue = E2ERunOverviewIssue(
                     suite: suiteKey,
                     test: testKey,
                     target: targetName,
                     outcome: outcome,
-                    attempts: observations.map {
-                        E2ERunOverviewIssueAttempt(
-                            attempt: $0.attempt,
-                            status: $0.status,
-                            detail: $0.detail,
-                            artifacts: $0.artifacts
-                        )
-                    }
+                    attempts: attempts
                 )
                 switch outcome {
                 case .failed:
@@ -274,18 +239,11 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
                 }
             }
 
-            targetOutcomes.sort { $0.target < $1.target }
-            guard !targetOutcomes.isEmpty else { continue }
-            uniqueTests.insert("\(suiteKey)/\(testKey)")
-            tests.append(E2ERunOverviewTest(key: testKey, targetOutcomes: targetOutcomes))
+            if hasTargetOutcome {
+                uniqueTests.insert("\(suiteKey)/\(testKey)")
+            }
         }
-
-        tests.sort { $0.key < $1.key }
-        guard !tests.isEmpty else { continue }
-        suites.append(E2ERunOverviewSuite(key: suiteKey, tests: tests))
     }
-
-    suites.sort { $0.key < $1.key }
 
     let targets = targetAccumulators.map { targetName, accumulator in
         E2ERunOverviewTarget(
@@ -316,7 +274,6 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
             unknown: summaryCounts.unknown
         ),
         targets: targets,
-        suites: suites,
         noteworthy: E2ERunOverviewNoteworthy(
             deterministicFailures: deterministicFailures.sorted(by: overviewIssueSort),
             flakes: flakes.sorted(by: overviewIssueSort),

--- a/swift/WendyE2ETests/Support/Schemas/wendy-e2e-overview.schema.json
+++ b/swift/WendyE2ETests/Support/Schemas/wendy-e2e-overview.schema.json
@@ -4,7 +4,7 @@
   "title": "Wendy E2E Run Overview",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema", "generatedAt", "summary", "targets", "suites", "noteworthy"],
+  "required": ["schema", "generatedAt", "summary", "targets", "noteworthy"],
   "properties": {
     "schema": { "const": "wendy.e2e.overview.v1" },
     "generatedAt": { "type": "string", "format": "date-time" },
@@ -12,10 +12,6 @@
     "targets": {
       "type": "array",
       "items": { "$ref": "#/$defs/target" }
-    },
-    "suites": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/suite" }
     },
     "noteworthy": { "$ref": "#/$defs/noteworthy" }
   },
@@ -80,55 +76,6 @@
         "unknown": { "type": "integer", "minimum": 0 }
       }
     },
-    "suite": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["key", "tests"],
-      "properties": {
-        "key": { "$ref": "#/$defs/pathKey" },
-        "tests": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/test" }
-        }
-      }
-    },
-    "test": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["key", "targetOutcomes"],
-      "properties": {
-        "key": { "$ref": "#/$defs/pathKey" },
-        "targetOutcomes": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/testTargetOutcome" }
-        }
-      }
-    },
-    "testTargetOutcome": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["target", "outcome", "attempts"],
-      "properties": {
-        "target": { "type": "string", "minLength": 1 },
-        "outcome": { "$ref": "#/$defs/outcome" },
-        "attempts": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/observation" }
-        }
-      }
-    },
-    "observation": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["attempt", "status", "artifacts"],
-      "properties": {
-        "attempt": { "$ref": "#/$defs/attemptKey" },
-        "status": { "$ref": "#/$defs/status" },
-        "durationSeconds": { "type": "number", "minimum": 0 },
-        "detail": { "type": "string" },
-        "artifacts": { "$ref": "#/$defs/artifacts" }
-      }
-    },
     "artifacts": {
       "type": "object",
       "additionalProperties": false,
@@ -179,6 +126,7 @@
       "properties": {
         "attempt": { "$ref": "#/$defs/attemptKey" },
         "status": { "$ref": "#/$defs/status" },
+        "durationSeconds": { "type": "number", "minimum": 0 },
         "detail": { "type": "string" },
         "artifacts": { "$ref": "#/$defs/artifacts" }
       }

--- a/swift/WendyE2ETests/Support/Schemas/wendy-e2e-overview.schema.json
+++ b/swift/WendyE2ETests/Support/Schemas/wendy-e2e-overview.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wendy.build/schemas/wendy-e2e-overview.schema.json",
+  "title": "Wendy E2E Run Overview",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "generatedAt", "summary", "targets", "suites", "noteworthy"],
+  "properties": {
+    "schema": { "const": "wendy.e2e.overview.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "summary": { "$ref": "#/$defs/summary" },
+    "targets": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/target" }
+    },
+    "suites": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/suite" }
+    },
+    "noteworthy": { "$ref": "#/$defs/noteworthy" }
+  },
+  "$defs": {
+    "outcome": {
+      "type": "string",
+      "enum": ["PASSED", "FLAKED", "FAILED", "SKIPPED", "UNKNOWN"]
+    },
+    "status": {
+      "type": "string",
+      "enum": ["PASSED", "FAILED", "SKIPPED", "UNKNOWN"]
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tests",
+        "testTargets",
+        "attemptResults",
+        "commands",
+        "passed",
+        "flaked",
+        "failed",
+        "skipped",
+        "unknown"
+      ],
+      "properties": {
+        "tests": { "type": "integer", "minimum": 0 },
+        "testTargets": { "type": "integer", "minimum": 0 },
+        "attemptResults": { "type": "integer", "minimum": 0 },
+        "commands": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "integer", "minimum": 0 },
+        "flaked": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "unknown": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "outcome",
+        "attempts",
+        "tests",
+        "passed",
+        "flaked",
+        "failed",
+        "skipped",
+        "unknown"
+      ],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "outcome": { "$ref": "#/$defs/outcome" },
+        "attempts": { "type": "integer", "minimum": 0 },
+        "tests": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "integer", "minimum": 0 },
+        "flaked": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "unknown": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "suite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "tests"],
+      "properties": {
+        "key": { "$ref": "#/$defs/pathKey" },
+        "tests": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/test" }
+        }
+      }
+    },
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "targetOutcomes"],
+      "properties": {
+        "key": { "$ref": "#/$defs/pathKey" },
+        "targetOutcomes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/testTargetOutcome" }
+        }
+      }
+    },
+    "testTargetOutcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "outcome", "attempts"],
+      "properties": {
+        "target": { "type": "string", "minLength": 1 },
+        "outcome": { "$ref": "#/$defs/outcome" },
+        "attempts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/observation" }
+        }
+      }
+    },
+    "observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attempt", "status", "artifacts"],
+      "properties": {
+        "attempt": { "$ref": "#/$defs/attemptKey" },
+        "status": { "$ref": "#/$defs/status" },
+        "durationSeconds": { "type": "number", "minimum": 0 },
+        "detail": { "type": "string" },
+        "artifacts": { "$ref": "#/$defs/artifacts" }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "recording": { "type": "string", "minLength": 1 },
+        "shell": { "type": "string", "minLength": 1 },
+        "testResults": { "type": "string", "minLength": 1 }
+      }
+    },
+    "noteworthy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["deterministicFailures", "flakes", "unknowns"],
+      "properties": {
+        "deterministicFailures": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/issue" }
+        },
+        "flakes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/issue" }
+        },
+        "unknowns": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/issue" }
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["suite", "test", "target", "outcome", "attempts"],
+      "properties": {
+        "suite": { "$ref": "#/$defs/pathKey" },
+        "test": { "$ref": "#/$defs/pathKey" },
+        "target": { "type": "string", "minLength": 1 },
+        "outcome": { "$ref": "#/$defs/outcome" },
+        "attempts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/issueAttempt" }
+        }
+      }
+    },
+    "issueAttempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attempt", "status", "artifacts"],
+      "properties": {
+        "attempt": { "$ref": "#/$defs/attemptKey" },
+        "status": { "$ref": "#/$defs/status" },
+        "detail": { "type": "string" },
+        "artifacts": { "$ref": "#/$defs/artifacts" }
+      }
+    },
+    "pathKey": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "attemptKey": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+$",
+      "minLength": 1
+    }
+  }
+}

--- a/swift/WendyE2ETests/Support/e2e-review-report.diff.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-report.diff.prompt.md
@@ -20,8 +20,10 @@ Guidelines:
 - Put evidence, reasoning, targeted diff references, links to relevant suite/test
   details, and longer analysis under the review file's `## Details` heading.
 - Do not repeat or summarize suite/test reviews already covered at lower levels.
-- Do not restate obvious counts/statuses that the report already shows, such as
-  how many tests or attempts failed.
+- Use `overview.json` as the source of truth for target-level behavior. It is
+  available before the HTML report is rendered.
+- Do not merely restate obvious counts/statuses; synthesize what diff-related
+  deterministic failures, flakes, and target differences mean for the run.
 - Prefer concise synthesis over copying suite findings.
 - Use JSON `locations` only when the review is attributable to source lines.
 - Do not edit source code, tests, xUnit files, recordings, or the run's

--- a/swift/WendyE2ETests/Support/e2e-review-report.diff.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-report.diff.prompt.md
@@ -9,9 +9,16 @@ Inspect targeted Git diffs on demand rather than looking for a saved full patch.
 
 Guidelines:
 
-- Prefer no top-level files over low-value files.
+- Prefer no top-level files over low-value files only when there are no failed
+  or flaked tests plausibly related to the diff.
 - Write one Markdown file per actionable diff-related run-level or cross-suite
   review issue under the top-level review directory named in the generated prompt.
+- If `overview.json` records any deterministic failure or flake plausibly related
+  to the diff, write a top-level review that covers every related failed or
+  flaked test-target outcome. Find the likely root cause or pattern, explain
+  what to do next, and cite the lower-level review/artifact evidence. For flakes,
+  explicitly explain why the outcome may be nondeterministic and how to
+  investigate or stabilize it.
 - Use JSON `severity` to classify each issue as `info`, `concern`, or
   `fail`. Do not write prose status/severity lines such as `Status: pass`,
   `Status: concern`, or `Status: fail`.
@@ -19,7 +26,9 @@ Guidelines:
   tied to the diff plus the suggested action.
 - Put evidence, reasoning, targeted diff references, links to relevant suite/test
   details, and longer analysis under the review file's `## Details` heading.
-- Do not repeat or summarize suite/test reviews already covered at lower levels.
+- Do not repeat suite/test reviews already covered at lower levels except when
+  summarizing diff-related failed or flaked tests for the required top-level
+  failure/flake synthesis.
 - Use `overview.json` as the source of truth for target-level behavior. It is
   available before the HTML report is rendered.
 - Do not merely restate obvious counts/statuses; synthesize what diff-related

--- a/swift/WendyE2ETests/Support/e2e-review-report.full.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-report.full.prompt.md
@@ -6,9 +6,15 @@ investigate next.
 
 Guidelines:
 
-- Prefer no top-level files over low-value files.
+- Prefer no top-level files over low-value files only when there are no failed
+  or flaked tests.
 - Write one Markdown file per actionable run-level or cross-suite review issue under
   the top-level review directory named in the generated prompt.
+- If `overview.json` records any deterministic failure or flake, write a
+  top-level review that covers every failed or flaked test-target outcome. Find
+  the likely root cause or pattern, explain what to do next, and cite the
+  lower-level review/artifact evidence. For flakes, explicitly explain why the
+  outcome may be nondeterministic and how to investigate or stabilize it.
 - Use JSON `severity` to classify each issue as `info`, `concern`, or
   `fail`. Do not write prose status/severity lines such as `Status: pass`,
   `Status: concern`, or `Status: fail`.
@@ -16,7 +22,11 @@ Guidelines:
   plus the suggested action.
 - Put evidence, reasoning, links to relevant suite/test details, and longer
   analysis under the review file's `## Details` heading.
-- Do not repeat or summarize suite/test reviews already covered at lower levels.
+- Do not repeat suite/test reviews already covered at lower levels except when
+  summarizing failed or flaked tests for the required top-level failure/flake
+  synthesis.
+- Use `overview.json` as the source of truth for target-level behavior. It is
+  available before the HTML report is rendered.
 - Do not restate obvious counts/statuses that the report already shows, such as
   how many tests or attempts failed.
 - Prefer concise synthesis over copying suite findings.

--- a/swift/WendyE2ETests/Support/e2e-review-report.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-report.prompt.md
@@ -17,8 +17,10 @@ Guidelines:
 - Put evidence, reasoning, links to relevant suite/test details, and longer
   analysis under the review file's `## Details` heading.
 - Do not repeat or summarize suite/test reviews already covered at lower levels.
-- Do not restate obvious counts/statuses that the report already shows, such as
-  how many tests or attempts failed.
+- Use `overview.json` as the source of truth for target-level behavior. It is
+  available before the HTML report is rendered.
+- Do not merely restate obvious counts/statuses; synthesize what deterministic
+  failures, flakes, and target differences mean for the run.
 - Prefer concise synthesis over copying suite findings.
 - Use JSON `locations` only when the review is attributable to source lines.
 - Do not edit source code, tests, xUnit files, or recordings.

--- a/swift/WendyE2ETests/Support/e2e-review-report.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-report.prompt.md
@@ -6,9 +6,15 @@ investigate next.
 
 Guidelines:
 
-- Prefer no top-level files over low-value files.
+- Prefer no top-level files over low-value files only when there are no failed
+  or flaked tests.
 - Write one Markdown file per actionable run-level or cross-suite review issue under
   the top-level review directory named in the generated prompt.
+- If `overview.json` records any deterministic failure or flake, write a
+  top-level review that covers every failed or flaked test-target outcome. Find
+  the likely root cause or pattern, explain what to do next, and cite the
+  lower-level review/artifact evidence. For flakes, explicitly explain why the
+  outcome may be nondeterministic and how to investigate or stabilize it.
 - Use JSON `severity` to classify each issue as `info`, `concern`, or
   `fail`. Do not write prose status/severity lines such as `Status: pass`,
   `Status: concern`, or `Status: fail`.
@@ -16,7 +22,9 @@ Guidelines:
   plus the suggested action.
 - Put evidence, reasoning, links to relevant suite/test details, and longer
   analysis under the review file's `## Details` heading.
-- Do not repeat or summarize suite/test reviews already covered at lower levels.
+- Do not repeat suite/test reviews already covered at lower levels except when
+  summarizing failed or flaked tests for the required top-level failure/flake
+  synthesis.
 - Use `overview.json` as the source of truth for target-level behavior. It is
   available before the HTML report is rendered.
 - Do not merely restate obvious counts/statuses; synthesize what deterministic

--- a/swift/WendyE2ETests/Support/e2e-review-suite.diff.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-suite.diff.prompt.md
@@ -23,9 +23,12 @@ Guidelines:
   tied to the diff plus the suggested action.
 - Put evidence, reasoning, targeted diff references, and longer analysis under
   the review file's `## Details` heading.
+- Treat the generated `overview.json` failure/flake section as the source of
+  truth for run outcomes. Prioritize diff-related deterministic `FAILED` target
+  outcomes, then `FLAKED` target outcomes, then unresolved `UNKNOWN` outcomes.
 - Cite concrete evidence in details: source paths, target/attempt names, result
-  details, recording paths, shell script paths, and the targeted diff files or
-  hunks you inspected.
+  details, recording paths, shell script paths, `overview.json` outcome data,
+  and the targeted diff files or hunks you inspected.
 - Use JSON `locations` only when the review is attributable to source lines.
 - Do not edit source code, tests, xUnit files, recordings, or the run's
   top-level `git-diff-*.txt` files.

--- a/swift/WendyE2ETests/Support/e2e-review-suite.diff.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-suite.diff.prompt.md
@@ -24,8 +24,11 @@ Guidelines:
 - Put evidence, reasoning, targeted diff references, and longer analysis under
   the review file's `## Details` heading.
 - Treat the generated `overview.json` failure/flake section as the source of
-  truth for run outcomes. Prioritize diff-related deterministic `FAILED` target
-  outcomes, then `FLAKED` target outcomes, then unresolved `UNKNOWN` outcomes.
+  truth for run outcomes. Every diff-related deterministic `FAILED` target
+  outcome must get an AI review explaining the likely root cause and what to do
+  next. Every diff-related `FLAKED` target outcome must get an AI review
+  explaining why it may have flaked and how to investigate or stabilize it. Then
+  consider unresolved `UNKNOWN` outcomes.
 - Cite concrete evidence in details: source paths, target/attempt names, result
   details, recording paths, shell script paths, `overview.json` outcome data,
   and the targeted diff files or hunks you inspected.

--- a/swift/WendyE2ETests/Support/e2e-review-suite.full.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-suite.full.prompt.md
@@ -22,7 +22,10 @@ Guidelines:
   plus the suggested action.
 - Put evidence, reasoning, and longer analysis under the review file's
   `## Details` heading.
+- Treat the generated `overview.json` failure/flake section as the source of
+  truth for run outcomes. Prioritize deterministic `FAILED` target outcomes,
+  then `FLAKED` target outcomes, then unresolved `UNKNOWN` outcomes.
 - Cite concrete evidence in details: source paths, target/attempt names, result
-  details, recording paths, and shell script paths.
+  details, recording paths, shell script paths, and `overview.json` outcome data.
 - Use JSON `locations` only when the review is attributable to source lines.
 - Do not edit source code, tests, xUnit files, or recordings.

--- a/swift/WendyE2ETests/Support/e2e-review-suite.full.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-suite.full.prompt.md
@@ -23,8 +23,11 @@ Guidelines:
 - Put evidence, reasoning, and longer analysis under the review file's
   `## Details` heading.
 - Treat the generated `overview.json` failure/flake section as the source of
-  truth for run outcomes. Prioritize deterministic `FAILED` target outcomes,
-  then `FLAKED` target outcomes, then unresolved `UNKNOWN` outcomes.
+  truth for run outcomes. Every deterministic `FAILED` target outcome must get
+  an AI review explaining the likely root cause and what to do next. Every
+  `FLAKED` target outcome must get an AI review explaining why it may have
+  flaked and how to investigate or stabilize it. Then consider unresolved
+  `UNKNOWN` outcomes.
 - Cite concrete evidence in details: source paths, target/attempt names, result
   details, recording paths, shell script paths, and `overview.json` outcome data.
 - Use JSON `locations` only when the review is attributable to source lines.

--- a/swift/WendyE2ETests/Support/e2e-review-suite.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-suite.prompt.md
@@ -22,7 +22,10 @@ Guidelines:
   plus the suggested action.
 - Put evidence, reasoning, and longer analysis under the review file's
   `## Details` heading.
+- Treat the generated `overview.json` failure/flake section as the source of
+  truth for run outcomes. Prioritize deterministic `FAILED` target outcomes,
+  then `FLAKED` target outcomes, then unresolved `UNKNOWN` outcomes.
 - Cite concrete evidence in details: source paths, target/attempt names, result
-  details, recording paths, and shell script paths.
+  details, recording paths, shell script paths, and `overview.json` outcome data.
 - Use JSON `locations` only when the review is attributable to source lines.
 - Do not edit source code, tests, xUnit files, or recordings.

--- a/swift/WendyE2ETests/Support/e2e-review-suite.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-suite.prompt.md
@@ -23,8 +23,11 @@ Guidelines:
 - Put evidence, reasoning, and longer analysis under the review file's
   `## Details` heading.
 - Treat the generated `overview.json` failure/flake section as the source of
-  truth for run outcomes. Prioritize deterministic `FAILED` target outcomes,
-  then `FLAKED` target outcomes, then unresolved `UNKNOWN` outcomes.
+  truth for run outcomes. Every deterministic `FAILED` target outcome must get
+  an AI review explaining the likely root cause and what to do next. Every
+  `FLAKED` target outcome must get an AI review explaining why it may have
+  flaked and how to investigate or stabilize it. Then consider unresolved
+  `UNKNOWN` outcomes.
 - Cite concrete evidence in details: source paths, target/attempt names, result
   details, recording paths, shell script paths, and `overview.json` outcome data.
 - Use JSON `locations` only when the review is attributable to source lines.

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+
+@testable import SwiftE2ETestingCLI
+
+@Suite
+struct `run overview` {
+    @Test
+    func `keeps noteworthy evidence without duplicating suite content`() throws {
+        let rootURL = e2eTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
+        let suiteURL = runURL.appendingPathComponent(
+            "wendy-device-info",
+            isDirectory: true
+        )
+        let testURL = suiteURL.appendingPathComponent(
+            "prints-json-device-information",
+            isDirectory: true
+        )
+        let targetURL = testURL.appendingPathComponent("macos-to-rpi", isDirectory: true)
+        let attemptOneURL = targetURL.appendingPathComponent("0001", isDirectory: true)
+        let attemptTwoURL = targetURL.appendingPathComponent("0002", isDirectory: true)
+
+        try FileManager.default.createDirectory(
+            at: attemptOneURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: attemptTwoURL,
+            withIntermediateDirectories: true
+        )
+
+        try writeXUnitResult(
+            to: attemptOneURL,
+            status: .failed("device did not respond"),
+            duration: 1.25
+        )
+        try writeXUnitResult(to: attemptTwoURL, status: .passed, duration: 0.75)
+        try "# Recording\n\n## Command 1\n".write(
+            to: attemptOneURL.appendingPathComponent("recording.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let overview = try writeRunOverview(in: runURL)
+        let overviewData = try Data(contentsOf: runOverviewURL(in: runURL))
+        let overviewJSON = String(data: overviewData, encoding: .utf8) ?? ""
+
+        #expect(overview.schema == "wendy.e2e.overview.v1")
+        #expect(!overviewJSON.contains("\"suites\""))
+        #expect(overview.summary.tests == 1)
+        #expect(overview.summary.testTargets == 1)
+        #expect(overview.summary.attemptResults == 2)
+        #expect(overview.summary.commands == 1)
+        #expect(overview.summary.flaked == 1)
+        #expect(overview.noteworthy.flakes.count == 1)
+
+        let flake = overview.noteworthy.flakes[0]
+        #expect(flake.suite == "wendy-device-info")
+        #expect(flake.test == "prints-json-device-information")
+        #expect(flake.target == "macos-to-rpi")
+        #expect(flake.attempts.map { $0.status } == [.failed, .passed])
+        #expect(flake.attempts.first?.durationSeconds == 1.25)
+    }
+
+}
+
+private func e2eTemporaryDirectory() -> URL {
+    URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("wendy-e2e-cli-tests-\(UUID().uuidString)", isDirectory: true)
+}
+
+private enum XUnitStatus {
+    case passed
+    case failed(String)
+}
+
+private func writeXUnitResult(
+    to attemptURL: URL,
+    status: XUnitStatus,
+    duration: Double
+) throws {
+    let result: String
+    switch status {
+    case .passed:
+        result = xUnitTestCase(duration: duration, body: nil)
+    case .failed(let message):
+        result = xUnitTestCase(duration: duration, body: "<failure message=\"\(message)\" />")
+    }
+
+    let xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<testsuite tests=\"1\">\(result)</testsuite>"
+    try xml.write(
+        to: attemptURL.appendingPathComponent("test-results.xml"),
+        atomically: true,
+        encoding: .utf8
+    )
+}
+
+private func xUnitTestCase(duration: Double, body: String?) -> String {
+    let attributes =
+        "classname=\"WendyE2ETests.`wendy device info`\" "
+        + "name=\"prints JSON device information()\" "
+        + "time=\"\(duration)\""
+    guard let body else {
+        return "<testcase \(attributes) />"
+    }
+    return "<testcase \(attributes)>\(body)</testcase>"
+}

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -65,6 +65,84 @@ struct `run overview` {
         #expect(flake.attempts.first?.durationSeconds == 1.25)
     }
 
+    @Test
+    func `aggregates failed outcomes with AI review summaries`() throws {
+        let rootURL = e2eTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
+        let suiteURL = runURL.appendingPathComponent(
+            "wendy-device-info",
+            isDirectory: true
+        )
+        let testURL = suiteURL.appendingPathComponent(
+            "prints-json-device-information",
+            isDirectory: true
+        )
+        let targetURL = testURL.appendingPathComponent("macos-to-rpi", isDirectory: true)
+        let attemptURL = targetURL.appendingPathComponent("0001", isDirectory: true)
+
+        try FileManager.default.createDirectory(
+            at: attemptURL,
+            withIntermediateDirectories: true
+        )
+        try writeXUnitResult(
+            to: attemptURL,
+            status: .failed("Unauthorized"),
+            duration: 2.0
+        )
+        try "# Recording\n".write(
+            to: attemptURL.appendingPathComponent("recording.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try writeTestReview(in: testURL)
+
+        _ = try writeRunOverview(in: runURL)
+        try writeE2EReviewAggregate(in: runURL)
+
+        let markdown = try String(
+            contentsOf: runURL.appendingPathComponent("review.md"),
+            encoding: .utf8
+        )
+
+        #expect(markdown.contains("## Failed and flaked tests"))
+        #expect(markdown.contains("### ❤️ `wendy-device-info/prints-json-device-information`"))
+        #expect(markdown.contains("AI review: **Agent rejected CLI auth**"))
+        #expect(markdown.contains("### ❤️ Agent rejected CLI auth"))
+        #expect(!markdown.contains("Fail: Agent rejected CLI auth"))
+    }
+}
+
+private func writeTestReview(in testURL: URL) throws {
+    let reviewURL = testURL.appendingPathComponent("review.default", isDirectory: true)
+    try FileManager.default.createDirectory(at: reviewURL, withIntermediateDirectories: true)
+    let reviewMarkdown = [
+        "---",
+        "{",
+        "  \"schema\": \"wendy.e2e.review.v1\",",
+        "  \"title\": \"Agent rejected CLI auth\",",
+        "  \"scope\": \"test\",",
+        "  \"reviewer\": \"default\",",
+        "  \"severity\": \"fail\",",
+        "  \"confidence\": \"high\"",
+        "}",
+        "---",
+        "# Agent rejected CLI auth",
+        "",
+        "The target rejected an otherwise valid authenticated request.",
+        "Recheck the agent auth state before rerunning this route.",
+        "",
+        "## Details",
+        "",
+        "The failing attempt returned `Unauthorized` while using the same fixture.",
+        "",
+    ].joined(separator: "\n")
+    try reviewMarkdown.write(
+        to: reviewURL.appendingPathComponent("agent-rejected-cli-auth.md"),
+        atomically: true,
+        encoding: .utf8
+    )
 }
 
 private func e2eTemporaryDirectory() -> URL {


### PR DESCRIPTION
## Summary
- Generate a top-level `overview.json` during Swift E2E aggregation so AI review has run-level target outcomes before the HTML report exists.
- Feed that overview into suite and report review prompts, with focused evidence for deterministic failures, flakes, and unknown results.
- Add a JSON Schema for the overview artifact and align review xUnit matching with the report fallback so unique test-name matches do not become false unknowns.

## Tests
- `python3 -m json.tool swift/WendyE2ETests/Support/Schemas/wendy-e2e-overview.schema.json >/dev/null`
- `cd swift/WendyE2ETests && swift build`
- Smoke-tested `swift-e2e-testing aggregate` with synthetic attempts and confirmed `overview.json` records a flaked target outcome.
