### PR TITLE
fix(ci): re-enable integration tests; fix security review severity regex

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -651,7 +651,6 @@ jobs:
 
   integration-tests:
     name: Integration Tests (macOS, stable gate)
-    if: false # temporarily disabled
     uses: ./.github/workflows/integration-tests.yml
     with:
       platform: macos


### PR DESCRIPTION
## Summary

- Re-enable the integration-tests stable gate in `build.yml` (was `if: false # temporarily disabled`)
- Fix bold-formatted severity parsing in security review fail-gate regex (matches `**CRITICAL**` etc.)

## Test plan

- [ ] Integration tests job runs in the build workflow on merge to main
- [ ] Security review correctly fails on bold-formatted HIGH/CRITICAL findings