### PR TITLE
fix: bind macOS registry proxy to loopback instead of 0.0.0.0

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1247,7 +1247,8 @@ func resolveRegistry(ctx context.Context, host string, port int) (registryAddr s
 		target = net.JoinHostPort(resolved, strconv.Itoa(port))
 	}
 
-	proxy, err := startRegistryProxy(ctx, "0.0.0.0:0", target)
+	// Bind loopback only; the Docker VM forwards host.docker.internal to it.
+	proxy, err := startRegistryProxy(ctx, registryProxyListenAddr, target)
 	if err != nil {
 		return "", nil, fmt.Errorf("starting registry proxy: %w", err)
 	}
@@ -1295,14 +1296,8 @@ func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnecti
 			return "", nil, err
 		}
 	} else {
-		// On Linux buildkitd uses host networking so 127.0.0.1 is reachable.
-		// On macOS it runs inside the Docker Desktop VM and must connect via
-		// host.docker.internal, which requires the proxy to bind on all interfaces.
-		listenAddr := "0.0.0.0:0"
-		if runtime.GOOS == "linux" {
-			listenAddr = "127.0.0.1:0"
-		}
-		proxy, proxyErr := startRegistryProxyWithDialer(context.Background(), listenAddr, func(ctx context.Context) (net.Conn, error) {
+		// Bind loopback only; the Docker VM forwards host.docker.internal to it.
+		proxy, proxyErr := startRegistryProxyWithDialer(context.Background(), registryProxyListenAddr, func(ctx context.Context) (net.Conn, error) {
 			return conn.RegistryDialer(ctx, port)
 		})
 		if proxyErr != nil {
@@ -1498,6 +1493,14 @@ func isLinkLocalIP(ip string) bool {
 	}
 	return addr.IsLinkLocalUnicast()
 }
+
+// registryProxyListenAddr is the address the host-side registry proxy binds to.
+// It is always loopback: on Linux buildkitd uses host networking and reaches
+// 127.0.0.1 directly; on macOS/Windows the Docker VM forwards
+// host.docker.internal to the host's loopback. Binding loopback rather than
+// 0.0.0.0 keeps the device registry tunnel off every other interface for the
+// duration of a build (WDY-1168).
+const registryProxyListenAddr = "127.0.0.1:0"
 
 // registryProxy forwards TCP connections from a local port to a remote device
 // registry. This bridges the gap between Docker Desktop's VM (which cannot

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -965,6 +965,31 @@ func TestStartRegistryProxy(t *testing.T) {
 	}
 }
 
+// TestRegistryProxyBindsLoopback guards WDY-1168: the registry proxy must bind
+// loopback only so the device registry tunnel is never exposed on other network
+// interfaces during a build. A regression to "0.0.0.0:0" binds the unspecified
+// address, which is not loopback and fails this test.
+func TestRegistryProxyBindsLoopback(t *testing.T) {
+	target, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxy, err := startRegistryProxy(ctx, registryProxyListenAddr, target.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxy.Close()
+
+	ip := proxy.listener.Addr().(*net.TCPAddr).IP
+	if !ip.IsLoopback() {
+		t.Fatalf("registry proxy bound to %s, want a loopback address", ip)
+	}
+}
+
 func TestFindIPv4ViaNeighborTable_UnknownAddress(t *testing.T) {
 	// This test would invoke findIPv4ViaNeighborTable, which may spawn real ndp/arp/ip
 	// commands and read the host's neighbor tables, making it environment-dependent.


### PR DESCRIPTION
## Summary

- The host-side TCP proxy that bridges Docker buildkitd to the device registry bound to `0.0.0.0` on macOS/Windows, exposing the device registry tunnel on **all** network interfaces for the duration of a build — any host on the LAN could reach it. PR #655 had narrowed only the Linux and Swift paths to `127.0.0.1`.
- Fix: bind loopback (`127.0.0.1`) on every platform. The Docker VM forwards `host.docker.internal` to the host's loopback, so `127.0.0.1` stays reachable while keeping the proxy off the LAN. Both bind sites — `resolveRegistry` (LAN/USB device path) and `resolveRegistryForAgent` (cloud-tunnel path) — now use a shared `registryProxyListenAddr` constant.
- Removed the now-stale "must bind on all interfaces" comment and the OS-conditional bind logic.

Closes WDY-1168.

## Test plan

- [x] `go build ./...` + full `internal/cli/commands` package tests pass; `gofmt` clean.
- [x] New `TestRegistryProxyBindsLoopback` asserts the proxy binds a loopback address (a regression to `0.0.0.0` binds the unspecified address and fails it).
- [x] **On-device:** real `wendy run --build-type docker` Docker push to a LAN device (Raspberry Pi 5, WendyOS) — `lsof` confirmed the proxy bound `127.0.0.1:<port>`, buildkit reached it via `host.docker.internal:<port>`, all layers + manifest pushed, container created — exit 0, no EOF.
- [ ] Cloud-tunneled (mTLS) device push — symmetric code path, not separately exercised.

Windows shares the same non-Linux path, so it is narrowed too, though only macOS was verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)