### PR TITLE
examples: add smaller HelloMLX model choices

### DIFF
--- a/Examples/HelloMLX/HelloMLX.xcodeproj/xcshareddata/xcschemes/HelloMLX.xcscheme
+++ b/Examples/HelloMLX/HelloMLX.xcodeproj/xcshareddata/xcschemes/HelloMLX.xcscheme
@@ -57,7 +57,7 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--prompt &quot;These frames were captured at a fixed interval from a webcam. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames.&quot;"
+            argument = "--prompt &quot;These frames were captured at a fixed interval from a webcam. Reply in English. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames.&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/HelloMLX/HelloMLX.xcodeproj/xcshareddata/xcschemes/HelloMLX.xcscheme
+++ b/Examples/HelloMLX/HelloMLX.xcodeproj/xcshareddata/xcschemes/HelloMLX.xcscheme
@@ -53,7 +53,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--model-path $PROJECT_DIR/Models/gemma-3-27b-it-qat-4bit"
+            argument = "--model-path $PROJECT_DIR/Models/Current"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Examples/HelloMLX/README.md
+++ b/Examples/HelloMLX/README.md
@@ -43,7 +43,7 @@ After launching the app, make sure camera access is allowed for `WendyAgentMac.a
 
 This example requires you to choose a model tier before running the demo. `wendy.json` deploys `Models/Current`, and the download script updates that symlink to point at the selected model.
 
-Choose one tier explicitly:
+Choose one tier explicitly. Each tier uses a model supported by the current `MLXVLM` dependency in this example:
 
 ```sh
 ./Scripts/DownloadVLM.sh small    # 8 GB Macs, fastest validation (~1.0 GiB)
@@ -52,12 +52,12 @@ Choose one tier explicitly:
 ./Scripts/DownloadVLM.sh xlarge   # 64 GB Macs, Gemma 27B (~15.7 GiB)
 ```
 
-| Tier | Recommended Mac | Model | Download size | Expectation |
-| ---- | --------------- | ----- | ------------- | ----------- |
-| `small` | 8 GB unified memory | `HuggingFaceTB/SmolVLM2-500M-Video-Instruct-mlx` | ~1.0 GiB | Smoothest validation path, lowest quality. |
-| `medium` | 16 GB unified memory | `mlx-community/Qwen2-VL-2B-Instruct-4bit` | ~1.2 GiB | Recommended beta demo tier for constrained Macs. |
-| `large` | 32 GB unified memory | `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` | ~2.9 GiB | Higher quality, larger transfer, more memory headroom. |
-| `xlarge` | 64 GB unified memory or more | `mlx-community/gemma-3-27b-it-qat-4bit` | ~15.7 GiB | Best large-model option; not practical on 16 GB Macs. |
+| Tier | Recommended Mac | Model | MLXVLM type | Download size | Expectation |
+| ---- | --------------- | ----- | ----------- | ------------- | ----------- |
+| `small` | 8 GB unified memory | `HuggingFaceTB/SmolVLM2-500M-Video-Instruct-mlx` | `smolvlm` | ~1.0 GiB | Smoothest validation path, lowest quality. |
+| `medium` | 16 GB unified memory | `mlx-community/Qwen2-VL-2B-Instruct-4bit` | `qwen2_vl` | ~1.2 GiB | Recommended beta demo tier for constrained Macs. |
+| `large` | 32 GB unified memory | `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` | `qwen2_5_vl` | ~2.9 GiB | Higher quality, larger transfer, more memory headroom. |
+| `xlarge` | 64 GB unified memory or more | `mlx-community/gemma-3-27b-it-qat-4bit` | `gemma3` | ~15.7 GiB | Best large-model option; not practical on 16 GB Macs. |
 
 The current selected model is available at:
 

--- a/Examples/HelloMLX/README.md
+++ b/Examples/HelloMLX/README.md
@@ -46,18 +46,16 @@ This example requires you to choose a model tier before running the demo. `wendy
 Choose one tier explicitly. Each tier uses a model supported by the current `MLXVLM` dependency in this example:
 
 ```sh
-./Scripts/DownloadVLM.sh small    # 8 GB Macs, fastest validation (~1.0 GiB)
-./Scripts/DownloadVLM.sh medium   # 16 GB Macs, recommended beta tier (~1.2 GiB)
-./Scripts/DownloadVLM.sh large    # 32 GB Macs, better quality/larger transfer (~2.9 GiB)
-./Scripts/DownloadVLM.sh xlarge   # 64 GB Macs, Gemma 27B (~15.7 GiB)
+./Scripts/DownloadVLM.sh small    # 16 GB Macs, recommended beta tier (~1.2 GiB)
+./Scripts/DownloadVLM.sh medium   # 32 GB Macs, better quality/larger transfer (~2.9 GiB)
+./Scripts/DownloadVLM.sh large    # 64 GB Macs, Gemma 27B (~15.7 GiB)
 ```
 
 | Tier | Recommended Mac | Model | MLXVLM type | Download size | Expectation |
 | ---- | --------------- | ----- | ----------- | ------------- | ----------- |
