### PR TITLE
feat(cli): mitigate GitHub API rate limiting for release fetches

### DIFF
--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1268,46 +1268,26 @@ func fetchAgentRelease(nightly bool) (*githubReleaseFull, error) {
 	client := newGitHubAPIClient(30 * time.Second)
 
 	if !nightly {
-		req, err := newGitHubAPIGetRequest(githubReleasesURL)
-		if err != nil {
-			return nil, fmt.Errorf("creating GitHub API request: %w", err)
-		}
-
-		resp, err := client.Do(req)
+		body, err := githubAPIGet(client, githubReleasesURL)
 		if err != nil {
 			return nil, fmt.Errorf("fetching latest release: %w", err)
 		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
-		}
 
 		var release githubReleaseFull
-		if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		if err := json.Unmarshal(body, &release); err != nil {
 			return nil, fmt.Errorf("decoding release: %w", err)
 		}
 		return &release, nil
 	}
 
 	// For nightly, list releases and find the latest prerelease.
-	req, err := newGitHubAPIGetRequest("https://api.github.com/repos/wendylabsinc/wendy-agent/releases")
-	if err != nil {
-		return nil, fmt.Errorf("creating GitHub API request: %w", err)
-	}
-
-	resp, err := client.Do(req)
+	body, err := githubAPIGet(client, "https://api.github.com/repos/wendylabsinc/wendy-agent/releases")
 	if err != nil {
 		return nil, fmt.Errorf("fetching releases: %w", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
-	}
 
 	var releases []githubReleaseFull
-	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+	if err := json.Unmarshal(body, &releases); err != nil {
 		return nil, fmt.Errorf("decoding releases: %w", err)
 	}
 

--- a/go/internal/cli/commands/github.go
+++ b/go/internal/cli/commands/github.go
@@ -102,8 +102,9 @@ func githubAPIGet(client *http.Client, rawURL string) ([]byte, error) {
 		return nil, fmt.Errorf("creating GitHub API request: %w", err)
 	}
 
-	cache := loadGitHubAPICache()
-	cached, hasCached := cache[rawURL]
+	githubAPICacheMu.Lock()
+	cached, hasCached := loadGitHubAPICache()[rawURL]
+	githubAPICacheMu.Unlock()
 	if hasCached && cached.ETag != "" {
 		req.Header.Set("If-None-Match", cached.ETag)
 	}
@@ -121,8 +122,13 @@ func githubAPIGet(client *http.Client, rawURL string) ([]byte, error) {
 			return nil, fmt.Errorf("reading GitHub API response: %w", err)
 		}
 		if etag := resp.Header.Get("Etag"); etag != "" && json.Valid(body) {
+			// Reload under the lock so concurrent fetches of different URLs
+			// (e.g. the background update check) don't overwrite each other.
+			githubAPICacheMu.Lock()
+			cache := loadGitHubAPICache()
 			cache[rawURL] = githubAPICacheEntry{ETag: etag, Body: body}
 			saveGitHubAPICache(cache)
+			githubAPICacheMu.Unlock()
 		}
 		return body, nil
 	case http.StatusNotModified:
@@ -138,6 +144,10 @@ func githubAPIGet(client *http.Client, rawURL string) ([]byte, error) {
 }
 
 const githubAPIMaxResponseBytes = 8 << 20 // 8 MiB; release listings are far smaller
+
+// githubAPICacheMu serializes read-modify-write cycles on the cache file
+// within this process (foreground command vs. background update check).
+var githubAPICacheMu sync.Mutex
 
 type githubAPICacheEntry struct {
 	ETag string          `json:"etag"`

--- a/go/internal/cli/commands/github.go
+++ b/go/internal/cli/commands/github.go
@@ -1,13 +1,20 @@
 package commands
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 )
 
@@ -47,11 +54,138 @@ func newGitHubAPIGetRequest(rawURL string) (*http.Request, error) {
 	req.Header.Set("User-Agent", githubAPIUserAgent())
 	// net/http header values are strings, so Go cannot zero this secret after use;
 	// keep it scoped to this request and avoid logging the returned request.
-	if token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); token != "" {
+	token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+	if token == "" {
+		token = ghCLIToken()
+	}
+	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	return req, nil
+}
+
+// ghCLIToken returns a GitHub token from the gh CLI when one is available.
+// Overridable in tests. The result is cached for the process lifetime so
+// repeated API calls don't spawn gh more than once.
+var ghCLIToken = sync.OnceValue(func() string {
+	ghPath, err := exec.LookPath("gh")
+	if err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, ghPath, "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+})
+
+// githubAPICachePath returns the path of the GitHub API response cache.
+// Overridable in tests.
+var githubAPICachePath = func() (string, error) {
+	dir, err := config.CacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "github-api-cache.json"), nil
+}
+
+// githubAPIGet performs a GET against the GitHub API and returns the response
+// body. Responses are cached by ETag so revalidations come back as 304, which
+// GitHub does not count against the rate limit. Rate-limit responses are
+// mapped to an actionable error.
+func githubAPIGet(client *http.Client, rawURL string) ([]byte, error) {
+	req, err := newGitHubAPIGetRequest(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("creating GitHub API request: %w", err)
+	}
+
+	cache := loadGitHubAPICache()
+	cached, hasCached := cache[rawURL]
+	if hasCached && cached.ETag != "" {
+		req.Header.Set("If-None-Match", cached.ETag)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		body, err := io.ReadAll(io.LimitReader(resp.Body, githubAPIMaxResponseBytes))
+		if err != nil {
+			return nil, fmt.Errorf("reading GitHub API response: %w", err)
+		}
+		if etag := resp.Header.Get("Etag"); etag != "" && json.Valid(body) {
+			cache[rawURL] = githubAPICacheEntry{ETag: etag, Body: body}
+			saveGitHubAPICache(cache)
+		}
+		return body, nil
+	case http.StatusNotModified:
+		if !hasCached {
+			return nil, fmt.Errorf("GitHub API returned 304 but no cached response is available")
+		}
+		return cached.Body, nil
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		return nil, fmt.Errorf("GitHub API rate limit exceeded (status %d); set GITHUB_TOKEN or run 'gh auth login' to raise the limit", resp.StatusCode)
+	default:
+		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+}
+
+const githubAPIMaxResponseBytes = 8 << 20 // 8 MiB; release listings are far smaller
+
+type githubAPICacheEntry struct {
+	ETag string          `json:"etag"`
+	Body json.RawMessage `json:"body"`
+}
+
+// loadGitHubAPICache reads the on-disk response cache. Failures degrade to an
+// empty cache: the request then simply runs unconditionally.
+func loadGitHubAPICache() map[string]githubAPICacheEntry {
+	cache := make(map[string]githubAPICacheEntry)
+	path, err := githubAPICachePath()
+	if err != nil {
+		return cache
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cache
+	}
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return make(map[string]githubAPICacheEntry)
+	}
+	return cache
+}
+
+// saveGitHubAPICache persists the response cache best-effort; a failed write
+// only costs a future revalidation opportunity.
+func saveGitHubAPICache(cache map[string]githubAPICacheEntry) {
+	path, err := githubAPICachePath()
+	if err != nil {
+		return
+	}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".github-api-cache-*")
+	if err != nil {
+		return
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		return
+	}
+	_ = os.Rename(tmp.Name(), path)
 }
 
 func isCanonicalGitHubAPIURL(u *url.URL) bool {

--- a/go/internal/cli/commands/github_test.go
+++ b/go/internal/cli/commands/github_test.go
@@ -1,11 +1,13 @@
 package commands
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
@@ -314,6 +316,42 @@ func TestGitHubAPIGetRefreshesCacheOnNewETag(t *testing.T) {
 	}
 	if got, want := string(third), `{"tag_name":"v2.0.0"}`; got != want {
 		t.Fatalf("cached body = %q; want %q", got, want)
+	}
+}
+
+func TestGitHubAPIGetConcurrentCachingPersistsAllEntries(t *testing.T) {
+	stubGitHubTokens(t)
+	stubGitHubAPICachePath(t)
+
+	urls := make([]string, 8)
+	for i := range urls {
+		urls[i] = fmt.Sprintf("https://api.github.com/repos/wendylabsinc/wendy-agent/releases?page=%d", i)
+	}
+	client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Etag": []string{`"etag-` + req.URL.Query().Get("page") + `"`}},
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		}, nil
+	})
+
+	var wg sync.WaitGroup
+	for _, u := range urls {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := githubAPIGet(client, u); err != nil {
+				t.Errorf("githubAPIGet(%s): %v", u, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	cache := loadGitHubAPICache()
+	for _, u := range urls {
+		if _, ok := cache[u]; !ok {
+			t.Errorf("cache missing entry for %s", u)
+		}
 	}
 }
 

--- a/go/internal/cli/commands/github_test.go
+++ b/go/internal/cli/commands/github_test.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,6 +13,9 @@ import (
 
 func TestNewGitHubAPIGetRequestWithoutToken(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "")
+	oldGhCLIToken := ghCLIToken
+	ghCLIToken = func() string { return "" }
+	t.Cleanup(func() { ghCLIToken = oldGhCLIToken })
 
 	req, err := newGitHubAPIGetRequest(githubReleasesURL)
 	if err != nil {
@@ -31,6 +36,38 @@ func TestNewGitHubAPIGetRequestWithoutToken(t *testing.T) {
 	}
 	if got, want := req.Header.Get("X-GitHub-Api-Version"), "2022-11-28"; got != want {
 		t.Fatalf("X-GitHub-Api-Version = %q; want %q", got, want)
+	}
+}
+
+func TestNewGitHubAPIGetRequestFallsBackToGhCLIToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	oldGhCLIToken := ghCLIToken
+	ghCLIToken = func() string { return "gh-cli-token" }
+	t.Cleanup(func() { ghCLIToken = oldGhCLIToken })
+
+	req, err := newGitHubAPIGetRequest(githubReleasesURL)
+	if err != nil {
+		t.Fatalf("newGitHubAPIGetRequest: %v", err)
+	}
+
+	if got, want := req.Header.Get("Authorization"), "Bearer gh-cli-token"; got != want {
+		t.Fatalf("Authorization = %q; want %q", got, want)
+	}
+}
+
+func TestNewGitHubAPIGetRequestPrefersGitHubTokenOverGhCLI(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-token")
+	oldGhCLIToken := ghCLIToken
+	ghCLIToken = func() string { return "gh-cli-token" }
+	t.Cleanup(func() { ghCLIToken = oldGhCLIToken })
+
+	req, err := newGitHubAPIGetRequest(githubReleasesURL)
+	if err != nil {
+		t.Fatalf("newGitHubAPIGetRequest: %v", err)
+	}
+
+	if got, want := req.Header.Get("Authorization"), "Bearer env-token"; got != want {
+		t.Fatalf("Authorization = %q; want %q", got, want)
 	}
 }
 
@@ -104,6 +141,179 @@ func TestGitHubAPIClientRedirectAuthorizationHandling(t *testing.T) {
 				t.Fatalf("Authorization after redirect = %q; want %q", got, tt.wantAuthorization)
 			}
 		})
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newFakeGitHubClient(rt roundTripperFunc) *http.Client {
+	return &http.Client{Transport: rt}
+}
+
+func stubGitHubTokens(t *testing.T) {
+	t.Helper()
+	t.Setenv("GITHUB_TOKEN", "")
+	oldGhCLIToken := ghCLIToken
+	ghCLIToken = func() string { return "" }
+	t.Cleanup(func() { ghCLIToken = oldGhCLIToken })
+}
+
+func stubGitHubAPICachePath(t *testing.T) {
+	t.Helper()
+	oldPath := githubAPICachePath
+	tmp := t.TempDir()
+	githubAPICachePath = func() (string, error) {
+		return filepath.Join(tmp, "github-api-cache.json"), nil
+	}
+	t.Cleanup(func() { githubAPICachePath = oldPath })
+}
+
+func TestGitHubAPIGetRateLimitErrorIsActionable(t *testing.T) {
+	stubGitHubTokens(t)
+	stubGitHubAPICachePath(t)
+
+	for _, status := range []int{http.StatusForbidden, http.StatusTooManyRequests} {
+		client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: status,
+				Header:     http.Header{"X-Ratelimit-Remaining": []string{"0"}},
+				Body:       io.NopCloser(strings.NewReader(`{"message":"API rate limit exceeded"}`)),
+			}, nil
+		})
+
+		_, err := githubAPIGet(client, githubReleasesURL)
+		if err == nil {
+			t.Fatalf("status %d: expected error", status)
+		}
+		if !strings.Contains(err.Error(), "rate limit") {
+			t.Fatalf("status %d: error should mention rate limit: %v", status, err)
+		}
+		if !strings.Contains(err.Error(), "GITHUB_TOKEN") {
+			t.Fatalf("status %d: error should suggest GITHUB_TOKEN: %v", status, err)
+		}
+	}
+}
+
+func TestGitHubAPIGetReturnsBodyOnSuccess(t *testing.T) {
+	stubGitHubTokens(t)
+	stubGitHubAPICachePath(t)
+
+	client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v1.2.3"}`)),
+		}, nil
+	})
+
+	body, err := githubAPIGet(client, githubReleasesURL)
+	if err != nil {
+		t.Fatalf("githubAPIGet: %v", err)
+	}
+	if got, want := string(body), `{"tag_name":"v1.2.3"}`; got != want {
+		t.Fatalf("body = %q; want %q", got, want)
+	}
+}
+
+func TestGitHubAPIGetUsesETagCacheOn304(t *testing.T) {
+	stubGitHubTokens(t)
+	stubGitHubAPICachePath(t)
+
+	calls := 0
+	client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+		calls++
+		switch calls {
+		case 1:
+			if got := req.Header.Get("If-None-Match"); got != "" {
+				t.Fatalf("first request If-None-Match = %q; want empty", got)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Etag": []string{`"etag-1"`}},
+				Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v1.2.3"}`)),
+			}, nil
+		default:
+			if got, want := req.Header.Get("If-None-Match"), `"etag-1"`; got != want {
+				t.Fatalf("second request If-None-Match = %q; want %q", got, want)
+			}
+			return &http.Response{
+				StatusCode: http.StatusNotModified,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}
+	})
+
+	first, err := githubAPIGet(client, githubReleasesURL)
+	if err != nil {
+		t.Fatalf("first githubAPIGet: %v", err)
+	}
+	second, err := githubAPIGet(client, githubReleasesURL)
+	if err != nil {
+		t.Fatalf("second githubAPIGet: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Fatalf("304 should return cached body; got %q, want %q", second, first)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d; want 2", calls)
+	}
+}
+
+func TestGitHubAPIGetRefreshesCacheOnNewETag(t *testing.T) {
+	stubGitHubTokens(t)
+	stubGitHubAPICachePath(t)
+
+	calls := 0
+	client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Etag": []string{`"etag-1"`}},
+				Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`)),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Etag": []string{`"etag-2"`}},
+			Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v2.0.0"}`)),
+		}, nil
+	})
+
+	if _, err := githubAPIGet(client, githubReleasesURL); err != nil {
+		t.Fatalf("first githubAPIGet: %v", err)
+	}
+	second, err := githubAPIGet(client, githubReleasesURL)
+	if err != nil {
+		t.Fatalf("second githubAPIGet: %v", err)
+	}
+	if got, want := string(second), `{"tag_name":"v2.0.0"}`; got != want {
+		t.Fatalf("body = %q; want %q", got, want)
+	}
+
+	// A third call must present the refreshed ETag.
+	client304 := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+		if got, want := req.Header.Get("If-None-Match"), `"etag-2"`; got != want {
+			t.Fatalf("If-None-Match = %q; want %q", got, want)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNotModified,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+	third, err := githubAPIGet(client304, githubReleasesURL)
+	if err != nil {
+		t.Fatalf("third githubAPIGet: %v", err)
+	}
+	if got, want := string(third), `{"tag_name":"v2.0.0"}`; got != want {
+		t.Fatalf("cached body = %q; want %q", got, want)
 	}
 }
 

