### PR TITLE
Show disk usage in device info

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
@@ -178,6 +178,10 @@ message GetAgentVersionResponse {
     optional string cuda_version = 11;
     // STORAGE value from /etc/wendyos/device-type (e.g. "sd", "nvme"). Only present on WendyOS.
     optional string storage_medium = 12;
+    // Root filesystem bytes currently used by the device. Only present when the agent can inspect disk usage.
+    optional int64 disk_used_bytes = 13;
+    // Root filesystem total bytes on the device. Only present when the agent can inspect disk usage.
+    optional int64 disk_total_bytes = 14;
 }
 
 // Request message for listing WiFi networks

--- a/Proto/wendy/agent/services/v2/device_info_service.proto
+++ b/Proto/wendy/agent/services/v2/device_info_service.proto
@@ -21,6 +21,8 @@ message GetDeviceInfoResponse {
     optional string gpu_vendor = 9;
     optional string jetpack_version = 10;
     optional string cuda_version = 11;
+    optional int64 disk_used_bytes = 12;
+    optional int64 disk_total_bytes = 13;
 }
 
 message ListHardwareCapabilitiesRequest {

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -88,6 +88,11 @@ func (s *AgentService) GetAgentVersion(_ context.Context, _ *agentpb.GetAgentVer
 		resp.CudaVersion = &gpuInfo.cudaVersion
 	}
 
+	if usage, ok := rootDiskUsage(); ok {
+		resp.DiskUsedBytes = &usage.usedBytes
+		resp.DiskTotalBytes = &usage.totalBytes
+	}
+
 	return resp, nil
 }
 

--- a/go/internal/agent/services/device_info_service.go
+++ b/go/internal/agent/services/device_info_service.go
@@ -53,6 +53,11 @@ func (s *DeviceInfoService) GetDeviceInfo(_ context.Context, _ *agentpbv2.GetDev
 		resp.CudaVersion = &gpuInfo.cudaVersion
 	}
 
+	if usage, ok := rootDiskUsage(); ok {
+		resp.DiskUsedBytes = &usage.usedBytes
+		resp.DiskTotalBytes = &usage.totalBytes
+	}
+
 	return resp, nil
 }
 

--- a/go/internal/agent/services/disk_usage.go
+++ b/go/internal/agent/services/disk_usage.go
@@ -1,0 +1,24 @@
+package services
+
+import "math"
+
+type diskUsage struct {
+	usedBytes  int64
+	totalBytes int64
+}
+
+func calculateDiskUsage(blocks, freeBlocks, blockSize uint64) (diskUsage, bool) {
+	if blockSize == 0 || blocks == 0 || freeBlocks > blocks {
+		return diskUsage{}, false
+	}
+
+	usedBlocks := blocks - freeBlocks
+	if blocks > math.MaxInt64/blockSize || usedBlocks > math.MaxInt64/blockSize {
+		return diskUsage{}, false
+	}
+
+	return diskUsage{
+		usedBytes:  int64(usedBlocks * blockSize),
+		totalBytes: int64(blocks * blockSize),
+	}, true
+}

--- a/go/internal/agent/services/disk_usage_bsd.go
+++ b/go/internal/agent/services/disk_usage_bsd.go
@@ -1,0 +1,16 @@
+//go:build darwin || freebsd
+
+package services
+
+import "golang.org/x/sys/unix"
+
+func rootDiskUsage() (diskUsage, bool) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs("/", &stat); err != nil {
+		return diskUsage{}, false
+	}
+	if stat.Bsize <= 0 {
+		return diskUsage{}, false
+	}
+	return calculateDiskUsage(stat.Blocks, stat.Bfree, uint64(stat.Bsize))
+}

--- a/go/internal/agent/services/disk_usage_linux.go
+++ b/go/internal/agent/services/disk_usage_linux.go
@@ -1,0 +1,22 @@
+//go:build linux
+
+package services
+
+import "golang.org/x/sys/unix"
+
+func rootDiskUsage() (diskUsage, bool) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs("/", &stat); err != nil {
+		return diskUsage{}, false
+	}
+
+	blockSize := stat.Frsize
+	if blockSize <= 0 {
+		blockSize = stat.Bsize
+	}
+	if blockSize <= 0 {
+		return diskUsage{}, false
+	}
+
+	return calculateDiskUsage(stat.Blocks, stat.Bfree, uint64(blockSize))
+}

