### PR TITLE
docs: verify Mac app lifecycle commands

### DIFF
--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -350,6 +350,30 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         await self.publishApps()
     }
 
+    private func removeNativeAppDirectory(appName: String) throws {
+        let appsBaseDirectory = self.appsBase.standardizedFileURL
+        let appDirectory = appsBaseDirectory.appendingPathComponent(appName).standardizedFileURL
+
+        guard appDirectory.path.hasPrefix(appsBaseDirectory.path + "/") else {
+            self.logger.warning(
+                "Skipping native app directory removal outside apps base",
+                metadata: [
+                    "app_name": "\(appName)",
+                    "directory": "\(appDirectory.path)",
+                    "apps_base": "\(appsBaseDirectory.path)",
+                ]
+            )
+            return
+        }
+
+        guard FileManager.default.fileExists(atPath: appDirectory.path) else { return }
+        try FileManager.default.removeItem(at: appDirectory)
+        self.logger.info(
+            "Native app directory removed",
+            metadata: ["app_name": "\(appName)", "directory": "\(appDirectory.path)"]
+        )
+    }
+
     nonisolated private static func makeProcessExitTask(
         _ process: Foundation.Process
     ) -> Task<Void, Never> {
@@ -706,6 +730,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             await self.removeApp(id: appName)
             logger.info("Docker container removed", metadata: ["app_name": "\(appName)"])
         } else {
+            try self.removeNativeAppDirectory(appName: appName)
             await self.removeApp(id: appName)
         }
 

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
@@ -54,6 +54,7 @@ struct ContainerServiceTests {
 
         try await deleteApp(service: service, appID: appID)
         #expect(await recorder.last() == .some([]))
+        #expect(!FileManager.default.fileExists(atPath: appDirectory.path))
     }
 
     @Test("spontaneous native exits publish a stopped app update")
@@ -347,6 +348,32 @@ struct ContainerServiceTests {
             appsBase: URL(fileURLWithPath: appsBase)
         )
 
