### PR TITLE
feat: auto-detect target hardware in wendy run and pick correct Dockerfile

### DIFF
--- a/.github/ci-tests/python-multi-dockerfile/Dockerfile
+++ b/.github/ci-tests/python-multi-dockerfile/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py .
+ENV PYTHONUNBUFFERED=1
+ENV WENDY_DOCKERFILE_VARIANT=default
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-multi-dockerfile/Dockerfile.gpu
+++ b/.github/ci-tests/python-multi-dockerfile/Dockerfile.gpu
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py .
+ENV PYTHONUNBUFFERED=1
+ENV WENDY_DOCKERFILE_VARIANT=gpu
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-multi-dockerfile/main.py
+++ b/.github/ci-tests/python-multi-dockerfile/main.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Multi-Dockerfile auto-selection test for Wendy CI.
+
+Verifies that wendy run correctly auto-selected a hardware-appropriate
+Dockerfile when multiple Dockerfiles are present in the project directory.
+
+The WENDY_DOCKERFILE_VARIANT env var is baked in at build time by the
+chosen Dockerfile:
+  - Dockerfile      -> "default"
+  - Dockerfile.gpu  -> "gpu"
+
+On a GPU device, wendy should have auto-selected Dockerfile.gpu, so
+WENDY_DOCKERFILE_VARIANT will equal "gpu".
+
+On a non-GPU device, wendy should have fallen back to Dockerfile, so
+WENDY_DOCKERFILE_VARIANT will equal "default".
+
+Both outcomes are valid — the test succeeds in either case. The CI log
+records which Dockerfile was selected so regressions in auto-selection
+are visible without requiring this test to know the device's GPU state.
+"""
+
+import os
+import sys
+
+variant = os.environ.get("WENDY_DOCKERFILE_VARIANT", "")
+
+if not variant:
+    print("FAIL: WENDY_DOCKERFILE_VARIANT is not set — Dockerfile was not embedded correctly")
+    sys.exit(1)
+
+print(f"WENDY_DOCKERFILE_VARIANT={variant!r}")
+print("PASS: Multi-Dockerfile auto-selection test complete")
+sys.exit(0)

--- a/.github/ci-tests/python-multi-dockerfile/wendy.json
+++ b/.github/ci-tests/python-multi-dockerfile/wendy.json
@@ -1,0 +1,5 @@
+{
+    "appId": "sh.wendy.ci.python-multi-dockerfile",
+    "version": "1.0.0",
+    "language": "python"
+}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -272,7 +272,7 @@ jobs:
               exit 0
             fi
           else
-            for t in swift-hello swift-network swift-bluetooth swift-resources python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-multiservice otel-localhost-only; do
+            for t in swift-hello swift-network swift-bluetooth swift-resources python-hello python-multi-dockerfile python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-multiservice otel-localhost-only; do
               TEST_ARGS+=(-t "$t")
             done
           fi
@@ -382,7 +382,7 @@ jobs:
               exit 0
             fi
           else
-            for t in python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-multiservice otel-localhost-only; do
+            for t in python-hello python-multi-dockerfile python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-multiservice otel-localhost-only; do
               TEST_ARGS+=(-t "$t")
             done
           fi

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -23,6 +23,26 @@ When building a Dockerfile project, `wendy run` passes the target device's hardw
 
 `WENDY_PLATFORM` and `WENDY_DEBUG` are always set. The remaining args are only injected when the agent reports them, so Dockerfiles can define their own `ARG` defaults for devices that predate the field.
 
+## Dockerfile auto-selection (agent path)
+
+When a project directory contains multiple Dockerfiles and no `--dockerfile` flag is given, `wendy run` uses hardware properties reported by the target device's agent to pick the best match automatically. Selection follows a most-specific-first priority order:
+
+| Priority | Condition | File selected |
+|---|---|---|
+| 1 | `deviceType` matches exactly | `Dockerfile.<deviceType>` (e.g. `Dockerfile.jetson-agx-orin`) |
+| 2 | `deviceType` starts with `jetson` | `Dockerfile.jetson` |
+| 3 | GPU vendor is known | `Dockerfile.<gpuVendor>` (e.g. `Dockerfile.nvidia`, `Dockerfile.amd`) |
+| 4 | Device has any GPU | `Dockerfile.gpu` |
+| 5 | No hardware match | Interactive picker, or `Dockerfile` as the non-interactive default |
+
+When a file is auto-selected, `wendy run` prints a notice:
+
+```
+Auto-selected "Dockerfile.jetson" based on target device hardware.
+```
+
+Auto-selection only applies on the **agent path** (WendyOS hardware targets). When running against a local provider (Docker Desktop, Local Machine), the interactive picker is used regardless of hardware.
+
 ## Multi-service projects (`wendy.json` with `services`)
 
 When `wendy.json` contains a `services` map, `wendy run` automatically switches to the multi-service path:

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -251,6 +251,81 @@ func resolveDockerfile(cwd, requested string, interactive bool) (string, error) 
 	return confine(picked.File)
 }
 
+// autoSelectDockerfile picks the best Dockerfile from the available list
+// based on target device hardware. Returns "" when no hardware-based match
+// is found and the caller should fall back to the interactive picker.
+//
+// Priority (most specific first):
+//  1. Exact device-type match (e.g. "Dockerfile.jetson-agx-orin")
+//  2. Jetson family ("Dockerfile.jetson") for any deviceType starting with "jetson"
+//  3. GPU vendor ("Dockerfile.nvidia", "Dockerfile.amd", etc.)
+//  4. Any GPU ("Dockerfile.gpu")
+func autoSelectDockerfile(dockerfiles []BuildOption, deviceType, gpuVendor string, hasGpu bool) string {
+	names := make(map[string]bool, len(dockerfiles))
+	for _, d := range dockerfiles {
+		names[d.File] = true
+	}
+
+	if deviceType != "" && names["Dockerfile."+deviceType] {
+		return "Dockerfile." + deviceType
+	}
+
+	if strings.HasPrefix(deviceType, "jetson") && names["Dockerfile.jetson"] {
+		return "Dockerfile.jetson"
+	}
+
+	if gpuVendor != "" && names["Dockerfile."+gpuVendor] {
+		return "Dockerfile." + gpuVendor
+	}
+
+	if hasGpu && names["Dockerfile.gpu"] {
+		return "Dockerfile.gpu"
+	}
+
+	return ""
+}
+
+// resolveDockerfileForDevice resolves which Dockerfile to build from, using
+// target device hardware properties to auto-select when multiple Dockerfiles
+// are present. Falls back to the interactive picker (or non-interactive
+// default) when hardware does not uniquely identify a Dockerfile.
+func resolveDockerfileForDevice(cwd, deviceType, gpuVendor string, hasGpu, interactive bool) (string, error) {
+	var dockerfiles []BuildOption
+	for _, opt := range detectBuildOptions(cwd) {
+		if opt.Type == "docker" {
+			dockerfiles = append(dockerfiles, opt)
+		}
+	}
+
+	if len(dockerfiles) == 0 {
+		return "", nil
+	}
+
+	confine := func(file string) (string, error) {
+		if _, err := confinedDockerfilePath(cwd, file); err != nil {
+			return "", err
+		}
+		return file, nil
+	}
+
+	if len(dockerfiles) == 1 {
+		return confine(dockerfiles[0].File)
+	}
+
+	// Multiple Dockerfiles: try hardware-based auto-selection first.
+	if auto := autoSelectDockerfile(dockerfiles, deviceType, gpuVendor, hasGpu); auto != "" {
+		result, err := confine(auto)
+		if err != nil {
+			return "", err
+		}
+		cliNotice("Auto-selected %q based on target device hardware.", result)
+		return result, nil
+	}
+
+	// No hardware match: fall back to the interactive picker / default logic.
+	return resolveDockerfile(cwd, "", interactive)
+}
+
 // BuildOption represents a detected build type in a project directory.
 type BuildOption struct {
 	Label string // display name shown in the picker

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -1613,3 +1613,64 @@ func TestResolveDockerfileForDevice_NoDockerfiles(t *testing.T) {
 		t.Fatalf("got %q, want empty", got)
 	}
 }
+
+func TestResolveDockerfileForDevice_ExactDeviceTypeMatch(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"Dockerfile", "Dockerfile.jetson", "Dockerfile.jetson-agx-orin"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("FROM scratch"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Exact device type should win over Jetson family.
+	got, err := resolveDockerfileForDevice(dir, "jetson-agx-orin", "nvidia", true, false)
+	if err != nil {
+		t.Fatalf("resolveDockerfileForDevice: %v", err)
+	}
+	if got != "Dockerfile.jetson-agx-orin" {
+		t.Fatalf("got %q, want Dockerfile.jetson-agx-orin", got)
+	}
+}
+
+// TestAutoSelectDockerfile_MaliciousDeviceType verifies that a deviceType
+// containing path separators or other special characters cannot be used to
+// select a Dockerfile outside the project. The map lookup against real
+// filesystem entries means no such name can ever match.
+func TestAutoSelectDockerfile_MaliciousDeviceType(t *testing.T) {
+	files := []BuildOption{
+		{File: "Dockerfile", Type: "docker"},
+		{File: "Dockerfile.nvidia", Type: "docker"},
+	}
+	malicious := []string{
+		"../evil",
+		"../../etc/passwd",
+		"nvidia/../../etc",
+		"nvidia\x00null",
+		"nvidia\nevil",
+	}
+	for _, dt := range malicious {
+		got := autoSelectDockerfile(files, dt, "", false)
+		if got != "" {
+			t.Errorf("autoSelectDockerfile with malicious deviceType %q returned %q, want empty", dt, got)
+		}
+	}
+}
+
+// TestAutoSelectDockerfile_MaliciousGPUVendor mirrors the deviceType test for
+// the gpuVendor field.
+func TestAutoSelectDockerfile_MaliciousGPUVendor(t *testing.T) {
+	files := []BuildOption{
+		{File: "Dockerfile", Type: "docker"},
+		{File: "Dockerfile.nvidia", Type: "docker"},
+	}
+	malicious := []string{
+		"../evil",
+		"nvidia/../../etc",
+		"nvidia\x00null",
+	}
+	for _, v := range malicious {
+		got := autoSelectDockerfile(files, "", v, false)
+		if got != "" {
+			t.Errorf("autoSelectDockerfile with malicious gpuVendor %q returned %q, want empty", v, got)
+		}
+	}
+}

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -1474,3 +1474,142 @@ func TestResolveDockerfile_AutoSelectionRejectsSymlinkEscape(t *testing.T) {
 		t.Fatal("expected error for auto-selected symlink escape, got nil")
 	}
 }
+
+func TestAutoSelectDockerfile_ExactDeviceType(t *testing.T) {
+	files := []BuildOption{
+		{File: "Dockerfile", Type: "docker"},
+		{File: "Dockerfile.jetson-agx-orin", Type: "docker"},
+		{File: "Dockerfile.nvidia", Type: "docker"},
+	}
+	got := autoSelectDockerfile(files, "jetson-agx-orin", "nvidia", true)
+	if got != "Dockerfile.jetson-agx-orin" {
+		t.Fatalf("got %q, want Dockerfile.jetson-agx-orin", got)
+	}
+}
+
+func TestAutoSelectDockerfile_JetsonFamily(t *testing.T) {
+	files := []BuildOption{
+		{File: "Dockerfile", Type: "docker"},
+		{File: "Dockerfile.jetson", Type: "docker"},
+		{File: "Dockerfile.nvidia", Type: "docker"},
+	}
+	got := autoSelectDockerfile(files, "jetson-orin-nano", "nvidia", true)
+	if got != "Dockerfile.jetson" {
+		t.Fatalf("got %q, want Dockerfile.jetson", got)
+	}
+}
+
+func TestAutoSelectDockerfile_NvidiaVendor(t *testing.T) {
+	files := []BuildOption{
+		{File: "Dockerfile", Type: "docker"},
+		{File: "Dockerfile.nvidia", Type: "docker"},
+	}
+	got := autoSelectDockerfile(files, "", "nvidia", true)
+	if got != "Dockerfile.nvidia" {
+		t.Fatalf("got %q, want Dockerfile.nvidia", got)
+	}
+}
+
+func TestAutoSelectDockerfile_AMDVendor(t *testing.T) {
+	files := []BuildOption{
+		{File: "Dockerfile", Type: "docker"},
+		{File: "Dockerfile.amd", Type: "docker"},
+		{File: "Dockerfile.nvidia", Type: "docker"},
+	}
+	got := autoSelectDockerfile(files, "", "amd", false)
+	if got != "Dockerfile.amd" {
+		t.Fatalf("got %q, want Dockerfile.amd", got)
+	}
+}
+
+func TestAutoSelectDockerfile_GenericGPU(t *testing.T) {
+	files := []BuildOption{
+		{File: "Dockerfile", Type: "docker"},
+		{File: "Dockerfile.gpu", Type: "docker"},
+	}
+	got := autoSelectDockerfile(files, "", "", true)
+	if got != "Dockerfile.gpu" {
+		t.Fatalf("got %q, want Dockerfile.gpu", got)
+	}
+}
+
+func TestAutoSelectDockerfile_NoMatch(t *testing.T) {
+	files := []BuildOption{
+		{File: "Dockerfile", Type: "docker"},
+		{File: "Dockerfile.prod", Type: "docker"},
+	}
+	got := autoSelectDockerfile(files, "jetson-agx-orin", "nvidia", true)
+	if got != "" {
+		t.Fatalf("got %q, want empty (no hardware-named Dockerfile present)", got)
+	}
+}
+
+func TestAutoSelectDockerfile_NoHardwareInfo(t *testing.T) {
+	files := []BuildOption{
+		{File: "Dockerfile", Type: "docker"},
+		{File: "Dockerfile.gpu", Type: "docker"},
+	}
+	// hasGpu=false and empty vendor/deviceType → no match
+	got := autoSelectDockerfile(files, "", "", false)
+	if got != "" {
+		t.Fatalf("got %q, want empty when no hardware info", got)
+	}
+}
+
+func TestResolveDockerfileForDevice_AutoSelectsJetson(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"Dockerfile", "Dockerfile.jetson", "Dockerfile.nvidia"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("FROM scratch"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := resolveDockerfileForDevice(dir, "jetson-agx-orin", "nvidia", true, false)
+	if err != nil {
+		t.Fatalf("resolveDockerfileForDevice: %v", err)
+	}
+	if got != "Dockerfile.jetson" {
+		t.Fatalf("got %q, want Dockerfile.jetson", got)
+	}
+}
+
+func TestResolveDockerfileForDevice_FallsBackToDefaultWhenNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"Dockerfile", "Dockerfile.prod"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("FROM scratch"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// No hardware-named Dockerfiles present; non-interactive → falls back to "Dockerfile".
+	got, err := resolveDockerfileForDevice(dir, "jetson-agx-orin", "nvidia", true, false)
+	if err != nil {
+		t.Fatalf("resolveDockerfileForDevice: %v", err)
+	}
+	if got != "Dockerfile" {
+		t.Fatalf("got %q, want Dockerfile (fallback)", got)
+	}
+}
+
+func TestResolveDockerfileForDevice_SingleDockerfile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile.nvidia"), []byte("FROM scratch"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveDockerfileForDevice(dir, "", "", false, false)
+	if err != nil {
+		t.Fatalf("resolveDockerfileForDevice: %v", err)
+	}
+	if got != "Dockerfile.nvidia" {
+		t.Fatalf("got %q, want Dockerfile.nvidia", got)
+	}
+}
+
+func TestResolveDockerfileForDevice_NoDockerfiles(t *testing.T) {
+	dir := t.TempDir()
+	got, err := resolveDockerfileForDevice(dir, "", "", false, false)
+	if err != nil {
+		t.Fatalf("resolveDockerfileForDevice: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -555,17 +555,6 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		return runComposeCommand(ctx, cwd, opts)
 	}
 
-	// For docker-type projects, resolve which Dockerfile to use before
-	// connecting to the target — so the picker shows regardless of whether
-	// we end up on the agent path or a provider path (Docker Desktop, etc.).
-	if projectType == "docker" && opts.dockerfile == "" {
-		resolved, err := resolveDockerfile(cwd, opts.dockerfile, !opts.yes && isInteractiveTerminal())
-		if err != nil {
-			return err
-		}
-		opts.dockerfile = resolved
-	}
-
 	cfgPath := filepath.Join(cwd, "wendy.json")
 	appCfg, err := ensureAppConfig(cfgPath, opts.yes)
 	if err != nil {
@@ -1081,6 +1070,16 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 		}
 	}
 
+	// For docker projects without an explicit --dockerfile, resolve which file
+	// to use via the interactive picker (no hardware info on the provider path).
+	if projectType == "docker" && opts.dockerfile == "" {
+		resolved, err := resolveDockerfile(projectPath, "", !opts.yes && isInteractiveTerminal())
+		if err != nil {
+			return err
+		}
+		opts.dockerfile = resolved
+	}
+
 	if app == nil {
 		cliLogln("Building with %s provider...", p.DisplayName())
 		var err error
@@ -1240,6 +1239,19 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		// Dockerfile exists; use the Docker build path.
 	default:
 		return fmt.Errorf("unable to detect project type; ensure a Dockerfile, requirements.txt, or Package.swift is present")
+	}
+
+	// Resolve which Dockerfile to build from. When multiple Dockerfiles exist
+	// and no explicit --dockerfile was given, use hardware properties reported
+	// by the agent to auto-select the best match before falling back to the
+	// interactive picker.
+	if opts.dockerfile == "" {
+		hasGpu := versionResp.HasGpu != nil && versionResp.GetHasGpu()
+		resolved, err := resolveDockerfileForDevice(cwd, versionResp.GetDeviceType(), versionResp.GetGpuVendor(), hasGpu, !opts.yes && isInteractiveTerminal())
+		if err != nil {
+			return err
+		}
+		opts.dockerfile = resolved
 	}
 
 	deviceType := versionResp.GetDeviceType()

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -19,6 +19,7 @@ Tests:
   swift-bluetooth           Swift with bluetooth entitlement
   swift-resources           Swift app with bundled resources (verifies resource loading)
   python-hello              Basic Python deployment (no entitlements)
+  python-multi-dockerfile   Verify hardware-based Dockerfile auto-selection (multi-Dockerfile project)
   python-network            Python with network entitlement (WiFi connectivity)
   python-gpu                Python with GPU entitlement (CUDA verification)
   python-onnx-gpu           Python with GPU entitlement (ONNX Runtime CUDA inference)
@@ -186,6 +187,7 @@ ALL_TESTS=(
     swift-bluetooth
     swift-resources
     python-hello
+    python-multi-dockerfile
     python-network
     python-gpu
     python-onnx-gpu


### PR DESCRIPTION
## Summary

- Adds `autoSelectDockerfile` which maps target device hardware (deviceType, gpuVendor, hasGpu) to the best matching Dockerfile by name, using a most-specific-first priority order
- Adds `resolveDockerfileForDevice` which wraps hardware auto-selection and falls back to the existing interactive picker when no hardware-named Dockerfile is present
- Removes the early `resolveDockerfile` call from `runCommand` (which ran before the device was known); replaces it with per-path resolution: provider path keeps the interactive picker in `runWithProvider`, agent path uses hardware-aware selection in `runWithAgent` after `GetAgentVersion`

Closes WDY-1263.

## Dockerfile naming convention

| Hardware | Auto-selected file |
|---|---|
| `deviceType` = `jetson-agx-orin` | `Dockerfile.jetson-agx-orin` → `Dockerfile.jetson` → `Dockerfile.nvidia` |
| `gpuVendor` = `nvidia` (non-Jetson) | `Dockerfile.nvidia` |
| `gpuVendor` = `amd` | `Dockerfile.amd` |
| `hasGpu` = true (any vendor) | `Dockerfile.gpu` |
| No match | interactive picker / `Dockerfile` fallback |

When auto-selected, a notice is printed: `Auto-selected "Dockerfile.jetson" based on target device hardware.`

## Test plan

- [ ] `go test ./internal/cli/commands ./internal/agent/services` — all pass (includes 11 new tests)
- [ ] `TestAutoSelectDockerfile_*` — covers exact device match, Jetson family, Nvidia/AMD vendor, generic GPU, no-match, and no-hardware-info cases
- [ ] `TestResolveDockerfileForDevice_*` — covers auto-select, fallback-to-default, single-file, and no-files cases
- [ ] Existing `TestResolveDockerfile_*` and `TestRun*` tests all pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)