### PR TITLE
docs(guides): sync language guides with current wendy init templates

### DIFF
--- a/go/internal/cli/assets/docs/guides/cpp/camera.mdx
+++ b/go/internal/cli/assets/docs/guides/cpp/camera.mdx
@@ -11,8 +11,6 @@ Use the Wendy camera template when you want a browser-viewable camera stream wit
 ### Prerequisites
 
 - Wendy CLI installed on your development machine
-- CMake 3.16 or later installed
-- A C++ compiler
 - A WendyOS device with a USB camera connected
 
 ## Setting Up Your Project

--- a/go/internal/cli/assets/docs/guides/cpp/hello-world.mdx
+++ b/go/internal/cli/assets/docs/guides/cpp/hello-world.mdx
@@ -6,17 +6,15 @@ language: cpp
 
 ## Creating Your First C++ Application
 
-This guide will walk you through creating a simple "Hello, World!" application for WendyOS using C++. This is a great way to prove that you can send your first app to your device and verify your development environment is set up correctly.
+This guide will walk you through creating your first WendyOS application in C++. The Wendy C++ template scaffolds a small HTTP server built on the [Drogon](https://drogon.org/) framework, so your very first app is a real, long-running service you can reach from a browser. This is a great way to prove you can send an app to your device and verify your development environment is set up correctly.
 
 ### Prerequisites
 
 - Wendy CLI installed on your development machine
-- CMake 3.16 or later installed
-- A C++ compiler (g++ or clang++)
 - A WendyOS device plugged in over USB or connectable over Wi-Fi
 
 <Callout type="info">
-  **Containerized Deployment**: C++ applications run inside Docker containers on your WendyOS device. The Dockerfiles in this guide are configured for the NVIDIA Jetson Orin Nano's ARM64 architecture using `arm64v8/debian:bookworm-slim` as the base image.
+  **Containerized Deployment**: C++ applications run inside containers on your WendyOS device. The Dockerfile in this guide is configured for the NVIDIA Jetson Orin Nano's ARM64 architecture using `arm64v8/debian:bookworm-slim` as the base image. The Wendy CLI handles the build and deploy for you — you do not need a local C++ toolchain.
 </Callout>
 
 ### Creating the Project
@@ -42,7 +40,7 @@ This guide will walk you through creating a simple "Hello, World!" application f
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and show the run output.
+    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and stream the run output. Because the generated `wendy.json` includes a `postStart` hook, your browser opens automatically once the server is ready and shows the JSON response from `/`.
   </Step>
 </Steps>
 
@@ -52,24 +50,83 @@ This guide will walk you through creating a simple "Hello, World!" application f
   <Step>
     ### Generated Application
 
-    The template includes a `main.cpp` entry point. A minimal hello-world binary looks like:
+    The generated `main.cpp` starts a Drogon HTTP server with three routes and listens on port `7001`:
 
     ```cpp
+    #include <drogon/drogon.h>
+    #include <cstdlib>
     #include <iostream>
+    #include <string>
+
+    using namespace drogon;
 
     int main() {
-        std::cout << "Hello, world!" << std::endl;
+        const char* env_hostname = std::getenv("WENDY_HOSTNAME");
+        std::string hostname = env_hostname ? env_hostname : "0.0.0.0";
+
+        app().registerHandler(
+            "/",
+            [](const HttpRequestPtr&, std::function<void(const HttpResponsePtr&)>&& callback) {
+                std::cout << "Received request: GET /" << std::endl;
+                Json::Value json;
+                json["message"] = "hello-world";
+                auto resp = HttpResponse::newHttpJsonResponse(json);
+                callback(resp);
+            },
+            {Get});
+
+        app().registerHandler(
+            "/health",
+            [](const HttpRequestPtr&, std::function<void(const HttpResponsePtr&)>&& callback) {
+                Json::Value json;
+                json["status"] = "ok";
+                auto resp = HttpResponse::newHttpJsonResponse(json);
+                callback(resp);
+            },
+            {Get});
+
+        app().registerHandler(
+            "/items",
+            [](const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)>&& callback) {
+                std::cout << "Received request: POST /items" << std::endl;
+                auto body = req->getJsonObject();
+                if (!body) {
+                    Json::Value err;
+                    err["error"] = "Invalid JSON";
+                    auto resp = HttpResponse::newHttpJsonResponse(err);
+                    resp->setStatusCode(k400BadRequest);
+                    callback(resp);
+                    return;
+                }
+
+                Json::Value item;
+                item["id"] = 1;
+                item["name"] = (*body)["name"].asString();
+                item["price"] = (*body)["price"].asDouble();
+                auto resp = HttpResponse::newHttpJsonResponse(item);
+                resp->setStatusCode(k201Created);
+                callback(resp);
+            },
+            {Post});
+
+        std::cout << "Server running on http://" << hostname << ":7001" << std::endl;
+
+        app().addListener("0.0.0.0", 7001);
+        app().run();
+
         return 0;
     }
     ```
 
-    This is the entry point for your WendyOS application.
+    <Callout type="info">
+      **A real server, not a print-and-exit app**: Unlike a classic "hello world" that prints a line and exits, this app calls `app().run()` and stays running so it can serve requests. The default route `GET /` returns `{"message":"hello-world"}`.
+    </Callout>
   </Step>
 
   <Step>
     ### Generated CMakeLists.txt
 
-    The generated `CMakeLists.txt` describes how the project builds:
+    The generated `CMakeLists.txt` finds Drogon and builds the server binary:
 
     ```cmake
     cmake_minimum_required(VERSION 3.16)
@@ -78,38 +135,95 @@ This guide will walk you through creating a simple "Hello, World!" application f
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+    find_package(Drogon REQUIRED)
+
     add_executable(hello-world main.cpp)
+
+    target_link_libraries(hello-world PRIVATE Drogon::Drogon)
     ```
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile configured for the NVIDIA Jetson Orin Nano (ARM64):
+    The generated project includes a multi-stage Dockerfile configured for the NVIDIA Jetson Orin Nano (ARM64). The build stage compiles Drogon `v1.9.12` from source, then builds the app; the runtime stage ships only the binary and its shared-library dependencies:
 
     ```dockerfile
-    # Build stage - using ARM64-compatible image for NVIDIA Jetson Orin Nano
     FROM arm64v8/debian:bookworm-slim AS builder
 
-    # Install build dependencies
     RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         cmake \
+        git \
+        ca-certificates \
+        libjsoncpp-dev \
+        libssl-dev \
+        uuid-dev \
+        zlib1g-dev \
         && rm -rf /var/lib/apt/lists/*
 
+    WORKDIR /deps
+
+    RUN git clone --branch v1.9.12 --depth 1 https://github.com/drogonframework/drogon.git && \
+        cd drogon && \
+        git submodule update --init && \
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=OFF -DBUILD_CTL=OFF -DBUILD_ORM=OFF && \
+        cmake --build build -j$(nproc) && \
+        cmake --install build
+
     WORKDIR /app
+
     COPY CMakeLists.txt main.cpp ./
 
-    # Build the application
     RUN cmake -B build -DCMAKE_BUILD_TYPE=Release && \
         cmake --build build --config Release
 
-    # Runtime stage
     FROM arm64v8/debian:bookworm-slim
+
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libjsoncpp25 \
+        libssl3 \
+        libuuid1 \
+        zlib1g \
+        && rm -rf /var/lib/apt/lists/*
 
     COPY --from=builder /app/build/hello-world /usr/local/bin/hello-world
 
+    EXPOSE 7001
+
     CMD ["hello-world"]
+    ```
+
+    <Callout type="info">
+      **Building Drogon from source takes a while**: The first `wendy run` compiles Drogon inside the build stage, which can take several minutes. Subsequent builds reuse the cached layer and are much faster.
+    </Callout>
+  </Step>
+
+  <Step>
+    ### Generated wendy.json
+
+    The generated `wendy.json` already wires up everything the app needs — the `network` entitlement, a readiness probe on port `7001`, and a `postStart` hook that opens your browser when the server is ready:
+
+    ```json
+    {
+        "appId": "hello-world",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 7001 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:7001"
+            }
+        }
+    }
     ```
   </Step>
 </Steps>
@@ -122,11 +236,15 @@ Deploy your application to a connected WendyOS device:
 wendy run
 ```
 
-This will build your application into a container and deploy it to your device.
+This will build your application into a container, deploy it to your device, and stream the logs. When the readiness probe passes, the `postStart` hook opens `http://${WENDY_HOSTNAME}:7001` in your browser, where you should see:
+
+```json
+{"message":"hello-world"}
+```
 
 ## Verifying Deployment on Your Device
 
-After deploying your application to a WendyOS device, you can verify it was successfully deployed and ran by listing the applications on your device:
+After deploying your application to a WendyOS device, you can verify it is running by listing the applications on your device:
 
 ```bash
 wendy device apps list
@@ -135,21 +253,21 @@ wendy device apps list
 ╭───────────────┬─────────┬─────────┬──────────╮
 │ App           │ Version │ State   │ Failures │
 ├───────────────┼─────────┼─────────┼──────────┤
-│ hello-world   │ 0.0.1   │ Stopped │ 0        │
+│ hello-world   │ 0.1.0   │ Running │ 0        │
 ╰───────────────┴─────────┴─────────┴──────────╯
 ```
 
 <Callout type="info">
-  **Expected State**: The app shows as "Stopped" because a hello-world application exits immediately after printing its message. This is expected behavior. The key indicator of success is the "Failures" column showing `0`, which confirms your application ran and exited successfully without any errors.
+  **Expected State**: Because this app is an HTTP server, it shows as "Running" — it stays up to serve requests rather than exiting. The "Failures" column showing `0` confirms it started cleanly. (To stop it, run `wendy device apps stop hello-world`.)
 </Callout>
 
 ## Next Steps
 
 Now that you have a basic C++ application running:
 
-- Learn how to build a [Simple Web Server](/docs/guides/cpp/simple-web-server) with cpp-httplib
+- Build out the API in the [Simple Web Server](/docs/guides/cpp/simple-web-server) guide
+- Stream a camera feed with the [Camera Feed](/docs/guides/cpp/camera) guide
 - Explore environment variables and configuration
-- Build more complex applications with networking and data processing
 - Integrate with WendyOS device features via HTTP APIs
 
 <Callout type="info">
@@ -158,37 +276,31 @@ Now that you have a basic C++ application running:
 
 <Accordions>
   <Accordion title="Testing the app on your own machine">
-    There are times when you might not have a WendyOS device around. You can still test your application locally using CMake or Docker.
-
-    ### Using CMake Directly
-
-    Build and run your application locally:
-
-    ```bash
-    cmake -B build -DCMAKE_BUILD_TYPE=Release
-    cmake --build build
-    ./build/hello-world
-    ```
-
-    You should see:
-
-    ```
-    Hello, world!
-    ```
+    There are times when you might not have a WendyOS device around. The easiest way to test locally is with Docker, which mirrors how the app is built and run on the device.
 
     ### Using Docker Locally
 
-    Build and run your application in a Docker container:
+    Build and run your application in a container, mapping the port so you can reach it:
 
     ```bash
     docker build --platform linux/arm64 -t hello-world .
-    docker run --platform linux/arm64 hello-world
+    docker run --platform linux/arm64 -p 7001:7001 hello-world
+    ```
+
+    In another terminal, send a request to the default route:
+
+    ```bash
+    curl http://localhost:7001
     ```
 
     You should see:
 
+    ```json
+    {"message":"hello-world"}
     ```
-    Hello, world!
-    ```
+
+    <Callout type="info">
+      **Building from source is required**: The app depends on the Drogon framework, which the Dockerfile compiles from source. Building locally without Docker means installing Drogon and its dependencies (libjsoncpp, libssl, uuid, zlib) yourself, so Docker is the recommended path.
+    </Callout>
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/cpp/simple-web-server.mdx
+++ b/go/internal/cli/assets/docs/guides/cpp/simple-web-server.mdx
@@ -4,17 +4,15 @@ description: Build a long-running HTTP server on WendyOS using C++
 language: cpp
 ---
 
-## Building a Web Server with cpp-httplib
+## Building a Web Server with Drogon
 
 Often times you'll want a long-running server where you can make HTTP or WebSocket calls to your WendyOS device. This allows your device to accept incoming requests and respond to them, making it easy to build interactive applications or APIs that can be accessed from other devices on your network.
 
-This guide shows you how to build a web server using cpp-httplib, a lightweight header-only HTTP library for C++, along with nlohmann/json for JSON handling.
+This guide shows you how to build a web server using [Drogon](https://drogon.org/), a high-performance C++14/17 HTTP application framework. The Wendy C++ template scaffolds the server, Dockerfile, and `wendy.json` for you.
 
 ### Prerequisites
 
 - Wendy CLI installed on your development machine
-- CMake 3.16 or later installed
-- A C++ compiler (g++ or clang++)
 - A WendyOS device plugged in over USB or connectable over Wi-Fi
 
 ## Setting Up Your Project
@@ -40,7 +38,7 @@ This guide shows you how to build a web server using cpp-httplib, a lightweight 
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and print the URL or run output.
+    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and stream the run output. The generated `wendy.json` includes a `postStart` hook, so your browser opens automatically once the server is ready.
   </Step>
 </Steps>
 
@@ -50,68 +48,90 @@ This guide shows you how to build a web server using cpp-httplib, a lightweight 
   <Step>
     ### Generated Web Server
 
-    The generated `main.cpp` contains the server logic:
+    The generated `main.cpp` registers three routes on a Drogon server listening on port `3000`:
 
     ```cpp
-    #include "httplib.h"
-    #include "json.hpp"
-
+    #include <drogon/drogon.h>
+    #include <cstdlib>
     #include <iostream>
     #include <string>
 
-    using json = nlohmann::json;
+    using namespace drogon;
 
     int main() {
-        httplib::Server svr;
+        const char* env_hostname = std::getenv("WENDY_HOSTNAME");
+        std::string hostname = env_hostname ? env_hostname : "0.0.0.0";
 
-        // GET / - Returns "Hello, World!"
-        svr.Get("/", [](const httplib::Request&, httplib::Response& res) {
-            res.set_content("Hello, World!", "text/plain");
-        });
+        app().registerHandler(
+            "/",
+            [](const HttpRequestPtr&, std::function<void(const HttpResponsePtr&)>&& callback) {
+                std::cout << "Received request: GET /" << std::endl;
+                Json::Value json;
+                json["message"] = "hello-world";
+                auto resp = HttpResponse::newHttpJsonResponse(json);
+                callback(resp);
+            },
+            {Get});
 
-        // GET /hello/:name - Returns personalized greeting
-        svr.Get(R"(/hello/(\w+))", [](const httplib::Request& req, httplib::Response& res) {
-            std::string name = req.matches[1];
-            res.set_content("Hello, " + name + "!", "text/plain");
-        });
+        app().registerHandler(
+            "/health",
+            [](const HttpRequestPtr&, std::function<void(const HttpResponsePtr&)>&& callback) {
+                Json::Value json;
+                json["status"] = "ok";
+                auto resp = HttpResponse::newHttpJsonResponse(json);
+                callback(resp);
+            },
+            {Get});
 
-        // POST /users - Creates a new user from JSON body
-        svr.Post("/users", [](const httplib::Request& req, httplib::Response& res) {
-            try {
-                auto body = json::parse(req.body);
-                std::string username = body.value("username", "");
+        app().registerHandler(
+            "/items",
+            [](const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)>&& callback) {
+                std::cout << "Received request: POST /items" << std::endl;
+                auto body = req->getJsonObject();
+                if (!body) {
+                    Json::Value err;
+                    err["error"] = "Invalid JSON";
+                    auto resp = HttpResponse::newHttpJsonResponse(err);
+                    resp->setStatusCode(k400BadRequest);
+                    callback(resp);
+                    return;
+                }
 
-                json user;
-                user["id"] = 1;
-                user["username"] = username;
+                Json::Value item;
+                item["id"] = 1;
+                item["name"] = (*body)["name"].asString();
+                item["price"] = (*body)["price"].asDouble();
+                auto resp = HttpResponse::newHttpJsonResponse(item);
+                resp->setStatusCode(k201Created);
+                callback(resp);
+            },
+            {Post});
 
-                res.status = 201;
-                res.set_content(user.dump(), "application/json");
-            } catch (const json::exception& e) {
-                res.status = 400;
-                res.set_content(R"({"error": "Invalid JSON"})", "application/json");
-            }
-        });
+        std::cout << "Server running on http://" << hostname << ":3000" << std::endl;
 
-        std::cout << "Server running on http://localhost:3000" << std::endl;
-        svr.listen("0.0.0.0", 3000);
+        app().addListener("0.0.0.0", 3000);
+        app().run();
 
         return 0;
     }
     ```
 
     <Callout type="info">
-      **Multiple Routes**: This example includes three routes:
-      - `GET /` - Returns "Hello, World!"
-      - `GET /hello/:name` - Returns a personalized greeting using regex path matching
-      - `POST /users` - Creates a new user from JSON body and returns it
+      **Three routes**: This example includes:
+      - `GET /` — returns `{"message":"hello-world"}`
+      - `GET /health` — returns `{"status":"ok"}`, handy for health checks
+      - `POST /items` — parses a JSON body (`name`, `price`) and echoes it back with an `id` and a `201 Created` status, or returns `400` for invalid JSON
+    </Callout>
+
+    <Callout type="warning">
+      **Important**: The server binds to `0.0.0.0` rather than `localhost` or `127.0.0.1`. This is because your WendyOS device needs to accept connections from other devices on the network. Binding to `0.0.0.0` makes the server reachable externally.
     </Callout>
   </Step>
 
   <Step>
     ### Generated CMakeLists.txt
 
-    Review the generated `CMakeLists.txt`:
+    The generated `CMakeLists.txt` finds Drogon and links it into the server binary:
 
     ```cmake
     cmake_minimum_required(VERSION 3.16)
@@ -120,54 +140,57 @@ This guide shows you how to build a web server using cpp-httplib, a lightweight 
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-    # Find required packages
-    find_package(Threads REQUIRED)
-
-    # Include directories for header-only libraries
-    include_directories(${CMAKE_SOURCE_DIR}/include)
+    find_package(Drogon REQUIRED)
 
     add_executable(simple-server main.cpp)
 
-    # Link pthread for httplib
-    target_link_libraries(simple-server PRIVATE Threads::Threads)
+    target_link_libraries(simple-server PRIVATE Drogon::Drogon)
     ```
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile. It downloads the header-only libraries during build and is configured for the NVIDIA Jetson Orin Nano (ARM64):
+    The generated project includes a multi-stage Dockerfile configured for the NVIDIA Jetson Orin Nano (ARM64). The build stage compiles Drogon `v1.9.12` from source and builds the app; the runtime stage ships only the binary and its shared-library dependencies:
 
     ```dockerfile
-    # Build stage - using ARM64-compatible image for NVIDIA Jetson Orin Nano
     FROM arm64v8/debian:bookworm-slim AS builder
 
-    # Install build dependencies
     RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         cmake \
-        curl \
+        git \
         ca-certificates \
