### PR TITLE
fix(cli): serialize concurrent builds so they don't kill each other (#1017)

### DIFF
--- a/go/internal/cli/commands/buildlock.go
+++ b/go/internal/cli/commands/buildlock.go
@@ -1,0 +1,132 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// buildLock serializes `wendy build`/`wendy run` builds across separate CLI
+// processes. The Docker build path shares a single buildx builder container
+// (see ensureBuildxBuilder); a second process that reconfigures or restarts
+// that builder kills the first process's in-flight build (issue #1017).
+//
+// The lock guarantees only one wendy process drives the shared builder at a
+// time. Within a single process, concurrent service builds (the multibuild
+// parallel path) share the lock via reference counting, so intra-build
+// parallelism is preserved — the OS-level lock is held from the first build
+// until the last concurrent build in the process finishes.
+var buildLock = &processBuildLock{}
+
+type processBuildLock struct {
+	mu   sync.Mutex
+	refs int
+	f    *os.File
+}
+
+// buildLockPath returns the path to the advisory lock file, creating its parent
+// directory. The file lives alongside the buildx builder config in ~/.cache/wendy.
+func buildLockPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".cache", "wendy")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("creating config directory: %w", err)
+	}
+	return filepath.Join(dir, "build.lock"), nil
+}
+
+// acquire blocks until this process holds the cross-process build lock and
+// returns a release function that must be called exactly once (typically via
+// defer). Concurrent callers in the same process share one OS-level lock via
+// reference counting; the lock is released to other processes only when the
+// last in-process holder releases. If another process holds the lock, a
+// "waiting for build lock" message is written to w and acquire blocks until the
+// lock is free or ctx is cancelled.
+func (l *processBuildLock) acquire(ctx context.Context, w io.Writer) (func(), error) {
+	l.mu.Lock()
+	if l.refs > 0 {
+		l.refs++
+		l.mu.Unlock()
+		return sync.OnceFunc(l.release), nil
+	}
+
+	path, err := buildLockPath()
+	if err != nil {
+		l.mu.Unlock()
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		l.mu.Unlock()
+		return nil, fmt.Errorf("opening build lock %q: %w", path, err)
+	}
+
+	// Try once without blocking so we can tell the user we're waiting before we
+	// stall on another process's build.
+	locked, err := tryLockFile(f)
+	if err != nil {
+		f.Close()
+		l.mu.Unlock()
+		return nil, fmt.Errorf("acquiring build lock: %w", err)
+	}
+	if !locked {
+		fmt.Fprintln(w, "waiting for build lock (another build in progress)...")
+		if err := blockLockFile(ctx, f); err != nil {
+			f.Close()
+			l.mu.Unlock()
+			return nil, fmt.Errorf("acquiring build lock: %w", err)
+		}
+	}
+
+	l.f = f
+	l.refs = 1
+	l.mu.Unlock()
+	return sync.OnceFunc(l.release), nil
+}
+
+// release drops one reference and frees the OS-level lock when the last
+// in-process holder releases.
+func (l *processBuildLock) release() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.refs == 0 {
+		return
+	}
+	l.refs--
+	if l.refs > 0 {
+		return
+	}
+	if l.f != nil {
+		_ = unlockFile(l.f)
+		_ = l.f.Close()
+		l.f = nil
+	}
+}
+
+// blockLockFile polls for the OS lock until it is acquired or ctx is cancelled.
+// Polling (rather than a blocking flock syscall) keeps the wait cancellable so
+// Ctrl+C during "waiting for build lock" returns promptly.
+func blockLockFile(ctx context.Context, f *os.File) error {
+	const pollInterval = 200 * time.Millisecond
+	for {
+		locked, err := tryLockFile(f)
+		if err != nil {
+			return err
+		}
+		if locked {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}

--- a/go/internal/cli/commands/buildlock_test.go
+++ b/go/internal/cli/commands/buildlock_test.go
@@ -1,0 +1,113 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// isolateBuildLockDir points the build lock at a temp directory so tests never
+// touch the real ~/.cache/wendy/build.lock. HOME covers darwin/linux and
+// USERPROFILE covers windows (os.UserHomeDir consults both).
+func isolateBuildLockDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+}
+
+// TestBuildLockRefCountSharing verifies that concurrent acquisitions within the
+// same process share a single OS-level lock and only free it once the last
+// holder releases — this is what preserves intra-build parallelism.
+func TestBuildLockRefCountSharing(t *testing.T) {
+	isolateBuildLockDir(t)
+	l := &processBuildLock{}
+
+	release1, err := l.acquire(context.Background(), io.Discard)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	release2, err := l.acquire(context.Background(), io.Discard)
+	if err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	if l.refs != 2 {
+		t.Fatalf("refs = %d, want 2", l.refs)
+	}
+
+	release1()
+	if l.refs != 1 {
+		t.Fatalf("after one release refs = %d, want 1", l.refs)
+	}
+	if l.f == nil {
+		t.Fatal("OS lock released while a holder still active")
+	}
+
+	// Releasing the same handle again must be a no-op (sync.OnceFunc) and must
+	// not over-decrement the refcount.
+	release1()
+	if l.refs != 1 {
+		t.Fatalf("double release of same handle changed refs to %d, want 1", l.refs)
+	}
+
+	release2()
+	if l.refs != 0 {
+		t.Fatalf("after final release refs = %d, want 0", l.refs)
+	}
+	if l.f != nil {
+		t.Fatal("OS lock not released after final holder released")
+	}
+}
+
+// TestBuildLockSerializesAcrossInstances verifies that a second independent
+// lock holder (modeling a second wendy process — flock treats each open file
+// description independently) blocks until the first releases, and surfaces the
+// "waiting for build lock" message.
+func TestBuildLockSerializesAcrossInstances(t *testing.T) {
+	isolateBuildLockDir(t)
+
+	first := &processBuildLock{}
+	releaseFirst, err := first.acquire(context.Background(), io.Discard)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// While the first lock is held, a second holder cannot acquire it.
+	second := &processBuildLock{}
+	var msg bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	if _, err := second.acquire(ctx, &msg); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second acquire while held: err = %v, want context.DeadlineExceeded", err)
+	}
+	if !strings.Contains(msg.String(), "waiting for build lock") {
+		t.Fatalf("expected waiting message, got %q", msg.String())
+	}
+
+	// Once the first releases, the second can acquire.
+	releaseFirst()
+	releaseSecond, err := second.acquire(context.Background(), io.Discard)
+	if err != nil {
+		t.Fatalf("second acquire after release: %v", err)
+	}
+	releaseSecond()
+}
+
+// TestBuildLockReacquireAfterRelease verifies the lock can be taken again by a
+// fresh holder once fully released (no leaked OS lock / fd).
+func TestBuildLockReacquireAfterRelease(t *testing.T) {
+	isolateBuildLockDir(t)
+
+	for i := 0; i < 3; i++ {
+		l := &processBuildLock{}
+		release, err := l.acquire(context.Background(), io.Discard)
+		if err != nil {
+			t.Fatalf("acquire iteration %d: %v", i, err)
+		}
+		release()
+	}
+}

