### PR TITLE
feat(discover): show provisioned state and no-access hint in device tables

### DIFF
--- a/Documentation/2026-06-11-discover-compact-table-design.md
+++ b/Documentation/2026-06-11-discover-compact-table-design.md
@@ -13,12 +13,12 @@ Description column (min 20) that is empty in discover output.
 Target layout (~78 columns):
 
 ```
-      Name            Type       Address        Agent     OS
- ★●   wendy-jetson    USB, LAN   wendy.local    1.2.3 ⚠   12.4
-  ○   pi5-dev         LAN        10.0.1.5       1.2.4     12.4
-      esp32-c6        ESP32      /dev/tty.usb1
+       Name            Type       Address        Agent     OS
+ ● ✦   wendy-jetson    USB, LAN   wendy.local    1.2.3 ⚠   12.4
+ ○     pi5-dev         LAN        10.0.1.5       1.2.4     12.4
+       esp32-c6        ESP32      /dev/tty.usb1
 
-  ● provisioned  ○ unprovisioned  ⚠ agent older than CLI
+  ● provisioned  ○ unprovisioned  ✦ default  ⚠ agent older than CLI
 ```
 
 Changes, all in the shared column definitions so discover and pickers stay
@@ -27,11 +27,12 @@ consistent:
 1. **Short headers.** "wendy-agent version" → "Agent" (minWidth 20 → 7),
    "WendyOS Version" → "OS" (minWidth 16 → 4).
 2. **Provisioned glyph in the marker column.** The leading unlabeled column
-   (previously only the ★ default marker) now also carries the provisioned
+   (previously only the default marker) now also carries the provisioned
    glyph: `●` provisioned, `○` unprovisioned, empty when unknown (non-LAN
-   devices). A default provisioned device renders `★●`. The column appears
-   when default tracking is on or any row has a glyph. The
-   `PickerItem.Provisioned` string field keeps its current
+   devices). The default marker is `✦` (was `★`) and renders to the right of
+   the glyph with a separating space: a default provisioned device shows
+   `● ✦`. The column appears when default tracking is on or any row has a
+   glyph. The `PickerItem.Provisioned` string field keeps its current
    "Provisioned"/"Unprovisioned"/"" semantics; only the rendering changes.
    The clipboard JSON (`discoverDeviceInfo.Provisioned`) keeps the full word.
 3. **Auto-hide empty Description.** Add an `optional` flag to
@@ -48,6 +49,9 @@ consistent:
    provider/device display name "Docker Desktop" → "Docker", and the local
    provider/device shows a platform name: "This Mac" on macOS, "This PC"
    elsewhere (replacing "Local Machine" and "This Device").
