### PR TITLE
ci: document disabled Jetson Swift E2E route

### DIFF
--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -102,6 +102,30 @@ jobs:
           setup: true
           managed_agent: true
 
+  # // DISABLED: Jetson mDNS discovery is unreliable; WDY-968 tracks re-enabling.
+  # swift-e2e-physical-macos-jetson:
+  #   name: macOS 26 → Jetson Orin Nano
+  #   if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
+  #   runs-on: [self-hosted, macos-26]
+  #   concurrency:
+  #     group: device-jetson-orin-nano
+  #     cancel-in-progress: false
+  #     queue: max
+  #   timeout-minutes: 120
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - uses: ./.github/actions/swift-e2e-run
+  #       with:
+  #         tests: ${{ inputs.tests || '' }}
+  #         target_id: macos-jetson-orin-nano
+  #         runner_id: macos-26
+  #         cli_os: macOS
+  #         device_address: wendyos-jetson-orin-nano.local
+  #         agent_os: wendyOS
+  #         transport: lan
+  #         setup: false
+  #         managed_agent: false
+
   swift-e2e-physical-macos-ubuntu:
     name: macOS 26 → Ubuntu 24
     if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}


### PR DESCRIPTION
## Summary

- Keep the macOS → Jetson Swift E2E route commented out while WDY-968 tracks the mDNS reliability issue.
- Leave the hosted local and SER9 routes unchanged.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/swift-e2e-tests.yml"); puts "ok"'`
- `actionlint .github/workflows/swift-e2e-tests.yml`