+        libjsoncpp-dev \
+        libssl-dev \
+        uuid-dev \
+        zlib1g-dev \
         && rm -rf /var/lib/apt/lists/*
+
+    WORKDIR /deps
+
+    RUN git clone --branch v1.9.12 --depth 1 https://github.com/drogonframework/drogon.git && \
+        cd drogon && \
+        git submodule update --init && \
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=OFF -DBUILD_CTL=OFF -DBUILD_ORM=OFF && \
+        cmake --build build -j$(nproc) && \
+        cmake --install build
 
     WORKDIR /app
 
-    # Download header-only libraries
-    RUN mkdir -p include && \
-        curl -sL https://raw.githubusercontent.com/yhirose/cpp-httplib/v0.18.1/httplib.h -o include/httplib.h && \
-        curl -sL https://raw.githubusercontent.com/nlohmann/json/v3.11.3/single_include/nlohmann/json.hpp -o include/json.hpp
-
     COPY CMakeLists.txt main.cpp ./
 
-    # Build the application
     RUN cmake -B build -DCMAKE_BUILD_TYPE=Release && \
         cmake --build build --config Release
 
-    # Runtime stage
     FROM arm64v8/debian:bookworm-slim
 
     RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
+        libjsoncpp25 \
+        libssl3 \
+        libuuid1 \
+        zlib1g \
         && rm -rf /var/lib/apt/lists/*
 
     COPY --from=builder /app/build/simple-server /usr/local/bin/simple-server
@@ -177,9 +200,36 @@ This guide shows you how to build a web server using cpp-httplib, a lightweight 
     CMD ["simple-server"]
     ```
 
-    <Callout type="warning">
-      **Important**: The server runs on `0.0.0.0` and not `localhost` or `127.0.0.1`. This is because your WendyOS device needs to accept connections from other devices on the network. Binding to `0.0.0.0` makes the server accessible externally.
+    <Callout type="info">
+      **Building Drogon from source takes a while**: The first `wendy run` compiles Drogon inside the build stage, which can take several minutes. Subsequent builds reuse the cached layer and are much faster.
     </Callout>
+  </Step>
+
+  <Step>
+    ### Generated wendy.json
+
+    The generated `wendy.json` already includes the `network` entitlement, a readiness probe on port `3000`, and a `postStart` hook that opens your browser once the server is ready — you don't need to add these by hand:
+
+    ```json
+    {
+        "appId": "simple-server",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 3000 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3000"
+            }
+        }
+    }
+    ```
   </Step>
 </Steps>
 
@@ -191,41 +241,24 @@ Deploy your containerized web server to your WendyOS device:
 wendy run
 ```
 
-The Wendy CLI will build your Docker image, transfer it to your device, and run it with the appropriate port mappings.
+The Wendy CLI will build your container, transfer it to your device, and run it with the appropriate port mapping.
 
 ## Test Your Server on WendyOS
 
-After deploying your server to your WendyOS device, you can test it from your development machine.
-
-You can configure `wendy.json` with a readiness probe and postStart hook to automatically open your browser when the server is ready:
-
-```json
-{
-  "readiness": {
-    "tcpSocket": { "port": 3000 },
-    "timeoutSeconds": 30
-  },
-  "hooks": {
-    "postStart": {
-      "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3000"
-    }
-  }
-}
-```
-Or open your browser manually and navigate to:
+After deploying your server, the `postStart` hook opens your browser automatically when the readiness probe passes. You can also open your browser manually and navigate to:
 
 ```
 http://wendyos-true-probe.local:3000
 ```
 
 <Callout type="warning">
-  **Replace the hostname**: Each WendyOS device has a unique hostname. Replace `wendyos-true-probe` with your device's actual hostname shown in the CLI output. In addition, don't forget to add the port to the hostname.
+  **Replace the hostname**: Each WendyOS device has a unique hostname. Replace `wendyos-true-probe` with your device's actual hostname shown in the CLI output. Don't forget to include the port.
 </Callout>
 
-You should see the following output:
+The default route returns:
 
-```
-Hello, World!
+```json
+{"message":"hello-world"}
 ```
 
 This confirms your web server is successfully running on your WendyOS device and accepting requests from your network.
@@ -241,44 +274,32 @@ wendy device apps list
 ╭───────────────┬─────────┬─────────┬──────────╮
 │ App           │ Version │ State   │ Failures │
 ├───────────────┼─────────┼─────────┼──────────┤
-│ simple-server │ 0.0.0   │ Stopped │ 0        │
+│ simple-server │ 0.1.0   │ Running │ 0        │
 ╰───────────────┴─────────┴─────────┴──────────╯
 ```
 
-You should see your containerized web server listed among the running applications.
+Because the server stays up to serve requests, it shows as "Running" with `0` failures.
 
 ## More Code Notes
 
 Let's break down what the code does:
 
-1. **Include Headers**: We include `httplib.h` for HTTP server functionality and `json.hpp` for JSON parsing/serialization.
+1. **Include Drogon**: `<drogon/drogon.h>` brings in the framework. JSON support is built in via `Json::Value`.
 
-2. **Create Server**: We create an `httplib::Server` instance that will handle incoming requests.
+2. **Read the hostname**: The app reads `WENDY_HOSTNAME` from the environment so it can log a reachable URL, falling back to `0.0.0.0`.
 
-3. **Define Routes**: We define three routes using lambda functions:
-   - `GET /` returns a simple text response
-   - `GET /hello/:name` uses regex to capture path parameters
-   - `POST /users` parses JSON from the request body and returns a JSON response
+3. **Register routes**: `app().registerHandler(...)` attaches a lambda handler and the allowed HTTP methods (`{Get}`, `{Post}`) to each path. `POST /items` parses the request body with `req->getJsonObject()` and validates it.
 
-4. **Start Server**: The `svr.listen()` function starts the server and blocks, listening for connections on port 3000.
-
-## Libraries Used
-
-This example uses two popular header-only C++ libraries:
-
-- **[cpp-httplib](https://github.com/yhirose/cpp-httplib)**: A lightweight, single-file HTTP/HTTPS server and client library
-- **[nlohmann/json](https://github.com/nlohmann/json)**: A modern C++ JSON library with an intuitive API
-
-Both libraries are header-only, meaning they don't require compilation or linking against external libraries.
+4. **Start the server**: `app().addListener("0.0.0.0", 3000)` binds the listener and `app().run()` blocks, serving connections on port `3000`.
 
 ## Alternative Frameworks
 
-While this guide uses cpp-httplib for simplicity, other excellent C++ web frameworks are available:
+While the template uses Drogon, other excellent C++ web frameworks are available:
 
 - **[Crow](https://crowcpp.org/)**: A Flask-inspired micro web framework
-- **[Drogon](https://drogon.org/)**: A high-performance C++14/17 HTTP framework
 - **[Pistache](http://pistache.io/)**: A modern and elegant HTTP and REST framework
 - **[Oat++](https://oatpp.io/)**: Light and powerful C++ web framework
+- **[cpp-httplib](https://github.com/yhirose/cpp-httplib)**: A lightweight, single-file HTTP/HTTPS server and client library
 
 All of these frameworks can be containerized and deployed to WendyOS following a similar Docker-based approach.
 
@@ -291,39 +312,15 @@ Now that you have a basic web server running:
 - Add request validation and error handling
 - Parse query parameters
 - Connect to WendyOS device features to control hardware via HTTP
-- Implement WebSocket support for real-time communication
+- Implement WebSocket support for real-time communication (see the [Camera Feed](/docs/guides/cpp/camera) guide)
 
 <Accordions>
   <Accordion title="Testing the app on your own machine">
-    There are times when you might not have a WendyOS device around. You can still test your application locally using CMake or Docker.
-
-    ### Using CMake Directly
-
-    First, download the header-only libraries:
-
-    ```bash
-    mkdir -p include
-    curl -sL https://raw.githubusercontent.com/yhirose/cpp-httplib/v0.18.1/httplib.h -o include/httplib.h
-    curl -sL https://raw.githubusercontent.com/nlohmann/json/v3.11.3/single_include/nlohmann/json.hpp -o include/json.hpp
-    ```
-
-    Then build and run:
-
-    ```bash
-    cmake -B build -DCMAKE_BUILD_TYPE=Release
-    cmake --build build
-    ./build/simple-server
-    ```
-
-    You should see:
-
-    ```
-    Server running on http://localhost:3000
-    ```
+    There are times when you might not have a WendyOS device around. The easiest way to test locally is with Docker, which mirrors how the app is built and run on the device.
 
     ### Using Docker Locally
 
-    Build and run the container:
+    Build and run the container, mapping the port:
 
     ```bash
     docker build --platform linux/arm64 -t simple-server .
@@ -332,7 +329,7 @@ Now that you have a basic web server running:
 
     ### Test Your Server
 
-    Open another terminal and test with curl:
+    Open another terminal and test the default route with curl:
 
     ```bash
     curl http://localhost:3000
@@ -340,34 +337,38 @@ Now that you have a basic web server running:
 
     You should see:
 
-    ```
-    Hello, World!
+    ```json
+    {"message":"hello-world"}
     ```
 
-    Test the parameterized route:
+    Test the health route:
 
     ```bash
-    curl http://localhost:3000/hello/Wendy
-    ```
-
-    You should see:
-
-    ```
-    Hello, Wendy!
-    ```
-
-    Test the POST endpoint:
-
-    ```bash
-    curl -X POST http://localhost:3000/users \
-      -H "Content-Type: application/json" \
-      -d '{"username": "wendy"}'
+    curl http://localhost:3000/health
     ```
 
     You should see:
 
     ```json
-    {"id":1,"username":"wendy"}
+    {"status":"ok"}
     ```
+
+    Test the POST endpoint:
+
+    ```bash
+    curl -X POST http://localhost:3000/items \
+      -H "Content-Type: application/json" \
+      -d '{"name": "widget", "price": 9.99}'
+    ```
+
+    You should see:
+
+    ```json
+    {"id":1,"name":"widget","price":9.99}
+    ```
+
+    <Callout type="info">
+      **Building from source is required**: The app depends on the Drogon framework, which the Dockerfile compiles from source. Building locally without Docker means installing Drogon and its dependencies (libjsoncpp, libssl, uuid, zlib) yourself, so Docker is the recommended path.
+    </Callout>
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/python/audio.mdx
+++ b/go/internal/cli/assets/docs/guides/python/audio.mdx
@@ -11,10 +11,10 @@ language: python
 </Callout>
 
 In this guide, we'll build an audio application that demonstrates two key capabilities:
-1.  **Audio Playback**: Triggering sound effects on the device from a web interface using `aplay`.
-2.  **Microphone Streaming**: Capturing live audio from the device's microphone using `arecord` and streaming it to a web client via WebSockets.
+1.  **Audio Playback**: Triggering sound effects on the device from a web interface, played through GStreamer to an ALSA speaker.
+2.  **Microphone Streaming**: Capturing live PCM audio from the device's microphone with GStreamer and streaming it to a web client over a WebSocket, where it's rendered as a waveform.
 
-This demonstrates how to use standard Linux audio utilities (`alsa-utils`) within a Python container.
+This demonstrates how to drive audio capture and playback with GStreamer and ALSA inside a Python container.
 
 ### Prerequisites
 
@@ -54,200 +54,226 @@ This demonstrates how to use standard Linux audio utilities (`alsa-utils`) withi
 
 ## Project Structure
 
+The template generates a single-file frontend (`index.html`) and a single-file backend (`app.py`), plus a few sample WAV files under `assets/`:
+
 ```
 audio/
 ├── Dockerfile
 ├── wendy.json
-├── frontend/           # React + Vite frontend
-│   └── src/
-│       └── App.tsx     # Audio visualizer & controls
-└── server/             # Python backend
-    ├── app.py          # FastAPI application
-    ├── requirements.txt
-    └── sounds/         # WAV files
+├── requirements.txt
+├── app.py            # FastAPI + GStreamer backend
+├── index.html        # Waveform visualizer & controls (Tailwind via CDN)
+└── assets/           # Bundled sound effects + logo
+    ├── car-horn.wav
+    ├── magic.wav
+    ├── piano.wav
+    ├── voice.wav
+    └── wendy-logo.svg
 ```
 
 ## Setting Up the Backend
 
-The backend uses [FastAPI](https://fastapi.tiangolo.com/) for the HTTP API and WebSockets. Instead of complex audio libraries, we use Python's `subprocess` module to call native Linux audio tools.
+The backend uses [FastAPI](https://fastapi.tiangolo.com/) for the HTTP API and WebSockets. Audio capture and playback are driven by GStreamer pipelines using the ALSA plugins (`alsasrc` / `alsasink`). ALSA devices are enumerated by parsing `arecord -l` / `aplay -l`.
 
 ### 1. Dependencies
 
-In `server/requirements.txt`, we include FastAPI and Uvicorn:
+The `requirements.txt` is just FastAPI and Uvicorn — GStreamer comes from the system packages installed in the Dockerfile:
 
 ```text
 fastapi
 uvicorn[standard]
-websockets
 ```
 
 ### 2. Audio Playback
 
-To play a sound, we invoke the `aplay` command. This is robust and doesn't require compiling complex Python audio bindings.
+To play a sound, the backend builds a GStreamer pipeline that reads a WAV file from `assets/` and sends it to the selected ALSA speaker (falling back to the first detected speaker, then `autoaudiosink`):
 
 ```python
-import subprocess
-from pathlib import Path
+@app.post("/play/{filename}")
+async def play_sound(filename: str):
+    """Play a wav file from ./assets on the device speaker via GStreamer."""
+    filepath = _assets_dir / filename
+    if not filepath.exists() or not filename.endswith(".wav"):
+        return JSONResponse(content={"error": "not found"}, status_code=404)
 
-def play_sound_file(sound_name: str) -> dict:
-    sound_file = Path(f"/app/sounds/{sound_name}.wav")
+    if _current_speaker:
+        sink = f'alsasink device="{_current_speaker}"'
+    else:
+        speakers = _list_speakers()
+        sink = f'alsasink device="{speakers[0]["id"]}"' if speakers else "autoaudiosink"
 
-    try:
-        # Use aplay to play the sound on the default device
-        result = subprocess.run(
-            ["aplay", str(sound_file)],
-            capture_output=True,
-            text=True,
-            timeout=30
-        )
-        return {"success": True}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
-
-@app.post("/api/play/{sound_name}")
-async def play_sound(sound_name: str):
-    # Run in thread pool to avoid blocking the async event loop
-    loop = asyncio.get_event_loop()
-    result = await loop.run_in_executor(None, play_sound_file, sound_name)
-    return result
+    desc = f'filesrc location="{filepath}" ! wavparse ! audioconvert ! audioresample ! {sink}'
+    pipeline = Gst.parse_launch(desc)
+    pipeline.set_state(Gst.State.PLAYING)
+    # ... a background thread watches the bus for EOS/ERROR, then tears the pipeline down ...
+    return JSONResponse(content={"status": "playing", "file": filename})
 ```
+
+The UI discovers playable sounds via `GET /sounds`, and available output devices via `GET /speakers`. Selecting a speaker posts to `/speaker/{device_id}`.
 
 ### 3. Microphone Streaming
 
-To stream audio, we spawn an `arecord` process that outputs raw PCM audio data to `stdout`. We read this stream in Python and send chunks over a WebSocket.
+Microphone capture is an `alsasrc` pipeline resampled to S16LE mono 16 kHz, ending in an `appsink`. Each captured buffer is pushed to every connected client's queue:
 
 ```python
-@app.websocket("/ws/microphone")
-async def microphone_stream(websocket: WebSocket):
-    await websocket.accept()
+def _start_pipeline(self) -> Gst.Pipeline | None:
+    appsink = "appsink name=sink emit-signals=true max-buffers=4 drop=true sync=false"
+    pcm_caps = "audio/x-raw,format=S16LE,channels=1,rate=16000"
+    # tries the selected device, then each device from `arecord -l`, then a generic alsasrc
+    desc = f'alsasrc device="{dev}" ! audioconvert ! audioresample ! {pcm_caps} ! {appsink}'
+    # ... parse_launch, probe PAUSED state, return the first pipeline that prerolls ...
 
-    # 16kHz, Mono, Signed 16-bit Little Endian
-    process = subprocess.Popen(
-        [
-            "arecord",
-            "-f", "S16_LE",
-            "-r", "16000",
-            "-c", "1",
-            "-t", "raw",
-            "-" # Output to stdout
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL
-    )
+def _on_new_sample(self, sink):
+    sample = sink.emit("pull-sample")
+    buf = sample.get_buffer()
+    ok, mapinfo = buf.map(Gst.MapFlags.READ)
+    data = bytes(mapinfo.data)
+    buf.unmap(mapinfo)
+    with self._lock:
+        for q in self.queues.values():
+            try:
+                q.put_nowait(data)
+            except asyncio.QueueFull:
+                pass
+    return Gst.FlowReturn.OK
+```
+
+The WebSocket endpoint streams those raw PCM bytes to the browser and accepts a `switch_microphone` command to change the active input device:
+
+```python
+@app.websocket("/stream")
+async def websocket_stream(websocket: WebSocket):
+    await websocket.accept()
+    q = await audio.add_client(websocket)
+
+    async def send_audio():
+        while True:
+            data = await q.get()
+            await websocket.send_bytes(data)
+
+    async def recv_commands():
+        try:
+            while True:
+                msg = json.loads(await websocket.receive_text())
+                if "switch_microphone" in msg:
+                    await audio.switch_microphone(msg["switch_microphone"])
+        except WebSocketDisconnect:
+            pass
 
     try:
-        while True:
-            # Read 2048 bytes (1024 samples * 2 bytes/sample)
-            data = process.stdout.read(2048)
-            if not data:
-                break
-
-            # Encode to Base64 and send
-            audio_data = base64.b64encode(data).decode("utf-8")
-            await websocket.send_json({
-                "type": "audio",
-                "data": audio_data,
-                "sampleRate": 16000
-            })
-
-            # Small yield to let other tasks run
-            await asyncio.sleep(0.01)
-
+        done, pending = await asyncio.wait(
+            [asyncio.create_task(send_audio()), asyncio.create_task(recv_commands())],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for t in pending:
+            t.cancel()
     finally:
-        process.terminate()
+        audio.remove_client(websocket)
 ```
+
+The backend also exposes `GET /microphones`, `GET /logs`, and `GET /debug`, and serves the UI at `GET /`.
 
 ## Frontend Implementation
 
-The frontend is a React application that connects to the WebSocket to receive audio data. It uses the Web Audio API to play the streamed audio and draws a visualization on a canvas.
+The frontend is a single `index.html` (Tailwind via CDN). It draws a fullscreen waveform on a `<canvas>` and renders buttons for the bundled sounds plus microphone/speaker pickers. It connects to `/stream` and receives raw PCM frames as binary:
 
-```tsx
-// Connect to WebSocket
-const ws = new WebSocket(`ws://${window.location.host}/ws/microphone`);
+```javascript
+const canvas = document.getElementById("waveform");
+const ctx = canvas.getContext("2d");
 
-ws.onmessage = async (event) => {
-  const message = JSON.parse(event.data);
-
-  if (message.type === "audio") {
-    // Decode base64
-    const binaryString = atob(message.data);
-    // Convert to Int16 samples
-    // ...
-
-    // Play using Web Audio API
+ws = new WebSocket(`${proto}//${location.host}/stream`);
+ws.binaryType = "arraybuffer";
+ws.onmessage = (e) => {
+  if (e.data instanceof ArrayBuffer) {
+    // interpret as Int16 PCM samples and push into the waveform ring buffer
+  } else {
+    // JSON control messages (e.g. mic_switched)
   }
 };
 ```
 
+Buttons are populated from `/sounds`; clicking one POSTs to `/play/{file}`. The microphone dropdown is filled from `/microphones` and triggers a `switch_microphone` command; the speaker dropdown is filled from `/speakers` and posts to `/speaker/{id}`.
+
 ## Docker Configuration
 
-We use a multi-stage build. We install `alsa-utils` in the final image to provide `aplay` and `arecord`.
+The Dockerfile uses a slim Debian base with GStreamer (including the ALSA plugin), `alsa-utils`, and the GStreamer Python bindings. It creates a virtualenv with system site packages so `import gi` works:
 
 ```dockerfile
-# Build Frontend
-FROM node:22-slim AS frontend-builder
-WORKDIR /app/frontend
-COPY frontend/package*.json ./
-RUN npm ci
-COPY frontend/ ./
-RUN npm run build
+FROM debian:bookworm-slim
 
-# Runtime Stage
-FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
-
-WORKDIR /app
-
-# Install ALSA utilities for audio
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-gi \
+    gir1.2-gst-plugins-base-1.0 \
+    gir1.2-gst-plugins-bad-1.0 \
+    gir1.2-gstreamer-1.0 \
+    gstreamer1.0-tools \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    gstreamer1.0-nice \
+    gstreamer1.0-alsa \
     alsa-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
-RUN uv pip install --system fastapi "uvicorn[standard]" websockets
+WORKDIR /app
 
-# Copy application code
-COPY server/requirements.txt ./
-COPY server/app.py ./
-COPY server/sounds ./sounds
-COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+RUN python3 -m venv --system-site-packages /app/venv
+ENV PATH="/app/venv/bin:$PATH"
 
-ENV FRONTEND_DIST=/app/frontend/dist
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-EXPOSE 3005
+COPY app.py index.html ./
+COPY assets/ ./assets/
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3005"]
+ENV PYTHONUNBUFFERED=1
+
+ARG WENDY_DEVICE_TYPE
+ARG WENDY_DEBUG=false
+ENV WENDY_DEVICE_TYPE=${WENDY_DEVICE_TYPE}
+ENV WENDY_DEBUG=${WENDY_DEBUG}
+RUN if [ "$WENDY_DEBUG" = "true" ]; then pip install --no-cache-dir debugpy; fi
+
+EXPOSE 3004
+
+CMD ["/app/venv/bin/uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3004"]
 ```
 
 ## Entitlements
 
-To access the microphone and speaker, the application needs the `audio` entitlement in `wendy.json`. This grants the container access to `/dev/snd`.
+To access the microphone and speaker, the application needs the `audio` entitlement in `wendy.json`. This grants the container access to `/dev/snd`. The generated file:
 
 ```json
 {
-  "appId": "com.example.python-audio",
-  "version": "0.0.1",
-  "entitlements": [
-    {
-      "type": "network",
-      "mode": "host"
+    "appId": "audio",
+    "version": "0.1.0",
+    "entitlements": [
+        {
+            "type": "network",
+            "mode": "host"
+        },
+        {
+            "type": "audio"
+        }
+    ],
+    "readiness": {
+        "tcpSocket": { "port": 3004 },
+        "timeoutSeconds": 30
     },
-    {
-      "type": "audio"
+    "hooks": {
+        "postStart": {
+            "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3004"
+        }
     }
-  ],
-  "readiness": {
-    "tcpSocket": { "port": 3005 },
-    "timeoutSeconds": 30
-  },
-  "hooks": {
-    "postStart": {
-      "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3005"
-    }
-  }
 }
 ```
 
-The `readiness` probe waits for port `3005` to accept connections. The `postStart` hook automatically opens the web interface in your browser.
+The `readiness` probe waits for port `3004` to accept connections. The `postStart` hook automatically opens the web interface in your browser.
 ## Run Again on WendyOS
 
 1.  Connect your WendyOS device.
@@ -257,14 +283,14 @@ The `readiness` probe waits for port `3005` to accept connections. The `postStar
 wendy run
 ```
 
-3.  Your browser will open automatically once the app is ready. If it doesn't, navigate to `http://<device-hostname>.local:3005`.
+3.  Your browser will open automatically once the app is ready. If it doesn't, navigate to `http://<device-hostname>.local:3004`.
 
 ## Troubleshooting
 
-1.  **"aplay: command not found"**: Ensure `alsa-utils` is installed in your Dockerfile.
+1.  **No devices listed**: The backend enumerates devices with `arecord -l` / `aplay -l` (provided by `alsa-utils`). If the dropdowns are empty, confirm a USB audio device is connected and check `GET /debug` to see what the app detected.
 2.  **No Audio**:
     - Check volume levels on the device (`alsamixer` via SSH).
-    - Ensure the correct audio device is selected. The sample code attempts to auto-detect USB devices, but falls back to `default`. You can modify the `aplay` command to specify a device (e.g., `-D plughw:1,0`).
+    - Pick a specific output from the speaker dropdown — the app uses `alsasink device="hw:<card>,<dev>"` for the selected device and falls back to `autoaudiosink` otherwise.
 3.  **Permissions**: If you see "Permission denied" errors accessing `/dev/snd`, ensure the `audio` entitlement is present in `wendy.json`.
 
 ## Learn More

--- a/go/internal/cli/assets/docs/guides/python/bluetooth-discovery.mdx
+++ b/go/internal/cli/assets/docs/guides/python/bluetooth-discovery.mdx
@@ -354,9 +354,8 @@ Bluetooth Low Energy (BLE) is essential for IoT applications, from connecting se
 
     ```json
     {
-        "appId": "sh.wendy.examples.bluetooth-discovery",
-        "version": "1.0.0",
-        "language": "python",
+        "appId": "bluetooth-discovery",
+        "version": "0.1.0",
         "entitlements": [
             {
                 "type": "network",

--- a/go/internal/cli/assets/docs/guides/python/hello-world.mdx
+++ b/go/internal/cli/assets/docs/guides/python/hello-world.mdx
@@ -6,7 +6,9 @@ language: python
 
 ## Creating Your First Python Application
 
-This guide will walk you through creating a simple "Hello, World!" application for WendyOS using Python. This is a great way to prove that you can send your first app to your device and verify your development environment is set up correctly.
+This guide walks you through creating your first WendyOS application in Python. It proves you can send an app to your device and that your development environment is set up correctly.
+
+The Python `simple-api` template generates a small FastAPI HTTP server. Unlike a one-shot script that prints and exits, this app **keeps running** and serves requests, so you can open it in your browser right after deploying.
 
 ### Prerequisites
 
@@ -27,7 +29,7 @@ This guide will walk you through creating a simple "Hello, World!" application f
     cd hello-world
     ```
 
-    This creates `wendy.json`, a Dockerfile, and a ready-to-run Python app from the template. The next steps explain the generated files.
+    This creates `wendy.json`, a `Dockerfile`, and a ready-to-run `app.py` from the template. The next steps explain the generated files.
   </Step>
 
   <Step>
@@ -37,7 +39,7 @@ This guide will walk you through creating a simple "Hello, World!" application f
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and show the run output.
+    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and show the run output. Because the generated `wendy.json` includes a `postStart` browser hook, your browser opens to the app automatically once it is ready.
   </Step>
 </Steps>
 
@@ -47,50 +49,113 @@ This guide will walk you through creating a simple "Hello, World!" application f
   <Step>
     ### Generated Application
 
-    The template includes an `app.py` entry point. For a minimal hello-world app, it can be as small as:
+    The template generates an `app.py` that defines a FastAPI server with a few routes:
 
     ```python
-    #!/usr/bin/env python3
+    import os
+    from fastapi import FastAPI
+    from pydantic import BaseModel
 
-    if __name__ == '__main__':
-        print("Hello World")
+    app = FastAPI()
+
+    hostname = (
+        os.environ.get("WENDY_DEVICE_HOSTNAME")
+        or os.environ.get("WENDY_HOSTNAME")
+        or "localhost"
+    )
+
+
+    class Item(BaseModel):
+        name: str
+        price: float
+
+
+    @app.on_event("startup")
+    async def startup_event():
+        print(f"Server running on {hostname}:3001", flush=True)
+
+
+    @app.get("/")
+    async def root():
+        print("Received request: GET /", flush=True)
+        return {"message": "hello-world"}
+
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+
+    @app.post("/items", status_code=201)
+    async def create_item(item: Item):
+        print(f"Received request: POST /items - {item.name}", flush=True)
+        return {"id": 1, "name": item.name, "price": item.price}
     ```
 
-    This is the entry point for your WendyOS application. The `if __name__ == '__main__'` guard ensures it only runs when executed directly.
-  </Step>
+    There is no `if __name__ == '__main__'` block — the app is started by `uvicorn` (see the Dockerfile). The `GET /` route is what you hit first; it returns `{"message": "hello-world"}`.
 
-  <Step>
-    ### Generated requirements.txt
-
-    The generated project includes a dependency file. A minimal hello-world app does not need extra packages:
-
-    ```txt
-    # No dependencies required
-    ```
+    <Callout type="info">
+      **Want the classic one-liner?** A bare hello-world like `print("Hello World")` would print once and exit. The template instead gives you a long-running server so you can interact with your device over HTTP — a more useful starting point for real apps.
+    </Callout>
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The template includes a Dockerfile similar to this:
+    The template includes a Dockerfile that installs FastAPI/Uvicorn with `uv` and runs the server with `uvicorn`:
 
     ```dockerfile
-    # Use uv with Python 3.14 (slim variant for better compatibility with Debian-based systems like NVIDIA Jetson Orin Nano)
     FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
 
-    # Set working directory
     WORKDIR /app
 
-    # Copy application code
+    ENV PYTHONUNBUFFERED=1
+
+    ARG WENDY_DEVICE_HOSTNAME=localhost
+    ENV WENDY_DEVICE_HOSTNAME=${WENDY_DEVICE_HOSTNAME}
+
+    ARG WENDY_DEVICE_TYPE
+    ARG WENDY_DEBUG=false
+    ENV WENDY_DEVICE_TYPE=${WENDY_DEVICE_TYPE}
+    ENV WENDY_DEBUG=${WENDY_DEBUG}
+
+    RUN uv pip install --system fastapi==0.135.3 "uvicorn[standard]"
+    RUN if [ "$WENDY_DEBUG" = "true" ]; then uv pip install --system debugpy; fi
+
     COPY app.py .
 
-    # Create a non-root user for security
-    RUN useradd --create-home --shell /bin/bash app && \
-        chown -R app:app /app
-    USER app
+    EXPOSE 3001
 
-    # Run the application
-    CMD ["python", "app.py"]
+    CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3001"]
+    ```
+
+    Dependencies are installed directly in the Dockerfile, so there is no `requirements.txt` in this template.
+  </Step>
+
+  <Step>
+    ### Generated wendy.json
+
+    The template also generates a `wendy.json` with the `network` entitlement, a readiness probe, and a `postStart` hook that opens your browser when the server is ready:
+
+    ```json
+    {
+        "appId": "hello-world",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 3001 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3001"
+            }
+        }
+    }
     ```
   </Step>
 </Steps>
@@ -103,11 +168,11 @@ Deploy your application to a connected WendyOS device:
 wendy run
 ```
 
-This will build your application into a container and deploy it to your device.
+This builds your application into a container, deploys it to your device, and starts the server.
 
 ## Verifying Deployment on Your Device
 
-After deploying your application to a WendyOS device, you can verify it was successfully deployed and ran by listing the applications on your device:
+After deploying, verify the app is running by listing the applications on your device:
 
 ```bash
 wendy device apps list
@@ -116,12 +181,12 @@ wendy device apps list
 ╭───────────────┬─────────┬─────────┬──────────╮
 │ App           │ Version │ State   │ Failures │
 ├───────────────┼─────────┼─────────┼──────────┤
-│ hello-world   │ 0.0.1   │ Stopped │ 0        │
+│ hello-world   │ 0.1.0   │ Running │ 0        │
 ╰───────────────┴─────────┴─────────┴──────────╯
 ```
 
 <Callout type="info">
-  **Expected State**: The app shows as "Stopped" because a hello-world application exits immediately after printing its message. This is expected behavior. The key indicator of success is the "Failures" column showing `0`, which confirms your application ran and exited successfully without any errors.
+  **Expected State**: The app shows as "Running" because it is a long-running HTTP server. The "Failures" column showing `0` confirms it started successfully. Reaching `/` in your browser returns `{"message":"hello-world"}`.
 </Callout>
 
 ## Next Steps
@@ -138,16 +203,33 @@ Now that you have a basic Python application running:
 
     ### Using Python Directly
 
-    Run your application locally:
+    The app has no `__main__` block, so run it with `uvicorn`. Install the dependencies first:
 
     ```bash
-    python app.py
+    pip install fastapi "uvicorn[standard]"
+    uvicorn app:app --host 0.0.0.0 --port 3001
     ```
 
-    You should see output:
+    You should see output indicating the server has started:
 
     ```
-    Hello World
+    INFO:     Started server process [12345]
+    INFO:     Waiting for application startup.
+    Server running on localhost:3001
+    INFO:     Application startup complete.
+    INFO:     Uvicorn running on http://0.0.0.0:3001 (Press CTRL+C to quit)
+    ```
+
+    In another terminal, hit the root route:
+
+    ```bash
+    curl http://localhost:3001
+    ```
+
+    You should see:
+
+    ```json
+    {"message":"hello-world"}
     ```
 
     ### Using Docker Locally
@@ -156,13 +238,9 @@ Now that you have a basic Python application running:
 
     ```bash
     docker build -t hello-world .
-    docker run hello-world
+    docker run -p 3001:3001 hello-world
     ```
 
-    You should see:
-
-    ```
-    Hello World
-    ```
+    Then visit `http://localhost:3001` in your browser or use `curl` as above.
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/python/simple-web-server.mdx
+++ b/go/internal/cli/assets/docs/guides/python/simple-web-server.mdx
@@ -51,74 +51,87 @@ To prove this out, we'll use FastAPI, a modern, fast (high-performance) web fram
 
 <Steps>
   <Step>
-    ### Generated requirements.txt
-
-    Review the generated `requirements.txt` file with FastAPI and Uvicorn:
-
-    ```txt
-    fastapi
-    uvicorn[standard]
-    ```
-  </Step>
-
-  <Step>
     ### Generated Web Server
 
-    The generated `app.py` contains the server logic:
+    The generated `app.py` contains the server logic — a FastAPI app with a few routes:
 
     ```python
-    #!/usr/bin/env python3
+    import os
     from fastapi import FastAPI
     from pydantic import BaseModel
 
     app = FastAPI()
 
-    class Car(BaseModel):
-        make: str
-        year: int
+    hostname = (
+        os.environ.get("WENDY_DEVICE_HOSTNAME")
+        or os.environ.get("WENDY_HOSTNAME")
+        or "localhost"
+    )
+
+
+    class Item(BaseModel):
+        name: str
+        price: float
+
+
+    @app.on_event("startup")
+    async def startup_event():
+        print(f"Server running on {hostname}:8000", flush=True)
+
 
     @app.get("/")
     async def root():
-        return "hello-world"
+        print("Received request: GET /", flush=True)
+        return {"message": "hello-world"}
 
-    @app.get("/json")
-    async def get_car():
-        return Car(make="Tesla", year=2024)
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+
+    @app.post("/items", status_code=201)
+    async def create_item(item: Item):
+        print(f"Received request: POST /items - {item.name}", flush=True)
+        return {"id": 1, "name": item.name, "price": item.price}
     ```
 
     <Callout type="info">
-      **Multiple Routes**: This example includes two routes:
-      - `GET /` - Returns a simple string "hello-world"
-      - `GET /json` - Returns a JSON object with a Pydantic model
+      **Multiple Routes**: This example includes three routes:
+      - `GET /` - Returns a JSON object `{"message": "hello-world"}`
+      - `GET /health` - A health check returning `{"status": "ok"}`
+      - `POST /items` - Accepts a JSON body validated by a Pydantic model and echoes it back
     </Callout>
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile:
+    The generated project includes a Dockerfile that installs FastAPI/Uvicorn with `uv` and starts the server with `uvicorn`. Dependencies are installed in the Dockerfile, so there is no `requirements.txt`:
 
     ```dockerfile
-    # Use uv with Python 3.14 (slim variant for better compatibility)
     FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
 
-    # Set working directory
     WORKDIR /app
 
-    # Copy application files
-    COPY requirements.txt .
+    ENV PYTHONUNBUFFERED=1
+
+    ARG WENDY_DEVICE_HOSTNAME=localhost
+    ENV WENDY_DEVICE_HOSTNAME=${WENDY_DEVICE_HOSTNAME}
+
+    ARG WENDY_DEVICE_TYPE
+    ARG WENDY_DEBUG=false
+    ENV WENDY_DEVICE_TYPE=${WENDY_DEVICE_TYPE}
+    ENV WENDY_DEBUG=${WENDY_DEBUG}
+
+    RUN uv pip install --system fastapi==0.135.3 "uvicorn[standard]"
+    RUN if [ "$WENDY_DEBUG" = "true" ]; then uv pip install --system debugpy; fi
+
     COPY app.py .
 
-    # Create a non-root user for security
-    RUN useradd --create-home --shell /bin/bash app && \
-        chown -R app:app /app
-    USER app
-
-    # Expose port 8000
     EXPOSE 8000
 
-    # Run the application with uvicorn, ensuring dependencies are available
-    CMD ["uv", "run", "--with", "fastapi", "--with", "uvicorn[standard]", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+    CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
     ```
 
     <Callout type="warning">
@@ -171,19 +184,26 @@ INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
 
 After deploying your server to your WendyOS device, you can test it from your development machine. As long as your WendyOS device is accessible over USB or the Local Area Network, you can reach it from your browser.
 
-You can configure `wendy.json` with a readiness probe and postStart hook to automatically open your browser when the server is ready:
+The generated `wendy.json` already includes the `network` entitlement, a readiness probe, and a `postStart` hook that opens your browser automatically once the server is ready:
 
 ```json
 {
-  "readiness": {
-    "tcpSocket": { "port": 8000 },
-    "timeoutSeconds": 30
-  },
-  "hooks": {
-    "postStart": {
-      "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:8000"
+    "appId": "simple-server",
+    "version": "0.1.0",
+    "entitlements": [
+        {
+            "type": "network"
+        }
+    ],
+    "readiness": {
+        "tcpSocket": { "port": 8000 },
+        "timeoutSeconds": 30
+    },
+    "hooks": {
+        "postStart": {
+            "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:8000"
+        }
     }
-  }
 }
 ```
 Or open your browser manually and navigate to:
@@ -198,8 +218,8 @@ http://wendyos-true-probe.local:8000
 
 You should see the following output:
 
-```
-"hello-world"
+```json
+{"message":"hello-world"}
 ```
 
 This confirms your web server is successfully running on your WendyOS device and accepting requests from your network.
@@ -215,7 +235,7 @@ wendy device apps list
 ╭───────────────┬─────────┬─────────┬──────────╮
 │ App           │ Version │ State   │ Failures │
 ├───────────────┼─────────┼─────────┼──────────┤
-│ simple-server │ 0.0.0   │ Stopped │ 0        │
+│ simple-server │ 0.1.0   │ Running │ 0        │
 ╰───────────────┴─────────┴─────────┴──────────╯
 ```
 
@@ -249,10 +269,10 @@ Now that you have a basic web server running:
 
     ### Using Python Directly
 
-    Install dependencies and run your server locally:
+    There is no `requirements.txt`, so install the dependencies directly, then run the server with `uvicorn`:
 
     ```bash
-    pip install -r requirements.txt
+    pip install fastapi "uvicorn[standard]"
     uvicorn app:app --host 0.0.0.0 --port 8000
     ```
 
@@ -261,6 +281,7 @@ Now that you have a basic web server running:
     ```
     INFO:     Started server process [12345]
     INFO:     Waiting for application startup.
+    Server running on localhost:8000
     INFO:     Application startup complete.
     INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
     ```
@@ -284,20 +305,34 @@ Now that you have a basic web server running:
 
     You should see:
 
-    ```
-    "hello-world"
+    ```json
+    {"message":"hello-world"}
     ```
 
-    Test the JSON endpoint:
+    Test the health endpoint:
 
     ```bash
-    curl http://localhost:8000/json
+    curl http://localhost:8000/health
     ```
 
     You should see:
 
     ```json
-    {"make":"Tesla","year":2024}
+    {"status":"ok"}
+    ```
+
+    Test the POST endpoint with a JSON body:
+
+    ```bash
+    curl -X POST http://localhost:8000/items \
+      -H "Content-Type: application/json" \
+      -d '{"name": "Widget", "price": 9.99}'
+    ```
+
+    You should see:
+
+    ```json
+    {"id":1,"name":"Widget","price":9.99}
     ```
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/python/web-app.mdx
+++ b/go/internal/cli/assets/docs/guides/python/web-app.mdx
@@ -1,10 +1,10 @@
 ---
 title: Full-Stack Web App
-description: Build a full-stack web application with a Vite/React frontend and FastAPI backend on WendyOS
+description: Build a full-stack device dashboard with a React/Vite frontend and FastAPI backend on WendyOS
 language: python
 ---
 
-## Building a Full-Stack Web App
+## Building a Full-Stack Device Dashboard
 
 <Callout type="info">
   **Source Code**: The complete source code for this example is available at [github.com/wendylabsinc/samples/python/web-app](https://github.com/wendylabsinc/samples/tree/main/python/web-app)
@@ -12,35 +12,43 @@ language: python
 
 <img src="/images/web-app-example.gif" alt="Web App Demo" style={{ width: '100%', borderRadius: '8px' }} />
 
-In this guide, we'll build a complete web application with a modern React frontend (using Vite, TypeScript, and shadcn/ui) and a FastAPI backend. The app displays an animated shader background with "WendyOS" text and includes an interactive feature to fetch and display random car data from an API.
+In this guide, we'll build a complete **device dashboard**: a modern React frontend (Vite, TypeScript, Tailwind v4, shadcn/ui) backed by a FastAPI server that exposes your device's camera, audio, GPU, system info, and a persistent SQLite-backed data store. The frontend is built into static files and served directly by the backend, so the whole stack ships as a single container.
+
+The template generates the entire frontend and backend for you — you don't scaffold the UI by hand. This guide explains how the generated pieces fit together.
 
 This demonstrates how to:
-- Serve a production-built React frontend from a Python backend
-- Create API endpoints that the frontend can consume
+- Serve a production-built React SPA from a Python backend (with client-side routing)
+- Expose device capabilities (camera, audio, GPU, system) over an `/api` surface
+- Persist data to a volume that survives restarts (a cars CRUD on SQLite)
 - Deploy the entire stack as a single container to your WendyOS device
 
 ### Prerequisites
 
 - Wendy CLI installed on your development machine
-- Node.js 22+ and npm installed (for building the frontend)
-- Python 3.14 installed
 - A WendyOS device plugged in over USB or connectable over Wi-Fi
+- (Optional, for local frontend dev) Node.js 22+ and npm
 
 ## Project Structure
+
+The template generates a top-level layout like this (the frontend's shadcn/ui components are omitted for brevity):
 
 ```
 web-app/
 ├── Dockerfile
 ├── wendy.json
-├── frontend/           # Vite + React + TypeScript + shadcn/ui
-│   ├── package.json
-│   ├── src/
-│   │   ├── App.tsx
-│   │   └── components/
-│   └── ...
-└── server/             # FastAPI backend
-    ├── app.py
-    └── requirements.txt
+├── requirements.txt
+├── app/                 # FastAPI backend
+│   ├── __init__.py      # builds the FastAPI app, mounts routers, serves the SPA
+│   ├── lib/             # db.py (SQLite), devices.py (ALSA/V4L2), gst_sink.py (GStreamer)
+│   └── routes/          # data.py, camera.py, audio.py, gpu.py, system.py
+└── frontend/            # Vite + React 19 + Tailwind v4 + shadcn/ui
+    ├── package.json
+    ├── vite.config.ts
+    └── src/
+        ├── App.tsx      # sidebar layout + react-router routes
+        ├── main.tsx
+        ├── components/  # app-sidebar, shadcn/ui, etc.
+        └── pages/       # camera, audio, persistence, gpu, system
 ```
 
 ## Setting Up Your Project
@@ -56,7 +64,7 @@ web-app/
     cd web-app
     ```
 
-    The template creates `wendy.json`, the Dockerfile, frontend files, and Python backend files. The sections below explain how the generated full-stack app fits together.
+    This generates `wendy.json`, the Dockerfile, the full React frontend, and the FastAPI backend. The sections below explain how the generated full-stack app fits together.
   </Step>
 
   <Step>
@@ -66,7 +74,7 @@ web-app/
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and print the URL or run output.
+    Wendy will build the app (frontend then backend), ask you to select a device if one is not already configured, deploy the app, and open your browser once it's ready.
   </Step>
 </Steps>
 
@@ -76,240 +84,208 @@ web-app/
   <Step>
     ### Generated Frontend
 
-    The template includes a Vite React TypeScript frontend:
-
-    ```bash
-    cd frontend
-    npm create vite@latest . -- --template react-ts
-    npm install
-    npm install -D tailwindcss @tailwindcss/vite
-    ```
-
-    Initialize shadcn/ui:
-
-    ```bash
-    npx shadcn@latest init --defaults
-    npx shadcn@latest add button table
-    ```
-  </Step>
-
-  <Step>
-    ### Generated Frontend App
-
-    The generated `src/App.tsx` drives the browser UI:
+    The frontend is a Vite + React 19 + Tailwind v4 app using shadcn/ui. It's a sidebar dashboard wired up with `react-router-dom` v7. The default route redirects to `/camera`:
 
     ```tsx
-    import { useState } from "react";
-    import { Button } from "@/components/ui/button";
-    import {
-      Table,
-      TableBody,
-      TableCell,
-      TableHead,
-      TableHeader,
-      TableRow,
-    } from "@/components/ui/table";
+    import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
+    import { AppSidebar } from "@/components/app-sidebar"
+    import { SiteHeader } from "@/components/site-header"
+    import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 
-    interface Car {
-      name: string;
-      make: string;
-      year: number;
-      color: string;
-      createdAt: string;
-    }
+    import CameraPage from "@/pages/camera"
+    import AudioPage from "@/pages/audio"
+    import PersistencePage from "@/pages/persistence"
+    import GpuPage from "@/pages/gpu"
+    import SystemPage from "@/pages/system"
 
-    function App() {
-      const [cars, setCars] = useState<Car[]>([]);
-      const [loading, setLoading] = useState(false);
-
-      const fetchCar = async () => {
-        setLoading(true);
-        try {
-          const response = await fetch("/api/random-car");
-          const car: Car = await response.json();
-          setCars((prev) => [car, ...prev].slice(0, 10));
-        } catch (error) {
-          console.error("Failed to fetch car:", error);
-        } finally {
-          setLoading(false);
-        }
-      };
-
+    export default function App() {
       return (
-        <div className="flex min-h-screen w-full flex-col items-center bg-blue-700 p-8">
-          <h1 className="text-7xl font-semibold text-white mb-8">WendyOS</h1>
-
-          <Button
-            onClick={fetchCar}
-            disabled={loading}
-            size="lg"
-            variant="secondary"
-          >
-            {loading ? "Fetching..." : "Fetch Car"}
-          </Button>
-
-          {cars.length > 0 && (
-            <div className="mt-8 w-full max-w-4xl rounded-lg bg-white/10 p-4">
-              <Table>
-                <TableHeader>
-                  <TableRow className="border-white/20">
-                    <TableHead className="text-white">Name</TableHead>
-                    <TableHead className="text-white">Make</TableHead>
-                    <TableHead className="text-white">Year</TableHead>
-                    <TableHead className="text-white">Color</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {cars.map((car, index) => (
-                    <TableRow key={index} className="border-white/20">
-                      <TableCell className="text-white">{car.name}</TableCell>
-                      <TableCell className="text-white">{car.make}</TableCell>
-                      <TableCell className="text-white">{car.year}</TableCell>
-                      <TableCell className="text-white">
-                        <div className="flex items-center gap-2">
-                          <div
-                            className="w-4 h-4 rounded"
-                            style={{ backgroundColor: car.color }}
-                          />
-                          {car.color}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </div>
-      );
+        <BrowserRouter>
+          <SidebarProvider>
+            <AppSidebar variant="inset" />
+            <SidebarInset>
+              <SiteHeader />
+              <Routes>
+                <Route path="/" element={<Navigate to="/camera" replace />} />
+                <Route path="/camera" element={<CameraPage />} />
+                <Route path="/audio" element={<AudioPage />} />
+                <Route path="/persistence" element={<PersistencePage />} />
+                <Route path="/gpu" element={<GpuPage />} />
+                <Route path="/system" element={<SystemPage />} />
+              </Routes>
+            </SidebarInset>
+          </SidebarProvider>
+        </BrowserRouter>
+      )
     }
-
-    export default App;
     ```
 
-    Build the frontend:
+    Each page calls the matching backend route — for example the **Persistence** page does a full cars CRUD against `/api/cars`:
 
-    ```bash
-    npm run build
-    cd ..
+    ```tsx
+    // create
+    await fetch("/api/cars", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ make, model, color, year }),
+    })
+
+    // read
+    const cars = await (await fetch("/api/cars")).json()
+
+    // update / delete
+    await fetch(`/api/cars/${id}`, { method: "PUT", /* ... */ })
+    await fetch(`/api/cars/${id}`, { method: "DELETE" })
     ```
+
+    The **camera** and **audio** pages connect to WebSockets (`/api/camera/stream`, `/api/audio/stream`); the **gpu** and **system** pages poll `/api/gpu` and `/api/system`.
+
+    <Callout type="info">
+      **No manual scaffolding**: The template ships the entire frontend (Vite config, Tailwind, shadcn/ui components, pages). You do not run `npm create vite` or `npx shadcn add` yourself — it's already there. The Dockerfile builds it for you.
+    </Callout>
   </Step>
 
   <Step>
     ### Generated FastAPI Backend
 
-    The generated `server/requirements.txt` lists:
+    The backend lives under `app/`. The `requirements.txt` is minimal — GStreamer comes from system packages installed in the Dockerfile:
 
     ```txt
