### PR TITLE
Audit artifact: WDY-1509 CLI surface handoff (do not merge)

### DIFF
--- a/.cli-surface-WDY-1509.json
+++ b/.cli-surface-WDY-1509.json
@@ -1,0 +1,1621 @@
+[
+  {
+    "command": "wendy",
+    "use": "wendy",
+    "short": "Wendy CLI - Edge Computing Development Tool",
+    "flags": [
+      {
+        "name": "device",
+        "usage": "Target device hostname"
+      },
+      {
+        "name": "json",
+        "usage": "Output in JSON format",
+        "default": "false"
+      }
+    ],
+    "persistentFlags": [
+      {
+        "name": "device",
+        "usage": "Target device hostname"
+      },
+      {
+        "name": "json",
+        "usage": "Output in JSON format",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy analytics",
+    "use": "wendy analytics",
+    "short": "Manage anonymous usage analytics"
+  },
+  {
+    "command": "wendy analytics disable",
+    "use": "wendy analytics disable",
+    "short": "Disable anonymous usage analytics"
+  },
+  {
+    "command": "wendy analytics enable",
+    "use": "wendy analytics enable",
+    "short": "Enable anonymous usage analytics"
+  },
+  {
+    "command": "wendy analytics status",
+    "use": "wendy analytics status",
+    "short": "Show current analytics status"
+  },
+  {
+    "command": "wendy auth",
+    "use": "wendy auth",
+    "short": "Manage authentication with Wendy Cloud"
+  },
+  {
+    "command": "wendy auth login",
+    "use": "wendy auth login [flags]",
+    "short": "Log in to Wendy Cloud or a local pki-core instance",
+    "flags": [
+      {
+        "name": "api-key",
+        "usage": "Bearer API key for local pki-core authentication"
+      },
+      {
+        "name": "cloud",
+        "usage": "Cloud dashboard URL"
+      },
+      {
+        "name": "cloud-grpc",
+        "usage": "Cloud gRPC endpoint, or local pki-core address (host:port) when using --api-key"
+      },
+      {
+        "name": "org",
+        "usage": "Organization ID (used with --api-key)",
+        "default": "1"
+      }
+    ]
+  },
+  {
+    "command": "wendy auth logout",
+    "use": "wendy auth logout",
+    "short": "Log out from Wendy Cloud"
+  },
+  {
+    "command": "wendy auth refresh-certs",
+    "use": "wendy auth refresh-certs",
+    "short": "Refresh mTLS certificates"
+  },
+  {
+    "command": "wendy auth status",
+    "use": "wendy auth status",
+    "short": "Show current authentication status"
+  },
+  {
+    "command": "wendy build",
+    "use": "wendy build [flags]",
+    "short": "Build the application in the current directory",
+    "flags": [
+      {
+        "name": "build-type",
+        "usage": "Build type to use when multiple project markers are present: docker, swift, or python"
+      },
+      {
+        "name": "dockerfile",
+        "usage": "Dockerfile to build from (e.g. Dockerfile.prod); shows a selection menu when multiple Dockerfiles exist"
+      }
+    ]
+  },
+  {
+    "command": "wendy cache",
+    "use": "wendy cache",
+    "short": "Manage local CLI cache"
+  },
+  {
+    "command": "wendy cache clear",
+    "use": "wendy cache clear",
+    "short": "Clear the local cache"
+  },
+  {
+    "command": "wendy cache list",
+    "use": "wendy cache list",
+    "short": "List cached items"
+  },
+  {
+    "command": "wendy cloud",
+    "use": "wendy cloud",
+    "short": "Manage Wendy Cloud resources"
+  },
+  {
+    "command": "wendy cloud device",
+    "use": "wendy cloud device",
+    "short": "Manage WendyOS devices through Wendy Cloud",
+    "flags": [
+      {
+        "name": "broker-url",
+        "usage": "Tunnel broker host:port (default: cloud :443 endpoint, otherwise \u003ccloud-host\u003e:50052)"
+      },
+      {
+        "name": "cloud-grpc",
+        "usage": "Cloud gRPC endpoint (required when multiple auth sessions exist)"
+      }
+    ],
+    "persistentFlags": [
+      {
+        "name": "broker-url",
+        "usage": "Tunnel broker host:port (default: cloud :443 endpoint, otherwise \u003ccloud-host\u003e:50052)"
+      },
+      {
+        "name": "cloud-grpc",
+        "usage": "Cloud gRPC endpoint (required when multiple auth sessions exist)"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device apps",
+    "use": "wendy cloud device apps",
+    "short": "Manage applications on the target device"
+  },
+  {
+    "command": "wendy cloud device apps list",
+    "use": "wendy cloud device apps list",
+    "short": "List deployed applications"
+  },
+  {
+    "command": "wendy cloud device apps remove",
+    "use": "wendy cloud device apps remove [app-name] [flags]",
+    "short": "Remove an application",
+    "flags": [
+      {
+        "name": "cleanup",
+        "usage": "Also delete the container image (frees disk space; agent-connected devices only)",
+        "default": "false"
+      },
+      {
+        "name": "delete-volumes",
+        "usage": "Also delete persistent volumes (/var/lib/wendy/volumes; agent-connected devices only)",
+        "default": "false"
+      },
+      {
+        "name": "force",
+        "usage": "Skip confirmation prompt",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device apps start",
+    "use": "wendy cloud device apps start [app-name] [flags]",
+    "short": "Start an application",
+    "flags": [
+      {
+        "name": "detach",
+        "shorthand": "d",
+        "usage": "Start without streaming output",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device apps stop",
+    "use": "wendy cloud device apps stop [app-name]",
+    "short": "Stop an application"
+  },
+  {
+    "command": "wendy cloud device audio",
+    "use": "wendy cloud device audio",
+    "short": "Manage audio devices on the target device"
+  },
+  {
+    "command": "wendy cloud device audio list",
+    "use": "wendy cloud device audio list",
+    "short": "List audio devices"
+  },
+  {
+    "command": "wendy cloud device audio listen",
+    "use": "wendy cloud device audio listen [flags]",
+    "short": "Stream raw audio from a device microphone",
+    "flags": [
+      {
+        "name": "channels",
+        "usage": "Number of audio channels",
+        "default": "1"
+      },
+      {
+        "name": "id",
+        "usage": "Audio device ID",
+        "default": "0"
+      },
+      {
+        "name": "sample-rate",
+        "usage": "Sample rate in Hz",
+        "default": "16000"
+      },
+      {
+        "name": "stdout",
+        "usage": "Write raw PCM to stdout instead of playing",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device audio monitor",
+    "use": "wendy cloud device audio monitor [flags]",
+    "short": "Real-time VU meter for audio levels",
+    "flags": [
+      {
+        "name": "id",
+        "usage": "Audio device ID",
+        "default": "0"
+      },
+      {
+        "name": "rate",
+        "usage": "Update rate in Hz",
+        "default": "10"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device audio set-default",
+    "use": "wendy cloud device audio set-default [flags]",
+    "short": "Set the default audio device",
+    "flags": [
+      {
+        "name": "id",
+        "usage": "Audio device ID",
+        "default": "0"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device bluetooth",
+    "use": "wendy cloud device bluetooth",
+    "short": "Manage Bluetooth on the target device"
+  },
+  {
+    "command": "wendy cloud device bluetooth connect",
+    "use": "wendy cloud device bluetooth connect [address] [flags]",
+    "short": "Connect to a Bluetooth peripheral",
+    "flags": [
+      {
+        "name": "pair",
+        "usage": "Pair with the device",
+        "default": "true"
+      },
+      {
+        "name": "trust",
+        "usage": "Trust the device",
+        "default": "true"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device bluetooth disconnect",
+    "use": "wendy cloud device bluetooth disconnect [address]",
+    "short": "Disconnect a Bluetooth peripheral"
+  },
+  {
+    "command": "wendy cloud device bluetooth forget",
+    "use": "wendy cloud device bluetooth forget [address]",
+    "short": "Forget a paired Bluetooth peripheral"
+  },
+  {
+    "command": "wendy cloud device bluetooth list",
+    "use": "wendy cloud device bluetooth list",
+    "short": "Scan for Bluetooth peripherals"
+  },
+  {
+    "command": "wendy cloud device camera",
+    "use": "wendy cloud device camera",
+    "short": "Manage cameras on the target device"
+  },
+  {
+    "command": "wendy cloud device camera list",
+    "use": "wendy cloud device camera list",
+    "short": "List cameras"
+  },
+  {
+    "command": "wendy cloud device camera view",
+    "use": "wendy cloud device camera view [flags]",
+    "short": "Stream H.264 video from a device camera",
+    "flags": [
+      {
+        "name": "fps",
+        "usage": "Framerate (0 = device default)",
+        "default": "0"
+      },
+      {
+        "name": "height",
+        "usage": "Frame height (0 = device default)",
+        "default": "0"
+      },
+      {
+        "name": "id",
+        "usage": "Camera device ID",
+        "default": "0"
+      },
+      {
+        "name": "stdout",
+        "usage": "Pipe encoded video to stdout instead of opening a window (codec: H.264 or VP8/WebM depending on device capabilities)",
+        "default": "false"
+      },
+      {
+        "name": "width",
+        "usage": "Frame width (0 = device default)",
+        "default": "0"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device dashboard",
+    "use": "wendy cloud device dashboard [flags]",
+    "short": "Live dashboard showing metrics and logs from a device",
+    "flags": [
+      {
+        "name": "app",
+        "usage": "Filter by application name"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device enroll",
+    "use": "wendy cloud device enroll [flags]",
+    "short": "Enroll this device with Wendy Cloud or a local pki-core",
+    "flags": [
+      {
+        "name": "cloud-grpc",
+        "usage": "Cloud/pki-core gRPC endpoint to use (required when multiple auth sessions exist)"
+      },
+      {
+        "name": "name",
+        "usage": "Device name"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device hardware",
+    "use": "wendy cloud device hardware",
+    "short": "Query hardware capabilities on the target device"
+  },
+  {
+    "command": "wendy cloud device hardware list",
+    "use": "wendy cloud device hardware list [flags]",
+    "short": "List hardware capabilities",
+    "flags": [
+      {
+        "name": "category",
+        "usage": "Filter by category (e.g., gpu, audio, camera)"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device info",
+    "use": "wendy cloud device info [flags]",
+    "short": "Show agent version, OS, architecture, GPU, and hardware info for the target device",
+    "flags": [
+      {
+        "name": "check-updates",
+        "usage": "Check for available agent updates on GitHub",
+        "default": "false"
+      },
+      {
+        "name": "prerelease",
+        "usage": "Include prerelease (nightly) builds when checking for updates",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device logs",
+    "use": "wendy cloud device logs [flags]",
+    "short": "Stream logs from containers on the device",
+    "flags": [
+      {
+        "name": "app",
+        "usage": "Filter by application name"
+      },
+      {
+        "name": "level",
+        "usage": "Minimum log level (trace, debug, info, warn, error, fatal)"
+      },
+      {
+        "name": "min-severity",
+        "usage": "Minimum log severity number",
+        "default": "0"
+      },
+      {
+        "name": "service",
+        "usage": "Filter by service name"
+      },
+      {
+        "name": "tail",
+        "usage": "Replay the last N log batches before streaming live (0 = live only)",
+        "default": "0"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device ps",
+    "use": "wendy cloud device ps",
+    "short": "List running containers (alias for 'apps list')"
+  },
+  {
+    "command": "wendy cloud device set-default",
+    "use": "wendy cloud device set-default [hostname]",
+    "short": "Set the default device hostname"
+  },
+  {
+    "command": "wendy cloud device setup",
+    "use": "wendy cloud device setup",
+    "short": "Interactive device setup: enroll, name, and configure WiFi"
+  },
+  {
+    "command": "wendy cloud device telemetry-stream",
+    "use": "wendy cloud device telemetry-stream [flags]",
+    "short": "Stream telemetry data (logs, metrics, traces) as JSONL",
+    "flags": [
+      {
+        "name": "app",
+        "usage": "Filter by application name"
+      },
+      {
+        "name": "logs",
+        "usage": "Include logs",
+        "default": "false"
+      },
+      {
+        "name": "metrics",
+        "usage": "Include metrics",
+        "default": "false"
+      },
+      {
+        "name": "service",
+        "usage": "Filter by service name"
+      },
+      {
+        "name": "traces",
+        "usage": "Include traces",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device unset-default",
+    "use": "wendy cloud device unset-default",
+    "short": "Clear the default device"
+  },
+  {
+    "command": "wendy cloud device update",
+    "use": "wendy cloud device update [flags]",
+    "short": "Update the agent binary on the target device",
+    "flags": [
+      {
+        "name": "binary",
+        "usage": "Path to a local agent binary to upload (skips download)"
+      },
+      {
+        "name": "nightly",
+        "usage": "Use the latest nightly (prerelease) build",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device version",
+    "use": "wendy cloud device version [flags]",
+    "short": "Show agent version, OS, architecture, GPU, and hardware info for the target device",
+    "hidden": true,
+    "flags": [
+      {
+        "name": "check-updates",
+        "usage": "Check for available agent updates on GitHub",
+        "default": "false"
+      },
+      {
+        "name": "prerelease",
+        "usage": "Include prerelease (nightly) builds when checking for updates",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device volumes",
+    "use": "wendy cloud device volumes",
+    "short": "Manage persistent volumes on the device"
+  },
+  {
+    "command": "wendy cloud device volumes list",
+    "use": "wendy cloud device volumes list",
+    "short": "List persistent volumes"
+  },
+  {
+    "command": "wendy cloud device volumes remove",
+    "use": "wendy cloud device volumes remove [name] [flags]",
+    "short": "Remove a persistent volume",
+    "flags": [
+      {
+        "name": "force",
+        "usage": "Skip confirmation prompt",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device wifi",
+    "use": "wendy cloud device wifi",
+    "short": "Manage WiFi on the target device"
+  },
+  {
+    "command": "wendy cloud device wifi connect",
+    "use": "wendy cloud device wifi connect [flags]",
+    "short": "Connect to a WiFi network",
+    "flags": [
+      {
+        "name": "password",
+        "usage": "WiFi network password"
+      },
+      {
+        "name": "ssid",
+        "usage": "WiFi network SSID"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device wifi disconnect",
+    "use": "wendy cloud device wifi disconnect",
+    "short": "Disconnect from the current WiFi network"
+  },
+  {
+    "command": "wendy cloud device wifi forget",
+    "use": "wendy cloud device wifi forget [flags]",
+    "short": "Remove a known WiFi network",
+    "flags": [
+      {
+        "name": "ssid",
+        "usage": "SSID of the known network to forget"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device wifi list",
+    "use": "wendy cloud device wifi list",
+    "short": "List available WiFi networks"
+  },
+  {
+    "command": "wendy cloud device wifi rank",
+    "use": "wendy cloud device wifi rank [flags]",
+    "short": "Set the autoconnect ranking of known WiFi networks",
+    "flags": [
+      {
+        "name": "order",
+        "usage": "Comma-separated list of SSIDs in priority order (highest first)"
+      },
+      {
+        "name": "priority",
+        "usage": "Autoconnect priority (higher = tried first)",
+        "default": "0"
+      },
+      {
+        "name": "ssid",
+        "usage": "SSID of the known network to rank"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud device wifi status",
+    "use": "wendy cloud device wifi status",
+    "short": "Get current WiFi connection status"
+  },
+  {
+    "command": "wendy cloud discover",
+    "use": "wendy cloud discover [flags]",
+    "short": "List enrolled devices in Wendy Cloud",
+    "flags": [
+      {
+        "name": "all",
+        "usage": "Include offline devices",
+        "default": "false"
+      },
+      {
+        "name": "broker-url",
+        "usage": "Tunnel broker host:port (default: cloud :443 endpoint, otherwise \u003ccloud-host\u003e:50052)"
+      },
+      {
+        "name": "cloud-grpc",
+        "usage": "Cloud gRPC endpoint (required when multiple auth sessions exist)"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud enroll-device",
+    "use": "wendy cloud enroll-device [flags]",
+    "short": "Enroll the connected device with Wendy Cloud or a local pki-core",
+    "flags": [
+      {
+        "name": "cloud-grpc",
+        "usage": "Cloud/pki-core gRPC endpoint to use (required when multiple auth sessions exist)"
+      },
+      {
+        "name": "name",
+        "usage": "Device name"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud run",
+    "use": "wendy cloud run [flags]",
+    "short": "Deprecated: use 'wendy run' instead",
+    "hidden": true,
+    "flags": [
+      {
+        "name": "broker-url",
+        "usage": "Tunnel broker host:port"
+      },
+      {
+        "name": "build-type",
+        "usage": "Build type: docker, swift, or python"
+      },
+      {
+        "name": "cloud-grpc",
+        "usage": "Cloud gRPC endpoint (required when multiple auth sessions exist)"
+      },
+      {
+        "name": "debug",
+        "usage": "Enable debug logging",
+        "default": "false"
+      },
+      {
+        "name": "deploy",
+        "usage": "Create container but do not start it",
+        "default": "false"
+      },
+      {
+        "name": "detach",
+        "usage": "Start container but do not stream logs",
+        "default": "false"
+      },
+      {
+        "name": "device",
+        "usage": "Device name (skips interactive picker)"
+      },
+      {
+        "name": "no-restart",
+        "usage": "Do not restart on exit",
+        "default": "false"
+      },
+      {
+        "name": "prefix",
+        "usage": "Project directory instead of current working directory"
+      },
+      {
+        "name": "product",
+        "usage": "Swift Package Manager product to build and run"
+      },
+      {
+        "name": "restart-on-failure",
+        "usage": "Restart on failure",
+        "default": "false"
+      },
+      {
+        "name": "restart-unless-stopped",
+        "usage": "Restart unless manually stopped",
+        "default": "false"
+      },
+      {
+        "name": "user-args",
+        "usage": "Extra arguments to pass to the container",
+        "default": "[]"
+      },
+      {
+        "name": "yes",
+        "shorthand": "y",
+        "usage": "Automatically accept all interactive prompts",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy cloud tunnel",
+    "use": "wendy cloud tunnel \u003clocal-port\u003e:\u003cremote-port\u003e [flags]",
+    "short": "Forward a local TCP port to a port on a cloud-enrolled device",
+    "flags": [
+      {
+        "name": "broker-url",
+        "usage": "Tunnel broker host:port (default: cloud :443 endpoint, otherwise \u003ccloud-host\u003e:50052)"
+      },
+      {
+        "name": "cloud-grpc",
+        "usage": "Cloud gRPC endpoint (required when multiple auth sessions exist)"
+      },
+      {
+        "name": "device",
+        "usage": "Device name (skips interactive picker)"
+      }
+    ]
+  },
+  {
+    "command": "wendy completion",
+    "use": "wendy completion",
+    "short": "Generate or install shell completion scripts"
+  },
+  {
+    "command": "wendy completion bash",
+    "use": "wendy completion bash",
+    "short": "Print bash completion script"
+  },
+  {
+    "command": "wendy completion fish",
+    "use": "wendy completion fish",
+    "short": "Print fish completion script"
+  },
+  {
+    "command": "wendy completion install",
+    "use": "wendy completion install [flags]",
+    "short": "Install shell completions into the user's standard config locations",
+    "flags": [
+      {
+        "name": "output-dir",
+        "usage": "Use this directory as $HOME (for testing)",
+        "hidden": true
+      },
+      {
+        "name": "print-path",
+        "usage": "Print install paths without writing",
+        "default": "false"
+      },
+      {
+        "name": "shell",
+        "usage": "Override shell (bash|zsh|fish|powershell)"
+      },
+      {
+        "name": "stdout",
+        "usage": "Print the completion script to stdout instead of installing",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy completion powershell",
+    "use": "wendy completion powershell",
+    "short": "Print PowerShell completion script"
+  },
+  {
+    "command": "wendy completion zsh",
+    "use": "wendy completion zsh",
+    "short": "Print zsh completion script"
+  },
+  {
+    "command": "wendy device",
+    "use": "wendy device",
+    "short": "Manage WendyOS devices"
+  },
+  {
+    "command": "wendy device apps",
+    "use": "wendy device apps",
+    "short": "Manage applications on the target device"
+  },
+  {
+    "command": "wendy device apps list",
+    "use": "wendy device apps list",
+    "short": "List deployed applications"
+  },
+  {
+    "command": "wendy device apps remove",
+    "use": "wendy device apps remove [app-name] [flags]",
+    "short": "Remove an application",
+    "flags": [
+      {
+        "name": "cleanup",
+        "usage": "Also delete the container image (frees disk space; agent-connected devices only)",
+        "default": "false"
+      },
+      {
+        "name": "delete-volumes",
+        "usage": "Also delete persistent volumes (/var/lib/wendy/volumes; agent-connected devices only)",
+        "default": "false"
+      },
+      {
+        "name": "force",
+        "usage": "Skip confirmation prompt",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy device apps start",
+    "use": "wendy device apps start [app-name] [flags]",
+    "short": "Start an application",
+    "flags": [
+      {
+        "name": "detach",
+        "shorthand": "d",
+        "usage": "Start without streaming output",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy device apps stop",
+    "use": "wendy device apps stop [app-name]",
+    "short": "Stop an application"
+  },
+  {
+    "command": "wendy device audio",
+    "use": "wendy device audio",
+    "short": "Manage audio devices on the target device"
+  },
+  {
+    "command": "wendy device audio list",
+    "use": "wendy device audio list",
+    "short": "List audio devices"
+  },
+  {
+    "command": "wendy device audio listen",
+    "use": "wendy device audio listen [flags]",
+    "short": "Stream raw audio from a device microphone",
+    "flags": [
+      {
+        "name": "channels",
+        "usage": "Number of audio channels",
+        "default": "1"
+      },
+      {
+        "name": "id",
+        "usage": "Audio device ID",
+        "default": "0"
+      },
+      {
+        "name": "sample-rate",
+        "usage": "Sample rate in Hz",
+        "default": "16000"
+      },
+      {
+        "name": "stdout",
+        "usage": "Write raw PCM to stdout instead of playing",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy device audio monitor",
+    "use": "wendy device audio monitor [flags]",
+    "short": "Real-time VU meter for audio levels",
+    "flags": [
+      {
+        "name": "id",
+        "usage": "Audio device ID",
+        "default": "0"
+      },
+      {
+        "name": "rate",
+        "usage": "Update rate in Hz",
+        "default": "10"
+      }
+    ]
+  },
+  {
+    "command": "wendy device audio set-default",
+    "use": "wendy device audio set-default [flags]",
+    "short": "Set the default audio device",
+    "flags": [
+      {
+        "name": "id",
+        "usage": "Audio device ID",
+        "default": "0"
+      }
+    ]
+  },
+  {
+    "command": "wendy device bluetooth",
+    "use": "wendy device bluetooth",
+    "short": "Manage Bluetooth on the target device"
+  },
+  {
+    "command": "wendy device bluetooth connect",
+    "use": "wendy device bluetooth connect [address] [flags]",
+    "short": "Connect to a Bluetooth peripheral",
+    "flags": [
+      {
+        "name": "pair",
+        "usage": "Pair with the device",
+        "default": "true"
+      },
+      {
+        "name": "trust",
+        "usage": "Trust the device",
+        "default": "true"
+      }
+    ]
+  },
+  {
+    "command": "wendy device bluetooth disconnect",
+    "use": "wendy device bluetooth disconnect [address]",
+    "short": "Disconnect a Bluetooth peripheral"
+  },
+  {
+    "command": "wendy device bluetooth forget",
+    "use": "wendy device bluetooth forget [address]",
+    "short": "Forget a paired Bluetooth peripheral"
+  },
+  {
+    "command": "wendy device bluetooth list",
+    "use": "wendy device bluetooth list",
+    "short": "Scan for Bluetooth peripherals"
+  },
+  {
+    "command": "wendy device camera",
+    "use": "wendy device camera",
+    "short": "Manage cameras on the target device"
+  },
+  {
+    "command": "wendy device camera list",
+    "use": "wendy device camera list",
+    "short": "List cameras"
+  },
+  {
+    "command": "wendy device camera view",
+    "use": "wendy device camera view [flags]",
+    "short": "Stream H.264 video from a device camera",
+    "flags": [
+      {
+        "name": "fps",
+        "usage": "Framerate (0 = device default)",
+        "default": "0"
+      },
+      {
+        "name": "height",
+        "usage": "Frame height (0 = device default)",
+        "default": "0"
+      },
+      {
+        "name": "id",
+        "usage": "Camera device ID",
+        "default": "0"
+      },
+      {
+        "name": "stdout",
+        "usage": "Pipe encoded video to stdout instead of opening a window (codec: H.264 or VP8/WebM depending on device capabilities)",
+        "default": "false"
+      },
+      {
+        "name": "width",
+        "usage": "Frame width (0 = device default)",
+        "default": "0"
+      }
+    ]
+  },
+  {
+    "command": "wendy device dashboard",
+    "use": "wendy device dashboard [flags]",
+    "short": "Live dashboard showing metrics and logs from a device",
+    "flags": [
+      {
+        "name": "app",
+        "usage": "Filter by application name"
+      }
+    ]
+  },
+  {
+    "command": "wendy device enroll",
+    "use": "wendy device enroll [flags]",
+    "short": "Enroll this device with Wendy Cloud or a local pki-core",
+    "flags": [
+      {
+        "name": "cloud-grpc",
+        "usage": "Cloud/pki-core gRPC endpoint to use (required when multiple auth sessions exist)"
+      },
+      {
+        "name": "name",
+        "usage": "Device name"
+      }
+    ]
+  },
+  {
+    "command": "wendy device hardware",
+    "use": "wendy device hardware",
+    "short": "Query hardware capabilities on the target device"
+  },
+  {
+    "command": "wendy device hardware list",
+    "use": "wendy device hardware list [flags]",
+    "short": "List hardware capabilities",
+    "flags": [
+      {
+        "name": "category",
+        "usage": "Filter by category (e.g., gpu, audio, camera)"
+      }
+    ]
+  },
+  {
+    "command": "wendy device info",
+    "use": "wendy device info [flags]",
+    "short": "Show agent version, OS, architecture, GPU, and hardware info for the target device",
+    "flags": [
+      {
+        "name": "check-updates",
+        "usage": "Check for available agent updates on GitHub",
+        "default": "false"
+      },
+      {
+        "name": "prerelease",
+        "usage": "Include prerelease (nightly) builds when checking for updates",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy device logs",
+    "use": "wendy device logs [flags]",
+    "short": "Stream logs from containers on the device",
+    "flags": [
+      {
+        "name": "app",
+        "usage": "Filter by application name"
+      },
+      {
+        "name": "level",
+        "usage": "Minimum log level (trace, debug, info, warn, error, fatal)"
+      },
+      {
+        "name": "min-severity",
+        "usage": "Minimum log severity number",
+        "default": "0"
+      },
+      {
+        "name": "service",
+        "usage": "Filter by service name"
+      },
+      {
+        "name": "tail",
+        "usage": "Replay the last N log batches before streaming live (0 = live only)",
+        "default": "0"
+      }
+    ]
+  },
+  {
+    "command": "wendy device ps",
+    "use": "wendy device ps",
+    "short": "List running containers (alias for 'apps list')"
+  },
+  {
+    "command": "wendy device set-default",
+    "use": "wendy device set-default [hostname]",
+    "short": "Set the default device hostname"
+  },
+  {
+    "command": "wendy device setup",
+    "use": "wendy device setup",
+    "short": "Interactive device setup: enroll, name, and configure WiFi"
+  },
+  {
+    "command": "wendy device telemetry-stream",
+    "use": "wendy device telemetry-stream [flags]",
+    "short": "Stream telemetry data (logs, metrics, traces) as JSONL",
+    "flags": [
+      {
+        "name": "app",
+        "usage": "Filter by application name"
+      },
+      {
+        "name": "logs",
+        "usage": "Include logs",
+        "default": "false"
+      },
+      {
+        "name": "metrics",
+        "usage": "Include metrics",
+        "default": "false"
+      },
+      {
+        "name": "service",
+        "usage": "Filter by service name"
+      },
+      {
+        "name": "traces",
+        "usage": "Include traces",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy device unset-default",
+    "use": "wendy device unset-default",
+    "short": "Clear the default device"
+  },
+  {
+    "command": "wendy device update",
+    "use": "wendy device update [flags]",
+    "short": "Update the agent binary on the target device",
+    "flags": [
+      {
+        "name": "binary",
+        "usage": "Path to a local agent binary to upload (skips download)"
+      },
+      {
+        "name": "nightly",
+        "usage": "Use the latest nightly (prerelease) build",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy device version",
+    "use": "wendy device version [flags]",
+    "short": "Show agent version, OS, architecture, GPU, and hardware info for the target device",
+    "hidden": true,
+    "flags": [
+      {
+        "name": "check-updates",
+        "usage": "Check for available agent updates on GitHub",
+        "default": "false"
+      },
+      {
+        "name": "prerelease",
+        "usage": "Include prerelease (nightly) builds when checking for updates",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy device volumes",
+    "use": "wendy device volumes",
+    "short": "Manage persistent volumes on the device"
+  },
+  {
+    "command": "wendy device volumes list",
+    "use": "wendy device volumes list",
+    "short": "List persistent volumes"
+  },
+  {
+    "command": "wendy device volumes remove",
+    "use": "wendy device volumes remove [name] [flags]",
+    "short": "Remove a persistent volume",
+    "flags": [
+      {
+        "name": "force",
+        "usage": "Skip confirmation prompt",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy device wifi",
+    "use": "wendy device wifi",
+    "short": "Manage WiFi on the target device"
+  },
+  {
+    "command": "wendy device wifi connect",
+    "use": "wendy device wifi connect [flags]",
+    "short": "Connect to a WiFi network",
+    "flags": [
+      {
+        "name": "password",
+        "usage": "WiFi network password"
+      },
+      {
+        "name": "ssid",
+        "usage": "WiFi network SSID"
+      }
+    ]
+  },
+  {
+    "command": "wendy device wifi disconnect",
+    "use": "wendy device wifi disconnect",
+    "short": "Disconnect from the current WiFi network"
+  },
+  {
+    "command": "wendy device wifi forget",
+    "use": "wendy device wifi forget [flags]",
+    "short": "Remove a known WiFi network",
+    "flags": [
+      {
+        "name": "ssid",
+        "usage": "SSID of the known network to forget"
+      }
+    ]
+  },
+  {
+    "command": "wendy device wifi list",
+    "use": "wendy device wifi list",
+    "short": "List available WiFi networks"
+  },
+  {
+    "command": "wendy device wifi rank",
+    "use": "wendy device wifi rank [flags]",
+    "short": "Set the autoconnect ranking of known WiFi networks",
+    "flags": [
+      {
+        "name": "order",
+        "usage": "Comma-separated list of SSIDs in priority order (highest first)"
+      },
+      {
+        "name": "priority",
+        "usage": "Autoconnect priority (higher = tried first)",
+        "default": "0"
+      },
+      {
+        "name": "ssid",
+        "usage": "SSID of the known network to rank"
+      }
+    ]
+  },
+  {
+    "command": "wendy device wifi status",
+    "use": "wendy device wifi status",
+    "short": "Get current WiFi connection status"
+  },
+  {
+    "command": "wendy discover",
+    "use": "wendy discover [flags]",
+    "short": "Discover WendyOS devices on the network",
+    "flags": [
+      {
+        "name": "timeout",
+        "usage": "Scan once for this duration then exit",
+        "default": "5s"
+      },
+      {
+        "name": "type",
+        "usage": "Discovery type: usb, lan, bluetooth, external, all",
+        "default": "all"
+      }
+    ]
+  },
+  {
+    "command": "wendy info",
+    "use": "wendy info",
+    "short": "Display CLI version and system information"
+  },
+  {
+    "command": "wendy init",
+    "use": "wendy init [app-id] [flags]",
+    "short": "Initialize a new Wendy project",
+    "flags": [
+      {
+        "name": "all-entitlements",
+        "usage": "Enable all entitlements (requires field flags for gpio, i2c, persist)",
+        "default": "false"
+      },
+      {
+        "name": "app-id",
+        "usage": "Application ID to write into wendy.json"
+      },
+      {
+        "name": "assistant",
+        "usage": "AI assistant to launch after init: claude, codex, or skip"
+      },
+      {
+        "name": "branch",
+        "usage": "Branch of the templates repo to use (default: main)"
+      },
+      {
+        "name": "entitlement",
+        "usage": "App entitlement to enable (repeatable or comma-separated)",
+        "default": "[]"
+      },
+      {
+        "name": "git-init",
+        "usage": "Initialize a git repo in the project directory (yes or no)"
+      },
+      {
+        "name": "gpio-pins",
+        "usage": "GPIO pins for the gpio entitlement (comma-separated, e.g. 17,27,22)"
+      },
+      {
+        "name": "i2c-device",
+        "usage": "I2C device path for the i2c entitlement (e.g. /dev/i2c-1)"
+      },
+      {
+        "name": "install-claude-skills",
+        "usage": "Install Wendy Claude skills before launching Claude",
+        "default": "false"
+      },
+      {
+        "name": "language",
+        "usage": "Project language: python, swift, rust, node, or cpp"
+      },
+      {
+        "name": "no-extra-entitlements",
+        "usage": "Skip entitlement prompts and use only the default network entitlement",
+        "default": "false"
+      },
+      {
+        "name": "persist-name",
+        "usage": "Container ID for the persist entitlement"
+      },
+      {
+        "name": "persist-path",
+        "usage": "Mount path for the persist entitlement (e.g. /data)"
+      },
+      {
+        "name": "target",
+        "usage": "Target platform: wendyos or wendy-lite"
+      },
+      {
+        "name": "template",
+        "usage": "Project template (e.g. simple-api, fullstack)"
+      },
+      {
+        "name": "var",
+        "usage": "Template variable override (repeatable, KEY=VALUE)",
+        "default": "[]"
+      }
+    ]
+  },
+  {
+    "command": "wendy json",
+    "use": "wendy json",
+    "short": "Inspect and validate wendy.json"
+  },
+  {
+    "command": "wendy json schema",
+    "use": "wendy json schema",
+    "short": "Print the JSON Schema for wendy.json"
+  },
+  {
+    "command": "wendy json validate",
+    "use": "wendy json validate [path]",
+    "short": "Validate a wendy.json file"
+  },
+  {
+    "command": "wendy mcp",
+    "use": "wendy mcp",
+    "short": "MCP server for AI assistant access to wendy devices"
+  },
+  {
+    "command": "wendy mcp serve",
+    "use": "wendy mcp serve [flags]",
+    "short": "Start the MCP server on stdio",
+    "flags": [
+      {
+        "name": "device",
+        "shorthand": "d",
+        "usage": "Device name or IP:port to connect on startup"
+      }
+    ]
+  },
+  {
+    "command": "wendy mcp setup",
+    "use": "wendy mcp setup",
+    "short": "Configure the Wendy MCP server in supported AI tools"
+  },
+  {
+    "command": "wendy os",
+    "use": "wendy os",
+    "short": "Manage the WendyOS operating system"
+  },
+  {
+    "command": "wendy os cache",
+    "use": "wendy os cache",
+    "short": "Manage cached OS images"
+  },
+  {
+    "command": "wendy os cache clear",
+    "use": "wendy os cache clear",
+    "short": "Clear all cached OS images"
+  },
+  {
+    "command": "wendy os cache list",
+    "use": "wendy os cache list",
+    "short": "List cached OS images"
+  },
+  {
+    "command": "wendy os download",
+    "use": "wendy os download [flags]",
+    "short": "Download a WendyOS image to the local cache",
+    "flags": [
+      {
+        "name": "overwrite",
+        "usage": "Overwrite cached image without prompting",
+        "default": "false"
+      },
+      {
+        "name": "version",
+        "usage": "OS version to download (interactive if omitted)"
+      }
+    ]
+  },
+  {
+    "command": "wendy os install",
+    "use": "wendy os install [image] [drive] [flags]",
+    "short": "Install WendyOS or Wendy Lite firmware on a device",
+    "flags": [
+      {
+        "name": "device-name",
+        "usage": "Set device name on first boot (e.g. brave-dolphin)"
+      },
+      {
+        "name": "device-type",
+        "usage": "Device type from manifest (e.g. raspberry-pi-5)"
+      },
+      {
+        "name": "drive",
+        "usage": "Target drive path (e.g. /dev/disk4)"
+      },
+      {
+        "name": "force",
+        "usage": "Skip confirmation prompt",
+        "default": "false"
+      },
+      {
+        "name": "nightly",
+        "usage": "Use nightly/prerelease builds",
+        "default": "false"
+      },
+      {
+        "name": "no-wifi",
+        "usage": "Skip WiFi setup entirely (no interactive prompt, no pre-seeded networks)",
+        "default": "false"
+      },
+      {
+        "name": "pre-enroll",
+        "usage": "Pre-enroll this device with Wendy Cloud during imaging (requires 'wendy auth login')",
+        "default": "false"
+      },
+      {
+        "name": "version",
+        "usage": "WendyOS version to install (interactive if omitted)"
+      },
+      {
+        "name": "wifi",
+        "usage": "Pre-configure a WiFi network. Repeatable. Format: ssid=X[,password=Y][,priority=N][,hidden=true][,security=wpa2]",
+        "default": "[]"
+      },
+      {
+        "name": "wifi-password",
+        "usage": "Password for --wifi-ssid"
+      },
+      {
+        "name": "wifi-ssid",
+        "usage": "Pre-configure a single WiFi SSID on first boot (shortcut for --wifi)"
+      },
+      {
+        "name": "yes-overwrite-internal",
+        "usage": "Required to wipe an internal (non-removable) drive in non-interactive mode",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy os list-drives",
+    "use": "wendy os list-drives [flags]",
+    "short": "List available drives",
+    "flags": [
+      {
+        "name": "all",
+        "usage": "List all external drives, including non-removable ones",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy os update",
+    "use": "wendy os update [artifact-path] [flags]",
+    "short": "Update WendyOS on the target device",
+    "flags": [
+      {
+        "name": "artifact-url",
+        "usage": "Mender artifact URL (remote)"
+      },
+      {
+        "name": "nightly",
+        "usage": "Use the latest nightly (prerelease) build for both agent and OS",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy project",
+    "use": "wendy project",
+    "short": "Manage Wendy project configuration"
+  },
+  {
+    "command": "wendy project entitlements",
+    "use": "wendy project entitlements",
+    "short": "Manage project entitlements"
+  },
+  {
+    "command": "wendy project entitlements add",
+    "use": "wendy project entitlements add [type]",
+    "short": "Add an entitlement to the project"
+  },
+  {
+    "command": "wendy project entitlements list",
+    "use": "wendy project entitlements list [flags]",
+    "short": "List project entitlements",
+    "flags": [
+      {
+        "name": "show-all",
+        "usage": "Show all available entitlement types",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy project entitlements remove",
+    "use": "wendy project entitlements remove [type]",
+    "short": "Remove an entitlement from the project"
+  },
+  {
+    "command": "wendy run",
+    "use": "wendy run [flags]",
+    "short": "Build and run application on a WendyOS device",
+    "flags": [
+      {
+        "name": "build-type",
+        "usage": "Build type to use when Dockerfile is present alongside Package.swift or Python project markers: docker, swift, or python"
+      },
+      {
+        "name": "debug",
+        "usage": "Enable debug logging",
+        "default": "false"
+      },
+      {
+        "name": "deploy",
+        "usage": "Create container but do not start it",
+        "default": "false"
+      },
+      {
+        "name": "detach",
+        "usage": "Start container but do not stream logs",
+        "default": "false"
+      },
+      {
+        "name": "dockerfile",
+        "usage": "Dockerfile to build from (e.g. Dockerfile.prod); shows a selection menu when multiple Dockerfiles exist"
+      },
+      {
+        "name": "no-restart",
+        "usage": "Do not restart on exit",
+        "default": "false"
+      },
+      {
+        "name": "prefix",
+        "usage": "Project directory to run from instead of the current working directory"
+      },
+      {
+        "name": "product",
+        "usage": "Swift Package Manager product to build and run"
+      },
+      {
+        "name": "restart-on-failure",
+        "usage": "Restart on failure",
+        "default": "false"
+      },
+      {
+        "name": "restart-unless-stopped",
+        "usage": "Restart unless manually stopped",
+        "default": "false"
+      },
+      {
+        "name": "service",
+        "usage": "Build and run only the named service and its dependencies (multi-service projects)"
+      },
+      {
+        "name": "user-args",
+        "usage": "Extra arguments to pass to the container",
+        "default": "[]"
+      },
+      {
+        "name": "yes",
+        "shorthand": "y",
+        "usage": "Automatically accept all interactive prompts",
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "command": "wendy tour",
+    "use": "wendy tour",
+    "short": "Interactive guided setup tour for new users"
+  },
+  {
+    "command": "wendy utils",
+    "use": "wendy utils",
+    "short": "Utility commands"
+  },
+  {
+    "command": "wendy utils open-browser",
+    "use": "wendy utils open-browser \u003curl\u003e",
+    "short": "Open a URL in the default browser"
+  }
+]

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,151 @@
+# WDY-1509 — Manually audit CLI surface against E2E stubs across Linux and Mac
+
+You are working in the dedicated issue worktree:
+
+`/Volumes/Projects/WendyLabs/wendy-agent/.worktrees/kb.wdy-1509-cli-e2e-surface-audit`
+
+Branch: `kb.wdy-1509-cli-e2e-surface-audit`
+Draft PR: https://github.com/wendylabsinc/WendyOS/pull/982
+Linear: https://linear.app/wendylabsinc/issue/WDY-1509/manually-audit-cli-surface-against-e2e-stubs-across-linux-and-mac
+
+## Goal
+
+WDY-1509 is now the umbrella/manual audit issue for the current `wendy` CLI
+surface. Preserve the generated command surface dump, the lightweight Swift E2E
+surface ledger, and the PR summary so the focused child issues can continue the
+actual cleanup/reference work.
+
+The durable coordinator plan lives at:
+
+`/Volumes/Projects/WendyLabs/wendy-agent/.worktrees/kb.macos-beta/PLAN.md`
+
+Use that coordinator plan for WDY-1511 through WDY-1517. Do not continue broad
+implementation/reference cleanup in this WDY-1509 PR.
+
+## Scope
+
+Do:
+
+- Preserve the generated command tree snapshot and note how it was produced.
+- Preserve a lightweight command ledger or equivalent notes.
+- Keep the ledger organized by the child issues now tracking the focused work:
+  WDY-1511 through WDY-1517.
+- Record known hidden/internal/deprecated/alias observations that child issues
+  need for handoff.
+- Update PR #982 with the narrow umbrella scope, validation, and child issue
+  handoff.
+
+Do not in this PR:
+
+- Continue broad Swift E2E implementation/reference cleanup.
+- Add or split E2E suites for the bucketed child issue work.
+- Sample additional device/cloud routes unless needed to keep the umbrella
+  ledger truthful.
+- File new follow-ups unless the umbrella ledger uncovers a missing coordinator
+  item.
+
+Avoid:
+
+- a full E2E infrastructure rewrite,
+- requiring every CLI command to become automated immediately,
+- broad new DSL work unless the current Swift Testing structure truly cannot
+  express what is needed,
+- mixing unrelated product fixes into the same PR,
+- changing Wendy for Mac public support promises.
+
+Tiny fixes are acceptable only if needed to make references truthful.
+
+## Useful starting points
+
+Command/help surface:
+
+```sh
+cd go
+make build-cli
+./bin/wendy --experimental-dump-help > ../.cli-surface-WDY-1509.json
+```
+
+If the built binary path differs, use the locally built `wendy` binary and record
+it in the PR.
+
+Existing E2E tests/stubs:
+
+- `swift/WendyE2ETests/Tests/WendyE2ETests/`
+- `swift/WendyE2ETests/Sources/WendyE2ETesting/`
+- `swift/WendyE2ETests/Tests/WendyE2ETestingTests/`
+- `swift/WendyE2ETests/README.md`
+
+Related recent work:
+
+- WDY-1481 — local E2E matrix coverage for macOS↔macOS and Ubuntu↔Ubuntu.
+- WDY-1494 — Swift E2E route matrix / commented route ledger cleanup.
+
+Related Mac-beta backlog/stub issues:
+
+- WDY-1349 — Audit CLI commands against Mac beta support matrix.
+- WDY-1364 — Review Swift E2E suite against Mac beta contract.
+- WDY-1381 — Add platform-aware Swift E2E spec gates and reference rendering.
+- WDY-1382 / WDY-1383 / WDY-1384 — smaller Mac-specific E2E specs.
+
+## Current narrow workflow
+
+1. Keep `.cli-surface-WDY-1509.json` as the captured surface snapshot.
+2. Keep `swift/WendyE2ETests/CLI_SURFACE_LEDGER.md` as the handoff ledger for
+   child issues, not as a fully reviewed contract.
+3. Keep `PLAN.md` and this handover aligned with the coordinator plan's
+   umbrella-only scope.
+4. Validate only the lightweight artifacts touched here.
+5. Update PR #982 body with:
+   - how the command surface was captured,
+   - what the ledger preserves,
+   - which child issue owns each follow-up bucket,
+   - what was intentionally left out of WDY-1509.
+6. Leave WDY-1511 through WDY-1517 to their dedicated issue worktrees.
+
+## Validation expectations
+
+For the current umbrella-only PR, no Swift/Go behavior should change. Run
+lightweight artifact validation instead, for example:
+
+```sh
+python3 -m json.tool .cli-surface-WDY-1509.json >/tmp/cli-surface-WDY-1509.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+items = json.loads(Path('.cli-surface-WDY-1509.json').read_text())
+commands = {item['command'] for item in items}
+leaf = [item for item in items if not any(
+    other != item['command'] and other.startswith(item['command'] + ' ')
+    for other in commands
+)]
+assert len(items) == 135
+assert len(leaf) == 106
+PY
+git diff --check
+```
+
+If a future WDY-1509 edit touches Swift E2E code or references, run the relevant
+Swift tests under `swift/WendyE2ETests` and document the command in the PR body.
+
+## Expected PR output
+
+- Keep `Closes WDY-1509` in the PR body.
+- Keep commits small and reviewable.
+- Push all commits to `kb.wdy-1509-cli-e2e-surface-audit`.
+- File follow-up Linear issues for product bugs or larger automation gaps rather
+  than expanding this PR indefinitely.
+
+## Current state
+
+- Linear is assigned to `konstantin@wendy.sh`, in the `E2E Tests` project, and
+  moved to In Progress.
+- WDY-1509 is the umbrella/manual audit. Focused work is tracked by:
+  - WDY-1511 — completion install hidden test seam.
+  - WDY-1512 — hidden/deprecated/public alias policy.
+  - WDY-1513 — host-only CLI E2E references.
+  - WDY-1514 — OS imaging and update E2E references.
+  - WDY-1515 — direct device command E2E references.
+  - WDY-1516 — cloud-routed device E2E references.
+  - WDY-1517 — build and run E2E references.
+- Draft PR #982 should remain a small umbrella artifact PR with
+  `Closes WDY-1509`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,348 @@
+# WDY-1509 CLI Surface Audit Plan
+
+## Goal
+
+WDY-1509 is now the umbrella/manual audit issue for the current `wendy` CLI
+surface. This worktree preserves the generated command surface dump, the
+lightweight Swift E2E surface ledger, and the PR summary that hand off focused
+cleanup/reference work to WDY-1511 through WDY-1517.
+
+The coordinator source of truth for the child issue sequence is:
+
+`/Volumes/Projects/WendyLabs/wendy-agent/.worktrees/kb.macos-beta/PLAN.md`
+
+Do not continue broad implementation/reference cleanup from this WDY-1509
+worktree.
+
+## Ground Rules
+
+- Keep WDY-1509 small: command surface dump, ledger, handoff notes, and PR body.
+- Do not edit Swift E2E stubs/references here; use WDY-1511 through WDY-1517.
+- Prefer lightweight notes/ledger updates over broad framework work.
+- Keep product fixes out of this PR.
+- File additional follow-ups only if the umbrella ledger finds a missing child
+  issue in the coordinator plan.
+- Keep commits small and bucketed by concern.
+
+## Current Observations
+
+- `go/bin/wendy --experimental-dump-help` is not supported by the current local build.
+- A temporary Cobra walker was used to generate `.cli-surface-WDY-1509.json` from `commands.NewRootCmd()`.
+- The dump found 135 non-internal commands including hidden deprecated compatibility commands, with 106 leaf commands.
+- Hidden/internal command surface observed:
+  - `wendy __ble-check` is an internal subprocess helper for CoreBluetooth probing and should stay excluded from user-facing E2E reference coverage.
+- Hidden deprecated compatibility commands observed:
+  - `wendy device version`
+  - `wendy cloud device version`
+  - `wendy cloud run`
+- Public alias commands observed:
+  - `wendy device ps` is surfaced in help as an alias for `wendy device apps list`.
+  - `wendy cloud device ps` is surfaced in help as an alias for `wendy cloud device apps list`.
+- Cobra aliases observed:
+  - `wendy device bluetooth` accepts `bt`.
+  - `wendy cloud device bluetooth` accepts `bt`.
+- Hidden test seam observed:
+  - `wendy completion install --output-dir`, which is misleading because it overrides the home directory used to compute install paths rather than selecting an output directory. Follow-up filed as WDY-1511.
+- Hidden/deprecated/public alias policy needs a focused cleanup pass for `device version`, `cloud device version`, `cloud run`, public `ps` aliases, and Bluetooth `bt`. Follow-up filed as WDY-1512.
+- WDY-1509 is now the umbrella audit issue. Ordered child issues WDY-1511 through WDY-1517 track focused cleanup/alignment passes.
+- `swift/WendyE2ETests/CLI_SURFACE_LEDGER.md` is a starting ledger and child
+  issue handoff map, not yet the reviewed source of truth.
+
+## Audit Buckets
+
+Review by bucket, not alphabetically.
+
+### A. Host-only CLI/config commands
+
+Examples:
+
+- `wendy analytics ...`
+- `wendy auth ...`
+- `wendy cache ...`
+- `wendy completion ...`
+- `wendy info`
+- `wendy init`
+- `wendy json ...`
+- `wendy mcp ...`
+- `wendy project ...`
+- `wendy tour`
+- `wendy utils open-browser`
+
+Questions:
+
+- Does the command require any agent/device?
+- Are Mac vs Linux differences limited to filesystem, shell, browser, or tool detection?
+- Do existing stubs accidentally imply device behavior?
+- Are JSON/help/no-state-change expectations accurate?
+
+### B. Host OS image-management commands
+
+Examples:
+
+- `wendy os cache ...`
+- `wendy os download`
+- `wendy os install`
+- `wendy os list-drives`
+
+Questions:
+
+- Is the command host-only?
+- Which host platforms are supported?
+- Does macOS have real behavior, degraded behavior, or explicit unsupported behavior?
+- Are destructive install paths clearly gated in reference prose?
+- Are JSON/reference expectations truthful for platform-specific drive metadata?
+
+### C. WendyOS OTA/device OS update commands
+
+Example:
+
+- `wendy os update`
+
+Questions:
+
+- Does the command require a WendyOS OTA-capable Linux target?
+- What is the expected behavior against a plain Linux agent?
+- What is the expected behavior against a Darwin/macOS agent?
+- Do stubs explicitly state that macOS agents are unsupported for WendyOS OTA?
+- Does failure happen before artifact serving or destructive side effects?
+
+### D. Direct local agent commands
+
+Examples:
+
+- `wendy device info`
+- `wendy device apps ...`
+- `wendy device logs`
+- `wendy device wifi ...`
+- `wendy device bluetooth ...`
+- `wendy device camera ...`
+- `wendy device hardware ...`
+- `wendy device volumes ...`
+- `wendy device dashboard`
+- `wendy device telemetry-stream`
+
+Questions:
+
+- Is this a full Linux/WendyOS support path?
+- Does Wendy Agent for Mac support this path?
+- If unsupported on Mac, is the expected diagnostic explicit?
+- Does the CLI return a macOS beta unsupported message when the agent returns `Unimplemented`?
+- Does the existing E2E prose overpromise Mac support?
+- Is this practical to automate today, or should it remain a disabled reference stub?
+
+### E. Cloud/tunnel agent commands
+
+Examples:
+
+- `wendy cloud device ...`
+- `wendy cloud tunnel`
+- hidden `wendy cloud run`
+
+Questions:
+
+- Is behavior the same as the direct route after tunnel establishment?
+- Does cloud auth/session validation happen before device mutation?
+- Are broker/tunnel errors distinguished from agent errors?
+- Do cloud stubs capture auth and tunnel semantics instead of merely duplicating direct-route prose?
+- Are hidden cloud aliases represented appropriately?
+
+### F. Build/run commands
+
+Examples:
+
+- `wendy build`
+- `wendy run`
+- hidden `wendy cloud run`
+
+Questions:
+
+- What host OS build paths are supported?
+- What target OS deploy paths are supported?
+- Does Darwin target mean native macOS app deployment, not Linux containers?
+- Are Linux containers on Mac agents explicitly unsupported?
+- Do existing stubs accidentally overpromise Mac container support?
+- Which build/run paths are reasonable E2E candidates vs manual/reference-only?
+
+## Ledger Review Process
+
+For every leaf command, track:
+
+```text
+command
+public/hidden/deprecated?
+host-only / direct-agent / cloud-agent / OS-imaging / build-deploy?
+Linux/WendyOS expectation
+macOS/Darwin expectation
+existing Swift E2E suite?
+gap/mismatch?
+manual sample needed?
+follow-up issue needed?
+```
+
+Use `.cli-surface-WDY-1509.json` and `swift/WendyE2ETests/CLI_SURFACE_LEDGER.md`
+as inputs, but treat the ledger as draft until manually reviewed.
+
+## Cross-Reference Process
+
+For each command bucket, compare against:
+
+- `swift/WendyE2ETests/Tests/WendyE2ETests/`
+- `swift/WendyE2ETests/Sources/WendyE2ETesting/`
+- `swift/WendyE2ETests/Tests/WendyE2ETestingTests/`
+- `swift/WendyE2ETests/README.md`
+
+Check:
+
+- Does a suite exist for the command or is the command intentionally covered by an alias/related suite?
+- Does the suite name match the command phrase?
+- If the command is hidden/deprecated, is that called out?
+- Does the prose distinguish direct local route vs cloud route?
+- Does the prose distinguish host-only behavior vs agent-target behavior?
+- Are Linux/WendyOS-specific expectations explicit?
+- Are macOS/Darwin-supported expectations explicit?
+- Are intentionally unsupported macOS beta paths explicit?
+- Are impractical-to-automate paths disabled with a useful reason?
+
+## Manual Sampling Strategy
+
+Do not run every command. Sample representative commands where classification or
+behavior is unclear.
+
+### Help shape
+
+```sh
+cd go
+make build-cli
+./bin/wendy --help
+./bin/wendy device --help
+./bin/wendy cloud device --help
+./bin/wendy os --help
+./bin/wendy run --help
+```
+
+Hidden aliases:
+
+```sh
+./bin/wendy device version --help
+./bin/wendy device ps --help
+./bin/wendy cloud device version --help
+./bin/wendy cloud device ps --help
+./bin/wendy cloud run --help
+```
+
+### No-device behavior
+
+```sh
+./bin/wendy --json device info
+./bin/wendy --json device hardware list
+./bin/wendy --json device wifi list
+./bin/wendy --json os update
+```
+
+### Host-only JSON/help behavior
+
+```sh
+./bin/wendy info --json
+./bin/wendy cache list --json
+./bin/wendy os cache list --json
+```
+
+### macOS beta unsupported checks
+
+If a Darwin/macOS agent route is available, sample:
+
+```sh
+wendy --device <mac-agent> device hardware list
+wendy --device <mac-agent> device wifi list
+wendy --device <mac-agent> device wifi status
+wendy --device <mac-agent> device camera list
+wendy --device <mac-agent> device bluetooth list
+wendy --device <mac-agent> os update
+```
+
+Goal: confirm diagnostics and side-effect boundaries, not create full automation.
+
+## Edit Strategy
+
+For this WDY-1509 worktree, edit only umbrella artifacts:
+
+1. Preserve `.cli-surface-WDY-1509.json` as the generated command surface
+   snapshot.
+2. Preserve `swift/WendyE2ETests/CLI_SURFACE_LEDGER.md` as the ledger and child
+   issue handoff map.
+3. Keep `HANDOVER.md`, this `PLAN.md`, and PR #982 aligned with the coordinator
+   plan.
+
+Leave implementation/reference cleanup to the child issues:
+
+- WDY-1511 handles the completion install hidden test seam.
+- WDY-1512 handles hidden/deprecated/public alias policy.
+- WDY-1513 handles host-only CLI references.
+- WDY-1514 handles OS imaging and update references.
+- WDY-1515 handles direct device command references.
+- WDY-1516 handles cloud-routed device references.
+- WDY-1517 handles build and run references.
+
+## Issue Breakdown
+
+WDY-1509 remains the umbrella/manual audit issue. Focused child issues are ordered
+as follows in Linear:
+
+1. WDY-1511 — Remove misleading hidden completion install `--output-dir` test seam.
+2. WDY-1512 — Audit and align hidden/deprecated CLI aliases.
+3. WDY-1513 — Align host-only CLI E2E references.
+4. WDY-1514 — Align OS imaging and update E2E references.
+5. WDY-1515 — Align direct device command E2E references.
+6. WDY-1516 — Align cloud-routed device E2E references.
+7. WDY-1517 — Align build and run E2E references.
+
+Use WDY-1509 to keep the command surface ledger and PR summary coherent. Use the
+child issues for implementation/reference cleanup so this PR does not grow into
+a full E2E rewrite.
+
+## Potential Follow-Up Issues
+
+File additional Linear issues instead of expanding this PR for:
+
+- Missing or broken `--experimental-dump-help` support.
+- Misleading command help not already covered by WDY-1511 or WDY-1512.
+- Incorrect macOS beta unsupported diagnostics.
+- Cloud route behavior that diverges unexpectedly from direct route behavior.
+- Hidden aliases that should be removed, documented, or explicitly deprecated beyond WDY-1512 scope.
+- JSON contract mismatches.
+- Larger E2E framework gaps or missing deterministic seams.
+
+## Validation
+
+For the current umbrella-only artifacts, run lightweight validation:
+
+```sh
+python3 -m json.tool .cli-surface-WDY-1509.json >/tmp/cli-surface-WDY-1509.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+items = json.loads(Path('.cli-surface-WDY-1509.json').read_text())
+commands = {item['command'] for item in items}
+leaf = [item for item in items if not any(
+    other != item['command'] and other.startswith(item['command'] + ' ')
+    for other in commands
+)]
+assert len(items) == 135
+assert len(leaf) == 106
+PY
+git diff --check
+```
+
+If a later WDY-1509 edit touches Swift E2E code or references, run the relevant
+Swift tests under `swift/WendyE2ETests` and document the command in the PR body.
+
+## PR Notes to Maintain
+
+The PR body should eventually include:
+
+- What command surface was reviewed.
+- How the surface was generated, especially because `--experimental-dump-help` is currently unavailable.
+- Which stubs/references changed.
+- Which commands/routes remain intentionally manual or out of automation scope.
+- Which follow-up Linear issues were filed.
+- `Closes WDY-1509`.

--- a/swift/WendyE2ETests/CLI_SURFACE_LEDGER.md
+++ b/swift/WendyE2ETests/CLI_SURFACE_LEDGER.md
@@ -1,0 +1,161 @@
+# WDY-1509 CLI Surface Ledger
+
+This ledger preserves the post-beta CLI surface snapshot for WDY-1509 and maps
+each leaf command to its current Swift E2E reference suite. Treat it as the
+umbrella handoff ledger for WDY-1511 through WDY-1517, not as a fully reviewed
+source of truth.
+
+## Surface dump
+
+- Built CLI: `go/bin/wendy` from this worktree with `make build-cli`.
+- `wendy --experimental-dump-help` is not present in the current binary; the command tree below was generated from `commands.NewRootCmd()` with a temporary Cobra walker.
+- Commands found: 135 total non-internal commands including hidden deprecated compatibility commands; 106 leaf commands.
+- The generated dump intentionally excludes the internal `wendy __ble-check` helper from the leaf command map.
+
+## Hidden/internal commands and aliases
+
+| Surface | Classification | Audit note |
+| --- | --- | --- |
+| `wendy __ble-check` | Internal hidden command | CoreBluetooth subprocess helper. Exclude from user-facing E2E reference coverage. |
+| `wendy device version` | Hidden deprecated compatibility command | Alias-like predecessor for `wendy device info`. Human mode warns; JSON/non-interactive output should remain clean. Covered by WDY-1512 follow-up policy work. |
+| `wendy cloud device version` | Hidden deprecated compatibility command | Cloud-routed predecessor for `wendy cloud device info`. Should warn in human mode and remain clean in JSON/non-interactive mode. Covered by WDY-1512 follow-up policy work. |
+| `wendy cloud run` | Hidden deprecated command | Delegates to `wendy run` with cloud context. Covered by WDY-1512 follow-up policy work. |
+| `wendy device ps` | Public alias command | Surfaced in `wendy device --help` as an alias for `wendy device apps list`. Covered by WDY-1512 follow-up policy work. |
+| `wendy cloud device ps` | Public alias command | Surfaced in `wendy cloud device --help` as an alias for `wendy cloud device apps list`. Covered by WDY-1512 follow-up policy work. |
+| `wendy device bluetooth` / `wendy device bt` | Cobra alias | `bt` is accepted and appears in the Bluetooth command's own help. Covered by WDY-1512 follow-up policy work. |
+| `wendy cloud device bluetooth` / `wendy cloud device bt` | Cobra alias | Cloud-routed mirror of the Bluetooth `bt` alias. Covered by WDY-1512 follow-up policy work. |
+| `wendy completion install --output-dir` | Hidden test seam | Misleading home-directory override used by tests. Cleanup tracked separately in WDY-1511. |
+
+## Route/platform buckets
+
+| Bucket | Commands | Current expectation |
+| --- | --- | --- |
+| Host-only CLI/config | `analytics`, `auth`, `cache`, `completion`, `info`, `init`, `json`, `mcp`, `project`, `tour`, `utils open-browser` | Runs on developer host; Mac/Linux differences are host filesystem, shell, browser, and tool-detection behavior only. |
+| Host OS imaging | `os cache`, `os download`, `os install`, `os list-drives` | Runs on developer host; drive enumeration/install has platform-specific implementations. Unsupported host platforms should fail before destructive actions. |
+| WendyOS OTA | `os update` | Requires a WendyOS OTA-capable target. Linux host agents and Darwin/macOS agents intentionally fail with unsupported-OS guidance. |
+| Direct local agent | `device ...` | Direct gRPC/BLE route to selected target. Linux/WendyOS is the full feature target; Darwin/macOS agent is beta and only selected app/native-process paths are expected. |
+| Cloud/tunnel agent | `cloud device ...`, `cloud tunnel`, hidden `cloud run` | Authenticated Wendy Cloud route. Device subcommands use the same agent semantics as direct routes after tunnel establishment. |
+| Not practical for fully automated E2E yet | live dashboards, long streams, audio/video playback, OS flashing, Wi-Fi/Bluetooth mutation, cloud auth/browser flows | Kept as disabled Swift Testing reference specs unless the harness already has a deterministic seam. |
+
+## Child issue handoff
+
+| Issue | Owns | Ledger rows / observations to start from |
+| --- | --- | --- |
+| WDY-1511 | Completion install hidden test seam | `wendy completion install --output-dir`; confirm the test-only home-directory override is removed or renamed without changing public completion behavior. |
+| WDY-1512 | Hidden/deprecated/public alias policy | `wendy device version`, `wendy cloud device version`, hidden `wendy cloud run`, public `device ps` / `cloud device ps`, and Bluetooth `bt` aliases. |
+| WDY-1513 | Host-only CLI E2E references | `analytics`, `auth`, `cache`, `completion`, `info`, `init`, `json`, `mcp`, `project`, `tour`, `utils open-browser`, plus host discovery semantics where relevant. |
+| WDY-1514 | OS imaging and update E2E references | `os cache`, `os download`, `os install`, `os list-drives`, and WendyOS-only `os update` behavior against non-OTA Linux or Darwin agents. |
+| WDY-1515 | Direct device command E2E references | Public `device ...` routes, including app/native-process beta paths and macOS unsupported diagnostics for hardware, camera, Wi-Fi, Bluetooth, audio, volumes, streams, and dashboards. |
+| WDY-1516 | Cloud-routed device E2E references | `cloud discover`, `cloud enroll-device`, `cloud tunnel`, and public `cloud device ...` routes, with auth/tunnel errors distinguished from agent errors. |
+| WDY-1517 | Build and run E2E references | `wendy build`, `wendy run`, and hidden `wendy cloud run`; separate host build behavior from target deployment behavior, and keep Darwin target support limited to native macOS apps. |
+
+## Leaf command map
+
+| Command | Surface | E2E suite | Route / platform expectation |
+| --- | --- | --- | --- |
+| `wendy analytics disable` | public | `WendyAnalyticsDisableTests.swift` | Host-only CLI/config command. |
+| `wendy analytics enable` | public | `WendyAnalyticsEnableTests.swift` | Host-only CLI/config command. |
+| `wendy analytics status` | public | `WendyAnalyticsStatusTests.swift` | Host-only CLI/config command. |
+| `wendy auth login` | public | `WendyAuthLoginTests.swift` | Host-only CLI/config command. |
+| `wendy auth logout` | public | `WendyAuthLogoutTests.swift` | Host-only CLI/config command. |
+| `wendy auth refresh-certs` | public | `WendyAuthRefreshCertsTests.swift` | Host-only CLI/config command. |
+| `wendy auth status` | public | `WendyAuthStatusTests.swift` | Host-only CLI/config command. |
+| `wendy build` | public | `WendyBuildTests.swift` | Host build route; macOS/Linux hosts supported for Swift image builds, Docker/provider availability controls other paths. |
+| `wendy cache clear` | public | `WendyCacheClearTests.swift` | Host-only CLI/config command. |
+| `wendy cache list` | public | `WendyCacheListTests.swift` | Host-only CLI/config command. |
+| `wendy cloud device apps list` | public | `WendyCloudDeviceAppsListTests.swift` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device apps remove` | public | `WendyCloudDeviceAppsRemoveTests.swift` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device apps start` | public | `WendyCloudDeviceAppsStartTests.swift` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device apps stop` | public | `WendyCloudDeviceAppsStopTests.swift` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device audio list` | public | `WendyCloudDeviceAudioListTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device audio listen` | public | `WendyCloudDeviceAudioListenTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device audio monitor` | public | `WendyCloudDeviceAudioMonitorTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device audio set-default` | public | `WendyCloudDeviceAudioSetDefaultTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device bluetooth connect` | public | `WendyCloudDeviceBluetoothConnectTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device bluetooth disconnect` | public | `WendyCloudDeviceBluetoothDisconnectTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device bluetooth forget` | public | `WendyCloudDeviceBluetoothForgetTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device bluetooth list` | public | `WendyCloudDeviceBluetoothListTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device camera list` | public | `WendyCloudDeviceCameraListTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device camera view` | public | `WendyCloudDeviceCameraViewTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device dashboard` | public | `WendyCloudDeviceDashboardTests.swift` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device enroll` | public | `WendyCloudDeviceEnrollTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device hardware list` | public | `WendyCloudDeviceHardwareListTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device info` | public | `MISSING` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device logs` | public | `WendyCloudDeviceLogsTests.swift` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device ps` | public | `MISSING` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device set-default` | public | `WendyCloudDeviceSetDefaultTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device setup` | public | `WendyCloudDeviceSetupTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device telemetry-stream` | public | `WendyCloudDeviceTelemetryStreamTests.swift` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device unset-default` | public | `WendyCloudDeviceUnsetDefaultTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device update` | public | `WendyCloudDeviceUpdateTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device version` | hidden | `WendyCloudDeviceVersionTests.swift` | Cloud tunnel to agent; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy cloud device volumes list` | public | `WendyCloudDeviceVolumesListTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device volumes remove` | public | `WendyCloudDeviceVolumesRemoveTests.swift` | Cloud tunnel to agent. Linux/WendyOS target expected unless command documents macOS beta support/unsupported behavior. |
+| `wendy cloud device wifi connect` | public | `WendyCloudDeviceWifiConnectTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device wifi disconnect` | public | `WendyCloudDeviceWifiDisconnectTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device wifi forget` | public | `WendyCloudDeviceWifiForgetTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device wifi list` | public | `WendyCloudDeviceWifiListTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device wifi rank` | public | `WendyCloudDeviceWifiRankTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud device wifi status` | public | `WendyCloudDeviceWifiStatusTests.swift` | Cloud tunnel to agent; Linux/WendyOS feature path, with macOS beta unsupported diagnostics expected for hardware/camera/Wi-Fi/Bluetooth probe paths. |
+| `wendy cloud discover` | public | `WendyCloudDiscoverTests.swift` | Host-to-Wendy Cloud route; no local agent required unless command opens a tunnel. |
+| `wendy cloud enroll-device` | public | `WendyCloudEnrollDeviceTests.swift` | Host-to-Wendy Cloud route; no local agent required unless command opens a tunnel. |
+| `wendy cloud run` | hidden | `WendyCloudRunTests.swift` | Hidden deprecated cloud alias for wendy run; cloud/tunnel route. |
+| `wendy cloud tunnel` | public | `WendyCloudTunnelTests.swift` | Host-to-Wendy Cloud route; no local agent required unless command opens a tunnel. |
+| `wendy completion bash` | public | `WendyCompletionBashTests.swift` | Host-only CLI/config command. |
+| `wendy completion fish` | public | `WendyCompletionFishTests.swift` | Host-only CLI/config command. |
+| `wendy completion install` | public | `WendyCompletionInstallTests.swift` | Host-only CLI/config command. |
+| `wendy completion powershell` | public | `WendyCompletionPowershellTests.swift` | Host-only CLI/config command. |
+| `wendy completion zsh` | public | `WendyCompletionZshTests.swift` | Host-only CLI/config command. |
+| `wendy device apps list` | public | `WendyDeviceAppsListTests.swift` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device apps remove` | public | `WendyDeviceAppsRemoveTests.swift` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device apps start` | public | `WendyDeviceAppsStartTests.swift` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device apps stop` | public | `WendyDeviceAppsStopTests.swift` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device audio list` | public | `WendyDeviceAudioListTests.swift` | Direct local agent route. |
+| `wendy device audio listen` | public | `WendyDeviceAudioListenTests.swift` | Direct local agent route. |
+| `wendy device audio monitor` | public | `WendyDeviceAudioMonitorTests.swift` | Direct local agent route. |
+| `wendy device audio set-default` | public | `WendyDeviceAudioSetDefaultTests.swift` | Direct device-management route; host config/cloud enrollment plus target-specific agent behavior. |
+| `wendy device bluetooth connect` | public | `WendyDeviceBluetoothConnectTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device bluetooth disconnect` | public | `WendyDeviceBluetoothDisconnectTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device bluetooth forget` | public | `WendyDeviceBluetoothForgetTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device bluetooth list` | public | `WendyDeviceBluetoothListTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device camera list` | public | `WendyDeviceCameraListTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device camera view` | public | `WendyDeviceCameraViewTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device dashboard` | public | `WendyDeviceDashboardTests.swift` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device enroll` | public | `WendyDeviceEnrollTests.swift` | Direct device-management route; host config/cloud enrollment plus target-specific agent behavior. |
+| `wendy device hardware list` | public | `WendyDeviceHardwareListTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device info` | public | `WendyDeviceInfoTests.swift` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device logs` | public | `WendyDeviceLogsTests.swift` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device ps` | public | `MISSING` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device set-default` | public | `WendyDeviceSetDefaultTests.swift` | Direct device-management route; host config/cloud enrollment plus target-specific agent behavior. |
+| `wendy device setup` | public | `WendyDeviceSetupTests.swift` | Direct device-management route; host config/cloud enrollment plus target-specific agent behavior. |
+| `wendy device telemetry-stream` | public | `WendyDeviceTelemetryStreamTests.swift` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device unset-default` | public | `WendyDeviceUnsetDefaultTests.swift` | Direct device-management route; host config/cloud enrollment plus target-specific agent behavior. |
+| `wendy device update` | public | `WendyDeviceUpdateTests.swift` | Direct device-management route; host config/cloud enrollment plus target-specific agent behavior. |
+| `wendy device version` | hidden | `MISSING` | Direct local agent route; Linux/WendyOS app/runtime path, Darwin agent route is native-app beta where applicable. |
+| `wendy device volumes list` | public | `WendyDeviceVolumesListTests.swift` | Direct local agent storage route; Linux/WendyOS container volume semantics, Darwin coverage not promised beyond clear failures. |
+| `wendy device volumes remove` | public | `WendyDeviceVolumesRemoveTests.swift` | Direct local agent storage route; Linux/WendyOS container volume semantics, Darwin coverage not promised beyond clear failures. |
+| `wendy device wifi connect` | public | `WendyDeviceWifiConnectTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device wifi disconnect` | public | `WendyDeviceWifiDisconnectTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device wifi forget` | public | `WendyDeviceWifiForgetTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device wifi list` | public | `WendyDeviceWifiListTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device wifi rank` | public | `WendyDeviceWifiRankTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy device wifi status` | public | `WendyDeviceWifiStatusTests.swift` | Direct local agent route; Linux/WendyOS feature path, macOS beta unsupported diagnostics expected where the agent returns Unimplemented. |
+| `wendy discover` | public | `WendyDiscoverTests.swift` | Host discovery route; LAN/BLE/provider discovery, platform-specific clipboard/BLE behavior. |
+| `wendy info` | public | `WendyInfoTests.swift` | Host-only CLI/config command. |
+| `wendy init` | public | `WendyInitTests.swift` | Host-only CLI/config command. |
+| `wendy json schema` | public | `WendyJsonSchemaTests.swift` | Host-only CLI/config command. |
+| `wendy json validate` | public | `WendyJsonValidateTests.swift` | Host-only CLI/config command. |
+| `wendy mcp serve` | public | `WendyMcpServeTests.swift` | Host-only CLI/config command. |
+| `wendy mcp setup` | public | `WendyMcpSetupTests.swift` | Host-only CLI/config command. |
+| `wendy os cache clear` | public | `WendyOsCacheClearTests.swift` | Host OS image-management route; platform behavior differs for drive listing/install provisioning on macOS/Linux/Windows. |
+| `wendy os cache list` | public | `WendyOsCacheListTests.swift` | Host OS image-management route; platform behavior differs for drive listing/install provisioning on macOS/Linux/Windows. |
+| `wendy os download` | public | `WendyOsDownloadTests.swift` | Host OS image-management route; platform behavior differs for drive listing/install provisioning on macOS/Linux/Windows. |
+| `wendy os install` | public | `WendyOsInstallTests.swift` | Host OS image-management route; platform behavior differs for drive listing/install provisioning on macOS/Linux/Windows. |
+| `wendy os list-drives` | public | `WendyOsListDrivesTests.swift` | Host OS image-management route; platform behavior differs for drive listing/install provisioning on macOS/Linux/Windows. |
+| `wendy os update` | public | `WendyOsUpdateTests.swift` | Direct agent route; WendyOS OTA only. Linux host agents and Darwin agents must fail with unsupported-OS guidance. |
+| `wendy project entitlements add` | public | `WendyProjectEntitlementsAddTests.swift` | Host-only CLI/config command. |
+| `wendy project entitlements list` | public | `WendyProjectEntitlementsListTests.swift` | Host-only CLI/config command. |
+| `wendy project entitlements remove` | public | `WendyProjectEntitlementsRemoveTests.swift` | Host-only CLI/config command. |
+| `wendy run` | public | `WendyRunTests.swift` | Host build/deploy route; direct device or internally managed cloud tunnel. Darwin agents accept native macOS projects only; Linux containers on Macs are intentionally unsupported. |
+| `wendy tour` | public | `WendyTourTests.swift` | Host-only CLI/config command. |
+| `wendy utils open-browser` | public | `WendyUtilsOpenBrowserTests.swift` | Host-only CLI/config command. |


### PR DESCRIPTION
> **In plain terms (for PMs):** This is a filing cabinet, not a code change — and it is deliberately never merged. We took an inventory of all 106 `wendy` CLI commands and recorded which ones are covered by automated tests and which aren't, so that follow-up tickets (WDY-1511 through WDY-1517) can close the gaps in small, reviewable slices. It stays open as a draft purely so the snapshot is easy to find.

## Summary
- **Audit artifact only — do not merge.** This draft PR preserves the WDY-1509 CLI surface snapshot and ledger context for handoff.
- The captured data maps 106 leaf commands to current Swift E2E suites or gaps so child issues can make focused, reviewable changes.
- Mergeable implementation/reference work belongs in WDY-1511 through WDY-1517, not this umbrella PR.

## Scope notes
- This PR is intentionally kept open as a draft/non-merge artifact and should not close WDY-1509.
- The current CLI build does not support `wendy --experimental-dump-help`; the snapshot was generated from `commands.NewRootCmd()` with a temporary Cobra walker.
- The ledger is a starting handoff artifact, not the final reviewed contract for every command.
- No Swift/Go behavior or E2E stubs should be changed here; those changes belong in the child issue worktrees coordinated from `kb.macos-beta/PLAN.md`.

## Child implementation path
- WDY-1511 — Remove misleading hidden completion install `--output-dir` test seam.
- WDY-1512 — Audit and align hidden/deprecated CLI aliases.
- WDY-1513 — Align host-only CLI E2E references.
- WDY-1514 — Align OS imaging and update E2E references.
- WDY-1515 — Align direct device command E2E references.
- WDY-1516 — Align cloud-routed device E2E references.
- WDY-1517 — Align build and run E2E references.

## Validation
- `python3 -m json.tool .cli-surface-WDY-1509.json >/tmp/cli-surface-WDY-1509.json`
- JSON count assertion: validated 135 commands and 106 leaf commands
- `git diff --check origin/main...HEAD`


