### PR TITLE
docs: verify Mac agent discovery and selection

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
@@ -1,9 +1,9 @@
 Selects a device as the [default device](../../device-selection.md), so that other commands default to this device if available.
 
-The default can be a hostname, IP address, provider key, or explicit `host:port` value. For the WendyAgentMac beta on the same Mac as the CLI, use:
+The default can be a hostname, IP address, provider key, or explicit `host:port` value:
 
 ```sh
-wendy device set-default localhost:50051
+wendy device set-default my-mac.local:50051
 wendy device info --json
 wendy run
 ```

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
@@ -1,1 +1,11 @@
 Selects a device as the [default device](../../device-selection.md), so that other commands default to this device if available.
+
+The default can be a hostname, IP address, provider key, or explicit `host:port` value. For the WendyAgentMac beta on the same Mac as the CLI, use:
+
+```sh
+wendy device set-default localhost:50051
+wendy device info --json
+wendy run
+```
+
+Use `wendy device unset-default` to clear the saved target.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
@@ -15,8 +15,8 @@ wendy discover [flags]
 - **Ethernet (USB NCM) discovery** — enumerates host network adapters and
   returns those whose name or interface description contains "wendy"
   (case-insensitive).
-- **LAN discovery** — uses mDNS/Bonjour to find WendyOS devices and
-  WendyAgentMac targets advertising themselves on the local network.
+- **LAN discovery** — uses mDNS/Bonjour to find WendyOS devices and Wendy Agent
+  for Mac targets advertising themselves on the local network.
 
 ## Platform support
 
@@ -34,12 +34,11 @@ mDNS discovery works on all platforms. On Linux, ensure `avahi-daemon` is
 running on the device. On macOS, the CLI shells out to `dns-sd` and requires
 Local Network TCC permission.
 
-WendyAgentMac advertises the same `_wendyos._udp` service during the Mac beta.
-When discovery succeeds, Mac agents appear under `lanDevices` in JSON output
-with `"os": "darwin"`. For automation, prefer an explicit target such as
-`--device localhost:50051` on the same Mac or
-`--device {hostname}.local:50051` for a remote Mac, because discovery can be
-blocked by network policy or macOS permissions.
+Wendy Agent for Mac advertises the same `_wendyos._udp` service. When discovery
+succeeds, Mac agents appear under `lanDevices` in JSON output with
+`"os": "darwin"`. For automation, prefer an explicit target such as
+`--device {hostname}:50051`, because discovery can be blocked by network policy
+or macOS permissions.
 
 ## Flags
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
@@ -12,8 +12,11 @@ wendy discover [flags]
 
 `wendy discover` combines two discovery mechanisms and merges the results:
 
-- **Ethernet (USB NCM) discovery** — enumerates host network adapters and returns those whose name or interface description contains "wendy" (case-insensitive).
-- **LAN discovery** — uses mDNS to find WendyOS devices advertising themselves on the local network.
+- **Ethernet (USB NCM) discovery** — enumerates host network adapters and
+  returns those whose name or interface description contains "wendy"
+  (case-insensitive).
+- **LAN discovery** — uses mDNS/Bonjour to find WendyOS devices and
+  WendyAgentMac targets advertising themselves on the local network.
 
 ## Platform support
 
@@ -27,7 +30,16 @@ wendy discover [flags]
 
 ### LAN (mDNS) discovery
 
-mDNS discovery works on all platforms. On Linux, ensure `avahi-daemon` is running on the device. On macOS, the CLI requires the Local Network TCC permission.
+mDNS discovery works on all platforms. On Linux, ensure `avahi-daemon` is
+running on the device. On macOS, the CLI shells out to `dns-sd` and requires
+Local Network TCC permission.
+
+WendyAgentMac advertises the same `_wendyos._udp` service during the Mac beta.
+When discovery succeeds, Mac agents appear under `lanDevices` in JSON output
+with `"os": "darwin"`. For automation, prefer an explicit target such as
+`--device localhost:50051` on the same Mac or
+`--device {hostname}.local:50051` for a remote Mac, because discovery can be
+blocked by network policy or macOS permissions.
 
 ## Flags
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
@@ -5,16 +5,12 @@ established, the CLI goes down a list in order to connect to this device.
 
 If the `--device` flag is specified, a connection is made against that target IP
 address or hostname. Include a port when the target should not use the default
