### PR TITLE
ci: re-enable macOS to Raspberry Pi Swift E2E

### DIFF
--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -359,30 +359,29 @@ jobs:
   #         setup: false
   #         managed_agent: false
   #
-  # // DISABLED: no CI hardware set up yet for this job.
-  # swift-e2e-physical-macos-raspberry-pi:
-  #   name: macOS 26 → Raspberry Pi 5
-  #   needs: swift-e2e-local-ubuntu
-  #   if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
-  #   runs-on: [self-hosted, macos-26]
-  #   concurrency:
-  #     group: device-raspberry-pi-5
-  #     cancel-in-progress: false
-  #     queue: max
-  #   timeout-minutes: 120
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: ./.github/actions/swift-e2e-run
-  #       with:
-  #         tests: ${{ inputs.tests || '' }}
-  #         target_id: macos-raspberry-pi-5
-  #         runner_id: macos-26
-  #         cli_os: macOS
-  #         device_address: wendyos-raspberry-pi-5.local
-  #         agent_os: wendyOS
-  #         transport: lan
-  #         setup: false
-  #         managed_agent: false
+  swift-e2e-physical-macos-raspberry-pi:
+    name: macOS 26 → Raspberry Pi 5
+    needs: swift-e2e-local-ubuntu
+    if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
+    runs-on: [self-hosted, macos-26]
+    concurrency:
+      group: device-raspberry-pi-5
+      cancel-in-progress: false
+      queue: max
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ./.github/actions/swift-e2e-run
+        with:
+          tests: ${{ inputs.tests || '' }}
+          target_id: macos-raspberry-pi-5
+          runner_id: macos-26
+          cli_os: macOS
+          device_address: ${{ vars.SWIFT_E2E_RASPBERRY_PI_5_DEVICE_ADDRESS }}
+          agent_os: wendyOS
+          transport: lan
+          setup: false
+          managed_agent: false
   #
   # // DISABLED: no CI hardware set up yet for this job.
   # swift-e2e-physical-ubuntu-mac-mini:
@@ -417,6 +416,7 @@ jobs:
       - swift-e2e-local-ubuntu
       - swift-e2e-physical-macos-ubuntu
       - swift-e2e-physical-macos-jetson
+      - swift-e2e-physical-macos-raspberry-pi
     runs-on: [self-hosted, AI]
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary
- Re-enable the macOS 26 → Raspberry Pi 5 physical Swift E2E route.
- Keep the route behind the hosted Ubuntu local gate used for WendyOS/Linux targets.
- Use `SWIFT_E2E_RASPBERRY_PI_5_DEVICE_ADDRESS` for the Raspberry Pi address, matching the restored SER9 and Jetson routes.

## Notes
- Configured the repository variable `SWIFT_E2E_RASPBERRY_PI_5_DEVICE_ADDRESS=wendyos-raspberry-pi-5.local` for this route.

## Tests
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/swift-e2e-tests.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/swift-e2e-tests.yml`

Closes WDY-1510