-    fastapi
+    fastapi==0.135.3
     uvicorn[standard]
     ```
 
-    The generated `server/app.py` handles the API:
+    `app/__init__.py` builds the FastAPI app (exposed as `api`), initializes GStreamer, mounts each router under `/api`, and serves the built SPA from `./static`, falling back to `index.html` for client-side routes:
 
     ```python
-    import os
-    import random
-    from datetime import datetime, timezone
+    import threading
     from pathlib import Path
+
+    import gi
+    gi.require_version("Gst", "1.0")
+    gi.require_version("GstApp", "1.0")
+    from gi.repository import Gst, GLib
     from fastapi import FastAPI
-    from fastapi.staticfiles import StaticFiles
-    from fastapi.responses import FileResponse, JSONResponse
+    from fastapi.responses import FileResponse
 
-    app = FastAPI()
+    from app.routes import data, camera, audio, gpu, system
 
-    CAR_NAMES = ["Honda", "Toyota", "Ford", "Chevrolet", "BMW", "Mercedes", "Audi", "Tesla", "Nissan", "Mazda"]
-    CAR_MAKES = ["Civic", "Camry", "Mustang", "Corvette", "M3", "C-Class", "A4", "Model 3", "Altima", "MX-5"]
+    Gst.init(None)
+    _glib_loop = GLib.MainLoop()
+    threading.Thread(target=_glib_loop.run, daemon=True).start()
 
-    def random_car():
-        return {
-            "name": random.choice(CAR_NAMES),
-            "make": random.choice(CAR_MAKES),
-            "year": random.randint(1990, 2024),
-            "color": f"#{random.randint(0, 0xFFFFFF):06X}",
-            "createdAt": datetime.now(timezone.utc).isoformat(),
-        }
+    api = FastAPI()
 
-    # Determine frontend dist path
-    container_path = Path("/app/frontend/dist")
-    local_path = Path(__file__).parent.parent / "frontend" / "dist"
+    api.include_router(data.router, prefix="/api")
+    api.include_router(camera.router, prefix="/api")
+    api.include_router(audio.router, prefix="/api")
+    api.include_router(gpu.router, prefix="/api")
+    api.include_router(system.router, prefix="/api")
 
-    if os.environ.get("FRONTEND_DIST"):
-        frontend_dist = os.environ["FRONTEND_DIST"]
-    elif container_path.exists():
-        frontend_dist = str(container_path)
-    else:
-        frontend_dist = str(local_path)
+    _static_dir = Path(__file__).resolve().parent.parent / "static"
 
-    hostname = os.environ.get("WENDY_HOSTNAME", "0.0.0.0")
-
-    print(f"Serving frontend from: {frontend_dist}")
-
-    # API routes
-    @app.get("/api/random-car")
-    async def get_random_car():
-        return JSONResponse(random_car())
-
-    # Mount static files for assets
-    assets_path = Path(frontend_dist) / "assets"
-    if assets_path.exists():
-        app.mount("/assets", StaticFiles(directory=str(assets_path)), name="assets")
-
-    @app.get("/{full_path:path}")
+    @api.get("/{full_path:path}")
     async def serve_spa(full_path: str):
-        """Serve the SPA - return index.html for all routes"""
-        file_path = Path(frontend_dist) / full_path
+        """Serve static files, fall back to index.html for SPA routing."""
+        file_path = _static_dir / full_path
         if file_path.is_file():
             return FileResponse(file_path)
