### PR TITLE
Security: enforce connecting client's org on agent mTLS gate (WDY-1535)

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/agent/registry"
 	"github.com/wendylabsinc/wendy/go/internal/agent/services"
 	"github.com/wendylabsinc/wendy/go/internal/shared/browseropen"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
@@ -309,6 +310,17 @@ func main() {
 		logger.Info("kernel dmesg collection disabled (set WENDY_COLLECT_DMESG=true to enable)")
 	}
 
+	// mTLS organization-equality enforcement mode. Read once here so the
+	// startMTLSServer closure can capture it. The default (empty value) is grace,
+	// which enforces org-equality for certs that carry an org identity but allows
+	// legacy certs without one — easing migration before cert rotation completes.
+	orgMode, ok := interceptor.ParseOrgMode(os.Getenv("WENDY_MTLS_ORG_ENFORCEMENT"))
+	if !ok {
+		logger.Warn("WENDY_MTLS_ORG_ENFORCEMENT has unrecognised value; defaulting to grace",
+			zap.String("value", os.Getenv("WENDY_MTLS_ORG_ENFORCEMENT")))
+	}
+	logger.Info("mTLS org enforcement mode", zap.String("mode", orgMode.String()))
+
 	// Main agent gRPC server port.
 	agentPort := defaultAgentPort
 	if p := os.Getenv("WENDY_AGENT_PORT"); p != "" {
@@ -388,7 +400,30 @@ func main() {
 			)
 		}
 