--- a/go/internal/agent/services/disk_usage_test.go
+++ b/go/internal/agent/services/disk_usage_test.go
@@ -1,0 +1,37 @@
+package services
+
+import "testing"
+
+func TestCalculateDiskUsage(t *testing.T) {
+	usage, ok := calculateDiskUsage(30_000_000, 29_415_000, 4_000)
+	if !ok {
+		t.Fatal("calculateDiskUsage returned false")
+	}
+	if usage.usedBytes != 2_340_000_000 {
+		t.Fatalf("usedBytes = %d, want 2340000000", usage.usedBytes)
+	}
+	if usage.totalBytes != 120_000_000_000 {
+		t.Fatalf("totalBytes = %d, want 120000000000", usage.totalBytes)
+	}
+}
+
+func TestCalculateDiskUsageRejectsInvalidStats(t *testing.T) {
+	tests := []struct {
+		name       string
+		blocks     uint64
+		freeBlocks uint64
+		blockSize  uint64
+	}{
+		{name: "zero blocks", blocks: 0, freeBlocks: 0, blockSize: 4096},
+		{name: "zero block size", blocks: 1, freeBlocks: 0, blockSize: 0},
+		{name: "free exceeds total", blocks: 1, freeBlocks: 2, blockSize: 4096},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, ok := calculateDiskUsage(tt.blocks, tt.freeBlocks, tt.blockSize); ok {
+				t.Fatal("calculateDiskUsage returned true")
+			}
+		})
+	}
+}

--- a/go/internal/agent/services/disk_usage_unsupported.go
+++ b/go/internal/agent/services/disk_usage_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !(linux || darwin || freebsd)
+
+package services
+
+func rootDiskUsage() (diskUsage, bool) {
+	return diskUsage{}, false
+}

--- a/go/internal/cli/commands/apps_dashboard_test.go
+++ b/go/internal/cli/commands/apps_dashboard_test.go
@@ -159,3 +159,10 @@ func TestFormatBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatDiskUsage(t *testing.T) {
+	got := formatDiskUsage(2_340_000_000, 120_000_000_000)
+	if got != "2.34 GB / 120 GB" {
+		t.Fatalf("formatDiskUsage() = %q, want %q", got, "2.34 GB / 120 GB")
+	}
+}

--- a/go/internal/cli/commands/bytes_format.go
+++ b/go/internal/cli/commands/bytes_format.go
@@ -1,6 +1,9 @@
 package commands
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // formatBytes converts a byte count to a human-readable string using SI units
 // (powers of 1000: kB, MB, GB). This is the package-level helper used by
@@ -16,4 +19,14 @@ func formatBytes(n int64) string {
 	default:
 		return fmt.Sprintf("%d B", n)
 	}
+}
+
+func formatDiskUsage(usedBytes, totalBytes int64) string {
+	return fmt.Sprintf("%s / %s", formatGigabytes(usedBytes), formatGigabytes(totalBytes))
+}
+
+func formatGigabytes(n int64) string {
+	s := fmt.Sprintf("%.2f", float64(n)/1_000_000_000)
+	s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	return s + " GB"
 }

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -112,6 +112,7 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 			defer target.Close()
 
 			var agentVersion, osName, osVersion, cpuArch, deviceType, storageMedium, gpuVendor, jetpackVersion, cudaVersion string
+			var diskUsedBytes, diskTotalBytes *int64
 			var hasGPU bool
 
 			if target.Bluetooth != nil && target.Bluetooth.IsWendyAgent() {
@@ -144,6 +145,8 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				gpuVendor = resp.GetGpuVendor()
 				jetpackVersion = resp.GetJetpackVersion()
 				cudaVersion = resp.GetCudaVersion()
+				diskUsedBytes = resp.DiskUsedBytes
+				diskTotalBytes = resp.DiskTotalBytes
 			} else {
 				return fmt.Errorf("selected device does not support this command")
 			}
