### PR TITLE
feat(entitlements): expose /dev/vcio on Raspberry Pi via the gpu entitlement

### DIFF
--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -177,6 +177,40 @@ func applyGPU(spec *Spec) {
 		"NVIDIA_VISIBLE_DEVICES=all",
 		"NVIDIA_DRIVER_CAPABILITIES=all",
 	)
+
+	// On Raspberry Pi, also expose the VideoCore mailbox device for board
+	// telemetry. The node is absent on Jetson/generic hosts, where this is
+	// skipped entirely.
+	if boardDetect().IsRaspberryPi() {
+		applyVCIO(spec)
+	}
+}
+
+// vcioDevicePath is the host VideoCore mailbox device. Behind a var so tests
+// can point it at a temp file (a real /dev/vcio only exists on a Raspberry Pi).
+var vcioDevicePath = "/dev/vcio"
+
+// applyVCIO exposes the Raspberry Pi VideoCore mailbox device so a container can
+// read board telemetry (power/voltage/current/temperature, Pi 5 PMIC ADC)
+// through the firmware property interface (e.g. vcgencmd). The node's major is
+// dynamically allocated by the firmware/mailbox driver, so it is derived from
+// the live node rather than hardcoded. Access is "rw" (no mknod): the container
+// only opens the host-created node, it never needs to create one. No-op when the
+// node is absent (e.g. vcio not enabled) so a missing bind source cannot stop
+// the container from starting.
+func applyVCIO(spec *Spec) {
+	if _, err := os.Stat(vcioDevicePath); err != nil {
+		return
+	}
+	spec.Mounts = append(spec.Mounts, Mount{
+		Destination: "/dev/vcio",
+		Source:      vcioDevicePath,
+		Type:        "bind",
+		Options:     []string{"rbind", "rw", "nosuid", "noexec"},
+	})
+	// /dev/vcio's major is dynamically allocated, so derive it from the live
+	// node. allowMajorsFromGlob dedups and grants the major "rw" (no mknod).
+	allowMajorsFromGlob(spec, vcioDevicePath)
 }
 
 // applyNetwork configures the network namespace.

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -157,6 +157,98 @@ func TestApplyEntitlements_GPU(t *testing.T) {
 	if !hasEnv(spec, "NVIDIA_VISIBLE_DEVICES") {
 		t.Error("GPU entitlement did not set NVIDIA_VISIBLE_DEVICES")
 	}
+
+	// On a generic (non-Pi) host, the GPU entitlement must not expose the
+	// Raspberry Pi VideoCore mailbox device.
+	if hasMountDest(spec, "/dev/vcio") {
+		t.Error("GPU entitlement must not mount /dev/vcio on a non-Raspberry-Pi host")
+	}
+}
+
+// installFakeVCIO points vcioDevicePath at a temp file, makes statMajor report
+// the given major for it, and reports the host as a Raspberry Pi — so the
+// vcio branch of applyGPU can be exercised without a real /dev/vcio (which only
+// exists on a Pi and whose major needs root/mknod to fake). Restored on cleanup.
+func installFakeVCIO(t *testing.T, major int64) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "vcio")
+	if err := os.WriteFile(p, nil, 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+
+	origPath := vcioDevicePath
+	origStat := statMajor
+	origBoard := boardDetect
+	t.Cleanup(func() {
+		vcioDevicePath = origPath
+		statMajor = origStat
+		boardDetect = origBoard
+	})
+
+	vcioDevicePath = p
+	statMajor = func(q string) (int64, error) {
+		if q == p {
+			return major, nil
+		}
+		return 0, os.ErrNotExist
+	}
+	boardDetect = func() board.Info { return board.Info{Kind: board.RaspberryPi} }
+	return p
+}
+
+func TestApplyGPU_RaspberryPiExposesVCIO(t *testing.T) {
+	source := installFakeVCIO(t, 249)
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID:        "test-app",
+		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementGPU}},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+
+	// /dev/vcio must be bind-mounted from the host node.
+	m, ok := mountForDest(spec, "/dev/vcio")
+	if !ok {
+		t.Fatal("GPU entitlement did not mount /dev/vcio on a Raspberry Pi")
+	}
+	if m.Type != "bind" || m.Source != source {
+		t.Errorf("/dev/vcio mount = {Type:%q Source:%q}, want bind from %q", m.Type, m.Source, source)
+	}
+
+	// The dynamic major must be allowed, exactly once, with "rw" (no mknod).
+	if !hasMajorRule(spec, 249) {
+		t.Error("GPU entitlement did not allow the /dev/vcio major on a Raspberry Pi")
+	}
+	if got := countMajorRule(spec, 249); got != 1 {
+		t.Errorf("vcio major rule should be deduplicated, got %d entries", got)
+	}
+	if acc, _ := majorRuleAccess(spec, 249); acc != "rw" {
+		t.Errorf("vcio major Access = %q, want %q (mknod must be withheld)", acc, "rw")
+	}
+}
+
+func TestApplyGPU_RaspberryPiSkipsVCIOWhenAbsent(t *testing.T) {
+	// Report a Pi, but leave vcioDevicePath at its default (/dev/vcio), which
+	// does not exist on the test host: the bind mount must be skipped so a
+	// missing source cannot stop the container from starting.
+	origBoard := boardDetect
+	t.Cleanup(func() { boardDetect = origBoard })
+	boardDetect = func() board.Info { return board.Info{Kind: board.RaspberryPi} }
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID:        "test-app",
+		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementGPU}},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+
+	if hasMountDest(spec, "/dev/vcio") {
+		t.Error("GPU entitlement mounted /dev/vcio even though the host node is absent")
+	}
 }
 
 func TestApplyEntitlements_Network_Host(t *testing.T) {

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -145,11 +145,19 @@ IP networking access.
 
 ### `gpu`
 
-GPU access for AI inference or general-purpose compute.
+Hardware-dependent GPU or board-telemetry access.
 
 ```json
 { "type": "gpu" }
 ```
+
+| Host hardware | Grant |
+|---------------|-------|
+| NVIDIA Jetson | NVIDIA CDI specs, CUDA env vars, `/dev/nvidia*` |
+| Raspberry Pi | `/dev/vcio` (VideoCore mailbox) for board telemetry — power, voltage/current, temperature, throttling, Pi 5 PMIC ADC |
+| Other | No hardware-specific grant |
+
+On Raspberry Pi, `/dev/vcio` is bind-mounted only when present on the host; access is `rw` (no `mknod`).
 
 ### `camera`
 

--- a/go/internal/cli/assets/docs/guides/device/entitlements.mdx
+++ b/go/internal/cli/assets/docs/guides/device/entitlements.mdx
@@ -80,8 +80,10 @@ When enabled, this entitlement:
 - Injects NVIDIA Container Device Interface (CDI) specifications
 - Sets up environment variables for CUDA and GPU libraries
 
-<Callout type="warning">
-  **Jetson Only**: GPU entitlements are specifically designed for NVIDIA Jetson devices. They enable access to the integrated GPU for AI/ML workloads.
+On **Raspberry Pi** hosts, the same entitlement also exposes the VideoCore mailbox device (`/dev/vcio`), letting your application read board telemetry — power, voltage/current, temperature, and (on Pi 5) PMIC ADC readings — through the firmware property interface (the interface `vcgencmd` uses). This is added only on Raspberry Pi hardware and only when the device node is present.
+
+<Callout type="info">
+  **NVIDIA vs Raspberry Pi**: The GPU device access (CDI specs, CUDA libraries, `/dev/nvidia*`) applies to NVIDIA Jetson devices. On Raspberry Pi, the entitlement instead grants the VideoCore mailbox (`/dev/vcio`) for board telemetry. The entitlement is a no-op on hardware that has neither.
 </Callout>
 
 ### Camera Entitlement

--- a/go/internal/cli/assets/docs/guides/device/entitlements.mdx
+++ b/go/internal/cli/assets/docs/guides/device/entitlements.mdx
@@ -81,7 +81,7 @@ When enabled, this entitlement:
 - Sets up environment variables for CUDA and GPU libraries
 
 <Callout type="info">
-  **Hardware-specific behavior**: What the `gpu` entitlement exposes depends on the device — NVIDIA GPU access on Jetson, and VideoCore board telemetry on Raspberry Pi. See [GPU Access](/docs/guides/device/hardware-gpu) for the details.
+  **Hardware-specific behavior**: What the `gpu` entitlement exposes depends on the device — NVIDIA GPU access on Jetson, and VideoCore board telemetry on Raspberry Pi. See [GPU Access](/docs/guides/device/hardware-gpu#raspberry-pi-board-telemetry) for the details.
 </Callout>
 
 ### Camera Entitlement

--- a/go/internal/cli/assets/docs/guides/device/entitlements.mdx
+++ b/go/internal/cli/assets/docs/guides/device/entitlements.mdx
@@ -80,10 +80,8 @@ When enabled, this entitlement:
 - Injects NVIDIA Container Device Interface (CDI) specifications
 - Sets up environment variables for CUDA and GPU libraries
 
-On **Raspberry Pi** hosts, the same entitlement also exposes the VideoCore mailbox device (`/dev/vcio`), letting your application read board telemetry — power, voltage/current, temperature, and (on Pi 5) PMIC ADC readings — through the firmware property interface (the interface `vcgencmd` uses). This is added only on Raspberry Pi hardware and only when the device node is present.
-
 <Callout type="info">
-  **NVIDIA vs Raspberry Pi**: The GPU device access (CDI specs, CUDA libraries, `/dev/nvidia*`) applies to NVIDIA Jetson devices. On Raspberry Pi, the entitlement instead grants the VideoCore mailbox (`/dev/vcio`) for board telemetry. The entitlement is a no-op on hardware that has neither.
+  **Hardware-specific behavior**: What the `gpu` entitlement exposes depends on the device — NVIDIA GPU access on Jetson, and VideoCore board telemetry on Raspberry Pi. See [GPU Access](/docs/guides/device/hardware-gpu) for the details.
 </Callout>
 
 ### Camera Entitlement

--- a/go/internal/cli/assets/docs/guides/device/hardware-gpu.mdx
+++ b/go/internal/cli/assets/docs/guides/device/hardware-gpu.mdx
@@ -76,7 +76,7 @@ wendy run
 
 On Raspberry Pi hosts, the `gpu` entitlement also exposes the VideoCore mailbox device (`/dev/vcio`). This lets your app read board telemetry — power, voltage and current, temperature, throttling state, and (on Raspberry Pi 5) the PMIC ADC channels — through the firmware property interface, the same channel the `vcgencmd` tool uses.
 
-This is added only on Raspberry Pi hardware, and only when the `/dev/vcio` node is present. On NVIDIA Jetson devices the entitlement instead grants the CUDA/CDI access described above; on hardware that has neither, it has no effect.
+This is added only on Raspberry Pi hardware, and only when the `/dev/vcio` node is present. On NVIDIA Jetson devices the entitlement grants the CUDA/CDI access described above instead — the VideoCore mailbox is not exposed there — and on hardware that is neither, it has no effect.
 
 ```json
 {

--- a/go/internal/cli/assets/docs/guides/device/hardware-gpu.mdx
+++ b/go/internal/cli/assets/docs/guides/device/hardware-gpu.mdx
@@ -71,3 +71,23 @@ Then deploy:
 ```bash
 wendy run
 ```
+
+## Raspberry Pi Board Telemetry
+
+On Raspberry Pi hosts, the `gpu` entitlement also exposes the VideoCore mailbox device (`/dev/vcio`). This lets your app read board telemetry — power, voltage and current, temperature, throttling state, and (on Raspberry Pi 5) the PMIC ADC channels — through the firmware property interface, the same channel the `vcgencmd` tool uses.
+
+This is added only on Raspberry Pi hardware, and only when the `/dev/vcio` node is present. On NVIDIA Jetson devices the entitlement instead grants the CUDA/CDI access described above; on hardware that has neither, it has no effect.
+
+```json
+{
+  "appId": "com.example.power-monitor",
+  "version": "1.0.0",
+  "entitlements": [
+    { "type": "gpu" }
+  ]
+}
+```
+
+<Callout type="info">
+  Access is read/write to the existing device node only — the container cannot create new device nodes (`mknod`). The grant applies solely when the agent detects Raspberry Pi hardware.
+</Callout>


### PR DESCRIPTION
## Summary

On Raspberry Pi, board telemetry — power, voltage/current, temperature, throttling state, and the Pi 5 PMIC ADC readings — is read through the VideoCore firmware **mailbox property interface**, exposed to userspace as `/dev/vcio` (the device `vcgencmd` opens). The `gpu` entitlement was NVIDIA-only (`/dev/nvidia*` + CUDA env), so a containerized app on a Pi got nothing useful and **could not read board power**.

This extends the existing `gpu` entitlement so that, **on Raspberry Pi hosts only**, it also exposes `/dev/vcio`. Jetson/NVIDIA behavior is unchanged; this is purely additive.

## What changed

- **`go/internal/agent/oci/entitlements.go`** — `applyGPU` now calls a new `applyVCIO` under `boardDetect().IsRaspberryPi()`. `applyVCIO` bind-mounts `/dev/vcio` and allows its device major. The major is **dynamically allocated** by the firmware/mailbox driver, so it's derived from the live node via the existing `allowMajorsFromGlob`/`statMajor` helpers rather than hardcoded.
- **`go/internal/agent/oci/entitlements_test.go`** — positive test (Pi + injected node ⇒ `/dev/vcio` mount + deduped `rw` major rule) and a guard test (Pi but node absent ⇒ mount skipped). Existing `TestApplyEntitlements_GPU` extended to assert non-Pi hosts never get `/dev/vcio`.
- **`docs/.../guides/device/entitlements.mdx`** — documents the Raspberry Pi board-telemetry behavior and replaces the "Jetson Only" callout.

## Security notes (for the Claude Security Review gate)

- **Opt-in + Pi-only**: only applied with the `gpu` entitlement, and only when `board.IsRaspberryPi()` and the `/dev/vcio` node both hold. Skipped entirely on Jetson/generic.
- **`rw`, not `rwm`** — the mknod bit is withheld (consistent with the camera grants), so this is not a container-escape primitive.
- The cgroup rule grants the device's whole **major**, consistent with every other entitlement in this file. `/dev/vcio`'s dynamically-allocated major is dedicated to the single mailbox device, so "whole major" ≈ "just vcio" here.
- `/dev/vchiq` (VPU/codec) is intentionally **not** included — unrelated to power reads and would broaden the grant.

## Verification

- `gofmt -l internal/agent/oci/` → clean
- `go build ./...` → ok
- `go test ./internal/agent/oci/...` → pass (new vcio tests + existing entitlement tests green)
- **On-device (pending)**: deploy an app with `{ "type": "gpu" }` on a Pi, confirm `/dev/vcio` is present in the container and a board-power read works (`vcgencmd pmic_read_adc` on Pi 5 / `vcgencmd measure_volts`). Confirm a Jetson/non-Pi device with `gpu` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)