### PR TITLE
docs: add Wendy Agent for macOS install page

### DIFF
--- a/go/internal/cli/assets/docs/guides/device/cli-agent-relationship.mdx
+++ b/go/internal/cli/assets/docs/guides/device/cli-agent-relationship.mdx
@@ -7,6 +7,6 @@ The diagram below illustrates the relationship between the `wendy` CLI on your d
 
 The `wendy` CLI is the developer-facing tool you install on your Mac, Linux, or Windows machine. It handles project scaffolding, cross-compilation, device discovery, and deployment. The `wendy-agent` is a service that runs on the target device and manages the container lifecycle, hardware access (GPU, audio, Bluetooth, GPIO), networking, and telemetry. When you run `wendy run`, the CLI cross-compiles your app, pushes the container image to the agent, and streams logs back to your terminal.
 
-The CLI discovers agents over the local network using mDNS, over a direct USB-C cable connection, or by targeting a remote hostname for devices behind a VPN. The `wendy-agent` comes pre-installed on [WendyOS](/docs/installation/wendyos-nvidia-jetson) devices, or you can [install it on any existing Linux machine](/docs/installation/linux-wendy-agent) -- Ubuntu, Raspberry Pi OS, Debian, Arch, and more.
+The CLI discovers agents over the local network using mDNS, over a direct USB-C cable connection, or by targeting a remote hostname for devices behind a VPN. The `wendy-agent` comes pre-installed on [WendyOS](/docs/installation/wendyos-nvidia-jetson) devices, or you can install it on an [existing Linux machine](/docs/installation/wendy-agent-linux) (Ubuntu, Raspberry Pi OS, Debian, Arch, and more). [Wendy Agent for macOS](/docs/installation/wendy-agent-macos) is available as a beta for Apple Silicon Mac targets.
 
 <CliToAgentRelationshipDiagram />

--- a/go/internal/cli/assets/docs/installation/developer-machine-setup.mdx
+++ b/go/internal/cli/assets/docs/installation/developer-machine-setup.mdx
@@ -81,5 +81,5 @@ Once your developer machine is ready, choose the branch that matches where you w
 
 - **[Setup your NVIDIA Jetson with WendyOS](/docs/installation/wendyos-nvidia-jetson)** if you are building for GPU-accelerated edge AI on Orin Nano or AGX Orin.
 - **[Setup your Raspberry Pi 5 with WendyOS](/docs/installation/wendyos-raspberry-pi-5)** if you want a compact ARM64 development or robotics target.
-- **[Setup an Ubuntu machine](/docs/installation/linux-wendy-agent)** if you want to run `wendy-agent` on an existing Linux box, VM, or remote machine.
-- **Track Wendy for Mac on the roadmap** if you want to deploy, manage, and debug headless Mac mini or Mac Studio targets.
+- **[Install Wendy Agent on Linux](/docs/installation/wendy-agent-linux)** if you want to run `wendy-agent` on an existing Linux box, VM, or remote machine.
+- **[Install Wendy Agent on macOS](/docs/installation/wendy-agent-macos)** if you want to deploy, manage, and debug Apple Silicon Mac targets; headless Mac mini systems are a good fit.

--- a/go/internal/cli/assets/docs/installation/meta.json
+++ b/go/internal/cli/assets/docs/installation/meta.json
@@ -4,7 +4,8 @@
     "developer-machine-setup",
     "wendyos-nvidia-jetson",
     "wendyos-raspberry-pi-5",
-    "esp32",
-    "linux-wendy-agent"
+    "wendy-lite-esp32",
+    "wendy-agent-linux",
+    "wendy-agent-macos"
   ]
 }

--- a/go/internal/cli/assets/docs/installation/wendy-agent-linux.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-linux.mdx
@@ -1,5 +1,5 @@
 ---
-title: Linux - Install wendy-agent
+title: Wendy Agent — Linux
 description: Install wendy-agent on any Linux machine to turn it into a managed Wendy device
 ---
 
@@ -7,9 +7,11 @@ description: Install wendy-agent on any Linux machine to turn it into a managed 
 
 `wendy-agent` comes pre-installed on WendyOS, which currently supports [NVIDIA Jetson Orin Nano and AGX Orin](/docs/installation/wendyos-nvidia-jetson) plus [Raspberry Pi 5](/docs/installation/wendyos-raspberry-pi-5). If you flashed WendyOS onto your device, you do not need to follow this guide.
 
