### PR TITLE
docs: document Darwin platform in wendy.json

### DIFF
--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -39,8 +39,23 @@ Target platform. One of:
 |-------|-------------|
 | `wendyos` | Linux edge device running WendyOS |
 | `wendy-lite` | ESP32 WASM target |
+| `darwin` | Native macOS app running through Wendy Agent for Mac |
 
 Omit to target the default platform.
+
+Use `"darwin"` for native macOS targets managed by [Wendy Agent for Mac](/docs/installation/wendy-agent-macos). The CLI builds the app on a Mac development machine, syncs the build output to the Mac agent, and launches it as a native macOS process. Darwin apps run natively and non-containerized; they do not use the WendyOS Linux container runtime.
+
+Minimal SwiftPM/macOS configuration:
+
+```json
+{
+  "$schema": "https://wendy.sh/schemas/wendy.json",
+  "appId": "com.example.hello-mac",
+  "version": "1.0.0",
+  "language": "swift",
+  "platform": "darwin"
+}
+```
 
 ### `language`
 

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -38,11 +38,10 @@ Target platform. One of:
 | Value | Description |
 |-------|-------------|
 | `wendyos` | Linux edge device running WendyOS |
-| `linux` | Linux target, including WendyOS or generic Linux agents |
 | `wendy-lite` | ESP32 WASM target |
 | `darwin` | Native macOS app running through Wendy Agent for Mac |
 
-Omit to target the default platform. Use `"linux"` when you want to target the connected agent's Linux architecture explicitly.
+Omit to target the default platform.
 
 Use `"darwin"` for native macOS targets managed by [Wendy Agent for Mac](/docs/installation/wendy-agent-macos). The CLI builds the app on a Mac development machine, syncs the build output to the Mac agent, and launches it as a native macOS process. Darwin apps run natively and non-containerized; they do not use the WendyOS Linux container runtime.
 

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -38,10 +38,11 @@ Target platform. One of:
 | Value | Description |
 |-------|-------------|
 | `wendyos` | Linux edge device running WendyOS |
+| `linux` | Linux target, including WendyOS or generic Linux agents |
 | `wendy-lite` | ESP32 WASM target |
 | `darwin` | Native macOS app running through Wendy Agent for Mac |
 
-Omit to target the default platform.
+Omit to target the default platform. Use `"linux"` when you want to target the connected agent's Linux architecture explicitly.
 
 Use `"darwin"` for native macOS targets managed by [Wendy Agent for Mac](/docs/installation/wendy-agent-macos). The CLI builds the app on a Mac development machine, syncs the build output to the Mac agent, and launches it as a native macOS process. Darwin apps run natively and non-containerized; they do not use the WendyOS Linux container runtime.
 

