### PR TITLE
docs: add headless Mac setup guidance

### DIFF
--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -44,7 +44,18 @@ for reliable desktop sessions and screen sharing.
    **Screen Sharing** for trusted admin users so you can administer the Mac for
    OS updates and troubleshooting. Use **Remote Management** only if you need
    Apple Remote Desktop features.
-6. When Wendy Agent first opens, leave **Open Wendy Agent automatically when you
+6. Recommended: in the same **Sharing** pane, enable **Remote Login** for
+   trusted admin users and set up key-based SSH access from your development
+   Mac:
+
+   ```bash
+   ssh-copy-id {user}@{hostname}
+   ssh {user}@{hostname}
+   ```
+
+   Replace `{user}` with the Mac account name and `{hostname}` with the Mac's
+   hostname or IP address.
+7. When Wendy Agent first opens, leave **Open Wendy Agent automatically when you
    log in** enabled in the Welcome screen. If you also choose macOS automatic
    login, configure it manually in **System Settings → Users & Groups** for a
    dedicated lab account, and only on a trusted, access-controlled Mac.

--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -56,9 +56,10 @@ for reliable desktop sessions and screen sharing.
    Replace `{user}` with the Mac account name and `{hostname}` with the Mac's
    hostname or IP address.
 7. When Wendy Agent first opens, leave **Open Wendy Agent automatically when you
-   log in** enabled in the Welcome screen. If you also choose macOS automatic
-   login, configure it manually in **System Settings → Users & Groups** for a
-   dedicated lab account, and only on a trusted, access-controlled Mac.
+   log in** enabled in the Welcome screen.
+8. Optional: if you also choose macOS automatic login, configure it manually in
+   **System Settings → Users & Groups** for a dedicated lab account, and only on
+   a trusted, access-controlled Mac.
 
 ## Installation
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -26,8 +26,9 @@ Native macOS app deployment requires a Mac development machine because the Wendy
 For a new Mac mini or Mac Studio that will run without a monitor, do the
 headless setup manually in System Settings before putting it on the shelf:
 
-1. Plug in a virtual display dongle / HDMI dummy plug. This makes headless
-   desktop sessions and screen sharing more reliable.
+1. Plug in a virtual display dongle / HDMI dummy plug, then open **System
+   Settings → Displays** and confirm macOS sees it. This makes headless desktop
+   sessions and screen sharing more reliable.
 2. Open **System Settings → Energy Saver** (or **Battery → Options** on a
    MacBook used as a target) and keep the Mac awake on AC power. Enable
    **Prevent automatic sleeping when the display is off** and **Wake for
@@ -38,9 +39,10 @@ headless setup manually in System Settings before putting it on the shelf:
 4. If you need remote UI access, open **System Settings → General → Sharing**
    and enable **Screen Sharing** or **Remote Management** for the accounts you
    trust. This is a macOS privacy-sensitive choice, so configure it manually.
-5. If the agent must come back after unattended reboots, consider automatic
-   login for a dedicated lab account and add Wendy Agent to Login Items. Only
-   enable automatic login on a trusted, access-controlled Mac.
+5. After installing Wendy Agent, if it must come back after unattended reboots,
+   open **System Settings → General → Login Items** and add it there. If you
+   also choose automatic login in **System Settings → Users & Groups**, use a
+   dedicated lab account and only enable it on a trusted, access-controlled Mac.
 
 Optional advanced reference for already configured lab machines:
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -21,6 +21,36 @@ Wendy Agent for Mac runs as a menu bar app. Once it is running, the Wendy CLI ca
 
 Native macOS app deployment requires a Mac development machine because the Wendy CLI builds the macOS app locally before syncing it to the Mac agent. If the same Mac is both your development machine and target, install both the CLI and Wendy Agent on that Mac.
 
