### PR TITLE
fix(mac): register login item from auto-start checkbox

### DIFF
--- a/swift/WendyAgentMac/Sources/AppDelegate.swift
+++ b/swift/WendyAgentMac/Sources/AppDelegate.swift
@@ -24,6 +24,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate,
     private var isQuitting = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        self.welcomeAndPermissions.prepareForLaunch()
+
         self.statusMenuController = StatusMenuController(
             wendyAgent: self.wendyAgent,
             delegate: self

--- a/swift/WendyAgentMac/Sources/WelcomeAndPermissions.swift
+++ b/swift/WendyAgentMac/Sources/WelcomeAndPermissions.swift
@@ -54,6 +54,14 @@ final class WelcomeAndPermissions: NSObject, CBCentralManagerDelegate {
         case restricted
     }
 
+    enum LaunchAtLoginStatus: Equatable {
+        case enabled
+        case disabled
+        case requiresApproval
+        case unavailable
+        case updateFailed
+    }
+
     private static let launchAtLoginEnabledKey = "launchAtLoginEnabled"
 
     private let logger = Logger(
@@ -62,6 +70,7 @@ final class WelcomeAndPermissions: NSObject, CBCentralManagerDelegate {
     )
 
     var launchAtLoginEnabled: Bool
+    var launchAtLoginStatus: LaunchAtLoginStatus
     var bluetoothStatus: PermissionStatus = .pending
     var cameraStatus: PermissionStatus = .pending
     var microphoneStatus: PermissionStatus = .pending
@@ -71,12 +80,8 @@ final class WelcomeAndPermissions: NSObject, CBCentralManagerDelegate {
     private var bluetoothContinuation: CheckedContinuation<PermissionStatus, Never>?
 
     override init() {
-        let defaults = UserDefaults.standard
-        if defaults.object(forKey: Self.launchAtLoginEnabledKey) == nil {
-            self.launchAtLoginEnabled = true
-        } else {
-            self.launchAtLoginEnabled = defaults.bool(forKey: Self.launchAtLoginEnabledKey)
-        }
+        self.launchAtLoginEnabled = Self.savedLaunchAtLoginPreference()
+        self.launchAtLoginStatus = Self.currentLaunchAtLoginStatus()
 
         super.init()
         self.refreshPermissionStatuses()
@@ -98,14 +103,21 @@ final class WelcomeAndPermissions: NSObject, CBCentralManagerDelegate {
         self.requestingPermission != nil
     }
 
+    func prepareForLaunch() {
+        self.launchAtLoginEnabled = Self.savedLaunchAtLoginPreference()
+        self.applyLaunchAtLoginPreference()
+    }
+
     func prepareForPresentation() {
-        self.launchAtLoginEnabled = Self.currentLaunchAtLoginPreference()
+        self.launchAtLoginEnabled = Self.savedLaunchAtLoginPreference()
+        self.applyLaunchAtLoginPreference()
         self.requestingPermission = nil
         self.refreshPermissionStatuses()
     }
 
     func refresh() {
         self.refreshPermissionStatuses()
+        self.refreshLaunchAtLoginStatus()
     }
 
     func setLaunchAtLoginEnabled(_ enabled: Bool) {
@@ -157,6 +169,19 @@ final class WelcomeAndPermissions: NSObject, CBCentralManagerDelegate {
         }
     }
 
+    func openLoginItemsSettings() {
+        guard let settingsURL = URL(
+            string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension"
+        ) else {
+            return
+        }
+
+        guard NSWorkspace.shared.open(settingsURL) else {
+            self.logger.error("Failed to open Login Items settings")
+            return
+        }
+    }
+
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         guard let bluetoothContinuation = self.bluetoothContinuation else { return }
 
@@ -169,6 +194,10 @@ final class WelcomeAndPermissions: NSObject, CBCentralManagerDelegate {
         self.bluetoothStatus = self.currentBluetoothStatus()
         self.cameraStatus = self.currentCameraStatus()
         self.microphoneStatus = self.currentMicrophoneStatus()
+    }
+
+    private func refreshLaunchAtLoginStatus() {
+        self.launchAtLoginStatus = Self.currentLaunchAtLoginStatus()
     }
 
     private func systemSettingsURL(for permission: Permission) -> URL? {
@@ -193,28 +222,16 @@ final class WelcomeAndPermissions: NSObject, CBCentralManagerDelegate {
                 switch loginItemService.status {
                 case .enabled:
                     self.logger.info("Wendy Agent is already configured to launch at login")
-                case .notRegistered, .requiresApproval, .notFound:
+                case .requiresApproval:
+                    self.logger.notice(
+                        "Wendy Agent launch at login requires user approval in System Settings"
+                    )
+                case .notRegistered, .notFound:
                     try loginItemService.register()
-
-                    switch loginItemService.status {
-                    case .enabled:
-                        self.logger.info("Configured Wendy Agent to launch at login")
-                    case .requiresApproval:
-                        self.logger.notice(
-                            "Wendy Agent launch at login requires user approval in System Settings"
-                        )
-                    case .notRegistered, .notFound:
-                        self.logger.warning(
-                            "Wendy Agent launch at login registration did not complete; status: \(String(describing: loginItemService.status), privacy: .public)"
-                        )
-                    @unknown default:
-                        self.logger.warning(
-                            "Wendy Agent launch at login registration returned an unknown status"
-                        )
-                    }
+                    self.logLaunchAtLoginRegistrationStatus(loginItemService.status)
                 @unknown default:
                     try loginItemService.register()
-                    self.logger.info("Configured Wendy Agent to launch at login")
+                    self.logLaunchAtLoginRegistrationStatus(loginItemService.status)
                 }
             } else {
                 switch loginItemService.status {
@@ -228,20 +245,58 @@ final class WelcomeAndPermissions: NSObject, CBCentralManagerDelegate {
                     self.logger.info("Disabled Wendy Agent launch at login")
                 }
             }
+
+            self.refreshLaunchAtLoginStatus()
         } catch {
+            self.launchAtLoginStatus = .updateFailed
             self.logger.error(
                 "Failed to configure Wendy Agent launch at login: \(String(describing: error), privacy: .public)"
             )
         }
     }
 
-    private static func currentLaunchAtLoginPreference() -> Bool {
+    private func logLaunchAtLoginRegistrationStatus(_ status: SMAppService.Status) {
+        switch status {
+        case .enabled:
+            self.logger.info("Configured Wendy Agent to launch at login")
+        case .requiresApproval:
+            self.logger.notice(
+                "Wendy Agent launch at login requires user approval in System Settings"
+            )
+        case .notRegistered, .notFound:
+            self.logger.warning(
+                "Wendy Agent launch at login registration did not complete; status: \(String(describing: status), privacy: .public)"
+            )
+        @unknown default:
+            self.logger.warning(
+                "Wendy Agent launch at login registration returned an unknown status"
+            )
+        }
+    }
+
+    private static func savedLaunchAtLoginPreference() -> Bool {
         let defaults = UserDefaults.standard
         if defaults.object(forKey: Self.launchAtLoginEnabledKey) == nil {
+            defaults.set(true, forKey: Self.launchAtLoginEnabledKey)
             return true
         }
 
         return defaults.bool(forKey: Self.launchAtLoginEnabledKey)
+    }
+
+    private static func currentLaunchAtLoginStatus() -> LaunchAtLoginStatus {
+        switch SMAppService.mainApp.status {
+        case .enabled:
+            return .enabled
+        case .requiresApproval:
+            return .requiresApproval
+        case .notRegistered:
+            return .disabled
+        case .notFound:
+            return .unavailable
+        @unknown default:
+            return .unavailable
+        }
     }
 
     private func currentBluetoothStatus() -> PermissionStatus {

--- a/swift/WendyAgentMac/Sources/WelcomeAndPermissionsView.swift
+++ b/swift/WendyAgentMac/Sources/WelcomeAndPermissionsView.swift
@@ -25,13 +25,7 @@ struct WelcomeAndPermissionsView: View {
 
             self.permissionsSection
 
-            Toggle(
-                "Open Wendy Agent automatically when you log in",
-                isOn: Binding(
-                    get: { self.welcomeAndPermissions.launchAtLoginEnabled },
-                    set: { self.welcomeAndPermissions.setLaunchAtLoginEnabled($0) }
-                )
-            )
+            self.launchAtLoginSection
         }
         .padding(28)
         .frame(width: 620, alignment: .topLeading)
@@ -98,6 +92,87 @@ struct WelcomeAndPermissionsView: View {
             RoundedRectangle(cornerRadius: 14)
                 .fill(.quaternary.opacity(0.4))
         )
+    }
+
+    private var launchAtLoginSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle(
+                "Open Wendy Agent automatically when you log in",
+                isOn: Binding(
+                    get: { self.welcomeAndPermissions.launchAtLoginEnabled },
+                    set: { self.welcomeAndPermissions.setLaunchAtLoginEnabled($0) }
+                )
+            )
+
+            if let message = self.launchAtLoginStatusMessage {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: self.launchAtLoginStatusSystemImage)
+                        .foregroundStyle(self.launchAtLoginStatusColor)
+                    Text(message)
+                        .foregroundStyle(.secondary)
+
+                    if self.shouldShowLoginItemsSettingsButton {
+                        Button("Open Login Items…") {
+                            self.welcomeAndPermissions.openLoginItemsSettings()
+                        }
+                        .buttonStyle(.link)
+                    }
+                }
+                .font(.subheadline)
+            }
+        }
+    }
+
+    private var launchAtLoginStatusMessage: String? {
+        switch self.welcomeAndPermissions.launchAtLoginStatus {
+        case .enabled:
+            return "Wendy Agent is registered in Login Items."
+        case .disabled:
+            return self.welcomeAndPermissions.launchAtLoginEnabled
+                ? "Wendy Agent is not registered in Login Items yet."
+                : nil
+        case .requiresApproval:
+            return "Approve Wendy Agent in System Settings → Login Items to finish enabling automatic launch."
+        case .unavailable:
+            return "Automatic launch is unavailable for this copy of Wendy Agent."
+        case .updateFailed:
+            return "Wendy Agent couldn't update Login Items. Check System Settings, then try toggling this setting again."
+        }
+    }
+
+    private var launchAtLoginStatusSystemImage: String {
+        switch self.welcomeAndPermissions.launchAtLoginStatus {
+        case .enabled:
+            return "checkmark.circle.fill"
+        case .disabled:
+            return "info.circle"
+        case .requiresApproval, .updateFailed:
+            return "exclamationmark.triangle.fill"
+        case .unavailable:
+            return "xmark.circle.fill"
+        }
+    }
+
+    private var launchAtLoginStatusColor: Color {
+        switch self.welcomeAndPermissions.launchAtLoginStatus {
+        case .enabled:
+            return .green
+        case .disabled:
+            return .secondary
+        case .requiresApproval, .updateFailed:
+            return .orange
+        case .unavailable:
+            return .red
+        }
+    }
+
+    private var shouldShowLoginItemsSettingsButton: Bool {
+        switch self.welcomeAndPermissions.launchAtLoginStatus {
+        case .requiresApproval, .updateFailed:
+            return true
+        case .enabled, .disabled, .unavailable:
+            return false
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Apply the saved launch-at-login preference when Wendy Agent starts, so the default-enabled welcome checkbox actually registers the app with `SMAppService` on first launch.
- Keep the checkbox honest by tracking `SMAppService.mainApp.status` and surfacing enabled, approval-required, unavailable, and failed states in the welcome UI.
- Add a direct “Open Login Items…” action when macOS reports that approval or manual review is needed.

Closes WDY-1486.

## Validation
Environment: macOS 26.5.1 (25F80), arm64, Xcode 26.4 (17E192).

- `xcodebuild -project swift/WendyAgentMac/WendyAgentMac.xcodeproj -scheme WendyAgentMac -configuration Debug -destination 'platform=macOS' build` — passed.
- `cd swift && VERSION=2026.06.10-170700-dev OUTPUT_DIR="$PWD/Build" DERIVED_DATA_PATH="$PWD/Build/Xcode" bash Scripts/Build.sh --dev` — passed, produced `swift/Build/WendyAgentMac.app` and `swift/Build/wendy-agent-macos-arm64-2026.06.10-170700-dev.zip`.
- Fresh-default smoke check from the packaged dev app:
  - `defaults delete sh.wendy.WendyAgentMac launchAtLoginEnabled`
  - `open swift/Build/WendyAgentMac.app`
  - `pgrep -fl WendyAgentMac` showed the app running from `swift/Build/WendyAgentMac.app`.
  - `defaults read sh.wendy.WendyAgentMac launchAtLoginEnabled` returned `1`, confirming the first-launch default path was exercised.

## Notes
- Full `/Applications` + System Settings → Login Items verification was not completed in this harness. The local `/Applications/WendyAgentMac.app` is owned by another user and replacing it failed with `Permission denied`; unified log access, System Events automation, and screenshot capture were also denied. The dev app was still built with the same packaging script and signed successfully.
