### PR TITLE
Revert "fix(auth): store PAT from login callback; fix certXFCC asset fallback (#959)"

### DIFF
--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -83,11 +83,6 @@ func newAuthLoginCmd() *cobra.Command {
 	return cmd
 }
 
-type loginCallbackResult struct {
-	EnrollmentToken string
-	APIKey          string
-}
-
 func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	// Step 1: Start a local HTTP server to receive the OAuth callback.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -96,8 +91,8 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
 
-	// Channel to receive the enrollment token and PAT from the callback.
-	tokenCh := make(chan loginCallbackResult, 1)
+	// Channel to receive the enrollment token from the callback.
+	tokenCh := make(chan string, 1)
 	errCh := make(chan error, 1)
 
 	mux := http.NewServeMux()
@@ -108,7 +103,6 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 			errCh <- fmt.Errorf("callback received without token")
 			return
 		}
-		apiKey := r.URL.Query().Get("api_key")
 
 		w.Header().Set("Content-Type", "text/html")
 		fmt.Fprintf(w, `<!DOCTYPE html>
@@ -158,7 +152,7 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
   </div>
 </body>
 </html>`)
-		tokenCh <- loginCallbackResult{EnrollmentToken: token, APIKey: apiKey}
+		tokenCh <- token
 	})
 
 	server := &http.Server{Handler: mux}
@@ -190,10 +184,10 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 
 	fmt.Println(tui.InfoMessage("Waiting for authentication..."))
 
-	// Wait for the token and PAT.
-	var result loginCallbackResult
+	// Wait for the token.
+	var enrollmentToken string
 	select {
-	case result = <-tokenCh:
+	case enrollmentToken = <-tokenCh:
 		fmt.Println(tui.SuccessMessage("Received enrollment token."))
 	case loginErr := <-errCh:
 		return fmt.Errorf("login failed: %w", loginErr)
@@ -207,7 +201,7 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 		return fmt.Errorf("generating key pair: %w", err)
 	}
 
-	commonName, err := enrollmentTokenCommonName(result.EnrollmentToken)
+	commonName, err := enrollmentTokenCommonName(enrollmentToken)
 	if err != nil {
 		return fmt.Errorf("reading enrollment token identity: %w", err)
 	}
@@ -235,7 +229,7 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	certClient := cloudpb.NewCertificateServiceClient(certConn)
 	issueResp, err := certClient.IssueCertificate(ctx, &cloudpb.IssueCertificateRequest{
 		PemCsr:          csrPEM,
-		EnrollmentToken: result.EnrollmentToken,
+		EnrollmentToken: enrollmentToken,
 	})
 	if err != nil {
 		return fmt.Errorf("issuing certificate: %w", err)
@@ -267,7 +261,6 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	authEntry := config.AuthConfig{
 		CloudDashboard: cloudDashboard,
 		CloudGRPC:      cloudGRPC,
-		APIKey:         result.APIKey,
 		Certificates:   []config.CertificateInfo{certInfo},
 	}
 
@@ -382,7 +375,6 @@ func performLocalLogin(ctx context.Context, cloudGRPC, apiKey string, orgID int3
 		PemCertificateChain: cert.GetPemCertificateChain(),
 		PemPrivateKey:       privateKeyPEM,
 		OrganizationID:      int(issueResp.GetOrganizationId()),
-		AssetID:             int(issueResp.GetAssetId()),
 	}
 	authEntry := config.AuthConfig{
 		CloudGRPC:    cloudGRPC,

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -43,10 +43,7 @@ func certXFCC(cert config.CertificateInfo) string {
 	if cert.UserID != "" {
 		return fmt.Sprintf("URI=urn:wendy:org:%d:user:%s", cert.OrganizationID, cert.UserID)
 	}
-	if cert.AssetID != 0 {
-		return fmt.Sprintf("URI=urn:wendy:org:%d:asset:%d", cert.OrganizationID, cert.AssetID)
-	}
-	return ""
+	return fmt.Sprintf("URI=urn:wendy:org:%d:user:unknown", cert.OrganizationID)
 }
 
 func cloudContext(ctx context.Context, auth *config.AuthConfig) context.Context {
@@ -59,10 +56,8 @@ func cloudContext(ctx context.Context, auth *config.AuthConfig) context.Context 
 		md.Set("authorization", "Bearer "+auth.APIKey)
 	}
 	certHeader := certXFCC(cert)
-	if certHeader != "" {
-		md.Set("x-wendy-client-cert", certHeader)
-		md.Set("x-forwarded-client-cert", certHeader)
-	}
+	md.Set("x-wendy-client-cert", certHeader)
+	md.Set("x-forwarded-client-cert", certHeader)
 	return metadata.NewOutgoingContext(ctx, md)
 }
 

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -31,7 +31,6 @@ type CertificateInfo struct {
 	PemPrivateKey       string `json:"pemPrivateKey,omitempty"`
 	OrganizationID      int    `json:"organizationId"`
 	UserID              string `json:"userId,omitempty"`
-	AssetID             int    `json:"assetId,omitempty"`
 }
 
 // AnalyticsConfig holds analytics preferences.


### PR DESCRIPTION
Reverts the squash merge that was applied without review.

The fix itself is correct; it is being re-submitted for review in a separate pull request.