-        return FileResponse(f"{frontend_dist}/index.html")
+        return FileResponse(_static_dir / "index.html")
+    ```
 
-    if __name__ == "__main__":
-        import uvicorn
-        print(f"Server running on http://{hostname}:3002")
-        # Bind to 0.0.0.0 to accept connections from all interfaces (required for container networking)
-        uvicorn.run(app, host="0.0.0.0", port=3002)
+    The routers expose:
+
+    - **`data.py`** — a cars CRUD (`GET/POST /api/cars`, `GET/PUT/DELETE /api/cars/{id}`) backed by SQLite at `/data/cars.db`
+    - **`system.py`** — `GET /api/system` returning hostname, platform, architecture, uptime, memory, disk, and CPU info from `/proc` and `shutil`
+    - **`gpu.py`** — `GET /api/gpu`, querying `nvidia-smi` (with a thermal-zone fallback for ARM GPUs)
+    - **`camera.py`** — `GET /api/cameras` plus a `/api/camera/stream` WebSocket (MJPEG over GStreamer)
+    - **`audio.py`** — `GET /api/microphones`, `GET /api/speakers`, plus an `/api/audio/stream` WebSocket (PCM over GStreamer)
+
+    The cars CRUD persists to a SQLite database that's created on demand:
+
+    ```python
+    DB_PATH = Path("/data/cars.db")
+
+    def get_db() -> sqlite3.Connection:
+        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(DB_PATH))
+        conn.row_factory = sqlite3.Row
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS cars (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                make TEXT NOT NULL,
+                model TEXT NOT NULL,
+                color TEXT NOT NULL,
+                year INTEGER NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT
+            )
+        """)
+        conn.commit()
+        return conn
     ```
 
     <Callout type="info">
-      **API Endpoint**: The `/api/random-car` endpoint returns a randomly generated car object with name, make, year, color, and timestamp. The frontend fetches this data and displays the last 10 cars in a table.
+      **Persistence**: `/data` is backed by the `persist` entitlement in `wendy.json`, so cars you add survive app restarts and redeploys.
     </Callout>
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile:
+    The Dockerfile is multi-stage: it builds the React frontend with Node, then assembles a Debian-based Python runtime with GStreamer (camera/audio), ALSA, and V4L tools. The built frontend is copied into the image as `./static`, and the app is served by `uvicorn app:api`:
 
     ```dockerfile
-    # Build frontend
-    FROM node:22-slim AS frontend-builder
-
-    WORKDIR /app/frontend
+    # Stage 1 — Build React frontend
+    FROM node:22-slim AS frontend
+    WORKDIR /frontend
     COPY frontend/package*.json ./
-    RUN npm ci
+    RUN npm install
     COPY frontend/ ./
     RUN npm run build
 
-    # Runtime stage
-    FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
-
+    # Stage 2 — FastAPI backend with GStreamer for camera/audio
+    FROM debian:bookworm-slim
     WORKDIR /app
+    ENV PYTHONUNBUFFERED=1
 
-    # Install dependencies during build
-    RUN uv pip install --system fastapi "uvicorn[standard]"
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-venv \
+        python3-gi \
+        gir1.2-gst-plugins-base-1.0 \
+        gir1.2-gst-plugins-bad-1.0 \
+        gir1.2-gstreamer-1.0 \
+        gstreamer1.0-tools \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-ugly \
+        gstreamer1.0-libav \
+        gstreamer1.0-alsa \
+        alsa-utils \
+        v4l-utils \
+        && rm -rf /var/lib/apt/lists/*
 
-    # Copy server files
-    COPY server/requirements.txt ./
-    COPY server/app.py ./
+    RUN python3 -m venv --system-site-packages /app/venv
+    ENV PATH="/app/venv/bin:$PATH"
 
-    # Copy the built frontend
-    COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+    COPY requirements.txt .
+    RUN pip install --no-cache-dir -r requirements.txt
 
-    ENV FRONTEND_DIST=/app/frontend/dist
+    COPY app/ ./app/
+    COPY --from=frontend /frontend/dist ./static
 
-    EXPOSE 3002
+    ARG WENDY_DEVICE_TYPE
+    ARG WENDY_DEBUG=false
+    ENV WENDY_DEVICE_TYPE=${WENDY_DEVICE_TYPE}
+    ENV WENDY_DEBUG=${WENDY_DEBUG}
+    RUN if [ "$WENDY_DEBUG" = "true" ]; then pip install --no-cache-dir debugpy; fi
 
-    CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3002"]
+    EXPOSE 8000
+
+    CMD ["/app/venv/bin/uvicorn", "app:api", "--host", "0.0.0.0", "--port", "8000"]
     ```
 
     <Callout type="warning">
@@ -320,28 +296,49 @@ web-app/
   <Step>
     ### Generated wendy.json
 
-    Review the generated `wendy.json` file:
+    The generated `wendy.json` requests the entitlements the dashboard needs — host networking, camera, audio, GPU, and a persistent volume mounted at `/data`:
 
     ```json
     {
-      "appId": "com.example.python-web-app",
-      "version": "0.0.1",
-      "entitlements": [
-        { "type": "network" }
-      ],
-      "readiness": {
-        "tcpSocket": { "port": 3002 },
-        "timeoutSeconds": 30
-      },
-      "hooks": {
-        "postStart": {
-          "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3002"
+        "appId": "web-app",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network",
+                "mode": "host"
+            },
+            {
+                "type": "camera"
+            },
+            {
+                "type": "audio"
+            },
+            {
+                "type": "gpu"
+            },
+            {
+                "type": "persist",
+                "name": "web-app-data",
+                "path": "/data"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 8000 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:8000"
+            }
         }
-      }
     }
     ```
 
-    The `readiness` probe tells the CLI to wait until port `3002` is accepting connections before proceeding. The `postStart` hook automatically opens your browser once the app is ready.
+    - **network (host mode)**: binds directly to the device's network so the dashboard is reachable
+    - **camera / audio / gpu**: grant access to webcams, microphones/speakers, and the GPU for the corresponding dashboard pages
+    - **persist**: mounts a named volume (`web-app-data`) at `/data`, where the cars SQLite database lives
+    - **readiness**: waits until port `8000` accepts connections before the `postStart` hook runs
+    - **postStart**: automatically opens your browser once the app is ready
     </Step>
 </Steps>
 
@@ -363,8 +360,7 @@ wendy run
 ✔︎ Container built and uploaded successfully!
 ✔ Success
   Started app
-Server running on http://wendyos-true-probe.local:3002
-Serving frontend from: /app/frontend/dist
+INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
 ```
 
 ## Test Your Web App
@@ -372,30 +368,35 @@ Serving frontend from: /app/frontend/dist
 Your browser will open automatically once the app is ready, thanks to the `postStart` hook. If it doesn't, navigate to:
 
 ```
-http://wendyos-true-probe.local:3002
+http://wendyos-true-probe.local:8000
 ```
 
 <Callout type="warning">
   **Replace the hostname**: Each WendyOS device has a unique hostname. Replace `wendyos-true-probe` with your device's actual hostname shown in the CLI output.
 </Callout>
 
-You should see:
-- The "WendyOS" heading
-- A "Fetch Car" button
-- When you click the button, a table appears showing randomly generated car data
-- Each click adds a new car to the top of the table (keeping the last 10)
+You should see the dashboard with a sidebar. The default page is **Camera**; the sidebar also links to **Audio**, **Persistence**, **GPU**, and **System**. On the Persistence page you can add, edit, and delete cars — and they'll still be there after you redeploy, thanks to the persistent volume.
 
 ## Test the API Directly
 
-You can also test the API endpoint directly:
+You can also hit the API endpoints directly. For example, fetch system info:
 
 ```bash
-curl http://wendyos-true-probe.local:3002/api/random-car
+curl http://wendyos-true-probe.local:8000/api/system
 ```
 
-Response:
-```json
-{"name":"Toyota","make":"Camry","year":2015,"color":"#A4F2C1","createdAt":"2024-01-15T10:30:00.000Z"}
+Or list the persisted cars:
+
+```bash
+curl http://wendyos-true-probe.local:8000/api/cars
+```
+
+Add a car:
+
+```bash
+curl -X POST http://wendyos-true-probe.local:8000/api/cars \
+  -H "Content-Type: application/json" \
+  -d '{"make": "Tesla", "model": "Model 3", "color": "#cc0000", "year": 2024}'
 ```
 
 ## Learn More
@@ -403,16 +404,16 @@ Response:
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 - [Vite Documentation](https://vitejs.dev/)
 - [shadcn/ui Components](https://ui.shadcn.com/)
+- [React Router](https://reactrouter.com/)
 
 ## Next Steps
 
-Now that you have a full-stack web app running:
+Now that you have a full-stack device dashboard running:
 
-- Add more API endpoints for CRUD operations
-- Implement real-time updates with WebSockets
-- Connect to WendyOS device sensors and display data in the UI
+- Add a new page and matching `/api` router for another device capability
+- Extend the SQLite schema and CRUD for your own data model
+- Stream additional sensor data to the UI over WebSockets
 - Add authentication to protect your API
-- Use a database for persistent storage
 
 <Accordions>
   <Accordion title="Testing locally without a WendyOS device">
@@ -421,24 +422,20 @@ Now that you have a full-stack web app running:
     ### Build and Run with Docker
 
     ```bash
-    docker build -t python-web-app .
-    docker run -p 3002:3002 python-web-app
+    docker build -t web-app .
+    docker run -p 8000:8000 web-app
     ```
 
-    Then open `http://localhost:3002` in your browser.
+    Then open `http://localhost:8000` in your browser. Note that camera, audio, and GPU pages depend on hardware/devices that may not be available on your laptop; the System and Persistence pages work anywhere.
 
-    ### Run the Backend Directly
+    ### Run the Frontend in Dev Mode
 
-    For faster development iteration:
+    For faster UI iteration, run the Vite dev server (you'll still need the backend running for `/api` calls):
 
     ```bash
-    # Build the frontend first
-    cd frontend && npm run build && cd ..
-
-    # Run the backend
-    cd server
-    pip install -r requirements.txt
-    python app.py
+    cd frontend
+    npm install
+    npm run dev
     ```
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/python/webcam-streaming.mdx
+++ b/go/internal/cli/assets/docs/guides/python/webcam-streaming.mdx
@@ -18,10 +18,10 @@ The complete sample is available in the [samples repository](https://github.com/
 
 ### What You'll Build
 
-- A FastAPI backend using GStreamer for hardware-accelerated webcam capture
-- WebSocket-based binary JPEG streaming with automatic client management
-- An HTML5 frontend with canvas rendering, FPS counter, and connection status
-- A Docker container built on the NVIDIA L4T JetPack base image
+- A FastAPI backend using GStreamer to capture MJPEG frames from a USB webcam
+- WebSocket-based binary JPEG streaming with automatic client management and lazy start/stop
+- An HTML5 frontend with an `<img>` viewer, camera picker, FPS counter, and connection status
+- A Docker container built on a slim Debian base with GStreamer installed
 
 ### Prerequisites
 
@@ -62,373 +62,361 @@ The complete sample is available in the [samples repository](https://github.com/
 
 ### Understanding the Architecture
 
-This sample uses the **NVIDIA L4T JetPack base image** (`nvcr.io/nvidia/l4t-jetpack:r36.4.0`) which provides:
-
-- GStreamer with NVIDIA hardware encoder plugins (`nvjpegenc`, `nvvidconv`)
-- V4L2 (Video4Linux) support for USB webcams
-- CUDA libraries for GPU-accelerated processing
+This sample uses a **slim Debian base image** (`debian:bookworm-slim`) with GStreamer and its Python bindings installed. Most USB webcams output **MJPEG natively**, so the app streams those JPEG frames straight through to the browser without re-encoding.
 
 The streaming pipeline works as follows:
 
-1. **GStreamer** captures frames from the webcam via V4L2
-2. Frames are encoded to JPEG using hardware acceleration (with a software fallback)
+1. **GStreamer** captures frames from the webcam via V4L2 (`v4l2src`)
+2. The app tries several pipelines in order, preferring native MJPEG passthrough and falling back to `jpegenc` software encoding when needed
 3. **FastAPI** serves a WebSocket endpoint that broadcasts JPEG frames to all connected browsers
-4. The **HTML5 frontend** renders frames on a canvas using `createImageBitmap` for efficient decoding
+4. The **HTML5 frontend** renders each frame by setting the `src` of an `<img>` element to a base64 data URL
 
-The camera pipeline starts lazily when the first client connects and stops when the last client disconnects, saving resources when nobody is watching.
+The camera pipeline starts lazily when the first client connects and stops when the last client disconnects, saving resources when nobody is watching. The app also enumerates available cameras (`GET /cameras`) so the frontend can offer a camera picker, and supports switching cameras over the WebSocket.
 
 
 <Steps>
   <Step>
     ### Understanding the Backend
 
-    The FastAPI backend (`app.py`) manages the GStreamer pipeline, WebSocket connections, and frame broadcasting:
+    The FastAPI backend (`app.py`) initializes GStreamer, runs a GLib main loop in a background thread, and serves both the UI and the WebSocket stream:
 
     ```python
     import asyncio
+    import json
     import logging
     import threading
     from pathlib import Path
 
     import gi
+
     gi.require_version("Gst", "1.0")
     gi.require_version("GstApp", "1.0")
 
-    from gi.repository import Gst, GstApp, GLib
+    from gi.repository import Gst, GLib
     from fastapi import FastAPI, WebSocket, WebSocketDisconnect
-    from fastapi.responses import FileResponse
-
-    logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger(__name__)
+    from fastapi.responses import FileResponse, JSONResponse
+    from fastapi.staticfiles import StaticFiles
 
     Gst.init(None)
 
-    app = FastAPI()
+    _glib_loop = GLib.MainLoop()
+    threading.Thread(target=_glib_loop.run, daemon=True).start()
 
-    # Video settings
-    FRAME_WIDTH = 1280
-    FRAME_HEIGHT = 720
-    FRAMERATE = 30
-    JPEG_QUALITY = 85
+    app = FastAPI()
     ```
 
     **GStreamer Pipeline**
 
-    The `GStreamerCamera` class creates a capture pipeline that tries the hardware NVJPEG encoder first and falls back to software encoding:
+    The `MJPEGCamera` class builds a capture pipeline. It prefers passing the camera's native MJPEG straight through and falls back to software JPEG encoding, trying each candidate until one reaches the `PAUSED` state:
 
     ```python
-    class GStreamerCamera:
-        """GStreamer-based camera capture with hardware encoding support."""
+    class MJPEGCamera:
+        """Captures MJPEG frames from a camera using GStreamer appsink."""
 
-        def __init__(self):
-            self.pipeline: Gst.Pipeline | None = None
-            self.appsink: GstApp.AppSink | None = None
-            self.clients: set[WebSocket] = set()
-            self.running = False
-            self._lock = threading.Lock()
-            self._loop: asyncio.AbstractEventLoop | None = None
+        def _start_pipeline(self, device_id: str | None = None) -> Gst.Pipeline | None:
+            src = build_source(device_id)  # v4l2src on Linux, avfvideosrc on macOS
+            appsink = "appsink name=sink emit-signals=true max-buffers=2 drop=true sync=false"
+            pipelines = [
+                f"{src} ! image/jpeg ! jpegdec ! jpegenc quality=85 ! {appsink}",
+                f"{src} ! image/jpeg,width=640,height=480 ! jpegdec ! jpegenc quality=85 ! {appsink}",
+                f"{src} ! videoconvert ! jpegenc quality=70 ! {appsink}",
+                f"{src} ! image/jpeg ! {appsink}",
+                f"{src} ! image/jpeg,width=640,height=480 ! {appsink}",
+            ]
 
-        def _create_pipeline(self) -> Gst.Pipeline:
-            """Create GStreamer pipeline - tries hardware encoder first."""
-
-            # Hardware pipeline for Jetson (NVJPEG encoder)
-            hw_pipeline = f"""
-                v4l2src device=/dev/video0 !
-                video/x-raw,width={FRAME_WIDTH},height={FRAME_HEIGHT},
-                    framerate={FRAMERATE}/1 !
-                nvvidconv !
-                video/x-raw(memory:NVMM) !
-                nvjpegenc quality={JPEG_QUALITY} !
-                appsink name=sink emit-signals=true max-buffers=2 drop=true
-            """
-
-            # Software fallback (works everywhere)
-            sw_pipeline = f"""
-                v4l2src device=/dev/video0 !
-                videoconvert ! videoscale ! videorate !
-                video/x-raw,width={FRAME_WIDTH},height={FRAME_HEIGHT},
-                    framerate={FRAMERATE}/1,format=I420 !
-                jpegenc quality={JPEG_QUALITY} !
-                appsink name=sink emit-signals=true max-buffers=2 drop=true
-            """
-
-            for name, pipeline_str in [
-                ("hardware", hw_pipeline),
-                ("software", sw_pipeline),
-            ]:
+            for p_str in pipelines:
                 try:
-                    pipeline = Gst.parse_launch(pipeline_str)
+                    pipeline = Gst.parse_launch(p_str)
                     ret = pipeline.set_state(Gst.State.PAUSED)
-                    if ret != Gst.StateChangeReturn.FAILURE:
-                        logger.info(f"Using {name} JPEG encoder")
+                    if ret == Gst.StateChangeReturn.FAILURE:
                         pipeline.set_state(Gst.State.NULL)
-                        return Gst.parse_launch(pipeline_str)
-                    pipeline.set_state(Gst.State.NULL)
+                        continue
+                    # ... wait for ASYNC preroll, check for errors ...
+                    logger.info("Pipeline ready: %s", p_str)
+                    return pipeline
                 except Exception as e:
-                    logger.debug(f"{name} pipeline failed: {e}")
-
-            raise RuntimeError("No working GStreamer pipeline found")
+                    logger.info("Pipeline exception: %s — %s", p_str, e)
+            return None
     ```
 
     **How it works:**
-    - `v4l2src` captures raw frames from the USB webcam at `/dev/video0`
-    - On Jetson, `nvvidconv` and `nvjpegenc` use the GPU for JPEG encoding
+    - `v4l2src` captures frames from the USB webcam (the device defaults to `/dev/video0`)
+    - The last two pipelines pass the camera's native `image/jpeg` straight through with no re-encoding
+    - The earlier pipelines decode and re-encode (`jpegdec ! jpegenc`) or convert raw frames (`videoconvert ! jpegenc`) as fallbacks
     - `appsink` with `max-buffers=2 drop=true` prevents frame buildup if clients are slow
-    - The pipeline probes `PAUSED` state to detect whether hardware encoding is available
 
     **WebSocket Frame Broadcasting**
 
-    When GStreamer produces a new JPEG frame, it is broadcast to all connected WebSocket clients:
+    Each connected client gets a small queue. When GStreamer produces a new JPEG frame, it is pushed to every client's queue:
 
     ```python
-    def _on_new_sample(self, sink) -> Gst.FlowReturn:
-        """Called by GStreamer when a new frame is ready."""
+    def _on_new_sample(self, sink):
         sample = sink.emit("pull-sample")
-        if sample is None:
+        if not sample:
             return Gst.FlowReturn.OK
-
-        buffer = sample.get_buffer()
-        success, map_info = buffer.map(Gst.MapFlags.READ)
-        if not success:
+        buf = sample.get_buffer()
+        ok, mapinfo = buf.map(Gst.MapFlags.READ)
+        if not ok:
             return Gst.FlowReturn.OK
+        data = bytes(mapinfo.data)
+        buf.unmap(mapinfo)
 
-        frame_data = bytes(map_info.data)
-        buffer.unmap(map_info)
-
-        # Schedule broadcast on asyncio loop
-        if self._loop and self.clients:
-            asyncio.run_coroutine_threadsafe(
-                self._broadcast_frame(frame_data),
-                self._loop
-            )
+        with self._lock:
+            for q in self.queues.values():
+                try:
+                    q.put_nowait(data)
+                except asyncio.QueueFull:
+                    pass
 
         return Gst.FlowReturn.OK
-
-    async def _broadcast_frame(self, frame_data: bytes):
-        """Send frame to all connected clients."""
-        disconnected = set()
-        for ws in self.clients.copy():
-            try:
-                await ws.send_bytes(frame_data)
-            except Exception:
-                disconnected.add(ws)
-        self.clients -= disconnected
     ```
 
     **Lazy Start/Stop**
 
-    The camera starts when the first client connects and stops when the last disconnects:
+    The camera starts when the first client connects (via a restart task) and stops when the last disconnects:
 
     ```python
-    async def add_client(self, websocket: WebSocket) -> bool:
-        """Add a client and start pipeline if needed."""
-        self.clients.add(websocket)
-        if self.pipeline is None:
-            try:
-                self.start(asyncio.get_event_loop())
-            except Exception as e:
-                logger.error(f"Failed to start camera: {e}")
-                self.clients.discard(websocket)
-                return False
-        return True
+    async def add_client(self, ws: WebSocket) -> asyncio.Queue:
+        self._loop = asyncio.get_running_loop()
+        q = asyncio.Queue(maxsize=2)
+        with self._lock:
+            self.queues[ws] = q
+            should_restart = self.pipeline is None
+        if should_restart:
+            self._ensure_restart_task("client connected")
+        return q
 
-    async def remove_client(self, websocket: WebSocket):
-        """Remove a client and stop pipeline if no clients remain."""
-        self.clients.discard(websocket)
-        if not self.clients:
-            self.stop()
+    def remove_client(self, ws: WebSocket):
+        with self._lock:
+            self.queues.pop(ws, None)
+            if not self.queues:
+                self._clear_pipeline_locked()
+                logger.info("Camera stopped (no clients)")
     ```
 
     **WebSocket Endpoint**
 
+    The endpoint runs a sender task (frames out) and a receiver task (commands in, such as switching cameras) concurrently:
+
     ```python
     @app.websocket("/stream")
     async def websocket_stream(websocket: WebSocket):
-        """WebSocket endpoint for video streaming."""
         await websocket.accept()
-
-        if not await camera.add_client(websocket):
-            await websocket.close(code=1011, reason="Failed to open camera")
+        try:
+            q = await camera.add_client(websocket)
+        except Exception as e:
+            logger.error(f"Failed to start camera: {e}")
+            await websocket.close(code=1011)
             return
 
-        try:
+        async def send_frames():
             while True:
-                try:
-                    await asyncio.wait_for(websocket.receive(), timeout=30.0)
-                except asyncio.TimeoutError:
-                    await websocket.send_json({"type": "ping"})
-        except WebSocketDisconnect:
-            pass
+                data = await q.get()
+                await websocket.send_bytes(data)
+
+        async def recv_commands():
+            try:
+                while True:
+                    msg = json.loads(await websocket.receive_text())
+                    if "switch_camera" in msg:
+                        await camera.switch_camera(msg["switch_camera"])
+            except WebSocketDisconnect:
+                pass
+
+        try:
+            done, pending = await asyncio.wait(
+                [asyncio.create_task(send_frames()), asyncio.create_task(recv_commands())],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for t in pending:
+                t.cancel()
         finally:
-            await camera.remove_client(websocket)
+            camera.remove_client(websocket)
     ```
+
+    **Other endpoints**
+
+    The backend also serves the UI and a few helpers:
+    - `GET /` — serves `index.html`
+    - `GET /cameras` — lists detected cameras (`{"id": ..., "name": ...}`) for the picker
+    - `GET /logs` — recent log lines (handy for debugging)
+    - `GET /debug` — current mode, cameras, pipeline state, and client count
   </Step>
 
   <Step>
     ### Understanding the Frontend
 
-    The frontend (`index.html`) is a single HTML file that connects to the WebSocket stream and renders JPEG frames on a canvas:
+    The frontend (`index.html`) is a single HTML file (Tailwind via CDN) that connects to the WebSocket stream and renders each JPEG frame into a fullscreen `<img>` element:
 
     ```html
-    <div class="bg-black rounded-lg shadow overflow-hidden relative">
-      <canvas
-        id="video-frame"
-        class="w-full aspect-video bg-gray-900"
-        aria-label="Video stream"
-      ></canvas>
+    <div class="fixed inset-0 z-0 flex items-center justify-center bg-black">
+      <img
+        id="video-stream"
+        class="max-w-full max-h-full w-full h-full object-contain"
+        alt=""
+      />
     </div>
     ```
 
     **WebSocket Connection**
 
+    Incoming binary frames are converted to a base64 data URL and assigned to the image's `src`:
+
     ```javascript
     function connect() {
-      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      ws = new WebSocket(`${protocol}//${window.location.host}/stream`);
+      if (ws) ws.close();
+      const proto = location.protocol === "https:" ? "wss:" : "ws:";
+      ws = new WebSocket(`${proto}//${location.host}/stream`);
       ws.binaryType = "arraybuffer";
-
-      ws.onopen = () => setStatus("Connected", "green");
-
-      ws.onmessage = (event) => {
-        if (event.data instanceof ArrayBuffer) {
-          latestFrame = event.data;
-          scheduleRender();
+      ws.onopen = () => setStatus("Connected", "yellow");
+      ws.onmessage = (e) => {
+        if (e.data instanceof ArrayBuffer) {
+          imgEl.src = arrayBufferToDataUrl(e.data);
+          frameCount++;
+          overlay.classList.add("opacity-0", "pointer-events-none");
+          setStatus("Live", "green");
         }
       };
-
       ws.onclose = () => {
         setStatus("Disconnected", "red");
-        // Auto-reconnect after 2 seconds
-        reconnectTimeout = setTimeout(connect, 2000);
+        setTimeout(connect, reconnectDelay);
+        reconnectDelay = Math.min(reconnectDelay * 1.5, 10000);
       };
     }
     ```
 
-    **Frame Rendering**
+    **Camera Picker**
 
-    Frames are decoded asynchronously using `createImageBitmap` for performance. A smart queueing system drops frames if decoding can't keep up:
+    The page fetches `/cameras` to populate a dropdown. Selecting a camera sends a `switch_camera` command over the open WebSocket:
 
     ```javascript
-    function renderFrame(buffer) {
-      const blob = new Blob([buffer], { type: "image/jpeg" });
-      return createImageBitmap(blob).then((bitmap) => {
-        if (videoFrame.width !== bitmap.width ||
-            videoFrame.height !== bitmap.height) {
-          videoFrame.width = bitmap.width;
-          videoFrame.height = bitmap.height;
-        }
-        ctx.drawImage(bitmap, 0, 0, videoFrame.width, videoFrame.height);
-        bitmap.close();
+    async function loadCameras() {
+      const cameras = await (await fetch("/cameras")).json();
+      camSelect.innerHTML = "";
+      cameras.forEach((c, i) => {
+        const o = document.createElement("option");
+        o.value = c.id; o.textContent = c.name || `Camera ${i}`;
+        camSelect.appendChild(o);
       });
     }
 
-    function scheduleRender() {
-      if (decoding || !latestFrame) return;
-      const buffer = latestFrame;
-      latestFrame = null;
-      decoding = true;
-
-      renderFrame(buffer)
-        .catch(() => null)
-        .finally(() => {
-          decoding = false;
-          frameCount++;
-          updateFps();
-          scheduleRender();
-        });
-    }
+    camSelect.addEventListener("change", () => {
+      if (camSelect.value && ws?.readyState === WebSocket.OPEN) {
+        setStatus("Switching...", "yellow");
+        ws.send(JSON.stringify({ switch_camera: camSelect.value }));
+      }
+    });
     ```
 
     **UI Features:**
     - Connection status indicator (yellow/green/red) with text
     - Live FPS counter updated every second
-    - Resolution display showing the actual frame dimensions
+    - Camera picker dropdown for switching between connected webcams
+    - Fullscreen toggle button
     - Loading spinner overlay while connecting
-    - Automatic reconnection on disconnect
+    - Automatic reconnection on disconnect, with backoff
   </Step>
 
   <Step>
     ### Understanding the Dockerfile
 
-    The Dockerfile uses the NVIDIA L4T JetPack base image with GStreamer support:
+    The Dockerfile uses a slim Debian base image with GStreamer and its Python bindings installed, and creates a virtualenv (with system site packages so the GStreamer bindings are visible):
 
     ```dockerfile
-    # Use NVIDIA L4T base for Jetson with GStreamer support
-    FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0
+    FROM debian:bookworm-slim
 
-    # Install GStreamer and Python dependencies
     RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 \
         python3-pip \
+        python3-venv \
         python3-gi \
         gir1.2-gst-plugins-base-1.0 \
+        gir1.2-gst-plugins-bad-1.0 \
         gir1.2-gstreamer-1.0 \
         gstreamer1.0-tools \
         gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-good \
         gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-ugly \
+        gstreamer1.0-libav \
+        gstreamer1.0-nice \
         v4l-utils \
         && rm -rf /var/lib/apt/lists/*
 
     WORKDIR /app
 
+    RUN python3 -m venv --system-site-packages /app/venv
+    ENV PATH="/app/venv/bin:$PATH"
+
     COPY requirements.txt .
-    RUN pip3 install --no-cache-dir -r requirements.txt
+    RUN pip install --no-cache-dir -r requirements.txt
 
-    COPY app.py .
-    COPY index.html .
-    COPY logo.svg .
+    COPY app.py index.html ./
+    COPY assets/ ./assets/
 
-    # Create a non-root user for security
-    RUN useradd --create-home --shell /bin/bash app && \
-        chown -R app:app /app && \
-        chmod -R u+r /app && \
-        usermod -aG video app
-    USER app
+    ENV PYTHONUNBUFFERED=1
+
+    ARG WENDY_DEVICE_TYPE
+    ARG WENDY_DEBUG=false
+    ENV WENDY_DEVICE_TYPE=${WENDY_DEVICE_TYPE}
+    ENV WENDY_DEBUG=${WENDY_DEBUG}
+    RUN if [ "$WENDY_DEBUG" = "true" ]; then pip install --no-cache-dir debugpy; fi
 
     EXPOSE 3003
 
-    CMD ["python3", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3003"]
+    CMD ["/app/venv/bin/uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3003"]
+    ```
+
+    The matching `requirements.txt` is just FastAPI and Uvicorn (GStreamer comes from the system packages):
+
+    ```txt
+    fastapi
+    uvicorn[standard]
     ```
 
     **Key points:**
-    - The L4T JetPack base image provides CUDA and NVIDIA GStreamer plugins
+    - The Debian base ships the GStreamer plugins needed for MJPEG capture and software JPEG encoding
     - GStreamer Python bindings (`python3-gi`, `gir1.2-*`) enable pipeline control from Python
-    - `v4l-utils` provides Video4Linux tools for webcam access
-    - A non-root `app` user is created and added to the `video` group for `/dev/video0` access
-    - No frontend build step needed since the UI is a single HTML file using Tailwind via CDN
+    - `v4l-utils` provides Video4Linux tools for webcam discovery and access
+    - No frontend build step is needed since the UI is a single HTML file using Tailwind via CDN
   </Step>
 
   <Step>
     ### Configure Entitlements
 
-    The `wendy.json` file specifies the required device permissions:
+    The generated `wendy.json` specifies the required device permissions:
 
     ```json
     {
-      "appId": "sh.wendy.examples.webcam",
-      "version": "1.0.0",
-      "language": "python",
-      "entitlements": [
-        { "type": "network", "mode": "host" },
-        { "type": "video" },
-        { "type": "gpu" }
-      ],
-      "readiness": {
-        "tcpSocket": { "port": 3003 },
-        "timeoutSeconds": 30
-      },
-      "hooks": {
-        "postStart": {
-          "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3003"
+        "appId": "webcam",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network",
+                "mode": "host"
+            },
+            {
+                "type": "camera"
+            },
+            {
+                "type": "gpu"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 3003 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3003"
+            }
         }
-      }
     }
     ```
 
     - **network (host mode)**: Allows binding to ports directly on the device and enables WebSocket connections
-    - **video**: Grants access to `/dev/video*` webcam devices
-    - **gpu**: Enables NVIDIA hardware-accelerated JPEG encoding via `nvjpegenc`
+    - **camera**: Grants access to `/dev/video*` webcam devices
+    - **gpu**: Allows hardware-accelerated paths when the device and GStreamer plugins support them
     - **readiness**: Waits for port `3003` to accept connections before proceeding
     - **postStart**: Automatically opens the stream in your browser once ready
   </Step>
@@ -456,7 +444,8 @@ wendy run
 ✔ Success
   Started app
 INFO:     Uvicorn running on http://0.0.0.0:3003
-INFO:     Using hardware JPEG encoder
+INFO:     Discovered 1 camera(s) via V4L2: /dev/video0 (HD Pro Webcam C920)
+INFO:     Pipeline ready: v4l2src device=/dev/video0 ! image/jpeg ! appsink name=sink emit-signals=true max-buffers=2 drop=true sync=false
 ```
 
 Your browser will open automatically once the stream is ready, thanks to the `postStart` hook. If it doesn't, navigate to:
@@ -471,25 +460,25 @@ Replace the hostname with your device's actual hostname.
 
 <Accordions>
   <Accordion title="Webcam not detected">
-    Ensure your webcam is connected before running the app. Check that the `video` entitlement is in your `wendy.json`. You can verify the webcam is visible on the device:
+    Ensure your webcam is connected before running the app. Check that the `camera` entitlement is in your `wendy.json`. You can verify the webcam is visible on the device:
 
     ```bash
-    ssh edge@wendyos-zestful-stork.local "ls /dev/video*"
+    ssh wendy@wendyos-zestful-stork.local "ls /dev/video*"
     ```
 
-    Common webcam devices are `/dev/video0` or `/dev/video1`. If your webcam is on a different device node, update the `v4l2src device=` path in `app.py`.
+    The app discovers cameras automatically (see `GET /cameras` and the picker in the UI). Common webcam devices are `/dev/video0` or `/dev/video1`. You can also hit `GET /debug` to see what the app detected.
   </Accordion>
 
-  <Accordion title="Falling back to software encoding">
-    If you see `Using software JPEG encoder` in the logs, the hardware encoder wasn't available. Ensure the `gpu` entitlement is configured in `wendy.json`. Software encoding still works but uses more CPU.
+  <Accordion title="No frames / pipeline failing">
+    The app tries several GStreamer pipelines and logs `Pipeline ready: ...` for the one it selects. If none work, you'll see `Pipeline failed` / `Pipeline exception` lines. Check `GET /logs` or the app logs, confirm the `camera` entitlement is present, and make sure the webcam outputs MJPEG (most USB webcams do).
   </Accordion>
 
   <Accordion title="High latency or choppy video">
-    The WebSocket stream delivers raw JPEG frames. If you experience latency:
+    The WebSocket stream delivers JPEG frames. If you experience latency:
 
     - Use a **USB 3.0 cable** for the webcam (not USB 2.0)
-    - Lower the resolution by changing `FRAME_WIDTH` and `FRAME_HEIGHT` in `app.py`
-    - Lower `JPEG_QUALITY` (e.g., 70) to reduce frame size
+    - Lower the requested resolution by editing the `width`/`height` caps in the pipeline strings in `app.py`
+    - Lower the `jpegenc quality=` value to reduce frame size when re-encoding
     - Ensure you're on a fast network (USB-C direct connection or wired LAN)
   </Accordion>
 

--- a/go/internal/cli/assets/docs/guides/python/yolov8-webcam-detection.mdx
+++ b/go/internal/cli/assets/docs/guides/python/yolov8-webcam-detection.mdx
@@ -1,6 +1,6 @@
 ---
 title: YOLOv8 Webcam Detection
-description: Build a full-screen real-time object detection app with YOLOv8, MJPEG streaming, and a React frontend on WendyOS
+description: Build a full-screen real-time object detection app with YOLOv8, WebSocket streaming, and a canvas overlay on WendyOS
 language: python
 ---
 
@@ -12,16 +12,16 @@ import { Accordions, Accordion } from 'fumadocs-ui/components/accordion';
 
 ## Real-Time COCO Object Detection with YOLOv8
 
-This guide walks you through building a complete webcam detection application that runs YOLOv8 on a WendyOS device. The app features a full-screen video feed with bounding box overlays and a detection log showing identified objects from the COCO dataset (80 classes including people, cars, animals, and everyday objects).
+This guide walks you through building a complete webcam detection application that runs YOLOv8 on a WendyOS device. The app features a full-screen video feed with bounding box overlays drawn on a canvas, a confidence slider, and a live count of identified objects from the COCO dataset (80 classes including people, cars, animals, and everyday objects).
 
 The complete sample is available in the [samples repository](https://github.com/wendylabsinc/samples/tree/main/python/yolov8).
 
 ### What You'll Build
 
-- A FastAPI backend that captures webcam frames and runs YOLOv8 inference
-- MJPEG video streaming with detection overlays drawn by YOLOv8
-- A React + Tailwind frontend with full-screen video and a detection log overlay
-- A Docker container optimized for NVIDIA Jetson devices
+- A FastAPI backend that captures webcam frames (via GStreamer, with an OpenCV fallback) and runs YOLOv8 inference in a background thread
+- A WebSocket stream that sends raw JPEG frames alongside JSON detection metadata
+- A single-file HTML/Tailwind frontend that renders frames in an `<img>` and overlays bounding boxes on a `<canvas>`, with a camera picker and confidence slider
+- A multi-stage Dockerfile that picks a CUDA (Jetson) or CPU base image at build time
 
 ### Prerequisites
 
@@ -64,17 +64,20 @@ The complete sample is available in the [samples repository](https://github.com/
 
 ### Understanding the Architecture
 
-This sample uses a **prebuilt Ultralytics Docker image** specifically optimized for Jetson devices. The `ultralytics/ultralytics:latest-jetson-jetpack6` image comes with:
+This sample uses a **multi-stage Dockerfile that selects its base image at build time** via the `WENDY_PLATFORM` build arg, which the Wendy CLI injects after probing the target device:
 
-- YOLOv8 and the Ultralytics library pre-installed
-- OpenCV with CUDA support
-- PyTorch optimized for Jetson GPUs
-- All necessary CUDA libraries
+- **`nvidia-jetson`** → `dustynv/pytorch` with CUDA/JetPack for GPU-accelerated inference
+- **`generic`** → `python:3.11-slim-bookworm` for CPU inference (Raspberry Pi, unknown devices, or a plain `docker build`)
 
-This means you don't need to compile OpenCV or PyTorch from source - saving significant build time.
+Frames flow through the app like this:
+
+1. **GStreamer** captures JPEG frames from the webcam (with an OpenCV fallback on CPU/RPi devices)
+2. The raw JPEG frames stream to the browser over a WebSocket at camera rate
+3. **YOLOv8 inference runs in a separate background thread** at a lower rate, publishing detection metadata (bounding boxes, classes, timings) as JSON
+4. The browser renders the JPEG in an `<img>` and **draws the boxes on a `<canvas>` overlay**, so slow inference never stalls the video
 
 <Callout type="warning">
-**Large Image Size**: The Ultralytics Jetson image is approximately **5-9 GB** in size. Initial uploads to your device can be slow depending on your network connection. See the [Speeding Up Uploads](#speeding-up-uploads) section for tips.
+**Large Image Size**: The Jetson CUDA base image is large (several GB). Initial uploads to your device can be slow depending on your network connection. See the [Speeding Up Uploads](#speeding-up-uploads) section for tips. The YOLOv8n weights file is small (~6 MB) and is baked into the image at build time so the app works offline.
 </Callout>
 
 
@@ -82,247 +85,303 @@ This means you don't need to compile OpenCV or PyTorch from source - saving sign
   <Step>
     ### Understanding the Dockerfile
 
-    The Dockerfile uses a multi-stage build:
+    The Dockerfile is multi-stage and chooses its base from the `WENDY_PLATFORM` build arg. There are two base stages — a CUDA Jetson base and a generic CPU base — and a final stage that copies in the app. Here is the structure (trimmed for readability):
 
     ```dockerfile
-    # Build frontend
-    FROM node:22-slim AS frontend-builder
+    # syntax=docker/dockerfile:1.6
+    ARG WENDY_PLATFORM=generic
 
-    WORKDIR /app/frontend
-    COPY frontend/package*.json ./
-    RUN npm ci
-    COPY frontend/ ./
-    RUN npm run build
+    # ── NVIDIA Jetson base (CUDA-accelerated via L4T) ──
+    FROM dustynv/pytorch:2.7-r36.4.0-cu128-24.04 AS base-nvidia-jetson
+    # L4T base already ships CUDA torch/torchvision/OpenCV/numpy.
+    # Add GStreamer + v4l so USB cameras work, then app-level deps.
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3-gi gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 \
+        gir1.2-gst-plugins-bad-1.0 gstreamer1.0-tools \
+        gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+        gstreamer1.0-libav v4l-utils \
+        && rm -rf /var/lib/apt/lists/*
+    ENV PATH="/opt/venv/bin:${PATH}"
+    RUN pip3 install --no-cache-dir --index-url https://pypi.org/simple/ \
+        fastapi 'uvicorn[standard]' ultralytics
 
-    # Runtime stage - Ultralytics official Jetson image
-    FROM ultralytics/ultralytics:latest-jetson-jetpack6
+    # ── Generic CPU base (Raspberry Pi, unknown, non-accelerated) ──
+    FROM python:3.11-slim-bookworm AS base-generic
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3-gi gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 \
+        gir1.2-gst-plugins-bad-1.0 gstreamer1.0-tools \
+        gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+        gstreamer1.0-libav gstreamer1.0-nice v4l-utils \
+        libgl1 libglib2.0-0 libgomp1 \
+        && rm -rf /var/lib/apt/lists/*
+    COPY requirements.txt /tmp/requirements.txt
+    RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
+    # ── Final stage: WENDY_PLATFORM selects the hardware path ──
+    FROM base-${WENDY_PLATFORM} AS final
     WORKDIR /app
 
-    # Only need to install web server dependencies
-    RUN pip3 install --no-cache-dir fastapi "uvicorn[standard]"
+    # apt's python3-gi lives under /usr/lib/python3/dist-packages;
+    # expose it so `import gi` works, and fail loudly if it regresses.
+    ENV PYTHONPATH=/usr/lib/python3/dist-packages
+    RUN python3 -c "import gi; gi.require_version('Gst','1.0'); from gi.repository import Gst; Gst.init(None); print('gi+Gst OK')"
 
-    # Pre-download the YOLOv8 model during build (so it works offline)
-    RUN python3 -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
+    # Bake YOLOv8n weights into the image (works offline on first run).
+    RUN python3 -c "from ultralytics import YOLO; YOLO('yolov8n.pt')" && \
+        [ -s /app/yolov8n.pt ] && [ "$(stat -c %s /app/yolov8n.pt)" -gt 6000000 ]
 
-    # Copy server files
-    COPY server/app.py ./
+    COPY app.py index.html ./
+    COPY assets/ ./assets/
 
-    # Copy the built frontend
-    COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
-
-    ENV FRONTEND_DIST=/app/frontend/dist
     ENV PYTHONUNBUFFERED=1
+    EXPOSE 3005
+    CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3005"]
+    ```
 
-    EXPOSE 3003
+    The accompanying `requirements.txt` (used by the generic CPU base) is:
 
-    CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3003"]
+    ```txt
+    fastapi
+    uvicorn[standard]
+    opencv-python-headless
+    ultralytics
     ```
 
     **Key points:**
-    - The first stage builds the React frontend with Node.js
-    - The second stage uses the prebuilt Ultralytics Jetson image
-    - The YOLOv8 model (`yolov8n.pt`) is downloaded during build, not at runtime
-    - This ensures the app works even if the device has no internet access
+    - `ARG WENDY_PLATFORM` + `FROM base-${WENDY_PLATFORM}` pick the CUDA or CPU base; the Wendy CLI sets this after probing your device (it falls back to `generic` for a plain `docker build`)
+    - Both bases install GStreamer and `v4l-utils` so USB cameras work
+    - The YOLOv8n weights (`yolov8n.pt`, ~6 MB) are baked in at build time, not downloaded at runtime, so the app works offline
+    - A build-time check confirms the GStreamer Python bindings (`import gi`) load successfully
   </Step>
 
   <Step>
     ### Understanding the Backend
 
-    The FastAPI backend (`server/app.py`) handles webcam capture, YOLOv8 inference, MJPEG streaming, and detection logging:
+    The FastAPI backend (`app.py`) captures frames with GStreamer, runs YOLOv8 inference on a **separate background thread**, and ships raw JPEG frames plus JSON detection metadata to the browser over a WebSocket. Capturing and inference are decoupled so a slow inference pass never stalls the video.
+
+    The base-image selection at build time is mirrored at runtime: the app reads the `WENDY_HAS_GPU` / `WENDY_GPU_VENDOR` hints the CLI baked in, and chooses CUDA vs CPU (and a sensible inference FPS/image size) accordingly:
 
     ```python
-    from collections import deque
-    from datetime import datetime, timezone
-    from fastapi import FastAPI
-    from fastapi.responses import StreamingResponse
-    import cv2
-    from ultralytics import YOLO
+    _HAS_CUDA = _has_cuda()  # uses WENDY_HAS_GPU hint, then torch.cuda.is_available()
+    _MAX_INFERENCE_FPS = float(os.environ.get("YOLO_MAX_FPS", "15" if _HAS_CUDA else "3"))
+    _INFERENCE_IMGSZ = 320 if _HAS_CUDA else 224
+    # RPi5 / CPU devices idle lighter on OpenCV than GStreamer + inference.
+    _FORCE_OPENCV = not _HAS_GSTREAMER or (_backend == "opencv") or (
+        _backend == "auto" and (IS_RPI or not _HAS_CUDA)
+    )
+    ```
 
-    app = FastAPI()
+    The model is loaded lazily (and warmed at startup on a background thread) so the first WebSocket connection isn't blocked by the multi-second torch load:
 
-    # Load YOLOv8 model (pre-downloaded in Docker build)
-    model = YOLO("yolov8n.pt")
+    ```python
+    def _get_model() -> YOLO:
+        global _model
+        if _model is not None:
+            return _model
+        with _model_lock:
+            if _model is not None:
+                return _model
+            model_path = "yolov8n.onnx" if Path("yolov8n.onnx").exists() else "yolov8n.pt"
+            m = YOLO(model_path)
+            logger.info("YOLOv8n ready — %d COCO classes, backend: %s", len(m.names), model_path)
+            _model = m
+            return _model
+    ```
 
-    # Store recent detections for the log
-    detection_log: deque = deque(maxlen=100)
+    Inference runs in its own loop, decoding the latest raw JPEG, running `model.predict`, and caching the resulting boxes/classes as JSON metadata:
 
-    def generate_frames():
-        """Generate MJPEG frames with YOLOv8 detection overlay."""
-        cap = cv2.VideoCapture(0)
-        cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
-        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
-
+    ```python
+    def _inference_loop(self):
+        last_inference = 0.0
         while True:
-            ret, frame = cap.read()
-            if not ret:
-                break
+            self._raw_event.wait(timeout=1.0)
+            self._raw_event.clear()
+            now = time.monotonic()
+            if now - last_inference < _MIN_INFERENCE_INTERVAL:
+                continue
 
-            # Run YOLOv8 inference
-            results = model(frame, verbose=False)
+            with self._lock:
+                raw, self._latest_raw = self._latest_raw, None
+                conf = self._confidence
+                has_clients = bool(self.queues)
+            if raw is None or not has_clients:
+                continue
 
-            # Log detections with confidence > 50%
-            timestamp = datetime.now(timezone.utc).isoformat()
-            for result in results:
-                for box in result.boxes:
-                    conf = float(box.conf[0])
-                    if conf > 0.5:
-                        cls_name = model.names[int(box.cls[0])]
-                        detection_log.append({
-                            "label": cls_name,
-                            "confidence": round(conf * 100, 1),
-                            "timestamp": timestamp
-                        })
+            model = _get_model()
+            frame = cv2.imdecode(np.frombuffer(raw, np.uint8), cv2.IMREAD_COLOR)
+            if frame is None:
+                continue
+            h, w = frame.shape[:2]
 
-            # Draw bounding boxes and encode as JPEG
-            annotated_frame = results[0].plot()
-            _, buffer = cv2.imencode('.jpg', annotated_frame,
-                                     [cv2.IMWRITE_JPEG_QUALITY, 80])
+            t0 = time.monotonic()
+            results = model.predict(frame, conf=conf, imgsz=_INFERENCE_IMGSZ, verbose=False)
+            inference_ms = (time.monotonic() - t0) * 1000
+            last_inference = time.monotonic()
 
-            yield (b'--frame\r\n'
-                   b'Content-Type: image/jpeg\r\n\r\n' +
-                   buffer.tobytes() + b'\r\n')
+            boxes_out, classes = [], {}
+            for box in results[0].boxes:
+                xyxy = box.xyxy[0].tolist()
+                cls_name = model.names[int(box.cls)]
+                boxes_out.append({
+                    "x1": xyxy[0], "y1": xyxy[1], "x2": xyxy[2], "y2": xyxy[3],
+                    "conf": float(box.conf), "cls": int(box.cls), "name": cls_name,
+                })
+                classes[cls_name] = classes.get(cls_name, 0) + 1
 
-    @app.get("/api/video-feed")
-    async def video_feed():
-        """Stream MJPEG video with YOLOv8 detections."""
-        return StreamingResponse(
-            generate_frames(),
-            media_type="multipart/x-mixed-replace; boundary=frame"
-        )
+            with self._lock:
+                self._cached_meta = json.dumps({
+                    "detections": len(boxes_out), "inference_ms": round(inference_ms, 1),
+                    "classes": classes, "boxes": boxes_out, "frame_w": w, "frame_h": h,
+                })
+    ```
 
-    @app.get("/api/detections")
-    async def get_detections():
-        """Get recent detections for the log overlay."""
-        return list(detection_log)[-20:]
+    The WebSocket endpoint runs a sender task (it sends the metadata as text, then the JPEG as binary) and a receiver task that handles `switch_camera` and `confidence` commands:
+
+    ```python
+    @app.websocket("/stream")
+    async def websocket_stream(websocket: WebSocket):
+        await websocket.accept()
+        q = await camera.add_client(websocket)
+
+        async def send_frames():
+            while True:
+                frame_data, meta = await q.get()
+                await websocket.send_text(meta)
+                await websocket.send_bytes(frame_data)
+
+        async def recv_commands():
+            try:
+                while True:
+                    msg = json.loads(await websocket.receive_text())
+                    if "switch_camera" in msg:
+                        await camera.switch_camera(msg["switch_camera"])
+                    if "confidence" in msg:
+                        camera.set_confidence(float(msg["confidence"]))
+            except WebSocketDisconnect:
+                pass
+
+        try:
+            done, pending = await asyncio.wait(
+                [asyncio.create_task(send_frames()), asyncio.create_task(recv_commands())],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for t in pending:
+                t.cancel()
+        finally:
+            camera.remove_client(websocket)
     ```
 
     **How it works:**
-    - `generate_frames()` captures webcam frames and runs YOLOv8 inference
-    - `results[0].plot()` draws bounding boxes directly on the frame
-    - Detections above 50% confidence are logged with label, confidence, and timestamp
-    - `/api/detections` returns the last 20 detections for the frontend overlay
+    - GStreamer (or OpenCV on CPU/RPi) captures JPEG frames and feeds them to all connected clients at camera rate
+    - A background thread runs YOLOv8 at its own throttled rate and caches detection metadata
+    - Each WebSocket message pair is `<json-metadata>` then `<binary-jpeg>`; the browser overlays the boxes
+    - `/cameras`, `/logs`, and `/debug` endpoints expose camera inventory, recent logs, and live state; `/` serves `index.html`
   </Step>
 
   <Step>
     ### Understanding the Frontend
 
-    The React frontend (`frontend/src/App.tsx`) displays a full-screen video feed with a detection log overlay:
+    The frontend is a single `index.html` file (Tailwind via CDN). A fullscreen `<img>` shows the raw JPEG frames, and a `<canvas id="overlay">` is positioned on top to draw the bounding boxes:
 
-    ```tsx
-    import { useState, useEffect, useRef } from "react";
+    ```html
+    <img id="video-stream" class="max-w-full max-h-full w-full h-full object-contain" alt="" />
+    <canvas id="overlay" class="pointer-events-none absolute"></canvas>
+    ```
 
-    interface Detection {
-      label: string;
-      confidence: number;
-      timestamp: string;
+    Each WebSocket message is either JSON metadata (stored in `latestMeta`) or a binary JPEG (decoded into the `<img>`):
+
+    ```javascript
+    ws.onmessage = (e) => {
+      if (e.data instanceof ArrayBuffer) {
+        imgEl.src = arrayBufferToDataUrl(e.data);
+        frameCount++;
+        setStatus("Live", "green");
+      } else {
+        latestMeta = JSON.parse(e.data);
+        updateMetaUI(latestMeta);
+      }
+    };
+    ```
+
+    The boxes are drawn on the canvas, sized to match the source frame so coordinates are 1:1. Each COCO class gets its own color:
+
+    ```javascript
+    function drawBoxes() {
+      const fw = latestMeta.frame_w || imgEl.naturalWidth;
+      const fh = latestMeta.frame_h || imgEl.naturalHeight;
+      if (!fw || !fh) return;
+      if (canvasEl.width !== fw) canvasEl.width = fw;
+      if (canvasEl.height !== fh) canvasEl.height = fh;
+      ctx.clearRect(0, 0, fw, fh);
+      for (const b of latestMeta.boxes || []) {
+        const color = COLORS[(b.cls | 0) % 80];
+        ctx.strokeStyle = color;
+        ctx.strokeRect(b.x1, b.y1, b.x2 - b.x1, b.y2 - b.y1);
+        const label = `${b.name || `class ${b.cls}`} ${(b.conf ?? 0).toFixed(2)}`;
+        // ... draw a filled label background and the text ...
+      }
     }
+    ```
 
-    function App() {
-      const [detections, setDetections] = useState<Detection[]>([]);
-      const logRef = useRef<HTMLDivElement>(null);
+    The confidence slider sends a `confidence` command to the server so YOLO re-thresholds in real time:
 
-      useEffect(() => {
-        // Poll for detections every 500ms
-        const fetchDetections = async () => {
-          const response = await fetch("/api/detections");
-          const data: Detection[] = await response.json();
-          setDetections(data);
-        };
-
-        fetchDetections();
-        const interval = setInterval(fetchDetections, 500);
-        return () => clearInterval(interval);
-      }, []);
-
-      useEffect(() => {
-        // Auto-scroll to bottom of log
-        if (logRef.current) {
-          logRef.current.scrollTop = logRef.current.scrollHeight;
-        }
-      }, [detections]);
-
-      return (
-        <div className="relative h-screen w-screen overflow-hidden bg-black">
-          {/* Full-screen video feed */}
-          <img
-            src="/api/video-feed"
-            alt="YOLOv8 Detection Feed"
-            className="absolute inset-0 h-full w-full object-contain"
-          />
-
-          {/* Bottom overlay for detection log (1/5 of screen) */}
-          <div className="absolute bottom-0 left-0 right-0 h-1/5
-                          bg-black/70 backdrop-blur-sm z-10">
-            <div className="h-full flex flex-col">
-              <div className="px-4 py-2 border-b border-white/20">
-                <h2 className="text-white text-sm font-semibold uppercase">
-                  COCO Object Detections
-                </h2>
-              </div>
-              <div ref={logRef}
-                   className="flex-1 overflow-y-auto px-4 py-2 font-mono text-sm">
-                {detections.map((detection, index) => (
-                  <div key={`${detection.timestamp}-${index}`}
-                       className="text-white/90 py-0.5">
-                    <span className="text-green-400">
-                      [{detection.confidence}%]
-                    </span>{" "}
-                    <span className="text-yellow-300">
-                      {detection.label}
-                    </span>{" "}
-                    <span className="text-white/50 text-xs">
-                      {new Date(detection.timestamp).toLocaleTimeString()}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    export default App;
+    ```javascript
+    confSlider.addEventListener("change", () => {
+      const val = confSlider.value / 100;
+      confValue.textContent = val.toFixed(2);
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ confidence: val }));
+      }
+    });
     ```
 
     **UI Features:**
-    - Full-screen MJPEG video feed via a simple `<img>` tag
-    - Semi-transparent overlay at the bottom (1/5 of screen height)
-    - Detection entries show confidence in green, label in yellow, time in gray
-    - Auto-scrolls to show the latest detections
+    - Fullscreen video feed (`<img>`) with bounding boxes drawn on a `<canvas>` overlay
+    - Live counters for FPS, object count, and inference time (ms)
+    - A per-class detection panel (e.g. "person 2, car 1")
+    - A camera picker (populated from `/cameras`) and a confidence slider
+    - Fullscreen toggle and automatic reconnect on disconnect
   </Step>
 
   <Step>
     ### Configure Entitlements
 
-    The `wendy.json` file specifies the required device permissions:
+    The generated `wendy.json` specifies the required device permissions. Note the longer readiness timeout — the YOLO/CUDA image and model load can take a while on first start:
 
     ```json
     {
-      "appId": "com.example.python-yolov8",
-      "version": "0.0.1",
-      "entitlements": [
-        { "type": "network", "mode": "host" },
-        { "type": "gpu" },
-        { "type": "video" }
-      ],
-      "readiness": {
-        "tcpSocket": { "port": 3003 },
-        "timeoutSeconds": 30
-      },
-      "hooks": {
-        "postStart": {
-          "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3003"
+        "appId": "yolov8",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network",
+                "mode": "host"
+            },
+            {
+                "type": "camera"
+            },
+            {
+                "type": "gpu"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 3005 },
+            "timeoutSeconds": 180
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3005"
+            }
         }
-      }
     }
     ```
 
     - **network (host mode)**: Allows binding to ports directly on the device
-    - **gpu**: Enables CUDA acceleration for YOLOv8 inference
-    - **video**: Grants access to `/dev/video*` webcam devices
-    - **readiness**: Waits for port `3003` to accept connections before proceeding
+    - **camera**: Grants access to `/dev/video*` webcam devices
+    - **gpu**: Enables CUDA acceleration for YOLOv8 inference on Jetson
+    - **readiness**: Waits up to `180s` for port `3005` to accept connections (the large image and model load can be slow)
     - **postStart**: Automatically opens the detection UI in your browser once ready
   </Step>
 </Steps>
@@ -348,13 +407,15 @@ wendy run
 ✔︎ Container built and uploaded successfully! [45.2s]
 ✔ Success
   Started app
-INFO:     Uvicorn running on http://0.0.0.0:3003
+INFO:     Uvicorn running on http://0.0.0.0:3005
+INFO:     Loading YOLOv8n model (CUDA: True)...
+INFO:     YOLOv8n ready — 80 COCO classes, backend: yolov8n.pt
 ```
 
 Your browser will open automatically once the detection server is ready, thanks to the `postStart` hook. If it doesn't, navigate to:
 
 ```
-http://wendyos-zestful-stork.local:3003
+http://wendyos-zestful-stork.local:3005
 ```
 
 Replace the hostname with your device's actual hostname.
@@ -392,17 +453,17 @@ Docker layer caching means that after the initial upload:
 
 <Accordions>
   <Accordion title="Webcam not detected">
-    Ensure your webcam is connected before running the app. Check that the `video` entitlement is in your `wendy.json`. You can verify the webcam is visible on the device:
+    Ensure your webcam is connected before running the app. Check that the `camera` entitlement is in your `wendy.json`. You can verify the webcam is visible on the device:
 
     ```bash
-    ssh edge@wendyos-zestful-stork.local "ls /dev/video*"
+    ssh wendy@wendyos-zestful-stork.local "ls /dev/video*"
     ```
 
-    Common webcam devices are `/dev/video0` or `/dev/video1`.
+    The app discovers cameras automatically (see `GET /cameras` and the picker in the UI). Common webcam devices are `/dev/video0` or `/dev/video1`. Hit `GET /debug` to see what the app detected, including the active capture backend.
   </Accordion>
 
   <Accordion title="Model download fails at runtime">
-    If you see errors about failing to download `yolov8n.pt`, the model wasn't properly baked into the image. Ensure your Dockerfile includes:
+    The weights are baked into the image at build time, so this normally never happens. If it does, the model wasn't properly baked in. Ensure your Dockerfile includes:
 
     ```dockerfile
     RUN python3 -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
@@ -412,9 +473,9 @@ Docker layer caching means that after the initial upload:
   </Accordion>
 
   <Accordion title="Slow inference / low FPS">
-    Ensure the `gpu` entitlement is configured. Without GPU access, YOLOv8 falls back to CPU inference which is significantly slower on Jetson devices.
+    Ensure the `gpu` entitlement is configured and that your device was detected as a Jetson — on CPU devices the app caps inference at a lower FPS and smaller image size by design. Check `GET /debug` for `cuda`, `capture_backend`, `max_inference_fps`, and `device`.
 
-    You can also try using a smaller model like `yolov8n.pt` (nano) instead of larger variants.
+    You can tune the inference rate with the `YOLO_MAX_FPS` environment variable, or force a capture backend with `CAMERA_BACKEND=opencv|gstreamer`.
   </Accordion>
 
   <Accordion title="Upload is very slow">

--- a/go/internal/cli/assets/docs/guides/rust/camera.mdx
+++ b/go/internal/cli/assets/docs/guides/rust/camera.mdx
@@ -6,12 +6,12 @@ language: rust
 
 ## Live Camera Feed with Rust
 
-Use the Wendy camera template when you want a browser-viewable camera stream without wiring the project from scratch. The template includes `wendy.json`, camera entitlements, a Dockerfile, Rust backend code, and the browser UI.
+Use the Wendy camera template when you want a browser-viewable camera stream without wiring the project from scratch. The template includes `wendy.json` (with camera entitlements), a Dockerfile, the Rust backend, and the browser UI. The backend captures MJPEG frames from a V4L2 camera with GStreamer and streams them to the browser over a WebSocket.
 
 ### Prerequisites
 
 - Wendy CLI installed on your development machine
-- Rust 1.83 or later installed
+- Rust 1.85 or later installed
 - A WendyOS device with a USB camera connected
 
 ## Setting Up Your Project
@@ -35,10 +35,199 @@ Use the Wendy camera template when you want a browser-viewable camera stream wit
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the container, and print the app URL.
+    Wendy will build the app, ask you to select a device if one is not already configured, deploy the container, and open your browser to the live stream once port `4003` is ready.
   </Step>
 </Steps>
 
+## Project Structure
+
+The generated project contains the Rust backend, the browser UI, and a small assets directory:
+
+```
+rust-camera/
+├── Cargo.toml
+├── Dockerfile
+├── wendy.json
+├── index.html        # browser UI (served at /)
+├── assets/
+│   └── wendy-logo.svg
+└── src/
+    └── main.rs        # Axum server + GStreamer pipeline
+```
+
 ## Code Breakdown
 
-Open the app URL from the Wendy run output to view the stream.
+<Steps>
+  <Step>
+    ### Generated Package Dependencies
+
+    The generated `Cargo.toml` adds GStreamer and `tower-http` (for serving the `assets/` directory) on top of the usual Axum stack:
+
+    ```toml
+    [package]
+    name = "rust-camera"
+    version = "0.1.0"
+    edition = "2021"
+
+    [dependencies]
+    axum = "0.8.8"
+    tokio = { version = "1", features = ["full"] }
+    serde = { version = "1", features = ["derive"] }
+    serde_json = "1"
+    gstreamer = "0.23"
+    gstreamer-app = "0.23"
+    tower-http = { version = "0.6", features = ["fs"] }
+    ```
+  </Step>
+
+  <Step>
+    ### Generated Server
+
+    The generated `src/main.rs` initializes GStreamer, builds an MJPEG capture pipeline (`v4l2src ! image/jpeg ! jpegdec ! jpegenc ! appsink`), and exposes four routes — the UI at `/`, the static `assets`, a `/cameras` list, and a `/stream` WebSocket that broadcasts JPEG frames to connected clients:
+
+    ```rust
+    #[tokio::main]
+    async fn main() {
+        gstreamer::init().expect("Failed to initialize GStreamer");
+
+        let hostname = std::env::var("WENDY_HOSTNAME").unwrap_or_else(|_| "unknown".to_string());
+
+        let (tx, _rx) = broadcast::channel::<Vec<u8>>(16);
+
+        let camera = Arc::new(Mutex::new(MJPEGCamera::new(tx.clone())));
+
+        let state = AppState {
+            camera,
+            tx,
+        };
+
+        let app = Router::new()
+            .route("/", get(index))
+            .nest_service("/assets", tower_http::services::ServeDir::new("./assets"))
+            .route("/cameras", get(list_cameras))
+            .route("/stream", get(ws_handler))
+            .with_state(state);
+
+        let addr = "0.0.0.0:4003";
+        println!("Starting server on {addr} (hostname: {hostname})");
+
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .expect("Failed to bind");
+
+        axum::serve(listener, app).await.expect("Server error");
+    }
+    ```
+
+    <Callout type="info">
+      **On-demand capture**: The GStreamer pipeline only runs while a browser is connected to `/stream`. The first WebSocket client starts the pipeline; when the last client disconnects, the pipeline stops to free the camera. The pipeline defaults to `/dev/video0`, and the browser can switch cameras by sending `{"switch_camera": "/dev/videoN"}` over the socket.
+    </Callout>
+  </Step>
+
+  <Step>
+    ### Generated Browser UI
+
+    The UI is a single `index.html` (styled with the Tailwind browser CDN) that is baked into the binary with `include_str!` and served at `/`. It opens a WebSocket to `/stream`, renders incoming JPEG frames into an `<img>` element, shows a connection-status indicator and FPS counter, and lets you pick a camera from a dropdown populated by the `/cameras` route.
+  </Step>
+
+  <Step>
+    ### Generated Dockerfile
+
+    The multi-stage Dockerfile installs the GStreamer development headers to build, then a runtime image with the GStreamer plugins and `v4l-utils` needed to talk to the camera:
+
+    ```dockerfile
+    # Stage 1: Build
+    FROM rust:1.85-slim AS builder
+
+    RUN apt-get update && apt-get install -y \
+        libgstreamer1.0-dev \
+        libgstreamer-plugins-base1.0-dev \
+        pkg-config \
+        && rm -rf /var/lib/apt/lists/*
+
+    WORKDIR /app
+    COPY Cargo.toml ./
+    COPY src ./src
+    COPY index.html ./
+    COPY assets ./assets
+
+    RUN cargo build --release
+
+    # Stage 2: Runtime
+    FROM debian:bookworm-slim
+
+    RUN apt-get update && apt-get install -y \
+        gstreamer1.0-tools \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-ugly \
+        v4l-utils \
+        ca-certificates \
+        && rm -rf /var/lib/apt/lists/*
+
+    COPY --from=builder /app/target/release/rust-camera /usr/local/bin/rust-camera
+    COPY --from=builder /app/index.html /usr/local/bin/index.html
+    COPY --from=builder /app/assets /usr/local/bin/assets
+
+    EXPOSE 4003
+
+    CMD ["rust-camera"]
+    ```
+  </Step>
+
+  <Step>
+    ### Generated wendy.json
+
+    The generated `wendy.json` requests the entitlements a camera app needs — `network` in host mode, `camera`, and `gpu` — and opens your browser to port `4003` once the stream is ready:
+
+    ```json
+    {
+        "appId": "rust-camera",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network",
+                "mode": "host"
+            },
+            {
+                "type": "camera"
+            },
+            {
+                "type": "gpu"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 4003 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:4003"
+            }
+        }
+    }
+    ```
+  </Step>
+</Steps>
+
+## View the Stream
+
+Your browser opens automatically once the app is ready, thanks to the `postStart` hook. If it doesn't, open the app URL from the `wendy run` output, or navigate to:
+
+```
+http://wendyos-true-probe.local:4003
+```
+
+<Callout type="warning">
+  **Replace the hostname**: Each WendyOS device has a unique hostname. Replace `wendyos-true-probe` with your device's actual hostname shown in the CLI output.
+</Callout>
+
+Use the camera dropdown in the top-right to switch between connected cameras.
+
+## Next Steps
+
+- Adjust the GStreamer pipeline in `src/main.rs` (resolution, JPEG quality, framerate)
+- Customize the browser UI in `index.html`
+- Add inference or processing on the frames before broadcasting them
+- Learn how to add object detection in the [YOLOv8 webcam detection guide](/docs/guides/python/yolov8-webcam-detection)

--- a/go/internal/cli/assets/docs/guides/rust/hello-world.mdx
+++ b/go/internal/cli/assets/docs/guides/rust/hello-world.mdx
@@ -6,12 +6,12 @@ language: rust
 
 ## Creating Your First Rust Application
 
-This guide will walk you through creating a simple "Hello, World!" application for WendyOS using Rust. This is a great way to prove that you can send your first app to your device and verify your development environment is set up correctly.
+This guide will walk you through creating your first WendyOS application in Rust. The Wendy Rust template scaffolds a small, long-running HTTP server (built with [Axum](https://docs.rs/axum/latest/axum/)) so you can prove out the full workflow: build on your machine, deploy over USB or Wi-Fi, and open the running app in your browser.
 
 ### Prerequisites
 
 - Wendy CLI installed on your development machine
-- Rust 1.83 or later installed (via `rustup`)
+- Rust 1.85 or later installed (via `rustup`)
 - A WendyOS device plugged in over USB or connectable over Wi-Fi
 
 <Callout type="info">
@@ -41,7 +41,7 @@ This guide will walk you through creating a simple "Hello, World!" application f
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and show the run output.
+    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and show the run output. Because the app is a web server, it keeps running and your browser opens to it automatically (see the `postStart` hook below).
   </Step>
 </Steps>
 
@@ -56,6 +56,8 @@ This guide will walk you through creating a simple "Hello, World!" application f
     ```
     hello-world/
     ├── Cargo.toml
+    ├── Dockerfile
+    ├── wendy.json
     └── src/
         └── main.rs
     ```
@@ -66,21 +68,73 @@ This guide will walk you through creating a simple "Hello, World!" application f
   <Step>
     ### Verify the Code
 
-    The generated `src/main.rs` file should contain:
+    The generated `src/main.rs` starts an Axum HTTP server. The root route (`/`) returns a JSON message, and there are also `/health` and `POST /items` routes to demonstrate JSON handling:
 
     ```rust
-    fn main() {
-        println!("Hello, world!");
+    use axum::{
+        http::StatusCode,
+        routing::{get, post},
+        Json, Router,
+    };
+    use serde::{Deserialize, Serialize};
+    use std::env;
+
+    #[tokio::main]
+    async fn main() {
+        let hostname = env::var("WENDY_HOSTNAME").unwrap_or_else(|_| "0.0.0.0".to_string());
+
+        let app = Router::new()
+            .route("/", get(root))
+            .route("/health", get(health))
+            .route("/items", post(create_item));
+
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:4001").await.unwrap();
+        println!("Server running on http://{}:4001", hostname);
+        axum::serve(listener, app).await.unwrap();
+    }
+
+    async fn root() -> Json<serde_json::Value> {
+        println!("Received request: GET /");
+        Json(serde_json::json!({"message": "hello-world"}))
+    }
+
+    async fn health() -> Json<serde_json::Value> {
+        Json(serde_json::json!({"status": "ok"}))
+    }
+
+    async fn create_item(Json(payload): Json<CreateItem>) -> (StatusCode, Json<ItemResponse>) {
+        println!("Received request: POST /items - {}", payload.name);
+        let item = ItemResponse {
+            id: 1,
+            name: payload.name,
+            price: payload.price,
+        };
+        (StatusCode::CREATED, Json(item))
+    }
+
+    #[derive(Deserialize)]
+    struct CreateItem {
+        name: String,
+        price: f64,
+    }
+
+    #[derive(Serialize)]
+    struct ItemResponse {
+        id: u64,
+        name: String,
+        price: f64,
     }
     ```
 
-    This is the entry point for your WendyOS application.
+    <Callout type="info">
+      **It's a server, not a one-shot script**: This app binds to `0.0.0.0:4001` and serves requests until it's stopped, so it stays in the `Running` state on your device. Requesting `/` returns `{"message":"hello-world"}`.
+    </Callout>
   </Step>
 
   <Step>
     ### Verify Cargo.toml
 
-    Your `Cargo.toml` should look like:
+    Your `Cargo.toml` declares the Axum, Tokio, and Serde dependencies:
 
     ```toml
     [package]
@@ -89,30 +143,65 @@ This guide will walk you through creating a simple "Hello, World!" application f
     edition = "2021"
 
     [dependencies]
+    axum = "0.8.8"
+    tokio = { version = "1", features = ["full"] }
+    serde = { version = "1", features = ["derive"] }
+    serde_json = "1"
     ```
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile for containerized deployment:
+    The generated project includes a multi-stage Dockerfile that builds the release binary with `rust:1.85-slim` and runs it on `debian:bookworm-slim`:
 
     ```dockerfile
-    # Build stage
-    FROM rust:1.83-slim AS builder
+    FROM rust:1.85-slim AS builder
 
     WORKDIR /app
-    COPY Cargo.toml Cargo.lock ./
+    COPY Cargo.toml ./
     COPY src ./src
 
     RUN cargo build --release
 
-    # Runtime stage
     FROM debian:bookworm-slim
+
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        && rm -rf /var/lib/apt/lists/*
 
     COPY --from=builder /app/target/release/hello-world /usr/local/bin/hello-world
 
+    EXPOSE 4001
+
     CMD ["hello-world"]
+    ```
+  </Step>
+
+  <Step>
+    ### Generated wendy.json
+
+    The generated `wendy.json` already wires up a readiness probe and a `postStart` hook, so the CLI waits for port `4001` and then opens your browser to the running app — you don't add these by hand:
+
+    ```json
+    {
+        "appId": "hello-world",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 4001 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:4001"
+            }
+        }
+    }
     ```
   </Step>
 </Steps>
@@ -125,11 +214,15 @@ Deploy your containerized application to your WendyOS device:
 wendy run
 ```
 
-The Wendy CLI will build your Docker image, transfer it to your device, and run it.
+The Wendy CLI will build your Docker image, transfer it to your device, and run it. Once port `4001` is accepting connections, your browser opens automatically to `http://<your-device-hostname>:4001`, where you'll see:
+
+```json
+{"message":"hello-world"}
+```
 
 ## Verifying Deployment on Your Device
 
-After deploying your application to a WendyOS device, you can verify it was successfully deployed and ran by listing the applications on your device:
+After deploying your application to a WendyOS device, you can verify it is running by listing the applications on your device:
 
 ```bash
 wendy device apps list
@@ -138,12 +231,12 @@ wendy device apps list
 ╭───────────────┬─────────┬─────────┬──────────╮
 │ App           │ Version │ State   │ Failures │
 ├───────────────┼─────────┼─────────┼──────────┤
-│ hello-world   │ 0.0.1   │ Stopped │ 0        │
+│ hello-world   │ 0.1.0   │ Running │ 0        │
 ╰───────────────┴─────────┴─────────┴──────────╯
 ```
 
 <Callout type="info">
-  **Expected State**: The app shows as "Stopped" because a hello-world application exits immediately after printing its message. This is expected behavior. The key indicator of success is the "Failures" column showing `0`, which confirms your application ran and exited successfully without any errors.
+  **Expected State**: The app shows as "Running" because it's a long-lived HTTP server — it keeps listening for requests until you stop it. The "Failures" column showing `0` confirms it started cleanly without crashing.
 </Callout>
 
 ## Next Steps
@@ -161,7 +254,7 @@ Now that you have a basic Rust application running:
 
 <Accordions>
   <Accordion title="Testing the app on your own machine">
-    There are times when you might not have a WendyOS device around. You can still test your application locally using Cargo or Docker.
+    There are times when you might not have a WendyOS device around. You can still run the server locally using Cargo or Docker.
 
     ### Using Cargo Directly
 
@@ -175,9 +268,21 @@ Now that you have a basic Rust application running:
 
     ```
        Compiling hello-world v0.1.0 (/path/to/hello-world)
-        Finished dev [unoptimized + debuginfo] target(s) in 0.75s
+        Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.21s
          Running `target/debug/hello-world`
-    Hello, world!
+    Server running on http://0.0.0.0:4001
+    ```
+
+    The server keeps running. In another terminal, hit the root route:
+
+    ```bash
+    curl http://localhost:4001
+    ```
+
+    You should see:
+
+    ```json
+    {"message":"hello-world"}
     ```
 
     ### Using Docker Locally
@@ -186,13 +291,19 @@ Now that you have a basic Rust application running:
 
     ```bash
     docker build -t hello-world .
-    docker run hello-world
+    docker run -p 4001:4001 hello-world
+    ```
+
+    Then, in another terminal:
+
+    ```bash
+    curl http://localhost:4001
     ```
 
     You should see:
 
-    ```
-    Hello, world!
+    ```json
+    {"message":"hello-world"}
     ```
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/rust/simple-web-server.mdx
+++ b/go/internal/cli/assets/docs/guides/rust/simple-web-server.mdx
@@ -17,7 +17,7 @@ To prove this out, we'll use Axum, the most popular and ergonomic web framework 
 ### Prerequisites
 
 - Wendy CLI installed on your development machine
-- Rust 1.83 or later installed (via `rustup`)
+- Rust 1.85 or later installed (via `rustup`)
 - A WendyOS device plugged in over USB or connectable over Wi-Fi
 
 ## Setting Up Your Project
@@ -53,7 +53,7 @@ To prove this out, we'll use Axum, the most popular and ergonomic web framework 
   <Step>
     ### Generated Package Dependencies
 
-    Review the generated `Cargo.toml` dependencies for Axum, Tokio, and Serde as dependencies:
+    Review the generated `Cargo.toml` dependencies for Axum, Tokio, and Serde:
 
     ```toml
     [package]
@@ -62,7 +62,7 @@ To prove this out, we'll use Axum, the most popular and ergonomic web framework 
     edition = "2021"
 
     [dependencies]
-    axum = "0.7"
+    axum = "0.8.8"
     tokio = { version = "1", features = ["full"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
@@ -76,76 +76,82 @@ To prove this out, we'll use Axum, the most popular and ergonomic web framework 
 
     ```rust
     use axum::{
-        routing::{get, post},
         http::StatusCode,
+        routing::{get, post},
         Json, Router,
     };
     use serde::{Deserialize, Serialize};
+    use std::env;
 
     #[tokio::main]
     async fn main() {
+        let hostname = env::var("WENDY_HOSTNAME").unwrap_or_else(|_| "0.0.0.0".to_string());
+
         let app = Router::new()
             .route("/", get(root))
-            .route("/hello/:name", get(hello))
-            .route("/users", post(create_user));
+            .route("/health", get(health))
+            .route("/items", post(create_item));
 
         let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-        println!("Server running on http://localhost:3000");
+        println!("Server running on http://{}:3000", hostname);
         axum::serve(listener, app).await.unwrap();
     }
 
-    async fn root() -> &'static str {
-        "Hello, World!"
+    async fn root() -> Json<serde_json::Value> {
+        println!("Received request: GET /");
+        Json(serde_json::json!({"message": "hello-world"}))
     }
 
-    async fn hello(axum::extract::Path(name): axum::extract::Path<String>) -> String {
-        format!("Hello, {}!", name)
+    async fn health() -> Json<serde_json::Value> {
+        Json(serde_json::json!({"status": "ok"}))
     }
 
-    async fn create_user(Json(payload): Json<CreateUser>) -> (StatusCode, Json<User>) {
-        let user = User {
+    async fn create_item(Json(payload): Json<CreateItem>) -> (StatusCode, Json<ItemResponse>) {
+        println!("Received request: POST /items - {}", payload.name);
+        let item = ItemResponse {
             id: 1,
-            username: payload.username,
+            name: payload.name,
+            price: payload.price,
         };
-        (StatusCode::CREATED, Json(user))
+        (StatusCode::CREATED, Json(item))
     }
 
     #[derive(Deserialize)]
-    struct CreateUser {
-        username: String,
+    struct CreateItem {
+        name: String,
+        price: f64,
     }
 
     #[derive(Serialize)]
-    struct User {
+    struct ItemResponse {
         id: u64,
-        username: String,
+        name: String,
+        price: f64,
     }
     ```
 
     <Callout type="info">
       **Multiple Routes**: This example includes three routes:
-      - `GET /` - Returns "Hello, World!"
-      - `GET /hello/:name` - Returns a personalized greeting using path parameters
-      - `POST /users` - Creates a new user from JSON body and returns it
+      - `GET /` - Returns `{"message":"hello-world"}`
+      - `GET /health` - Returns `{"status":"ok"}` (handy as a health check)
+      - `POST /items` - Creates an item from a JSON body and returns it with a generated `id`
     </Callout>
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile for containerized deployment:
+    The generated project includes a multi-stage Dockerfile that builds the release binary with `rust:1.85-slim` and runs it on `debian:bookworm-slim`:
 
     ```dockerfile
-    # Build stage
-    FROM rust:1.83-slim AS builder
+    FROM rust:1.85-slim AS builder
 
     WORKDIR /app
-    COPY Cargo.toml Cargo.lock ./
+    COPY Cargo.toml ./
     COPY src ./src
 
     RUN cargo build --release
 
-    # Runtime stage
     FROM debian:bookworm-slim
 
     RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -157,6 +163,33 @@ To prove this out, we'll use Axum, the most popular and ergonomic web framework 
     EXPOSE 3000
 
     CMD ["simple-server"]
+    ```
+  </Step>
+
+  <Step>
+    ### Generated wendy.json
+
+    The generated `wendy.json` already includes a readiness probe and a `postStart` hook, so the CLI waits for port `3000` and then opens your browser to the running server automatically:
+
+    ```json
+    {
+        "appId": "simple-server",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 3000 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3000"
+            }
+        }
+    }
     ```
   </Step>
 </Steps>
@@ -173,24 +206,7 @@ The Wendy CLI will build your Docker image, transfer it to your device, and run 
 
 ## Test Your Server on WendyOS
 
-After deploying your server to your WendyOS device, you can test it from your development machine.
-
-You can configure `wendy.json` with a readiness probe and postStart hook to automatically open your browser when the server is ready:
-
-```json
-{
-  "readiness": {
-    "tcpSocket": { "port": 3000 },
-    "timeoutSeconds": 30
-  },
-  "hooks": {
-    "postStart": {
-      "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3000"
-    }
-  }
-}
-```
-Or open your browser manually and navigate to:
+Your browser will open automatically once the server is ready, thanks to the generated `postStart` hook. If it doesn't, open your browser manually and navigate to:
 
 ```
 http://wendyos-true-probe.local:3000
@@ -200,10 +216,10 @@ http://wendyos-true-probe.local:3000
   **Replace the hostname**: Each WendyOS device has a unique hostname. Replace `wendyos-true-probe` with your device's actual hostname shown in the CLI output. In addition, don't forget to add the port to the hostname.
 </Callout>
 
-You should see the following output:
+You should see the following response from the root route:
 
-```
-Hello, World!
+```json
+{"message":"hello-world"}
 ```
 
 This confirms your web server is successfully running on your WendyOS device and accepting requests from your network.
@@ -219,7 +235,7 @@ wendy device apps list
 ╭───────────────┬─────────┬─────────┬──────────╮
 │ App           │ Version │ State   │ Failures │
 ├───────────────┼─────────┼─────────┼──────────┤
-│ simple-server │ 0.0.0   │ Stopped │ 0        │
+│ simple-server │ 0.1.0   │ Running │ 0        │
 ╰───────────────┴─────────┴─────────┴──────────╯
 ```
 
@@ -235,9 +251,9 @@ Let's break down what the code does:
 
 3. **Create a Router**: We create a `Router` and define three routes with different HTTP methods and handlers.
 
-4. **Path Parameters**: The `/hello/:name` route demonstrates extracting path parameters using Axum's `Path` extractor.
+4. **JSON Responses**: The `/` and `/health` routes return JSON using `serde_json::json!`.
 
-5. **JSON Handling**: The `POST /users` route shows how to deserialize JSON request bodies and serialize JSON responses using Serde.
+5. **JSON Handling**: The `POST /items` route shows how to deserialize a JSON request body into `CreateItem` and serialize a JSON response (`ItemResponse`) using Serde.
 
 6. **Bind to Address**: We create a `TcpListener` that binds to `0.0.0.0:3000`, listening on all network interfaces.
 
@@ -284,9 +300,9 @@ Now that you have a basic web server running:
 
     ```
        Compiling simple-server v0.1.0
-        Finished dev [unoptimized + debuginfo] target(s) in 3.21s
+        Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.21s
          Running `target/debug/simple-server`
-    Server running on http://localhost:3000
+    Server running on http://0.0.0.0:3000
     ```
 
     ### Using Docker Locally
@@ -308,34 +324,34 @@ Now that you have a basic web server running:
 
     You should see:
 
-    ```
-    Hello, World!
+    ```json
+    {"message":"hello-world"}
     ```
 
-    Test the parameterized route:
+    Test the health route:
 
     ```bash
-    curl http://localhost:3000/hello/Wendy
-    ```
-
-    You should see:
-
-    ```
-    Hello, Wendy!
-    ```
-
-    Test the POST endpoint:
-
-    ```bash
-    curl -X POST http://localhost:3000/users \
-      -H "Content-Type: application/json" \
-      -d '{"username": "wendy"}'
+    curl http://localhost:3000/health
     ```
 
     You should see:
 
     ```json
-    {"id":1,"username":"wendy"}
+    {"status":"ok"}
+    ```
+
+    Test the POST endpoint:
+
+    ```bash
+    curl -X POST http://localhost:3000/items \
+      -H "Content-Type: application/json" \
+      -d '{"name": "widget", "price": 9.99}'
+    ```
+
+    You should see:
+
+    ```json
+    {"id":1,"name":"widget","price":9.99}
     ```
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/rust/web-app.mdx
+++ b/go/internal/cli/assets/docs/guides/rust/web-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: Full-Stack Web App
-description: Build a full-stack web application with a Vite/React frontend and Axum backend on WendyOS
+description: Build a full-stack device dashboard with a React frontend and Axum backend on WendyOS
 language: rust
 ---
 
@@ -12,37 +12,19 @@ language: rust
 
 <img src="/images/web-app-example.gif" alt="Web App Demo" style={{ width: '100%', borderRadius: '8px' }} />
 
-In this guide, we'll build a complete web application with a modern React frontend (using Vite, TypeScript, and shadcn/ui) and an Axum backend. The app displays an animated shader background with "WendyOS" text and includes an interactive feature to fetch and display random car data from an API.
+The Wendy full-stack template scaffolds a complete **device dashboard**: a modern React frontend (Vite, TypeScript, Tailwind v4, shadcn/ui) talking to an Axum backend that exposes your device's hardware over HTTP. The whole stack ships as a single container — the backend serves the built frontend and the API from one binary.
 
 This demonstrates how to:
-- Serve a production-built React frontend from a Rust backend
-- Create API endpoints that the frontend can consume
+- Serve a production-built React single-page app from a Rust backend
+- Expose device features (camera, audio, GPU, system info) and persistent data through `/api/*` routes
 - Deploy the entire stack as a single container to your WendyOS device
 
 ### Prerequisites
 
 - Wendy CLI installed on your development machine
 - Node.js 22+ and npm installed (for building the frontend)
-- Rust 1.83 or later installed (via `rustup`)
+- Rust 1.85 or later installed (via `rustup`)
 - A WendyOS device plugged in over USB or connectable over Wi-Fi
-
-## Project Structure
-
-```
-web-app/
-├── Dockerfile
-├── wendy.json
-├── frontend/           # Vite + React + TypeScript + shadcn/ui
-│   ├── package.json
-│   ├── src/
-│   │   ├── App.tsx
-│   │   └── components/
-│   └── ...
-└── server/             # Axum backend
-    ├── Cargo.toml
-    └── src/
-        └── main.rs
-```
 
 ## Setting Up Your Project
 
@@ -57,7 +39,7 @@ web-app/
     cd web-app
     ```
 
-    The template creates `wendy.json`, the Dockerfile, frontend files, and Rust backend files. The sections below explain how the generated full-stack app fits together.
+    The template generates the entire project — `wendy.json`, the Dockerfile, the Rust backend, and the full React frontend. You don't scaffold the frontend by hand. The sections below explain how the generated full-stack app fits together.
   </Step>
 
   <Step>
@@ -67,9 +49,33 @@ web-app/
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and print the URL or run output.
+    Wendy will build the frontend and backend, ask you to select a device if one is not already configured, deploy the app, and open your browser to the dashboard.
   </Step>
 </Steps>
+
+## Project Structure
+
+The generated project has a Rust backend at the root and the React frontend under `frontend/`:
+
+```
+web-app/
+├── Cargo.toml          # Rust backend dependencies
+├── Dockerfile          # multi-stage: build frontend, build backend, runtime
+├── wendy.json          # entitlements + readiness + postStart hook
+├── src/
+│   └── main.rs         # Axum backend: /api/* routes + static SPA
+└── frontend/           # React 19 + Vite + Tailwind v4 + shadcn/ui
+    ├── package.json
+    ├── vite.config.ts
+    ├── index.html
+    └── src/
+        ├── App.tsx     # sidebar dashboard + react-router routes
+        ├── main.tsx
+        ├── components/ # app-sidebar, site-header, shadcn/ui, ...
+        └── pages/      # camera, audio, persistence, gpu, system
+```
+
+The frontend builds to `frontend/dist`, which the Dockerfile copies into the backend image as `./static`.
 
 ## Code Breakdown
 
@@ -77,295 +83,238 @@ web-app/
   <Step>
     ### Generated Frontend
 
-    The template includes a Vite React TypeScript frontend:
-
-    ```bash
-    cd frontend
-    npm create vite@latest . -- --template react-ts
-    npm install
-    npm install -D tailwindcss @tailwindcss/vite
-    ```
-
-    Initialize shadcn/ui:
-
-    ```bash
-    npx shadcn@latest init --defaults
-    npx shadcn@latest add button table
-    ```
-  </Step>
-
-  <Step>
-    ### Generated Frontend App
-
-    The generated `src/App.tsx` drives the browser UI:
+    The frontend is a React 19 single-page app built with Vite, Tailwind v4, and shadcn/ui. `App.tsx` sets up a sidebar dashboard and uses `react-router-dom` v7 for client-side routing across five pages — **camera, audio, persistence, gpu, system** — with the default route redirecting to `/camera`:
 
     ```tsx
-    import { useState } from "react";
-    import { Button } from "@/components/ui/button";
-    import {
-      Table,
-      TableBody,
-      TableCell,
-      TableHead,
-      TableHeader,
-      TableRow,
-    } from "@/components/ui/table";
+    import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
+    import { AppSidebar } from "@/components/app-sidebar"
+    import { SiteHeader } from "@/components/site-header"
+    import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 
-    interface Car {
-      name: string;
-      make: string;
-      year: number;
-      color: string;
-      createdAt: string;
-    }
+    import CameraPage from "@/pages/camera"
+    import AudioPage from "@/pages/audio"
+    import PersistencePage from "@/pages/persistence"
+    import GpuPage from "@/pages/gpu"
+    import SystemPage from "@/pages/system"
 
-    function App() {
-      const [cars, setCars] = useState<Car[]>([]);
-      const [loading, setLoading] = useState(false);
-
-      const fetchCar = async () => {
-        setLoading(true);
-        try {
-          const response = await fetch("/api/random-car");
-          const car: Car = await response.json();
-          setCars((prev) => [car, ...prev].slice(0, 10));
-        } catch (error) {
-          console.error("Failed to fetch car:", error);
-        } finally {
-          setLoading(false);
-        }
-      };
-
+    export default function App() {
       return (
-        <div className="flex min-h-screen w-full flex-col items-center bg-blue-700 p-8">
-          <h1 className="text-7xl font-semibold text-white mb-8">WendyOS</h1>
-
-          <Button
-            onClick={fetchCar}
-            disabled={loading}
-            size="lg"
-            variant="secondary"
+        <BrowserRouter>
+          <SidebarProvider
+            style={
+              {
+                "--sidebar-width": "calc(var(--spacing) * 72)",
+                "--header-height": "calc(var(--spacing) * 12)",
+              } as React.CSSProperties
+            }
           >
-            {loading ? "Fetching..." : "Fetch Car"}
-          </Button>
-
-          {cars.length > 0 && (
-            <div className="mt-8 w-full max-w-4xl rounded-lg bg-white/10 p-4">
-              <Table>
-                <TableHeader>
-                  <TableRow className="border-white/20">
-                    <TableHead className="text-white">Name</TableHead>
-                    <TableHead className="text-white">Make</TableHead>
-                    <TableHead className="text-white">Year</TableHead>
-                    <TableHead className="text-white">Color</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {cars.map((car, index) => (
-                    <TableRow key={index} className="border-white/20">
-                      <TableCell className="text-white">{car.name}</TableCell>
-                      <TableCell className="text-white">{car.make}</TableCell>
-                      <TableCell className="text-white">{car.year}</TableCell>
-                      <TableCell className="text-white">
-                        <div className="flex items-center gap-2">
-                          <div
-                            className="w-4 h-4 rounded"
-                            style={{ backgroundColor: car.color }}
-                          />
-                          {car.color}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </div>
-      );
+            <AppSidebar variant="inset" />
+            <SidebarInset>
+              <SiteHeader />
+              <div className="flex flex-1 flex-col">
+                <div className="@container/main flex flex-1 flex-col gap-2">
+                  <Routes>
+                    <Route path="/" element={<Navigate to="/camera" replace />} />
+                    <Route path="/camera" element={<CameraPage />} />
+                    <Route path="/audio" element={<AudioPage />} />
+                    <Route path="/persistence" element={<PersistencePage />} />
+                    <Route path="/gpu" element={<GpuPage />} />
+                    <Route path="/system" element={<SystemPage />} />
+                  </Routes>
+                </div>
+              </div>
+            </SidebarInset>
+          </SidebarProvider>
+        </BrowserRouter>
+      )
     }
-
-    export default App;
     ```
 
-    Build the frontend:
-
-    ```bash
-    npm run build
-    cd ..
-    ```
+    Each page under `frontend/src/pages/` calls the matching backend `/api/*` route — for example, the camera page opens a WebSocket to `/api/camera/stream`, and the persistence page does CRUD against `/api/cars`. To work on the UI you only need `npm install` and `npm run build` (or `npm run dev`) inside `frontend/`; `wendy run` does the build for you.
   </Step>
 
   <Step>
     ### Generated Axum Backend
 
-    The generated `server/Cargo.toml` describes the backend:
+    The generated `Cargo.toml` describes the backend. It pulls in Axum (with WebSocket support), GStreamer for camera/audio capture, and `rusqlite` (bundled SQLite) for persistence:
 
     ```toml
     [package]
-    name = "web-app-server"
+    name = "web-app"
     version = "0.1.0"
     edition = "2021"
 
     [dependencies]
-    axum = "0.7"
+    axum = { version = "0.8.8", features = ["ws"] }
     tokio = { version = "1", features = ["full"] }
-    tower-http = { version = "0.6", features = ["fs", "cors"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
-    rand = "0.8"
-    chrono = { version = "0.4", features = ["serde"] }
+    rusqlite = { version = "0.32", features = ["bundled"] }
+    tower-http = { version = "0.6", features = ["fs", "trace"] }
+    gstreamer = "0.23"
+    gstreamer-app = "0.23"
+    futures-util = "0.3"
     ```
 
-    The generated `server/src/main.rs` handles the API:
+    The `main()` function in `src/main.rs` wires up the `/api/*` routes, then falls back to serving the built SPA from `./static` (with `index.html` as the SPA fallback for client-side routing):
 
     ```rust
-    use axum::{routing::get, Json, Router};
-    use chrono::Utc;
-    use rand::Rng;
-    use serde::Serialize;
-    use std::env;
-    use std::path::PathBuf;
-    use tower_http::services::{ServeDir, ServeFile};
-
-    #[derive(Serialize)]
-    #[serde(rename_all = "camelCase")]
-    struct Car {
-        name: String,
-        make: String,
-        year: u32,
-        color: String,
-        created_at: String,
-    }
-
-    const CAR_NAMES: &[&str] = &["Honda", "Toyota", "Ford", "Chevrolet", "BMW", "Mercedes", "Audi", "Tesla", "Nissan", "Mazda"];
-    const CAR_MAKES: &[&str] = &["Civic", "Camry", "Mustang", "Corvette", "M3", "C-Class", "A4", "Model 3", "Altima", "MX-5"];
-
-    fn random_car() -> Car {
-        let mut rng = rand::thread_rng();
-        Car {
-            name: CAR_NAMES[rng.gen_range(0..CAR_NAMES.len())].to_string(),
-            make: CAR_MAKES[rng.gen_range(0..CAR_MAKES.len())].to_string(),
-            year: rng.gen_range(1990..2025),
-            color: format!("#{:02X}{:02X}{:02X}", rng.gen_range(0..=255), rng.gen_range(0..=255), rng.gen_range(0..=255)),
-            created_at: Utc::now().to_rfc3339(),
-        }
-    }
-
-    async fn get_random_car() -> Json<Car> {
-        Json(random_car())
-    }
-
     #[tokio::main]
     async fn main() {
-        let hostname = env::var("WENDY_HOSTNAME").unwrap_or_else(|_| "0.0.0.0".to_string());
+        gstreamer::init().expect("Failed to initialise GStreamer");
 
-        // Determine frontend dist path
-        let frontend_dist = env::var("FRONTEND_DIST")
-            .map(PathBuf::from)
-            .ok()
-            .or_else(|| {
-                let container_path = PathBuf::from("/app/frontend/dist");
-                if container_path.exists() { return Some(container_path); }
-                let cwd_path = PathBuf::from("frontend/dist");
-                if cwd_path.exists() { return Some(cwd_path); }
-                None
-            })
-            .unwrap_or_else(|| PathBuf::from("/app/frontend/dist"));
+        let hostname = std::env::var("WENDY_HOSTNAME").unwrap_or_else(|_| "unknown".to_string());
 
-        println!("Server running on http://{}:4002", hostname);
-        println!("Serving frontend from: {:?}", frontend_dist);
+        let (cam_tx, _) = broadcast::channel::<Vec<u8>>(16);
+        let (aud_tx, _) = broadcast::channel::<Vec<u8>>(16);
 
-        let index_file = frontend_dist.join("index.html");
-        let serve_dir = ServeDir::new(&frontend_dist)
-            .not_found_service(ServeFile::new(&index_file));
+        let state = AppState {
+            db: Arc::new(Mutex::new(init_db())),
+            camera: Arc::new(CameraSingleton(Mutex::new(GstCapture {
+                pipeline: None,
+                current_device: None,
+                tx: cam_tx,
+                client_count: 0,
+            }))),
+            audio: Arc::new(AudioSingleton(Mutex::new(GstCapture {
+                pipeline: None,
+                current_device: None,
+                tx: aud_tx,
+                client_count: 0,
+            }))),
+        };
 
-        let app = Router::new()
-            .route("/api/random-car", get(get_random_car))
-            .fallback_service(serve_dir);
+        let api_routes = Router::new()
+            .route("/api/cars", get(list_cars).post(create_car))
+            .route(
+                "/api/cars/{id}",
+                get(get_car).put(update_car).delete(delete_car),
+            )
+            .route("/api/cameras", get(get_cameras))
+            .route("/api/microphones", get(get_microphones))
+            .route("/api/speakers", get(get_speakers))
+            .route("/api/gpu", get(gpu_info))
+            .route("/api/system", get(system_info))
+            .route("/api/camera/stream", get(camera_ws_handler))
+            .route("/api/audio/stream", get(audio_ws_handler))
+            .with_state(state);
 
-        // Bind to 0.0.0.0 to accept connections from all interfaces (required for container networking)
-        let listener = tokio::net::TcpListener::bind("0.0.0.0:4002").await.unwrap();
+        let serve_dir = ServeDir::new("./static").fallback(ServeFile::new("./static/index.html"));
+
+        let app = api_routes.fallback_service(serve_dir);
+
+        let addr = "0.0.0.0:8000";
+        eprintln!("Starting server on {addr} (hostname: {hostname})");
+
+        let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
         axum::serve(listener, app).await.unwrap();
     }
     ```
 
     <Callout type="info">
-      **API Endpoint**: The `/api/random-car` endpoint returns a randomly generated car object with name, make, year, color, and timestamp. The frontend fetches this data and displays the last 10 cars in a table.
+      **API surface**: The backend exposes routes for `system` (host/CPU/memory/disk/uptime), `gpu`, `camera` and `audio` (MJPEG/PCM streamed over WebSockets via GStreamer), and `data` — a **cars CRUD** backed by SQLite. The database is created at `/data/cars.db`, which is mounted by the `persist` entitlement so the data survives restarts.
     </Callout>
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile:
+    The generated Dockerfile is multi-stage: build the frontend with Node, build the Rust backend (with GStreamer and SQLite dev headers), then assemble a slim runtime image with the GStreamer plugins, ALSA, v4l, and SQLite tooling needed at runtime:
 
     ```dockerfile
-    # Build frontend
-    FROM node:22-slim AS frontend-builder
-
-    WORKDIR /app/frontend
+    # Stage 1: Build frontend
+    FROM node:22-slim AS frontend
+    WORKDIR /frontend
     COPY frontend/package*.json ./
-    RUN npm ci
-    COPY frontend/ ./
+    RUN npm install
+    COPY frontend/ .
     RUN npm run build
 
-    # Build Rust server
-    FROM rust:1.83-slim AS rust-builder
-
+    # Stage 2: Build Rust backend
+    FROM rust:1.85-slim AS builder
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libgstreamer1.0-dev \
+        libgstreamer-plugins-base1.0-dev \
+        libgstreamer-plugins-bad1.0-dev \
+        libsqlite3-dev \
+        && rm -rf /var/lib/apt/lists/*
     WORKDIR /app
-    COPY server/Cargo.toml server/Cargo.lock* ./
-    COPY server/src ./src
+    COPY Cargo.toml ./
+    # Create a dummy main.rs so dependencies can be cached
+    RUN mkdir src && echo "fn main() {}" > src/main.rs
+    RUN cargo build --release || true
+    # Now copy the real source and build
+    COPY src ./src
+    RUN touch src/main.rs && cargo build --release
 
-    RUN mkdir -p /app/../frontend/dist
-    RUN cargo build --release
-
-    # Runtime stage
+    # Stage 3: Final image
     FROM debian:bookworm-slim
-
     RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
+        gstreamer1.0-tools \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-ugly \
+        gstreamer1.0-libav \
+        gstreamer1.0-alsa \
+        libgstreamer1.0-0 \
+        libgstreamer-plugins-base1.0-0 \
+        alsa-utils \
+        v4l-utils \
+        sqlite3 \
         && rm -rf /var/lib/apt/lists/*
-
-    WORKDIR /app
-
-    COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
-    COPY --from=rust-builder /app/target/release/web-app-server /usr/local/bin/web-app-server
-
-    ENV FRONTEND_DIST=/app/frontend/dist
-
-    EXPOSE 4002
-
-    CMD ["web-app-server"]
+    COPY --from=builder /app/target/release/web-app /usr/local/bin/web-app
+    COPY --from=frontend /frontend/dist ./static
+    EXPOSE 8000
+    CMD ["web-app"]
     ```
   </Step>
 
   <Step>
     ### Generated wendy.json
 
-    Review the generated `wendy.json` file:
+    The generated `wendy.json` grants the entitlements the dashboard needs — `network` in host mode, plus `camera`, `audio`, `gpu`, and a `persist` volume (`web-app-data`) mounted at `/data` for the SQLite database. The readiness probe and `postStart` hook target port `8000`:
 
     ```json
     {
-      "appId": "com.example.rust-web-app",
-      "version": "0.0.1",
-      "entitlements": [
-        { "type": "network" }
-      ],
-      "readiness": {
-        "tcpSocket": { "port": 4002 },
-        "timeoutSeconds": 30
-      },
-      "hooks": {
-        "postStart": {
-          "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:4002"
+        "appId": "web-app",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network",
+                "mode": "host"
+            },
+            {
+                "type": "camera"
+            },
+            {
+                "type": "audio"
+            },
+            {
+                "type": "gpu"
+            },
+            {
+                "type": "persist",
+                "name": "web-app-data",
+                "path": "/data"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 8000 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:8000"
+            }
         }
-      }
     }
     ```
 
-    The `readiness` probe tells the CLI to wait until port `4002` is accepting connections before proceeding. The `postStart` hook automatically opens your browser once the app is ready.
-    </Step>
+    The `readiness` probe tells the CLI to wait until port `8000` is accepting connections before proceeding. The `postStart` hook automatically opens your browser once the app is ready.
+  </Step>
 </Steps>
 
 ## Run Again on WendyOS
@@ -381,22 +330,40 @@ wendy run
 Your browser will open automatically once the app is ready, thanks to the `postStart` hook. If it doesn't, navigate to:
 
 ```
-http://wendyos-true-probe.local:4002
+http://wendyos-true-probe.local:8000
 ```
 
 <Callout type="warning">
   **Replace the hostname**: Each WendyOS device has a unique hostname. Replace `wendyos-true-probe` with your device's actual hostname shown in the CLI output.
 </Callout>
 
+You'll land on the camera page; use the sidebar to switch between the camera, audio, persistence, GPU, and system pages.
+
 ## Test the API Directly
 
+Query the system info endpoint:
+
 ```bash
-curl http://wendyos-true-probe.local:4002/api/random-car
+curl http://wendyos-true-probe.local:8000/api/system
+```
+
+Add a car to the persistent SQLite store:
+
+```bash
+curl -X POST http://wendyos-true-probe.local:8000/api/cars \
+  -H "Content-Type: application/json" \
+  -d '{"make":"Toyota","model":"Camry","color":"#1E88E5","year":2015}'
+```
+
+List the saved cars:
+
+```bash
+curl http://wendyos-true-probe.local:8000/api/cars
 ```
 
 Response:
 ```json
-{"name":"Toyota","make":"Camry","year":2015,"color":"#A4F2C1","createdAt":"2024-01-15T10:30:00.000Z"}
+[{"id":1,"make":"Toyota","model":"Camry","color":"#1E88E5","year":2015,"created_at":"2026-06-06 10:30:00","updated_at":null}]
 ```
 
 ## Learn More
@@ -409,32 +376,38 @@ Response:
 
 Now that you have a full-stack web app running:
 
-- Add more API endpoints for CRUD operations
-- Implement real-time updates with WebSockets
-- Connect to WendyOS device sensors and display data in the UI
+- Add more `/api/*` endpoints and a matching page under `frontend/src/pages/`
+- Implement real-time updates with WebSockets (the camera and audio pages already do)
+- Connect to more WendyOS device sensors and display data in the UI
 - Add authentication middleware
-- Use a database for persistent storage
+- Extend the SQLite schema for richer persistent storage
 
 <Accordions>
   <Accordion title="Testing locally without a WendyOS device">
+    Some features (camera, audio, GPU) need real device hardware, but you can still build and run the stack locally.
+
     ### Build and Run with Docker
 
     ```bash
-    docker build -t rust-web-app .
-    docker run -p 4002:4002 rust-web-app
+    docker build -t web-app .
+    docker run -p 8000:8000 -v "$(pwd)/data:/data" web-app
     ```
 
-    Then open `http://localhost:4002` in your browser.
+    Then open `http://localhost:8000` in your browser.
 
     ### Run Locally with Cargo
 
     ```bash
-    # Build the frontend first
-    cd frontend && npm run build && cd ..
+    # Build the frontend first (output goes to frontend/dist)
+    cd frontend && npm install && npm run build && cd ..
+
+    # The backend serves the SPA from ./static, so make it available:
+    rm -rf static && cp -r frontend/dist static
 
     # Run the backend
-    cd server
     cargo run --release
     ```
+
+    The backend writes its SQLite database to `/data/cars.db`, so create that directory (or adjust permissions) when running outside a container.
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/swift/audio.mdx
+++ b/go/internal/cli/assets/docs/guides/swift/audio.mdx
@@ -82,7 +82,7 @@ The backend uses [Hummingbird](https://hummingbird.codes) for the HTTP/WebSocket
 
 ### 1. Package Dependencies
 
-The generated `Package.swift` pins Swift 6.3 and includes the GStreamer Swift wrapper alongside Hummingbird and its WebSocket support:
+The generated `Package.swift` declares a minimum `swift-tools-version` of 6.2 (the project still builds with the Swift 6.3 toolchain in the Dockerfile) and includes the GStreamer Swift wrapper alongside Hummingbird and its WebSocket support:
 
 ```swift
 // swift-tools-version: 6.2

--- a/go/internal/cli/assets/docs/guides/swift/audio.mdx
+++ b/go/internal/cli/assets/docs/guides/swift/audio.mdx
@@ -55,19 +55,25 @@ This demonstrates how to use **GStreamer** with Swift to handle complex multimed
 
 ## Project Structure
 
+The template ships a single Swift backend that also serves a static browser UI (`index.html`), plus a folder of sample `.wav` files in `assets/`:
+
 ```
 audio/
+├── Package.swift
 ├── Dockerfile
 ├── wendy.json
-├── frontend/           # React + Vite frontend
-│   └── src/
-│       └── App.tsx     # Audio visualizer & controls
-└── server/             # Swift backend
-    ├── Package.swift
-    └── Sources/
-        └── audio-server/
-            ├── main.swift
-            └── sounds/ # WAV files
+├── .swift-version
+├── index.html          # Browser UI: audio visualizer & controls
+├── assets/             # Sample sounds + logo
+│   ├── car-horn.wav
+│   ├── magic.wav
+│   ├── piano.wav
+│   ├── voice.wav
+│   └── wendy-logo.svg
+└── Sources/
+    └── audio/
+        ├── main.swift             # Routes, GStreamer pipelines, WebSocket
+        └── StaticFileMiddleware.swift
 ```
 
 ## Setting Up the Backend
@@ -76,170 +82,184 @@ The backend uses [Hummingbird](https://hummingbird.codes) for the HTTP/WebSocket
 
 ### 1. Package Dependencies
 
-In `server/Package.swift`, we include the GStreamer Swift wrapper:
+The generated `Package.swift` pins Swift 6.3 and includes the GStreamer Swift wrapper alongside Hummingbird and its WebSocket support:
 
 ```swift
-dependencies: [
-    .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-    .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.0.0"),
-    .package(url: "https://github.com/wendylabsinc/gstreamer.git", from: "0.0.3"),
-],
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "audio",
+    platforms: [
+        .macOS("26.0"),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.0.0"),
+        .package(url: "https://github.com/wendylabsinc/gstreamer-swift.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-container-plugin.git", from: "1.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "audio",
+            dependencies: [
+                .product(name: "Hummingbird", package: "hummingbird", condition: nil),
+                .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
+                .product(name: "GStreamer", package: "gstreamer-swift"),
+            ]
+        ),
+    ]
+)
 ```
 
-### 2. Audio Playback Pipeline
+<Callout type="note">
+  The build runs against Swift 6.3 (the Dockerfile uses `swift:6.3-bookworm`). The `swift-tools-version` line in `Package.swift` declares the minimum Package Manager version and is independent of the toolchain that compiles the code.
+</Callout>
 
-To play a sound, we construct a GStreamer pipeline that reads a file, parses the WAV format, converts it to the correct audio format, and sends it to the default audio sink (speaker).
+### 2. Routes
+
+`Sources/audio/main.swift` wires up the HTTP routes and a WebSocket endpoint:
+
+- `GET /sounds` — lists the bundled `.wav` files in `./assets`
+- `GET /microphones` — enumerates capture devices via `arecord -l`
+- `GET /speakers` — enumerates output devices via `aplay -l`
+- `POST /speaker/{deviceID}` — selects the active speaker (ALSA `hw:card,device`)
+- `POST /play/{filename}` — plays a bundled sound through the selected speaker
+- `WS /stream` — streams live microphone PCM to the browser; send `{"switch_microphone": "<deviceID>"}` to change the source
+- `GET /` and `GET {path+}` — serve the bundled `index.html` UI
+
+### 3. Audio Playback Pipeline
+
+To play a sound, the app builds a GStreamer pipeline that reads a file, parses the WAV format, converts/resamples it, and sends it to the chosen sink (a specific ALSA speaker, or `autoaudiosink`):
 
 ```swift
-func playSound(_ soundName: String, soundsPath: String) async -> PlayResponse {
-    let soundFile = "\(soundsPath)/\(soundName).wav"
-
-    // GStreamer pipeline description
-    let pipelineDesc = """
-        filesrc location=\(soundFile) ! \
-        wavparse ! \
-        audioconvert ! \
-        audioresample ! \
-        autoaudiosink
-        """
-
+func playSound(filename: String, speaker: String?, playback: PlaybackManager) async -> Bool {
+    guard let path = resolveSoundPath(filename) else { return false }
+    let sink = speaker.map { "alsasink device=\($0)" } ?? "autoaudiosink"
+    let description =
+        "filesrc location=\"\(path)\" ! wavparse ! audioconvert ! audioresample ! \(sink)"
     do {
-        let pipeline = try Pipeline(pipelineDesc)
+        let pipeline = try Pipeline(description)
         try pipeline.play()
-
-        // Wait for End of Stream (EOS)
-        for await message in pipeline.bus.messages() {
-            if case .eos = message {
-                pipeline.stop()
-                return PlayResponse(success: true, sound: soundName, error: nil)
-            }
-        }
+        await playback.play(pipeline: pipeline)
+        return true
     } catch {
-        return PlayResponse(success: false, sound: nil, error: "\(error)")
+        return false
     }
-    return PlayResponse(success: false, sound: nil, error: "Unknown error")
 }
 ```
 
-### 3. Microphone Streaming Pipeline
+### 4. Microphone Streaming Pipeline
 
-To stream audio, we capture from the microphone (using ALSA, PulseAudio, or PipeWire), convert it to raw PCM data, and send it to an `appsink` where our Swift code can read the buffers.
+To stream audio, an `AudioCapture` actor builds a microphone source (16 kHz, mono, S16LE) and broadcasts the raw PCM buffers to every connected WebSocket client:
 
 ```swift
-func handleMicrophoneWebSocket(inbound: WebSocketInboundStream, outbound: WebSocketOutboundWriter) async {
-    // Pipeline: Capture -> Convert -> Resample -> Raw PCM (16kHz, Mono) -> AppSink
-    let pipelineDesc = """
-        autoaudiosrc ! \
-        audioconvert ! \
-        audioresample ! \
-        audio/x-raw,format=S16LE,rate=16000,channels=1 ! \
-        appsink name=sink
-        """
+let source = try builder
+    .withSampleRate(16_000)
+    .withChannels(1)
+    .withFormat(.s16le)
+    .build()
 
-    guard let pipeline = try? Pipeline(pipelineDesc),
-          let sink = try? pipeline.audioSink(named: "sink") else {
-        return
+captureTask = Task {
+    for await buffer in source.buffers() {
+        var chunk = ByteBuffer()
+        _ = buffer.bytes.withUnsafeBytes { raw in
+            chunk.writeBytes(raw)
+        }
+        guard chunk.readableBytes > 0 else { continue }
+        await self.broadcast(chunk)
     }
+}
+```
 
-    try? pipeline.play()
-    defer { pipeline.stop() }
+Each `/stream` WebSocket client registers a sender, and the actor writes binary audio frames out to all of them:
 
-    // Stream buffers to the client
-    for await buffer in sink.buffers() {
-        let data = extractAudioBytes(from: buffer)
-        let base64Data = data.base64EncodedString()
-
-        // Send JSON message to client
-        let json = """
-            {\"type\":\"audio\",\"data\":\"\(base64Data)\",\"sampleRate\":16000,\"channels\":1}
-            """
-        try? await outbound.write(.text(json))
+```swift
+wsRouter.ws("/stream") { inbound, outbound, _ in
+    let clientId = UUID()
+    await audioCapture.addClient(id: clientId) { buffer in
+        try? await outbound.write(.binary(buffer))
     }
+    // ... handle inbound switch_microphone commands ...
+    await audioCapture.removeClient(id: clientId)
 }
 ```
 
 ## Frontend Implementation
 
-The frontend is a React application that connects to the WebSocket to receive audio data. It uses the Web Audio API to play the streamed audio and draws a visualization on a canvas.
-
-```tsx
-// Connect to WebSocket
-const ws = new WebSocket(`ws://${window.location.host}/ws/microphone`);
-
-ws.onmessage = async (event) => {
-  const message = JSON.parse(event.data);
-
-  if (message.type === "audio") {
-    // Decode base64
-    const binaryString = atob(message.data);
-    // Convert to Int16 samples
-    // ...
-
-    // Play using Web Audio API
-    const source = audioContext.createBufferSource();
-    source.buffer = audioBuffer;
-    source.connect(audioContext.destination);
-    source.start(nextPlayTime);
-  }
-};
-```
+The frontend is the bundled `index.html` page. It connects to the `/stream` WebSocket to receive binary PCM frames, plays them back with the Web Audio API, and renders a live waveform on a canvas. It also calls `GET /sounds` to populate the play buttons and `POST /play/{filename}` when you click one.
 
 ## Docker Configuration
 
-Working with audio requires system-level dependencies. The `Dockerfile` installs GStreamer development files for building and runtime libraries for the final image.
+Working with audio requires system-level dependencies. The generated `Dockerfile` is a multi-stage build: GStreamer dev packages in the builder, and runtime GStreamer + ALSA libraries in the slim final image. It also copies the `index.html` UI and the `assets/` sounds:
 
 ```dockerfile
-# Build Stage
-FROM swift:6.2.3-noble AS swift-builder
-RUN apt-get update && apt-get install -y \
+FROM swift:6.3-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgstreamer1.0-dev \
     libgstreamer-plugins-base1.0-dev \
-    # ... other plugins
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    && rm -rf /var/lib/apt/lists/*
 
-# Runtime Stage
-FROM swift:6.2.3-noble-slim
-RUN apt-get update && apt-get install -y \
+WORKDIR /app
+COPY Package.swift .
+COPY Sources/ Sources/
+RUN swift build -c release
+
+FROM swift:6.3-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgstreamer1.0-0 \
+    gstreamer1.0-tools \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     gstreamer1.0-alsa \
-    gstreamer1.0-pulseaudio \
-    alsa-utils
+    alsa-utils \
+    && rm -rf /var/lib/apt/lists/*
 
-# Copy sounds
-COPY server/Sources/audio-server/sounds ./sounds
+WORKDIR /app
+COPY --from=builder /app/.build/release/audio /usr/local/bin/audio
+COPY index.html /app/index.html
+COPY assets/ /app/assets/
+
+EXPOSE 6004
+
+CMD ["audio"]
 ```
 
 ## Entitlements
 
-To access the microphone and speaker, the application needs the `audio` entitlement in `wendy.json`:
+To access the microphone and speaker, the generated `wendy.json` already requests the `audio` entitlement (plus host networking). It also includes a readiness probe and a `postStart` browser hook on port `6004`:
 
 ```json
 {
-  "appId": "com.example.swift-audio",
-  "version": "0.0.1",
-  "entitlements": [
-    {
-      "type": "network",
-      "mode": "host"
+    "appId": "audio",
+    "version": "0.1.0",
+    "entitlements": [
+        {
+            "type": "network",
+            "mode": "host"
+        },
+        {
+            "type": "audio"
+        }
+    ],
+    "readiness": {
+        "tcpSocket": { "port": 6004 },
+        "timeoutSeconds": 30
     },
-    {
-      "type": "audio"
+    "hooks": {
+        "postStart": {
+            "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:6004"
+        }
     }
-  ],
-  "readiness": {
-    "tcpSocket": { "port": 3005 },
-    "timeoutSeconds": 30
-  },
-  "hooks": {
-    "postStart": {
-      "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3005"
-    }
-  }
 }
 ```
 
-The `readiness` probe waits for port `3005` to accept connections. The `postStart` hook automatically opens the web interface in your browser.
+The `readiness` probe waits for port `6004` to accept connections. The `postStart` hook automatically opens the web interface in your browser.
 ## Run Again on WendyOS
 
 1.  Connect your WendyOS device.
@@ -249,7 +269,7 @@ The `readiness` probe waits for port `3005` to accept connections. The `postStar
 wendy run
 ```
 
-3.  Your browser will open automatically once the app is ready. If it doesn't, navigate to `http://<device-hostname>.local:3005`.
+3.  Your browser will open automatically once the app is ready. If it doesn't, navigate to `http://<device-hostname>.local:6004`.
 
 You should be able to click buttons to play sounds on the device and toggle the microphone to see the waveform of the audio captured by the device.
 

--- a/go/internal/cli/assets/docs/guides/swift/camera.mdx
+++ b/go/internal/cli/assets/docs/guides/swift/camera.mdx
@@ -41,4 +41,99 @@ Use the Wendy camera template when you want a browser-viewable camera stream wit
 
 ## Code Breakdown
 
-Open the app URL from the Wendy run output to view the stream.
+Open the app URL (`http://${WENDY_HOSTNAME}:6003`) from the Wendy run output to view the stream. The `postStart` hook in `wendy.json` opens it for you automatically once the server is ready.
+
+### Project Structure
+
+The generated project looks like this:
+
+```
+swift-camera/
+├── Package.swift
+├── Dockerfile
+├── wendy.json
+├── .swift-version
+├── index.html
+├── assets/
+│   └── wendy-logo.svg
+└── Sources/
+    └── swift-camera/
+        ├── App.swift
+        ├── MJPEGCamera.swift
+        ├── CameraDiscovery.swift
+        ├── JPEGFrameParser.swift
+        └── StaticFileMiddleware.swift
+```
+
+### Generated wendy.json
+
+The template requests host networking, camera, and GPU entitlements, and registers a readiness probe plus a browser hook on port `6003`:
+
+```json
+{
+    "appId": "swift-camera",
+    "version": "0.1.0",
+    "entitlements": [
+        {
+            "type": "network",
+            "mode": "host"
+        },
+        {
+            "type": "camera"
+        },
+        {
+            "type": "gpu"
+        }
+    ],
+    "readiness": {
+        "tcpSocket": { "port": 6003 },
+        "timeoutSeconds": 30
+    },
+    "hooks": {
+        "postStart": {
+            "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:6003"
+        }
+    }
+}
+```
+
+### Generated Server Routes
+
+`Sources/swift-camera/App.swift` builds a Hummingbird server with WebSocket support and exposes:
+
+- `GET /health` — returns `200 OK`
+- `GET /cameras` — lists detected cameras as JSON
+- `WS /stream` — streams MJPEG frames over a WebSocket; send `{"switch_camera": "<device>"}` to change the source camera
+- `GET /` and `GET {path+}` — serve the bundled `index.html` single-page UI
+
+The camera is captured via GStreamer/V4L2 in `MJPEGCamera.swift`, with device enumeration in `CameraDiscovery.swift` and JPEG frame extraction in `JPEGFrameParser.swift`.
+
+### Generated Dockerfile
+
+The multi-stage Dockerfile builds the binary with `swift:6.3-bookworm` and runs it on `swift:6.3-bookworm-slim` with GStreamer and V4L2 installed:
+
+```dockerfile
+# Stage 1: Build the Swift application
+FROM swift:6.3-bookworm AS builder
+WORKDIR /app
+COPY Package.swift ./
+COPY Sources Sources
+RUN swift build -c release
+
+# Stage 2: Runtime image with GStreamer and V4L2
+FROM swift:6.3-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gstreamer1.0-tools \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    v4l-utils \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/.build/release/swift-camera /usr/local/bin/swift-camera
+COPY index.html ./index.html
+COPY assets/ ./assets/
+EXPOSE 6003
+CMD ["swift-camera"]
+```

--- a/go/internal/cli/assets/docs/guides/swift/hello-world.mdx
+++ b/go/internal/cli/assets/docs/guides/swift/hello-world.mdx
@@ -6,7 +6,9 @@ language: swift
 
 ## Creating Your First Swift Application
 
-This guide will walk you through creating a simple "Hello, World!" application for WendyOS using Swift. This is a great way to prove that you can send your first app to your device and verify your development environment is set up correctly.
+This guide will walk you through creating your first WendyOS application in Swift. This is a great way to prove that you can send an app to your device and verify your development environment is set up correctly.
+
+The `simple-api` template generates a small, long-running HTTP server built on [Hummingbird](https://hummingbird.codes/). It stays running on your device and responds to requests, so you can open it in a browser and see a live response.
 
 ### Prerequisites
 
@@ -37,7 +39,7 @@ This guide will walk you through creating a simple "Hello, World!" application f
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and show the run output.
+    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and stream the run output. Because this is a long-running server, the app stays running after deploy and the generated `postStart` hook opens the response in your browser automatically.
   </Step>
 </Steps>
 
@@ -52,12 +54,169 @@ This guide will walk you through creating a simple "Hello, World!" application f
     ```
     hello-world/
     ├── Package.swift
+    ├── Dockerfile
+    ├── wendy.json
+    ├── .swift-version
     └── Sources/
         └── hello-world/
-            └── hello_world.swift
+            └── App.swift
     ```
 
-    The main application code is in `Sources/hello-world/hello_world.swift`.
+    The main application code is in `Sources/hello-world/App.swift`.
+  </Step>
+
+  <Step>
+    ### Generated Package.swift
+
+    The generated `Package.swift` pins Swift 6.3 and pulls in Hummingbird plus OpenTelemetry support:
+
+    ```swift
+    // swift-tools-version: 6.3
+
+    import PackageDescription
+
+    let package = Package(
+        name: "hello-world",
+        platforms: [
+            .macOS(.v14)
+        ],
+        dependencies: [
+            .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1", traits: []),
+            .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0", traits: ["OTLPHTTP", "OTLPGRPC"]),
+            .package(url: "https://github.com/apple/swift-container-plugin", from: "1.0.0"),
+        ],
+        targets: [
+            .executableTarget(
+                name: "hello-world",
+                dependencies: [
+                    .product(name: "Hummingbird", package: "hummingbird"),
+                    .product(name: "OTel", package: "swift-otel"),
+                ]
+            )
+        ]
+    )
+    ```
+  </Step>
+
+  <Step>
+    ### Generated Application Code
+
+    The generated `Sources/hello-world/App.swift` starts a Hummingbird server that listens on port `6001` and serves a few routes:
+
+    ```swift
+    import Hummingbird
+    import Logging
+    import OTel
+    import ServiceLifecycle
+
+    struct Item: Decodable {
+        let name: String
+        let price: Double
+    }
+
+    struct ItemResponse: ResponseCodable {
+        let id: Int
+        let name: String
+        let price: Double
+    }
+
+    @main
+    struct SimpleAPI {
+        static func main() async throws {
+            let observability = try OTel.bootstrap()
+
+            let logger = Logger(label: "hello-world")
+
+            let router = Router()
+            router.middlewares.add(TracingMiddleware())
+            router.middlewares.add(MetricsMiddleware())
+            router.middlewares.add(LogRequestsMiddleware(.info))
+
+            router.get("/") { _, _ in
+                ["message": "hello-world"]
+            }
+
+            router.get("/health") { _, _ -> HTTPResponse.Status in
+                .ok
+            }
+
+            router.post("/items") { request, context -> ItemResponse in
+                let item = try await request.decode(as: Item.self, context: context)
+                return ItemResponse(id: 1, name: item.name, price: item.price)
+            }
+
+            let app = Application(
+                router: router,
+                configuration: .init(address: .hostname("0.0.0.0", port: 6001))
+            )
+
+            let serviceGroup = ServiceGroup(
+                services: [observability, app],
+                gracefulShutdownSignals: [.sigterm, .sigint],
+                logger: logger
+            )
+
+            try await serviceGroup.run()
+        }
+    }
+    ```
+
+    The `@main` attribute marks the entry point. `GET /` returns `{"message":"hello-world"}`, `GET /health` returns `200 OK`, and `POST /items` echoes a decoded item back as JSON. The server binds to `0.0.0.0` so it's reachable from your host machine and the local network, and it runs until it receives a shutdown signal.
+  </Step>
+
+  <Step>
+    ### Generated wendy.json
+
+    The generated `wendy.json` requests the `network` entitlement, adds a readiness probe on port `6001`, and registers a `postStart` hook that opens your browser once the server is ready:
+
+    ```json
+    {
+        "appId": "hello-world",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 6001 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:6001"
+            }
+        }
+    }
+    ```
+  </Step>
+
+  <Step>
+    ### Generated Dockerfile
+
+    The generated `Dockerfile` is a multi-stage build: it compiles a release binary with `swift:6.3-bookworm` and runs it on the smaller `swift:6.3-bookworm-slim` image:
+
+    ```dockerfile
+    FROM swift:6.3-bookworm AS builder
+
+    WORKDIR /app
+    COPY Package.swift ./
+    COPY Sources Sources
+    RUN swift build -c release
+
+    FROM swift:6.3-bookworm-slim
+
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        && rm -rf /var/lib/apt/lists/*
+
+    WORKDIR /app
+    COPY --from=builder /app/.build/release/hello-world /usr/local/bin/hello-world
+
+    EXPOSE 6001
+
+    CMD ["hello-world"]
+    ```
   </Step>
 </Steps>
 
@@ -67,20 +226,20 @@ You have two options to run your Swift application:
 
 ### Option 1: Run Locally with Swift
 
-Run your application locally on your development machine using the Swift Package Manager:
+You can run the server on your development machine first to make sure everything builds:
 
 ```bash
 swift run
 ```
 
-You should see output similar to:
+The first build fetches the Hummingbird and OpenTelemetry dependencies, then starts the server. It will keep running and listening on `0.0.0.0:6001`. In another terminal you can test it:
 
+```bash
+curl http://localhost:6001
+# {"message":"hello-world"}
 ```
-Building for debugging...
-[8/8] Applying hello-world
-Build of product 'hello-world' complete! (1.93s)
-Hello, world!
-```
+
+Press `Ctrl+C` to stop the local server.
 
 ### Option 2: Deploy to a WendyOS Device
 
@@ -90,34 +249,15 @@ Use the Wendy CLI to cross-compile, push, and start your app on a connected devi
 wendy run
 ```
 
-You should see output similar to:
+Wendy cross-compiles the binary with Swift 6.3 for the target device, deploys it, and streams logs. Once the readiness probe passes, the `postStart` hook opens `http://${WENDY_HOSTNAME}:6001` in your browser, where you'll see:
 
+```json
+{"message":"hello-world"}
 ```
-swift run
-Building for debugging...
-[8/8] Applying hello-world
-Build of product 'hello-world' complete! (1.93s)
-Hello, world!
-```
-
-## More Code Notes
-
-The generated `hello_world.swift` file contains a simple Swift program:
-
-```swift
-@main
-struct HelloWorld {
-    static func main() {
-        print("Hello, world!")
-    }
-}
-```
-
-This is the entry point for your WendyOS application. The `@main` attribute marks this as the main entry point, and the `main()` function is called when the application starts.
 
 ## Verifying Deployment on Your Device
 
-After deploying your application to a WendyOS device, you can verify it was successfully deployed and ran by listing the applications on your device:
+After deploying, you can verify the app is running by listing the applications on your device:
 
 ```bash
 wendy device apps list
@@ -132,22 +272,22 @@ wendy device apps list
 ╭───────────────┬─────────┬─────────┬──────────╮
 │ App           │ Version │ State   │ Failures │
 ├───────────────┼─────────┼─────────┼──────────┤
-│ hello-world   │ 0.0.1   │ Stopped │ 0        │
+│ hello-world   │ 0.1.0   │ Running │ 0        │
 ╰───────────────┴─────────┴─────────┴──────────╯
 ```
 
 <Callout type="info">
-  **Expected State**: The app shows as "Stopped" because a hello-world application exits immediately after printing its message. This is expected behavior. The key indicator of success is the "Failures" column showing `0`, which confirms your application ran and exited successfully without any errors.
+  **Expected State**: The app shows as "Running" because it is a long-running HTTP server that keeps listening for requests. The "Failures" column showing `0` confirms your application started successfully without errors. To stop it later, run `wendy device apps stop hello-world`.
 </Callout>
 
 ## Next Steps
 
-Now that you have a basic Swift application running:
+Now that you have a basic Swift server running:
 
-- Learn how to deploy your app to a WendyOS device
+- Add more routes to handle different endpoints (see the [Simple Web Server](/docs/guides/swift/simple-web-server) guide)
 - Explore WendyOS frameworks for hardware access
 - Build more complex applications with user input and data processing
 
 <Callout type="info">
-  **Local vs Device**: `swift run` compiles and runs your application locally on your development machine. `wendy run` cross-compiles with Swift 6.2.3 for the target device and deploys it automatically.
+  **Local vs Device**: `swift run` compiles and runs your application locally on your development machine. `wendy run` cross-compiles with Swift 6.3 for the target device and deploys it automatically.
 </Callout>

--- a/go/internal/cli/assets/docs/guides/swift/simple-web-server.mdx
+++ b/go/internal/cli/assets/docs/guides/swift/simple-web-server.mdx
@@ -6,13 +6,9 @@ language: swift
 
 ## Building a Web Server with Hummingbird
 
-<Callout type="info">
-  **Source Code**: The complete source code for this example is available at [github.com/wendylabsinc/samples/swift/simple-server](https://github.com/wendylabsinc/samples/tree/main/swift/simple-server)
-</Callout>
+Often times you'll want a long-running server where you can make HTTP calls to your WendyOS device. This allows your device to accept incoming requests and respond to them, making it easy to build interactive applications or APIs that can be accessed from other devices on your network.
 
-Often times you'll want a long-running server where you can make HTTP or WebSocket calls to your WendyOS device. This allows your device to accept incoming requests and respond to them, making it easy to build interactive applications or APIs that can be accessed from other devices on your network.
-
-To prove this out, we'll use Hummingbird, a lightweight and flexible HTTP server framework for Swift.
+To prove this out, we'll use [Hummingbird](https://hummingbird.codes/), a lightweight and flexible HTTP server framework for Swift. The `simple-api` template generates a ready-to-run Hummingbird server with OpenTelemetry instrumentation wired in.
 
 ### Prerequisites
 
@@ -43,7 +39,7 @@ To prove this out, we'll use Hummingbird, a lightweight and flexible HTTP server
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and print the URL or run output.
+    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and stream the run output. Because this is a long-running server, the app stays running after deploy.
   </Step>
 </Steps>
 
@@ -56,23 +52,26 @@ To prove this out, we'll use Hummingbird, a lightweight and flexible HTTP server
     The generated `Package.swift` at the project root looks like this:
 
     ```swift
-    // swift-tools-version: 6.2
+    // swift-tools-version: 6.3
+
     import PackageDescription
 
     let package = Package(
-        name: "SimpleServer",
+        name: "simple-web-server",
         platforms: [
             .macOS(.v14)
         ],
         dependencies: [
-            .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0", traits: []),
+            .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1", traits: []),
+            .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0", traits: ["OTLPHTTP", "OTLPGRPC"]),
             .package(url: "https://github.com/apple/swift-container-plugin", from: "1.0.0"),
         ],
         targets: [
             .executableTarget(
-                name: "SimpleServer",
+                name: "simple-web-server",
                 dependencies: [
-                    .product(name: "Hummingbird", package: "hummingbird")
+                    .product(name: "Hummingbird", package: "hummingbird"),
+                    .product(name: "OTel", package: "swift-otel"),
                 ]
             )
         ]
@@ -86,54 +85,77 @@ Your project layout should look like this:
 ```
 simple-web-server/
 ├── Package.swift
-├── Sources/
-│   └── SimpleServer/
-│       └── main.swift
-└── wendy.json
+├── Dockerfile
+├── wendy.json
+├── .swift-version
+└── Sources/
+    └── simple-web-server/
+        └── App.swift
 ```
 
 ## Generated Web Server
 
-The generated `Sources/SimpleServer/main.swift` contains the server logic:
+The generated `Sources/simple-web-server/App.swift` contains the server logic. It listens on port `8000` and exposes three routes:
 
 ```swift
-import Foundation
 import Hummingbird
+import Logging
+import OTel
+import ServiceLifecycle
 
-struct Car: ResponseEncodable {
-    let make: String
-    let year: Int
+struct Item: Decodable {
+    let name: String
+    let price: Double
+}
+
+struct ItemResponse: ResponseCodable {
+    let id: Int
+    let name: String
+    let price: Double
 }
 
 @main
-struct SimpleServer {
+struct SimpleAPI {
     static func main() async throws {
-        let hostname = ProcessInfo.processInfo.environment["WENDY_HOSTNAME"] ?? "0.0.0.0"
+        let observability = try OTel.bootstrap()
+
+        let logger = Logger(label: "simple-web-server")
 
         let router = Router()
+        router.middlewares.add(TracingMiddleware())
+        router.middlewares.add(MetricsMiddleware())
+        router.middlewares.add(LogRequestsMiddleware(.info))
 
-        // GET / - Returns "hello-world"
         router.get("/") { _, _ in
-            print("Received request: GET /")
-            return "hello-world"
+            ["message": "hello-world"]
         }
 
-        // GET /json - Returns a Car JSON object
-        router.get("/json") { _, _ in
-            print("Received request: GET /json")
-            return Car(make: "Tesla", year: 2024)
+        router.get("/health") { _, _ -> HTTPResponse.Status in
+            .ok
+        }
+
+        router.post("/items") { request, context -> ItemResponse in
+            let item = try await request.decode(as: Item.self, context: context)
+            return ItemResponse(id: 1, name: item.name, price: item.price)
         }
 
         let app = Application(
             router: router,
-            configuration: .init(address: .hostname("0.0.0.0", port: 6001))
+            configuration: .init(address: .hostname("0.0.0.0", port: 8000))
         )
 
-        print("Server running on http://\(hostname):6001")
-        try await app.runService()
+        let serviceGroup = ServiceGroup(
+            services: [observability, app],
+            gracefulShutdownSignals: [.sigterm, .sigint],
+            logger: logger
+        )
+
+        try await serviceGroup.run()
     }
 }
 ```
+
+`GET /` returns `{"message":"hello-world"}`, `GET /health` returns `200 OK`, and `POST /items` decodes an item from the request body and echoes it back as JSON. The `ServiceGroup` runs both the OpenTelemetry observability service and the HTTP server, and shuts them down gracefully on `SIGTERM`/`SIGINT`.
 
 <Callout type="warning">
   **Important**: It's important that your Hummingbird server is running on `0.0.0.0` and not `localhost` or `127.0.0.1`. `0.0.0.0` binds to all network interfaces on the device, making your server reachable from the host machine and the local network. Using `localhost` or `127.0.0.1` binds only to the loopback interface, so the server would not be accessible from outside the device.
@@ -147,20 +169,46 @@ You can test your server on your development machine before deploying to a Wendy
 swift run
 ```
 
-Once the build completes, the server will start and you'll see:
-
-```
-Server running on http://0.0.0.0:6001
-```
-
-You can then test it from another terminal:
+Once the build completes, the server starts listening on `0.0.0.0:8000`. You can then test it from another terminal:
 
 ```bash
-curl http://localhost:6001
-# hello-world
+curl http://localhost:8000
+# {"message":"hello-world"}
 
-curl http://localhost:6001/json
-# {"make":"Tesla","year":2024}
+curl http://localhost:8000/health
+# (returns HTTP 200)
+
+curl -X POST http://localhost:8000/items \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Widget","price":9.99}'
+# {"id":1,"name":"Widget","price":9.99}
+```
+
+Press `Ctrl+C` to stop the local server.
+
+## Generated wendy.json
+
+The generated `wendy.json` requests the `network` entitlement and already includes a readiness probe plus a `postStart` hook that opens your browser when the server is ready — you don't need to add these by hand:
+
+```json
+{
+    "appId": "simple-web-server",
+    "version": "0.1.0",
+    "entitlements": [
+        {
+            "type": "network"
+        }
+    ],
+    "readiness": {
+        "tcpSocket": { "port": 8000 },
+        "timeoutSeconds": 30
+    },
+    "hooks": {
+        "postStart": {
+            "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:8000"
+        }
+    }
+}
 ```
 
 ## Run Again on WendyOS
@@ -171,35 +219,19 @@ When you're ready to deploy, run:
 wendy run
 ```
 
-You can configure `wendy.json` with a readiness probe and postStart hook to automatically open your browser when the server is ready:
-
-```json
-{
-  "readiness": {
-    "tcpSocket": { "port": 6001 },
-    "timeoutSeconds": 30
-  },
-  "hooks": {
-    "postStart": {
-      "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:6001"
-    }
-  }
-}
-```
-Or access it manually by opening a web browser or using curl:
+Once the readiness probe passes, the `postStart` hook opens `http://${WENDY_HOSTNAME}:8000` in your browser. You can also access it manually with curl:
 
 ```bash
-curl http://wendyos-device.local:6001
+curl http://wendyos-device.local:8000
 ```
 
-Take note of the hostname of your WendyOS device. It will be something like `wendyos-device.local`, `wendy run` will output the hostname of your device.
+Take note of the hostname of your WendyOS device. It will be something like `wendyos-device.local`; `wendy run` will output the hostname of your device.
 
 You should see the response:
 
+```json
+{"message":"hello-world"}
 ```
-hello-world
-```
-
 
 ## Verifying Deployment
 
@@ -209,12 +241,14 @@ You can also verify the server is running by listing the applications on your de
 wendy device apps list
 ✔︎ Searching for WendyOS devices [5.3s]
 ✔︎ Listing applications: True Probe [USB, Ethernet, LAN]
-╭───────────────┬─────────┬─────────┬──────────╮
-│ App           │ Version │ State   │ Failures │
-├───────────────┼─────────┼─────────┼──────────┤
-│ simple-server │ 0.0.0   │ Stopped │ 0        │
-╰───────────────┴─────────┴─────────┴──────────╯
+╭───────────────────┬─────────┬─────────┬──────────╮
+│ App               │ Version │ State   │ Failures │
+├───────────────────┼─────────┼─────────┼──────────┤
+│ simple-web-server │ 0.1.0   │ Running │ 0        │
+╰───────────────────┴─────────┴─────────┴──────────╯
 ```
+
+The app shows as **Running** because it is a long-running HTTP server.
 
 ## Learn More
 

--- a/go/internal/cli/assets/docs/guides/swift/web-app.mdx
+++ b/go/internal/cli/assets/docs/guides/swift/web-app.mdx
@@ -1,10 +1,10 @@
 ---
 title: Full-Stack Web App
-description: Build a full-stack web application with a Vite/React frontend and Hummingbird backend on WendyOS
+description: Build a full-stack device dashboard with a React/Vite frontend and Hummingbird backend on WendyOS
 language: swift
 ---
 
-## Building a Full-Stack Web App
+## Building a Full-Stack Device Dashboard
 
 <Callout type="info">
   **Source Code**: The complete source code for this example is available at [github.com/wendylabsinc/samples/swift/web-app](https://github.com/wendylabsinc/samples/tree/main/swift/web-app)
@@ -12,38 +12,60 @@ language: swift
 
 <img src="/images/web-app-example.gif" alt="Web App Demo" style={{ width: '100%', borderRadius: '8px' }} />
 
-In this guide, we'll build a complete web application with a modern React frontend (using Vite, TypeScript, and shadcn/ui) and a Hummingbird backend. The app displays an animated shader background with "WendyOS" text and includes an interactive feature to fetch and display random car data from an API.
+The `fullstack` template generates a complete **device dashboard**: a modern React frontend bundled inside a [Hummingbird](https://hummingbird.codes/) backend that exposes your device's hardware over HTTP and WebSockets. Out of the box it gives you live camera and microphone streams, GPU and system info, and a small SQLite-backed CRUD example — all served from a single container.
 
 This demonstrates how to:
-- Serve a production-built React frontend from a Swift backend
-- Create API endpoints that the frontend can consume
+- Serve a production-built React single-page app (SPA) from a Swift backend
+- Expose device hardware (camera, audio, GPU, system) through `/api/*` routes
+- Persist data on the device with SQLite and a `persist` entitlement
 - Deploy the entire stack as a single container to your WendyOS device
 
 ### Prerequisites
 
 - Wendy CLI installed on your development machine
-- Node.js 22+ and npm installed (for building the frontend)
-- Swift 6.2 installed **via [swiftly](/docs/installation/developer-machine-setup#install-swift)** (Xcode's Swift is not supported)
+- Node.js 22+ and npm installed (only needed if you want to run the frontend dev server locally; the Docker build handles it otherwise)
+- Swift 6.2 or later installed **via [swiftly](/docs/installation/developer-machine-setup#install-swift)** (Xcode's Swift is not supported)
 - A WendyOS device plugged in over USB or connectable over Wi-Fi
 
 ## Project Structure
 
+The template ships a complete frontend under `frontend/` and a Swift backend at the project root. The frontend is built to static assets and copied into the backend image as `./static`:
+
 ```
 web-app/
+├── Package.swift
 ├── Dockerfile
 ├── wendy.json
-├── frontend/           # Vite + React + TypeScript + shadcn/ui
-│   ├── package.json
-│   ├── src/
-│   │   ├── App.tsx
-│   │   └── components/
-│   └── ...
-└── server/             # Hummingbird backend
-    ├── Package.swift
-    └── Sources/
-        └── web-app-server/
-            └── main.swift
+├── .swift-version
+├── Sources/
+│   └── web-app/
+│       ├── App.swift                 # Router, /api routes, WebSockets, static serving
+│       ├── CarStore.swift            # SQLite-backed cars CRUD (GRDB)
+│       ├── MJPEGCamera.swift         # GStreamer/V4L2 camera capture
+│       ├── AudioCapture.swift        # Microphone capture
+│       ├── GPUInfo.swift             # GPU info
+│       ├── SystemInfo.swift          # Host/CPU/mem/disk/uptime
+│       ├── DeviceDiscovery.swift     # Camera/ALSA device enumeration
+│       └── StaticFileMiddleware.swift
+└── frontend/                         # React 19 + Vite + Tailwind v4 + shadcn/ui
+    ├── package.json
+    ├── vite.config.ts
+    ├── index.html
+    └── src/
+        ├── App.tsx                   # Sidebar dashboard + react-router routes
+        ├── main.tsx
+        ├── components/               # app-sidebar, ui/ (shadcn), ...
+        └── pages/
+            ├── camera.tsx
+            ├── audio.tsx
+            ├── persistence.tsx
+            ├── gpu.tsx
+            └── system.tsx
 ```
+
+<Callout type="info">
+  The generated project contains many more frontend files (the full shadcn/ui component library lives under `frontend/src/components/ui/`). The tree above shows the meaningful structure — you don't build any of it by hand; the template ships the whole thing.
+</Callout>
 
 ## Setting Up Your Project
 
@@ -58,7 +80,7 @@ web-app/
     cd web-app
     ```
 
-    The template creates `wendy.json`, the Dockerfile, frontend files, and Swift backend files. The sections below explain how the generated full-stack app fits together.
+    The template creates `wendy.json`, the Dockerfile, the entire React frontend, and the Swift backend. The sections below explain how the generated full-stack app fits together.
   </Step>
 
   <Step>
@@ -68,7 +90,7 @@ web-app/
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and print the URL or run output.
+    Wendy will build the frontend, build and cross-compile the Swift backend, deploy the container, and stream the run output. Once the readiness probe passes, the `postStart` hook opens the dashboard in your browser.
   </Step>
 </Steps>
 
@@ -78,34 +100,53 @@ web-app/
   <Step>
     ### Generated Frontend
 
-    The template includes a Vite React TypeScript frontend:
+    The frontend is a React 19 SPA built with Vite, Tailwind CSS v4, and shadcn/ui. It uses `react-router-dom` v7 for client-side routing and renders a sidebar dashboard. The default route redirects to `/camera`:
 
-    ```bash
-    cd frontend
-    npm create vite@latest . -- --template react-ts
-    npm install
-    npm install -D tailwindcss @tailwindcss/vite
+    ```tsx
+    import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
+    import { AppSidebar } from "@/components/app-sidebar"
+    import { SiteHeader } from "@/components/site-header"
+    import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+
+    import CameraPage from "@/pages/camera"
+    import AudioPage from "@/pages/audio"
+    import PersistencePage from "@/pages/persistence"
+    import GpuPage from "@/pages/gpu"
+    import SystemPage from "@/pages/system"
+
+    export default function App() {
+      return (
+        <BrowserRouter>
+          <SidebarProvider /* ... */>
+            <AppSidebar variant="inset" />
+            <SidebarInset>
+              <SiteHeader />
+              <Routes>
+                <Route path="/" element={<Navigate to="/camera" replace />} />
+                <Route path="/camera" element={<CameraPage />} />
+                <Route path="/audio" element={<AudioPage />} />
+                <Route path="/persistence" element={<PersistencePage />} />
+                <Route path="/gpu" element={<GpuPage />} />
+                <Route path="/system" element={<SystemPage />} />
+              </Routes>
+            </SidebarInset>
+          </SidebarProvider>
+        </BrowserRouter>
+      )
+    }
     ```
 
-    Initialize shadcn/ui:
+    Each page talks to the backend's `/api/*` routes (and the camera/audio WebSocket streams). The frontend's `package.json` pins React 19, `react-router-dom` v7, Tailwind v4, and the shadcn/ui dependency set; `npm run build` runs `tsc -b && vite build` to produce the static `dist/` output.
 
-    ```bash
-    npx shadcn@latest init --defaults
-    npx shadcn@latest add button table
-    ```
-
-    Build the frontend:
-
-    ```bash
-    npm run build
-    cd ..
-    ```
+    <Callout type="info">
+      You don't scaffold the frontend manually. The template already includes the full Vite + React + shadcn/ui project. The Docker build runs `npm install` and `npm run build` for you.
+    </Callout>
   </Step>
 
   <Step>
-    ### Generated Hummingbird Backend
+    ### Generated Backend Package
 
-    The generated `server/Package.swift` describes the backend:
+    The generated `Package.swift` pulls in Hummingbird (with WebSockets), GRDB for SQLite persistence, and the GStreamer Swift wrapper (Linux only) for camera/audio capture:
 
     ```swift
     // swift-tools-version: 6.2
@@ -113,163 +154,185 @@ web-app/
     import PackageDescription
 
     let package = Package(
-        name: "web-app-server",
+        name: "web-app",
         platforms: [
-            .macOS(.v14)
+            .macOS(.v14),
         ],
         dependencies: [
-            .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+            .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1", traits: []),
+            .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.0.0"),
+            .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.0.0"),
+            .package(url: "https://github.com/wendylabsinc/gstreamer-swift.git", branch: "main"),
+            .package(url: "https://github.com/apple/swift-container-plugin.git", from: "1.0.0"),
         ],
         targets: [
             .executableTarget(
-                name: "web-app-server",
+                name: "web-app",
                 dependencies: [
-                    .product(name: "Hummingbird", package: "hummingbird")
+                    .product(name: "Hummingbird", package: "hummingbird"),
+                    .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
+                    .product(name: "GRDB", package: "GRDB.swift"),
+                    .product(name: "GStreamer", package: "gstreamer-swift", condition: .when(platforms: [.linux])),
                 ]
-            )
+            ),
         ]
     )
     ```
 
-    The generated `server/Sources/web-app-server/main.swift` handles the API:
+    <Callout type="note">
+      The build runs against Swift 6.3 (the Dockerfile uses `swift:6.3-bookworm`). The `swift-tools-version` line declares the minimum Package Manager version and is independent of the toolchain that compiles the code.
+    </Callout>
+  </Step>
+
+  <Step>
+    ### Generated Backend Routes
+
+    `Sources/web-app/App.swift` builds the Hummingbird server on port `8000`. It opens a SQLite database at `/data/cars.db`, wires up the device endpoints, and serves the built SPA from `./static`, falling back to `index.html` for client-side routing:
 
     ```swift
-    import Foundation
-    import Hummingbird
+    let carStore = try CarStore(path: "/data/cars.db")
+    let camera = MJPEGCamera(device: "/dev/video0")
+    let audio = AudioCapture()
+    let staticDir = "./static"
 
-    struct Car: ResponseEncodable {
-        let name: String
-        let make: String
-        let year: Int
-        let color: String
-        let createdAt: String
-    }
+    let router = Router()
+    router.get("/health") { _, _ -> HTTPResponse.Status in .ok }
 
-    let carNames = ["Honda", "Toyota", "Ford", "Chevrolet", "BMW", "Mercedes", "Audi", "Tesla", "Nissan", "Mazda"]
-    let carMakes = ["Civic", "Camry", "Mustang", "Corvette", "M3", "C-Class", "A4", "Model 3", "Altima", "MX-5"]
+    // Cars CRUD, backed by SQLite at /data/cars.db
+    let carsGroup = router.group("api/cars")
+    carsGroup.get { _, _ in try jsonResponse(await carStore.all(), status: .ok) }
+    carsGroup.post { request, context in /* create */ }
+    carsGroup.get(":id") { _, context in /* read */ }
+    carsGroup.put(":id") { request, context in /* update */ }
+    carsGroup.delete(":id") { _, context in /* delete */ }
 
-    func randomCar() -> Car {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return Car(
-            name: carNames.randomElement()!,
-            make: carMakes.randomElement()!,
-            year: Int.random(in: 1990...2024),
-            color: String(format: "#%06X", Int.random(in: 0...0xFFFFFF)),
-            createdAt: formatter.string(from: Date())
-        )
-    }
+    // Device endpoints
+    router.get("api/cameras")     { _, _ in try jsonResponse(listCameras(), status: .ok) }
+    router.get("api/microphones") { _, _ in try jsonResponse(listAlsaDevices(args: ["arecord", "-l"]), status: .ok) }
+    router.get("api/speakers")    { _, _ in try jsonResponse(listAlsaDevices(args: ["aplay", "-l"]), status: .ok) }
+    router.get("api/gpu")         { _, _ in try jsonResponse(gpuInfo(), status: .ok) }
+    router.get("api/system")      { _, _ in try jsonResponse(systemInfo(), status: .ok) }
 
-    @main
-    struct WebAppServer {
-        static func main() async throws {
-            let hostname = ProcessInfo.processInfo.environment["WENDY_HOSTNAME"] ?? "0.0.0.0"
-
-            // Determine frontend dist path
-            let containerPath = "/app/frontend/dist"
-            let frontendDist = ProcessInfo.processInfo.environment["FRONTEND_DIST"]
-                ?? (FileManager.default.fileExists(atPath: containerPath + "/index.html") ? containerPath : "../frontend/dist")
-
-            print("Serving frontend from: \(frontendDist)")
-
-            let router = Router()
-
-            // API route for random car
-            router.get("/api/random-car") { _, _ in
-                return randomCar()
-            }
-
-            // Serve static files using FileMiddleware
-            router.add(middleware: FileMiddleware(frontendDist, searchForIndexHtml: true))
-
-            // Bind to 0.0.0.0 to accept connections from all interfaces (required for container networking)
-            let app = Application(
-                router: router,
-                configuration: .init(address: .hostname("0.0.0.0", port: 6002))
-            )
-
-            print("Server running on http://\(hostname):6002")
-            try await app.runService()
-        }
-    }
+    // Serve the SPA and fall back to index.html
+    router.get("/",            use: spaHandler(staticDir: staticDir))
+    router.get("assets/{path+}", use: spaHandler(staticDir: staticDir))
+    router.get("{path+}",      use: spaHandler(staticDir: staticDir))
     ```
 
-    <Callout type="info">
-      **FileMiddleware**: Hummingbird's `FileMiddleware` automatically serves static files from the specified directory. The `searchForIndexHtml: true` option serves `index.html` for directory requests, enabling SPA routing.
-    </Callout>
+    Live media is delivered over WebSockets on a separate router:
+
+    ```swift
+    let wsRouter = Router(context: BasicWebSocketRequestContext.self)
+    wsRouter.ws("api/camera/stream") { inbound, outbound, _ in /* MJPEG frames */ }
+    wsRouter.ws("api/audio/stream")  { inbound, outbound, _ in /* PCM frames */ }
+
+    let app = Application(
+        router: router,
+        server: .http1WebSocketUpgrade(webSocketRouter: wsRouter),
+        configuration: .init(address: .hostname("0.0.0.0", port: 8000))
+    )
+    ```
+
+    The camera stream accepts `{"switch_camera": "<device>"}` and the audio stream accepts `{"switch_microphone": "<deviceID>"}` to change the active source.
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile:
+    The Dockerfile is a three-stage build: build the frontend with Node, build the Swift backend with `swift:6.3-bookworm` (plus GStreamer and SQLite dev libraries), and run on `swift:6.3-bookworm-slim` with the GStreamer/ALSA/V4L runtime plugins and SQLite. The built frontend is copied in as `./static`:
 
     ```dockerfile
-    # Build frontend
-    FROM node:22-slim AS frontend-builder
-
-    WORKDIR /app/frontend
+    # Stage 1: Build the frontend
+    FROM node:22-slim AS frontend
+    WORKDIR /frontend
     COPY frontend/package*.json ./
-    RUN npm ci
-    COPY frontend/ ./
+    RUN npm install
+    COPY frontend/ .
     RUN npm run build
 
-    # Build Swift server
-    FROM swift:6.2.3-noble AS swift-builder
-
+    # Stage 2: Build the Swift backend
+    FROM swift:6.3-bookworm AS builder
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgstreamer1.0-dev \
+        libgstreamer-plugins-base1.0-dev \
+        libgstreamer-plugins-bad1.0-dev \
+        libsqlite3-dev \
+        && rm -rf /var/lib/apt/lists/*
     WORKDIR /app
-    COPY server/Package.swift server/Package.resolved* ./
-    COPY server/Sources ./Sources
-
+    COPY Package.swift ./
+    COPY Sources Sources
     RUN swift build -c release
 
-    # Runtime stage
-    FROM swift:6.2.3-noble-slim
-
-    WORKDIR /app
-
-    COPY --from=swift-builder /app/.build/release/web-app-server /usr/local/bin/web-app-server
-    COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
-
-    ENV FRONTEND_DIST=/app/frontend/dist
-
-    EXPOSE 6002
-
-    CMD ["web-app-server"]
+    # Stage 3: Runtime image
+    FROM swift:6.3-bookworm-slim
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        gstreamer1.0-tools \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-ugly \
+        gstreamer1.0-libav \
+        gstreamer1.0-alsa \
+        alsa-utils \
+        v4l-utils \
+        sqlite3 \
+        ca-certificates \
+        && rm -rf /var/lib/apt/lists/*
+    COPY --from=builder /app/.build/release/web-app /usr/local/bin/web-app
+    COPY --from=frontend /frontend/dist ./static
+    EXPOSE 8000
+    CMD ["web-app"]
     ```
   </Step>
 
   <Step>
     ### Generated wendy.json
 
-    Review the generated `wendy.json` file:
+    Because the dashboard touches the camera, microphone, GPU, and persistent storage, the generated `wendy.json` requests host networking plus the `camera`, `audio`, `gpu`, and `persist` entitlements. The `persist` volume `web-app-data` is mounted at `/data`, where the SQLite database lives:
 
     ```json
     {
-      "appId": "com.example.swift-web-app",
-      "version": "0.0.1",
-      "entitlements": [
-        { "type": "network" }
-      ],
-      "readiness": {
-        "tcpSocket": { "port": 6002 },
-        "timeoutSeconds": 30
-      },
-      "hooks": {
-        "postStart": {
-          "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:6002"
+        "appId": "web-app",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network",
+                "mode": "host"
+            },
+            {
+                "type": "camera"
+            },
+            {
+                "type": "audio"
+            },
+            {
+                "type": "gpu"
+            },
+            {
+                "type": "persist",
+                "name": "web-app-data",
+                "path": "/data"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 8000 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:8000"
+            }
         }
-      }
     }
     ```
 
-    The `readiness` probe tells the CLI to wait until port `6002` is accepting connections before proceeding. The `postStart` hook automatically opens your browser once the app is ready.
-    </Step>
+    The `readiness` probe waits until port `8000` is accepting connections before proceeding. The `postStart` hook automatically opens your browser once the app is ready.
+  </Step>
 </Steps>
 
 ## Run Again on WendyOS
 
-Deploy your full-stack web application to your WendyOS device:
+Deploy your full-stack dashboard to your WendyOS device:
 
 ```bash
 wendy run
@@ -280,7 +343,7 @@ wendy run
 Your browser will open automatically once the app is ready, thanks to the `postStart` hook. If it doesn't, navigate to:
 
 ```
-http://wendyos-true-probe.local:6002
+http://wendyos-true-probe.local:8000
 ```
 
 <Callout type="warning">
@@ -290,12 +353,16 @@ http://wendyos-true-probe.local:6002
 ## Test the API Directly
 
 ```bash
-curl http://wendyos-true-probe.local:6002/api/random-car
-```
+# System info (host, CPU, memory, disk, uptime)
+curl http://wendyos-true-probe.local:8000/api/system
 
-Response:
-```json
-{"name":"Toyota","make":"Camry","year":2015,"color":"#A4F2C1","createdAt":"2024-01-15T10:30:00.000Z"}
+# List cars (SQLite-backed CRUD)
+curl http://wendyos-true-probe.local:8000/api/cars
+
+# Create a car
+curl -X POST http://wendyos-true-probe.local:8000/api/cars \
+  -H "Content-Type: application/json" \
+  -d '{"make":"Tesla","model":"Model 3","color":"#cc0000","year":2024}'
 ```
 
 ## Learn More
@@ -306,34 +373,35 @@ Response:
 
 ## Next Steps
 
-Now that you have a full-stack web app running:
+Now that you have a full-stack device dashboard running:
 
-- Add more API endpoints for CRUD operations
-- Implement real-time updates with WebSockets
-- Connect to WendyOS device sensors and display data in the UI
+- Add new `/api/*` routes and a matching page in `frontend/src/pages/`
+- Extend the cars example into your own SQLite-backed data model
+- Stream additional device data over WebSockets
 - Add authentication middleware
-- Use a database for persistent storage
+- Customize the shadcn/ui theme and sidebar navigation
 
 <Accordions>
   <Accordion title="Testing locally without a WendyOS device">
+    ### Run the frontend dev server
+
+    For fast UI iteration, run Vite's dev server:
+
+    ```bash
+    cd frontend
+    npm install
+    npm run dev
+    ```
+
     ### Build and Run with Docker
+
+    To run the whole stack the same way it runs on a device:
 
     ```bash
     docker build -t swift-web-app .
-    docker run -p 6002:6002 swift-web-app
+    docker run -p 8000:8000 -v "$PWD/data:/data" swift-web-app
     ```
 
-    Then open `http://localhost:6002` in your browser.
-
-    ### Run Locally with Swift
-
-    ```bash
-    # Build the frontend first
-    cd frontend && npm run build && cd ..
-
-    # Run the backend
-    cd server
-    swift run
-    ```
+    Then open `http://localhost:8000` in your browser. Note that camera, audio, and GPU endpoints depend on hardware that may not be available on your development machine.
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/swift/wrapping-c-library.mdx
+++ b/go/internal/cli/assets/docs/guides/swift/wrapping-c-library.mdx
@@ -516,7 +516,7 @@ Your wrapped library works seamlessly on WendyOS:
 .package(url: "https://github.com/yourusername/grayskull-swift.git", from: "0.0.1")
 
 # Build and deploy
-wendy deploy
+wendy run
 ```
 
 The C library compiles natively for ARM64, and your Swift wrapper provides the same safe, ergonomic API across development and deployment.

--- a/go/internal/cli/assets/docs/guides/typescript/camera.mdx
+++ b/go/internal/cli/assets/docs/guides/typescript/camera.mdx
@@ -6,7 +6,7 @@ language: typescript
 
 ## Live Camera Feed with TypeScript
 
-Use the Wendy camera template when you want a browser-viewable camera stream without wiring the project from scratch. The template includes `wendy.json`, camera entitlements, a Dockerfile, TypeScript backend code, and the browser UI.
+Use the Wendy camera template when you want a browser-viewable camera stream without wiring the project from scratch. The template ships an Express + WebSocket backend (`src/index.ts`) that runs a GStreamer pipeline to capture MJPEG frames from `/dev/video0` and broadcast them over a `/stream` WebSocket, plus the browser UI (`index.html`, `assets/`), a `Dockerfile`, and a `wendy.json` with the `network` (host mode), `camera`, and `gpu` entitlements.
 
 ### Prerequisites
 
@@ -41,4 +41,13 @@ Use the Wendy camera template when you want a browser-viewable camera stream wit
 
 ## Code Breakdown
 
-Open the app URL from the Wendy run output to view the stream.
+The generated `wendy.json` includes a readiness probe on port `5003` and a `postStart` hook that opens your browser automatically once the stream is ready. Otherwise, open the app URL from the Wendy run output to view the stream.
+
+The backend in `src/index.ts` does the heavy lifting:
+
+- `GET /` serves the browser UI from `index.html`.
+- `GET /cameras` lists connected cameras via `v4l2-ctl --list-devices`.
+- The `/stream` WebSocket starts a GStreamer pipeline on the first client, extracts JPEG frames, and broadcasts them to all connected viewers; the pipeline is torn down when the last client disconnects.
+- Send a `{"switch_camera": "/dev/videoN"}` message over the WebSocket to switch the active camera.
+
+The runtime image installs the GStreamer plugin set and `v4l-utils` so the pipeline and camera enumeration work on the device.

--- a/go/internal/cli/assets/docs/guides/typescript/hello-world.mdx
+++ b/go/internal/cli/assets/docs/guides/typescript/hello-world.mdx
@@ -6,7 +6,7 @@ language: typescript
 
 ## Creating Your First TypeScript Application
 
-This guide will walk you through creating a simple "Hello, World!" application for WendyOS using TypeScript. This is a great way to prove that you can send your first app to your device and verify your development environment is set up correctly.
+This guide will walk you through creating your first WendyOS application using TypeScript. The Wendy template scaffolds a small long-running [Express](https://expressjs.com/) server that responds with `{"message":"hello-world"}`. It's a great way to prove that you can send your first app to your device and verify your development environment is set up correctly.
 
 ### Prerequisites
 
@@ -41,7 +41,7 @@ This guide will walk you through creating a simple "Hello, World!" application f
     wendy run
     ```
 
-    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and show the run output.
+    Wendy will build the app, ask you to select a device if one is not already configured, deploy the app, and show the run output. Because this is an HTTP server, the app keeps running and the generated `postStart` hook opens your browser to the device.
   </Step>
 </Steps>
 
@@ -51,22 +51,61 @@ This guide will walk you through creating a simple "Hello, World!" application f
   <Step>
     ### Generated Application
 
-    The template includes `src/index.ts`. A minimal hello-world entry point looks like:
-
-    ```bash
-    mkdir src
-    ```
+    The template includes `src/index.ts`, a small Express server. The root route returns a JSON greeting, and there's a `/health` check plus an example `POST /items` route:
 
     ```typescript
     // src/index.ts
-    console.log("Hello, World!");
+    import express, { Request, Response } from "express";
+
+    const app = express();
+    const port = 5001;
+    const hostname = process.env.WENDY_HOSTNAME || "0.0.0.0";
+
+    app.use(express.json());
+
+    app.get("/", (_req: Request, res: Response) => {
+      console.log("Received request: GET /");
+      res.json({ message: "hello-world" });
+    });
+
+    app.get("/health", (_req: Request, res: Response) => {
+      res.json({ status: "ok" });
+    });
+
+    interface CreateItemBody {
+      name: string;
+      price: number;
+    }
+
+    interface ItemResponse {
+      id: number;
+      name: string;
+      price: number;
+    }
+
+    app.post(
+      "/items",
+      (req: Request<{}, ItemResponse, CreateItemBody>, res: Response) => {
+        console.log(`Received request: POST /items - ${req.body.name}`);
+        const item: ItemResponse = {
+          id: 1,
+          name: req.body.name,
+          price: req.body.price,
+        };
+        res.status(201).json(item);
+      }
+    );
+
+    app.listen(port, () => {
+      console.log(`Server running on http://${hostname}:${port}`);
+    });
     ```
   </Step>
 
   <Step>
     ### Generated package.json
 
-    The generated `package.json` includes build and start scripts:
+    The generated `package.json` includes build and start scripts, plus Express as the one runtime dependency:
 
     ```json
     {
@@ -76,9 +115,13 @@ This guide will walk you through creating a simple "Hello, World!" application f
       "scripts": {
         "build": "tsc",
         "start": "node dist/index.js",
-        "dev": "tsx src/index.ts"
+        "dev": "tsx watch src/index.ts"
+      },
+      "dependencies": {
+        "express": "^4"
       },
       "devDependencies": {
+        "@types/express": "^5",
         "@types/node": "^22",
         "typescript": "^5.7",
         "tsx": "^4"
@@ -118,10 +161,9 @@ This guide will walk you through creating a simple "Hello, World!" application f
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile:
+    The generated project includes a multi-stage Dockerfile that builds the TypeScript and ships only the compiled output plus dependencies:
 
     ```dockerfile
-    # Build stage
     FROM node:22-slim AS builder
 
     WORKDIR /app
@@ -132,13 +174,42 @@ This guide will walk you through creating a simple "Hello, World!" application f
     COPY src ./src
     RUN npm run build
 
-    # Runtime stage
     FROM node:22-slim
 
     WORKDIR /app
     COPY --from=builder /app/dist ./dist
+    COPY --from=builder /app/node_modules ./node_modules
+
+    EXPOSE 5001
 
     CMD ["node", "dist/index.js"]
+    ```
+  </Step>
+
+  <Step>
+    ### Generated wendy.json
+
+    The generated `wendy.json` requests the `network` entitlement, declares a TCP readiness check on the server port, and wires a `postStart` hook that opens your browser once the app is ready:
+
+    ```json
+    {
+        "appId": "hello-world",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 5001 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:5001"
+            }
+        }
+    }
     ```
   </Step>
 </Steps>
@@ -153,7 +224,7 @@ wendy run
 
 ## Verifying Deployment on Your Device
 
-After deploying your application to a WendyOS device, you can verify it was successfully deployed and ran by listing the applications on your device:
+After deploying your application to a WendyOS device, you can verify it is running by listing the applications on your device:
 
 ```bash
 wendy device apps list
@@ -162,12 +233,12 @@ wendy device apps list
 ╭───────────────┬─────────┬─────────┬──────────╮
 │ App           │ Version │ State   │ Failures │
 ├───────────────┼─────────┼─────────┼──────────┤
-│ hello-world   │ 0.0.1   │ Stopped │ 0        │
+│ hello-world   │ 0.1.0   │ Running │ 0        │
 ╰───────────────┴─────────┴─────────┴──────────╯
 ```
 
 <Callout type="info">
-  **Expected State**: The app shows as "Stopped" because a hello-world application exits immediately after printing its message. This is expected behavior. The key indicator of success is the "Failures" column showing `0`, which confirms your application ran and exited successfully without any errors.
+  **Expected State**: The app shows as "Running" because it's a long-running HTTP server that stays up to serve requests. The "Failures" column showing `0` confirms it started cleanly. The generated `postStart` hook opens your browser to `http://<device>:5001`, where the root route returns `{"message":"hello-world"}`.
 </Callout>
 
 ## Next Steps
@@ -185,32 +256,40 @@ Now that you have a basic TypeScript application running:
 
     ### Using Node.js Directly
 
-    Build and run your application locally:
+    Install dependencies, build, and start the server:
 
     ```bash
+    npm install
     npm run build
     npm start
     ```
 
-    Or use the dev script with tsx for faster iteration:
+    Or use the dev script with tsx for live-reload iteration:
 
     ```bash
     npm run dev
     ```
 
-    You should see:
+    Either way you should see:
 
     ```
-    Hello, World!
+    Server running on http://0.0.0.0:5001
+    ```
+
+    In another terminal, hit the root route:
+
+    ```bash
+    curl http://localhost:5001/
+    # {"message":"hello-world"}
     ```
 
     ### Using Docker Locally
 
-    Build and run your application in a Docker container:
+    Build and run your application in a Docker container, mapping the port so you can reach it:
 
     ```bash
     docker build -t hello-world .
-    docker run hello-world
+    docker run -p 5001:5001 hello-world
     ```
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/typescript/simple-web-server.mdx
+++ b/go/internal/cli/assets/docs/guides/typescript/simple-web-server.mdx
@@ -116,54 +116,62 @@ This guide shows you how to build a web server using Node.js with Express, the m
 
     const app = express();
     const port = 3000;
+    const hostname = process.env.WENDY_HOSTNAME || "0.0.0.0";
 
     app.use(express.json());
 
     app.get("/", (_req: Request, res: Response) => {
-      res.send("Hello, World!");
+      console.log("Received request: GET /");
+      res.json({ message: "hello-world" });
     });
 
-    app.get("/hello/:name", (req: Request, res: Response) => {
-      res.send(`Hello, ${req.params.name}!`);
+    app.get("/health", (_req: Request, res: Response) => {
+      res.json({ status: "ok" });
     });
 
-    interface CreateUserBody {
-      username: string;
+    interface CreateItemBody {
+      name: string;
+      price: number;
     }
 
-    interface User {
+    interface ItemResponse {
       id: number;
-      username: string;
+      name: string;
+      price: number;
     }
 
-    app.post("/users", (req: Request<{}, User, CreateUserBody>, res: Response) => {
-      const user: User = {
-        id: 1,
-        username: req.body.username,
-      };
-      res.status(201).json(user);
-    });
+    app.post(
+      "/items",
+      (req: Request<{}, ItemResponse, CreateItemBody>, res: Response) => {
+        console.log(`Received request: POST /items - ${req.body.name}`);
+        const item: ItemResponse = {
+          id: 1,
+          name: req.body.name,
+          price: req.body.price,
+        };
+        res.status(201).json(item);
+      }
+    );
 
     app.listen(port, () => {
-      console.log(`Server running on http://localhost:${port}`);
+      console.log(`Server running on http://${hostname}:${port}`);
     });
     ```
 
     <Callout type="info">
       **Multiple Routes**: This example includes three routes:
-      - `GET /` - Returns "Hello, World!"
-      - `GET /hello/:name` - Returns a personalized greeting
-      - `POST /users` - Creates a new user from JSON body
+      - `GET /` - Returns `{"message":"hello-world"}`
+      - `GET /health` - Returns `{"status":"ok"}` for health checks
+      - `POST /items` - Creates an item from a JSON body and echoes it back
     </Callout>
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile:
+    The generated project includes a multi-stage Dockerfile:
 
     ```dockerfile
-    # Build stage
     FROM node:22-slim AS builder
 
     WORKDIR /app
@@ -174,7 +182,6 @@ This guide shows you how to build a web server using Node.js with Express, the m
     COPY src ./src
     RUN npm run build
 
-    # Runtime stage
     FROM node:22-slim
 
     WORKDIR /app
@@ -184,6 +191,33 @@ This guide shows you how to build a web server using Node.js with Express, the m
     EXPOSE 3000
 
     CMD ["node", "dist/index.js"]
+    ```
+  </Step>
+
+  <Step>
+    ### Generated wendy.json
+
+    The generated `wendy.json` requests the `network` entitlement and already includes a readiness probe plus a `postStart` hook that opens your browser to the device when the server is ready:
+
+    ```json
+    {
+        "appId": "simple-server",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 3000 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3000"
+            }
+        }
+    }
     ```
   </Step>
 </Steps>
@@ -200,22 +234,7 @@ wendy run
 
 After deploying your server to your WendyOS device, you can test it from your development machine.
 
-You can configure `wendy.json` with a readiness probe and postStart hook to automatically open your browser when the server is ready:
-
-```json
-{
-  "readiness": {
-    "tcpSocket": { "port": 3000 },
-    "timeoutSeconds": 30
-  },
-  "hooks": {
-    "postStart": {
-      "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:3000"
-    }
-  }
-}
-```
-Or open your browser manually and navigate to:
+The generated `wendy.json` already includes a readiness probe and a `postStart` hook, so Wendy automatically opens your browser to the device once the server is ready. You can also open it manually and navigate to:
 
 ```
 http://wendyos-true-probe.local:3000
@@ -225,10 +244,10 @@ http://wendyos-true-probe.local:3000
   **Replace the hostname**: Each WendyOS device has a unique hostname. Replace `wendyos-true-probe` with your device's actual hostname shown in the CLI output. In addition, don't forget to add the port to the hostname.
 </Callout>
 
-You should see the following output:
+You should see the following JSON response:
 
-```
-Hello, World!
+```json
+{"message":"hello-world"}
 ```
 
 This confirms your web server is successfully running on your WendyOS device and accepting requests from your network.
@@ -284,7 +303,7 @@ Now that you have a basic web server running:
     You should see:
 
     ```
-    Server running on http://localhost:3000
+    Server running on http://0.0.0.0:3000
     ```
 
     ### Using Docker Locally
@@ -307,34 +326,34 @@ Now that you have a basic web server running:
 
     You should see:
 
-    ```
-    Hello, World!
+    ```json
+    {"message":"hello-world"}
     ```
 
-    Test the parameterized route:
+    Test the health endpoint:
 
     ```bash
-    curl http://localhost:3000/hello/Wendy
-    ```
-
-    You should see:
-
-    ```
-    Hello, Wendy!
-    ```
-
-    Test the POST endpoint:
-
-    ```bash
-    curl -X POST http://localhost:3000/users \
-      -H "Content-Type: application/json" \
-      -d '{"username": "wendy"}'
+    curl http://localhost:3000/health
     ```
 
     You should see:
 
     ```json
-    {"id":1,"username":"wendy"}
+    {"status":"ok"}
+    ```
+
+    Test the POST endpoint:
+
+    ```bash
+    curl -X POST http://localhost:3000/items \
+      -H "Content-Type: application/json" \
+      -d '{"name": "widget", "price": 9.99}'
+    ```
+
+    You should see:
+
+    ```json
+    {"id":1,"name":"widget","price":9.99}
     ```
   </Accordion>
 </Accordions>

--- a/go/internal/cli/assets/docs/guides/typescript/web-app.mdx
+++ b/go/internal/cli/assets/docs/guides/typescript/web-app.mdx
@@ -193,6 +193,7 @@ The built frontend (`frontend/dist`) is copied into the backend image as `./stat
 
     ```typescript
     import express, { Request, Response } from "express";
+    import { createServer } from "http";
     import Database from "better-sqlite3";
 
     const PORT = 8000;
@@ -227,6 +228,10 @@ The built frontend (`frontend/dist`) is copied into the backend image as `./stat
     });
 
     // ...more routes, plus static serving + SPA fallback...
+
+    // Wrap the Express app in an HTTP server so the camera/audio
+    // WebSocket streams can share the same port.
+    const server = createServer(app);
 
     server.listen(PORT, () => {
         console.log(`Server running on http://${WENDY_HOSTNAME}:${PORT}`);

--- a/go/internal/cli/assets/docs/guides/typescript/web-app.mdx
+++ b/go/internal/cli/assets/docs/guides/typescript/web-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: Full-Stack Web App
-description: Build a full-stack web application with a Vite/React frontend and Express backend on WendyOS
+description: Build a full-stack device dashboard with a Vite/React frontend and Express backend on WendyOS
 language: typescript
 ---
 
@@ -12,11 +12,14 @@ language: typescript
 
 <img src="/images/web-app-example.gif" alt="Web App Demo" style={{ width: '100%', borderRadius: '8px' }} />
 
-In this guide, we'll build a complete web application with a modern React frontend (using Vite, TypeScript, and shadcn/ui) and an Express backend. The app displays an animated shader background with "WendyOS" text and includes an interactive feature to fetch and display random car data from an API.
+The Wendy `fullstack` template scaffolds a complete **device dashboard**: a modern React 19 frontend (Vite, TypeScript, Tailwind v4, shadcn/ui) talking to an Express backend that exposes your WendyOS device's camera, audio, GPU, system info, and a persistent SQLite-backed data store. The whole thing is packaged and deployed as a single container.
+
+The dashboard uses a sidebar layout with pages for **camera, audio, persistence, gpu, and system**, wired together with `react-router-dom` (the default route redirects to `/camera`). The backend serves `/api/*` routes and the built frontend as static files, falling back to `index.html` for client-side routing.
 
 This demonstrates how to:
-- Serve a production-built React frontend from a Node.js backend
-- Create API endpoints that the frontend can consume
+- Serve a production-built React SPA from a Node.js backend
+- Expose device features (camera, audio, GPU, system) through HTTP and WebSocket APIs
+- Persist data on the device with SQLite and a `persist` volume
 - Deploy the entire stack as a single container to your WendyOS device
 
 ### Prerequisites
@@ -27,22 +30,26 @@ This demonstrates how to:
 
 ## Project Structure
 
+The template ships the full frontend and backend — you don't scaffold them by hand. At the top level it looks like:
+
 ```
 web-app/
-├── Dockerfile
-├── wendy.json
-├── frontend/           # Vite + React + TypeScript + shadcn/ui
-│   ├── package.json
-│   ├── src/
-│   │   ├── App.tsx
-│   │   └── components/
-│   └── ...
-└── server/             # Express backend
+├── Dockerfile          # Multi-stage build: frontend -> backend -> runtime
+├── wendy.json          # Entitlements, readiness probe, postStart hook
+├── package.json        # Express backend (better-sqlite3, ws)
+├── tsconfig.json
+├── src/
+│   └── index.ts        # Express + WebSocket backend (/api/* routes)
+└── frontend/           # Vite + React 19 + Tailwind v4 + shadcn/ui
     ├── package.json
-    ├── tsconfig.json
+    ├── vite.config.ts
     └── src/
-        └── index.ts
+        ├── App.tsx     # Sidebar layout + react-router routes
+        ├── pages/      # camera, audio, persistence, gpu, system
+        └── components/ # shadcn/ui + dashboard components
 ```
+
+The built frontend (`frontend/dist`) is copied into the backend image as `./static`.
 
 ## Setting Up Your Project
 
@@ -57,7 +64,7 @@ web-app/
     cd web-app
     ```
 
-    The template creates `wendy.json`, the Dockerfile, frontend files, and TypeScript backend files. The sections below explain how the generated full-stack app fits together.
+    The template creates `wendy.json`, the Dockerfile, the complete frontend under `frontend/`, and the TypeScript backend (`package.json`, `tsconfig.json`, `src/index.ts`). The sections below explain how the generated full-stack app fits together.
   </Step>
 
   <Step>
@@ -77,185 +84,219 @@ web-app/
   <Step>
     ### Generated Frontend
 
-    The template includes a Vite React TypeScript frontend:
+    The `frontend/` directory is a complete Vite + React 19 app using Tailwind v4 and shadcn/ui. It uses `react-router-dom` v7 for a sidebar dashboard. The router lives in `frontend/src/App.tsx`:
+
+    ```tsx
+    import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
+    import { AppSidebar } from "@/components/app-sidebar"
+    import { SiteHeader } from "@/components/site-header"
+    import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+
+    import CameraPage from "@/pages/camera"
+    import AudioPage from "@/pages/audio"
+    import PersistencePage from "@/pages/persistence"
+    import GpuPage from "@/pages/gpu"
+    import SystemPage from "@/pages/system"
+
+    export default function App() {
+      return (
+        <BrowserRouter>
+          {/* ...sidebar layout... */}
+          <Routes>
+            <Route path="/" element={<Navigate to="/camera" replace />} />
+            <Route path="/camera" element={<CameraPage />} />
+            <Route path="/audio" element={<AudioPage />} />
+            <Route path="/persistence" element={<PersistencePage />} />
+            <Route path="/gpu" element={<GpuPage />} />
+            <Route path="/system" element={<SystemPage />} />
+          </Routes>
+        </BrowserRouter>
+      )
+    }
+    ```
+
+    Each page (`frontend/src/pages/*.tsx`) calls the matching backend API. You build it with Vite:
 
     ```bash
     cd frontend
-    npm create vite@latest . -- --template react-ts
     npm install
-    npm install -D tailwindcss @tailwindcss/vite
-    ```
-
-    Initialize shadcn/ui:
-
-    ```bash
-    npx shadcn@latest init --defaults
-    npx shadcn@latest add button table
-    ```
-
-    Build the frontend:
-
-    ```bash
     npm run build
     cd ..
     ```
+
+    The Dockerfile runs this build for you in its own stage and copies the output into the backend image.
   </Step>
 
   <Step>
     ### Generated Express Backend
 
-    The generated `server/package.json` describes the backend:
+    The backend lives at the project root. The generated `package.json` pulls in Express, `ws` (for camera/audio streaming), and `better-sqlite3` (for persistence):
 
     ```json
     {
-      "name": "web-app-server",
-      "version": "0.1.0",
-      "type": "module",
-      "scripts": {
-        "build": "tsc",
-        "start": "node dist/index.js",
-        "dev": "tsx watch src/index.ts"
-      },
-      "dependencies": {
-        "express": "^4"
-      },
-      "devDependencies": {
-        "@types/express": "^5",
-        "@types/node": "^22",
-        "typescript": "^5.7",
-        "tsx": "^4"
-      },
-      "engines": {
-        "node": ">=22"
-      }
+        "name": "web-app",
+        "version": "0.1.0",
+        "type": "module",
+        "scripts": {
+            "build": "tsc",
+            "start": "node dist/index.js",
+            "dev": "tsx watch src/index.ts"
+        },
+        "dependencies": {
+            "express": "^4",
+            "ws": "^8",
+            "better-sqlite3": "^11"
+        },
+        "devDependencies": {
+            "@types/express": "^5",
+            "@types/ws": "^8",
+            "@types/better-sqlite3": "^7",
+            "@types/node": "^22",
+            "typescript": "^5.7",
+            "tsx": "^4"
+        },
+        "engines": {
+            "node": ">=22"
+        }
     }
     ```
 
-    The generated `server/tsconfig.json` configures TypeScript:
+    The generated `tsconfig.json` configures TypeScript:
 
     ```json
     {
-      "compilerOptions": {
-        "target": "ES2022",
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
-        "outDir": "./dist",
-        "rootDir": "./src",
-        "strict": true,
-        "esModuleInterop": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true
-      },
-      "include": ["src/**/*"]
+        "compilerOptions": {
+            "target": "ES2022",
+            "module": "NodeNext",
+            "moduleResolution": "NodeNext",
+            "outDir": "./dist",
+            "rootDir": "./src",
+            "strict": true,
+            "esModuleInterop": true,
+            "skipLibCheck": true,
+            "declaration": true
+        },
+        "include": ["src"]
     }
     ```
 
-    The generated `server/src/index.ts` handles the API:
+    `src/index.ts` is the heart of the app. It listens on port `8000` and exposes:
+
+    - **`/api/cars`** — a CRUD API (`GET`, `POST`, `GET/:id`, `PUT/:id`, `DELETE/:id`) backed by a SQLite database stored at `/data/cars.db`.
+    - **`/api/system`** — host, CPU, memory, disk, and uptime info.
+    - **`/api/gpu`** — GPU details via `nvidia-smi` (with a thermal-zone fallback).
+    - **`/api/cameras`**, **`/api/microphones`**, **`/api/speakers`** — device enumeration via `v4l2-ctl` and ALSA.
+    - **`/api/camera/stream`** and **`/api/audio/stream`** — WebSocket endpoints that run GStreamer pipelines to stream MJPEG video and PCM audio.
+    - Static serving of the built frontend from `./static`, with an `index.html` fallback for SPA routing.
+
+    The SQLite setup and a couple of the routes look like this:
 
     ```typescript
-    import express from "express";
-    import fs from "fs";
-    import path from "path";
-    import { fileURLToPath } from "url";
+    import express, { Request, Response } from "express";
+    import Database from "better-sqlite3";
 
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = path.dirname(__filename);
+    const PORT = 8000;
+    const WENDY_HOSTNAME = process.env.WENDY_HOSTNAME ?? "localhost";
+    const DB_PATH = "/data/cars.db";
+
+    const db = new Database(DB_PATH);
+    db.pragma("journal_mode = WAL");
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS cars (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            make       TEXT    NOT NULL,
+            model      TEXT    NOT NULL,
+            color      TEXT    NOT NULL,
+            year       INTEGER NOT NULL,
+            created_at TEXT    NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT
+        )
+    `);
 
     const app = express();
-    const hostname = process.env.WENDY_HOSTNAME || "0.0.0.0";
-    const port = 5002;
+    app.use(express.json());
 
-    const CAR_NAMES = ["Honda", "Toyota", "Ford", "Chevrolet", "BMW", "Mercedes", "Audi", "Tesla", "Nissan", "Mazda"];
-    const CAR_MAKES = ["Civic", "Camry", "Mustang", "Corvette", "M3", "C-Class", "A4", "Model 3", "Altima", "MX-5"];
-
-    function randomCar() {
-      return {
-        name: CAR_NAMES[Math.floor(Math.random() * CAR_NAMES.length)],
-        make: CAR_MAKES[Math.floor(Math.random() * CAR_MAKES.length)],
-        year: Math.floor(Math.random() * (2025 - 1990)) + 1990,
-        color: `#${Math.floor(Math.random() * 16777215).toString(16).padStart(6, "0").toUpperCase()}`,
-        createdAt: new Date().toISOString(),
-      };
-    }
-
-    // Determine frontend dist path
-    const frontendDist =
-      process.env.FRONTEND_DIST ||
-      (fs.existsSync("/app/frontend/dist") ? "/app/frontend/dist" : path.join(__dirname, "../../frontend/dist"));
-
-    console.log(`Serving frontend from: ${frontendDist}`);
-
-    // API routes
-    app.get("/api/random-car", (_req, res) => {
-      res.json(randomCar());
+    app.get("/api/cars", (_req: Request, res: Response) => {
+        res.json(listCars.all());
     });
 
-    // Static files
-    app.use(express.static(frontendDist));
-
-    // Fallback to index.html for SPA routing
-    app.get("*", (_req, res) => {
-      res.sendFile(path.join(frontendDist, "index.html"));
+    app.post("/api/cars", (req: Request, res: Response) => {
+        const { make, model, color, year } = req.body;
+        const info = insertCar.run({ make, model, color, year });
+        res.status(201).json(getCar.get(info.lastInsertRowid));
     });
 
-    // Bind to 0.0.0.0 to accept connections from all interfaces (required for container networking)
-    app.listen(port, "0.0.0.0", () => {
-      console.log(`Server running on http://${hostname}:${port}`);
+    // ...more routes, plus static serving + SPA fallback...
+
+    server.listen(PORT, () => {
+        console.log(`Server running on http://${WENDY_HOSTNAME}:${PORT}`);
     });
     ```
 
-    Install dependencies and build:
+    Install and build the backend with:
 
     ```bash
-    cd server
     npm install
     npm run build
-    cd ..
     ```
 
     <Callout type="info">
-      **API Endpoint**: The `/api/random-car` endpoint returns a randomly generated car object with name, make, year, color, and timestamp. The frontend fetches this data and displays the last 10 cars in a table.
+      **Persistence**: The cars database lives at `/data/cars.db`. The `persist` entitlement in `wendy.json` mounts a volume named `web-app-data` at `/data`, so your data survives app restarts and redeploys.
     </Callout>
   </Step>
 
   <Step>
     ### Generated Dockerfile
 
-    The generated project includes a Dockerfile:
+    The generated multi-stage Dockerfile builds the frontend, builds the backend, and assembles a runtime image with the GStreamer/ALSA/v4l tooling the device APIs need. The runtime stage also installs `python3`, `make`, and `g++` so npm can rebuild the native `better-sqlite3` addon:
 
     ```dockerfile
-    # Build frontend
-    FROM node:22-slim AS frontend-builder
-
-    WORKDIR /app/frontend
+    # Stage 1 — Build React frontend
+    FROM node:22-slim AS frontend
+    WORKDIR /frontend
     COPY frontend/package*.json ./
-    RUN npm ci
+    RUN npm install
     COPY frontend/ ./
     RUN npm run build
 
-    # Build server
-    FROM node:22-slim AS server-builder
-
+    # Stage 2 — Build backend TypeScript
+    FROM node:22-slim AS builder
     WORKDIR /app
-    COPY server/package*.json ./
+    COPY package*.json ./
     RUN npm install
-
-    COPY server/tsconfig.json ./
-    COPY server/src ./src
+    COPY tsconfig.json ./
+    COPY src/ ./src/
     RUN npm run build
 
-    # Runtime stage
+    # Stage 3 — Production runtime
     FROM node:22-slim
-
     WORKDIR /app
-    COPY --from=server-builder /app/dist ./dist
-    COPY --from=server-builder /app/node_modules ./node_modules
-    COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 
-    ENV FRONTEND_DIST=/app/frontend/dist
+    # Install GStreamer, ALSA, v4l-utils, and native build tools for better-sqlite3
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        gstreamer1.0-tools \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-ugly \
+        gstreamer1.0-libav \
+        gstreamer1.0-alsa \
+        alsa-utils \
+        v4l-utils \
+        python3 \
+        make \
+        g++ \
+        && rm -rf /var/lib/apt/lists/*
 
-    EXPOSE 5002
+    # Install production dependencies (rebuilds better-sqlite3 native addon)
+    COPY package*.json ./
+    RUN npm install --omit=dev
 
+    # Copy compiled backend and frontend assets
+    COPY --from=builder /app/dist ./dist
+    COPY --from=frontend /frontend/dist ./static
+
+    EXPOSE 8000
     CMD ["node", "dist/index.js"]
     ```
   </Step>
@@ -263,28 +304,45 @@ web-app/
   <Step>
     ### Generated wendy.json
 
-    Review the generated `wendy.json` file:
+    The generated `wendy.json` requests the entitlements the dashboard needs: host-mode `network`, plus `camera`, `audio`, `gpu`, and a `persist` volume for the SQLite database:
 
     ```json
     {
-      "appId": "com.example.node-web-app",
-      "version": "0.0.1",
-      "entitlements": [
-        { "type": "network" }
-      ],
-      "readiness": {
-        "tcpSocket": { "port": 5002 },
-        "timeoutSeconds": 30
-      },
-      "hooks": {
-        "postStart": {
-          "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:5002"
+        "appId": "web-app",
+        "version": "0.1.0",
+        "entitlements": [
+            {
+                "type": "network",
+                "mode": "host"
+            },
+            {
+                "type": "camera"
+            },
+            {
+                "type": "audio"
+            },
+            {
+                "type": "gpu"
+            },
+            {
+                "type": "persist",
+                "name": "web-app-data",
+                "path": "/data"
+            }
+        ],
+        "readiness": {
+            "tcpSocket": { "port": 8000 },
+            "timeoutSeconds": 30
+        },
+        "hooks": {
+            "postStart": {
+                "cli": "wendy utils open-browser http://${WENDY_HOSTNAME}:8000"
+            }
         }
-      }
     }
     ```
 
-    The `readiness` probe tells the CLI to wait until port `5002` is accepting connections before proceeding. The `postStart` hook automatically opens your browser once the app is ready.
+    The `readiness` probe tells the CLI to wait until port `8000` is accepting connections before proceeding. The `postStart` hook automatically opens your browser once the app is ready.
     </Step>
 </Steps>
 
@@ -301,22 +359,40 @@ wendy run
 Your browser will open automatically once the app is ready, thanks to the `postStart` hook. If it doesn't, navigate to:
 
 ```
-http://wendyos-true-probe.local:5002
+http://wendyos-true-probe.local:8000
 ```
 
 <Callout type="warning">
   **Replace the hostname**: Each WendyOS device has a unique hostname. Replace `wendyos-true-probe` with your device's actual hostname shown in the CLI output.
 </Callout>
 
+The dashboard opens on the **Camera** page by default. Use the sidebar to switch between the camera, audio, persistence, GPU, and system pages.
+
 ## Test the API Directly
 
+List the system info reported by the device:
+
 ```bash
-curl http://wendyos-true-probe.local:5002/api/random-car
+curl http://wendyos-true-probe.local:8000/api/system
+```
+
+Add a car to the persistent store:
+
+```bash
+curl -X POST http://wendyos-true-probe.local:8000/api/cars \
+  -H "Content-Type: application/json" \
+  -d '{"make":"Toyota","model":"Camry","color":"Blue","year":2015}'
 ```
 
 Response:
 ```json
-{"name":"Toyota","make":"Camry","year":2015,"color":"#A4F2C1","createdAt":"2024-01-15T10:30:00.000Z"}
+{"id":1,"make":"Toyota","model":"Camry","color":"Blue","year":2015,"created_at":"2026-06-06 10:30:00","updated_at":null}
+```
+
+List all cars:
+
+```bash
+curl http://wendyos-true-probe.local:8000/api/cars
 ```
 
 ## Learn More
@@ -329,31 +405,34 @@ Response:
 
 Now that you have a full-stack web app running:
 
-- Add more API endpoints for CRUD operations
-- Implement real-time updates with Socket.io
-- Connect to WendyOS device sensors and display data in the UI
+- Add more API endpoints and dashboard pages
+- Stream the camera or microphone in your own UI via the WebSocket endpoints
+- Extend the SQLite schema for your own persistent data
 - Add authentication middleware
-- Use a database for persistent storage
+- Connect to additional WendyOS device sensors and display data in the UI
 
 <Accordions>
   <Accordion title="Testing locally without a WendyOS device">
     ### Build and Run with Docker
 
     ```bash
-    docker build -t node-web-app .
-    docker run -p 5002:5002 node-web-app
+    docker build -t web-app .
+    docker run -p 8000:8000 web-app
     ```
 
-    Then open `http://localhost:5002` in your browser.
+    Then open `http://localhost:8000` in your browser.
+
+    <Callout type="info">
+      **Device features off-device**: Camera, audio, and GPU endpoints rely on hardware and tooling that aren't present on a typical laptop, so those pages will be empty when running locally. The system info and the cars CRUD (persistence) work anywhere.
+    </Callout>
 
     ### Run Locally
 
     ```bash
     # Build the frontend first
-    cd frontend && npm run build && cd ..
+    cd frontend && npm install && npm run build && cd ..
 
     # Run the backend
-    cd server
     npm install
     npm run dev
     ```


### PR DESCRIPTION
## What

Regenerated **every template × language combination** with `wendy init --template` in `/tmp` (using each guide's own documented `APP_ID` / `PORT` / `SWIFT_VERSION` vars) and updated the fumadocs guides so their embedded code, commands, file trees, entitlements, and expected output match what the templates actually generate today.

24 guide files updated across Python, Rust, Swift, C++, and TypeScript.

## Why

The guides had drifted significantly from the templates:
- The `simple-api` template (used by every **hello-world** guide) now scaffolds a **full long-running HTTP server**, not a print-and-exit app.
- The `fullstack` template (used by **web-app** guides) is now a **multi-page device dashboard**, not the old "Fetch Car" demo.
- `wendy.json` (appId, `version: 0.1.0`, entitlements, readiness probe, `postStart` browser hook), Dockerfiles, ports, and dependency manifests had all changed.

## Key changes

- **hello-world** (all langs): reframed around the real generated server — app stays **Running** (not "Stopped/exits immediately"), browser opens via the generated `postStart` hook, real source / Dockerfile / `wendy.json` shown. Removed stale "Generated requirements.txt" steps for Python (deps now installed in the Dockerfile via `uv`).
- **web-app** (python, typescript, rust, swift): **full rewrites** describing the actual device dashboard — React 19 + Vite + Tailwind v4 + shadcn/ui sidebar (camera/audio/persistence/gpu/system pages) + an `/api` backend with SQLite persistence at `/data`. Removed the obsolete manual `npm create vite` / `npx shadcn` scaffolding and the `/api/random-car` demo.
- **simple-web-server / camera / audio / webcam-streaming / yolov8**: snippets, ports, Dockerfiles, manifests, and `wendy.json` updated to match generated output. YOLOv8 now documents the `WENDY_PLATFORM`-selected multi-stage build (Jetson CUDA vs generic CPU) and 180s readiness.
- **Minor**: `wrapping-c-library` `wendy deploy` → `wendy run` (no `deploy` subcommand); `bluetooth-discovery` `wendy.json` conventions.

## How it was verified

- All snippets sourced from freshly generated projects; spot-checked guide code against generated `app.py` / `App.swift` / `main.rs` / `index.ts` / `main.cpp`.
- MDX hygiene checked across all 24 files: balanced `<Steps>/<Step>/<Callout>/<Accordions>` tags and code fences; no leftover `com.example`, `0.0.1`, `video` entitlement, `random-car`, or wrong ports.

## Follow-up (not in this PR)

- `web-app` guides still embed `/images/web-app-example.gif` (old car demo); the webcam/yolov8 guides reference older screenshots. These should be **re-recorded** against the new UIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)