### PR TITLE
feat(cli): resolve stable releases via github.com redirect, not the API

### DIFF
--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1268,6 +1268,12 @@ func fetchAgentRelease(nightly bool) (*githubReleaseFull, error) {
 	client := newGitHubAPIClient(30 * time.Second)
 
 	if !nightly {
+		// Prefer the github.com web redirect, which is not subject to the
+		// API rate limit; fall back to the API if it fails.
+		if release, err := fetchAgentReleaseViaWeb(&http.Client{Timeout: 30 * time.Second}); err == nil {
+			return release, nil
+		}
+
 		body, err := githubAPIGet(client, githubReleasesURL)
 		if err != nil {
 			return nil, fmt.Errorf("fetching latest release: %w", err)

--- a/go/internal/cli/commands/github.go
+++ b/go/internal/cli/commands/github.go
@@ -198,6 +198,86 @@ func saveGitHubAPICache(cache map[string]githubAPICacheEntry) {
 	_ = os.Rename(tmp.Name(), path)
 }
 
+// Web (non-API) endpoints for release discovery. Requests to github.com are
+// served by the website/CDN and are not subject to the API rate limit.
+const (
+	githubWebLatestReleaseURL = "https://github.com/wendylabsinc/wendy-agent/releases/latest"
+	githubWebDownloadBaseURL  = "https://github.com/wendylabsinc/wendy-agent/releases/download"
+)
+
+// agentReleaseArchitectures lists the linux architectures the release CI
+// publishes agent tarballs for (see .github/workflows/build.yml).
+var agentReleaseArchitectures = []string{"amd64", "arm64"}
+
+// resolveLatestReleaseTagViaWeb resolves the latest stable release tag by
+// following github.com's /releases/latest redirect to the tag page.
+func resolveLatestReleaseTagViaWeb(client *http.Client) (string, error) {
+	req, err := http.NewRequest(http.MethodHead, githubWebLatestReleaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", githubAPIUserAgent())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("resolving latest release: github.com returned status %d", resp.StatusCode)
+	}
+
+	const tagMarker = "/releases/tag/"
+	finalPath := resp.Request.URL.Path
+	idx := strings.LastIndex(finalPath, tagMarker)
+	if idx < 0 {
+		return "", fmt.Errorf("latest release redirect did not land on a tag page")
+	}
+	tag, err := url.PathUnescape(finalPath[idx+len(tagMarker):])
+	if err != nil || tag == "" || strings.Contains(tag, "/") {
+		return "", fmt.Errorf("could not extract release tag from redirect")
+	}
+	return tag, nil
+}
+
+// fetchAgentReleaseViaWeb resolves the latest stable agent release without the
+// GitHub API: the tag comes from the github.com redirect and asset names follow
+// the release CI convention wendy-agent-linux-<arch>-<tag>.tar.gz. One
+// synthesized URL is validated with a HEAD request (the CI uploads all assets
+// atomically with fail_on_unmatched_files), so a convention change surfaces as
+// an error here and the caller can fall back to the API.
+func fetchAgentReleaseViaWeb(client *http.Client) (*githubReleaseFull, error) {
+	tag, err := resolveLatestReleaseTagViaWeb(client)
+	if err != nil {
+		return nil, err
+	}
+
+	release := &githubReleaseFull{TagName: tag}
+	for _, arch := range agentReleaseArchitectures {
+		name := fmt.Sprintf("wendy-agent-linux-%s-%s.tar.gz", arch, tag)
+		release.Assets = append(release.Assets, githubReleaseAsset{
+			Name:               name,
+			BrowserDownloadURL: fmt.Sprintf("%s/%s/%s", githubWebDownloadBaseURL, url.PathEscape(tag), url.PathEscape(name)),
+		})
+	}
+
+	req, err := http.NewRequest(http.MethodHead, release.Assets[0].BrowserDownloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", githubAPIUserAgent())
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("release asset %s returned status %d", release.Assets[0].Name, resp.StatusCode)
+	}
+
+	return release, nil
+}
+
 func isCanonicalGitHubAPIURL(u *url.URL) bool {
 	return u != nil && u.Scheme == "https" && strings.EqualFold(u.Host, githubAPIHost)
 }

--- a/go/internal/cli/commands/github.go
+++ b/go/internal/cli/commands/github.go
@@ -227,8 +227,16 @@ func resolveLatestReleaseTagViaWeb(client *http.Client) (string, error) {
 		return "", fmt.Errorf("resolving latest release: github.com returned status %d", resp.StatusCode)
 	}
 
+	// Only trust the tag if the redirect chain stayed on github.com inside
+	// our org (the repo segment may differ after a repo rename).
+	finalURL := resp.Request.URL
+	if finalURL.Scheme != "https" || !strings.EqualFold(finalURL.Host, "github.com") ||
+		!strings.HasPrefix(finalURL.Path, "/wendylabsinc/") {
+		return "", fmt.Errorf("latest release redirect left the expected GitHub org")
+	}
+
 	const tagMarker = "/releases/tag/"
-	finalPath := resp.Request.URL.Path
+	finalPath := finalURL.Path
 	idx := strings.LastIndex(finalPath, tagMarker)
 	if idx < 0 {
 		return "", fmt.Errorf("latest release redirect did not land on a tag page")
@@ -246,6 +254,9 @@ func resolveLatestReleaseTagViaWeb(client *http.Client) (string, error) {
 // synthesized URL is validated with a HEAD request (the CI uploads all assets
 // atomically with fail_on_unmatched_files), so a convention change surfaces as
 // an error here and the caller can fall back to the API.
+//
+// The synthesized Assets list intentionally contains only the linux agent
+// tarballs; callers needing other release assets must use the API path.
 func fetchAgentReleaseViaWeb(client *http.Client) (*githubReleaseFull, error) {
 	tag, err := resolveLatestReleaseTagViaWeb(client)
 	if err != nil {

--- a/go/internal/cli/commands/github_test.go
+++ b/go/internal/cli/commands/github_test.go
@@ -392,6 +392,40 @@ func TestResolveLatestReleaseTagViaWeb(t *testing.T) {
 	}
 }
 
+func TestResolveLatestReleaseTagViaWebRejectsForeignFinalURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		finalURL string
+	}{
+		{name: "foreign host", finalURL: "https://evil.example.com/wendylabsinc/WendyOS/releases/tag/2026.06.10-142200"},
+		{name: "http downgrade", finalURL: "http://github.com/wendylabsinc/WendyOS/releases/tag/2026.06.10-142200"},
+		{name: "foreign org", finalURL: "https://github.com/attacker/repo/releases/tag/2026.06.10-142200"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+				if req.URL.String() == githubWebLatestReleaseURL {
+					return &http.Response{
+						StatusCode: http.StatusFound,
+						Header:     http.Header{"Location": []string{tt.finalURL}},
+						Body:       io.NopCloser(strings.NewReader("")),
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{},
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			})
+
+			if _, err := resolveLatestReleaseTagViaWeb(client); err == nil {
+				t.Fatalf("expected error when redirect lands on %s", tt.finalURL)
+			}
+		})
+	}
+}
+
 func TestResolveLatestReleaseTagViaWebRejectsNonTagPage(t *testing.T) {
 	client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{

--- a/go/internal/cli/commands/github_test.go
+++ b/go/internal/cli/commands/github_test.go
@@ -153,7 +153,15 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func newFakeGitHubClient(rt roundTripperFunc) *http.Client {
-	return &http.Client{Transport: rt}
+	// Mirror http.Transport's contract: the returned Response carries the
+	// Request that produced it.
+	return &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		resp, err := rt(req)
+		if resp != nil && resp.Request == nil {
+			resp.Request = req
+		}
+		return resp, err
+	})}
 }
 
 func stubGitHubTokens(t *testing.T) {
@@ -352,6 +360,140 @@ func TestGitHubAPIGetConcurrentCachingPersistsAllEntries(t *testing.T) {
 		if _, ok := cache[u]; !ok {
 			t.Errorf("cache missing entry for %s", u)
 		}
+	}
+}
+
+func TestResolveLatestReleaseTagViaWeb(t *testing.T) {
+	client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.String() {
+		case githubWebLatestReleaseURL:
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{"https://github.com/wendylabsinc/WendyOS/releases/tag/2026.06.10-142200"}},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		case "https://github.com/wendylabsinc/WendyOS/releases/tag/2026.06.10-142200":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}
+		t.Fatalf("unexpected request: %s", req.URL)
+		return nil, nil
+	})
+
+	tag, err := resolveLatestReleaseTagViaWeb(client)
+	if err != nil {
+		t.Fatalf("resolveLatestReleaseTagViaWeb: %v", err)
+	}
+	if got, want := tag, "2026.06.10-142200"; got != want {
+		t.Fatalf("tag = %q; want %q", got, want)
+	}
+}
+
+func TestResolveLatestReleaseTagViaWebRejectsNonTagPage(t *testing.T) {
+	client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	if _, err := resolveLatestReleaseTagViaWeb(client); err == nil {
+		t.Fatal("expected error for non-tag final page")
+	}
+}
+
+func TestFetchAgentReleaseViaWebSynthesizesAssets(t *testing.T) {
+	const tagURL = "https://github.com/wendylabsinc/WendyOS/releases/tag/2026.06.10-142200"
+	var headedURLs []string
+	client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.String() == githubWebLatestReleaseURL:
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{tagURL}},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		case req.URL.String() == tagURL:
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		case req.Method == http.MethodHead && strings.Contains(req.URL.Path, "/releases/download/"):
+			headedURLs = append(headedURLs, req.URL.String())
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL)
+		return nil, nil
+	})
+
+	release, err := fetchAgentReleaseViaWeb(client)
+	if err != nil {
+		t.Fatalf("fetchAgentReleaseViaWeb: %v", err)
+	}
+	if got, want := release.TagName, "2026.06.10-142200"; got != want {
+		t.Fatalf("TagName = %q; want %q", got, want)
+	}
+	if release.Prerelease {
+		t.Fatal("synthesized stable release should not be marked prerelease")
+	}
+
+	wantAssets := map[string]string{
+		"wendy-agent-linux-amd64-2026.06.10-142200.tar.gz": "https://github.com/wendylabsinc/wendy-agent/releases/download/2026.06.10-142200/wendy-agent-linux-amd64-2026.06.10-142200.tar.gz",
+		"wendy-agent-linux-arm64-2026.06.10-142200.tar.gz": "https://github.com/wendylabsinc/wendy-agent/releases/download/2026.06.10-142200/wendy-agent-linux-arm64-2026.06.10-142200.tar.gz",
+	}
+	if len(release.Assets) != len(wantAssets) {
+		t.Fatalf("len(Assets) = %d; want %d", len(release.Assets), len(wantAssets))
+	}
+	for _, a := range release.Assets {
+		wantURL, ok := wantAssets[a.Name]
+		if !ok {
+			t.Fatalf("unexpected asset %q", a.Name)
+		}
+		if a.BrowserDownloadURL != wantURL {
+			t.Fatalf("asset %q URL = %q; want %q", a.Name, a.BrowserDownloadURL, wantURL)
+		}
+	}
+	if len(headedURLs) == 0 {
+		t.Fatal("expected at least one HEAD validation of a synthesized asset URL")
+	}
+}
+
+func TestFetchAgentReleaseViaWebFailsWhenAssetMissing(t *testing.T) {
+	const tagURL = "https://github.com/wendylabsinc/WendyOS/releases/tag/2026.06.10-142200"
+	client := newFakeGitHubClient(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.String() == githubWebLatestReleaseURL:
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{tagURL}},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		case req.URL.String() == tagURL:
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		default:
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}
+	})
+
+	if _, err := fetchAgentReleaseViaWeb(client); err == nil {
+		t.Fatal("expected error when synthesized asset URL does not exist")
 	}
 }
 