-agent port, or when you want to make the beta Mac-agent path explicit:
+agent port:
 
 ```sh
-wendy --device localhost:50051 device info --json
+wendy --device 192.168.1.42 device apps list
 wendy run --device my-mac.local:50051
 ```
-
-For WendyAgentMac, `localhost:50051` targets an agent running on the same Mac as
-the CLI. To target a different Mac, use that Mac's `.local` hostname or IP
-address; `localhost` never points at a remote machine.
 
 Failing to connect to an explicit device results in a failure.
 
@@ -24,11 +20,10 @@ Failing to connect to an explicit device results in a failure.
 
 If a Default Device is set using [`wendy device set-default`](./commands/device/set-default.md),
 the CLI attempts to connect to it. The saved value may be a hostname, IP
-address, provider key, or explicit `host:port` value such as
-`localhost:50051`.
+address, provider key, or explicit `host:port` value.
 
 ```sh
-wendy device set-default localhost:50051
+wendy device set-default my-mac.local:50051
 wendy device info --json
 wendy run
 ```
@@ -46,8 +41,8 @@ mDNS and BLE discover nearby [WendyOS](../../wendyos/),
 A device picker is shown only when the terminal is interactive, so a user can
 select their target device for the current command invocation.
 
-WendyAgentMac advertises over Bonjour/mDNS as `_wendyos._udp` and appears as a
-LAN device when local discovery is allowed by the network and macOS Local
+Wendy Agent for Mac advertises over Bonjour/mDNS as `_wendyos._udp` and appears
+as a LAN device when local discovery is allowed by the network and macOS Local
 Network permissions.
 
 In scripts, CI, SSH sessions without a TTY, or any other non-interactive

--- a/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
@@ -1,20 +1,58 @@
-Many CLI operations run on the remote device. When a connection is to be established, the CLI goes down a list in order to connect to this device.
+Many CLI operations run on the remote device. When a connection is to be
+established, the CLI goes down a list in order to connect to this device.
 
 ## 1. `--device`
 
-If the `--device` flag is specified, a connection will be made against the target IP or Hostname. Failing to connect results in a failure.
+If the `--device` flag is specified, a connection is made against that target IP
+address or hostname. Include a port when the target should not use the default
+agent port, or when you want to make the beta Mac-agent path explicit:
+
+```sh
+wendy --device localhost:50051 device info --json
+wendy run --device my-mac.local:50051
+```
+
+For WendyAgentMac, `localhost:50051` targets an agent running on the same Mac as
+the CLI. To target a different Mac, use that Mac's `.local` hostname or IP
+address; `localhost` never points at a remote machine.
+
+Failing to connect to an explicit device results in a failure.
 
 > **TODO (test)**: If the target device is outdated, and `--json` is not specified, a warning will be printed to indicate an update is available.
 
 ## 2. Default Device
 
-If a Default Device is set using [`wendy device set-default`](./commands/device/set-default.md) - it is attempted to connect to. If this fails, a warning is printed and a picker is shown.
+If a Default Device is set using [`wendy device set-default`](./commands/device/set-default.md),
+the CLI attempts to connect to it. The saved value may be a hostname, IP
+address, provider key, or explicit `host:port` value such as
+`localhost:50051`.
+
+```sh
+wendy device set-default localhost:50051
+wendy device info --json
+wendy run
+```
+
+If the default device cannot be reached from an interactive terminal, the CLI
+shows the picker so you can select another device. In non-interactive shells,
+the command fails instead of opening a picker.
 
 > **TODO (test)**: If the target device is outdated, and `--json` is not specified, a warning will be printed to indicate an update is available.
 
 ## 3. Show Picker
 
-mDNS and BLE discover nearby [WendyOS](../../wendyos/), [Wendy-Agent](../../wendy-agent/) and [Wendy Lite](../../wendy-lite/) devices. A device picker is shown in the terminal, so a user can select their target device for the current command invocation.
+mDNS and BLE discover nearby [WendyOS](../../wendyos/),
+[Wendy-Agent](../../wendy-agent/) and [Wendy Lite](../../wendy-lite/) devices.
+A device picker is shown only when the terminal is interactive, so a user can
+select their target device for the current command invocation.
+
+WendyAgentMac advertises over Bonjour/mDNS as `_wendyos._udp` and appears as a
+LAN device when local discovery is allowed by the network and macOS Local
+Network permissions.
+
+In scripts, CI, SSH sessions without a TTY, or any other non-interactive
+context, no picker is shown. Pass `--device`, or configure a default with
+`wendy device set-default`, before running commands that need a target.
 
 > **TODO (test)**: If the target device is outdated, and `--json` is not specified, a warning will be printed to indicate an update is available.
 > If the terminal is interactive, a prompt will be made to update the device right now.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/global-flags.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/global-flags.md
