### PR TITLE
fix: keep sudo credential alive during long OS image downloads

### DIFF
--- a/go/internal/cli/commands/elevation_unix.go
+++ b/go/internal/cli/commands/elevation_unix.go
@@ -3,8 +3,10 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
+	"time"
 )
 
 // preAuthElevation pre-authenticates sudo so the password prompt appears
@@ -15,6 +17,24 @@ func preAuthElevation() error {
 		return fmt.Errorf("sudo authentication failed: %w", err)
 	}
 	return nil
+}
+
+// keepElevationAlive refreshes the sudo timestamp every minute until ctx is
+// cancelled. Call after preAuthElevation() to prevent the cached credential
+// from expiring during a long-running operation such as a multi-GB download.
+func keepElevationAlive(ctx context.Context) {
+	go func() {
+		t := time.NewTicker(60 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				exec.Command("sudo", "-v").Run() //nolint:errcheck
+			}
+		}
+	}()
 }
 
 func elevationHint() string {

--- a/go/internal/cli/commands/elevation_windows.go
+++ b/go/internal/cli/commands/elevation_windows.go
@@ -3,6 +3,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -161,3 +162,7 @@ func preAuthElevation() error {
 func elevationHint() string {
 	return "Administrator privileges are required for disk writing."
 }
+
+// keepElevationAlive is a no-op on Windows: UAC elevation is process-wide and
+// does not expire, so there is no credential cache to refresh.
+func keepElevationAlive(_ context.Context) {}

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -349,6 +349,12 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	if err := preAuthElevation(); err != nil {
 		return err
 	}
+	// The download can take minutes or hours, which is longer than the default
+	// sudo credential cache window. Refresh in the background so the cached
+	// timestamp never expires before writeImageToDisk runs.
+	elevationCtx, cancelElevation := context.WithCancel(ctx)
+	defer cancelElevation()
+	keepElevationAlive(elevationCtx)
 
 	// Step 1: Resolve version — use flag, nightly shortcut, or pick interactively.
 	selectedVersion := device.RawVersion // default: latest (or nightly if --nightly)


### PR DESCRIPTION
## Summary

- `preAuthElevation` caches the sudo timestamp, but a multi-GB image download can outlast the default 5-minute cache window
- When `writeImageToDisk` later runs `sudo dd`, the expired timestamp triggers an interactive password prompt on a stdin that can't accept input
- New `keepElevationAlive(ctx)` runs `sudo -v` every 60s in the background from the moment elevation is granted until `installLinuxImage` returns — the credential never expires mid-operation
- No-op stub added for Windows where UAC elevation is process-wide and permanent

## Test plan

- [ ] `go test ./internal/cli/commands/` passes (confirmed locally)
- [ ] `wendy os install` on a slow connection: verify no sudo password prompt appears after a long download

🤖 Generated with [Claude Code](https://claude.com/claude-code)