### PR TITLE
WDY-1528: Add Swift E2E test metadata sidecars

### DIFF
--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/AggregateCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/AggregateCommand.swift
@@ -98,6 +98,10 @@ struct AggregateCommand: ParsableCommand {
                 withIntermediateDirectories: true
             )
             try copyItem(at: testDirectory, to: destinationURL)
+            try copyTestMetadataIfPresent(
+                from: testDirectory,
+                to: destinationURL.deletingLastPathComponent().deletingLastPathComponent()
+            )
         }
     }
 }
@@ -159,6 +163,12 @@ private func attemptTestDirectories(in attemptURL: URL) throws -> [URL] {
 
 private func isDirectory(_ url: URL) throws -> Bool {
     try url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true
+}
+
+private func copyTestMetadataIfPresent(from testDirectoryURL: URL, to testRootURL: URL) throws {
+    let sourceURL = testDirectoryURL.appendingPathComponent(e2eTestMetadataFileName)
+    guard FileManager.default.fileExists(atPath: sourceURL.path) else { return }
+    try copyItem(at: sourceURL, to: testRootURL.appendingPathComponent(e2eTestMetadataFileName))
 }
 
 private func copyAttemptLevelArtifacts(from attemptURL: URL, to destinationURL: URL) throws {

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ETestMetadata.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ETestMetadata.swift
@@ -20,6 +20,47 @@ struct E2ETestMetadata: Codable, Sendable {
             testName: testName
         )
     }
+
+    func validate(sourceURL: URL) throws {
+        try validatePath(sourceFilePath, field: "sourceFilePath", sourceURL: sourceURL)
+        try validateName(sourceFileName, field: "sourceFileName", sourceURL: sourceURL)
+        try validateText(suiteName, field: "suiteName", sourceURL: sourceURL)
+        try validateText(testName, field: "testName", sourceURL: sourceURL)
+        try validateText(functionName, field: "functionName", sourceURL: sourceURL)
+        guard line > 0 else {
+            throw ValidationError("Test metadata has invalid line in \(sourceURL.path)")
+        }
+    }
+
+    private func validatePath(_ value: String, field: String, sourceURL: URL) throws {
+        try validateText(value, field: field, maxLength: 1024, sourceURL: sourceURL)
+        guard !value.hasPrefix("/"), !value.split(separator: "/").contains("..") else {
+            throw ValidationError("Test metadata has invalid \(field) in \(sourceURL.path)")
+        }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-")
+        guard value.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            throw ValidationError("Test metadata has invalid \(field) characters in \(sourceURL.path)")
+        }
+    }
+
+    private func validateName(_ value: String, field: String, sourceURL: URL) throws {
+        try validateText(value, field: field, maxLength: 255, sourceURL: sourceURL)
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+        guard value.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            throw ValidationError("Test metadata has invalid \(field) characters in \(sourceURL.path)")
+        }
+    }
+
+    private func validateText(
+        _ value: String,
+        field: String,
+        maxLength: Int = 512,
+        sourceURL: URL
+    ) throws {
+        guard !value.isEmpty, value.count <= maxLength else {
+            throw ValidationError("Test metadata has invalid \(field) in \(sourceURL.path)")
+        }
+    }
 }
 
 struct E2ETestIdentityKey: Hashable, Sendable {
@@ -35,6 +76,7 @@ func loadE2ETestMetadata(in observationURL: URL) throws -> E2ETestMetadata {
     guard metadata.schema == e2eTestMetadataSchemaID else {
         throw ValidationError("Test metadata has unsupported schema: \(url.path)")
     }
+    try metadata.validate(sourceURL: url)
     return metadata
 }
 
@@ -67,12 +109,15 @@ func e2ePackageRelativePath(from packageURL: URL, to url: URL) -> String {
 }
 
 private func e2eMetadataDirectoryChildren(of url: URL) throws -> [URL] {
-    guard FileManager.default.fileExists(atPath: url.path) else { return [] }
-    return try FileManager.default.contentsOfDirectory(
-        at: url,
-        includingPropertiesForKeys: [.isDirectoryKey],
-        options: [.skipsHiddenFiles]
-    )
-    .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
-    .sorted { $0.path < $1.path }
+    do {
+        return try FileManager.default.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+        .sorted { $0.path < $1.path }
+    } catch let error as CocoaError where error.code == .fileNoSuchFile {
+        return []
+    }
 }

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ETestMetadata.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ETestMetadata.swift
@@ -1,0 +1,78 @@
+import ArgumentParser
+import Foundation
+
+let e2eTestMetadataFileName = "test.json"
+let e2eTestMetadataSchemaID = "wendy.e2e.test.v1"
+
+struct E2ETestMetadata: Codable, Sendable {
+    var schema: String
+    var sourceFilePath: String
+    var sourceFileName: String
+    var suiteName: String
+    var testName: String
+    var functionName: String
+    var line: Int
+
+    var identityKey: E2ETestIdentityKey {
+        E2ETestIdentityKey(
+            sourceFilePath: sourceFilePath,
+            suiteName: suiteName,
+            testName: testName
+        )
+    }
+}
+
+struct E2ETestIdentityKey: Hashable, Sendable {
+    var sourceFilePath: String
+    var suiteName: String
+    var testName: String
+}
+
+func loadE2ETestMetadata(in observationURL: URL) throws -> E2ETestMetadata {
+    let url = observationURL.appendingPathComponent(e2eTestMetadataFileName)
+    let data = try Data(contentsOf: url)
+    let metadata = try JSONDecoder().decode(E2ETestMetadata.self, from: data)
+    guard metadata.schema == e2eTestMetadataSchemaID else {
+        throw ValidationError("Test metadata has unsupported schema: \(url.path)")
+    }
+    return metadata
+}
+
+func firstE2ETestMetadata(in testObservationURL: URL) throws -> E2ETestMetadata? {
+    let directURL = testObservationURL.appendingPathComponent(e2eTestMetadataFileName)
+    if FileManager.default.fileExists(atPath: directURL.path) {
+        return try loadE2ETestMetadata(in: testObservationURL)
+    }
+
+    for targetURL in try e2eMetadataDirectoryChildren(of: testObservationURL) {
+        for attemptURL in try e2eMetadataDirectoryChildren(of: targetURL) {
+            let metadataURL = attemptURL.appendingPathComponent(e2eTestMetadataFileName)
+            if FileManager.default.fileExists(atPath: metadataURL.path) {
+                return try loadE2ETestMetadata(in: attemptURL)
+            }
+        }
+    }
+
+    return nil
+}
+
+func e2ePackageRelativePath(from packageURL: URL, to url: URL) -> String {
+    let basePath = packageURL.standardizedFileURL.path
+    let path = url.standardizedFileURL.path
+    let prefix = basePath.hasSuffix("/") ? basePath : basePath + "/"
+    guard path.hasPrefix(prefix) else {
+        return url.lastPathComponent
+    }
+    return String(path.dropFirst(prefix.count))
+}
+
+private func e2eMetadataDirectoryChildren(of url: URL) throws -> [URL] {
+    guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+    return try FileManager.default.contentsOfDirectory(
+        at: url,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+    )
+    .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+    .sorted { $0.path < $1.path }
+}

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -47,6 +47,7 @@ struct ReportCommand: ParsableCommand {
         let testResults = try loadRunTestResults(in: runURL)
         let files = try parseTests(
             in: testsURL,
+            packageURL: packageURL,
             runURL: runURL,
             records: records,
             aiReviews: aiReviews,
@@ -386,12 +387,14 @@ private func defaultTestsDir(packageURL: URL) -> URL {
     return packageURL.appendingPathComponent("Tests")
 }
 
-private func loadRecords(in runURL: URL) throws -> [String: [CommandRun]] {
+private func loadRecords(in runURL: URL) throws -> [E2ETestIdentityKey: [CommandRun]] {
     let recordURLs = try commandRecordURLs(in: runURL)
 
-    var records: [String: [CommandRun]] = [:]
+    var records: [E2ETestIdentityKey: [CommandRun]] = [:]
     for recordURL in recordURLs {
-        records[recordKey(for: recordURL, relativeTo: runURL), default: []] +=
+        let observationURL = recordURL.deletingLastPathComponent()
+        let metadata = try loadE2ETestMetadata(in: observationURL)
+        records[metadata.identityKey, default: []] +=
             try parseRecord(
                 at: recordURL,
                 relativeTo: runURL
@@ -443,21 +446,6 @@ private func commandRecordURLs(in runURL: URL) throws -> [URL] {
     }
 
     return try runObservationFileURLs(in: runURL, fileName: "recording.md")
-}
-
-private func recordKey(for recordURL: URL, relativeTo runURL: URL) -> String {
-    if recordURL.lastPathComponent == "recording.md" {
-        let relative = relativePath(from: runURL, to: recordURL)
-        let components = relative.split(separator: "/").map(String.init)
-        if components.count >= 3, components[0] == e2eObservationsDirectoryName {
-            return "\(components[1]).\(components[2])"
-        }
-        if components.count >= 2 {
-            return "\(components[0]).\(components[1])"
-        }
-        return recordURL.deletingLastPathComponent().lastPathComponent
-    }
-    return recordURL.deletingPathExtension().lastPathComponent
 }
 
 private func relativePath(from baseURL: URL, to url: URL) -> String {
@@ -528,17 +516,15 @@ private func parseXUnitResults(at resultURL: URL) throws -> [TestResultKey: Repo
 
 private func loadRunTestResults(
     in runURL: URL
-) throws -> [RunPathKey: ReportRunTestResult] {
-    var observed: [RunPathKey: [String: [ReportTestStatus]]] = [:]
-    var durations: [RunPathKey: [Double]] = [:]
-    var observations: [RunPathKey: [ReportTestObservation]] = [:]
+) throws -> [E2ETestIdentityKey: ReportRunTestResult] {
+    var observed: [E2ETestIdentityKey: [String: [ReportTestStatus]]] = [:]
+    var durations: [E2ETestIdentityKey: [Double]] = [:]
+    var observations: [E2ETestIdentityKey: [ReportTestObservation]] = [:]
 
     for suiteURL in try directoryChildren(of: e2eObservationsRootURL(in: runURL)) {
         let suiteKey = suiteURL.lastPathComponent
         guard !isE2EReviewDirectoryName(suiteKey) else { continue }
         for testURL in try directoryChildren(of: suiteURL) {
-            let testKey = testURL.lastPathComponent
-            let pathKey = RunPathKey(suiteKey: suiteKey, testKey: testKey)
             for targetURL in try directoryChildren(of: testURL) {
                 let targetName = targetURL.lastPathComponent
                 for attemptURL in try directoryChildren(of: targetURL) {
@@ -548,13 +534,14 @@ private func loadRunTestResults(
                         targetName: targetName,
                         attempt: attemptName
                     )
+                    let metadata = try loadE2ETestMetadata(in: attemptURL)
+                    let identityKey = metadata.identityKey
                     let status = try runObservationStatus(
-                        suiteKey: suiteKey,
-                        testKey: testKey,
+                        metadata: metadata,
                         attemptURL: attemptArtifactsURL
                     )
-                    observed[pathKey, default: [:]][targetName, default: []].append(status)
-                    observations[pathKey, default: []].append(
+                    observed[identityKey, default: [:]][targetName, default: []].append(status)
+                    observations[identityKey, default: []].append(
                         ReportTestObservation(
                             target: targetName,
                             route: try targetRoute(for: targetName, attemptURL: attemptArtifactsURL),
@@ -573,7 +560,7 @@ private func loadRunTestResults(
                         )
                     )
                     if let duration = status.duration {
-                        durations[pathKey, default: []].append(duration.seconds)
+                        durations[identityKey, default: []].append(duration.seconds)
                     }
                 }
             }
@@ -608,8 +595,7 @@ private func observationFilePath(fileName: String, attemptURL: URL, runURL: URL)
 }
 
 private func runObservationStatus(
-    suiteKey: String,
-    testKey: String,
+    metadata: E2ETestMetadata,
     attemptURL: URL
 ) throws -> ReportTestStatus {
     let resultURL = attemptURL.appendingPathComponent("test-results.xml")
@@ -618,20 +604,7 @@ private func runObservationStatus(
     }
 
     let results = try parseXUnitResults(at: resultURL)
-    if let status = results.first(where: { key, _ in
-        slug(key.suite) == suiteKey && slug(key.name) == testKey
-    })?.value {
-        return status
-    }
-
-    let matchingTestNames = results.filter { key, _ in
-        slug(key.name) == testKey
-    }
-    if matchingTestNames.count == 1, let status = matchingTestNames.first?.value {
-        return status
-    }
-
-    return .unknown
+    return results[TestResultKey(suite: metadata.suiteName, name: metadata.testName)] ?? .unknown
 }
 
 private func observationSort(_ lhs: ReportTestObservation, _ rhs: ReportTestObservation) -> Bool {
@@ -927,10 +900,11 @@ private func stripBackticks(_ value: String) -> String {
 
 private func parseTests(
     in testsURL: URL,
+    packageURL: URL,
     runURL: URL,
-    records: [String: [CommandRun]],
+    records: [E2ETestIdentityKey: [CommandRun]],
     aiReviews: RunAIReviews,
-    testResults: [RunPathKey: ReportRunTestResult]
+    testResults: [E2ETestIdentityKey: ReportRunTestResult]
 ) throws -> [ReportTestFile] {
     let sourceURLs = try swiftTestFiles(in: testsURL)
     var files: [ReportTestFile] = []
@@ -983,7 +957,11 @@ private func parseTests(
             tests[testIndex].aiItems = extractAIItems(from: body)
             let recordSuiteKey = recordFileStem(sourceURL)
             let recordTestKey = slug(tests[testIndex].name)
-            let recordKey = "\(recordSuiteKey).\(recordTestKey)"
+            let identityKey = E2ETestIdentityKey(
+                sourceFilePath: e2ePackageRelativePath(from: packageURL, to: sourceURL),
+                suiteName: tests[testIndex].suite,
+                testName: tests[testIndex].name
+            )
             let directRecordName = "recording.md"
             let nestedRecordName = [
                 e2eObservationsDirectoryName,
@@ -991,7 +969,7 @@ private func parseTests(
                 recordTestKey,
                 "recording.md",
             ].joined(separator: "/")
-            if records[recordKey] != nil,
+            if records[identityKey] != nil,
                 FileManager.default.fileExists(
                     atPath: runURL.appendingPathComponent(directRecordName).path
                 )
@@ -1002,13 +980,12 @@ private func parseTests(
             }
             let key = RunPathKey(suiteKey: recordSuiteKey, testKey: recordTestKey)
             tests[testIndex].aiReviews = aiReviews.tests[key, default: []]
-            tests[testIndex].commands = records[recordKey, default: []].filter {
-                command in
+            tests[testIndex].commands = records[identityKey, default: []].filter { command in
                 command.sourceFile == sourceURL.lastPathComponent
                     && tests[testIndex].funcLine <= command.sourceLine
                     && command.sourceLine < nextLine
             }
-            if let result = testResults[key] {
+            if let result = testResults[identityKey] {
                 tests[testIndex].targetOutcomes = result.targetOutcomes
                 tests[testIndex].durationRange = result.durationRange
                 tests[testIndex].observations = result.observations

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
@@ -728,8 +728,6 @@ private func loadRunReviewSuites(
                     suiteKey: suiteKey,
                     testKey: testKey,
                     observations: try runReviewObservations(
-                        suiteKey: suiteKey,
-                        testKey: testKey,
                         testURL: testURL,
                         runURL: runURL
                     ),
@@ -769,8 +767,6 @@ private struct RunReviewPathKey: Hashable {
 }
 
 private func runReviewObservations(
-    suiteKey: String,
-    testKey: String,
     testURL: URL,
     runURL: URL
 ) throws -> [RunReviewObservation] {
@@ -779,9 +775,9 @@ private func runReviewObservations(
         let targetName = targetURL.lastPathComponent
         for attemptURL in try runReviewDirectoryChildren(of: targetURL) {
             let attemptName = attemptURL.lastPathComponent
+            let metadata = try loadE2ETestMetadata(in: attemptURL)
             let result = try runReviewObservationResult(
-                suiteKey: suiteKey,
-                testKey: testKey,
+                metadata: metadata,
                 attemptURL: e2eAttemptArtifactsURL(
                     in: runURL,
                     targetName: targetName,
@@ -815,8 +811,7 @@ private func runReviewObservations(
 }
 
 private func runReviewObservationResult(
-    suiteKey: String,
-    testKey: String,
+    metadata: E2ETestMetadata,
     attemptURL: URL
 ) throws -> ReviewTestObservation {
     let resultURL = attemptURL.appendingPathComponent("test-results.xml")
@@ -830,20 +825,8 @@ private func runReviewObservationResult(
     guard xmlParser.parse() else {
         throw ValidationError("Could not parse Swift Testing xUnit results: \(resultURL.path)")
     }
-    if let result = parser.results.first(where: { key, _ in
-        reviewSlug(key.suite) == suiteKey && reviewSlug(key.name) == testKey
-    })?.value {
-        return result
-    }
-
-    let matchingTestNames = parser.results.filter { key, _ in
-        reviewSlug(key.name) == testKey
-    }
-    if matchingTestNames.count == 1, let result = matchingTestNames.first?.value {
-        return result
-    }
-
-    return ReviewTestObservation(status: .unknown, durationSeconds: nil)
+    return parser.results[ReviewResultKey(suite: metadata.suiteName, name: metadata.testName)]
+        ?? ReviewTestObservation(status: .unknown, durationSeconds: nil)
 }
 
 private func runReviewDirectoryChildren(of url: URL) throws -> [URL] {

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
@@ -192,9 +192,8 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
                         attempt: attemptName
                     )
                     let result = try overviewObservationResult(
-                        suiteKey: suiteKey,
-                        testKey: testKey,
-                        attemptURL: attemptArtifactsURL
+                        observationURL: attemptURL,
+                        attemptArtifactsURL: attemptArtifactsURL
                     )
                     let artifacts = overviewArtifacts(
                         observationURL: attemptURL,
@@ -249,7 +248,13 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
             }
 
             if hasTargetOutcome {
-                uniqueTests.insert("\(suiteKey)/\(testKey)")
+                if let metadata = try firstE2ETestMetadata(in: testURL) {
+                    uniqueTests.insert(
+                        "\(metadata.sourceFilePath)/\(metadata.suiteName)/\(metadata.testName)"
+                    )
+                } else {
+                    uniqueTests.insert("\(suiteKey)/\(testKey)")
+                }
             }
         }
     }
@@ -292,11 +297,10 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
 }
 
 private func overviewObservationResult(
-    suiteKey: String,
-    testKey: String,
-    attemptURL: URL
+    observationURL: URL,
+    attemptArtifactsURL: URL
 ) throws -> OverviewObservationResult {
-    let resultURL = attemptURL.appendingPathComponent("test-results.xml")
+    let resultURL = attemptArtifactsURL.appendingPathComponent("test-results.xml")
     guard FileManager.default.fileExists(atPath: resultURL.path) else {
         return OverviewObservationResult(
             status: .unknown,
@@ -316,23 +320,25 @@ private func overviewObservationResult(
         )
     }
 
-    if let result = results.first(where: { key, _ in
-        overviewSlug(key.suite) == suiteKey && overviewSlug(key.name) == testKey
-    })?.value {
-        return result
+    let metadata: E2ETestMetadata
+    do {
+        metadata = try loadE2ETestMetadata(in: observationURL)
+    } catch {
+        return OverviewObservationResult(
+            status: .unknown,
+            durationSeconds: nil,
+            detail: "Could not read test.json for this recording: \(error)"
+        )
     }
 
-    let matchingTestNames = results.filter { key, _ in
-        overviewSlug(key.name) == testKey
-    }
-    if matchingTestNames.count == 1, let result = matchingTestNames.first?.value {
+    if let result = results[OverviewResultKey(suite: metadata.suiteName, name: metadata.testName)] {
         return result
     }
 
     return OverviewObservationResult(
         status: .unknown,
         durationSeconds: nil,
-        detail: "No Swift Testing result was found for this test in test-results.xml"
+        detail: "No Swift Testing result was found for \(metadata.suiteName) › \(metadata.testName) in test-results.xml"
     )
 }
 

--- a/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2ERecorder.swift
+++ b/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2ERecorder.swift
@@ -47,12 +47,12 @@ public struct WendyE2ERecorder: Sendable {
             let recordURL = URL(fileURLWithPath: self.recordPath, isDirectory: false)
             let recordExists = FileManager.default.fileExists(atPath: recordURL.path)
 
-            try self.writeTestMetadata(nextTo: recordURL)
-
             if !recordExists {
                 try Self.recordHeader(source: self.source)
                     .write(to: recordURL, atomically: true, encoding: .utf8)
             }
+
+            try self.writeTestMetadata(nextTo: recordURL)
 
             let recordHandle = try FileHandle(forWritingTo: recordURL)
             defer { try? recordHandle.close() }

--- a/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2ERecorder.swift
+++ b/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2ERecorder.swift
@@ -21,6 +21,15 @@ public struct WendyE2ERecorder: Sendable {
             testName: identity.testName,
             line: line
         )
+        self.metadata = TestMetadata(
+            schema: Self.testMetadataSchemaID,
+            sourceFilePath: Self.packageRelativeSourceFilePath(filePath),
+            sourceFileName: identity.fileName,
+            suiteName: identity.suite,
+            testName: identity.testName,
+            functionName: function,
+            line: line
+        )
     }
 
     public func record(
@@ -37,6 +46,8 @@ public struct WendyE2ERecorder: Sendable {
         do {
             let recordURL = URL(fileURLWithPath: self.recordPath, isDirectory: false)
             let recordExists = FileManager.default.fileExists(atPath: recordURL.path)
+
+            try self.writeTestMetadata(nextTo: recordURL)
 
             if !recordExists {
                 try Self.recordHeader(source: self.source)
@@ -136,6 +147,16 @@ public struct WendyE2ERecorder: Sendable {
         let line: Int
     }
 
+    struct TestMetadata: Codable, Sendable {
+        let schema: String
+        let sourceFilePath: String
+        let sourceFileName: String
+        let suiteName: String
+        let testName: String
+        let functionName: String
+        let line: Int
+    }
+
     private struct TestIdentity: Sendable {
         let filePath: String
         let fileName: String
@@ -168,6 +189,10 @@ public struct WendyE2ERecorder: Sendable {
     }
 
     private let source: Source
+    private let metadata: TestMetadata
+
+    private static let testMetadataFileName = "test.json"
+    private static let testMetadataSchemaID = "wendy.e2e.test.v1"
 
     private static let e2eTestRecordsDirectoryName: String = {
         let formatter = DateFormatter()
@@ -257,6 +282,17 @@ public struct WendyE2ERecorder: Sendable {
 
     private static func fileName(from filePath: String) -> String {
         URL(fileURLWithPath: filePath, isDirectory: false).deletingPathExtension().lastPathComponent
+    }
+
+    private static func packageRelativeSourceFilePath(_ filePath: String) -> String {
+        let sourceURL = URL(fileURLWithPath: filePath, isDirectory: false).standardizedFileURL
+        let packageURL = Self.packageRootDirectoryURL().standardizedFileURL
+        let packagePath = packageURL.path.hasSuffix("/") ? packageURL.path : packageURL.path + "/"
+        let sourcePath = sourceURL.path
+        guard sourcePath.hasPrefix(packagePath) else {
+            return sourceURL.lastPathComponent
+        }
+        return String(sourcePath.dropFirst(packagePath.count))
     }
 
     private static func recordingFileStem(filePath: String) -> String {
@@ -501,6 +537,14 @@ public struct WendyE2ERecorder: Sendable {
             ```
 
             """
+    }
+
+    private func writeTestMetadata(nextTo recordURL: URL) throws {
+        let metadataURL = recordURL.deletingLastPathComponent()
+            .appendingPathComponent(Self.testMetadataFileName, isDirectory: false)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        try encoder.encode(self.metadata).write(to: metadataURL, options: .atomic)
     }
 
     private func recordShellScript(

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
@@ -42,6 +42,21 @@ struct `aggregate command` {
             atomically: true,
             encoding: .utf8
         )
+        try """
+            {
+              "schema": "wendy.e2e.test.v1",
+              "sourceFilePath": "Tests/WendyE2ETests/WendyDeviceInfoTests.swift",
+              "sourceFileName": "WendyDeviceInfoTests",
+              "suiteName": "wendy device info",
+              "testName": "prints JSON device information",
+              "functionName": "`prints JSON device information`()`",
+              "line": 12
+            }
+            """.write(
+            to: observationURL.appendingPathComponent("test.json"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         var command = try AggregateCommand.parse(["--output-dir", outputURL.path, attemptURL.path])
         try command.run()
@@ -63,6 +78,8 @@ struct `aggregate command` {
         #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.log").path))
         #expect(!FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("observations").path))
         #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("recording.md").path))
+        #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("test.json").path))
+        #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("test.json").path))
         #expect(!FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("attempt.json").path))
         #expect(!FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("test-results.xml").path))
     }

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
@@ -42,21 +42,7 @@ struct `aggregate command` {
             atomically: true,
             encoding: .utf8
         )
-        try """
-            {
-              "schema": "wendy.e2e.test.v1",
-              "sourceFilePath": "Tests/WendyE2ETests/WendyDeviceInfoTests.swift",
-              "sourceFileName": "WendyDeviceInfoTests",
-              "suiteName": "wendy device info",
-              "testName": "prints JSON device information",
-              "functionName": "`prints JSON device information`()`",
-              "line": 12
-            }
-            """.write(
-            to: observationURL.appendingPathComponent("test.json"),
-            atomically: true,
-            encoding: .utf8
-        )
+        try writeAggregateTestMetadata(to: observationURL)
 
         var command = try AggregateCommand.parse(["--output-dir", outputURL.path, attemptURL.path])
         try command.run()
@@ -118,6 +104,24 @@ struct `aggregate command` {
         #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path))
         #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path))
     }
+}
+
+private func writeAggregateTestMetadata(to observationURL: URL) throws {
+    let metadata = E2ETestMetadata(
+        schema: e2eTestMetadataSchemaID,
+        sourceFilePath: "Tests/WendyE2ETests/WendyDeviceInfoTests.swift",
+        sourceFileName: "WendyDeviceInfoTests",
+        suiteName: "wendy device info",
+        testName: "prints JSON device information",
+        functionName: "`prints JSON device information`()",
+        line: 12
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    try encoder.encode(metadata).write(
+        to: observationURL.appendingPathComponent(e2eTestMetadataFileName),
+        options: .atomic
+    )
 }
 
 private func aggregateTemporaryDirectory() -> URL {

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
@@ -96,21 +96,20 @@ struct `report command` {
 }
 
 private func writeReportTestMetadata(to observationURL: URL) throws {
-    let json = """
-        {
-          "schema": "wendy.e2e.test.v1",
-          "sourceFilePath": "Tests/ReportSecurityTests.swift",
-          "sourceFileName": "ReportSecurityTests",
-          "suiteName": "report security",
-          "testName": "escapes malicious target",
-          "functionName": "`escapes malicious target`()`",
-          "line": 5
-        }
-        """
-    try json.write(
-        to: observationURL.appendingPathComponent("test.json"),
-        atomically: true,
-        encoding: .utf8
+    let metadata = E2ETestMetadata(
+        schema: e2eTestMetadataSchemaID,
+        sourceFilePath: "Tests/ReportSecurityTests.swift",
+        sourceFileName: "ReportSecurityTests",
+        suiteName: "report security",
+        testName: "escapes malicious target",
+        functionName: "`escapes malicious target`()",
+        line: 5
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    try encoder.encode(metadata).write(
+        to: observationURL.appendingPathComponent(e2eTestMetadataFileName),
+        options: .atomic
     )
 }
 

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
@@ -35,6 +35,7 @@ struct `report command` {
         try FileManager.default.createDirectory(at: attemptArtifactsURL, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: observationURL, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: noObservationAttemptURL, withIntermediateDirectories: true)
+        try writeReportTestMetadata(to: observationURL)
 
         try """
             import Testing
@@ -92,6 +93,25 @@ struct `report command` {
         #expect(html.contains("title=\"macos-to-&lt;img src=x onerror=&quot;alert(1)&quot;&gt;\""))
         #expect(html.contains("macos-to-no-observations"))
     }
+}
+
+private func writeReportTestMetadata(to observationURL: URL) throws {
+    let json = """
+        {
+          "schema": "wendy.e2e.test.v1",
+          "sourceFilePath": "Tests/ReportSecurityTests.swift",
+          "sourceFileName": "ReportSecurityTests",
+          "suiteName": "report security",
+          "testName": "escapes malicious target",
+          "functionName": "`escapes malicious target`()`",
+          "line": 5
+        }
+        """
+    try json.write(
+        to: observationURL.appendingPathComponent("test.json"),
+        atomically: true,
+        encoding: .utf8
+    )
 }
 
 private func temporaryDirectory() -> URL {

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -50,6 +50,8 @@ struct `run overview` {
             duration: 1.25
         )
         try writeXUnitResult(to: attemptTwoURL, status: .passed, duration: 0.75)
+        try writeTestMetadata(to: attemptOneObservationURL)
+        try writeTestMetadata(to: attemptTwoObservationURL)
         try "# Recording\n\n## Command 1\n".write(
             to: attemptOneObservationURL.appendingPathComponent("recording.md"),
             atomically: true,
@@ -75,6 +77,70 @@ struct `run overview` {
         #expect(flake.target == "macos-to-rpi")
         #expect(flake.attempts.map { $0.status } == [.failed, .passed])
         #expect(flake.attempts.first?.durationSeconds == 1.25)
+    }
+
+    @Test
+    func `uses test metadata to distinguish duplicate test names`() throws {
+        let rootURL = e2eTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
+        let target = "macos-to-rpi"
+        let attempt = "0001"
+        let firstObservationURL = runURL
+            .appendingPathComponent("observations", isDirectory: true)
+            .appendingPathComponent("first-file", isDirectory: true)
+            .appendingPathComponent("same-name", isDirectory: true)
+            .appendingPathComponent(target, isDirectory: true)
+            .appendingPathComponent(attempt, isDirectory: true)
+        let secondObservationURL = runURL
+            .appendingPathComponent("observations", isDirectory: true)
+            .appendingPathComponent("second-file", isDirectory: true)
+            .appendingPathComponent("same-name", isDirectory: true)
+            .appendingPathComponent(target, isDirectory: true)
+            .appendingPathComponent(attempt, isDirectory: true)
+        let attemptURL = runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent(target, isDirectory: true)
+            .appendingPathComponent(attempt, isDirectory: true)
+
+        try FileManager.default.createDirectory(at: firstObservationURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: secondObservationURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: attemptURL, withIntermediateDirectories: true)
+        try writeTestMetadata(
+            to: firstObservationURL,
+            sourceFilePath: "Tests/WendyE2ETests/FirstTests.swift",
+            sourceFileName: "FirstTests",
+            suiteName: "first suite",
+            testName: "same name"
+        )
+        try writeTestMetadata(
+            to: secondObservationURL,
+            sourceFilePath: "Tests/WendyE2ETests/SecondTests.swift",
+            sourceFileName: "SecondTests",
+            suiteName: "second suite",
+            testName: "same name"
+        )
+        try """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite tests="2">
+              <testcase classname="WendyE2ETests.`first suite`" name="same name()" time="0.1" />
+              <testcase classname="WendyE2ETests.`second suite`" name="same name()" time="0.2"><failure message="nope" /></testcase>
+            </testsuite>
+            """.write(
+            to: attemptURL.appendingPathComponent("test-results.xml"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let overview = try writeRunOverview(in: runURL)
+
+        #expect(overview.summary.tests == 2)
+        #expect(overview.summary.passed == 1)
+        #expect(overview.summary.failed == 1)
+        #expect(overview.summary.unknown == 0)
+        #expect(overview.noteworthy.deterministicFailures.count == 1)
+        #expect(overview.noteworthy.deterministicFailures.first?.suite == "second-file")
     }
 
     @Test
@@ -110,6 +176,7 @@ struct `run overview` {
             status: .failed("Unauthorized"),
             duration: 2.0
         )
+        try writeTestMetadata(to: attemptObservationURL)
         try "# Recording\n".write(
             to: attemptObservationURL.appendingPathComponent("recording.md"),
             atomically: true,
@@ -134,6 +201,31 @@ struct `run overview` {
         #expect(!markdown.contains("🛑 Error: The target rejected an otherwise valid authenticated request."))
         #expect(!markdown.contains("Fail: Agent rejected CLI auth"))
     }
+}
+
+private func writeTestMetadata(
+    to observationURL: URL,
+    sourceFilePath: String = "Tests/WendyE2ETests/WendyDeviceInfoTests.swift",
+    sourceFileName: String = "WendyDeviceInfoTests",
+    suiteName: String = "wendy device info",
+    testName: String = "prints JSON device information"
+) throws {
+    let json = """
+        {
+          "schema": "wendy.e2e.test.v1",
+          "sourceFilePath": "\(sourceFilePath)",
+          "sourceFileName": "\(sourceFileName)",
+          "suiteName": "\(suiteName)",
+          "testName": "\(testName)",
+          "functionName": "`\(testName)`()",
+          "line": 12
+        }
+        """
+    try json.write(
+        to: observationURL.appendingPathComponent("test.json"),
+        atomically: true,
+        encoding: .utf8
+    )
 }
 
 private func writeTestReview(in testURL: URL) throws {

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -210,21 +210,20 @@ private func writeTestMetadata(
     suiteName: String = "wendy device info",
     testName: String = "prints JSON device information"
 ) throws {
-    let json = """
-        {
-          "schema": "wendy.e2e.test.v1",
-          "sourceFilePath": "\(sourceFilePath)",
-          "sourceFileName": "\(sourceFileName)",
-          "suiteName": "\(suiteName)",
-          "testName": "\(testName)",
-          "functionName": "`\(testName)`()",
-          "line": 12
-        }
-        """
-    try json.write(
-        to: observationURL.appendingPathComponent("test.json"),
-        atomically: true,
-        encoding: .utf8
+    let metadata = E2ETestMetadata(
+        schema: e2eTestMetadataSchemaID,
+        sourceFilePath: sourceFilePath,
+        sourceFileName: sourceFileName,
+        suiteName: suiteName,
+        testName: testName,
+        functionName: "`\(testName)`()",
+        line: 12
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    try encoder.encode(metadata).write(
+        to: observationURL.appendingPathComponent(e2eTestMetadataFileName),
+        options: .atomic
     )
 }
 

--- a/swift/WendyE2ETests/Tests/WendyE2ETestingTests/WendyE2ERecorderTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETestingTests/WendyE2ERecorderTests.swift
@@ -1,9 +1,46 @@
+import Foundation
 import Testing
 
 @testable import WendyE2ETesting
 
 @Suite
 struct `recorder` {
+    @Test
+    func `writes test metadata JSON`() async throws {
+        let recorder = try WendyE2ERecorder(filePath: #filePath, function: #function, line: #line)
+        let session = try await WendyE2ESession.begin(
+            for: WendyE2EMachine(id: "local", name: "Local", os: .linux)
+        )
+
+        recorder.record(
+            session: session,
+            command: "printf 'ok'",
+            processID: "123",
+            status: "exit(0)",
+            duration: .seconds(1),
+            standardOutput: "ok",
+            standardError: "",
+            harnessPrefix: [],
+            scriptShellName: "sh"
+        )
+
+        let metadataURL = URL(fileURLWithPath: recorder.testDirectoryPath, isDirectory: true)
+            .appendingPathComponent("test.json")
+        let metadata = try JSONDecoder().decode(
+            WendyE2ERecorder.TestMetadata.self,
+            from: Data(contentsOf: metadataURL)
+        )
+
+        #expect(metadata.schema == "wendy.e2e.test.v1")
+        #expect(
+            metadata.sourceFilePath == "Tests/WendyE2ETestingTests/WendyE2ERecorderTests.swift"
+        )
+        #expect(metadata.sourceFileName == "WendyE2ERecorderTests")
+        #expect(metadata.suiteName == "recorder")
+        #expect(metadata.testName == "writes test metadata JSON")
+        #expect(metadata.functionName.contains("writes test metadata JSON"))
+    }
+
     @Test
     func `redacts sensitive environment values`() {
         let description = WendyE2ERecorder.redactedEnvironmentDescription([


### PR DESCRIPTION
## Summary

- Setup PR for WDY-1528.
- Implementation will add a narrow, versioned `recording.json` alongside Swift E2E recordings with source/test identity metadata.
- Run overview, report, and review paths should prefer JSON metadata with `recording.md` fallback.

Closes WDY-1528

## Testing

- Not run yet (setup-only draft).
