### PR TITLE
feat(cli): responsive, filterable WiFi selectors with security info

### DIFF
--- a/go/internal/agent/network/networkmanager.go
+++ b/go/internal/agent/network/networkmanager.go
@@ -193,15 +193,32 @@ func (n *NMCLINetworkManager) ListWiFiNetworks(ctx context.Context) ([]*agentpb.
 		// columns will be blank.
 		n.logger.Warn("Failed to list saved WiFi profiles; continuing with scan-only results", zap.Error(knownErr))
 	}
+
+	networks := parseWiFiList(string(output), known)
+	n.logger.Info("Listed WiFi networks", zap.Int("count", len(networks)))
+	return networks, nil
+}
+
+// parseWiFiList merges the output of `nmcli -t -f IN-USE,SSID,SIGNAL,SECURITY
+// device wifi list` with the saved profiles, producing one entry per SSID.
+//
+// A single SSID often surfaces on several BSS rows (multi-band APs, mesh nodes,
+// repeaters). nmcli marks IN-USE (`*`) only on the one BSS the device is
+// actually associated with, and sorts the list by signal — so the marked BSS is
+// not necessarily the first row for its SSID. We keep the first (strongest) row
+// for the displayed signal/security but OR the IN-USE marker across every BSS of
+// the SSID. Without this, the "Connected" status flaps off whenever the
+// associated BSS's signal dips below a sibling BSS between polls.
+func parseWiFiList(scanOutput string, known []knownProfile) []*agentpb.ListWiFiNetworksResponse_WiFiNetwork {
 	knownBySSID := make(map[string]knownProfile, len(known))
 	for _, k := range known {
 		knownBySSID[k.SSID] = k
 	}
 
 	var networks []*agentpb.ListWiFiNetworksResponse_WiFiNetwork
-	seen := make(map[string]bool)
+	bySSID := make(map[string]*agentpb.ListWiFiNetworksResponse_WiFiNetwork)
 
-	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	scanner := bufio.NewScanner(strings.NewReader(scanOutput))
 	for scanner.Scan() {
 		fields := splitNMCLI(scanner.Text(), 4)
 		if len(fields) < 4 {
@@ -209,10 +226,18 @@ func (n *NMCLINetworkManager) ListWiFiNetworks(ctx context.Context) ([]*agentpb.
 		}
 		inUse := strings.TrimSpace(fields[0]) == "*"
 		ssid := fields[1]
-		if ssid == "" || seen[ssid] {
+		if ssid == "" {
 			continue
 		}
-		seen[ssid] = true
+		if existing, ok := bySSID[ssid]; ok {
+			// Another BSS for an SSID we've already recorded. Keep the
+			// stronger first row's display fields, but a connected marker on
+			// any BSS means the SSID is connected.
+			if inUse {
+				existing.IsConnected = true
+			}
+			continue
+		}
 
 		net := &agentpb.ListWiFiNetworksResponse_WiFiNetwork{
 			Ssid:     ssid,
@@ -235,6 +260,7 @@ func (n *NMCLINetworkManager) ListWiFiNetworks(ctx context.Context) ([]*agentpb.
 			delete(knownBySSID, ssid)
 		}
 		networks = append(networks, net)
+		bySSID[ssid] = net
 	}
 
 	// Include saved-but-not-currently-visible networks so the TUI can still
@@ -249,8 +275,7 @@ func (n *NMCLINetworkManager) ListWiFiNetworks(ctx context.Context) ([]*agentpb.
 		})
 	}
 
-	n.logger.Info("Listed WiFi networks", zap.Int("count", len(networks)))
-	return networks, nil
+	return networks
 }
 
 // Connect connects to a WiFi network using nmcli, resolving the binary path

--- a/go/internal/agent/network/networkmanager_test.go
+++ b/go/internal/agent/network/networkmanager_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"strings"
 	"testing"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -54,46 +55,82 @@ func TestClassifySecurity(t *testing.T) {
 	}
 }
 
