### PR TITLE
feat(cli): auto-refresh MCP setup when CLI version changes

### DIFF
--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -293,7 +293,7 @@ func (m cloudDiscoverModel) View() string {
 				sb.WriteString(m.viewLine(dimStyle.Render("No online devices found. Use --all to include offline devices.")) + "\n")
 			}
 		} else {
-			sb.WriteString(m.viewLine(dimStyle.Render("Fetching devices from cloud...")) + "\n")
+			sb.WriteString(m.viewLine(dimStyle.Render("Fetching active devices from cloud...")) + "\n")
 		}
 	}
 

--- a/go/internal/cli/commands/mcp_cmd_test.go
+++ b/go/internal/cli/commands/mcp_cmd_test.go
@@ -93,6 +93,30 @@ func TestCodexConfigPath_ReturnsDirBasedPath(t *testing.T) {
 	}
 }
 
+func TestShouldRefreshMCPSetup(t *testing.T) {
+	tests := []struct {
+		name        string
+		lastVersion string
+		current     string
+		want        bool
+	}{
+		{name: "never set up", lastVersion: "", current: "0.11.0", want: false},
+		{name: "dev build never refreshes", lastVersion: "0.10.0", current: "dev", want: false},
+		{name: "same version", lastVersion: "0.11.0", current: "0.11.0", want: false},
+		{name: "upgraded", lastVersion: "0.10.0", current: "0.11.0", want: true},
+		{name: "downgraded", lastVersion: "0.11.0", current: "0.10.0", want: true},
+		{name: "set up on dev then real build", lastVersion: "dev", current: "0.11.0", want: true},
+		{name: "never set up on dev build", lastVersion: "", current: "dev", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRefreshMCPSetup(tt.lastVersion, tt.current); got != tt.want {
+				t.Errorf("shouldRefreshMCPSetup(%q, %q) = %v, want %v", tt.lastVersion, tt.current, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMCPCmd_HelpText(t *testing.T) {
 	cmd := newMCPCmd()
 	buf := new(bytes.Buffer)

--- a/go/internal/cli/commands/mcp_setup.go
+++ b/go/internal/cli/commands/mcp_setup.go
@@ -10,6 +10,8 @@ import (
 
 	toml "github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 )
 
 func newMCPSetupCmd() *cobra.Command {
@@ -31,9 +33,55 @@ func newMCPSetupCmd() *cobra.Command {
 				fmt.Fprintln(cmd.OutOrStdout(), "No supported AI tools detected.")
 				fmt.Fprintln(cmd.OutOrStdout(), "Install Claude Code: npm install -g @anthropic-ai/claude-code")
 			}
+			// Record the CLI version so the root command can auto-refresh the
+			// configuration and skills after a later upgrade.
+			recordMCPSetupVersion()
 			return nil
 		},
 	}
+}
+
+// recordMCPSetupVersion stores the running CLI version as the last version that
+// performed MCP setup. Failures are non-fatal: at worst auto-refresh re-runs the
+// (idempotent) setup again on the next invocation.
+func recordMCPSetupVersion() {
+	cfg, err := config.Load()
+	if err != nil {
+		return
+	}
+	cfg.LastMCPSetupVersion = version.Version
+	_ = config.Save(cfg)
+}
+
+// shouldRefreshMCPSetup reports whether the root command should silently re-run
+// MCP setup. It refreshes only when the user has previously run `wendy mcp
+// setup` (non-empty lastSetupVersion) and the running CLI differs from the
+// version that last set it up. A "dev" build never auto-refreshes, and the
+// comparison is an exact mismatch so downgrades re-install the matching skills
+// too. It never opts a user into the MCP server on its own.
+func shouldRefreshMCPSetup(lastSetupVersion, currentVersion string) bool {
+	if currentVersion == "dev" {
+		return false
+	}
+	if lastSetupVersion == "" {
+		return false
+	}
+	return lastSetupVersion != currentVersion
+}
+
+// maybeRefreshMCPSetup re-applies the MCP server configuration and re-installs
+// the bundled skills when the CLI has been upgraded (or downgraded) since
+// `wendy mcp setup` last ran, so users automatically pick up the latest skills.
+// It runs silently and only touches tools that are already configured; the
+// underlying setup helpers no-op for tools they don't detect.
+func maybeRefreshMCPSetup(cfg *config.Config) {
+	if !shouldRefreshMCPSetup(cfg.LastMCPSetupVersion, version.Version) {
+		return
+	}
+	setupMCPForAllTools()
+	installSkillsForAllTools()
+	cfg.LastMCPSetupVersion = version.Version
+	_ = config.Save(cfg)
 }
 
 type mcpSetupResult struct {

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
-	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -175,15 +175,15 @@ func runOSInstallDirect(imagePath string, driveID string, force bool, yesOverwri
 		}
 	}
 
-	r, size, err := openLocalImageStream(imagePath)
+	stream, err := openLocalImageStream(imagePath)
 	if err != nil {
 		return fmt.Errorf("opening image: %w", err)
 	}
-	defer r.Close()
+	defer stream.Close()
 
 	fmt.Printf("Writing image to %s...\n", targetDrive.DevicePath)
 	fmt.Println(elevationHint())
-	if err := writeImageToDisk(r, size, *targetDrive, nil); err != nil {
+	if err := writeImageToDisk(stream, stream.uncompressedSize, *targetDrive, nil); err != nil {
 		return fmt.Errorf("writing image: %w", err)
 	}
 
@@ -445,11 +445,25 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		return fmt.Errorf("getting image info: %w", err)
 	}
 
-	r, totalSize, err := openOSImageStream(deviceKey, imgInfo)
+	stream, err := openOSImageStream(deviceKey, imgInfo)
 	if err != nil {
 		return fmt.Errorf("opening OS image: %w", err)
 	}
-	defer r.Close()
+	defer stream.Close()
+
+	// One-time sizing pass for compressed images that cannot report their
+	// decompressed size (gzip). Without it the write bar has no usable total.
+	// The result is cached in a sidecar, so this only runs on the first flash
+	// of a given image. Failure is non-fatal: the bar falls back to
+	// compressed-consumption progress.
+	if stream.uncompressedSize == 0 && stream.sourcePath != "" {
+		if err := measureImageWithProgress(stream); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return err
+			}
+			fmt.Printf("Could not determine image size: %v\n", err)
+		}
+	}
 
 	// Step 6: Write image to drive with progress bar.
 	fmt.Printf("Writing image to %s...\n", targetDrive.DevicePath)
@@ -457,13 +471,9 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	wp := tea.NewProgram(writeProg)
 
 	go func() {
-		writeErr := writeImageToDisk(r, totalSize, targetDrive, func(written int64) {
-			if totalSize > 0 {
-				wp.Send(tui.ProgressUpdateMsg{
-					Percent: float64(written) / float64(totalSize),
-					Written: written,
-					Total:   totalSize,
-				})
+		writeErr := writeImageToDisk(stream, stream.uncompressedSize, targetDrive, func(written int64) {
+			if msg, ok := stream.writeProgressMsg(written); ok {
+				wp.Send(msg)
 			}
 		})
 		wp.Send(tui.ProgressDoneMsg{Err: writeErr})
@@ -864,12 +874,13 @@ func (z *zipReadCloser) Close() error {
 }
 
 // streamZipImageEntry opens a zip archive and returns a streaming reader over
-// the first .img, .raw, .wic, or .sdimg entry it finds, plus the uncompressed
-// size. The caller must Close the returned reader.
-func streamZipImageEntry(zipPath string) (io.ReadCloser, int64, error) {
+// the first .img, .raw, .wic, or .sdimg entry it finds. The zip directory
+// stores an exact 64-bit uncompressed size, so the stream carries it for
+// byte-accurate progress. The caller must Close the returned reader.
+func streamZipImageEntry(zipPath string) (*imageStream, error) {
 	r, err := zip.OpenReader(zipPath)
 	if err != nil {
-		return nil, 0, fmt.Errorf("opening zip: %w", err)
+		return nil, fmt.Errorf("opening zip: %w", err)
 	}
 
 	for _, f := range r.File {
@@ -885,7 +896,7 @@ func streamZipImageEntry(zipPath string) (io.ReadCloser, int64, error) {
 		rc, err := f.Open()
 		if err != nil {
 			r.Close()
-			return nil, 0, fmt.Errorf("opening %s in zip: %w", f.Name, err)
+			return nil, fmt.Errorf("opening %s in zip: %w", f.Name, err)
 		}
 
 		size := int64(f.UncompressedSize64)
@@ -895,14 +906,17 @@ func streamZipImageEntry(zipPath string) (io.ReadCloser, int64, error) {
 		if size == 0 {
 			rc.Close()
 			r.Close()
-			return nil, 0, fmt.Errorf("zip entry %s has unknown uncompressed size", f.Name)
+			return nil, fmt.Errorf("zip entry %s has unknown uncompressed size", f.Name)
 		}
 
-		return &zipReadCloser{archive: r, entry: rc}, size, nil
+		return &imageStream{
+			ReadCloser:       &zipReadCloser{archive: r, entry: rc},
+			uncompressedSize: size,
+		}, nil
 	}
 
 	r.Close()
-	return nil, 0, fmt.Errorf("no .img, .raw, .wic, or .sdimg file found in zip archive")
+	return nil, fmt.Errorf("no .img, .raw, .wic, or .sdimg file found in zip archive")
 }
 
 func resolveOSImage(deviceKey string, img *imageInfo) (string, error) {
@@ -954,6 +968,177 @@ func resolveOSImage(deviceKey string, img *imageInfo) (string, error) {
 	return imgCached, nil
 }
 
+// imageStream couples a streaming image reader with the size information
+// available for driving a progress bar. Exactly one of two progress modes
+// applies: when uncompressedSize is non-zero it is exact and the bar tracks
+// decompressed bytes written; otherwise compressedRead/compressedSize track
+// how much of the compressed source has been consumed.
+type imageStream struct {
+	io.ReadCloser
+	// uncompressedSize is the exact decompressed byte count, or 0 when the
+	// source cannot report one reliably.
+	uncompressedSize int64
+	// compressedRead reports compressed source bytes consumed so far.
+	// nil when uncompressedSize is known.
+	compressedRead func() int64
+	// compressedSize is the total compressed source size in bytes.
+	compressedSize int64
+	// sourcePath is the compressed file on disk; set when uncompressedSize
+	// can be determined by measureUncompressedSize.
+	sourcePath string
+}
+
+// measureUncompressedSize determines the exact decompressed size by
+// decompressing the source once and counting the bytes, then records it in a
+// sidecar file so later flashes of the same image skip the pass. No-op when
+// the size is already known or the source is not measurable. progress
+// receives (compressedBytesRead, compressedTotal).
+func (s *imageStream) measureUncompressedSize(progress func(read, total int64)) error {
+	if s.uncompressedSize > 0 || s.sourcePath == "" {
+		return nil
+	}
+	size, err := measureGzipImage(s.sourcePath, progress)
+	if err != nil {
+		return err
+	}
+	s.uncompressedSize = size
+	writeImageSizeSidecar(s.sourcePath, s.compressedSize, size)
+	return nil
+}
+
+// measureGzipImage decompresses the gzip file at path, discarding the bytes,
+// and returns the exact decompressed size. This is the only reliable way to
+// size a gzip stream: the ISIZE trailer is truncated mod 2^32, and the
+// compressed-consumption fraction is wildly nonlinear for zero-heavy disk
+// images. The pass is CPU-bound and costs a few tens of seconds for a
+// multi-GiB image, against minutes of disk writing.
+func measureGzipImage(path string, progress func(read, total int64)) (int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("opening gzip image: %w", err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat gzip image: %w", err)
+	}
+
+	cr := &countingReader{r: f}
+	gr, err := gzip.NewReader(cr)
+	if err != nil {
+		return 0, fmt.Errorf("creating gzip reader: %w", err)
+	}
+	defer gr.Close()
+
+	var size int64
+	buf := make([]byte, 1<<20)
+	for {
+		n, readErr := gr.Read(buf)
+		size += int64(n)
+		if progress != nil && n > 0 {
+			progress(cr.n.Load(), info.Size())
+		}
+		if readErr == io.EOF {
+			return size, nil
+		}
+		if readErr != nil {
+			return 0, fmt.Errorf("decompressing image: %w", readErr)
+		}
+	}
+}
+
+// measureImageWithProgress runs stream.measureUncompressedSize behind a
+// progress bar tracking compressed bytes read. Returns context.Canceled when
+// the user quits the bar.
+func measureImageWithProgress(stream *imageStream) error {
+	prog := tui.NewProgress("Determining image size (one-time per image)...")
+	p := tea.NewProgram(prog)
+	sendProgress := throttledProgress(p, 33*time.Millisecond)
+
+	go func() {
+		p.Send(tui.ProgressDoneMsg{Err: stream.measureUncompressedSize(sendProgress)})
+	}()
+
+	final, err := p.Run()
+	if err != nil {
+		return fmt.Errorf("progress TUI: %w", err)
+	}
+	return final.(tui.ProgressModel).Err()
+}
+
+// imageSizeSidecar caches a measured decompressed size next to the compressed
+// image, keyed to the compressed size so a replaced file invalidates it.
+type imageSizeSidecar struct {
+	CompressedSize   int64 `json:"compressed_size"`
+	UncompressedSize int64 `json:"uncompressed_size"`
+}
+
+func imageSizeSidecarPath(imagePath string) string { return imagePath + ".size" }
+
+// readImageSizeSidecar returns the cached decompressed size for imagePath,
+// or 0 when no valid sidecar exists for the given compressed size.
+func readImageSizeSidecar(imagePath string, compressedSize int64) int64 {
+	data, err := os.ReadFile(imageSizeSidecarPath(imagePath))
+	if err != nil {
+		return 0
+	}
+	var sc imageSizeSidecar
+	if json.Unmarshal(data, &sc) != nil || sc.CompressedSize != compressedSize || sc.UncompressedSize <= 0 {
+		return 0
+	}
+	return sc.UncompressedSize
+}
+
+// writeImageSizeSidecar persists a measured size. Best-effort: a failure just
+// means the next flash measures again.
+func writeImageSizeSidecar(imagePath string, compressedSize, uncompressedSize int64) {
+	data, err := json.Marshal(imageSizeSidecar{
+		CompressedSize:   compressedSize,
+		UncompressedSize: uncompressedSize,
+	})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(imageSizeSidecarPath(imagePath), data, 0o644)
+}
+
+// writeProgressMsg converts dd's running byte count into a progress update.
+// Returns false when the stream carries no usable size information.
+func (s *imageStream) writeProgressMsg(written int64) (tui.ProgressUpdateMsg, bool) {
+	switch {
+	case s.uncompressedSize > 0:
+		return tui.ProgressUpdateMsg{
+			Percent: float64(written) / float64(s.uncompressedSize),
+			Written: written,
+			Total:   s.uncompressedSize,
+		}, true
+	case s.compressedRead != nil && s.compressedSize > 0:
+		// Decompression is demand-driven by dd's reads, so the fraction of
+		// compressed input consumed tracks write completion. Total stays 0:
+		// the decompressed size is unknown and must not be guessed at.
+		return tui.ProgressUpdateMsg{
+			Percent: float64(s.compressedRead()) / float64(s.compressedSize),
+			Written: written,
+		}, true
+	default:
+		return tui.ProgressUpdateMsg{}, false
+	}
+}
+
+// countingReader counts bytes read through it. The count is read from a
+// progress goroutine while Read is called from the dd-feeding goroutine,
+// hence the atomic.
+type countingReader struct {
+	r io.Reader
+	n atomic.Int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n.Add(int64(n))
+	return n, err
+}
+
 // gzipReadCloser wraps a gzip.Reader so that closing it also closes the
 // underlying file, matching the io.ReadCloser contract.
 type gzipReadCloser struct {
@@ -971,36 +1156,36 @@ func (g *gzipReadCloser) Close() error {
 }
 
 // streamGzipImage opens a gzip-compressed image file and returns a streaming
-// reader over the decompressed bytes, plus the uncompressed size from the gzip
-// ISIZE trailer. ISIZE is stored mod 2^32, so it is only accurate for images
-// smaller than 4 GiB; larger images will show an incorrect size in the progress
-// bar but will still be written correctly.
-func streamGzipImage(path string) (io.ReadCloser, int64, error) {
+// reader over the decompressed bytes. The gzip format cannot report the
+// uncompressed size of large images — its ISIZE trailer is stored mod 2^32,
+// so a 19.2 GiB image reports 3.2 GiB and the progress bar overshoots its
+// total. The exact size comes from a sidecar written by a previous
+// measureUncompressedSize pass when available; otherwise it is 0 and the
+// caller should measure (or fall back to compressed-consumption progress).
+func streamGzipImage(path string) (*imageStream, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, 0, fmt.Errorf("opening gzip image: %w", err)
+		return nil, fmt.Errorf("opening gzip image: %w", err)
 	}
-
-	// Read the ISIZE field (last 4 LE bytes of the file) before creating the
-	// gzip reader, which advances the read position.
-	var isizeBuf [4]byte
-	var uncompressedSize int64
-	if _, seekErr := f.Seek(-4, io.SeekEnd); seekErr == nil {
-		if _, readErr := io.ReadFull(f, isizeBuf[:]); readErr == nil {
-			uncompressedSize = int64(binary.LittleEndian.Uint32(isizeBuf[:]))
-		}
-	}
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		f.Close()
-		return nil, 0, fmt.Errorf("seeking gzip image: %w", err)
-	}
-
-	gr, err := gzip.NewReader(f)
+	info, err := f.Stat()
 	if err != nil {
 		f.Close()
-		return nil, 0, fmt.Errorf("creating gzip reader: %w", err)
+		return nil, fmt.Errorf("stat gzip image: %w", err)
 	}
-	return &gzipReadCloser{gz: gr, f: f}, uncompressedSize, nil
+
+	cr := &countingReader{r: f}
+	gr, err := gzip.NewReader(cr)
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("creating gzip reader: %w", err)
+	}
+	return &imageStream{
+		ReadCloser:       &gzipReadCloser{gz: gr, f: f},
+		uncompressedSize: readImageSizeSidecar(path, info.Size()),
+		compressedRead:   cr.n.Load,
+		compressedSize:   info.Size(),
+		sourcePath:       path,
+	}, nil
 }
 
 // isGzipFile returns true when path begins with the gzip magic bytes (0x1f 0x8b).
@@ -1018,12 +1203,11 @@ func isGzipFile(path string) bool {
 }
 
 // openOSImageStream resolves the cached file for deviceKey+img, then returns
-// a streaming reader over the image bytes and the total uncompressed size.
-// The caller must Close the returned reader.
-func openOSImageStream(deviceKey string, img *imageInfo) (io.ReadCloser, int64, error) {
+// a streaming reader over the image bytes. The caller must Close it.
+func openOSImageStream(deviceKey string, img *imageInfo) (*imageStream, error) {
 	cachePath, err := resolveOSImage(deviceKey, img)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	if strings.HasSuffix(strings.ToLower(cachePath), ".zip") {
 		return streamZipImageEntry(cachePath)
@@ -1031,38 +1215,35 @@ func openOSImageStream(deviceKey string, img *imageInfo) (io.ReadCloser, int64, 
 	if isGzipFile(cachePath) {
 		return streamGzipImage(cachePath)
 	}
-	f, err := os.Open(cachePath)
-	if err != nil {
-		return nil, 0, fmt.Errorf("opening cached image: %w", err)
-	}
-	info, err := f.Stat()
-	if err != nil {
-		f.Close()
-		return nil, 0, fmt.Errorf("stat cached image: %w", err)
-	}
-	return f, info.Size(), nil
+	return openRawImageStream(cachePath)
 }
 
 // openLocalImageStream opens an arbitrary local file for streaming.
 // If the path ends in .zip it finds the first image entry inside it.
 // Otherwise it opens the file directly as a reader.
-func openLocalImageStream(imagePath string) (io.ReadCloser, int64, error) {
+func openLocalImageStream(imagePath string) (*imageStream, error) {
 	if strings.HasSuffix(strings.ToLower(imagePath), ".zip") {
 		return streamZipImageEntry(imagePath)
 	}
 	if isGzipFile(imagePath) {
 		return streamGzipImage(imagePath)
 	}
-	f, err := os.Open(imagePath)
+	return openRawImageStream(imagePath)
+}
+
+// openRawImageStream opens an uncompressed image file; its size on disk is
+// the exact byte count that will be written.
+func openRawImageStream(path string) (*imageStream, error) {
+	f, err := os.Open(path)
 	if err != nil {
-		return nil, 0, fmt.Errorf("opening image: %w", err)
+		return nil, fmt.Errorf("opening image: %w", err)
 	}
 	info, err := f.Stat()
 	if err != nil {
 		f.Close()
-		return nil, 0, fmt.Errorf("stat image: %w", err)
+		return nil, fmt.Errorf("stat image: %w", err)
 	}
-	return f, info.Size(), nil
+	return &imageStream{ReadCloser: f, uncompressedSize: info.Size()}, nil
 }
 
 // wifiCLIOptions captures the WiFi-related flags coming from cobra so they

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -202,15 +202,15 @@ func TestStreamZipImageEntry(t *testing.T) {
 
 	t.Run("reads img entry", func(t *testing.T) {
 		zipPath := makeTestZip(t, "wendyos.img", content)
-		r, size, err := streamZipImageEntry(zipPath)
+		stream, err := streamZipImageEntry(zipPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		defer r.Close()
-		if size != int64(len(content)) {
-			t.Errorf("size = %d; want %d", size, len(content))
+		defer stream.Close()
+		if stream.uncompressedSize != int64(len(content)) {
+			t.Errorf("uncompressedSize = %d; want %d", stream.uncompressedSize, len(content))
 		}
-		got, err := io.ReadAll(r)
+		got, err := io.ReadAll(stream)
 		if err != nil {
 			t.Fatalf("reading: %v", err)
 		}
@@ -221,41 +221,41 @@ func TestStreamZipImageEntry(t *testing.T) {
 
 	t.Run("reads raw entry", func(t *testing.T) {
 		zipPath := makeTestZip(t, "wendyos.raw", content)
-		r, _, err := streamZipImageEntry(zipPath)
+		stream, err := streamZipImageEntry(zipPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		r.Close()
+		stream.Close()
 	})
 
 	t.Run("reads wic entry", func(t *testing.T) {
 		zipPath := makeTestZip(t, "wendyos.wic", content)
-		r, _, err := streamZipImageEntry(zipPath)
+		stream, err := streamZipImageEntry(zipPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		r.Close()
+		stream.Close()
 	})
 
 	t.Run("reads sdimg entry", func(t *testing.T) {
 		zipPath := makeTestZip(t, "wendyos.sdimg", content)
-		r, _, err := streamZipImageEntry(zipPath)
+		stream, err := streamZipImageEntry(zipPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		r.Close()
+		stream.Close()
 	})
 
 	t.Run("no image entry returns error", func(t *testing.T) {
 		zipPath := makeTestZip(t, "readme.txt", content)
-		_, _, err := streamZipImageEntry(zipPath)
+		_, err := streamZipImageEntry(zipPath)
 		if err == nil {
 			t.Fatal("expected error for zip with no image entry")
 		}
 	})
 
 	t.Run("nonexistent file returns error", func(t *testing.T) {
-		_, _, err := streamZipImageEntry("/nonexistent/path/image.zip")
+		_, err := streamZipImageEntry("/nonexistent/path/image.zip")
 		if err == nil {
 			t.Fatal("expected error for nonexistent file")
 		}
@@ -322,30 +322,206 @@ func TestIsGzipFile(t *testing.T) {
 func TestStreamGzipImage(t *testing.T) {
 	content := []byte("fake decompressed wendyos image payload")
 
-	t.Run("decompresses content and reports ISIZE", func(t *testing.T) {
+	t.Run("decompresses content and reports compressed progress", func(t *testing.T) {
 		path := makeTestGzip(t, "image-*.img.gz", content)
-		r, size, err := streamGzipImage(path)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stream, err := streamGzipImage(path)
 		if err != nil {
 			t.Fatalf("streamGzipImage() error = %v", err)
 		}
-		defer r.Close()
+		defer stream.Close()
 
-		if size != int64(len(content)) {
-			t.Errorf("size = %d; want %d (gzip ISIZE trailer)", size, len(content))
+		// gzip's ISIZE trailer stores the uncompressed size mod 2^32, so it
+		// must never be trusted: a 19.2 GiB image reports 3.2 GiB and the
+		// progress bar overshoots its total (WDY: writing 17.3 GiB / 3.2 GiB).
+		if stream.uncompressedSize != 0 {
+			t.Errorf("uncompressedSize = %d; want 0 (unknown before measuring)", stream.uncompressedSize)
+		}
+		if stream.compressedSize != info.Size() {
+			t.Errorf("compressedSize = %d; want %d (gzip file size)", stream.compressedSize, info.Size())
+		}
+		if stream.compressedRead == nil {
+			t.Fatal("compressedRead = nil; want counter over the compressed source")
+		}
+		if stream.sourcePath != path {
+			t.Errorf("sourcePath = %q; want %q (needed for measuring)", stream.sourcePath, path)
 		}
 
-		got, err := io.ReadAll(r)
+		got, err := io.ReadAll(stream)
 		if err != nil {
 			t.Fatalf("reading decompressed stream: %v", err)
 		}
 		if !bytes.Equal(got, content) {
 			t.Errorf("decompressed content = %q; want %q", got, content)
 		}
+		if read := stream.compressedRead(); read != info.Size() {
+			t.Errorf("compressedRead() after full read = %d; want %d", read, info.Size())
+		}
 	})
 
 	t.Run("nonexistent file returns error", func(t *testing.T) {
-		if _, _, err := streamGzipImage("/nonexistent/path/image.img.gz"); err == nil {
+		if _, err := streamGzipImage("/nonexistent/path/image.img.gz"); err == nil {
 			t.Fatal("expected error for nonexistent file")
+		}
+	})
+}
+
+func TestMeasureGzipImage(t *testing.T) {
+	// Zero-heavy payload mimicking a sparse disk image: the decompressed size
+	// vastly exceeds the compressed size, the case where the ISIZE trailer
+	// and compressed-progress heuristics both mislead.
+	content := make([]byte, 4<<20)
+	copy(content, []byte("partition data at the front"))
+	path := makeTestGzip(t, "image-*.img.gz", content)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var lastRead, lastTotal int64
+	size, err := measureGzipImage(path, func(read, total int64) { lastRead, lastTotal = read, total })
+	if err != nil {
+		t.Fatalf("measureGzipImage() error = %v", err)
+	}
+	if size != int64(len(content)) {
+		t.Errorf("size = %d; want %d (exact decompressed size)", size, len(content))
+	}
+	if lastTotal != info.Size() {
+		t.Errorf("progress total = %d; want %d (compressed file size)", lastTotal, info.Size())
+	}
+	if lastRead != info.Size() {
+		t.Errorf("final progress read = %d; want %d (whole compressed file)", lastRead, info.Size())
+	}
+
+	t.Run("nil progress is allowed", func(t *testing.T) {
+		if _, err := measureGzipImage(path, nil); err != nil {
+			t.Fatalf("measureGzipImage() error = %v", err)
+		}
+	})
+
+	t.Run("corrupt file returns error", func(t *testing.T) {
+		bad := makeTestPlainFile(t, "image-*.img.gz", []byte("not gzip at all"))
+		if _, err := measureGzipImage(bad, nil); err == nil {
+			t.Fatal("expected error for non-gzip file")
+		}
+	})
+}
+
+func TestImageStreamMeasureUncompressedSize(t *testing.T) {
+	content := bytes.Repeat([]byte("wendyos"), 1<<16)
+
+	t.Run("measures once and caches in a sidecar", func(t *testing.T) {
+		path := makeTestGzip(t, "image-*.img.gz", content)
+
+		stream, err := streamGzipImage(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer stream.Close()
+		if stream.uncompressedSize != 0 {
+			t.Fatalf("uncompressedSize = %d before measuring; want 0", stream.uncompressedSize)
+		}
+
+		if err := stream.measureUncompressedSize(nil); err != nil {
+			t.Fatalf("measureUncompressedSize() error = %v", err)
+		}
+		if stream.uncompressedSize != int64(len(content)) {
+			t.Errorf("uncompressedSize = %d; want %d", stream.uncompressedSize, len(content))
+		}
+
+		// A fresh stream over the same file must pick the size up from the
+		// sidecar without another measuring pass.
+		again, err := streamGzipImage(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer again.Close()
+		if again.uncompressedSize != int64(len(content)) {
+			t.Errorf("uncompressedSize from sidecar = %d; want %d", again.uncompressedSize, len(content))
+		}
+	})
+
+	t.Run("stale sidecar is ignored", func(t *testing.T) {
+		path := makeTestGzip(t, "image-*.img.gz", content)
+		// Sidecar recorded against a different compressed size — e.g. the
+		// cached image was replaced by a new version under the same name.
+		writeImageSizeSidecar(path, 12345, 99999)
+
+		stream, err := streamGzipImage(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer stream.Close()
+		if stream.uncompressedSize != 0 {
+			t.Errorf("uncompressedSize = %d; want 0 (stale sidecar must be ignored)", stream.uncompressedSize)
+		}
+	})
+
+	t.Run("no-op when size already known", func(t *testing.T) {
+		s := &imageStream{uncompressedSize: 42}
+		if err := s.measureUncompressedSize(nil); err != nil {
+			t.Fatalf("measureUncompressedSize() error = %v", err)
+		}
+		if s.uncompressedSize != 42 {
+			t.Errorf("uncompressedSize = %d; want 42 (unchanged)", s.uncompressedSize)
+		}
+	})
+
+	t.Run("no-op without a source path", func(t *testing.T) {
+		s := &imageStream{}
+		if err := s.measureUncompressedSize(nil); err != nil {
+			t.Fatalf("measureUncompressedSize() error = %v", err)
+		}
+		if s.uncompressedSize != 0 {
+			t.Errorf("uncompressedSize = %d; want 0", s.uncompressedSize)
+		}
+	})
+}
+
+func TestImageStreamWriteProgressMsg(t *testing.T) {
+	t.Run("exact uncompressed size drives percent and total", func(t *testing.T) {
+		s := &imageStream{uncompressedSize: 200}
+		msg, ok := s.writeProgressMsg(50)
+		if !ok {
+			t.Fatal("writeProgressMsg() ok = false; want true")
+		}
+		if msg.Percent != 0.25 {
+			t.Errorf("Percent = %v; want 0.25", msg.Percent)
+		}
+		if msg.Written != 50 || msg.Total != 200 {
+			t.Errorf("Written/Total = %d/%d; want 50/200", msg.Written, msg.Total)
+		}
+	})
+
+	t.Run("unknown size falls back to compressed progress without a total", func(t *testing.T) {
+		s := &imageStream{
+			compressedRead: func() int64 { return 75 },
+			compressedSize: 100,
+		}
+		const written = int64(18_575_000_000) // ~17.3 GiB, far past any bogus total
+		msg, ok := s.writeProgressMsg(written)
+		if !ok {
+			t.Fatal("writeProgressMsg() ok = false; want true")
+		}
+		if msg.Percent != 0.75 {
+			t.Errorf("Percent = %v; want 0.75 (compressed bytes consumed)", msg.Percent)
+		}
+		if msg.Written != written {
+			t.Errorf("Written = %d; want %d", msg.Written, written)
+		}
+		if msg.Total != 0 {
+			t.Errorf("Total = %d; want 0 (unknown, must not render a bogus total)", msg.Total)
+		}
+	})
+
+	t.Run("no size information yields no update", func(t *testing.T) {
+		s := &imageStream{}
+		if _, ok := s.writeProgressMsg(50); ok {
+			t.Error("writeProgressMsg() ok = true; want false with no size info")
 		}
 	})
 }
@@ -768,16 +944,16 @@ func TestOpenOSImageStream_ZipCacheHit(t *testing.T) {
 	}
 
 	img := &imageInfo{Version: "7.7.7", DownloadURL: "https://example.com/image.zip"}
-	r, size, err := openOSImageStream("stream-device", img)
+	stream, err := openOSImageStream("stream-device", img)
 	if err != nil {
 		t.Fatalf("openOSImageStream: %v", err)
 	}
-	defer r.Close()
+	defer stream.Close()
 
-	if size != int64(len(content)) {
-		t.Errorf("size = %d; want %d", size, len(content))
+	if stream.uncompressedSize != int64(len(content)) {
+		t.Errorf("uncompressedSize = %d; want %d", stream.uncompressedSize, len(content))
 	}
-	got, err := io.ReadAll(r)
+	got, err := io.ReadAll(stream)
 	if err != nil {
 		t.Fatalf("reading: %v", err)
 	}
@@ -801,16 +977,16 @@ func TestOpenOSImageStream_LegacyImgCacheHit(t *testing.T) {
 	}
 
 	img := &imageInfo{Version: "6.6.6", DownloadURL: "https://example.com/image.zip"}
-	r, size, err := openOSImageStream("legacy-device", img)
+	stream, err := openOSImageStream("legacy-device", img)
 	if err != nil {
 		t.Fatalf("openOSImageStream: %v", err)
 	}
-	defer r.Close()
+	defer stream.Close()
 
-	if size != int64(len(content)) {
-		t.Errorf("size = %d; want %d", size, len(content))
+	if stream.uncompressedSize != int64(len(content)) {
+		t.Errorf("uncompressedSize = %d; want %d", stream.uncompressedSize, len(content))
 	}
-	got, err := io.ReadAll(r)
+	got, err := io.ReadAll(stream)
 	if err != nil {
 		t.Fatalf("reading: %v", err)
 	}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -58,6 +58,11 @@ func NewRootCmd() *cobra.Command {
 				}
 			}
 
+			// Refresh MCP config and skills if the CLI was upgraded since the
+			// user last ran `wendy mcp setup`. Runs synchronously here, before
+			// the update-check goroutine below also mutates and saves cfg.
+			maybeRefreshMCPSetup(cfg)
+
 			if dueCLIUpdateCheck(cfg) {
 				scheduleCLIUpdateCheck(cfg)
 			}

--- a/go/internal/cli/tui/progress.go
+++ b/go/internal/cli/tui/progress.go
@@ -13,7 +13,8 @@ const maxProgressDetailLines = 4
 
 // ProgressUpdateMsg updates the progress bar percentage.
 // Written and Total are optional; when both are non-zero the view renders
-// a byte counter like "4.00%  (420.0 MiB / 10.5 GiB)".
+// a byte counter like "4.00%  (420.0 MiB / 10.5 GiB)". When only Written is
+// non-zero (total unknown, e.g. gzip streams) it renders "(420.0 MiB)".
 type ProgressUpdateMsg struct {
 	Percent float64
 	Written int64
@@ -107,6 +108,8 @@ func (m ProgressModel) View() string {
 	byteInfo := ""
 	if m.written > 0 && m.total > 0 {
 		byteInfo = fmt.Sprintf("  (%s / %s)", FormatBytes(m.written), FormatBytes(m.total))
+	} else if m.written > 0 {
+		byteInfo = fmt.Sprintf("  (%s)", FormatBytes(m.written))
 	}
 	details := m.detailView()
 

--- a/go/internal/cli/tui/progress_test.go
+++ b/go/internal/cli/tui/progress_test.go
@@ -1,0 +1,50 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func progressAfterUpdate(t *testing.T, msg ProgressUpdateMsg) ProgressModel {
+	t.Helper()
+	m, _ := NewProgress("Writing...").Update(msg)
+	return m.(ProgressModel)
+}
+
+func TestProgressViewByteInfo(t *testing.T) {
+	t.Run("renders written and total when both known", func(t *testing.T) {
+		m := progressAfterUpdate(t, ProgressUpdateMsg{
+			Percent: 0.25,
+			Written: 50 * 1024 * 1024,
+			Total:   200 * 1024 * 1024,
+		})
+		if view := m.View(); !strings.Contains(view, "(50.0 MiB / 200.0 MiB)") {
+			t.Errorf("View() = %q; want it to contain %q", view, "(50.0 MiB / 200.0 MiB)")
+		}
+	})
+
+	t.Run("renders written alone when total is unknown", func(t *testing.T) {
+		m := progressAfterUpdate(t, ProgressUpdateMsg{
+			Percent: 0.25,
+			Written: 50 * 1024 * 1024,
+		})
+		view := m.View()
+		if !strings.Contains(view, "(50.0 MiB)") {
+			t.Errorf("View() = %q; want it to contain %q", view, "(50.0 MiB)")
+		}
+		if strings.Contains(view, "/") {
+			t.Errorf("View() = %q; must not render a total when none is known", view)
+		}
+	})
+
+	t.Run("done with unknown total keeps written-only counter", func(t *testing.T) {
+		m := progressAfterUpdate(t, ProgressUpdateMsg{
+			Percent: 1.0,
+			Written: 50 * 1024 * 1024,
+		})
+		next, _ := m.Update(ProgressDoneMsg{})
+		if view := next.View(); !strings.Contains(view, "(50.0 MiB)") {
+			t.Errorf("View() after done = %q; want it to contain %q", view, "(50.0 MiB)")
+		}
+	})
+}

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -14,6 +14,11 @@ type Config struct {
 	Analytics          *AnalyticsConfig `json:"analytics,omitempty"`
 	DefaultDevice      string           `json:"defaultDevice,omitempty"`
 	LastCLIUpdateCheck string           `json:"lastCLIUpdateCheck,omitempty"` // RFC3339
+	// LastMCPSetupVersion records the CLI version that last ran `wendy mcp
+	// setup`. It lets the root command detect when an upgrade should refresh
+	// the MCP server config and bundled skills. Empty means the user has never
+	// run setup, so auto-refresh stays off.
+	LastMCPSetupVersion string `json:"lastMCPSetupVersion,omitempty"`
 }
 
 // AuthConfig holds authentication details for a cloud environment.


### PR DESCRIPTION
## Problem

`wendy mcp setup` installs the Wendy MCP server config and bundled skills, but once it has run there was no mechanism to refresh it. After a CLI upgrade, users kept running against the MCP config and skills written by the older binary — missing the latest skills, tool definitions, and any fixes shipped in the newer setup.

## Change

- Add `LastMCPSetupVersion` to `~/.wendy/config.json`, recording the CLI version that last performed `wendy mcp setup`.
- The explicit `wendy mcp setup` command now records that version after running.
- On CLI startup (`PersistentPreRunE`), if the running CLI version differs from the recorded one, silently re-apply the MCP server config and re-install the bundled skills, then record the new version.

### Behavior details

- **Opt-in preserved:** auto-refresh only runs when the user has previously run `wendy mcp setup` (non-empty `LastMCPSetupVersion`). It never opts a user into the MCP server just because they have an AI tool installed.
- **Idempotent & scoped:** the underlying setup helpers already no-op for tools they don't detect, so refresh only touches tools the user already configured.
- **Exact-mismatch comparison:** upgrades *and* downgrades trigger a refresh, so the installed skills always match the running binary.
- **`dev` builds never auto-refresh.**
- Runs synchronously before the update-check goroutine to avoid sharing the `cfg` pointer across goroutines.

## Outcome

After a CLI upgrade, users automatically have the latest skills and MCP configuration without needing to remember to re-run `wendy mcp setup`.

## Testing

- New table-driven test `TestShouldRefreshMCPSetup` covering never-set-up, dev builds, same version, upgrade, downgrade, and dev→real transitions.
- `go build ./...`, `go vet`, and the commands/config package tests pass.

Closes WDY-1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)