### PR TITLE
ci: stop running Swift E2E on PRs

### DIFF
--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -1,12 +1,6 @@
 name: Swift E2E Tests
 
 on:
-  pull_request:
-    paths:
-      - 'swift/**'
-      - 'Proto/**'
-      - '.github/actions/swift-e2e-run/**'
-      - '.github/workflows/swift-e2e-tests.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Stop running Swift E2E automatically on pull requests.
- Keep Swift E2E truthful by continuing to fail real failures on main, manual dispatch, and reusable workflow runs.
- Leave maintainer-triggered `/e2e` PR runs for a dedicated follow-up PR.

## Tests
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/swift-e2e-tests.yml"); puts "ok"'`