+// bySSID finds the parsed network for an SSID, or nil if absent.
+func bySSID(nets []*agentpb.ListWiFiNetworksResponse_WiFiNetwork, ssid string) *agentpb.ListWiFiNetworksResponse_WiFiNetwork {
+	for _, n := range nets {
+		if n.GetSsid() == ssid {
+			return n
+		}
+	}
+	return nil
+}
+
 func TestParseWiFiList(t *testing.T) {
-	// Simulate nmcli -t output format: SSID:SIGNAL:SECURITY:IN-USE
-	lines := []string{
-		"HomeNet:80:WPA2:*",
-		"OfficeNet:65:WPA2:",
-		"OpenNet:45::",
-		":30:WPA2:",        // empty SSID, should be skipped
-		"HomeNet:75:WPA2:", // duplicate SSID, should be skipped
-	}
+	// Real nmcli -t output format: IN-USE:SSID:SIGNAL:SECURITY.
+	scan := strings.Join([]string{
+		"*:HomeNet:80:WPA2",
+		":OfficeNet:65:WPA2",
+		":OpenNet:45:",
+		"::30:WPA2",        // empty SSID, should be skipped
+		":HomeNet:75:WPA2", // duplicate SSID, keeps the first row
+	}, "\n")
 
-	seen := make(map[string]bool)
-	type network struct {
-		ssid string
+	got := parseWiFiList(scan, nil)
+	if len(got) != 3 {
+		t.Fatalf("parsed %d networks; want 3 (got=%v)", len(got), got)
 	}
-	var networks []network
+	if got[0].GetSsid() != "HomeNet" || got[1].GetSsid() != "OfficeNet" || got[2].GetSsid() != "OpenNet" {
+		t.Errorf("ssids = [%q %q %q]; want [HomeNet OfficeNet OpenNet]",
+			got[0].GetSsid(), got[1].GetSsid(), got[2].GetSsid())
+	}
+	if home := bySSID(got, "HomeNet"); home == nil || !home.GetIsConnected() {
+		t.Errorf("HomeNet IsConnected = %v; want true", home.GetIsConnected())
+	}
+	if office := bySSID(got, "OfficeNet"); office == nil || office.GetIsConnected() {
+		t.Errorf("OfficeNet should not be connected")
+	}
+}
 
-	for _, line := range lines {
-		fields := splitFields(line, 4)
-		if len(fields) < 4 {
-			continue
+// TestParseWiFiList_ConnectedNotStrongestBSS reproduces the "Connected" label
+// flicker: when the associated BSS (carrying nmcli's `*` IN-USE marker) is not
+// the strongest BSS for its SSID, nmcli sorts it below a sibling BSS, so the
+// first row for the SSID lacks the marker. The SSID must still report connected
+// — the marker on any BSS counts. Modeled on a real multi-AP capture where the
+// connected AP's signal dipped below a same-SSID sibling between polls.
+func TestParseWiFiList_ConnectedNotStrongestBSS(t *testing.T) {
+	scan := strings.Join([]string{
+		":Cafe5G:100:WPA2",
+		":GuestWiFi:100:WPA2",
+		":Cafe5G:100:WPA2",
+		":MeshNet:92:WPA2", // first row for the connected SSID: no marker
+		":GuestWiFi:92:WPA2",
+		"*:MeshNet:84:WPA2", // the associated BSS, sorted lower by signal
+		":MeshNet:82:WPA2",
+		":Patio:39:WPA2",
+	}, "\n")
+
+	got := parseWiFiList(scan, nil)
+
+	mesh := bySSID(got, "MeshNet")
+	if mesh == nil {
+		t.Fatal("MeshNet missing from parsed networks")
+	}
+	if !mesh.GetIsConnected() {
+		t.Errorf("MeshNet IsConnected = false; want true (the `*` BSS was not the strongest, so the marker was dropped)")
+	}
+	// The display row should still reflect the strongest BSS for the SSID.
+	if mesh.GetSignalStrength() != 92 {
+		t.Errorf("MeshNet signal = %d; want 92 (strongest BSS)", mesh.GetSignalStrength())
+	}
+	// Exactly one SSID entry for the connected network (BSS rows collapsed).
+	count := 0
+	for _, n := range got {
+		if n.GetSsid() == "MeshNet" {
+			count++
 		}
-		ssid := fields[0]
-		if ssid == "" || seen[ssid] {
-			continue
-		}
-		seen[ssid] = true
-		networks = append(networks, network{ssid: ssid})
 	}
-
-	if len(networks) != 3 {
-		t.Fatalf("parsed %d networks; want 3", len(networks))
-	}
-	if networks[0].ssid != "HomeNet" {
-		t.Errorf("networks[0].ssid = %q; want HomeNet", networks[0].ssid)
-	}
-	if networks[1].ssid != "OfficeNet" {
-		t.Errorf("networks[1].ssid = %q; want OfficeNet", networks[1].ssid)
-	}
-	if networks[2].ssid != "OpenNet" {
-		t.Errorf("networks[2].ssid = %q; want OpenNet", networks[2].ssid)
+	if count != 1 {
+		t.Errorf("MeshNet appears %d times; want 1", count)
 	}
 }
 

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1249,11 +1249,18 @@ func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 		picker := tui.NewPickerWithTitleAndColumns("Select WiFi network (or esc to type manually)", wifiPickerColumns())
 		picker.Filterable = true
 		p := tea.NewProgram(picker)
+
+		var scanErrMu sync.Mutex
+		var scanErr error
 		go func() {
 			defer p.Send(tui.PickerDoneMsg{})
 			nets, err := scanLocalWifiNetworks()
 			if err != nil {
-				// Scan failures fall through to the manual SSID prompt below.
+				// Recorded so the fallthrough to the manual prompt can say
+				// why the list stayed empty.
+				scanErrMu.Lock()
+				scanErr = err
+				scanErrMu.Unlock()
 				return
 			}
 			p.Send(tui.PickerAddMsg{Items: localWifiPickerItems(nets)})
@@ -1271,6 +1278,13 @@ func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 		// prompt, as the title advertises.
 		if sel := pm.Selected(); sel != nil {
 			c.SSID, _ = sel.Value.(string)
+		} else {
+			scanErrMu.Lock()
+			err := scanErr
+			scanErrMu.Unlock()
+			if err != nil {
+				cliNotice("WiFi scan failed (%v) — enter the network name manually.", err)
+			}
 		}
 	}
 

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1242,46 +1242,35 @@ func splitEscaped(s string, sep byte) []string {
 func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 	var c wendyconf.WifiCredential
 
-	var networks []localWifiNetwork
-	var scanErr error
+	// Show the picker immediately and stream the scan results in: the
+	// CoreWLAN/nmcli/netsh scan can take several seconds, and a visible
+	// "Scanning..." list reads better than blocking before any UI appears.
 	{
-		spin := tui.NewSpinner("Scanning for nearby WiFi networks…")
-		p := tea.NewProgram(spin)
+		picker := tui.NewPickerWithTitleAndColumns("Select WiFi network (or esc to type manually)", wifiPickerColumns())
+		picker.Filterable = true
+		p := tea.NewProgram(picker)
 		go func() {
+			defer p.Send(tui.PickerDoneMsg{})
 			nets, err := scanLocalWifiNetworks()
-			p.Send(tui.SpinnerDoneMsg{Result: nets, Err: err})
+			if err != nil {
+				// Scan failures fall through to the manual SSID prompt below.
+				return
+			}
+			p.Send(tui.PickerAddMsg{Items: localWifiPickerItems(nets)})
 		}()
+		fmt.Println()
 		finalModel, runErr := p.Run()
 		if runErr != nil {
 			return c, false, fmt.Errorf("scanning WiFi networks: %w", runErr)
 		}
-		sm, ok := finalModel.(tui.SpinnerModel)
+		pm, ok := finalModel.(tui.PickerModel)
 		if !ok {
-			return c, false, fmt.Errorf("scanning WiFi networks: unexpected spinner model %T", finalModel)
+			return c, false, fmt.Errorf("scanning WiFi networks: unexpected picker model %T", finalModel)
 		}
-		// A spinner that quit before receiving SpinnerDoneMsg means the user
-		// pressed Ctrl+C/q during the scan; treat that as a cancellation rather
-		// than silently falling through to the manual SSID prompt.
-		if !sm.Done() {
-			return c, false, ErrUserCancelled
-		}
-		result, err := sm.Result()
-		networks, _ = result.([]localWifiNetwork)
-		scanErr = err
-	}
-	if scanErr == nil && len(networks) > 0 {
-		var items []tui.PickerItem
-		for _, n := range networks {
-			signal := ""
-			if n.SignalStrength > 0 {
-				signal = fmt.Sprintf("%d%%", n.SignalStrength)
-			}
-			items = append(items, tui.PickerItem{Name: n.SSID, Type: signal, Value: n.SSID})
-		}
-		fmt.Println()
-		picked, pickErr := pickFromItems("Select WiFi network (or Ctrl+C to type manually)", items)
-		if pickErr == nil {
-			c.SSID = picked
+		// Cancelling the picker (esc/Ctrl+C) falls through to the manual SSID
+		// prompt, as the title advertises.
+		if sel := pm.Selected(); sel != nil {
+			c.SSID, _ = sel.Value.(string)
 		}
 	}
 

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -903,7 +903,9 @@ func wifiListFromHost() error {
 		if n.SignalStrength > 0 {
 			signal = fmt.Sprintf("%d%%", n.SignalStrength)
 		}
-		rows = append(rows, []string{n.SSID, n.Security, signal})
+		// Scanner output is already sanitized at ingestion; strip again at
+		// the render boundary so this site is safe in isolation.
+		rows = append(rows, []string{tui.StripControl(n.SSID), tui.StripControl(n.Security), signal})
 	}
 	fmt.Print(tui.RenderTable(headers, rows))
 	return nil

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -56,12 +58,10 @@ func runWifiInteractive(cmd *cobra.Command) error {
 	}
 	defer client.Close()
 
-	networks, err := client.List(ctx)
-	if err != nil {
-		return err
-	}
-
-	model := wifitable.NewModel(networksToView(networks)).WithHandler(&wifiTUIHandler{ctx: ctx, client: client})
+	// Start with an empty table: the model's Init fires the first refresh and
+	// keeps polling, so the TUI opens instantly and rows stream in while the
+	// device-side rescan (which can take several seconds) fills its cache.
+	model := wifitable.NewModel(nil).WithHandler(&wifiTUIHandler{ctx: ctx, client: client})
 	p := tea.NewProgram(model)
 	if _, err := p.Run(); err != nil {
 		return fmt.Errorf("wifi TUI: %w", err)
@@ -628,90 +628,139 @@ func newWifiForgetCmd() *cobra.Command {
 	return cmd
 }
 
-// ── WiFi network picker (legacy, still used by `connect`) ──────────
+// ── WiFi network picker (used by `connect`) ────────────────────────
 
+// wifiPickerColumns renders PickerItems built by wifiPickerItems /
+// localWifiPickerItems: Name carries the SSID, Type the security label and
+// Size the signal percentage.
+func wifiPickerColumns() []tui.PickerColumn {
+	return []tui.PickerColumn{
+		{Title: "SSID", MinWidth: 24, Required: true, Value: func(it tui.PickerItem) string { return it.Name }},
+		{Title: "Security", MinWidth: 10, Value: func(it tui.PickerItem) string { return it.Type }},
+		{Title: "Signal", MinWidth: 8, Value: func(it tui.PickerItem) string { return it.Size }},
+	}
+}
+
+func wifiPickerItems(networks []*agentpb.ListWiFiNetworksResponse_WiFiNetwork) []tui.PickerItem {
+	items := make([]tui.PickerItem, 0, len(networks))
+	for _, n := range networks {
+		signal := ""
+		if n.GetSignalStrength() > 0 {
+			signal = fmt.Sprintf("%d%%", n.GetSignalStrength())
+		}
+		items = append(items, tui.PickerItem{
+			Name:  n.GetSsid(),
+			Type:  wifitable.SecurityLabel(n.GetSecurity()),
+			Size:  signal,
+			Value: n.GetSsid(),
+		})
+	}
+	return items
+}
+
+func localWifiPickerItems(networks []localWifiNetwork) []tui.PickerItem {
+	items := make([]tui.PickerItem, 0, len(networks))
+	for _, n := range networks {
+		signal := ""
+		if n.SignalStrength > 0 {
+			signal = fmt.Sprintf("%d%%", n.SignalStrength)
+		}
+		items = append(items, tui.PickerItem{
+			Name:  n.SSID,
+			Type:  n.Security,
+			Size:  signal,
+			Value: n.SSID,
+		})
+	}
+	return items
+}
+
+// pickWifiNetwork shows the network picker immediately and feeds scan results
+// in as they arrive, instead of blocking on the scan before any UI appears.
+// Typing filters the list; matches are highlighted in the SSID column.
 func pickWifiNetwork(ctx context.Context, target *SelectedDevice) (string, error) {
-	type wifiEntry struct {
-		ssid           string
-		signalStrength int32
+	picker := tui.NewPickerWithTitleAndColumns("Select a WiFi network", wifiPickerColumns())
+	picker.Filterable = true
+	p := tea.NewProgram(picker)
+
+	scanCtx, cancelScan := context.WithCancel(ctx)
+	defer cancelScan()
+
+	var scanErrMu sync.Mutex
+	var scanErr error
+	recordScanErr := func(err error) {
+		scanErrMu.Lock()
+		defer scanErrMu.Unlock()
+		if scanErr == nil {
+			scanErr = err
+		}
 	}
 
-	var networks []wifiEntry
-
 	switch {
-	case target.Bluetooth != nil && target.Bluetooth.IsWendyAgent():
-		cliLogln("Scanning for WiFi networks on %s...", target.Bluetooth.DisplayName)
-		tlsCfg, err := bleTLSConfig()
+	case target.Bluetooth != nil && !target.Bluetooth.IsWendyAgent():
+		// Wendy Lite — scan from the host machine (one-shot).
+		go func() {
+			defer p.Send(tui.PickerDoneMsg{})
+			nets, err := scanLocalWifiNetworks()
+			if err != nil {
+				recordScanErr(fmt.Errorf("scanning local WiFi networks: %w", err))
+				return
+			}
+			p.Send(tui.PickerAddMsg{Items: localWifiPickerItems(nets)})
+		}()
+
+	case target.Bluetooth != nil || target.Agent != nil:
+		client, err := newWifiClient(target)
 		if err != nil {
 			return "", err
 		}
-		client, err := ble.ConnectAgent(target.Bluetooth, tlsCfg)
-		if err != nil {
-			return "", fmt.Errorf("connecting to device: %w", err)
-		}
 		defer client.Close()
 
-		nets, err := client.WifiList()
-		if err != nil {
-			return "", fmt.Errorf("listing WiFi networks: %w", err)
-		}
-		for _, n := range nets {
-			networks = append(networks, wifiEntry{ssid: n.GetSsid(), signalStrength: n.GetSignalStrength()})
-		}
+		// Authoritative scan: blocks until the device-side rescan finishes.
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			defer p.Send(tui.PickerDoneMsg{})
+			nets, err := client.List(scanCtx)
+			if err != nil {
+				recordScanErr(err)
+				return
+			}
+			p.Send(tui.PickerAddMsg{Items: wifiPickerItems(nets)})
+		}()
 
-	case target.Bluetooth != nil:
-		cliLogln("Scanning for WiFi networks on this computer...")
-		nets, err := scanLocalWifiNetworks()
-		if err != nil {
-			return "", fmt.Errorf("scanning local WiFi networks: %w", err)
-		}
-		for _, n := range nets {
-			networks = append(networks, wifiEntry{ssid: n.SSID, signalStrength: n.SignalStrength})
-		}
-
-	case target.Agent != nil:
-		cliLogln("Scanning for WiFi networks...")
-		resp, err := target.Agent.AgentService.ListWiFiNetworks(ctx, &agentpb.ListWiFiNetworksRequest{})
-		if err != nil {
-			return "", fmt.Errorf("listing WiFi networks: %w", err)
-		}
-		for _, n := range resp.GetNetworks() {
-			networks = append(networks, wifiEntry{ssid: n.GetSsid(), signalStrength: n.GetSignalStrength()})
+		// While the rescan runs, poll the device's scan cache so SSIDs stream
+		// into the picker as they are found. Each poll returns quickly: the
+		// in-progress scan rejects new rescan requests and the list call reads
+		// the cache. Only over gRPC — the BLE transport can't multiplex
+		// concurrent calls.
+		if client.agent != nil {
+			go func() {
+				ticker := time.NewTicker(1500 * time.Millisecond)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-done:
+						return
+					case <-scanCtx.Done():
+						return
+					case <-ticker.C:
+						nets, err := client.List(scanCtx)
+						if err != nil {
+							continue
+						}
+						p.Send(tui.PickerAddMsg{Items: wifiPickerItems(nets)})
+					}
+				}
+			}()
 		}
 
 	default:
 		return "", fmt.Errorf("selected device does not support WiFi network scanning")
 	}
 
-	if len(networks) == 0 {
-		if wifiScanCacheHint != "" {
-			return "", fmt.Errorf("no WiFi networks found (%s)", wifiScanCacheHint)
-		}
-		return "", fmt.Errorf("no WiFi networks found")
-	}
-
-	var items []tui.PickerItem
-	for _, n := range networks {
-		signal := ""
-		if n.signalStrength > 0 {
-			signal = fmt.Sprintf("%d%%", n.signalStrength)
-		}
-		items = append(items, tui.PickerItem{
-			Name:  n.ssid,
-			Type:  signal,
-			Value: n.ssid,
-		})
-	}
-
-	picker := tui.NewPickerWithTitle("Select a WiFi network")
-	p := tea.NewProgram(picker)
-
-	go func() {
-		p.Send(tui.PickerAddMsg{Items: items})
-		p.Send(tui.PickerDoneMsg{})
-	}()
-
 	finalModel, err := p.Run()
+	cancelScan()
 	if err != nil {
 		return "", fmt.Errorf("network picker: %w", err)
 	}
@@ -722,7 +771,16 @@ func pickWifiNetwork(ctx context.Context, target *SelectedDevice) (string, error
 	}
 	sel := pm.Selected()
 	if sel == nil {
-		return "", fmt.Errorf("no network selected")
+		scanErrMu.Lock()
+		err := scanErr
+		scanErrMu.Unlock()
+		if err != nil {
+			return "", err
+		}
+		if wifiScanCacheHint != "" {
+			return "", fmt.Errorf("no WiFi networks found (%s)", wifiScanCacheHint)
+		}
+		return "", fmt.Errorf("no WiFi networks found")
 	}
 
 	ssid, ok := sel.Value.(string)
@@ -816,14 +874,14 @@ func wifiListFromHost() error {
 		return nil
 	}
 
-	headers := []string{"SSID", "Signal"}
+	headers := []string{"SSID", "Security", "Signal"}
 	var rows [][]string
 	for _, n := range networks {
 		signal := ""
 		if n.SignalStrength > 0 {
 			signal = fmt.Sprintf("%d%%", n.SignalStrength)
 		}
-		rows = append(rows, []string{n.SSID, signal})
+		rows = append(rows, []string{n.SSID, n.Security, signal})
 	}
 	fmt.Print(tui.RenderTable(headers, rows))
 	return nil

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -648,11 +648,14 @@ func wifiPickerItems(networks []*agentpb.ListWiFiNetworksResponse_WiFiNetwork) [
 		if n.GetSignalStrength() > 0 {
 			signal = fmt.Sprintf("%d%%", n.GetSignalStrength())
 		}
+		// SSIDs come from over-the-air beacon frames; strip control
+		// characters so hostile names can't inject escape sequences.
+		ssid := tui.StripControl(n.GetSsid())
 		items = append(items, tui.PickerItem{
-			Name:  n.GetSsid(),
+			Name:  ssid,
 			Type:  wifitable.SecurityLabel(n.GetSecurity()),
 			Size:  signal,
-			Value: n.GetSsid(),
+			Value: ssid,
 		})
 	}
 	return items

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -670,7 +670,7 @@ func localWifiPickerItems(networks []localWifiNetwork) []tui.PickerItem {
 		}
 		items = append(items, tui.PickerItem{
 			Name:  n.SSID,
-			Type:  n.Security,
+			Type:  tui.StripControl(n.Security),
 			Size:  signal,
 			Value: n.SSID,
 		})
@@ -756,6 +756,10 @@ func pickWifiNetwork(ctx context.Context, target *SelectedDevice) (string, error
 					case <-ticker.C:
 						nets, err := client.List(scanCtx)
 						if err != nil {
+							// Surfaced after the picker exits if nothing was
+							// ever found; transient poll errors are expected
+							// while the device scan is busy.
+							recordScanErr(err)
 							continue
 						}
 						items := wifiPickerItems(nets)

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -736,23 +736,38 @@ func pickWifiNetwork(ctx context.Context, target *SelectedDevice) (string, error
 		// into the picker as they are found. Each poll returns quickly: the
 		// in-progress scan rejects new rescan requests and the list call reads
 		// the cache. Only over gRPC — the BLE transport can't multiplex
-		// concurrent calls.
+		// concurrent calls. The deadline caps RPC traffic if the
+		// authoritative scan wedges; its result still lands whenever it
+		// finishes.
 		if client.agent != nil {
 			go func() {
 				ticker := time.NewTicker(1500 * time.Millisecond)
 				defer ticker.Stop()
+				deadline := time.After(30 * time.Second)
+				lastSeen := ""
 				for {
 					select {
 					case <-done:
 						return
 					case <-scanCtx.Done():
 						return
+					case <-deadline:
+						return
 					case <-ticker.C:
 						nets, err := client.List(scanCtx)
 						if err != nil {
 							continue
 						}
-						p.Send(tui.PickerAddMsg{Items: wifiPickerItems(nets)})
+						items := wifiPickerItems(nets)
+						// Skip redraws when the cache hasn't changed.
+						sig := make([]string, 0, len(items))
+						for _, it := range items {
+							sig = append(sig, it.Name)
+						}
+						if joined := strings.Join(sig, "\x00"); joined != lastSeen {
+							lastSeen = joined
+							p.Send(tui.PickerAddMsg{Items: items})
+						}
 					}
 				}
 			}()

--- a/go/internal/cli/commands/wifi_scan_darwin.go
+++ b/go/internal/cli/commands/wifi_scan_darwin.go
@@ -41,7 +41,14 @@ do {
     let networks = try iface.scanForNetworks(withSSID: nil)
     for net in networks.sorted(by: { $0.rssiValue > $1.rssiValue }) {
         guard let ssid = net.ssid, !ssid.isEmpty else { continue }
-        print("\(ssid)\t\(net.rssiValue)\t\(securityLabel(net))")
+        // Strip C0/DEL/C1 control characters before printing: SSIDs come
+        // from beacon frames, and a tab would shift the tab-delimited
+        // fields, letting attacker bytes land in the security column.
+        let clean = String(ssid.unicodeScalars.filter {
+            $0.value >= 0x20 && $0.value != 0x7F && !(0x80...0x9F).contains($0.value)
+        }.map { Character($0) })
+        guard !clean.isEmpty else { continue }
+        print("\(clean)\t\(net.rssiValue)\t\(securityLabel(net))")
     }
 } catch {
     fputs("scan failed: \(error)\n", stderr)
@@ -91,7 +98,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 
 		security := ""
 		if len(parts) >= 3 {
-			security = strings.TrimSpace(parts[2])
+			security = tui.StripControl(strings.TrimSpace(parts[2]))
 		}
 
 		networks = append(networks, localWifiNetwork{SSID: ssid, SignalStrength: signal, Security: security})

--- a/go/internal/cli/commands/wifi_scan_darwin.go
+++ b/go/internal/cli/commands/wifi_scan_darwin.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
 
 // wifiScanCacheHint is empty on macOS: CoreWLAN's scanForNetworks performs
@@ -68,7 +70,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 			continue
 		}
 
-		ssid := parts[0]
+		ssid := tui.StripControl(parts[0])
 		if ssid == "" || seen[ssid] {
 			continue
 		}

--- a/go/internal/cli/commands/wifi_scan_darwin.go
+++ b/go/internal/cli/commands/wifi_scan_darwin.go
@@ -23,11 +23,23 @@ guard let iface = client.interface() else {
     fputs("no wifi interface\n", stderr)
     exit(1)
 }
+// Strongest advertised suite wins; transition (mixed-mode) networks count as
+// the newer suite, matching how the agent labels nmcli scan results.
+func securityLabel(_ net: CWNetwork) -> String {
+    if net.supportsSecurity(.wpa3Personal) || net.supportsSecurity(.wpa3Transition) { return "WPA3" }
+    if net.supportsSecurity(.wpa3Enterprise) { return "WPA3-Ent" }
+    if net.supportsSecurity(.wpa2Enterprise) || net.supportsSecurity(.enterprise) || net.supportsSecurity(.wpaEnterprise) || net.supportsSecurity(.wpaEnterpriseMixed) { return "WPA2-Ent" }
+    if net.supportsSecurity(.wpa2Personal) || net.supportsSecurity(.personal) { return "WPA2" }
+    if net.supportsSecurity(.wpaPersonal) || net.supportsSecurity(.wpaPersonalMixed) { return "WPA" }
+    if net.supportsSecurity(.WEP) || net.supportsSecurity(.dynamicWEP) { return "WEP" }
+    if net.supportsSecurity(.none) || net.supportsSecurity(.OWE) || net.supportsSecurity(.oweTransition) { return "Open" }
+    return ""
+}
 do {
     let networks = try iface.scanForNetworks(withSSID: nil)
     for net in networks.sorted(by: { $0.rssiValue > $1.rssiValue }) {
         guard let ssid = net.ssid, !ssid.isEmpty else { continue }
-        print("\(ssid)\t\(net.rssiValue)")
+        print("\(ssid)\t\(net.rssiValue)\t\(securityLabel(net))")
     }
 } catch {
     fputs("scan failed: \(error)\n", stderr)
@@ -51,7 +63,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 	for scanner.Scan() {
-		parts := strings.SplitN(scanner.Text(), "\t", 2)
+		parts := strings.SplitN(scanner.Text(), "\t", 3)
 		if len(parts) < 2 {
 			continue
 		}
@@ -75,7 +87,12 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 			signal = int32(pct)
 		}
 
-		networks = append(networks, localWifiNetwork{SSID: ssid, SignalStrength: signal})
+		security := ""
+		if len(parts) >= 3 {
+			security = strings.TrimSpace(parts[2])
+		}
+
+		networks = append(networks, localWifiNetwork{SSID: ssid, SignalStrength: signal, Security: security})
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/go/internal/cli/commands/wifi_scan_linux.go
+++ b/go/internal/cli/commands/wifi_scan_linux.go
@@ -28,7 +28,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	// Trigger a rescan first (may fail if already scanning).
 	_ = nmcli.Command(context.Background(), nmcliPath, "device", "wifi", "rescan").Run()
 
-	cmd := nmcli.Command(context.Background(), nmcliPath, "-t", "-f", "SSID,SIGNAL", "device", "wifi", "list")
+	cmd := nmcli.Command(context.Background(), nmcliPath, "-t", "-f", "SSID,SIGNAL,SECURITY", "device", "wifi", "list")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("scanning WiFi networks: %w", err)
@@ -42,7 +42,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 		// Use the shared nmcli parser so SSIDs containing literal `:` (escaped
 		// by nmcli as `\:`) and `\` survive intact, and so the parsing is
 		// consistent with the agent side.
-		fields := nmcli.Split(scanner.Text(), 2)
+		fields := nmcli.Split(scanner.Text(), 3)
 		if len(fields) < 2 {
 			continue
 		}
@@ -58,7 +58,12 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 			signal = int32(s)
 		}
 
-		networks = append(networks, localWifiNetwork{SSID: ssid, SignalStrength: signal})
+		security := ""
+		if len(fields) >= 3 {
+			security = normalizeWifiSecurity(fields[2])
+		}
+
+		networks = append(networks, localWifiNetwork{SSID: ssid, SignalStrength: signal, Security: security})
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/go/internal/cli/commands/wifi_scan_linux.go
+++ b/go/internal/cli/commands/wifi_scan_linux.go
@@ -61,7 +61,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 
 		security := ""
 		if len(fields) >= 3 {
-			security = normalizeWifiSecurity(fields[2])
+			security = normalizeWifiSecurity(tui.StripControl(fields[2]))
 		}
 
 		networks = append(networks, localWifiNetwork{SSID: ssid, SignalStrength: signal, Security: security})

--- a/go/internal/cli/commands/wifi_scan_linux.go
+++ b/go/internal/cli/commands/wifi_scan_linux.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/nmcli"
 )
 
@@ -47,7 +48,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 			continue
 		}
 
-		ssid := fields[0]
+		ssid := tui.StripControl(fields[0])
 		if ssid == "" || seen[ssid] {
 			continue
 		}

--- a/go/internal/cli/commands/wifi_scan_netsh.go
+++ b/go/internal/cli/commands/wifi_scan_netsh.go
@@ -20,8 +20,9 @@ type localWifiNetwork struct {
 
 // normalizeWifiSecurity maps raw scanner security strings (nmcli's
 // "WPA1 WPA2", netsh's "WPA2-Personal", ...) onto the short labels the agent
-// side uses, picking the strongest advertised suite. Returns the raw string
-// when nothing matches so unusual suites still surface, and "" for unknown.
+// side uses, picking the strongest advertised suite. Unrecognized strings map
+// to "" — the raw value comes from over-the-air scan data, so omitting an
+// exotic suite is safer than rendering it verbatim.
 func normalizeWifiSecurity(raw string) string {
 	s := strings.ToUpper(strings.TrimSpace(raw))
 	if s == "" {
@@ -40,10 +41,12 @@ func normalizeWifiSecurity(raw string) string {
 		return "WPA" + suffix
 	case strings.Contains(s, "WEP"):
 		return "WEP"
-	case s == "--" || s == "NONE" || strings.Contains(s, "OPEN"):
+	case s == "--" || s == "NONE" || strings.Contains(s, "OPEN") || strings.Contains(s, "OWE"):
+		// OWE is "enhanced open" — encrypted but passwordless, so Open is
+		// the honest label for connection purposes.
 		return "Open"
 	}
-	return tui.StripControl(strings.TrimSpace(raw))
+	return ""
 }
 
 // ssidLine matches `SSID 1 : MyNetwork`. The `\d+` between `SSID` and the

--- a/go/internal/cli/commands/wifi_scan_netsh.go
+++ b/go/internal/cli/commands/wifi_scan_netsh.go
@@ -11,6 +11,37 @@ import (
 type localWifiNetwork struct {
 	SSID           string
 	SignalStrength int32 // 0–100 percentage, or 0 if unknown
+	// Security is a best-effort human label ("Open", "WPA2", "WPA3", ...)
+	// normalized across the per-platform scanners; empty when unknown.
+	Security string
+}
+
+// normalizeWifiSecurity maps raw scanner security strings (nmcli's
+// "WPA1 WPA2", netsh's "WPA2-Personal", ...) onto the short labels the agent
+// side uses, picking the strongest advertised suite. Returns the raw string
+// when nothing matches so unusual suites still surface, and "" for unknown.
+func normalizeWifiSecurity(raw string) string {
+	s := strings.ToUpper(strings.TrimSpace(raw))
+	if s == "" {
+		return ""
+	}
+	suffix := ""
+	if strings.Contains(s, "ENTERPRISE") || strings.Contains(s, "802.1X") || strings.Contains(s, "EAP") {
+		suffix = "-Ent"
+	}
+	switch {
+	case strings.Contains(s, "WPA3") || strings.Contains(s, "SAE"):
+		return "WPA3" + suffix
+	case strings.Contains(s, "WPA2") || strings.Contains(s, "RSNA"):
+		return "WPA2" + suffix
+	case strings.Contains(s, "WPA"):
+		return "WPA" + suffix
+	case strings.Contains(s, "WEP"):
+		return "WEP"
+	case s == "--" || s == "NONE" || strings.Contains(s, "OPEN"):
+		return "Open"
+	}
+	return strings.TrimSpace(raw)
 }
 
 // ssidLine matches `SSID 1 : MyNetwork`. The `\d+` between `SSID` and the
@@ -19,6 +50,9 @@ var ssidLine = regexp.MustCompile(`^SSID\s+\d+\s*:\s*(.*)$`)
 
 // signalLine matches `         Signal             : 78%`.
 var signalLine = regexp.MustCompile(`^\s*Signal\s*:\s*(\d+)%`)
+
+// authLine matches `    Authentication          : WPA2-Personal`.
+var authLine = regexp.MustCompile(`^\s*Authentication\s*:\s*(.+)$`)
 
 // parseNetshNetworks parses the localized text output of
 // `netsh wlan show networks mode=bssid` into a deduplicated list of SSIDs,
@@ -30,8 +64,9 @@ var signalLine = regexp.MustCompile(`^\s*Signal\s*:\s*(\d+)%`)
 // `scanLocalWifiNetworks` implementation.
 func parseNetshNetworks(output string) []localWifiNetwork {
 	type entry struct {
-		index  int
-		signal int32
+		index    int
+		signal   int32
+		security string
 	}
 	entries := make(map[string]*entry)
 	order := 0
@@ -66,12 +101,19 @@ func parseNetshNetworks(output string) []localWifiNetwork {
 					e.signal = signal
 				}
 			}
+			continue
+		}
+
+		if m := authLine.FindStringSubmatch(line); m != nil {
+			if e := entries[currentSSID]; e != nil && e.security == "" {
+				e.security = normalizeWifiSecurity(m[1])
+			}
 		}
 	}
 
 	out := make([]localWifiNetwork, len(entries))
 	for ssid, e := range entries {
-		out[e.index] = localWifiNetwork{SSID: ssid, SignalStrength: e.signal}
+		out[e.index] = localWifiNetwork{SSID: ssid, SignalStrength: e.signal, Security: e.security}
 	}
 	return out
 }

--- a/go/internal/cli/commands/wifi_scan_netsh.go
+++ b/go/internal/cli/commands/wifi_scan_netsh.go
@@ -56,8 +56,10 @@ var ssidLine = regexp.MustCompile(`^SSID\s+\d+\s*:\s*(.*)$`)
 // signalLine matches `         Signal             : 78%`.
 var signalLine = regexp.MustCompile(`^\s*Signal\s*:\s*(\d+)%`)
 
-// authLine matches `    Authentication          : WPA2-Personal`.
-var authLine = regexp.MustCompile(`^\s*Authentication\s*:\s*(.+)$`)
+// authLine matches `    Authentication          : WPA2-Personal`. The capture
+// is bounded — real netsh values are short, and the value comes from
+// over-the-air scan data.
+var authLine = regexp.MustCompile(`^\s*Authentication\s*:\s*(.{1,64})`)
 
 // parseNetshNetworks parses the localized text output of
 // `netsh wlan show networks mode=bssid` into a deduplicated list of SSIDs,
@@ -111,7 +113,7 @@ func parseNetshNetworks(output string) []localWifiNetwork {
 
 		if m := authLine.FindStringSubmatch(line); m != nil {
 			if e := entries[currentSSID]; e != nil && e.security == "" {
-				e.security = normalizeWifiSecurity(m[1])
+				e.security = normalizeWifiSecurity(tui.StripControl(m[1]))
 			}
 		}
 	}

--- a/go/internal/cli/commands/wifi_scan_netsh.go
+++ b/go/internal/cli/commands/wifi_scan_netsh.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
 
 // localWifiNetwork is the host-side scan result type shared across platforms.
@@ -41,7 +43,7 @@ func normalizeWifiSecurity(raw string) string {
 	case s == "--" || s == "NONE" || strings.Contains(s, "OPEN"):
 		return "Open"
 	}
-	return strings.TrimSpace(raw)
+	return tui.StripControl(strings.TrimSpace(raw))
 }
 
 // ssidLine matches `SSID 1 : MyNetwork`. The `\d+` between `SSID` and the
@@ -79,7 +81,7 @@ func parseNetshNetworks(output string) []localWifiNetwork {
 		line := scanner.Text()
 
 		if m := ssidLine.FindStringSubmatch(line); m != nil {
-			currentSSID = strings.TrimSpace(m[1])
+			currentSSID = tui.StripControl(strings.TrimSpace(m[1]))
 			haveSSID = currentSSID != ""
 			if haveSSID {
 				if _, ok := entries[currentSSID]; !ok {

--- a/go/internal/cli/commands/wifi_scan_netsh_test.go
+++ b/go/internal/cli/commands/wifi_scan_netsh_test.go
@@ -189,7 +189,8 @@ func TestNormalizeWifiSecurity(t *testing.T) {
 		{"WPA2 802.1X", "WPA2-Ent"},
 		{"WPA3-Enterprise", "WPA3-Ent"},
 		{"SAE", "WPA3"},
-		{"SomethingElse", "SomethingElse"}, // unknown suites pass through
+		{"OWE", "Open"},
+		{"SomethingElse", ""}, // unknown scan-derived suites are omitted, not echoed
 	}
 	for _, c := range cases {
 		if got := normalizeWifiSecurity(c.in); got != c.want {

--- a/go/internal/cli/commands/wifi_scan_netsh_test.go
+++ b/go/internal/cli/commands/wifi_scan_netsh_test.go
@@ -26,6 +26,31 @@ func TestParseNetshNetworks(t *testing.T) {
 		if got[0].SignalStrength != 78 {
 			t.Errorf("SignalStrength = %d, want 78", got[0].SignalStrength)
 		}
+		if got[0].Security != "WPA2" {
+			t.Errorf("Security = %q, want WPA2", got[0].Security)
+		}
+	})
+
+	t.Run("authentication labels are normalized", func(t *testing.T) {
+		input := "SSID 1 : Third\r\n" +
+			"    Authentication          : WPA3-Personal\r\n" +
+			"         Signal             : 70%\r\n" +
+			"SSID 2 : Corp\r\n" +
+			"    Authentication          : WPA2-Enterprise\r\n" +
+			"         Signal             : 60%\r\n" +
+			"SSID 3 : Free\r\n" +
+			"    Authentication          : Open\r\n" +
+			"         Signal             : 50%\r\n"
+		got := parseNetshNetworks(input)
+		if len(got) != 3 {
+			t.Fatalf("got %d networks, want 3: %+v", len(got), got)
+		}
+		want := []string{"WPA3", "WPA2-Ent", "Open"}
+		for i, n := range got {
+			if n.Security != want[i] {
+				t.Errorf("got[%d].Security = %q, want %q", i, n.Security, want[i])
+			}
+		}
 	})
 
 	t.Run("multiple networks preserve order", func(t *testing.T) {
@@ -147,4 +172,28 @@ func TestParseNetshNetworks(t *testing.T) {
 			t.Errorf("SSID = %q, want %q", got[0].SSID, "Café: Wi-Fi")
 		}
 	})
+}
+
+func TestNormalizeWifiSecurity(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"--", "Open"},
+		{"none", "Open"},
+		{"Open", "Open"},
+		{"WEP", "WEP"},
+		{"WPA1 WPA2", "WPA2"},
+		{"WPA2", "WPA2"},
+		{"WPA2 WPA3", "WPA3"},
+		{"WPA3-Personal", "WPA3"},
+		{"WPA2-Enterprise", "WPA2-Ent"},
+		{"WPA2 802.1X", "WPA2-Ent"},
+		{"WPA3-Enterprise", "WPA3-Ent"},
+		{"SAE", "WPA3"},
+		{"SomethingElse", "SomethingElse"}, // unknown suites pass through
+	}
+	for _, c := range cases {
+		if got := normalizeWifiSecurity(c.in); got != c.want {
+			t.Errorf("normalizeWifiSecurity(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
 }

--- a/go/internal/cli/tui/highlight.go
+++ b/go/internal/cli/tui/highlight.go
@@ -1,0 +1,96 @@
+package tui
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// MatchHighlightStyle marks filter-matched characters: a light seafoam green
+// background with black text so matches read at a glance on both dark and
+// light terminals.
+var MatchHighlightStyle = lipgloss.NewStyle().
+	Background(lipgloss.Color("#9FE2BF")).
+	Foreground(lipgloss.Color("#000000"))
+
+// HighlightMatches re-renders a plain-text table view so every
+// case-insensitive occurrence of query between rune columns start (inclusive)
+// and end (exclusive) of each line is wrapped in MatchHighlightStyle. The
+// column bounds restrict highlighting to the column being filtered (e.g. the
+// SSID cell) so query text doesn't light up unrelated columns.
+//
+// Lines that already contain ANSI sequences (the styled header, the selected
+// row) are left untouched: the bubbles table wraps whole rows in a single
+// style, and injecting another style mid-line would reset the row's
+// background for the rest of the line.
+func HighlightMatches(view, query string, start, end int) string {
+	queryRunes := lowerRunes([]rune(query))
+	if len(queryRunes) == 0 || end <= start || start < 0 {
+		return view
+	}
+
+	lines := strings.Split(view, "\n")
+	for i, line := range lines {
+		if strings.ContainsRune(line, '\x1b') {
+			continue
+		}
+		runes := []rune(line)
+		regionEnd := min(end, len(runes))
+		if start >= regionEnd {
+			continue
+		}
+		ranges := matchRanges(lowerRunes(runes[start:regionEnd]), queryRunes)
+		if len(ranges) == 0 {
+			continue
+		}
+
+		var sb strings.Builder
+		sb.WriteString(string(runes[:start]))
+		prev := start
+		for _, r := range ranges {
+			s, e := r[0]+start, r[1]+start
+			sb.WriteString(string(runes[prev:s]))
+			sb.WriteString(MatchHighlightStyle.Render(string(runes[s:e])))
+			prev = e
+		}
+		sb.WriteString(string(runes[prev:]))
+		lines[i] = sb.String()
+	}
+	return strings.Join(lines, "\n")
+}
+
+// matchRanges returns the [start, end) rune indexes of every non-overlapping
+// occurrence of query in text. Both inputs must already be case-folded.
+func matchRanges(text, query []rune) [][2]int {
+	var out [][2]int
+	if len(query) == 0 {
+		return out
+	}
+	for i := 0; i+len(query) <= len(text); {
+		matched := true
+		for j := range query {
+			if text[i+j] != query[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			out = append(out, [2]int{i, i + len(query)})
+			i += len(query)
+		} else {
+			i++
+		}
+	}
+	return out
+}
+
+// lowerRunes folds rune-by-rune so indexes in the folded slice line up with
+// the original (strings.ToLower can change the rune count for some locales).
+func lowerRunes(rs []rune) []rune {
+	out := make([]rune, len(rs))
+	for i, r := range rs {
+		out[i] = unicode.ToLower(r)
+	}
+	return out
+}

--- a/go/internal/cli/tui/highlight_test.go
+++ b/go/internal/cli/tui/highlight_test.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMatchRangesCaseFoldedOccurrences(t *testing.T) {
+	cases := []struct {
+		text, query string
+		want        [][2]int
+	}{
+		{"my home network", "home", [][2]int{{3, 7}}},
+		{"abcabcabc", "abc", [][2]int{{0, 3}, {3, 6}, {6, 9}}},
+		{"aaaa", "aa", [][2]int{{0, 2}, {2, 4}}}, // non-overlapping
+		{"nothing here", "zz", nil},
+		{"short", "longer than text", nil},
+		{"", "x", nil},
+	}
+	for _, c := range cases {
+		got := matchRanges(lowerRunes([]rune(c.text)), lowerRunes([]rune(c.query)))
+		if len(got) != len(c.want) {
+			t.Errorf("matchRanges(%q, %q) = %v; want %v", c.text, c.query, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("matchRanges(%q, %q)[%d] = %v; want %v", c.text, c.query, i, got[i], c.want[i])
+			}
+		}
+	}
+}
+
+func TestMatchRangesIsCaseInsensitive(t *testing.T) {
+	got := matchRanges(lowerRunes([]rune("MyHomeNet")), lowerRunes([]rune("HOME")))
+	if len(got) != 1 || got[0] != [2]int{2, 6} {
+		t.Errorf("expected case-insensitive match at [2,6), got %v", got)
+	}
+}
+
+func TestHighlightMatchesPreservesText(t *testing.T) {
+	// Styles render as plain passthrough without a color terminal, so assert
+	// the text content survives intact regardless of profile.
+	view := " HomeNet    70%  \n CafeSpot   55%  "
+	out := HighlightMatches(view, "home", 0, 12)
+	if stripped := out; !strings.Contains(stripped, "HomeNet") || !strings.Contains(stripped, "CafeSpot") {
+		t.Errorf("highlighting mangled the view: %q", out)
+	}
+	if got, want := len(strings.Split(out, "\n")), 2; got != want {
+		t.Errorf("line count changed: got %d want %d", got, want)
+	}
+}
+
+func TestHighlightMatchesSkipsANSILines(t *testing.T) {
+	selected := "\x1b[7m HomeNet \x1b[0m"
+	out := HighlightMatches(selected, "home", 0, 30)
+	if out != selected {
+		t.Errorf("ANSI line should be untouched; got %q", out)
+	}
+}
+
+func TestHighlightMatchesRespectsColumnBounds(t *testing.T) {
+	// "open" appears in both the SSID column (cols 0-9) and the security
+	// column; only the in-bounds occurrence may be rewritten. With a plain
+	// color profile the style is a no-op, so verify bounds via a query that
+	// only matches outside the region: the view must come back unchanged
+	// byte-for-byte (no rebuild artifacts).
+	view := " WPA2Net   Open  "
+	out := HighlightMatches(view, "open", 0, 8)
+	if out != view {
+		t.Errorf("out-of-bounds match should leave line unchanged; got %q", out)
+	}
+}
+
+func TestHighlightMatchesEmptyQueryNoop(t *testing.T) {
+	view := "anything"
+	if out := HighlightMatches(view, "", 0, 10); out != view {
+		t.Errorf("empty query must be a no-op, got %q", out)
+	}
+}

--- a/go/internal/cli/tui/highlight_test.go
+++ b/go/internal/cli/tui/highlight_test.go
@@ -78,3 +78,19 @@ func TestHighlightMatchesEmptyQueryNoop(t *testing.T) {
 		t.Errorf("empty query must be a no-op, got %q", out)
 	}
 }
+
+func TestStripControl(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"PlainNet", "PlainNet"},
+		{"\x1b[2J\x1b[HFake Header\x1b[0m", "[2J[HFake Header[0m"},
+		{"\x1b]8;;http://evil\x07click\x1b]8;;\x07", "]8;;http://evilclick]8;;"},
+		{"tab\tand\nnewline", "tabandnewline"},
+		{"del\x7fchar", "delchar"},
+		{"emoji 📶 ok", "emoji 📶 ok"},
+	}
+	for _, c := range cases {
+		if got := StripControl(c.in); got != c.want {
+			t.Errorf("StripControl(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/go/internal/cli/tui/highlight_test.go
+++ b/go/internal/cli/tui/highlight_test.go
@@ -88,6 +88,8 @@ func TestStripControl(t *testing.T) {
 		{"del\x7fchar", "delchar"},
 		{"c1\u009bcsi", "c1csi"}, // U+009B is a single-rune CSI introducer
 		{"c1\u0085nel", "c1nel"},
+		{"bidi\u202eflip", "bidiflip"}, // RLO override (Trojan Source spoofing)
+		{"zero\u200bwidth\u200djoin", "zerowidthjoin"},
 		{"emoji 📶 ok", "emoji 📶 ok"},
 	}
 	for _, c := range cases {

--- a/go/internal/cli/tui/highlight_test.go
+++ b/go/internal/cli/tui/highlight_test.go
@@ -86,6 +86,8 @@ func TestStripControl(t *testing.T) {
 		{"\x1b]8;;http://evil\x07click\x1b]8;;\x07", "]8;;http://evilclick]8;;"},
 		{"tab\tand\nnewline", "tabandnewline"},
 		{"del\x7fchar", "delchar"},
+		{"c1\u009bcsi", "c1csi"}, // U+009B is a single-rune CSI introducer
+		{"c1\u0085nel", "c1nel"},
 		{"emoji 📶 ok", "emoji 📶 ok"},
 	}
 	for _, c := range cases {

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -312,7 +312,9 @@ func (m PickerModel) View() string {
 	sb.WriteString(m.viewLine(pickerTitle.Render(m.Title)+pickerHint.Render(hint)) + "\n\n")
 
 	if m.Filterable && m.filter != "" {
-		sb.WriteString(m.viewLine("  Filter: "+m.filter+pickerHint.Render("  (esc to clear)")) + "\n\n")
+		// The query is sanitized as it is typed; strip again here so this
+		// render site is safe in isolation.
+		sb.WriteString(m.viewLine("  Filter: "+StripControl(m.filter)+pickerHint.Render("  (esc to clear)")) + "\n\n")
 	}
 
 	if len(m.items) == 0 {

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -213,11 +213,19 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case (msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace) && m.Filterable:
 			// Pasted input can carry control characters; keep them out of
-			// the query (it is echoed back to the terminal verbatim).
+			// the query (it is echoed back to the terminal verbatim), and
+			// cap its length so a large paste can't distort the layout.
 			if typed := StripControl(string(msg.Runes)); typed != "" {
-				m.filter += typed
-				m.table.SetCursor(0)
-				m.refreshTable()
+				const maxFilterLen = 64
+				if room := maxFilterLen - len([]rune(m.filter)); room > 0 {
+					runes := []rune(typed)
+					if len(runes) > room {
+						runes = runes[:room]
+					}
+					m.filter += string(runes)
+					m.table.SetCursor(0)
+					m.refreshTable()
+				}
 			}
 			return m, nil
 		default:

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -84,6 +84,16 @@ type PickerModel struct {
 	// Shown with a ★ indicator in the table.
 	DefaultKey string
 
+	// Filterable enables find-as-you-type filtering: printable keys narrow
+	// the list to items whose Name contains the typed query
+	// (case-insensitive), backspace edits the query, and esc clears it (esc
+	// and ctrl+c quit when the query is empty). Matched characters are
+	// highlighted in the Name column. Enabling this retargets the plain
+	// 'q'/'d'/'x' hotkeys into the filter query, so only use it for pickers
+	// whose items are free-form text (e.g. WiFi SSIDs).
+	Filterable bool
+
+	filter       string
 	items        []PickerItem
 	seenIdx      map[string]int // dedup key -> index in items
 	table        BubbleTable
@@ -153,15 +163,17 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshTable()
 		return m, cmd
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "enter":
+		key := msg.String()
+		switch {
+		case key == "enter":
+			visible := m.visibleItems()
 			cursor := m.table.Cursor()
-			if len(m.items) > 0 && cursor >= 0 && cursor < len(m.items) {
-				item := m.items[cursor]
+			if len(visible) > 0 && cursor >= 0 && cursor < len(visible) {
+				item := visible[cursor]
 				m.selected = &item
 				return m, tea.Quit
 			}
-		case "d":
+		case key == "d" && !m.Filterable:
 			if m.OnSetDefault != nil {
 				cursor := m.table.Cursor()
 				if len(m.items) > 0 && cursor >= 0 && cursor < len(m.items) {
@@ -176,16 +188,34 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			return m, nil
-		case "x":
+		case key == "x" && !m.Filterable:
 			if m.OnUnsetDefault != nil {
 				m.DefaultKey = ""
 				m.OnUnsetDefault()
 				m.refreshTable()
 			}
 			return m, nil
-		case "q", "ctrl+c":
+		case key == "esc" && m.Filterable && m.filter != "":
+			m.filter = ""
+			m.table.SetCursor(0)
+			m.refreshTable()
+			return m, nil
+		case key == "ctrl+c", key == "esc", key == "q" && !m.Filterable:
 			m.quitting = true
 			return m, tea.Quit
+		case key == "backspace" && m.Filterable:
+			if m.filter != "" {
+				runes := []rune(m.filter)
+				m.filter = string(runes[:len(runes)-1])
+				m.table.SetCursor(0)
+				m.refreshTable()
+			}
+			return m, nil
+		case (msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace) && m.Filterable:
+			m.filter += string(msg.Runes)
+			m.table.SetCursor(0)
+			m.refreshTable()
+			return m, nil
 		default:
 			var cmd tea.Cmd
 			m.table, cmd = m.table.Update(msg)
@@ -254,6 +284,9 @@ func (m PickerModel) View() string {
 		scrollHint = ", ←/→ scroll"
 	}
 	hint := " (↑/↓ navigate" + scrollHint + ", enter select, q quit)"
+	if m.Filterable {
+		hint = " (type to filter, ↑/↓ navigate" + scrollHint + ", enter select, esc quit)"
+	}
 	if m.OnSetDefault != nil || m.OnUnsetDefault != nil {
 		extras := ""
 		if m.OnSetDefault != nil {
@@ -266,6 +299,10 @@ func (m PickerModel) View() string {
 	}
 	sb.WriteString(m.viewLine(pickerTitle.Render(m.Title)+pickerHint.Render(hint)) + "\n\n")
 
+	if m.Filterable && m.filter != "" {
+		sb.WriteString(m.viewLine("  Filter: "+m.filter+pickerHint.Render("  (esc to clear)")) + "\n\n")
+	}
+
 	if len(m.items) == 0 {
 		if m.scanning {
 			sb.WriteString(m.viewLine(pickerScanning.Render("  Scanning...")) + "\n")
@@ -275,10 +312,16 @@ func (m PickerModel) View() string {
 		return sb.String()
 	}
 
+	visible := m.visibleItems()
+	if len(visible) == 0 {
+		sb.WriteString(m.viewLine(pickerHint.Render("  No matches — esc to clear the filter.")) + "\n")
+		return sb.String()
+	}
+
 	sb.WriteString(m.tableView() + "\n")
 
 	cursor := m.table.Cursor()
-	if cursor >= 0 && cursor < len(m.items) && m.items[cursor].Insecure {
+	if cursor >= 0 && cursor < len(visible) && visible[cursor].Insecure {
 		sb.WriteString(m.viewLine(pickerInsecure.Render("  ⚠  Connection is not secured with mTLS. PKI support is coming soon.")) + "\n")
 	}
 
@@ -297,11 +340,12 @@ func (m PickerModel) View() string {
 }
 
 func (m PickerModel) selectedHint() string {
+	visible := m.visibleItems()
 	cursor := m.table.Cursor()
-	if cursor < 0 || cursor >= len(m.items) {
+	if cursor < 0 || cursor >= len(visible) {
 		return ""
 	}
-	return strings.TrimSpace(m.items[cursor].Hint)
+	return strings.TrimSpace(visible[cursor].Hint)
 }
 
 func (m PickerModel) viewLine(line string) string {
@@ -312,7 +356,27 @@ func (m PickerModel) viewLine(line string) string {
 }
 
 func (m PickerModel) tableView() string {
-	return m.table.View()
+	if !m.Filterable || m.filter == "" {
+		return m.table.View()
+	}
+	// Highlight filter matches in the Name column. The cell layout is
+	// 1 padding + content + 1 padding per column; the Name column is first
+	// unless the ★ default column (width 3 + padding) precedes it.
+	cols := m.table.Columns()
+	nameIdx := 0
+	start := 1
+	if m.OnSetDefault != nil && len(cols) > 1 {
+		nameIdx = 1
+		start += cols[0].Width + 2
+	}
+	if nameIdx >= len(cols) {
+		return m.table.View()
+	}
+	view := HighlightMatches(m.table.FullView(), m.filter, start, start+cols[nameIdx].Width)
+	if w := m.table.ViewportWidth(); w > 0 {
+		view = CropANSIView(view, m.table.ScrollOffset(), w)
+	}
+	return view
 }
 
 // Cancelled returns true if the user quit the picker without selecting (e.g. Ctrl+C).
@@ -411,9 +475,27 @@ func newPickerTable() BubbleTable {
 	return NewBubbleTable(true, nil)
 }
 
+// visibleItems returns the items that pass the active filter, in display
+// order. With no filter (or filtering disabled) it returns the full list, so
+// table cursor indexes always address this slice.
+func (m PickerModel) visibleItems() []PickerItem {
+	if !m.Filterable || m.filter == "" {
+		return m.items
+	}
+	query := strings.ToLower(m.filter)
+	out := make([]PickerItem, 0, len(m.items))
+	for _, item := range m.items {
+		if strings.Contains(strings.ToLower(item.Name), query) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
 func (m *PickerModel) currentCursorKey() string {
-	if cursor := m.table.Cursor(); cursor >= 0 && cursor < len(m.items) {
-		return strings.ToLower(pickerItemKey(m.items[cursor]))
+	visible := m.visibleItems()
+	if cursor := m.table.Cursor(); cursor >= 0 && cursor < len(visible) {
+		return strings.ToLower(pickerItemKey(visible[cursor]))
 	}
 	return ""
 }
@@ -446,8 +528,9 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 		m.seenIdx[strings.ToLower(pickerItemKey(item))] = i
 	}
 
+	visible := m.visibleItems()
 	hasDefaultCol := m.OnSetDefault != nil
-	cols, rows := pickerTableDataForColumns(m.items, m.DefaultKey, hasDefaultCol, m.columns, m.fixedColumns)
+	cols, rows := pickerTableDataForColumns(visible, m.DefaultKey, hasDefaultCol, m.columns, m.fixedColumns)
 	m.table.SetRows(nil)
 	m.table.SetColumns(cols)
 	m.table.SetRows(rows)
@@ -455,12 +538,17 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 	// Restore cursor to the same item when possible. If that item disappeared,
 	// keep the cursor near its previous position and clamp it into range.
 	if len(rows) > 0 {
+		visIdx := -1
 		if cursorKey != "" {
-			if idx, ok := m.seenIdx[cursorKey]; ok {
-				m.table.SetCursor(idx)
-			} else if m.table.Cursor() < 0 || m.table.Cursor() >= len(rows) {
-				m.table.SetCursor(len(rows) - 1)
+			for i, item := range visible {
+				if strings.ToLower(pickerItemKey(item)) == cursorKey {
+					visIdx = i
+					break
+				}
 			}
+		}
+		if visIdx >= 0 {
+			m.table.SetCursor(visIdx)
 		} else if m.table.Cursor() < 0 {
 			m.table.SetCursor(0)
 		} else if m.table.Cursor() >= len(rows) {

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -212,9 +212,13 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case (msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace) && m.Filterable:
-			m.filter += string(msg.Runes)
-			m.table.SetCursor(0)
-			m.refreshTable()
+			// Pasted input can carry control characters; keep them out of
+			// the query (it is echoed back to the terminal verbatim).
+			if typed := StripControl(string(msg.Runes)); typed != "" {
+				m.filter += typed
+				m.table.SetCursor(0)
+				m.refreshTable()
+			}
 			return m, nil
 		default:
 			var cmd tea.Cmd

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -582,3 +582,126 @@ func lastNonEmptyLine(view string) string {
 	}
 	return strings.TrimSpace(lines[len(lines)-1])
 }
+
+// ── Filterable picker ────────────────────────────────────────────────
+
+func typeIntoPicker(t *testing.T, m PickerModel, s string) PickerModel {
+	t.Helper()
+	for _, r := range s {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = updated.(PickerModel)
+	}
+	return m
+}
+
+func newFilterablePicker(t *testing.T) PickerModel {
+	t.Helper()
+	m := NewPickerWithTitle("Select a WiFi network")
+	m.Filterable = true
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "HomeNet", Type: "82%", Value: "HomeNet"},
+		{Name: "my home 5G", Type: "70%", Value: "my home 5G"},
+		{Name: "CafeSpot", Type: "55%", Value: "CafeSpot"},
+	}})
+	return updated.(PickerModel)
+}
+
+func TestPickerModel_FilterNarrowsCaseInsensitively(t *testing.T) {
+	pm := typeIntoPicker(t, newFilterablePicker(t), "home")
+
+	visible := pm.visibleItems()
+	if len(visible) != 2 {
+		t.Fatalf("expected 2 matches for 'home', got %d: %+v", len(visible), visible)
+	}
+	for _, item := range visible {
+		if !strings.Contains(strings.ToLower(item.Name), "home") {
+			t.Errorf("unexpected item in filtered view: %q", item.Name)
+		}
+	}
+	if view := pm.View(); !strings.Contains(view, "Filter: home") {
+		t.Errorf("expected the active filter to be shown, got %q", view)
+	}
+}
+
+func TestPickerModel_FilterSpaceAndBackspace(t *testing.T) {
+	pm := typeIntoPicker(t, newFilterablePicker(t), "my")
+	updated, _ := pm.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
+	pm = updated.(PickerModel)
+	pm = typeIntoPicker(t, pm, "homex")
+
+	if got := len(pm.visibleItems()); got != 0 {
+		t.Fatalf("expected 0 matches for 'my homex', got %d", got)
+	}
+
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	pm = updated.(PickerModel)
+	if got := pm.filter; got != "my home" {
+		t.Fatalf("filter after backspace = %q, want %q", got, "my home")
+	}
+	if got := len(pm.visibleItems()); got != 1 {
+		t.Fatalf("expected 1 match for 'my home', got %d", got)
+	}
+}
+
+func TestPickerModel_EnterSelectsFromFilteredView(t *testing.T) {
+	pm := typeIntoPicker(t, newFilterablePicker(t), "cafe")
+
+	updated, _ := pm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm = updated.(PickerModel)
+	if pm.Selected() == nil {
+		t.Fatal("expected a selection")
+	}
+	if got := pm.Selected().Value.(string); got != "CafeSpot" {
+		t.Fatalf("selected %q, want CafeSpot", got)
+	}
+}
+
+func TestPickerModel_EscClearsFilterThenQuits(t *testing.T) {
+	pm := typeIntoPicker(t, newFilterablePicker(t), "cafe")
+
+	updated, _ := pm.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	pm = updated.(PickerModel)
+	if pm.filter != "" {
+		t.Fatalf("first esc should clear the filter, got %q", pm.filter)
+	}
+	if pm.Cancelled() {
+		t.Fatal("first esc must not quit while a filter is active")
+	}
+	if got := len(pm.visibleItems()); got != 3 {
+		t.Fatalf("expected full list after clearing filter, got %d", got)
+	}
+
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	pm = updated.(PickerModel)
+	if !pm.Cancelled() {
+		t.Fatal("second esc should quit the picker")
+	}
+}
+
+func TestPickerModel_FilterableRoutesQToQuery(t *testing.T) {
+	pm := typeIntoPicker(t, newFilterablePicker(t), "q")
+	if pm.Cancelled() {
+		t.Fatal("'q' must filter, not quit, when Filterable is set")
+	}
+	if pm.filter != "q" {
+		t.Fatalf("filter = %q, want %q", pm.filter, "q")
+	}
+}
+
+func TestPickerModel_NonFilterableKeepsQQuit(t *testing.T) {
+	m := NewPickerWithTitle("plain")
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{Name: "a", Value: "a"}}})
+	pm := updated.(PickerModel)
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	pm = updated.(PickerModel)
+	if !pm.Cancelled() {
+		t.Fatal("'q' should still quit a non-filterable picker")
+	}
+}
+
+func TestPickerModel_NoMatchesShowsHint(t *testing.T) {
+	pm := typeIntoPicker(t, newFilterablePicker(t), "zzz")
+	if view := pm.View(); !strings.Contains(view, "No matches") {
+		t.Errorf("expected a no-matches hint, got %q", view)
+	}
+}

--- a/go/internal/cli/tui/sanitize.go
+++ b/go/internal/cli/tui/sanitize.go
@@ -1,15 +1,20 @@
 package tui
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
-// StripControl removes terminal control characters (C0 controls and DEL)
-// from externally-sourced strings before they reach the terminal. WiFi SSIDs
-// arrive from beacon frames and can contain arbitrary bytes — including ANSI
-// escape sequences — so every scanner-derived SSID or security label must
-// pass through here before being rendered.
+// StripControl removes control characters from externally-sourced strings
+// before they reach the terminal. This covers C0 controls (incl. ESC), DEL,
+// and the C1 range (U+0080–U+009F) — U+009B is a single-rune CSI introducer
+// on VTE-style terminals, so stripping only C0 would still allow escape
+// injection. WiFi SSIDs arrive from beacon frames and can contain arbitrary
+// bytes, so every scanner-derived SSID or security label must pass through
+// here before being rendered.
 func StripControl(s string) string {
 	return strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
+		if unicode.IsControl(r) {
 			return -1
 		}
 		return r

--- a/go/internal/cli/tui/sanitize.go
+++ b/go/internal/cli/tui/sanitize.go
@@ -1,0 +1,17 @@
+package tui
+
+import "strings"
+
+// StripControl removes terminal control characters (C0 controls and DEL)
+// from externally-sourced strings before they reach the terminal. WiFi SSIDs
+// arrive from beacon frames and can contain arbitrary bytes — including ANSI
+// escape sequences — so every scanner-derived SSID or security label must
+// pass through here before being rendered.
+func StripControl(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+}

--- a/go/internal/cli/tui/sanitize.go
+++ b/go/internal/cli/tui/sanitize.go
@@ -5,16 +5,23 @@ import (
 	"unicode"
 )
 
-// StripControl removes control characters from externally-sourced strings
-// before they reach the terminal. This covers C0 controls (incl. ESC), DEL,
-// and the C1 range (U+0080–U+009F) — U+009B is a single-rune CSI introducer
-// on VTE-style terminals, so stripping only C0 would still allow escape
-// injection. WiFi SSIDs arrive from beacon frames and can contain arbitrary
-// bytes, so every scanner-derived SSID or security label must pass through
-// here before being rendered.
+// StripControl removes control and formatting characters from
+// externally-sourced strings before they reach the terminal:
+//
+//   - C0 controls (incl. ESC), DEL, and the C1 range (U+0080–U+009F) —
+//     U+009B is a single-rune CSI introducer on VTE-style terminals, so
+//     stripping only C0 would still allow escape injection.
+//   - Unicode format characters (category Cf): bidirectional overrides like
+//     U+202E can visually reorder rendered text ("Trojan Source"-style SSID
+//     spoofing), and zero-width characters can make distinct SSIDs look
+//     identical.
+//
+// WiFi SSIDs arrive from beacon frames and can contain arbitrary bytes, so
+// every scanner-derived SSID or security label must pass through here before
+// being rendered.
 func StripControl(s string) string {
 	return strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
 			return -1
 		}
 		return r

--- a/go/internal/cli/tui/wifitable/filter_test.go
+++ b/go/internal/cli/tui/wifitable/filter_test.go
@@ -1,0 +1,231 @@
+package wifitable
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func filterFixture() []Network {
+	return []Network{
+		{SSID: "HomeNet", Known: true, Priority: 5, Signal: 80},
+		{SSID: "my home 5G", Signal: 70, Security: agentpb.WiFiSecurityType_WIFI_SECURITY_TYPE_WPA2_PSK},
+		{SSID: "CafeSpot", Signal: 55, Security: agentpb.WiFiSecurityType_WIFI_SECURITY_TYPE_OPEN},
+	}
+}
+
+func typeRunes(m Model, s string) Model {
+	for _, r := range s {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(Model)
+	}
+	return m
+}
+
+func TestTypingEntersFilterModeAndNarrows(t *testing.T) {
+	m := NewModel(filterFixture())
+
+	m = typeRunes(m, "home") // 'h' is table-nav; seed with... use a non-nav rune first
+	// 'h' is reserved for horizontal scroll, so the seed comes from 'o'.
+	if m.mode != modeFiltering {
+		t.Fatalf("typing should enter filter mode, got mode=%v", m.mode)
+	}
+	// Query is "ome" (h swallowed by scroll). Both home networks match.
+	if got := m.filterInput.Value(); got != "ome" {
+		t.Fatalf("filter query = %q, want %q", got, "ome")
+	}
+	visible := m.filteredNetworks()
+	if len(visible) != 2 {
+		t.Fatalf("expected 2 matches, got %d: %v", len(visible), ssids(visible))
+	}
+}
+
+func TestSlashEntersFilterModeAndMatchesCaseInsensitively(t *testing.T) {
+	m := NewModel(filterFixture())
+	m = sendKey(m, "/")
+	if m.mode != modeFiltering {
+		t.Fatalf("/ should enter filter mode, got %v", m.mode)
+	}
+	m = typeRunes(m, "HOME")
+	visible := m.filteredNetworks()
+	if len(visible) != 2 {
+		t.Fatalf("expected case-insensitive matches for HOME, got %v", ssids(visible))
+	}
+	for _, n := range visible {
+		if !strings.Contains(strings.ToLower(n.SSID), "home") {
+			t.Errorf("unexpected network in filtered view: %q", n.SSID)
+		}
+	}
+}
+
+func TestFilterEnterConnectsToFilteredSelection(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel(filterFixture()).WithHandler(h)
+
+	m = typeRunes(m, "cafe")
+	if m.mode != modeFiltering {
+		t.Fatalf("expected filter mode, got %v", m.mode)
+	}
+	if got := len(m.filteredNetworks()); got != 1 {
+		t.Fatalf("expected 1 match for cafe, got %d", got)
+	}
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+
+	// CafeSpot is open → direct connect, no password prompt.
+	if h.connectCalls != 1 || h.lastSSID != "CafeSpot" {
+		t.Fatalf("expected connect to CafeSpot, got calls=%d ssid=%q", h.connectCalls, h.lastSSID)
+	}
+	if got := m.filterInput.Value(); got != "" {
+		t.Errorf("filter should clear after connect, got %q", got)
+	}
+}
+
+func TestFilterEnterOnSecuredNetworkPromptsForPassword(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel(filterFixture()).WithHandler(h)
+
+	m = typeRunes(m, "my")
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+
+	if m.mode != modePassword {
+		t.Fatalf("secured unknown network must prompt for password, got mode=%v", m.mode)
+	}
+	if m.pwFor != "my home 5G" {
+		t.Errorf("password prompt is for %q, want %q", m.pwFor, "my home 5G")
+	}
+	if h.connectCalls != 0 {
+		t.Errorf("connect must not fire before the password is entered")
+	}
+}
+
+func TestFilterEscRestoresFullListAndCursor(t *testing.T) {
+	m := NewModel(filterFixture())
+	m = typeRunes(m, "cafe")
+	if got := len(m.filteredNetworks()); got != 1 {
+		t.Fatalf("expected 1 match, got %d", got)
+	}
+
+	m = sendKey(m, "esc")
+	if m.mode != modeBrowsing {
+		t.Fatalf("esc should return to browsing, got %v", m.mode)
+	}
+	if got := len(m.filteredNetworks()); got != 3 {
+		t.Fatalf("filter should be cleared, got %d visible", got)
+	}
+	if idx := m.table.Cursor(); idx < 0 || idx >= len(m.networks) || m.networks[idx].SSID != "CafeSpot" {
+		t.Errorf("cursor should stay on CafeSpot after esc, got idx=%d", idx)
+	}
+}
+
+func TestFilterBackspaceOnEmptyExitsFilterMode(t *testing.T) {
+	m := NewModel(filterFixture())
+	m = typeRunes(m, "x")
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = next.(Model)
+	if m.mode != modeFiltering {
+		t.Fatalf("backspace with a query should stay in filter mode")
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = next.(Model)
+	if m.mode != modeBrowsing {
+		t.Fatalf("backspace on empty query should exit filter mode, got %v", m.mode)
+	}
+}
+
+func TestNavKeysDoNotEnterFilterMode(t *testing.T) {
+	m := NewModel(filterFixture())
+	for _, k := range []string{"j", "k", "h", "l"} {
+		m = sendKey(m, k)
+		if m.mode != modeBrowsing {
+			t.Fatalf("%q must stay table navigation, got mode=%v", k, m.mode)
+		}
+	}
+}
+
+func TestRefreshAppliesWhileFiltering(t *testing.T) {
+	m := NewModel(filterFixture())
+	m = typeRunes(m, "ome")
+
+	next, _ := m.Update(RefreshMsg{Networks: []Network{
+		{SSID: "HomeNet", Known: true, Signal: 81},
+		{SSID: "my home 5G", Signal: 71},
+		{SSID: "OtherHome", Signal: 30},
+		{SSID: "CafeSpot", Signal: 55},
+	}})
+	m = next.(Model)
+
+	if m.mode != modeFiltering {
+		t.Fatalf("refresh must not kick the user out of filter mode")
+	}
+	if got := len(m.filteredNetworks()); got != 3 {
+		t.Errorf("filtered view should track refreshed networks, got %d", got)
+	}
+	if got := len(m.networks); got != 4 {
+		t.Errorf("full list should be replaced by refresh, got %d", got)
+	}
+}
+
+func TestScanningPlaceholderUntilFirstRefresh(t *testing.T) {
+	m := NewModel(nil)
+	if view := m.View(); !strings.Contains(view, "Scanning for nearby networks") {
+		t.Fatalf("empty model should show the scanning placeholder, got %q", view)
+	}
+
+	next, _ := m.Update(RefreshMsg{Networks: nil})
+	m = next.(Model)
+	if view := m.View(); !strings.Contains(view, "No networks found") {
+		t.Errorf("after an empty refresh the placeholder should say no networks, got %q", view)
+	}
+}
+
+func TestRefreshTickPollsHandlerOnlyWhenIdle(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel(nil).WithHandler(h)
+
+	// WithHandler marks the Init refresh as in flight: the first tick must
+	// not stack another refresh.
+	next, _ := m.Update(refreshTickMsg{})
+	m = next.(Model)
+	if h.refreshCalls != 0 {
+		t.Fatalf("tick should skip refresh while one is in flight, got %d calls", h.refreshCalls)
+	}
+
+	// A RefreshMsg lands → next tick may poll again.
+	next, _ = m.Update(RefreshMsg{Networks: filterFixture()})
+	m = next.(Model)
+	next, _ = m.Update(refreshTickMsg{})
+	m = next.(Model)
+	if h.refreshCalls != 1 {
+		t.Fatalf("tick should poll once idle, got %d calls", h.refreshCalls)
+	}
+
+	// While that poll is outstanding, further ticks stay quiet.
+	next, _ = m.Update(refreshTickMsg{})
+	m = next.(Model)
+	if h.refreshCalls != 1 {
+		t.Errorf("tick must not stack refreshes, got %d calls", h.refreshCalls)
+	}
+}
+
+func TestRefreshTickSkipsWhileRanking(t *testing.T) {
+	h := &fakeHandler{}
+	m := NewModel(filterFixture()).WithHandler(h)
+	next, _ := m.Update(RefreshMsg{Networks: filterFixture()}) // clear in-flight
+	m = next.(Model)
+
+	m = sendKey(m, "r")
+	if m.mode != modeRanking {
+		t.Fatalf("expected rank mode, got %v", m.mode)
+	}
+	next, _ = m.Update(refreshTickMsg{})
+	m = next.(Model)
+	if h.refreshCalls != 0 {
+		t.Errorf("tick should not poll while ranking, got %d calls", h.refreshCalls)
+	}
+}

--- a/go/internal/cli/tui/wifitable/model.go
+++ b/go/internal/cli/tui/wifitable/model.go
@@ -19,6 +19,7 @@ type mode int
 
 const (
 	modeBrowsing mode = iota
+	modeFiltering
 	modeRanking
 	modeUnlisted
 	modePassword
@@ -79,7 +80,22 @@ type OpResultMsg struct {
 // flashClearMsg clears the current flash message after a delay.
 type flashClearMsg struct{}
 
-const flashDuration = 4 * time.Second
+// refreshTickMsg drives the periodic background refresh that keeps the table
+// populating while the device-side scan fills its cache.
+type refreshTickMsg struct{}
+
+const (
+	flashDuration = 4 * time.Second
+	// refreshInterval is how often the model re-polls the device. The first
+	// device-side rescan blocks for several seconds, but repeated list calls
+	// return the partially-filled scan cache immediately — so polling makes
+	// SSIDs stream into the table instead of arriving all at once.
+	refreshInterval = 2500 * time.Millisecond
+)
+
+func refreshTick() tea.Cmd {
+	return tea.Tick(refreshInterval, func(time.Time) tea.Msg { return refreshTickMsg{} })
+}
 
 // Model is the Bubble Tea model for the interactive WiFi table.
 type Model struct {
@@ -101,9 +117,18 @@ type Model struct {
 	// per-row password prompt
 	pwFor string
 
+	// find-as-you-type filter over SSIDs (modeFiltering)
+	filterInput textinput.Model
+
 	flashMessage string
 	flashIsError bool
 	busy         bool // true while an op is in-flight
+	// scanning is true until the first RefreshMsg arrives, so an empty table
+	// reads as "scan in progress" rather than "no networks".
+	scanning bool
+	// refreshInFlight guards against stacking refresh RPCs when ticks fire
+	// faster than the device answers (BLE transports can't multiplex).
+	refreshInFlight bool
 	// stickyConnectedSSID is the SSID of the most recent successful connect.
 	// It survives RefreshMsgs that haven't yet reflected the new state
 	// (nmcli rescan can lag behind association by a few seconds). Cleared
@@ -141,13 +166,20 @@ func NewModel(networks []Network) Model {
 	pw.CharLimit = 128
 	pw.Width = 32
 
+	fi := textinput.New()
+	fi.Prompt = "Filter: "
+	fi.CharLimit = 64
+	fi.Width = 32
+
 	m := Model{
 		networks:      networks,
 		table:         tui.NewBubbleTable(true, wifiColumns()),
 		mode:          modeBrowsing,
 		ssidInput:     ti,
 		passwordInput: pw,
+		filterInput:   fi,
 		secIndex:      3, // WPA2-PSK default
+		scanning:      len(networks) == 0,
 	}
 	m.refreshRows()
 	return m
@@ -157,10 +189,21 @@ func NewModel(networks []Network) Model {
 // so the TUI stays open between edits.
 func (m Model) WithHandler(h Handler) Model {
 	m.handler = h
+	// Init dispatches the first Refresh; mark it in flight so the first tick
+	// doesn't stack a second one on top.
+	m.refreshInFlight = true
 	return m
 }
 
-func (m Model) Init() tea.Cmd { return nil }
+// Init kicks off the first refresh and the polling loop. The caller starts
+// the TUI without waiting for an initial list, so the table appears
+// immediately and rows stream in as the device scan progresses.
+func (m Model) Init() tea.Cmd {
+	if m.handler == nil {
+		return nil
+	}
+	return tea.Batch(m.handler.Refresh(), refreshTick())
+}
 
 func wifiColumns() []bubbleTable.Column {
 	return []bubbleTable.Column{
@@ -172,9 +215,27 @@ func wifiColumns() []bubbleTable.Column {
 	}
 }
 
-func (m *Model) refreshRows() {
-	rows := make([]bubbleTable.Row, 0, len(m.networks))
+// filteredNetworks returns the networks whose SSID contains the filter query
+// (case-insensitive). With no active query it returns the full list, so table
+// cursor indexes always address this slice in every mode.
+func (m Model) filteredNetworks() []Network {
+	query := strings.ToLower(m.filterInput.Value())
+	if query == "" {
+		return m.networks
+	}
+	out := make([]Network, 0, len(m.networks))
 	for _, n := range m.networks {
+		if strings.Contains(strings.ToLower(n.SSID), query) {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func (m *Model) refreshRows() {
+	visible := m.filteredNetworks()
+	rows := make([]bubbleTable.Row, 0, len(visible))
+	for _, n := range visible {
 		known := ""
 		if n.Known {
 			known = "★"
@@ -214,15 +275,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case RefreshMsg:
-		if m.mode == modeBrowsing {
+		m.refreshInFlight = false
+		m.scanning = false
+		if m.mode == modeBrowsing || m.mode == modeFiltering {
 			m.networks = m.reconcileRefresh(msg.Networks)
 			Sort(m.networks)
 			m.refreshRows()
 		}
 		return m, nil
 
+	case refreshTickMsg:
+		cmds := []tea.Cmd{refreshTick()}
+		// Re-poll only while the user is looking at the list; skip when an
+		// op or refresh is already talking to the device.
+		if m.handler != nil && !m.refreshInFlight && !m.busy &&
+			(m.mode == modeBrowsing || m.mode == modeFiltering) {
+			m.refreshInFlight = true
+			cmds = append(cmds, m.handler.Refresh())
+		}
+		return m, tea.Batch(cmds...)
+
 	case OpResultMsg:
 		m.busy = false
+		if msg.Action == ActionNone {
+			// A refresh (not a user op) failed; the next tick retries.
+			m.refreshInFlight = false
+		}
 		m.flashMessage, m.flashIsError = flashFor(msg)
 		if msg.Err != nil {
 			return m, clearFlashAfter(flashDuration)
@@ -233,6 +311,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.applyOptimisticUpdate(msg)
 		m.refreshRows()
 		if m.handler != nil {
+			m.refreshInFlight = true
 			return m, tea.Batch(m.handler.Refresh(), clearFlashAfter(flashDuration))
 		}
 		return m, clearFlashAfter(flashDuration)
@@ -246,6 +325,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m.mode {
 	case modeBrowsing:
 		return m.updateBrowsing(msg)
+	case modeFiltering:
+		return m.updateFiltering(msg)
 	case modeRanking:
 		return m.updateRanking(msg)
 	case modeUnlisted:
@@ -276,24 +357,9 @@ func (m Model) updateBrowsing(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if idx < 0 || idx >= len(m.networks) {
 			return m, nil
 		}
-		n := m.networks[idx]
-		if n.Known {
-			// nmcli will reuse the saved profile (and its stored password).
-			return m.dispatchConnect(n.SSID, "", n.Security, false)
-		}
-		if n.Security == agentpb.WiFiSecurityType_WIFI_SECURITY_TYPE_OPEN {
-			return m.dispatchConnect(n.SSID, "", n.Security, false)
-		}
-		// Unknown with a secured or ambiguous (UNSPECIFIED) security type →
-		// prompt for a password. Treating UNSPECIFIED as open is unsafe,
-		// since many drivers omit the security field in scan output. The
-		// password input accepts an empty value for networks that turn out
-		// to be open.
-		m.pwFor = n.SSID
-		m.passwordInput.SetValue("")
-		m.passwordInput.Focus()
-		m.mode = modePassword
-		return m, textinput.Blink
+		return m.connectTo(m.networks[idx])
+	case "/":
+		return m.startFiltering("")
 	case "r":
 		if m.busy {
 			return m, nil
@@ -341,8 +407,120 @@ func (m Model) updateBrowsing(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.dispatchForget(m.networks[idx].SSID)
 	}
 
+	// Any other printable key starts find-as-you-type filtering, seeded with
+	// that key — except j/k/h/l, which stay table navigation (their letters
+	// can still be matched after entering filter mode via another key or /).
+	if km.Type == tea.KeyRunes || km.Type == tea.KeySpace {
+		switch km.String() {
+		case "j", "k", "h", "l":
+		default:
+			return m.startFiltering(string(km.Runes))
+		}
+	}
+
 	var cmd tea.Cmd
 	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+// connectTo runs the shared connect flow for a row picked in browse or filter
+// mode: known profiles and explicitly-open networks connect directly,
+// everything else prompts for a password. Treating UNSPECIFIED as open would
+// be unsafe — many drivers omit the security field in scan output — so the
+// prompt appears for ambiguous networks too (it accepts an empty password for
+// networks that turn out to be open).
+func (m Model) connectTo(n Network) (tea.Model, tea.Cmd) {
+	if n.Known {
+		// nmcli will reuse the saved profile (and its stored password).
+		return m.dispatchConnect(n.SSID, "", n.Security, false)
+	}
+	if n.Security == agentpb.WiFiSecurityType_WIFI_SECURITY_TYPE_OPEN {
+		return m.dispatchConnect(n.SSID, "", n.Security, false)
+	}
+	m.pwFor = n.SSID
+	m.passwordInput.SetValue("")
+	m.passwordInput.Focus()
+	m.mode = modePassword
+	return m, textinput.Blink
+}
+
+func (m Model) startFiltering(seed string) (tea.Model, tea.Cmd) {
+	m.mode = modeFiltering
+	m.filterInput.SetValue(seed)
+	m.filterInput.CursorEnd()
+	m.filterInput.Focus()
+	m.table.SetCursor(0)
+	m.refreshRows()
+	return m, textinput.Blink
+}
+
+// stopFiltering clears the query and returns to browse mode, keeping the
+// cursor on the network that was highlighted in the filtered view.
+func (m Model) stopFiltering() (tea.Model, tea.Cmd) {
+	var selectedSSID string
+	if visible := m.filteredNetworks(); len(visible) > 0 {
+		if idx := m.table.Cursor(); idx >= 0 && idx < len(visible) {
+			selectedSSID = visible[idx].SSID
+		}
+	}
+	m.filterInput.SetValue("")
+	m.filterInput.Blur()
+	m.mode = modeBrowsing
+	m.refreshRows()
+	for i, n := range m.networks {
+		if n.SSID == selectedSSID {
+			m.table.SetCursor(i)
+			break
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateFiltering(msg tea.Msg) (tea.Model, tea.Cmd) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		var cmd tea.Cmd
+		m.filterInput, cmd = m.filterInput.Update(msg)
+		return m, cmd
+	}
+	switch km.String() {
+	case "ctrl+c":
+		m.result.Action = ActionQuit
+		m.done = true
+		return m, tea.Quit
+	case "esc":
+		return m.stopFiltering()
+	case "up", "down":
+		var cmd tea.Cmd
+		m.table, cmd = m.table.Update(msg)
+		return m, cmd
+	case "enter":
+		if m.busy {
+			return m, nil
+		}
+		visible := m.filteredNetworks()
+		idx := m.table.Cursor()
+		if idx < 0 || idx >= len(visible) {
+			return m, nil
+		}
+		n := visible[idx]
+		// Leave filter mode before dispatching so the table under the
+		// password prompt (and after the op) shows the full list again.
+		next, _ := m.stopFiltering()
+		return next.(Model).connectTo(n)
+	case "backspace":
+		if m.filterInput.Value() == "" {
+			return m.stopFiltering()
+		}
+	}
+
+	before := m.filterInput.Value()
+	var cmd tea.Cmd
+	m.filterInput, cmd = m.filterInput.Update(msg)
+	if m.filterInput.Value() != before {
+		m.table.SetCursor(0)
+		m.refreshRows()
+	}
 	return m, cmd
 }
 
@@ -706,6 +884,7 @@ func restoreOrder(networks []Network, origOrder []string) []Network {
 
 var (
 	footerStyle     = lipgloss.NewStyle().Foreground(tui.ColorDim)
+	scanningStyle   = lipgloss.NewStyle().Foreground(tui.ColorPrimary)
 	titleStyle      = lipgloss.NewStyle().Bold(true).Foreground(tui.ColorPrimary)
 	modalBorder     = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(tui.ColorBorder).Padding(0, 1)
 	modalSelected   = lipgloss.NewStyle().Bold(true).Foreground(tui.ColorPrimary)
@@ -719,8 +898,22 @@ func (m Model) View() string {
 	}
 	var sb strings.Builder
 	sb.WriteString(m.viewLine(titleStyle.Render("WiFi networks")) + "\n\n")
-	sb.WriteString(m.table.View())
+	if m.mode == modeFiltering {
+		count := footerStyle.Render(fmt.Sprintf("  %d/%d", len(m.filteredNetworks()), len(m.networks)))
+		sb.WriteString(m.viewLine(m.filterInput.View()+count) + "\n\n")
+	}
+	sb.WriteString(m.tableView())
 	sb.WriteString("\n")
+
+	if len(m.networks) == 0 {
+		if m.scanning {
+			sb.WriteString(m.viewLine(scanningStyle.Render("  Scanning for nearby networks...")) + "\n")
+		} else {
+			sb.WriteString(m.viewLine(footerStyle.Render("  No networks found.")) + "\n")
+		}
+	} else if m.mode == modeFiltering && len(m.filteredNetworks()) == 0 {
+		sb.WriteString(m.viewLine(footerStyle.Render("  No SSIDs match the filter.")) + "\n")
+	}
 
 	if m.flashMessage != "" {
 		style := flashStyle
@@ -732,11 +925,13 @@ func (m Model) View() string {
 
 	switch m.mode {
 	case modeBrowsing:
-		hint := "↑/↓ move · enter connect · r rank · n new · f forget · q quit"
+		hint := "↑/↓ move · enter connect · / filter · r rank · n new · f forget · q quit"
 		if m.table.CanScroll() {
-			hint = "↑/↓ move · ←/→ scroll · enter connect · r rank · n new · f forget · q quit"
+			hint = "↑/↓ move · ←/→ scroll · enter connect · / filter · r rank · n new · f forget · q quit"
 		}
 		sb.WriteString(m.viewLine(footerStyle.Render(hint)) + "\n")
+	case modeFiltering:
+		sb.WriteString(m.viewLine(footerStyle.Render("type to filter · ↑/↓ move · enter connect · esc cancel")) + "\n")
 	case modeRanking:
 		sb.WriteString(m.viewLine(footerStyle.Render("rank mode: ↑/↓ reorder · enter commit · esc cancel")) + "\n")
 	case modePassword:
@@ -754,6 +949,22 @@ func (m Model) viewLine(line string) string {
 		return line
 	}
 	return tui.CropANSIView(line, 0, m.width)
+}
+
+// tableView renders the table, wrapping filter matches in the SSID column
+// with the shared highlight style. Highlighting happens on the uncropped view
+// so match positions line up, then the horizontal crop is reapplied.
+func (m Model) tableView() string {
+	query := m.filterInput.Value()
+	if m.mode != modeFiltering || query == "" {
+		return m.table.View()
+	}
+	ssidWidth := wifiColumns()[0].Width
+	view := tui.HighlightMatches(m.table.FullView(), query, 1, 1+ssidWidth)
+	if w := m.table.ViewportWidth(); w > 0 {
+		view = tui.CropANSIView(view, m.table.ScrollOffset(), w)
+	}
+	return view
 }
 
 func (m Model) renderUnlistedModal() string {

--- a/go/internal/cli/tui/wifitable/networks.go
+++ b/go/internal/cli/tui/wifitable/networks.go
@@ -4,6 +4,7 @@ package wifitable
 import (
 	"sort"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
@@ -23,10 +24,12 @@ type Network struct {
 	Priority int32
 }
 
-// FromProto converts a ListWiFiNetworksResponse network into the local Network.
+// FromProto converts a ListWiFiNetworksResponse network into the local
+// Network. The SSID comes from over-the-air beacon frames, so control
+// characters are stripped to keep escape sequences out of the terminal.
 func FromProto(n *agentpb.ListWiFiNetworksResponse_WiFiNetwork) Network {
 	out := Network{
-		SSID:      n.GetSsid(),
+		SSID:      tui.StripControl(n.GetSsid()),
 		Known:     n.GetIsKnown(),
 		Connected: n.GetIsConnected(),
 		Security:  n.GetSecurity(),


### PR DESCRIPTION
## Problem

The interactive WiFi selectors had three UX issues:

1. **Slow first paint.** `wendy device wifi` ran the full device-side rescan (several seconds of blocking `nmcli rescan`) *before* the TUI even appeared — the terminal just sat there, which read as a hang. The `connect` and `os install` pickers similarly blocked behind a spinner/log line until the whole scan finished.
2. **No security info in the pickers.** The `connect` and `os install` pickers showed only SSID + signal (the main table already had a Security column).
3. **No way to narrow long SSID lists** — no filtering at all.

## Changes

### `wendy device wifi` (interactive table)
- The TUI opens **immediately** with a `Scanning for nearby networks...` placeholder. `Init` fires the first refresh and a 2.5 s poll re-reads the device's scan cache, so **SSIDs stream into the table progressively** while the rescan runs (repeat list calls return the partially-filled cache instantly). The poll also keeps the list fresh while browsing; it pauses while an op/refresh is in flight or rank mode is active.
- **Find-as-you-type filtering**: `/` or any unbound printable key enters filter mode (j/k/h/l stay navigation). Matching is **case-insensitive** on SSIDs; matched characters are highlighted with a **light seafoam green background and black text**. `enter` connects to the highlighted match (with the usual password prompt for secured/ambiguous networks), `esc` cancels and keeps the cursor on the selected row, backspace-on-empty exits. A `N/M` match counter renders next to the query.

### `wendy device wifi connect` + `wendy os install` pickers
- The picker shows instantly with a `Scanning...` state; results stream in while the scan runs. gRPC targets additionally poll the device scan cache every 1.5 s until the authoritative scan lands (BLE stays single-call — that transport can't multiplex).
- New **Security** and **Signal** columns. Host-side scanners now report a best-effort security label: CoreWLAN `supportsSecurity` (macOS), `nmcli … SECURITY` (Linux), `netsh` `Authentication` lines (Windows), normalized to the same labels the agent uses (`Open`, `WEP`, `WPA`, `WPA2`, `WPA3`, `*-Ent`).
- `tui.PickerModel` gains an opt-in `Filterable` mode with the same highlighted type-to-filter behavior (`esc` clears the filter, then quits). Non-filterable pickers keep their existing `q`/`d`/`x` hotkeys.
- `wendy device wifi list` host fallback also prints the new Security column.

### Behavior notes
- A failed initial scan now surfaces as an in-TUI error flash (and retries on the next poll) instead of aborting before the UI opens.
- In the os-install credential flow, cancelling the picker (`esc`/`Ctrl+C`) falls through to the manual SSID prompt, as its title advertises; the previous separate spinner stage is gone.
- The bubbles table can't carry ANSI inside cells (escape bytes count against column width, and the selected row is wrapped in a single style), so match highlighting post-processes the rendered view and skips already-styled lines — i.e. the cursor row shows its selection style instead of highlights.

## Testing
- `go test ./go/...` passes; new unit tests cover the highlight ranges, filterable picker (narrowing, space/backspace, q-routing, esc semantics), and the wifitable filter/scan/poll state machine.
- Cross-compiled `GOOS=linux` and `GOOS=windows`.
- Verified the CoreWLAN script (incl. new security labels) runs on macOS.
- **Live-tested against a WendyOS device** (`spark-edeb.local`): table opens instantly with the scanning placeholder, rows stream in, Security column populated, `ccd` filter narrowed 51 → 6 rows with the count indicator, esc restored browsing; `connect` picker showed `Scanning...` immediately, streamed rows with Security/Signal columns, and filtered correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)