### PR TITLE
feat(certs): request digitalSignature and clientAuth in enrollment CSRs

### DIFF
--- a/go/internal/shared/certs/certs.go
+++ b/go/internal/shared/certs/certs.go
@@ -36,15 +36,44 @@ func GenerateKeyPair() (privateKeyPEM string, err error) {
 // GenerateCSR creates a PKCS#10 certificate signing request using the provided
 // PEM-encoded private key (as bytes, so callers can zero the slice after use)
 // and common name. The CSR is returned as a PEM string.
+//
+// The CSR requests digitalSignature key usage and the clientAuth EKU so that
+// CAs honoring CSR extensions issue certs the wendy-agent mTLS interceptor
+// accepts (it requires an explicit clientAuth EKU). The Wendy cloud backends
+// set key usages server-side and ignore these, so this only matters for CAs
+// that derive extensions from the CSR.
 func GenerateCSR(privateKeyPEM []byte, commonName string) (csrPEM string, err error) {
 	key, err := parseECPrivateKey(privateKeyPEM)
 	if err != nil {
 		return "", err
 	}
 
+	// KeyUsage is a BIT STRING; digitalSignature is bit 0 (RFC 5280 4.2.1.3).
+	keyUsageValue, err := asn1.Marshal(asn1.BitString{Bytes: []byte{0x80}, BitLength: 1})
+	if err != nil {
+		return "", fmt.Errorf("marshaling key usage: %w", err)
+	}
+	ekuValue, err := asn1.Marshal([]asn1.ObjectIdentifier{
+		{1, 3, 6, 1, 5, 5, 7, 3, 2}, // id-kp-clientAuth
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshaling extended key usage: %w", err)
+	}
+
 	template := &x509.CertificateRequest{
 		Subject: pkix.Name{
 			CommonName: commonName,
+		},
+		ExtraExtensions: []pkix.Extension{
+			{
+				Id:       asn1.ObjectIdentifier{2, 5, 29, 15}, // id-ce-keyUsage
+				Critical: true,
+				Value:    keyUsageValue,
+			},
+			{
+				Id:    asn1.ObjectIdentifier{2, 5, 29, 37}, // id-ce-extKeyUsage
+				Value: ekuValue,
+			},
 		},
 	}
 

--- a/go/internal/shared/certs/certs_test.go
+++ b/go/internal/shared/certs/certs_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"math/big"
 	"strings"
@@ -264,5 +265,57 @@ func TestGenerateAndCSR_RoundTrip(t *testing.T) {
 
 	if csrPub.X.Cmp(extPub.X) != 0 || csrPub.Y.Cmp(extPub.Y) != 0 {
 		t.Error("CSR public key does not match extracted public key")
+	}
+}
+
+func TestGenerateCSRRequestsClientAuthUsage(t *testing.T) {
+	keyPEM, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair() error = %v", err)
+	}
+
+	csrPEM, err := GenerateCSR([]byte(keyPEM), "wendy/user/abc")
+	if err != nil {
+		t.Fatalf("GenerateCSR() error = %v", err)
+	}
+
+	block, _ := pem.Decode([]byte(csrPEM))
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatalf("parsing generated CSR: %v", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		t.Fatalf("CSR signature invalid: %v", err)
+	}
+
+	var keyUsage asn1.BitString
+	var ekus []asn1.ObjectIdentifier
+	for _, ext := range csr.Extensions {
+		switch {
+		case ext.Id.Equal(asn1.ObjectIdentifier{2, 5, 29, 15}):
+			if _, err := asn1.Unmarshal(ext.Value, &keyUsage); err != nil {
+				t.Fatalf("unmarshaling key usage: %v", err)
+			}
+		case ext.Id.Equal(asn1.ObjectIdentifier{2, 5, 29, 37}):
+			if _, err := asn1.Unmarshal(ext.Value, &ekus); err != nil {
+				t.Fatalf("unmarshaling extended key usage: %v", err)
+			}
+		}
+	}
+
+	// digitalSignature is bit 0 of the KeyUsage BIT STRING.
+	if keyUsage.BitLength == 0 || keyUsage.At(0) != 1 {
+		t.Errorf("CSR key usage missing digitalSignature, got %v", keyUsage)
+	}
+
+	clientAuthOID := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 2}
+	found := false
+	for _, oid := range ekus {
+		if oid.Equal(clientAuthOID) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("CSR extended key usage missing clientAuth, got %v", ekus)
 	}
 }


### PR DESCRIPTION
## Change

Enrollment CSRs (`certs.GenerateCSR`, used by `wendy auth login`, cert refresh, and device provisioning) previously carried only a subject CN — no key usage, no EKU. The Wendy cloud backends now set key usages server-side (wendylabsinc/cloud#145) and ignore CSR extensions, but CAs that derive extensions from the CSR had nothing to work with, which is how EKU-less client certificates were issued in the first place.

The CSR now explicitly requests:
- KeyUsage `digitalSignature` (critical, per RFC 5280)
- ExtendedKeyUsage `clientAuth`

This makes the CSR self-describing for any CA, with serverAuth for device certs remaining a server-side decision.

## Testing

New test parses the generated CSR and asserts the requested KeyUsage bit and clientAuth EKU OID; `go test ./internal/shared/certs/` passes, as does the full `internal/cli/commands` suite.

Follow-up to #965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)