### PR TITLE
fix: trust Homebrew tap before trusting formula in installer

### DIFF
--- a/go/internal/cli/assets/docs/cli.sh
+++ b/go/internal/cli/assets/docs/cli.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 REPO="wendylabsinc/wendy-agent"
 INSTALL_DIR="/usr/local/bin"
 BINARY_NAME="wendy"
+HOMEBREW_TAP="wendylabsinc/tap"
 HOMEBREW_FORMULA="wendylabsinc/tap/wendy"
 YES=false
 
@@ -92,6 +93,24 @@ homebrew_supports_trust() {
   brew help trust >/dev/null 2>&1
 }
 
+trust_homebrew_tap() {
+  local tap="$1"
+
+  if ! homebrew_supports_trust; then
+    return 0
+  fi
+
+  echo "Trusting Homebrew tap: ${tap}"
+  if brew trust "$tap"; then
+    return 0
+  fi
+
+  echo "Error: Homebrew could not trust ${tap}." >&2
+  echo "Run this command, then re-run the installer:" >&2
+  echo "  brew trust ${tap}" >&2
+  exit 1
+}
+
 trust_homebrew_formula() {
   local formula="$1"
 
@@ -157,12 +176,14 @@ if [[ "$OS" == "darwin" ]]; then
   if command -v brew &>/dev/null; then
     if homebrew_supports_trust; then
       echo "Homebrew detected. Will trust and install via:"
+      echo "  brew trust ${HOMEBREW_TAP}"
       echo "  brew trust --formula ${HOMEBREW_FORMULA}"
       echo "  brew install ${HOMEBREW_FORMULA}"
     else
       echo "Homebrew detected. Will install via: brew install ${HOMEBREW_FORMULA}"
     fi
     confirm "Proceed?"
+    trust_homebrew_tap "$HOMEBREW_TAP"
     trust_homebrew_formula "$HOMEBREW_FORMULA"
     brew install "$HOMEBREW_FORMULA"
   else


### PR DESCRIPTION
## Summary

- `brew trust` operates at the tap level, not the formula level — the installer was calling `trust --formula` without first trusting the tap, causing it to fail on newer Homebrew versions
- Adds `HOMEBREW_TAP="wendylabsinc/tap"` constant
- Adds `trust_homebrew_tap` helper (mirrors the existing `trust_homebrew_formula` pattern)
- Calls `trust_homebrew_tap` before `trust_homebrew_formula` in the macOS install path

## Test plan

- [ ] Run the installer on macOS with a fresh Homebrew install to confirm tap is trusted before formula install proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)