### PR TITLE
feat(cli): add wendy device unenroll

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_provisioning_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_provisioning_service.proto
@@ -5,6 +5,10 @@ package wendy.agent.services.v1;
 service WendyProvisioningService {
     rpc StartProvisioning(StartProvisioningRequest) returns (StartProvisioningResponse);
     rpc IsProvisioned(IsProvisionedRequest) returns (IsProvisionedResponse);
+    // Unprovision resets the device to an unprovisioned state: it deletes the
+    // stored enrollment certificates and provisioning state, then restarts the
+    // agent so it comes back up serving plaintext on the unprovisioned port.
+    rpc Unprovision(UnprovisionRequest) returns (UnprovisionResponse);
 }
 
 message IsProvisionedRequest {
@@ -35,3 +39,7 @@ message StartProvisioningRequest {
 message StartProvisioningResponse {
 
 }
+
+message UnprovisionRequest {}
+
+message UnprovisionResponse {}

--- a/Proto/wendy/agent/services/v2/provisioning_service.proto
+++ b/Proto/wendy/agent/services/v2/provisioning_service.proto
@@ -5,6 +5,10 @@ option go_package = "github.com/wendylabsinc/wendy/proto/gen/agentpb/v2;agentpbv
 service WendyProvisioningService {
     rpc StartProvisioning(StartProvisioningRequest) returns (StartProvisioningResponse);
     rpc IsProvisioned(IsProvisionedRequest) returns (IsProvisionedResponse);
+    // Unprovision resets the device to an unprovisioned state: it deletes the
+    // stored enrollment certificates and provisioning state, then restarts the
+    // agent so it comes back up serving plaintext on the unprovisioned port.
+    rpc Unprovision(UnprovisionRequest) returns (UnprovisionResponse);
 }
 
 message IsProvisionedRequest {}
@@ -32,3 +36,7 @@ message StartProvisioningRequest {
 }
 
 message StartProvisioningResponse {}
+
+message UnprovisionRequest {}
+
+message UnprovisionResponse {}

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -522,6 +522,16 @@ func main() {
 		}
 	}
 
+	// Set up the unprovisioning callback: revert the mDNS advertisement to the
+	// plaintext port and exit so systemd restarts the agent into unprovisioned
+	// mode. A clean restart is simpler and more reliable than tearing down the
+	// mTLS server, tunnel broker, BLE peripheral, and HTTPS registry in place.
+	provisioningSvc.OnUnprovisioned = func() {
+		configpartition.UpdateAvahiForUnprovisioning(logger, agentPortNum)
+		logger.Info("Device unprovisioned — restarting agent into unprovisioned mode")
+		os.Exit(0)
+	}
+
 	otelPort := defaultOTELPort
 	if p := os.Getenv("WENDY_OTEL_PORT"); p != "" {
 		otelPort = p

--- a/go/internal/agent/configpartition/apply.go
+++ b/go/internal/agent/configpartition/apply.go
@@ -348,11 +348,24 @@ func updateAvahiDeviceName(logger *zap.Logger, name string, env []string) {
 // avahi service file to advertise the mTLS port and a tls=true TXT record,
 // then restarts avahi-daemon so the mDNS advertisement reflects that the
 // device is now provisioned.
-//
-// The service file name varies by image (e.g. wendyos-mdns.service or
-// wendy-agent.service), so we scan all files in /etc/avahi/services/ and
-// update the first one that contains a _wendyos._udp block.
 func UpdateAvahiForProvisioning(logger *zap.Logger, mtlsPort int) {
+	updateAvahiService(logger, mtlsPort, true)
+}
+
+// UpdateAvahiForUnprovisioning reverts the _wendyos._udp service block to
+// advertise the plaintext agent port and a tls=false TXT record, then restarts
+// avahi-daemon. It is the inverse of UpdateAvahiForProvisioning, used when a
+// device is unprovisioned so it is rediscoverable for re-enrollment.
+func UpdateAvahiForUnprovisioning(logger *zap.Logger, plaintextPort int) {
+	updateAvahiService(logger, plaintextPort, false)
+}
+
+// updateAvahiService points the _wendyos._udp advertisement at the given port
+// and sets its tls TXT record. The service file name varies by image (e.g.
+// wendyos-mdns.service or wendy-agent.service), so we scan all files in
+// /etc/avahi/services/ and update the first one that contains a _wendyos._udp
+// block.
+func updateAvahiService(logger *zap.Logger, port int, tls bool) {
 	const serviceDir = "/etc/avahi/services"
 
 	entries, err := os.ReadDir(serviceDir)
@@ -374,7 +387,7 @@ func UpdateAvahiForProvisioning(logger *zap.Logger, mtlsPort int) {
 			continue
 		}
 
-		content := updateWendyOSServicePort(string(data), mtlsPort)
+		content := updateWendyOSServicePort(string(data), port, tls)
 		if err := os.WriteFile(serviceFile, []byte(content), 0o644); err != nil {
 			logger.Warn("Could not write avahi service file",
 				zap.String("path", serviceFile), zap.Error(err))
@@ -383,11 +396,11 @@ func UpdateAvahiForProvisioning(logger *zap.Logger, mtlsPort int) {
 
 		restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
 		if out, err := restart.CombinedOutput(); err != nil {
-			logger.Warn("systemctl restart avahi-daemon failed after provisioning",
+			logger.Warn("systemctl restart avahi-daemon failed",
 				zap.Error(err), zap.String("output", string(out)))
 		} else {
-			logger.Info("Updated avahi advertisement for mTLS",
-				zap.String("file", e.Name()), zap.Int("port", mtlsPort))
+			logger.Info("Updated avahi advertisement",
+				zap.String("file", e.Name()), zap.Int("port", port), zap.Bool("tls", tls))
 		}
 		return
 	}
@@ -396,9 +409,9 @@ func UpdateAvahiForProvisioning(logger *zap.Logger, mtlsPort int) {
 }
 
 // updateWendyOSServicePort finds the _wendyos._udp service block and updates
-// its port to mtlsPort and adds/updates a tls=true TXT record. Other service
-// blocks (SSH, HTTP, etc.) are left untouched.
-func updateWendyOSServicePort(content string, mtlsPort int) string {
+// its port and tls TXT record. Other service blocks (SSH, HTTP, etc.) are left
+// untouched.
+func updateWendyOSServicePort(content string, port int, tls bool) string {
 	const typeTag = "<type>_wendyos._udp</type>"
 	portRe := regexp.MustCompile(`<port>\d+</port>`)
 
@@ -423,14 +436,18 @@ func updateWendyOSServicePort(content string, mtlsPort int) string {
 	block := content[serviceStart:serviceEnd]
 
 	// Update port only within this block.
-	block = portRe.ReplaceAllString(block, fmt.Sprintf("<port>%d</port>", mtlsPort))
+	block = portRe.ReplaceAllString(block, fmt.Sprintf("<port>%d</port>", port))
 
-	// Add or update the tls=true TXT record.
+	// Add or update the tls TXT record.
+	tlsValue := "false"
+	if tls {
+		tlsValue = "true"
+	}
 	if strings.Contains(block, "<txt-record>tls=") {
-		block = replaceTXTRecord(block, "tls", "true")
+		block = replaceTXTRecord(block, "tls", tlsValue)
 	} else {
 		block = strings.Replace(block, "</service>",
-			"    <txt-record>tls=true</txt-record>\n  </service>", 1)
+			"    <txt-record>tls="+tlsValue+"</txt-record>\n  </service>", 1)
 	}
 
 	return content[:serviceStart] + block + content[serviceEnd:]

--- a/go/internal/agent/configpartition/apply_test.go
+++ b/go/internal/agent/configpartition/apply_test.go
@@ -424,3 +424,48 @@ func TestApplyPreProvisioning_CreatesConfigDir(t *testing.T) {
 		t.Errorf("configPath should be created automatically: %v", err)
 	}
 }
+
+const avahiServiceTemplate = `<?xml version="1.0" standalone='no'?>
+<service-group>
+  <name replace-wildcards="yes">WendyOS on %h</name>
+  <service>
+    <type>_wendyos._udp</type>
+    <port>50051</port>
+  </service>
+  <service>
+    <type>_ssh._tcp</type>
+    <port>22</port>
+  </service>
+</service-group>
+`
+
+func TestUpdateWendyOSServicePort_Provisioned(t *testing.T) {
+	out := updateWendyOSServicePort(avahiServiceTemplate, 50052, true)
+
+	if !strings.Contains(out, "<port>50052</port>") {
+		t.Errorf("expected wendyos port updated to 50052:\n%s", out)
+	}
+	if !strings.Contains(out, "<txt-record>tls=true</txt-record>") {
+		t.Errorf("expected tls=true TXT record:\n%s", out)
+	}
+	// The unrelated SSH block must be left untouched.
+	if !strings.Contains(out, "<port>22</port>") {
+		t.Errorf("ssh port should be untouched:\n%s", out)
+	}
+}
+
+func TestUpdateWendyOSServicePort_Unprovisioned(t *testing.T) {
+	// Start from a provisioned advertisement and revert it.
+	provisioned := updateWendyOSServicePort(avahiServiceTemplate, 50052, true)
+	out := updateWendyOSServicePort(provisioned, 50051, false)
+
+	if !strings.Contains(out, "<port>50051</port>") {
+		t.Errorf("expected wendyos port reverted to 50051:\n%s", out)
+	}
+	if !strings.Contains(out, "<txt-record>tls=false</txt-record>") {
+		t.Errorf("expected tls=false TXT record after revert:\n%s", out)
+	}
+	if strings.Contains(out, "tls=true") {
+		t.Errorf("tls=true should have been replaced:\n%s", out)
+	}
+}

--- a/go/internal/agent/services/provisioning_service.go
+++ b/go/internal/agent/services/provisioning_service.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -59,21 +60,28 @@ func certificateServiceAddr(cloudHost string) string {
 // when done. certPEM and chainPEM are plain strings (public material).
 type OnProvisionedFunc func(certPEM, chainPEM string, keyData []byte)
 
+// OnUnprovisionedFunc is called after the device has been unprovisioned and its
+// state has been cleared. It is invoked asynchronously, shortly after the RPC
+// response is sent, so implementations can revert the mDNS advertisement and
+// restart the agent process. If nil, no post-unprovision action is taken.
+type OnUnprovisionedFunc func()
+
 // ProvisioningService implements agentpb.WendyProvisioningServiceServer.
 type ProvisioningService struct {
 	agentpb.UnimplementedWendyProvisioningServiceServer
-	logger        *zap.Logger
-	configPath    string
-	mu            sync.Mutex
-	enrolled      bool
-	cloudHost     string
-	orgID         int32
-	assetID       int32
-	keyPEM        []byte // stored as []byte so it can be zeroed on rotation/shutdown
-	certPEM       string
-	chainPEM      string
-	CloudDialer   CloudDialer
-	OnProvisioned OnProvisionedFunc
+	logger          *zap.Logger
+	configPath      string
+	mu              sync.Mutex
+	enrolled        bool
+	cloudHost       string
+	orgID           int32
+	assetID         int32
+	keyPEM          []byte // stored as []byte so it can be zeroed on rotation/shutdown
+	certPEM         string
+	chainPEM        string
+	CloudDialer     CloudDialer
+	OnProvisioned   OnProvisionedFunc
+	OnUnprovisioned OnUnprovisionedFunc
 }
 
 func NewProvisioningService(logger *zap.Logger, configPath string) *ProvisioningService {
@@ -250,6 +258,84 @@ func (s *ProvisioningService) StartProvisioning(ctx context.Context, req *agentp
 		cb(certPEM, chainPEM, cbKeyPEM)
 	}
 	return &agentpb.StartProvisioningResponse{}, nil
+}
+
+// Unprovision resets the device to an unprovisioned state. It deletes the
+// stored enrollment certificates and provisioning state from disk, clears the
+// in-memory state, and (if configured) invokes OnUnprovisioned shortly after
+// the response is sent so the agent can revert its mDNS advertisement and
+// restart into plaintext mode.
+func (s *ProvisioningService) Unprovision(_ context.Context, _ *agentpb.UnprovisionRequest) (*agentpb.UnprovisionResponse, error) {
+	s.mu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			s.mu.Unlock()
+		}
+	}()
+
+	if !s.enrolled {
+		return nil, status.Error(codes.FailedPrecondition, "agent is not provisioned")
+	}
+
+	s.logger.Info("Unprovisioning device",
+		zap.Int32("org_id", s.orgID),
+		zap.Int32("asset_id", s.assetID),
+	)
+
+	if err := s.clearStateFiles(); err != nil {
+		s.logger.Error("Failed to delete provisioning state files", zap.Error(err))
+		return nil, status.Errorf(codes.Internal, "failed to delete provisioning state: %v", err)
+	}
+
+	// Zero the in-memory key before dropping the reference, then clear state.
+	for i := range s.keyPEM {
+		s.keyPEM[i] = 0
+	}
+	s.enrolled = false
+	s.cloudHost = ""
+	s.orgID = 0
+	s.assetID = 0
+	s.keyPEM = nil
+	s.certPEM = ""
+	s.chainPEM = ""
+
+	s.logger.Info("Device unprovisioned; agent will restart into unprovisioned mode")
+
+	cb := s.OnUnprovisioned
+	locked = false
+	s.mu.Unlock()
+
+	if cb != nil {
+		// Invoke asynchronously after a short delay so the RPC response is
+		// flushed to the client before the agent restarts. Mirrors the agent
+		// update and reboot flows.
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			cb()
+		}()
+	}
+
+	return &agentpb.UnprovisionResponse{}, nil
+}
+
+// clearStateFiles removes all on-disk provisioning artifacts: the state file,
+// the device private key, the mounted PEM files, and the .provisioned marker.
+// A missing file is not treated as an error.
+func (s *ProvisioningService) clearStateFiles() error {
+	files := []string{
+		s.statePath(),
+		filepath.Join(s.configPath, "device-key.pem"),
+		filepath.Join(s.configPath, "device.pem"),
+		filepath.Join(s.configPath, "ca.pem"),
+		filepath.Join(s.configPath, ".provisioned"),
+	}
+	for _, f := range files {
+		if err := os.Remove(f); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing %s: %w", f, err)
+		}
+	}
+	return nil
 }
 
 func (s *ProvisioningService) statePath() string {

--- a/go/internal/agent/services/provisioning_service_test.go
+++ b/go/internal/agent/services/provisioning_service_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -154,6 +156,71 @@ func TestStartProvisioning(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error when already provisioned")
+	}
+}
+
+func TestUnprovision_NotProvisioned(t *testing.T) {
+	svc, tmpDir := newTestProvisioningService(t)
+	defer os.RemoveAll(tmpDir)
+
+	if _, err := svc.Unprovision(context.Background(), &agentpb.UnprovisionRequest{}); err == nil {
+		t.Fatal("expected error when unprovisioning a device that is not provisioned")
+	}
+}
+
+func TestUnprovision_ClearsStateAndFiles(t *testing.T) {
+	svc, tmpDir := newTestProvisioningService(t)
+	defer os.RemoveAll(tmpDir)
+
+	if _, err := svc.StartProvisioning(context.Background(), &agentpb.StartProvisioningRequest{
+		OrganizationId: 7,
+		CloudHost:      "unprov.wendy.io",
+		AssetId:        70,
+	}); err != nil {
+		t.Fatalf("StartProvisioning: %v", err)
+	}
+
+	// All on-disk artifacts should exist after provisioning.
+	stateFiles := []string{"provisioning.json", "device-key.pem", "device.pem", "ca.pem", ".provisioned"}
+	for _, f := range stateFiles {
+		if _, err := os.Stat(filepath.Join(tmpDir, f)); err != nil {
+			t.Fatalf("expected %s to exist after provisioning: %v", f, err)
+		}
+	}
+
+	// OnUnprovisioned fires asynchronously after the response; capture it.
+	called := make(chan struct{}, 1)
+	svc.OnUnprovisioned = func() { called <- struct{}{} }
+
+	if _, err := svc.Unprovision(context.Background(), &agentpb.UnprovisionRequest{}); err != nil {
+		t.Fatalf("Unprovision: %v", err)
+	}
+
+	// All artifacts should be gone.
+	for _, f := range stateFiles {
+		if _, err := os.Stat(filepath.Join(tmpDir, f)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed after unprovision (err=%v)", f, err)
+		}
+	}
+
+	// In-memory state should report not provisioned.
+	resp, err := svc.IsProvisioned(context.Background(), &agentpb.IsProvisionedRequest{})
+	if err != nil {
+		t.Fatalf("IsProvisioned: %v", err)
+	}
+	if resp.GetNotProvisioned() == nil {
+		t.Error("expected NotProvisioned after unprovision")
+	}
+
+	select {
+	case <-called:
+	case <-time.After(3 * time.Second):
+		t.Error("OnUnprovisioned callback was not invoked")
+	}
+
+	// A subsequent unprovision should fail (already cleared).
+	if _, err := svc.Unprovision(context.Background(), &agentpb.UnprovisionRequest{}); err == nil {
+		t.Error("expected error when unprovisioning an already-unprovisioned device")
 	}
 }
 

--- a/go/internal/agent/services/provisioning_service_v2.go
+++ b/go/internal/agent/services/provisioning_service_v2.go
@@ -53,3 +53,10 @@ func (s *ProvisioningServiceV2) StartProvisioning(ctx context.Context, req *agen
 	}
 	return &agentpbv2.StartProvisioningResponse{}, nil
 }
+
+func (s *ProvisioningServiceV2) Unprovision(ctx context.Context, _ *agentpbv2.UnprovisionRequest) (*agentpbv2.UnprovisionResponse, error) {
+	if _, err := s.v1.Unprovision(ctx, &agentpb.UnprovisionRequest{}); err != nil {
+		return nil, err
+	}
+	return &agentpbv2.UnprovisionResponse{}, nil
+}

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -30,8 +30,10 @@ import (
 	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
 	"golang.org/x/term"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 func newDeviceCmd() *cobra.Command {
@@ -61,6 +63,7 @@ func newDeviceCmd() *cobra.Command {
 		newDeviceUnsetDefaultCmd(),
 		newDeviceSetupCmd(),
 		newDeviceEnrollCmd(),
+		newDeviceUnenrollCmd(),
 		newDeviceUpdateCmd(),
 	)
 	addToGroup("monitor",
@@ -614,6 +617,181 @@ func pickAuthEntry(cloudGRPC string) (*config.AuthConfig, error) {
 		return nil, fmt.Errorf("auth entry has no certificates; re-run 'wendy auth login'")
 	}
 	return &cfg.Auth[0], nil
+}
+
+func newDeviceUnenrollCmd() *cobra.Command {
+	var assumeYes bool
+	var cloudGRPC string
+
+	cmd := &cobra.Command{
+		Use:   "unenroll",
+		Short: "Unenroll a device and remove it from Wendy Cloud",
+		Long: "Reverses 'wendy device enroll': deletes the device's enrollment certificates and " +
+			"provisioning state (the agent restarts into unprovisioned mode), then revokes the " +
+			"device's certificates and deletes its asset record in Wendy Cloud.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			conn, err := connectToAgent(ctx, SuppressProvisioningHint())
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			// Determine the device's current enrollment so we know which cloud
+			// asset to clean up afterwards.
+			provResp, err := conn.ProvisioningService.IsProvisioned(ctx, &agentpb.IsProvisionedRequest{})
+			if err != nil {
+				return fmt.Errorf("checking provisioning status: %w", err)
+			}
+			prov := provResp.GetProvisioned()
+			if prov == nil {
+				return fmt.Errorf("device is not provisioned")
+			}
+			cloudHost := prov.GetCloudHost()
+			orgID := prov.GetOrganizationId()
+			assetID := prov.GetAssetId()
+
+			if !assumeYes {
+				if !isInteractiveTerminal() {
+					return fmt.Errorf("unenroll is destructive; pass --yes to confirm when not running interactively")
+				}
+				fmt.Printf("This will unenroll the device (org: %d, asset: %d) and delete its asset in Wendy Cloud.\n", orgID, assetID)
+				fmt.Print("Continue? [y/N] ")
+				reader := bufio.NewReader(os.Stdin)
+				line, _ := reader.ReadString('\n')
+				answer := strings.TrimSpace(strings.ToLower(line))
+				if answer != "y" && answer != "yes" {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
+			// Step 1: reset the device. The agent deletes its state and restarts,
+			// so the connection may drop right after the response — tolerate that.
+			if _, err := conn.ProvisioningService.Unprovision(ctx, &agentpb.UnprovisionRequest{}); err != nil {
+				if status.Code(err) == codes.Unavailable {
+					cliLogln("Device connection closed (agent is restarting).")
+				} else {
+					return fmt.Errorf("unprovisioning device: %w", err)
+				}
+			}
+
+			// Step 2: clean up the cloud asset. Best-effort — a failure here leaves
+			// a dangling asset that can be removed from the dashboard, but the
+			// device itself is already reset.
+			certsRevoked, assetDeleted, cloudErr := cloudUnenrollCleanup(ctx, cloudGRPC, cloudHost, assetID)
+
+			if jsonOutput {
+				out := map[string]any{
+					"deviceReset":  true,
+					"certsRevoked": certsRevoked,
+					"assetDeleted": assetDeleted,
+				}
+				if cloudErr != nil {
+					out["cloudError"] = cloudErr.Error()
+				}
+				data, marshalErr := json.MarshalIndent(out, "", "  ")
+				if marshalErr != nil {
+					return marshalErr
+				}
+				fmt.Println(string(data))
+			} else {
+				fmt.Println("Device reset to unprovisioned state.")
+				if cloudErr != nil {
+					fmt.Printf("Warning: cloud cleanup failed: %v\n", cloudErr)
+					fmt.Printf("Delete asset %d from the Wendy Cloud dashboard to finish.\n", assetID)
+				} else {
+					fmt.Printf("Revoked %d certificate(s) and deleted asset %d from Wendy Cloud.\n", certsRevoked, assetID)
+				}
+			}
+
+			if cloudErr != nil {
+				return cloudErr
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint to use for cleanup (defaults to the device's enrolled cloud host)")
+	return cmd
+}
+
+// cloudUnenrollCleanup revokes the asset's active certificates and then
+// deletes the asset record in Wendy Cloud. It authenticates with the user's
+// stored session for the device's cloud host (or cloudGRPC if provided).
+func cloudUnenrollCleanup(ctx context.Context, cloudGRPC, deviceCloudHost string, assetID int32) (certsRevoked int, assetDeleted bool, err error) {
+	target := cloudGRPC
+	if target == "" {
+		target = deviceCloudHost
+	}
+	auth, err := pickAuthEntry(target)
+	if err != nil {
+		return 0, false, fmt.Errorf("selecting cloud auth session: %w", err)
+	}
+	if len(auth.Certificates) == 0 {
+		return 0, false, fmt.Errorf("auth session has no certificates; re-run 'wendy auth login'")
+	}
+	cert := auth.Certificates[0]
+
+	var transport grpc.DialOption
+	if strings.HasSuffix(auth.CloudGRPC, ":443") {
+		tlsCfg, tlsErr := certs.LoadTLSConfig(
+			cert.PemCertificate,
+			cert.PemCertificateChain,
+			cert.PemPrivateKey,
+			"",
+		)
+		if tlsErr != nil {
+			return 0, false, fmt.Errorf("loading TLS config: %w", tlsErr)
+		}
+		transport = grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg))
+	} else {
+		transport = grpc.WithTransportCredentials(insecure.NewCredentials())
+	}
+
+	cloudConn, dialErr := grpc.NewClient(auth.CloudGRPC, transport)
+	if dialErr != nil {
+		return 0, false, fmt.Errorf("connecting to cloud: %w", dialErr)
+	}
+	defer cloudConn.Close()
+
+	tokenCtx := cloudContext(ctx, auth)
+
+	// Revoke the asset's active certificates first so a stale identity cannot be
+	// reused, then delete the asset record.
+	certClient := cloudpb.NewCertificateServiceClient(cloudConn)
+	stream, listErr := certClient.ListCertificates(tokenCtx, &cloudpb.ListCertificatesRequest{AssetId: assetID})
+	if listErr != nil {
+		return 0, false, fmt.Errorf("listing certificates: %w", listErr)
+	}
+	for {
+		resp, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			return certsRevoked, false, fmt.Errorf("listing certificates: %w", recvErr)
+		}
+		c := resp.GetCertificate()
+		if c == nil || c.GetStatus() != cloudpb.CertificateStatus_CERTIFICATE_STATUS_ACTIVE {
+			continue
+		}
+		if _, revErr := certClient.RevokeCertificate(tokenCtx, &cloudpb.RevokeCertificateRequest{
+			CertificateId: c.GetId(),
+			Reason:        "device unprovisioned",
+		}); revErr != nil {
+			return certsRevoked, false, fmt.Errorf("revoking certificate %d: %w", c.GetId(), revErr)
+		}
+		certsRevoked++
+	}
+
+	assetClient := cloudpb.NewAssetServiceClient(cloudConn)
+	if _, delErr := assetClient.DeleteAsset(tokenCtx, &cloudpb.DeleteAssetRequest{Id: assetID}); delErr != nil {
+		return certsRevoked, false, fmt.Errorf("deleting asset %d: %w", assetID, delErr)
+	}
+	return certsRevoked, true, nil
 }
 
 // scanWiFiNetworks queries the agent for available WiFi networks.

--- a/go/proto/gen/agentpb/v2/provisioning_service.pb.go
+++ b/go/proto/gen/agentpb/v2/provisioning_service.pb.go
@@ -339,6 +339,78 @@ func (*StartProvisioningResponse) Descriptor() ([]byte, []int) {
 	return file_wendy_agent_services_v2_provisioning_service_proto_rawDescGZIP(), []int{5}
 }
 
+type UnprovisionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnprovisionRequest) Reset() {
+	*x = UnprovisionRequest{}
+	mi := &file_wendy_agent_services_v2_provisioning_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnprovisionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnprovisionRequest) ProtoMessage() {}
+
+func (x *UnprovisionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_provisioning_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnprovisionRequest.ProtoReflect.Descriptor instead.
+func (*UnprovisionRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_provisioning_service_proto_rawDescGZIP(), []int{6}
+}
+
+type UnprovisionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnprovisionResponse) Reset() {
+	*x = UnprovisionResponse{}
+	mi := &file_wendy_agent_services_v2_provisioning_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnprovisionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnprovisionResponse) ProtoMessage() {}
+
+func (x *UnprovisionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_provisioning_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnprovisionResponse.ProtoReflect.Descriptor instead.
+func (*UnprovisionResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_provisioning_service_proto_rawDescGZIP(), []int{7}
+}
+
 var File_wendy_agent_services_v2_provisioning_service_proto protoreflect.FileDescriptor
 
 const file_wendy_agent_services_v2_provisioning_service_proto_rawDesc = "" +
@@ -361,10 +433,13 @@ const file_wendy_agent_services_v2_provisioning_service_proto_rawDesc = "" +
 	"\n" +
 	"cloud_host\x18\x03 \x01(\tR\tcloudHost\x12\x19\n" +
 	"\basset_id\x18\x04 \x01(\x05R\aassetId\"\x1b\n" +
-	"\x19StartProvisioningResponse2\x86\x02\n" +
+	"\x19StartProvisioningResponse\"\x14\n" +
+	"\x12UnprovisionRequest\"\x15\n" +
+	"\x13UnprovisionResponse2\xf0\x02\n" +
 	"\x18WendyProvisioningService\x12z\n" +
 	"\x11StartProvisioning\x121.wendy.agent.services.v2.StartProvisioningRequest\x1a2.wendy.agent.services.v2.StartProvisioningResponse\x12n\n" +
-	"\rIsProvisioned\x12-.wendy.agent.services.v2.IsProvisionedRequest\x1a..wendy.agent.services.v2.IsProvisionedResponseB>Z<github.com/wendylabsinc/wendy/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
+	"\rIsProvisioned\x12-.wendy.agent.services.v2.IsProvisionedRequest\x1a..wendy.agent.services.v2.IsProvisionedResponse\x12h\n" +
+	"\vUnprovision\x12+.wendy.agent.services.v2.UnprovisionRequest\x1a,.wendy.agent.services.v2.UnprovisionResponseB>Z<github.com/wendylabsinc/wendy/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
 
 var (
 	file_wendy_agent_services_v2_provisioning_service_proto_rawDescOnce sync.Once
@@ -378,7 +453,7 @@ func file_wendy_agent_services_v2_provisioning_service_proto_rawDescGZIP() []byt
 	return file_wendy_agent_services_v2_provisioning_service_proto_rawDescData
 }
 
-var file_wendy_agent_services_v2_provisioning_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_wendy_agent_services_v2_provisioning_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_wendy_agent_services_v2_provisioning_service_proto_goTypes = []any{
 	(*IsProvisionedRequest)(nil),      // 0: wendy.agent.services.v2.IsProvisionedRequest
 	(*IsProvisionedResponse)(nil),     // 1: wendy.agent.services.v2.IsProvisionedResponse
@@ -386,16 +461,20 @@ var file_wendy_agent_services_v2_provisioning_service_proto_goTypes = []any{
 	(*ProvisionedResponse)(nil),       // 3: wendy.agent.services.v2.ProvisionedResponse
 	(*StartProvisioningRequest)(nil),  // 4: wendy.agent.services.v2.StartProvisioningRequest
 	(*StartProvisioningResponse)(nil), // 5: wendy.agent.services.v2.StartProvisioningResponse
+	(*UnprovisionRequest)(nil),        // 6: wendy.agent.services.v2.UnprovisionRequest
+	(*UnprovisionResponse)(nil),       // 7: wendy.agent.services.v2.UnprovisionResponse
 }
 var file_wendy_agent_services_v2_provisioning_service_proto_depIdxs = []int32{
 	2, // 0: wendy.agent.services.v2.IsProvisionedResponse.not_provisioned:type_name -> wendy.agent.services.v2.NotProvisionedResponse
 	3, // 1: wendy.agent.services.v2.IsProvisionedResponse.provisioned:type_name -> wendy.agent.services.v2.ProvisionedResponse
 	4, // 2: wendy.agent.services.v2.WendyProvisioningService.StartProvisioning:input_type -> wendy.agent.services.v2.StartProvisioningRequest
 	0, // 3: wendy.agent.services.v2.WendyProvisioningService.IsProvisioned:input_type -> wendy.agent.services.v2.IsProvisionedRequest
-	5, // 4: wendy.agent.services.v2.WendyProvisioningService.StartProvisioning:output_type -> wendy.agent.services.v2.StartProvisioningResponse
-	1, // 5: wendy.agent.services.v2.WendyProvisioningService.IsProvisioned:output_type -> wendy.agent.services.v2.IsProvisionedResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
+	6, // 4: wendy.agent.services.v2.WendyProvisioningService.Unprovision:input_type -> wendy.agent.services.v2.UnprovisionRequest
+	5, // 5: wendy.agent.services.v2.WendyProvisioningService.StartProvisioning:output_type -> wendy.agent.services.v2.StartProvisioningResponse
+	1, // 6: wendy.agent.services.v2.WendyProvisioningService.IsProvisioned:output_type -> wendy.agent.services.v2.IsProvisionedResponse
+	7, // 7: wendy.agent.services.v2.WendyProvisioningService.Unprovision:output_type -> wendy.agent.services.v2.UnprovisionResponse
+	5, // [5:8] is the sub-list for method output_type
+	2, // [2:5] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
 	2, // [2:2] is the sub-list for extension extendee
 	0, // [0:2] is the sub-list for field type_name
@@ -416,7 +495,7 @@ func file_wendy_agent_services_v2_provisioning_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v2_provisioning_service_proto_rawDesc), len(file_wendy_agent_services_v2_provisioning_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/agentpb/v2/provisioning_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/v2/provisioning_service_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	WendyProvisioningService_StartProvisioning_FullMethodName = "/wendy.agent.services.v2.WendyProvisioningService/StartProvisioning"
 	WendyProvisioningService_IsProvisioned_FullMethodName     = "/wendy.agent.services.v2.WendyProvisioningService/IsProvisioned"
+	WendyProvisioningService_Unprovision_FullMethodName       = "/wendy.agent.services.v2.WendyProvisioningService/Unprovision"
 )
 
 // WendyProvisioningServiceClient is the client API for WendyProvisioningService service.
@@ -29,6 +30,10 @@ const (
 type WendyProvisioningServiceClient interface {
 	StartProvisioning(ctx context.Context, in *StartProvisioningRequest, opts ...grpc.CallOption) (*StartProvisioningResponse, error)
 	IsProvisioned(ctx context.Context, in *IsProvisionedRequest, opts ...grpc.CallOption) (*IsProvisionedResponse, error)
+	// Unprovision resets the device to an unprovisioned state: it deletes the
+	// stored enrollment certificates and provisioning state, then restarts the
+	// agent so it comes back up serving plaintext on the unprovisioned port.
+	Unprovision(ctx context.Context, in *UnprovisionRequest, opts ...grpc.CallOption) (*UnprovisionResponse, error)
 }
 
 type wendyProvisioningServiceClient struct {
@@ -59,12 +64,26 @@ func (c *wendyProvisioningServiceClient) IsProvisioned(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *wendyProvisioningServiceClient) Unprovision(ctx context.Context, in *UnprovisionRequest, opts ...grpc.CallOption) (*UnprovisionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UnprovisionResponse)
+	err := c.cc.Invoke(ctx, WendyProvisioningService_Unprovision_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // WendyProvisioningServiceServer is the server API for WendyProvisioningService service.
 // All implementations must embed UnimplementedWendyProvisioningServiceServer
 // for forward compatibility.
 type WendyProvisioningServiceServer interface {
 	StartProvisioning(context.Context, *StartProvisioningRequest) (*StartProvisioningResponse, error)
 	IsProvisioned(context.Context, *IsProvisionedRequest) (*IsProvisionedResponse, error)
+	// Unprovision resets the device to an unprovisioned state: it deletes the
+	// stored enrollment certificates and provisioning state, then restarts the
+	// agent so it comes back up serving plaintext on the unprovisioned port.
+	Unprovision(context.Context, *UnprovisionRequest) (*UnprovisionResponse, error)
 	mustEmbedUnimplementedWendyProvisioningServiceServer()
 }
 
@@ -80,6 +99,9 @@ func (UnimplementedWendyProvisioningServiceServer) StartProvisioning(context.Con
 }
 func (UnimplementedWendyProvisioningServiceServer) IsProvisioned(context.Context, *IsProvisionedRequest) (*IsProvisionedResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method IsProvisioned not implemented")
+}
+func (UnimplementedWendyProvisioningServiceServer) Unprovision(context.Context, *UnprovisionRequest) (*UnprovisionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Unprovision not implemented")
 }
 func (UnimplementedWendyProvisioningServiceServer) mustEmbedUnimplementedWendyProvisioningServiceServer() {
 }
@@ -139,6 +161,24 @@ func _WendyProvisioningService_IsProvisioned_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _WendyProvisioningService_Unprovision_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UnprovisionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendyProvisioningServiceServer).Unprovision(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendyProvisioningService_Unprovision_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendyProvisioningServiceServer).Unprovision(ctx, req.(*UnprovisionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // WendyProvisioningService_ServiceDesc is the grpc.ServiceDesc for WendyProvisioningService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -153,6 +193,10 @@ var WendyProvisioningService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "IsProvisioned",
 			Handler:    _WendyProvisioningService_IsProvisioned_Handler,
+		},
+		{
+			MethodName: "Unprovision",
+			Handler:    _WendyProvisioningService_Unprovision_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/go/proto/gen/agentpb/wendy_agent_v1_provisioning_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_provisioning_service.pb.go
@@ -339,6 +339,78 @@ func (*StartProvisioningResponse) Descriptor() ([]byte, []int) {
 	return file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_rawDescGZIP(), []int{5}
 }
 
+type UnprovisionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnprovisionRequest) Reset() {
+	*x = UnprovisionRequest{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnprovisionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnprovisionRequest) ProtoMessage() {}
+
+func (x *UnprovisionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnprovisionRequest.ProtoReflect.Descriptor instead.
+func (*UnprovisionRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_rawDescGZIP(), []int{6}
+}
+
+type UnprovisionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnprovisionResponse) Reset() {
+	*x = UnprovisionResponse{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnprovisionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnprovisionResponse) ProtoMessage() {}
+
+func (x *UnprovisionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnprovisionResponse.ProtoReflect.Descriptor instead.
+func (*UnprovisionResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_rawDescGZIP(), []int{7}
+}
+
 var File_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto protoreflect.FileDescriptor
 
 const file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_rawDesc = "" +
@@ -362,10 +434,13 @@ const file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_raw
 	"\n" +
 	"cloud_host\x18\x03 \x01(\tR\tcloudHost\x12\x19\n" +
 	"\basset_id\x18\x04 \x01(\x05R\aassetId\"\x1b\n" +
-	"\x19StartProvisioningResponse2\x86\x02\n" +
+	"\x19StartProvisioningResponse\"\x14\n" +
+	"\x12UnprovisionRequest\"\x15\n" +
+	"\x13UnprovisionResponse2\xf0\x02\n" +
 	"\x18WendyProvisioningService\x12z\n" +
 	"\x11StartProvisioning\x121.wendy.agent.services.v1.StartProvisioningRequest\x1a2.wendy.agent.services.v1.StartProvisioningResponse\x12n\n" +
-	"\rIsProvisioned\x12-.wendy.agent.services.v1.IsProvisionedRequest\x1a..wendy.agent.services.v1.IsProvisionedResponseb\x06proto3"
+	"\rIsProvisioned\x12-.wendy.agent.services.v1.IsProvisionedRequest\x1a..wendy.agent.services.v1.IsProvisionedResponse\x12h\n" +
+	"\vUnprovision\x12+.wendy.agent.services.v1.UnprovisionRequest\x1a,.wendy.agent.services.v1.UnprovisionResponseb\x06proto3"
 
 var (
 	file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_rawDescOnce sync.Once
@@ -379,7 +454,7 @@ func file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_rawD
 	return file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_rawDescData
 }
 
-var file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_goTypes = []any{
 	(*IsProvisionedRequest)(nil),      // 0: wendy.agent.services.v1.IsProvisionedRequest
 	(*IsProvisionedResponse)(nil),     // 1: wendy.agent.services.v1.IsProvisionedResponse
@@ -387,16 +462,20 @@ var file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_goTyp
 	(*ProvisionedResponse)(nil),       // 3: wendy.agent.services.v1.ProvisionedResponse
 	(*StartProvisioningRequest)(nil),  // 4: wendy.agent.services.v1.StartProvisioningRequest
 	(*StartProvisioningResponse)(nil), // 5: wendy.agent.services.v1.StartProvisioningResponse
+	(*UnprovisionRequest)(nil),        // 6: wendy.agent.services.v1.UnprovisionRequest
+	(*UnprovisionResponse)(nil),       // 7: wendy.agent.services.v1.UnprovisionResponse
 }
 var file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_depIdxs = []int32{
 	2, // 0: wendy.agent.services.v1.IsProvisionedResponse.not_provisioned:type_name -> wendy.agent.services.v1.NotProvisionedResponse
 	3, // 1: wendy.agent.services.v1.IsProvisionedResponse.provisioned:type_name -> wendy.agent.services.v1.ProvisionedResponse
 	4, // 2: wendy.agent.services.v1.WendyProvisioningService.StartProvisioning:input_type -> wendy.agent.services.v1.StartProvisioningRequest
 	0, // 3: wendy.agent.services.v1.WendyProvisioningService.IsProvisioned:input_type -> wendy.agent.services.v1.IsProvisionedRequest
-	5, // 4: wendy.agent.services.v1.WendyProvisioningService.StartProvisioning:output_type -> wendy.agent.services.v1.StartProvisioningResponse
-	1, // 5: wendy.agent.services.v1.WendyProvisioningService.IsProvisioned:output_type -> wendy.agent.services.v1.IsProvisionedResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
+	6, // 4: wendy.agent.services.v1.WendyProvisioningService.Unprovision:input_type -> wendy.agent.services.v1.UnprovisionRequest
+	5, // 5: wendy.agent.services.v1.WendyProvisioningService.StartProvisioning:output_type -> wendy.agent.services.v1.StartProvisioningResponse
+	1, // 6: wendy.agent.services.v1.WendyProvisioningService.IsProvisioned:output_type -> wendy.agent.services.v1.IsProvisionedResponse
+	7, // 7: wendy.agent.services.v1.WendyProvisioningService.Unprovision:output_type -> wendy.agent.services.v1.UnprovisionResponse
+	5, // [5:8] is the sub-list for method output_type
+	2, // [2:5] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
 	2, // [2:2] is the sub-list for extension extendee
 	0, // [0:2] is the sub-list for field type_name
@@ -417,7 +496,7 @@ func file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_init
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_rawDesc), len(file_wendy_agent_services_v1_wendy_agent_v1_provisioning_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/agentpb/wendy_agent_v1_provisioning_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_provisioning_service_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	WendyProvisioningService_StartProvisioning_FullMethodName = "/wendy.agent.services.v1.WendyProvisioningService/StartProvisioning"
 	WendyProvisioningService_IsProvisioned_FullMethodName     = "/wendy.agent.services.v1.WendyProvisioningService/IsProvisioned"
+	WendyProvisioningService_Unprovision_FullMethodName       = "/wendy.agent.services.v1.WendyProvisioningService/Unprovision"
 )
 
 // WendyProvisioningServiceClient is the client API for WendyProvisioningService service.
@@ -29,6 +30,10 @@ const (
 type WendyProvisioningServiceClient interface {
 	StartProvisioning(ctx context.Context, in *StartProvisioningRequest, opts ...grpc.CallOption) (*StartProvisioningResponse, error)
 	IsProvisioned(ctx context.Context, in *IsProvisionedRequest, opts ...grpc.CallOption) (*IsProvisionedResponse, error)
+	// Unprovision resets the device to an unprovisioned state: it deletes the
+	// stored enrollment certificates and provisioning state, then restarts the
+	// agent so it comes back up serving plaintext on the unprovisioned port.
+	Unprovision(ctx context.Context, in *UnprovisionRequest, opts ...grpc.CallOption) (*UnprovisionResponse, error)
 }
 
 type wendyProvisioningServiceClient struct {
@@ -59,12 +64,26 @@ func (c *wendyProvisioningServiceClient) IsProvisioned(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *wendyProvisioningServiceClient) Unprovision(ctx context.Context, in *UnprovisionRequest, opts ...grpc.CallOption) (*UnprovisionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UnprovisionResponse)
+	err := c.cc.Invoke(ctx, WendyProvisioningService_Unprovision_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // WendyProvisioningServiceServer is the server API for WendyProvisioningService service.
 // All implementations must embed UnimplementedWendyProvisioningServiceServer
 // for forward compatibility.
 type WendyProvisioningServiceServer interface {
 	StartProvisioning(context.Context, *StartProvisioningRequest) (*StartProvisioningResponse, error)
 	IsProvisioned(context.Context, *IsProvisionedRequest) (*IsProvisionedResponse, error)
+	// Unprovision resets the device to an unprovisioned state: it deletes the
+	// stored enrollment certificates and provisioning state, then restarts the
+	// agent so it comes back up serving plaintext on the unprovisioned port.
+	Unprovision(context.Context, *UnprovisionRequest) (*UnprovisionResponse, error)
 	mustEmbedUnimplementedWendyProvisioningServiceServer()
 }
 
@@ -80,6 +99,9 @@ func (UnimplementedWendyProvisioningServiceServer) StartProvisioning(context.Con
 }
 func (UnimplementedWendyProvisioningServiceServer) IsProvisioned(context.Context, *IsProvisionedRequest) (*IsProvisionedResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method IsProvisioned not implemented")
+}
+func (UnimplementedWendyProvisioningServiceServer) Unprovision(context.Context, *UnprovisionRequest) (*UnprovisionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Unprovision not implemented")
 }
 func (UnimplementedWendyProvisioningServiceServer) mustEmbedUnimplementedWendyProvisioningServiceServer() {
 }
@@ -139,6 +161,24 @@ func _WendyProvisioningService_IsProvisioned_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _WendyProvisioningService_Unprovision_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UnprovisionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendyProvisioningServiceServer).Unprovision(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendyProvisioningService_Unprovision_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendyProvisioningServiceServer).Unprovision(ctx, req.(*UnprovisionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // WendyProvisioningService_ServiceDesc is the grpc.ServiceDesc for WendyProvisioningService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -153,6 +193,10 @@ var WendyProvisioningService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "IsProvisioned",
 			Handler:    _WendyProvisioningService_IsProvisioned_Handler,
+		},
+		{
+			MethodName: "Unprovision",
+			Handler:    _WendyProvisioningService_Unprovision_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
## Summary

Adds `wendy device unenroll`, the inverse of `wendy device enroll`. It resets a device to an unprovisioned, re-enrollable state **and** cleans up Wendy Cloud (revokes the device's certs, then deletes its asset record).

Naming follows the existing convention: the CLI `enroll` command drives the agent's `StartProvisioning` RPC, so `unenroll` drives the agent's `Unprovision` RPC. The user-facing command is `unenroll`; the agent/provisioning-domain code keeps the `Unprovision` / `OnUnprovisioned` names.

## What it does

1. Connects to the (provisioned) device over mTLS and reads its enrollment (`IsProvisioned` → cloud host, org, asset).
2. Prompts for confirmation (skippable with `--yes`; required when non-interactive).
3. **Resets the device** via the agent `Unprovision` RPC: deletes `provisioning.json`, `device-key.pem`, `device.pem`, `ca.pem`, and the `.provisioned` marker, zeroes/clears in-memory state, then — via an `OnUnprovisioned` callback — reverts the mDNS advertisement to the plaintext port and exits so **systemd restarts the agent into unprovisioned mode**.
4. **Cleans up cloud** using the user's auth session: lists the asset's certificates, `RevokeCertificate` on each active one (reason `device unprovisioned`), then `DeleteAsset`.

## Design notes

- **Restart instead of live teardown.** Once provisioned, the agent serves only over mTLS and `OnProvisioned` spins up the mTLS server, tunnel broker, Avahi update, BLE peripheral, and HTTPS registry. Rather than reverse all of that in place, the agent deletes state and exits; `Restart=always` brings it back up clean. Mirrors the existing agent-update/reboot exit pattern (response sent, then `os.Exit` after a short delay).
- **mDNS revert.** `UpdateAvahiForProvisioning` had no inverse, so an unenrolled device would keep advertising the mTLS port with `tls=true` and break re-discovery. Added `UpdateAvahiForUnprovisioning`.
- **Ordering: device first, then cloud.** The device always ends re-enrollable. If cloud cleanup fails, the only residue is a dangling asset (removable from the dashboard); the command warns and exits non-zero. The cloud-first failure mode (revoked cert + deleted asset but device still stuck provisioned) is strictly worse.
- **No cloud-repo changes needed** — `ListCertificates`, `RevokeCertificate`, and `DeleteAsset` already exist server-side.

## Tests

- Agent: `Unprovision` clears state + all on-disk files, reports not-provisioned, fires `OnUnprovisioned`, and errors when not provisioned / when run twice.
- configpartition: Avahi service-block rewrite for both provisioned (`tls=true`, mTLS port) and unprovisioned (`tls=false`, plaintext port), leaving unrelated service blocks untouched.
- `go build ./...`, `go vet`, and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)