-If you already have an existing OS running (Raspberry Pi OS, Ubuntu, Debian, DGX Spark's Linux image, or any other Linux distribution), you can install `wendy-agent` directly. Once installed, your `wendy` CLI and device can discover each other over the local area network.
+Wendy Agent is also available as a standalone install for targets that already run an existing operating system.
 
-For headless Mac mini and Mac Studio targets, Wendy for Mac is in progress. It follows the same `wendy-agent` model, but uses a macOS-specific agent path instead of this Linux install script.
+For Linux targets (Raspberry Pi OS, Ubuntu, Debian, DGX Spark's Linux image, or another Linux distribution), install the Linux agent directly. Once installed, your `wendy` CLI and device can discover each other over the local area network.
+
+For Apple Silicon Mac targets, use [Wendy Agent for macOS](/docs/installation/wendy-agent-macos). It follows the same `wendy-agent` model, but uses a macOS-specific app instead of this Linux install script.
 
 This works on:
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -1,0 +1,136 @@
+---
+title: Wendy Agent — macOS
+description: Install Wendy Agent on an Apple Silicon Mac target
+---
+
+## Overview
+
+`wendy-agent` comes pre-installed on WendyOS. If you want to use an existing Apple Silicon Mac as a Wendy target instead, install Wendy Agent for Mac on that machine.
+
+Wendy Agent for Mac runs as a menu bar app. Once it is running, the Wendy CLI can connect to the Mac target, sync native macOS apps, and launch them as native macOS processes.
+
+<Callout type="warn">
+  Wendy Agent for macOS is beta software. It works on Apple Silicon Macs. Intel Macs are not supported. Deploying native macOS apps requires a Mac development machine because the CLI builds the app locally before syncing it to the agent.
+</Callout>
+
+## Requirements
+
+- An Apple Silicon Mac target running macOS 15 or later
+- Wendy CLI installed on a Mac development machine ([Developer Machine Setup](/docs/installation/developer-machine-setup))
+- A native macOS app project to deploy
+
+Native macOS app deployment requires a Mac development machine because the Wendy CLI builds the macOS app locally before syncing it to the Mac agent. If the same Mac is both your development machine and target, install both the CLI and Wendy Agent on that Mac.
+
+## Installation
+
+The recommended installation path uses Homebrew:
+
+```bash
+brew tap wendylabsinc/tap
+brew install --cask wendy-agent
+```
+
+For the nightly beta build, use:
+
+```bash
+brew install --cask wendy-agent-nightly
+```
+
+If you do not use Homebrew, download the `wendy-agent-macos-arm64` zip from the [Wendy releases page](https://github.com/wendylabsinc/wendy-agent/releases), unzip it, and move `WendyAgentMac.app` to `/Applications`.
+
+Then launch the app:
+
+```bash
+open /Applications/WendyAgentMac.app
+```
+
+Wendy Agent appears in the macOS menu bar. Open the menu to confirm that the agent is running.
+
+## Verify the Installation
+
+From the Mac development machine, check that the CLI can reach the Mac agent.
+
+If the CLI and agent are on the same Mac, use `localhost`:
+
+```bash
+wendy --device localhost:50051 device info --json
+```
+
+If the agent is running on another Mac on your network, replace `localhost` with that Mac's hostname or IP address:
+
+```bash
+wendy --device {hostname}:50051 device info --json
+```
+
+Replace `{hostname}` with the Mac target's hostname or IP address.
+
+## Set the Mac as Your Default Device
+
+Once the CLI can connect, set the Mac target as your default Wendy device:
+
+```bash
+wendy device set-default localhost:50051
+```
+
+For a remote Mac target, use its hostname or IP address instead:
+
+```bash
+wendy device set-default {hostname}:50051
+```
+
+## Deploying Native macOS Apps
+
+From a native macOS app project configured for a Darwin target, run:
+
+```bash
+wendy run --device localhost:50051
+```
+
+For a remote Mac target, pass that target explicitly:
+
+```bash
+wendy run --device {hostname}:50051
+```
+
+The CLI builds the app on the Mac development machine, syncs the build output to Wendy Agent for Mac, and starts it as a native macOS process. These apps currently run natively on macOS, not inside a Linux-style container.
+
+## Beta Support Notes
+
+Wendy for Mac beta is intentionally smaller than WendyOS on Raspberry Pi or NVIDIA Jetson. macOS does not currently provide the same app containerization path that Wendy Agent uses on Linux, so apps run as native macOS processes rather than Linux containers.
+
+Currently supported first:
+
+- Apple Silicon Mac targets
+- WendyAgentMac running as a menu bar app
+- CLI connection to the Mac agent
+- Native macOS app deployment through file sync
+- Native, non-containerized app execution on macOS
+- Native app lifecycle management where supported by the current agent
+
+Current limitations:
+
+- Intel Macs are not supported
+- Native macOS app deployment requires a Mac development machine
+- Wi-Fi management, Bluetooth peripheral control, camera/video, audio, GPU, USB, GPIO, and I2C access are not available through Wendy hardware APIs in the initial Mac beta
+- Virtualized Linux containers, once enabled later, are intended for self-contained services such as databases, queues, and web workers, not hardware access
+
+Unsupported features should either be hidden, clearly marked as unsupported, or fail with an actionable unsupported message.
+
+## Troubleshooting
+
+If the CLI cannot connect:
+
+1. Confirm Wendy Agent is open in the menu bar.
+2. Run the command with an explicit device address:
+
+   ```bash
+   wendy --device localhost:50051 device info --json
+   ```
+
+3. If the agent is on another Mac, use that Mac's hostname or IP address instead of `localhost`.
+4. Quit and reopen Wendy Agent from the menu bar.
+5. If you installed both stable and nightly builds, quit both apps and open only the one you want to test.
+
+## Next Steps
+
+Once the Mac target is reachable, deploy a native macOS app with `wendy run`. The Mac beta support matrix and smoke checklist will expand this page as more flows are verified.

--- a/go/internal/cli/assets/docs/installation/wendy-lite-esp32.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-lite-esp32.mdx
@@ -1,9 +1,9 @@
 ---
-title: ESP32 Installation (Wendy Lite)
+title: Wendy Lite — ESP32
 description: Install Wendy Lite on ESP32 RISC-V microcontrollers
 ---
 
-## ESP32 Installation (Wendy Lite)
+## Wendy Lite — ESP32
 
 Wendy Lite is a WebAssembly runtime for ESP32 RISC-V microcontrollers. It lets you write firmware in Swift and deploy it as a `.wasm` binary to ESP32-C6 and ESP32-C5 devices.
 

--- a/go/internal/cli/assets/docs/installation/wendyos-nvidia-jetson.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-nvidia-jetson.mdx
@@ -1,5 +1,5 @@
 ---
-title: WendyOS - NVIDIA Jetson
+title: WendyOS — NVIDIA Jetson
 description: Install WendyOS on your NVIDIA Jetson device
 ---
 
@@ -16,7 +16,7 @@ description: Install WendyOS on your NVIDIA Jetson device
 
 This guide will walk you through installing WendyOS on supported NVIDIA Jetson devices. WendyOS supports Jetson Orin Nano today, AGX Orin support is imminent, and AGX Thor support is in progress.
 
-For DGX Spark, use the [Linux wendy-agent install](/docs/installation/linux-wendy-agent) on the existing OS instead of flashing WendyOS.
+For DGX Spark, use [Wendy Agent — Linux](/docs/installation/wendy-agent-linux) on the existing OS instead of flashing WendyOS.
 
 Prefer to follow along with video? Watch the [WendyOS NVIDIA Jetson Orin Nano installation video](https://youtu.be/TtDJAtBUEZI).
 

--- a/go/internal/cli/assets/docs/installation/wendyos-raspberry-pi-5.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-raspberry-pi-5.mdx
@@ -1,5 +1,5 @@
 ---
-title: WendyOS - Raspberry Pi 5
+title: WendyOS — Raspberry Pi 5
 description: Install WendyOS on your Raspberry Pi 5
 ---
 


### PR DESCRIPTION
## Summary
- Add a practical Wendy Agent for macOS installation page for WDY-1343.
- Expose the macOS page in the Installation nav alongside Linux, WendyOS, and Wendy Lite targets.
- Rename the Linux and ESP32 installation slugs/titles to match the requested menu labels.

Closes WDY-1343.

## Tests
- `cd docs && npm run types:check`

## Manual validation
- Confirmed WendyAgentMac launches on Apple Silicon macOS and appears in the menu bar.
- Confirmed first-launch welcome/permission prompts were shown and allowed.
- Confirmed stable CLI `2026.06.06-232448` can connect to stable WendyAgentMac `2026.06.06-232448` with `wendy --device localhost:50051 device info --json`.
- Confirmed the agent listens on `*:50051` and the CLI can connect using this Mac's LAN IP.
- Confirmed `wendy device set-default localhost:50051` followed by `wendy device info --json` works.
- Confirmed `wendy run --device localhost:50051` deploys and runs a minimal native Darwin SwiftPM executable with `platform: "darwin"`.
- Confirmed smoke app cleanup leaves no deployed test app behind.