+        #expect(await service.currentAppInfosForTesting().isEmpty)
+    }
+
+    @Test("delete removes orphaned native app directories")
+    func deleteRemovesOrphanedNativeAppDirectories() async throws {
+        let appsBase = try makeTempDir()
+        defer { cleanup(appsBase) }
+
+        let appID = "sh.wendy.tests.OrphanedAppDirectory"
+        let appDirectory = URL(fileURLWithPath: appsBase).appendingPathComponent(appID)
+        try FileManager.default.createDirectory(at: appDirectory, withIntermediateDirectories: true)
+        try "orphaned".write(
+            to: appDirectory.appendingPathComponent("payload.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let service = ContainerService(
+            broadcaster: TelemetryBroadcaster(),
+            executablePath: "/usr/bin/false",
+            appsBase: URL(fileURLWithPath: appsBase)
+        )
+
+        try await deleteApp(service: service, appID: appID)
+
+        #expect(!FileManager.default.fileExists(atPath: appDirectory.path))
         #expect(await service.currentAppInfosForTesting().isEmpty)
     }
 


### PR DESCRIPTION
## Summary
- Validated the narrow Mac beta app lifecycle sanity pass against Wendy Agent for Mac.
- Found that `device apps remove --force` removed native Mac apps from the lifecycle registry but left their synced app directory on disk.
- Fixed native Mac app deletion so it also removes the expected app payload directory under the agent apps directory, including orphaned payloads from prior registry-only removals.

Closes WDY-1350.

## Validation
Initial target environment:
- CLI: `./go/bin/wendy` built from this branch (`dev`)
- Device: `localhost:50051`
- Agent OS: `darwin` `26.5.1`, `arm64`
- Agent version: `2026.06.09-034757`

Initial lifecycle commands run:
- `cd go && make build-cli`
- `./go/bin/wendy --device localhost:50051 device info --json`
  - Returned the Mac agent details above.
- `./go/bin/wendy --device localhost:50051 device apps list --json`
  - Returned `sh.wendy.examples.HelloMLX` and `sh.wendy.smoke.native-run`, both `STOPPED`.
- `./go/bin/wendy --device localhost:50051 device apps stop sh.wendy.smoke.native-run --json`
  - Succeeded: `Application sh.wendy.smoke.native-run stopped.`
- `./go/bin/wendy --device localhost:50051 device apps remove sh.wendy.smoke.native-run --force --json`
  - Succeeded: `Application sh.wendy.smoke.native-run removed.`
- `./go/bin/wendy --device localhost:50051 device apps stop sh.wendy.examples.HelloMLX --json`
  - Succeeded: `Application sh.wendy.examples.HelloMLX stopped.`
- `./go/bin/wendy --device localhost:50051 device apps remove sh.wendy.examples.HelloMLX --force --json`
  - Succeeded: `Application sh.wendy.examples.HelloMLX removed.`
- `./go/bin/wendy --device localhost:50051 device apps list --json`
  - Returned `[]` after removal.

Follow-up disk validation after the fix:
- `cd swift && make agent-start`
  - Built and launched dev `WendyAgentMac.app` with agent version `0000.00.00-000000-dev`.
- `./go/bin/wendy --device localhost:50051 run --prefix Examples/HelloMac --detach --yes`
  - Built, synced, created, and started `sh.wendy.examples.HelloMac`.
- `./go/bin/wendy --device localhost:50051 device apps list --json`
  - Returned `sh.wendy.examples.HelloMac` as `RUNNING`.
- Checked disk payload at `~/Library/Application Support/sh.wendy.WendyAgentMac/apps/sh.wendy.examples.HelloMac`
  - Confirmed synced files existed: `HelloMac`, `HelloMac_HelloMac.bundle/Example.txt`, and `sandbox.sb`.
- `./go/bin/wendy --device localhost:50051 device apps stop sh.wendy.examples.HelloMac --json`
  - Succeeded: `Application sh.wendy.examples.HelloMac stopped.`
- `./go/bin/wendy --device localhost:50051 device apps list --json`
  - Returned `sh.wendy.examples.HelloMac` as `STOPPED`.
- `pgrep -fl 'HelloMac|sh.wendy.examples.HelloMac'`
  - Returned no running app process after stop.
- `./go/bin/wendy --device localhost:50051 device apps remove sh.wendy.examples.HelloMac --force --json`
  - Succeeded: `Application sh.wendy.examples.HelloMac removed.`
- `./go/bin/wendy --device localhost:50051 device apps list --json`
  - Returned `[]`.
- Checked `~/Library/Application Support/sh.wendy.WendyAgentMac/apps/sh.wendy.examples.HelloMac`
  - Confirmed the app directory was removed.
- Checked `~/Library/Application Support/sh.wendy.WendyAgentMac/info.json`
  - Confirmed `sh.wendy.examples.HelloMac` was no longer present.

Orphan cleanup validation:
- With the fixed dev agent running, checked stale payloads left by the earlier registry-only removals:
  - `~/Library/Application Support/sh.wendy.WendyAgentMac/apps/sh.wendy.smoke.native-run` existed (`52K`).
  - `~/Library/Application Support/sh.wendy.WendyAgentMac/apps/sh.wendy.examples.HelloMLX` existed (`16G`).
- `./go/bin/wendy --device localhost:50051 device apps remove sh.wendy.smoke.native-run --force --json`
  - Succeeded and removed the stale app directory.
- `./go/bin/wendy --device localhost:50051 device apps remove sh.wendy.examples.HelloMLX --force --json`
  - Succeeded and removed the stale app directory.
- `./go/bin/wendy --device localhost:50051 device apps list --json`
  - Returned `[]`.
- `cd swift && make agent-stop`

Automated tests:
- `cd swift && swift format --in-place WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift`
- `cd swift/WendyAgentCore && swift test --filter ContainerServiceTests`
  - Passed: 16 tests.
