### PR TITLE
Revert "ci: disable Swift E2E PR runs"

### DIFF
--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -1,9 +1,12 @@
 name: Swift E2E Tests
 
-# TEMPORARILY DISABLED: Pull request Swift E2E runs are disabled while
-# WDY-1479 investigates the SER9 mTLS auth failure. Keep main, manual dispatch,
-# and workflow_call available for targeted debugging.
 on:
+  pull_request:
+    paths:
+      - 'swift/**'
+      - 'Proto/**'
+      - '.github/actions/swift-e2e-run/**'
+      - '.github/workflows/swift-e2e-tests.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Revert the WDY-1479 temporary removal of Swift E2E pull request triggers.
- Keep the Jetson E2E route disabled separately via PR #974 while WDY-968 tracks the mDNS issue.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/swift-e2e-tests.yml"); puts "ok"'`
- `actionlint .github/workflows/swift-e2e-tests.yml`
