### PR TITLE
fix(ci): match bold-formatted severity in security review fail-gate

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -169,7 +169,7 @@ jobs:
           print(report)
 
           severities = re.findall(
-              r'^\|\s*(CRITICAL|HIGH|MEDIUM|LOW|INFORMATIONAL)\s*\|',
+              r'^\|\s*\*{0,2}(CRITICAL|HIGH|MEDIUM|LOW|INFORMATIONAL)\*{0,2}\s*\|',
               report,
               re.MULTILINE,
           )


### PR DESCRIPTION
## Summary

- The `HAS_HIGH_SEVERITY` env var was never set because the regex matched plain `CRITICAL`/`HIGH` but Claude formats table cells as `**CRITICAL**` (bold markdown).
- As a result the "Fail on high or critical severity findings" step was always skipped, even when critical findings were present — the gate was silently broken.
- Fix: allow optional `**` wrappers in the pattern: `\*{0,2}(CRITICAL|HIGH|...)\*{0,2}`.

## Test plan

- [x] Verified against PR #931's review output, which contains `| **CRITICAL** |` — the updated regex matches it correctly.