### PR TITLE
docs: record Mac beta smoke test

### DIFF
--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -54,7 +54,11 @@ From the Mac development machine, check that the CLI can reach the Mac agent:
 wendy --device {hostname}:50051 device info --json
 ```
 
-Replace `{hostname}` with the Mac target's hostname or IP address. Use `localhost` if the CLI and agent are on the same Mac.
+Replace `{hostname}` with the Mac target's hostname or IP address. Use `localhost`
+only if the CLI and agent are on the same Mac.
+
+The JSON response should report `"os": "darwin"` and
+`"cpuArchitecture": "arm64"`.
 
 ## Set the Mac as Your Default Device
 
@@ -91,7 +95,10 @@ Wendy for Mac is focused on native macOS app deployment first. Apps run as regul
 
 - Intel Macs.
 - Linux-container deployment to Mac targets, including Dockerfile and Compose projects.
-- Wendy hardware APIs on the Mac agent, including Wi-Fi management, Bluetooth, audio, camera/video, GPU, USB, GPIO, and I2C.
+- Wendy hardware APIs on the Mac agent, including Wi-Fi management, Bluetooth,
+  audio, camera/video, GPU, USB, GPIO, and I2C. Hardware commands such as
+  `wendy --device {hostname}:50051 device hardware list` should fail with a
+  clear not-supported error.
 - WendyOS OTA updates with `wendy os update`. Update macOS and WendyAgentMac through their normal macOS installation/update path.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Clarify the Wendy Agent for macOS beta health check without adding broad troubleshooting content.
- Record the Mac beta smoke test against signed 2026.06.09-034757 release artifacts on Apple Silicon.

Closes WDY-1345.

## Validation
- Docs-only change; no automated tests run.

### Mac beta smoke test — 2026-06-09

Platform:

```sh
sw_vers
# ProductName:    macOS
# ProductVersion: 26.5.1
# BuildVersion:   25F80

uname -m
# arm64
```

Release artifacts used:

```sh
/tmp/wdy-1345-smoke/wendy-cli-darwin-arm64/wendy --version
# wendy version 2026.06.09-034757

/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' /tmp/wdy-1345-smoke/WendyAgentMac.app/Contents/Info.plist
# 2026.06.09

codesign -dv --verbose=4 /tmp/wdy-1345-smoke/WendyAgentMac.app
# Authority=Developer ID Application: Wendy Labs Inc. (3YVC792H3S)
# Notarization Ticket=stapled

spctl --assess --type execute --verbose=4 /tmp/wdy-1345-smoke/WendyAgentMac.app
# /tmp/wdy-1345-smoke/WendyAgentMac.app: accepted
# source=Notarized Developer ID
```

Launched the signed Mac agent and confirmed it was running as a menu bar app:

```sh
open /tmp/wdy-1345-smoke/WendyAgentMac.app
osascript -e 'application id "sh.wendy.WendyAgentMac" is running'
# true

lsof -nP -iTCP:50051 -sTCP:LISTEN
# WendyAgentMac ... TCP *:50051 (LISTEN)
```

Used `localhost:50051` because the CLI and agent were on the same Mac:

```sh
/tmp/wdy-1345-smoke/wendy-cli-darwin-arm64/wendy --device localhost:50051 device info --json
# {
#   "cliVersion": "2026.06.09-034757",
#   "cpuArchitecture": "arm64",
#   "deviceType": "",
#   "hasGpu": false,
#   "os": "darwin",
#   "osVersion": "26.5.1",
#   "version": "2026.06.09-034757"
# }
```

Confirmed an unsupported hardware path fails clearly:

```sh
/tmp/wdy-1345-smoke/wendy-cli-darwin-arm64/wendy --device localhost:50051 device hardware list
# ✗ listing hardware capabilities: Not supported by this agent version. Try updating the agent.
# exit 1
```

