### PR TITLE
ci: add docs preview PR comments

### DIFF
--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -372,10 +372,15 @@ jobs:
   comment-preview:
     name: Comment with docs preview URL
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - build
       - deploy
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.build.result == 'success' &&
+      needs.deploy.result == 'success'
     permissions:
       pull-requests: write
     steps:
@@ -405,57 +410,52 @@ jobs:
 
           tmp_dir="$(mktemp -d)"
           trap 'rm -rf "${tmp_dir}"' EXIT
-          body_file="${tmp_dir}/body.md"
           payload_file="${tmp_dir}/payload.json"
-          comments_file="${tmp_dir}/comments.json"
 
-          cat > "${body_file}" <<EOF
-          ${marker}
-          ## Docs preview
-
-          Preview this PR's docs at: <${DOCS_PREVIEW_URL}>
-
-          _This comment is updated automatically when the docs preview is redeployed._
-          EOF
-
-          python3 - "${body_file}" "${payload_file}" <<'PY'
+          MARKER="${marker}" DOCS_PREVIEW_URL="${DOCS_PREVIEW_URL}" python3 - "${payload_file}" <<'PY'
           import json
+          import os
           import pathlib
           import sys
 
-          body = pathlib.Path(sys.argv[1]).read_text()
-          pathlib.Path(sys.argv[2]).write_text(json.dumps({"body": body}))
-          PY
-
-          gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --slurp > "${comments_file}"
-          mapfile -t comment_ids < <(MARKER="${marker}" python3 - "${comments_file}" <<'PY'
-          import json
-          import os
-          import sys
-
           marker = os.environ["MARKER"]
-          with open(sys.argv[1], encoding="utf-8") as file:
-              pages = json.load(file)
-
-          for page in pages:
-              comments = page if isinstance(page, list) else [page]
-              for comment in comments:
-                  body = comment.get("body") or ""
-                  comment_id = comment.get("id")
-                  if body.startswith(marker):
-                      if not isinstance(comment_id, int):
-                          raise SystemExit(f"Unexpected comment id: {comment_id!r}")
-                      print(comment_id)
-          PY
+          preview_url = os.environ["DOCS_PREVIEW_URL"]
+          body = (
+              f"{marker}\n"
+              "## Docs preview\n\n"
+              f"Preview this PR's docs at: <{preview_url}>\n\n"
+              "_This comment is updated automatically when the docs preview is redeployed._\n"
           )
+          pathlib.Path(sys.argv[1]).write_text(json.dumps({"body": body}))
+          PY
+
+          mapfile -t comment_ids < <(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq '.[] | select((.body // "") | startswith("<!-- wendy-docs-preview -->")) | .id')
+
+          for comment_id in "${comment_ids[@]}"; do
+            if ! [[ "${comment_id}" =~ ^[0-9]+$ ]]; then
+              echo "::error::Unexpected comment ID: ${comment_id}"
+              exit 1
+            fi
+          done
 
           if (( ${#comment_ids[@]} > 0 )); then
             comment_id="${comment_ids[$((${#comment_ids[@]} - 1))]}"
-            gh api --method PATCH "repos/${REPOSITORY}/issues/comments/${comment_id}" --input "${payload_file}"
+            updated_id="$(gh api --method PATCH "repos/${REPOSITORY}/issues/comments/${comment_id}" \
+              --input "${payload_file}" \
+              --jq '.id')"
+            echo "Updated docs preview comment ${updated_id}"
 
-            for stale_comment_id in "${comment_ids[@]:0:$((${#comment_ids[@]} - 1))}"; do
+            stale_count=$((${#comment_ids[@]} - 1))
+            for (( i = 0; i < stale_count; i++ )); do
+              stale_comment_id="${comment_ids[$i]}"
               gh api --method DELETE "repos/${REPOSITORY}/issues/comments/${stale_comment_id}" >/dev/null
+              echo "Deleted stale docs preview comment ${stale_comment_id}"
             done
           else
-            gh api --method POST "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" --input "${payload_file}"
+            created_id="$(gh api --method POST "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --input "${payload_file}" \
+              --jq '.id')"
+            echo "Created docs preview comment ${created_id}"
           fi

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -405,7 +405,7 @@ jobs:
               for comment in comments:
                   body = comment.get("body") or ""
                   comment_id = comment.get("id")
-                  if marker in body:
+                  if body.startswith(marker):
                       if not isinstance(comment_id, int):
                           raise SystemExit(f"Unexpected comment id: {comment_id!r}")
                       print(comment_id)

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -382,6 +382,7 @@ jobs:
       needs.build.result == 'success' &&
       needs.deploy.result == 'success'
     permissions:
+      contents: none
       pull-requests: write
     steps:
       - name: Comment with docs preview URL
@@ -403,6 +404,8 @@ jobs:
             echo "::error::Unexpected PR number: ${PR_NUMBER}"
             exit 1
           fi
+          # This regex is the trust boundary for needs.build.outputs.url. Keep it
+          # in sync with Compute docs path if preview URL formats change.
           if ! [[ "${DOCS_PREVIEW_URL}" =~ ^https://docs\.wendy\.dev/[a-z0-9][a-z0-9._-]{0,200}/$ ]]; then
             echo "::error::Unexpected docs preview URL: ${DOCS_PREVIEW_URL}"
             exit 1
@@ -412,22 +415,10 @@ jobs:
           trap 'rm -rf "${tmp_dir}"' EXIT
           payload_file="${tmp_dir}/payload.json"
 
-          MARKER="${marker}" DOCS_PREVIEW_URL="${DOCS_PREVIEW_URL}" python3 - "${payload_file}" <<'PY'
-          import json
-          import os
-          import pathlib
-          import sys
-
-          marker = os.environ["MARKER"]
-          preview_url = os.environ["DOCS_PREVIEW_URL"]
-          body = (
-              f"{marker}\n"
-              "## Docs preview\n\n"
-              f"Preview this PR's docs at: <{preview_url}>\n\n"
-              "_This comment is updated automatically when the docs preview is redeployed._\n"
-          )
-          pathlib.Path(sys.argv[1]).write_text(json.dumps({"body": body}))
-          PY
+          printf -v body '%s\n## Docs preview\n\nPreview this PR'"'"'s docs at: <%s>\n\n_This comment is updated automatically when the docs preview is redeployed._\n' \
+            "${marker}" \
+            "${DOCS_PREVIEW_URL}"
+          jq -n --arg body "${body}" '{ body: $body }' > "${payload_file}"
 
           mapfile -t comment_ids < <(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --paginate \

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -245,7 +245,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      pull-requests: write
     environment:
       name: docs
       url: ${{ needs.build.outputs.url }}
@@ -341,8 +340,46 @@ jobs:
             grep -q "WendyOS Docs" "${response_file}"
           done <<< "${DEPLOY_PATHS}"
 
+      - name: Delete expired branch previews
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          DOCS_BUCKET: wendy-docs-public
+          RETENTION_DAYS: "30"
+        run: |
+          set -euo pipefail
+
+          cutoff_epoch="$(date -u -d "${RETENTION_DAYS} days ago" +%s)"
+          listing_file="$(mktemp)"
+          delete_file="$(mktemp)"
+
+          gcloud storage ls -l --recursive "gs://${DOCS_BUCKET}/branch-*/**" \
+            --project="${GCP_PROJECT_ID}" > "${listing_file}" 2>/dev/null || true
+
+          while read -r size updated_at object_url _; do
+            [[ "${size}" =~ ^[0-9]+$ ]] || continue
+            [[ "${object_url}" == gs://* ]] || continue
+
+            object_epoch="$(date -u -d "${updated_at}" +%s 2>/dev/null || echo 0)"
+            if (( object_epoch > 0 && object_epoch < cutoff_epoch )); then
+              printf '%s\n' "${object_url}" >> "${delete_file}"
+            fi
+          done < "${listing_file}"
+
+          if [[ -s "${delete_file}" ]]; then
+            xargs -r -n 100 gcloud storage rm --quiet --project="${GCP_PROJECT_ID}" < "${delete_file}"
+          fi
+
+  comment-preview:
+    name: Comment with docs preview URL
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - deploy
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
+    steps:
       - name: Comment with docs preview URL
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           DOCS_PREVIEW_URL: ${{ needs.build.outputs.url }}
@@ -376,7 +413,7 @@ jobs:
           ${marker}
           ## Docs preview
 
-          Preview this PR's docs at: ${DOCS_PREVIEW_URL}
+          Preview this PR's docs at: <${DOCS_PREVIEW_URL}>
 
           _This comment is updated automatically when the docs preview is redeployed._
           EOF
@@ -421,33 +458,4 @@ jobs:
             done
           else
             gh api --method POST "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" --input "${payload_file}"
-          fi
-
-      - name: Delete expired branch previews
-        env:
-          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-          DOCS_BUCKET: wendy-docs-public
-          RETENTION_DAYS: "30"
-        run: |
-          set -euo pipefail
-
-          cutoff_epoch="$(date -u -d "${RETENTION_DAYS} days ago" +%s)"
-          listing_file="$(mktemp)"
-          delete_file="$(mktemp)"
-
-          gcloud storage ls -l --recursive "gs://${DOCS_BUCKET}/branch-*/**" \
-            --project="${GCP_PROJECT_ID}" > "${listing_file}" 2>/dev/null || true
-
-          while read -r size updated_at object_url _; do
-            [[ "${size}" =~ ^[0-9]+$ ]] || continue
-            [[ "${object_url}" == gs://* ]] || continue
-
-            object_epoch="$(date -u -d "${updated_at}" +%s 2>/dev/null || echo 0)"
-            if (( object_epoch > 0 && object_epoch < cutoff_epoch )); then
-              printf '%s\n' "${object_url}" >> "${delete_file}"
-            fi
-          done < "${listing_file}"
-
-          if [[ -s "${delete_file}" ]]; then
-            xargs -r -n 100 gcloud storage rm --quiet --project="${GCP_PROJECT_ID}" < "${delete_file}"
           fi

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -366,13 +366,17 @@ jobs:
 
           jq -n --rawfile body "${body_file}" '{ body: $body }' > "${payload_file}"
 
-          comment_id="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+          mapfile -t comment_ids < <(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --paginate \
-            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
-            | tail -n 1)"
+            --jq ".[] | select(.body | contains(\"${marker}\")) | .id")
 
-          if [[ -n "${comment_id}" ]]; then
+          if (( ${#comment_ids[@]} > 0 )); then
+            comment_id="${comment_ids[$((${#comment_ids[@]} - 1))]}"
             gh api --method PATCH "repos/${REPOSITORY}/issues/comments/${comment_id}" --input "${payload_file}"
+
+            for stale_comment_id in "${comment_ids[@]:0:$((${#comment_ids[@]} - 1))}"; do
+              gh api --method DELETE "repos/${REPOSITORY}/issues/comments/${stale_comment_id}" >/dev/null
+            done
           else
             gh api --method POST "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" --input "${payload_file}"
           fi

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -245,7 +245,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      issues: write
+      pull-requests: write
     environment:
       name: docs
       url: ${{ needs.build.outputs.url }}
@@ -352,8 +352,25 @@ jobs:
           set -euo pipefail
 
           marker='<!-- wendy-docs-preview -->'
-          body_file="$(mktemp)"
-          payload_file="$(mktemp)"
+
+          if ! [[ "${REPOSITORY}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "::error::Unexpected repository value: ${REPOSITORY}"
+            exit 1
+          fi
+          if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unexpected PR number: ${PR_NUMBER}"
+            exit 1
+          fi
+          if ! [[ "${DOCS_PREVIEW_URL}" =~ ^https://docs\.wendy\.dev/[a-z0-9][a-z0-9._-]{0,200}/$ ]]; then
+            echo "::error::Unexpected docs preview URL: ${DOCS_PREVIEW_URL}"
+            exit 1
+          fi
+
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "${tmp_dir}"' EXIT
+          body_file="${tmp_dir}/body.md"
+          payload_file="${tmp_dir}/payload.json"
+          comments_file="${tmp_dir}/comments.json"
 
           cat > "${body_file}" <<EOF
           ${marker}
@@ -364,11 +381,36 @@ jobs:
           _This comment is updated automatically when the docs preview is redeployed._
           EOF
 
-          jq -n --rawfile body "${body_file}" '{ body: $body }' > "${payload_file}"
+          python3 - "${body_file}" "${payload_file}" <<'PY'
+          import json
+          import pathlib
+          import sys
 
-          mapfile -t comment_ids < <(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --paginate \
-            --jq ".[] | select(.body | contains(\"${marker}\")) | .id")
+          body = pathlib.Path(sys.argv[1]).read_text()
+          pathlib.Path(sys.argv[2]).write_text(json.dumps({"body": body}))
+          PY
+
+          gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --slurp > "${comments_file}"
+          mapfile -t comment_ids < <(MARKER="${marker}" python3 - "${comments_file}" <<'PY'
+          import json
+          import os
+          import sys
+
+          marker = os.environ["MARKER"]
+          with open(sys.argv[1], encoding="utf-8") as file:
+              pages = json.load(file)
+
+          for page in pages:
+              comments = page if isinstance(page, list) else [page]
+              for comment in comments:
+                  body = comment.get("body") or ""
+                  comment_id = comment.get("id")
+                  if marker in body:
+                      if not isinstance(comment_id, int):
+                          raise SystemExit(f"Unexpected comment id: {comment_id!r}")
+                      print(comment_id)
+          PY
+          )
 
           if (( ${#comment_ids[@]} > 0 )); then
             comment_id="${comment_ids[$((${#comment_ids[@]} - 1))]}"

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -180,14 +180,14 @@ jobs:
             validate_deploy_path "${PATH_TO_VALIDATE}"
           done
 
-          echo "deploy_path=${DEPLOY_PATH}" >> "$GITHUB_OUTPUT"
           {
+            echo "deploy_path=${DEPLOY_PATH}"
             echo "deploy_paths<<EOF"
             printf '%s\n' "${DEPLOY_PATHS[@]}"
             echo "EOF"
+            echo "is_release_deploy=${IS_RELEASE_DEPLOY}"
+            echo "url=https://docs.wendy.dev/${DEPLOY_PATH}/"
           } >> "$GITHUB_OUTPUT"
-          echo "is_release_deploy=${IS_RELEASE_DEPLOY}" >> "$GITHUB_OUTPUT"
-          echo "url=https://docs.wendy.dev/${DEPLOY_PATH}/" >> "$GITHUB_OUTPUT"
 
       - name: Build static site exports
         env:

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -245,6 +245,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      issues: write
     environment:
       name: docs
       url: ${{ needs.build.outputs.url }}
@@ -339,6 +340,42 @@ jobs:
             curl -fsS --max-time 30 -o "${response_file}" "${DOCS_URL}"
             grep -q "WendyOS Docs" "${response_file}"
           done <<< "${DEPLOY_PATHS}"
+
+      - name: Comment with docs preview URL
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DOCS_PREVIEW_URL: ${{ needs.build.outputs.url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          marker='<!-- wendy-docs-preview -->'
+          body_file="$(mktemp)"
+          payload_file="$(mktemp)"
+
+          cat > "${body_file}" <<EOF
+          ${marker}
+          ## Docs preview
+
+          Preview this PR's docs at: ${DOCS_PREVIEW_URL}
+
+          _This comment is updated automatically when the docs preview is redeployed._
+          EOF
+
+          jq -n --rawfile body "${body_file}" '{ body: $body }' > "${payload_file}"
+
+          comment_id="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
+            | tail -n 1)"
+
+          if [[ -n "${comment_id}" ]]; then
+            gh api --method PATCH "repos/${REPOSITORY}/issues/comments/${comment_id}" --input "${payload_file}"
+          else
+            gh api --method POST "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" --input "${payload_file}"
+          fi
 
       - name: Delete expired branch previews
         env:

--- a/go/internal/cli/assets/docs/development/docs-site.md
+++ b/go/internal/cli/assets/docs/development/docs-site.md
@@ -77,7 +77,7 @@ The `.github/workflows/fumadocs.yml` workflow runs when `docs`,
 | Trigger | Behavior |
 |---|---|
 | `main` branch push | Builds and deploys a branch preview |
-| Pull request to `main` from this repository | Builds and deploys a branch preview |
+| Pull request to `main` from this repository | Builds and deploys a branch preview, then posts or updates a sticky PR comment with the preview URL. Fork PRs do not receive preview comments. |
 | Published stable release | Deploys `release-<version>/` and updates `latest/` |
 | Published prerelease/nightly | Deploys `release-nightly-<version>/` and updates `latest-nightly/` |
 | Manual dispatch (no inputs) | Builds a branch-style preview artifact without deploying |

--- a/go/internal/cli/assets/docs/development/docs-site.md
+++ b/go/internal/cli/assets/docs/development/docs-site.md
@@ -83,6 +83,10 @@ The `.github/workflows/fumadocs.yml` workflow runs when `docs`,
 | Manual dispatch (no inputs) | Builds a branch-style preview artifact without deploying |
 | Manual dispatch with `release_tag` input | Deploys a release, identical to a published-release trigger. The `release_prerelease` input selects the target: `false` (default) deploys `release-<version>/` and updates `latest/`; `true` deploys `release-nightly-<version>/` and updates `latest-nightly/`. The dispatch ref must match `release_tag` (dispatch with `--ref "<release_tag>"`), otherwise the deploy fails fast so docs built from one ref are never published under a different release path. |
 
+Preview URLs are posted to same-repository PR comments and are visible to anyone
+who can read the PR. This is intentional; deploy paths are public preview paths
+and should not include sensitive information.
+
 The deploy job authenticates to GCP with Workload Identity Federation and syncs
 static files to `gs://wendy-docs-public/<deploy-path>`. Static exports include
 SHA-256 manifests that are verified before each deploy path is synced.


### PR DESCRIPTION
## Summary
- Add a sticky docs preview comment for same-repo documentation PRs after the Fumadocs preview deploys.
- Reuse a stable marker so workflow reruns update the existing comment instead of adding duplicates.
- Keep release deploys, main pushes, unsupported fork PRs, and cloud deploy credentials out of the comment flow.
- Document the new PR comment behavior and preview URL visibility in the docs site development guide.

Closes WDY-1386.

## Tests
- `gh workflow view fumadocs.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fumadocs.yml"); puts "YAML parsed"'`
- `ruby -e 'require "yaml"; y=YAML.load_file(".github/workflows/fumadocs.yml"); print y["jobs"]["comment-preview"]["steps"].find{|s| s["name"]=="Comment with docs preview URL"}["run"]' | bash -n`
- `actionlint .github/workflows/fumadocs.yml`
- Fumadocs PR run passed: https://github.com/wendylabsinc/WendyOS/actions/runs/27198948213
- `gh pr checks 927`
- Verified the PR has one sticky docs preview comment after rerun.