@@ -26,7 +26,7 @@ Specifies a target device by IP address, hostname, provider key, or explicit `ho
 
 ```sh
 wendy --device 192.168.1.42 device apps list
-wendy --device localhost:50051 device info --json
+wendy --device my-mac.local:50051 device info --json
 ```
 
 ## Environment variables

--- a/go/internal/cli/assets/docs/clients/wendy-cli/global-flags.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/global-flags.md
@@ -22,10 +22,11 @@ wendy device list --json=false | cat
 
 ## `--device`
 
-Specifies a target device by IP address or hostname, bypassing [device selection](./device-selection.md).
+Specifies a target device by IP address, hostname, provider key, or explicit `host:port`, bypassing [device selection](./device-selection.md).
 
 ```sh
 wendy --device 192.168.1.42 device apps list
+wendy --device localhost:50051 device info --json
 ```
 
 ## Environment variables

--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -30,7 +30,7 @@ brew tap wendylabsinc/tap
 brew install --cask wendy-agent
 ```
 
-For the nightly beta build, use:
+For the nightly build, use:
 
 ```bash
 brew install --cask wendy-agent-nightly
@@ -48,36 +48,19 @@ Wendy Agent appears in the macOS menu bar. Open the menu to confirm that the age
 
 ## Verify the Installation
 
-From the Mac development machine, check that the CLI can reach the Mac agent.
-The recommended beta path is to target the agent explicitly with a host and
-port instead of relying on the picker.
-
-If the CLI and agent are on the same Mac, use `localhost:50051`:
+From the Mac development machine, check that the CLI can reach the Mac agent:
 
 ```bash
-wendy --device localhost:50051 device info --json
+wendy --device {hostname}:50051 device info --json
 ```
 
-If the agent is running on another Mac on your network, replace `localhost`
-with that Mac's `.local` hostname or IP address. `localhost` always means the
-Mac running the CLI, not a different Mac target.
+Replace `{hostname}` with the Mac target's hostname or IP address.
 
-```bash
-wendy --device {hostname}.local:50051 device info --json
-# or
-wendy --device {ip-address}:50051 device info --json
-```
+## Discovery and Device Selection
 
-Replace `{hostname}` or `{ip-address}` with the Mac target's actual hostname or
-IP address.
-
-## Discovery and Device Selection During Beta
-
-WendyAgentMac advertises over Bonjour/mDNS as `_wendyos._udp`. The
+Wendy Agent for Mac advertises over Bonjour/mDNS as `_wendyos._udp`. The
 `wendy discover --json` command can list Mac agents in `lanDevices` with
-`"os": "darwin"`. Discovery depends on the local network allowing mDNS and on
-macOS Local Network permission for the CLI process, so it is useful for
-verification but should not be the only automation path during beta.
+`"os": "darwin"` when the network and macOS Local Network permission allow it.
 
 For scripts, CI, SSH sessions, and other non-interactive shells, pass
 `--device` or set a default device first. The CLI does not open the interactive
@@ -88,20 +71,10 @@ Use `--json` for stable machine-readable output.
 ## Set the Mac as Your Default Device
 
 Once the CLI can connect, you can save the Mac target as your default Wendy
-device.
-
-Same-Mac workflow:
+device:
 
 ```bash
-wendy device set-default localhost:50051
-wendy device info --json
-wendy run
-```
-
-Remote Mac workflow:
-
-```bash
-wendy device set-default {hostname}.local:50051
+wendy device set-default {hostname}:50051
 wendy device info --json
 wendy run
 ```
@@ -117,13 +90,7 @@ wendy device unset-default
 From a native macOS app project configured for a Darwin target, run:
 
 ```bash