-| `small` | 8 GB unified memory | `HuggingFaceTB/SmolVLM2-500M-Video-Instruct-mlx` | `smolvlm` | ~1.0 GiB | Smoothest validation path, lowest quality. |
-| `medium` | 16 GB unified memory | `mlx-community/Qwen2-VL-2B-Instruct-4bit` | `qwen2_vl` | ~1.2 GiB | Recommended beta demo tier for constrained Macs. |
-| `large` | 32 GB unified memory | `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` | `qwen2_5_vl` | ~2.9 GiB | Higher quality, larger transfer, more memory headroom. |
-| `xlarge` | 64 GB unified memory or more | `mlx-community/gemma-3-27b-it-qat-4bit` | `gemma3` | ~15.7 GiB | Best large-model option; not practical on 16 GB Macs. |
+| `small` | 16 GB unified memory | `mlx-community/Qwen2-VL-2B-Instruct-4bit` | `qwen2_vl` | ~1.2 GiB | Recommended beta demo tier for constrained Macs. |
+| `medium` | 32 GB unified memory | `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` | `qwen2_5_vl` | ~2.9 GiB | Higher quality, larger transfer, more memory headroom. |
+| `large` | 64 GB unified memory or more | `mlx-community/gemma-3-27b-it-qat-4bit` | `gemma3` | ~15.7 GiB | Best large-model option; not practical on 16 GB Macs. |
 
 The current selected model is available at:
 
@@ -81,7 +79,7 @@ xcodebuild -downloadComponent MetalToolchain
 
 Connect the development Mac and target Mac with a Thunderbolt 4 or Thunderbolt 5 cable.
 
-This is strongly recommended for the `large` and `xlarge` tiers, especially because `xlarge` transfers roughly 16 GB of model files.
+This is strongly recommended for the `medium` and `large` tiers, especially because `large` transfers roughly 16 GB of model files.
 
 ## 6. Run the demo
 
@@ -104,7 +102,7 @@ By default, the app configuration includes:
 - a local model path: `Current`, which is the deployed copy of `Models/Current`
 - a square frame resolution of `256x256` (override with `--resolution Y`)
 - a web server on port `8080`
-- a prompt that asks the model to comment on the captured frames
+- a prompt that asks the model to comment on the captured frames in English
 
 At startup the app prints its final runtime configuration to stdout, for example:
 
@@ -117,7 +115,7 @@ Final app config:
   "interval" : 5,
   "modelPath" : "Current",
   "port" : 8080,
-  "prompt" : "These frames were captured at a fixed interval from a webcam. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames.",
+  "prompt" : "These frames were captured at a fixed interval from a webcam. Reply in English. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames.",
   "resolution" : 256
 }
 HELLO_MLX_URL=http://konstantins-macbook-pro-m5.local:8080/

--- a/Examples/HelloMLX/README.md
+++ b/Examples/HelloMLX/README.md
@@ -57,7 +57,7 @@ Choose one tier explicitly. Each tier uses a model supported by the current `MLX
 | `medium` | 32 GB unified memory | `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` | `qwen2_5_vl` | ~2.9 GiB | Higher quality, larger transfer, more memory headroom. |
 | `large` | 64 GB unified memory or more | `mlx-community/gemma-3-27b-it-qat-4bit` | `gemma3` | ~15.7 GiB | Best large-model option; not practical on 16 GB Macs. |
 
-Quality note: `small` and `medium` are low-quality validation tiers for constrained Macs. Use `large` when you need the demo to actually do the job well.
+Quality note: `small` and `medium` are low-quality validation tiers for constrained Macs. Use a Mac with lots of RAM and the `large` model when you need the demo to actually do the job well.
 
 The current selected model is available at:
 

--- a/Examples/HelloMLX/README.md
+++ b/Examples/HelloMLX/README.md
@@ -65,6 +65,8 @@ The current selected model is available at:
 Models/Current -> <selected-model-directory>
 ```
 
+The script also writes `Models/Current/info.json` with the selected tier, Hugging Face model ID, and local model size. The web UI displays this metadata in the Model status field.
+
 Make sure the development Mac has enough disk space for the selected tier before continuing.
 
 ## 4. Install Metal Toolchain on the development Mac

--- a/Examples/HelloMLX/README.md
+++ b/Examples/HelloMLX/README.md
@@ -57,6 +57,8 @@ Choose one tier explicitly. Each tier uses a model supported by the current `MLX
 | `medium` | 32 GB unified memory | `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` | `qwen2_5_vl` | ~2.9 GiB | Higher quality, larger transfer, more memory headroom. |
 | `large` | 64 GB unified memory or more | `mlx-community/gemma-3-27b-it-qat-4bit` | `gemma3` | ~15.7 GiB | Best large-model option; not practical on 16 GB Macs. |
 
+Quality note: `small` and `medium` are low-quality validation tiers for constrained Macs. Use `large` when you need the demo to actually do the job well.
+
 The current selected model is available at:
 
 ```text

--- a/Examples/HelloMLX/README.md
+++ b/Examples/HelloMLX/README.md
@@ -2,7 +2,7 @@
 
 This demo is intended to be deployed from one Mac to another Mac running `wendy-agent`.
 
-The development Mac holds the VLM model locally and `wendy run` deploys that model to the target Mac along with the app. Because the model is large, the target Mac should be connected to the development Mac with a Thunderbolt cable for a practical transfer speed.
+The development Mac holds the selected VLM model locally and `wendy run` deploys that model to the target Mac along with the app. Larger model tiers should be transferred over Thunderbolt for practical transfer speed.
 
 ## 1. Install the `wendy` CLI
 
