### PR TITLE
Fix release workflow runner labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   determine-version:
     name: Determine Version
-    runs-on: runs-on,runner=c7i.24xlarge
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.set-version.outputs.version }}
       is_release: ${{ steps.set-version.outputs.is_release }}
@@ -72,7 +72,7 @@ jobs:
 
   build:
     name: ${{ matrix.artifact-name }}
-    runs-on: runs-on,runner=c7i.24xlarge
+    runs-on: ubuntu-latest
     needs: [determine-version]
     strategy:
       matrix:
@@ -266,7 +266,7 @@ jobs:
 
   package-linux:
     name: Package Linux (${{ matrix.arch }})
-    runs-on: runs-on,runner=c7i.24xlarge
+    runs-on: ubuntu-latest
     needs: [determine-version, build]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
     strategy:
@@ -591,7 +591,7 @@ jobs:
 
   publish-linux-repos:
     name: Publish to GCP Artifact Registry
-    runs-on: runs-on,runner=c7i.24xlarge
+    runs-on: ubuntu-latest
     needs: [determine-version, package-linux, test-templates, integration-tests]
     if: |
       always() &&
@@ -659,7 +659,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: runs-on,runner=c7i.24xlarge
+    runs-on: ubuntu-latest
     needs: [determine-version, build, build-go-macos, build-agent-macos-app, package-linux, package-windows, test-templates, integration-tests]
     if: |
       always() &&
@@ -965,7 +965,7 @@ jobs:
   # contents: write.
   dispatch-docs:
     name: Dispatch docs deployment
-    runs-on: runs-on,runner=c7i.24xlarge
+    runs-on: ubuntu-latest
     needs: [determine-version, release]
     # `always()` is required: without it the job is skipped whenever any `needs`
     # entry (e.g. determine-version) is itself skipped or non-success, even
@@ -998,7 +998,7 @@ jobs:
 
   publish-aur:
     name: Publish AUR Packages
-    runs-on: runs-on,runner=c7i.24xlarge
+    runs-on: ubuntu-latest
     needs: [determine-version, release]
     if: |
       always() &&
@@ -1323,7 +1323,7 @@ jobs:
 
   announce:
     name: Announce Release
-    runs-on: runs-on,runner=c7i.24xlarge
+    runs-on: ubuntu-latest
     needs: [determine-version, release, publish-linux-repos, publish-aur, publish-winget]
     if: |
       always() &&


### PR DESCRIPTION
## Summary
- restore hosted Ubuntu runners for release workflow Linux jobs
- unblocks release dispatches while the RunsOn `c7i.24xlarge` spec is unavailable

## Evidence
- release run 27181095004 failed in `Determine Version` before checkout with `runner spec c7i.24xlarge not found`
- rerun 27181312721 reproduced the same setup failure

## Tests
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "ok"'