### PR TITLE
feat(cli): offer certificate refresh when a device rejects the client cert

### DIFF
--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -440,41 +440,51 @@ func newAuthRefreshCertsCmd() *cobra.Command {
 		Short: "Refresh mTLS certificates",
 		Long:  "Generates a new key pair and CSR, then issues new certificates using existing credentials.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-
-			cfg, err := config.Load()
-			if err != nil {
-				return fmt.Errorf("loading config: %w", err)
-			}
-
-			if len(cfg.Auth) == 0 {
-				return fmt.Errorf("not logged in; run 'wendy auth login' first")
-			}
-
-			// Refresh certificates for each auth entry.
-			for i, auth := range cfg.Auth {
-				if len(auth.Certificates) == 0 {
-					fmt.Println(tui.WarningMessage(fmt.Sprintf("Skipping %s: no certificates to refresh", auth.CloudDashboard)))
-					continue
-				}
-
-				fmt.Println(tui.InfoMessage(fmt.Sprintf("Refreshing certificates for %s...", auth.CloudDashboard)))
-
-				if err := refreshCertsForAuth(ctx, &cfg.Auth[i]); err != nil {
-					fmt.Println(tui.ErrorMessage(fmt.Sprintf("Failed to refresh for %s: %v", auth.CloudDashboard, err)))
-					continue
-				}
-
-				fmt.Println(tui.SuccessMessage(fmt.Sprintf("Certificates refreshed for %s.", auth.CloudDashboard)))
-			}
-
-			if err := config.Save(cfg); err != nil {
-				return fmt.Errorf("saving config: %w", err)
-			}
-
-			return nil
+			return refreshAllCerts(cmd.Context())
 		},
 	}