@@ -41,15 +41,31 @@ After launching the app, make sure camera access is allowed for `WendyAgentMac.a
 
 ## 3. Download the VLM model on the development Mac
 
-This example expects the model directory referenced by `wendy.json` to exist locally before you run the demo.
+This example requires you to choose a model tier before running the demo. `wendy.json` deploys `Models/Current`, and the download script updates that symlink to point at the selected model.
 
-Download it with:
+Choose one tier explicitly:
 
 ```sh
-./Scripts/DownloadVLM.sh
+./Scripts/DownloadVLM.sh small    # 8 GB Macs, fastest validation (~0.3 GiB)
+./Scripts/DownloadVLM.sh medium   # 16 GB Macs, recommended beta tier (~1.2 GiB)
+./Scripts/DownloadVLM.sh large    # 32 GB Macs, better quality/larger transfer (~2.9 GiB)
+./Scripts/DownloadVLM.sh xlarge   # 64 GB Macs, Gemma 27B (~15.7 GiB)
 ```
 
-The model is about 16 GB, so make sure you have enough disk space on the development Mac before continuing.
+| Tier | Recommended Mac | Model | Download size | Expectation |
+| ---- | --------------- | ----- | ------------- | ----------- |
+| `small` | 8 GB unified memory | `mlx-community/SmolVLM-500M-Instruct-4bit` | ~0.3 GiB | Smoothest validation path, lowest quality. |
+| `medium` | 16 GB unified memory | `mlx-community/Qwen2-VL-2B-Instruct-4bit` | ~1.2 GiB | Recommended beta demo tier for constrained Macs. |
+| `large` | 32 GB unified memory | `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` | ~2.9 GiB | Higher quality, larger transfer, more memory headroom. |
+| `xlarge` | 64 GB unified memory or more | `mlx-community/gemma-3-27b-it-qat-4bit` | ~15.7 GiB | Best large-model option; not practical on 16 GB Macs. |
+
+The current selected model is available at:
+
+```text
+Models/Current -> <selected-model-directory>
+```
+
+Make sure the development Mac has enough disk space for the selected tier before continuing.
 
 ## 4. Install Metal Toolchain on the development Mac
 
@@ -63,7 +79,7 @@ xcodebuild -downloadComponent MetalToolchain
 
 Connect the development Mac and target Mac with a Thunderbolt 4 or Thunderbolt 5 cable.
 
-This is strongly recommended because the VLM model is about 16 GB and will take a long time to transfer over slower links.
+This is strongly recommended for the `large` and `xlarge` tiers, especially because `xlarge` transfers roughly 16 GB of model files.
 
 ## 6. Run the demo
 
@@ -83,7 +99,7 @@ This demo runs a vision-language model on the target Mac and evaluates a prompt 
 
 By default, the app configuration includes:
 
-- a local model path: `gemma-3-27b-it-qat-4bit`
+- a local model path: `Current`, which is the deployed copy of `Models/Current`
 - a square frame resolution of `256x256` (override with `--resolution Y`)
 - a web server on port `8080`
 - a prompt that asks the model to comment on the captured frames
@@ -97,7 +113,7 @@ Final app config:
 {
   "fps" : 2,
   "interval" : 5,
-  "modelPath" : "gemma-3-27b-it-qat-4bit",
+  "modelPath" : "Current",
   "port" : 8080,
   "prompt" : "These frames were captured at a fixed interval from a webcam. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames.",
   "resolution" : 256

--- a/Examples/HelloMLX/README.md
+++ b/Examples/HelloMLX/README.md
@@ -46,7 +46,7 @@ This example requires you to choose a model tier before running the demo. `wendy
 Choose one tier explicitly:
 
 ```sh
-./Scripts/DownloadVLM.sh small    # 8 GB Macs, fastest validation (~0.3 GiB)
+./Scripts/DownloadVLM.sh small    # 8 GB Macs, fastest validation (~1.0 GiB)
 ./Scripts/DownloadVLM.sh medium   # 16 GB Macs, recommended beta tier (~1.2 GiB)
 ./Scripts/DownloadVLM.sh large    # 32 GB Macs, better quality/larger transfer (~2.9 GiB)
 ./Scripts/DownloadVLM.sh xlarge   # 64 GB Macs, Gemma 27B (~15.7 GiB)
@@ -54,7 +54,7 @@ Choose one tier explicitly:
 
 | Tier | Recommended Mac | Model | Download size | Expectation |
 | ---- | --------------- | ----- | ------------- | ----------- |
-| `small` | 8 GB unified memory | `mlx-community/SmolVLM-500M-Instruct-4bit` | ~0.3 GiB | Smoothest validation path, lowest quality. |
+| `small` | 8 GB unified memory | `HuggingFaceTB/SmolVLM2-500M-Video-Instruct-mlx` | ~1.0 GiB | Smoothest validation path, lowest quality. |
 | `medium` | 16 GB unified memory | `mlx-community/Qwen2-VL-2B-Instruct-4bit` | ~1.2 GiB | Recommended beta demo tier for constrained Macs. |
 | `large` | 32 GB unified memory | `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` | ~2.9 GiB | Higher quality, larger transfer, more memory headroom. |
 | `xlarge` | 64 GB unified memory or more | `mlx-community/gemma-3-27b-it-qat-4bit` | ~15.7 GiB | Best large-model option; not practical on 16 GB Macs. |

--- a/Examples/HelloMLX/Resources/index.html
+++ b/Examples/HelloMLX/Resources/index.html
@@ -561,6 +561,30 @@
       return value.toFixed(3).replace(/\.0+$|0+$/g, '').replace(/\.$/, '');
     }
 
+    function formatBytes(value) {
+      if (!Number.isFinite(value)) return null;
+      const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+      let size = value;
+      let unitIndex = 0;
+      while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex += 1;
+      }
+      return `${formatNumber(size)} ${units[unitIndex]}`;
+    }
+
+    function formatModel(model) {
+      const parts = [model.status];
+      if (model.metadata) {
+        parts.push(model.metadata.class, model.metadata.huggingFaceId);
+        const size = formatBytes(model.metadata.size?.bytes);
+        if (size) parts.push(size);
+      } else if (model.name) {
+        parts.push(model.name);
+      }
+      return parts.join(' · ');
+    }
+
     function formatSquareResolution(value) {
       return `${value}x${value}`;
     }
@@ -625,9 +649,7 @@
       elements.cameraStatus.textContent = payload.camera.name
         ? `${payload.camera.status} · ${payload.camera.name}`
         : payload.camera.status;
-      elements.modelStatus.textContent = payload.model.name
-        ? `${payload.model.status} · ${payload.model.name}`
-        : payload.model.status;
+      elements.modelStatus.textContent = formatModel(payload.model);
       elements.runConfig.textContent = `${formatNumber(payload.run.interval)}s window · ${formatNumber(payload.run.fps)} fps · ${formatSquareResolution(payload.run.resolution)}`;
       elements.lastRunDuration.textContent = formatDuration(payload.run.latestRunDuration);
       elements.latestRun.textContent = payload.run.latestRunID

--- a/Examples/HelloMLX/Scripts/DownloadVLM.sh
+++ b/Examples/HelloMLX/Scripts/DownloadVLM.sh
@@ -1,39 +1,97 @@
 #!/usr/bin/env bash
 # DownloadVLM.sh
 #
-# Downloads an MLX vision-language model suitable for general computer-vision
-# inference (evaluating a text prompt against a live camera frame) and places
-# it in the HelloMLX/ directory next to this script's parent project.
-#
-# Model: mlx-community/gemma-3-27b-it-qat-4bit
-#   • Gemma 3 27B is a large multimodal model with strong multi-image
-#     reasoning, well suited for temporal scene summarisation.
-#   • The 4-bit quantised variant weighs ~14 GB and fits comfortably in
-#     the unified memory of a Mac with 32 GB RAM or more.
+# Downloads a selected MLX vision-language model for HelloMLX and points
+# Models/Current at that model. The app, wendy.json, and Xcode scheme all use
+# the stable "Current" path so the selected tier stays in sync without editing
+# configuration files.
 #
 # Usage:
-#   Scripts/DownloadVLM.sh
+#   Scripts/DownloadVLM.sh <small|medium|large|xlarge>
 #
 # Requirements:
 #   pip install huggingface_hub   (provides the hf command)
 
 set -euo pipefail
 
+usage() {
+    cat <<'EOF'
+Usage:
+  Scripts/DownloadVLM.sh <small|medium|large|xlarge>
+
+Choose a model tier explicitly:
+  small   8 GB Macs     mlx-community/SmolVLM-500M-Instruct-4bit        (~0.3 GiB)
+  medium  16 GB Macs    mlx-community/Qwen2-VL-2B-Instruct-4bit         (~1.2 GiB)
+  large   32 GB Macs    mlx-community/Qwen2.5-VL-3B-Instruct-4bit       (~2.9 GiB)
+  xlarge  64 GB Macs    mlx-community/gemma-3-27b-it-qat-4bit           (~15.7 GiB)
+
+The selected model is downloaded under Models/<model-dir>, then Models/Current
+is updated to point at it. wendy.json deploys Models/Current and the app runs
+with --model-path Current.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+    usage >&2
+    exit 64
+fi
+
 # ── Homebrew bootstrap ────────────────────────────────────────────────────────
 
-eval "$(/opt/homebrew/bin/brew shellenv bash)"
+if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv bash)"
+elif command -v brew &>/dev/null; then
+    eval "$(brew shellenv bash)"
+fi
 
 # ── configuration ─────────────────────────────────────────────────────────────
 
-HF_REPO="mlx-community/gemma-3-27b-it-qat-4bit"
-MODEL_DIR="gemma-3-27b-it-qat-4bit"
-SIZE_HINT="~14 GB"
+TIER="$1"
+case "$TIER" in
+    small)
+        HF_REPO="mlx-community/SmolVLM-500M-Instruct-4bit"
+        MODEL_DIR="SmolVLM-500M-Instruct-4bit"
+        SIZE_HINT="~0.3 GiB"
+        MEMORY_HINT="recommended starting point for 8 GB Macs"
+        ;;
+    medium)
+        HF_REPO="mlx-community/Qwen2-VL-2B-Instruct-4bit"
+        MODEL_DIR="Qwen2-VL-2B-Instruct-4bit"
+        SIZE_HINT="~1.2 GiB"
+        MEMORY_HINT="recommended starting point for 16 GB Macs"
+        ;;
+    large)
+        HF_REPO="mlx-community/Qwen2.5-VL-3B-Instruct-4bit"
+        MODEL_DIR="Qwen2.5-VL-3B-Instruct-4bit"
+        SIZE_HINT="~2.9 GiB"
+        MEMORY_HINT="recommended starting point for 32 GB Macs"
+        ;;
+    xlarge)
+        HF_REPO="mlx-community/gemma-3-27b-it-qat-4bit"
+        MODEL_DIR="gemma-3-27b-it-qat-4bit"
+        SIZE_HINT="~15.7 GiB"
+        MEMORY_HINT="for high-memory Macs; use 64 GB unified memory or more"
+        ;;
+    *)
+        echo "❌  Unknown model tier: $TIER" >&2
+        echo "" >&2
+        usage >&2
+        exit 64
+        ;;
+esac
 
 # ── locate destination ────────────────────────────────────────────────────────
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-DEST="$PROJECT_ROOT/Models/$MODEL_DIR"
+MODELS_ROOT="$PROJECT_ROOT/Models"
+DEST="$MODELS_ROOT/$MODEL_DIR"
+CURRENT_LINK="$MODELS_ROOT/Current"
 
 # ── check dependencies ────────────────────────────────────────────────────────
 
@@ -51,9 +109,11 @@ fi
 # ── download ──────────────────────────────────────────────────────────────────
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Tier  : $TIER ($MEMORY_HINT)"
 echo "  Model : $HF_REPO"
 echo "  Size  : $SIZE_HINT (4-bit quantised MLX weights)"
 echo "  Dest  : $DEST"
+echo "  Link  : $CURRENT_LINK -> $MODEL_DIR"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
@@ -64,7 +124,7 @@ mkdir -p "$DEST"
 # the next run will copy from the cache instead of hitting the network.
 hf download "$HF_REPO"
 
-# Step 2 – copy from cache into the project's HelloMLX/ directory.
+# Step 2 – copy from cache into the project's Models/ directory.
 hf download \
     "$HF_REPO" \
     --local-dir "$DEST"
@@ -73,6 +133,17 @@ hf download \
 # model and is not needed by MLX or the app.
 rm -rf "$DEST/.cache"
 
+if [[ -e "$CURRENT_LINK" && ! -L "$CURRENT_LINK" ]]; then
+    echo "❌  $CURRENT_LINK exists and is not a symlink. Move it aside before selecting a model." >&2
+    exit 1
+fi
+
+rm -f "$CURRENT_LINK"
+ln -s "$MODEL_DIR" "$CURRENT_LINK"
+
 echo ""
 echo "✅  Model downloaded to:"
 echo "    $DEST"
+echo ""
+echo "✅  Current model selected:"
+echo "    $CURRENT_LINK -> $MODEL_DIR"

--- a/Examples/HelloMLX/Scripts/DownloadVLM.sh
+++ b/Examples/HelloMLX/Scripts/DownloadVLM.sh
@@ -106,6 +106,13 @@ if ! command -v hf &>/dev/null; then
     exit 1
 fi
 
+if ! command -v python3 &>/dev/null; then
+    echo "❌  python3 not found."
+    echo ""
+    echo "python3 is required to write Models/Current/info.json metadata."
+    exit 1
+fi
+
 # ── download ──────────────────────────────────────────────────────────────────
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -132,6 +139,45 @@ hf download \
 # Remove the .cache/ metadata folder created by hf; it's not part of the
 # model and is not needed by MLX or the app.
 rm -rf "$DEST/.cache"
+
+MODEL_SIZE_BYTES="$(python3 - "$DEST" <<'PY'
+import os
+import sys
+
+root = sys.argv[1]
+total = 0
+for directory, _, filenames in os.walk(root):
+    for filename in filenames:
+        path = os.path.join(directory, filename)
+        try:
+            total += os.path.getsize(path)
+        except OSError:
+            pass
+print(total)
+PY
+)"
+
+python3 - "$DEST/info.json" "$TIER" "$HF_REPO" "$MODEL_DIR" "$SIZE_HINT" "$MODEL_SIZE_BYTES" "$MEMORY_HINT" <<'PY'
+import datetime
+import json
+import sys
+
+info_path, model_class, hf_repo, model_dir, size_hint, size_bytes, memory_hint = sys.argv[1:]
+metadata = {
+    "class": model_class,
+    "huggingFaceId": hf_repo,
+    "directory": model_dir,
+    "size": {
+        "hint": size_hint,
+        "bytes": int(size_bytes),
+    },
+    "memoryHint": memory_hint,
+    "generatedAt": datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z"),
+}
+with open(info_path, "w", encoding="utf-8") as f:
+    json.dump(metadata, f, indent=2)
+    f.write("\n")
+PY
 
 if [[ -e "$CURRENT_LINK" && ! -L "$CURRENT_LINK" ]]; then
     echo "❌  $CURRENT_LINK exists and is not a symlink. Move it aside before selecting a model." >&2

--- a/Examples/HelloMLX/Scripts/DownloadVLM.sh
+++ b/Examples/HelloMLX/Scripts/DownloadVLM.sh
@@ -27,7 +27,8 @@ current MLXVLM dependency in this example:
 
 Quality note:
   small and medium are low-quality validation tiers for constrained Macs.
-  Use large when you need the demo to actually do the job well.
+  Use a Mac with lots of RAM and the large model when you need the demo
+  to actually do the job well.
 
 The selected model is downloaded under Models/<model-dir>, then Models/Current
 is updated to point at it. wendy.json deploys Models/Current and the app runs

--- a/Examples/HelloMLX/Scripts/DownloadVLM.sh
+++ b/Examples/HelloMLX/Scripts/DownloadVLM.sh
@@ -25,6 +25,10 @@ current MLXVLM dependency in this example:
   medium  32 GB Macs    mlx-community/Qwen2.5-VL-3B-Instruct-4bit       (~2.9 GiB)
   large   64 GB Macs    mlx-community/gemma-3-27b-it-qat-4bit           (~15.7 GiB)
 
+Quality note:
+  small and medium are low-quality validation tiers for constrained Macs.
+  Use large when you need the demo to actually do the job well.
+
 The selected model is downloaded under Models/<model-dir>, then Models/Current
 is updated to point at it. wendy.json deploys Models/Current and the app runs
 with --model-path Current.
@@ -58,18 +62,21 @@ case "$TIER" in
         MODEL_DIR="Qwen2-VL-2B-Instruct-4bit"
         SIZE_HINT="~1.2 GiB"
         MEMORY_HINT="recommended starting point for 16 GB Macs"
+        QUALITY_WARNING="low-quality validation tier; use large for best results"
         ;;
     medium)
         HF_REPO="mlx-community/Qwen2.5-VL-3B-Instruct-4bit"
         MODEL_DIR="Qwen2.5-VL-3B-Instruct-4bit"
         SIZE_HINT="~2.9 GiB"
         MEMORY_HINT="recommended starting point for 32 GB Macs"
+        QUALITY_WARNING="low-quality validation tier; use large for best results"
         ;;
     large)
         HF_REPO="mlx-community/gemma-3-27b-it-qat-4bit"
         MODEL_DIR="gemma-3-27b-it-qat-4bit"
         SIZE_HINT="~15.7 GiB"
         MEMORY_HINT="for high-memory Macs; use 64 GB unified memory or more"
+        QUALITY_WARNING=""
         ;;
     *)
         echo "❌  Unknown model tier: $TIER" >&2
@@ -117,6 +124,11 @@ echo "  Dest  : $DEST"
 echo "  Link  : $CURRENT_LINK -> $MODEL_DIR"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
+
+if [[ -n "$QUALITY_WARNING" ]]; then
+    echo "⚠️   Quality warning: $TIER is a $QUALITY_WARNING."
+    echo ""
+fi
 
 mkdir -p "$DEST"
 

--- a/Examples/HelloMLX/Scripts/DownloadVLM.sh
+++ b/Examples/HelloMLX/Scripts/DownloadVLM.sh
@@ -20,7 +20,7 @@ Usage:
   Scripts/DownloadVLM.sh <small|medium|large|xlarge>
 
 Choose a model tier explicitly:
-  small   8 GB Macs     mlx-community/SmolVLM-500M-Instruct-4bit        (~0.3 GiB)
+  small   8 GB Macs     HuggingFaceTB/SmolVLM2-500M-Video-Instruct-mlx  (~1.0 GiB)
   medium  16 GB Macs    mlx-community/Qwen2-VL-2B-Instruct-4bit         (~1.2 GiB)
   large   32 GB Macs    mlx-community/Qwen2.5-VL-3B-Instruct-4bit       (~2.9 GiB)
   xlarge  64 GB Macs    mlx-community/gemma-3-27b-it-qat-4bit           (~15.7 GiB)
@@ -54,9 +54,9 @@ fi
 TIER="$1"
 case "$TIER" in
     small)
-        HF_REPO="mlx-community/SmolVLM-500M-Instruct-4bit"
-        MODEL_DIR="SmolVLM-500M-Instruct-4bit"
-        SIZE_HINT="~0.3 GiB"
+        HF_REPO="HuggingFaceTB/SmolVLM2-500M-Video-Instruct-mlx"
+        MODEL_DIR="SmolVLM2-500M-Video-Instruct-mlx"
+        SIZE_HINT="~1.0 GiB"
         MEMORY_HINT="recommended starting point for 8 GB Macs"
         ;;
     medium)

--- a/Examples/HelloMLX/Scripts/DownloadVLM.sh
+++ b/Examples/HelloMLX/Scripts/DownloadVLM.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # DownloadVLM.sh
 #
-# Downloads a selected MLX vision-language model for HelloMLX and points
-# Models/Current at that model. The app, wendy.json, and Xcode scheme all use
-# the stable "Current" path so the selected tier stays in sync without editing
-# configuration files.
+# Downloads a selected MLXVLM-compatible vision-language model for HelloMLX
+# and points Models/Current at that model. The app, wendy.json, and Xcode
+# scheme all use the stable "Current" path so the selected tier stays in sync
+# without editing configuration files.
 #
 # Usage:
 #   Scripts/DownloadVLM.sh <small|medium|large|xlarge>
@@ -19,7 +19,8 @@ usage() {
 Usage:
   Scripts/DownloadVLM.sh <small|medium|large|xlarge>
 
-Choose a model tier explicitly:
+Choose a model tier explicitly. Each tier uses a model supported by the
+current MLXVLM dependency in this example:
   small   8 GB Macs     HuggingFaceTB/SmolVLM2-500M-Video-Instruct-mlx  (~1.0 GiB)
   medium  16 GB Macs    mlx-community/Qwen2-VL-2B-Instruct-4bit         (~1.2 GiB)
   large   32 GB Macs    mlx-community/Qwen2.5-VL-3B-Instruct-4bit       (~2.9 GiB)

--- a/Examples/HelloMLX/Scripts/DownloadVLM.sh
+++ b/Examples/HelloMLX/Scripts/DownloadVLM.sh
@@ -7,7 +7,7 @@
 # without editing configuration files.
 #
 # Usage:
-#   Scripts/DownloadVLM.sh <small|medium|large|xlarge>
+#   Scripts/DownloadVLM.sh <small|medium|large>
 #
 # Requirements:
 #   pip install huggingface_hub   (provides the hf command)
@@ -17,14 +17,13 @@ set -euo pipefail
 usage() {
     cat <<'EOF'
 Usage:
-  Scripts/DownloadVLM.sh <small|medium|large|xlarge>
+  Scripts/DownloadVLM.sh <small|medium|large>
 
 Choose a model tier explicitly. Each tier uses a model supported by the
 current MLXVLM dependency in this example:
-  small   8 GB Macs     HuggingFaceTB/SmolVLM2-500M-Video-Instruct-mlx  (~1.0 GiB)
-  medium  16 GB Macs    mlx-community/Qwen2-VL-2B-Instruct-4bit         (~1.2 GiB)
-  large   32 GB Macs    mlx-community/Qwen2.5-VL-3B-Instruct-4bit       (~2.9 GiB)
-  xlarge  64 GB Macs    mlx-community/gemma-3-27b-it-qat-4bit           (~15.7 GiB)
+  small   16 GB Macs    mlx-community/Qwen2-VL-2B-Instruct-4bit         (~1.2 GiB)
+  medium  32 GB Macs    mlx-community/Qwen2.5-VL-3B-Instruct-4bit       (~2.9 GiB)
+  large   64 GB Macs    mlx-community/gemma-3-27b-it-qat-4bit           (~15.7 GiB)
 
 The selected model is downloaded under Models/<model-dir>, then Models/Current
 is updated to point at it. wendy.json deploys Models/Current and the app runs
@@ -55,24 +54,18 @@ fi
 TIER="$1"
 case "$TIER" in
     small)
-        HF_REPO="HuggingFaceTB/SmolVLM2-500M-Video-Instruct-mlx"
-        MODEL_DIR="SmolVLM2-500M-Video-Instruct-mlx"
-        SIZE_HINT="~1.0 GiB"
-        MEMORY_HINT="recommended starting point for 8 GB Macs"
-        ;;
-    medium)
         HF_REPO="mlx-community/Qwen2-VL-2B-Instruct-4bit"
         MODEL_DIR="Qwen2-VL-2B-Instruct-4bit"
         SIZE_HINT="~1.2 GiB"
         MEMORY_HINT="recommended starting point for 16 GB Macs"
         ;;
-    large)
+    medium)
         HF_REPO="mlx-community/Qwen2.5-VL-3B-Instruct-4bit"
         MODEL_DIR="Qwen2.5-VL-3B-Instruct-4bit"
         SIZE_HINT="~2.9 GiB"
         MEMORY_HINT="recommended starting point for 32 GB Macs"
         ;;
-    xlarge)
+    large)
         HF_REPO="mlx-community/gemma-3-27b-it-qat-4bit"
         MODEL_DIR="gemma-3-27b-it-qat-4bit"
         SIZE_HINT="~15.7 GiB"

--- a/Examples/HelloMLX/Sources/AppState.swift
+++ b/Examples/HelloMLX/Sources/AppState.swift
@@ -25,9 +25,35 @@ struct CameraInfo: Codable {
     let frameURL: String?
 }
 
+struct ModelSizeInfo: Codable {
+    let hint: String
+    let bytes: Int64
+}
+
+struct ModelMetadata: Codable {
+    let modelClass: String
+    let huggingFaceId: String
+    let directory: String
+    let size: ModelSizeInfo
+    let memoryHint: String
+
+    var displayName: String {
+        "\(modelClass) · \(huggingFaceId)"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelClass = "class"
+        case huggingFaceId
+        case directory
+        case size
+        case memoryHint
+    }
+}
+
 struct ModelInfo: Codable {
     let status: ModelStatus
     let name: String?
+    let metadata: ModelMetadata?
 }
 
 struct PromptInfo: Codable {
@@ -77,6 +103,7 @@ actor AppState {
 
     private var modelStatus: ModelStatus
     private var modelName: String?
+    private var modelMetadata: ModelMetadata?
 
     private var promptText: String
     private var promptUpdatedAt = Date()
@@ -94,6 +121,7 @@ actor AppState {
         self.resolution = config.resolution
         self.modelStatus = config.modelPath == nil ? .notConfigured : .loading
         self.modelName = config.modelPath.map { URL(fileURLWithPath: $0).lastPathComponent }
+        self.modelMetadata = nil
         self.promptText = config.prompt
         self.latestRunID = latestRun?.id
         self.latestRunDuration = latestRun?.duration
@@ -112,7 +140,7 @@ actor AppState {
                     return "/frame.jpg?t=\(encoded.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? encoded)"
                 }
             ),
-            model: ModelInfo(status: modelStatus, name: modelName),
+            model: ModelInfo(status: modelStatus, name: modelName, metadata: modelMetadata),
             prompt: PromptInfo(text: promptText, updatedAt: promptUpdatedAt),
             run: RunInfo(
                 interval: interval,
@@ -164,20 +192,23 @@ actor AppState {
         lastFrameAt = date
     }
 
-    func setModelLoading(name: String?) {
+    func setModelLoading(name: String?, metadata: ModelMetadata? = nil) {
         modelStatus = .loading
         modelName = name
+        modelMetadata = metadata
         lastError = nil
     }
 
-    func setModelReady(name: String?) {
+    func setModelReady(name: String?, metadata: ModelMetadata? = nil) {
         modelStatus = .ready
         modelName = name
+        modelMetadata = metadata
     }
 
-    func setModelFailed(message: String, name: String?) {
+    func setModelFailed(message: String, name: String?, metadata: ModelMetadata? = nil) {
         modelStatus = .failed
         modelName = name
+        modelMetadata = metadata
         lastError = message
     }
 

--- a/Examples/HelloMLX/Sources/HelloMLX.swift
+++ b/Examples/HelloMLX/Sources/HelloMLX.swift
@@ -254,9 +254,13 @@ final class Camera: NSObject {
         }
 
         let modelDirectory = URL(fileURLWithPath: (modelPath as NSString).expandingTildeInPath)
-        let configuredName = modelDirectory.lastPathComponent
-        await state.setModelLoading(name: configuredName)
+        let metadata = loadModelMetadata(from: modelDirectory)
+        let configuredName = metadata?.displayName ?? modelDirectory.lastPathComponent
+        await state.setModelLoading(name: configuredName, metadata: metadata)
         print("Loading model: \(modelDirectory.path) …")
+        if let metadata {
+            print("Selected model: \(metadata.modelClass) · \(metadata.huggingFaceId) · \(metadata.size.hint)")
+        }
 
         do {
             let container = try await VLMModelFactory.shared.loadContainer(
@@ -266,13 +270,33 @@ final class Camera: NSObject {
                 print("  Loading: \(percent)%")
             }
             let loadedName = await container.perform { context in context.configuration.name }
+            let displayName = metadata?.displayName ?? loadedName
             model = container
-            modelName = loadedName
-            print("Model loaded successfully: \(loadedName)")
-            await state.setModelReady(name: loadedName)
+            modelName = displayName
+            print("Model loaded successfully: \(displayName)")
+            await state.setModelReady(name: displayName, metadata: metadata)
         } catch {
             print("Failed to load model: \(error)")
-            await state.setModelFailed(message: "Failed to load model: \(error.localizedDescription)", name: configuredName)
+            await state.setModelFailed(
+                message: "Failed to load model: \(error.localizedDescription)",
+                name: configuredName,
+                metadata: metadata
+            )
+        }
+    }
+
+    private func loadModelMetadata(from modelDirectory: URL) -> ModelMetadata? {
+        let metadataURL = modelDirectory.appendingPathComponent("info.json")
+        guard FileManager.default.fileExists(atPath: metadataURL.path) else {
+            return nil
+        }
+
+        do {
+            let data = try Data(contentsOf: metadataURL)
+            return try AppJSON.decoder.decode(ModelMetadata.self, from: data)
+        } catch {
+            print("Failed to read model metadata at \(metadataURL.path): \(error)")
+            return nil
         }
     }
 

--- a/Examples/HelloMLX/wendy.json
+++ b/Examples/HelloMLX/wendy.json
@@ -5,15 +5,15 @@
   "run": {
     "args": [
       "--model-path",
-      "gemma-3-27b-it-qat-4bit",
+      "Current",
       "--prompt",
       "These frames were captured at a fixed interval from a webcam. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames."
     ]
   },
   "files": [
     {
-      "path": "Models/gemma-3-27b-it-qat-4bit",
-      "to": "gemma-3-27b-it-qat-4bit"
+      "path": "Models/Current",
+      "to": "Current"
     }
   ]
 }

--- a/Examples/HelloMLX/wendy.json
+++ b/Examples/HelloMLX/wendy.json
@@ -7,7 +7,7 @@
       "--model-path",
       "Current",
       "--prompt",
-      "These frames were captured at a fixed interval from a webcam. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames."
+      "These frames were captured at a fixed interval from a webcam. Reply in English. You are a comedian using dark humor below the waist line. Ridicule what is shown by the frames."
     ]
   },
   "files": [


### PR DESCRIPTION
## Summary
- Adds explicit HelloMLX model tiers selected with `Scripts/DownloadVLM.sh small|medium|large`, with no implicit default download.
- Keeps `wendy.json` and the Xcode scheme stable by deploying `Models/Current`, while the download script points that symlink at the selected model.
- Carries tier/model metadata into the app UI so beta testers can see which Hugging Face model is running.
- Documents that `small` and `medium` are low-quality validation tiers; a high-memory Mac with the `large` Gemma model is the intended high-quality demo path.

Closes WDY-1495.

## Tests
- `bash -n Examples/HelloMLX/Scripts/DownloadVLM.sh`
- `Examples/HelloMLX/Scripts/DownloadVLM.sh --help`
- `go run ./go/cmd/wendy json validate Examples/HelloMLX`
- `xcodebuild -list -project Examples/HelloMLX/HelloMLX.xcodeproj`
- `xcodebuild -project Examples/HelloMLX/HelloMLX.xcodeproj -scheme HelloMLX -configuration Release -destination 'platform=macOS,arch=arm64' build CODE_SIGNING_ALLOWED=NO`
- `git diff --check`