+## Headless Mac Setup (Beta)
+
+For a new Mac mini or Mac Studio that will run without a monitor, do the
+headless setup manually in System Settings before putting it on the shelf:
+
+1. Plug in a virtual display dongle / HDMI dummy plug. This makes headless
+   desktop sessions and screen sharing more reliable.
+2. Open **System Settings → Energy Saver** (or **Battery → Options** on a
+   MacBook used as a target) and keep the Mac awake on AC power. Enable
+   **Prevent automatic sleeping when the display is off** and **Wake for
+   network access** if those options are available.
+3. Open **System Settings → Lock Screen** and choose when the display should
+   turn off. The display can sleep; the Mac itself should stay awake while on
+   AC power.
+4. If you need remote UI access, open **System Settings → General → Sharing**
+   and enable **Screen Sharing** or **Remote Management** for the accounts you
+   trust. This is a macOS privacy-sensitive choice, so configure it manually.
+5. If the agent must come back after unattended reboots, consider automatic
+   login for a dedicated lab account and add Wendy Agent to Login Items. Only
+   enable automatic login on a trusted, access-controlled Mac.
+
+Optional advanced reference for already configured lab machines:
+
+```bash
+sudo pmset -c sleep 0 displaysleep 10 disksleep 0 womp 1
+```
+
+This only adjusts AC power behavior. Configure Screen Sharing, permissions, and
+automatic login manually in System Settings.
+
 ## Installation
 
 The recommended installation path uses Homebrew:

--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -21,37 +21,33 @@ Wendy Agent for Mac runs as a menu bar app. Once it is running, the Wendy CLI ca
 
 Native macOS app deployment requires a Mac development machine because the Wendy CLI builds the macOS app locally before syncing it to the Mac agent. If the same Mac is both your development machine and target, install both the CLI and Wendy Agent on that Mac.
 
-## Headless Mac Setup (Beta)
+## Headless Mac Setup
 
-For a new Mac mini or Mac Studio that will run without a monitor, do the
-headless setup manually in System Settings before putting it on the shelf:
+For any Mac that will run without a monitor, set it up once with a keyboard,
+mouse, and display attached before putting it on the shelf. Use a virtual
+display dongle / HDMI dummy plug for the final headless setup; it is required
+for reliable desktop sessions and screen sharing.
 
-1. Plug in a virtual display dongle / HDMI dummy plug, then open **System
-   Settings → Displays** and confirm macOS sees it. This makes headless desktop
-   sessions and screen sharing more reliable.
-2. Open **System Settings → Energy Saver** (or **Battery → Options** on a
-   MacBook used as a target) and keep the Mac awake on AC power. Enable
-   **Prevent automatic sleeping when the display is off** and **Wake for
+1. Plug in the virtual display dongle, then open **System Settings → Displays**
+   and confirm macOS sees it.
+2. Open **System Settings → Energy Saver** and keep the Mac awake on AC power:
+   enable **Prevent automatic sleeping when the display is off** and **Wake for
    network access** if those options are available.
-3. Open **System Settings → Lock Screen** and choose when the display should
-   turn off. The display can sleep; the Mac itself should stay awake while on
-   AC power.
-4. If you need remote UI access, open **System Settings → General → Sharing**
-   and enable **Screen Sharing** or **Remote Management** for the accounts you
-   trust. This is a macOS privacy-sensitive choice, so configure it manually.
-5. After installing Wendy Agent, if it must come back after unattended reboots,
-   open **System Settings → General → Login Items** and add it there. If you
-   also choose automatic login in **System Settings → Users & Groups**, use a
-   dedicated lab account and only enable it on a trusted, access-controlled Mac.
-
-Optional advanced reference for already configured lab machines:
-
-```bash
-sudo pmset -c sleep 0 displaysleep 10 disksleep 0 womp 1
-```
-
-This only adjusts AC power behavior. Configure Screen Sharing, permissions, and
-automatic login manually in System Settings.
+3. For a MacBook used as a target, open **System Settings → Battery → Options**,
+   enable **Prevent automatic sleeping on power adapter when the display is
+   off**, keep it connected to AC power, and test that Wendy CLI can still reach
+   it after closing the lid.
+4. Open **System Settings → Lock Screen** and set **Turn display off on power
+   adapter when inactive** to a short interval, such as 10 minutes. The display
+   can sleep; the Mac itself should stay awake while on AC power.
+5. Recommended: open **System Settings → General → Sharing** and enable
+   **Screen Sharing** for trusted admin users so you can administer the Mac for
+   OS updates and troubleshooting. Use **Remote Management** only if you need
+   Apple Remote Desktop features.
+6. When Wendy Agent first opens, leave **Open Wendy Agent automatically when you
+   log in** enabled in the Welcome screen. If you also choose macOS automatic
+   login, configure it manually in **System Settings → Users & Groups** for a
+   dedicated lab account, and only on a trusted, access-controlled Mac.
 
 ## Installation
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -41,10 +41,11 @@ for reliable desktop sessions and screen sharing.
    adapter when inactive** to a short interval, such as 10 minutes. The display
    can sleep; the Mac itself should stay awake while on AC power.
 5. Recommended: open **System Settings → General → Sharing** and enable