-wendy run --device localhost:50051
-```
-
-For a remote Mac target, pass that target explicitly:
-
-```bash
-wendy run --device {hostname}.local:50051
+wendy run --device {hostname}:50051
 ```
 
 If you saved the Mac target as the default device, you can omit `--device`:
@@ -136,26 +103,26 @@ The CLI builds the app on the Mac development machine, syncs the build output
 to Wendy Agent for Mac, and starts it as a native macOS process. These apps
 currently run natively on macOS, not inside a Linux-style container.
 
-## What Works in the Mac Beta
+## What Works
 
 Wendy for Mac is focused on native macOS app deployment first. Apps run as regular macOS processes, not Linux containers.
 
 ### Should work
 
 - Apple Silicon Mac targets running macOS 15 or later.
-- Installing WendyAgentMac with Homebrew or the release zip.
-- Running WendyAgentMac as a menu bar app.
-- Connecting from the Wendy CLI with an explicit `localhost:50051`, `{hostname}.local:50051`, or `{ip-address}:50051` address.
-- Discovering WendyAgentMac over Bonjour/mDNS when the network and macOS Local Network permission allow it.
+- Installing Wendy Agent for Mac with Homebrew or the release zip.
+- Running Wendy Agent for Mac as a menu bar app.
+- Connecting from the Wendy CLI with an explicit `{hostname}:50051` address.
+- Discovering Wendy Agent for Mac over Bonjour/mDNS when the network and macOS Local Network permission allow it.
 - Setting the Mac as your default Wendy device.
 - Deploying native SwiftPM macOS apps with `wendy run` and `platform: "darwin"`.
 
-### Not supported in this beta
+### Not supported
 
 - Intel Macs.
 - Linux-container deployment to Mac targets, including Dockerfile and Compose projects.
 - Wendy hardware APIs on the Mac agent, including Wi-Fi management, Bluetooth, audio, camera/video, GPU, USB, GPIO, and I2C.
-- WendyOS OTA updates with `wendy os update`. Update macOS and WendyAgentMac through their normal macOS installation/update path.
+- WendyOS OTA updates with `wendy os update`. Update macOS and Wendy Agent for Mac through their normal macOS installation/update path.
 
 Unsupported features should either be hidden, clearly marked as unsupported, or
 fail with an actionable unsupported message.
@@ -168,20 +135,16 @@ If the CLI cannot connect:
 2. Run the command with an explicit device address:
 
    ```bash
-   wendy --device localhost:50051 device info --json
+   wendy --device {hostname}:50051 device info --json
    ```
 
-3. If the agent is on another Mac, use that Mac's hostname or IP address
-   instead of `localhost`.
-4. If `wendy discover` does not show the Mac agent, use the explicit
+3. If `wendy discover` does not show the Mac agent, use the explicit
    `--device` command above and check macOS Local Network permission for the CLI
    process.
-5. Quit and reopen Wendy Agent from the menu bar.
-6. If you installed both stable and nightly builds, quit both apps and open only
+4. Quit and reopen Wendy Agent from the menu bar.
+5. If you installed both stable and nightly builds, quit both apps and open only
    the one you want to test.
 
 ## Next Steps
 
 Once the Mac target is reachable, deploy a native macOS app with `wendy run`.
-The Mac beta support matrix and smoke checklist will expand this page as more
-flows are verified.

--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -49,33 +49,67 @@ Wendy Agent appears in the macOS menu bar. Open the menu to confirm that the age
 ## Verify the Installation
 
 From the Mac development machine, check that the CLI can reach the Mac agent.
+The recommended beta path is to target the agent explicitly with a host and
+port instead of relying on the picker.
 
-If the CLI and agent are on the same Mac, use `localhost`:
+If the CLI and agent are on the same Mac, use `localhost:50051`:
 
 ```bash
 wendy --device localhost:50051 device info --json
 ```
 
-If the agent is running on another Mac on your network, replace `localhost` with that Mac's hostname or IP address:
+If the agent is running on another Mac on your network, replace `localhost`
+with that Mac's `.local` hostname or IP address. `localhost` always means the
+Mac running the CLI, not a different Mac target.
 
 ```bash
