### PR TITLE
Surface contextual macOS unsupported errors

### DIFF
--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -174,13 +174,38 @@ func formatError(err error) error {
 	case strings.Contains(msg, "code = DeadlineExceeded"):
 		return fmt.Errorf("%sConnection timed out.", prefix)
 	case strings.Contains(msg, "code = Unimplemented"):
+		// Preserve intentional, contextual Unimplemented descriptions from the
+		// agent (for example Wendy Agent for Mac feature gaps). Keep the legacy
+		// update hint only for generic protocol-mismatch responses where gRPC or
+		// an old agent did not recognize the service/method.
+		if desc, ok := grpcDesc(msg); ok && !isGenericUnimplementedDesc(desc) {
+			return fmt.Errorf("%s%s", prefix, desc)
+		}
 		return fmt.Errorf("%sNot supported by this agent version. Try updating the agent.", prefix)
 	default:
 		// Strip transport noise, keep the desc message.
-		if idx := strings.Index(msg, "desc = "); idx >= 0 {
-			desc := msg[idx+len("desc = "):]
+		if desc, ok := grpcDesc(msg); ok {
 			return fmt.Errorf("%s%s", prefix, desc)
 		}
 		return err
 	}
+}
+
+func grpcDesc(msg string) (string, bool) {
+	idx := strings.Index(msg, "desc = ")
+	if idx < 0 {
+		return "", false
+	}
+	desc := strings.TrimSpace(msg[idx+len("desc = "):])
+	return desc, desc != ""
+}
+
+func isGenericUnimplementedDesc(desc string) bool {
+	lower := strings.ToLower(strings.TrimSpace(desc))
+	if lower == "" {
+		return true
+	}
+	return strings.HasPrefix(lower, "unknown service ") ||
+		strings.HasPrefix(lower, "unknown method ") ||
+		(strings.HasPrefix(lower, "method ") && strings.HasSuffix(lower, " not implemented"))
 }