-   **Screen Sharing** for trusted admin users so you can administer the Mac for
-   OS updates and troubleshooting. Use **Remote Management** only if you need
+   **Screen Sharing** for named trusted admin users, not all users, so you can
+   administer the Mac for OS updates and troubleshooting. Keep Screen Sharing on
+   a trusted, firewalled lab network. Use **Remote Management** only if you need
    Apple Remote Desktop features.
-6. Recommended: in the same **Sharing** pane, enable **Remote Login** for
+6. Recommended: in the same **Sharing** pane, enable **Remote Login** for named
    trusted admin users and set up key-based SSH access from your development
    Mac:
 
@@ -54,12 +55,23 @@ for reliable desktop sessions and screen sharing.
    ```
 
    Replace `{user}` with the Mac account name and `{hostname}` with the Mac's
-   hostname or IP address.
+   stable hostname or IP address. On first connect, verify the SSH host
+   fingerprint against the value shown on the Mac:
+
+   ```bash
+   ssh-keygen -l -f /etc/ssh/ssh_host_ed25519_key.pub
+   ```
+
+   After key-based login works, disable password SSH authentication if your lab
+   setup allows it by setting `PasswordAuthentication no` in
+   `/etc/ssh/sshd_config`, then turn **Remote Login** off and on again.
 7. When Wendy Agent first opens, leave **Open Wendy Agent automatically when you
    log in** enabled in the Welcome screen.
 8. Optional: if you also choose macOS automatic login, configure it manually in
-   **System Settings → Users & Groups** for a dedicated lab account, and only on
-   a trusted, access-controlled Mac.
+   **System Settings → Users & Groups** for a dedicated non-admin lab account.
+   Automatic login starts an unlocked desktop session after boot, which weakens
+   FileVault and keychain protection; only enable it when unattended reboot
+   recovery is required and the Mac is in a locked, access-controlled lab.
 
 ## Installation
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-macos.mdx
@@ -23,55 +23,29 @@ Native macOS app deployment requires a Mac development machine because the Wendy
 
 ## Headless Mac Setup
 
-For any Mac that will run without a monitor, set it up once with a keyboard,
-mouse, and display attached before putting it on the shelf. Use a virtual
-display dongle / HDMI dummy plug for the final headless setup; it is required
-for reliable desktop sessions and screen sharing.
+For any Mac that will run without a monitor, set it up once with a keyboard, mouse, and display attached before putting it on the shelf. Use a virtual display dongle / HDMI dummy plug for the final headless setup; it is required for reliable desktop sessions and screen sharing.
 
-1. Plug in the virtual display dongle, then open **System Settings → Displays**
-   and confirm macOS sees it.
-2. Open **System Settings → Energy Saver** and keep the Mac awake on AC power:
-   enable **Prevent automatic sleeping when the display is off** and **Wake for
-   network access** if those options are available.
-3. For a MacBook used as a target, open **System Settings → Battery → Options**,
-   enable **Prevent automatic sleeping on power adapter when the display is
-   off**, keep it connected to AC power, and test that Wendy CLI can still reach
-   it after closing the lid.
-4. Open **System Settings → Lock Screen** and set **Turn display off on power
-   adapter when inactive** to a short interval, such as 10 minutes. The display
-   can sleep; the Mac itself should stay awake while on AC power.
-5. Recommended: open **System Settings → General → Sharing** and enable
-   **Screen Sharing** for named trusted admin users, not all users, so you can
-   administer the Mac for OS updates and troubleshooting. Keep Screen Sharing on
-   a trusted, firewalled lab network. Use **Remote Management** only if you need
-   Apple Remote Desktop features.
-6. Recommended: in the same **Sharing** pane, enable **Remote Login** for named
-   trusted admin users and set up key-based SSH access from your development
-   Mac:
+1. Plug in the virtual display dongle, then open **System Settings → Displays** and confirm macOS sees it.
+2. Open **System Settings → Energy Saver** and keep the Mac awake on AC power: enable **Prevent automatic sleeping when the display is off** and **Wake for network access** if those options are available.
+3. For a MacBook used as a target, open **System Settings → Battery → Options**, enable **Prevent automatic sleeping on power adapter when the display is off**, keep it connected to AC power, and test that Wendy CLI can still reach it after closing the lid.
+4. Open **System Settings → Lock Screen** and set **Turn display off on power adapter when inactive** to a short interval, such as 10 minutes. The display can sleep; the Mac itself should stay awake while on AC power.
+5. Recommended: open **System Settings → General → Sharing** and enable **Screen Sharing** for named trusted admin users, not all users, so you can administer the Mac for OS updates and troubleshooting. Keep Screen Sharing on a trusted, firewalled lab network. Use **Remote Management** only if you need Apple Remote Desktop features.
+6. Recommended: in the same **Sharing** pane, enable **Remote Login** for named trusted admin users and set up key-based SSH access from your development Mac:
 
    ```bash
    ssh-copy-id {user}@{hostname}
    ssh {user}@{hostname}
    ```
 
-   Replace `{user}` with the Mac account name and `{hostname}` with the Mac's
-   stable hostname or IP address. On first connect, verify the SSH host
-   fingerprint against the value shown on the Mac:
+   Replace `{user}` with the Mac account name and `{hostname}` with the Mac's stable hostname or IP address. On first connect, verify the SSH host fingerprint against the value shown on the Mac:
 
    ```bash
    ssh-keygen -l -f /etc/ssh/ssh_host_ed25519_key.pub
    ```
 
-   After key-based login works, disable password SSH authentication if your lab
-   setup allows it by setting `PasswordAuthentication no` in
-   `/etc/ssh/sshd_config`, then turn **Remote Login** off and on again.
-7. When Wendy Agent first opens, leave **Open Wendy Agent automatically when you
-   log in** enabled in the Welcome screen.
-8. Optional: if you also choose macOS automatic login, configure it manually in
-   **System Settings → Users & Groups** for a dedicated non-admin lab account.
-   Automatic login starts an unlocked desktop session after boot, which weakens
-   FileVault and keychain protection; only enable it when unattended reboot
-   recovery is required and the Mac is in a locked, access-controlled lab.
+   After key-based login works, disable password SSH authentication if your lab setup allows it by setting `PasswordAuthentication no` in `/etc/ssh/sshd_config`, then turn **Remote Login** off and on again.
+7. When Wendy Agent first opens, leave **Open Wendy Agent automatically when you log in** enabled in the Welcome screen.
+8. Optional: if you also choose macOS automatic login, configure it manually in **System Settings → Users & Groups** for a dedicated non-admin lab account. Automatic login starts an unlocked desktop session after boot, which weakens FileVault and keychain protection; only enable it when unattended reboot recovery is required and the Mac is in a locked, access-controlled lab.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Add a concise checklist for setting up headless Mac targets before installing Wendy Agent.
- Lead with manual System Settings choices for the virtual display dongle, AC power/sleep behavior, MacBook clamshell use, Screen Sharing, and Remote Login.
- Include key-based SSH setup, host fingerprint verification, password-auth hardening, and automatic-login guardrails.

Closes WDY-1396.

## Notes
- Coordinate with WDY-1360 so clean-machine validation covers this setup when the validation environment supports a headless Mac or dummy display.

## Tests
- `cd go/internal/cli/assets/docs && npm run types:check`
