### PR TITLE
docs: verify native macOS run flow

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -43,7 +43,7 @@ If the current directory contains a `docker-compose.yml` (or `compose.yml`) but 
 
 ## Swift Package Manager projects (macOS)
 
-From a Darwin SwiftPM project, target the Mac agent explicitly:
+From a macOS (Darwin) SwiftPM project, target the Mac agent explicitly:
 
 ```bash
 wendy run --device <hostname-or-ip>:50051

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -43,6 +43,12 @@ If the current directory contains a `docker-compose.yml` (or `compose.yml`) but 
 
 ## Swift Package Manager projects (macOS)
 
+From a Darwin SwiftPM project, target the Mac agent explicitly:
+
+```bash
+wendy run --device <hostname-or-ip>:50051
+```
+
 When running a Swift Package Manager project on a macOS target, `wendy run`:
 
 1. Builds the project with `swift build -c release` (or `-c debug` when `--debug` is passed).


### PR DESCRIPTION
## Summary
- Add the explicit native macOS SwiftPM `wendy run --device <hostname-or-ip>:50051` command to the run reference.
- Validate the KISS beta path with the smallest temporary Darwin SwiftPM executable on the Mac agent.

Closes WDY-1346.

## Validation
- `wendy --device localhost:50051 device info --json` returned `"os": "darwin"`, `"cpuArchitecture": "arm64"`, agent version `2026.06.09-034757`.
- Temporary app: SwiftPM executable with `wendy.json` containing `appId`, `version`, `language: "swift"`, and `platform: "darwin"`.
- `/Volumes/Projects/WendyLabs/wendy-agent/.worktrees/kb.wdy-1346-native-macos-run-flow/go/bin/wendy run --device localhost:50051`:
  - create worked: `Container sh.wendy.smoke.native-run created.`
  - start worked: `Application sh.wendy.smoke.native-run started.`
  - log streaming worked: stdout included `native macOS smoke: started` and ticks `0` through `2`.
  - stop worked: after SIGINT, output ended with `Application sh.wendy.smoke.native-run stopped.` and exit status `0`.
- `cd go/internal/cli/assets/docs && npm run types:check`
