### PR TITLE
docs: validate Mac beta on clean Apple Silicon

### DIFF
--- a/Examples/HelloMLX/Scripts/DownloadVLM.sh
+++ b/Examples/HelloMLX/Scripts/DownloadVLM.sh
@@ -179,7 +179,7 @@ metadata = {
         "bytes": int(size_bytes),
     },
     "memoryHint": memory_hint,
-    "generatedAt": datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z"),
+    "generatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
 }
 with open(info_path, "w", encoding="utf-8") as f:
     json.dump(metadata, f, indent=2)

--- a/go/internal/cli/assets/docs/cli.sh
+++ b/go/internal/cli/assets/docs/cli.sh
@@ -199,6 +199,9 @@ if [[ "$OS" == "darwin" ]]; then
     echo "Downloading ${URL}..."
     download "$URL" "${TMPDIR_DL}/${ARTIFACT}"
     tar -xzf "${TMPDIR_DL}/${ARTIFACT}" -C "$TMPDIR_DL"
+    if [[ ! -d "$INSTALL_DIR" ]]; then
+      mkdir -p "$INSTALL_DIR" 2>/dev/null || sudo mkdir -p "$INSTALL_DIR"
+    fi
     sudo install -m 755 "${TMPDIR_DL}/wendy-cli-darwin-${ARCH}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
   fi
 


### PR DESCRIPTION
## Summary
- Validated the Wendy Agent for Mac beta path on a freshly reset Apple Silicon Mac mini.
- Fixed the macOS CLI installer fallback path so clean systems without `/usr/local/bin` create the install directory before installing `wendy`.
- Fixed the HelloMLX model-tier download script to work with Xcode Python 3.9 on clean Macs.

Closes WDY-1360.
Closes WDY-1483.
Closes WDY-1495.

## Clean Mac environment
- Mac mini (M1, 2020), 16 GB RAM.
- macOS Tahoe 26.3.2 build 25D2140.
- Fresh reset / clean slate.
- No Homebrew, Xcode, Wendy CLI, or Wendy Agent preinstalled.
- Hostname: `kb-macos-26-01.local`; user: `ci`.
- Real display/keyboard/mouse attached for setup; virtual display dongle present.

## Validation
- Public docs CLI install path initially failed because `/usr/local/bin` did not exist on the fresh Mac; fixed in this PR and workaround validated.
- Homebrew installed successfully; it installed Xcode Command Line Tools as part of its own setup.
- Wendy Agent installed via Homebrew cask and launched successfully.
- Permission flows worked: Local Network, Bluetooth, Camera, Microphone.
- Welcome screen appeared and menu bar item appeared.
- `wendy --device localhost:50051 device info --json` reported Darwin/arm64.
- Default device and hostname/mDNS discovery paths worked.
- `Examples/HelloMac` SwiftPM/Darwin app built, synced, launched, streamed stdout/stderr and bundled resource output, stopped, and cleaned up.
- Full Xcode 26.5 and Metal Toolchain setup validated for HelloMLX.
- HelloMLX `xcodebuild -list` and Release build succeeded after installing Metal Toolchain.
- Original large Gemma 27B model path built/deployed/loaded and began inference, but was unbearably slow and swap-bound on the 16 GB M1 Mac mini.
- Resumed after WDY-1495 model tiers landed:
  - `small` tier download exposed a Python 3.9 compatibility bug fixed in this PR.
  - `small` tier then downloaded, selected, deployed, loaded, and ran repeated inference quickly.
  - `medium` tier downloaded, synced 3.1 GB of model files, loaded, ran repeated inference at practical speed, and the web UI showed results.
- Final cleanup succeeded; `wendy device apps list --json` returned `[]`.

## Follow-ups filed during validation
- WDY-1484: document Homebrew tap trust for the Wendy Agent macOS cask.
- WDY-1485: clarify `hasGpu` semantics for macOS agents.
- WDY-1486: fix first-launch auto-start checkbox registration.
- WDY-1487: use native macOS app wording instead of container wording for Darwin app output.
- WDY-1488: make `device apps stop/remove --json` honor JSON success output.
- WDY-1491: document Mac development machine setup for Wendy Agent for Mac apps.
- WDY-1493: document HelloMLX `huggingface_hub` / `hf` prerequisite and PATH behavior.

## Notes
- Detailed command/output log is kept locally in `.validation-notes-WDY-1360.md` in this worktree.