--- a/go/internal/cli/commands/buildlock_unix.go
+++ b/go/internal/cli/commands/buildlock_unix.go
@@ -1,0 +1,29 @@
+//go:build darwin || linux
+
+package commands
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// tryLockFile attempts a non-blocking exclusive (advisory) lock on f. It
+// returns (true, nil) when the lock was acquired, (false, nil) when another
+// process holds it, and a non-nil error for any other failure.
+func tryLockFile(f *os.File) (bool, error) {
+	err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, unix.EWOULDBLOCK) {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlockFile releases the advisory lock held on f.
+func unlockFile(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}

--- a/go/internal/cli/commands/buildlock_windows.go
+++ b/go/internal/cli/commands/buildlock_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package commands
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// tryLockFile attempts a non-blocking exclusive lock on f via LockFileEx. It
+// returns (true, nil) when the lock was acquired, (false, nil) when another
+// process holds it, and a non-nil error for any other failure.
+func tryLockFile(f *os.File) (bool, error) {
+	ol := new(windows.Overlapped)
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, ol,
+	)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlockFile releases the lock held on f.
+func unlockFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1066,6 +1066,15 @@ func updateBuilderConfig(ctx context.Context, builderName, config string, w io.W
 }
 
 func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {
+	// Serialize against other wendy processes: the buildx builder is shared, and
+	// reconfiguring or restarting it mid-build kills a concurrent build (#1017).
+	// Concurrent builds within this process share the lock via reference counting.
+	releaseLock, err := buildLock.acquire(ctx, logOutput)
+	if err != nil {
+		return err
+	}
+	defer releaseLock()
+
 	builder, effectiveAddr, err := ensureBuildxBuilder(ctx, registryAddr, useMTLS, logOutput)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Closes #1017. Running two `wendy build` / `wendy run` invocations at the same time was not isolated — starting a second build **killed the first** with `ERROR: ... use of closed network connection`.

**Root cause:** every `wendy` process starts its own ephemeral registry proxy, so each computes a different `host.docker.internal:<port>` registry address. The Docker build path shares a single buildx builder container (`buildx_buildkit_wendy[-mtls]0`), whose last-applied config is cached in `~/.cache/wendy/<builder>.applied`. When the second process sees a changed config, it `docker restart`s / recreates the shared builder out from under the first process's in-flight build. The existing `ensureBuildxBuilderMu` is an in-process `sync.Mutex` — it only serializes builder setup *within* one process, never across processes.

## Fix

Add a cross-process advisory build lock acquired at `buildAndPushImage` — the single chokepoint that drives the shared builder (`buildSwiftContainerImage` uses the Swift container plugin, not buildx, so it isn't affected).

- `flock(LOCK_EX)` on `~/.cache/wendy/build.lock` (Unix) / `LockFileEx` (Windows).
- A second process prints `waiting for build lock (another build in progress)...` and proceeds once the first finishes — matching the behaviour described in the issue.
- The lock is **reference-counted within a process**, so the multibuild parallel path (concurrent service builds) still shares a single lock and keeps its parallelism. The OS lock is held from the first concurrent build until the last one finishes.
- The wait is poll-based (200 ms) rather than a blocking syscall, so `Ctrl+C` during the wait cancels promptly.

This implements the issue's accepted fallback ("serialize cleanly with a clear *waiting for build lock* message rather than killing an in-flight build"). True parallel isolation (per-config builders) was considered but is a larger change with shared-cache-dir contention risk; serialization is the low-risk fix.

## Files

- `buildlock.go` — refcounted process lock + cancellable poll-based wait
- `buildlock_unix.go` / `buildlock_windows.go` — platform `flock` / `LockFileEx` helpers
- `buildlock_test.go` — refcount sharing, cross-instance serialization, re-acquire
- `docker.go` — acquire/release around `buildAndPushImage`

## Testing

- `go test ./go/internal/cli/commands/` (full package) ✅
- `go test -race -run TestBuildLock ./go/internal/cli/commands/` ✅ (refcount sharing, serialization + waiting message, re-acquire)
- `go build` + `go vet` on host; cross-compiled `GOOS=linux/arm64` and `GOOS=windows/amd64` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)