+}
+
+// refreshAllCerts re-issues certificates for every stored auth entry and
+// saves the updated config. It returns an error when not logged in or when
+// no entry could be refreshed, so callers that retry a connection afterwards
+// do not retry with the same stale certificates.
+func refreshAllCerts(ctx context.Context) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	if len(cfg.Auth) == 0 {
+		return fmt.Errorf("not logged in; run 'wendy auth login' first")
+	}
+
+	refreshed := 0
+	for i, auth := range cfg.Auth {
+		if len(auth.Certificates) == 0 {
+			fmt.Println(tui.WarningMessage(fmt.Sprintf("Skipping %s: no certificates to refresh", auth.CloudDashboard)))
+			continue
+		}
+
+		fmt.Println(tui.InfoMessage(fmt.Sprintf("Refreshing certificates for %s...", auth.CloudDashboard)))
+
+		if err := refreshCertsForAuth(ctx, &cfg.Auth[i]); err != nil {
+			fmt.Println(tui.ErrorMessage(fmt.Sprintf("Failed to refresh for %s: %v", auth.CloudDashboard, err)))
+			continue
+		}
+
+		refreshed++
+		fmt.Println(tui.SuccessMessage(fmt.Sprintf("Certificates refreshed for %s.", auth.CloudDashboard)))
+	}
+
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+
+	if refreshed == 0 {
+		return fmt.Errorf("no certificates were refreshed")
+	}
+	return nil
 }
 
 // certCommonName extracts the Subject CN from a PEM-encoded certificate.

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -55,7 +55,78 @@ func newProvisionedAgentUnauthorizedError(cause error) error {
 }
 
 func (e provisionedAgentUnauthorizedError) Error() string {
-	return fmt.Sprintf("%s\nLast mTLS error: %v", provisionedAgentUnauthorizedMessage, e.cause)
+	msg := fmt.Sprintf("%s\nLast mTLS error: %v", provisionedAgentUnauthorizedMessage, e.cause)
+	if isCertRefreshableError(e.cause) {
+		msg += "\nYour stored certificates may be outdated. Run 'wendy auth refresh-certs' to re-issue them."
+	}
+	return msg
+}
+
+// isCertRefreshableError reports whether an mTLS failure is one that
+// re-issuing the client certificate can fix: the agent rejecting a cert
+// without the clientAuth EKU, an expired or not-yet-valid cert, or a
+// server-sent TLS alert rejecting the presented cert. Reachability problems
+// and plaintext ports probed with TLS are excluded — new certs cannot fix
+// those.
+func isCertRefreshableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "first record does not look like a TLS handshake") {
+		return false
+	}
+	for _, signal := range []string{
+		"certificate is not valid for client authentication",
+		"certificate not valid at current time",
+		"certificate has expired",
+		"expired certificate",
+		"remote error: tls: bad certificate",
+		"remote error: tls: certificate required",
+	} {
+		if strings.Contains(msg, signal) {
+			return true
+		}
+	}
+	return false
+}
+
+// promptYesNoFn reads a Y/n answer from stdin; empty input counts as yes.
+// Stubbed in tests.
+var promptYesNoFn = func(prompt string) bool {
+	fmt.Fprint(os.Stderr, prompt)
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "" || answer == "y" || answer == "yes"
+}
+
+var refreshAllCertsFn = refreshAllCerts
+
+// offerCertRefreshAndRetry prompts to re-issue mTLS certificates after a
+// provisioned agent rejected the client certificate for a reason that
+// re-issuance fixes, then retries the connection once. Returns (conn, true)
+// only when the user accepted, the refresh succeeded, and the retry
+// connected; in every other case the caller should surface the original
+// error (whose message already carries the refresh-certs hint).
+func offerCertRefreshAndRetry(ctx context.Context, cause error, retry func() (*grpcclient.AgentConnection, error)) (*grpcclient.AgentConnection, bool) {
+	if jsonOutput || !isInteractiveTerminal() || !isCertRefreshableError(cause) {
+		return nil, false
+	}
+	fmt.Fprintln(os.Stderr, "The device rejected your client certificate; it may be outdated.")
+	if !promptYesNoFn("Refresh certificates and retry? [Y/n] ") {
+		return nil, false
+	}
+	if err := refreshAllCertsFn(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "Certificate refresh failed: %v\n", err)
+		return nil, false
+	}
+	conn, err := retry()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Still unable to connect after refreshing certificates: %v\n", err)
+		return nil, false
+	}
+	return conn, true
 }
 
 func (e provisionedAgentUnauthorizedError) Is(target error) bool {
@@ -523,18 +594,24 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 				return nil, connErr
 			}
 			if errors.Is(connErr, errProvisionedAgentUnauthorized) {
-				return nil, connErr
-			}
-			// Default device is unreachable — offer interactive recovery.
-			if isDefault && !jsonOutput && isInteractiveTerminal() {
+				refreshedConn, ok := offerCertRefreshAndRetry(ctx, connErr, func() (*grpcclient.AgentConnection, error) {
+					return connectResolvedAgentWithProvisionedHint(ctx, hostname, addr, isDefault, knownProvisionedMTLS)
+				})
+				if !ok {
+					return nil, connErr
+				}
+				conn = refreshedConn
+			} else if isDefault && !jsonOutput && isInteractiveTerminal() {
+				// Default device is unreachable — offer interactive recovery.
 				hostname, _, _ := net.SplitHostPort(addr)
 				target, recErr := handleDefaultDeviceRecovery(ctx, hostname, time.Since(startedAt), connErr, cfg.excludeProviderKeys, cfg.excludeBluetooth, cfg.suppressUpdateCheck)
 				if recErr != nil {
 					return nil, recErr
 				}
 				return connectFromSelectedDevice(target, cfg)
+			} else {
+				return nil, connErr
 			}
