### PR TITLE
feat(cli): interactive TUI for `wendy device bluetooth` (WDY-1115)

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/bluetooth.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/bluetooth.md
@@ -1,0 +1,69 @@
+# `wendy device bluetooth`
+
+Manages Bluetooth peripherals on the connected WendyOS device. Aliased as `wendy device bt`.
+
+Run without a subcommand to open an interactive table for browsing and managing peripherals; the subcommands below remain available for scripting.
+
+## Interactive TUI
+
+```sh
+wendy device bluetooth
+```
+
+Scans the device for nearby Bluetooth peripherals and presents them in an interactive table that stays open between actions. A spinner is shown while the scan window runs (~8s). Discovered peripherals are deduplicated by address and sorted with connected devices first, then paired devices.
+
+| Key | Action |
+|-----|--------|
+| `↑`/`↓` | Move the selection |
+| `←`/`→` | Scroll the table horizontally (when it overflows) |
+| `enter` | Connect to the selected peripheral (pairs and trusts it) |
+| `d` | Disconnect the selected (connected) peripheral |
+| `f` | Forget the selected (paired) peripheral |
+| `r` | Rescan |
+| `q` / `esc` | Quit |
+
+Actions update the table immediately (optimistically) on success. Because a Bluetooth rescan takes several seconds, the table is not rescanned automatically after each action — press `r` to refresh against the device.
+
+## Subcommands
+
+### `wendy device bluetooth list`
+
+Scans for peripherals and prints them as a table, or as JSON with `--json`.
+
+```sh
+wendy device bluetooth list [--json]
+```
+
+### `wendy device bluetooth connect`
+
+Connects to a peripheral by address.
+
+```sh
+wendy device bluetooth connect <address> [--pair] [--trust]
+```
+
+### `wendy device bluetooth disconnect`
+
+Disconnects a peripheral by address.
+
+```sh
+wendy device bluetooth disconnect <address>
+```
+
+### `wendy device bluetooth forget`
+
+Removes the pairing for a peripheral by address.
+
+```sh
+wendy device bluetooth forget <address>
+```
+
+---
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--pair` | Pair with the device when connecting (default `true`, `connect` only). |
+| `--trust` | Trust the device when connecting (default `true`, `connect` only). |
+| `--json` | Output the scan result as JSON (`list` only). |

--- a/go/internal/cli/commands/bluetooth.go
+++ b/go/internal/cli/commands/bluetooth.go
@@ -1,12 +1,17 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui/bttable"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
@@ -15,6 +20,9 @@ func newBluetoothCmd() *cobra.Command {
 		Use:     "bluetooth",
 		Aliases: []string{"bt"},
 		Short:   "Manage Bluetooth on the target device",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runBluetoothInteractive(cmd)
+		},
 	}
 
 	cmd.AddCommand(
@@ -25,6 +33,117 @@ func newBluetoothCmd() *cobra.Command {
 	)
 
 	return cmd
+}
+
+// ── Interactive TUI entry point ─────────────────────────────────────
+
+func runBluetoothInteractive(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+	conn, err := connectToAgent(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	model := bttable.NewModel(nil).WithHandler(&btTUIHandler{ctx: ctx, agent: conn.AgentService})
+	p := tea.NewProgram(model)
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("bluetooth TUI: %w", err)
+	}
+	return nil
+}
+
+// btTUIHandler adapts the agent client to the bttable.Handler interface so the
+// TUI can scan and execute operations inline and stay open between actions.
+type btTUIHandler struct {
+	ctx    context.Context
+	agent  agentpb.WendyAgentServiceClient
+	stream grpc.BidiStreamingClient[agentpb.ScanBluetoothPeripheralsRequest, agentpb.ScanBluetoothPeripheralsResponse]
+}
+
+// openScan (re)opens a scan stream and sends the scan request, mirroring the
+// `list` command's error handling for unsupported (macOS beta) agents.
+func (h *btTUIHandler) openScan() error {
+	stream, err := h.agent.ScanBluetoothPeripherals(h.ctx)
+	if err != nil {
+		return h.wrapScanErr(err)
+	}
+	if err := stream.Send(&agentpb.ScanBluetoothPeripheralsRequest{}); err != nil && err != io.EOF {
+		return h.wrapScanErr(err)
+	}
+	if err := stream.CloseSend(); err != nil && err != io.EOF {
+		return h.wrapScanErr(err)
+	}
+	h.stream = stream
+	return nil
+}
+
+func (h *btTUIHandler) wrapScanErr(err error) error {
+	if macErr := macOSBetaUnsupportedFeatureError(h.ctx, h.agent, err, "Bluetooth scanning"); macErr != nil {
+		return macErr
+	}
+	return err
+}
+
+// recv reads the next scan event and maps it to a model message.
+func (h *btTUIHandler) recv() tea.Msg {
+	if h.stream == nil {
+		return bttable.ScanDoneMsg{}
+	}
+	resp, err := h.stream.Recv()
+	if err == io.EOF {
+		return bttable.ScanDoneMsg{}
+	}
+	if err != nil {
+		return bttable.ScanDoneMsg{Err: h.wrapScanErr(err)}
+	}
+	return bttable.ScanResultMsg{Peripherals: peripheralsFromProto(resp.GetDiscoveredDevices())}
+}
+
+func (h *btTUIHandler) StartScan() tea.Cmd {
+	return func() tea.Msg {
+		if err := h.openScan(); err != nil {
+			return bttable.ScanDoneMsg{Err: err}
+		}
+		return h.recv()
+	}
+}
+
+func (h *btTUIHandler) NextScanEvent() tea.Cmd {
+	return func() tea.Msg { return h.recv() }
+}
+
+func (h *btTUIHandler) Connect(address string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := h.agent.ConnectBluetoothPeripheral(h.ctx, &agentpb.ConnectBluetoothPeripheralRequest{
+			Address: address,
+			Pair:    true,
+			Trust:   true,
+		})
+		return bttable.OpResultMsg{Action: bttable.ActionConnect, Address: address, Err: err}
+	}
+}
+
+func (h *btTUIHandler) Disconnect(address string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := h.agent.DisconnectBluetoothPeripheral(h.ctx, &agentpb.DisconnectBluetoothPeripheralRequest{Address: address})
+		return bttable.OpResultMsg{Action: bttable.ActionDisconnect, Address: address, Err: err}
+	}
+}
+
+func (h *btTUIHandler) Forget(address string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := h.agent.ForgetBluetoothPeripheral(h.ctx, &agentpb.ForgetBluetoothPeripheralRequest{Address: address})
+		return bttable.OpResultMsg{Action: bttable.ActionForget, Address: address, Err: err}
+	}
+}
+
+func peripheralsFromProto(devs []*agentpb.DiscoveredBluetoothPeripheral) []bttable.Peripheral {
+	out := make([]bttable.Peripheral, 0, len(devs))
+	for _, d := range devs {
+		out = append(out, bttable.FromProto(d))
+	}
+	return out
 }
 
 func newBluetoothListCmd() *cobra.Command {

--- a/go/internal/cli/commands/bluetooth.go
+++ b/go/internal/cli/commands/bluetooth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -13,6 +14,15 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui/bttable"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// Per-operation timeouts bound each Bluetooth gRPC call so a hung agent cannot
+// block the TUI indefinitely. They are generous: pairing in particular can be
+// slow and may require user interaction on the peripheral.
+const (
+	btConnectTimeout    = 60 * time.Second
+	btDisconnectTimeout = 30 * time.Second
+	btForgetTimeout     = 30 * time.Second
 )
 
 func newBluetoothCmd() *cobra.Command {
@@ -62,8 +72,13 @@ type btTUIHandler struct {
 }
 
 // openScan (re)opens a scan stream and sends the scan request, mirroring the
-// `list` command's error handling for unsupported (macOS beta) agents.
+// `list` command's error handling for unsupported (macOS beta) agents. Any
+// prior stream is closed first so a rescan never leaves one half-open.
 func (h *btTUIHandler) openScan() error {
+	if h.stream != nil {
+		_ = h.stream.CloseSend()
+		h.stream = nil
+	}
 	stream, err := h.agent.ScanBluetoothPeripherals(h.ctx)
 	if err != nil {
 		return h.wrapScanErr(err)
@@ -115,7 +130,9 @@ func (h *btTUIHandler) NextScanEvent() tea.Cmd {
 
 func (h *btTUIHandler) Connect(address string) tea.Cmd {
 	return func() tea.Msg {
-		_, err := h.agent.ConnectBluetoothPeripheral(h.ctx, &agentpb.ConnectBluetoothPeripheralRequest{
+		ctx, cancel := context.WithTimeout(h.ctx, btConnectTimeout)
+		defer cancel()
+		_, err := h.agent.ConnectBluetoothPeripheral(ctx, &agentpb.ConnectBluetoothPeripheralRequest{
 			Address: address,
 			Pair:    true,
 			Trust:   true,
@@ -126,14 +143,18 @@ func (h *btTUIHandler) Connect(address string) tea.Cmd {
 
 func (h *btTUIHandler) Disconnect(address string) tea.Cmd {
 	return func() tea.Msg {
-		_, err := h.agent.DisconnectBluetoothPeripheral(h.ctx, &agentpb.DisconnectBluetoothPeripheralRequest{Address: address})
+		ctx, cancel := context.WithTimeout(h.ctx, btDisconnectTimeout)
+		defer cancel()
+		_, err := h.agent.DisconnectBluetoothPeripheral(ctx, &agentpb.DisconnectBluetoothPeripheralRequest{Address: address})
 		return bttable.OpResultMsg{Action: bttable.ActionDisconnect, Address: address, Err: err}
 	}
 }
 
 func (h *btTUIHandler) Forget(address string) tea.Cmd {
 	return func() tea.Msg {
-		_, err := h.agent.ForgetBluetoothPeripheral(h.ctx, &agentpb.ForgetBluetoothPeripheralRequest{Address: address})
+		ctx, cancel := context.WithTimeout(h.ctx, btForgetTimeout)
+		defer cancel()
+		_, err := h.agent.ForgetBluetoothPeripheral(ctx, &agentpb.ForgetBluetoothPeripheralRequest{Address: address})
 		return bttable.OpResultMsg{Action: bttable.ActionForget, Address: address, Err: err}
 	}
 }

--- a/go/internal/cli/tui/bttable/model.go
+++ b/go/internal/cli/tui/bttable/model.go
@@ -1,0 +1,466 @@
+package bttable
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	bubbleTable "github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+// Action is the intent the user picked. When a Handler is attached the model
+// dispatches Actions as async tea.Cmds and stays open; with no Handler it falls
+// back to recording the Action on Result and quitting (used by tests).
+type Action int
+
+const (
+	ActionNone Action = iota
+	ActionQuit
+	ActionConnect
+	ActionDisconnect
+	ActionForget
+)
+
+// Result is what the caller reads after the TUI exits. Only populated for the
+// no-Handler code path.
+type Result struct {
+	Action  Action
+	Address string
+	Name    string
+}
+
+// Handler performs Bluetooth operations on behalf of the Model so the TUI can
+// stay open between actions. Scan events arrive as ScanResultMsg / ScanDoneMsg;
+// each op command must eventually emit an OpResultMsg.
+type Handler interface {
+	// StartScan (re)opens a scan stream and returns a command that reads the
+	// first event. Used by the `r` rescan key.
+	StartScan() tea.Cmd
+	// NextScanEvent reads the next event from the currently-open scan stream.
+	NextScanEvent() tea.Cmd
+	Connect(address string) tea.Cmd
+	Disconnect(address string) tea.Cmd
+	Forget(address string) tea.Cmd
+}
+
+// ScanResultMsg carries a batch of discovered peripherals. The agent currently
+// sends the whole list in a single message, but the model upserts by address so
+// an incremental stream would work without changes.
+type ScanResultMsg struct {
+	Peripherals []Peripheral
+}
+
+// ScanDoneMsg signals the scan stream ended (Err is nil on a clean EOF).
+type ScanDoneMsg struct {
+	Err error
+}
+
+// OpResultMsg reports the outcome of an async connect/disconnect/forget.
+type OpResultMsg struct {
+	Action  Action
+	Name    string
+	Address string
+	Err     error
+}
+
+// flashClearMsg clears the current flash message after a delay.
+type flashClearMsg struct{}
+
+const flashDuration = 4 * time.Second
+
+// Model is the Bubble Tea model for the interactive Bluetooth table.
+type Model struct {
+	peripherals []Peripheral
+	table       tui.BubbleTable
+	spinner     spinner.Model
+
+	handler Handler
+
+	scanning     bool
+	busy         bool
+	flashMessage string
+	flashIsError bool
+
+	result Result
+	done   bool
+	width  int
+	height int
+}
+
+// NewModel constructs the model seeded with any peripherals already received and
+// starts in the scanning state (the caller continues reading the scan stream).
+func NewModel(peripherals []Peripheral) Model {
+	Sort(peripherals)
+
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+
+	m := Model{
+		peripherals: peripherals,
+		table:       tui.NewBubbleTable(true, btColumns()),
+		spinner:     s,
+		scanning:    true,
+	}
+	m.refreshRows()
+	return m
+}
+
+// WithHandler attaches a Handler, enabling inline async execution of actions so
+// the TUI stays open between edits.
+func (m Model) WithHandler(h Handler) Model {
+	m.handler = h
+	return m
+}
+
+func (m Model) Init() tea.Cmd {
+	// Run the scan inside the TUI so the spinner is visible during the agent's
+	// ~8s scan window. StartScan opens the stream and reads the first event;
+	// subsequent events are chained from the ScanResultMsg handler.
+	if m.handler != nil && m.scanning {
+		return tea.Batch(m.handler.StartScan(), m.spinner.Tick)
+	}
+	if m.scanning {
+		return m.spinner.Tick
+	}
+	return nil
+}
+
+func btColumns() []bubbleTable.Column {
+	return []bubbleTable.Column{
+		{Title: "Name", Width: 28},
+		{Title: "Address", Width: 20},
+		{Title: "Type", Width: 10},
+		{Title: "Paired", Width: 8},
+		{Title: "Connected", Width: 10},
+	}
+}
+
+func (m *Model) refreshRows() {
+	rows := make([]bubbleTable.Row, 0, len(m.peripherals))
+	for _, p := range m.peripherals {
+		rows = append(rows, bubbleTable.Row{
+			p.Name,
+			p.Address,
+			DeviceTypeLabel(p.DeviceType),
+			yesNo(p.Paired),
+			yesNo(p.Connected),
+		})
+	}
+	m.table.SetRows(rows)
+	if cur := m.table.Cursor(); cur >= len(rows) && len(rows) > 0 {
+		m.table.SetCursor(len(rows) - 1)
+	}
+	h := len(rows) + 2
+	if h < 6 {
+		h = 6
+	}
+	if m.height > 0 && h > m.height-6 {
+		h = m.height - 6
+	}
+	m.table.SetHeight(h)
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return ""
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		var cmd tea.Cmd
+		m.table, cmd = m.table.Update(msg)
+		m.refreshRows()
+		return m, cmd
+
+	case spinner.TickMsg:
+		if !m.scanning {
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case ScanResultMsg:
+		for _, p := range msg.Peripherals {
+			m.peripherals = Upsert(m.peripherals, p)
+		}
+		Sort(m.peripherals)
+		m.refreshRows()
+		if m.scanning && m.handler != nil {
+			return m, m.handler.NextScanEvent()
+		}
+		return m, nil
+
+	case ScanDoneMsg:
+		m.scanning = false
+		if msg.Err != nil {
+			m.flashMessage = fmt.Sprintf("Scan failed: %v", msg.Err)
+			m.flashIsError = true
+			return m, clearFlashAfter(flashDuration)
+		}
+		return m, nil
+
+	case OpResultMsg:
+		m.busy = false
+		m.flashMessage, m.flashIsError = flashFor(msg)
+		if msg.Err == nil {
+			m.applyOptimisticUpdate(msg)
+			m.refreshRows()
+		}
+		// Deliberately no auto-rescan: a Bluetooth rescan is an ~8s window, so we
+		// rely on the optimistic update and let the user press `r` to reconcile.
+		return m, clearFlashAfter(flashDuration)
+
+	case flashClearMsg:
+		m.flashMessage = ""
+		m.flashIsError = false
+		return m, nil
+	}
+
+	return m.updateBrowsing(msg)
+}
+
+func (m Model) updateBrowsing(msg tea.Msg) (tea.Model, tea.Cmd) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		var cmd tea.Cmd
+		m.table, cmd = m.table.Update(msg)
+		return m, cmd
+	}
+	switch km.String() {
+	case "q", "ctrl+c", "esc":
+		m.result.Action = ActionQuit
+		m.done = true
+		return m, tea.Quit
+
+	case "enter":
+		if m.busy {
+			return m, nil
+		}
+		p, ok := m.selected()
+		if !ok {
+			return m, nil
+		}
+		if p.Connected {
+			m.flashMessage = fmt.Sprintf("Already connected to %s.", displayName(p))
+			m.flashIsError = false
+			return m, clearFlashAfter(flashDuration)
+		}
+		return m.dispatchConnect(p)
+
+	case "d":
+		if m.busy {
+			return m, nil
+		}
+		p, ok := m.selected()
+		if !ok {
+			return m, nil
+		}
+		if !p.Connected {
+			m.flashMessage = "Only connected devices can be disconnected."
+			m.flashIsError = true
+			return m, clearFlashAfter(flashDuration)
+		}
+		return m.dispatchDisconnect(p)
+
+	case "f":
+		if m.busy {
+			return m, nil
+		}
+		p, ok := m.selected()
+		if !ok {
+			return m, nil
+		}
+		if !p.Paired {
+			m.flashMessage = "Only paired devices can be forgotten."
+			m.flashIsError = true
+			return m, clearFlashAfter(flashDuration)
+		}
+		return m.dispatchForget(p)
+
+	case "r":
+		if m.busy || m.scanning || m.handler == nil {
+			return m, nil
+		}
+		m.scanning = true
+		m.flashMessage = ""
+		m.flashIsError = false
+		return m, tea.Batch(m.handler.StartScan(), m.spinner.Tick)
+	}
+
+	var cmd tea.Cmd
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+func (m Model) selected() (Peripheral, bool) {
+	idx := m.table.Cursor()
+	if idx < 0 || idx >= len(m.peripherals) {
+		return Peripheral{}, false
+	}
+	return m.peripherals[idx], true
+}
+
+func (m Model) dispatchConnect(p Peripheral) (tea.Model, tea.Cmd) {
+	if m.handler == nil {
+		m.result = Result{Action: ActionConnect, Address: p.Address, Name: p.Name}
+		m.done = true
+		return m, tea.Quit
+	}
+	m.busy = true
+	m.flashMessage = fmt.Sprintf("Connecting to %s...", displayName(p))
+	m.flashIsError = false
+	return m, m.handler.Connect(p.Address)
+}
+
+func (m Model) dispatchDisconnect(p Peripheral) (tea.Model, tea.Cmd) {
+	if m.handler == nil {
+		m.result = Result{Action: ActionDisconnect, Address: p.Address, Name: p.Name}
+		m.done = true
+		return m, tea.Quit
+	}
+	m.busy = true
+	m.flashMessage = fmt.Sprintf("Disconnecting %s...", displayName(p))
+	m.flashIsError = false
+	return m, m.handler.Disconnect(p.Address)
+}
+
+func (m Model) dispatchForget(p Peripheral) (tea.Model, tea.Cmd) {
+	if m.handler == nil {
+		m.result = Result{Action: ActionForget, Address: p.Address, Name: p.Name}
+		m.done = true
+		return m, tea.Quit
+	}
+	m.busy = true
+	m.flashMessage = fmt.Sprintf("Forgetting %s...", displayName(p))
+	m.flashIsError = false
+	return m, m.handler.Forget(p.Address)
+}
+
+// applyOptimisticUpdate reflects a completed operation in the local list so the
+// table updates immediately. Unlike WiFi, connecting does not clear other rows'
+// Connected flag — Bluetooth supports multiple simultaneous connections.
+func (m *Model) applyOptimisticUpdate(msg OpResultMsg) {
+	for i := range m.peripherals {
+		if m.peripherals[i].Address != msg.Address {
+			continue
+		}
+		switch msg.Action {
+		case ActionConnect:
+			m.peripherals[i].Connected = true
+			m.peripherals[i].Paired = true
+			m.peripherals[i].Trusted = true
+		case ActionDisconnect:
+			m.peripherals[i].Connected = false
+		case ActionForget:
+			m.peripherals[i].Paired = false
+			m.peripherals[i].Connected = false
+			m.peripherals[i].Trusted = false
+		}
+	}
+	Sort(m.peripherals)
+}
+
+func flashFor(msg OpResultMsg) (string, bool) {
+	label := msg.Name
+	if label == "" {
+		label = msg.Address
+	}
+	if msg.Err != nil {
+		switch msg.Action {
+		case ActionConnect:
+			return fmt.Sprintf("Connect to %s failed: %v", label, msg.Err), true
+		case ActionDisconnect:
+			return fmt.Sprintf("Disconnect %s failed: %v", label, msg.Err), true
+		case ActionForget:
+			return fmt.Sprintf("Forget %s failed: %v", label, msg.Err), true
+		default:
+			return msg.Err.Error(), true
+		}
+	}
+	switch msg.Action {
+	case ActionConnect:
+		return fmt.Sprintf("Connected to %s.", label), false
+	case ActionDisconnect:
+		return fmt.Sprintf("Disconnected %s.", label), false
+	case ActionForget:
+		return fmt.Sprintf("Forgot %s.", label), false
+	}
+	return "", false
+}
+
+func clearFlashAfter(d time.Duration) tea.Cmd {
+	return func() tea.Msg {
+		time.Sleep(d)
+		return flashClearMsg{}
+	}
+}
+
+func displayName(p Peripheral) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.Address
+}
+
+var (
+	footerStyle     = lipgloss.NewStyle().Foreground(tui.ColorDim)
+	titleStyle      = lipgloss.NewStyle().Bold(true).Foreground(tui.ColorPrimary)
+	flashStyle      = lipgloss.NewStyle().Foreground(tui.ColorNotice)
+	flashErrorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+)
+
+func (m Model) View() string {
+	if m.done {
+		return ""
+	}
+	var sb strings.Builder
+
+	title := titleStyle.Render("Bluetooth peripherals")
+	if m.scanning {
+		title += "  " + m.spinner.View() + " scanning… (~8s)"
+	}
+	sb.WriteString(m.viewLine(title) + "\n\n")
+
+	if len(m.peripherals) == 0 && !m.scanning {
+		sb.WriteString(m.viewLine(footerStyle.Render("No Bluetooth devices found. Press r to rescan.")) + "\n\n")
+	} else {
+		sb.WriteString(m.table.View())
+		sb.WriteString("\n")
+	}
+
+	if m.flashMessage != "" {
+		style := flashStyle
+		if m.flashIsError {
+			style = flashErrorStyle
+		}
+		sb.WriteString(m.viewLine(style.Render(m.flashMessage)) + "\n")
+	}
+
+	hint := "↑/↓ move · enter connect · d disconnect · f forget · r rescan · q quit"
+	if m.table.CanScroll() {
+		hint = "↑/↓ move · ←/→ scroll · enter connect · d disconnect · f forget · r rescan · q quit"
+	}
+	sb.WriteString(m.viewLine(footerStyle.Render(hint)) + "\n")
+	return sb.String()
+}
+
+func (m Model) viewLine(line string) string {
+	if m.width <= 0 {
+		return line
+	}
+	return tui.CropANSIView(line, 0, m.width)
+}
+
+func (m Model) Result() Result { return m.result }

--- a/go/internal/cli/tui/bttable/model.go
+++ b/go/internal/cli/tui/bttable/model.go
@@ -9,6 +9,7 @@ import (
 	bubbleTable "github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"google.golang.org/grpc/status"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
@@ -68,8 +69,10 @@ type OpResultMsg struct {
 	Err     error
 }
 
-// flashClearMsg clears the current flash message after a delay.
-type flashClearMsg struct{}
+// flashClearMsg clears the current flash message after a delay. The token
+// identifies which flash scheduled the clear so a stale timer cannot wipe a
+// newer message.
+type flashClearMsg struct{ token int }
 
 const flashDuration = 4 * time.Second
 
@@ -85,6 +88,11 @@ type Model struct {
 	busy         bool
 	flashMessage string
 	flashIsError bool
+	flashToken   int
+
+	// scanSeen records the addresses observed during the in-flight scan so a
+	// successful ScanDoneMsg can prune devices that have disappeared.
+	scanSeen map[string]bool
 
 	result Result
 	done   bool
@@ -106,6 +114,7 @@ func NewModel(peripherals []Peripheral) Model {
 		table:       tui.NewBubbleTable(true, btColumns()),
 		spinner:     s,
 		scanning:    true,
+		scanSeen:    map[string]bool{},
 	}
 	m.refreshRows()
 	return m
@@ -192,8 +201,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case ScanResultMsg:
+		if m.scanSeen == nil {
+			m.scanSeen = map[string]bool{}
+		}
 		for _, p := range msg.Peripherals {
 			m.peripherals = Upsert(m.peripherals, p)
+			m.scanSeen[p.Address] = true
 		}
 		Sort(m.peripherals)
 		m.refreshRows()
@@ -205,26 +218,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ScanDoneMsg:
 		m.scanning = false
 		if msg.Err != nil {
-			m.flashMessage = fmt.Sprintf("Scan failed: %v", msg.Err)
-			m.flashIsError = true
-			return m, clearFlashAfter(flashDuration)
+			// Keep the previously-known peripherals on a failed scan.
+			m.scanSeen = map[string]bool{}
+			return m, m.setFlash(fmt.Sprintf("Scan failed: %s", userFacingError(msg.Err)), true)
 		}
+		// Reconcile: drop devices that this completed scan did not report.
+		m.peripherals = pruneUnseen(m.peripherals, m.scanSeen)
+		m.scanSeen = map[string]bool{}
+		Sort(m.peripherals)
+		m.refreshRows()
 		return m, nil
 
 	case OpResultMsg:
 		m.busy = false
-		m.flashMessage, m.flashIsError = flashFor(msg)
+		text, isErr := flashFor(msg)
 		if msg.Err == nil {
 			m.applyOptimisticUpdate(msg)
 			m.refreshRows()
 		}
 		// Deliberately no auto-rescan: a Bluetooth rescan is an ~8s window, so we
 		// rely on the optimistic update and let the user press `r` to reconcile.
-		return m, clearFlashAfter(flashDuration)
+		return m, m.setFlash(text, isErr)
 
 	case flashClearMsg:
-		m.flashMessage = ""
-		m.flashIsError = false
+		if msg.token == m.flashToken {
+			m.flashMessage = ""
+			m.flashIsError = false
+		}
 		return m, nil
 	}
 
@@ -253,9 +273,7 @@ func (m Model) updateBrowsing(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if p.Connected {
-			m.flashMessage = fmt.Sprintf("Already connected to %s.", displayName(p))
-			m.flashIsError = false
-			return m, clearFlashAfter(flashDuration)
+			return m, m.setFlash(fmt.Sprintf("Already connected to %s.", displayName(p)), false)
 		}
 		return m.dispatchConnect(p)
 
@@ -268,9 +286,7 @@ func (m Model) updateBrowsing(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if !p.Connected {
-			m.flashMessage = "Only connected devices can be disconnected."
-			m.flashIsError = true
-			return m, clearFlashAfter(flashDuration)
+			return m, m.setFlash("Only connected devices can be disconnected.", true)
 		}
 		return m.dispatchDisconnect(p)
 
@@ -283,9 +299,7 @@ func (m Model) updateBrowsing(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if !p.Paired {
-			m.flashMessage = "Only paired devices can be forgotten."
-			m.flashIsError = true
-			return m, clearFlashAfter(flashDuration)
+			return m, m.setFlash("Only paired devices can be forgotten.", true)
 		}
 		return m.dispatchForget(p)
 
@@ -294,8 +308,8 @@ func (m Model) updateBrowsing(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.scanning = true
-		m.flashMessage = ""
-		m.flashIsError = false
+		m.scanSeen = map[string]bool{}
+		m.setFlashText("", false)
 		return m, tea.Batch(m.handler.StartScan(), m.spinner.Tick)
 	}
 
@@ -319,8 +333,7 @@ func (m Model) dispatchConnect(p Peripheral) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 	m.busy = true
-	m.flashMessage = fmt.Sprintf("Connecting to %s...", displayName(p))
-	m.flashIsError = false
+	m.setFlashText(fmt.Sprintf("Connecting to %s...", displayName(p)), false)
 	return m, m.handler.Connect(p.Address)
 }
 
@@ -331,8 +344,7 @@ func (m Model) dispatchDisconnect(p Peripheral) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 	m.busy = true
-	m.flashMessage = fmt.Sprintf("Disconnecting %s...", displayName(p))
-	m.flashIsError = false
+	m.setFlashText(fmt.Sprintf("Disconnecting %s...", displayName(p)), false)
 	return m, m.handler.Disconnect(p.Address)
 }
 
@@ -343,8 +355,7 @@ func (m Model) dispatchForget(p Peripheral) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 	m.busy = true
-	m.flashMessage = fmt.Sprintf("Forgetting %s...", displayName(p))
-	m.flashIsError = false
+	m.setFlashText(fmt.Sprintf("Forgetting %s...", displayName(p)), false)
 	return m, m.handler.Forget(p.Address)
 }
 
@@ -378,15 +389,16 @@ func flashFor(msg OpResultMsg) (string, bool) {
 		label = msg.Address
 	}
 	if msg.Err != nil {
+		reason := userFacingError(msg.Err)
 		switch msg.Action {
 		case ActionConnect:
-			return fmt.Sprintf("Connect to %s failed: %v", label, msg.Err), true
+			return fmt.Sprintf("Connect to %s failed: %s", label, reason), true
 		case ActionDisconnect:
-			return fmt.Sprintf("Disconnect %s failed: %v", label, msg.Err), true
+			return fmt.Sprintf("Disconnect %s failed: %s", label, reason), true
 		case ActionForget:
-			return fmt.Sprintf("Forget %s failed: %v", label, msg.Err), true
+			return fmt.Sprintf("Forget %s failed: %s", label, reason), true
 		default:
-			return msg.Err.Error(), true
+			return reason, true
 		}
 	}
 	switch msg.Action {
@@ -400,11 +412,48 @@ func flashFor(msg OpResultMsg) (string, bool) {
 	return "", false
 }
 
-func clearFlashAfter(d time.Duration) tea.Cmd {
-	return func() tea.Msg {
-		time.Sleep(d)
-		return flashClearMsg{}
+// userFacingError renders a remote error for display, preferring the gRPC
+// status message so internal "rpc error: code = ..." framing and metadata are
+// not surfaced in the UI. Non-gRPC errors fall back to their plain text.
+func userFacingError(err error) string {
+	if err == nil {
+		return ""
 	}
+	if st, ok := status.FromError(err); ok {
+		return st.Message()
+	}
+	return err.Error()
+}
+
+// setFlash sets a transient message and returns a command that clears it after
+// flashDuration, unless a newer flash supersedes it first (tracked by token).
+func (m *Model) setFlash(msg string, isErr bool) tea.Cmd {
+	m.setFlashText(msg, isErr)
+	token := m.flashToken
+	return func() tea.Msg {
+		time.Sleep(flashDuration)
+		return flashClearMsg{token: token}
+	}
+}
+
+// setFlashText sets a message without scheduling an automatic clear, for
+// in-progress status that a follow-up message replaces.
+func (m *Model) setFlashText(msg string, isErr bool) {
+	m.flashMessage = msg
+	m.flashIsError = isErr
+	m.flashToken++
+}
+
+// pruneUnseen returns the peripherals whose address was observed in the
+// completed scan (present in seen).
+func pruneUnseen(list []Peripheral, seen map[string]bool) []Peripheral {
+	kept := make([]Peripheral, 0, len(list))
+	for _, p := range list {
+		if seen[p.Address] {
+			kept = append(kept, p)
+		}
+	}
+	return kept
 }
 
 func displayName(p Peripheral) string {

--- a/go/internal/cli/tui/bttable/model_test.go
+++ b/go/internal/cli/tui/bttable/model_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // fakeHandler records dispatched ops and returns canned tea.Cmds so callers can
@@ -338,6 +340,103 @@ func TestViewRendersTitleFooterAndScanning(t *testing.T) {
 	m, _ = updateModel(m, ScanDoneMsg{})
 	if strings.Contains(strings.ToLower(m.View()), "scanning") {
 		t.Errorf("View should not show scanning after ScanDoneMsg")
+	}
+}
+
+func TestRescanRemovesStalePeripherals(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel(nil).WithHandler(h)
+
+	// Initial scan finds two devices.
+	m, _ = updateModel(m, ScanResultMsg{Peripherals: []Peripheral{
+		{Name: "A", Address: "AA"},
+		{Name: "B", Address: "BB"},
+	}})
+	m, _ = updateModel(m, ScanDoneMsg{})
+	if len(m.peripherals) != 2 {
+		t.Fatalf("setup: expected 2 peripherals, got %d", len(m.peripherals))
+	}
+
+	// Rescan: only A is still present — B must be reconciled away.
+	m = sendKey(m, "r")
+	m, _ = updateModel(m, ScanResultMsg{Peripherals: []Peripheral{{Name: "A", Address: "AA"}}})
+	m, _ = updateModel(m, ScanDoneMsg{})
+	if len(m.peripherals) != 1 || m.peripherals[0].Address != "AA" {
+		t.Fatalf("stale peripheral B not removed: %+v", m.peripherals)
+	}
+
+	// A rescan that returns no ScanResultMsg before ScanDoneMsg clears the table
+	// (the Linux agent omits the batch entirely when nothing is found).
+	m = sendKey(m, "r")
+	m, _ = updateModel(m, ScanDoneMsg{})
+	if len(m.peripherals) != 0 {
+		t.Fatalf("expected empty table after an empty rescan, got %d", len(m.peripherals))
+	}
+}
+
+func TestFailedRescanKeepsExistingPeripherals(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel(nil).WithHandler(h)
+	m, _ = updateModel(m, ScanResultMsg{Peripherals: []Peripheral{{Name: "A", Address: "AA"}}})
+	m, _ = updateModel(m, ScanDoneMsg{})
+
+	// A rescan that fails must not wipe the previously-known devices.
+	m = sendKey(m, "r")
+	m, _ = updateModel(m, ScanDoneMsg{Err: errors.New("scan boom")})
+	if len(m.peripherals) != 1 {
+		t.Fatalf("failed rescan should preserve existing peripherals, got %d", len(m.peripherals))
+	}
+	if !m.flashIsError {
+		t.Errorf("expected an error flash on failed scan")
+	}
+}
+
+func TestStaleFlashClearIgnored(t *testing.T) {
+	m := NewModel(nil)
+	m.setFlash("A", false)
+	tokenA := m.flashToken
+	m.setFlash("B", true)
+
+	// A clear stamped with the older token must not wipe the newer flash.
+	next, _ := m.Update(flashClearMsg{token: tokenA})
+	m = next.(Model)
+	if m.flashMessage != "B" {
+		t.Errorf("stale clear wiped a newer flash: %q", m.flashMessage)
+	}
+
+	// The current token's clear does wipe it.
+	next2, _ := m.Update(flashClearMsg{token: m.flashToken})
+	m = next2.(Model)
+	if m.flashMessage != "" {
+		t.Errorf("matching clear should wipe the flash, got %q", m.flashMessage)
+	}
+}
+
+func TestUserFacingErrorStripsGRPCFraming(t *testing.T) {
+	err := status.Error(codes.Internal, "failed to connect bluetooth peripheral: boom")
+	got := userFacingError(err)
+	if got != "failed to connect bluetooth peripheral: boom" {
+		t.Errorf("userFacingError = %q", got)
+	}
+	if strings.Contains(got, "rpc error") {
+		t.Errorf("grpc framing leaked into UI string: %q", got)
+	}
+	if userFacingError(errors.New("plain")) != "plain" {
+		t.Errorf("non-grpc error should fall back to Error()")
+	}
+}
+
+func TestOpErrorFlashIsSanitized(t *testing.T) {
+	h := &fakeHandler{connectResult: status.Error(codes.Internal, "pair failed")}
+	m := NewModel([]Peripheral{{Name: "Buds", Address: "BB"}}).WithHandler(h)
+	m.table.SetCursor(0)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = runCmd(next.(Model), cmd)
+	if strings.Contains(m.flashMessage, "rpc error") {
+		t.Errorf("op error flash should be sanitized, got %q", m.flashMessage)
+	}
+	if !strings.Contains(m.flashMessage, "pair failed") {
+		t.Errorf("sanitized flash should keep the useful message, got %q", m.flashMessage)
 	}
 }
 

--- a/go/internal/cli/tui/bttable/model_test.go
+++ b/go/internal/cli/tui/bttable/model_test.go
@@ -1,0 +1,349 @@
+package bttable
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// fakeHandler records dispatched ops and returns canned tea.Cmds so callers can
+// drive the Model's async lifecycle manually.
+type fakeHandler struct {
+	startScanCalls   int
+	nextCalls        int
+	connectCalls     int
+	disconnectCalls  int
+	forgetCalls      int
+	lastAddress      string
+	connectResult    error
+	disconnectResult error
+	forgetResult     error
+}
+
+func (h *fakeHandler) StartScan() tea.Cmd {
+	h.startScanCalls++
+	return func() tea.Msg { return ScanResultMsg{} }
+}
+
+func (h *fakeHandler) NextScanEvent() tea.Cmd {
+	h.nextCalls++
+	return func() tea.Msg { return ScanDoneMsg{} }
+}
+
+func (h *fakeHandler) Connect(address string) tea.Cmd {
+	h.connectCalls++
+	h.lastAddress = address
+	err := h.connectResult
+	return func() tea.Msg { return OpResultMsg{Action: ActionConnect, Address: address, Err: err} }
+}
+
+func (h *fakeHandler) Disconnect(address string) tea.Cmd {
+	h.disconnectCalls++
+	h.lastAddress = address
+	err := h.disconnectResult
+	return func() tea.Msg { return OpResultMsg{Action: ActionDisconnect, Address: address, Err: err} }
+}
+
+func (h *fakeHandler) Forget(address string) tea.Cmd {
+	h.forgetCalls++
+	h.lastAddress = address
+	err := h.forgetResult
+	return func() tea.Msg { return OpResultMsg{Action: ActionForget, Address: address, Err: err} }
+}
+
+func sendKey(m Model, k string) Model {
+	var msg tea.KeyMsg
+	switch k {
+	case "up":
+		msg = tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		msg = tea.KeyMsg{Type: tea.KeyDown}
+	case "enter":
+		msg = tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		msg = tea.KeyMsg{Type: tea.KeyEsc}
+	default:
+		msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)}
+	}
+	next, _ := m.Update(msg)
+	return next.(Model)
+}
+
+// runCmd fires a tea.Cmd synchronously and pipes the resulting msg through the
+// Model — used to simulate the async lifecycle in tests.
+func runCmd(m Model, cmd tea.Cmd) Model {
+	if cmd == nil {
+		return m
+	}
+	msg := cmd()
+	next, _ := m.Update(msg)
+	return next.(Model)
+}
+
+func cursorTo(m *Model, address string) {
+	for i, p := range m.peripherals {
+		if p.Address == address {
+			m.table.SetCursor(i)
+			return
+		}
+	}
+}
+
+func find(m Model, address string) *Peripheral {
+	for i := range m.peripherals {
+		if m.peripherals[i].Address == address {
+			return &m.peripherals[i]
+		}
+	}
+	return nil
+}
+
+func TestScanResultUpsertsDedupsAndSorts(t *testing.T) {
+	m := NewModel(nil)
+	m, _ = updateModel(m, ScanResultMsg{Peripherals: []Peripheral{
+		{Name: "Buds", Address: "BB", Paired: true, RSSI: -60},
+		{Name: "Watch", Address: "CC", Connected: true, Paired: true, RSSI: -70},
+	}})
+	// Same address rediscovered with updated state — must dedup, not append.
+	m, _ = updateModel(m, ScanResultMsg{Peripherals: []Peripheral{
+		{Name: "Buds", Address: "BB", Paired: true, Connected: true, RSSI: -55},
+	}})
+
+	if len(m.peripherals) != 2 {
+		t.Fatalf("expected 2 deduped peripherals, got %d", len(m.peripherals))
+	}
+	// Connected sorts first; Watch and Buds are both connected now, tie broken by
+	// RSSI (Buds -55 > Watch -70).
+	if m.peripherals[0].Address != "BB" {
+		t.Errorf("sort order wrong: want BB first, got %s", m.peripherals[0].Address)
+	}
+	if buds := find(m, "BB"); buds == nil || !buds.Connected {
+		t.Errorf("Buds should have been updated to connected: %+v", buds)
+	}
+}
+
+func TestScanDoneStopsScanning(t *testing.T) {
+	m := NewModel(nil)
+	if !m.scanning {
+		t.Fatalf("model should start scanning")
+	}
+	m, _ = updateModel(m, ScanDoneMsg{})
+	if m.scanning {
+		t.Errorf("scanning should be false after ScanDoneMsg")
+	}
+}
+
+func TestScanDoneWithErrorFlashes(t *testing.T) {
+	m := NewModel(nil)
+	m, _ = updateModel(m, ScanDoneMsg{Err: errors.New("boom")})
+	if m.scanning {
+		t.Errorf("scanning should stop on error")
+	}
+	if !m.flashIsError || m.flashMessage == "" {
+		t.Errorf("expected an error flash, got %q isErr=%v", m.flashMessage, m.flashIsError)
+	}
+}
+
+func TestEnterConnectsDisconnectedDevice(t *testing.T) {
+	m := NewModel([]Peripheral{{Name: "Buds", Address: "BB"}})
+	m.table.SetCursor(0)
+	m = sendKey(m, "enter")
+	if !m.done {
+		t.Fatalf("no-handler enter should record Result and quit")
+	}
+	if r := m.Result(); r.Action != ActionConnect || r.Address != "BB" {
+		t.Errorf("result = %+v; want ActionConnect BB", r)
+	}
+}
+
+func TestEnterOnConnectedDeviceFlashesNoAction(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel([]Peripheral{{Name: "Watch", Address: "CC", Connected: true, Paired: true}}).WithHandler(h)
+	m.table.SetCursor(0)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if h.connectCalls != 0 {
+		t.Errorf("connect should not dispatch for an already-connected device")
+	}
+	if m.flashMessage == "" {
+		t.Errorf("expected an 'already connected' flash")
+	}
+}
+
+func TestDisconnectGuardedToConnected(t *testing.T) {
+	// Not connected → flash, no dispatch.
+	h := &fakeHandler{}
+	m := NewModel([]Peripheral{{Name: "Buds", Address: "BB", Paired: true}}).WithHandler(h)
+	m.table.SetCursor(0)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = next.(Model)
+	if h.disconnectCalls != 0 {
+		t.Errorf("disconnect should not dispatch for a non-connected device")
+	}
+	if !m.flashIsError {
+		t.Errorf("expected an error flash for invalid disconnect")
+	}
+
+	// Connected → dispatch.
+	h2 := &fakeHandler{}
+	m2 := NewModel([]Peripheral{{Name: "Watch", Address: "CC", Connected: true, Paired: true}}).WithHandler(h2)
+	m2.table.SetCursor(0)
+	next2, cmd := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m2 = next2.(Model)
+	if h2.disconnectCalls != 1 || h2.lastAddress != "CC" {
+		t.Errorf("disconnect not dispatched: calls=%d addr=%s", h2.disconnectCalls, h2.lastAddress)
+	}
+	if !m2.busy {
+		t.Errorf("expected busy=true during disconnect")
+	}
+	_ = cmd
+}
+
+func TestForgetGuardedToPaired(t *testing.T) {
+	// Not paired → flash, no dispatch.
+	h := &fakeHandler{}
+	m := NewModel([]Peripheral{{Name: "Stranger", Address: "EE"}}).WithHandler(h)
+	m.table.SetCursor(0)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = next.(Model)
+	if h.forgetCalls != 0 {
+		t.Errorf("forget should not dispatch for an unpaired device")
+	}
+	if !m.flashIsError {
+		t.Errorf("expected an error flash for invalid forget")
+	}
+
+	// Paired → dispatch.
+	h2 := &fakeHandler{}
+	m2 := NewModel([]Peripheral{{Name: "Buds", Address: "BB", Paired: true}}).WithHandler(h2)
+	m2.table.SetCursor(0)
+	next2, _ := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m2 = next2.(Model)
+	if h2.forgetCalls != 1 || h2.lastAddress != "BB" {
+		t.Errorf("forget not dispatched: calls=%d addr=%s", h2.forgetCalls, h2.lastAddress)
+	}
+}
+
+func TestConnectOptimisticUpdateAndNoAutoRescan(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel([]Peripheral{{Name: "Buds", Address: "BB", Paired: false}}).WithHandler(h)
+	m.table.SetCursor(0)
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if !m.busy {
+		t.Fatalf("expected busy=true while connect is in-flight")
+	}
+	if h.connectCalls != 1 {
+		t.Fatalf("expected Connect dispatch, got %d", h.connectCalls)
+	}
+
+	// Drive the OpResultMsg back through the model.
+	m = runCmd(m, cmd)
+	if m.busy {
+		t.Errorf("busy should reset after OpResultMsg")
+	}
+	buds := find(m, "BB")
+	if buds == nil || !buds.Connected || !buds.Paired || !buds.Trusted {
+		t.Errorf("optimistic update should mark connected/paired/trusted: %+v", buds)
+	}
+	// Divergence from wifi: no auto-rescan after a successful op.
+	if h.startScanCalls != 0 {
+		t.Errorf("expected NO auto-rescan after op, got %d StartScan calls", h.startScanCalls)
+	}
+}
+
+func TestDisconnectOptimisticUpdate(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel([]Peripheral{{Name: "Watch", Address: "CC", Connected: true, Paired: true, Trusted: true}}).WithHandler(h)
+	m.table.SetCursor(0)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = runCmd(next.(Model), cmd)
+	watch := find(m, "CC")
+	if watch == nil || watch.Connected {
+		t.Errorf("disconnect should clear Connected: %+v", watch)
+	}
+}
+
+func TestForgetOptimisticUpdateKeepsRow(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel([]Peripheral{{Name: "Buds", Address: "BB", Paired: true, Connected: true, Trusted: true}}).WithHandler(h)
+	m.table.SetCursor(0)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = runCmd(next.(Model), cmd)
+	buds := find(m, "BB")
+	if buds == nil {
+		t.Fatalf("forget should keep the row (device may still advertise)")
+	}
+	if buds.Paired || buds.Connected || buds.Trusted {
+		t.Errorf("forget should clear paired/connected/trusted: %+v", buds)
+	}
+}
+
+func TestOpErrorSurfacesAndSkipsOptimisticUpdate(t *testing.T) {
+	h := &fakeHandler{connectResult: errors.New("pair failed")}
+	m := NewModel([]Peripheral{{Name: "Buds", Address: "BB"}}).WithHandler(h)
+	m.table.SetCursor(0)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = runCmd(next.(Model), cmd)
+	if !m.flashIsError {
+		t.Errorf("expected error flash on failed connect")
+	}
+	if buds := find(m, "BB"); buds != nil && buds.Connected {
+		t.Errorf("failed connect must not optimistically mark connected")
+	}
+}
+
+func TestRescanKeyStartsScan(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel(nil).WithHandler(h)
+	// Finish the initial scan first.
+	m, _ = updateModel(m, ScanDoneMsg{})
+	if m.scanning {
+		t.Fatalf("precondition: scanning should be false")
+	}
+	m = sendKey(m, "r")
+	if !m.scanning {
+		t.Errorf("'r' should set scanning=true")
+	}
+	if h.startScanCalls != 1 {
+		t.Errorf("'r' should call StartScan once, got %d", h.startScanCalls)
+	}
+}
+
+func TestQuitKeyExits(t *testing.T) {
+	m := NewModel(nil)
+	m = sendKey(m, "q")
+	if !m.done {
+		t.Errorf("'q' should quit")
+	}
+	if m.Result().Action != ActionQuit {
+		t.Errorf("result action = %v; want ActionQuit", m.Result().Action)
+	}
+}
+
+func TestViewRendersTitleFooterAndScanning(t *testing.T) {
+	m := NewModel([]Peripheral{{Name: "Buds", Address: "BB"}})
+	view := m.View()
+	for _, want := range []string{"Bluetooth", "connect", "disconnect", "forget", "rescan", "quit"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("View missing %q\n%s", want, view)
+		}
+	}
+	if !strings.Contains(strings.ToLower(view), "scanning") {
+		t.Errorf("View should show a scanning indicator while scanning\n%s", view)
+	}
+	m, _ = updateModel(m, ScanDoneMsg{})
+	if strings.Contains(strings.ToLower(m.View()), "scanning") {
+		t.Errorf("View should not show scanning after ScanDoneMsg")
+	}
+}
+
+// updateModel is a thin wrapper that applies a message and returns the concrete
+// Model plus the command, keeping the test bodies terse.
+func updateModel(m Model, msg tea.Msg) (Model, tea.Cmd) {
+	next, cmd := m.Update(msg)
+	return next.(Model), cmd
+}

--- a/go/internal/cli/tui/bttable/peripherals.go
+++ b/go/internal/cli/tui/bttable/peripherals.go
@@ -1,0 +1,86 @@
+// Package bttable implements the interactive `wendy device bluetooth` table.
+package bttable
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// Peripheral is a CLI-side view of a discovered Bluetooth peripheral. Fields are
+// plain values so the TUI and sorting logic can be unit-tested without a gRPC
+// transport.
+type Peripheral struct {
+	Name       string
+	Address    string
+	DeviceType string
+	Paired     bool
+	Connected  bool
+	Trusted    bool
+	// RSSI is the signal strength in dBm (higher/closer-to-zero is stronger), or
+	// 0 when the agent does not report it. Used only as a sort tiebreak today;
+	// it has no dedicated column because the current agent never populates it.
+	RSSI int32
+}
+
+// FromProto converts a DiscoveredBluetoothPeripheral into the local Peripheral.
+func FromProto(p *agentpb.DiscoveredBluetoothPeripheral) Peripheral {
+	return Peripheral{
+		Name:       p.GetName(),
+		Address:    p.GetAddress(),
+		DeviceType: p.GetDeviceType(),
+		Paired:     p.GetPaired(),
+		Connected:  p.GetConnected(),
+		Trusted:    p.GetTrusted(),
+		RSSI:       p.GetRssi(),
+	}
+}
+
+// Sort sorts peripherals in-place: connected first, then paired, then by
+// descending RSSI (stronger signal first), then by name and address ascending
+// so the ordering is stable and obvious at a glance.
+func Sort(ps []Peripheral) {
+	sort.SliceStable(ps, func(i, j int) bool {
+		a, b := ps[i], ps[j]
+		if a.Connected != b.Connected {
+			return a.Connected
+		}
+		if a.Paired != b.Paired {
+			return a.Paired
+		}
+		if a.RSSI != b.RSSI {
+			return a.RSSI > b.RSSI
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.Address < b.Address
+	})
+}
+
+// DeviceTypeLabel renders a peripheral's device type for display, capitalizing
+// the first letter (e.g. "audio" → "Audio"). An empty type renders as empty.
+func DeviceTypeLabel(t string) string {
+	if t == "" {
+		return ""
+	}
+	r := []rune(t)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}
+
+// Upsert merges a discovered peripheral into list, keyed by Address: it replaces
+// an existing entry's fields when the address is already present, or appends a
+// new entry otherwise. This lets the model accept either today's single batched
+// scan response or a future incremental stream without changing behavior.
+func Upsert(list []Peripheral, p Peripheral) []Peripheral {
+	for i := range list {
+		if strings.EqualFold(list[i].Address, p.Address) {
+			list[i] = p
+			return list
+		}
+	}
+	return append(list, p)
+}

--- a/go/internal/cli/tui/bttable/peripherals.go
+++ b/go/internal/cli/tui/bttable/peripherals.go
@@ -26,16 +26,25 @@ type Peripheral struct {
 }
 
 // FromProto converts a DiscoveredBluetoothPeripheral into the local Peripheral.
+// The address is canonicalized to upper-case so identity comparisons (Upsert,
+// optimistic updates) are exact and two scans reporting the same MAC in
+// different case can never shadow one another.
 func FromProto(p *agentpb.DiscoveredBluetoothPeripheral) Peripheral {
 	return Peripheral{
 		Name:       p.GetName(),
-		Address:    p.GetAddress(),
+		Address:    NormalizeAddress(p.GetAddress()),
 		DeviceType: p.GetDeviceType(),
 		Paired:     p.GetPaired(),
 		Connected:  p.GetConnected(),
 		Trusted:    p.GetTrusted(),
 		RSSI:       p.GetRssi(),
 	}
+}
+
+// NormalizeAddress canonicalizes a Bluetooth MAC to upper-case (BlueZ already
+// reports upper-case, so this is normally a no-op) and trims surrounding space.
+func NormalizeAddress(addr string) string {
+	return strings.ToUpper(strings.TrimSpace(addr))
 }
 
 // Sort sorts peripherals in-place: connected first, then paired, then by
@@ -77,7 +86,7 @@ func DeviceTypeLabel(t string) string {
 // scan response or a future incremental stream without changing behavior.
 func Upsert(list []Peripheral, p Peripheral) []Peripheral {
 	for i := range list {
-		if strings.EqualFold(list[i].Address, p.Address) {
+		if list[i].Address == p.Address {
 			list[i] = p
 			return list
 		}

--- a/go/internal/cli/tui/bttable/peripherals_test.go
+++ b/go/internal/cli/tui/bttable/peripherals_test.go
@@ -101,3 +101,24 @@ func TestUpsertAppendsNewAddress(t *testing.T) {
 		t.Fatalf("Upsert should append a new address; got %d entries", len(list))
 	}
 }
+
+func TestFromProtoNormalizesAddressToUpper(t *testing.T) {
+	p := FromProto(&agentpb.DiscoveredBluetoothPeripheral{Address: "ac:12:34:56:78:9f", Name: "x"})
+	if p.Address != "AC:12:34:56:78:9F" {
+		t.Fatalf("address not normalized to upper: %q", p.Address)
+	}
+}
+
+func TestUpsertDedupsCaseDifferingAddressesAfterNormalization(t *testing.T) {
+	// Two scans report the same MAC in different case; after FromProto
+	// normalization they must collapse to a single entry, not shadow each other.
+	upper := FromProto(&agentpb.DiscoveredBluetoothPeripheral{Address: "AC:12:34:56:78:9F", Name: "Upper"})
+	lower := FromProto(&agentpb.DiscoveredBluetoothPeripheral{Address: "ac:12:34:56:78:9f", Name: "Lower", Paired: true})
+	list := Upsert([]Peripheral{upper}, lower)
+	if len(list) != 1 {
+		t.Fatalf("expected a single deduped entry, got %d", len(list))
+	}
+	if !list[0].Paired {
+		t.Errorf("expected the existing entry to be updated in place: %+v", list[0])
+	}
+}

--- a/go/internal/cli/tui/bttable/peripherals_test.go
+++ b/go/internal/cli/tui/bttable/peripherals_test.go
@@ -1,0 +1,103 @@
+package bttable
+
+import (
+	"reflect"
+	"testing"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func TestFromProtoPopulatesFields(t *testing.T) {
+	pb := &agentpb.DiscoveredBluetoothPeripheral{
+		Name:       "AirPods Pro",
+		Address:    "AC:12:34:56:78:9F",
+		Rssi:       -42,
+		DeviceType: "audio",
+		Paired:     true,
+		Connected:  true,
+		Trusted:    true,
+	}
+	p := FromProto(pb)
+	want := Peripheral{
+		Name:       "AirPods Pro",
+		Address:    "AC:12:34:56:78:9F",
+		RSSI:       -42,
+		DeviceType: "audio",
+		Paired:     true,
+		Connected:  true,
+		Trusted:    true,
+	}
+	if p != want {
+		t.Fatalf("FromProto = %+v; want %+v", p, want)
+	}
+}
+
+func TestSortConnectedThenPairedThenRSSIThenName(t *testing.T) {
+	ps := []Peripheral{
+		{Name: "Zeta", Address: "00:00:00:00:00:05", RSSI: -90},
+		{Name: "Paired Weak", Address: "00:00:00:00:00:02", Paired: true, RSSI: -80},
+		{Name: "Paired Strong", Address: "00:00:00:00:00:03", Paired: true, RSSI: -40},
+		{Name: "Connected", Address: "00:00:00:00:00:01", Connected: true, Paired: true, RSSI: -70},
+		{Name: "Alpha", Address: "00:00:00:00:00:04", RSSI: -90},
+	}
+	Sort(ps)
+
+	var got []string
+	for _, p := range ps {
+		got = append(got, p.Name)
+	}
+	// Connected first; then paired (strong RSSI before weak); then unpaired by
+	// RSSI tie (-90 == -90) broken by name ascending (Alpha before Zeta).
+	want := []string{"Connected", "Paired Strong", "Paired Weak", "Alpha", "Zeta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Sort order = %v; want %v", got, want)
+	}
+}
+
+func TestSortRSSITiebreakByAddress(t *testing.T) {
+	ps := []Peripheral{
+		{Name: "Dup", Address: "BB:BB:BB:BB:BB:BB", RSSI: -50},
+		{Name: "Dup", Address: "AA:AA:AA:AA:AA:AA", RSSI: -50},
+	}
+	Sort(ps)
+	if ps[0].Address != "AA:AA:AA:AA:AA:AA" {
+		t.Fatalf("expected lower address first on full tie, got %v", ps[0].Address)
+	}
+}
+
+func TestDeviceTypeLabel(t *testing.T) {
+	cases := map[string]string{
+		"audio":    "Audio",
+		"wearable": "Wearable",
+		"":         "",
+	}
+	for in, want := range cases {
+		if got := DeviceTypeLabel(in); got != want {
+			t.Errorf("DeviceTypeLabel(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestUpsertReplacesByAddress(t *testing.T) {
+	list := []Peripheral{
+		{Name: "Buds", Address: "D8:3A:11:22:33:21", Paired: false},
+	}
+	// Same address rediscovered, now paired — should update in place, not append.
+	list = Upsert(list, Peripheral{Name: "Buds", Address: "D8:3A:11:22:33:21", Paired: true, Connected: true})
+	if len(list) != 1 {
+		t.Fatalf("Upsert should dedup by address; got %d entries", len(list))
+	}
+	if !list[0].Paired || !list[0].Connected {
+		t.Fatalf("Upsert should update existing entry fields; got %+v", list[0])
+	}
+}
+
+func TestUpsertAppendsNewAddress(t *testing.T) {
+	list := []Peripheral{
+		{Name: "Buds", Address: "D8:3A:11:22:33:21"},
+	}
+	list = Upsert(list, Peripheral{Name: "Watch", Address: "C0:98:AA:BB:CC:7B"})
+	if len(list) != 2 {
+		t.Fatalf("Upsert should append a new address; got %d entries", len(list))
+	}
+}


### PR DESCRIPTION
## Summary

Resolves **WDY-1115** — `wendy device bluetooth` had no interactive TUI, unlike `wendy device wifi`. The bare command now launches a Bubble Tea table for browsing and managing peripherals. All existing subcommands (`list`, `connect`, `disconnect`, `forget`) and their flags are unchanged.

### Behavior

```
Bluetooth peripherals          ⠋ scanning… (~8s)

  Name              Address             Type      Paired  Connected