+6. **Hidden addresses for Docker/local.** Their provider-qualified IDs are
+   fixed and meaningless ("docker: docker", "local: local"), so the Address
+   cell is blank for them. Other external providers keep "provider: id".
 
 Out of scope: `cloud_discover.go` has its own table (`discoverTableColumns`)
 and is unchanged. Connection-type glyphs were considered and rejected (chosen

--- a/Documentation/2026-06-11-discover-compact-table-design.md
+++ b/Documentation/2026-06-11-discover-compact-table-design.md
@@ -1,0 +1,53 @@
+# Compact device table for `wendy discover` and device pickers
+
+## Problem
+
+The shared device table (`pickerDeviceColumnDefs` in `go/internal/cli/tui/picker.go`,
+used by `wendy discover` and the device pickers) is ~132 columns wide at minimum.
+Most of the width comes from verbose headers ("wendy-agent version" min 20,
+"WendyOS Version" min 16, "Provisioned" min 13) and an always-rendered
+Description column (min 20) that is empty in discover output.
+
+## Design
+
+Target layout (~80 columns):
+
+```
+     Name            Type       Address        Agent     OS      P
+ ★   wendy-jetson    USB, LAN   wendy.local    1.2.3 ⚠   12.4    ●
+     pi5-dev         LAN        10.0.1.5       1.2.4     12.4    ○
+     esp32-c6        ESP32      /dev/tty.usb1
+
+  ● provisioned  ○ unprovisioned  ⚠ agent older than CLI
+```
+
+Changes, all in the shared column definitions so discover and pickers stay
+consistent:
+
+1. **Short headers.** "wendy-agent version" → "Agent" (minWidth 20 → 7),
+   "WendyOS Version" → "OS" (minWidth 16 → 4).
+2. **Provisioned glyph column.** Header "P", minWidth 3. Values: `●` for
+   provisioned, `○` for unprovisioned, empty when unknown (non-LAN devices).
+   The `PickerItem.Provisioned` string field keeps its current
+   "Provisioned"/"Unprovisioned"/"" semantics; only the rendered cell changes.
+   The clipboard JSON (`discoverDeviceInfo.Provisioned`) keeps the full word.
+3. **Auto-hide empty Description.** Add an `optional` flag to
+   `pickerColumnDef`: an optional column is hidden when no item has a value,
+   even in fixed-column mode. Only Description in the device defs is marked
+   optional. Discover never sets Description, so it never appears there; static
+   picker lists that set it still show it. Because discover items never gain a
+   Description mid-scan, the column cannot pop in/out during continuous
+   refresh.
+4. **Legend line.** A dim legend rendered under the table in both the discover
+   TUI and the device picker: `● provisioned  ○ unprovisioned  ⚠ agent older
+   than CLI`. Shown whenever the table has rows.
+
+Out of scope: `cloud_discover.go` has its own table (`discoverTableColumns`)
+and is unchanged. Connection-type glyphs were considered and rejected (chosen
+option keeps "USB, LAN" text).
+
+## Testing
+
+Update `picker_test.go` / `discover_test.go` expectations for the new headers,
+glyph values, and hidden Description column; add coverage for the
+optional-column behavior (hidden when empty, shown when any item sets it).

--- a/Documentation/2026-06-11-discover-compact-table-design.md
+++ b/Documentation/2026-06-11-discover-compact-table-design.md
@@ -44,6 +44,10 @@ consistent:
 4. **Legend line.** A dim legend rendered under the table in both the discover
    TUI and the device picker: `● provisioned  ○ unprovisioned  ⚠ agent older
    than CLI`. Shown whenever the table has rows.
+5. **Short Type labels.** "Bluetooth" → "BLE" (ConnectionTypes), the Docker
+   provider/device display name "Docker Desktop" → "Docker", and the local
+   provider/device shows a platform name: "This Mac" on macOS, "This PC"
+   elsewhere (replacing "Local Machine" and "This Device").
 
 Out of scope: `cloud_discover.go` has its own table (`discoverTableColumns`)
 and is unchanged. Connection-type glyphs were considered and rejected (chosen

--- a/Documentation/2026-06-11-discover-compact-table-design.md
+++ b/Documentation/2026-06-11-discover-compact-table-design.md
@@ -10,13 +10,13 @@ Description column (min 20) that is empty in discover output.
 
 ## Design
 
-Target layout (~80 columns):
+Target layout (~78 columns):
 
 ```
-     Name            Type       Address        Agent     OS      P
- ★   wendy-jetson    USB, LAN   wendy.local    1.2.3 ⚠   12.4    ●
-     pi5-dev         LAN        10.0.1.5       1.2.4     12.4    ○
-     esp32-c6        ESP32      /dev/tty.usb1
+      Name            Type       Address        Agent     OS
+ ★●   wendy-jetson    USB, LAN   wendy.local    1.2.3 ⚠   12.4
+  ○   pi5-dev         LAN        10.0.1.5       1.2.4     12.4
+      esp32-c6        ESP32      /dev/tty.usb1
 
   ● provisioned  ○ unprovisioned  ⚠ agent older than CLI
 ```
@@ -26,10 +26,13 @@ consistent:
 
 1. **Short headers.** "wendy-agent version" → "Agent" (minWidth 20 → 7),
    "WendyOS Version" → "OS" (minWidth 16 → 4).
-2. **Provisioned glyph column.** Header "P", minWidth 3. Values: `●` for
-   provisioned, `○` for unprovisioned, empty when unknown (non-LAN devices).
-   The `PickerItem.Provisioned` string field keeps its current
-   "Provisioned"/"Unprovisioned"/"" semantics; only the rendered cell changes.
+2. **Provisioned glyph in the marker column.** The leading unlabeled column
+   (previously only the ★ default marker) now also carries the provisioned
+   glyph: `●` provisioned, `○` unprovisioned, empty when unknown (non-LAN
+   devices). A default provisioned device renders `★●`. The column appears
+   when default tracking is on or any row has a glyph. The
+   `PickerItem.Provisioned` string field keeps its current
+   "Provisioned"/"Unprovisioned"/"" semantics; only the rendering changes.
    The clipboard JSON (`discoverDeviceInfo.Provisioned`) keeps the full word.
 3. **Auto-hide empty Description.** Add an `optional` flag to
    `pickerColumnDef`: an optional column is hidden when no item has a value,

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
@@ -46,3 +46,49 @@ or macOS permissions.
 |------|---------|-------------|
 | `--timeout` | `5s` | How long to wait for mDNS responses |
 | `--json` | `false` | Output results as a JSON array instead of a table |
+
+## Interactive table
+
+Without `--json`, discover renders a live table that refreshes as devices come
+and go (`↑`/`↓` navigate, `enter` copy, `a` copy all, `u` update agent, `d` set
+default, `x` unset default, `q` quit). A leading `★` marks the current default
+device.
+
+| Column | Description |
+|--------|-------------|
+| Name | Device display name |
+| Type | Transport(s) the device was discovered on (LAN, USB, Bluetooth, …) |
+| Address | IP address (or hostname) and port |
+| wendy-agent version | Running agent version; `⚠` marks an agent older than the CLI; blank when the metadata probe hasn't succeeded |
+| WendyOS Version | OS version reported by the agent |
+| Provisioned | `Provisioned` or `Unprovisioned` for LAN devices, from the mDNS-advertised mTLS state; blank for transports that don't report it (BLE-only, USB, external providers) |
+
+### No-access hint
+
+When the highlighted row is a provisioned LAN device whose agent metadata could
+not be read — the signature of an unprovisioned CLI, or one logged in with
+credentials that don't have access to the device — an amber hint appears below
+the table:
+
+```
+⚠  This device is provisioned and this CLI does not have access, so agent details cannot be read. Run 'wendy auth login' with an account that can access it.
+```
+
+The hint clears automatically once a probe succeeds (for example, after
+`wendy auth login` with an authorized account). If a version is already known
+from an earlier successful probe or another transport, it stays in the table
+and the hint is suppressed.
+
+### Clipboard JSON
+
+Pressing `enter` copies the highlighted device as a JSON object; `a` copies all
+devices as a JSON array. Each object contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Device display name |
+| `type` | string | Transport(s), e.g. `LAN` or `USB, LAN` |
+| `usb` | string | USB interface summary (omitted when not connected over USB) |
+| `address` | string | IP address (or hostname) and port |
+| `version` | string | Agent version (omitted when unknown) |
+| `provisioned` | string | `Provisioned` or `Unprovisioned` for LAN devices (omitted for other transports) |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
@@ -45,6 +45,13 @@ Wendy Agent for Mac advertises over Bonjour/mDNS as `_wendyos._udp` and appears
 as a LAN device when local discovery is allowed by the network and macOS Local
 Network permissions.
 
+The picker table shows the same columns as
+[`wendy discover`](./commands/discover.md#interactive-table), including a
+**Provisioned** column for LAN devices. When the highlighted device is
+provisioned but this CLI cannot read its agent details (unprovisioned CLI, or
+logged in with credentials that don't have access), a footer hint explains why
+the version is blank and suggests `wendy auth login`.
+
 In scripts, CI, SSH sessions without a TTY, or any other non-interactive
 context, no picker is shown. Pass `--device`, or configure a default with
 `wendy device set-default`, before running commands that need a target.

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -418,12 +418,9 @@ func ensureProviderSupportsProjectType(provider providers.DeviceProvider, projec
 	}
 
 	providerName := provider.DisplayName()
-	if provider.Key() == providers.ProviderKeyLocal {
-		providerName = "Local Machine"
-	}
 
 	if provider.Key() == providers.ProviderKeyLocal && (projectType == "docker" || projectType == "compose") {
-		return fmt.Errorf("%s runs host-native apps and does not support %s projects; choose Docker Desktop with --device docker for local container runs", providerName, projectType)
+		return fmt.Errorf("%s runs host-native apps and does not support %s projects; choose Docker with --device docker for local container runs", providerName, projectType)
 	}
 
 	return fmt.Errorf("%s provider does not support %s projects; supported build types: %s", providerName, projectType, strings.Join(provider.SupportedBuildTypes(), ", "))

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -1058,9 +1058,9 @@ func externalProviderSortKey(providerKey, name string) string {
 func externalProviderPickerHint(providerKey string) string {
 	switch providerKey {
 	case providers.ProviderKeyDocker:
-		return "Hint: Use Docker Desktop for local container or Compose runs when you do not need WendyOS hardware."
+		return "Hint: Use Docker for local container or Compose runs when you do not need WendyOS hardware."
 	case providers.ProviderKeyLocal:
-		return "Hint: Use Local Machine for native Swift, Go, or Python apps that should run directly on this computer."
+		return fmt.Sprintf("Hint: Use %s for native Swift, Go, or Python apps that should run directly on this computer.", providers.LocalDisplayName())
 	}
 	return ""
 }

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -973,7 +973,7 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 		if d.ProviderKey == "wendy-lite" {
 			continue
 		}
-		addr := fmt.Sprintf("%s: %s", d.ProviderKey, d.ID)
+		addr := externalProviderAddress(d.ProviderKey, d.ID)
 		deviceType := externalProviderDisplayName(d.ProviderKey)
 		items = append(items, discoverTableItem{
 			picker: tui.PickerItem{
@@ -1053,6 +1053,17 @@ func externalProviderSortKey(providerKey, name string) string {
 		return "~1_" + strings.ToLower(name)
 	}
 	return ""
+}
+
+// externalProviderAddress returns the provider-qualified ID shown in the
+// Address column. Docker and the local machine have fixed, meaningless IDs
+// ("docker: docker", "local: local"), so their address is hidden.
+func externalProviderAddress(providerKey, id string) string {
+	switch providerKey {
+	case providers.ProviderKeyDocker, providers.ProviderKeyLocal:
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", providerKey, id)
 }
 
 func externalProviderPickerHint(providerKey string) string {

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -198,11 +198,12 @@ type extScanMsg struct{ devices []models.ExternalDevice }
 
 // discoverDeviceInfo is the JSON structure copied to the clipboard.
 type discoverDeviceInfo struct {
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	USB     string `json:"usb,omitempty"`
-	Address string `json:"address"`
-	Version string `json:"version,omitempty"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	USB         string `json:"usb,omitempty"`
+	Address     string `json:"address"`
+	Version     string `json:"version,omitempty"`
+	Provisioned string `json:"provisioned,omitempty"`
 }
 
 type discoverTableItem struct {
@@ -535,6 +536,7 @@ var (
 	scanStyle       = lipgloss.NewStyle().Foreground(tui.ColorPrimary)
 	flashStyle      = lipgloss.NewStyle().Foreground(tui.ColorAccent)
 	flashErrorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196")) // red
+	hintWarnStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // amber
 )
 
 func (m discoverModel) View() string {
@@ -567,6 +569,9 @@ func (m discoverModel) View() string {
 
 	if !m.collection.IsEmpty() {
 		sb.WriteString(m.tableView() + "\n")
+		if hint := m.selectedHint(); hint != "" {
+			sb.WriteString(m.viewLine(hintWarnStyle.Render("  ⚠  "+hint)) + "\n")
+		}
 	} else if m.hasResults {
 		sb.WriteString(m.viewLine(dimStyle.Render("No devices found yet...")) + "\n")
 	}
@@ -595,6 +600,17 @@ func (m *discoverModel) refreshTable() {
 	}
 	m.table.SetWidth(tui.PickerTableWidth(m.table.Columns()))
 	m.table.SetHeight(tui.PickerTableHeight(len(rows), m.windowHeight))
+}
+
+// selectedHint returns the hint for the highlighted table row, e.g. the
+// no-access explanation for a provisioned device this CLI cannot query.
+func (m discoverModel) selectedHint() string {
+	items := discoverTableItems(m.collection)
+	cursor := m.table.Cursor()
+	if cursor < 0 || cursor >= len(items) {
+		return ""
+	}
+	return strings.TrimSpace(items[cursor].picker.Hint)
 }
 
 func (m discoverModel) viewLine(line string) string {
@@ -733,6 +749,34 @@ func humanReadableDeviceType(dt string) string {
 		return name
 	}
 	return dt
+}
+
+// discoverNoAccessHint explains a blank version column on a provisioned
+// device: the metadata probe failed because this CLI has no certificate the
+// device accepts (unprovisioned CLI, or logged into a different account).
+const discoverNoAccessHint = "This device is provisioned and this CLI does not have access, so agent details cannot be read. Run 'wendy auth login' with an account that can access it."
+
+// lanProvisionedDisplay maps a LAN device's advertised mTLS state to the
+// "Provisioned" column value. Non-LAN devices don't advertise this, so nil
+// returns "".
+func lanProvisionedDisplay(lan *models.LANDevice) string {
+	if lan == nil {
+		return ""
+	}
+	if lan.IsMTLS {
+		return "Provisioned"
+	}
+	return "Unprovisioned"
+}
+
+// lanNoAccessHint returns discoverNoAccessHint when the device advertises
+// mTLS (provisioned) but the agent metadata probe came back empty — the
+// signature of a CLI that cannot authenticate to it.
+func lanNoAccessHint(lan *models.LANDevice, agentVersion string) string {
+	if lan != nil && lan.IsMTLS && agentVersion == "" {
+		return discoverNoAccessHint
+	}
+	return ""
 }
 
 // markOutdated prefixes the version string with "* " when the agent is behind
@@ -897,6 +941,7 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 			address = preferredLANAddress(*d.LAN)
 			defaultDevice = firstNonEmpty(d.LAN.Hostname, d.LAN.IPAddress, d.LAN.DisplayName)
 		}
+		provisioned := lanProvisionedDisplay(d.LAN)
 		items = append(items, discoverTableItem{
 			picker: tui.PickerItem{
 				Name:         discovery.SanitiseDisplayName(d.DisplayName),
@@ -905,15 +950,18 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 				Address:      address,
 				AgentVersion: discoverAgentVersionDisplay(d.AgentVersion),
 				OSVersion:    d.OSVersion,
+				Provisioned:  provisioned,
+				Hint:         lanNoAccessHint(d.LAN, d.AgentVersion),
 				DedupKey:     d.DisplayName,
 				SortKey:      usbFirstSortKey(d.DisplayName, usb),
 			},
 			info: discoverDeviceInfo{
-				Name:    d.DisplayName,
-				Type:    deviceType,
-				USB:     usb,
-				Address: address,
-				Version: d.AgentVersion,
+				Name:        d.DisplayName,
+				Type:        deviceType,
+				USB:         usb,
+				Address:     address,
+				Version:     d.AgentVersion,
+				Provisioned: provisioned,
 			},
 			lanName:       lanName,
 			defaultDevice: defaultDevice,

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -232,6 +232,7 @@ type discoverModel struct {
 	ctx                context.Context
 	opts               discovery.DiscoveryOptions
 	collection         *models.DevicesCollection
+	tableItems         []discoverTableItem  // cached by refreshTable; row order matches the table
 	bleSeen            map[string]time.Time // device ID -> time last seen in a BLE scan
 	usbInterval        increasingRefreshInterval
 	ethernetInterval   increasingRefreshInterval
@@ -346,7 +347,7 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			return m, tea.Quit
 		case "enter":
-			items := discoverTableItems(m.collection)
+			items := m.tableItems
 			cursor := m.table.Cursor()
 			if len(items) > 0 && cursor >= 0 && cursor < len(items) {
 				m.flashMessage, m.flashIsError = copyDeviceJSON(items[cursor].info)
@@ -354,7 +355,7 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case "a":
-			items := discoverTableItems(m.collection)
+			items := m.tableItems
 			if len(items) > 0 {
 				var all []discoverDeviceInfo
 				for _, item := range items {
@@ -371,7 +372,7 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.updatingDeviceName != "" {
 				return m, nil // already updating
 			}
-			items := discoverTableItems(m.collection)
+			items := m.tableItems
 			cursor := m.table.Cursor()
 			if len(items) == 0 || cursor < 0 || cursor >= len(items) {
 				return m, nil
@@ -393,7 +394,7 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.flashIsError = false
 			return m, m.startDeviceUpdateCmd(addr, item.info.Name)
 		case "d":
-			items := discoverTableItems(m.collection)
+			items := m.tableItems
 			cursor := m.table.Cursor()
 			if len(items) > 0 && cursor >= 0 && cursor < len(items) {
 				deviceID := items[cursor].defaultDevice
@@ -590,8 +591,8 @@ func (m discoverModel) View() string {
 }
 
 func (m *discoverModel) refreshTable() {
-	items := discoverTableItems(m.collection)
-	pickerItems := discoverPickerItems(items)
+	m.tableItems = discoverTableItems(m.collection)
+	pickerItems := discoverPickerItems(m.tableItems)
 	cols, rows := tui.PickerDeviceTableData(pickerItems, discoverDefaultKey(), true)
 	m.table.SetColumns(cols)
 	m.table.SetRows(rows)
@@ -605,12 +606,11 @@ func (m *discoverModel) refreshTable() {
 // selectedHint returns the hint for the highlighted table row, e.g. the
 // no-access explanation for a provisioned device this CLI cannot query.
 func (m discoverModel) selectedHint() string {
-	items := discoverTableItems(m.collection)
 	cursor := m.table.Cursor()
-	if cursor < 0 || cursor >= len(items) {
+	if cursor < 0 || cursor >= len(m.tableItems) {
 		return ""
 	}
-	return strings.TrimSpace(items[cursor].picker.Hint)
+	return strings.TrimSpace(m.tableItems[cursor].picker.Hint)
 }
 
 func (m discoverModel) viewLine(line string) string {

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -537,7 +537,7 @@ var (
 	scanStyle       = lipgloss.NewStyle().Foreground(tui.ColorPrimary)
 	flashStyle      = lipgloss.NewStyle().Foreground(tui.ColorAccent)
 	flashErrorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196")) // red
-	hintWarnStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // amber
+	hintWarnStyle   = lipgloss.NewStyle().Foreground(tui.ColorNotice)
 )
 
 func (m discoverModel) View() string {

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -570,6 +570,7 @@ func (m discoverModel) View() string {
 
 	if !m.collection.IsEmpty() {
 		sb.WriteString(m.tableView() + "\n")
+		sb.WriteString(m.viewLine(dimStyle.Render("  "+tui.DeviceTableLegend)) + "\n")
 		if hint := m.selectedHint(); hint != "" {
 			sb.WriteString(m.viewLine(hintWarnStyle.Render("  ⚠  "+hint)) + "\n")
 		}
@@ -722,7 +723,7 @@ func renderDeviceTable(collection *models.DevicesCollection) string {
 	t.SetWidth(tui.PickerTableWidth(t.Columns()))
 	t.SetHeight(max(len(rows)+1, 1))
 
-	return t.View() + "\n"
+	return t.View() + "\n" + dimStyle.Render("  "+tui.DeviceTableLegend) + "\n"
 }
 
 func newDiscoverTable(interactive bool) tui.BubbleTable {

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -277,6 +277,25 @@ func TestDiscoverModel_DKeySetsDefaultAndMarksSelectedDevice(t *testing.T) {
 	}
 }
 
+func TestDiscoverModel_ViewShowsLegendWithDevices(t *testing.T) {
+	m := newDiscoverModel(context.Background(), defaultOpts())
+
+	if strings.Contains(m.View(), tui.DeviceTableLegend) {
+		t.Fatalf("expected no legend before any device is found, got %q", m.View())
+	}
+
+	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{
+		DisplayName: "ubuntu",
+		Hostname:    "ubuntu.local",
+		Port:        defaultAgentPort,
+	}}})
+	m = updated.(discoverModel)
+
+	if !strings.Contains(m.View(), tui.DeviceTableLegend) {
+		t.Fatalf("expected legend under device table, got %q", m.View())
+	}
+}
+
 func TestRenderDeviceTable(t *testing.T) {
 	collection := &models.DevicesCollection{
 		LANDevices: []models.LANDevice{{
@@ -289,7 +308,7 @@ func TestRenderDeviceTable(t *testing.T) {
 	}
 
 	output := renderDeviceTable(collection)
-	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "wendy-alpha", "1.2.3", "WendyOS-0.10.4", "LAN", "192.168.1.10:8443"} {
+	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS", "wendy-alpha", "1.2.3", "WendyOS-0.10.4", "LAN", "192.168.1.10:8443", tui.DeviceTableLegend} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, output)
 		}
@@ -415,9 +434,9 @@ func TestDiscoverTableItemsProvisionedStateAndNoAccessHint(t *testing.T) {
 	}
 
 	_, rows := tui.PickerDeviceTableData(discoverPickerItems(items), "", true)
-	// Columns with default marker: 0=★ 1=Name 2=Type 3=Address 4=agent 5=OS 6=Provisioned.
-	if rows[0][6] != "Provisioned" {
-		t.Fatalf("Provisioned cell = %q, want \"Provisioned\"", rows[0][6])
+	// Columns with default marker: 0=★ 1=Name 2=Type 3=Address 4=Agent 5=OS 6=P.
+	if rows[0][6] != "●" {
+		t.Fatalf("Provisioned cell = %q, want \"●\"", rows[0][6])
 	}
 }
 

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -461,6 +461,28 @@ func TestMergePickerItemClearsNoAccessHintWhenVersionKnown(t *testing.T) {
 	if existing.Hint != discoverNoAccessHint {
 		t.Fatalf("Hint = %q, want no-access hint to persist", existing.Hint)
 	}
+
+	// A BLE backfill that supplies the version must also clear the hint,
+	// not just LAN merges.
+	existing = lanItem(models.LANDevice{DisplayName: "wendy-locked", IsMTLS: true})
+	bleDev := models.BluetoothDevice{DisplayName: "wendy-locked", AgentVersion: "1.2.3"}
+	mergePickerItem(&existing, tui.PickerItem{
+		Name:         bleDev.DisplayName,
+		Type:         "Bluetooth",
+		AgentVersion: bleDev.AgentVersion,
+		DedupKey:     bleDev.DisplayName,
+		Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
+			DisplayName:  bleDev.DisplayName,
+			AgentVersion: bleDev.AgentVersion,
+			Bluetooth:    &bleDev,
+		}},
+	})
+	if existing.AgentVersion != "1.2.3" {
+		t.Fatalf("AgentVersion = %q, want BLE-backfilled version", existing.AgentVersion)
+	}
+	if existing.Hint != "" {
+		t.Fatalf("Hint = %q, want cleared after BLE version backfill", existing.Hint)
+	}
 }
 
 func TestDiscoverModelViewShowsNoAccessHintForHighlightedDevice(t *testing.T) {

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -434,9 +434,9 @@ func TestDiscoverTableItemsProvisionedStateAndNoAccessHint(t *testing.T) {
 	}
 
 	_, rows := tui.PickerDeviceTableData(discoverPickerItems(items), "", true)
-	// Columns with default marker: 0=★ 1=Name 2=Type 3=Address 4=Agent 5=OS 6=P.
-	if rows[0][6] != "●" {
-		t.Fatalf("Provisioned cell = %q, want \"●\"", rows[0][6])
+	// Columns: 0=marker (★ default + provisioned glyph) 1=Name 2=Type 3=Address 4=Agent 5=OS.
+	if rows[0][0] != "●" {
+		t.Fatalf("provisioned marker cell = %q, want \"●\"", rows[0][0])
 	}
 }
 

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -366,6 +366,95 @@ func TestDiscoverTableItemsAnnotatesLANUSBFromEthernetInterface(t *testing.T) {
 	}
 }
 
+func TestDiscoverTableItemsProvisionedStateAndNoAccessHint(t *testing.T) {
+	collection := &models.DevicesCollection{
+		LANDevices: []models.LANDevice{
+			// Provisioned device the CLI cannot read (metadata probe failed).
+			{DisplayName: "wendy-locked", IPAddress: "192.168.1.30", IsMTLS: true},
+			// Provisioned device the CLI can read.
+			{DisplayName: "wendy-mine", IPAddress: "192.168.1.31", IsMTLS: true, AgentVersion: "1.2.3"},
+			// Unprovisioned device.
+			{DisplayName: "wendy-open", IPAddress: "192.168.1.32", AgentVersion: "1.2.3"},
+		},
+	}
+
+	items := discoverTableItems(collection)
+	if len(items) != 3 {
+		t.Fatalf("got %d items, want 3", len(items))
+	}
+	byName := make(map[string]discoverTableItem, len(items))
+	for _, item := range items {
+		byName[item.info.Name] = item
+	}
+
+	locked := byName["wendy-locked"]
+	if locked.picker.Provisioned != "Provisioned" {
+		t.Fatalf("locked Provisioned = %q, want \"Provisioned\"", locked.picker.Provisioned)
+	}
+	if locked.picker.Hint != discoverNoAccessHint {
+		t.Fatalf("locked Hint = %q, want no-access hint", locked.picker.Hint)
+	}
+	if locked.info.Provisioned != "Provisioned" {
+		t.Fatalf("locked info.Provisioned = %q, want \"Provisioned\"", locked.info.Provisioned)
+	}
+
+	mine := byName["wendy-mine"]
+	if mine.picker.Provisioned != "Provisioned" {
+		t.Fatalf("mine Provisioned = %q, want \"Provisioned\"", mine.picker.Provisioned)
+	}
+	if mine.picker.Hint != "" {
+		t.Fatalf("mine Hint = %q, want empty for accessible device", mine.picker.Hint)
+	}
+
+	open := byName["wendy-open"]
+	if open.picker.Provisioned != "Unprovisioned" {
+		t.Fatalf("open Provisioned = %q, want \"Unprovisioned\"", open.picker.Provisioned)
+	}
+	if open.picker.Hint != "" {
+		t.Fatalf("open Hint = %q, want empty", open.picker.Hint)
+	}
+
+	_, rows := tui.PickerDeviceTableData(discoverPickerItems(items), "", true)
+	// Columns with default marker: 0=★ 1=Name 2=Type 3=Address 4=agent 5=OS 6=Provisioned.
+	if rows[0][6] != "Provisioned" {
+		t.Fatalf("Provisioned cell = %q, want \"Provisioned\"", rows[0][6])
+	}
+}
+
+func TestDiscoverModelViewShowsNoAccessHintForHighlightedDevice(t *testing.T) {
+	m := newDiscoverModel(context.Background(), discovery.DiscoveryOptions{})
+	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{
+		DisplayName: "wendy-locked",
+		IPAddress:   "192.168.1.30",
+		IsMTLS:      true,
+	}}})
+	dm := updated.(discoverModel)
+
+	view := ansi.Strip(dm.View())
+	if !strings.Contains(view, "does not have access") {
+		t.Fatalf("expected no-access hint in view, got %q", view)
+	}
+	if !strings.Contains(view, "wendy auth login") {
+		t.Fatalf("expected login suggestion in view, got %q", view)
+	}
+}
+
+func TestDiscoverModelViewOmitsHintForAccessibleDevice(t *testing.T) {
+	m := newDiscoverModel(context.Background(), discovery.DiscoveryOptions{})
+	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{
+		DisplayName:  "wendy-mine",
+		IPAddress:    "192.168.1.31",
+		IsMTLS:       true,
+		AgentVersion: "1.2.3",
+	}}})
+	dm := updated.(discoverModel)
+
+	view := ansi.Strip(dm.View())
+	if strings.Contains(view, "does not have access") {
+		t.Fatalf("unexpected no-access hint for accessible device: %q", view)
+	}
+}
+
 func TestDiscoverDeviceInfo_JSONSingleDevice(t *testing.T) {
 	info := discoverDeviceInfo{
 		Name:    "wendyos-brave-phoenix",

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -421,6 +421,48 @@ func TestDiscoverTableItemsProvisionedStateAndNoAccessHint(t *testing.T) {
 	}
 }
 
+func TestMergePickerItemClearsNoAccessHintWhenVersionKnown(t *testing.T) {
+	lanItem := func(dev models.LANDevice) tui.PickerItem {
+		return tui.PickerItem{
+			Name:         dev.DisplayName,
+			Type:         "LAN",
+			AgentVersion: dev.AgentVersion,
+			Provisioned:  lanProvisionedDisplay(&dev),
+			Hint:         lanNoAccessHint(&dev, dev.AgentVersion),
+			DedupKey:     dev.DisplayName,
+			Value:        &pickerEntry{mergedDevice: &models.DiscoveredDevice{DisplayName: dev.DisplayName, AgentVersion: dev.AgentVersion, LAN: &dev}},
+		}
+	}
+
+	// A successful probe followed by a failed re-probe: the carried-over
+	// version must not coexist with a hint claiming details are unreadable.
+	existing := lanItem(models.LANDevice{DisplayName: "wendy-mine", IsMTLS: true, AgentVersion: "1.2.3"})
+	mergePickerItem(&existing, lanItem(models.LANDevice{DisplayName: "wendy-mine", IsMTLS: true}))
+	if existing.Hint != "" {
+		t.Fatalf("Hint = %q, want empty when AgentVersion is already known", existing.Hint)
+	}
+	if existing.AgentVersion != "1.2.3" {
+		t.Fatalf("AgentVersion = %q, want carried-over version", existing.AgentVersion)
+	}
+
+	// A failed probe followed by a successful one clears the hint.
+	existing = lanItem(models.LANDevice{DisplayName: "wendy-locked", IsMTLS: true})
+	if existing.Hint == "" {
+		t.Fatal("expected no-access hint on inaccessible provisioned device")
+	}
+	mergePickerItem(&existing, lanItem(models.LANDevice{DisplayName: "wendy-locked", IsMTLS: true, AgentVersion: "1.2.3"}))
+	if existing.Hint != "" {
+		t.Fatalf("Hint = %q, want cleared after successful probe", existing.Hint)
+	}
+
+	// Still-failing probes keep the hint while no version is known.
+	existing = lanItem(models.LANDevice{DisplayName: "wendy-locked", IsMTLS: true})
+	mergePickerItem(&existing, lanItem(models.LANDevice{DisplayName: "wendy-locked", IsMTLS: true}))
+	if existing.Hint != discoverNoAccessHint {
+		t.Fatalf("Hint = %q, want no-access hint to persist", existing.Hint)
+	}
+}
+
 func TestDiscoverModelViewShowsNoAccessHintForHighlightedDevice(t *testing.T) {
 	m := newDiscoverModel(context.Background(), discovery.DiscoveryOptions{})
 	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -272,8 +272,33 @@ func TestDiscoverModel_DKeySetsDefaultAndMarksSelectedDevice(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected clearFlashAfter cmd")
 	}
-	if !strings.Contains(um.table.View(), "★") {
+	if !strings.Contains(um.table.View(), "✦") {
 		t.Fatalf("expected selected default device to show marker, got %q", um.table.View())
+	}
+}
+
+func TestDiscoverTableItemsHidesAddressForDockerAndLocal(t *testing.T) {
+	collection := &models.DevicesCollection{
+		ExternalDevices: []models.ExternalDevice{
+			{ID: "docker", DisplayName: "Docker", ProviderKey: "docker"},
+			{ID: "local", DisplayName: "This Mac", ProviderKey: "local"},
+			{ID: "emulator-5554", DisplayName: "Pixel 8", ProviderKey: "android-adb"},
+		},
+	}
+
+	items := discoverTableItems(collection)
+	byName := make(map[string]discoverTableItem, len(items))
+	for _, item := range items {
+		byName[item.info.Name] = item
+	}
+
+	for _, name := range []string{"Docker", "This Mac"} {
+		if got := byName[name].picker.Address; got != "" {
+			t.Fatalf("%s Address = %q, want hidden", name, got)
+		}
+	}
+	if got := byName["Pixel 8"].picker.Address; got != "android-adb: emulator-5554" {
+		t.Fatalf("Pixel 8 Address = %q, want provider-qualified ID", got)
 	}
 }
 
@@ -434,7 +459,7 @@ func TestDiscoverTableItemsProvisionedStateAndNoAccessHint(t *testing.T) {
 	}
 
 	_, rows := tui.PickerDeviceTableData(discoverPickerItems(items), "", true)
-	// Columns: 0=marker (★ default + provisioned glyph) 1=Name 2=Type 3=Address 4=Agent 5=OS.
+	// Columns: 0=marker (provisioned glyph + ✦ default) 1=Name 2=Type 3=Address 4=Agent 5=OS.
 	if rows[0][0] != "●" {
 		t.Fatalf("provisioned marker cell = %q, want \"●\"", rows[0][0])
 	}

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -518,7 +518,7 @@ func TestEnsureProviderSupportsProjectType_LocalRejectsContainerProjects(t *test
 				t.Fatal("expected error")
 			}
 			msg := err.Error()
-			for _, want := range []string{"Local Machine", "host-native", "Docker Desktop", "--device docker"} {
+			for _, want := range []string{providers.LocalDisplayName(), "host-native", "Docker", "--device docker"} {
 				if !strings.Contains(msg, want) {
 					t.Fatalf("error = %q, want substring %q", msg, want)
 				}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1282,11 +1282,17 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 	// Propagate security status: LAN probes determine mTLS, BLE doesn't. Once
 	// we know a device is insecure (or secure), update the existing item.
 	// The same goes for the provisioned state and the no-access hint, which
-	// clears once a probe succeeds.
+	// clears once a probe succeeds. The hint must stay consistent with the
+	// version cell: AgentVersion is carried over from earlier probes (or
+	// backfilled from BLE) above, so a failed re-probe must not claim the
+	// agent details are unreadable while a version is displayed.
 	if nd.LAN != nil {
 		existing.Insecure = incoming.Insecure
 		existing.Provisioned = incoming.Provisioned
 		existing.Hint = incoming.Hint
+		if existing.AgentVersion != "" {
+			existing.Hint = ""
+		}
 	}
 }
 

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1282,17 +1282,18 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 	// Propagate security status: LAN probes determine mTLS, BLE doesn't. Once
 	// we know a device is insecure (or secure), update the existing item.
 	// The same goes for the provisioned state and the no-access hint, which
-	// clears once a probe succeeds. The hint must stay consistent with the
-	// version cell: AgentVersion is carried over from earlier probes (or
-	// backfilled from BLE) above, so a failed re-probe must not claim the
-	// agent details are unreadable while a version is displayed.
+	// clears once a probe succeeds.
 	if nd.LAN != nil {
 		existing.Insecure = incoming.Insecure
 		existing.Provisioned = incoming.Provisioned
 		existing.Hint = incoming.Hint
-		if existing.AgentVersion != "" {
-			existing.Hint = ""
-		}
+	}
+	// The no-access hint must stay consistent with the version cell no matter
+	// which transport supplied the version: AgentVersion is carried over from
+	// earlier LAN probes or backfilled from BLE above, and a hint claiming
+	// agent details are unreadable must not accompany a displayed version.
+	if existing.AgentVersion != "" && existing.Hint == discoverNoAccessHint {
+		existing.Hint = ""
 	}
 }
 

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1457,7 +1457,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 				if err == nil && len(bleDevices) > 0 {
 					var items []tui.PickerItem
 					for i := range bleDevices {
-						connType := "Bluetooth"
+						connType := "BLE"
 						if !bleDevices[i].IsWendyAgent() {
 							connType = "BLE (Lite)"
 						}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1281,8 +1281,12 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 
 	// Propagate security status: LAN probes determine mTLS, BLE doesn't. Once
 	// we know a device is insecure (or secure), update the existing item.
+	// The same goes for the provisioned state and the no-access hint, which
+	// clears once a probe succeeds.
 	if nd.LAN != nil {
 		existing.Insecure = incoming.Insecure
+		existing.Provisioned = incoming.Provisioned
+		existing.Hint = incoming.Hint
 	}
 }
 
@@ -1342,6 +1346,8 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 			Address:      preferredLANAddress(dev),
 			AgentVersion: dev.AgentVersion,
 			OSVersion:    dev.OSVersion,
+			Provisioned:  lanProvisionedDisplay(&devCopy),
+			Hint:         lanNoAccessHint(&devCopy, dev.AgentVersion),
 			DedupKey:     dev.DisplayName,
 			SortKey:      usbFirstSortKey(dev.DisplayName, dev.USB),
 			Insecure:     insecure,

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1313,7 +1313,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 	picker := tui.NewPicker()
 	picker.MergeItem = mergePickerItem
 
-	// Load current default device to show ★ indicator.
+	// Load current default device to show ✦ indicator.
 	if loadedCfg, err := config.Load(); err == nil && loadedCfg.DefaultDevice != "" {
 		picker.DefaultKey = strings.ToLower(loadedCfg.DefaultDevice)
 	}
@@ -1425,7 +1425,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 							items = append(items, tui.PickerItem{
 								Name:         devices[i].DisplayName,
 								Type:         prov.DisplayName(),
-								Address:      fmt.Sprintf("%s: %s", devices[i].ProviderKey, devices[i].ID),
+								Address:      externalProviderAddress(devices[i].ProviderKey, devices[i].ID),
 								AgentVersion: devices[i].AgentVersion,
 								OSVersion:    devices[i].OSVersion,
 								DedupKey:     devices[i].DisplayName,

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -87,12 +87,12 @@ func TestExternalProviderPickerHint(t *testing.T) {
 		{
 			name:        "docker",
 			providerKey: providers.ProviderKeyDocker,
-			want:        "Docker Desktop",
+			want:        "Docker",
 		},
 		{
 			name:        "local",
 			providerKey: providers.ProviderKeyLocal,
-			want:        "Local Machine",
+			want:        providers.LocalDisplayName(),
 		},
 		{
 			name:        "other",
@@ -112,6 +112,11 @@ func TestExternalProviderPickerHint(t *testing.T) {
 			}
 			if !strings.Contains(got, tt.want) {
 				t.Fatalf("hint = %q, want it to mention %q", got, tt.want)
+			}
+			for _, stale := range []string{"Docker Desktop", "Local Machine"} {
+				if strings.Contains(got, stale) {
+					t.Fatalf("hint = %q, want long label %q replaced", got, stale)
+				}
 			}
 		})
 	}

--- a/go/internal/cli/providers/display_test.go
+++ b/go/internal/cli/providers/display_test.go
@@ -1,0 +1,43 @@
+package providers
+
+import (
+	"context"
+	"runtime"
+	"testing"
+)
+
+func TestDockerProviderShortDisplayName(t *testing.T) {
+	p := &DockerProvider{}
+	if got := p.DisplayName(); got != "Docker" {
+		t.Fatalf("DisplayName() = %q, want \"Docker\"", got)
+	}
+}
+
+func TestLocalDisplayNameByPlatform(t *testing.T) {
+	tests := map[string]string{
+		"darwin":  "This Mac",
+		"windows": "This PC",
+		"linux":   "This PC",
+	}
+	for goos, want := range tests {
+		if got := localDisplayNameFor(goos); got != want {
+			t.Fatalf("localDisplayNameFor(%q) = %q, want %q", goos, got, want)
+		}
+	}
+}
+
+func TestLocalProviderUsesPlatformDisplayName(t *testing.T) {
+	p := &LocalProvider{}
+	want := localDisplayNameFor(runtime.GOOS)
+	if got := p.DisplayName(); got != want {
+		t.Fatalf("DisplayName() = %q, want %q", got, want)
+	}
+
+	devices, err := p.DiscoverDevices(context.Background())
+	if err != nil || len(devices) != 1 {
+		t.Fatalf("DiscoverDevices() = %v, %v; want 1 device", devices, err)
+	}
+	if devices[0].DisplayName != want {
+		t.Fatalf("device DisplayName = %q, want %q", devices[0].DisplayName, want)
+	}
+}

--- a/go/internal/cli/providers/docker.go
+++ b/go/internal/cli/providers/docker.go
@@ -40,7 +40,7 @@ func composeFile(dir string) string {
 type DockerProvider struct{}
 
 func (p *DockerProvider) Key() string         { return ProviderKeyDocker }
-func (p *DockerProvider) DisplayName() string { return "Docker Desktop" }
+func (p *DockerProvider) DisplayName() string { return "Docker" }
 
 func (p *DockerProvider) IsAvailable(ctx context.Context) bool {
 	cmd := exec.CommandContext(ctx, "docker", "--version")
@@ -68,7 +68,7 @@ func (p *DockerProvider) DiscoverDevices(ctx context.Context) ([]models.External
 	return []models.ExternalDevice{
 		{
 			ID:            "docker",
-			DisplayName:   "Docker Desktop",
+			DisplayName:   "Docker",
 			ProviderKey:   p.Key(),
 			IsWendyDevice: false,
 			AgentVersion:  version,

--- a/go/internal/cli/providers/local.go
+++ b/go/internal/cli/providers/local.go
@@ -21,8 +21,19 @@ type localBuildContext struct {
 // LocalProvider builds and runs applications on the local machine.
 type LocalProvider struct{}
 
+// LocalDisplayName is the user-facing name for the local machine, e.g.
+// "This Mac" on macOS and "This PC" elsewhere.
+func LocalDisplayName() string { return localDisplayNameFor(runtime.GOOS) }
+
+func localDisplayNameFor(goos string) string {
+	if goos == "darwin" {
+		return "This Mac"
+	}
+	return "This PC"
+}
+
 func (p *LocalProvider) Key() string         { return ProviderKeyLocal }
-func (p *LocalProvider) DisplayName() string { return "This Device" }
+func (p *LocalProvider) DisplayName() string { return LocalDisplayName() }
 
 func (p *LocalProvider) IsAvailable(_ context.Context) bool { return true }
 
@@ -32,7 +43,7 @@ func (p *LocalProvider) DiscoverDevices(_ context.Context) ([]models.ExternalDev
 	return []models.ExternalDevice{
 		{
 			ID:              "local",
-			DisplayName:     "Local Machine",
+			DisplayName:     LocalDisplayName(),
 			ProviderKey:     p.Key(),
 			IsWendyDevice:   false,
 			OS:              runtime.GOOS,

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -14,7 +14,7 @@ type PickerItem struct {
 	// Display columns rendered in the table.
 	Name         string
 	Description  string // optional secondary text rendered dimmed
-	Type         string // "LAN", "Bluetooth", "External", etc.
+	Type         string // "LAN", "BLE", "External", etc.
 	Size         string // optional picker-specific metadata column
 	Parameters   string // optional picker-specific metadata column
 	Comments     string // optional picker-specific metadata column

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -82,7 +82,7 @@ type PickerModel struct {
 
 	// DefaultKey is compared case-insensitively against each item's DedupKey
 	// (or Name if DedupKey is empty). Should be stored lowercase for consistency.
-	// Shown with a ★ indicator in the table.
+	// Shown with a ✦ indicator in the table.
 	DefaultKey string
 
 	items        []PickerItem
@@ -332,7 +332,7 @@ func (m PickerModel) Selected() *PickerItem {
 }
 
 // DeviceTableLegend explains the glyphs used in the compact device table.
-const DeviceTableLegend = "● provisioned  ○ unprovisioned  ⚠ agent older than CLI"
+const DeviceTableLegend = "● provisioned  ○ unprovisioned  ✦ default  ⚠ agent older than CLI"
 
 type pickerColumnDef struct {
 	title    string
@@ -560,14 +560,17 @@ func pickerRows(items []PickerItem, cols []pickerColumnDef, defaultKey string, h
 	rows := make([]bubbleTable.Row, 0, len(items))
 	for _, item := range items {
 		var row bubbleTable.Row
-		// The marker column combines the ★ default indicator with the
-		// provisioned-state glyph (see DeviceTableLegend).
+		// The marker column combines the provisioned-state glyph with the
+		// ✦ default indicator (see DeviceTableLegend).
 		if hasMarkerCol {
-			marker := ""
+			cell := provisionedGlyph(item.Provisioned)
 			if hasDefaultCol && pickerItemMatchesDefaultKey(item, defaultKey) {
-				marker = "★"
+				if cell != "" {
+					cell += " "
+				}
+				cell += "✦"
 			}
-			row = append(row, marker+provisionedGlyph(item.Provisioned))
+			row = append(row, cell)
 		}
 		for _, col := range cols {
 			val := col.value(item)

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -342,8 +342,8 @@ type pickerColumnDef struct {
 	optional bool // hidden when no item has a value, even with fixed columns
 }
 
-// provisionedGlyph maps the PickerItem.Provisioned state to the 1-char cell
-// rendered in the compact "P" column. See DeviceTableLegend.
+// provisionedGlyph maps the PickerItem.Provisioned state to the 1-char glyph
+// rendered in the leading marker column. See DeviceTableLegend.
 func provisionedGlyph(provisioned string) string {
 	switch provisioned {
 	case "Provisioned":
@@ -425,13 +425,6 @@ var pickerDeviceColumnDefs = []pickerColumnDef{
 		minWidth: 4,
 		value: func(item PickerItem) string {
 			return item.OSVersion
-		},
-	},
-	{
-		title:    "P",
-		minWidth: 3,
-		value: func(item PickerItem) string {
-			return provisionedGlyph(item.Provisioned)
 		},
 	},
 	{
@@ -549,21 +542,32 @@ func PickerDeviceTableData(items []PickerItem, defaultKey string, hasDefaultCol 
 
 func pickerTableDataForColumns(items []PickerItem, defaultKey string, hasDefaultCol bool, defs []pickerColumnDef, fixed bool) ([]bubbleTable.Column, []bubbleTable.Row) {
 	activeCols := pickerActiveColumnsForDefs(items, defs, fixed)
-	rows := pickerRows(items, activeCols, defaultKey, hasDefaultCol)
-	return pickerColumns(rows, activeCols, hasDefaultCol), rows
+	hasMarkerCol := hasDefaultCol || anyProvisionedGlyph(items)
+	rows := pickerRows(items, activeCols, defaultKey, hasDefaultCol, hasMarkerCol)
+	return pickerColumns(rows, activeCols, hasMarkerCol), rows
 }
 
-func pickerRows(items []PickerItem, cols []pickerColumnDef, defaultKey string, hasDefaultCol bool) []bubbleTable.Row {
+func anyProvisionedGlyph(items []PickerItem) bool {
+	for _, item := range items {
+		if provisionedGlyph(item.Provisioned) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func pickerRows(items []PickerItem, cols []pickerColumnDef, defaultKey string, hasDefaultCol, hasMarkerCol bool) []bubbleTable.Row {
 	rows := make([]bubbleTable.Row, 0, len(items))
 	for _, item := range items {
 		var row bubbleTable.Row
-		// Always add the ★ column when default tracking is enabled.
-		if hasDefaultCol {
-			if pickerItemMatchesDefaultKey(item, defaultKey) {
-				row = append(row, "★")
-			} else {
-				row = append(row, "")
+		// The marker column combines the ★ default indicator with the
+		// provisioned-state glyph (see DeviceTableLegend).
+		if hasMarkerCol {
+			marker := ""
+			if hasDefaultCol && pickerItemMatchesDefaultKey(item, defaultKey) {
+				marker = "★"
 			}
+			row = append(row, marker+provisionedGlyph(item.Provisioned))
 		}
 		for _, col := range cols {
 			val := col.value(item)
@@ -594,10 +598,10 @@ func pickerItemMatchesDefaultKey(item PickerItem, defaultKey string) bool {
 	return key == defaultKey
 }
 
-func pickerColumns(rows []bubbleTable.Row, defs []pickerColumnDef, hasDefaultCol bool) []bubbleTable.Column {
+func pickerColumns(rows []bubbleTable.Row, defs []pickerColumnDef, hasMarkerCol bool) []bubbleTable.Column {
 	cols := make([]bubbleTable.Column, 0, len(defs)+1)
 	offset := 0
-	if hasDefaultCol {
+	if hasMarkerCol {
 		cols = append(cols, bubbleTable.Column{Title: "", Width: 3})
 		offset = 1
 	}

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -22,6 +22,7 @@ type PickerItem struct {
 	Address      string
 	AgentVersion string
 	OSVersion    string
+	Provisioned  string // "Provisioned" or "Unprovisioned" when known, empty otherwise
 	Hint         string // optional footer text shown when this item is highlighted
 
 	// DedupKey is used for deduplication. If empty, Name is used.
@@ -402,6 +403,13 @@ var pickerDeviceColumnDefs = []pickerColumnDef{
 		minWidth: 16,
 		value: func(item PickerItem) string {
 			return item.OSVersion
+		},
+	},
+	{
+		title:    "Provisioned",
+		minWidth: 13,
+		value: func(item PickerItem) string {
+			return item.Provisioned
 		},
 	},
 	pickerColumnDefs[3],

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -90,6 +90,7 @@ type PickerModel struct {
 	table        BubbleTable
 	columns      []pickerColumnDef
 	fixedColumns bool
+	legend       string // optional glyph legend rendered under the table
 	selected     *PickerItem
 	scanning     bool
 	quitting     bool
@@ -112,6 +113,7 @@ func NewPicker() PickerModel {
 		table:        newPickerTable(),
 		columns:      pickerDeviceColumnDefs,
 		fixedColumns: true,
+		legend:       DeviceTableLegend,
 		scanning:     true,
 	}
 	m.refreshTable()
@@ -278,6 +280,10 @@ func (m PickerModel) View() string {
 
 	sb.WriteString(m.tableView() + "\n")
 
+	if m.legend != "" {
+		sb.WriteString(m.viewLine(pickerHint.Render("  "+m.legend)) + "\n")
+	}
+
 	cursor := m.table.Cursor()
 	if cursor >= 0 && cursor < len(m.items) && m.items[cursor].Insecure {
 		sb.WriteString(m.viewLine(pickerInsecure.Render("  ⚠  Connection is not secured with mTLS. PKI support is coming soon.")) + "\n")
@@ -325,11 +331,27 @@ func (m PickerModel) Selected() *PickerItem {
 	return m.selected
 }
 
+// DeviceTableLegend explains the glyphs used in the compact device table.
+const DeviceTableLegend = "● provisioned  ○ unprovisioned  ⚠ agent older than CLI"
+
 type pickerColumnDef struct {
 	title    string
 	minWidth int
 	value    func(PickerItem) string
 	required bool
+	optional bool // hidden when no item has a value, even with fixed columns
+}
+
+// provisionedGlyph maps the PickerItem.Provisioned state to the 1-char cell
+// rendered in the compact "P" column. See DeviceTableLegend.
+func provisionedGlyph(provisioned string) string {
+	switch provisioned {
+	case "Provisioned":
+		return "●"
+	case "Unprovisioned":
+		return "○"
+	}
+	return ""
 }
 
 func pickerColumnDefsFromColumns(columns []PickerColumn) []pickerColumnDef {
@@ -392,27 +414,34 @@ var pickerDeviceColumnDefs = []pickerColumnDef{
 	pickerColumnDefs[1],
 	pickerColumnDefs[2],
 	{
-		title:    "wendy-agent version",
-		minWidth: 20,
+		title:    "Agent",
+		minWidth: 7,
 		value: func(item PickerItem) string {
 			return item.AgentVersion
 		},
 	},
 	{
-		title:    "WendyOS Version",
-		minWidth: 16,
+		title:    "OS",
+		minWidth: 4,
 		value: func(item PickerItem) string {
 			return item.OSVersion
 		},
 	},
 	{
-		title:    "Provisioned",
-		minWidth: 13,
+		title:    "P",
+		minWidth: 3,
 		value: func(item PickerItem) string {
-			return item.Provisioned
+			return provisionedGlyph(item.Provisioned)
 		},
 	},
-	pickerColumnDefs[3],
+	{
+		title:    "Description",
+		minWidth: 20,
+		value: func(item PickerItem) string {
+			return item.Description
+		},
+		optional: true,
+	},
 }
 
 func newPickerTable() BubbleTable {
@@ -491,12 +520,9 @@ func pickerActiveColumnsForDefs(items []PickerItem, defs []pickerColumnDef, fixe
 	if len(defs) == 0 {
 		defs = pickerColumnDefs
 	}
-	if fixed {
-		return defs
-	}
 	var active []pickerColumnDef
 	for _, def := range defs {
-		if def.required {
+		if def.required || (fixed && !def.optional) {
 			active = append(active, def)
 			continue
 		}

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -192,13 +192,27 @@ func TestPickerDeviceTableData_UsesStableDeviceSchema(t *testing.T) {
 		Name: "alpha",
 	}}, "", false)
 
-	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "Provisioned", "Description"} {
+	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS", "P"} {
 		if !hasColumn(cols, want) {
 			t.Fatalf("expected stable device column %q, got %v", want, cols)
 		}
 	}
+	if hasColumn(cols, "Description") {
+		t.Fatalf("expected Description column hidden when no item sets it, got %v", cols)
+	}
 	if len(rows) != 1 || len(rows[0]) != len(cols) {
 		t.Fatalf("row/column mismatch: rows=%v cols=%v", rows, cols)
+	}
+}
+
+func TestPickerDeviceTableData_ShowsDescriptionWhenAnyItemSetsIt(t *testing.T) {
+	cols, _ := PickerDeviceTableData([]PickerItem{
+		{Name: "alpha"},
+		{Name: "beta", Description: "Full Linux-based edge device"},
+	}, "", false)
+
+	if !hasColumn(cols, "Description") {
+		t.Fatalf("expected Description column when an item sets it, got %v", cols)
 	}
 }
 
@@ -208,7 +222,7 @@ func TestNewPicker_UsesStableDeviceSchemaBeforeMetadataArrives(t *testing.T) {
 	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{Name: "alpha", Value: "alpha"}}})
 	pm := updated.(PickerModel)
 
-	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "Provisioned", "Description"} {
+	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS", "P"} {
 		if !hasColumn(pm.table.Columns(), want) {
 			t.Fatalf("expected stable device column %q, got %v", want, pm.table.Columns())
 		}
@@ -225,14 +239,36 @@ func TestPickerDeviceTableData_ShowsProvisionedState(t *testing.T) {
 	if len(rows) != 3 {
 		t.Fatalf("rows = %v, want 3", rows)
 	}
-	if rows[0][5] != "Provisioned" {
-		t.Fatalf("provisioned cell = %q, want \"Provisioned\"", rows[0][5])
+	if rows[0][5] != "●" {
+		t.Fatalf("provisioned cell = %q, want \"●\"", rows[0][5])
 	}
-	if rows[1][5] != "Unprovisioned" {
-		t.Fatalf("provisioned cell = %q, want \"Unprovisioned\"", rows[1][5])
+	if rows[1][5] != "○" {
+		t.Fatalf("provisioned cell = %q, want \"○\"", rows[1][5])
 	}
 	if rows[2][5] != "" {
 		t.Fatalf("provisioned cell = %q, want empty for unknown state", rows[2][5])
+	}
+}
+
+func TestNewPicker_ShowsDeviceTableLegend(t *testing.T) {
+	m := NewPicker()
+
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{Name: "alpha", Value: "alpha"}}})
+	pm := updated.(PickerModel)
+
+	if !strings.Contains(pm.View(), DeviceTableLegend) {
+		t.Fatalf("expected device picker view to contain legend %q, got %q", DeviceTableLegend, pm.View())
+	}
+}
+
+func TestNewPickerWithTitle_HasNoDeviceTableLegend(t *testing.T) {
+	m := NewPickerWithTitle("Select a WiFi network")
+
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{Name: "alpha", Value: "alpha"}}})
+	pm := updated.(PickerModel)
+
+	if strings.Contains(pm.View(), "● provisioned") {
+		t.Fatalf("expected non-device picker view without legend, got %q", pm.View())
 	}
 }
 

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -427,13 +427,13 @@ func TestPickerModel_ShowsUSBInTypeColumn(t *testing.T) {
 }
 
 func TestPickerModel_ShowsSelectedHintAtBottom(t *testing.T) {
-	dockerHint := "Hint: Use Docker Desktop for local container or Compose runs when you do not need WendyOS hardware."
-	localHint := "Hint: Use Local Machine for native Swift, Go, or Python apps that should run directly on this computer."
+	dockerHint := "Hint: Use Docker for local container or Compose runs when you do not need WendyOS hardware."
+	localHint := "Hint: Use This Mac for native Swift, Go, or Python apps that should run directly on this computer."
 	m := NewPicker()
 
 	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
-		{Name: "Docker Desktop", Type: "Docker Desktop", Hint: dockerHint, Value: "docker"},
-		{Name: "Local Machine", Type: "This Device", Hint: localHint, Value: "local"},
+		{Name: "Docker", Type: "Docker", Hint: dockerHint, Value: "docker"},
+		{Name: "This Mac", Type: "This Mac", Hint: localHint, Value: "local"},
 	}})
 	pm := updated.(PickerModel)
 

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -192,13 +192,15 @@ func TestPickerDeviceTableData_UsesStableDeviceSchema(t *testing.T) {
 		Name: "alpha",
 	}}, "", false)
 
-	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS", "P"} {
+	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS"} {
 		if !hasColumn(cols, want) {
 			t.Fatalf("expected stable device column %q, got %v", want, cols)
 		}
 	}
-	if hasColumn(cols, "Description") {
-		t.Fatalf("expected Description column hidden when no item sets it, got %v", cols)
+	for _, gone := range []string{"Description", "P"} {
+		if hasColumn(cols, gone) {
+			t.Fatalf("expected no %q column, got %v", gone, cols)
+		}
 	}
 	if len(rows) != 1 || len(rows[0]) != len(cols) {
 		t.Fatalf("row/column mismatch: rows=%v cols=%v", rows, cols)
@@ -222,31 +224,54 @@ func TestNewPicker_UsesStableDeviceSchemaBeforeMetadataArrives(t *testing.T) {
 	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{Name: "alpha", Value: "alpha"}}})
 	pm := updated.(PickerModel)
 
-	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS", "P"} {
+	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS"} {
 		if !hasColumn(pm.table.Columns(), want) {
 			t.Fatalf("expected stable device column %q, got %v", want, pm.table.Columns())
 		}
 	}
 }
 
-func TestPickerDeviceTableData_ShowsProvisionedState(t *testing.T) {
-	_, rows := PickerDeviceTableData([]PickerItem{
+func TestPickerDeviceTableData_ShowsProvisionedStateInMarkerColumn(t *testing.T) {
+	cols, rows := PickerDeviceTableData([]PickerItem{
 		{Name: "alpha", Provisioned: "Provisioned"},
 		{Name: "beta", Provisioned: "Unprovisioned"},
 		{Name: "gamma"},
 	}, "", false)
 
+	// The marker column appears even without default tracking because rows
+	// carry provisioned glyphs.
+	if cols[0].Title != "" {
+		t.Fatalf("cols[0] = %v, want unlabeled marker column", cols)
+	}
 	if len(rows) != 3 {
 		t.Fatalf("rows = %v, want 3", rows)
 	}
-	if rows[0][5] != "●" {
-		t.Fatalf("provisioned cell = %q, want \"●\"", rows[0][5])
+	if rows[0][0] != "●" {
+		t.Fatalf("provisioned cell = %q, want \"●\"", rows[0][0])
 	}
-	if rows[1][5] != "○" {
-		t.Fatalf("provisioned cell = %q, want \"○\"", rows[1][5])
+	if rows[1][0] != "○" {
+		t.Fatalf("provisioned cell = %q, want \"○\"", rows[1][0])
 	}
-	if rows[2][5] != "" {
-		t.Fatalf("provisioned cell = %q, want empty for unknown state", rows[2][5])
+	if rows[2][0] != "" {
+		t.Fatalf("provisioned cell = %q, want empty for unknown state", rows[2][0])
+	}
+}
+
+func TestPickerDeviceTableData_CombinesDefaultMarkerAndProvisionedGlyph(t *testing.T) {
+	_, rows := PickerDeviceTableData([]PickerItem{
+		{Name: "alpha", Provisioned: "Provisioned"},
+	}, "alpha", true)
+
+	if rows[0][0] != "★●" {
+		t.Fatalf("marker cell = %q, want \"★●\"", rows[0][0])
+	}
+}
+
+func TestPickerDeviceTableData_OmitsMarkerColumnWithoutDefaultsOrGlyphs(t *testing.T) {
+	cols, _ := PickerDeviceTableData([]PickerItem{{Name: "alpha"}}, "", false)
+
+	if cols[0].Title != "Name" {
+		t.Fatalf("cols = %v, want Name first without marker column", cols)
 	}
 }
 

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -192,7 +192,7 @@ func TestPickerDeviceTableData_UsesStableDeviceSchema(t *testing.T) {
 		Name: "alpha",
 	}}, "", false)
 
-	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "Description"} {
+	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "Provisioned", "Description"} {
 		if !hasColumn(cols, want) {
 			t.Fatalf("expected stable device column %q, got %v", want, cols)
 		}
@@ -208,10 +208,31 @@ func TestNewPicker_UsesStableDeviceSchemaBeforeMetadataArrives(t *testing.T) {
 	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{Name: "alpha", Value: "alpha"}}})
 	pm := updated.(PickerModel)
 
-	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "Description"} {
+	for _, want := range []string{"Name", "Type", "Address", "wendy-agent version", "WendyOS Version", "Provisioned", "Description"} {
 		if !hasColumn(pm.table.Columns(), want) {
 			t.Fatalf("expected stable device column %q, got %v", want, pm.table.Columns())
 		}
+	}
+}
+
+func TestPickerDeviceTableData_ShowsProvisionedState(t *testing.T) {
+	_, rows := PickerDeviceTableData([]PickerItem{
+		{Name: "alpha", Provisioned: "Provisioned"},
+		{Name: "beta", Provisioned: "Unprovisioned"},
+		{Name: "gamma"},
+	}, "", false)
+
+	if len(rows) != 3 {
+		t.Fatalf("rows = %v, want 3", rows)
+	}
+	if rows[0][5] != "Provisioned" {
+		t.Fatalf("provisioned cell = %q, want \"Provisioned\"", rows[0][5])
+	}
+	if rows[1][5] != "Unprovisioned" {
+		t.Fatalf("provisioned cell = %q, want \"Unprovisioned\"", rows[1][5])
+	}
+	if rows[2][5] != "" {
+		t.Fatalf("provisioned cell = %q, want empty for unknown state", rows[2][5])
 	}
 }
 

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -182,7 +182,7 @@ func TestPickerTableData_KeepsDefaultMarkerInNarrowWidth(t *testing.T) {
 	if len(cols) < 2 || cols[0].Title != "" || cols[1].Title != "Name" {
 		t.Fatalf("columns = %v, want marker and Name columns", cols)
 	}
-	if len(rows) != 1 || len(rows[0]) < 1 || rows[0][0] != "★" {
+	if len(rows) != 1 || len(rows[0]) < 1 || rows[0][0] != "✦" {
 		t.Fatalf("default marker row = %v, want leading star", rows)
 	}
 }
@@ -262,8 +262,8 @@ func TestPickerDeviceTableData_CombinesDefaultMarkerAndProvisionedGlyph(t *testi
 		{Name: "alpha", Provisioned: "Provisioned"},
 	}, "alpha", true)
 
-	if rows[0][0] != "★●" {
-		t.Fatalf("marker cell = %q, want \"★●\"", rows[0][0])
+	if rows[0][0] != "● ✦" {
+		t.Fatalf("marker cell = %q, want \"● ✦\"", rows[0][0])
 	}
 }
 
@@ -470,8 +470,8 @@ func TestPickerModel_DefaultKeyShowsStar(t *testing.T) {
 	pm := updated.(PickerModel)
 
 	view := pm.View()
-	if !strings.Contains(view, "★") {
-		t.Error("expected ★ indicator for default item")
+	if !strings.Contains(view, "✦") {
+		t.Error("expected ✦ indicator for default item")
 	}
 	if !strings.Contains(view, "d set default") {
 		t.Error("expected hint text to contain 'd set default'")
@@ -492,8 +492,8 @@ func TestPickerTableData_DefaultKeysShowStar(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("got %d rows, want 1", len(rows))
 	}
-	if rows[0][0] != "★" {
-		t.Fatalf("default marker = %q, want ★", rows[0][0])
+	if rows[0][0] != "✦" {
+		t.Fatalf("default marker = %q, want ✦", rows[0][0])
 	}
 }
 

--- a/go/internal/shared/models/devices.go
+++ b/go/internal/shared/models/devices.go
@@ -157,7 +157,7 @@ type DiscoveredDevice struct {
 }
 
 // ConnectionTypes returns a human-readable list of available transports,
-// e.g. "LAN", "Bluetooth", or "LAN, Bluetooth".
+// e.g. "LAN", "BLE", or "LAN, BLE".
 func (d *DiscoveredDevice) ConnectionTypes() string {
 	var types []string
 	if d.LAN != nil {
@@ -165,7 +165,7 @@ func (d *DiscoveredDevice) ConnectionTypes() string {
 	}
 	if d.Bluetooth != nil {
 		if d.Bluetooth.IsWendyAgent() {
-			types = append(types, "Bluetooth")
+			types = append(types, "BLE")
 		} else {
 			types = append(types, "BLE (Lite)")
 		}

--- a/go/internal/shared/models/devices_test.go
+++ b/go/internal/shared/models/devices_test.go
@@ -187,8 +187,8 @@ func TestMergedDevices_LANAndBLESameName(t *testing.T) {
 	if d.Bluetooth == nil {
 		t.Fatal("Bluetooth is nil, want non-nil")
 	}
-	if d.ConnectionTypes() != "LAN, Bluetooth" {
-		t.Errorf("ConnectionTypes() = %q, want %q", d.ConnectionTypes(), "LAN, Bluetooth")
+	if d.ConnectionTypes() != "LAN, BLE" {
+		t.Errorf("ConnectionTypes() = %q, want %q", d.ConnectionTypes(), "LAN, BLE")
 	}
 	if d.Address() != "192.168.1.10" {
 		t.Errorf("Address() = %q, want %q", d.Address(), "192.168.1.10")
@@ -240,8 +240,8 @@ func TestMergedDevices_BLEOnly(t *testing.T) {
 	if d.Bluetooth == nil {
 		t.Fatal("Bluetooth should be non-nil")
 	}
-	if d.ConnectionTypes() != "Bluetooth" {
-		t.Errorf("ConnectionTypes() = %q, want %q", d.ConnectionTypes(), "Bluetooth")
+	if d.ConnectionTypes() != "BLE" {
+		t.Errorf("ConnectionTypes() = %q, want %q", d.ConnectionTypes(), "BLE")
 	}
 	if d.Address() != "11:22:33:44:55:66" {
 		t.Errorf("Address() = %q, want BLE address", d.Address())


### PR DESCRIPTION
Closes #955

## Problem

When the CLI is unprovisioned or logged into Wendy Cloud with credentials that don't have access to a device, `wendy discover` shows the device with a blank wendy-agent version and no explanation of why.

## Changes

- **New "Provisioned" column** in the shared device table schema (`tui.PickerItem.Provisioned`), shown in `wendy discover` (continuous and `--timeout` modes) and the interactive device picker. LAN devices show `Provisioned`/`Unprovisioned` from the mDNS-advertised mTLS state; transports that don't report it (BLE-only, USB, external providers) stay blank.
- **No-access hint on the highlighted row:** when a device advertises mTLS (provisioned) but the agent metadata probe came back empty — the signature of a CLI that can't authenticate to it — an amber hint renders under the table:

  > ⚠  This device is provisioned and this CLI does not have access, so agent details cannot be read. Run 'wendy auth login' with an account that can access it.

  The hint clears once a probe succeeds (e.g. after logging in), and the existing last-known-version carry-over keeps transient probe blips from flashing it. The same hint flows into the device picker via its existing `Hint` footer.
- The clipboard JSON copied with enter/`a` now includes a `provisioned` field.

## Rendered view

```
⟳ Scanning for WendyOS devices...
  ↑/↓ navigate, enter copy, a copy all, u update, d set default, x unset default, q quit

      Name                     Type     Address               wendy-agent version    WendyOS Version    Provisioned
      wendyos-sunny-daisy      LAN      192.168.1.31:50051    2026.05.30-161141      WendyOS-0.10.4     Unprovisioned
      wendyos-zestful-stork    LAN      192.168.1.30:50051                                              Provisioned
  ⚠  This device is provisioned and this CLI does not have access, so agent details cannot be read. Run 'wendy auth login' with an account that can access it.
```
(hint shown when the cursor is on `wendyos-zestful-stork`)

## Testing

- `go build ./...`, `go vet`, `gofmt` clean
- `go test ./internal/cli/tui/... ./internal/cli/commands/...` passes, including 5 new tests covering column values for provisioned/unprovisioned/unknown devices, hint conditions (no hint for accessible or unprovisioned devices), and the rendered bubbletea view.