### PR TITLE
feat(cli): add hidden "watch" alias for "camera view"

### DIFF
--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -23,6 +23,9 @@ func newCameraCmd() *cobra.Command {
 	cmd.AddCommand(
 		newCameraListCmd(),
 		newCameraViewCmd(),
+		// "watch" is a hidden alias for "view": it just works for muscle memory
+		// but stays out of help to keep the listed commands focused.
+		newCameraWatchCmd(),
 	)
 	return cmd
 }
@@ -93,12 +96,26 @@ func transportLabel(t agentpb.VideoTransport) string {
 }
 
 func newCameraViewCmd() *cobra.Command {
+	return newCameraStreamCmd("view", false)
+}
+
+// newCameraWatchCmd is a hidden alias for "view". It just works for muscle
+// memory but is kept out of help so the listed subcommands stay focused.
+func newCameraWatchCmd() *cobra.Command {
+	return newCameraStreamCmd("watch", true)
+}
+
+// newCameraStreamCmd builds the camera streaming command under the given name.
+// "view" is the canonical, listed command; "watch" reuses the same logic as a
+// hidden alias.
+func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 	var deviceID, width, height, fps uint32
 	var toStdout bool
 
 	cmd := &cobra.Command{
-		Use:   "view",
-		Short: "Stream H.264 video from a device camera",
+		Use:    use,
+		Hidden: hidden,
+		Short:  "Stream H.264 video from a device camera",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			conn, err := connectToAgent(ctx)

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -384,6 +384,45 @@ func TestBluetoothBtAliasMirrorsVisibleCommand(t *testing.T) {
 	}
 }
 
+func TestCameraWatchIsHiddenAliasForView(t *testing.T) {
+	cameraCmd := newCameraCmd()
+
+	watchCmd, _, err := cameraCmd.Find([]string{"watch"})
+	if err != nil {
+		t.Fatalf("Find(watch): %v", err)
+	}
+	if watchCmd.Name() != "watch" || !watchCmd.Hidden {
+		t.Fatalf("watch should be a hidden command; cmd=%v hidden=%v", watchCmd.Name(), watchCmd.Hidden)
+	}
+
+	viewCmd, _, err := cameraCmd.Find([]string{"view"})
+	if err != nil {
+		t.Fatalf("Find(view): %v", err)
+	}
+	if viewCmd.Hidden {
+		t.Fatal("view should remain a visible command")
+	}
+
+	// watch must accept the same flags as view so it behaves identically.
+	for _, flag := range []string{"id", "width", "height", "fps", "stdout"} {
+		if watchCmd.Flags().Lookup(flag) == nil {
+			t.Fatalf("watch is missing the %q flag that view exposes", flag)
+		}
+	}
+
+	// watch must stay out of the parent's help output.
+	buf := new(bytes.Buffer)
+	cameraCmd.SetOut(buf)
+	cameraCmd.SetErr(new(bytes.Buffer))
+	cameraCmd.SetArgs([]string{"--help"})
+	if err := cameraCmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	if strings.Contains(buf.String(), "watch") {
+		t.Fatalf("camera help should not list the hidden watch alias: %s", buf.String())
+	}
+}
+
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {


### PR DESCRIPTION
## Summary

`wendy device camera watch` now works as a hidden, muscle-memory alias for `wendy device camera view`. It shares the exact same streaming logic and flags (`--id`, `--width`, `--height`, `--fps`, `--stdout`) by building both commands through a single `newCameraStreamCmd(use, hidden)` helper.

The alias is registered with `Hidden: true`, so it just works on the command line but stays out of `wendy device camera --help` — the listed subcommands remain focused on `list` and `view`.

## Changes

- `camera.go`: extract `newCameraStreamCmd(use, hidden)` shared by `view` (visible) and the new `watch` (hidden) command.
- `commands_test.go`: `TestCameraWatchIsHiddenAliasForView` verifies `watch` resolves, is hidden, carries the same flags as `view`, leaves `view` visible, and does not appear in the parent help output.

## Testing

- `gofmt -l` — clean
- `go test ./internal/cli/commands/` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)