### PR TITLE
WDY-1531: reject unsupported Mac run project types

### DIFF
--- a/Examples/HelloCrash/wendy.json
+++ b/Examples/HelloCrash/wendy.json
@@ -1,0 +1,5 @@
+{
+  "appId": "sh.wendy.examples.hellocrash",
+  "version": "1.0.0",
+  "language": "swift"
+}

--- a/go/internal/cli/assets/docs/apps/compose.md
+++ b/go/internal/cli/assets/docs/apps/compose.md
@@ -122,6 +122,7 @@ All `wendy run` flags work with compose projects:
 
 ## Limitations
 
+- Wendy Agent for Mac is not supported. `wendy run` rejects compose projects before any registry or Docker setup when the selected target is Wendy Agent for Mac. Target a Linux/WendyOS device to use compose.
 - Wendy-specific hardware access entitlements such as `gpu`, `camera`, `audio`, `bluetooth`, `usb`, `i2c`, `gpio`, `spi`, and `input` are not inferred from compose fields.
 - Service-specific lifecycle behavior is not supported yet: Compose services cannot declare Wendy readiness probes or `postStart` hooks, and top-level `wendy.json` hooks do not apply to generated Compose service apps.
 - Host networking does not imply shared IPC or shared `/dev/shm`; ROS 2 shared-memory transport requires an app shape that can explicitly share namespaces.

--- a/go/internal/cli/assets/docs/apps/wendy-services.md
+++ b/go/internal/cli/assets/docs/apps/wendy-services.md
@@ -119,3 +119,4 @@ wendy run --service api   # builds db and api only (frontend excluded)
 
 - Log output is multiplexed with a `[serviceName]` prefix on each line. Per-service log stream routing is not yet available.
 - Containers are created via individual `CreateContainer` calls in dependency order. A grouped `CreateAppGroup` RPC for atomic creation is planned as a follow-up.
+- Wendy Agent for Mac is not supported. `wendy run` rejects multi-service `wendy.json` projects when the selected target is Wendy Agent for Mac, before any build or registry operation. Target a Linux/WendyOS device for multi-service workloads.

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -40,10 +40,13 @@ Target platform. One of:
 | `wendyos` | Linux edge device running WendyOS |
 | `wendy-lite` | ESP32 WASM target |
 | `darwin` | Native macOS app running through Wendy Agent for Mac |
+| `linux/arm64`, `linux/amd64`, etc. | Explicit Linux architecture target |
 
 Omit to target the default platform.
 
 Use `"darwin"` for native macOS targets managed by [Wendy Agent for Mac](/docs/installation/wendy-agent-macos). The CLI builds the app on a Mac development machine, syncs the build output to the Mac agent, and launches it as a native macOS process. Darwin apps run natively and non-containerized; they do not use the WendyOS Linux container runtime.
+
+> **Wendy Agent for Mac:** If the selected target is Wendy Agent for Mac, `wendy run` rejects any `platform` value that does not resolve to `darwin` (for example, `linux/arm64` or `wendyos`). Set `platform: "darwin"` and use a native SwiftPM or Xcode project.
 
 Minimal SwiftPM/macOS configuration:
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -7,6 +7,24 @@ Runs your app on a Wendy-enabled device:
 5. [Starts the app](./device/apps/start.md)
 6. [Attaches the logs](./device/logs.md) if needed (when `--detach` is not provided)
 
+> **Note:** When `wendy.json` is absent, `wendy run` resolves the target device before prompting to create one. If the target is Wendy Agent for Mac and the detected project type is unsupported, the project/target mismatch error is returned immediately without opening the config creation prompt.
+
+## Wendy Agent for Mac — supported project types
+
+Wendy Agent for Mac (Darwin targets) currently runs native macOS apps only. When the selected agent reports `os: darwin`, `wendy run` rejects Linux/container deployment paths before any build, registry auth, or registry setup.
+
+| Project type | Mac target support |
+|---|---|
+| Native SwiftPM (`Package.swift`, `platform: "darwin"`) | Supported |
+| Native Xcode (`.xcodeproj`, `platform: "darwin"`) | Supported |
+| Dockerfile / container image | Rejected |
+| Python container path | Rejected |
+| Docker Compose | Rejected |
+| Multi-service `wendy.json` (`services` map) | Rejected |
+| `platform: "linux/..."` or `platform: "wendyos"` | Rejected |
+
+The error explains the project/target mismatch and tells you to set `platform: "darwin"` with a Mac-compatible native SwiftPM or Xcode project, or to target a Linux/WendyOS device. Linux container support on Mac is planned for a future release.
+
 ## Docker build-args
 
 When building a Dockerfile project, `wendy run` passes the target device's hardware parameters as `--build-arg` values so the Dockerfile can branch on platform, GPU vendor, or CUDA version. Declare any arg you want to use with `ARG`:
@@ -37,9 +55,13 @@ Use `--service <name>` to build and run only a specific service and its transiti
 
 See [Multi-Service Apps with `wendy.json`](../../../apps/wendy-services.md) for a full walkthrough.
 