--- a/go/internal/cli/commands/update.go
+++ b/go/internal/cli/commands/update.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
@@ -70,6 +71,12 @@ type githubRelease struct {
 }
 
 func checkLatestRelease() (string, error) {
+	// Prefer the github.com web redirect, which is not subject to the API
+	// rate limit; fall back to the API if it fails.
+	if tag, err := resolveLatestReleaseTagViaWeb(&http.Client{Timeout: 10 * time.Second}); err == nil {
+		return tag, nil
+	}
+
 	client := newGitHubAPIClient(10 * time.Second)
 
 	body, err := githubAPIGet(client, githubReleasesURL)


### PR DESCRIPTION
> Stacked on #968 — merge that first; this PR's base is `feat/github-rate-limit-mitigations`.

## Problem

Even with #968's mitigations, the stable-release lookup still consumes the unauthenticated GitHub API quota (60/hour per IP). For stable releases the API call is avoidable entirely.

## Approach

- `https://github.com/wendylabsinc/wendy-agent/releases/latest` is a website redirect (not API rate limited) whose final URL is `/releases/tag/<tag>` — that gives us the latest stable tag.
- The release CI (`.github/workflows/build.yml`) sets `tag_name == version` and names agent assets `wendy-agent-linux-<arch>-<tag>.tar.gz`, so download URLs are fully derivable from the tag. No CI changes needed.

`fetchAgentReleaseViaWeb` resolves the tag via the redirect, synthesizes the release object (covering the `amd64`/`arm64` linux assets all call sites match on), and validates one synthesized URL with a HEAD request — CI uploads assets atomically with `fail_on_unmatched_files: true`, so one HEAD validates the convention. Any failure falls back silently to the existing API path, so behavior can only improve.

`checkLatestRelease` (the daily background update check, which runs on every installed CLI) uses the same redirect first.

Nightly lookups still need the API listing to find the latest prerelease; they keep the ETag-cache + token mitigations from #968. If we want nightly off the API too, the follow-up would be a rolling `nightly` release in CI.

Verified live: the redirect chain (including the wendy-agent → WendyOS rename hop) resolves to `2026.06.10-142200`, and the constructed asset URL serves the tarball.

## Tests

- New unit tests for redirect tag extraction, non-tag-page rejection, asset synthesis (names/URLs/HEAD validation), and missing-asset failure — all against a fake `http.RoundTripper`, no network.
- `go test ./internal/cli/commands ./internal/agent/services`, `go build ./...`, `gofmt`, `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)