--- a/go/internal/cli/assets/skills/wendy/references/wendy.json.md
+++ b/go/internal/cli/assets/skills/wendy/references/wendy.json.md
@@ -8,6 +8,7 @@ The `wendy.json` file configures your WendyOS application's identity and entitle
 {
   "appId": "com.example.myapp",
   "version": "1.0.0",
+  "platform": "wendyos",
   "entitlements": [
     { "type": "network", "mode": "host" }
   ]
@@ -18,7 +19,29 @@ The `wendy.json` file configures your WendyOS application's identity and entitle
 |-------|-------------|
 | `appId` | Unique identifier (reverse domain notation recommended) |
 | `version` | Application version string |
+| `platform` | Target platform: `wendyos`, `wendy-lite`, or `darwin` |
 | `entitlements` | Array of entitlement objects specifying required permissions |
+
+## Platforms
+
+| Value | Description |
+|-------|-------------|
+| `wendyos` | Linux edge device running WendyOS; apps run in containers |
+| `wendy-lite` | ESP32 WASM target |
+| `darwin` | Native macOS execution through [Wendy Agent for Mac](/docs/installation/wendy-agent-macos) |
+
+Use `"darwin"` for Apple Silicon Mac targets managed by Wendy Agent for Mac. The CLI builds SwiftPM or Xcode projects on a Mac development machine, syncs the build output to the Mac agent, and starts the app as a native macOS process. Darwin apps run natively and non-containerized, so WendyOS Linux container semantics and hardware entitlements do not apply.
+
+Minimal SwiftPM/macOS configuration:
+
+```json
+{
+  "appId": "com.example.hello-mac",
+  "version": "1.0.0",
+  "language": "swift",
+  "platform": "darwin"
+}
+```
 
 ## Entitlements Overview
 

--- a/go/internal/cli/assets/skills/wendy/references/wendy.json.md
+++ b/go/internal/cli/assets/skills/wendy/references/wendy.json.md
@@ -19,7 +19,7 @@ The `wendy.json` file configures your WendyOS application's identity and entitle
 |-------|-------------|
 | `appId` | Unique identifier (reverse domain notation recommended) |
 | `version` | Application version string |
-| `platform` | Target platform: `wendyos`, `wendy-lite`, or `darwin` |
+| `platform` | Target platform: `wendyos`, `linux`, `wendy-lite`, or `darwin` |
 | `entitlements` | Array of entitlement objects specifying required permissions |
 
 ## Platforms
@@ -27,6 +27,7 @@ The `wendy.json` file configures your WendyOS application's identity and entitle
 | Value | Description |
 |-------|-------------|
 | `wendyos` | Linux edge device running WendyOS; apps run in containers |
+| `linux` | Linux target, including WendyOS or generic Linux agents; apps run in containers |
 | `wendy-lite` | ESP32 WASM target |
 | `darwin` | Native macOS execution through [Wendy Agent for Mac](/docs/installation/wendy-agent-macos) |
 

--- a/go/internal/cli/assets/skills/wendy/references/wendy.json.md
+++ b/go/internal/cli/assets/skills/wendy/references/wendy.json.md
@@ -19,7 +19,7 @@ The `wendy.json` file configures your WendyOS application's identity and entitle
 |-------|-------------|
 | `appId` | Unique identifier (reverse domain notation recommended) |
 | `version` | Application version string |
-| `platform` | Target platform: `wendyos`, `linux`, `wendy-lite`, or `darwin` |
+| `platform` | Target platform: `wendyos`, `wendy-lite`, or `darwin` |
 | `entitlements` | Array of entitlement objects specifying required permissions |
 
 ## Platforms
@@ -27,7 +27,6 @@ The `wendy.json` file configures your WendyOS application's identity and entitle
 | Value | Description |
 |-------|-------------|
 | `wendyos` | Linux edge device running WendyOS; apps run in containers |
-| `linux` | Linux target, including WendyOS or generic Linux agents; apps run in containers |
 | `wendy-lite` | ESP32 WASM target |
 | `darwin` | Native macOS execution through [Wendy Agent for Mac](/docs/installation/wendy-agent-macos) |
 

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -86,6 +86,7 @@ var allowedKeys = map[string][]string{
 const (
 	PlatformWendyOS   = "wendyos"
 	PlatformWendyLite = "wendy-lite"
+	PlatformDarwin    = "darwin"
 )
 
 // FileSyncEntry describes a file or directory to sync to the device's app

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -85,6 +85,7 @@ var allowedKeys = map[string][]string{
 // Platform constants identify the target hardware family.
 const (
 	PlatformWendyOS   = "wendyos"
+	PlatformLinux     = "linux"
 	PlatformWendyLite = "wendy-lite"
 	PlatformDarwin    = "darwin"
 )

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -85,7 +85,6 @@ var allowedKeys = map[string][]string{
 // Platform constants identify the target hardware family.
 const (
 	PlatformWendyOS   = "wendyos"
-	PlatformLinux     = "linux"
 	PlatformWendyLite = "wendy-lite"
 	PlatformDarwin    = "darwin"
 )

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -24,8 +24,8 @@
     },
     "platform": {
       "type": "string",
-      "enum": ["wendyos", "wendy-lite"],
-      "description": "Target platform: wendyos (Linux edge devices) or wendy-lite (ESP32 WASM)."
+      "enum": ["wendyos", "wendy-lite", "darwin"],
+      "description": "Target platform: wendyos (Linux edge devices), wendy-lite (ESP32 WASM), or darwin (native macOS via Wendy Agent for Mac)."
     },
     "language": {
       "type": "string",

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -24,8 +24,8 @@
     },
     "platform": {
       "type": "string",
-      "enum": ["wendyos", "wendy-lite", "darwin"],
-      "description": "Target platform: wendyos (Linux edge devices), wendy-lite (ESP32 WASM), or darwin (native macOS via Wendy Agent for Mac)."
+      "enum": ["wendyos", "linux", "wendy-lite", "darwin"],
+      "description": "Target platform: wendyos (Linux edge devices), linux (Linux agents), wendy-lite (ESP32 WASM), or darwin (native macOS via Wendy Agent for Mac)."
     },
     "language": {
       "type": "string",

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -24,8 +24,8 @@
     },
     "platform": {
       "type": "string",
-      "enum": ["wendyos", "linux", "wendy-lite", "darwin"],
-      "description": "Target platform: wendyos (Linux edge devices), linux (Linux agents), wendy-lite (ESP32 WASM), or darwin (native macOS via Wendy Agent for Mac)."
+      "enum": ["wendyos", "wendy-lite", "darwin"],
+      "description": "Target platform: wendyos (Linux edge devices), wendy-lite (ESP32 WASM), or darwin (native macOS via Wendy Agent for Mac)."
     },
     "language": {
       "type": "string",


### PR DESCRIPTION
## Summary
- Set up WDY-1378.
- Document `platform: "darwin"` in `wendy.json` docs.

Closes WDY-1378.

## Tests
- Not run yet.