+> **Wendy Agent for Mac:** Multi-service `wendy.json` projects are not supported when the selected target is Wendy Agent for Mac. `wendy run` returns an error immediately. Target a Linux/WendyOS device for multi-service workloads.
+
 ## Compose projects
 
 If the current directory contains a `docker-compose.yml` (or `compose.yml`) but no `wendy.json`, `wendy run` automatically runs it as a multi-service compose project. Each service is built, pushed, and started on the device in dependency order. See [Multi-Service Apps with Docker Compose](../../../apps/compose.md) for full details.
+
+> **Wendy Agent for Mac:** Compose projects are not supported when the selected target is Wendy Agent for Mac. `wendy run` returns an error before performing any registry or Docker setup. To deploy a compose workload, target a Linux/WendyOS device. For Mac targets, use a native SwiftPM or Xcode project with `platform: "darwin"`.
 
 ## Swift Package Manager projects (macOS)
 

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -604,10 +604,6 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		cliLogln("warning: %s", w)
 	}
 
-	if err := requireRegistryAuth(ctx, conn); err != nil {
-		return err
-	}
-
 	versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
@@ -618,6 +614,13 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		architecture = "arm64"
 	}
 	platform := resolveAgentPlatform("", agentOS, architecture)
+	if strings.EqualFold(agentOS, appconfig.PlatformDarwin) {
+		return rejectUnsupportedMacRunProject("compose", platform)
+	}
+
+	if err := requireRegistryAuth(ctx, conn); err != nil {
+		return err
+	}
 
 	regPort := registryPort(agentOS)
 	registryAddr, proxyCleanup, err := resolveRegistryForAgent(ctx, conn, regPort)

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -76,10 +76,6 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 		return err
 	}
 
-	if err := requireRegistryAuth(ctx, conn); err != nil {
-		return err
-	}
-
 	versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
@@ -91,6 +87,13 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 		architecture = "arm64"
 	}
 	platform := resolveAgentPlatform(appCfg.Platform, agentOS, architecture)
+	if strings.EqualFold(agentOS, appconfig.PlatformDarwin) {
+		return rejectUnsupportedMacRunProject("multi-service", platform)
+	}
+
+	if err := requireRegistryAuth(ctx, conn); err != nil {
+		return err
+	}
 
 	regPort := registryPort(agentOS)
 	registryAddr, proxyCleanup, err := resolveRegistryForAgent(ctx, conn, regPort)

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -582,6 +582,34 @@ func runCommand(ctx context.Context, opts runOptions) error {
 	}
 
 	cfgPath := filepath.Join(cwd, "wendy.json")