-		srv, err := mtls.NewServer(certPEM, chainPEM, keyPEM, logger, floor,
+		// Derive this device's own organization from its leaf certificate so the
+		// mTLS interceptor can enforce org-equality. We deliberately derive from
+		// certPEM (the device's own leaf) rather than provisioningSvc.ProvisioningInfo():
+		// startMTLSServer is also invoked from inside the OnProvisioned callback,
+		// where taking the provisioning mutex would risk re-entrancy (see the comment
+		// at the startTunnelBroker closure). Both call sites already pass certPEM.
+		expectedOrg, haveOrg := deviceOrgFromCertPEM(certPEM)
+		effectiveMode := orgMode
+		if orgMode != interceptor.OrgModeOff && !haveOrg {
+			// Fail safe: the device cannot determine its own org, so it cannot
+			// meaningfully compare a client's org against it. Rather than brick the
+			// device (rejecting all clients) or silently enforce against an unknown
+			// self-org, disable enforcement for this server and log loudly.
+			logger.Error("cannot determine device organization from own certificate; mTLS org enforcement DISABLED for this server",
+				zap.String("configuredMode", orgMode.String()))
+			effectiveMode = interceptor.OrgModeOff
+		}
+		if effectiveMode != interceptor.OrgModeOff {
+			logger.Info("mTLS server enforcing org",
+				zap.Int32("org", expectedOrg),
+				zap.String("mode", effectiveMode.String()))
+		}
+
+		srv, err := mtls.NewServer(certPEM, chainPEM, keyPEM, logger, floor, expectedOrg, effectiveMode,
 			// UnaryMTLSInterceptor and StreamMTLSInterceptor are embedded inside
 			// mtls.NewServer and run before these caller-provided interceptors.
 			grpc.ChainUnaryInterceptor(interceptor.UnaryErrorInterceptor(logger)),
@@ -645,6 +680,39 @@ func certNotBeforeFloor(certPEM string) time.Time {
 		return time.Time{}
 	}
 	return cert.NotBefore
+}
+
+// deviceOrgFromCertPEM parses the device's own leaf certificate (ML-DSA aware,
+// mirroring certNotBeforeFloor) and extracts its organization ID via
+// certs.OrgFromClientCert. It returns (org, true) when an org identity is present
+// and valid, and (0, false) on any parse/extract error or when the cert carries no
+// org identity. The caller treats (0, false) as "device org unknown".
+func deviceOrgFromCertPEM(certPEM string) (int32, bool) {
+	if certPEM == "" {
+		return 0, false
+	}
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return 0, false
+	}
+	// ML-DSA certs from pki-core have trailing ASN.1 bytes that cause
+	// x509.ParseCertificate to fail. Strip them with the same fallback used by
+	// certNotBeforeFloor and internal/agent/mtls/mldsa_verify.go.
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		var raw asn1.RawValue
+		if _, asn1Err := asn1.Unmarshal(block.Bytes, &raw); asn1Err == nil {
+			cert, err = x509.ParseCertificate(raw.FullBytes)
+		}
+	}
+	if err != nil {
+		return 0, false
+	}
+	org, hasOrg, err := certs.OrgFromClientCert(cert)
+	if err != nil || !hasOrg {
+		return 0, false
+	}
+	return org, true
 }
 
 func brokerURLForCloudHost(cloudHost string) string {

--- a/go/internal/agent/interceptor/mtls.go
+++ b/go/internal/agent/interceptor/mtls.go
@@ -3,7 +3,9 @@ package interceptor
 import (
 	"context"
 	"crypto/x509"
+	"strings"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -11,6 +13,57 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
+
+// OrgMode selects how the mTLS gate enforces organization-equality between the
+// connecting client certificate and the device's own organization.
+type OrgMode int
+
+const (
+	// OrgModeOff disables the org check entirely; any validly-issued client cert
+	// is accepted regardless of its organization.
+	OrgModeOff OrgMode = iota
+	// OrgModeGrace enforces org-equality for certs that carry an org identity but
+	// allows legacy certs that carry no org identity (logging a warning), easing
+	// migration before cert rotation completes.
+	OrgModeGrace
+	// OrgModeStrict enforces org-equality and additionally requires every client
+	// cert to carry an org identity; legacy certs without one are rejected.
+	OrgModeStrict
+)
+
+// String returns the canonical lowercase name of the mode for logging.
+func (m OrgMode) String() string {
+	switch m {
+	case OrgModeOff:
+		return "off"
+	case OrgModeStrict:
+		return "strict"
+	case OrgModeGrace:
+		return "grace"
+	default:
+		return "grace"
+	}
+}
+
+// ParseOrgMode maps the WENDY_MTLS_ORG_ENFORCEMENT env value to a mode.
+// An empty string yields (OrgModeGrace, true) — grace is the default. The values
+// "grace", "strict", and "off" (case-insensitive, surrounding whitespace trimmed)
+// yield the corresponding mode and true. Any other value yields (OrgModeGrace,
+// false) so the caller can warn and fall back to grace.
+func ParseOrgMode(s string) (OrgMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return OrgModeGrace, true
+	case "grace":
+		return OrgModeGrace, true
+	case "strict":
+		return OrgModeStrict, true
+	case "off":
+		return OrgModeOff, true
+	default:
+		return OrgModeGrace, false
+	}
+}
 
 func peerAddr(ctx context.Context) string {
 	p, ok := peer.FromContext(ctx)
@@ -34,7 +87,14 @@ func peerAddr(ctx context.Context) string {
 // Audit logging: the certificate serial number (not PII) is logged at Debug level.
 // Subject CN is intentionally omitted from per-call logs to satisfy data-minimisation
 // requirements — it may contain a username or device identifier.
-func CheckMTLS(ctx context.Context, logger *zap.Logger) error {
+//
+// Organization enforcement: after the certificate is structurally validated, the
+// caller's organization (extracted from the leaf via certs.OrgFromClientCert) is
+// compared against expectedOrgID under the given mode. This prevents a validly-issued
+// user cert from one organization being accepted by a device belonging to another
+// (cross-tenant access). Only org IDs (ints, non-PII), the serial, and the remote
+// address are logged — never the CN/subject, which may carry a username.
+func CheckMTLS(ctx context.Context, logger *zap.Logger, expectedOrgID int32, mode OrgMode) error {
 	p, ok := peer.FromContext(ctx)
 	if !ok || p.AuthInfo == nil {
 		logger.Warn("rejected unauthenticated gRPC caller",
@@ -87,23 +147,63 @@ func CheckMTLS(ctx context.Context, logger *zap.Logger) error {
 		zap.String("remote", peerAddr(ctx)),
 		zap.String("serial", leaf.SerialNumber.String()),
 	)
-	return nil
+
+	// Organization-equality enforcement. OrgModeOff disables the check entirely,
+	// preserving pre-WDY-1535 behaviour. For grace/strict we extract the cert's org
+	// and compare it to this device's org (expectedOrgID).
+	if mode == OrgModeOff {
+		return nil
+	}
+	org, hasOrg, err := certs.OrgFromClientCert(leaf)
+	switch {
+	case err != nil:
+		// An org claim was present but malformed/ambiguous/non-positive. This is
+		// anomalous; reject in BOTH grace and strict. The CN/subject is not logged.
+		logger.Warn("rejected cert with undeterminable organization",
+			zap.String("remote", peerAddr(ctx)),
+			zap.String("serial", leaf.SerialNumber.String()),
+			zap.Error(err))
+		return status.Errorf(codes.PermissionDenied, "certificate organization could not be determined")
+	case hasOrg && org == expectedOrgID:
+		return nil
+	case hasOrg && org != expectedOrgID:
+		logger.Warn("rejected cert from non-permitted organization",
+			zap.String("remote", peerAddr(ctx)),
+			zap.String("serial", leaf.SerialNumber.String()),
+			zap.Int32("presentedOrg", org),
+			zap.Int32("expectedOrg", expectedOrgID))
+		return status.Errorf(codes.PermissionDenied, "certificate organization not permitted")
+	default:
+		// !hasOrg: a legacy cert with no org identity.
+		if mode == OrgModeStrict {
+			logger.Warn("rejected cert with no organization identity under strict mode",
+				zap.String("remote", peerAddr(ctx)),
+				zap.String("serial", leaf.SerialNumber.String()))
+			return status.Errorf(codes.PermissionDenied, "certificate organization identity required")
+		}
+		logger.Warn("client certificate has no organization identity; allowed under grace mode (set WENDY_MTLS_ORG_ENFORCEMENT=strict after cert rotation)",
+			zap.String("remote", peerAddr(ctx)),
+			zap.String("serial", leaf.SerialNumber.String()))
+		return nil
+	}
 }
 
-// UnaryMTLSInterceptor rejects unary calls that do not carry verified mTLS peer credentials.
-func UnaryMTLSInterceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
+// UnaryMTLSInterceptor rejects unary calls that do not carry verified mTLS peer
+// credentials or whose client organization is not permitted under the given mode.
+func UnaryMTLSInterceptor(logger *zap.Logger, expectedOrgID int32, mode OrgMode) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		if err := CheckMTLS(ctx, logger); err != nil {
+		if err := CheckMTLS(ctx, logger, expectedOrgID, mode); err != nil {
 			return nil, err
 		}
 		return handler(ctx, req)
 	}
 }
 
-// StreamMTLSInterceptor rejects streaming calls that do not carry verified mTLS peer credentials.
-func StreamMTLSInterceptor(logger *zap.Logger) grpc.StreamServerInterceptor {
+// StreamMTLSInterceptor rejects streaming calls that do not carry verified mTLS peer
+// credentials or whose client organization is not permitted under the given mode.
+func StreamMTLSInterceptor(logger *zap.Logger, expectedOrgID int32, mode OrgMode) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if err := CheckMTLS(ss.Context(), logger); err != nil {
+		if err := CheckMTLS(ss.Context(), logger, expectedOrgID, mode); err != nil {
 			return err
 		}
 		return handler(srv, ss)

--- a/go/internal/agent/interceptor/mtls_test.go
+++ b/go/internal/agent/interceptor/mtls_test.go
@@ -1,0 +1,221 @@
+package interceptor
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"testing"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// mustParseURL parses a raw URL for use in a cert's SAN URIs, failing the test
+// if it cannot be parsed.
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parsing URL %q: %v", raw, err)
+	}
+	return u
+}
+
+// leafOptions configures the hand-constructed leaf certificate used in tests.
+type leafOptions struct {
+	commonName  string
+	uris        []*url.URL
+	noClientEKU bool
+}
+
+// buildLeaf constructs an *x509.Certificate suitable for the CheckMTLS struct-field
+// inspection. CheckMTLS only reads struct fields (the handshake already verified the
+// signature) so a literal works — no real signed cert is needed.
+func buildLeaf(opts leafOptions) *x509.Certificate {
+	leaf := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: opts.commonName},
+		URIs:         opts.uris,
+	}
+	if !opts.noClientEKU {
+		leaf.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	return leaf
+}
+
+// ctxWithLeaf builds a gRPC context carrying the given leaf as the peer's single
+// presented client certificate.
+func ctxWithLeaf(leaf *x509.Certificate) context.Context {
+	return peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{leaf},
+			},
+		},
+	})
+}
+
+func TestCheckMTLS_OrgEnforcement(t *testing.T) {
+	logger := zap.NewNop()
+	const expectedOrg int32 = 7
+
+	tests := []struct {
+		name     string
+		leaf     *x509.Certificate
+		mode     OrgMode
+		wantCode codes.Code // codes.OK means no error expected
+	}{
+		{
+			name:     "asset CN org match grace",
+			leaf:     buildLeaf(leafOptions{commonName: "sh/wendy/7/5"}),
+			mode:     OrgModeGrace,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "asset CN org match strict",
+			leaf:     buildLeaf(leafOptions{commonName: "sh/wendy/7/5"}),
+			mode:     OrgModeStrict,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "user SAN org match grace",
+			leaf:     buildLeaf(leafOptions{uris: []*url.URL{mustParseURL(t, "urn:wendy:org:7:user:abc")}}),
+			mode:     OrgModeGrace,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "user SAN org match strict",
+			leaf:     buildLeaf(leafOptions{uris: []*url.URL{mustParseURL(t, "urn:wendy:org:7:user:abc")}}),
+			mode:     OrgModeStrict,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "CN org mismatch grace",
+			leaf:     buildLeaf(leafOptions{commonName: "sh/wendy/9/5"}),
+			mode:     OrgModeGrace,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "CN org mismatch strict",
+			leaf:     buildLeaf(leafOptions{commonName: "sh/wendy/9/5"}),
+			mode:     OrgModeStrict,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "user SAN mismatch grace",
+			leaf:     buildLeaf(leafOptions{uris: []*url.URL{mustParseURL(t, "urn:wendy:org:9:user:x")}}),
+			mode:     OrgModeGrace,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "user SAN mismatch strict",
+			leaf:     buildLeaf(leafOptions{uris: []*url.URL{mustParseURL(t, "urn:wendy:org:9:user:x")}}),
+			mode:     OrgModeStrict,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "no-org legacy user cert grace allowed",
+			leaf:     buildLeaf(leafOptions{commonName: "wendy/user/abc"}),
+			mode:     OrgModeGrace,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "no-org legacy user cert strict rejected",
+			leaf:     buildLeaf(leafOptions{commonName: "wendy/user/abc"}),
+			mode:     OrgModeStrict,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "malformed org claim grace rejected",
+			leaf:     buildLeaf(leafOptions{uris: []*url.URL{mustParseURL(t, "urn:wendy:org:0:user:x")}}),
+			mode:     OrgModeGrace,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "malformed org claim strict rejected",
+			leaf:     buildLeaf(leafOptions{uris: []*url.URL{mustParseURL(t, "urn:wendy:org:0:user:x")}}),
+			mode:     OrgModeStrict,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "mode off skips org check on mismatch",
+			leaf:     buildLeaf(leafOptions{commonName: "sh/wendy/9/5"}),
+			mode:     OrgModeOff,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "regression no clientAuth EKU rejected in grace",
+			leaf:     buildLeaf(leafOptions{commonName: "sh/wendy/7/5", noClientEKU: true}),
+			mode:     OrgModeGrace,
+			wantCode: codes.Unauthenticated,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := ctxWithLeaf(tc.leaf)
+			err := CheckMTLS(ctx, logger, expectedOrg, tc.mode)
+			if got := status.Code(err); got != tc.wantCode {
+				t.Fatalf("CheckMTLS code = %v (err=%v); want %v", got, err, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestCheckMTLS_NoPeerCertificates(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{PeerCertificates: nil}},
+	})
+	err := CheckMTLS(ctx, logger, 7, OrgModeGrace)
+	if got := status.Code(err); got != codes.Unauthenticated {
+		t.Fatalf("CheckMTLS code = %v (err=%v); want Unauthenticated", got, err)
+	}
+}
+
+func TestParseOrgMode(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantMode OrgMode
+		wantOK   bool
+	}{
+		{"", OrgModeGrace, true},
+		{"grace", OrgModeGrace, true},
+		{"GRACE", OrgModeGrace, true},
+		{" strict ", OrgModeStrict, true},
+		{"strict", OrgModeStrict, true},
+		{"off", OrgModeOff, true},
+		{"OFF", OrgModeOff, true},
+		{"bogus", OrgModeGrace, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			gotMode, gotOK := ParseOrgMode(tc.in)
+			if gotMode != tc.wantMode || gotOK != tc.wantOK {
+				t.Fatalf("ParseOrgMode(%q) = (%v, %v); want (%v, %v)", tc.in, gotMode, gotOK, tc.wantMode, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestOrgModeString(t *testing.T) {
+	tests := []struct {
+		mode OrgMode
+		want string
+	}{
+		{OrgModeOff, "off"},
+		{OrgModeGrace, "grace"},
+		{OrgModeStrict, "strict"},
+	}
+	for _, tc := range tests {
+		if got := tc.mode.String(); got != tc.want {
+			t.Fatalf("OrgMode(%d).String() = %q; want %q", tc.mode, got, tc.want)
+		}
+	}
+}

--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -78,7 +78,9 @@ func NewTLSConfig(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBefor
 // extraOpts; those run after the mandatory mTLS check.
 // logger may be nil; when provided, rejected client certificates are logged at WARN level.
 // notBeforeFloor is forwarded to NewTLSConfig; see its documentation for details.
-func NewServer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBeforeFloor time.Time, extraOpts ...grpc.ServerOption) (*grpc.Server, error) {
+// expectedOrgID and orgMode are forwarded to the mandatory mTLS interceptors, which
+// enforce organization-equality between the connecting client cert and this device.
+func NewServer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBeforeFloor time.Time, expectedOrgID int32, orgMode interceptor.OrgMode, extraOpts ...grpc.ServerOption) (*grpc.Server, error) {
 	tlsConfig, err := NewTLSConfig(certPEM, chainPEM, keyPEM, logger, notBeforeFloor)
 	if err != nil {
 		return nil, fmt.Errorf("creating TLS config: %w", err)
@@ -89,8 +91,8 @@ func NewServer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBeforeFl
 		grpc.Creds(creds),
 		// mTLS interceptors are mandatory: they run before any caller-provided interceptors
 		// so that no handler can be reached without a verified client certificate.
-		grpc.ChainUnaryInterceptor(interceptor.UnaryMTLSInterceptor(logger)),
-		grpc.ChainStreamInterceptor(interceptor.StreamMTLSInterceptor(logger)),
+		grpc.ChainUnaryInterceptor(interceptor.UnaryMTLSInterceptor(logger, expectedOrgID, orgMode)),
+		grpc.ChainStreamInterceptor(interceptor.StreamMTLSInterceptor(logger, expectedOrgID, orgMode)),
 		grpc.InitialWindowSize(8 * 1024 * 1024),
 		grpc.InitialConnWindowSize(16 * 1024 * 1024),
 		grpc.KeepaliveParams(keepalive.ServerParameters{

--- a/go/internal/cli/assets/docs/development/debugging.md
+++ b/go/internal/cli/assets/docs/development/debugging.md
@@ -59,6 +59,13 @@ All environment variables are read at startup. Restart the agent after changing 
 | `WENDY_OTEL_PORT` | `4317` | Port for the OTEL gRPC receiver |
 | `WENDY_OTEL_HTTP_PORT` | `4318` | Port for the OTEL HTTP/protobuf receiver |
 | `WENDY_NETWORK_MANAGER` | `auto` | Network manager preference: `auto`, `connman`, `networkmanager`, `force-connman`, `force-networkmanager` |
+| `WENDY_MTLS_ORG_ENFORCEMENT` | `grace` | mTLS client organization enforcement on the device's mTLS gate: `off` (no org check), `grace` (reject any client cert whose organization differs from the device's own org, but allow legacy certs that carry no org identity), `strict` (as `grace`, and additionally reject certs that carry no org identity). See note below. |
+
+### `WENDY_MTLS_ORG_ENFORCEMENT` migration
+
+The device derives its own organization from its provisioning certificate and rejects connecting client certificates from a different organization (WDY-1535). A client cert carries its org either as a SAN URI `urn:wendy:org:<org>:user:<id>` (newer certs) or, for devices, in the CN `sh/wendy/<org>/<asset>`.
+
+Until cloud-issued **user** certificates carry the org SAN URI, legacy user certs have no org identity. Run in the default `grace` mode during this window: cross-org certs that *do* carry an org are still rejected, while org-less legacy certs are allowed and logged at WARN. After user certs have rotated to carry the org SAN, switch to `strict` to also reject any cert lacking an org identity. If the device cannot determine its own org from its certificate, enforcement is disabled for safety and logged at ERROR.
 
 ## gRPC Ports and Provisioning State
 

--- a/go/internal/shared/certs/orgident.go
+++ b/go/internal/shared/certs/orgident.go
@@ -1,0 +1,99 @@
+package certs
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// OrgFromClientCert extracts the Wendy organization ID a certificate is bound to.
+//
+// Resolution order:
+//  1. If the cert has any SAN URI beginning with "urn:wendy:org:", that URI is
+//     authoritative. It MUST parse as urn:wendy:org:<org>:(user|asset):<id>;
+//     a present-but-malformed wendy URN returns an error (anomalous/suspicious).
+//     The CN is NOT consulted in this case.
+//  2. Otherwise, if the CommonName has the form sh/wendy/<org>/<asset>, the org is
+//     parsed from it. A CN that begins with "sh/wendy/" but does not parse cleanly
+//     returns an error.
+//  3. Otherwise no org identity is present: returns (0, false, nil). (e.g. a user
+//     cert with CN wendy/user/<id> and no SAN.)
+//
+// Returns:
+//
+//	(org, true, nil)  — a valid org identity was found
+//	(0, false, nil)   — no org identity present (legacy/unknown); not an error
+//	(0, false, err)   — an org identity was present but malformed/unparseable
+func OrgFromClientCert(leaf *x509.Certificate) (orgID int32, hasOrg bool, err error) {
+	// Step 1: check SAN URIs for a wendy org URN.
+	const wendyURNPrefix = "urn:wendy:org:"
+	for _, u := range leaf.URIs {
+		raw := u.String()
+		if !strings.HasPrefix(raw, wendyURNPrefix) {
+			continue
+		}
+		// Found a wendy URN — it is authoritative; parse it or return error.
+		org, err := parseWendyOrgURN(raw)
+		if err != nil {
+			return 0, false, err
+		}
+		return org, true, nil
+	}
+
+	// Step 2: fall back to CommonName.
+	cn := leaf.Subject.CommonName
+	if strings.HasPrefix(cn, "sh/wendy/") {
+		org, err := parseShWendyCN(cn)
+		if err != nil {
+			return 0, false, err
+		}
+		return org, true, nil
+	}
+
+	// Step 3: no org identity present.
+	return 0, false, nil
+}
+
+// parseWendyOrgURN parses a URN of the form urn:wendy:org:<org>:(user|asset):<id>
+// and returns the org ID as int32.
+func parseWendyOrgURN(uri string) (int32, error) {
+	parts := strings.Split(uri, ":")
+	if len(parts) != 6 {
+		return 0, fmt.Errorf("invalid wendy URN format (want 6 colon-separated parts): %s", uri)
+	}
+	if parts[0] != "urn" || parts[1] != "wendy" || parts[2] != "org" {
+		return 0, fmt.Errorf("invalid wendy URN prefix: %s", uri)
+	}
+	orgID, err := strconv.ParseInt(parts[3], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid organization ID in URN %q: %w", parts[3], err)
+	}
+	entityType := parts[4]
+	if entityType != "user" && entityType != "asset" {
+		return 0, fmt.Errorf("unknown entity type in wendy URN %q: %s", uri, entityType)
+	}
+	if parts[5] == "" {
+		return 0, fmt.Errorf("empty entity ID in wendy URN: %s", uri)
+	}
+	return int32(orgID), nil
+}
+
+// parseShWendyCN parses a CommonName of the form sh/wendy/<org>/<asset>
+// and returns the org ID as int32. The caller must have already verified
+// the CN starts with "sh/wendy/".
+func parseShWendyCN(cn string) (int32, error) {
+	parts := strings.Split(cn, "/")
+	// Expect exactly ["sh", "wendy", "<org>", "<asset>"].
+	if len(parts) != 4 {
+		return 0, fmt.Errorf("invalid sh/wendy CommonName (want 4 slash-separated segments): %s", cn)
+	}
+	orgID, err := strconv.ParseInt(parts[2], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid organization ID in CommonName %q: %w", parts[2], err)
+	}
+	if parts[3] == "" {
+		return 0, fmt.Errorf("empty asset ID in CommonName: %s", cn)
+	}
+	return int32(orgID), nil
+}

--- a/go/internal/shared/certs/orgident.go
+++ b/go/internal/shared/certs/orgident.go
@@ -7,16 +7,21 @@ import (
 	"strings"
 )
 
+// wendyOrgURNPrefix is the URI prefix used to encode Wendy org identity in SAN URIs.
+const wendyOrgURNPrefix = "urn:wendy:org:"
+
 // OrgFromClientCert extracts the Wendy organization ID a certificate is bound to.
 //
 // Resolution order:
-//  1. If the cert has any SAN URI beginning with "urn:wendy:org:", that URI is
-//     authoritative. It MUST parse as urn:wendy:org:<org>:(user|asset):<id>;
-//     a present-but-malformed wendy URN returns an error (anomalous/suspicious).
-//     The CN is NOT consulted in this case.
+//  1. If the cert has any SAN URI beginning with "urn:wendy:org:", those URIs are
+//     authoritative. Exactly one such URI must be present; more than one returns an
+//     error (ambiguous/mis-issued cert). The single URN MUST parse as
+//     urn:wendy:org:<org>:(user|asset):<id>; a present-but-malformed wendy URN
+//     returns an error (anomalous/suspicious). The org ID must be positive (> 0);
+//     zero or negative values return an error. The CN is NOT consulted in this case.
 //  2. Otherwise, if the CommonName has the form sh/wendy/<org>/<asset>, the org is
 //     parsed from it. A CN that begins with "sh/wendy/" but does not parse cleanly
-//     returns an error.
+//     returns an error. The org ID must be positive (> 0).
 //  3. Otherwise no org identity is present: returns (0, false, nil). (e.g. a user
 //     cert with CN wendy/user/<id> and no SAN.)
 //
@@ -24,17 +29,24 @@ import (
 //
 //	(org, true, nil)  — a valid org identity was found
 //	(0, false, nil)   — no org identity present (legacy/unknown); not an error
-//	(0, false, err)   — an org identity was present but malformed/unparseable
+//	(0, false, err)   — an org identity was present but malformed/unparseable,
+//	                    the org ID was non-positive, or multiple wendy org URNs
+//	                    were found (ambiguous).
 func OrgFromClientCert(leaf *x509.Certificate) (orgID int32, hasOrg bool, err error) {
-	// Step 1: check SAN URIs for a wendy org URN.
-	const wendyURNPrefix = "urn:wendy:org:"
+	// Step 1: check SAN URIs for wendy org URNs.
+	var wendyURNs []string
 	for _, u := range leaf.URIs {
 		raw := u.String()
-		if !strings.HasPrefix(raw, wendyURNPrefix) {
-			continue
+		if strings.HasPrefix(raw, wendyOrgURNPrefix) {
+			wendyURNs = append(wendyURNs, raw)
 		}
-		// Found a wendy URN — it is authoritative; parse it or return error.
-		org, err := parseWendyOrgURN(raw)
+	}
+	if len(wendyURNs) > 1 {
+		return 0, false, fmt.Errorf("certificate contains %d wendy org URNs; expected at most one", len(wendyURNs))
+	}
+	if len(wendyURNs) == 1 {
+		// Found exactly one wendy URN — it is authoritative; parse it or return error.
+		org, err := parseWendyOrgURN(wendyURNs[0])
 		if err != nil {
 			return 0, false, err
 		}
@@ -69,6 +81,9 @@ func parseWendyOrgURN(uri string) (int32, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid organization ID in URN %q: %w", parts[3], err)
 	}
+	if orgID <= 0 {
+		return 0, fmt.Errorf("organization ID must be positive, got %d", orgID)
+	}
 	entityType := parts[4]
 	if entityType != "user" && entityType != "asset" {
 		return 0, fmt.Errorf("unknown entity type in wendy URN %q: %s", uri, entityType)
@@ -91,6 +106,9 @@ func parseShWendyCN(cn string) (int32, error) {
 	orgID, err := strconv.ParseInt(parts[2], 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("invalid organization ID in CommonName %q: %w", parts[2], err)
+	}
+	if orgID <= 0 {
+		return 0, fmt.Errorf("organization ID must be positive, got %d", orgID)
 	}
 	if parts[3] == "" {
 		return 0, fmt.Errorf("empty asset ID in CommonName: %s", cn)

--- a/go/internal/shared/certs/orgident_test.go
+++ b/go/internal/shared/certs/orgident_test.go
@@ -1,0 +1,140 @@
+package certs
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net/url"
+	"testing"
+)
+
+// mustParseURL is a test helper that parses a URL or fatals.
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return u
+}
+
+func TestOrgFromClientCert(t *testing.T) {
+	tests := []struct {
+		name       string
+		cn         string
+		uris       []string
+		wantOrg    int32
+		wantHasOrg bool
+		wantErr    bool
+	}{
+		// SAN URI: user type.
+		{
+			name:       "SAN user URN",
+			uris:       []string{"urn:wendy:org:7:user:abc"},
+			wantOrg:    7,
+			wantHasOrg: true,
+		},
+		// SAN URI: asset type.
+		{
+			name:       "SAN asset URN",
+			uris:       []string{"urn:wendy:org:42:asset:5"},
+			wantOrg:    42,
+			wantHasOrg: true,
+		},
+		// Non-wendy URI before valid wendy URN — the wendy URN is still found.
+		{
+			name:       "non-wendy URI before wendy URN",
+			uris:       []string{"spiffe://x", "urn:wendy:org:99:asset:1"},
+			wantOrg:    99,
+			wantHasOrg: true,
+		},
+		// No URIs, device CN.
+		{
+			name:       "no URIs device CN sh/wendy/7/5",
+			cn:         "sh/wendy/7/5",
+			wantOrg:    7,
+			wantHasOrg: true,
+		},
+		// No URIs, user CN — no org (not an error).
+		{
+			name:       "no URIs user CN wendy/user/abc",
+			cn:         "wendy/user/abc",
+			wantOrg:    0,
+			wantHasOrg: false,
+		},
+		// No URIs, empty CN.
+		{
+			name:       "no URIs empty CN",
+			cn:         "",
+			wantOrg:    0,
+			wantHasOrg: false,
+		},
+		// No URIs, unrelated CN.
+		{
+			name:       "no URIs unrelated CN",
+			cn:         "example.com",
+			wantOrg:    0,
+			wantHasOrg: false,
+		},
+		// Malformed wendy URN: non-numeric org.
+		{
+			name:    "malformed URN non-numeric org",
+			uris:    []string{"urn:wendy:org:notanumber:user:x"},
+			wantErr: true,
+		},
+		// Malformed wendy URN: wrong segment count (5 parts).
+		{
+			name:    "malformed URN wrong segment count",
+			uris:    []string{"urn:wendy:org:7:user"},
+			wantErr: true,
+		},
+		// Unknown entity type.
+		{
+			name:    "URN unknown entity type",
+			uris:    []string{"urn:wendy:org:7:group:x"},
+			wantErr: true,
+		},
+		// Valid wendy URN present — CN with different sh/wendy value must NOT be consulted.
+		{
+			name:       "SAN wins over CN",
+			cn:         "sh/wendy/100/200",
+			uris:       []string{"urn:wendy:org:7:asset:1"},
+			wantOrg:    7,
+			wantHasOrg: true,
+		},
+		// No URIs, CN sh/wendy/abc/5 — bad org in CN.
+		{
+			name:    "CN sh/wendy bad org",
+			cn:      "sh/wendy/abc/5",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cert := &x509.Certificate{
+				Subject: pkix.Name{CommonName: tc.cn},
+			}
+			for _, raw := range tc.uris {
+				cert.URIs = append(cert.URIs, mustParseURL(t, raw))
+			}
+
+			org, hasOrg, err := OrgFromClientCert(cert)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("OrgFromClientCert() error = nil, want non-nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("OrgFromClientCert() unexpected error: %v", err)
+			}
+			if org != tc.wantOrg {
+				t.Errorf("OrgFromClientCert() orgID = %d, want %d", org, tc.wantOrg)
+			}
+			if hasOrg != tc.wantHasOrg {
+				t.Errorf("OrgFromClientCert() hasOrg = %v, want %v", hasOrg, tc.wantHasOrg)
+			}
+		})
+	}
+}

--- a/go/internal/shared/certs/orgident_test.go
+++ b/go/internal/shared/certs/orgident_test.go
@@ -107,6 +107,42 @@ func TestOrgFromClientCert(t *testing.T) {
 			cn:      "sh/wendy/abc/5",
 			wantErr: true,
 		},
+		// Two wendy URNs — ambiguous, must error.
+		{
+			name:    "two wendy URNs ambiguous",
+			uris:    []string{"urn:wendy:org:10:user:a", "urn:wendy:org:20:user:b"},
+			wantErr: true,
+		},
+		// URN with org ID 0 — non-positive, must error.
+		{
+			name:    "URN org zero",
+			uris:    []string{"urn:wendy:org:0:user:abc"},
+			wantErr: true,
+		},
+		// URN with negative org ID — non-positive, must error.
+		{
+			name:    "URN org negative",
+			uris:    []string{"urn:wendy:org:-1:user:abc"},
+			wantErr: true,
+		},
+		// URN with int32 overflow org ID — must error.
+		{
+			name:    "URN org int32 overflow",
+			uris:    []string{"urn:wendy:org:2147483648:user:abc"},
+			wantErr: true,
+		},
+		// URN with empty org segment — must error.
+		{
+			name:    "URN empty org segment",
+			uris:    []string{"urn:wendy:org::user:abc"},
+			wantErr: true,
+		},
+		// CN with org ID 0 — non-positive, must error.
+		{
+			name:    "CN sh/wendy org zero",
+			cn:      "sh/wendy/0/5",
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Closes part of [WDY-1535](https://linear.app/wendylabsinc/issue/WDY-1535).

## Problem

The agent's direct mTLS port (50052) authenticated a client cert by chain-to-CA + `clientAuth` EKU + expiry + lifetime, but performed **no organization check**. Because dev/prod use a single shared device CA across orgs, any validly-issued Wendy *user* cert (self-serviceable by creating an org) chains to that CA and was accepted by a device in **any** org — cross-tenant access on the direct LAN path, where the agent is the sole authorizer. This is the device-side counterpart to WDY-1489 (cloud broker).

## What this PR does (agent-side enforcement — half of the fix)

- **`OrgFromClientCert` helper** (`internal/shared/certs/orgident.go`): extracts the Wendy org from a client cert — from a SAN URI `urn:wendy:org:<org>:(user|asset):<id>` (the forward format), falling back to the device CN `sh/wendy/<org>/<asset>`. Rejects non-positive and ambiguous (multiple-URN) org claims.
- **Org enforcement in `CheckMTLS`** (the sole mTLS auth gate, applied to both unary and streaming): a connecting client whose org differs from the device's own org is rejected with `PermissionDenied`. The device derives its own org from its own leaf cert (ML-DSA-aware parse), avoiding the provisioning-mutex re-entrancy in the `OnProvisioned` path.
- **`WENDY_MTLS_ORG_ENFORCEMENT` env flag** (default `grace`):
  - `off` — no org check (pre-WDY-1535 behavior).
  - `grace` — reject any cert whose org mismatches; **allow** legacy certs that carry no org identity (WARN-logged).
  - `strict` — also reject certs lacking an org identity.
- **Fail-safe:** if the device cannot determine its own org from its cert, enforcement is disabled for that server (ERROR-logged) rather than bricking the device or comparing against an unknown self-org.

## Rollout

Mismatch and malformed-org rejection apply in **both** grace and strict immediately. Ship in `grace` (default) so existing user certs (no org SAN, valid up to ~2y) keep working; flip to `strict` once user certs rotate to carry the org SAN. Gate the flip on a "% connections presenting an org SAN" metric, not a calendar.

## Testing

- `internal/shared/certs/orgident_test.go` — 18 cases (user/asset SAN, CN fallback, no-org, malformed/ambiguous/non-positive, SAN-wins-over-CN, int32 overflow).
- `internal/agent/interceptor/mtls_test.go` (new) — org match/mismatch in both modes, no-org grace-allow vs strict-reject, malformed→reject, mode-off bypass, EKU/no-cert regressions still `Unauthenticated`; plus `ParseOrgMode`.
- `go build ./...`, `go vet`, `gofmt` all clean.

## Follow-ups (NOT in this PR — tracked for delegation)

This PR is the **agent enforcement** half. The other half — issuing **user** certs that actually carry the `urn:wendy:org:` SAN — is a cross-repo change in **pki-core** + **WendyCloud** cert backends (and the shared `service-protos` contract). Until that lands, production user certs have no org SAN, so grace mode will WARN-and-allow them (the log message tells operators what to do). A delegation doc captures that remaining work. The `strict` flip depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)