### PR TITLE
Remove severity labels from E2E AI review headings

### DIFF
--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2EReview.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2EReview.swift
@@ -48,6 +48,17 @@ enum E2EReviewSeverity: String, Codable, Sendable {
             "💡 Info"
         }
     }
+
+    var symbol: String {
+        switch self {
+        case .fail:
+            "🛑"
+        case .concern:
+            "⚠️"
+        case .info:
+            "💡"
+        }
+    }
 }
 
 struct E2EReviewLocation: Codable, Sendable {

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
@@ -235,7 +235,7 @@ private func appendE2EReviewAggregateOutcome(
             let review = reviewIssue.review
             lines.append("- AI review: **\(reviewAggregateSingleLine(review.title))**")
             lines.append("")
-            lines.append(review.summaryMarkdown)
+            lines.append(reviewAggregateSummaryMarkdown(review.summaryMarkdown))
             lines.append("")
         }
     }
@@ -310,7 +310,7 @@ private func reviewAggregateAttemptSummary(_ attempts: [E2ERunOverviewIssueAttem
 }
 
 private func reviewAggregateSeverityMarker(_ severity: E2EReviewSeverity) -> String {
-    severity.displayName
+    severity.symbol
 }
 
 private func appendE2EReviewAggregateIssue(
@@ -321,7 +321,7 @@ private func appendE2EReviewAggregateIssue(
     let review = issue.review
     lines.append(reviewAggregateTitleLine(for: issue, headingLevel: headingLevel))
     lines.append("")
-    lines.append(review.summaryMarkdown)
+    lines.append(reviewAggregateSummaryMarkdown(review.summaryMarkdown))
     lines.append("")
     lines.append("<details>")
     lines.append("<summary>Details</summary>")
@@ -390,4 +390,33 @@ private func reviewAggregateSingleLine(_ value: String) -> String {
         .replacingOccurrences(of: "\r", with: " ")
         .replacingOccurrences(of: "\n", with: " ")
         .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private func reviewAggregateSummaryMarkdown(_ value: String) -> String {
+    let original = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    let patterns = [
+        #"^(?:\*\*|__)?\s*(?:🛑|⚠️|💡)\s*(?:(?:Error|Fail(?:ure)?|Concern|Info)\b)?\s*(?::|[-–—])?\s*(?:\*\*|__)?\s*"#,
+        #"^(?:\*\*|__)?\s*(?:Error|Fail(?:ure)?|Concern|Info)\b\s*(?::|[-–—])\s*(?:\*\*|__)?\s*"#,
+    ]
+
+    for pattern in patterns {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            continue
+        }
+        let range = NSRange(original.startIndex..<original.endIndex, in: original)
+        guard let match = regex.firstMatch(in: original, range: range), match.range.location == 0,
+            match.range.length > 0,
+            let swiftRange = Range(match.range, in: original)
+        else {
+            continue
+        }
+
+        let stripped = String(original[swiftRange.upperBound...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !stripped.isEmpty {
+            return stripped
+        }
+    }
+
+    return original
 }

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
@@ -1031,7 +1031,7 @@ private func appendReviewOutputContract(
         "The file name must be the review title slug with `.md`: lowercase ASCII letters/digits, non-alphanumerics replaced by `-`, repeated dashes collapsed, and leading/trailing dashes removed. Example: `seed-cache-fixtures-before-listing.md`."
     )
     lines.append(
-        "Use JSON `severity` to classify each issue as `info`, `concern`, or `fail`. Keep those exact JSON values. If human-facing review text mentions a severity label, use `🛑 Error`, `⚠️ Concern`, and `💡 Info` for `fail`, `concern`, and `info`, respectively. Do not use heart emojis as severity markers. Do not write prose status/severity lines such as `Status: pass`, `Status: concern`, or `Status: fail`."
+        "Use JSON `severity` to classify each issue as `info`, `concern`, or `fail`. Keep those exact JSON values. Do not include severity labels or severity emoji in review titles, Markdown headings, or summary text; the aggregate renderer adds the severity emoji from JSON. Do not use heart emojis as severity markers. Do not write prose status/severity lines such as `Status: pass`, `Status: concern`, or `Status: fail`."
     )
     lines.append(
         "If nothing is noteworthy at a scope, leave that `\(reviewDirectoryName)/` directory absent or empty."

--- a/swift/WendyE2ETests/Support/e2e-review-report.diff.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-report.diff.prompt.md
@@ -20,11 +20,11 @@ Guidelines:
   explicitly explain why the outcome may be nondeterministic and how to
   investigate or stabilize it.
 - Use JSON `severity` to classify each issue as `info`, `concern`, or
-  `fail`. Keep those exact JSON values. If human-facing review text mentions a
-  severity label, use `🛑 Error`, `⚠️ Concern`, and `💡 Info` for `fail`,
-  `concern`, and `info`, respectively. Do not use heart emojis as severity
-  markers. Do not write prose status/severity lines such as `Status: pass`,
-  `Status: concern`, or `Status: fail`.
+  `fail`. Keep those exact JSON values. Do not include severity labels or
+  severity emoji in review titles, Markdown headings, or summary text; the
+  aggregate renderer adds the severity emoji from JSON. Do not use heart emojis
+  as severity markers. Do not write prose status/severity lines such as
+  `Status: pass`, `Status: concern`, or `Status: fail`.
 - Each review summary should be GitHub-comment-sized: one concise explanation
   tied to the diff plus the suggested action.
 - Put evidence, reasoning, targeted diff references, links to relevant suite/test

--- a/swift/WendyE2ETests/Support/e2e-review-report.full.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-report.full.prompt.md
@@ -16,11 +16,11 @@ Guidelines:
   lower-level review/artifact evidence. For flakes, explicitly explain why the
   outcome may be nondeterministic and how to investigate or stabilize it.
 - Use JSON `severity` to classify each issue as `info`, `concern`, or
-  `fail`. Keep those exact JSON values. If human-facing review text mentions a
-  severity label, use `🛑 Error`, `⚠️ Concern`, and `💡 Info` for `fail`,
-  `concern`, and `info`, respectively. Do not use heart emojis as severity
-  markers. Do not write prose status/severity lines such as `Status: pass`,
-  `Status: concern`, or `Status: fail`.
+  `fail`. Keep those exact JSON values. Do not include severity labels or
+  severity emoji in review titles, Markdown headings, or summary text; the
+  aggregate renderer adds the severity emoji from JSON. Do not use heart emojis
+  as severity markers. Do not write prose status/severity lines such as
+  `Status: pass`, `Status: concern`, or `Status: fail`.
 - Each review summary should be GitHub-comment-sized: one concise explanation
   plus the suggested action.
 - Put evidence, reasoning, links to relevant suite/test details, and longer

--- a/swift/WendyE2ETests/Support/e2e-review-report.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-report.prompt.md
@@ -16,11 +16,11 @@ Guidelines:
   lower-level review/artifact evidence. For flakes, explicitly explain why the
   outcome may be nondeterministic and how to investigate or stabilize it.
 - Use JSON `severity` to classify each issue as `info`, `concern`, or
-  `fail`. Keep those exact JSON values. If human-facing review text mentions a
-  severity label, use `🛑 Error`, `⚠️ Concern`, and `💡 Info` for `fail`,
-  `concern`, and `info`, respectively. Do not use heart emojis as severity
-  markers. Do not write prose status/severity lines such as `Status: pass`,
-  `Status: concern`, or `Status: fail`.
+  `fail`. Keep those exact JSON values. Do not include severity labels or
+  severity emoji in review titles, Markdown headings, or summary text; the
+  aggregate renderer adds the severity emoji from JSON. Do not use heart emojis
+  as severity markers. Do not write prose status/severity lines such as
+  `Status: pass`, `Status: concern`, or `Status: fail`.
 - Each review summary should be GitHub-comment-sized: one concise explanation
   plus the suggested action.
 - Put evidence, reasoning, links to relevant suite/test details, and longer

--- a/swift/WendyE2ETests/Support/e2e-review-suite.diff.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-suite.diff.prompt.md
@@ -17,11 +17,11 @@ Guidelines:
   files for that scope.
 - Do not write pass/OK reviews for tests or suites.
 - Use JSON `severity` to classify each issue as `info`, `concern`, or
-  `fail`. Keep those exact JSON values. If human-facing review text mentions a
-  severity label, use `🛑 Error`, `⚠️ Concern`, and `💡 Info` for `fail`,
-  `concern`, and `info`, respectively. Do not use heart emojis as severity
-  markers. Do not write prose status/severity lines such as `Status: pass`,
-  `Status: concern`, or `Status: fail`.
+  `fail`. Keep those exact JSON values. Do not include severity labels or
+  severity emoji in review titles, Markdown headings, or summary text; the
+  aggregate renderer adds the severity emoji from JSON. Do not use heart emojis
+  as severity markers. Do not write prose status/severity lines such as
+  `Status: pass`, `Status: concern`, or `Status: fail`.
 - Each review summary should be GitHub-comment-sized: one concise explanation
   tied to the diff plus the suggested action.
 - Put evidence, reasoning, targeted diff references, and longer analysis under

--- a/swift/WendyE2ETests/Support/e2e-review-suite.full.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-suite.full.prompt.md
@@ -16,11 +16,11 @@ Guidelines:
   scope.
 - Do not write pass/OK reviews for tests or suites.
 - Use JSON `severity` to classify each issue as `info`, `concern`, or
-  `fail`. Keep those exact JSON values. If human-facing review text mentions a
-  severity label, use `🛑 Error`, `⚠️ Concern`, and `💡 Info` for `fail`,
-  `concern`, and `info`, respectively. Do not use heart emojis as severity
-  markers. Do not write prose status/severity lines such as `Status: pass`,
-  `Status: concern`, or `Status: fail`.
+  `fail`. Keep those exact JSON values. Do not include severity labels or
+  severity emoji in review titles, Markdown headings, or summary text; the
+  aggregate renderer adds the severity emoji from JSON. Do not use heart emojis
+  as severity markers. Do not write prose status/severity lines such as
+  `Status: pass`, `Status: concern`, or `Status: fail`.
 - Each review summary should be GitHub-comment-sized: one concise explanation
   plus the suggested action.
 - Put evidence, reasoning, and longer analysis under the review file's

--- a/swift/WendyE2ETests/Support/e2e-review-suite.prompt.md
+++ b/swift/WendyE2ETests/Support/e2e-review-suite.prompt.md
@@ -16,11 +16,11 @@ Guidelines:
   scope.
 - Do not write pass/OK reviews for tests or suites.
 - Use JSON `severity` to classify each issue as `info`, `concern`, or
-  `fail`. Keep those exact JSON values. If human-facing review text mentions a
-  severity label, use `🛑 Error`, `⚠️ Concern`, and `💡 Info` for `fail`,
-  `concern`, and `info`, respectively. Do not use heart emojis as severity
-  markers. Do not write prose status/severity lines such as `Status: pass`,
-  `Status: concern`, or `Status: fail`.
+  `fail`. Keep those exact JSON values. Do not include severity labels or
+  severity emoji in review titles, Markdown headings, or summary text; the
+  aggregate renderer adds the severity emoji from JSON. Do not use heart emojis
+  as severity markers. Do not write prose status/severity lines such as
+  `Status: pass`, `Status: concern`, or `Status: fail`.
 - Each review summary should be GitHub-comment-sized: one concise explanation
   plus the suggested action.
 - Put evidence, reasoning, and longer analysis under the review file's

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -109,7 +109,10 @@ struct `run overview` {
         #expect(markdown.contains("## Failed and flaked tests"))
         #expect(markdown.contains("### 🛑 `wendy-device-info/prints-json-device-information`"))
         #expect(markdown.contains("AI review: **Agent rejected CLI auth**"))
-        #expect(markdown.contains("### 🛑 Error Agent rejected CLI auth"))
+        #expect(markdown.contains("### 🛑 Agent rejected CLI auth"))
+        #expect(!markdown.contains("### 🛑 Error Agent rejected CLI auth"))
+        #expect(markdown.contains("The target rejected an otherwise valid authenticated request."))
+        #expect(!markdown.contains("🛑 Error: The target rejected an otherwise valid authenticated request."))
         #expect(!markdown.contains("Fail: Agent rejected CLI auth"))
     }
 }
@@ -130,7 +133,7 @@ private func writeTestReview(in testURL: URL) throws {
         "---",
         "# Agent rejected CLI auth",
         "",
-        "The target rejected an otherwise valid authenticated request.",
+        "🛑 Error: The target rejected an otherwise valid authenticated request.",
         "Recheck the agent auth state before rerunning this route.",
         "",
         "## Details",


### PR DESCRIPTION
## Summary
- Show only the severity emoji in E2E AI review aggregate headings, e.g. `⚠️ Seed cache fixtures before listing` instead of `⚠️ Concern ...`.
- Strip leading severity labels/emoji from rendered review summaries so generated comments do not repeat `⚠️ Concern:` in the body.
- Update the AI review prompt guidance to keep severity in JSON while leaving titles, headings, and summaries label-free.

## Tests
- `cd swift/WendyE2ETests && swift test --filter 'run overview'`