+	cfgMissing, err := appConfigFileMissing(cfgPath)
+	if err != nil {
+		return fmt.Errorf("checking wendy.json: %w", err)
+	}
+
+	// If wendy.json is missing, resolve the target before prompting to create
+	// one. That lets Mac beta targets reject container-only project shapes with
+	// the real project/target mismatch instead of first asking about config.
+	var target *SelectedDevice
+	defer func() {
+		if target != nil && target.Agent != nil {
+			target.Agent.Close()
+		}
+	}()
+	if cfgMissing {
+		var resolveOpts []resolveOption
+		if opts.yes {
+			resolveOpts = append(resolveOpts, NonInteractive())
+		}
+		target, err = resolveRunTarget(ctx, resolveOpts...)
+		if err != nil {
+			return err
+		}
+		if err := preflightMissingAppConfigForMacTarget(ctx, target, projectType); err != nil {
+			return err
+		}
+	}
+
 	appCfg, err := ensureAppConfig(cfgPath, opts.yes)
 	if err != nil {
 		return fmt.Errorf("loading wendy.json: %w", err)
@@ -614,13 +642,15 @@ func runCommand(ctx context.Context, opts runOptions) error {
 	}
 
 	// Step 2: Resolve the target device.
-	var resolveOpts []resolveOption
-	if opts.yes {
-		resolveOpts = append(resolveOpts, NonInteractive())
-	}
-	target, err := resolveRunTarget(ctx, resolveOpts...)
-	if err != nil {
-		return err
+	if target == nil {
+		var resolveOpts []resolveOption
+		if opts.yes {
+			resolveOpts = append(resolveOpts, NonInteractive())
+		}
+		target, err = resolveRunTarget(ctx, resolveOpts...)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Provider-based run path.
@@ -648,8 +678,37 @@ func runCommand(ctx context.Context, opts runOptions) error {
 	}
 
 	// Agent-based run path (existing gRPC pipeline).
-	defer target.Agent.Close()
 	return runWithAgent(ctx, target.Agent, cwd, appCfg, opts)
+}
+
+func appConfigFileMissing(cfgPath string) (bool, error) {
+	if _, err := os.Stat(cfgPath); err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
+}
+
+func preflightMissingAppConfigForMacTarget(ctx context.Context, target *SelectedDevice, projectType string) error {
+	if target == nil || target.Agent == nil {
+		return nil
+	}
+	versionResp, err := target.Agent.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	if err != nil {
+		return nil
+	}
+	agentOS := versionResp.GetOs()
+	architecture := versionResp.GetCpuArchitecture()
+	if architecture == "" {
+		architecture = "arm64"
+	}
+	platform := resolveAgentPlatform("", agentOS, architecture)
+	if strings.EqualFold(agentOS, appconfig.PlatformDarwin) {
+		return rejectUnsupportedMacRunProject(projectType, platform)
+	}
+	return nil
 }
 
 // runComposeCommand handles the full device-selection + execution flow for

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -38,18 +38,22 @@ var cliStyle = lipgloss.NewStyle().Foreground(tui.ColorDim)
 var cliNoticeStyle = lipgloss.NewStyle().Foreground(tui.ColorNotice)
 var execCommandContext = exec.CommandContext
 
-const linuxContainersOnMacsUnsupportedMessage = "Project/target mismatch: selected target is Wendy Agent for Mac, but this project uses the Linux/container deployment path. Linux containers aren't supported on Macs yet. Wendy Agent for Mac currently runs native macOS apps only. To fix this, set `platform: \"darwin\"` and use a Mac-compatible native SwiftPM or Xcode template, or target a Linux/WendyOS device."
+const macContainersUnsupportedMessage = "Project/target mismatch: selected target is Wendy Agent for Mac, but this project uses the Linux/container deployment path. Linux containers aren't supported on Macs yet. Wendy Agent for Mac currently runs native macOS apps only. To fix this, set `platform: \"darwin\"` and use a Mac-compatible native SwiftPM or Xcode template, or target a Linux/WendyOS device."
+
+func macPlatformMismatchMessage(platform string) string {
+	return fmt.Sprintf("Project/target mismatch: selected target is Wendy Agent for Mac, but wendy.json resolves to platform %q. Wendy Agent for Mac currently runs native macOS apps only. To fix this, set `platform: \"darwin\"` and use a Mac-compatible native SwiftPM or Xcode template, or target a Linux/WendyOS device.", platform)
+}
 
 func rejectUnsupportedMacRunProject(projectType, platform string) error {
 	if !strings.EqualFold(platformOS(platform), appconfig.PlatformDarwin) {
-		return errors.New(linuxContainersOnMacsUnsupportedMessage)
+		return errors.New(macPlatformMismatchMessage(platform))
 	}
 
 	switch projectType {
 	case "swift", "xcode":
 		return nil
 	case "docker", "python", "compose", "multi-service":
-		return errors.New(linuxContainersOnMacsUnsupportedMessage)
+		return errors.New(macContainersUnsupportedMessage)
 	default:
 		return nil
 	}
@@ -589,7 +593,9 @@ func runCommand(ctx context.Context, opts runOptions) error {
 
 	// If wendy.json is missing, resolve the target before prompting to create
 	// one. That lets Mac beta targets reject container-only project shapes with
-	// the real project/target mismatch instead of first asking about config.
+	// the real project/target mismatch instead of first asking about config. The
+	// CLI owns the selected connection lifetime for both the preflight and normal
+	// run paths; lower-level run helpers do not close it.
 	var target *SelectedDevice
 	defer func() {
 		if target != nil && target.Agent != nil {
@@ -697,7 +703,7 @@ func preflightMissingAppConfigForMacTarget(ctx context.Context, target *Selected
 	}
 	versionResp, err := target.Agent.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
 	if err != nil {
-		return nil
+		return fmt.Errorf("querying device version for Mac target preflight: %w", err)
 	}
 	agentOS := versionResp.GetOs()
 	architecture := versionResp.GetCpuArchitecture()

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -38,7 +38,22 @@ var cliStyle = lipgloss.NewStyle().Foreground(tui.ColorDim)
 var cliNoticeStyle = lipgloss.NewStyle().Foreground(tui.ColorNotice)
 var execCommandContext = exec.CommandContext
 
-const linuxContainersOnMacsUnsupportedMessage = "Linux containers aren't supported on Macs yet. Support is planned for a future release. For now, deploy a native macOS app (platform: darwin) or target a Linux/WendyOS device."
+const linuxContainersOnMacsUnsupportedMessage = "Project/target mismatch: selected target is Wendy Agent for Mac, but this project uses the Linux/container deployment path. Linux containers aren't supported on Macs yet. Wendy Agent for Mac currently runs native macOS apps only. To fix this, set `platform: \"darwin\"` and use a Mac-compatible native SwiftPM or Xcode template, or target a Linux/WendyOS device."
+
+func rejectUnsupportedMacRunProject(projectType, platform string) error {
+	if !strings.EqualFold(platformOS(platform), appconfig.PlatformDarwin) {
+		return errors.New(linuxContainersOnMacsUnsupportedMessage)
+	}
+
+	switch projectType {
+	case "swift", "xcode":
+		return nil
+	case "docker", "python", "compose", "multi-service":
+		return errors.New(linuxContainersOnMacsUnsupportedMessage)
+	default:
+		return nil
+	}
+}
 
 type dimWriter struct {
 	buf strings.Builder
@@ -1177,8 +1192,10 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	}
 
 	platform := resolveAgentPlatform(appCfg.Platform, agentOS, architecture)
-	if agentOS == "darwin" && platformOS(platform) == "linux" {
-		return errors.New(linuxContainersOnMacsUnsupportedMessage)
+	if strings.EqualFold(agentOS, appconfig.PlatformDarwin) {
+		if err := rejectUnsupportedMacRunProject(projectType, platform); err != nil {
+			return err
+		}
 	}
 
 	// Xcode projects: always use the local-build + file-sync path (darwin only).

--- a/go/internal/cli/commands/run_macos_test.go
+++ b/go/internal/cli/commands/run_macos_test.go
@@ -84,7 +84,7 @@ func startFakeMacRunServer(t *testing.T, state *fakeMacRunState) (*grpcclient.Ag
 	return ac, cleanup
 }
 
-func TestRunMacOSXcodeWithAgent_UsesRunArgsFromAppConfig(t *testing.T) {
+func TestRunWithAgent_AllowsNativeDarwinXcodeAndUsesRunArgsFromAppConfig(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.Mkdir(filepath.Join(dir, "MyApp.xcodeproj"), 0o755); err != nil {
 		t.Fatalf("Mkdir: %v", err)
@@ -115,17 +115,18 @@ func TestRunMacOSXcodeWithAgent_UsesRunArgsFromAppConfig(t *testing.T) {
 	defer cleanup()
 
 	appCfg := &appconfig.AppConfig{
-		AppID: "sh.wendy.MyXcodeApp",
-		Xcode: &appconfig.XcodeConfig{Scheme: "MyScheme"},
-		Run:   &appconfig.RunConfig{Args: []string{"--from-config", "hello world"}},
+		AppID:    "sh.wendy.MyXcodeApp",
+		Platform: appconfig.PlatformDarwin,
+		Xcode:    &appconfig.XcodeConfig{Scheme: "MyScheme"},
+		Run:      &appconfig.RunConfig{Args: []string{"--from-config", "hello world"}},
 	}
 
-	err := runMacOSXcodeWithAgent(context.Background(), conn, dir, appCfg, runOptions{
+	err := runWithAgent(context.Background(), conn, dir, appCfg, runOptions{
 		deploy:   true,
 		userArgs: []string{"--ignored-cli"},
 	})
 	if err != nil {
-		t.Fatalf("runMacOSXcodeWithAgent: %v", err)
+		t.Fatalf("runWithAgent: %v", err)
 	}
 
 	if len(state.createReqs) != 1 {
@@ -253,8 +254,101 @@ func TestAssembleSwiftPMSyncEntries_IncludesSiblingResourceDirectories(t *testin
 	}
 }
 
-func TestRunWithAgent_RejectsLinuxContainersOnMacs(t *testing.T) {
+func TestRunWithAgent_RejectsUnsupportedMacProjectShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, dir string)
+		appCfg *appconfig.AppConfig
+	}{
+		{
+			name: "dockerfile with explicit linux platform",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+					t.Fatalf("WriteFile Dockerfile: %v", err)
+				}
+			},
+			appCfg: &appconfig.AppConfig{AppID: "sh.wendy.MacLinuxContainer", Platform: "linux/arm64"},
+		},
+		{
+			name: "dockerfile with implicit target platform",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+					t.Fatalf("WriteFile Dockerfile: %v", err)
+				}
+			},
+			appCfg: &appconfig.AppConfig{AppID: "sh.wendy.MacDockerContainer"},
+		},
+		{
+			name: "python project with darwin platform",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("flask\n"), 0o644); err != nil {
+					t.Fatalf("WriteFile requirements.txt: %v", err)
+				}
+			},
+			appCfg: &appconfig.AppConfig{AppID: "sh.wendy.MacPythonContainer", Platform: appconfig.PlatformDarwin},
+		},
+		{
+			name: "wendyos platform template",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("flask\n"), 0o644); err != nil {
+					t.Fatalf("WriteFile requirements.txt: %v", err)
+				}
+			},
+			appCfg: &appconfig.AppConfig{AppID: "sh.wendy.WendyOSTemplate", Platform: appconfig.PlatformWendyOS},
+		},
+		{
+			name:  "multi-service config",
+			setup: func(t *testing.T, dir string) { t.Helper() },
+			appCfg: &appconfig.AppConfig{
+				AppID:    "sh.wendy.MultiService",
+				Platform: appconfig.PlatformDarwin,
+				Services: map[string]*appconfig.ServiceConfig{
+					"api": {Context: "api"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.setup(t, dir)
+
+			state := &fakeMacRunState{}
+			conn, cleanup := startFakeMacRunServer(t, state)
+			defer cleanup()
+
+			err := runWithAgent(context.Background(), conn, dir, tt.appCfg, runOptions{})
+			if err == nil {
+				t.Fatal("runWithAgent error = nil, want unsupported platform error")
+			}
+			got := err.Error()
+			if !strings.Contains(got, "Wendy Agent for Mac currently runs native macOS apps only") || !strings.Contains(got, "target a Linux/WendyOS device") {
+				t.Fatalf("runWithAgent error = %q, want unsupported Macs guidance", got)
+			}
+			if strings.Contains(got, "agent version") || strings.Contains(got, "updating") {
+				t.Fatalf("runWithAgent error = %q, should not suggest updating the agent", got)
+			}
+			if len(state.createReqs) != 0 {
+				t.Fatalf("CreateContainer calls = %d, want 0", len(state.createReqs))
+			}
+			if len(state.startReqs) != 0 {
+				t.Fatalf("StartContainer calls = %d, want 0", len(state.startReqs))
+			}
+		})
+	}
+}
+
+func TestRunComposeWithAgent_RejectsMacAgentBeforeRegistrySetup(t *testing.T) {
 	dir := t.TempDir()
+	compose := []byte("services:\n  web:\n    build: .\n")
+	if err := os.WriteFile(filepath.Join(dir, "compose.yaml"), compose, 0o644); err != nil {
+		t.Fatalf("WriteFile compose.yaml: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile Dockerfile: %v", err)
 	}
@@ -263,23 +357,15 @@ func TestRunWithAgent_RejectsLinuxContainersOnMacs(t *testing.T) {
 	conn, cleanup := startFakeMacRunServer(t, state)
 	defer cleanup()
 
-	appCfg := &appconfig.AppConfig{
-		AppID:    "sh.wendy.MacLinuxContainer",
-		Platform: "linux/arm64",
-	}
-
-	err := runWithAgent(context.Background(), conn, dir, appCfg, runOptions{})
+	err := runComposeWithAgent(context.Background(), conn, dir, runOptions{})
 	if err == nil {
-		t.Fatal("runWithAgent error = nil, want unsupported platform error")
+		t.Fatal("runComposeWithAgent error = nil, want unsupported Mac project error")
 	}
-	if got := err.Error(); !strings.Contains(got, "Linux containers aren't supported on Macs yet") {
-		t.Fatalf("runWithAgent error = %q, want unsupported Macs message", got)
+	if got := err.Error(); !strings.Contains(got, "Wendy Agent for Mac currently runs native macOS apps only") {
+		t.Fatalf("runComposeWithAgent error = %q, want Mac beta native-only guidance", got)
 	}
 	if len(state.createReqs) != 0 {
 		t.Fatalf("CreateContainer calls = %d, want 0", len(state.createReqs))
-	}
-	if len(state.startReqs) != 0 {
-		t.Fatalf("StartContainer calls = %d, want 0", len(state.startReqs))
 	}
 }
 

--- a/go/internal/cli/commands/run_macos_test.go
+++ b/go/internal/cli/commands/run_macos_test.go
@@ -254,6 +254,32 @@ func TestAssembleSwiftPMSyncEntries_IncludesSiblingResourceDirectories(t *testin
 	}
 }
 
+func TestPreflightMissingAppConfigForMacTarget_RejectsContainerProjectBeforeConfigPrompt(t *testing.T) {
+	state := &fakeMacRunState{}
+	conn, cleanup := startFakeMacRunServer(t, state)
+	defer cleanup()
+
+	target := &SelectedDevice{Agent: conn}
+	err := preflightMissingAppConfigForMacTarget(context.Background(), target, "docker")
+	if err == nil {
+		t.Fatal("preflightMissingAppConfigForMacTarget error = nil, want unsupported Mac project error")
+	}
+	if got := err.Error(); !strings.Contains(got, "Project/target mismatch") || !strings.Contains(got, "platform: \"darwin\"") {
+		t.Fatalf("preflightMissingAppConfigForMacTarget error = %q, want Mac project guidance", got)
+	}
+}
+
+func TestPreflightMissingAppConfigForMacTarget_AllowsNativeSwiftProject(t *testing.T) {
+	state := &fakeMacRunState{}
+	conn, cleanup := startFakeMacRunServer(t, state)
+	defer cleanup()
+
+	target := &SelectedDevice{Agent: conn}
+	if err := preflightMissingAppConfigForMacTarget(context.Background(), target, "swift"); err != nil {
+		t.Fatalf("preflightMissingAppConfigForMacTarget swift error = %v, want nil", err)
+	}
+}
+
 func TestRunWithAgent_RejectsUnsupportedMacProjectShapes(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ETestMetadata.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ETestMetadata.swift
@@ -37,17 +37,25 @@ struct E2ETestMetadata: Codable, Sendable {
         guard !value.hasPrefix("/"), !value.split(separator: "/").contains("..") else {
             throw ValidationError("Test metadata has invalid \(field) in \(sourceURL.path)")
         }
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-")
+        let allowed = CharacterSet(
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-"
+        )
         guard value.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
-            throw ValidationError("Test metadata has invalid \(field) characters in \(sourceURL.path)")
+            throw ValidationError(
+                "Test metadata has invalid \(field) characters in \(sourceURL.path)"
+            )
         }
     }
 
     private func validateName(_ value: String, field: String, sourceURL: URL) throws {
         try validateText(value, field: field, maxLength: 255, sourceURL: sourceURL)
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+        let allowed = CharacterSet(
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-"
+        )
         guard value.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
-            throw ValidationError("Test metadata has invalid \(field) characters in \(sourceURL.path)")
+            throw ValidationError(
+                "Test metadata has invalid \(field) characters in \(sourceURL.path)"
+            )
         }
     }
 

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -544,7 +544,10 @@ private func loadRunTestResults(
                     observations[identityKey, default: []].append(
                         ReportTestObservation(
                             target: targetName,
-                            route: try targetRoute(for: targetName, attemptURL: attemptArtifactsURL),
+                            route: try targetRoute(
+                                for: targetName,
+                                attemptURL: attemptArtifactsURL
+                            ),
                             attempt: attemptName,
                             status: status,
                             recordingPath: observationFilePath(
@@ -1531,7 +1534,8 @@ private func renderObservations(
         let escapedTarget = isFirstTargetRow ? escapeHTML(observation.target) : ""
         let target = escapedTarget
         let route =
-            isFirstTargetRow ? renderTargetRoute(observation.route, escapedTitle: escapedTarget) : ""
+            isFirstTargetRow
+            ? renderTargetRoute(observation.route, escapedTitle: escapedTarget) : ""
         let rowClass = isFirstTargetRow ? "observation-row" : "observation-row same-target"
         chunks.append(
             "<div class=\"\(rowClass)\"><span class=\"observation-route-cell\">\(route)</span><span class=\"observation-target\">\(target)</span><span class=\"observation-spacer\" aria-hidden=\"true\"></span>\(renderObservationLinks(observation))<span class=\"observation-attempt\">\(escapeHTML(observation.attempt))</span><span class=\"badge \(observation.status.statusClass)\">\(observation.status.statusText)</span>\(observationDurationBadge(observation.duration))</div>"

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewAggregate.swift
@@ -400,7 +400,8 @@ private func reviewAggregateSummaryMarkdown(_ value: String) -> String {
     ]
 
     for pattern in patterns {
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+        else {
             continue
         }
         let range = NSRange(original.startIndex..<original.endIndex, in: original)

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
@@ -338,7 +338,8 @@ private func overviewObservationResult(
     return OverviewObservationResult(
         status: .unknown,
         durationSeconds: nil,
-        detail: "No Swift Testing result was found for \(metadata.suiteName) › \(metadata.testName) in test-results.xml"
+        detail:
+            "No Swift Testing result was found for \(metadata.suiteName) › \(metadata.testName) in test-results.xml"
     )
 }
 

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/AggregateCommandTests.swift
@@ -16,12 +16,16 @@ struct `aggregate command` {
             "swift-e2e-tests.local0000.macos-to-rpi.0001",
             isDirectory: true
         )
-        let observationURL = attemptURL
+        let observationURL =
+            attemptURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("wendy-device-info", isDirectory: true)
             .appendingPathComponent("prints-json-device-information", isDirectory: true)
 
-        try FileManager.default.createDirectory(at: observationURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: observationURL,
+            withIntermediateDirectories: true
+        )
         try "{}\n".write(
             to: attemptURL.appendingPathComponent("attempt.json"),
             atomically: true,
@@ -47,27 +51,69 @@ struct `aggregate command` {
         var command = try AggregateCommand.parse(["--output-dir", outputURL.path, attemptURL.path])
         try command.run()
 
-        let runURL = outputURL.appendingPathComponent("swift-e2e-tests.local0000", isDirectory: true)
-        let attemptArtifactsURL = runURL
+        let runURL = outputURL.appendingPathComponent(
+            "swift-e2e-tests.local0000",
+            isDirectory: true
+        )
+        let attemptArtifactsURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
             .appendingPathComponent("0001", isDirectory: true)
-        let aggregateObservationURL = runURL
+        let aggregateObservationURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("wendy-device-info", isDirectory: true)
             .appendingPathComponent("prints-json-device-information", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
             .appendingPathComponent("0001", isDirectory: true)
 
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path))
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path))
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.log").path))
-        #expect(!FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("observations").path))
-        #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("recording.md").path))
-        #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("test.json").path))
-        #expect(FileManager.default.fileExists(atPath: aggregateObservationURL.deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("test.json").path))
-        #expect(!FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("attempt.json").path))
-        #expect(!FileManager.default.fileExists(atPath: aggregateObservationURL.appendingPathComponent("test-results.xml").path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("attempt.log").path
+            )
+        )
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("observations").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: aggregateObservationURL.appendingPathComponent("recording.md").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: aggregateObservationURL.appendingPathComponent("test.json").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: aggregateObservationURL.deletingLastPathComponent()
+                    .deletingLastPathComponent().appendingPathComponent("test.json").path
+            )
+        )
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: aggregateObservationURL.appendingPathComponent("attempt.json").path
+            )
+        )
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: aggregateObservationURL.appendingPathComponent("test-results.xml").path
+            )
+        )
     }
 
     @Test
@@ -95,14 +141,26 @@ struct `aggregate command` {
         var command = try AggregateCommand.parse(["--output-dir", outputURL.path, attemptURL.path])
         try command.run()
 
-        let runURL = outputURL.appendingPathComponent("swift-e2e-tests.local0000", isDirectory: true)
-        let attemptArtifactsURL = runURL
+        let runURL = outputURL.appendingPathComponent(
+            "swift-e2e-tests.local0000",
+            isDirectory: true
+        )
+        let attemptArtifactsURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
             .appendingPathComponent("0001", isDirectory: true)
 
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path))
-        #expect(FileManager.default.fileExists(atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("attempt.json").path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: attemptArtifactsURL.appendingPathComponent("test-results.xml").path
+            )
+        )
     }
 }
 

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
@@ -15,67 +15,79 @@ struct `report command` {
         let testsURL = packageURL.appendingPathComponent("Tests", isDirectory: true)
         let supportURL = packageURL.appendingPathComponent("Support", isDirectory: true)
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
-        let attemptArtifactsURL = runURL
+        let attemptArtifactsURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-<img src=x onerror=\"alert(1)\">", isDirectory: true)
             .appendingPathComponent("attempt-1", isDirectory: true)