@@ -169,6 +172,10 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				}
 				if storageMedium != "" {
 					out["storageMedium"] = storageMedium
+				}
+				if diskUsedBytes != nil && diskTotalBytes != nil {
+					out["diskUsedBytes"] = *diskUsedBytes
+					out["diskTotalBytes"] = *diskTotalBytes
 				}
 				if gpuVendor != "" {
 					out["gpuVendor"] = gpuVendor
@@ -199,6 +206,9 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 			}
 			if storageMedium != "" {
 				fmt.Printf("Storage: %s\n", storageMedium)
+			}
+			if diskUsedBytes != nil && diskTotalBytes != nil {
+				fmt.Printf("Disk Usage: %s\n", formatDiskUsage(*diskUsedBytes, *diskTotalBytes))
 			}
 			if hasGPU {
 				vendor := gpuVendor

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -145,6 +145,10 @@ func (s *mcpServer) handleDeviceInfo(ctx context.Context, _ mcpgo.CallToolReques
 	if resp.StorageMedium != nil {
 		info["storage_medium"] = resp.GetStorageMedium()
 	}
+	if resp.DiskUsedBytes != nil && resp.DiskTotalBytes != nil {
+		info["disk_used_bytes"] = resp.GetDiskUsedBytes()
+		info["disk_total_bytes"] = resp.GetDiskTotalBytes()
+	}
 	if resp.HasGpu != nil {
 		info["has_gpu"] = resp.GetHasGpu()
 	}

--- a/go/proto/gen/agentpb/v2/device_info_service.pb.go
+++ b/go/proto/gen/agentpb/v2/device_info_service.pb.go
@@ -70,6 +70,8 @@ type GetDeviceInfoResponse struct {
 	GpuVendor       *string                `protobuf:"bytes,9,opt,name=gpu_vendor,json=gpuVendor,proto3,oneof" json:"gpu_vendor,omitempty"`
 	JetpackVersion  *string                `protobuf:"bytes,10,opt,name=jetpack_version,json=jetpackVersion,proto3,oneof" json:"jetpack_version,omitempty"`
 	CudaVersion     *string                `protobuf:"bytes,11,opt,name=cuda_version,json=cudaVersion,proto3,oneof" json:"cuda_version,omitempty"`
+	DiskUsedBytes   *int64                 `protobuf:"varint,12,opt,name=disk_used_bytes,json=diskUsedBytes,proto3,oneof" json:"disk_used_bytes,omitempty"`
+	DiskTotalBytes  *int64                 `protobuf:"varint,13,opt,name=disk_total_bytes,json=diskTotalBytes,proto3,oneof" json:"disk_total_bytes,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -179,6 +181,20 @@ func (x *GetDeviceInfoResponse) GetCudaVersion() string {
 		return *x.CudaVersion
 	}
 	return ""
+}
+
+func (x *GetDeviceInfoResponse) GetDiskUsedBytes() int64 {
+	if x != nil && x.DiskUsedBytes != nil {
+		return *x.DiskUsedBytes
+	}
+	return 0
+}
+
+func (x *GetDeviceInfoResponse) GetDiskTotalBytes() int64 {
+	if x != nil && x.DiskTotalBytes != nil {
+		return *x.DiskTotalBytes
+	}
+	return 0
 }
 
 type ListHardwareCapabilitiesRequest struct {
@@ -342,7 +358,7 @@ var File_wendy_agent_services_v2_device_info_service_proto protoreflect.FileDesc
 const file_wendy_agent_services_v2_device_info_service_proto_rawDesc = "" +
 	"\n" +
 	"1wendy/agent/services/v2/device_info_service.proto\x12\x17wendy.agent.services.v2\"\x16\n" +
-	"\x14GetDeviceInfoRequest\"\x80\x04\n" +
+	"\x14GetDeviceInfoRequest\"\x85\x05\n" +
 	"\x15GetDeviceInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\"\n" +
 	"\n" +
@@ -361,7 +377,9 @@ const file_wendy_agent_services_v2_device_info_service_proto_rawDesc = "" +
 	"gpu_vendor\x18\t \x01(\tH\x04R\tgpuVendor\x88\x01\x01\x12,\n" +
 	"\x0fjetpack_version\x18\n" +
 	" \x01(\tH\x05R\x0ejetpackVersion\x88\x01\x01\x12&\n" +
-	"\fcuda_version\x18\v \x01(\tH\x06R\vcudaVersion\x88\x01\x01B\r\n" +
+	"\fcuda_version\x18\v \x01(\tH\x06R\vcudaVersion\x88\x01\x01\x12+\n" +
+	"\x0fdisk_used_bytes\x18\f \x01(\x03H\aR\rdiskUsedBytes\x88\x01\x01\x12-\n" +
+	"\x10disk_total_bytes\x18\r \x01(\x03H\bR\x0ediskTotalBytes\x88\x01\x01B\r\n" +
 	"\v_os_versionB\r\n" +
 	"\v_public_keyB\x0e\n" +
 	"\f_device_typeB\n" +
@@ -369,7 +387,9 @@ const file_wendy_agent_services_v2_device_info_service_proto_rawDesc = "" +
 	"\b_has_gpuB\r\n" +
 	"\v_gpu_vendorB\x12\n" +
 	"\x10_jetpack_versionB\x0f\n" +
-	"\r_cuda_version\"c\n" +
+	"\r_cuda_versionB\x12\n" +
+	"\x10_disk_used_bytesB\x13\n" +
+	"\x11_disk_total_bytes\"c\n" +
 	"\x1fListHardwareCapabilitiesRequest\x12,\n" +
 	"\x0fcategory_filter\x18\x01 \x01(\tH\x00R\x0ecategoryFilter\x88\x01\x01B\x12\n" +
 	"\x10_category_filter\"\xc7\x03\n" +

--- a/go/proto/gen/agentpb/wendy_agent_v1_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_service.pb.go
@@ -585,8 +585,12 @@ type GetAgentVersionResponse struct {
 	CudaVersion *string `protobuf:"bytes,11,opt,name=cuda_version,json=cudaVersion,proto3,oneof" json:"cuda_version,omitempty"`
 	// STORAGE value from /etc/wendyos/device-type (e.g. "sd", "nvme"). Only present on WendyOS.
 	StorageMedium *string `protobuf:"bytes,12,opt,name=storage_medium,json=storageMedium,proto3,oneof" json:"storage_medium,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Root filesystem bytes currently used by the device. Only present when the agent can inspect disk usage.
+	DiskUsedBytes *int64 `protobuf:"varint,13,opt,name=disk_used_bytes,json=diskUsedBytes,proto3,oneof" json:"disk_used_bytes,omitempty"`
+	// Root filesystem total bytes on the device. Only present when the agent can inspect disk usage.
+	DiskTotalBytes *int64 `protobuf:"varint,14,opt,name=disk_total_bytes,json=diskTotalBytes,proto3,oneof" json:"disk_total_bytes,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *GetAgentVersionResponse) Reset() {
@@ -701,6 +705,20 @@ func (x *GetAgentVersionResponse) GetStorageMedium() string {
 		return *x.StorageMedium
 	}
 	return ""
+}
+
+func (x *GetAgentVersionResponse) GetDiskUsedBytes() int64 {
+	if x != nil && x.DiskUsedBytes != nil {
+		return *x.DiskUsedBytes
+	}
+	return 0
+}
+
+func (x *GetAgentVersionResponse) GetDiskTotalBytes() int64 {
+	if x != nil && x.DiskTotalBytes != nil {
+		return *x.DiskTotalBytes
+	}
+	return 0
 }
 
 // Request message for listing WiFi networks
@@ -3119,7 +3137,7 @@ const file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc = "" +
 	"\aupdated\x18\x01 \x01(\v24.wendy.agent.services.v1.UpdateAgentResponse.UpdatedH\x00R\aupdated\x1a\t\n" +
 	"\aUpdatedB\x0f\n" +
 	"\rresponse_type\"\x18\n" +
-	"\x16GetAgentVersionRequest\"\xc1\x04\n" +
+	"\x16GetAgentVersionRequest\"\xc6\x05\n" +
 	"\x17GetAgentVersionResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\"\n" +
 	"\n" +
@@ -3139,7 +3157,9 @@ const file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc = "" +
 	"\x0fjetpack_version\x18\n" +
 	" \x01(\tH\x05R\x0ejetpackVersion\x88\x01\x01\x12&\n" +
 	"\fcuda_version\x18\v \x01(\tH\x06R\vcudaVersion\x88\x01\x01\x12*\n" +
-	"\x0estorage_medium\x18\f \x01(\tH\aR\rstorageMedium\x88\x01\x01B\r\n" +
+	"\x0estorage_medium\x18\f \x01(\tH\aR\rstorageMedium\x88\x01\x01\x12+\n" +
+	"\x0fdisk_used_bytes\x18\r \x01(\x03H\bR\rdiskUsedBytes\x88\x01\x01\x12-\n" +
+	"\x10disk_total_bytes\x18\x0e \x01(\x03H\tR\x0ediskTotalBytes\x88\x01\x01B\r\n" +
 	"\v_os_versionB\r\n" +
 	"\v_public_keyB\x0e\n" +
 	"\f_device_typeB\n" +
@@ -3148,7 +3168,9 @@ const file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc = "" +
 	"\v_gpu_vendorB\x12\n" +
 	"\x10_jetpack_versionB\x0f\n" +
 	"\r_cuda_versionB\x11\n" +
-	"\x0f_storage_medium\"\x19\n" +
+	"\x0f_storage_mediumB\x12\n" +
+	"\x10_disk_used_bytesB\x13\n" +
+	"\x11_disk_total_bytes\"\x19\n" +
 	"\x17ListWiFiNetworksRequest\"\xbb\x03\n" +
 	"\x18ListWiFiNetworksResponse\x12Y\n" +
 	"\bnetworks\x18\x01 \x03(\v2=.wendy.agent.services.v1.ListWiFiNetworksResponse.WiFiNetworkR\bnetworks\x1a\xc3\x02\n" +


### PR DESCRIPTION
## Summary
- add optional root filesystem disk usage byte counts to v1 and v2 device info responses
- collect root filesystem used/total bytes in the agent
- show human CLI output as `Disk Usage: 2.34 GB / 120 GB` and expose raw bytes in JSON/MCP output

Fixes #918

## Tests
- `git diff --check`
- `CC=/usr/bin/clang go test ./go/internal/agent/services ./go/internal/cli/commands ./go/internal/cli/mcp`