--- a/go/cmd/wendy/main_test.go
+++ b/go/cmd/wendy/main_test.go
@@ -373,10 +373,10 @@ func TestFormatError_LocalPKICoreUnavailable(t *testing.T) {
 }
 
 func TestFormatError_UnimplementedPreservesContextualDescription(t *testing.T) {
-	err := fmt.Errorf("listing audio devices: %w", status.Error(codes.Unimplemented, "Audio device management is not supported by Wendy Agent for Mac."))
+	err := fmt.Errorf("listing audio devices: %w", status.Error(codes.Unimplemented, "Audio device management is currently not supported by Wendy Agent for Mac."))
 
 	got := formatError(err).Error()
-	want := "listing audio devices: Audio device management is not supported by Wendy Agent for Mac."
+	want := "listing audio devices: Audio device management is currently not supported by Wendy Agent for Mac."
 	if got != want {
 		t.Fatalf("formatError() = %q, want %q", got, want)
 	}

--- a/go/cmd/wendy/main_test.go
+++ b/go/cmd/wendy/main_test.go
@@ -373,10 +373,10 @@ func TestFormatError_LocalPKICoreUnavailable(t *testing.T) {
 }
 
 func TestFormatError_UnimplementedPreservesContextualDescription(t *testing.T) {
-	err := fmt.Errorf("listing audio devices: %w", status.Error(codes.Unimplemented, "Audio device management is currently not supported on macOS."))
+	err := fmt.Errorf("listing audio devices: %w", status.Error(codes.Unimplemented, "Audio device management is not supported by Wendy Agent for Mac."))
 
 	got := formatError(err).Error()
-	want := "listing audio devices: Audio device management is currently not supported on macOS."
+	want := "listing audio devices: Audio device management is not supported by Wendy Agent for Mac."
 	if got != want {
 		t.Fatalf("formatError() = %q, want %q", got, want)
 	}

--- a/go/cmd/wendy/main_test.go
+++ b/go/cmd/wendy/main_test.go
@@ -372,6 +372,39 @@ func TestFormatError_LocalPKICoreUnavailable(t *testing.T) {
 	}
 }
 
+func TestFormatError_UnimplementedPreservesContextualDescription(t *testing.T) {
+	err := fmt.Errorf("listing audio devices: %w", status.Error(codes.Unimplemented, "Audio device management is currently not supported on macOS."))
+
+	got := formatError(err).Error()
+	want := "listing audio devices: Audio device management is currently not supported on macOS."
+	if got != want {
+		t.Fatalf("formatError() = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "Try updating") || strings.Contains(got, "rpc error") {
+		t.Fatalf("formatError() should not render generic update advice or raw gRPC text: %q", got)
+	}
+}
+
+func TestFormatError_UnimplementedKeepsUpdateHintForUnknownMethod(t *testing.T) {
+	err := fmt.Errorf("listing volumes: %w", status.Error(codes.Unimplemented, "unknown method ListVolumes for service agent.ContainerService"))
+
+	got := formatError(err).Error()
+	want := "listing volumes: Not supported by this agent version. Try updating the agent."
+	if got != want {
+		t.Fatalf("formatError() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatError_UnimplementedKeepsUpdateHintForGeneratedStub(t *testing.T) {
+	err := fmt.Errorf("listing volumes: %w", status.Error(codes.Unimplemented, "method ListVolumes not implemented"))
+
+	got := formatError(err).Error()
+	want := "listing volumes: Not supported by this agent version. Try updating the agent."
+	if got != want {
+		t.Fatalf("formatError() = %q, want %q", got, want)
+	}
+}
+
 func TestEnv_IsCITripsKillSwitch(t *testing.T) {
 	// Sanity check that env.IsCI() recognizes the CI variable. The deeper
 	// contract — that analytics.Init refuses to enable in CI — is covered

--- a/go/internal/cli/commands/apps_dashboard.go
+++ b/go/internal/cli/commands/apps_dashboard.go
@@ -252,6 +252,34 @@ func waitForAppsDashVolumes(ch chan appsDashVolumesMsg) tea.Cmd {
 	}
 }
 
+func appsDashPollFlash(err error) string {
+	if status.Code(err) == codes.Unimplemented {
+		return "Poll notice: " + userFacingGRPCError(err)
+	}
+	return "Poll error: " + userFacingGRPCError(err)
+}
+
+func userFacingGRPCError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if _, ok := status.FromError(err); ok {
+		if desc, descOK := grpcDescFromErrorString(err.Error()); descOK {
+			return desc
+		}
+	}
+	return err.Error()
+}
+
+func grpcDescFromErrorString(msg string) (string, bool) {
+	idx := strings.Index(msg, "desc = ")
+	if idx < 0 {
+		return "", false
+	}
+	desc := strings.TrimSpace(msg[idx+len("desc = "):])
+	return desc, desc != ""
+}
+
 // --- Polling goroutines ---
 
 func (m appsDashboardModel) runContainersPoll() {
@@ -353,28 +381,33 @@ func (m appsDashboardModel) runVolumesPoll() {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
-	fetch := func() {
+	fetch := func() bool {
 		resp, err := m.conn.ContainerService.ListVolumes(m.ctx, &agentpb.ListVolumesRequest{})
 		if err != nil {
 			select {
 			case m.volumesCh <- appsDashVolumesMsg{err: err}:
 			case <-m.ctx.Done():
 			}
-			return
+			return status.Code(err) != codes.Unimplemented
 		}
 		select {
 		case m.volumesCh <- appsDashVolumesMsg{volumes: resp.GetVolumes()}:
 		case <-m.ctx.Done():
 		}
+		return true
 	}
 
-	fetch()
+	if !fetch() {
+		return
+	}
 	for {
 		select {
 		case <-m.ctx.Done():
 			return
 		case <-ticker.C:
-			fetch()
+			if !fetch() {
+				return
+			}
 		}
 	}
 }
@@ -470,7 +503,7 @@ func (m appsDashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case appsDashVolumesMsg:
 		if msg.err != nil {
-			m.flash = fmt.Sprintf("Poll error: %s", msg.err)
+			m.flash = appsDashPollFlash(msg.err)
 		} else {
 			m.cachedVolumes = msg.volumes
 			m.refreshTable()

--- a/go/internal/cli/commands/apps_dashboard_test.go
+++ b/go/internal/cli/commands/apps_dashboard_test.go
@@ -119,12 +119,12 @@ func TestAppsDashboardModel_QuitAction(t *testing.T) {
 
 func TestAppsDashboardModel_VolumesUnimplementedShowsCleanNotice(t *testing.T) {
 	m := newAppsDashboardModel(nil, context.Background())
-	err := status.Error(codes.Unimplemented, "Container volume management is not supported by Wendy Agent for Mac.")
+	err := status.Error(codes.Unimplemented, "Container volume management is currently not supported by Wendy Agent for Mac.")
 
 	updated, _ := m.Update(appsDashVolumesMsg{err: err})
 	m = updated.(appsDashboardModel)
 
-	want := "Poll notice: Container volume management is not supported by Wendy Agent for Mac."
+	want := "Poll notice: Container volume management is currently not supported by Wendy Agent for Mac."
 	if m.flash != want {
 		t.Fatalf("flash = %q, want %q", m.flash, want)
 	}

--- a/go/internal/cli/commands/apps_dashboard_test.go
+++ b/go/internal/cli/commands/apps_dashboard_test.go
@@ -2,10 +2,13 @@ package commands
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestBuildDashboardRows(t *testing.T) {
@@ -112,6 +115,22 @@ func TestAppsDashboardModel_QuitAction(t *testing.T) {
 		t.Fatal("expected quit command after q")
 	}
 	_ = m
+}
+
+func TestAppsDashboardModel_VolumesUnimplementedShowsCleanNotice(t *testing.T) {
+	m := newAppsDashboardModel(nil, context.Background())
+	err := status.Error(codes.Unimplemented, "Container volume management is currently not supported on macOS.")
+
+	updated, _ := m.Update(appsDashVolumesMsg{err: err})
+	m = updated.(appsDashboardModel)
+
+	want := "Poll notice: Container volume management is currently not supported on macOS."
+	if m.flash != want {
+		t.Fatalf("flash = %q, want %q", m.flash, want)
+	}
+	if strings.Contains(m.flash, "rpc error") || strings.Contains(m.flash, "code = Unimplemented") {
+		t.Fatalf("flash should not leak raw gRPC status: %q", m.flash)
+	}
 }
 
 func TestAppsDashboardModel_EnterSetsActionLogs(t *testing.T) {

--- a/go/internal/cli/commands/apps_dashboard_test.go
+++ b/go/internal/cli/commands/apps_dashboard_test.go
@@ -119,12 +119,12 @@ func TestAppsDashboardModel_QuitAction(t *testing.T) {
 
 func TestAppsDashboardModel_VolumesUnimplementedShowsCleanNotice(t *testing.T) {
 	m := newAppsDashboardModel(nil, context.Background())
-	err := status.Error(codes.Unimplemented, "Container volume management is currently not supported on macOS.")
+	err := status.Error(codes.Unimplemented, "Container volume management is not supported by Wendy Agent for Mac.")
 
 	updated, _ := m.Update(appsDashVolumesMsg{err: err})
 	m = updated.(appsDashboardModel)
 
-	want := "Poll notice: Container volume management is currently not supported on macOS."
+	want := "Poll notice: Container volume management is not supported by Wendy Agent for Mac."
 	if m.flash != want {
 		t.Fatalf("flash = %q, want %q", m.flash, want)
 	}

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -158,12 +158,9 @@ func pipeVideoToStdout(stream videoStream, w io.Writer) error {
 // playVideoWithGStreamer spawns gst-launch-1.0 and feeds it the video stream via stdin.
 // It peeks the first frame to determine the codec, then starts the matching decoder pipeline.
 func playVideoWithGStreamer(ctx context.Context, stream videoStream) error {
-	gstPath, err := resolveGSTLaunch()
-	if err != nil {
-		return err
-	}
-
-	// Peek the first frame to learn the codec.
+	// Peek the first frame before checking local playback dependencies. Server-
+	// streaming RPCs can surface Unimplemented only on Recv(), and that remote
+	// unsupported error is more actionable than a missing local GStreamer binary.
 	first, err := stream.Recv()
 	if err == io.EOF {
 		return nil
@@ -172,6 +169,11 @@ func playVideoWithGStreamer(ctx context.Context, stream videoStream) error {
 		return fmt.Errorf("receiving video: %w", err)
 	}
 	codec := first.GetCodec()
+
+	gstPath, err := resolveGSTLaunch()
+	if err != nil {
+		return err
+	}
 
 	gst := exec.CommandContext(ctx, gstPath, playbackPipelineArgs(codec)...)
 	gst.Stderr = os.Stderr

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
@@ -107,7 +108,10 @@ func newCameraViewCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
-			stream, err := conn.VideoService.StreamVideo(ctx, &agentpb.StreamVideoRequest{
+			streamCtx, cancelStream := context.WithCancel(ctx)
+			defer cancelStream()
+
+			stream, err := conn.VideoService.StreamVideo(streamCtx, &agentpb.StreamVideoRequest{
 				DeviceId:  deviceID,
 				Width:     width,
 				Height:    height,
@@ -122,7 +126,7 @@ func newCameraViewCmd() *cobra.Command {
 			if toStdout {
 				return pipeVideoToStdout(stream, cmd.OutOrStdout())
 			}
-			return playVideoWithGStreamer(ctx, stream)
+			return playVideoWithGStreamer(streamCtx, stream)
 		},
 	}
 
@@ -155,25 +159,44 @@ func pipeVideoToStdout(stream videoStream, w io.Writer) error {
 	}
 }
 
+const gstMissingRemoteErrorGrace = 500 * time.Millisecond
+
+type firstVideoFrameResult struct {
+	frame *agentpb.VideoFrame
+	err   error
+}
+
+type gstLaunchResult struct {
+	path string
+	err  error
+}
+
 // playVideoWithGStreamer spawns gst-launch-1.0 and feeds it the video stream via stdin.
 // It peeks the first frame to determine the codec, then starts the matching decoder pipeline.
 func playVideoWithGStreamer(ctx context.Context, stream videoStream) error {
-	// Peek the first frame before checking local playback dependencies. Server-
-	// streaming RPCs can surface Unimplemented only on Recv(), and that remote
-	// unsupported error is more actionable than a missing local GStreamer binary.
-	first, err := stream.Recv()
-	if err == io.EOF {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("receiving video: %w", err)
-	}
-	codec := first.GetCodec()
+	firstCh := make(chan firstVideoFrameResult, 1)
+	go func() {
+		first, err := stream.Recv()
+		if err == io.EOF {
+			err = nil
+		}
+		if err != nil {
+			err = fmt.Errorf("receiving video: %w", err)
+		}
+		firstCh <- firstVideoFrameResult{frame: first, err: err}
+	}()
 
-	gstPath, err := resolveGSTLaunch()
-	if err != nil {
+	gstCh := make(chan gstLaunchResult, 1)
+	go func() {
+		path, err := resolveGSTLaunch()
+		gstCh <- gstLaunchResult{path: path, err: err}
+	}()
+
+	first, gstPath, err := waitForFirstVideoFrameAndGStreamer(ctx, firstCh, gstCh)
+	if err != nil || first == nil {
 		return err
 	}
+	codec := first.GetCodec()
 
 	gst := exec.CommandContext(ctx, gstPath, playbackPipelineArgs(codec)...)
 	gst.Stderr = os.Stderr
@@ -200,6 +223,60 @@ func playVideoWithGStreamer(ctx context.Context, stream videoStream) error {
 		return err
 	case <-ctx.Done():
 		return nil
+	}
+}
+
+func waitForFirstVideoFrameAndGStreamer(
+	ctx context.Context,
+	firstCh <-chan firstVideoFrameResult,
+	gstCh <-chan gstLaunchResult,
+) (*agentpb.VideoFrame, string, error) {
+	var first *agentpb.VideoFrame
+	var gstPath string
+	var gstErr error
+	firstDone := false
+	gstDone := false
+
+	for {
+		select {
+		case r := <-firstCh:
+			if r.err != nil || r.frame == nil {
+				return nil, "", r.err
+			}
+			first = r.frame
+			firstDone = true
+			if gstDone {
+				return first, gstPath, gstErr
+			}
+
+		case g := <-gstCh:
+			gstPath, gstErr = g.path, g.err
+			gstDone = true
+			if firstDone {
+				return first, gstPath, gstErr
+			}
+			if gstErr != nil {
+				// A server-streaming Unimplemented can arrive on Recv(), while a
+				// missing local GStreamer binary is usually known immediately. Give
+				// a remote unsupported status a brief chance to arrive so we don't
+				// mask it, but still fail promptly if a working device never sends a
+				// frame and playback is impossible locally.
+				select {
+				case r := <-firstCh:
+					if r.err != nil || r.frame == nil {
+						return nil, "", r.err
+					}
+					return r.frame, "", gstErr
+				case <-time.After(gstMissingRemoteErrorGrace):
+					return nil, "", gstErr
+				case <-ctx.Done():
+					return nil, "", nil
+				}
+			}
+
+		case <-ctx.Done():
+			return nil, "", nil
+		}
 	}
 }
 

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"sync"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
@@ -108,10 +107,7 @@ func newCameraViewCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
-			streamCtx, cancelStream := context.WithCancel(ctx)
-			defer cancelStream()
-
-			stream, err := conn.VideoService.StreamVideo(streamCtx, &agentpb.StreamVideoRequest{
+			stream, err := conn.VideoService.StreamVideo(ctx, &agentpb.StreamVideoRequest{
 				DeviceId:  deviceID,
 				Width:     width,
 				Height:    height,
@@ -126,7 +122,7 @@ func newCameraViewCmd() *cobra.Command {
 			if toStdout {
 				return pipeVideoToStdout(stream, cmd.OutOrStdout())
 			}
-			return playVideoWithGStreamer(streamCtx, stream)
+			return playVideoWithGStreamer(ctx, stream)
 		},
 	}
 
@@ -159,44 +155,25 @@ func pipeVideoToStdout(stream videoStream, w io.Writer) error {
 	}
 }
 
-const gstMissingRemoteErrorGrace = 500 * time.Millisecond
-
-type firstVideoFrameResult struct {
-	frame *agentpb.VideoFrame
-	err   error
-}
-
-type gstLaunchResult struct {
-	path string
-	err  error
-}
-
 // playVideoWithGStreamer spawns gst-launch-1.0 and feeds it the video stream via stdin.
 // It peeks the first frame to determine the codec, then starts the matching decoder pipeline.
 func playVideoWithGStreamer(ctx context.Context, stream videoStream) error {
-	firstCh := make(chan firstVideoFrameResult, 1)
-	go func() {
-		first, err := stream.Recv()
-		if err == io.EOF {
-			err = nil
-		}
-		if err != nil {
-			err = fmt.Errorf("receiving video: %w", err)
-		}
-		firstCh <- firstVideoFrameResult{frame: first, err: err}
-	}()
-
-	gstCh := make(chan gstLaunchResult, 1)
-	go func() {
-		path, err := resolveGSTLaunch()
-		gstCh <- gstLaunchResult{path: path, err: err}
-	}()
-
-	first, gstPath, err := waitForFirstVideoFrameAndGStreamer(ctx, firstCh, gstCh)
-	if err != nil || first == nil {
-		return err
+	// Peek the first frame before checking local playback dependencies. Server-
+	// streaming RPCs can surface Unimplemented only on Recv(), and that remote
+	// unsupported error is more actionable than a missing local GStreamer binary.
+	first, err := stream.Recv()
+	if err == io.EOF {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("receiving video: %w", err)
 	}
 	codec := first.GetCodec()
+
+	gstPath, err := resolveGSTLaunch()
+	if err != nil {
+		return err
+	}
 
 	gst := exec.CommandContext(ctx, gstPath, playbackPipelineArgs(codec)...)
 	gst.Stderr = os.Stderr
@@ -223,60 +200,6 @@ func playVideoWithGStreamer(ctx context.Context, stream videoStream) error {
 		return err
 	case <-ctx.Done():
 		return nil
-	}
-}
-
-func waitForFirstVideoFrameAndGStreamer(
-	ctx context.Context,
-	firstCh <-chan firstVideoFrameResult,
-	gstCh <-chan gstLaunchResult,
-) (*agentpb.VideoFrame, string, error) {
-	var first *agentpb.VideoFrame
-	var gstPath string
-	var gstErr error
-	firstDone := false
-	gstDone := false
-
-	for {
-		select {
-		case r := <-firstCh:
-			if r.err != nil || r.frame == nil {
-				return nil, "", r.err
-			}
-			first = r.frame
-			firstDone = true
-			if gstDone {
-				return first, gstPath, gstErr
-			}
-
-		case g := <-gstCh:
-			gstPath, gstErr = g.path, g.err
-			gstDone = true
-			if firstDone {
-				return first, gstPath, gstErr
-			}
-			if gstErr != nil {
-				// A server-streaming Unimplemented can arrive on Recv(), while a
-				// missing local GStreamer binary is usually known immediately. Give
-				// a remote unsupported status a brief chance to arrive so we don't
-				// mask it, but still fail promptly if a working device never sends a
-				// frame and playback is impossible locally.
-				select {
-				case r := <-firstCh:
-					if r.err != nil || r.frame == nil {
-						return nil, "", r.err
-					}
-					return r.frame, "", gstErr
-				case <-time.After(gstMissingRemoteErrorGrace):
-					return nil, "", gstErr
-				case <-ctx.Done():
-					return nil, "", nil
-				}
-			}
-
-		case <-ctx.Done():
-			return nil, "", nil
-		}
 	}
 }
 

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Annex-B NAL header bytes (forbidden_zero | nal_ref_idc | nal_unit_type).
@@ -36,11 +38,17 @@ func joinBytes(parts ...[]byte) []byte {
 }
 
 type mockVideoStream struct {
-	frames []*agentpb.VideoFrame
-	idx    int
+	frames      []*agentpb.VideoFrame
+	idx         int
+	err         error
+	errReturned bool
 }
 
 func (m *mockVideoStream) Recv() (*agentpb.VideoFrame, error) {
+	if m.err != nil && !m.errReturned {
+		m.errReturned = true
+		return nil, m.err
+	}
 	if m.idx >= len(m.frames) {
 		return nil, io.EOF
 	}
@@ -136,13 +144,31 @@ func TestPlayVideoWithGStreamer_MissingGStreamer(t *testing.T) {
 	t.Setenv("PATH", t.TempDir()) // empty dir — no executables on PATH
 	stubGSTFallback(t, nil)       // no install-location fallbacks either
 
-	stream := &mockVideoStream{}
+	stream := &mockVideoStream{frames: []*agentpb.VideoFrame{{Data: []byte{0x00}, Codec: agentpb.VideoCodec_VIDEO_CODEC_H264}}}
 	err := playVideoWithGStreamer(context.Background(), stream)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestPlayVideoWithGStreamer_RemoteStreamErrorPrecedesMissingGStreamer(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir — no executables on PATH
+	stubGSTFallback(t, nil)       // no install-location fallbacks either
+
+	remoteErr := status.Error(codes.Unimplemented, "Camera streaming is currently not supported on macOS.")
+	stream := &mockVideoStream{err: remoteErr}
+	err := playVideoWithGStreamer(context.Background(), stream)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Camera streaming is currently not supported on macOS.") {
+		t.Fatalf("expected remote unsupported error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "not found") {
+		t.Fatalf("remote unsupported error should not be masked by missing GStreamer: %v", err)
 	}
 }
 

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -158,13 +158,13 @@ func TestPlayVideoWithGStreamer_RemoteStreamErrorPrecedesMissingGStreamer(t *tes
 	t.Setenv("PATH", t.TempDir()) // empty dir — no executables on PATH
 	stubGSTFallback(t, nil)       // no install-location fallbacks either
 
-	remoteErr := status.Error(codes.Unimplemented, "Camera streaming is currently not supported on macOS.")
+	remoteErr := status.Error(codes.Unimplemented, "Camera streaming is not supported by Wendy Agent for Mac.")
 	stream := &mockVideoStream{err: remoteErr}
 	err := playVideoWithGStreamer(context.Background(), stream)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "Camera streaming is currently not supported on macOS.") {
+	if !strings.Contains(err.Error(), "Camera streaming is not supported by Wendy Agent for Mac.") {
 		t.Fatalf("expected remote unsupported error, got: %v", err)
 	}
 	if strings.Contains(err.Error(), "not found") {

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"google.golang.org/grpc/codes"
@@ -56,15 +55,6 @@ func (m *mockVideoStream) Recv() (*agentpb.VideoFrame, error) {
 	f := m.frames[m.idx]
 	m.idx++
 	return f, nil
-}
-
-type blockingVideoStream struct {
-	unblock chan struct{}
-}
-
-func (s *blockingVideoStream) Recv() (*agentpb.VideoFrame, error) {
-	<-s.unblock
-	return nil, io.EOF
 }
 
 func TestPipeVideoToStdout_WritesAllFrames(t *testing.T) {
@@ -179,26 +169,6 @@ func TestPlayVideoWithGStreamer_RemoteStreamErrorPrecedesMissingGStreamer(t *tes
 	}
 	if strings.Contains(err.Error(), "not found") {
 		t.Fatalf("remote unsupported error should not be masked by missing GStreamer: %v", err)
-	}
-}
-
-func TestPlayVideoWithGStreamer_MissingGStreamerDoesNotWaitForeverForFirstFrame(t *testing.T) {
-	t.Setenv("PATH", t.TempDir()) // empty dir — no executables on PATH
-	stubGSTFallback(t, nil)       // no install-location fallbacks either
-
-	stream := &blockingVideoStream{unblock: make(chan struct{})}
-	defer close(stream.unblock)
-
-	start := time.Now()
-	err := playVideoWithGStreamer(context.Background(), stream)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("expected missing GStreamer error, got: %v", err)
-	}
-	if elapsed := time.Since(start); elapsed > 2*time.Second {
-		t.Fatalf("missing GStreamer should fail promptly, took %s", elapsed)
 	}
 }
 

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"google.golang.org/grpc/codes"
@@ -55,6 +56,15 @@ func (m *mockVideoStream) Recv() (*agentpb.VideoFrame, error) {
 	f := m.frames[m.idx]
 	m.idx++
 	return f, nil
+}
+
+type blockingVideoStream struct {
+	unblock chan struct{}
+}
+
+func (s *blockingVideoStream) Recv() (*agentpb.VideoFrame, error) {
+	<-s.unblock
+	return nil, io.EOF
 }
 
 func TestPipeVideoToStdout_WritesAllFrames(t *testing.T) {
@@ -169,6 +179,26 @@ func TestPlayVideoWithGStreamer_RemoteStreamErrorPrecedesMissingGStreamer(t *tes
 	}
 	if strings.Contains(err.Error(), "not found") {
 		t.Fatalf("remote unsupported error should not be masked by missing GStreamer: %v", err)
+	}
+}
+
+func TestPlayVideoWithGStreamer_MissingGStreamerDoesNotWaitForeverForFirstFrame(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir — no executables on PATH
+	stubGSTFallback(t, nil)       // no install-location fallbacks either
+
+	stream := &blockingVideoStream{unblock: make(chan struct{})}
+	defer close(stream.unblock)
+
+	start := time.Now()
+	err := playVideoWithGStreamer(context.Background(), stream)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected missing GStreamer error, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("missing GStreamer should fail promptly, took %s", elapsed)
 	}
 }
 

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -158,13 +158,13 @@ func TestPlayVideoWithGStreamer_RemoteStreamErrorPrecedesMissingGStreamer(t *tes
 	t.Setenv("PATH", t.TempDir()) // empty dir — no executables on PATH
 	stubGSTFallback(t, nil)       // no install-location fallbacks either
 
-	remoteErr := status.Error(codes.Unimplemented, "Camera streaming is not supported by Wendy Agent for Mac.")
+	remoteErr := status.Error(codes.Unimplemented, "Camera streaming is currently not supported by Wendy Agent for Mac.")
 	stream := &mockVideoStream{err: remoteErr}
 	err := playVideoWithGStreamer(context.Background(), stream)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "Camera streaming is not supported by Wendy Agent for Mac.") {
+	if !strings.Contains(err.Error(), "Camera streaming is currently not supported by Wendy Agent for Mac.") {
 		t.Fatalf("expected remote unsupported error, got: %v", err)
 	}
 	if strings.Contains(err.Error(), "not found") {

--- a/go/internal/cli/tui/bttable/model.go
+++ b/go/internal/cli/tui/bttable/model.go
@@ -419,10 +419,21 @@ func userFacingError(err error) string {
 	if err == nil {
 		return ""
 	}
-	if st, ok := status.FromError(err); ok {
-		return st.Message()
+	if _, ok := status.FromError(err); ok {
+		if desc, descOK := grpcDescFromErrorString(err.Error()); descOK {
+			return desc
+		}
 	}
 	return err.Error()
+}
+
+func grpcDescFromErrorString(msg string) (string, bool) {
+	idx := strings.Index(msg, "desc = ")
+	if idx < 0 {
+		return "", false
+	}
+	desc := strings.TrimSpace(msg[idx+len("desc = "):])
+	return desc, desc != ""
 }
 
 // setFlash sets a transient message and returns a command that clears it after

--- a/go/internal/cli/tui/wifitable/model.go
+++ b/go/internal/cli/tui/wifitable/model.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc/status"
 )
 
 // mode tracks which sub-view the model is showing.
@@ -811,15 +812,16 @@ func (m *Model) reconcileRefresh(incoming []Network) []Network {
 // flashFor renders a user-facing message for a completed operation.
 func flashFor(msg OpResultMsg) (string, bool) {
 	if msg.Err != nil {
+		reason := userFacingError(msg.Err)
 		switch msg.Action {
 		case ActionConnect, ActionConnectUnlisted:
-			return fmt.Sprintf("Connect to %s failed: %v", msg.SSID, msg.Err), true
+			return fmt.Sprintf("Connect to %s failed: %s", msg.SSID, reason), true
 		case ActionForget:
-			return fmt.Sprintf("Forget %s failed: %v", msg.SSID, msg.Err), true
+			return fmt.Sprintf("Forget %s failed: %s", msg.SSID, reason), true
 		case ActionReorder:
-			return fmt.Sprintf("Reorder failed: %v", msg.Err), true
+			return fmt.Sprintf("Reorder failed: %s", reason), true
 		default:
-			return msg.Err.Error(), true
+			return reason, true
 		}
 	}
 	switch msg.Action {
@@ -831,6 +833,30 @@ func flashFor(msg OpResultMsg) (string, bool) {
 		return fmt.Sprintf("Updated priority for %d known networks.", msg.Count), false
 	}
 	return "", false
+}
+
+// userFacingError renders a remote error for display, preferring the gRPC
+// status description so internal "rpc error: code = ..." framing is not shown
+// in the table status line. Non-gRPC errors fall back to their plain text.
+func userFacingError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if _, ok := status.FromError(err); ok {
+		if desc, descOK := grpcDescFromErrorString(err.Error()); descOK {
+			return desc
+		}
+	}
+	return err.Error()
+}
+
+func grpcDescFromErrorString(msg string) (string, bool) {
+	idx := strings.Index(msg, "desc = ")
+	if idx < 0 {
+		return "", false
+	}
+	desc := strings.TrimSpace(msg[idx+len("desc = "):])
+	return desc, desc != ""
 }
 
 func clearFlashAfter(d time.Duration) tea.Cmd {

--- a/go/internal/cli/tui/wifitable/model_test.go
+++ b/go/internal/cli/tui/wifitable/model_test.go
@@ -236,14 +236,14 @@ func TestForgetErrorSurfacesAndSkipsRefresh(t *testing.T) {
 
 func TestOpErrorFlashStripsGRPCFraming(t *testing.T) {
 	networks := []Network{{SSID: "Home", Known: true}}
-	h := &fakeHandler{forgetResult: status.Error(codes.Unimplemented, "Wi-Fi configuration is not supported by Wendy Agent for Mac.")}
+	h := &fakeHandler{forgetResult: status.Error(codes.Unimplemented, "Wi-Fi configuration is currently not supported by Wendy Agent for Mac.")}
 	m := NewModel(networks).WithHandler(h)
 	m.table.SetCursor(0)
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 	m = runCmd(next.(Model), cmd)
 
-	if !strings.Contains(m.flashMessage, "Wi-Fi configuration is not supported by Wendy Agent for Mac.") {
+	if !strings.Contains(m.flashMessage, "Wi-Fi configuration is currently not supported by Wendy Agent for Mac.") {
 		t.Fatalf("flash should keep contextual error, got %q", m.flashMessage)
 	}
 	if strings.Contains(m.flashMessage, "rpc error") || strings.Contains(m.flashMessage, "code = Unimplemented") {

--- a/go/internal/cli/tui/wifitable/model_test.go
+++ b/go/internal/cli/tui/wifitable/model_test.go
@@ -2,11 +2,14 @@ package wifitable
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // fakeHandler records dispatched ops and never blocks — callers drive the
@@ -228,6 +231,23 @@ func TestForgetErrorSurfacesAndSkipsRefresh(t *testing.T) {
 	}
 	if h.refreshCalls != 0 {
 		t.Errorf("Refresh should not run on failure, got %d calls", h.refreshCalls)
+	}
+}
+
+func TestOpErrorFlashStripsGRPCFraming(t *testing.T) {
+	networks := []Network{{SSID: "Home", Known: true}}
+	h := &fakeHandler{forgetResult: status.Error(codes.Unimplemented, "Wi-Fi configuration is currently not supported on macOS.")}
+	m := NewModel(networks).WithHandler(h)
+	m.table.SetCursor(0)
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = runCmd(next.(Model), cmd)
+
+	if !strings.Contains(m.flashMessage, "Wi-Fi configuration is currently not supported on macOS.") {
+		t.Fatalf("flash should keep contextual error, got %q", m.flashMessage)
+	}
+	if strings.Contains(m.flashMessage, "rpc error") || strings.Contains(m.flashMessage, "code = Unimplemented") {
+		t.Fatalf("flash should not leak raw gRPC status: %q", m.flashMessage)
 	}
 }
 

--- a/go/internal/cli/tui/wifitable/model_test.go
+++ b/go/internal/cli/tui/wifitable/model_test.go
@@ -236,14 +236,14 @@ func TestForgetErrorSurfacesAndSkipsRefresh(t *testing.T) {
 
 func TestOpErrorFlashStripsGRPCFraming(t *testing.T) {
 	networks := []Network{{SSID: "Home", Known: true}}
-	h := &fakeHandler{forgetResult: status.Error(codes.Unimplemented, "Wi-Fi configuration is currently not supported on macOS.")}
+	h := &fakeHandler{forgetResult: status.Error(codes.Unimplemented, "Wi-Fi configuration is not supported by Wendy Agent for Mac.")}
 	m := NewModel(networks).WithHandler(h)
 	m.table.SetCursor(0)
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 	m = runCmd(next.(Model), cmd)
 
-	if !strings.Contains(m.flashMessage, "Wi-Fi configuration is currently not supported on macOS.") {
+	if !strings.Contains(m.flashMessage, "Wi-Fi configuration is not supported by Wendy Agent for Mac.") {
 		t.Fatalf("flash should keep contextual error, got %q", m.flashMessage)
 	}
 	if strings.Contains(m.flashMessage, "rpc error") || strings.Contains(m.flashMessage, "code = Unimplemented") {

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -9,7 +9,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_RunContainerResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Streaming container upload and execution is currently not supported on macOS."
+            message: "Streaming container upload and execution is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -19,7 +19,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_UpdateAgentResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Updating the agent is currently not supported on macOS."
+            message: "Updating the agent is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -47,7 +47,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListWiFiNetworksResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Wi-Fi network scanning is currently not supported on macOS."
+            message: "Wi-Fi network scanning is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -57,7 +57,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ConnectToWiFiResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Connecting to Wi-Fi networks is currently not supported on macOS."
+            message: "Connecting to Wi-Fi networks is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -67,7 +67,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_GetWiFiStatusResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Wi-Fi status reporting is currently not supported on macOS."
+            message: "Wi-Fi status reporting is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -77,7 +77,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_DisconnectWiFiResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Disconnecting from Wi-Fi networks is currently not supported on macOS."
+            message: "Disconnecting from Wi-Fi networks is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -87,7 +87,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Listing saved Wi-Fi networks is currently not supported on macOS."
+            message: "Listing saved Wi-Fi networks is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -97,7 +97,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_SetWiFiNetworkPriorityResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Wi-Fi network priority management is currently not supported on macOS."
+            message: "Wi-Fi network priority management is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -107,7 +107,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Reordering saved Wi-Fi networks is currently not supported on macOS."
+            message: "Reordering saved Wi-Fi networks is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -117,7 +117,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ForgetWiFiNetworkResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Removing saved Wi-Fi networks is currently not supported on macOS."
+            message: "Removing saved Wi-Fi networks is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -127,7 +127,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Hardware capability discovery is currently not supported on macOS."
+            message: "Hardware capability discovery is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -139,7 +139,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     > {
         throw RPCError(
             code: .unimplemented,
-            message: "Bluetooth scanning is currently not supported on macOS."
+            message: "Bluetooth scanning is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -149,7 +149,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ConnectBluetoothPeripheralResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Connecting Bluetooth peripherals is currently not supported on macOS."
+            message: "Connecting Bluetooth peripherals is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -160,7 +160,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     {
         throw RPCError(
             code: .unimplemented,
-            message: "Disconnecting Bluetooth peripherals is currently not supported on macOS."
+            message: "Disconnecting Bluetooth peripherals is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -170,7 +170,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ForgetBluetoothPeripheralResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Forgetting Bluetooth peripherals is currently not supported on macOS."
+            message: "Forgetting Bluetooth peripherals is not supported by Wendy Agent for Mac."
         )
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -9,7 +9,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_RunContainerResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Streaming container upload and execution is not supported by Wendy Agent for Mac."
+            message:
+                "Streaming container upload and execution is not supported by Wendy Agent for Mac."
         )
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -58,7 +58,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ConnectToWiFiResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Connecting to Wi-Fi networks is currently not supported by Wendy Agent for Mac."
+            message:
+                "Connecting to Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -78,7 +79,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_DisconnectWiFiResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Disconnecting from Wi-Fi networks is currently not supported by Wendy Agent for Mac."
+            message:
+                "Disconnecting from Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -88,7 +90,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Listing saved Wi-Fi networks is currently not supported by Wendy Agent for Mac."
+            message:
+                "Listing saved Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -98,7 +101,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_SetWiFiNetworkPriorityResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Wi-Fi network priority management is currently not supported by Wendy Agent for Mac."
+            message:
+                "Wi-Fi network priority management is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -108,7 +112,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Reordering saved Wi-Fi networks is currently not supported by Wendy Agent for Mac."
+            message:
+                "Reordering saved Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -118,7 +123,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ForgetWiFiNetworkResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Removing saved Wi-Fi networks is currently not supported by Wendy Agent for Mac."
+            message:
+                "Removing saved Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -128,7 +134,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Hardware capability discovery is currently not supported by Wendy Agent for Mac."
+            message:
+                "Hardware capability discovery is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -150,7 +157,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ConnectBluetoothPeripheralResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Connecting Bluetooth peripherals is currently not supported by Wendy Agent for Mac."
+            message:
+                "Connecting Bluetooth peripherals is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -161,7 +169,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     {
         throw RPCError(
             code: .unimplemented,
-            message: "Disconnecting Bluetooth peripherals is currently not supported by Wendy Agent for Mac."
+            message:
+                "Disconnecting Bluetooth peripherals is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -171,7 +180,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ForgetBluetoothPeripheralResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Forgetting Bluetooth peripherals is currently not supported by Wendy Agent for Mac."
+            message:
+                "Forgetting Bluetooth peripherals is currently not supported by Wendy Agent for Mac."
         )
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -10,7 +10,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
         throw RPCError(
             code: .unimplemented,
             message:
-                "Streaming container upload and execution is not supported by Wendy Agent for Mac."
+                "Streaming container upload and execution is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -20,7 +20,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_UpdateAgentResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Updating the agent is not supported by Wendy Agent for Mac."
+            message: "Updating the agent is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -48,7 +48,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListWiFiNetworksResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Wi-Fi network scanning is not supported by Wendy Agent for Mac."
+            message: "Wi-Fi network scanning is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -58,7 +58,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ConnectToWiFiResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Connecting to Wi-Fi networks is not supported by Wendy Agent for Mac."
+            message: "Connecting to Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -68,7 +68,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_GetWiFiStatusResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Wi-Fi status reporting is not supported by Wendy Agent for Mac."
+            message: "Wi-Fi status reporting is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -78,7 +78,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_DisconnectWiFiResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Disconnecting from Wi-Fi networks is not supported by Wendy Agent for Mac."
+            message: "Disconnecting from Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -88,7 +88,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Listing saved Wi-Fi networks is not supported by Wendy Agent for Mac."
+            message: "Listing saved Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -98,7 +98,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_SetWiFiNetworkPriorityResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Wi-Fi network priority management is not supported by Wendy Agent for Mac."
+            message: "Wi-Fi network priority management is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -108,7 +108,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Reordering saved Wi-Fi networks is not supported by Wendy Agent for Mac."
+            message: "Reordering saved Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -118,7 +118,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ForgetWiFiNetworkResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Removing saved Wi-Fi networks is not supported by Wendy Agent for Mac."
+            message: "Removing saved Wi-Fi networks is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -128,7 +128,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Hardware capability discovery is not supported by Wendy Agent for Mac."
+            message: "Hardware capability discovery is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -140,7 +140,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     > {
         throw RPCError(
             code: .unimplemented,
-            message: "Bluetooth scanning is not supported by Wendy Agent for Mac."
+            message: "Bluetooth scanning is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -150,7 +150,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ConnectBluetoothPeripheralResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Connecting Bluetooth peripherals is not supported by Wendy Agent for Mac."
+            message: "Connecting Bluetooth peripherals is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -161,7 +161,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     {
         throw RPCError(
             code: .unimplemented,
-            message: "Disconnecting Bluetooth peripherals is not supported by Wendy Agent for Mac."
+            message: "Disconnecting Bluetooth peripherals is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -171,7 +171,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ForgetBluetoothPeripheralResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Forgetting Bluetooth peripherals is not supported by Wendy Agent for Mac."
+            message: "Forgetting Bluetooth peripherals is currently not supported by Wendy Agent for Mac."
         )
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AudioService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AudioService.swift
@@ -8,7 +8,7 @@ struct AudioService: Wendy_Agent_Services_V1_WendyAudioService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListAudioDevicesResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Listing audio devices is currently not supported on macOS."
+            message: "Listing audio devices is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -18,7 +18,7 @@ struct AudioService: Wendy_Agent_Services_V1_WendyAudioService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_SetDefaultAudioDeviceResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Changing the default audio device is currently not supported on macOS."
+            message: "Changing the default audio device is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -28,7 +28,7 @@ struct AudioService: Wendy_Agent_Services_V1_WendyAudioService.ServiceProtocol {
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_AudioLevelUpdate> {
         throw RPCError(
             code: .unimplemented,
-            message: "Streaming audio levels is currently not supported on macOS."
+            message: "Streaming audio levels is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -38,7 +38,7 @@ struct AudioService: Wendy_Agent_Services_V1_WendyAudioService.ServiceProtocol {
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_AudioChunk> {
         throw RPCError(
             code: .unimplemented,
-            message: "Streaming audio is currently not supported on macOS."
+            message: "Streaming audio is not supported by Wendy Agent for Mac."
         )
     }
 }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AudioService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AudioService.swift
@@ -18,7 +18,8 @@ struct AudioService: Wendy_Agent_Services_V1_WendyAudioService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_SetDefaultAudioDeviceResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Changing the default audio device is currently not supported by Wendy Agent for Mac."
+            message:
+                "Changing the default audio device is currently not supported by Wendy Agent for Mac."
         )
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AudioService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AudioService.swift
@@ -8,7 +8,7 @@ struct AudioService: Wendy_Agent_Services_V1_WendyAudioService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListAudioDevicesResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Listing audio devices is not supported by Wendy Agent for Mac."
+            message: "Listing audio devices is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -18,7 +18,7 @@ struct AudioService: Wendy_Agent_Services_V1_WendyAudioService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_SetDefaultAudioDeviceResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Changing the default audio device is not supported by Wendy Agent for Mac."
+            message: "Changing the default audio device is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -28,7 +28,7 @@ struct AudioService: Wendy_Agent_Services_V1_WendyAudioService.ServiceProtocol {
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_AudioLevelUpdate> {
         throw RPCError(
             code: .unimplemented,
-            message: "Streaming audio levels is not supported by Wendy Agent for Mac."
+            message: "Streaming audio levels is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -38,7 +38,7 @@ struct AudioService: Wendy_Agent_Services_V1_WendyAudioService.ServiceProtocol {
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_AudioChunk> {
         throw RPCError(
             code: .unimplemented,
-            message: "Streaming audio is not supported by Wendy Agent for Mac."
+            message: "Streaming audio is currently not supported by Wendy Agent for Mac."
         )
     }
 }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -781,7 +781,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_RunContainerLayersResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Linux container attach is not supported by Wendy Agent for Mac."
+            message: "Linux container attach is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -791,7 +791,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListVolumesResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Container volume management is not supported by Wendy Agent for Mac."
+            message: "Container volume management is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -801,7 +801,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_RemoveVolumeResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Removing container volumes is not supported by Wendy Agent for Mac."
+            message: "Removing container volumes is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -811,7 +811,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_LayerHeader> {
         throw RPCError(
             code: .unimplemented,
-            message: "Container layer listing is not supported by Wendy Agent for Mac."
+            message: "Container layer listing is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -921,7 +921,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         throw RPCError(
             code: .unimplemented,
             message:
-                "Container creation progress streaming is not supported by Wendy Agent for Mac."
+                "Container creation progress streaming is currently not supported by Wendy Agent for Mac."
         )
     }
 
@@ -932,7 +932,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         throw RPCError(
             code: .unimplemented,
             message:
-                "Legacy container streaming execution is not supported by Wendy Agent for Mac. Use the native app lifecycle RPCs instead when applicable."
+                "Legacy container streaming execution is currently not supported by Wendy Agent for Mac. Use the native app lifecycle RPCs instead when applicable."
         )
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -781,7 +781,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_RunContainerLayersResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Linux container attach is currently not supported on macOS."
+            message: "Linux container attach is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -791,7 +791,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListVolumesResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Container volume management is currently not supported on macOS."
+            message: "Container volume management is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -801,7 +801,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_RemoveVolumeResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Removing container volumes is currently not supported on macOS."
+            message: "Removing container volumes is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -811,7 +811,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_LayerHeader> {
         throw RPCError(
             code: .unimplemented,
-            message: "Container layer listing is currently not supported on macOS."
+            message: "Container layer listing is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -920,7 +920,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     > {
         throw RPCError(
             code: .unimplemented,
-            message: "Container creation progress streaming is currently not supported on macOS."
+            message: "Container creation progress streaming is not supported by Wendy Agent for Mac."
         )
     }
 
@@ -931,7 +931,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         throw RPCError(
             code: .unimplemented,
             message:
-                "Legacy container streaming execution is currently not supported on macOS. Use the native app lifecycle RPCs instead when applicable."
+                "Legacy container streaming execution is not supported by Wendy Agent for Mac. Use the native app lifecycle RPCs instead when applicable."
         )
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -920,7 +920,8 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     > {
         throw RPCError(
             code: .unimplemented,
-            message: "Container creation progress streaming is not supported by Wendy Agent for Mac."
+            message:
+                "Container creation progress streaming is not supported by Wendy Agent for Mac."
         )
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -791,7 +791,8 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_ListVolumesResponse> {
         throw RPCError(
             code: .unimplemented,
-            message: "Container volume management is currently not supported by Wendy Agent for Mac."
+            message:
+                "Container volume management is currently not supported by Wendy Agent for Mac."
         )
     }
 

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/UnsupportedRPCTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/UnsupportedRPCTests.swift
@@ -13,7 +13,7 @@ struct UnsupportedRPCTests {
         await assertUnsupportedCases([
             (
                 "RunContainer",
-                "Streaming container upload and execution is not supported by Wendy Agent for Mac.",
+                "Streaming container upload and execution is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.runContainer(
                         request: makeStreamingRequest(
@@ -28,7 +28,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "UpdateAgent",
-                "Updating the agent is not supported by Wendy Agent for Mac.",
+                "Updating the agent is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.updateAgent(
                         request: makeStreamingRequest(
@@ -43,7 +43,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListWiFiNetworks",
-                "Wi-Fi network scanning is not supported by Wendy Agent for Mac.",
+                "Wi-Fi network scanning is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listWiFiNetworks(
                         request: ServerRequest(
@@ -59,7 +59,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ConnectToWiFi",
-                "Connecting to Wi-Fi networks is not supported by Wendy Agent for Mac.",
+                "Connecting to Wi-Fi networks is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.connectToWiFi(
                         request: ServerRequest(
@@ -75,7 +75,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "GetWiFiStatus",
-                "Wi-Fi status reporting is not supported by Wendy Agent for Mac.",
+                "Wi-Fi status reporting is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.getWiFiStatus(
                         request: ServerRequest(
@@ -91,7 +91,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "DisconnectWiFi",
-                "Disconnecting from Wi-Fi networks is not supported by Wendy Agent for Mac.",
+                "Disconnecting from Wi-Fi networks is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.disconnectWiFi(
                         request: ServerRequest(
@@ -107,7 +107,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListKnownWiFiNetworks",
-                "Listing saved Wi-Fi networks is not supported by Wendy Agent for Mac.",
+                "Listing saved Wi-Fi networks is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listKnownWiFiNetworks(
                         request: ServerRequest(
@@ -123,7 +123,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "SetWiFiNetworkPriority",
-                "Wi-Fi network priority management is not supported by Wendy Agent for Mac.",
+                "Wi-Fi network priority management is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.setWiFiNetworkPriority(
                         request: ServerRequest(
@@ -139,7 +139,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ReorderKnownWiFiNetworks",
-                "Reordering saved Wi-Fi networks is not supported by Wendy Agent for Mac.",
+                "Reordering saved Wi-Fi networks is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.reorderKnownWiFiNetworks(
                         request: ServerRequest(
@@ -155,7 +155,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ForgetWiFiNetwork",
-                "Removing saved Wi-Fi networks is not supported by Wendy Agent for Mac.",
+                "Removing saved Wi-Fi networks is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.forgetWiFiNetwork(
                         request: ServerRequest(
@@ -171,7 +171,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListHardwareCapabilities",
-                "Hardware capability discovery is not supported by Wendy Agent for Mac.",
+                "Hardware capability discovery is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listHardwareCapabilities(
                         request: ServerRequest(
@@ -187,7 +187,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ScanBluetoothPeripherals",
-                "Bluetooth scanning is not supported by Wendy Agent for Mac.",
+                "Bluetooth scanning is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.scanBluetoothPeripherals(
                         request: makeStreamingRequest(
@@ -202,7 +202,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ConnectBluetoothPeripheral",
-                "Connecting Bluetooth peripherals is not supported by Wendy Agent for Mac.",
+                "Connecting Bluetooth peripherals is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.connectBluetoothPeripheral(
                         request: ServerRequest(
@@ -218,7 +218,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "DisconnectBluetoothPeripheral",
-                "Disconnecting Bluetooth peripherals is not supported by Wendy Agent for Mac.",
+                "Disconnecting Bluetooth peripherals is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.disconnectBluetoothPeripheral(
                         request: ServerRequest(
@@ -235,7 +235,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ForgetBluetoothPeripheral",
-                "Forgetting Bluetooth peripherals is not supported by Wendy Agent for Mac.",
+                "Forgetting Bluetooth peripherals is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.forgetBluetoothPeripheral(
                         request: ServerRequest(
@@ -275,7 +275,7 @@ struct UnsupportedRPCTests {
         await assertUnsupportedCases([
             (
                 "ListAudioDevices",
-                "Listing audio devices is not supported by Wendy Agent for Mac.",
+                "Listing audio devices is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listAudioDevices(
                         request: ServerRequest(
@@ -291,7 +291,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "SetDefaultAudioDevice",
-                "Changing the default audio device is not supported by Wendy Agent for Mac.",
+                "Changing the default audio device is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.setDefaultAudioDevice(
                         request: ServerRequest(
@@ -307,7 +307,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "StreamAudioLevels",
-                "Streaming audio levels is not supported by Wendy Agent for Mac.",
+                "Streaming audio levels is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.streamAudioLevels(
                         request: ServerRequest(
@@ -323,7 +323,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "StreamAudio",
-                "Streaming audio is not supported by Wendy Agent for Mac.",
+                "Streaming audio is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.streamAudio(
                         request: ServerRequest(
@@ -350,7 +350,7 @@ struct UnsupportedRPCTests {
         await assertUnsupportedCases([
             (
                 "AttachContainer",
-                "Linux container attach is not supported by Wendy Agent for Mac.",
+                "Linux container attach is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.attachContainer(
                         request: makeStreamingRequest(
@@ -365,7 +365,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListVolumes",
-                "Container volume management is not supported by Wendy Agent for Mac.",
+                "Container volume management is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listVolumes(
                         request: ServerRequest(
@@ -381,7 +381,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "RemoveVolume",
-                "Removing container volumes is not supported by Wendy Agent for Mac.",
+                "Removing container volumes is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.removeVolume(
                         request: ServerRequest(
@@ -397,7 +397,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListLayers",
-                "Container layer listing is not supported by Wendy Agent for Mac.",
+                "Container layer listing is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listLayers(
                         request: ServerRequest(
@@ -413,7 +413,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "CreateContainerWithProgress",
-                "Container creation progress streaming is not supported by Wendy Agent for Mac.",
+                "Container creation progress streaming is currently not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.createContainerWithProgress(
                         request: ServerRequest(
@@ -429,7 +429,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "RunContainer",
-                "Legacy container streaming execution is not supported by Wendy Agent for Mac. Use the native app lifecycle RPCs instead when applicable.",
+                "Legacy container streaming execution is currently not supported by Wendy Agent for Mac. Use the native app lifecycle RPCs instead when applicable.",
                 {
                     _ = try await service.runContainer(
                         request: ServerRequest(

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/UnsupportedRPCTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/UnsupportedRPCTests.swift
@@ -13,7 +13,7 @@ struct UnsupportedRPCTests {
         await assertUnsupportedCases([
             (
                 "RunContainer",
-                "Streaming container upload and execution is currently not supported on macOS.",
+                "Streaming container upload and execution is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.runContainer(
                         request: makeStreamingRequest(
@@ -28,7 +28,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "UpdateAgent",
-                "Updating the agent is currently not supported on macOS.",
+                "Updating the agent is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.updateAgent(
                         request: makeStreamingRequest(
@@ -43,7 +43,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListWiFiNetworks",
-                "Wi-Fi network scanning is currently not supported on macOS.",
+                "Wi-Fi network scanning is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listWiFiNetworks(
                         request: ServerRequest(
@@ -59,7 +59,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ConnectToWiFi",
-                "Connecting to Wi-Fi networks is currently not supported on macOS.",
+                "Connecting to Wi-Fi networks is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.connectToWiFi(
                         request: ServerRequest(
@@ -75,7 +75,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "GetWiFiStatus",
-                "Wi-Fi status reporting is currently not supported on macOS.",
+                "Wi-Fi status reporting is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.getWiFiStatus(
                         request: ServerRequest(
@@ -91,7 +91,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "DisconnectWiFi",
-                "Disconnecting from Wi-Fi networks is currently not supported on macOS.",
+                "Disconnecting from Wi-Fi networks is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.disconnectWiFi(
                         request: ServerRequest(
@@ -107,7 +107,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListKnownWiFiNetworks",
-                "Listing saved Wi-Fi networks is currently not supported on macOS.",
+                "Listing saved Wi-Fi networks is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listKnownWiFiNetworks(
                         request: ServerRequest(
@@ -123,7 +123,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "SetWiFiNetworkPriority",
-                "Wi-Fi network priority management is currently not supported on macOS.",
+                "Wi-Fi network priority management is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.setWiFiNetworkPriority(
                         request: ServerRequest(
@@ -139,7 +139,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ReorderKnownWiFiNetworks",
-                "Reordering saved Wi-Fi networks is currently not supported on macOS.",
+                "Reordering saved Wi-Fi networks is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.reorderKnownWiFiNetworks(
                         request: ServerRequest(
@@ -155,7 +155,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ForgetWiFiNetwork",
-                "Removing saved Wi-Fi networks is currently not supported on macOS.",
+                "Removing saved Wi-Fi networks is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.forgetWiFiNetwork(
                         request: ServerRequest(
@@ -171,7 +171,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListHardwareCapabilities",
-                "Hardware capability discovery is currently not supported on macOS.",
+                "Hardware capability discovery is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listHardwareCapabilities(
                         request: ServerRequest(
@@ -187,7 +187,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ScanBluetoothPeripherals",
-                "Bluetooth scanning is currently not supported on macOS.",
+                "Bluetooth scanning is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.scanBluetoothPeripherals(
                         request: makeStreamingRequest(
@@ -202,7 +202,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ConnectBluetoothPeripheral",
-                "Connecting Bluetooth peripherals is currently not supported on macOS.",
+                "Connecting Bluetooth peripherals is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.connectBluetoothPeripheral(
                         request: ServerRequest(
@@ -218,7 +218,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "DisconnectBluetoothPeripheral",
-                "Disconnecting Bluetooth peripherals is currently not supported on macOS.",
+                "Disconnecting Bluetooth peripherals is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.disconnectBluetoothPeripheral(
                         request: ServerRequest(
@@ -235,7 +235,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ForgetBluetoothPeripheral",
-                "Forgetting Bluetooth peripherals is currently not supported on macOS.",
+                "Forgetting Bluetooth peripherals is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.forgetBluetoothPeripheral(
                         request: ServerRequest(
@@ -275,7 +275,7 @@ struct UnsupportedRPCTests {
         await assertUnsupportedCases([
             (
                 "ListAudioDevices",
-                "Listing audio devices is currently not supported on macOS.",
+                "Listing audio devices is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listAudioDevices(
                         request: ServerRequest(
@@ -291,7 +291,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "SetDefaultAudioDevice",
-                "Changing the default audio device is currently not supported on macOS.",
+                "Changing the default audio device is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.setDefaultAudioDevice(
                         request: ServerRequest(
@@ -307,7 +307,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "StreamAudioLevels",
-                "Streaming audio levels is currently not supported on macOS.",
+                "Streaming audio levels is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.streamAudioLevels(
                         request: ServerRequest(
@@ -323,7 +323,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "StreamAudio",
-                "Streaming audio is currently not supported on macOS.",
+                "Streaming audio is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.streamAudio(
                         request: ServerRequest(
@@ -350,7 +350,7 @@ struct UnsupportedRPCTests {
         await assertUnsupportedCases([
             (
                 "AttachContainer",
-                "Linux container attach is currently not supported on macOS.",
+                "Linux container attach is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.attachContainer(
                         request: makeStreamingRequest(
@@ -365,7 +365,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListVolumes",
-                "Container volume management is currently not supported on macOS.",
+                "Container volume management is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listVolumes(
                         request: ServerRequest(
@@ -381,7 +381,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "RemoveVolume",
-                "Removing container volumes is currently not supported on macOS.",
+                "Removing container volumes is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.removeVolume(
                         request: ServerRequest(
@@ -397,7 +397,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "ListLayers",
-                "Container layer listing is currently not supported on macOS.",
+                "Container layer listing is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.listLayers(
                         request: ServerRequest(
@@ -413,7 +413,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "CreateContainerWithProgress",
-                "Container creation progress streaming is currently not supported on macOS.",
+                "Container creation progress streaming is not supported by Wendy Agent for Mac.",
                 {
                     _ = try await service.createContainerWithProgress(
                         request: ServerRequest(
@@ -429,7 +429,7 @@ struct UnsupportedRPCTests {
             ),
             (
                 "RunContainer",
-                "Legacy container streaming execution is currently not supported on macOS. Use the native app lifecycle RPCs instead when applicable.",
+                "Legacy container streaming execution is not supported by Wendy Agent for Mac. Use the native app lifecycle RPCs instead when applicable.",
                 {
                     _ = try await service.runContainer(
                         request: ServerRequest(

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ETestMetadata.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ETestMetadata.swift
@@ -37,17 +37,25 @@ struct E2ETestMetadata: Codable, Sendable {
         guard !value.hasPrefix("/"), !value.split(separator: "/").contains("..") else {
             throw ValidationError("Test metadata has invalid \(field) in \(sourceURL.path)")
         }
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-")
+        let allowed = CharacterSet(
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-"
+        )
         guard value.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
-            throw ValidationError("Test metadata has invalid \(field) characters in \(sourceURL.path)")
+            throw ValidationError(
+                "Test metadata has invalid \(field) characters in \(sourceURL.path)"
+            )
         }
     }
 
     private func validateName(_ value: String, field: String, sourceURL: URL) throws {
         try validateText(value, field: field, maxLength: 255, sourceURL: sourceURL)
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+        let allowed = CharacterSet(
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-"
+        )
         guard value.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
-            throw ValidationError("Test metadata has invalid \(field) characters in \(sourceURL.path)")
+            throw ValidationError(
+                "Test metadata has invalid \(field) characters in \(sourceURL.path)"
+            )
         }
     }
 

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -1531,7 +1531,8 @@ private func renderObservations(
         let escapedTarget = isFirstTargetRow ? escapeHTML(observation.target) : ""
         let target = escapedTarget
         let route =
-            isFirstTargetRow ? renderTargetRoute(observation.route, escapedTitle: escapedTarget) : ""
+            isFirstTargetRow
+            ? renderTargetRoute(observation.route, escapedTitle: escapedTarget) : ""
         let rowClass = isFirstTargetRow ? "observation-row" : "observation-row same-target"
         chunks.append(
             "<div class=\"\(rowClass)\"><span class=\"observation-route-cell\">\(route)</span><span class=\"observation-target\">\(target)</span><span class=\"observation-spacer\" aria-hidden=\"true\"></span>\(renderObservationLinks(observation))<span class=\"observation-attempt\">\(escapeHTML(observation.attempt))</span><span class=\"badge \(observation.status.statusClass)\">\(observation.status.statusText)</span>\(observationDurationBadge(observation.duration))</div>"

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -544,7 +544,10 @@ private func loadRunTestResults(
                     observations[identityKey, default: []].append(
                         ReportTestObservation(
                             target: targetName,
-                            route: try targetRoute(for: targetName, attemptURL: attemptArtifactsURL),
+                            route: try targetRoute(
+                                for: targetName,
+                                attemptURL: attemptArtifactsURL
+                            ),
                             attempt: attemptName,
                             status: status,
                             recordingPath: observationFilePath(

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
@@ -400,7 +400,8 @@ private func reviewAggregateSummaryMarkdown(_ value: String) -> String {
     ]
 
     for pattern in patterns {
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+        else {
             continue
         }
         let range = NSRange(original.startIndex..<original.endIndex, in: original)

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
@@ -338,7 +338,8 @@ private func overviewObservationResult(
     return OverviewObservationResult(
         status: .unknown,
         durationSeconds: nil,
-        detail: "No Swift Testing result was found for \(metadata.suiteName) › \(metadata.testName) in test-results.xml"
+        detail:
+            "No Swift Testing result was found for \(metadata.suiteName) › \(metadata.testName) in test-results.xml"
     )
 }
 

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
@@ -16,12 +16,16 @@ struct `aggregate command` {
             "swift-e2e-tests.local0000.macos-to-rpi.0001",
             isDirectory: true
         )
-        let observationURL = attemptURL
+        let observationURL =
+            attemptURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("wendy-device-info", isDirectory: true)
             .appendingPathComponent("prints-json-device-information", isDirectory: true)
 
-        try FileManager.default.createDirectory(at: observationURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: observationURL,
+            withIntermediateDirectories: true
+        )
         try "{}\n".write(
             to: attemptURL.appendingPathComponent("attempt.json"),
             atomically: true,
@@ -47,27 +51,69 @@ struct `aggregate command` {
         var command = try AggregateCommand.parse(["--output-dir", outputURL.path, attemptURL.path])
         try command.run()
 
-        let runURL = outputURL.appendingPathComponent("swift-e2e-tests.local0000", isDirectory: true)
-        let attemptArtifactsURL = runURL
+        let runURL = outputURL.appendingPathComponent(
+            "swift-e2e-tests.local0000",
+            isDirectory: true
+        )
+        let attemptArtifactsURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
             .appendingPathComponent("0001", isDirectory: true)
-        let aggregateObservationURL = runURL
+        let aggregateObservationURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("wendy-device-info", isDirectory: true)
             .appendingPathComponent("prints-json-device-information", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
             .appendingPathComponent("0001", isDirectory: true)
 
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path))
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path))
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.log").path))
-        #expect(!FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("observations").path))
-        #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("recording.md").path))
-        #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("test.json").path))
-        #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("test.json").path))
-        #expect(!FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("attempt.json").path))
-        #expect(!FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("test-results.xml").path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("attempt.log").path
+            )
+        )
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("observations").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: aggregateObservationURL.appendingPathComponent("recording.md").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: aggregateObservationURL.appendingPathComponent("test.json").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: aggregateObservationURL.deletingLastPathComponent()
+                    .deletingLastPathComponent().appendingPathComponent("test.json").path
+            )
+        )
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: aggregateObservationURL.appendingPathComponent("attempt.json").path
+            )
+        )
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: aggregateObservationURL.appendingPathComponent("test-results.xml").path
+            )
+        )
     }
 
     @Test
@@ -95,14 +141,26 @@ struct `aggregate command` {
         var command = try AggregateCommand.parse(["--output-dir", outputURL.path, attemptURL.path])
         try command.run()
 
-        let runURL = outputURL.appendingPathComponent("swift-e2e-tests.local0000", isDirectory: true)
-        let attemptArtifactsURL = runURL
+        let runURL = outputURL.appendingPathComponent(
+            "swift-e2e-tests.local0000",
+            isDirectory: true
+        )
+        let attemptArtifactsURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
             .appendingPathComponent("0001", isDirectory: true)
 
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path))
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path
+            )
+        )
     }
 }
 

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
@@ -15,67 +15,79 @@ struct `report command` {
         let testsURL = packageURL.appendingPathComponent("Tests", isDirectory: true)
         let supportURL = packageURL.appendingPathComponent("Support", isDirectory: true)
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
-        let attemptArtifactsURL = runURL
+        let attemptArtifactsURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-<img src=x onerror=\"alert(1)\">", isDirectory: true)
             .appendingPathComponent("attempt-1", isDirectory: true)
-        let observationURL = runURL
+        let observationURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("report-security", isDirectory: true)
             .appendingPathComponent("escapes-malicious-target", isDirectory: true)
             .appendingPathComponent("macos-to-<img src=x onerror=\"alert(1)\">", isDirectory: true)
             .appendingPathComponent("attempt-1", isDirectory: true)
-        let noObservationAttemptURL = runURL
+        let noObservationAttemptURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-no-observations", isDirectory: true)
             .appendingPathComponent("attempt-1", isDirectory: true)
 
         try FileManager.default.createDirectory(at: testsURL, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: supportURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: attemptArtifactsURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: observationURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: noObservationAttemptURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: attemptArtifactsURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: observationURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: noObservationAttemptURL,
+            withIntermediateDirectories: true
+        )
         try writeReportTestMetadata(to: observationURL)
 
         try """
-            import Testing
+        import Testing
 
-            @Suite
-            struct `report security` {
-                @Test
-                func `escapes malicious target`() async throws {}
-            }
-            """.write(
-                to: testsURL.appendingPathComponent("ReportSecurityTests.swift"),
-                atomically: true,
-                encoding: .utf8
-            )
-
-        try """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <testsuite tests="1" failures="0" skipped="0">
-              <testcase classname="WendyE2ETests.`report security`" name="escapes malicious target()" time="0.01" />
-            </testsuite>
-            """.write(
-                to: attemptArtifactsURL.appendingPathComponent("test-results.xml"),
-                atomically: true,
-                encoding: .utf8
-            )
+        @Suite
+        struct `report security` {
+            @Test
+            func `escapes malicious target`() async throws {}
+        }
+        """.write(
+            to: testsURL.appendingPathComponent("ReportSecurityTests.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         try """
-            <!doctype html>
-            <html>
-              <body>
-                {{TARGET_OVERVIEW}}
-                <!-- Repeat this .card section once per test file. -->
-                <footer></footer>
-              </body>
-            </html>
-            """.write(
-                to: supportURL.appendingPathComponent("e2e-report.template.html"),
-                atomically: true,
-                encoding: .utf8
-            )
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuite tests="1" failures="0" skipped="0">
+          <testcase classname="WendyE2ETests.`report security`" name="escapes malicious target()" time="0.01" />
+        </testsuite>
+        """.write(
+            to: attemptArtifactsURL.appendingPathComponent("test-results.xml"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try """
+        <!doctype html>
+        <html>
+          <body>
+            {{TARGET_OVERVIEW}}
+            <!-- Repeat this .card section once per test file. -->
+            <footer></footer>
+          </body>
+        </html>
+        """.write(
+            to: supportURL.appendingPathComponent("e2e-report.template.html"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         var command = try ReportCommand.parse([
             "--package-dir", packageURL.path,

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -198,7 +198,11 @@ struct `run overview` {
         #expect(markdown.contains("### 🛑 Agent rejected CLI auth"))
         #expect(!markdown.contains("### 🛑 Error Agent rejected CLI auth"))
         #expect(markdown.contains("The target rejected an otherwise valid authenticated request."))
-        #expect(!markdown.contains("🛑 Error: The target rejected an otherwise valid authenticated request."))
+        #expect(
+            !markdown.contains(
+                "🛑 Error: The target rejected an otherwise valid authenticated request."
+            )
+        )
         #expect(!markdown.contains("Fail: Agent rejected CLI auth"))
     }
 }

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -11,7 +11,8 @@ struct `run overview` {
         defer { try? FileManager.default.removeItem(at: rootURL) }
 
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
-        let suiteURL = runURL
+        let suiteURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("wendy-device-info", isDirectory: true)
         let testURL = suiteURL.appendingPathComponent(
@@ -21,11 +22,18 @@ struct `run overview` {
         let targetURL = testURL.appendingPathComponent("macos-to-rpi", isDirectory: true)
         let attemptOneObservationURL = targetURL.appendingPathComponent("0001", isDirectory: true)
         let attemptTwoObservationURL = targetURL.appendingPathComponent("0002", isDirectory: true)
-        let attemptArtifactsRootURL = runURL
+        let attemptArtifactsRootURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
-        let attemptOneURL = attemptArtifactsRootURL.appendingPathComponent("0001", isDirectory: true)
-        let attemptTwoURL = attemptArtifactsRootURL.appendingPathComponent("0002", isDirectory: true)
+        let attemptOneURL = attemptArtifactsRootURL.appendingPathComponent(
+            "0001",
+            isDirectory: true
+        )
+        let attemptTwoURL = attemptArtifactsRootURL.appendingPathComponent(
+            "0002",
+            isDirectory: true
+        )
 
         try FileManager.default.createDirectory(
             at: attemptOneObservationURL,
@@ -87,25 +95,34 @@ struct `run overview` {
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
         let target = "macos-to-rpi"
         let attempt = "0001"
-        let firstObservationURL = runURL
+        let firstObservationURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("first-file", isDirectory: true)
             .appendingPathComponent("same-name", isDirectory: true)
             .appendingPathComponent(target, isDirectory: true)
             .appendingPathComponent(attempt, isDirectory: true)
-        let secondObservationURL = runURL
+        let secondObservationURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("second-file", isDirectory: true)
             .appendingPathComponent("same-name", isDirectory: true)
             .appendingPathComponent(target, isDirectory: true)
             .appendingPathComponent(attempt, isDirectory: true)
-        let attemptURL = runURL
+        let attemptURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent(target, isDirectory: true)
             .appendingPathComponent(attempt, isDirectory: true)
 
-        try FileManager.default.createDirectory(at: firstObservationURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: secondObservationURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: firstObservationURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: secondObservationURL,
+            withIntermediateDirectories: true
+        )
         try FileManager.default.createDirectory(at: attemptURL, withIntermediateDirectories: true)
         try writeTestMetadata(
             to: firstObservationURL,
@@ -122,12 +139,12 @@ struct `run overview` {
             testName: "same name"
         )
         try """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <testsuite tests="2">
-              <testcase classname="WendyE2ETests.`first suite`" name="same name()" time="0.1" />
-              <testcase classname="WendyE2ETests.`second suite`" name="same name()" time="0.2"><failure message="nope" /></testcase>
-            </testsuite>
-            """.write(
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuite tests="2">
+          <testcase classname="WendyE2ETests.`first suite`" name="same name()" time="0.1" />
+          <testcase classname="WendyE2ETests.`second suite`" name="same name()" time="0.2"><failure message="nope" /></testcase>
+        </testsuite>
+        """.write(
             to: attemptURL.appendingPathComponent("test-results.xml"),
             atomically: true,
             encoding: .utf8
@@ -149,7 +166,8 @@ struct `run overview` {
         defer { try? FileManager.default.removeItem(at: rootURL) }
 
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
-        let suiteURL = runURL
+        let suiteURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("wendy-device-info", isDirectory: true)
         let testURL = suiteURL.appendingPathComponent(
@@ -158,7 +176,8 @@ struct `run overview` {
         )
         let targetURL = testURL.appendingPathComponent("macos-to-rpi", isDirectory: true)
         let attemptObservationURL = targetURL.appendingPathComponent("0001", isDirectory: true)
-        let attemptURL = runURL
+        let attemptURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
             .appendingPathComponent("0001", isDirectory: true)


### PR DESCRIPTION
## Summary
- Preserve contextual `Unimplemented` descriptions from the agent so Wendy for Mac unsupported features no longer tell users to update the agent.
- Keep the generic update hint for real protocol-mismatch cases such as unknown services, unknown methods, or generated unimplemented stubs.
- Clean up TUI edge cases: app volume polling shows a clean notice, and Wi-Fi/Bluetooth TUI operation errors strip raw gRPC framing.
- Name Wendy Agent for Mac directly in unsupported RPC messages, while making clear these are current limitations.

## Follow-up
- WDY-1534 tracks the remaining `camera view` UX tradeoff where a missing local GStreamer install can mask the remote unsupported camera streaming status in non-`--stdout` mode. This PR keeps the simpler Linux/WendyOS-friendly preflight behavior for now.

## Tests
- `cd go && go test ./cmd/wendy ./internal/cli/commands ./internal/cli/tui/wifitable ./internal/cli/tui/bttable -run 'TestFormatError|TestMacOSBetaUnsupported|Test.*Unsupported|Test.*Audio|Test.*Camera|Test.*Wifi|Test.*Bluetooth|Test.*Volumes|TestPlayVideoWithGStreamer|TestAppsDashboardModel_Volumes|TestOpErrorFlash|TestUserFacingError'`
- `cd go && go test ./internal/cli/commands -run 'TestMacOSBetaUnsupported|Test.*Unsupported|Test.*Audio|Test.*Camera|Test.*Wifi|Test.*Bluetooth|Test.*Volumes'`
- `cd go && go test ./cmd/wendy ./internal/cli/commands ./internal/cli/tui/wifitable -run 'TestFormatError_UnimplementedPreserves|TestPlayVideoWithGStreamer_Remote|TestAppsDashboardModel_Volumes|TestOpErrorFlash'`
- `cd go && go test ./internal/cli/commands -run 'TestPlayVideoWithGStreamer|Test.*Camera'`
- `cd swift/WendyAgentCore && swift test --filter UnsupportedRPCTests`
- `cd go && git diff --check`
- `git diff --check`

Closes WDY-1529
