### PR TITLE
fix(auth): store PAT from login callback; fix certXFCC asset fallback

### DIFF
--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -83,6 +83,11 @@ func newAuthLoginCmd() *cobra.Command {
 	return cmd
 }
 
+type loginCallbackResult struct {
+	EnrollmentToken string
+	APIKey          string
+}
+
 func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	// Step 1: Start a local HTTP server to receive the OAuth callback.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -91,8 +96,8 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
 
-	// Channel to receive the enrollment token from the callback.
-	tokenCh := make(chan string, 1)
+	// Channel to receive the enrollment token and PAT from the callback.
+	tokenCh := make(chan loginCallbackResult, 1)
 	errCh := make(chan error, 1)
 
 	mux := http.NewServeMux()
@@ -103,6 +108,7 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 			errCh <- fmt.Errorf("callback received without token")
 			return
 		}
+		apiKey := r.URL.Query().Get("api_key")
 
 		w.Header().Set("Content-Type", "text/html")
 		fmt.Fprintf(w, `<!DOCTYPE html>
@@ -152,7 +158,7 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
   </div>
 </body>
 </html>`)
-		tokenCh <- token
+		tokenCh <- loginCallbackResult{EnrollmentToken: token, APIKey: apiKey}
 	})
 
 	server := &http.Server{Handler: mux}
@@ -184,10 +190,10 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 
 	fmt.Println(tui.InfoMessage("Waiting for authentication..."))
 
-	// Wait for the token.
-	var enrollmentToken string
+	// Wait for the token and PAT.
+	var result loginCallbackResult
 	select {
-	case enrollmentToken = <-tokenCh:
+	case result = <-tokenCh:
 		fmt.Println(tui.SuccessMessage("Received enrollment token."))
 	case loginErr := <-errCh:
 		return fmt.Errorf("login failed: %w", loginErr)
@@ -201,7 +207,7 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 		return fmt.Errorf("generating key pair: %w", err)
 	}
 
-	commonName, err := enrollmentTokenCommonName(enrollmentToken)
+	commonName, err := enrollmentTokenCommonName(result.EnrollmentToken)
 	if err != nil {
 		return fmt.Errorf("reading enrollment token identity: %w", err)
 	}
@@ -229,7 +235,7 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	certClient := cloudpb.NewCertificateServiceClient(certConn)
 	issueResp, err := certClient.IssueCertificate(ctx, &cloudpb.IssueCertificateRequest{
 		PemCsr:          csrPEM,
-		EnrollmentToken: enrollmentToken,
+		EnrollmentToken: result.EnrollmentToken,
 	})
 	if err != nil {
 		return fmt.Errorf("issuing certificate: %w", err)
@@ -261,6 +267,7 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	authEntry := config.AuthConfig{
 		CloudDashboard: cloudDashboard,
 		CloudGRPC:      cloudGRPC,
+		APIKey:         result.APIKey,
 		Certificates:   []config.CertificateInfo{certInfo},
 	}
 
@@ -375,6 +382,7 @@ func performLocalLogin(ctx context.Context, cloudGRPC, apiKey string, orgID int3
 		PemCertificateChain: cert.GetPemCertificateChain(),
 		PemPrivateKey:       privateKeyPEM,
 		OrganizationID:      int(issueResp.GetOrganizationId()),
+		AssetID:             int(issueResp.GetAssetId()),
 	}
 	authEntry := config.AuthConfig{
 		CloudGRPC:    cloudGRPC,

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -109,6 +109,9 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 			return
 		}
 		apiKey := r.URL.Query().Get("api_key")
+		if !strings.HasPrefix(apiKey, "wnd_pat_") || len(apiKey) > 256 {
+			apiKey = ""
+		}
 
 		w.Header().Set("Content-Type", "text/html")
 		fmt.Fprintf(w, `<!DOCTYPE html>

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -43,7 +43,10 @@ func certXFCC(cert config.CertificateInfo) string {
 	if cert.UserID != "" {
 		return fmt.Sprintf("URI=urn:wendy:org:%d:user:%s", cert.OrganizationID, cert.UserID)
 	}
-	return fmt.Sprintf("URI=urn:wendy:org:%d:user:unknown", cert.OrganizationID)
+	if cert.AssetID != 0 {
+		return fmt.Sprintf("URI=urn:wendy:org:%d:asset:%d", cert.OrganizationID, cert.AssetID)
+	}
+	return ""
 }
 
 func cloudContext(ctx context.Context, auth *config.AuthConfig) context.Context {
@@ -56,8 +59,10 @@ func cloudContext(ctx context.Context, auth *config.AuthConfig) context.Context 
 		md.Set("authorization", "Bearer "+auth.APIKey)
 	}
 	certHeader := certXFCC(cert)
-	md.Set("x-wendy-client-cert", certHeader)
-	md.Set("x-forwarded-client-cert", certHeader)
+	if certHeader != "" {
+		md.Set("x-wendy-client-cert", certHeader)
+		md.Set("x-forwarded-client-cert", certHeader)
+	}
 	return metadata.NewOutgoingContext(ctx, md)
 }
 

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -31,6 +31,7 @@ type CertificateInfo struct {
 	PemPrivateKey       string `json:"pemPrivateKey,omitempty"`
 	OrganizationID      int    `json:"organizationId"`
 	UserID              string `json:"userId,omitempty"`
+	AssetID             int    `json:"assetId,omitempty"`
 }
 
 // AnalyticsConfig holds analytics preferences.


### PR DESCRIPTION
## Summary

- Reads `api_key` from the CLI auth callback URL and stores it as `AuthConfig.APIKey`. The cloud dashboard (companion PR wendylabsinc/cloud#144) creates a Personal Access Token (PAT) during `wendy auth login` and appends it to the callback redirect URL.
- `cloudContext()` already sends `Authorization: Bearer <APIKey>` when the field is non-empty, so pre-enrollment calls to `CreateAssetEnrollmentToken` (a `DualAuthMethods` endpoint) now have a valid Bearer credential.
- Fixes `certXFCC`: previously returned `URI=urn:wendy:org:<id>:user:unknown` for asset certificates. Now returns the correct `URI=urn:wendy:org:<id>:asset:<id>` form, or empty string when neither user nor asset identity is available, in which case the header is omitted entirely.
- Adds `AssetID int` to `CertificateInfo` so asset certificates can be identified when building the XFCC header.

## Related

- Linear: WDY-1478
- Companion cloud PR: wendylabsinc/cloud#144

## Test plan

- Run `wendy auth login` against a local dev stack; confirm `~/.wendy/config.json` contains a non-empty `APIKey` field.
- Run `wendy os install --pre-enroll` and confirm the "missing authorization header" warning no longer appears.
- Verify that an asset certificate produces `URI=urn:wendy:org:<id>:asset:<id>` in `certXFCC` and that a cert with neither user nor asset ID produces an empty string with no header set.