--- a/go/internal/cli/commands/update.go
+++ b/go/internal/cli/commands/update.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
@@ -73,23 +72,13 @@ type githubRelease struct {
 func checkLatestRelease() (string, error) {
 	client := newGitHubAPIClient(10 * time.Second)
 
-	req, err := newGitHubAPIGetRequest(githubReleasesURL)
-	if err != nil {
-		return "", fmt.Errorf("creating GitHub API request: %w", err)
-	}
-
-	resp, err := client.Do(req)
+	body, err := githubAPIGet(client, githubReleasesURL)
 	if err != nil {
 		return "", fmt.Errorf("fetching releases: %w", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
-	}
 
 	var release githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+	if err := json.Unmarshal(body, &release); err != nil {
 		return "", fmt.Errorf("decoding release: %w", err)
 	}
 


### PR DESCRIPTION
## Problem

Unauthenticated GitHub API calls are limited to 60 requests/hour per IP. Shared office NATs, VPNs, and CI burn through that quickly, so `wendy device update` (and the background CLI update check) fails with:

```
✗ fetching release: GitHub API returned status 403
```

## Changes

- **`gh auth token` fallback**: when `GITHUB_TOKEN` is not set, the CLI asks the gh CLI for a token (cached per process, 5s timeout, silently skipped if gh is absent). `GITHUB_TOKEN` still takes precedence.
- **ETag response cache**: GitHub API responses are cached in `<cache-dir>/github-api-cache.json` and revalidated with `If-None-Match`. GitHub does not count 304 responses against the rate limit, so the 24h update check and repeated release lookups become nearly free. Cache read/write failures degrade gracefully to an unconditional request.
- **Actionable rate-limit error**: 403/429 now produce `GitHub API rate limit exceeded (status 403); set GITHUB_TOKEN or run 'gh auth login' to raise the limit` instead of a bare status code.

All release lookups (`checkLatestRelease`, `fetchAgentRelease` — used by update check, device update, discover, cloud discover, and os install) now funnel through one `githubAPIGet` helper. The existing protections (canonical-host check, Authorization stripping on cross-host redirects) are unchanged.

## Tests

- New unit tests for token fallback/precedence, rate-limit error mapping, success body passthrough, 304 cache reuse, and ETag refresh (fake `http.RoundTripper`, no network).
- Ran `go test ./internal/cli/commands ./internal/agent/services`, `go build ./...`, `gofmt`, `git diff --check` — all clean.

A follow-up PR will remove the API call from the download path entirely via stable asset names and `releases/latest/download/` URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)