### PR TITLE
refactor: separate Swift E2E attempt artifacts

### DIFF
--- a/swift/Scripts/E2EReport.ps1
+++ b/swift/Scripts/E2EReport.ps1
@@ -37,17 +37,14 @@ Write-Output "    Run dir: $script:RunDir"
 Write-Output "    Output:  $ReportPath"
 
 $resultPaths = @()
-Get-ChildItem -LiteralPath $script:RunDir -Directory | ForEach-Object {
-    $suiteDir = $_.FullName
-    Get-ChildItem -LiteralPath $suiteDir -Directory | ForEach-Object {
-        $testDir = $_.FullName
-        Get-ChildItem -LiteralPath $testDir -Directory | ForEach-Object {
-            $targetDir = $_.FullName
-            Get-ChildItem -LiteralPath $targetDir -Directory | ForEach-Object {
-                $candidate = Join-Path $_.FullName 'test-results.xml'
-                if (Test-Path -LiteralPath $candidate -PathType Leaf) {
-                    $resultPaths += $candidate
-                }
+$attemptsDir = Join-Path $script:RunDir 'attempts'
+if (Test-Path -LiteralPath $attemptsDir -PathType Container) {
+    Get-ChildItem -LiteralPath $attemptsDir -Directory | ForEach-Object {
+        $targetDir = $_.FullName
+        Get-ChildItem -LiteralPath $targetDir -Directory | ForEach-Object {
+            $candidate = Join-Path $_.FullName 'test-results.xml'
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                $resultPaths += $candidate
             }
         }
     }

--- a/swift/Scripts/E2EReport.sh
+++ b/swift/Scripts/E2EReport.sh
@@ -76,20 +76,14 @@ PACKAGE_DIR="$(absolute_existing_dir_path "$PACKAGE_DIR")"
 REPORT_PATH="$RUN_DIR/index.html"
 
 run_test_result_files() {
-  local suite_dir test_dir target_dir attempt_dir result_path
-  for suite_dir in "$RUN_DIR"/*; do
-    [[ -d "$suite_dir" ]] || continue
-    for test_dir in "$suite_dir"/*; do
-      [[ -d "$test_dir" ]] || continue
-      for target_dir in "$test_dir"/*; do
-        [[ -d "$target_dir" ]] || continue
-        for attempt_dir in "$target_dir"/*; do
-          [[ -d "$attempt_dir" ]] || continue
-          result_path="$attempt_dir/test-results.xml"
-          [[ -f "$result_path" ]] || continue
-          printf '%s\n' "$result_path"
-        done
-      done
+  local target_dir attempt_dir result_path
+  for target_dir in "$RUN_DIR"/attempts/*; do
+    [[ -d "$target_dir" ]] || continue
+    for attempt_dir in "$target_dir"/*; do
+      [[ -d "$attempt_dir" ]] || continue
+      result_path="$attempt_dir/test-results.xml"
+      [[ -f "$result_path" ]] || continue
+      printf '%s\n' "$result_path"
     done
   done | sort -u
 }

--- a/swift/WendyE2ETests/README.md
+++ b/swift/WendyE2ETests/README.md
@@ -113,23 +113,25 @@ the runner uses the current CLI user's `~/.wendy/config.json` where possible.
 ## Artifacts
 
 The E2E workflow uses two artifact layouts: attempt directories from individual
-test runs, and aggregate run directories that collect attempts by suite, test,
-target, and attempt number.
+test runs, and aggregate run directories that keep attempt-level artifacts
+separate from per-test observations.
 
 ### Attempt directory
 
 `Scripts/E2ETest.sh` writes one attempt directory under the output directory.
-Suite directories use the test file stem without the `Tests` suffix, dasherized;
-test directories use the dasherized test name.
+Attempt-level artifacts stay at the attempt root. Per-test observation
+directories use the test file stem without the `Tests` suffix, dasherized; test
+directories use the dasherized test name.
 
 ```text
 <output-dir>/<attempt-id>/
 ├── attempt.json
 ├── test-results.xml
 ├── test-results.raw.xml          # only when XML sanitization changed the file
-└── <suite>/<test>/
-    ├── recording.md
-    └── recording.sh.txt
+└── observations/
+    └── <suite>/<test>/
+        ├── recording.md
+        └── recording.sh.txt
 ```
 
 The attempt ID has the shape:
@@ -151,21 +153,27 @@ directories into a run directory:
 
 ```text
 <output-dir>/<workflow-name>.<run-id>/
-└── <suite>/<test>/<target-name>/<attempt-number>/
-    ├── attempt.json
-    ├── test-results.xml
-    ├── test-results.raw.xml      # only when present in the source attempt
-    ├── recording.md
-    └── recording.sh.txt
+├── attempts/
+│   └── <target-name>/<attempt-number>/
+│       ├── attempt.json
+│       ├── test-results.xml
+│       └── test-results.raw.xml  # only when present in the source attempt
+└── observations/
+    └── <suite>/<test>/<target-name>/<attempt-number>/
+        ├── recording.md
+        └── recording.sh.txt
 ```
+
+The `attempts/` tree keeps every attempt-root artifact except `observations/`,
+so preflight logs and metadata remain attached to the attempt.
 
 `make e2e-review` writes scoped AI review issue files into the aggregate run
 directory:
 
 ```text
 <run>/review.<reviewer>/<slug>.md
-<run>/<suite>/review.<reviewer>/<slug>.md
-<run>/<suite>/<test>/review.<reviewer>/<slug>.md
+<run>/observations/<suite>/review.<reviewer>/<slug>.md
+<run>/observations/<suite>/<test>/review.<reviewer>/<slug>.md
 ```
 
 `make e2e-report` writes the rendered report files at the aggregate run root:

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/AggregateCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/AggregateCommand.swift
@@ -69,12 +69,24 @@ struct AggregateCommand: ParsableCommand {
             throw ValidationError("Attempt directory does not exist: \(attemptURL.path)")
         }
 
+        let attemptArtifactsURL = e2eAttemptArtifactsURL(
+            in: runURL,
+            targetName: components.targetName,
+            attempt: components.attempt
+        )
+        try? FileManager.default.removeItem(at: attemptArtifactsURL)
+        try FileManager.default.createDirectory(
+            at: attemptArtifactsURL,
+            withIntermediateDirectories: true
+        )
+        try copyAttemptLevelArtifacts(from: attemptURL, to: attemptArtifactsURL)
+
         let testDirectories = try attemptTestDirectories(in: attemptURL)
         for testDirectory in testDirectories {
             let suiteKey = testDirectory.deletingLastPathComponent().lastPathComponent
             let testKey = testDirectory.lastPathComponent
             let destinationURL =
-                runURL
+                e2eObservationsRootURL(in: runURL)
                 .appendingPathComponent(suiteKey, isDirectory: true)
                 .appendingPathComponent(testKey, isDirectory: true)
                 .appendingPathComponent(components.targetName, isDirectory: true)
@@ -86,7 +98,6 @@ struct AggregateCommand: ParsableCommand {
                 withIntermediateDirectories: true
             )
             try copyItem(at: testDirectory, to: destinationURL)
-            try copyAttemptLevelFiles(from: attemptURL, to: destinationURL)
         }
     }
 }
@@ -115,12 +126,16 @@ private struct AttemptID {
 }
 
 private func attemptTestDirectories(in attemptURL: URL) throws -> [URL] {
-    guard FileManager.default.fileExists(atPath: attemptURL.path) else {
+    let observationsURL = attemptURL.appendingPathComponent(
+        e2eObservationsDirectoryName,
+        isDirectory: true
+    )
+    guard FileManager.default.fileExists(atPath: observationsURL.path) else {
         return []
     }
 
     let suiteURLs = try FileManager.default.contentsOfDirectory(
-        at: attemptURL,
+        at: observationsURL,
         includingPropertiesForKeys: [.isDirectoryKey],
         options: [.skipsHiddenFiles]
     )
@@ -146,11 +161,17 @@ private func isDirectory(_ url: URL) throws -> Bool {
     try url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true
 }
 
-private func copyAttemptLevelFiles(from attemptURL: URL, to destinationURL: URL) throws {
-    for fileName in ["attempt.json", "test-results.xml", "test-results.raw.xml"] {
-        let sourceURL = attemptURL.appendingPathComponent(fileName)
-        guard FileManager.default.fileExists(atPath: sourceURL.path) else { continue }
-        try copyItem(at: sourceURL, to: destinationURL.appendingPathComponent(fileName))
+private func copyAttemptLevelArtifacts(from attemptURL: URL, to destinationURL: URL) throws {
+    let entries = try FileManager.default.contentsOfDirectory(
+        at: attemptURL,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles]
+    )
+    for sourceURL in entries where sourceURL.lastPathComponent != e2eObservationsDirectoryName {
+        try copyItem(
+            at: sourceURL,
+            to: destinationURL.appendingPathComponent(sourceURL.lastPathComponent)
+        )
     }
 }
 

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+let e2eAttemptArtifactsDirectoryName = "attempts"
+let e2eObservationsDirectoryName = "observations"
+
+func e2eAttemptArtifactsRootURL(in runURL: URL) -> URL {
+    runURL.appendingPathComponent(e2eAttemptArtifactsDirectoryName, isDirectory: true)
+}
+
+func e2eObservationsRootURL(in runURL: URL) -> URL {
+    runURL.appendingPathComponent(e2eObservationsDirectoryName, isDirectory: true)
+}
+
+func e2eAttemptArtifactsURL(in runURL: URL, targetName: String, attempt: String) -> URL {
+    e2eAttemptArtifactsRootURL(in: runURL)
+        .appendingPathComponent(targetName, isDirectory: true)
+        .appendingPathComponent(attempt, isDirectory: true)
+}

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -409,7 +409,7 @@ private func loadRunAIReviews(in runURL: URL) throws -> RunAIReviews {
         root: try loadE2EReviews(in: runURL, expectedScope: "report", relativeTo: runURL)
     )
 
-    for suiteURL in try directoryChildren(of: runURL) {
+    for suiteURL in try directoryChildren(of: e2eObservationsRootURL(in: runURL)) {
         let suiteKey = suiteURL.lastPathComponent
         guard !isE2EReviewDirectoryName(suiteKey) else { continue }
         let suiteReviews = try loadE2EReviews(
@@ -449,6 +449,9 @@ private func recordKey(for recordURL: URL, relativeTo runURL: URL) -> String {
     if recordURL.lastPathComponent == "recording.md" {
         let relative = relativePath(from: runURL, to: recordURL)
         let components = relative.split(separator: "/").map(String.init)
+        if components.count >= 3, components[0] == e2eObservationsDirectoryName {
+            return "\(components[1]).\(components[2])"
+        }
         if components.count >= 2 {
             return "\(components[0]).\(components[1])"
         }
@@ -530,7 +533,7 @@ private func loadRunTestResults(
     var durations: [RunPathKey: [Double]] = [:]
     var observations: [RunPathKey: [ReportTestObservation]] = [:]
 
-    for suiteURL in try directoryChildren(of: runURL) {
+    for suiteURL in try directoryChildren(of: e2eObservationsRootURL(in: runURL)) {
         let suiteKey = suiteURL.lastPathComponent
         guard !isE2EReviewDirectoryName(suiteKey) else { continue }
         for testURL in try directoryChildren(of: suiteURL) {
@@ -540,16 +543,21 @@ private func loadRunTestResults(
                 let targetName = targetURL.lastPathComponent
                 for attemptURL in try directoryChildren(of: targetURL) {
                     let attemptName = attemptURL.lastPathComponent
+                    let attemptArtifactsURL = e2eAttemptArtifactsURL(
+                        in: runURL,
+                        targetName: targetName,
+                        attempt: attemptName
+                    )
                     let status = try runObservationStatus(
                         suiteKey: suiteKey,
                         testKey: testKey,
-                        attemptURL: attemptURL
+                        attemptURL: attemptArtifactsURL
                     )
                     observed[pathKey, default: [:]][targetName, default: []].append(status)
                     observations[pathKey, default: []].append(
                         ReportTestObservation(
                             target: targetName,
-                            route: try targetRoute(for: targetName, attemptURL: attemptURL),
+                            route: try targetRoute(for: targetName, attemptURL: attemptArtifactsURL),
                             attempt: attemptName,
                             status: status,
                             recordingPath: observationFilePath(
@@ -639,7 +647,7 @@ private func runObservationFileURLs(in runURL: URL, fileName: String) throws -> 
     }
 
     var urls: [URL] = []
-    for suiteURL in try directoryChildren(of: runURL) {
+    for suiteURL in try directoryChildren(of: e2eObservationsRootURL(in: runURL)) {
         for testURL in try directoryChildren(of: suiteURL) {
             for targetURL in try directoryChildren(of: testURL) {
                 for attemptURL in try directoryChildren(of: targetURL) {
@@ -977,7 +985,12 @@ private func parseTests(
             let recordTestKey = slug(tests[testIndex].name)
             let recordKey = "\(recordSuiteKey).\(recordTestKey)"
             let directRecordName = "recording.md"
-            let nestedRecordName = "\(recordSuiteKey)/\(recordTestKey)/recording.md"
+            let nestedRecordName = [
+                e2eObservationsDirectoryName,
+                recordSuiteKey,
+                recordTestKey,
+                "recording.md",
+            ].joined(separator: "/")
             if records[recordKey] != nil,
                 FileManager.default.fileExists(
                     atPath: runURL.appendingPathComponent(directRecordName).path
@@ -1069,8 +1082,20 @@ private func extractAIItems(from lines: [String]) -> [String] {
     return items
 }
 
-private func buildTargetOverview(files: [ReportTestFile]) -> [ReportTargetOverviewRow] {
+private func buildTargetOverview(
+    runURL: URL,
+    files: [ReportTestFile]
+) throws -> [ReportTargetOverviewRow] {
     var rowsByTarget: [String: ReportTargetOverviewAccumulator] = [:]
+
+    for (target, attemptURLs) in try runAttemptArtifactURLsByTarget(in: runURL) {
+        var row = rowsByTarget[target] ?? ReportTargetOverviewAccumulator()
+        row.attempts.formUnion(attemptURLs.map(\.lastPathComponent))
+        if row.route == nil, let attemptURL = attemptURLs.first {
+            row.route = try? targetRoute(for: target, attemptURL: attemptURL)
+        }
+        rowsByTarget[target] = row
+    }
 
     for test in files.flatMap(\.tests) {
         let observationsByTarget = Dictionary(grouping: test.observations, by: \.target)
@@ -1094,6 +1119,15 @@ private func buildTargetOverview(files: [ReportTestFile]) -> [ReportTargetOvervi
         )
     }
     .sorted { $0.target < $1.target }
+}
+
+private func runAttemptArtifactURLsByTarget(in runURL: URL) throws -> [String: [URL]] {
+    var urlsByTarget: [String: [URL]] = [:]
+    for targetURL in try directoryChildren(of: e2eAttemptArtifactsRootURL(in: runURL)) {
+        let target = targetURL.lastPathComponent
+        urlsByTarget[target] = try directoryChildren(of: targetURL)
+    }
+    return urlsByTarget
 }
 
 private func renderReport(
@@ -1133,7 +1167,7 @@ private func renderReport(
     try renderReviewAggregateHTMLIfPresent(runURL: runURL)
 
     let reviewHTML = renderRunAIReview(aiReviews.root)
-    let targetOverview = renderTargetOverview(buildTargetOverview(files: files))
+    let targetOverview = try renderTargetOverview(buildTargetOverview(runURL: runURL, files: files))
     let testCards = renderCards(files: files)
 
     template.replaceSubrange(

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
@@ -47,7 +47,7 @@ private func loadE2EReviewAggregateIssues(in runURL: URL) throws -> [E2EReviewAg
         E2EReviewAggregateIssue(scope: .report, suiteKey: nil, testKey: nil, review: review)
     }
 
-    for suiteURL in try reviewAggregateDirectoryChildren(of: runURL) {
+    for suiteURL in try reviewAggregateDirectoryChildren(of: e2eObservationsRootURL(in: runURL)) {
         let suiteKey = suiteURL.lastPathComponent
         guard !isE2EReviewDirectoryName(suiteKey) else { continue }
 

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
@@ -703,7 +703,7 @@ private func loadRunReviewSuites(
     }
 
     var suites: [RunReviewSuite] = []
-    for suiteURL in try runReviewDirectoryChildren(of: runURL) {
+    for suiteURL in try runReviewDirectoryChildren(of: e2eObservationsRootURL(in: runURL)) {
         let suiteKey = suiteURL.lastPathComponent
         guard !isE2EReviewDirectoryName(suiteKey) else { continue }
         var suiteTests: [RunReviewTest] = []
@@ -782,7 +782,11 @@ private func runReviewObservations(
             let result = try runReviewObservationResult(
                 suiteKey: suiteKey,
                 testKey: testKey,
-                attemptURL: attemptURL
+                attemptURL: e2eAttemptArtifactsURL(
+                    in: runURL,
+                    targetName: targetName,
+                    attempt: attemptName
+                )
             )
             observations.append(
                 RunReviewObservation(
@@ -891,11 +895,12 @@ private func runSuitePrompt(
     lines.append("- Suite key: `\(suite.suiteKey)`")
     lines.append("- Suite name: `\(suite.displayName)`")
     lines.append("- Source: `\(suite.sourceURL.path)`")
+    let suiteReviewURL = e2eObservationsRootURL(in: runURL)
+        .appendingPathComponent(suite.suiteKey)
+        .appendingPathComponent(reviewDirectoryName)
+    lines.append("- Suite review directory: `\(suiteReviewURL.path)`")
     lines.append(
-        "- Suite review directory: `\(runURL.appendingPathComponent(suite.suiteKey).appendingPathComponent(reviewDirectoryName).path)`"
-    )
-    lines.append(
-        "- Test review directories: `<run>/\(suite.suiteKey)/<test-key>/\(reviewDirectoryName)/`"
+        "- Test review directories: `<run>/\(e2eObservationsDirectoryName)/\(suite.suiteKey)/<test-key>/\(reviewDirectoryName)/`"
     )
     appendReviewOutputContract(
         to: &lines,
@@ -1060,7 +1065,7 @@ private func appendReviewOutputContract(
     lines.append("  ],")
     lines.append("  \"evidence\": [")
     lines.append(
-        "    { \"path\": \"wendy-cache-list/prints-values/ubuntu-24-04/0001/recording.md\" }"
+        "    { \"path\": \"observations/wendy-cache-list/prints-values/ubuntu-24-04/0001/recording.md\" }"
     )
     lines.append("  ]")
     lines.append("}")
@@ -1288,9 +1293,11 @@ private func appendRunReviewTest(
     lines.append("### \(test.test.suite) › \(test.test.name)")
     lines.append("- Test key: `\(test.suiteKey)/\(test.testKey)`")
     lines.append("- Source: `\(test.test.sourcePath):\(test.test.funcLine)`")
-    lines.append(
-        "- Review directory: `\(runURL.appendingPathComponent(test.suiteKey).appendingPathComponent(test.testKey).appendingPathComponent(reviewDirectoryName).path)`"
-    )
+    let testReviewURL = e2eObservationsRootURL(in: runURL)
+        .appendingPathComponent(test.suiteKey)
+        .appendingPathComponent(test.testKey)
+        .appendingPathComponent(reviewDirectoryName)
+    lines.append("- Review directory: `\(testReviewURL.path)`")
     appendExistingReviews(test.existingReviews, label: "Existing reviews", to: &lines)
     if !test.test.aiComments.isEmpty {
         lines.append("- `// AI:` comments:")
@@ -1356,7 +1363,7 @@ private func runReviewTargetOutcomeCounts(
 
 private func removeExistingRunReviews(in runURL: URL, reviewer: String) throws {
     removeRunReviews(in: runURL, reviewer: reviewer)
-    for suiteURL in try runReviewDirectoryChildren(of: runURL) {
+    for suiteURL in try runReviewDirectoryChildren(of: e2eObservationsRootURL(in: runURL)) {
         guard !isE2EReviewDirectoryName(suiteURL.lastPathComponent) else { continue }
         removeRunReviews(in: suiteURL, reviewer: reviewer)
         for testURL in try runReviewDirectoryChildren(of: suiteURL) {
@@ -1374,7 +1381,7 @@ private func removeRunReviews(in directoryURL: URL, reviewer: String) {
 @discardableResult
 private func enforceRunSuiteReviewContract(in runURL: URL, reviewer: String) throws -> Int {
     var count = 0
-    for suiteURL in try runReviewDirectoryChildren(of: runURL) {
+    for suiteURL in try runReviewDirectoryChildren(of: e2eObservationsRootURL(in: runURL)) {
         guard !isE2EReviewDirectoryName(suiteURL.lastPathComponent) else { continue }
         count += try enforceReviews(
             in: suiteURL,

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
@@ -169,7 +169,7 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
     var flakes: [E2ERunOverviewIssue] = []
     var unknowns: [E2ERunOverviewIssue] = []
 
-    for suiteURL in try overviewDirectoryChildren(of: runURL) {
+    for suiteURL in try overviewDirectoryChildren(of: e2eObservationsRootURL(in: runURL)) {
         let suiteKey = suiteURL.lastPathComponent
         guard !isE2EReviewDirectoryName(suiteKey) else { continue }
 
@@ -186,12 +186,21 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
                 for attemptURL in try overviewDirectoryChildren(of: targetURL) {
                     let attemptName = attemptURL.lastPathComponent
                     guard !isE2EReviewDirectoryName(attemptName) else { continue }
+                    let attemptArtifactsURL = e2eAttemptArtifactsURL(
+                        in: runURL,
+                        targetName: targetName,
+                        attempt: attemptName
+                    )
                     let result = try overviewObservationResult(
                         suiteKey: suiteKey,
                         testKey: testKey,
-                        attemptURL: attemptURL
+                        attemptURL: attemptArtifactsURL
                     )
-                    let artifacts = overviewArtifacts(attemptURL: attemptURL, runURL: runURL)
+                    let artifacts = overviewArtifacts(
+                        observationURL: attemptURL,
+                        attemptArtifactsURL: attemptArtifactsURL,
+                        runURL: runURL
+                    )
                     attempts.append(
                         E2ERunOverviewIssueAttempt(
                             attempt: attemptName,
@@ -340,21 +349,25 @@ private func overviewParseXUnitResults(
     return parser.results
 }
 
-private func overviewArtifacts(attemptURL: URL, runURL: URL) -> E2ERunOverviewArtifacts {
+private func overviewArtifacts(
+    observationURL: URL,
+    attemptArtifactsURL: URL,
+    runURL: URL
+) -> E2ERunOverviewArtifacts {
     E2ERunOverviewArtifacts(
         recording: overviewRelativeFilePath(
             fileName: "recording.md",
-            attemptURL: attemptURL,
+            attemptURL: observationURL,
             runURL: runURL
         ),
         shell: overviewRelativeFilePath(
             fileName: "recording.sh.txt",
-            attemptURL: attemptURL,
+            attemptURL: observationURL,
             runURL: runURL
         ),
         testResults: overviewRelativeFilePath(
             fileName: "test-results.xml",
-            attemptURL: attemptURL,
+            attemptURL: attemptArtifactsURL,
             runURL: runURL
         )
     )

--- a/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2ERecorder.swift
+++ b/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2ERecorder.swift
@@ -182,6 +182,7 @@ public struct WendyE2ERecorder: Sendable {
     private static func testDirectoryURL(identity: TestIdentity) throws -> URL {
         if let runDirectory = WendyE2EEnvironment.runDirectory {
             let directoryURL = URL(fileURLWithPath: runDirectory, isDirectory: true)
+                .appendingPathComponent("observations", isDirectory: true)
                 .appendingPathComponent(
                     Self.recordingSuiteDirectoryName(filePath: identity.filePath),
                     isDirectory: true

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
@@ -1,0 +1,109 @@
+import ArgumentParser
+import Foundation
+import Testing
+
+@testable import SwiftE2ETestingCLI
+
+@Suite
+struct `aggregate command` {
+    @Test
+    func `stores attempt artifacts once and observations separately`() throws {
+        let rootURL = aggregateTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let outputURL = rootURL.appendingPathComponent("aggregate", isDirectory: true)
+        let attemptURL = rootURL.appendingPathComponent(
+            "swift-e2e-tests.local0000.macos-to-rpi.0001",
+            isDirectory: true
+        )
+        let observationURL = attemptURL
+            .appendingPathComponent("observations", isDirectory: true)
+            .appendingPathComponent("wendy-device-info", isDirectory: true)
+            .appendingPathComponent("prints-json-device-information", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: observationURL, withIntermediateDirectories: true)
+        try "{}\n".write(
+            to: attemptURL.appendingPathComponent("attempt.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "<testsuite />\n".write(
+            to: attemptURL.appendingPathComponent("test-results.xml"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "preflight log\n".write(
+            to: attemptURL.appendingPathComponent("attempt.log"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "# Recording\n".write(
+            to: observationURL.appendingPathComponent("recording.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        var command = try AggregateCommand.parse(["--output-dir", outputURL.path, attemptURL.path])
+        try command.run()
+
+        let runURL = outputURL.appendingPathComponent("swift-e2e-tests.local0000", isDirectory: true)
+        let attemptArtifactsURL = runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent("macos-to-rpi", isDirectory: true)
+            .appendingPathComponent("0001", isDirectory: true)
+        let aggregateObservationURL = runURL
+            .appendingPathComponent("observations", isDirectory: true)
+            .appendingPathComponent("wendy-device-info", isDirectory: true)
+            .appendingPathComponent("prints-json-device-information", isDirectory: true)
+            .appendingPathComponent("macos-to-rpi", isDirectory: true)
+            .appendingPathComponent("0001", isDirectory: true)
+
+        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path))
+        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path))
+        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.log").path))
+        #expect(!FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("observations").path))
+        #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("recording.md").path))
+        #expect(!FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("attempt.json").path))
+        #expect(!FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("test-results.xml").path))
+    }
+
+    @Test
+    func `preserves attempt artifacts when there are no observations`() throws {
+        let rootURL = aggregateTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let outputURL = rootURL.appendingPathComponent("aggregate", isDirectory: true)
+        let attemptURL = rootURL.appendingPathComponent(
+            "swift-e2e-tests.local0000.macos-to-rpi.0001",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: attemptURL, withIntermediateDirectories: true)
+        try "{}\n".write(
+            to: attemptURL.appendingPathComponent("attempt.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "<testsuite />\n".write(
+            to: attemptURL.appendingPathComponent("test-results.xml"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        var command = try AggregateCommand.parse(["--output-dir", outputURL.path, attemptURL.path])
+        try command.run()
+
+        let runURL = outputURL.appendingPathComponent("swift-e2e-tests.local0000", isDirectory: true)
+        let attemptArtifactsURL = runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent("macos-to-rpi", isDirectory: true)
+            .appendingPathComponent("0001", isDirectory: true)
+
+        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path))
+        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path))
+    }
+}
+
+private func aggregateTemporaryDirectory() -> URL {
+    URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("wendy-e2e-cli-tests-\(UUID().uuidString)", isDirectory: true)
+}

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
@@ -15,15 +15,26 @@ struct `report command` {
         let testsURL = packageURL.appendingPathComponent("Tests", isDirectory: true)
         let supportURL = packageURL.appendingPathComponent("Support", isDirectory: true)
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
-        let attemptURL = runURL
+        let attemptArtifactsURL = runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent("macos-to-<img src=x onerror=\"alert(1)\">", isDirectory: true)
+            .appendingPathComponent("attempt-1", isDirectory: true)
+        let observationURL = runURL
+            .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("report-security", isDirectory: true)
             .appendingPathComponent("escapes-malicious-target", isDirectory: true)
             .appendingPathComponent("macos-to-<img src=x onerror=\"alert(1)\">", isDirectory: true)
             .appendingPathComponent("attempt-1", isDirectory: true)
+        let noObservationAttemptURL = runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent("macos-to-no-observations", isDirectory: true)
+            .appendingPathComponent("attempt-1", isDirectory: true)
 
         try FileManager.default.createDirectory(at: testsURL, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: supportURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: attemptURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: attemptArtifactsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: observationURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: noObservationAttemptURL, withIntermediateDirectories: true)
 
         try """
             import Testing
@@ -45,7 +56,7 @@ struct `report command` {
               <testcase classname="WendyE2ETests.`report security`" name="escapes malicious target()" time="0.01" />
             </testsuite>
             """.write(
-                to: attemptURL.appendingPathComponent("test-results.xml"),
+                to: attemptArtifactsURL.appendingPathComponent("test-results.xml"),
                 atomically: true,
                 encoding: .utf8
             )
@@ -79,6 +90,7 @@ struct `report command` {
         #expect(!html.contains("<img src=x onerror="))
         #expect(html.contains("macos-to-&lt;img src=x onerror=&quot;alert(1)&quot;&gt;"))
         #expect(html.contains("title=\"macos-to-&lt;img src=x onerror=&quot;alert(1)&quot;&gt;\""))
+        #expect(html.contains("macos-to-no-observations"))
     }
 }
 

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -11,18 +11,30 @@ struct `run overview` {
         defer { try? FileManager.default.removeItem(at: rootURL) }
 
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
-        let suiteURL = runURL.appendingPathComponent(
-            "wendy-device-info",
-            isDirectory: true
-        )
+        let suiteURL = runURL
+            .appendingPathComponent("observations", isDirectory: true)
+            .appendingPathComponent("wendy-device-info", isDirectory: true)
         let testURL = suiteURL.appendingPathComponent(
             "prints-json-device-information",
             isDirectory: true
         )
         let targetURL = testURL.appendingPathComponent("macos-to-rpi", isDirectory: true)
-        let attemptOneURL = targetURL.appendingPathComponent("0001", isDirectory: true)
-        let attemptTwoURL = targetURL.appendingPathComponent("0002", isDirectory: true)
+        let attemptOneObservationURL = targetURL.appendingPathComponent("0001", isDirectory: true)
+        let attemptTwoObservationURL = targetURL.appendingPathComponent("0002", isDirectory: true)
+        let attemptArtifactsRootURL = runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent("macos-to-rpi", isDirectory: true)
+        let attemptOneURL = attemptArtifactsRootURL.appendingPathComponent("0001", isDirectory: true)
+        let attemptTwoURL = attemptArtifactsRootURL.appendingPathComponent("0002", isDirectory: true)
 
+        try FileManager.default.createDirectory(
+            at: attemptOneObservationURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: attemptTwoObservationURL,
+            withIntermediateDirectories: true
+        )
         try FileManager.default.createDirectory(
             at: attemptOneURL,
             withIntermediateDirectories: true
@@ -39,7 +51,7 @@ struct `run overview` {
         )
         try writeXUnitResult(to: attemptTwoURL, status: .passed, duration: 0.75)
         try "# Recording\n\n## Command 1\n".write(
-            to: attemptOneURL.appendingPathComponent("recording.md"),
+            to: attemptOneObservationURL.appendingPathComponent("recording.md"),
             atomically: true,
             encoding: .utf8
         )
@@ -71,17 +83,24 @@ struct `run overview` {
         defer { try? FileManager.default.removeItem(at: rootURL) }
 
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
-        let suiteURL = runURL.appendingPathComponent(
-            "wendy-device-info",
-            isDirectory: true
-        )
+        let suiteURL = runURL
+            .appendingPathComponent("observations", isDirectory: true)
+            .appendingPathComponent("wendy-device-info", isDirectory: true)
         let testURL = suiteURL.appendingPathComponent(
             "prints-json-device-information",
             isDirectory: true
         )
         let targetURL = testURL.appendingPathComponent("macos-to-rpi", isDirectory: true)
-        let attemptURL = targetURL.appendingPathComponent("0001", isDirectory: true)
+        let attemptObservationURL = targetURL.appendingPathComponent("0001", isDirectory: true)
+        let attemptURL = runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent("macos-to-rpi", isDirectory: true)
+            .appendingPathComponent("0001", isDirectory: true)
 
+        try FileManager.default.createDirectory(
+            at: attemptObservationURL,
+            withIntermediateDirectories: true
+        )
         try FileManager.default.createDirectory(
             at: attemptURL,
             withIntermediateDirectories: true
@@ -92,7 +111,7 @@ struct `run overview` {
             duration: 2.0
         )
         try "# Recording\n".write(
-            to: attemptURL.appendingPathComponent("recording.md"),
+            to: attemptObservationURL.appendingPathComponent("recording.md"),
             atomically: true,
             encoding: .utf8
         )


### PR DESCRIPTION
## Summary
- Split Swift E2E artifacts into attempt-level and per-test namespaces.
- Raw attempts now keep recordings under `observations/`, and aggregate runs store attempt-root artifacts once under `attempts/<target>/<attempt>/`.
- Reports, reviews, and overviews now read attempt metadata/results from `attempts/` and per-test evidence from `observations/`, so no-observation/preflight failures still retain attempt evidence without duplicating it per test.

## Tests
- `bash -n swift/Scripts/E2EAggregate.sh`
- `bash -n swift/Scripts/E2EReport.sh`
- `bash -n swift/Scripts/E2EReview.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/swift-e2e-tests.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/swift-e2e-tests.yml`
- `cd swift/WendyE2ETests && swift test --filter SwiftE2ETestingCLITests`
- `cd swift/WendyE2ETests && swift test --filter WendyE2ETestingTests`

Closes WDY-1527
