### PR TITLE
docs: verify Xcode HelloMLX run flow

### DIFF
--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -31,8 +31,12 @@ const (
 	grpcInitialConnWindow   = 512 * 1024
 	grpcReadBufferSize      = 256 * 1024
 	grpcWriteBufferSize     = 256 * 1024
-	grpcKeepaliveTime       = 30 * time.Second
-	grpcKeepaliveTimeout    = 10 * time.Second
+
+	// Keep direct-agent pings conservative. macOS agents may close long-running
+	// build/deploy/log streams when clients ping more frequently than the
+	// server's HTTP/2 keepalive policy allows.
+	grpcKeepaliveTime    = 5 * time.Minute
+	grpcKeepaliveTimeout = 10 * time.Second
 )
 
 type AgentConnection struct {
@@ -61,7 +65,7 @@ func Connect(ctx context.Context, address string) (*AgentConnection, error) {
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:                grpcKeepaliveTime,
 			Timeout:             grpcKeepaliveTimeout,
-			PermitWithoutStream: true,
+			PermitWithoutStream: false,
 		}),
 	)
 	if err != nil {
@@ -102,7 +106,7 @@ func ConnectWithTLS(ctx context.Context, address string, certInfo *config.Certif
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:                grpcKeepaliveTime,
 			Timeout:             grpcKeepaliveTimeout,
-			PermitWithoutStream: true,
+			PermitWithoutStream: false,
 		}),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Validated the beta Xcode/macOS run path with `Examples/HelloMLX/HelloMLX.xcodeproj` and `Examples/HelloMLX/wendy.json`.
- Confirmed `wendy run` detects the Xcode project, builds with Xcode, syncs the VLM model/resources, starts HelloMLX on Wendy Agent for Mac, and streams runtime logs.
- Relaxed direct-agent gRPC keepalive pings after the remote Mac run exposed an actionable `too_many_pings` stream failure.

Closes WDY-1353.

## Validation
- Host: Apple Silicon macOS 26.5.1 (`arm64`)
- Xcode: 26.4 / build 17E192
- CLI: `wendy version dev`
- Local target agent: `localhost:50051`, Wendy Agent for Mac `2026.06.09-034757`, macOS 26.5.1, `arm64`
- Remote target observed before the keepalive fix: `mac-mini.local:50051`, Wendy Agent for Mac `0000.00.00-000000-dev`, macOS 26.3.2, `arm64`

Commands run:

```sh
xcodebuild -list -project Examples/HelloMLX/HelloMLX.xcodeproj
xcodebuild -project Examples/HelloMLX/HelloMLX.xcodeproj \
  -scheme HelloMLX \
  -configuration Release \
  -destination 'platform=macOS,arch=arm64' \
  build CODE_SIGNING_ALLOWED=NO

cd Examples/HelloMLX
./Scripts/DownloadVLM.sh
wendy run --device localhost:50051 --yes
wendy device apps stop sh.wendy.examples.HelloMLX --device localhost:50051 --json
```

Result:

- Xcode project listing/build: passed.
- Model setup: downloaded `mlx-community/gemma-3-27b-it-qat-4bit` locally.
- Local `wendy run --device localhost:50051 --yes`: passed.
  - `Building Xcode project HelloMLX.xcodeproj (scheme: HelloMLX)...`
  - `Total: 17 GB in 26 file(s)`
  - `Container sh.wendy.examples.HelloMLX created.`
  - `Application sh.wendy.examples.HelloMLX started.`
  - `HELLO_MLX_URL=http://konstantins-macbook-pro-m5.local:8080/`
  - `Model loaded successfully: sh.wendy.examples.HelloMLX/gemma-3-27b-it-qat-4bit`
  - `Sampling at 1.0 fps, evaluating last 5.0s of frames at 256x256.`
- The CLI session was interrupted after runtime proof because HelloMLX is a long-running app/log stream.
- Remote `mac-mini.local:50051` run also built, synced, started, loaded the model, and streamed logs, then hit `ENHANCE_YOUR_CALM` / `too_many_pings`; this PR includes the keepalive fix for that failure mode.

Narrow code validation:

```sh
cd go
go test ./internal/cli/grpcclient ./internal/cli/commands
make build-cli
```
