### PR TITLE
os install: classify WiFi scan failures and offer skip; show device-name constraints

### DIFF
--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1242,39 +1242,63 @@ func splitEscaped(s string, sep byte) []string {
 	return out
 }
 
+// Interactive hooks used by promptAddOneCredential, declared as package vars
+// so unit tests can stub them (same pattern as promptDeviceName below).
+var (
+	scanWifiNetworksWithSpinner = scanWifiNetworksSpinner
+	confirmManualWifiEntry      = func() (bool, error) {
+		return tui.ConfirmDefaultYes("Enter WiFi network details manually?")
+	}
+	confirmKeychainLookup = func(ssid string) (bool, error) {
+		return tui.ConfirmDefaultYes(fmt.Sprintf("Look up password for '%s' from keychain? (macOS will ask for permission)", ssid))
+	}
+	promptWifiSSID = func() (string, error) {
+		return tui.PromptText("WiFi SSID", "", nonEmptyValidator)
+	}
+	promptWifiPassword = func(ssid string) (string, error) {
+		return tui.PromptText(fmt.Sprintf("Password for %s", ssid), "(leave empty for open network)", nil)
+	}
+)
+
+// scanWifiNetworksSpinner runs the platform WiFi scan behind a spinner.
+// Returns ErrUserCancelled when the user quits the spinner (Ctrl+C/q) before
+// the scan completes.
+func scanWifiNetworksSpinner() ([]localWifiNetwork, error) {
+	spin := tui.NewSpinner("Scanning for nearby WiFi networks…")
+	p := tea.NewProgram(spin)
+	go func() {
+		nets, err := scanLocalWifiNetworks()
+		p.Send(tui.SpinnerDoneMsg{Result: nets, Err: err})
+	}()
+	finalModel, runErr := p.Run()
+	if runErr != nil {
+		return nil, fmt.Errorf("scanning WiFi networks: %w", runErr)
+	}
+	sm, ok := finalModel.(tui.SpinnerModel)
+	if !ok {
+		return nil, fmt.Errorf("scanning WiFi networks: unexpected spinner model %T", finalModel)
+	}
+	if !sm.Done() {
+		return nil, ErrUserCancelled
+	}
+	result, err := sm.Result()
+	nets, _ := result.([]localWifiNetwork)
+	return nets, err
+}
+
 // promptAddOneCredential runs the local scan + picker + password prompt to
 // collect a single WiFi credential. index is the zero-based count of entries
-// already collected (used to suggest a descending priority).
+// already collected (used to suggest a descending priority). Returns
+// added=false (with nil error) when the user chooses to skip WiFi setup
+// after a failed or empty scan (WDY-1474).
 func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 	var c wendyconf.WifiCredential
 
