### PR TITLE
ci: disable Swift E2E PR runs

### DIFF
--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -1,12 +1,9 @@
 name: Swift E2E Tests
 
+# TEMPORARILY DISABLED: Pull request Swift E2E runs are disabled while
+# WDY-1479 investigates the SER9 mTLS auth failure. Keep main, manual dispatch,
+# and workflow_call available for targeted debugging.
 on:
-  pull_request:
-    paths:
-      - 'swift/**'
-      - 'Proto/**'
-      - '.github/actions/swift-e2e-run/**'
-      - '.github/workflows/swift-e2e-tests.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Temporarily disables Swift E2E runs on pull requests while SER9 mTLS auth is investigated.
- Keeps `push` to `main`, `workflow_dispatch`, and `workflow_call` enabled for mainline coverage and targeted debugging.

## Tracking
- Investigating in [WDY-1479](https://linear.app/wendylabsinc/issue/WDY-1479/investigate-ser9-swift-e2e-mtls-auth-failure).

## Testing
- Not run; workflow trigger-only change.