-			return nil, connErr
 		}
 		if !cfg.suppressProvisioningHint {
 			suggestProvisioning(conn)
@@ -1063,13 +1140,19 @@ func resolveTarget(ctx context.Context, opts ...resolveOption) (*SelectedDevice,
 				return nil, err
 			}
 			if errors.Is(err, errProvisionedAgentUnauthorized) {
+				refreshedConn, ok := offerCertRefreshAndRetry(ctx, err, func() (*grpcclient.AgentConnection, error) {
+					return connectResolvedAgentWithProvisionedHint(ctx, device, addr, isDefault, knownProvisionedMTLS)
+				})
+				if !ok {
+					return nil, err
+				}
+				conn = refreshedConn
+			} else if isDefault && !jsonOutput && !cfg.nonInteractive && isInteractiveTerminal() {
+				// Default device is unreachable — offer interactive recovery.
+				return handleDefaultDeviceRecovery(ctx, device, time.Since(startedAt), err, cfg.excludeProviderKeys, cfg.excludeBluetooth, cfg.suppressUpdateCheck)
+			} else {
 				return nil, err
 			}
-			// Default device is unreachable — offer interactive recovery.
-			if isDefault && !jsonOutput && !cfg.nonInteractive && isInteractiveTerminal() {
-				return handleDefaultDeviceRecovery(ctx, device, time.Since(startedAt), err, cfg.excludeProviderKeys, cfg.excludeBluetooth, cfg.suppressUpdateCheck)
-			}
-			return nil, err
 		}
 		if !cfg.suppressUpdateCheck {
 			var updateErr error

--- a/go/internal/cli/commands/helpers_certrefresh_test.go
+++ b/go/internal/cli/commands/helpers_certrefresh_test.go
@@ -1,0 +1,180 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+)
+
+func TestIsCertRefreshableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "agent clientAuth EKU rejection",
+			err:  errors.New("rpc error: code = Unauthenticated desc = certificate is not valid for client authentication"),
+			want: true,
+		},
+		{
+			name: "expired certificate",
+			err:  errors.New("certificate not valid at current time (NotBefore=2025 NotAfter=2026)"),
+			want: true,
+		},
+		{
+			name: "tls expired alert",
+			err:  errors.New("remote error: tls: expired certificate"),
+			want: true,
+		},
+		{
+			name: "tls bad certificate alert",
+			err:  errors.New("remote error: tls: bad certificate"),
+			want: true,
+		},
+		{
+			name: "connection refused",
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+		{
+			name: "plaintext port probed with TLS",
+			err:  errors.New("tls: first record does not look like a TLS handshake"),
+			want: false,
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCertRefreshableError(tc.err); got != tc.want {
+				t.Errorf("isCertRefreshableError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProvisionedAgentUnauthorizedErrorIncludesRefreshHint(t *testing.T) {
+	refreshable := newProvisionedAgentUnauthorizedError(
+		errors.New("host:50052: certificate is not valid for client authentication"))
+	if !strings.Contains(refreshable.Error(), "wendy auth refresh-certs") {
+		t.Errorf("expected refresh hint for cert rejection, got %q", refreshable.Error())
+	}
+
+	unreachable := newProvisionedAgentUnauthorizedError(errors.New("host:50052: connection refused"))
+	if strings.Contains(unreachable.Error(), "wendy auth refresh-certs") {
+		t.Errorf("did not expect refresh hint for reachability error, got %q", unreachable.Error())
+	}
+}
+
+func TestOfferCertRefreshAndRetry(t *testing.T) {
+	certErr := errors.New("certificate is not valid for client authentication")
+
+	setup := func(interactive, accept bool, refreshErr error) (restore func(), refreshCalls, retryCalls *int) {
+		origInteractive := isInteractiveTerminalFn
+		origJSON := jsonOutput
+		origPrompt := promptYesNoFn
+		origRefresh := refreshAllCertsFn
+		refreshCalls = new(int)
+		retryCalls = new(int)
+		isInteractiveTerminalFn = func() bool { return interactive }
+		jsonOutput = false
+		promptYesNoFn = func(string) bool { return accept }
+		refreshAllCertsFn = func(context.Context) error {
+			*refreshCalls++
+			return refreshErr
+		}
+		return func() {
+			isInteractiveTerminalFn = origInteractive
+			jsonOutput = origJSON
+			promptYesNoFn = origPrompt
+			refreshAllCertsFn = origRefresh
+		}, refreshCalls, retryCalls
+	}
+
+	t.Run("accepted refresh retries and returns connection", func(t *testing.T) {
+		restore, refreshCalls, retryCalls := setup(true, true, nil)
+		defer restore()
+
+		wantConn := &grpcclient.AgentConnection{Host: "device.local"}
+		conn, ok := offerCertRefreshAndRetry(context.Background(), certErr, func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return wantConn, nil
+		})
+		if !ok || conn != wantConn {
+			t.Fatalf("offerCertRefreshAndRetry() = (%v, %v), want (%v, true)", conn, ok, wantConn)
+		}
+		if *refreshCalls != 1 || *retryCalls != 1 {
+			t.Fatalf("refreshCalls=%d retryCalls=%d, want 1 and 1", *refreshCalls, *retryCalls)
+		}
+	})
+
+	t.Run("declined prompt does not refresh or retry", func(t *testing.T) {
+		restore, refreshCalls, retryCalls := setup(true, false, nil)
+		defer restore()
+
+		_, ok := offerCertRefreshAndRetry(context.Background(), certErr, func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return nil, nil
+		})
+		if ok || *refreshCalls != 0 || *retryCalls != 0 {
+			t.Fatalf("ok=%v refreshCalls=%d retryCalls=%d, want false, 0, 0", ok, *refreshCalls, *retryCalls)
+		}
+	})
+
+	t.Run("non-interactive terminal never prompts", func(t *testing.T) {
+		restore, refreshCalls, _ := setup(false, true, nil)
+		defer restore()
+
+		_, ok := offerCertRefreshAndRetry(context.Background(), certErr, func() (*grpcclient.AgentConnection, error) {
+			return nil, nil
+		})
+		if ok || *refreshCalls != 0 {
+			t.Fatalf("ok=%v refreshCalls=%d, want false, 0", ok, *refreshCalls)
+		}
+	})
+
+	t.Run("non-refreshable error never prompts", func(t *testing.T) {
+		restore, refreshCalls, _ := setup(true, true, nil)
+		defer restore()
+
+		_, ok := offerCertRefreshAndRetry(context.Background(), errors.New("connection refused"), func() (*grpcclient.AgentConnection, error) {
+			return nil, nil
+		})
+		if ok || *refreshCalls != 0 {
+			t.Fatalf("ok=%v refreshCalls=%d, want false, 0", ok, *refreshCalls)
+		}
+	})
+
+	t.Run("failed refresh does not retry", func(t *testing.T) {
+		restore, refreshCalls, retryCalls := setup(true, true, fmt.Errorf("cloud unreachable"))
+		defer restore()
+
+		_, ok := offerCertRefreshAndRetry(context.Background(), certErr, func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return nil, nil
+		})
+		if ok || *refreshCalls != 1 || *retryCalls != 0 {
+			t.Fatalf("ok=%v refreshCalls=%d retryCalls=%d, want false, 1, 0", ok, *refreshCalls, *retryCalls)
+		}
+	})
+
+	t.Run("failed retry returns not ok", func(t *testing.T) {
+		restore, _, _ := setup(true, true, nil)
+		defer restore()
+
+		_, ok := offerCertRefreshAndRetry(context.Background(), certErr, func() (*grpcclient.AgentConnection, error) {
+			return nil, errors.New("still unauthorized")
+		})
+		if ok {
+			t.Fatal("expected ok=false when retry fails")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

When the cloud issues a certificate the agent won't accept (e.g. the EKU-less certs fixed in wendylabsinc/cloud#145), users hit a dead-end error:

```
Unauthorized. Run 'wendy auth login' with an account that can access this provisioned wendy-agent.
Last mTLS error: <device>:50052: certificate is not valid for client authentication
```

`wendy auth login` is the wrong remediation here — the session is fine, the stored certificate just needs to be re-issued. The same applies to expired certs.

## Change

- New `isCertRefreshableError`: classifies mTLS failures that re-issuance fixes — agent clientAuth-EKU rejection, expired/not-yet-valid certs, server TLS alerts rejecting the cert. Reachability errors and plaintext ports probed with TLS are explicitly excluded.
- Interactive sessions: when a provisioned agent rejects the cert for a refreshable reason, `connectToAgent`/`resolveTarget` now prompt `Refresh certificates and retry? [Y/n]`, run the refresh, and retry the connection once. Decline or failure falls back to the original error.
- Non-interactive/JSON runs: the unauthorized error message now appends `Run 'wendy auth refresh-certs' to re-issue them.` when the cause is refreshable.
- `wendy auth refresh-certs` body extracted into `refreshAllCerts`, shared by the command and the prompt path. It now errors when no entry could be refreshed (previously exited 0), so the retry never reuses stale certs.

## Testing

TDD — new tests cover error classification, the hint in the error message, and prompt/refresh/retry orchestration (accept, decline, non-interactive, non-refreshable, refresh failure, retry failure) via the existing stub-var pattern. Full `go test ./internal/cli/commands/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)