### PR TITLE
fix(security): bump postcss nested dep to 8.5.14 (XSS in CSS stringify)

### DIFF
--- a/go/internal/cli/assets/docs/package-lock.json
+++ b/go/internal/cli/assets/docs/package-lock.json
@@ -5712,9 +5712,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary

- Bumps `postcss` from 8.4.31 to 8.5.14 in `node_modules/next/node_modules/postcss`
- `next@16.2.6` vendors postcss 8.4.31 which is affected by [GHSA-952p-6jpr-xmg3](https://github.com/advisories/GHSA-952p-6jpr-xmg3): XSS via a crafted `</style>` sequence in CSS source maps
- Directly pinning the version in `package-lock.json` is the correct approach — `npm ci` installs exactly the resolved versions in the lock file, and `npm audit` checks the resolved version (8.5.14, not vulnerable)
- Minimal diff: 3 lines changed in `package-lock.json` only

## Test plan

- [ ] CI `Build docs` workflow passes with `npm ci` and `npm audit --audit-level=high`
- [ ] No change to `package.json` (direct deps remain the same)
- [ ] Docs build produces the same output as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)