### PR TITLE
ci: disable flaky Jetson Swift E2E route

### DIFF
--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -1,6 +1,12 @@
 name: Swift E2E Tests
 
 on:
+  pull_request:
+    paths:
+      - 'swift/**'
+      - 'Proto/**'
+      - '.github/actions/swift-e2e-run/**'
+      - '.github/workflows/swift-e2e-tests.yml'
   push:
     branches:
       - main

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -62,15 +62,16 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - name: macOS 26 → Jetson Orin Nano
-            target_id: macos-jetson-orin-nano
-            runner_id: macos-26
-            runner_label: macos-26
-            cli_os: macOS
-            device_id: jetson-orin-nano
-            device_address: wendyos-strong-dunlin.local
-            agent_os: wendyOS
-            transport: lan
+          # // DISABLED: Mac <> Jetson Swift E2E is flaky; re-enable after stabilization.
+          # - name: macOS 26 → Jetson Orin Nano
+          #   target_id: macos-jetson-orin-nano
+          #   runner_id: macos-26
+          #   runner_label: macos-26
+          #   cli_os: macOS
+          #   device_id: jetson-orin-nano
+          #   device_address: wendyos-strong-dunlin.local
+          #   agent_os: wendyOS
+          #   transport: lan
 
           # // DISABLED: no CI hardware set up yet for this job.
           # - name: Windows 11 → Ubuntu 24


### PR DESCRIPTION
## Summary
- Revert PR #880 so Swift E2E runs on pull requests again.
- Temporarily disable the macOS 26 → Jetson Orin Nano route because it is flaky.
- Leave the remaining active route, macOS 26 → Ubuntu 24, enabled so PRs still exercise a stable path.

## Tests
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/swift-e2e-tests.yml"); puts "ok"'`