-        let observationURL = runURL
+        let observationURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("report-security", isDirectory: true)
             .appendingPathComponent("escapes-malicious-target", isDirectory: true)
             .appendingPathComponent("macos-to-<img src=x onerror=\"alert(1)\">", isDirectory: true)
             .appendingPathComponent("attempt-1", isDirectory: true)
-        let noObservationAttemptURL = runURL
+        let noObservationAttemptURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-no-observations", isDirectory: true)
             .appendingPathComponent("attempt-1", isDirectory: true)
 
         try FileManager.default.createDirectory(at: testsURL, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: supportURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: attemptArtifactsURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: observationURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: noObservationAttemptURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: attemptArtifactsURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: observationURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: noObservationAttemptURL,
+            withIntermediateDirectories: true
+        )
         try writeReportTestMetadata(to: observationURL)
 
         try """
-            import Testing
+        import Testing
 
-            @Suite
-            struct `report security` {
-                @Test
-                func `escapes malicious target`() async throws {}
-            }
-            """.write(
-                to: testsURL.appendingPathComponent("ReportSecurityTests.swift"),
-                atomically: true,
-                encoding: .utf8
-            )
-
-        try """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <testsuite tests="1" failures="0" skipped="0">
-              <testcase classname="WendyE2ETests.`report security`" name="escapes malicious target()" time="0.01" />
-            </testsuite>
-            """.write(
-                to: attemptArtifactsURL.appendingPathComponent("test-results.xml"),
-                atomically: true,
-                encoding: .utf8
-            )
+        @Suite
+        struct `report security` {
+            @Test
+            func `escapes malicious target`() async throws {}
+        }
+        """.write(
+            to: testsURL.appendingPathComponent("ReportSecurityTests.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         try """
-            <!doctype html>
-            <html>
-              <body>
-                {{TARGET_OVERVIEW}}
-                <!-- Repeat this .card section once per test file. -->
-                <footer></footer>
-              </body>
-            </html>
-            """.write(
-                to: supportURL.appendingPathComponent("e2e-report.template.html"),
-                atomically: true,
-                encoding: .utf8
-            )
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuite tests="1" failures="0" skipped="0">
+          <testcase classname="WendyE2ETests.`report security`" name="escapes malicious target()" time="0.01" />
+        </testsuite>
+        """.write(
+            to: attemptArtifactsURL.appendingPathComponent("test-results.xml"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try """
+        <!doctype html>
+        <html>
+          <body>
+            {{TARGET_OVERVIEW}}
+            <!-- Repeat this .card section once per test file. -->
+            <footer></footer>
+          </body>
+        </html>
+        """.write(
+            to: supportURL.appendingPathComponent("e2e-report.template.html"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         var command = try ReportCommand.parse([
             "--package-dir", packageURL.path,

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -11,7 +11,8 @@ struct `run overview` {
         defer { try? FileManager.default.removeItem(at: rootURL) }
 
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
-        let suiteURL = runURL
+        let suiteURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("wendy-device-info", isDirectory: true)
         let testURL = suiteURL.appendingPathComponent(
@@ -21,11 +22,18 @@ struct `run overview` {
         let targetURL = testURL.appendingPathComponent("macos-to-rpi", isDirectory: true)
         let attemptOneObservationURL = targetURL.appendingPathComponent("0001", isDirectory: true)
         let attemptTwoObservationURL = targetURL.appendingPathComponent("0002", isDirectory: true)
-        let attemptArtifactsRootURL = runURL
+        let attemptArtifactsRootURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
-        let attemptOneURL = attemptArtifactsRootURL.appendingPathComponent("0001", isDirectory: true)
-        let attemptTwoURL = attemptArtifactsRootURL.appendingPathComponent("0002", isDirectory: true)
+        let attemptOneURL = attemptArtifactsRootURL.appendingPathComponent(
+            "0001",
+            isDirectory: true
+        )
+        let attemptTwoURL = attemptArtifactsRootURL.appendingPathComponent(
+            "0002",
+            isDirectory: true
+        )
 
         try FileManager.default.createDirectory(
             at: attemptOneObservationURL,
@@ -87,25 +95,34 @@ struct `run overview` {
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
         let target = "macos-to-rpi"
         let attempt = "0001"
-        let firstObservationURL = runURL
+        let firstObservationURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("first-file", isDirectory: true)
             .appendingPathComponent("same-name", isDirectory: true)
             .appendingPathComponent(target, isDirectory: true)
             .appendingPathComponent(attempt, isDirectory: true)
-        let secondObservationURL = runURL
+        let secondObservationURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("second-file", isDirectory: true)
             .appendingPathComponent("same-name", isDirectory: true)
             .appendingPathComponent(target, isDirectory: true)
             .appendingPathComponent(attempt, isDirectory: true)
-        let attemptURL = runURL
+        let attemptURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent(target, isDirectory: true)
             .appendingPathComponent(attempt, isDirectory: true)
 
-        try FileManager.default.createDirectory(at: firstObservationURL, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: secondObservationURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: firstObservationURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: secondObservationURL,
+            withIntermediateDirectories: true
+        )
         try FileManager.default.createDirectory(at: attemptURL, withIntermediateDirectories: true)
         try writeTestMetadata(
             to: firstObservationURL,
@@ -122,12 +139,12 @@ struct `run overview` {
             testName: "same name"
         )
         try """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <testsuite tests="2">
-              <testcase classname="WendyE2ETests.`first suite`" name="same name()" time="0.1" />
-              <testcase classname="WendyE2ETests.`second suite`" name="same name()" time="0.2"><failure message="nope" /></testcase>
-            </testsuite>
-            """.write(
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuite tests="2">
+          <testcase classname="WendyE2ETests.`first suite`" name="same name()" time="0.1" />
+          <testcase classname="WendyE2ETests.`second suite`" name="same name()" time="0.2"><failure message="nope" /></testcase>
+        </testsuite>
+        """.write(
             to: attemptURL.appendingPathComponent("test-results.xml"),
             atomically: true,
             encoding: .utf8
@@ -149,7 +166,8 @@ struct `run overview` {
         defer { try? FileManager.default.removeItem(at: rootURL) }
 
         let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
-        let suiteURL = runURL
+        let suiteURL =
+            runURL
             .appendingPathComponent("observations", isDirectory: true)
             .appendingPathComponent("wendy-device-info", isDirectory: true)
         let testURL = suiteURL.appendingPathComponent(
@@ -158,7 +176,8 @@ struct `run overview` {
         )
         let targetURL = testURL.appendingPathComponent("macos-to-rpi", isDirectory: true)
         let attemptObservationURL = targetURL.appendingPathComponent("0001", isDirectory: true)
-        let attemptURL = runURL
+        let attemptURL =
+            runURL
             .appendingPathComponent("attempts", isDirectory: true)
             .appendingPathComponent("macos-to-rpi", isDirectory: true)
             .appendingPathComponent("0001", isDirectory: true)
@@ -198,7 +217,11 @@ struct `run overview` {
         #expect(markdown.contains("### 🛑 Agent rejected CLI auth"))
         #expect(!markdown.contains("### 🛑 Error Agent rejected CLI auth"))
         #expect(markdown.contains("The target rejected an otherwise valid authenticated request."))
-        #expect(!markdown.contains("🛑 Error: The target rejected an otherwise valid authenticated request."))
+        #expect(
+            !markdown.contains(
+                "🛑 Error: The target rejected an otherwise valid authenticated request."
+            )
+        )
         #expect(!markdown.contains("Fail: Agent rejected CLI auth"))
     }
 }


### PR DESCRIPTION
## Summary

- Make `wendy run` fail early when the selected target is Wendy Agent for Mac but the local project would use the Linux/container deployment path.
- Return a Mac beta-specific diagnostic before config creation prompts, registry auth, registry proxy setup, Docker/buildx, or agent container capability errors.
- Preserve the native Darwin SwiftPM and Xcode paths for the current Mac beta.

Closes WDY-1531.

## Rejected for Mac targets

- `wendy.json` platforms that do not resolve to Darwin, including `linux/...` and `wendyos`.
- Dockerfile/container projects, even when the effective platform is Darwin.
- Python projects that would generate/build a container image.
- Compose projects.
- Multi-service `wendy.json` configs.
- Missing-`wendy.json` container projects after the Mac target is selected.

## Still accepted

- Native Darwin SwiftPM projects.
- Native Darwin Xcode projects.
- `Examples/HelloCrash`, which now has an explicit Swift example config.

## Follow-ups / notes

- This does not add Linux container support on Mac; that remains follow-up work.
- Unknown project shapes still fall through to the existing project detection error rather than a new Mac-specific project-shape classifier.

## Testing

- `cd go && go test ./internal/cli/commands`
- `cd go && go test ./internal/cli/commands ./internal/cli/providers ./internal/shared/appconfig`