> AirPods Pro       AC:12:34:56:78:9F   Audio
  Pixel Buds        D8:3A:11:22:33:21   Audio     yes
  Heart Rate Mon    C0:98:AA:BB:CC:7B             yes     yes

↑/↓ move · enter connect · d disconnect · f forget · r rescan · q quit
```

- `enter` → connect (pair + trust, matching the `connect` subcommand defaults)
- `d` → disconnect (guarded to connected devices) · `f` → forget (guarded to paired devices)
- `r` → rescan · `q`/`esc` → quit
- Actions apply optimistically on success; no auto-rescan (a BT rescan is an ~8s window), press `r` to reconcile.

### Changes

- **`internal/cli/tui/bttable/`** (new, unit-tested): `Peripheral` view type + `Sort`/`FromProto`/`DeviceTypeLabel`/`Upsert`, and the Bubble Tea `Model` + `Handler` interface. Discovered peripherals are upserted by address, so the same model works with today's single-batch agent and a future incremental stream.
- **`commands/bluetooth.go`**: `RunE` → `runBluetoothInteractive` + `btTUIHandler` (agent gRPC adapter). The scan runs **inside** the TUI so the spinner stays visible during the agent's ~8s scan window; the macOS-beta "unsupported" case surfaces as a clear flash.
- **`device/bluetooth.md`**: new command doc (auto-embedded via the `docs/clients` glob).

### Scope

CLI-only and forward-compatible. The current agent batches the full device list after an ~8s `bluetoothctl` scan and never populates RSSI, so there is no RSSI column and devices appear in one batch today. If the agent is later enhanced to stream incrementally + report RSSI, this TUI lights up live with no CLI change (tracked as a follow-up).

### Test plan

- [x] `gofmt -l .` clean · `go build ./...` · `go vet ./...` · `go test ./...` → no failures
- [x] New `bttable` package fully unit-tested (sort/upsert/guards/optimistic updates/view)
- [x] `wendy device bluetooth --help` shows the runnable command with all four subcommands intact
- [ ] On-device manual run against a WendyOS agent (spinner → populate → connect/disconnect/forget/rescan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)