### PR TITLE
WDY-1481: add local E2E matrix coverage

### DIFF
--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -92,12 +92,21 @@ runs:
           local value="$1" filter
           [[ ${#value} -le 500 ]] || return 1
           [[ -z "$value" || "$value" =~ ^[A-Za-z0-9][A-Za-z0-9\,\ \._:/\|\(\)_-]*$ ]] || return 1
+          [[ "$value" != *'<<'* ]] || return 1
           IFS=',' read -ra filters <<< "$value"
           for filter in "${filters[@]}"; do
             filter="${filter#${filter%%[![:space:]]*}}"
             filter="${filter%${filter##*[![:space:]]}}"
             [[ -z "$filter" || "$filter" != -* ]] || return 1
           done
+        }
+        write_output() {
+          local name="$1" value="$2" delimiter="WENDY_EOF_${name}"
+          {
+            printf '%s<<%s\n' "$name" "$delimiter"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_OUTPUT"
         }
         require_match WORKFLOW_ID "$WORKFLOW_ID" '^[A-Za-z0-9._-]{1,80}$'
         require_match TARGET_ID "$TARGET_ID" '^[A-Za-z0-9._-]{1,80}$'
@@ -116,15 +125,13 @@ runs:
           echo "ERROR: invalid TESTS" >&2
           exit 64
         fi
-        {
-          echo "validated=true"
-          echo "tests=$TESTS"
-          echo "managed_agent=$MANAGED_AGENT"
-          echo "device_address=$DEVICE_ADDRESS"
-          echo "cli_os=$CLI_OS"
-          echo "agent_os=$AGENT_OS"
-          echo "transport=$TRANSPORT"
-        } >> "$GITHUB_OUTPUT"
+        write_output validated true
+        write_output tests "$TESTS"
+        write_output managed_agent "$MANAGED_AGENT"
+        write_output device_address "$DEVICE_ADDRESS"
+        write_output cli_os "$CLI_OS"
+        write_output agent_os "$AGENT_OS"
+        write_output transport "$TRANSPORT"
 
     - name: Validate Swift E2E inputs (Windows)
       id: validate-windows
@@ -168,11 +175,18 @@ runs:
         function Test-Tests([string]$Value) {
           if ($Value.Length -gt 500) { return $false }
           if ($Value.Length -gt 0 -and $Value -notmatch '^[A-Za-z0-9][A-Za-z0-9, ._:/|()_-]*$') { return $false }
+          if ($Value.Contains('<<')) { return $false }
           foreach ($Filter in ($Value -split ',')) {
             $Trimmed = $Filter.Trim()
             if ($Trimmed.StartsWith('-')) { return $false }
           }
           return $true
+        }
+        function Write-OutputValue([string]$Name, [string]$Value) {
+          $Delimiter = "WENDY_EOF_$Name"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "$Name<<$Delimiter"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value $Value
+          Add-Content -Path $env:GITHUB_OUTPUT -Value $Delimiter
         }
         Require-Match WORKFLOW_ID $env:WORKFLOW_ID '^[A-Za-z0-9._-]{1,80}$'
         Require-Match TARGET_ID $env:TARGET_ID '^[A-Za-z0-9._-]{1,80}$'
@@ -189,13 +203,13 @@ runs:
         if (-not (Test-Tests $env:TESTS)) {
           throw 'invalid TESTS'
         }
-        "validated=true" >> $env:GITHUB_OUTPUT
-        "tests=$env:TESTS" >> $env:GITHUB_OUTPUT
-        "managed_agent=$env:MANAGED_AGENT" >> $env:GITHUB_OUTPUT
-        "device_address=$env:DEVICE_ADDRESS" >> $env:GITHUB_OUTPUT
-        "cli_os=$env:CLI_OS" >> $env:GITHUB_OUTPUT
-        "agent_os=$env:AGENT_OS" >> $env:GITHUB_OUTPUT
-        "transport=$env:TRANSPORT" >> $env:GITHUB_OUTPUT
+        Write-OutputValue validated 'true'
+        Write-OutputValue tests $env:TESTS
+        Write-OutputValue managed_agent $env:MANAGED_AGENT
+        Write-OutputValue device_address $env:DEVICE_ADDRESS
+        Write-OutputValue cli_os $env:CLI_OS
+        Write-OutputValue agent_os $env:AGENT_OS
+        Write-OutputValue transport $env:TRANSPORT
 
     - name: Set up Swift E2E host (Unix)
       if: runner.os != 'Windows' && inputs.setup == 'true'

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -29,10 +29,45 @@ inputs:
     description: Transport label for run metadata.
     required: false
     default: lan
+  setup:
+    description: Run the platform Swift E2E setup script before tests.
+    required: false
+    default: 'false'
+  managed_agent:
+    description: Build and launch a local wendy-agent process for this run.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
   steps:
+    - name: Set up Swift E2E host (Unix)
+      if: runner.os != 'Windows' && inputs.setup == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        bash swift/Scripts/E2ESetup.sh
+
+    - name: Configure Swiftly PATH (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        for env_file in \
+          "$HOME/.swiftly/env.sh" \
+          "$HOME/.local/share/swiftly/env.sh"
+        do
+          if [[ -f "$env_file" ]]; then
+            # shellcheck disable=SC1090
+            . "$env_file"
+          fi
+        done
+        for tool in swift swiftly; do
+          if command -v "$tool" >/dev/null 2>&1; then
+            dirname "$(command -v "$tool")" >> "$GITHUB_PATH"
+          fi
+        done
+
     - name: Capture Swift toolchain version (Unix)
       if: runner.os != 'Windows'
       id: swift-toolchain-unix
@@ -118,9 +153,13 @@ runs:
       run: |
         set -euo pipefail
         output_dir="${RUNNER_TEMP}/wendy"
-        bash ./Scripts/E2ETest.sh \
-          --output-dir "$output_dir" \
-          --agent-address "${{ inputs.device_address }}"
+        args=(--output-dir "$output_dir")
+        if [[ "${{ inputs.managed_agent }}" == "true" ]]; then
+          args+=(--managed-agent --agent-connect-address "${{ inputs.device_address }}")
+        else
+          args+=(--agent-address "${{ inputs.device_address }}")
+        fi
+        bash ./Scripts/E2ETest.sh "${args[@]}"
 
     - name: Run Swift E2E tests (Windows)
       if: runner.os == 'Windows'
@@ -135,6 +174,9 @@ runs:
         WENDY_E2E_TRANSPORT: ${{ inputs.transport }}
       run: |
         $ErrorActionPreference = 'Stop'
+        if ('${{ inputs.managed_agent }}' -eq 'true') {
+          throw 'managed_agent is not supported by the Windows Swift E2E runner yet.'
+        }
         $outputDir = Join-Path $env:RUNNER_TEMP 'wendy'
         & ./Scripts/E2ETest.ps1 --output-dir $outputDir --agent-address "${{ inputs.device_address }}"
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -90,9 +90,11 @@ runs:
         }
         validate_tests() {
           local value="$1" filter
+          local filters=()
           [[ ${#value} -le 500 ]] || return 1
-          [[ -z "$value" || "$value" =~ ^[A-Za-z0-9][A-Za-z0-9\,\ \._:/\|\(\)_-]*$ ]] || return 1
           [[ "$value" != *'<<'* ]] || return 1
+          [[ -n "$value" ]] || return 0
+          [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9\,\ \._:/\|\(\)_-]*$ ]] || return 1
           IFS=',' read -ra filters <<< "$value"
           for filter in "${filters[@]}"; do
             filter="${filter#${filter%%[![:space:]]*}}"

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -79,7 +79,7 @@ runs:
         require_match MANAGED_AGENT "$MANAGED_AGENT" '^(true|false)$'
         reject_newline DEVICE_ADDRESS "$DEVICE_ADDRESS"
         reject_newline TESTS "$TESTS"
-        if [[ "$DEVICE_ADDRESS" == *@* || ! "$DEVICE_ADDRESS" =~ ^[][A-Za-z0-9._:%-]{1,255}$ ]]; then
+        if [[ "$DEVICE_ADDRESS" == *@* || ! "$DEVICE_ADDRESS" =~ ^[][A-Za-z0-9._:-]{1,255}$ ]]; then
           echo "ERROR: invalid DEVICE_ADDRESS" >&2
           exit 64
         fi
@@ -114,7 +114,7 @@ runs:
         Require-Match MANAGED_AGENT $env:MANAGED_AGENT '^(true|false)$'
         Reject-Newline DEVICE_ADDRESS $env:DEVICE_ADDRESS
         Reject-Newline TESTS $env:TESTS
-        if ($env:DEVICE_ADDRESS -match '@' -or $env:DEVICE_ADDRESS -notmatch '^[A-Za-z0-9._:%\[\]-]{1,255}$') {
+        if ($env:DEVICE_ADDRESS -match '@' -or $env:DEVICE_ADDRESS -notmatch '^[A-Za-z0-9._:\[\]-]{1,255}$') {
           throw 'invalid DEVICE_ADDRESS'
         }
 
@@ -130,18 +130,26 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        for env_file in \
-          "$HOME/.swiftly/env.sh" \
-          "$HOME/.local/share/swiftly/env.sh"
-        do
-          if [[ -f "$env_file" ]]; then
-            # shellcheck disable=SC1090
-            . "$env_file"
+        append_path_dir() {
+          local dir="$1"
+          if [[ -z "$dir" || "$dir" != /* || "$dir" == *$'\n'* || "$dir" == *$'\r'* ]]; then
+            return 0
+          fi
+          case "$dir" in
+            "$HOME/.swiftly/bin"|"$HOME/.local/share/swiftly/bin"|/usr/bin|/usr/local/bin|/usr/share/swift/usr/bin|/opt/hostedtoolcache/*|/Applications/*|/Library/*)
+              printf '%s\n' "$dir" >> "$GITHUB_PATH"
+              ;;
+          esac
+        }
+
+        for dir in "$HOME/.swiftly/bin" "$HOME/.local/share/swiftly/bin"; do
+          if [[ -d "$dir" ]]; then
+            append_path_dir "$dir"
           fi
         done
         for tool in swift swiftly; do
-          if command -v "$tool" >/dev/null 2>&1; then
-            dirname "$(command -v "$tool")" >> "$GITHUB_PATH"
+          if tool_path="$(command -v "$tool" 2>/dev/null)"; then
+            append_path_dir "$(dirname "$tool_path")"
           fi
         done
 

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -101,7 +101,8 @@ runs:
           done
         }
         write_output() {
-          local name="$1" value="$2" delimiter="WENDY_EOF_${name}"
+          local name="$1" value="$2" delimiter
+          delimiter="WENDY_EOF_${name}"
           {
             printf '%s<<%s\n' "$name" "$delimiter"
             printf '%s\n' "$value"

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -267,7 +267,7 @@ runs:
           throw 'managed_agent is not supported by the Windows Swift E2E runner yet.'
         }
         $outputDir = Join-Path $env:RUNNER_TEMP 'wendy'
-        & ./Scripts/E2ETest.ps1 --output-dir $outputDir --agent-address $env:DEVICE_ADDRESS
+        & ./Scripts/E2ETest.ps1 --output-dir $outputDir --agent-address "$env:DEVICE_ADDRESS"
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Upload Swift E2E run (Unix)

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -165,7 +165,7 @@ runs:
         output_dir="${RUNNER_TEMP}/wendy"
         args=(--output-dir "$output_dir")
         if [[ "$MANAGED_AGENT" == "true" ]]; then
-          args+=(--managed-agent --agent-connect-address "$DEVICE_ADDRESS")
+          args+=(--managed-agent --device-address "$DEVICE_ADDRESS")
         else
           args+=(--agent-address "$DEVICE_ADDRESS")
         fi

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -187,7 +187,7 @@ runs:
         bash swift/Scripts/E2ESetup.sh
 
     - name: Configure Swiftly PATH (Unix)
-      if: runner.os != 'Windows'
+      if: runner.os != 'Windows' && runner.environment == 'github-hosted'
       shell: bash
       run: |
         set -euo pipefail
@@ -197,7 +197,7 @@ runs:
             return 0
           fi
           case "$dir" in
-            "$HOME/.swiftly/bin"|"$HOME/.local/share/swiftly/bin"|/usr/bin|/usr/local/bin|/usr/share/swift/usr/bin|/opt/hostedtoolcache/*|/Applications/*|/Library/*)
+            "$HOME/.swiftly/bin"|"$HOME/.local/share/swiftly/bin"|/usr/bin|/usr/local/bin|/usr/share/swift/usr/bin)
               printf '%s\n' "$dir" >> "$GITHUB_PATH"
               ;;
           esac
@@ -332,11 +332,33 @@ runs:
         DEVICE_ADDRESS: ${{ inputs.device_address }}
       run: |
         $ErrorActionPreference = 'Stop'
+        function Test-Port([string]$Port) {
+          if ($Port -notmatch '^[0-9]{1,5}$') { return $false }
+          $Number = [int]$Port
+          return ($Number -ge 1 -and $Number -le 65535)
+        }
+        function Test-DeviceAddress([string]$Value) {
+          if ($Value -match '@') { return $false }
+          $Port = $null
+          if ($Value -match '^[A-Za-z0-9._-]{1,253}(:([0-9]{1,5}))?$') {
+            $Port = $Matches[2]
+          } elseif ($Value -match '^\[[0-9A-Fa-f:]+\](:([0-9]{1,5}))?$') {
+            $Port = $Matches[2]
+          } else {
+            return $false
+          }
+          return ([string]::IsNullOrEmpty($Port) -or (Test-Port $Port))
+        }
         if ($env:MANAGED_AGENT -eq 'true') {
           throw 'managed_agent is not supported by the Windows Swift E2E runner yet.'
         }
+        if (-not (Test-DeviceAddress $env:DEVICE_ADDRESS)) {
+          throw 'invalid DEVICE_ADDRESS'
+        }
         $outputDir = Join-Path $env:RUNNER_TEMP 'wendy'
-        & ./Scripts/E2ETest.ps1 --output-dir $outputDir --agent-address "$env:DEVICE_ADDRESS"
+        $deviceAddress = [string]$env:DEVICE_ADDRESS
+        $e2eArgs = @('--output-dir', $outputDir, '--agent-address', $deviceAddress)
+        & ./Scripts/E2ETest.ps1 @e2eArgs
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Upload Swift E2E run (Unix)

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -41,6 +41,83 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate Swift E2E inputs (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        WORKFLOW_ID: ${{ inputs.workflow_id }}
+        TARGET_ID: ${{ inputs.target_id }}
+        RUNNER_ID: ${{ inputs.runner_id }}
+        CLI_OS: ${{ inputs.cli_os }}
+        AGENT_OS: ${{ inputs.agent_os }}
+        TRANSPORT: ${{ inputs.transport }}
+        MANAGED_AGENT: ${{ inputs.managed_agent }}
+        DEVICE_ADDRESS: ${{ inputs.device_address }}
+        TESTS: ${{ inputs.tests }}
+      run: |
+        set -euo pipefail
+        require_match() {
+          local name="$1" value="$2" pattern="$3"
+          if [[ ! "$value" =~ $pattern ]]; then
+            echo "ERROR: invalid $name" >&2
+            exit 64
+          fi
+        }
+        reject_newline() {
+          local name="$1" value="$2"
+          if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+            echo "ERROR: invalid newline in $name" >&2
+            exit 64
+          fi
+        }
+        require_match WORKFLOW_ID "$WORKFLOW_ID" '^[A-Za-z0-9._-]{1,80}$'
+        require_match TARGET_ID "$TARGET_ID" '^[A-Za-z0-9._-]{1,80}$'
+        require_match RUNNER_ID "$RUNNER_ID" '^[A-Za-z0-9._-]{1,80}$'
+        require_match CLI_OS "$CLI_OS" '^[A-Za-z0-9._-]{1,40}$'
+        require_match AGENT_OS "$AGENT_OS" '^[A-Za-z0-9._-]{1,40}$'
+        require_match TRANSPORT "$TRANSPORT" '^[A-Za-z0-9._-]{1,40}$'
+        require_match MANAGED_AGENT "$MANAGED_AGENT" '^(true|false)$'
+        reject_newline DEVICE_ADDRESS "$DEVICE_ADDRESS"
+        reject_newline TESTS "$TESTS"
+        if [[ "$DEVICE_ADDRESS" == *@* || ! "$DEVICE_ADDRESS" =~ ^[][A-Za-z0-9._:%-]{1,255}$ ]]; then
+          echo "ERROR: invalid DEVICE_ADDRESS" >&2
+          exit 64
+        fi
+
+    - name: Validate Swift E2E inputs (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        WORKFLOW_ID: ${{ inputs.workflow_id }}
+        TARGET_ID: ${{ inputs.target_id }}
+        RUNNER_ID: ${{ inputs.runner_id }}
+        CLI_OS: ${{ inputs.cli_os }}
+        AGENT_OS: ${{ inputs.agent_os }}
+        TRANSPORT: ${{ inputs.transport }}
+        MANAGED_AGENT: ${{ inputs.managed_agent }}
+        DEVICE_ADDRESS: ${{ inputs.device_address }}
+        TESTS: ${{ inputs.tests }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        function Require-Match([string]$Name, [string]$Value, [string]$Pattern) {
+          if ($Value -notmatch $Pattern) { throw "invalid $Name" }
+        }
+        function Reject-Newline([string]$Name, [string]$Value) {
+          if ($Value -match "[`r`n]") { throw "invalid newline in $Name" }
+        }
+        Require-Match WORKFLOW_ID $env:WORKFLOW_ID '^[A-Za-z0-9._-]{1,80}$'
+        Require-Match TARGET_ID $env:TARGET_ID '^[A-Za-z0-9._-]{1,80}$'
+        Require-Match RUNNER_ID $env:RUNNER_ID '^[A-Za-z0-9._-]{1,80}$'
+        Require-Match CLI_OS $env:CLI_OS '^[A-Za-z0-9._-]{1,40}$'
+        Require-Match AGENT_OS $env:AGENT_OS '^[A-Za-z0-9._-]{1,40}$'
+        Require-Match TRANSPORT $env:TRANSPORT '^[A-Za-z0-9._-]{1,40}$'
+        Require-Match MANAGED_AGENT $env:MANAGED_AGENT '^(true|false)$'
+        Reject-Newline DEVICE_ADDRESS $env:DEVICE_ADDRESS
+        Reject-Newline TESTS $env:TESTS
+        if ($env:DEVICE_ADDRESS -match '@' -or $env:DEVICE_ADDRESS -notmatch '^[A-Za-z0-9._:%\[\]-]{1,255}$') {
+          throw 'invalid DEVICE_ADDRESS'
+        }
+
     - name: Set up Swift E2E host (Unix)
       if: runner.os != 'Windows' && inputs.setup == 'true'
       shell: bash

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -70,6 +70,34 @@ runs:
             exit 64
           fi
         }
+        validate_port() {
+          local port="$1"
+          [[ "$port" =~ ^[0-9]{1,5}$ ]] || return 1
+          (( 10#$port >= 1 && 10#$port <= 65535 ))
+        }
+        valid_device_address() {
+          local value="$1" port=""
+          [[ "$value" != *@* ]] || return 1
+          if [[ "$value" =~ ^[A-Za-z0-9._-]{1,253}(:([0-9]{1,5}))?$ ]]; then
+            port="${BASH_REMATCH[2]:-}"
+          elif [[ "$value" =~ ^\[[0-9A-Fa-f:]+\](:([0-9]{1,5}))?$ ]]; then
+            port="${BASH_REMATCH[2]:-}"
+          else
+            return 1
+          fi
+          [[ -z "$port" ]] || validate_port "$port"
+        }
+        validate_tests() {
+          local value="$1" filter
+          [[ ${#value} -le 500 ]] || return 1
+          [[ -z "$value" || "$value" =~ ^[A-Za-z0-9][A-Za-z0-9\,\ \._:/\|\(\)_-]*$ ]] || return 1
+          IFS=',' read -ra filters <<< "$value"
+          for filter in "${filters[@]}"; do
+            filter="${filter#${filter%%[![:space:]]*}}"
+            filter="${filter%${filter##*[![:space:]]}}"
+            [[ -z "$filter" || "$filter" != -* ]] || return 1
+          done
+        }
         require_match WORKFLOW_ID "$WORKFLOW_ID" '^[A-Za-z0-9._-]{1,80}$'
         require_match TARGET_ID "$TARGET_ID" '^[A-Za-z0-9._-]{1,80}$'
         require_match RUNNER_ID "$RUNNER_ID" '^[A-Za-z0-9._-]{1,80}$'
@@ -79,8 +107,12 @@ runs:
         require_match MANAGED_AGENT "$MANAGED_AGENT" '^(true|false)$'
         reject_newline DEVICE_ADDRESS "$DEVICE_ADDRESS"
         reject_newline TESTS "$TESTS"
-        if [[ "$DEVICE_ADDRESS" == *@* || ! "$DEVICE_ADDRESS" =~ ^[][A-Za-z0-9._:-]{1,255}$ ]]; then
+        if ! valid_device_address "$DEVICE_ADDRESS"; then
           echo "ERROR: invalid DEVICE_ADDRESS" >&2
+          exit 64
+        fi
+        if ! validate_tests "$TESTS"; then
+          echo "ERROR: invalid TESTS" >&2
           exit 64
         fi
 
@@ -105,6 +137,32 @@ runs:
         function Reject-Newline([string]$Name, [string]$Value) {
           if ($Value -match "[`r`n]") { throw "invalid newline in $Name" }
         }
+        function Test-Port([string]$Port) {
+          if ($Port -notmatch '^[0-9]{1,5}$') { return $false }
+          $Number = [int]$Port
+          return ($Number -ge 1 -and $Number -le 65535)
+        }
+        function Test-DeviceAddress([string]$Value) {
+          if ($Value -match '@') { return $false }
+          $Port = $null
+          if ($Value -match '^[A-Za-z0-9._-]{1,253}(:([0-9]{1,5}))?$') {
+            $Port = $Matches[2]
+          } elseif ($Value -match '^\[[0-9A-Fa-f:]+\](:([0-9]{1,5}))?$') {
+            $Port = $Matches[2]
+          } else {
+            return $false
+          }
+          return ([string]::IsNullOrEmpty($Port) -or (Test-Port $Port))
+        }
+        function Test-Tests([string]$Value) {
+          if ($Value.Length -gt 500) { return $false }
+          if ($Value.Length -gt 0 -and $Value -notmatch '^[A-Za-z0-9][A-Za-z0-9, ._:/|()_-]*$') { return $false }
+          foreach ($Filter in ($Value -split ',')) {
+            $Trimmed = $Filter.Trim()
+            if ($Trimmed.StartsWith('-')) { return $false }
+          }
+          return $true
+        }
         Require-Match WORKFLOW_ID $env:WORKFLOW_ID '^[A-Za-z0-9._-]{1,80}$'
         Require-Match TARGET_ID $env:TARGET_ID '^[A-Za-z0-9._-]{1,80}$'
         Require-Match RUNNER_ID $env:RUNNER_ID '^[A-Za-z0-9._-]{1,80}$'
@@ -114,8 +172,11 @@ runs:
         Require-Match MANAGED_AGENT $env:MANAGED_AGENT '^(true|false)$'
         Reject-Newline DEVICE_ADDRESS $env:DEVICE_ADDRESS
         Reject-Newline TESTS $env:TESTS
-        if ($env:DEVICE_ADDRESS -match '@' -or $env:DEVICE_ADDRESS -notmatch '^[A-Za-z0-9._:\[\]-]{1,255}$') {
+        if (-not (Test-DeviceAddress $env:DEVICE_ADDRESS)) {
           throw 'invalid DEVICE_ADDRESS'
+        }
+        if (-not (Test-Tests $env:TESTS)) {
+          throw 'invalid TESTS'
         }
 
     - name: Set up Swift E2E host (Unix)

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -232,6 +232,9 @@ runs:
             "$HOME/.swiftly/bin"|"$HOME/.local/share/swiftly/bin"|/usr/bin|/usr/local/bin|/usr/share/swift/usr/bin)
               printf '%s\n' "$dir" >> "$GITHUB_PATH"
               ;;
+            *)
+              echo "WARN: skipping non-allowlisted Swift PATH directory: $dir" >&2
+              ;;
           esac
         }
 
@@ -364,28 +367,9 @@ runs:
         DEVICE_ADDRESS: ${{ steps.validate-windows.outputs.device_address }}
       run: |
         $ErrorActionPreference = 'Stop'
-        function Test-Port([string]$Port) {
-          if ($Port -notmatch '^[0-9]{1,5}$') { return $false }
-          $Number = [int]$Port
-          return ($Number -ge 1 -and $Number -le 65535)
-        }
-        function Test-DeviceAddress([string]$Value) {
-          if ($Value -match '@') { return $false }
-          $Port = $null
-          if ($Value -match '^[A-Za-z0-9._-]{1,253}(:([0-9]{1,5}))?$') {
-            $Port = $Matches[2]
-          } elseif ($Value -match '^\[[0-9A-Fa-f:]+\](:([0-9]{1,5}))?$') {
-            $Port = $Matches[2]
-          } else {
-            return $false
-          }
-          return ([string]::IsNullOrEmpty($Port) -or (Test-Port $Port))
-        }
+        # This step only consumes values emitted by validate-windows above.
         if ($env:MANAGED_AGENT -eq 'true') {
           throw 'managed_agent is not supported by the Windows Swift E2E runner yet.'
-        }
-        if (-not (Test-DeviceAddress $env:DEVICE_ADDRESS)) {
-          throw 'invalid DEVICE_ADDRESS'
         }
         $outputDir = Join-Path $env:RUNNER_TEMP 'wendy'
         $deviceAddress = [string]$env:DEVICE_ADDRESS

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -72,9 +72,11 @@ runs:
       if: runner.os != 'Windows'
       id: swift-toolchain-unix
       shell: bash
+      env:
+        RUNNER_ID: ${{ inputs.runner_id }}
       run: |
         set -euo pipefail
-        if [[ "${{ inputs.runner_id }}" == "macos-26" ]]; then
+        if [[ "$RUNNER_ID" == "macos-26" ]]; then
           version="$(xcodebuild -version | awk '/Xcode/ { print $2 }')"
         else
           version="$(swift --version | head -n 1 | tr -cs '[:alnum:]._-' '-')"
@@ -108,6 +110,9 @@ runs:
       if: runner.os != 'Windows'
       id: e2e-run-unix
       shell: bash
+      env:
+        WORKFLOW_ID: ${{ inputs.workflow_id }}
+        TARGET_ID: ${{ inputs.target_id }}
       run: |
         set -euo pipefail
         slug() {
@@ -116,8 +121,8 @@ runs:
             | sed -E 's/[^[:alnum:]._-]+/-/g; s/-+/-/g; s/^-//; s/-$//'
         }
 
-        workflow_id="$(slug "${{ inputs.workflow_id }}")"
-        target_id="$(slug "${{ inputs.target_id }}")"
+        workflow_id="$(slug "$WORKFLOW_ID")"
+        target_id="$(slug "$TARGET_ID")"
         printf -v attempt_suffix '%04d' "${GITHUB_RUN_ATTEMPT:-1}"
         echo "run_id=${workflow_id}.gh${GITHUB_RUN_ID}.${target_id}.${attempt_suffix}" >> "$GITHUB_OUTPUT"
 
@@ -125,6 +130,9 @@ runs:
       if: runner.os == 'Windows'
       id: e2e-run-windows
       shell: pwsh
+      env:
+        WORKFLOW_ID: ${{ inputs.workflow_id }}
+        TARGET_ID: ${{ inputs.target_id }}
       run: |
         $ErrorActionPreference = 'Stop'
         function Convert-ToSlug([string]$Value) {
@@ -133,8 +141,8 @@ runs:
           return $slug.Trim('-')
         }
 
-        $workflowID = Convert-ToSlug '${{ inputs.workflow_id }}'
-        $targetID = Convert-ToSlug '${{ inputs.target_id }}'
+        $workflowID = Convert-ToSlug $env:WORKFLOW_ID
+        $targetID = Convert-ToSlug $env:TARGET_ID
         $attempt = if ($env:GITHUB_RUN_ATTEMPT) { [int]$env:GITHUB_RUN_ATTEMPT } else { 1 }
         $runID = '{0}.gh{1}.{2}.{3:D4}' -f $workflowID, $env:GITHUB_RUN_ID, $targetID, $attempt
         "run_id=$runID" >> $env:GITHUB_OUTPUT
@@ -150,14 +158,16 @@ runs:
         WENDY_E2E_CLI_OS: ${{ inputs.cli_os }}
         WENDY_E2E_AGENT_OS: ${{ inputs.agent_os }}
         WENDY_E2E_TRANSPORT: ${{ inputs.transport }}
+        MANAGED_AGENT: ${{ inputs.managed_agent }}
+        DEVICE_ADDRESS: ${{ inputs.device_address }}
       run: |
         set -euo pipefail
         output_dir="${RUNNER_TEMP}/wendy"
         args=(--output-dir "$output_dir")
-        if [[ "${{ inputs.managed_agent }}" == "true" ]]; then
-          args+=(--managed-agent --agent-connect-address "${{ inputs.device_address }}")
+        if [[ "$MANAGED_AGENT" == "true" ]]; then
+          args+=(--managed-agent --agent-connect-address "$DEVICE_ADDRESS")
         else
-          args+=(--agent-address "${{ inputs.device_address }}")
+          args+=(--agent-address "$DEVICE_ADDRESS")
         fi
         bash ./Scripts/E2ETest.sh "${args[@]}"
 
@@ -172,13 +182,15 @@ runs:
         WENDY_E2E_CLI_OS: ${{ inputs.cli_os }}
         WENDY_E2E_AGENT_OS: ${{ inputs.agent_os }}
         WENDY_E2E_TRANSPORT: ${{ inputs.transport }}
+        MANAGED_AGENT: ${{ inputs.managed_agent }}
+        DEVICE_ADDRESS: ${{ inputs.device_address }}
       run: |
         $ErrorActionPreference = 'Stop'
-        if ('${{ inputs.managed_agent }}' -eq 'true') {
+        if ($env:MANAGED_AGENT -eq 'true') {
           throw 'managed_agent is not supported by the Windows Swift E2E runner yet.'
         }
         $outputDir = Join-Path $env:RUNNER_TEMP 'wendy'
-        & ./Scripts/E2ETest.ps1 --output-dir $outputDir --agent-address "${{ inputs.device_address }}"
+        & ./Scripts/E2ETest.ps1 --output-dir $outputDir --agent-address $env:DEVICE_ADDRESS
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Upload Swift E2E run (Unix)

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -42,6 +42,7 @@ runs:
   using: composite
   steps:
     - name: Validate Swift E2E inputs (Unix)
+      id: validate-unix
       if: runner.os != 'Windows'
       shell: bash
       env:
@@ -115,8 +116,18 @@ runs:
           echo "ERROR: invalid TESTS" >&2
           exit 64
         fi
+        {
+          echo "validated=true"
+          echo "tests=$TESTS"
+          echo "managed_agent=$MANAGED_AGENT"
+          echo "device_address=$DEVICE_ADDRESS"
+          echo "cli_os=$CLI_OS"
+          echo "agent_os=$AGENT_OS"
+          echo "transport=$TRANSPORT"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Validate Swift E2E inputs (Windows)
+      id: validate-windows
       if: runner.os == 'Windows'
       shell: pwsh
       env:
@@ -178,6 +189,13 @@ runs:
         if (-not (Test-Tests $env:TESTS)) {
           throw 'invalid TESTS'
         }
+        "validated=true" >> $env:GITHUB_OUTPUT
+        "tests=$env:TESTS" >> $env:GITHUB_OUTPUT
+        "managed_agent=$env:MANAGED_AGENT" >> $env:GITHUB_OUTPUT
+        "device_address=$env:DEVICE_ADDRESS" >> $env:GITHUB_OUTPUT
+        "cli_os=$env:CLI_OS" >> $env:GITHUB_OUTPUT
+        "agent_os=$env:AGENT_OS" >> $env:GITHUB_OUTPUT
+        "transport=$env:TRANSPORT" >> $env:GITHUB_OUTPUT
 
     - name: Set up Swift E2E host (Unix)
       if: runner.os != 'Windows' && inputs.setup == 'true'
@@ -294,18 +312,18 @@ runs:
         "run_id=$runID" >> $env:GITHUB_OUTPUT
 
     - name: Run Swift E2E tests (Unix)
-      if: runner.os != 'Windows'
+      if: runner.os != 'Windows' && steps.validate-unix.outputs.validated == 'true'
       working-directory: swift
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        WENDY_E2E_TEST_FILTERS: ${{ inputs.tests }}
+        WENDY_E2E_TEST_FILTERS: ${{ steps.validate-unix.outputs.tests }}
         WENDY_E2E_RUN_ID: ${{ steps.e2e-run-unix.outputs.run_id }}
-        WENDY_E2E_CLI_OS: ${{ inputs.cli_os }}
-        WENDY_E2E_AGENT_OS: ${{ inputs.agent_os }}
-        WENDY_E2E_TRANSPORT: ${{ inputs.transport }}
-        MANAGED_AGENT: ${{ inputs.managed_agent }}
-        DEVICE_ADDRESS: ${{ inputs.device_address }}
+        WENDY_E2E_CLI_OS: ${{ steps.validate-unix.outputs.cli_os }}
+        WENDY_E2E_AGENT_OS: ${{ steps.validate-unix.outputs.agent_os }}
+        WENDY_E2E_TRANSPORT: ${{ steps.validate-unix.outputs.transport }}
+        MANAGED_AGENT: ${{ steps.validate-unix.outputs.managed_agent }}
+        DEVICE_ADDRESS: ${{ steps.validate-unix.outputs.device_address }}
       run: |
         set -euo pipefail
         output_dir="${RUNNER_TEMP}/wendy"
@@ -318,18 +336,18 @@ runs:
         bash ./Scripts/E2ETest.sh "${args[@]}"
 
     - name: Run Swift E2E tests (Windows)
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && steps.validate-windows.outputs.validated == 'true'
       working-directory: swift
       shell: pwsh
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        WENDY_E2E_TEST_FILTERS: ${{ inputs.tests }}
+        WENDY_E2E_TEST_FILTERS: ${{ steps.validate-windows.outputs.tests }}
         WENDY_E2E_RUN_ID: ${{ steps.e2e-run-windows.outputs.run_id }}
-        WENDY_E2E_CLI_OS: ${{ inputs.cli_os }}
-        WENDY_E2E_AGENT_OS: ${{ inputs.agent_os }}
-        WENDY_E2E_TRANSPORT: ${{ inputs.transport }}
-        MANAGED_AGENT: ${{ inputs.managed_agent }}
-        DEVICE_ADDRESS: ${{ inputs.device_address }}
+        WENDY_E2E_CLI_OS: ${{ steps.validate-windows.outputs.cli_os }}
+        WENDY_E2E_AGENT_OS: ${{ steps.validate-windows.outputs.agent_os }}
+        WENDY_E2E_TRANSPORT: ${{ steps.validate-windows.outputs.transport }}
+        MANAGED_AGENT: ${{ steps.validate-windows.outputs.managed_agent }}
+        DEVICE_ADDRESS: ${{ steps.validate-windows.outputs.device_address }}
       run: |
         $ErrorActionPreference = 'Stop'
         function Test-Port([string]$Port) {

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -61,7 +61,7 @@ jobs:
   # instead of canceling older pending routes.
   swift-e2e-tests:
     name: ${{ matrix.target.name }}
-    runs-on: ${{ fromJSON(matrix.target.runs_on) }}
+    runs-on: ${{ matrix.target.runs_on }}
     concurrency:
       group: device-${{ matrix.target.device_id }}
       cancel-in-progress: false
@@ -77,7 +77,7 @@ jobs:
             target_id: local-macos
             runner_id: macos-26
             runner_label: macos-26
-            runs_on: '["macos-26"]'
+            runs_on: [macos-26]
             cli_os: macOS
             device_id: local-macos-hosted
             device_address: 127.0.0.1:50051
@@ -91,7 +91,7 @@ jobs:
             target_id: local-ubuntu-24
             runner_id: ubuntu-24-04
             runner_label: ubuntu-24-04
-            runs_on: '["ubuntu-24.04"]'
+            runs_on: [ubuntu-24.04]
             cli_os: linux
             device_id: local-ubuntu-hosted
             device_address: 127.0.0.1:50051
@@ -127,7 +127,7 @@ jobs:
             target_id: macos-ubuntu-24
             runner_id: macos-26
             runner_label: macos-26
-            runs_on: '["self-hosted","macos-26"]'
+            runs_on: [self-hosted, macos-26]
             cli_os: macOS
             device_id: ubuntu-24
             device_address: wendy-SER9.local

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - name: local macOS 26 → local macOS 26
+          - name: 'Local: macOS 26'
             target_id: local-macos-macos
             runner_id: macos-26
             runner_label: macos-26
@@ -82,7 +82,7 @@ jobs:
             setup: true
             managed_agent: true
 
-          - name: local Ubuntu 24 → local Ubuntu 24
+          - name: 'Local: Ubuntu 24'
             target_id: local-ubuntu-ubuntu-24
             runner_id: ubuntu-24-04
             runner_label: ubuntu-24-04

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -68,7 +68,8 @@ jobs:
       queue: max
     timeout-minutes: 120
     env:
-      WENDY_E2E_TARGET_GROUP: ${{ inputs.target_group || 'all' }}
+      WENDY_E2E_TARGET_GROUP: ${{ (inputs.target_group == 'local' || inputs.target_group == 'all') && inputs.target_group || 'all' }}
+      WENDY_E2E_TESTS: ${{ inputs.tests || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -239,7 +240,7 @@ jobs:
       - uses: ./.github/actions/swift-e2e-run
         if: ${{ env.WENDY_E2E_TARGET_GROUP == 'all' || matrix.target.target_group == env.WENDY_E2E_TARGET_GROUP }}
         with:
-          tests: ${{ inputs.tests || '' }}
+          tests: ${{ env.WENDY_E2E_TESTS }}
           target_id: ${{ matrix.target.target_id }}
           runner_id: ${{ matrix.target.runner_id }}
           cli_os: ${{ matrix.target.cli_os }}

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -49,7 +49,7 @@ jobs:
   # instead of canceling older pending routes.
   swift-e2e-tests:
     name: ${{ matrix.target.name }}
-    runs-on: ["self-hosted", "${{ matrix.target.runner_label }}"]
+    runs-on: ${{ fromJSON(matrix.target.runs_on) }}
     concurrency:
       group: device-${{ matrix.target.device_id }}
       cancel-in-progress: false
@@ -59,6 +59,32 @@ jobs:
       fail-fast: false
       matrix:
         target:
+          - name: local macOS 26 → local macOS 26
+            target_id: local-macos-macos
+            runner_id: macos-26
+            runner_label: macos-26
+            runs_on: '["macos-26"]'
+            cli_os: macOS
+            device_id: local-macos-hosted
+            device_address: 127.0.0.1:50051
+            agent_os: macOS
+            transport: local
+            setup: true
+            managed_agent: true
+
+          - name: local Ubuntu 24 → local Ubuntu 24
+            target_id: local-ubuntu-ubuntu-24
+            runner_id: ubuntu-24-04
+            runner_label: ubuntu-24-04
+            runs_on: '["ubuntu-24.04"]'
+            cli_os: linux
+            device_id: local-ubuntu-hosted
+            device_address: 127.0.0.1:50051
+            agent_os: linux
+            transport: local
+            setup: true
+            managed_agent: true
+
           # // DISABLED: Mac <> Jetson Swift E2E is flaky; re-enable after stabilization.
           # - name: macOS 26 → Jetson Orin Nano
           #   target_id: macos-jetson-orin-nano
@@ -85,6 +111,7 @@ jobs:
             target_id: macos-ubuntu-24
             runner_id: macos-26
             runner_label: macos-26
+            runs_on: '["self-hosted","macos-26"]'
             cli_os: macOS
             device_id: ubuntu-24
             device_address: wendy-SER9.local
@@ -200,6 +227,8 @@ jobs:
           device_address: ${{ matrix.target.device_address }}
           agent_os: ${{ matrix.target.agent_os }}
           transport: ${{ matrix.target.transport }}
+          setup: ${{ matrix.target.setup || false }}
+          managed_agent: ${{ matrix.target.managed_agent || false }}
 
   swift-e2e-analyze:
     name: Analyze E2E Results

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -56,203 +56,82 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Run routes as a matrix while serializing access to each physical target.
-  # queue: max keeps pending matrix jobs in the same device concurrency group
-  # instead of canceling older pending routes.
-  swift-e2e-tests:
-    name: ${{ matrix.target.name }}
-    runs-on: ${{ matrix.target.runs_on }}
+  swift-e2e-local-macos:
+    name: 'Local: macOS 26'
+    if: ${{ inputs.target_group == '' || inputs.target_group == 'all' || inputs.target_group == 'local' }}
+    runs-on: macos-26
     concurrency:
-      group: device-${{ matrix.target.device_id }}
+      group: device-local-macos-hosted
       cancel-in-progress: false
       queue: max
     timeout-minutes: 120
-    env:
-      WENDY_E2E_TARGET_GROUP: ${{ inputs.target_group || 'all' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - name: 'Local: macOS 26'
-            target_id: local-macos
-            runner_id: macos-26
-            runner_label: macos-26
-            runs_on: [macos-26]
-            cli_os: macOS
-            device_id: local-macos-hosted
-            device_address: 127.0.0.1:50051
-            agent_os: macOS
-            transport: local
-            target_group: local
-            setup: true
-            managed_agent: true
-
-          - name: 'Local: Ubuntu 24'
-            target_id: local-ubuntu-24
-            runner_id: ubuntu-24-04
-            runner_label: ubuntu-24-04
-            runs_on: [ubuntu-24.04]
-            cli_os: linux
-            device_id: local-ubuntu-hosted
-            device_address: 127.0.0.1:50051
-            agent_os: linux
-            transport: local
-            target_group: local
-            setup: true
-            managed_agent: true
-
-          # // DISABLED: Mac <> Jetson Swift E2E is flaky; re-enable after stabilization.
-          # - name: macOS 26 → Jetson Orin Nano
-          #   target_id: macos-jetson-orin-nano
-          #   runner_id: macos-26
-          #   runner_label: macos-26
-          #   cli_os: macOS
-          #   device_id: jetson-orin-nano
-          #   device_address: wendyos-strong-dunlin.local
-          #   agent_os: wendyOS
-          #   transport: lan
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: Windows 11 → Ubuntu 24
-          #   target_id: windows-ubuntu-24
-          #   runner_id: windows-11
-          #   runner_label: windows-11
-          #   cli_os: windows
-          #   device_id: ubuntu-24
-          #   device_address: wendy-SER9.local
-          #   agent_os: linux
-          #   transport: lan
-
-          - name: macOS 26 → Ubuntu 24
-            target_id: macos-ubuntu-24
-            runner_id: macos-26
-            runner_label: macos-26
-            runs_on: [self-hosted, macos-26]
-            cli_os: macOS
-            device_id: ubuntu-24
-            device_address: wendy-SER9.local
-            agent_os: linux
-            transport: lan
-            target_group: physical
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: Ubuntu 24 → Ubuntu 24
-          #   target_id: ubuntu-ubuntu-24
-          #   runner_id: ubuntu-24-04
-          #   runner_label: ubuntu-24
-          #   cli_os: linux
-          #   device_id: ubuntu-24
-          #   device_address: wendy-SER9.local
-          #   agent_os: linux
-          #   transport: lan
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: Ubuntu 24 → Raspberry Pi 5
-          #   target_id: ubuntu-raspberry-pi-5
-          #   runner_id: ubuntu-24-04
-          #   runner_label: ubuntu-24
-          #   cli_os: linux
-          #   device_id: raspberry-pi-5
-          #   device_address: wendyos-raspberry-pi-5.local
-          #   agent_os: wendyOS
-          #   transport: lan
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: Windows 11 → Mac mini
-          #   target_id: windows-mac-mini
-          #   runner_id: windows-11
-          #   runner_label: windows-11
-          #   cli_os: windows
-          #   device_id: mac-mini
-          #   device_address: mac-mini.local
-          #   agent_os: macOS
-          #   transport: lan
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: Ubuntu 24 → Jetson Orin Nano
-          #   target_id: ubuntu-jetson-orin-nano
-          #   runner_id: ubuntu-24-04
-          #   runner_label: ubuntu-24
-          #   cli_os: linux
-          #   device_id: jetson-orin-nano
-          #   device_address: wendyos-jetson-orin-nano.local
-          #   agent_os: wendyOS
-          #   transport: lan
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: Windows 11 → Raspberry Pi 5
-          #   target_id: windows-raspberry-pi-5
-          #   runner_id: windows-11
-          #   runner_label: windows-11
-          #   cli_os: windows
-          #   device_id: raspberry-pi-5
-          #   device_address: wendyos-raspberry-pi-5.local
-          #   agent_os: wendyOS
-          #   transport: lan
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: macOS 26 → Mac mini
-          #   target_id: macos-mac-mini
-          #   runner_id: macos-26
-          #   runner_label: macos-26
-          #   cli_os: macOS
-          #   device_id: mac-mini
-          #   device_address: mac-mini.local
-          #   agent_os: macOS
-          #   transport: lan
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: Windows 11 → Jetson Orin Nano
-          #   target_id: windows-jetson-orin-nano
-          #   runner_id: windows-11
-          #   runner_label: windows-11
-          #   cli_os: windows
-          #   device_id: jetson-orin-nano
-          #   device_address: wendyos-jetson-orin-nano.local
-          #   agent_os: wendyOS
-          #   transport: lan
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: macOS 26 → Raspberry Pi 5
-          #   target_id: macos-raspberry-pi-5
-          #   runner_id: macos-26
-          #   runner_label: macos-26
-          #   cli_os: macOS
-          #   device_id: raspberry-pi-5
-          #   device_address: wendyos-raspberry-pi-5.local
-          #   agent_os: wendyOS
-          #   transport: lan
-
-          # // DISABLED: no CI hardware set up yet for this job.
-          # - name: Ubuntu 24 → Mac mini
-          #   target_id: ubuntu-mac-mini
-          #   runner_id: ubuntu-24-04
-          #   runner_label: ubuntu-24
-          #   cli_os: linux
-          #   device_id: mac-mini
-          #   device_address: mac-mini.local
-          #   agent_os: macOS
-          #   transport: lan
     steps:
       - uses: actions/checkout@v6
-        if: ${{ env.WENDY_E2E_TARGET_GROUP == 'all' || matrix.target.target_group == env.WENDY_E2E_TARGET_GROUP }}
       - uses: ./.github/actions/swift-e2e-run
-        if: ${{ env.WENDY_E2E_TARGET_GROUP == 'all' || matrix.target.target_group == env.WENDY_E2E_TARGET_GROUP }}
         with:
           tests: ${{ inputs.tests || '' }}
-          target_id: ${{ matrix.target.target_id }}
-          runner_id: ${{ matrix.target.runner_id }}
-          cli_os: ${{ matrix.target.cli_os }}
-          device_address: ${{ matrix.target.device_address }}
-          agent_os: ${{ matrix.target.agent_os }}
-          transport: ${{ matrix.target.transport }}
-          setup: ${{ matrix.target.setup || false }}
-          managed_agent: ${{ matrix.target.managed_agent || false }}
+          target_id: local-macos
+          runner_id: macos-26
+          cli_os: macOS
+          device_address: 127.0.0.1:50051
+          agent_os: macOS
+          transport: local
+          setup: true
+          managed_agent: true
+
+  swift-e2e-local-ubuntu:
+    name: 'Local: Ubuntu 24'
+    if: ${{ inputs.target_group == '' || inputs.target_group == 'all' || inputs.target_group == 'local' }}
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: device-local-ubuntu-hosted
+      cancel-in-progress: false
+      queue: max
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/swift-e2e-run
+        with:
+          tests: ${{ inputs.tests || '' }}
+          target_id: local-ubuntu-24
+          runner_id: ubuntu-24-04
+          cli_os: linux
+          device_address: 127.0.0.1:50051
+          agent_os: linux
+          transport: local
+          setup: true
+          managed_agent: true
+
+  swift-e2e-physical-macos-ubuntu:
+    name: macOS 26 → Ubuntu 24
+    if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
+    runs-on: [self-hosted, macos-26]
+    concurrency:
+      group: device-ubuntu-24
+      cancel-in-progress: false
+      queue: max
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/swift-e2e-run
+        with:
+          tests: ${{ inputs.tests || '' }}
+          target_id: macos-ubuntu-24
+          runner_id: macos-26
+          cli_os: macOS
+          device_address: wendy-SER9.local
+          agent_os: linux
+          transport: lan
+          setup: false
+          managed_agent: false
 
   swift-e2e-analyze:
     name: Analyze E2E Results
     if: ${{ always() && !cancelled() }}
-    needs: swift-e2e-tests
+    needs:
+      - swift-e2e-local-macos
+      - swift-e2e-local-ubuntu
+      - swift-e2e-physical-macos-ubuntu
     runs-on: [self-hosted, AI]
     timeout-minutes: 60
     steps:
@@ -533,7 +412,7 @@ jobs:
           REPORT_ARTIFACT_URL: ${{ steps.upload_e2e_report.outputs['artifact-url'] }}
           DIFF_BASE_REF: ${{ inputs.diff_base_ref || '' }}
           TESTS: ${{ inputs.tests || '' }}
-          E2E_RESULT: ${{ needs.swift-e2e-tests.result }}
+          E2E_RESULT: ${{ contains(needs.*.result, 'failure') && 'failure' || contains(needs.*.result, 'cancelled') && 'cancelled' || 'success' }}
         run: |
           set -euo pipefail
           if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -68,8 +68,7 @@ jobs:
       queue: max
     timeout-minutes: 120
     env:
-      WENDY_E2E_TARGET_GROUP: ${{ (inputs.target_group == 'local' || inputs.target_group == 'all') && inputs.target_group || 'all' }}
-      WENDY_E2E_TESTS: ${{ inputs.tests || '' }}
+      WENDY_E2E_TARGET_GROUP: ${{ inputs.target_group || 'all' }}
     strategy:
       fail-fast: false
       matrix:
@@ -240,7 +239,7 @@ jobs:
       - uses: ./.github/actions/swift-e2e-run
         if: ${{ env.WENDY_E2E_TARGET_GROUP == 'all' || matrix.target.target_group == env.WENDY_E2E_TARGET_GROUP }}
         with:
-          tests: ${{ env.WENDY_E2E_TESTS }}
+          tests: ${{ inputs.tests || '' }}
           target_id: ${{ matrix.target.target_id }}
           runner_id: ${{ matrix.target.runner_id }}
           cli_os: ${{ matrix.target.cli_os }}

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -13,6 +13,10 @@ on:
         description: 'Comma-separated SwiftPM test filters (empty = WendyE2ETests)'
         required: false
         default: ''
+      target_ids:
+        description: 'Comma-separated matrix target IDs to run (empty = all)'
+        required: false
+        default: ''
       diff_base_ref:
         description: 'Optional ref to diff against (empty = full review)'
         required: false
@@ -20,6 +24,10 @@ on:
   workflow_call:
     inputs:
       tests:
+        type: string
+        required: false
+        default: ''
+      target_ids:
         type: string
         required: false
         default: ''
@@ -55,6 +63,8 @@ jobs:
       cancel-in-progress: false
       queue: max
     timeout-minutes: 120
+    env:
+      WENDY_E2E_TARGET_IDS: ${{ inputs.target_ids || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -218,7 +228,9 @@ jobs:
           #   transport: lan
     steps:
       - uses: actions/checkout@v6
+        if: ${{ env.WENDY_E2E_TARGET_IDS == '' || contains(format(',{0},', env.WENDY_E2E_TARGET_IDS), format(',{0},', matrix.target.target_id)) }}
       - uses: ./.github/actions/swift-e2e-run
+        if: ${{ env.WENDY_E2E_TARGET_IDS == '' || contains(format(',{0},', env.WENDY_E2E_TARGET_IDS), format(',{0},', matrix.target.target_id)) }}
         with:
           tests: ${{ inputs.tests || '' }}
           target_id: ${{ matrix.target.target_id }}

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         target:
           - name: 'Local: macOS 26'
-            target_id: local-macos-macos
+            target_id: local-macos
             runner_id: macos-26
             runner_label: macos-26
             runs_on: '["macos-26"]'
@@ -83,7 +83,7 @@ jobs:
             managed_agent: true
 
           - name: 'Local: Ubuntu 24'
-            target_id: local-ubuntu-ubuntu-24
+            target_id: local-ubuntu-24
             runner_id: ubuntu-24-04
             runner_label: ubuntu-24-04
             runs_on: '["ubuntu-24.04"]'

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -13,10 +13,14 @@ on:
         description: 'Comma-separated SwiftPM test filters (empty = WendyE2ETests)'
         required: false
         default: ''
-      target_ids:
-        description: 'Comma-separated matrix target IDs to run (empty = all)'
+      target_group:
+        description: 'Matrix target group to run'
         required: false
-        default: ''
+        default: all
+        type: choice
+        options:
+          - all
+          - local
       diff_base_ref:
         description: 'Optional ref to diff against (empty = full review)'
         required: false
@@ -27,10 +31,10 @@ on:
         type: string
         required: false
         default: ''
-      target_ids:
+      target_group:
         type: string
         required: false
-        default: ''
+        default: all
       diff_base_ref:
         type: string
         required: false
@@ -64,7 +68,7 @@ jobs:
       queue: max
     timeout-minutes: 120
     env:
-      WENDY_E2E_TARGET_IDS: ${{ inputs.target_ids || '' }}
+      WENDY_E2E_TARGET_GROUP: ${{ inputs.target_group || 'all' }}
     strategy:
       fail-fast: false
       matrix:
@@ -79,6 +83,7 @@ jobs:
             device_address: 127.0.0.1:50051
             agent_os: macOS
             transport: local
+            target_group: local
             setup: true
             managed_agent: true
 
@@ -92,6 +97,7 @@ jobs:
             device_address: 127.0.0.1:50051
             agent_os: linux
             transport: local
+            target_group: local
             setup: true
             managed_agent: true
 
@@ -127,6 +133,7 @@ jobs:
             device_address: wendy-SER9.local
             agent_os: linux
             transport: lan
+            target_group: physical
 
           # // DISABLED: no CI hardware set up yet for this job.
           # - name: Ubuntu 24 → Ubuntu 24
@@ -228,9 +235,9 @@ jobs:
           #   transport: lan
     steps:
       - uses: actions/checkout@v6
-        if: ${{ env.WENDY_E2E_TARGET_IDS == '' || contains(format(',{0},', env.WENDY_E2E_TARGET_IDS), format(',{0},', matrix.target.target_id)) }}
+        if: ${{ env.WENDY_E2E_TARGET_GROUP == 'all' || matrix.target.target_group == env.WENDY_E2E_TARGET_GROUP }}
       - uses: ./.github/actions/swift-e2e-run
-        if: ${{ env.WENDY_E2E_TARGET_IDS == '' || contains(format(',{0},', env.WENDY_E2E_TARGET_IDS), format(',{0},', matrix.target.target_id)) }}
+        if: ${{ env.WENDY_E2E_TARGET_GROUP == 'all' || matrix.target.target_group == env.WENDY_E2E_TARGET_GROUP }}
         with:
           tests: ${{ inputs.tests || '' }}
           target_id: ${{ matrix.target.target_id }}

--- a/swift/Scripts/E2ESetup.macOS.sh
+++ b/swift/Scripts/E2ESetup.macOS.sh
@@ -188,7 +188,6 @@ setupE2EMacOS() {
   checkCommand go
   checkCommand make
   checkCommand swift
-  checkCommand swiftly
   checkCommand zip
   checkCommand ssh "openssh-client"
   checkCommand ssh-keygen

--- a/swift/Scripts/E2ESetup.ubuntu.sh
+++ b/swift/Scripts/E2ESetup.ubuntu.sh
@@ -227,7 +227,6 @@ setupE2EUbuntu() {
   checkCommand go
   checkCommand make
   checkCommand swift
-  checkCommand swiftly
   checkCommand zip
   checkCommand unzip
   checkCommand ssh "openssh-client"

--- a/swift/Scripts/E2ESetup.ubuntu.sh
+++ b/swift/Scripts/E2ESetup.ubuntu.sh
@@ -155,7 +155,7 @@ configureSSHDForE2E() {
   local config_dir="/etc/ssh/sshd_config.d"
   local config_file="$config_dir/99-wendy-e2e.conf"
 
-  sudo mkdir -p "$config_dir"
+  sudo mkdir -p "$config_dir" /run/sshd
   sudo tee "$config_file" >/dev/null <<'EOF'
 # Managed by Wendy Swift E2E setup.
 # The E2E harness runs each command through SSH; parallel tests can briefly

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -339,6 +339,19 @@ if [[ "$MANAGED_AGENT" == "true" && -n "$AGENT_ADDRESS" ]]; then
   exit 64
 fi
 
+if [[ "$DEVICE_ADDRESS" == *@* ]]; then
+  echo "ERROR: --device-address must not contain credentials." >&2
+  exit 64
+fi
+if [[ -n "$DEVICE_ADDRESS" && ! "$DEVICE_ADDRESS" =~ ^[][A-Za-z0-9._:%-]{1,255}$ ]]; then
+  echo "ERROR: invalid --device-address." >&2
+  exit 64
+fi
+if [[ -n "$TRANSPORT" && ! "$TRANSPORT" =~ ^[A-Za-z0-9._-]{1,40}$ ]]; then
+  echo "ERROR: WENDY_E2E_TRANSPORT contains invalid characters." >&2
+  exit 64
+fi
+
 shell_quote() {
   printf "'%s'" "${1//\'/\'\\\'\'}"
 }
@@ -588,12 +601,10 @@ start_managed_agent() {
   local pid_path="$managed_dir/pid"
   local port="50051"
 
-  if [[ "$DEVICE_ADDRESS" == *@* ]]; then
-    echo "ERROR: --device-address must not contain credentials." >&2
-    return 64
-  fi
-  if [[ "$DEVICE_ADDRESS" == *:* ]]; then
-    port="${DEVICE_ADDRESS##*:}"
+  if [[ "$DEVICE_ADDRESS" =~ ^\[[^]]+\]:([0-9]+)$ ]]; then
+    port="${BASH_REMATCH[1]}"
+  elif [[ "$DEVICE_ADDRESS" =~ ^[^:]+:([0-9]+)$ ]]; then
+    port="${BASH_REMATCH[1]}"
   fi
   if ! [[ "$port" =~ ^[0-9]{1,5}$ ]] || (( port < 1 || port > 65535 )); then
     echo "ERROR: invalid managed agent port in --device-address: $port" >&2
@@ -880,7 +891,7 @@ else
   echo "    Agent:   <local>:${AGENT_REPO_DIR:-<no-repo>}"
 fi
 if [[ -n "$DEVICE_ADDRESS" ]]; then
-  echo "    Device address: $DEVICE_ADDRESS"
+  echo "    Device address: ${DEVICE_ADDRESS##*@}"
 fi
 echo "    Agent OS: ${AGENT_OS:-<current>}"
 echo "    Transport: ${TRANSPORT:-<none>}"

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -58,7 +58,7 @@ AGENT_REPO_DIR="${WENDY_E2E_AGENT_REPO_DIR:-}"
 AGENT_BIN_DIR="${WENDY_E2E_AGENT_BIN_DIR:-}"
 AGENT_USER="${WENDY_E2E_AGENT_USER:-}"
 AGENT_ADDRESS="${WENDY_E2E_AGENT_ADDRESS:-}"
-AGENT_CONNECT_ADDRESS="${WENDY_E2E_AGENT_CONNECT_ADDRESS:-}"
+DEVICE_ADDRESS="${WENDY_E2E_DEVICE_ADDRESS:-}"
 AGENT_OS="${WENDY_E2E_AGENT_OS:-}"
 TRANSPORT="${WENDY_E2E_TRANSPORT:-}"
 MANAGED_AGENT="${WENDY_E2E_MANAGED_AGENT:-false}"
@@ -127,8 +127,8 @@ Options:
   --agent-bin-dir DIR   Optional directory prepended to PATH on the agent machine.
   --agent-user USER     Optional SSH user for the agent machine.
   --agent-address HOST  Optional SSH address for the agent machine; defaults to local.
-  --agent-connect-address ADDRESS
-                        Optional Wendy agent device address while commands run locally.
+  --device-address ADDRESS
+                        Optional Wendy device address while commands run locally.
   --agent-os OS         Optional OS override for the agent machine.
   --managed-agent       Build and launch a local wendy-agent for this run.
   --no-managed-agent    Do not launch a managed local wendy-agent.
@@ -157,7 +157,7 @@ Environment:
   WENDY_E2E_AGENT_BIN_DIR             Optional directory prepended to PATH on the agent machine.
   WENDY_E2E_AGENT_USER                Optional SSH user for the agent machine.
   WENDY_E2E_AGENT_ADDRESS             Optional SSH address for the agent machine.
-  WENDY_E2E_AGENT_CONNECT_ADDRESS     Optional Wendy agent device address while commands run locally.
+  WENDY_E2E_DEVICE_ADDRESS           Optional Wendy device address while commands run locally.
   WENDY_E2E_AGENT_OS                  Optional OS override for the agent machine.
   WENDY_E2E_MANAGED_AGENT             Boolean; build and launch a local wendy-agent.
   WENDY_E2E_TRANSPORT                 Optional transport label for report metadata.
@@ -231,8 +231,8 @@ while [[ $# -gt 0 ]]; do
       AGENT_ADDRESS="$2"
       shift 2
       ;;
-    --agent-connect-address)
-      AGENT_CONNECT_ADDRESS="$2"
+    --device-address)
+      DEVICE_ADDRESS="$2"
       shift 2
       ;;
     --agent-os)
@@ -335,7 +335,7 @@ fi
 
 if [[ "$MANAGED_AGENT" == "true" && -n "$AGENT_ADDRESS" ]]; then
   echo "ERROR: --managed-agent cannot be combined with --agent-address." >&2
-  echo "Use --agent-connect-address for the local device address instead." >&2
+  echo "Use --device-address for the local device address instead." >&2
   exit 64
 fi
 
@@ -421,8 +421,8 @@ if [[ -z "$AGENT_ADDRESS" ]]; then
 fi
 mkdir -p "$RUN_DIR"
 
-if [[ "$MANAGED_AGENT" == "true" && -z "$AGENT_CONNECT_ADDRESS" ]]; then
-  AGENT_CONNECT_ADDRESS="127.0.0.1:${WENDY_AGENT_PORT:-50051}"
+if [[ "$MANAGED_AGENT" == "true" && -z "$DEVICE_ADDRESS" ]]; then
+  DEVICE_ADDRESS="127.0.0.1:${WENDY_AGENT_PORT:-50051}"
 fi
 
 ssh_target() {
@@ -588,20 +588,20 @@ start_managed_agent() {
   local pid_path="$managed_dir/pid"
   local port="50051"
 
-  if [[ "$AGENT_CONNECT_ADDRESS" == *@* ]]; then
-    echo "ERROR: --agent-connect-address must not contain credentials." >&2
+  if [[ "$DEVICE_ADDRESS" == *@* ]]; then
+    echo "ERROR: --device-address must not contain credentials." >&2
     return 64
   fi
-  if [[ "$AGENT_CONNECT_ADDRESS" == *:* ]]; then
-    port="${AGENT_CONNECT_ADDRESS##*:}"
+  if [[ "$DEVICE_ADDRESS" == *:* ]]; then
+    port="${DEVICE_ADDRESS##*:}"
   fi
   if ! [[ "$port" =~ ^[0-9]{1,5}$ ]] || (( port < 1 || port > 65535 )); then
-    echo "ERROR: invalid managed agent port in --agent-connect-address: $port" >&2
+    echo "ERROR: invalid managed agent port in --device-address: $port" >&2
     return 64
   fi
 
   echo "==> Starting managed wendy-agent"
-  echo "    Address: $AGENT_CONNECT_ADDRESS"
+  echo "    Address: $DEVICE_ADDRESS"
   echo "    Config:  $config_dir"
   echo "    Logs:    $stdout_path, $stderr_path"
 
@@ -627,14 +627,14 @@ start_managed_agent() {
       echo "ERROR: managed wendy-agent exited before becoming ready; see $stderr_path in the E2E artifact." >&2
       return 1
     fi
-    if "$CLI_BIN_DIR/wendy" --json --device "$AGENT_CONNECT_ADDRESS" device info >/dev/null 2>&1; then
+    if "$CLI_BIN_DIR/wendy" --json --device "$DEVICE_ADDRESS" device info >/dev/null 2>&1; then
       echo "    Ready"
       return 0
     fi
     sleep 1
   done
 
-  echo "ERROR: managed wendy-agent did not become ready at $AGENT_CONNECT_ADDRESS; see $stderr_path in the E2E artifact." >&2
+  echo "ERROR: managed wendy-agent did not become ready at $DEVICE_ADDRESS; see $stderr_path in the E2E artifact." >&2
   return 1
 }
 
@@ -737,7 +737,7 @@ write_attempt_info() {
 
   mkdir -p "$RUN_DIR"
 
-  local created_at git_commit git_branch git_ref git_remote git_dirty github_sha swift_version go_version safe_agent_connect_address
+  local created_at git_commit git_branch git_ref git_remote git_dirty github_sha swift_version go_version safe_device_address
   created_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   git_commit="$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)"
   git_branch="$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || true)"
@@ -751,7 +751,7 @@ write_attempt_info() {
   github_sha="${GITHUB_SHA:-}"
   swift_version="$(swift --version 2>/dev/null | head -n 1 || true)"
   go_version="$(go version 2>/dev/null || true)"
-  safe_agent_connect_address="${AGENT_CONNECT_ADDRESS##*@}"
+  safe_device_address="${DEVICE_ADDRESS##*@}"
 
   {
     echo "{"
@@ -782,7 +782,7 @@ write_attempt_info() {
     printf '    "cliUser": '; json_string_or_null "$CLI_USER"; echo ","
     printf '    "agentOS": '; json_string_or_null "$AGENT_OS"; echo ","
     printf '    "agentAddress": '; json_string_or_null "$AGENT_ADDRESS"; echo ","
-    printf '    "agentConnectAddress": '; json_string_or_null "$safe_agent_connect_address"; echo ","
+    printf '    "deviceAddress": '; json_string_or_null "$safe_device_address"; echo ","
     printf '    "agentUser": '; json_string_or_null "$AGENT_USER"; echo ","
     printf '    "transport": '; json_string_or_null "$TRANSPORT"; echo ","
     printf '    "agentInfo": '; json_raw_or_null "$AGENT_INFO_JSON"; echo
@@ -852,7 +852,7 @@ SWIFT_TEST_ENV=(
   "WENDY_E2E_AGENT_BIN_DIR=$AGENT_BIN_DIR"
   "WENDY_E2E_AGENT_USER=$AGENT_USER"
   "WENDY_E2E_AGENT_ADDRESS=$AGENT_ADDRESS"
-  "WENDY_E2E_AGENT_CONNECT_ADDRESS=$AGENT_CONNECT_ADDRESS"
+  "WENDY_E2E_DEVICE_ADDRESS=$DEVICE_ADDRESS"
   "WENDY_E2E_CLI_OS=$CLI_OS"
   "WENDY_E2E_AGENT_OS=$AGENT_OS"
   "WENDY_E2E_ISOLATION=$ISOLATION"
@@ -879,8 +879,8 @@ if [[ -n "$AGENT_ADDRESS" ]]; then
 else
   echo "    Agent:   <local>:${AGENT_REPO_DIR:-<no-repo>}"
 fi
-if [[ -n "$AGENT_CONNECT_ADDRESS" ]]; then
-  echo "    Agent device address: $AGENT_CONNECT_ADDRESS"
+if [[ -n "$DEVICE_ADDRESS" ]]; then
+  echo "    Device address: $DEVICE_ADDRESS"
 fi
 echo "    Agent OS: ${AGENT_OS:-<current>}"
 echo "    Transport: ${TRANSPORT:-<none>}"

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -102,6 +102,32 @@ normalize_isolation() {
   esac
 }
 
+validate_port() {
+  local port="$1"
+  [[ "$port" =~ ^[0-9]{1,5}$ ]] || return 1
+  (( 10#$port >= 1 && 10#$port <= 65535 ))
+}
+
+valid_device_address() {
+  local value="$1" port=""
+  [[ "$value" != *@* ]] || return 1
+  if [[ "$value" =~ ^[A-Za-z0-9._-]{1,253}(:([0-9]{1,5}))?$ ]]; then
+    port="${BASH_REMATCH[2]:-}"
+  elif [[ "$value" =~ ^\[[0-9A-Fa-f:]+\](:([0-9]{1,5}))?$ ]]; then
+    port="${BASH_REMATCH[2]:-}"
+  else
+    return 1
+  fi
+  [[ -z "$port" ]] || validate_port "$port"
+}
+
+validate_test_filter() {
+  local filter="$1"
+  [[ -n "$filter" && ${#filter} -le 200 ]] || return 1
+  [[ "$filter" != -* ]] || return 1
+  [[ "$filter" =~ ^[A-Za-z0-9][A-Za-z0-9\ \._:/\|\(\),_-]*$ ]]
+}
+
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
@@ -282,7 +308,8 @@ done
 if [[ ${#TEST_FILTERS[@]} -eq 0 && -n "${WENDY_E2E_TEST_FILTERS:-}" ]]; then
   IFS=',' read -ra RAW_FILTERS <<< "${WENDY_E2E_TEST_FILTERS}"
   for filter in "${RAW_FILTERS[@]}"; do
-    filter="$(echo "$filter" | xargs)"
+    filter="${filter#${filter%%[![:space:]]*}}"
+    filter="${filter%${filter##*[![:space:]]}}"
     [[ -n "$filter" ]] && TEST_FILTERS+=("$filter")
   done
 fi
@@ -339,14 +366,16 @@ if [[ "$MANAGED_AGENT" == "true" && -n "$AGENT_ADDRESS" ]]; then
   exit 64
 fi
 
-if [[ "$DEVICE_ADDRESS" == *@* ]]; then
-  echo "ERROR: --device-address must not contain credentials." >&2
-  exit 64
-fi
-if [[ -n "$DEVICE_ADDRESS" && ! "$DEVICE_ADDRESS" =~ ^[][A-Za-z0-9._:-]{1,255}$ ]]; then
+if [[ -n "$DEVICE_ADDRESS" ]] && ! valid_device_address "$DEVICE_ADDRESS"; then
   echo "ERROR: invalid --device-address." >&2
   exit 64
 fi
+for filter in "${TEST_FILTERS[@]}"; do
+  if ! validate_test_filter "$filter"; then
+    echo "ERROR: invalid SwiftPM test filter: $filter" >&2
+    exit 64
+  fi
+done
 if [[ -n "$TRANSPORT" && ! "$TRANSPORT" =~ ^[A-Za-z0-9._-]{1,40}$ ]]; then
   echo "ERROR: WENDY_E2E_TRANSPORT contains invalid characters." >&2
   exit 64
@@ -601,18 +630,18 @@ start_managed_agent() {
   local pid_path="$managed_dir/pid"
   local port="50051"
 
-  if [[ "$DEVICE_ADDRESS" =~ ^\[[^]]+\]:([0-9]+)$ ]]; then
+  if [[ "$DEVICE_ADDRESS" =~ ^[A-Za-z0-9._-]{1,253}:([0-9]{1,5})$ ]]; then
     port="${BASH_REMATCH[1]}"
-  elif [[ "$DEVICE_ADDRESS" =~ ^[^:]+:([0-9]+)$ ]]; then
+  elif [[ "$DEVICE_ADDRESS" =~ ^\[[0-9A-Fa-f:]+\]:([0-9]{1,5})$ ]]; then
     port="${BASH_REMATCH[1]}"
   fi
-  if ! [[ "$port" =~ ^[0-9]{1,5}$ ]] || (( port < 1 || port > 65535 )); then
+  if ! validate_port "$port"; then
     echo "ERROR: invalid managed agent port in --device-address: $port" >&2
     return 64
   fi
 
   echo "==> Starting managed wendy-agent"
-  echo "    Address: $DEVICE_ADDRESS"
+  echo "    Address: ${DEVICE_ADDRESS##*@}"
   echo "    Config:  $config_dir"
   echo "    Logs:    $stdout_path, $stderr_path"
 
@@ -620,7 +649,7 @@ start_managed_agent() {
   env -i \
     HOME="${HOME:-}" \
     LOGNAME="${LOGNAME:-${USER:-}}" \
-    PATH="$PATH" \
+    PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
     TMPDIR="${TMPDIR:-/tmp}" \
     USER="${USER:-}" \
     WENDY_CONFIG_PATH="$config_dir" \

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -343,7 +343,7 @@ if [[ "$DEVICE_ADDRESS" == *@* ]]; then
   echo "ERROR: --device-address must not contain credentials." >&2
   exit 64
 fi
-if [[ -n "$DEVICE_ADDRESS" && ! "$DEVICE_ADDRESS" =~ ^[][A-Za-z0-9._:%-]{1,255}$ ]]; then
+if [[ -n "$DEVICE_ADDRESS" && ! "$DEVICE_ADDRESS" =~ ^[][A-Za-z0-9._:-]{1,255}$ ]]; then
   echo "ERROR: invalid --device-address." >&2
   exit 64
 fi

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -588,8 +588,16 @@ start_managed_agent() {
   local pid_path="$managed_dir/pid"
   local port="50051"
 
+  if [[ "$AGENT_CONNECT_ADDRESS" == *@* ]]; then
+    echo "ERROR: --agent-connect-address must not contain credentials." >&2
+    return 64
+  fi
   if [[ "$AGENT_CONNECT_ADDRESS" == *:* ]]; then
     port="${AGENT_CONNECT_ADDRESS##*:}"
+  fi
+  if ! [[ "$port" =~ ^[0-9]{1,5}$ ]] || (( port < 1 || port > 65535 )); then
+    echo "ERROR: invalid managed agent port in --agent-connect-address: $port" >&2
+    return 64
   fi
 
   echo "==> Starting managed wendy-agent"
@@ -598,20 +606,25 @@ start_managed_agent() {
   echo "    Logs:    $stdout_path, $stderr_path"
 
   mkdir -p "$config_dir"
-  WENDY_CONFIG_PATH="$config_dir" \
-  WENDY_AGENT_PORT="$port" \
-  WENDY_OTEL_PORT=0 \
-  WENDY_OTEL_HTTP_PORT=0 \
-  WENDY_REGISTRY_ADDR=127.0.0.1:0 \
+  env -i \
+    HOME="${HOME:-}" \
+    LOGNAME="${LOGNAME:-${USER:-}}" \
+    PATH="$PATH" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    USER="${USER:-}" \
+    WENDY_CONFIG_PATH="$config_dir" \
+    WENDY_AGENT_PORT="$port" \
+    WENDY_OTEL_PORT=0 \
+    WENDY_OTEL_HTTP_PORT=0 \
+    WENDY_REGISTRY_ADDR=127.0.0.1:0 \
     "$agent_path" >"$stdout_path" 2>"$stderr_path" &
   MANAGED_AGENT_PID=$!
   printf '%s\n' "$MANAGED_AGENT_PID" > "$pid_path"
 
-  local deadline=$((SECONDS + 30))
-  while (( SECONDS < deadline )); do
+  local attempt max_attempts=30
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     if ! kill -0 "$MANAGED_AGENT_PID" 2>/dev/null; then
-      echo "ERROR: managed wendy-agent exited before becoming ready." >&2
-      sed -n '1,160p' "$stderr_path" >&2 || true
+      echo "ERROR: managed wendy-agent exited before becoming ready; see $stderr_path in the E2E artifact." >&2
       return 1
     fi
     if "$CLI_BIN_DIR/wendy" --json --device "$AGENT_CONNECT_ADDRESS" device info >/dev/null 2>&1; then
@@ -621,8 +634,7 @@ start_managed_agent() {
     sleep 1
   done
 
-  echo "ERROR: managed wendy-agent did not become ready at $AGENT_CONNECT_ADDRESS." >&2
-  sed -n '1,160p' "$stderr_path" >&2 || true
+  echo "ERROR: managed wendy-agent did not become ready at $AGENT_CONNECT_ADDRESS; see $stderr_path in the E2E artifact." >&2
   return 1
 }
 
@@ -725,7 +737,7 @@ write_attempt_info() {
 
   mkdir -p "$RUN_DIR"
 
-  local created_at git_commit git_branch git_ref git_remote git_dirty github_sha swift_version go_version
+  local created_at git_commit git_branch git_ref git_remote git_dirty github_sha swift_version go_version safe_agent_connect_address
   created_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   git_commit="$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)"
   git_branch="$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || true)"
@@ -739,6 +751,7 @@ write_attempt_info() {
   github_sha="${GITHUB_SHA:-}"
   swift_version="$(swift --version 2>/dev/null | head -n 1 || true)"
   go_version="$(go version 2>/dev/null || true)"
+  safe_agent_connect_address="${AGENT_CONNECT_ADDRESS##*@}"
 
   {
     echo "{"
@@ -769,7 +782,7 @@ write_attempt_info() {
     printf '    "cliUser": '; json_string_or_null "$CLI_USER"; echo ","
     printf '    "agentOS": '; json_string_or_null "$AGENT_OS"; echo ","
     printf '    "agentAddress": '; json_string_or_null "$AGENT_ADDRESS"; echo ","
-    printf '    "agentConnectAddress": '; json_string_or_null "$AGENT_CONNECT_ADDRESS"; echo ","
+    printf '    "agentConnectAddress": '; json_string_or_null "$safe_agent_connect_address"; echo ","
     printf '    "agentUser": '; json_string_or_null "$AGENT_USER"; echo ","
     printf '    "transport": '; json_string_or_null "$TRANSPORT"; echo ","
     printf '    "agentInfo": '; json_raw_or_null "$AGENT_INFO_JSON"; echo

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -665,7 +665,7 @@ start_managed_agent() {
     WENDY_REGISTRY_ADDR=127.0.0.1:0 \
     "$agent_path" >"$stdout_path" 2>"$stderr_path" &
   MANAGED_AGENT_PID=$!
-  printf '%s\n' "$MANAGED_AGENT_PID" > "$pid_path"
+  (umask 077; printf '%s\n' "$MANAGED_AGENT_PID" > "$pid_path")
 
   if ! valid_device_address "$DEVICE_ADDRESS"; then
     echo "ERROR: invalid --device-address." >&2

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -645,14 +645,16 @@ start_managed_agent() {
   echo "    Config:  $config_dir"
   echo "    Logs:    $stdout_path, $stderr_path"
 
-  mkdir -p "$config_dir"
+  mkdir -p "$config_dir/home" "$config_dir/xdg-config" "$config_dir/xdg-data"
   env -i \
-    HOME="${HOME:-}" \
-    LOGNAME="${LOGNAME:-${USER:-}}" \
+    HOME="$config_dir/home" \
+    LOGNAME="wendy-e2e-agent" \
     PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
     TMPDIR="${TMPDIR:-/tmp}" \
-    USER="${USER:-}" \
+    USER="wendy-e2e-agent" \
     WENDY_CONFIG_PATH="$config_dir" \
+    XDG_CONFIG_HOME="$config_dir/xdg-config" \
+    XDG_DATA_HOME="$config_dir/xdg-data" \
     WENDY_AGENT_PORT="$port" \
     WENDY_OTEL_PORT=0 \
     WENDY_OTEL_HTTP_PORT=0 \

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -48,7 +48,8 @@ OUTPUT_DIR="${WENDY_E2E_OUTPUT_DIR:-}"
 CLI_ROOT_DIR="${WENDY_E2E_CLI_ROOT_DIR:-}"
 CLI_REPO_DIR="${WENDY_E2E_CLI_REPO_DIR:-}"
 CLI_BIN_DIR="${WENDY_E2E_CLI_BIN_DIR:-}"
-CLI_AUTH_CONFIG_PATH="${WENDY_E2E_CLI_AUTH_CONFIG_PATH:-}"
+CLI_AUTH_CONFIG_EXPLICIT="${WENDY_E2E_CLI_AUTH_CONFIG_PATH:-}"
+CLI_AUTH_CONFIG_PATH="$CLI_AUTH_CONFIG_EXPLICIT"
 CLI_USER="${WENDY_E2E_CLI_USER:-}"
 CLI_ADDRESS="${WENDY_E2E_CLI_ADDRESS:-}"
 CLI_OS="${WENDY_E2E_CLI_OS:-}"
@@ -57,8 +58,10 @@ AGENT_REPO_DIR="${WENDY_E2E_AGENT_REPO_DIR:-}"
 AGENT_BIN_DIR="${WENDY_E2E_AGENT_BIN_DIR:-}"
 AGENT_USER="${WENDY_E2E_AGENT_USER:-}"
 AGENT_ADDRESS="${WENDY_E2E_AGENT_ADDRESS:-}"
+AGENT_CONNECT_ADDRESS="${WENDY_E2E_AGENT_CONNECT_ADDRESS:-}"
 AGENT_OS="${WENDY_E2E_AGENT_OS:-}"
 TRANSPORT="${WENDY_E2E_TRANSPORT:-}"
+MANAGED_AGENT="${WENDY_E2E_MANAGED_AGENT:-false}"
 AGENT_INFO_JSON=""
 ISOLATION="${WENDY_E2E_ISOLATION:-per-test}"
 VERBOSE="${WENDY_E2E_VERBOSE:-false}"
@@ -123,8 +126,12 @@ Options:
   --agent-repo-dir DIR  wendy-agent repo root on the agent machine.
   --agent-bin-dir DIR   Optional directory prepended to PATH on the agent machine.
   --agent-user USER     Optional SSH user for the agent machine.
-  --agent-address HOST  Optional address for the agent machine; defaults to hostname.
+  --agent-address HOST  Optional SSH address for the agent machine; defaults to local.
+  --agent-connect-address ADDRESS
+                        Optional Wendy agent device address while commands run locally.
   --agent-os OS         Optional OS override for the agent machine.
+  --managed-agent       Build and launch a local wendy-agent for this run.
+  --no-managed-agent    Do not launch a managed local wendy-agent.
   --isolation MODE      Sandbox isolation: none, per-run, or per-test; defaults to per-test.
   --parallel            Allow SwiftPM to run tests in parallel. Only valid when
                         both CLI and agent machines use local transport.
@@ -149,8 +156,10 @@ Environment:
   WENDY_E2E_AGENT_REPO_DIR            wendy-agent repo root on the agent machine.
   WENDY_E2E_AGENT_BIN_DIR             Optional directory prepended to PATH on the agent machine.
   WENDY_E2E_AGENT_USER                Optional SSH user for the agent machine.
-  WENDY_E2E_AGENT_ADDRESS             Optional address for the agent machine.
+  WENDY_E2E_AGENT_ADDRESS             Optional SSH address for the agent machine.
+  WENDY_E2E_AGENT_CONNECT_ADDRESS     Optional Wendy agent device address while commands run locally.
   WENDY_E2E_AGENT_OS                  Optional OS override for the agent machine.
+  WENDY_E2E_MANAGED_AGENT             Boolean; build and launch a local wendy-agent.
   WENDY_E2E_TRANSPORT                 Optional transport label for report metadata.
   WENDY_E2E_ISOLATION                 none, per-run, or per-test; defaults to per-test.
   WENDY_E2E_PARALLEL                  Boolean; enables SwiftPM parallel tests.
@@ -222,9 +231,21 @@ while [[ $# -gt 0 ]]; do
       AGENT_ADDRESS="$2"
       shift 2
       ;;
+    --agent-connect-address)
+      AGENT_CONNECT_ADDRESS="$2"
+      shift 2
+      ;;
     --agent-os)
       AGENT_OS="$2"
       shift 2
+      ;;
+    --managed-agent)
+      MANAGED_AGENT="true"
+      shift
+      ;;
+    --no-managed-agent)
+      MANAGED_AGENT="false"
+      shift
       ;;
     --isolation)
       ISOLATION="$2"
@@ -294,6 +315,7 @@ fi
 ISOLATION="$(normalize_isolation "$ISOLATION")"
 PARALLEL="$(normalize_bool "WENDY_E2E_PARALLEL" "$PARALLEL")"
 VERBOSE="$(normalize_bool "WENDY_E2E_VERBOSE" "$VERBOSE")"
+MANAGED_AGENT="$(normalize_bool "WENDY_E2E_MANAGED_AGENT" "$MANAGED_AGENT")"
 
 if [[ "$PARALLEL" == "true" && "$ISOLATION" != "per-test" ]]; then
   echo "ERROR: --parallel requires --isolation per-test." >&2
@@ -308,6 +330,12 @@ fi
 
 if [[ -n "$CLI_ADDRESS" && -z "$CLI_REPO_DIR" ]]; then
   echo "ERROR: --cli-repo-dir is required when --cli-address is set." >&2
+  exit 64
+fi
+
+if [[ "$MANAGED_AGENT" == "true" && -n "$AGENT_ADDRESS" ]]; then
+  echo "ERROR: --managed-agent cannot be combined with --agent-address." >&2
+  echo "Use --agent-connect-address for the local device address instead." >&2
   exit 64
 fi
 
@@ -374,6 +402,9 @@ fi
 if [[ -z "$CLI_ADDRESS" ]]; then
   CLI_BIN_DIR="$(absolute_dir_path "$CLI_BIN_DIR")"
 fi
+if [[ "$MANAGED_AGENT" == "true" && -z "$AGENT_BIN_DIR" ]]; then
+  AGENT_BIN_DIR="${AGENT_REPO_DIR%/}/go/bin"
+fi
 if [[ -n "$AGENT_BIN_DIR" && -z "$AGENT_ADDRESS" ]]; then
   AGENT_BIN_DIR="$(absolute_dir_path "$AGENT_BIN_DIR")"
 fi
@@ -382,12 +413,17 @@ RUN_DIR="$OUTPUT_DIR/$RUN_ID"
 CLI_RUN_DIR="$CLI_ROOT_DIR/$RUN_ID/cli"
 AGENT_RUN_DIR="$AGENT_ROOT_DIR/$RUN_ID/agent"
 TEST_RESULTS_OUTPUT_PATH="$RUN_DIR/test-results.xml"
+MANAGED_AGENT_PID=""
 
 rm -rf "$RUN_DIR"
 if [[ -z "$AGENT_ADDRESS" ]]; then
   rm -rf "$AGENT_RUN_DIR"
 fi
 mkdir -p "$RUN_DIR"
+
+if [[ "$MANAGED_AGENT" == "true" && -z "$AGENT_CONNECT_ADDRESS" ]]; then
+  AGENT_CONNECT_ADDRESS="127.0.0.1:${WENDY_AGENT_PORT:-50051}"
+fi
 
 ssh_target() {
   local user="$1"
@@ -528,6 +564,101 @@ EOF
   echo "    Version: $version"
 }
 
+build_managed_agent() {
+  local agent_path="$AGENT_BIN_DIR/wendy-agent"
+
+  echo "==> Building managed wendy-agent"
+  echo "    Output: $agent_path"
+
+  mkdir -p "$AGENT_BIN_DIR"
+  (
+    cd "$REPO_DIR/go"
+    go build -o "$agent_path" ./cmd/wendy-agent
+  )
+
+  "$agent_path" --version
+}
+
+start_managed_agent() {
+  local agent_path="$AGENT_BIN_DIR/wendy-agent"
+  local managed_dir="$RUN_DIR/managed-agent"
+  local config_dir="$managed_dir/config"
+  local stdout_path="$managed_dir/stdout.log"
+  local stderr_path="$managed_dir/stderr.log"
+  local pid_path="$managed_dir/pid"
+  local port="50051"
+
+  if [[ "$AGENT_CONNECT_ADDRESS" == *:* ]]; then
+    port="${AGENT_CONNECT_ADDRESS##*:}"
+  fi
+
+  echo "==> Starting managed wendy-agent"
+  echo "    Address: $AGENT_CONNECT_ADDRESS"
+  echo "    Config:  $config_dir"
+  echo "    Logs:    $stdout_path, $stderr_path"
+
+  mkdir -p "$config_dir"
+  WENDY_CONFIG_PATH="$config_dir" \
+  WENDY_AGENT_PORT="$port" \
+  WENDY_OTEL_PORT=0 \
+  WENDY_OTEL_HTTP_PORT=0 \
+  WENDY_REGISTRY_ADDR=127.0.0.1:0 \
+    "$agent_path" >"$stdout_path" 2>"$stderr_path" &
+  MANAGED_AGENT_PID=$!
+  printf '%s\n' "$MANAGED_AGENT_PID" > "$pid_path"
+
+  local deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    if ! kill -0 "$MANAGED_AGENT_PID" 2>/dev/null; then
+      echo "ERROR: managed wendy-agent exited before becoming ready." >&2
+      sed -n '1,160p' "$stderr_path" >&2 || true
+      return 1
+    fi
+    if "$CLI_BIN_DIR/wendy" --json --device "$AGENT_CONNECT_ADDRESS" device info >/dev/null 2>&1; then
+      echo "    Ready"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "ERROR: managed wendy-agent did not become ready at $AGENT_CONNECT_ADDRESS." >&2
+  sed -n '1,160p' "$stderr_path" >&2 || true
+  return 1
+}
+
+stop_managed_agent() {
+  if [[ -z "${MANAGED_AGENT_PID:-}" ]]; then
+    return
+  fi
+  if kill -0 "$MANAGED_AGENT_PID" 2>/dev/null; then
+    kill "$MANAGED_AGENT_PID" 2>/dev/null || true
+    local deadline=$((SECONDS + 10))
+    while (( SECONDS < deadline )); do
+      if ! kill -0 "$MANAGED_AGENT_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+    if kill -0 "$MANAGED_AGENT_PID" 2>/dev/null; then
+      kill -9 "$MANAGED_AGENT_PID" 2>/dev/null || true
+    fi
+  fi
+  wait "$MANAGED_AGENT_PID" 2>/dev/null || true
+  MANAGED_AGENT_PID=""
+}
+
+prepare_managed_agent_auth_fixture() {
+  if [[ "$MANAGED_AGENT" != "true" || -n "$CLI_AUTH_CONFIG_EXPLICIT" ]]; then
+    return
+  fi
+
+  local auth_dir="$RUN_DIR/managed-agent/cli-auth"
+  mkdir -p "$auth_dir"
+  CLI_AUTH_CONFIG_PATH="$auth_dir/config.json"
+  printf '{}\n' > "$CLI_AUTH_CONFIG_PATH"
+  chmod 600 "$CLI_AUTH_CONFIG_PATH" 2>/dev/null || true
+}
+
 json_escape() {
   local value="${1:-}"
   value="${value//\\/\\\\}"
@@ -638,6 +769,7 @@ write_attempt_info() {
     printf '    "cliUser": '; json_string_or_null "$CLI_USER"; echo ","
     printf '    "agentOS": '; json_string_or_null "$AGENT_OS"; echo ","
     printf '    "agentAddress": '; json_string_or_null "$AGENT_ADDRESS"; echo ","
+    printf '    "agentConnectAddress": '; json_string_or_null "$AGENT_CONNECT_ADDRESS"; echo ","
     printf '    "agentUser": '; json_string_or_null "$AGENT_USER"; echo ","
     printf '    "transport": '; json_string_or_null "$TRANSPORT"; echo ","
     printf '    "agentInfo": '; json_raw_or_null "$AGENT_INFO_JSON"; echo
@@ -653,7 +785,8 @@ write_attempt_info() {
     echo '  "test": {'
     printf '    "filters": '; json_string_array "${TEST_FILTERS[@]}"; echo ","
     printf '    "isolation": '; json_string "$ISOLATION"; echo ","
-    printf '    "parallel": '; json_bool "$PARALLEL"; echo
+    printf '    "parallel": '; json_bool "$PARALLEL"; echo ","
+    printf '    "managedAgent": '; json_bool "$MANAGED_AGENT"; echo
     echo '  },'
     echo '  "tools": {'
     printf '    "swift": '; json_string_or_null "$swift_version"; echo ","
@@ -682,8 +815,14 @@ CLI_AUTH_CONFIG_PATH="$(resolve_cli_auth_config_path)"
 if [[ -z "$CLI_ADDRESS" ]]; then
   CLI_AUTH_CONFIG_PATH="$(expand_local_path "$CLI_AUTH_CONFIG_PATH")"
 fi
+prepare_managed_agent_auth_fixture
 
 build_cli
+if [[ "$MANAGED_AGENT" == "true" ]]; then
+  trap stop_managed_agent EXIT
+  build_managed_agent
+  start_managed_agent
+fi
 preflight_cli_auth_fixture
 
 SWIFT_TEST_ENV=(
@@ -700,6 +839,7 @@ SWIFT_TEST_ENV=(
   "WENDY_E2E_AGENT_BIN_DIR=$AGENT_BIN_DIR"
   "WENDY_E2E_AGENT_USER=$AGENT_USER"
   "WENDY_E2E_AGENT_ADDRESS=$AGENT_ADDRESS"
+  "WENDY_E2E_AGENT_CONNECT_ADDRESS=$AGENT_CONNECT_ADDRESS"
   "WENDY_E2E_CLI_OS=$CLI_OS"
   "WENDY_E2E_AGENT_OS=$AGENT_OS"
   "WENDY_E2E_ISOLATION=$ISOLATION"
@@ -726,8 +866,12 @@ if [[ -n "$AGENT_ADDRESS" ]]; then
 else
   echo "    Agent:   <local>:${AGENT_REPO_DIR:-<no-repo>}"
 fi
+if [[ -n "$AGENT_CONNECT_ADDRESS" ]]; then
+  echo "    Agent device address: $AGENT_CONNECT_ADDRESS"
+fi
 echo "    Agent OS: ${AGENT_OS:-<current>}"
 echo "    Transport: ${TRANSPORT:-<none>}"
+echo "    Managed agent: $MANAGED_AGENT"
 
 set +e
 (

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -466,6 +466,10 @@ mkdir -p "$RUN_DIR"
 if [[ "$MANAGED_AGENT" == "true" && -z "$DEVICE_ADDRESS" ]]; then
   DEVICE_ADDRESS="127.0.0.1:${WENDY_AGENT_PORT:-50051}"
 fi
+if [[ -n "$DEVICE_ADDRESS" ]] && ! valid_device_address "$DEVICE_ADDRESS"; then
+  echo "ERROR: invalid --device-address." >&2
+  exit 64
+fi
 
 ssh_target() {
   local user="$1"
@@ -649,7 +653,7 @@ start_managed_agent() {
   env -i \
     HOME="$config_dir/home" \
     LOGNAME="wendy-e2e-agent" \
-    PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
     TMPDIR="${TMPDIR:-/tmp}" \
     USER="wendy-e2e-agent" \
     WENDY_CONFIG_PATH="$config_dir" \
@@ -662,6 +666,11 @@ start_managed_agent() {
     "$agent_path" >"$stdout_path" 2>"$stderr_path" &
   MANAGED_AGENT_PID=$!
   printf '%s\n' "$MANAGED_AGENT_PID" > "$pid_path"
+
+  if ! valid_device_address "$DEVICE_ADDRESS"; then
+    echo "ERROR: invalid --device-address." >&2
+    return 64
+  fi
 
   local attempt max_attempts=30
   for ((attempt = 1; attempt <= max_attempts; attempt++)); do

--- a/swift/WendyE2ETests/README.md
+++ b/swift/WendyE2ETests/README.md
@@ -88,7 +88,7 @@ The most useful environment variables are:
 | `WENDY_E2E_CLI_AUTH_CONFIG_PATH` | Dedicated Wendy CLI auth config fixture for authenticated tests. |
 | `WENDY_E2E_CLI_ADDRESS` | Optional SSH host for the CLI machine. |
 | `WENDY_E2E_AGENT_ADDRESS` | Optional SSH host for the agent/device machine. |
-| `WENDY_E2E_AGENT_CONNECT_ADDRESS` | Device address used by CLI commands while the agent session still runs locally; must not include credentials. |
+| `WENDY_E2E_DEVICE_ADDRESS` | Device address used by CLI commands while the agent session still runs locally; must not include credentials. |
 | `WENDY_E2E_MANAGED_AGENT` | Build and launch a local `wendy-agent` process for the run. |
 | `WENDY_E2E_CLI_OS` / `WENDY_E2E_AGENT_OS` | Override machine OS metadata. |
 | `WENDY_E2E_ISOLATION` | Sandbox mode: `per-test`, `per-run`, or `none`. |

--- a/swift/WendyE2ETests/README.md
+++ b/swift/WendyE2ETests/README.md
@@ -88,7 +88,7 @@ The most useful environment variables are:
 | `WENDY_E2E_CLI_AUTH_CONFIG_PATH` | Dedicated Wendy CLI auth config fixture for authenticated tests. |
 | `WENDY_E2E_CLI_ADDRESS` | Optional SSH host for the CLI machine. |
 | `WENDY_E2E_AGENT_ADDRESS` | Optional SSH host for the agent/device machine. |
-| `WENDY_E2E_AGENT_CONNECT_ADDRESS` | Device address used by CLI commands while the agent session still runs locally. |
+| `WENDY_E2E_AGENT_CONNECT_ADDRESS` | Device address used by CLI commands while the agent session still runs locally; must not include credentials. |
 | `WENDY_E2E_MANAGED_AGENT` | Build and launch a local `wendy-agent` process for the run. |
 | `WENDY_E2E_CLI_OS` / `WENDY_E2E_AGENT_OS` | Override machine OS metadata. |
 | `WENDY_E2E_ISOLATION` | Sandbox mode: `per-test`, `per-run`, or `none`. |

--- a/swift/WendyE2ETests/README.md
+++ b/swift/WendyE2ETests/README.md
@@ -88,6 +88,8 @@ The most useful environment variables are:
 | `WENDY_E2E_CLI_AUTH_CONFIG_PATH` | Dedicated Wendy CLI auth config fixture for authenticated tests. |
 | `WENDY_E2E_CLI_ADDRESS` | Optional SSH host for the CLI machine. |
 | `WENDY_E2E_AGENT_ADDRESS` | Optional SSH host for the agent/device machine. |
+| `WENDY_E2E_AGENT_CONNECT_ADDRESS` | Device address used by CLI commands while the agent session still runs locally. |
+| `WENDY_E2E_MANAGED_AGENT` | Build and launch a local `wendy-agent` process for the run. |
 | `WENDY_E2E_CLI_OS` / `WENDY_E2E_AGENT_OS` | Override machine OS metadata. |
 | `WENDY_E2E_ISOLATION` | Sandbox mode: `per-test`, `per-run`, or `none`. |
 | `WENDY_E2E_PARALLEL` | Enables parallel test execution when supported by the runner. |

--- a/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2EEnvironment.swift
+++ b/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2EEnvironment.swift
@@ -72,8 +72,8 @@ public enum WendyE2EEnvironment {
         value("WENDY_E2E_AGENT_ADDRESS")
     }
 
-    public static var agentConnectAddress: String? {
-        value("WENDY_E2E_AGENT_CONNECT_ADDRESS")
+    public static var deviceAddress: String? {
+        value("WENDY_E2E_DEVICE_ADDRESS")
     }
 
     public static var agentRunDirectory: String? {

--- a/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2EEnvironment.swift
+++ b/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2EEnvironment.swift
@@ -72,6 +72,10 @@ public enum WendyE2EEnvironment {
         value("WENDY_E2E_AGENT_ADDRESS")
     }
 
+    public static var agentConnectAddress: String? {
+        value("WENDY_E2E_AGENT_CONNECT_ADDRESS")
+    }
+
     public static var agentRunDirectory: String? {
         value("WENDY_E2E_AGENT_RUN_DIR")
     }

--- a/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2EMachine.swift
+++ b/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2EMachine.swift
@@ -105,7 +105,7 @@ public struct WendyE2EMachine: Sendable, Equatable {
             os: WendyE2EEnvironment.agentOS ?? .current,
             tags: [.agent],
             user: WendyE2EEnvironment.agentUser,
-            address: WendyE2EEnvironment.agentAddress ?? WendyE2EEnvironment.agentConnectAddress,
+            address: WendyE2EEnvironment.agentAddress ?? WendyE2EEnvironment.deviceAddress,
             isLocal: WendyE2EEnvironment.agentAddress == nil ? true : nil
         )
     }

--- a/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2EMachine.swift
+++ b/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2EMachine.swift
@@ -57,7 +57,8 @@ public struct WendyE2EMachine: Sendable, Equatable {
         os: WendyE2EMachineOS = .current,
         tags: Set<WendyE2EMachineTag> = [],
         user: String? = nil,
-        address: String? = nil
+        address: String? = nil,
+        isLocal: Bool? = nil
     ) {
         precondition(!id.isEmpty, "id must not be empty")
         precondition(!name.isEmpty, "name must not be empty")
@@ -70,7 +71,7 @@ public struct WendyE2EMachine: Sendable, Equatable {
         self.name = name
         self.os = os
         self.tags = tags
-        self.isLocal = address == nil
+        self.isLocal = isLocal ?? (address == nil)
         self.user = user
         self.address = resolvedAddress
     }
@@ -104,7 +105,8 @@ public struct WendyE2EMachine: Sendable, Equatable {
             os: WendyE2EEnvironment.agentOS ?? .current,
             tags: [.agent],
             user: WendyE2EEnvironment.agentUser,
-            address: WendyE2EEnvironment.agentAddress
+            address: WendyE2EEnvironment.agentAddress ?? WendyE2EEnvironment.agentConnectAddress,
+            isLocal: WendyE2EEnvironment.agentAddress == nil ? true : nil
         )
     }
 

--- a/swift/WendyE2ETests/Tests/WendyE2ETestingTests/WendyE2EMachineTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETestingTests/WendyE2EMachineTests.swift
@@ -68,6 +68,19 @@ struct `machine` {
         #expect(machine.isLocal == false)
         #expect(machine.address == "192.168.64.2")
     }
+
+    @Test
+    func `can use an explicit address for a local machine`() {
+        let machine = WendyE2EMachine(
+            id: "local-agent",
+            name: "Local Agent",
+            address: "127.0.0.1:50051",
+            isLocal: true
+        )
+
+        #expect(machine.isLocal)
+        #expect(machine.address == "127.0.0.1:50051")
+    }
 }
 
 @Suite


### PR DESCRIPTION
## Summary

- Add explicit hosted-runner Swift E2E routes for local macOS→macOS and local Ubuntu→Ubuntu coverage.
- Launch a managed local `wendy-agent` for those routes so they exercise CLI↔agent behavior without SER9, mDNS, cloud tunnels, or physical devices.
- Preserve the existing physical LAN SER9 route while avoiding runner-label indirection for the hosted local routes.
- Add a manual `target_group=local` selector so hosted local routes can be dispatched and diagnosed independently of physical-device routes.
- Harden the managed-agent workflow path with validated action inputs, delimited outputs, static runner labels, restricted PATH/HOME for the local agent, and credential-free device addresses.

Closes WDY-1481

## Testing

- `bash -n swift/Scripts/E2ETest.sh swift/Scripts/E2ESetup.sh swift/Scripts/E2ESetup.macOS.sh swift/Scripts/E2ESetup.ubuntu.sh`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "#{p} ok" }' .github/workflows/swift-e2e-tests.yml .github/actions/swift-e2e-run/action.yml`
- `actionlint .github/workflows/swift-e2e-tests.yml`
- `swift test --package-path swift/WendyE2ETests --filter 'machine'`
- `WENDY_E2E_TRANSPORT=local swift/Scripts/E2ETest.sh --managed-agent --device-address 127.0.0.1:50051 --output-dir "$tmp" --filter 'prints JSON device information'`
- Successful manual local-only workflow dispatch with `target_group=local`: https://github.com/wendylabsinc/WendyOS/actions/runs/27285022185
- Claude Security Review passed after hardening: https://github.com/wendylabsinc/WendyOS/actions/runs/27285023399/job/80589728954

Notes:
- The local-only dispatch intentionally skips the physical `macOS 26 → Ubuntu 24` SER9 job; that route is preserved for all-target runs.
- The Swift E2E pull_request trigger remains intentionally disabled while WDY-1479 is in progress.
