### PR TITLE
Preserve Wendy CLI path in init project shell

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -1057,6 +1057,14 @@ func projectShellTerm(term string) string {
 }
 
 func projectShellPath() string {
+	executable := ""
+	if exe, err := os.Executable(); err == nil {
+		executable = exe
+	}
+	return projectShellPathForExecutable(executable)
+}
+
+func projectShellPathForExecutable(executable string) string {
 	parts := make([]string, 0)
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		parts = appendProjectShellPathDir(parts, dir)
@@ -1070,10 +1078,22 @@ func projectShellPath() string {
 		parts = appendProjectShellPathDir(parts, "/usr/bin")
 		parts = appendProjectShellPathDir(parts, "/bin")
 	}
-	if exe, err := os.Executable(); err == nil {
-		parts = appendProjectShellPathDir(parts, filepath.Dir(exe))
+	for _, dir := range projectShellExecutableDirs(executable) {
+		parts = appendProjectShellPathDir(parts, dir)
 	}
 	return strings.Join(parts, string(os.PathListSeparator))
+}
+
+func projectShellExecutableDirs(executable string) []string {
+	if strings.TrimSpace(executable) == "" {
+		return nil
+	}
+
+	dirs := []string{filepath.Dir(executable)}
+	if resolved, err := filepath.EvalSymlinks(executable); err == nil {
+		dirs = append(dirs, filepath.Dir(resolved))
+	}
+	return dirs
 }
 
 func appendProjectShellPathDir(parts []string, dir string) []string {

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -390,6 +390,48 @@ func TestProjectShellPath_PreservesUsableParentPath(t *testing.T) {
 	}
 }
 
+func TestProjectShellPath_PreservesResolvedExecutableDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix symlink behavior is covered on Unix")
+	}
+
+	root := t.TempDir()
+	homebrewBin := filepath.Join(root, "homebrew", "bin")
+	cellarBin := filepath.Join(root, "homebrew", "Cellar", "wendy", "2026.06.04-163109", "bin")
+	if err := os.MkdirAll(homebrewBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll homebrew bin: %v", err)
+	}
+	if err := os.MkdirAll(cellarBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll cellar bin: %v", err)
+	}
+	if err := os.Chmod(homebrewBin, 0o775); err != nil {
+		t.Fatalf("Chmod homebrew bin: %v", err)
+	}
+
+	realExe := filepath.Join(cellarBin, "wendy")
+	if err := os.WriteFile(realExe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile real exe: %v", err)
+	}
+	linkedExe := filepath.Join(homebrewBin, "wendy")
+	if err := os.Symlink(filepath.Join("..", "Cellar", "wendy", "2026.06.04-163109", "bin", "wendy"), linkedExe); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	t.Setenv("PATH", homebrewBin)
+
+	got := filepath.SplitList(projectShellPathForExecutable(linkedExe))
+	if slices.Contains(got, filepath.Clean(homebrewBin)) {
+		t.Fatalf("projectShellPathForExecutable() = %q, did not expect group-writable Homebrew bin", got)
+	}
+	resolvedCellarBin, err := filepath.EvalSymlinks(cellarBin)
+	if err != nil {
+		t.Fatalf("EvalSymlinks cellar bin: %v", err)
+	}
+	if !slices.Contains(got, filepath.Clean(resolvedCellarBin)) {
+		t.Fatalf("projectShellPathForExecutable() = %q, want resolved executable directory %q", got, resolvedCellarBin)
+	}
+}
+
 func TestProjectShellEnv_RejectsInvalidShell(t *testing.T) {
 	if _, err := projectShellEnv("test-shell"); err == nil {
 		t.Fatal("expected invalid shell to fail")


### PR DESCRIPTION
## Summary

- preserve the resolved Wendy executable directory when building the sanitized project-shell `PATH`
- keep filtering unsafe parent `PATH` entries such as group-writable Homebrew `bin` directories
- add coverage for a Homebrew-style symlink where `/opt/homebrew/bin/wendy` points into a Cellar version directory

## Root cause

`wendy init --template` can auto-open a shell in the generated project directory and tell the user to run `wendy run`. On macOS Homebrew installs, the launched shell may omit `/opt/homebrew/bin` because the project-shell sanitizer rejects group-writable PATH entries. The existing fallback tried to append `filepath.Dir(os.Executable())`, but for a symlinked Homebrew executable that can still be the rejected symlink directory rather than the safe resolved Cellar directory.

This patch tries both the executable directory and the resolved executable directory, while still passing each directory through the existing sanitizer.

Fixes #890.

## Validation

- `CC=/usr/bin/clang CXX=/usr/bin/clang++ go test ./go/internal/cli/commands -run 'TestProjectShellPath'`
- `CC=/usr/bin/clang CXX=/usr/bin/clang++ go test ./go/internal/cli/commands ./go/internal/agent/services`
- `git diff --check`
