### PR TITLE
ci: re-enable physical Swift E2E routes

### DIFF
--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -122,14 +122,14 @@ jobs:
       queue: max
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: ./.github/actions/swift-e2e-run
         with:
           tests: ${{ inputs.tests || '' }}
           target_id: macos-ubuntu-24
           runner_id: macos-26
           cli_os: macOS
-          device_address: wendy-SER9.local
+          device_address: ${{ vars.SWIFT_E2E_UBUNTU_24_DEVICE_ADDRESS }}
           agent_os: linux
           transport: lan
           setup: false
@@ -146,14 +146,14 @@ jobs:
       queue: max
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: ./.github/actions/swift-e2e-run
         with:
           tests: ${{ inputs.tests || '' }}
           target_id: macos-jetson-orin-nano
           runner_id: macos-26
           cli_os: macOS
-          device_address: wendyos-strong-dunlin.local
+          device_address: ${{ vars.SWIFT_E2E_JETSON_ORIN_NANO_DEVICE_ADDRESS }}
           agent_os: wendyOS
           transport: lan
           setup: false

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -135,31 +135,30 @@ jobs:
           setup: false
           managed_agent: false
 
-  # // DISABLED: Mac <> Jetson Swift E2E is flaky; re-enable after stabilization.
-  # swift-e2e-physical-macos-jetson:
-  #   name: macOS 26 → Jetson Orin Nano
-  #   needs: swift-e2e-local-ubuntu
-  #   if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
-  #   runs-on: [self-hosted, macos-26]
-  #   concurrency:
-  #     group: device-jetson-orin-nano
-  #     cancel-in-progress: false
-  #     queue: max
-  #   timeout-minutes: 120
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: ./.github/actions/swift-e2e-run
-  #       with:
-  #         tests: ${{ inputs.tests || '' }}
-  #         target_id: macos-jetson-orin-nano
-  #         runner_id: macos-26
-  #         cli_os: macOS
-  #         device_address: wendyos-strong-dunlin.local
-  #         agent_os: wendyOS
-  #         transport: lan
-  #         setup: false
-  #         managed_agent: false
-  #
+  swift-e2e-physical-macos-jetson:
+    name: macOS 26 → Jetson Orin Nano
+    needs: swift-e2e-local-ubuntu
+    if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
+    runs-on: [self-hosted, macos-26]
+    concurrency:
+      group: device-jetson-orin-nano
+      cancel-in-progress: false
+      queue: max
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/swift-e2e-run
+        with:
+          tests: ${{ inputs.tests || '' }}
+          target_id: macos-jetson-orin-nano
+          runner_id: macos-26
+          cli_os: macOS
+          device_address: wendyos-strong-dunlin.local
+          agent_os: wendyOS
+          transport: lan
+          setup: false
+          managed_agent: false
+
   # // DISABLED: no CI hardware set up yet for this job.
   # swift-e2e-physical-windows-ubuntu:
   #   name: Windows 11 → Ubuntu 24
@@ -417,6 +416,7 @@ jobs:
       - swift-e2e-local-macos
       - swift-e2e-local-ubuntu
       - swift-e2e-physical-macos-ubuntu
+      - swift-e2e-physical-macos-jetson
     runs-on: [self-hosted, AI]
     timeout-minutes: 60
     steps:

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -111,31 +111,30 @@ jobs:
   # Physical routes are gated by target agent OS: Linux/WendyOS targets depend on
   # the local Ubuntu run, while macOS targets depend on the local macOS run.
   #
-  # // DISABLED: Mac → Ubuntu/SER9 mDNS discovery is unreliable; WDY-968 tracks re-enabling.
-  # swift-e2e-physical-macos-ubuntu:
-  #   name: macOS 26 → Ubuntu 24
-  #   needs: swift-e2e-local-ubuntu
-  #   if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
-  #   runs-on: [self-hosted, macos-26]
-  #   concurrency:
-  #     group: device-ubuntu-24
-  #     cancel-in-progress: false
-  #     queue: max
-  #   timeout-minutes: 120
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: ./.github/actions/swift-e2e-run
-  #       with:
-  #         tests: ${{ inputs.tests || '' }}
-  #         target_id: macos-ubuntu-24
-  #         runner_id: macos-26
-  #         cli_os: macOS
-  #         device_address: wendy-SER9.local
-  #         agent_os: linux
-  #         transport: lan
-  #         setup: false
-  #         managed_agent: false
-  #
+  swift-e2e-physical-macos-ubuntu:
+    name: macOS 26 → Ubuntu 24
+    needs: swift-e2e-local-ubuntu
+    if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
+    runs-on: [self-hosted, macos-26]
+    concurrency:
+      group: device-ubuntu-24
+      cancel-in-progress: false
+      queue: max
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/swift-e2e-run
+        with:
+          tests: ${{ inputs.tests || '' }}
+          target_id: macos-ubuntu-24
+          runner_id: macos-26
+          cli_os: macOS
+          device_address: wendy-SER9.local
+          agent_os: linux
+          transport: lan
+          setup: false
+          managed_agent: false
+
   # // DISABLED: Mac <> Jetson Swift E2E is flaky; re-enable after stabilization.
   # swift-e2e-physical-macos-jetson:
   #   name: macOS 26 → Jetson Orin Nano
@@ -417,6 +416,7 @@ jobs:
     needs:
       - swift-e2e-local-macos
       - swift-e2e-local-ubuntu
+      - swift-e2e-physical-macos-ubuntu
     runs-on: [self-hosted, AI]
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary

- Re-enable the physical macOS 26 → Ubuntu 24 Swift E2E route.
- Re-enable the physical macOS 26 → Jetson Orin Nano Swift E2E route.
- Keep both physical routes gated behind the hosted Ubuntu local E2E run.
- Include both physical routes in the E2E analysis dependency list so the aggregate report always runs after attempted test runs complete.
- Read physical device addresses from repository-level GitHub Actions variables and pin checkout in the re-enabled physical jobs.

## Context

Recent LAN discovery checks showed the lab devices are consistently discoverable again, so the physical Swift E2E routes can be exercised in CI.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/swift-e2e-tests.yml"); puts "ok"'`
- `actionlint .github/workflows/swift-e2e-tests.yml`
- CI on the previous revision passed both physical Swift E2E routes and `Analyze E2E Results`.