-	var networks []localWifiNetwork
-	var scanErr error
-	{
-		spin := tui.NewSpinner("Scanning for nearby WiFi networks…")
-		p := tea.NewProgram(spin)
-		go func() {
-			nets, err := scanLocalWifiNetworks()
-			p.Send(tui.SpinnerDoneMsg{Result: nets, Err: err})
-		}()
-		finalModel, runErr := p.Run()
-		if runErr != nil {
-			return c, false, fmt.Errorf("scanning WiFi networks: %w", runErr)
-		}
-		sm, ok := finalModel.(tui.SpinnerModel)
-		if !ok {
-			return c, false, fmt.Errorf("scanning WiFi networks: unexpected spinner model %T", finalModel)
-		}
-		// A spinner that quit before receiving SpinnerDoneMsg means the user
-		// pressed Ctrl+C/q during the scan; treat that as a cancellation rather
-		// than silently falling through to the manual SSID prompt.
-		if !sm.Done() {
-			return c, false, ErrUserCancelled
-		}
-		result, err := sm.Result()
-		networks, _ = result.([]localWifiNetwork)
-		scanErr = err
+	networks, scanErr := scanWifiNetworksWithSpinner()
+	if errors.Is(scanErr, ErrUserCancelled) {
+		return c, false, scanErr
 	}
+
 	if scanErr == nil && len(networks) > 0 {
 		var items []tui.PickerItem
 		for _, n := range networks {
@@ -1289,10 +1313,23 @@ func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 		if pickErr == nil {
 			c.SSID = picked
 		}
+	} else {
+		// Scan failed or found nothing: say why, then let the user choose
+		// between manual entry and skipping WiFi setup entirely instead of
+		// trapping them in a mandatory SSID prompt (WDY-1474).
+		fmt.Println(wifiScanFailureNotice(scanErr))
+		manual, err := confirmManualWifiEntry()
+		if err != nil {
+			return c, false, err
+		}
+		if !manual {
+			fmt.Println("Skipping WiFi setup. You can configure WiFi after first boot with 'wendy wifi connect'.")
+			return c, false, nil
+		}
 	}
 
 	if c.SSID == "" {
-		ssid, err := tui.PromptText("WiFi SSID", "", nonEmptyValidator)
+		ssid, err := promptWifiSSID()
 		if err != nil {
 			return c, false, err
 		}
@@ -1300,7 +1337,7 @@ func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 	}
 
 	if supportsKeychainLookup {
-		useKeychain, err := tui.ConfirmDefaultYes(fmt.Sprintf("Look up password for '%s' from keychain? (macOS will ask for permission)", c.SSID))
+		useKeychain, err := confirmKeychainLookup(c.SSID)
 		if err != nil {
 			return c, false, err
 		}
@@ -1315,7 +1352,7 @@ func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 	}
 
 	if c.Password == "" {
-		pw, err := tui.PromptText(fmt.Sprintf("Password for %s", c.SSID), "(leave empty for open network)", nil)
+		pw, err := promptWifiPassword(c.SSID)
 		if err != nil {
 			return c, false, err
 		}

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1323,7 +1323,7 @@ func promptAddOneCredential(index int) (wendyconf.WifiCredential, bool, error) {
 			return c, false, err
 		}
 		if !manual {
-			fmt.Println("Skipping WiFi setup. You can configure WiFi after first boot with 'wendy wifi connect'.")
+			fmt.Println("Skipping WiFi setup. You can configure WiFi later with 'wendy wifi connect' once the device is reachable (e.g. over ethernet or USB).")
 			return c, false, nil
 		}
 	}
@@ -1414,7 +1414,11 @@ func resolveDeviceName(flagName string) (string, error) {
 	}
 
 	fmt.Println()
-	name, err := promptDeviceName("Device name", "(leave empty to auto-generate)", optionalDeviceNameValidator)
+	name, err := promptDeviceName(
+		"Device name",
+		"(a-z, 0-9 and hyphens, starts with a letter, 3–64 chars; empty = auto-generate)",
+		optionalDeviceNameValidator,
+	)
 	if err != nil {
 		if errors.Is(err, tui.ErrCancelled) {
 			return "", ErrUserCancelled

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -497,6 +497,89 @@ func TestResolveDeviceNameInteractiveBlankReturnsEmpty(t *testing.T) {
 	}
 }
 
+// stubWifiPrompts replaces all interactive prompt hooks used by
+// promptAddOneCredential and restores them on test cleanup.
+func stubWifiPrompts(t *testing.T) {
+	t.Helper()
+	origScan := scanWifiNetworksWithSpinner
+	origManual := confirmManualWifiEntry
+	origKeychain := confirmKeychainLookup
+	origSSID := promptWifiSSID
+	origPassword := promptWifiPassword
+	t.Cleanup(func() {
+		scanWifiNetworksWithSpinner = origScan
+		confirmManualWifiEntry = origManual
+		confirmKeychainLookup = origKeychain
+		promptWifiSSID = origSSID
+		promptWifiPassword = origPassword
+	})
+}
+
+func TestPromptAddOneCredentialSkipsWhenManualEntryDeclined(t *testing.T) {
+	stubWifiPrompts(t)
+	scanWifiNetworksWithSpinner = func() ([]localWifiNetwork, error) { return nil, errNoWifiAdapter }
+	confirmManualWifiEntry = func() (bool, error) { return false, nil }
+	promptWifiSSID = func() (string, error) {
+		t.Fatal("SSID prompt must not be shown after declining manual entry")
+		return "", nil
+	}
+
+	_, added, err := promptAddOneCredential(0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if added {
+		t.Fatal("expected added=false when the user skips WiFi setup")
+	}
+}
+
+func TestPromptAddOneCredentialManualEntryAfterScanFailure(t *testing.T) {
+	stubWifiPrompts(t)
+	scanWifiNetworksWithSpinner = func() ([]localWifiNetwork, error) { return nil, errors.New("exit status 1") }
+	confirmManualWifiEntry = func() (bool, error) { return true, nil }
+	confirmKeychainLookup = func(string) (bool, error) { return false, nil }
+	promptWifiSSID = func() (string, error) { return "homenet", nil }
+	promptWifiPassword = func(string) (string, error) { return "hunter2", nil }
+
+	c, added, err := promptAddOneCredential(0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !added {
+		t.Fatal("expected added=true after manual entry")
+	}
+	if c.SSID != "homenet" || c.Password != "hunter2" {
+		t.Fatalf("got SSID=%q password=%q; want homenet/hunter2", c.SSID, c.Password)
+	}
+	if c.Priority != 100 {
+		t.Fatalf("got priority %d; want 100 for first network", c.Priority)
+	}
+}
+
+func TestPromptAddOneCredentialEmptyScanOffersSkip(t *testing.T) {
+	stubWifiPrompts(t)
+	scanWifiNetworksWithSpinner = func() ([]localWifiNetwork, error) { return nil, nil }
+	confirmManualWifiEntry = func() (bool, error) { return false, nil }
+
+	_, added, err := promptAddOneCredential(0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if added {
+		t.Fatal("expected added=false when scan finds nothing and user declines manual entry")
+	}
+}
+
+func TestPromptAddOneCredentialScanCancelled(t *testing.T) {
+	stubWifiPrompts(t)
+	scanWifiNetworksWithSpinner = func() ([]localWifiNetwork, error) { return nil, ErrUserCancelled }
+
+	_, _, err := promptAddOneCredential(0)
+	if !errors.Is(err, ErrUserCancelled) {
+		t.Fatalf("expected ErrUserCancelled, got %v", err)
+	}
+}
+
 func TestResolveDeviceNameFlagValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -978,3 +978,44 @@ func TestDownloadParallel(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveDeviceNamePromptStatesConstraints(t *testing.T) {
+	origInteractive := isInteractiveTerminalFn
+	origPrompt := promptDeviceName
+	isInteractiveTerminalFn = func() bool { return true }
+
+	var gotHint string
+	var gotValidate tui.ValidateFunc
+	promptDeviceName = func(_, hint string, validate tui.ValidateFunc) (string, error) {
+		gotHint = hint
+		gotValidate = validate
+		return "brave-dolphin", nil
+	}
+	t.Cleanup(func() {
+		isInteractiveTerminalFn = origInteractive
+		promptDeviceName = origPrompt
+	})
+
+	if _, err := resolveDeviceName(""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The hint must surface the naming constraints inline (WDY-1475).
+	for _, want := range []string{"a-z", "3–64", "auto-generate"} {
+		if !strings.Contains(gotHint, want) {
+			t.Errorf("hint %q should mention %q", gotHint, want)
+		}
+	}
+
+	// The prompt must be wired to the real validator so invalid input
+	// re-prompts with the specific violation instead of terminating.
+	if gotValidate == nil {
+		t.Fatal("prompt must receive a validator")
+	}
+	if err := gotValidate("MyDevice"); err == nil || !strings.Contains(err.Error(), "lowercase") {
+		t.Fatalf("validator should reject uppercase with a specific message, got %v", err)
+	}
+	if err := gotValidate(""); err != nil {
+		t.Fatalf("validator should accept empty (auto-generate), got %v", err)
+	}
+}

--- a/go/internal/cli/commands/wifi_scan_darwin.go
+++ b/go/internal/cli/commands/wifi_scan_darwin.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -43,7 +44,11 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("scanning WiFi networks: %w", err)
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && strings.Contains(string(ee.Stderr), "no wifi interface") {
+			return nil, errNoWifiAdapter
+		}
+		return nil, fmt.Errorf("scanning WiFi networks: %w", exitErrWithStderr(err))
 	}
 
 	seen := make(map[string]bool)

--- a/go/internal/cli/commands/wifi_scan_linux.go
+++ b/go/internal/cli/commands/wifi_scan_linux.go
@@ -18,11 +18,21 @@ import (
 const wifiScanCacheHint = ""
 
 // scanLocalWifiNetworks uses nmcli on Linux to list WiFi networks visible to
-// the host machine.
+// the host machine. Returns errNoWifiAdapter when the host has no wifi-type
+// device, so callers can offer to skip WiFi setup instead of failing.
 func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	nmcliPath, err := exec.LookPath("nmcli")
 	if err != nil {
 		return nil, fmt.Errorf("nmcli not found on PATH: %w", err)
+	}
+
+	// Distinguish "no WiFi hardware" from a transient scan failure before
+	// attempting the scan (WDY-1474). A status-command failure is ignored:
+	// the scan below will surface its own error.
+	if statusOut, statusErr := nmcli.Command(context.Background(), nmcliPath, "-t", "-f", "DEVICE,TYPE", "device", "status").Output(); statusErr == nil {
+		if !nmcliHasWifiDevice(string(statusOut)) {
+			return nil, errNoWifiAdapter
+		}
 	}
 
 	// Trigger a rescan first (may fail if already scanning).
@@ -31,7 +41,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	cmd := nmcli.Command(context.Background(), nmcliPath, "-t", "-f", "SSID,SIGNAL", "device", "wifi", "list")
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("scanning WiFi networks: %w", err)
+		return nil, fmt.Errorf("scanning WiFi networks: %w", exitErrWithStderr(err))
 	}
 
 	seen := make(map[string]bool)
@@ -66,6 +76,20 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	}
 
 	return networks, nil
+}
+
+// nmcliHasWifiDevice reports whether `nmcli -t -f DEVICE,TYPE device status`
+// output lists at least one wifi-type device. wifi-p2p entries don't count —
+// they are virtual P2P interfaces, not scannable adapters.
+func nmcliHasWifiDevice(output string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		fields := nmcli.Split(scanner.Text(), 2)
+		if len(fields) >= 2 && fields[1] == "wifi" {
+			return true
+		}
+	}
+	return false
 }
 
 const supportsKeychainLookup = false

--- a/go/internal/cli/commands/wifi_scan_linux_test.go
+++ b/go/internal/cli/commands/wifi_scan_linux_test.go
@@ -31,6 +31,11 @@ func TestNmcliHasWifiDevice(t *testing.T) {
 			"weird\\:name:wifi\n",
 			true,
 		},
+		{
+			"unexpected third column does not match",
+			"wlan0:wifi:connected\n",
+			false,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/internal/cli/commands/wifi_scan_linux_test.go
+++ b/go/internal/cli/commands/wifi_scan_linux_test.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package commands
+
+import "testing"
+
+func TestNmcliHasWifiDevice(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			"wifi device present",
+			"lo:loopback\nenp3s0:ethernet\nwlan0:wifi\n",
+			true,
+		},
+		{
+			"no wifi device",
+			"lo:loopback\nenp3s0:ethernet\n",
+			false,
+		},
+		{"empty output", "", false},
+		{
+			"wifi-p2p does not count",
+			"lo:loopback\np2p-dev-wlan0:wifi-p2p\n",
+			false,
+		},
+		{
+			"device name containing escaped colon",
+			"weird\\:name:wifi\n",
+			true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nmcliHasWifiDevice(tc.output); got != tc.want {
+				t.Fatalf("nmcliHasWifiDevice(%q) = %v; want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/wifi_scan_shared.go
+++ b/go/internal/cli/commands/wifi_scan_shared.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+// errNoWifiAdapter signals that the host has no usable WiFi hardware, as
+// opposed to a transient scan failure. Platform scanners return it (possibly
+// wrapped) so the install flow can show a specific message (WDY-1474).
+var errNoWifiAdapter = errors.New("no WiFi adapter detected on this machine")
+
+// exitErrWithStderr enriches an error from exec's Output() with the captured
+// stderr, which otherwise surfaces only as "exit status N". Non-ExitError
+// values and empty stderr pass through unchanged.
+func exitErrWithStderr(err error) error {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		if stderr := bytes.TrimSpace(ee.Stderr); len(stderr) > 0 {
+			return fmt.Errorf("%w: %s", err, stderr)
+		}
+	}
+	return err
+}
+
+// wifiScanFailureNotice renders the user-facing message shown when a host
+// WiFi scan produced no usable networks. scanErr == nil means the scan
+// succeeded but found nothing.
+func wifiScanFailureNotice(scanErr error) string {
+	switch {
+	case scanErr == nil:
+		msg := "No WiFi networks found."
+		if wifiScanCacheHint != "" {
+			msg += " " + wifiScanCacheHint + "."
+		}
+		return msg
+	case errors.Is(scanErr, errNoWifiAdapter):
+		return "No WiFi adapter detected on this machine."
+	default:
+		return fmt.Sprintf("WiFi scan failed: %v", scanErr)
+	}
+}

--- a/go/internal/cli/commands/wifi_scan_shared.go
+++ b/go/internal/cli/commands/wifi_scan_shared.go
@@ -10,6 +10,7 @@ import (
 // errNoWifiAdapter signals that the host has no usable WiFi hardware, as
 // opposed to a transient scan failure. Platform scanners return it (possibly
 // wrapped) so the install flow can show a specific message (WDY-1474).
+// Keep its text in sync with the user-facing copy in wifiScanFailureNotice.
 var errNoWifiAdapter = errors.New("no WiFi adapter detected on this machine")
 
 // exitErrWithStderr enriches an error from exec's Output() with the captured

--- a/go/internal/cli/commands/wifi_scan_shared_test.go
+++ b/go/internal/cli/commands/wifi_scan_shared_test.go
@@ -1,0 +1,73 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestExitErrWithStderr(t *testing.T) {
+	t.Run("plain error passes through", func(t *testing.T) {
+		err := errors.New("boom")
+		if got := exitErrWithStderr(err); got != err {
+			t.Fatalf("got %v; want original error", got)
+		}
+	})
+
+	t.Run("exit error with stderr is enriched", func(t *testing.T) {
+		// Real ExitError with captured stderr, the same shape exec.Output()
+		// produces on command failure.
+		_, err := exec.Command("sh", "-c", "echo 'no WiFi device found' >&2; exit 1").Output()
+		if err == nil {
+			t.Skip("sh unavailable on this platform")
+		}
+		got := exitErrWithStderr(err)
+		if !strings.Contains(got.Error(), "no WiFi device found") {
+			t.Fatalf("error %q should contain captured stderr", got.Error())
+		}
+		var ee *exec.ExitError
+		if !errors.As(got, &ee) {
+			t.Fatalf("enriched error should still wrap the ExitError, got %T", got)
+		}
+	})
+
+	t.Run("exit error with empty stderr passes through", func(t *testing.T) {
+		_, err := exec.Command("sh", "-c", "exit 1").Output()
+		if err == nil {
+			t.Skip("sh unavailable on this platform")
+		}
+		if got := exitErrWithStderr(err); got != err {
+			t.Fatalf("got %v; want original error", got)
+		}
+	})
+}
+
+func TestWifiScanFailureNotice(t *testing.T) {
+	tests := []struct {
+		name    string
+		scanErr error
+		want    string
+	}{
+		{"no adapter", errNoWifiAdapter, "No WiFi adapter detected on this machine."},
+		{"wrapped no adapter", fmt.Errorf("scan: %w", errNoWifiAdapter), "No WiFi adapter detected on this machine."},
+		{"generic failure", errors.New("exit status 1: something broke"), "WiFi scan failed: exit status 1: something broke"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := wifiScanFailureNotice(tc.scanErr); got != tc.want {
+				t.Fatalf("got %q; want %q", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("empty scan result", func(t *testing.T) {
+		got := wifiScanFailureNotice(nil)
+		if !strings.HasPrefix(got, "No WiFi networks found.") {
+			t.Fatalf("got %q; want 'No WiFi networks found.' prefix", got)
+		}
+	})
+}

--- a/go/internal/cli/commands/wifi_scan_windows.go
+++ b/go/internal/cli/commands/wifi_scan_windows.go
@@ -25,7 +25,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	cmd := exec.Command("netsh", "wlan", "show", "networks", "mode=bssid")
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("scanning WiFi networks: %w", err)
+		return nil, fmt.Errorf("scanning WiFi networks: %w", exitErrWithStderr(err))
 	}
 	return parseNetshNetworks(string(output)), nil
 }


### PR DESCRIPTION
## Summary

Fixes two interactive-UX bugs in `wendy os install`:

**WDY-1474 — WiFi scan failure showed a bare `exit status 1` with no exit path.**
- Platform scanners now distinguish "no WiFi adapter" from transient failures via a shared `errNoWifiAdapter` sentinel (Linux: checks `nmcli device status` for a wifi-type device before scanning; macOS: maps the CoreWLAN script's `no wifi interface` stderr).
- Scan errors are enriched with the captured stderr instead of surfacing only `exit status N`.
- On a failed or empty scan, the flow now prints a specific notice (e.g. "No WiFi adapter detected on this machine.") and asks "Enter WiFi network details manually?" — declining skips WiFi setup and the install continues, instead of trapping the user in a mandatory SSID prompt where Ctrl+C cancelled the whole install.
- `wendy wifi` subcommands sharing the scanner get the clearer messages for free.

**WDY-1475 — device-name prompt didn't state naming constraints.**
- The hint now reads `(a-z, 0-9 and hyphens, starts with a letter, 3–64 chars; empty = auto-generate)`.
- Note: the "terminates on invalid input" half of WDY-1475 was already fixed by #793 (inline validation + re-prompt); this PR only adds the missing constraints hint.

Fixes WDY-1474
Fixes WDY-1475

## Implementation notes

- The five interactive prompts in `promptAddOneCredential` became package-level stub vars (same pattern as the existing `promptDeviceName`), making the flow unit-testable for the first time.
- No sentinel detection on Windows (netsh output is localized); it gets stderr enrichment plus the same skip option on empty results.
- Skip works through the existing `added=false` loop-break in `resolveWiFiCredentialsList` — no caller changes.

## Testing

- 16 new unit-test cases across the scan-error helpers, the nmcli device-status parser, the skip/manual/cancel flows, and the device-name hint wiring.
- Full `go test ./...` (35 packages), `go vet`, `gofmt` clean; `GOOS=windows` build clean. (`GOOS=darwin` cross-build is blocked locally by pre-existing unrelated cgo deps in `discovery`/`ble` — darwin CI should confirm.)
- Manual check of the interactive flow on Linux: specific notice + skip option appear when the scan fails; constraints hint shows at the device-name prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)