-wendy --device {hostname}:50051 device info --json
+wendy --device {hostname}.local:50051 device info --json
+# or
+wendy --device {ip-address}:50051 device info --json
 ```
 
-Replace `{hostname}` with the Mac target's hostname or IP address.
+Replace `{hostname}` or `{ip-address}` with the Mac target's actual hostname or
+IP address.
+
+## Discovery and Device Selection During Beta
+
+WendyAgentMac advertises over Bonjour/mDNS as `_wendyos._udp`. The
+`wendy discover --json` command can list Mac agents in `lanDevices` with
+`"os": "darwin"`. Discovery depends on the local network allowing mDNS and on
+macOS Local Network permission for the CLI process, so it is useful for
+verification but should not be the only automation path during beta.
+
+For scripts, CI, SSH sessions, and other non-interactive shells, pass
+`--device` or set a default device first. The CLI does not open the interactive
+picker when it is not attached to a TTY; without `--device` or a saved default,
+device commands fail with an error asking you to specify or configure a device.
+Use `--json` for stable machine-readable output.
 
 ## Set the Mac as Your Default Device
 
-Once the CLI can connect, set the Mac target as your default Wendy device:
+Once the CLI can connect, you can save the Mac target as your default Wendy
+device.
+
+Same-Mac workflow:
 
 ```bash
 wendy device set-default localhost:50051
+wendy device info --json
+wendy run
 ```
 
-For a remote Mac target, use its hostname or IP address instead:
+Remote Mac workflow:
 
 ```bash
-wendy device set-default {hostname}:50051
+wendy device set-default {hostname}.local:50051
+wendy device info --json
+wendy run
+```
+
+Clear the default when you want commands to require an explicit target again:
+
+```bash
+wendy device unset-default
 ```
 
 ## Deploying Native macOS Apps
@@ -89,10 +123,18 @@ wendy run --device localhost:50051
 For a remote Mac target, pass that target explicitly:
 
 ```bash
-wendy run --device {hostname}:50051
+wendy run --device {hostname}.local:50051
 ```
 
-The CLI builds the app on the Mac development machine, syncs the build output to Wendy Agent for Mac, and starts it as a native macOS process. These apps currently run natively on macOS, not inside a Linux-style container.
+If you saved the Mac target as the default device, you can omit `--device`:
+
+```bash
+wendy run
+```
+
+The CLI builds the app on the Mac development machine, syncs the build output
+to Wendy Agent for Mac, and starts it as a native macOS process. These apps
+currently run natively on macOS, not inside a Linux-style container.
 
 ## Beta Support Notes
 
@@ -111,10 +153,15 @@ Current limitations:
 
 - Intel Macs are not supported
 - Native macOS app deployment requires a Mac development machine
-- Wi-Fi management, Bluetooth peripheral control, camera/video, audio, GPU, USB, GPIO, and I2C access are not available through Wendy hardware APIs in the initial Mac beta
-- Virtualized Linux containers, once enabled later, are intended for self-contained services such as databases, queues, and web workers, not hardware access
+- Wi-Fi management, Bluetooth peripheral control, camera/video, audio, GPU,
+  USB, GPIO, and I2C access are not available through Wendy hardware APIs in
+  the initial Mac beta
+- Virtualized Linux containers, once enabled later, are intended for
+  self-contained services such as databases, queues, and web workers, not
+  hardware access
 
-Unsupported features should either be hidden, clearly marked as unsupported, or fail with an actionable unsupported message.
+Unsupported features should either be hidden, clearly marked as unsupported, or
+fail with an actionable unsupported message.
 
 ## Troubleshooting
 
@@ -127,10 +174,17 @@ If the CLI cannot connect:
    wendy --device localhost:50051 device info --json
    ```
 
-3. If the agent is on another Mac, use that Mac's hostname or IP address instead of `localhost`.
-4. Quit and reopen Wendy Agent from the menu bar.
-5. If you installed both stable and nightly builds, quit both apps and open only the one you want to test.
+3. If the agent is on another Mac, use that Mac's hostname or IP address
+   instead of `localhost`.
+4. If `wendy discover` does not show the Mac agent, use the explicit
+   `--device` command above and check macOS Local Network permission for the CLI
+   process.
+5. Quit and reopen Wendy Agent from the menu bar.
+6. If you installed both stable and nightly builds, quit both apps and open only
+   the one you want to test.
 
 ## Next Steps
 
-Once the Mac target is reachable, deploy a native macOS app with `wendy run`. The Mac beta support matrix and smoke checklist will expand this page as more flows are verified.
+Once the Mac target is reachable, deploy a native macOS app with `wendy run`.
+The Mac beta support matrix and smoke checklist will expand this page as more
+flows are verified.

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -334,10 +334,10 @@ func TestResolveDeviceAddress_DefaultDevice(t *testing.T) {
 	}
 }
 
