### PR TITLE
fix: clarify unsupported macOS hardware API errors

### DIFF
--- a/go/internal/cli/commands/bluetooth.go
+++ b/go/internal/cli/commands/bluetooth.go
@@ -41,14 +41,23 @@ func newBluetoothListCmd() *cobra.Command {
 
 			stream, err := conn.AgentService.ScanBluetoothPeripherals(ctx)
 			if err != nil {
+				if macErr := macOSBetaUnsupportedFeatureError(ctx, conn.AgentService, err, "Bluetooth scanning"); macErr != nil {
+					return fmt.Errorf("starting Bluetooth scan: %w", macErr)
+				}
 				return fmt.Errorf("starting Bluetooth scan: %w", err)
 			}
 
 			// Send a scan request to start scanning.
 			if err := stream.Send(&agentpb.ScanBluetoothPeripheralsRequest{}); err != nil {
+				if macErr := macOSBetaUnsupportedFeatureError(ctx, conn.AgentService, err, "Bluetooth scanning"); macErr != nil {
+					return fmt.Errorf("sending scan request: %w", macErr)
+				}
 				return fmt.Errorf("sending scan request: %w", err)
 			}
 			if err := stream.CloseSend(); err != nil {
+				if macErr := macOSBetaUnsupportedFeatureError(ctx, conn.AgentService, err, "Bluetooth scanning"); macErr != nil {
+					return fmt.Errorf("closing send: %w", macErr)
+				}
 				return fmt.Errorf("closing send: %w", err)
 			}
 
@@ -59,6 +68,9 @@ func newBluetoothListCmd() *cobra.Command {
 					break
 				}
 				if err != nil {
+					if macErr := macOSBetaUnsupportedFeatureError(ctx, conn.AgentService, err, "Bluetooth scanning"); macErr != nil {
+						return fmt.Errorf("receiving Bluetooth scan result: %w", macErr)
+					}
 					return fmt.Errorf("receiving Bluetooth scan result: %w", err)
 				}
 				allDevices = append(allDevices, resp.GetDiscoveredDevices()...)

--- a/go/internal/cli/commands/bluetooth.go
+++ b/go/internal/cli/commands/bluetooth.go
@@ -47,14 +47,16 @@ func newBluetoothListCmd() *cobra.Command {
 				return fmt.Errorf("starting Bluetooth scan: %w", err)
 			}
 
-			// Send a scan request to start scanning.
-			if err := stream.Send(&agentpb.ScanBluetoothPeripheralsRequest{}); err != nil {
+			// Send a scan request to start scanning. A server that rejects the
+			// stream immediately may surface io.EOF here; continue to Recv so
+			// grpc-go can expose the terminal status.
+			if err := stream.Send(&agentpb.ScanBluetoothPeripheralsRequest{}); err != nil && err != io.EOF {
 				if macErr := macOSBetaUnsupportedFeatureError(ctx, conn.AgentService, err, "Bluetooth scanning"); macErr != nil {
 					return fmt.Errorf("sending scan request: %w", macErr)
 				}
 				return fmt.Errorf("sending scan request: %w", err)
 			}
-			if err := stream.CloseSend(); err != nil {
+			if err := stream.CloseSend(); err != nil && err != io.EOF {
 				if macErr := macOSBetaUnsupportedFeatureError(ctx, conn.AgentService, err, "Bluetooth scanning"); macErr != nil {
 					return fmt.Errorf("closing send: %w", macErr)
 				}

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -41,6 +41,9 @@ func newCameraListCmd() *cobra.Command {
 
 			resp, err := conn.VideoService.ListVideoDevices(ctx, &agentpb.ListVideoDevicesRequest{})
 			if err != nil {
+				if macErr := macOSBetaUnsupportedFeatureError(ctx, conn.AgentService, err, "Camera listing"); macErr != nil {
+					return fmt.Errorf("listing cameras: %w", macErr)
+				}
 				return fmt.Errorf("listing cameras: %w", err)
 			}
 

--- a/go/internal/cli/commands/hardware.go
+++ b/go/internal/cli/commands/hardware.go
@@ -80,6 +80,9 @@ func newHardwareListCmd() *cobra.Command {
 			}
 			resp, respErr := target.Agent.AgentService.ListHardwareCapabilities(ctx, req)
 			if respErr != nil {
+				if macErr := macOSBetaUnsupportedFeatureError(ctx, target.Agent.AgentService, respErr, "Hardware capability discovery"); macErr != nil {
+					return fmt.Errorf("listing hardware capabilities: %w", macErr)
+				}
 				return fmt.Errorf("listing hardware capabilities: %w", respErr)
 			}
 			caps := resp.GetCapabilities()

--- a/go/internal/cli/commands/macos_unsupported.go
+++ b/go/internal/cli/commands/macos_unsupported.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const macOSBetaUnsupportedSuffix = "is not available in the current Wendy Agent for macOS beta."
+
+func macOSBetaUnsupportedFeatureError(ctx context.Context, agent agentpb.WendyAgentServiceClient, err error, feature string) error {
+	if agent == nil || status.Code(err) != codes.Unimplemented {
+		return nil
+	}
+
+	resp, versionErr := agent.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	if versionErr != nil || !strings.EqualFold(resp.GetOs(), "darwin") {
+		return nil
+	}
+
+	return fmt.Errorf("%s %s", feature, macOSBetaUnsupportedSuffix)
+}

--- a/go/internal/cli/commands/macos_unsupported_test.go
+++ b/go/internal/cli/commands/macos_unsupported_test.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+type fakeUnsupportedAgentServer struct {
+	agentpb.UnimplementedWendyAgentServiceServer
+	os string
+}
+
+func (s *fakeUnsupportedAgentServer) GetAgentVersion(_ context.Context, _ *agentpb.GetAgentVersionRequest) (*agentpb.GetAgentVersionResponse, error) {
+	return &agentpb.GetAgentVersionResponse{Os: s.os}, nil
+}
+
+func startUnsupportedAgentClient(t *testing.T, osName string) agentpb.WendyAgentServiceClient {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	srv := grpc.NewServer()
+	agentpb.RegisterWendyAgentServiceServer(srv, &fakeUnsupportedAgentServer{os: osName})
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = ln.Close()
+	})
+
+	conn, err := grpc.NewClient(ln.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return agentpb.NewWendyAgentServiceClient(conn)
+}
+
+func TestMacOSBetaUnsupportedFeatureError_ReturnsMacBetaMessage(t *testing.T) {
+	ctx := context.Background()
+	client := startUnsupportedAgentClient(t, "darwin")
+
+	_, rpcErr := client.ListWiFiNetworks(ctx, &agentpb.ListWiFiNetworksRequest{})
+	if status.Code(rpcErr) != codes.Unimplemented {
+		t.Fatalf("ListWiFiNetworks code = %s, want Unimplemented", status.Code(rpcErr))
+	}
+
+	err := macOSBetaUnsupportedFeatureError(ctx, client, rpcErr, "Wi-Fi network scanning")
+	if err == nil {
+		t.Fatal("macOSBetaUnsupportedFeatureError returned nil")
+	}
+
+	got := err.Error()
+	if !strings.Contains(got, "current Wendy Agent for macOS beta") {
+		t.Fatalf("error = %q, want macOS beta message", got)
+	}
+	if strings.Contains(got, "updating") || strings.Contains(got, "agent version") {
+		t.Fatalf("error = %q, should not suggest updating the agent", got)
+	}
+}
+
+func TestMacOSBetaUnsupportedFeatureError_IgnoresNonMacAgents(t *testing.T) {
+	ctx := context.Background()
+	client := startUnsupportedAgentClient(t, "linux")
+
+	_, rpcErr := client.ListWiFiNetworks(ctx, &agentpb.ListWiFiNetworksRequest{})
+	if status.Code(rpcErr) != codes.Unimplemented {
+		t.Fatalf("ListWiFiNetworks code = %s, want Unimplemented", status.Code(rpcErr))
+	}
+
+	if err := macOSBetaUnsupportedFeatureError(ctx, client, rpcErr, "Wi-Fi network scanning"); err != nil {
+		t.Fatalf("macOSBetaUnsupportedFeatureError returned %v, want nil", err)
+	}
+}
+
+func TestMacOSBetaUnsupportedFeatureError_IgnoresNonUnimplementedErrors(t *testing.T) {
+	client := startUnsupportedAgentClient(t, "darwin")
+
+	err := macOSBetaUnsupportedFeatureError(context.Background(), client, errors.New("boom"), "Wi-Fi network scanning")
+	if err != nil {
+		t.Fatalf("macOSBetaUnsupportedFeatureError returned %v, want nil", err)
+	}
+}

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -172,6 +172,9 @@ func (c *wifiClient) List(ctx context.Context) ([]*agentpb.ListWiFiNetworksRespo
 	if c.agent != nil {
 		resp, err := c.agent.ListWiFiNetworks(ctx, &agentpb.ListWiFiNetworksRequest{})
 		if err != nil {
+			if macErr := macOSBetaUnsupportedFeatureError(ctx, c.agent, err, "Wi-Fi network scanning"); macErr != nil {
+				return nil, fmt.Errorf("listing WiFi networks: %w", macErr)
+			}
 			return nil, fmt.Errorf("listing WiFi networks: %w", err)
 		}
 		return resp.GetNetworks(), nil
@@ -459,6 +462,9 @@ func newWifiStatusCmd() *cobra.Command {
 
 			resp, err := target.Agent.AgentService.GetWiFiStatus(ctx, &agentpb.GetWiFiStatusRequest{})
 			if err != nil {
+				if macErr := macOSBetaUnsupportedFeatureError(ctx, target.Agent.AgentService, err, "Wi-Fi status reporting"); macErr != nil {
+					return fmt.Errorf("getting WiFi status: %w", macErr)
+				}
 				return fmt.Errorf("getting WiFi status: %w", err)
 			}
 


### PR DESCRIPTION
## Summary
- Show macOS-beta unsupported messages for hardware-related CLI calls when a macOS agent returns `Unimplemented`.
- Cover hardware list, Wi-Fi list/status, camera list, and Bluetooth list without suggesting an agent update.

Closes WDY-1377.

## Tests
- `cd go && go test ./internal/cli/commands`