-func TestResolveDeviceAddress_ExplicitLocalhostPortFlag(t *testing.T) {
+func TestResolveDeviceAddress_ExplicitHostPortFlag(t *testing.T) {
 	origFlag := deviceFlag
 	defer func() { deviceFlag = origFlag }()
-	deviceFlag = "localhost:50051"
+	deviceFlag = "my-mac.local:50051"
 
 	addr, isDefault, err := resolveDeviceAddress()
 	if err != nil {
@@ -346,17 +346,17 @@ func TestResolveDeviceAddress_ExplicitLocalhostPortFlag(t *testing.T) {
 	if isDefault {
 		t.Fatal("expected isDefault=false when --device flag is set")
 	}
-	if addr != "localhost:50051" {
-		t.Fatalf("addr = %q, want %q", addr, "localhost:50051")
+	if addr != "my-mac.local:50051" {
+		t.Fatalf("addr = %q, want %q", addr, "my-mac.local:50051")
 	}
 }
 
-func TestResolveDeviceAddress_ExplicitLocalhostPortDefault(t *testing.T) {
+func TestResolveDeviceAddress_ExplicitHostPortDefault(t *testing.T) {
 	origFlag := deviceFlag
 	defer func() { deviceFlag = origFlag }()
 	deviceFlag = ""
 
-	setTempConfig(t, &config.Config{DefaultDevice: "localhost:50051"})
+	setTempConfig(t, &config.Config{DefaultDevice: "my-mac.local:50051"})
 
 	addr, isDefault, err := resolveDeviceAddress()
 	if err != nil {
@@ -365,8 +365,8 @@ func TestResolveDeviceAddress_ExplicitLocalhostPortDefault(t *testing.T) {
 	if !isDefault {
 		t.Fatal("expected isDefault=true when using default device from config")
 	}
-	if addr != "localhost:50051" {
-		t.Fatalf("addr = %q, want %q", addr, "localhost:50051")
+	if addr != "my-mac.local:50051" {
+		t.Fatalf("addr = %q, want %q", addr, "my-mac.local:50051")
 	}
 }
 

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -334,6 +334,42 @@ func TestResolveDeviceAddress_DefaultDevice(t *testing.T) {
 	}
 }
 
+func TestResolveDeviceAddress_ExplicitLocalhostPortFlag(t *testing.T) {
+	origFlag := deviceFlag
+	defer func() { deviceFlag = origFlag }()
+	deviceFlag = "localhost:50051"
+
+	addr, isDefault, err := resolveDeviceAddress()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isDefault {
+		t.Fatal("expected isDefault=false when --device flag is set")
+	}
+	if addr != "localhost:50051" {
+		t.Fatalf("addr = %q, want %q", addr, "localhost:50051")
+	}
+}
+
+func TestResolveDeviceAddress_ExplicitLocalhostPortDefault(t *testing.T) {
+	origFlag := deviceFlag
+	defer func() { deviceFlag = origFlag }()
+	deviceFlag = ""
+
+	setTempConfig(t, &config.Config{DefaultDevice: "localhost:50051"})
+
+	addr, isDefault, err := resolveDeviceAddress()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isDefault {
+		t.Fatal("expected isDefault=true when using default device from config")
+	}
+	if addr != "localhost:50051" {
+		t.Fatalf("addr = %q, want %q", addr, "localhost:50051")
+	}
+}
+
 func TestResolveDeviceAddress_IPv6ZoneFlag(t *testing.T) {
 	origFlag := deviceFlag
 	defer func() { deviceFlag = origFlag }()


### PR DESCRIPTION
## Summary
- Document the Wendy Agent for Mac targeting path with the standard explicit `{hostname}:50051` workflow.
- Clarify discovery, default-device, and non-interactive behavior without adding a separate Mac-specific selection model.
- Add unit coverage for explicit `host:port` device resolution.

Closes WDY-1352.

## Tests
- `go test ./go/internal/cli/commands -run 'TestResolveDeviceAddress_(Flag|DefaultDevice|ExplicitHostPortFlag|ExplicitHostPortDefault|NoDevice)$'`
- Manual: `wendy --device <host>:50051 device info --json` against Wendy Agent for Mac (`os: darwin`, `cpuArchitecture: arm64`).
- Manual: `wendy device set-default <host>:50051 && wendy device info --json && wendy device unset-default` using a temporary HOME.
- Manual: after unsetting the default in a non-interactive shell, `wendy device info --json` exits 1 with the expected “no device specified” error.
- Manual: `wendy discover --json` lists Wendy Agent for Mac as a darwin LAN device on port 50051.
