### PR TITLE
[codex] Add Apple Container local provider

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -18,7 +18,7 @@ If multiple manifests are present you can override detection with `--build-type`
 
 | Manifest | Required host | Notes |
 |---|---|---|
-| `Dockerfile` | Docker Desktop, Apple `container` on Apple silicon macOS, or WendyOS | Local Docker builds use `docker buildx`; `--device apple-container` uses `container build` |
+| `Dockerfile` | Docker Desktop, Apple `container` on Apple silicon macOS, or WendyOS | Local Docker builds use `docker buildx`; `--device apple-container` uses `container build`; WendyOS device builds can select `--builder docker` or `--builder apple-container` |
 | `Package.swift` | macOS or Linux | Requires a host Swift toolchain |
 | `*.xcodeproj` | macOS only | Built with `xcodebuild`; `Brewfile` managed automatically |
 
@@ -29,9 +29,17 @@ If multiple manifests are present you can override detection with `--build-type`
 `wendy build` invokes `docker buildx build` targeting the device's CPU architecture. It passes the following build-args so the Dockerfile can adapt to the target hardware — declare them with `ARG` to use them:
 
 On Apple silicon Macs with [Apple `container`](https://github.com/apple/container)
-installed and started, select `--device apple-container` to build a local
-Dockerfile project with `container build` instead of Docker. Compose projects
-and WendyOS device deployments still use Docker build paths.
+installed and started, select `--builder apple-container` when the target is a
+WendyOS device:
+
+```sh
+container system start
+wendy --device my-wendy.local build --builder apple-container
+```
+
+For local-only Dockerfile builds on the Mac itself, select the local provider
+with `--device apple-container` instead. Compose projects still require Docker
+for local provider runs.
 
 | Build-arg | Values | Notes |
 |---|---|---|

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -7,7 +7,7 @@ The build command is mainly used to verify your app can build/compile.
 `wendy build` scans the project directory for a build manifest in the following priority order:
 
 1. `docker-compose.yml` / `compose.yml` — multi-service Compose project
-2. `Dockerfile` (or `Dockerfile.<variant>` / `Dockerfile-<variant>`) — container image build
+2. `Dockerfile` / `Containerfile` (or dot/hyphen variants) — container image build
 3. `Package.swift` — Swift Package Manager project
 4. `*.xcodeproj` — Xcode project (macOS targets only)
 5. `requirements.txt` / `setup.py` / `pyproject.toml` — Python project (Dockerfile auto-generated)
@@ -18,28 +18,31 @@ If multiple manifests are present you can override detection with `--build-type`
 
 | Manifest | Required host | Notes |
 |---|---|---|
-| `Dockerfile` | Docker Desktop, Apple `container` on Apple silicon macOS, or WendyOS | Local Docker builds use `docker buildx`; `--device apple-container` uses `container build`; WendyOS device builds can select `--builder docker` or `--builder apple-container` |
+| `Dockerfile` / `Containerfile` | Docker Desktop, Apple `container` on Apple silicon macOS, or WendyOS | Local Docker builds use `docker buildx`; `--device apple-container` uses `container build`; WendyOS device builds can select `--builder docker` or `--builder apple-container` |
 | `Package.swift` | macOS or Linux | Requires a host Swift toolchain |
 | `*.xcodeproj` | macOS only | Built with `xcodebuild`; `Brewfile` managed automatically |
 
 ## Build paths
 
-### Dockerfile projects
+### Dockerfile and Containerfile projects
 
-`wendy build` invokes `docker buildx build` targeting the device's CPU architecture. It passes the following build-args so the Dockerfile can adapt to the target hardware — declare them with `ARG` to use them:
+`wendy build` invokes an image builder targeting the device's CPU architecture. It passes the following build-args so the Dockerfile or Containerfile can adapt to the target hardware — declare them with `ARG` to use them:
 
 On Apple silicon Macs with [Apple `container`](https://github.com/apple/container)
-installed and started, select `--builder apple-container` when the target is a
-WendyOS device:
+installed and started, Wendy tries Apple Container first for Dockerfile and
+Containerfile builds when `--builder` is omitted. If Apple Container is
+unavailable or the build fails, Wendy falls back to Docker. Use
+`--builder docker` to force Docker, or `--builder apple-container` to require
+Apple Container:
 
 ```sh
 container system start
-wendy --device my-wendy.local build --builder apple-container
+wendy --device my-wendy.local build
 ```
 
-For local-only Dockerfile builds on the Mac itself, select the local provider
-with `--device apple-container` instead. Compose projects still require Docker
-for local provider runs.
+For local-only Dockerfile or Containerfile builds on the Mac itself, select the
+local provider with `--device apple-container`. Compose projects still require
+Docker for local provider runs.
 
 | Build-arg | Values | Notes |
 |---|---|---|
@@ -69,4 +72,4 @@ Builds with `xcodebuild`. If a `Brewfile` is present in the project root, Wendy 
 
 ## Platform support for Swift projects
 
-`wendy build` for Swift packages requires a host Swift toolchain and is supported on **macOS and Linux hosts only**. On Windows, `wendy build` returns an error for Swift projects. The recommended alternative is to provide a `Dockerfile` and use `wendy run`, which routes through the Docker buildx path on all platforms.
+`wendy build` for Swift packages requires a host Swift toolchain and is supported on **macOS and Linux hosts only**. On Windows, `wendy build` returns an error for Swift projects. The recommended alternative is to provide a `Dockerfile` or `Containerfile` and use `wendy run`, which routes through the image build path on all platforms.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -18,7 +18,7 @@ If multiple manifests are present you can override detection with `--build-type`
 
 | Manifest | Required host | Notes |
 |---|---|---|
-| `Dockerfile` | Docker Desktop (macOS/Windows/Linux) or WendyOS | Built with `docker buildx` |
+| `Dockerfile` | Docker Desktop, Apple `container` on Apple silicon macOS, or WendyOS | Local Docker builds use `docker buildx`; `--device apple-container` uses `container build` |
 | `Package.swift` | macOS or Linux | Requires a host Swift toolchain |
 | `*.xcodeproj` | macOS only | Built with `xcodebuild`; `Brewfile` managed automatically |
 
@@ -27,6 +27,11 @@ If multiple manifests are present you can override detection with `--build-type`
 ### Dockerfile projects
 
 `wendy build` invokes `docker buildx build` targeting the device's CPU architecture. It passes the following build-args so the Dockerfile can adapt to the target hardware — declare them with `ARG` to use them:
+
+On Apple silicon Macs with [Apple `container`](https://github.com/apple/container)
+installed and started, select `--device apple-container` to build a local
+Dockerfile project with `container build` instead of Docker. Compose projects
+and WendyOS device deployments still use Docker build paths.
 
 | Build-arg | Values | Notes |
 |---|---|---|

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -29,10 +29,19 @@ The error explains the project/target mismatch and tells you to set `platform: "
 
 When building a Dockerfile project, `wendy run` passes the target device's hardware parameters as `--build-arg` values so the Dockerfile can branch on platform, GPU vendor, or CUDA version. Declare any arg you want to use with `ARG`:
 
-For local-only Dockerfile runs on Apple silicon Macs, `wendy run --device
-apple-container` uses Apple's `container build` and `container run` instead of
-Docker. Start the runtime first with `container system start`. Compose projects
-and WendyOS device deployments continue through the Docker build paths.
+On Apple silicon Macs with Apple's `container` runtime started, select
+`--builder apple-container` to build and push a Dockerfile image to the selected
+WendyOS device without Docker:
+
+```sh
+container system start
+wendy --device my-wendy.local run --builder apple-container
+```
+
+For local-only Dockerfile runs on the Mac itself, use `wendy run --device
+apple-container` instead. Compose projects still require the Docker provider for
+local runs, but compose service builds targeting a WendyOS device can use
+`--builder apple-container`.
 
 | Build-arg | Values | Notes |
 |---|---|---|

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -29,6 +29,11 @@ The error explains the project/target mismatch and tells you to set `platform: "
 
 When building a Dockerfile project, `wendy run` passes the target device's hardware parameters as `--build-arg` values so the Dockerfile can branch on platform, GPU vendor, or CUDA version. Declare any arg you want to use with `ARG`:
 
+For local-only Dockerfile runs on Apple silicon Macs, `wendy run --device
+apple-container` uses Apple's `container build` and `container run` instead of
+Docker. Start the runtime first with `container system start`. Compose projects
+and WendyOS device deployments continue through the Docker build paths.
+
 | Build-arg | Values | Notes |
 |---|---|---|
 | `WENDY_PLATFORM` | `nvidia-jetson` \| `generic` | Platform tier derived from the device type |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -17,7 +17,7 @@ Wendy Agent for Mac (Darwin targets) currently runs native macOS apps only. When
 |---|---|
 | Native SwiftPM (`Package.swift`, `platform: "darwin"`) | Supported |
 | Native Xcode (`.xcodeproj`, `platform: "darwin"`) | Supported |
-| Dockerfile / container image | Rejected |
+| Dockerfile / Containerfile / container image | Rejected |
 | Python container path | Rejected |
 | Docker Compose | Rejected |
 | Multi-service `wendy.json` (`services` map) | Rejected |
@@ -25,20 +25,22 @@ Wendy Agent for Mac (Darwin targets) currently runs native macOS apps only. When
 
 The error explains the project/target mismatch and tells you to set `platform: "darwin"` with a Mac-compatible native SwiftPM or Xcode project, or to target a Linux/WendyOS device. Linux container support on Mac is planned for a future release.
 
-## Docker build-args
+## Image build-args
 
-When building a Dockerfile project, `wendy run` passes the target device's hardware parameters as `--build-arg` values so the Dockerfile can branch on platform, GPU vendor, or CUDA version. Declare any arg you want to use with `ARG`:
+When building a Dockerfile or Containerfile project, `wendy run` passes the target device's hardware parameters as `--build-arg` values so the build file can branch on platform, GPU vendor, or CUDA version. Declare any arg you want to use with `ARG`:
 
-On Apple silicon Macs with Apple's `container` runtime started, select
-`--builder apple-container` to build and push a Dockerfile image to the selected
-WendyOS device without Docker:
+On Apple silicon Macs with Apple's `container` runtime started, Wendy tries
+Apple Container first when `--builder` is omitted. If Apple Container is
+unavailable or the build fails, Wendy falls back to Docker. Use
+`--builder docker` to force Docker, or `--builder apple-container` to require
+Apple Container:
 
 ```sh
 container system start
-wendy --device my-wendy.local run --builder apple-container
+wendy --device my-wendy.local run
 ```
 
-For local-only Dockerfile runs on the Mac itself, use `wendy run --device
+For local-only Dockerfile or Containerfile runs on the Mac itself, use `wendy run --device
 apple-container` instead. Compose projects still require the Docker provider for
 local runs, but compose service builds targeting a WendyOS device can use
 `--builder apple-container`.
@@ -53,7 +55,7 @@ local runs, but compose service builds targeting a WendyOS device can use
 | `WENDY_JETPACK_VERSION` | e.g. `6.0` | Jetson only |
 | `WENDY_CUDA_VERSION` | e.g. `12.6` | Jetson only |
 
-`WENDY_PLATFORM` and `WENDY_DEBUG` are always set. The remaining args are only injected when the agent reports them, so Dockerfiles can define their own `ARG` defaults for devices that predate the field.
+`WENDY_PLATFORM` and `WENDY_DEBUG` are always set. The remaining args are only injected when the agent reports them, so Dockerfiles and Containerfiles can define their own `ARG` defaults for devices that predate the field.
 
 ## Multi-service projects (`wendy.json` with `services`)
 
@@ -95,14 +97,14 @@ When running a Swift Package Manager project on a macOS target, `wendy run`:
 
 ## Swift Package Manager projects — host requirements
 
-Both the macOS-target and Linux-target Swift paths shell out to a host Swift toolchain. The following host OS requirements apply when no `Dockerfile` is present (or when `--build-type=swift` is set explicitly):
+Both the macOS-target and Linux-target Swift paths shell out to a host Swift toolchain. The following host OS requirements apply when no `Dockerfile` or `Containerfile` is present (or when `--build-type=swift` is set explicitly):
 
 | Target platform | Supported host OS | Notes |
 |-----------------|------------------|-------|
 | macOS device | macOS only | Linux's Swift toolchain cannot cross-compile to macOS. |
 | Linux device | macOS or Linux | swift-container-plugin does not yet ship for Windows. |
 
-On a **Windows host**, `wendy run` returns an actionable error for Swift projects that would require the host toolchain. Providing a `Dockerfile` bypasses these restrictions — the build is routed through Docker buildx, which works on all platforms.
+On a **Windows host**, `wendy run` returns an actionable error for Swift projects that would require the host toolchain. Providing a `Dockerfile` or `Containerfile` bypasses these restrictions — the build is routed through the image build path, which works on all platforms.
 
 ## Flags
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
@@ -96,6 +96,13 @@ Use this target when you want to build and run a single Dockerfile project with
 Apple's lightweight Linux container runtime. Compose projects still require the
 Docker target.
 
+To deploy to a WendyOS device while using Apple Container only as the image
+builder, keep `--device` pointed at the WendyOS device and set `--builder`:
+
+```sh
+wendy --device my-wendy.local run --builder apple-container
+```
+
 ### Local
 
 Use the local target for host-native apps. The app runs directly on the computer

--- a/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
@@ -82,6 +82,20 @@ You can select it directly with:
 wendy run --device docker
 ```
 
+### Apple Container
+
+On Apple silicon Macs, Wendy can use Apple's `container` CLI for local
+Dockerfile runs without Docker Desktop:
+
+```sh
+container system start
+wendy run --device apple-container
+```
+
+Use this target when you want to build and run a single Dockerfile project with
+Apple's lightweight Linux container runtime. Compose projects still require the
+Docker target.
+
 ### Local
 
 Use the local target for host-native apps. The app runs directly on the computer

--- a/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/device-selection.md
@@ -67,7 +67,7 @@ These are not WendyOS devices.
 
 ### Docker
 
-Use Docker for local container runs. Dockerfile and Compose projects run
+Use Docker for local container runs. Dockerfile, Containerfile, and Compose projects run
 through the local Docker daemon. On macOS and Windows, Docker runs Linux
 containers inside Docker's Linux environment rather than as native macOS or
 Windows processes.
@@ -85,19 +85,22 @@ wendy run --device docker
 ### Apple Container
 
 On Apple silicon Macs, Wendy can use Apple's `container` CLI for local
-Dockerfile runs without Docker Desktop:
+Dockerfile and Containerfile runs without Docker Desktop:
 
 ```sh
 container system start
 wendy run --device apple-container
 ```
 
-Use this target when you want to build and run a single Dockerfile project with
-Apple's lightweight Linux container runtime. Compose projects still require the
-Docker target.
+Use this target when you want to build and run a single Dockerfile or
+Containerfile project with Apple's lightweight Linux container runtime. Compose
+projects still require the Docker target.
 
 To deploy to a WendyOS device while using Apple Container only as the image
-builder, keep `--device` pointed at the WendyOS device and set `--builder`:
+builder, keep `--device` pointed at the WendyOS device. On Apple silicon Macs,
+Apple Container is tried first by default when it is installed and running, then
+Docker is used as a fallback. Set `--builder apple-container` to require Apple
+Container, or `--builder docker` to force Docker:
 
 ```sh
 wendy --device my-wendy.local run --builder apple-container

--- a/go/internal/cli/assets/docs/package-lock.json
+++ b/go/internal/cli/assets/docs/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -151,9 +151,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -183,9 +183,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -199,9 +199,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -263,9 +263,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -295,9 +295,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -375,9 +375,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -407,9 +407,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -423,9 +423,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -439,9 +439,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -455,9 +455,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -2183,7 +2183,6 @@
       "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20"
       },
@@ -2209,7 +2208,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2226,7 +2224,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2243,7 +2240,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2260,7 +2256,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2277,7 +2272,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2294,7 +2288,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2311,7 +2304,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2328,7 +2320,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2345,7 +2336,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2370,7 +2360,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2392,7 +2381,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,7 +2397,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2471,7 +2458,6 @@
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -2480,8 +2466,7 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2505,7 +2490,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2516,7 +2500,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2545,7 +2528,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3291,9 +3273,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3303,32 +3285,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3549,7 +3531,6 @@
       "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-16.9.0.tgz",
       "integrity": "sha512-L5bXpKsN0m7kK483KqviQ7g0l6PA7M32K5yCXS0KUrVWJDUu038ASb08G59RFwWjxhahCAHf0H0ntwzF91lqnQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@orama/orama": "^3.1.18",
         "estree-util-value-to-estree": "^3.5.0",
@@ -4164,9 +4145,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4458,7 +4449,6 @@
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
       "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -5652,7 +5642,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
       "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
@@ -5944,7 +5933,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5954,7 +5942,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6655,8 +6642,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -28,6 +28,7 @@ type BuildResult struct {
 type buildOptions struct {
 	buildType  string
 	dockerfile string
+	builder    string
 }
 
 func newBuildCmd() *cobra.Command {
@@ -40,6 +41,9 @@ func newBuildCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.dockerfile != "" && opts.buildType != "" && normalizeBuildType(opts.buildType) != "docker" {
 				return fmt.Errorf("--dockerfile cannot be used with --build-type=%s", opts.buildType)
+			}
+			if _, err := normalizeImageBuilder(opts.builder); err != nil {
+				return err
 			}
 			// --dockerfile implies a Docker build; prevent the provider from
 			// auto-selecting a Compose file when both markers are present.
@@ -76,6 +80,9 @@ func newBuildCmd() *cobra.Command {
 
 			// If the target is an external provider device, use the provider build path.
 			if target != nil && target.External != nil && target.Provider != nil {
+				if opts.builder != "" {
+					return fmt.Errorf("--builder is only used when --device selects a WendyOS device; use --device docker or --device apple-container for local provider builds")
+				}
 				product := filepath.Base(cwd)
 				if cfgErr == nil {
 					product = appCfg.AppID
@@ -196,12 +203,13 @@ func newBuildCmd() *cobra.Command {
 				appID = appCfg.AppID
 			}
 
-			return buildProject(cmd.Context(), cwd, selected, appID, platform)
+			return buildProject(cmd.Context(), cwd, selected, appID, platform, opts.builder)
 		},
 	}
 
 	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type to use when multiple project markers are present: docker, swift, or python")
 	cmd.Flags().StringVar(&opts.dockerfile, "dockerfile", "", "Dockerfile to build from (e.g. Dockerfile.prod); shows a selection menu when multiple Dockerfiles exist")
+	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to use for Dockerfile builds: docker or apple-container")
 
 	return cmd
 }
@@ -457,23 +465,36 @@ func detectProjectTypeWithLanguage(dir, language string) string {
 	return t
 }
 
-func buildProject(ctx context.Context, dir string, option *BuildOption, appID, platform string) error {
+func buildProject(ctx context.Context, dir string, option *BuildOption, appID, platform, builder string) error {
 	imageName := strings.ToLower(appID) + ":latest"
+	normalizedBuilder, err := normalizeImageBuilder(builder)
+	if err != nil {
+		return err
+	}
 
 	switch option.Type {
 	case "compose":
+		if normalizedBuilder == imageBuilderAppleContainer {
+			return fmt.Errorf("Apple Container builder does not support Compose builds; use --builder docker")
+		}
 		return buildComposeProject(dir)
 	case "docker":
-		return buildDockerProject(dir, imageName, platform, option.File)
+		return buildDockerProjectWithBuilder(ctx, builder, dir, imageName, platform, option.File)
 	case "python":
-		return buildPythonProject(dir, imageName, platform)
+		return buildPythonProject(ctx, builder, dir, imageName, platform)
 	case "swift":
+		if normalizedBuilder == imageBuilderAppleContainer {
+			return fmt.Errorf("Apple Container builder is only supported for Dockerfile builds; provide a Dockerfile or omit --builder")
+		}
 		// Cross-compiling Swift requires a host toolchain; only darwin and linux ship one.
 		if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
 			return fmt.Errorf("`wendy build` for Swift packages is not supported on %s; provide a Dockerfile", runtime.GOOS)
 		}
 		return buildSwiftContainerProject(ctx, dir, appID, platform)
 	case "xcode":
+		if normalizedBuilder == imageBuilderAppleContainer {
+			return fmt.Errorf("Apple Container builder is only supported for Dockerfile builds; provide a Dockerfile or omit --builder")
+		}
 		return buildXcodeProject(ctx, dir, option.File)
 	default:
 		return fmt.Errorf("unknown project type; add a Dockerfile, a Compose file (docker-compose.yml, docker-compose.yaml, compose.yml, or compose.yaml), Package.swift, or requirements.txt")
@@ -539,7 +560,27 @@ func buildDockerProject(dir, imageName, platform, dockerfile string) error {
 	return nil
 }
 
-func buildPythonProject(dir, imageName, platform string) error {
+func buildDockerProjectWithBuilder(ctx context.Context, builder, dir, imageName, platform, dockerfile string) error {
+	normalized, err := normalizeImageBuilder(builder)
+	if err != nil {
+		return err
+	}
+	if normalized == imageBuilderDocker {
+		return buildDockerProject(dir, imageName, platform, dockerfile)
+	}
+
+	cliLogln("Building Apple Container image %s for %s...", imageName, platform)
+	if err := checkAppleContainerBuilder(ctx); err != nil {
+		return err
+	}
+	if err := buildImageWithAppleContainer(ctx, dir, imageName, platform, dockerfile, nil, os.Stdout, os.Stderr); err != nil {
+		return err
+	}
+	cliSuccess("Build completed successfully.")
+	return nil
+}
+
+func buildPythonProject(ctx context.Context, builder, dir, imageName, platform string) error {
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
 	generatedDockerfile := false
 	if _, err := os.Stat(dockerfilePath); os.IsNotExist(err) {
@@ -551,7 +592,7 @@ func buildPythonProject(dir, imageName, platform string) error {
 		cliSuccess("Generated Dockerfile.")
 	}
 
-	err := buildDockerProject(dir, imageName, platform, "Dockerfile")
+	err := buildDockerProjectWithBuilder(ctx, builder, dir, imageName, platform, "Dockerfile")
 
 	if generatedDockerfile {
 		os.Remove(dockerfilePath)

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -325,7 +325,6 @@ func pickBuildOptionWithTitle(options []BuildOption, title string) (*BuildOption
 func preferredBuildOption(options []BuildOption, interactive bool) *BuildOption {
 	hasLanguageMarker := false
 	dockerCount := 0
-	buildFile := (*BuildOption)(nil)
 	for i := range options {
 		switch {
 		case options[i].Type == "swift" || options[i].Type == "python":
@@ -334,7 +333,7 @@ func preferredBuildOption(options []BuildOption, interactive bool) *BuildOption 
 			dockerCount++
 		}
 	}
-	buildFile = preferredContainerBuildFileOption(options)
+	buildFile := preferredContainerBuildFileOption(options)
 	if !hasLanguageMarker || buildFile == nil {
 		return nil
 	}

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -420,7 +420,11 @@ func ensureProviderSupportsProjectType(provider providers.DeviceProvider, projec
 	providerName := provider.DisplayName()
 
 	if provider.Key() == providers.ProviderKeyLocal && (projectType == "docker" || projectType == "compose") {
-		return fmt.Errorf("%s runs host-native apps and does not support %s projects; choose Docker with --device docker for local container runs", providerName, projectType)
+		containerTargets := "Docker with --device docker"
+		if runtime.GOOS == "darwin" {
+			containerTargets += " or Apple Container with --device apple-container"
+		}
+		return fmt.Errorf("%s runs host-native apps and does not support %s projects; choose %s for local container runs", providerName, projectType, containerTargets)
 	}
 
 	return fmt.Errorf("%s provider does not support %s projects; supported build types: %s", providerName, projectType, strings.Join(provider.SupportedBuildTypes(), ", "))

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -103,12 +103,12 @@ func newBuildCmd() *cobra.Command {
 					return err
 				}
 
-				// Swift projects without a Dockerfile: cross-compile on the host and
+				// Swift projects without a container build file: cross-compile on the host and
 				// build a Docker image, bypassing the provider's normal Build method.
 				if projectType == "swift" {
 					if _, ok := target.Provider.(providers.ImageBuilder); ok {
 						if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-							return fmt.Errorf("`wendy build` for Swift packages is not supported on %s; provide a Dockerfile", runtime.GOOS)
+							return fmt.Errorf("`wendy build` for Swift packages is not supported on %s; provide a Dockerfile or Containerfile", runtime.GOOS)
 						}
 						if err := swifttoolchain.EnsureSwiftVersion(cmd.Context(), &dimWriter{}, os.Stderr); err != nil {
 							return err
@@ -124,9 +124,9 @@ func newBuildCmd() *cobra.Command {
 					}
 				}
 
-				// For docker-type projects, resolve which Dockerfile to use before
+				// For docker-type projects, resolve which build file to use before
 				// calling the provider — shows an interactive picker when multiple
-				// Dockerfiles exist and no --dockerfile flag was given.
+				// build files exist and no --dockerfile flag was given.
 				if projectType == "docker" && opts.dockerfile == "" {
 					resolved, resolveErr := resolveDockerfile(cwd, "", isInteractiveTerminal())
 					if resolveErr != nil {
@@ -208,8 +208,8 @@ func newBuildCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type to use when multiple project markers are present: docker, swift, or python")
-	cmd.Flags().StringVar(&opts.dockerfile, "dockerfile", "", "Dockerfile to build from (e.g. Dockerfile.prod); shows a selection menu when multiple Dockerfiles exist")
-	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to use for Dockerfile builds: docker or apple-container")
+	cmd.Flags().StringVar(&opts.dockerfile, "dockerfile", "", "Dockerfile or Containerfile to build from (e.g. Dockerfile.prod or Containerfile); shows a selection menu when multiple build files exist")
+	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to force for Dockerfile/Containerfile builds: docker or apple-container")
 
 	return cmd
 }
@@ -238,10 +238,11 @@ func resolveDetectedBuildOption(options []BuildOption, requestedType, requestedD
 		return preferred, nil
 	}
 
-	// Non-interactive (CI) fallback: when all detected options are Dockerfiles,
-	// prefer the base "Dockerfile" and fall back to the first variant rather than
-	// failing with "multiple build types detected". This mirrors the run-command
-	// behaviour and lets CI pipelines that omit --dockerfile build predictably.
+	// Non-interactive (CI) fallback: when all detected options are container build
+	// files, prefer the base "Dockerfile" or "Containerfile" and fall back to the
+	// first variant rather than failing with "multiple build types detected".
+	// This mirrors the run-command behaviour and lets CI pipelines that omit
+	// --dockerfile build predictably.
 	if !interactive {
 		allDocker := len(options) > 0
 		for _, opt := range options {
@@ -251,13 +252,14 @@ func resolveDetectedBuildOption(options []BuildOption, requestedType, requestedD
 			}
 		}
 		if allDocker {
-			for i := range options {
-				if options[i].File == "Dockerfile" {
-					cliNotice("multiple Dockerfiles detected; using %q. Use --dockerfile to select explicitly.", options[i].File)
-					return &options[i], nil
-				}
+			if len(options) == 1 {
+				return &options[0], nil
 			}
-			cliNotice("multiple Dockerfiles detected; using %q. Use --dockerfile to select explicitly.", options[0].File)
+			if preferred := preferredContainerBuildFileOption(options); preferred != nil {
+				cliNotice("multiple container build files detected; using %q. Use --dockerfile to select explicitly.", preferred.File)
+				return preferred, nil
+			}
+			cliNotice("multiple container build files detected; using %q. Use --dockerfile to select explicitly.", options[0].File)
 			return &options[0], nil
 		}
 	}
@@ -323,23 +325,21 @@ func pickBuildOptionWithTitle(options []BuildOption, title string) (*BuildOption
 func preferredBuildOption(options []BuildOption, interactive bool) *BuildOption {
 	hasLanguageMarker := false
 	dockerCount := 0
-	dockerfile := (*BuildOption)(nil)
+	buildFile := (*BuildOption)(nil)
 	for i := range options {
 		switch {
 		case options[i].Type == "swift" || options[i].Type == "python":
 			hasLanguageMarker = true
 		case options[i].Type == "docker":
 			dockerCount++
-			if options[i].File == "Dockerfile" {
-				dockerfile = &options[i]
-			}
 		}
 	}
-	if !hasLanguageMarker || dockerfile == nil {
+	buildFile = preferredContainerBuildFileOption(options)
+	if !hasLanguageMarker || buildFile == nil {
 		return nil
 	}
 	if dockerCount == 1 || !interactive {
-		return dockerfile
+		return buildFile
 	}
 	return nil
 }
@@ -361,23 +361,18 @@ func buildOptionForType(options []BuildOption, requestedType string, interactive
 	}
 
 	if buildType == "docker" {
-		var dockerfile *BuildOption
-		for i := range matches {
-			if matches[i].File == "Dockerfile" {
-				dockerfile = &matches[i]
-				if !interactive {
-					return dockerfile, nil
-				}
-			}
+		buildFile := preferredContainerBuildFileOption(matches)
+		if buildFile != nil && !interactive {
+			return buildFile, nil
 		}
 		if len(matches) > 1 {
 			if interactive {
-				return pickBuildOptionWithTitle(matches, "Select a Dockerfile")
+				return pickBuildOptionWithTitle(matches, "Select a container build file")
 			}
-			return nil, fmt.Errorf("multiple Dockerfiles detected (%s); keep only one Dockerfile or omit --build-type to choose interactively", strings.Join(buildOptionLabels(matches), ", "))
+			return nil, fmt.Errorf("multiple container build files detected (%s); keep only one build file or omit --build-type to choose interactively", strings.Join(buildOptionLabels(matches), ", "))
 		}
-		if dockerfile != nil {
-			return dockerfile, nil
+		if buildFile != nil {
+			return buildFile, nil
 		}
 	}
 
@@ -484,20 +479,20 @@ func buildProject(ctx context.Context, dir string, option *BuildOption, appID, p
 		return buildPythonProject(ctx, builder, dir, imageName, platform)
 	case "swift":
 		if normalizedBuilder == imageBuilderAppleContainer {
-			return fmt.Errorf("Apple Container builder is only supported for Dockerfile builds; provide a Dockerfile or omit --builder")
+			return fmt.Errorf("Apple Container builder is only supported for Dockerfile/Containerfile builds; provide a build file or omit --builder")
 		}
 		// Cross-compiling Swift requires a host toolchain; only darwin and linux ship one.
 		if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-			return fmt.Errorf("`wendy build` for Swift packages is not supported on %s; provide a Dockerfile", runtime.GOOS)
+			return fmt.Errorf("`wendy build` for Swift packages is not supported on %s; provide a Dockerfile or Containerfile", runtime.GOOS)
 		}
 		return buildSwiftContainerProject(ctx, dir, appID, platform)
 	case "xcode":
 		if normalizedBuilder == imageBuilderAppleContainer {
-			return fmt.Errorf("Apple Container builder is only supported for Dockerfile builds; provide a Dockerfile or omit --builder")
+			return fmt.Errorf("Apple Container builder is only supported for Dockerfile/Containerfile builds; provide a build file or omit --builder")
 		}
 		return buildXcodeProject(ctx, dir, option.File)
 	default:
-		return fmt.Errorf("unknown project type; add a Dockerfile, a Compose file (docker-compose.yml, docker-compose.yaml, compose.yml, or compose.yaml), Package.swift, or requirements.txt")
+		return fmt.Errorf("unknown project type; add a Dockerfile/Containerfile, a Compose file (docker-compose.yml, docker-compose.yaml, compose.yml, or compose.yaml), Package.swift, or requirements.txt")
 	}
 }
 
@@ -565,8 +560,21 @@ func buildDockerProjectWithBuilder(ctx context.Context, builder, dir, imageName,
 	if err != nil {
 		return err
 	}
+	if !imageBuilderWasExplicit(builder) && shouldAutoAttemptAppleContainerBuilder() {
+		cliLogln("Building Apple Container image %s for %s...", imageName, platform)
+		if err := checkAppleContainerBuilder(ctx); err == nil {
+			if err := buildImageWithAppleContainer(ctx, dir, imageName, platform, dockerfile, nil, os.Stdout, os.Stderr); err == nil {
+				cliSuccess("Build completed successfully.")
+				return nil
+			} else {
+				logAppleContainerFallback(os.Stderr, err)
+			}
+		} else {
+			logAppleContainerFallback(os.Stderr, err)
+		}
+	}
 	if normalized == imageBuilderDocker {
-		return buildDockerProject(dir, imageName, platform, dockerfile)
+		return buildDockerProjectWithDocker(dir, imageName, platform, dockerfile)
 	}
 
 	cliLogln("Building Apple Container image %s for %s...", imageName, platform)

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -31,6 +31,10 @@ type buildOptions struct {
 	builder    string
 }
 
+var appleContainerLocalProviderHintSupported = func() bool {
+	return runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
+}
+
 func newBuildCmd() *cobra.Command {
 	var opts buildOptions
 
@@ -423,7 +427,7 @@ func ensureProviderSupportsProjectType(provider providers.DeviceProvider, projec
 
 	if provider.Key() == providers.ProviderKeyLocal && (projectType == "docker" || projectType == "compose") {
 		containerTargets := "Docker with --device docker"
-		if runtime.GOOS == "darwin" {
+		if projectType == "docker" && appleContainerLocalProviderHintSupported() {
 			containerTargets += " or Apple Container with --device apple-container"
 		}
 		return fmt.Errorf("%s runs host-native apps and does not support %s projects; choose %s for local container runs", providerName, projectType, containerTargets)

--- a/go/internal/cli/commands/build_windows_test.go
+++ b/go/internal/cli/commands/build_windows_test.go
@@ -12,7 +12,7 @@ import (
 // Swift project fails fast on Windows with an actionable message instead of
 // shelling out to a non-existent `swift` binary.
 func TestBuildProject_SwiftRejectedOnWindows(t *testing.T) {
-	err := buildProject(context.Background(), t.TempDir(), &BuildOption{Type: "swift"}, "test-app", "linux/arm64")
+	err := buildProject(context.Background(), t.TempDir(), &BuildOption{Type: "swift"}, "test-app", "linux/arm64", "")
 	if err == nil {
 		t.Fatal("buildProject(swift) on Windows: error = nil, want non-nil")
 	}

--- a/go/internal/cli/commands/cloud_run.go
+++ b/go/internal/cli/commands/cloud_run.go
@@ -28,7 +28,7 @@ func newCloudRunCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type: docker, swift, or python")
-	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to use for Dockerfile builds: docker or apple-container")
+	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to force for Dockerfile/Containerfile builds: docker or apple-container")
 	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Enable debug logging")
 	cmd.Flags().BoolVar(&opts.deploy, "deploy", false, "Create container but do not start it")
 	cmd.Flags().BoolVar(&opts.detach, "detach", false, "Start container but do not stream logs")

--- a/go/internal/cli/commands/cloud_run.go
+++ b/go/internal/cli/commands/cloud_run.go
@@ -28,6 +28,7 @@ func newCloudRunCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type: docker, swift, or python")
+	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to use for Dockerfile builds: docker or apple-container")
 	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Enable debug logging")
 	cmd.Flags().BoolVar(&opts.deploy, "deploy", false, "Create container but do not start it")
 	cmd.Flags().BoolVar(&opts.detach, "detach", false, "Start container but do not stream logs")

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -69,7 +69,7 @@ func TestNewRunCmd(t *testing.T) {
 	}
 
 	// Verify expected flags exist.
-	expectedFlags := []string{"build-type", "debug", "deploy", "detach", "restart-unless-stopped", "restart-on-failure", "no-restart", "prefix", "user-args"}
+	expectedFlags := []string{"build-type", "builder", "debug", "deploy", "detach", "restart-unless-stopped", "restart-on-failure", "no-restart", "prefix", "user-args"}
 	for _, name := range expectedFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("missing flag %q", name)
@@ -172,6 +172,9 @@ func TestNewBuildCmd(t *testing.T) {
 	}
 	if cmd.Flags().Lookup("build-type") == nil {
 		t.Error("missing flag \"build-type\"")
+	}
+	if cmd.Flags().Lookup("builder") == nil {
+		t.Error("missing flag \"builder\"")
 	}
 }
 

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -623,11 +623,6 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 	}
 
 	regPort := registryPort(agentOS)
-	registryAddr, proxyCleanup, useMTLS, err := resolveRegistryForImageBuilder(ctx, conn, regPort, opts.builder)
-	if err != nil {
-		return err
-	}
-	defer proxyCleanup()
 
 	// Use the project directory name as the project name.
 	projectName := strings.ToLower(filepath.Base(projectDir))
@@ -642,7 +637,6 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			continue // uses pre-built image
 		}
 
-		imageName := fmt.Sprintf("%s/%s-%s:latest", registryAddr, projectName, name)
 		allBuildArgs := map[string]string{
 			"WENDY_PLATFORM": wendyPlatform(versionResp.GetDeviceType()),
 			"WENDY_DEBUG":    fmt.Sprintf("%t", opts.debug),
@@ -668,24 +662,8 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			allBuildArgs[k] = v
 		}
 
-		builder, _ := normalizeImageBuilder(opts.builder)
-		cliLogln("Building image for service %s with %s...", name, imageBuilderDisplayName(builder))
-
-		// If a non-default Dockerfile is specified, we need to pass it via -f.
-		// buildAndPushImage always uses "." as the path; for compose we pass the
-		// build context dir and rely on a Dockerfile inside it (or via ARG).
-		// We temporarily write a wrapper that delegates to the real Dockerfile when
-		// the dockerfile field differs. For the common case (Dockerfile in context),
-		// it just works.
-		if dockerfile != "Dockerfile" {
-			// Rewrite -f by creating a temp Dockerfile that uses the named file.
-			// Actually, buildAndPushImage doesn't support -f. We need a small workaround:
-			// copy the Dockerfile to the context dir as "Dockerfile" temporarily.
-			// For now, just error with a helpful message.
-			return fmt.Errorf("service %s: custom Dockerfile path %q is not yet supported; rename it to 'Dockerfile'", name, dockerfile)
-		}
-
-		if err := buildAndPushImageWithBuilder(ctx, opts.builder, ctxDir, registryAddr, imageName, platform, "", allBuildArgs, os.Stdout, os.Stderr, useMTLS); err != nil {
+		repo := fmt.Sprintf("%s-%s", projectName, name)
+		if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, ctxDir, repo, platform, dockerfile, allBuildArgs, os.Stdout, os.Stderr); err != nil {
 			return fmt.Errorf("building service %s: %w", name, err)
 		}
 		cliLogln("Service %s image built and pushed.", name)

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -623,7 +623,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 	}
 
 	regPort := registryPort(agentOS)
-	registryAddr, proxyCleanup, err := resolveRegistryForAgent(ctx, conn, regPort)
+	registryAddr, proxyCleanup, useMTLS, err := resolveRegistryForImageBuilder(ctx, conn, regPort, opts.builder)
 	if err != nil {
 		return err
 	}
@@ -668,7 +668,8 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			allBuildArgs[k] = v
 		}
 
-		cliLogln("Building image for service %s...", name)
+		builder, _ := normalizeImageBuilder(opts.builder)
+		cliLogln("Building image for service %s with %s...", name, imageBuilderDisplayName(builder))
 
 		// If a non-default Dockerfile is specified, we need to pass it via -f.
 		// buildAndPushImage always uses "." as the path; for compose we pass the
@@ -684,7 +685,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			return fmt.Errorf("service %s: custom Dockerfile path %q is not yet supported; rename it to 'Dockerfile'", name, dockerfile)
 		}
 
-		if err := buildAndPushImage(ctx, ctxDir, registryAddr, imageName, platform, "", allBuildArgs, os.Stdout, os.Stderr, conn.IsMTLS); err != nil {
+		if err := buildAndPushImageWithBuilder(ctx, opts.builder, ctxDir, registryAddr, imageName, platform, "", allBuildArgs, os.Stdout, os.Stderr, useMTLS); err != nil {
 			return fmt.Errorf("building service %s: %w", name, err)
 		}
 		cliLogln("Service %s image built and pushed.", name)

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -1047,8 +1047,10 @@ func externalProviderDisplayName(key string) string {
 
 func externalProviderSortKey(providerKey, name string) string {
 	switch providerKey {
+	case providers.ProviderKeyAppleContainer:
+		return "~0_apple_container_" + strings.ToLower(name)
 	case providers.ProviderKeyDocker:
-		return "~0_" + strings.ToLower(name)
+		return "~0_docker_" + strings.ToLower(name)
 	case providers.ProviderKeyLocal:
 		return "~1_" + strings.ToLower(name)
 	}
@@ -1056,11 +1058,11 @@ func externalProviderSortKey(providerKey, name string) string {
 }
 
 // externalProviderAddress returns the provider-qualified ID shown in the
-// Address column. Docker and the local machine have fixed, meaningless IDs
-// ("docker: docker", "local: local"), so their address is hidden.
+// Address column. Local runtime providers have fixed, meaningless IDs, so
+// their address is hidden.
 func externalProviderAddress(providerKey, id string) string {
 	switch providerKey {
-	case providers.ProviderKeyDocker, providers.ProviderKeyLocal:
+	case providers.ProviderKeyAppleContainer, providers.ProviderKeyDocker, providers.ProviderKeyLocal:
 		return ""
 	}
 	return fmt.Sprintf("%s: %s", providerKey, id)
@@ -1068,6 +1070,8 @@ func externalProviderAddress(providerKey, id string) string {
 
 func externalProviderPickerHint(providerKey string) string {
 	switch providerKey {
+	case providers.ProviderKeyAppleContainer:
+		return "Hint: Use Apple Container for local Dockerfile runs on Apple silicon Macs. Compose projects still require Docker."
 	case providers.ProviderKeyDocker:
 		return "Hint: Use Docker for local container or Compose runs when you do not need WendyOS hardware."
 	case providers.ProviderKeyLocal:

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -1071,7 +1071,7 @@ func externalProviderAddress(providerKey, id string) string {
 func externalProviderPickerHint(providerKey string) string {
 	switch providerKey {
 	case providers.ProviderKeyAppleContainer:
-		return "Hint: Use Apple Container for local Dockerfile runs on Apple silicon Macs. Compose projects still require Docker."
+		return "Hint: Use Apple Container for local Dockerfile/Containerfile runs on Apple silicon Macs. Compose projects still require Docker."
 	case providers.ProviderKeyDocker:
 		return "Hint: Use Docker for local container or Compose runs when you do not need WendyOS hardware."
 	case providers.ProviderKeyLocal:

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -81,8 +81,26 @@ func shouldAutoAttemptAppleContainerBuilder() bool {
 	return imageBuilderHostGOOS() == "darwin" && imageBuilderHostGOARCH() == "arm64"
 }
 
-func logAppleContainerFallback(w io.Writer, err error) {
-	fmt.Fprintf(w, "[apple-container] unavailable or failed; falling back to Docker: %v\n", err)
+func logAppleContainerFallback(w io.Writer, _ error) {
+	fmt.Fprintln(w, "[WARN] Apple Container unavailable or failed; falling back to Docker. Use --builder apple-container to require Apple Container.")
+}
+
+func safeCommandOutputSummary(out []byte, max int) string {
+	s := strings.TrimSpace(string(out))
+	if s == "" {
+		return ""
+	}
+	s = strings.Map(func(r rune) rune {
+		if r < 32 || r == 127 {
+			return ' '
+		}
+		return r
+	}, s)
+	s = strings.Join(strings.Fields(s), " ")
+	if max > 0 && len(s) > max {
+		return s[:max] + "..."
+	}
+	return s
 }
 
 func registryImageUsesLoopbackRegistry(image string) bool {
@@ -195,7 +213,7 @@ var validBuildArgNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 // but keep a narrow allowlist so shell-like metacharacters, whitespace,
 // digests, embedded key separators, and flag-looking values cannot cross into
 // builder CLIs.
-var validBuildArgValueRe = regexp.MustCompile(`^[A-Za-z0-9_./:,-]*$`)
+var validBuildArgValueRe = regexp.MustCompile(`^[A-Za-z0-9_.-]*$`)
 
 func isContainerBuildFileName(name string) bool {
 	if strings.HasSuffix(name, ".dockerignore") {
@@ -1444,7 +1462,7 @@ func checkAppleContainerBuilder(ctx context.Context) error {
 	}
 	cmd := imageBuilderCommandContext(ctx, "container", "system", "status")
 	if out, err := cmd.CombinedOutput(); err != nil {
-		msg := strings.TrimSpace(string(out))
+		msg := safeCommandOutputSummary(out, 256)
 		if msg != "" {
 			msg = ": " + msg
 		}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -154,6 +154,7 @@ func detectProjectType(dir string) (string, error) {
 // "Containerfile", or either base name followed by a dot or hyphen and one or
 // more safe characters.
 var validDockerfileNameRe = regexp.MustCompile(`^(Dockerfile|Containerfile)([.\-][a-zA-Z0-9][a-zA-Z0-9._-]*)?$`)
+var validBuildArgNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 func isContainerBuildFileName(name string) bool {
 	if strings.HasSuffix(name, ".dockerignore") {
@@ -185,6 +186,28 @@ func validateDockerfileName(name string) error {
 		return fmt.Errorf("invalid container build file name %q: must be Dockerfile, Containerfile, or a dot/hyphen variant of either", cleaned)
 	}
 	return nil
+}
+
+func validateBuildArgPair(key, value string) error {
+	if !validBuildArgNameRe.MatchString(key) {
+		return fmt.Errorf("invalid build arg name %q: must match [A-Za-z_][A-Za-z0-9_]*", key)
+	}
+	if strings.ContainsAny(value, "\x00\r\n") {
+		return fmt.Errorf("invalid build arg %q: value must not contain NUL or newline characters", key)
+	}
+	return nil
+}
+
+func sortedValidatedBuildArgKeys(buildArgs map[string]string) ([]string, error) {
+	keys := make([]string, 0, len(buildArgs))
+	for k, v := range buildArgs {
+		if err := validateBuildArgPair(k, v); err != nil {
+			return nil, err
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys, nil
 }
 
 // validComposeDockerfileNameRe matches the broader naming convention allowed by
@@ -1222,11 +1245,10 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 	args = append(args, "--cache-to", "type=local,dest="+cacheDirSlash)
 	// Sort keys so the argument order is stable across runs, which keeps
 	// build logs reproducible and avoids flakiness in tests that assert args.
-	keys := make([]string, 0, len(buildArgs))
-	for k := range buildArgs {
-		keys = append(keys, k)
+	keys, err := sortedValidatedBuildArgKeys(buildArgs)
+	if err != nil {
+		return err
 	}
-	sort.Strings(keys)
 	for _, k := range keys {
 		args = append(args, "--build-arg", k+"="+buildArgs[k])
 	}
@@ -1336,17 +1358,16 @@ func buildImageWithAppleContainer(ctx context.Context, dir, imageName, platform,
 	}
 	args := []string{"build", "--platform", platform, "-t", imageName}
 	if dockerfile != "" {
-		resolvedDockerfile, err := confinedDockerfilePath(dir, dockerfile)
+		resolvedDockerfile, err := appleContainerBuildFilePath(dir, dockerfile)
 		if err != nil {
 			return err
 		}
 		args = append(args, "-f", resolvedDockerfile)
 	}
-	keys := make([]string, 0, len(buildArgs))
-	for k := range buildArgs {
-		keys = append(keys, k)
+	keys, err := sortedValidatedBuildArgKeys(buildArgs)
+	if err != nil {
+		return err
 	}
-	sort.Strings(keys)
 	for _, k := range keys {
 		args = append(args, "--build-arg", k+"="+buildArgs[k])
 	}
@@ -1395,6 +1416,19 @@ func appleContainerBuildContextPath(projectPath string) (string, error) {
 		}
 	}
 	return buildContext, nil
+}
+
+func appleContainerBuildFilePath(projectPath, dockerfile string) (string, error) {
+	resolved, err := confinedDockerfilePath(projectPath, dockerfile)
+	if err != nil {
+		return "", err
+	}
+	if imageBuilderHostGOOS() == "darwin" {
+		if normalized, ok := appleContainerTmpAlias(resolved); ok {
+			return normalized, nil
+		}
+	}
+	return resolved, nil
 }
 
 func appleContainerTmpAlias(path string) (string, bool) {

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -49,6 +49,8 @@ const (
 	imageBuilderAppleContainer = "apple-container"
 )
 
+var buildDockerProjectWithDocker = buildDockerProject
+
 func normalizeImageBuilder(builder string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(builder)) {
 	case "":
@@ -71,6 +73,18 @@ func imageBuilderDisplayName(builder string) string {
 	}
 }
 
+func imageBuilderWasExplicit(builder string) bool {
+	return strings.TrimSpace(builder) != ""
+}
+
+func shouldAutoAttemptAppleContainerBuilder() bool {
+	return imageBuilderHostGOOS() == "darwin" && imageBuilderHostGOARCH() == "arm64"
+}
+
+func logAppleContainerFallback(w io.Writer, err error) {
+	fmt.Fprintf(w, "[apple-container] unavailable or failed; falling back to Docker: %v\n", err)
+}
+
 // requireRegistryAuth checks whether the device's registry requires mTLS
 // authentication and verifies the CLI has the necessary certs.
 // Returns an error if the device is provisioned but no CLI certs are available.
@@ -89,7 +103,7 @@ func requireRegistryAuth(ctx context.Context, conn *grpcclient.AgentConnection) 
 
 // detectProjectType determines the project type from the directory contents.
 //
-// Precedence: compose > Dockerfile > Package.swift > *.xcodeproj > Python markers.
+// Precedence: compose > Dockerfile/Containerfile > Package.swift > *.xcodeproj > Python markers.
 // Returns an error only when multiple .xcodeproj directories are found.
 func detectProjectType(dir string) (string, error) {
 	for _, name := range []string{"docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"} {
@@ -97,9 +111,11 @@ func detectProjectType(dir string) (string, error) {
 			return "compose", nil
 		}
 	}
-	// Check base Dockerfile first (fast path), then any Dockerfile.* / Dockerfile-* variant.
-	if _, err := os.Stat(filepath.Join(dir, "Dockerfile")); err == nil {
-		return "docker", nil
+	// Check base build files first (fast path), then any variant.
+	for _, name := range []string{"Dockerfile", "Containerfile"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return "docker", nil
+		}
 	}
 	if entries, readErr := os.ReadDir(dir); readErr == nil {
 		for _, e := range entries {
@@ -107,7 +123,7 @@ func detectProjectType(dir string) (string, error) {
 				continue
 			}
 			name := e.Name()
-			if (strings.HasPrefix(name, "Dockerfile.") || strings.HasPrefix(name, "Dockerfile-")) && !strings.HasSuffix(name, ".dockerignore") {
+			if isContainerBuildFileName(name) {
 				return "docker", nil
 			}
 		}
@@ -134,20 +150,39 @@ func detectProjectType(dir string) (string, error) {
 	return "unknown", nil
 }
 
-// validDockerfileNameRe matches valid Dockerfile names: "Dockerfile" or
-// "Dockerfile" followed by a dot or hyphen and one or more safe characters.
-var validDockerfileNameRe = regexp.MustCompile(`^Dockerfile([.\-][a-zA-Z0-9][a-zA-Z0-9._-]*)?$`)
+// validDockerfileNameRe matches valid container build file names: "Dockerfile",
+// "Containerfile", or either base name followed by a dot or hyphen and one or
+// more safe characters.
+var validDockerfileNameRe = regexp.MustCompile(`^(Dockerfile|Containerfile)([.\-][a-zA-Z0-9][a-zA-Z0-9._-]*)?$`)
+
+func isContainerBuildFileName(name string) bool {
+	if strings.HasSuffix(name, ".dockerignore") {
+		return false
+	}
+	return validDockerfileNameRe.MatchString(name)
+}
+
+func preferredContainerBuildFileOption(options []BuildOption) *BuildOption {
+	for _, preferred := range []string{"Dockerfile", "Containerfile"} {
+		for i := range options {
+			if options[i].Type == "docker" && options[i].File == preferred {
+				return &options[i]
+			}
+		}
+	}
+	return nil
+}
 
 func validateDockerfileName(name string) error {
 	cleaned := filepath.Clean(name)
 	if cleaned != filepath.Base(cleaned) {
-		return fmt.Errorf("invalid Dockerfile name %q: path separators are not allowed", name)
+		return fmt.Errorf("invalid container build file name %q: path separators are not allowed", name)
 	}
 	if strings.HasSuffix(cleaned, ".dockerignore") {
-		return fmt.Errorf("invalid Dockerfile name %q: .dockerignore files are not Dockerfiles", cleaned)
+		return fmt.Errorf("invalid container build file name %q: .dockerignore files are not build files", cleaned)
 	}
 	if !validDockerfileNameRe.MatchString(cleaned) {
-		return fmt.Errorf("invalid Dockerfile name %q: must be Dockerfile, Dockerfile.<variant>, or Dockerfile-<variant>", cleaned)
+		return fmt.Errorf("invalid container build file name %q: must be Dockerfile, Containerfile, or a dot/hyphen variant of either", cleaned)
 	}
 	return nil
 }
@@ -262,25 +297,23 @@ func resolveDockerfile(cwd, requested string, interactive bool) (string, error) 
 	}
 
 	if !interactive {
-		for _, opt := range dockerfiles {
-			if opt.File == "Dockerfile" {
-				file, err := confine(opt.File)
-				if err != nil {
-					return "", err
-				}
-				cliNotice("multiple Dockerfiles detected; using %q. Use --dockerfile to select explicitly.", file)
-				return file, nil
+		if preferred := preferredContainerBuildFileOption(dockerfiles); preferred != nil {
+			file, err := confine(preferred.File)
+			if err != nil {
+				return "", err
 			}
+			cliNotice("multiple container build files detected; using %q. Use --dockerfile to select explicitly.", file)
+			return file, nil
 		}
 		file, err := confine(dockerfiles[0].File)
 		if err != nil {
 			return "", err
 		}
-		cliNotice("multiple Dockerfiles detected; using %q. Use --dockerfile to select explicitly.", file)
+		cliNotice("multiple container build files detected; using %q. Use --dockerfile to select explicitly.", file)
 		return file, nil
 	}
 
-	picked, err := pickBuildOptionWithTitle(dockerfiles, "Select a Dockerfile")
+	picked, err := pickBuildOptionWithTitle(dockerfiles, "Select a container build file")
 	if err != nil {
 		return "", err
 	}
@@ -296,7 +329,7 @@ type BuildOption struct {
 
 // detectBuildOptions finds all buildable project markers in the given directory.
 // Unlike detectProjectType, this returns ALL options rather than the first match,
-// including multiple Dockerfiles (Dockerfile, Dockerfile.*, Dockerfile-*).
+// including multiple container build files (Dockerfile, Containerfile, and variants).
 func detectBuildOptions(dir string) []BuildOption {
 	var options []BuildOption
 
@@ -312,7 +345,7 @@ func detectBuildOptions(dir string) []BuildOption {
 		}
 	}
 
-	// Find all Dockerfiles.
+	// Find all container build files.
 	entries, err := os.ReadDir(dir)
 	if err == nil {
 		for _, e := range entries {
@@ -320,7 +353,7 @@ func detectBuildOptions(dir string) []BuildOption {
 				continue
 			}
 			name := e.Name()
-			if (name == "Dockerfile" || strings.HasPrefix(name, "Dockerfile.") || strings.HasPrefix(name, "Dockerfile-")) && !strings.HasSuffix(name, ".dockerignore") {
+			if isContainerBuildFileName(name) {
 				options = append(options, BuildOption{
 					Label: name,
 					Type:  "docker",
@@ -1239,6 +1272,39 @@ func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAdd
 	default:
 		return fmt.Errorf("unsupported image builder %q", normalized)
 	}
+}
+
+func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer) error {
+	if _, err := normalizeImageBuilder(builder); err != nil {
+		return err
+	}
+	if imageBuilderWasExplicit(builder) {
+		return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, builder, dir, repo, platform, dockerfile, buildArgs, streamOutput, logOutput)
+	}
+	if shouldAutoAttemptAppleContainerBuilder() {
+		if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, streamOutput, logOutput); err == nil {
+			return nil
+		} else {
+			logAppleContainerFallback(logOutput, err)
+		}
+	}
+	return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderDocker, dir, repo, platform, dockerfile, buildArgs, streamOutput, logOutput)
+}
+
+func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer) error {
+	normalized, err := normalizeImageBuilder(builder)
+	if err != nil {
+		return err
+	}
+	registryAddr, cleanup, useMTLS, err := resolveRegistryForImageBuilder(ctx, conn, regPort, normalized)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	registryImage := fmt.Sprintf("%s/%s:latest", registryAddr, strings.ToLower(repo))
+	cliLogln("Building and pushing image with %s for %s...", imageBuilderDisplayName(normalized), platform)
+	return buildAndPushImageWithBuilder(ctx, normalized, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
 }
 
 func buildAndPushImageWithAppleContainer(ctx context.Context, dir, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -184,6 +184,7 @@ func detectProjectType(dir string) (string, error) {
 // more safe characters.
 var validDockerfileNameRe = regexp.MustCompile(`^(Dockerfile|Containerfile)([.\-][a-zA-Z0-9][a-zA-Z0-9._-]*)?$`)
 var validBuildArgNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var validBuildArgValueRe = regexp.MustCompile(`^[A-Za-z0-9_./:=,@+-]*$`)
 
 func isContainerBuildFileName(name string) bool {
 	if strings.HasSuffix(name, ".dockerignore") {
@@ -221,8 +222,11 @@ func validateBuildArgPair(key, value string) error {
 	if !validBuildArgNameRe.MatchString(key) {
 		return fmt.Errorf("invalid build arg name %q: must match [A-Za-z_][A-Za-z0-9_]*", key)
 	}
-	if strings.ContainsAny(value, "\x00\r\n") {
-		return fmt.Errorf("invalid build arg %q: value must not contain NUL or newline characters", key)
+	if strings.HasPrefix(value, "-") {
+		return fmt.Errorf("invalid build arg %q: value must not start with '-'", key)
+	}
+	if !validBuildArgValueRe.MatchString(value) {
+		return fmt.Errorf("invalid build arg %q: value must contain only safe ASCII characters", key)
 	}
 	return nil
 }

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -85,6 +85,35 @@ func logAppleContainerFallback(w io.Writer, err error) {
 	fmt.Fprintf(w, "[apple-container] unavailable or failed; falling back to Docker: %v\n", err)
 }
 
+func registryImageUsesLoopbackRegistry(image string) bool {
+	registry, _, ok := strings.Cut(image, "/")
+	if !ok || registry == "" {
+		return false
+	}
+	return registryAddrUsesLoopback(registry)
+}
+
+func registryAddrUsesLoopback(registry string) bool {
+	host := registry
+	if splitHost, _, err := net.SplitHostPort(registry); err == nil {
+		host = splitHost
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.IsLoopback()
+}
+
+func appleContainerPushScheme(registryImage string) (string, error) {
+	if !registryImageUsesLoopbackRegistry(registryImage) {
+		registry, _, _ := strings.Cut(registryImage, "/")
+		return "", fmt.Errorf("Apple Container builder refuses plaintext push to non-loopback registry %q; use --builder docker", registry)
+	}
+	return "http", nil
+}
+
 // requireRegistryAuth checks whether the device's registry requires mTLS
 // authentication and verifies the CLI has the necessary certs.
 // Returns an error if the device is provisioned but no CLI certs are available.
@@ -1340,7 +1369,11 @@ func buildAndPushImageWithAppleContainer(ctx context.Context, dir, registryImage
 		return err
 	}
 
-	args := []string{"image", "push", "--scheme", "http", "--platform", platform, registryImage}
+	scheme, err := appleContainerPushScheme(registryImage)
+	if err != nil {
+		return err
+	}
+	args := []string{"image", "push", "--scheme", scheme, "--platform", platform, registryImage}
 	fmt.Fprintf(logOutput, "[apple-container] pushing image: container %s\n", strings.Join(args, " "))
 	cmd := imageBuilderCommandContext(ctx, "container", args...)
 	cmd.Stdout = streamOutput
@@ -1465,16 +1498,7 @@ func resolveRegistryForImageBuilder(ctx context.Context, conn *grpcclient.AgentC
 		registryAddr, cleanup, err = resolveRegistryForAgent(ctx, conn, port)
 		return registryAddr, cleanup, conn.IsMTLS, err
 	case imageBuilderAppleContainer:
-		var appleUseMTLS bool
-		registryAddr, appleUseMTLS, cleanup, err = resolveRegistryForSwiftAgent(ctx, conn, port)
-		if err != nil {
-			return "", nil, false, err
-		}
-		if appleUseMTLS {
-			cleanup()
-			return "", nil, false, fmt.Errorf("Apple Container builder cannot push directly to an mTLS registry over this connection; use --builder docker")
-		}
-		return registryAddr, cleanup, false, nil
+		return resolveRegistryForAppleContainer(ctx, conn, port)
 	default:
 		return "", nil, false, fmt.Errorf("unsupported image builder %q", normalized)
 	}
@@ -1669,6 +1693,35 @@ func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentCon
 		return "", false, nil, fmt.Errorf("starting cloud registry proxy for Swift: %w", proxyErr)
 	}
 	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), conn.IsMTLS, proxy.Close, nil
+}
+
+func resolveRegistryForAppleContainer(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), useMTLS bool, err error) {
+	if conn.RegistryDialer != nil || conn.IsMTLS {
+		registryAddr, appleUseMTLS, cleanup, err := resolveRegistryForSwiftAgent(ctx, conn, port)
+		if err != nil {
+			return "", nil, false, err
+		}
+		if appleUseMTLS {
+			cleanup()
+			return "", nil, false, fmt.Errorf("Apple Container builder cannot push directly to an mTLS registry over this connection; use --builder docker")
+		}
+		if !registryAddrUsesLoopback(registryAddr) {
+			cleanup()
+			return "", nil, false, fmt.Errorf("Apple Container builder expected loopback registry proxy, got %q", registryAddr)
+		}
+		return registryAddr, cleanup, false, nil
+	}
+
+	targetHost := resolveRegistryIP(conn.Host)
+	if isLinkLocalIP(targetHost) {
+		targetHost = conn.Host
+	}
+	target := net.JoinHostPort(targetHost, strconv.Itoa(port))
+	proxy, proxyErr := startRegistryProxy(ctx, "127.0.0.1:0", target)
+	if proxyErr != nil {
+		return "", nil, false, fmt.Errorf("starting Apple Container registry proxy: %w", proxyErr)
+	}
+	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), proxy.Close, false, nil
 }
 
 // mtlsRegistryHTTPProxy is a plain-HTTP reverse proxy that forwards requests

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -103,7 +103,15 @@ func registryAddrUsesLoopback(registry string) bool {
 		return true
 	}
 	addr, err := netip.ParseAddr(host)
-	return err == nil && addr.IsLoopback()
+	if err != nil {
+		// Do not resolve arbitrary hostnames here; Apple Container plaintext
+		// pushes are allowed only to local addresses emitted by Wendy helpers.
+		return false
+	}
+	addr = addr.Unmap()
+	// Unspecified addresses cover local proxy bind addresses such as
+	// 0.0.0.0:PORT or [::]:PORT when Wendy controls the proxy endpoint.
+	return addr.IsLoopback() || addr.IsUnspecified()
 }
 
 func appleContainerPushScheme(registryImage string) (string, error) {
@@ -1470,26 +1478,14 @@ func appleContainerBuildFilePath(projectPath, dockerfile string) (string, error)
 
 func appleContainerTmpAlias(path string) (string, bool) {
 	const privateTmp = "/private/tmp"
-	if path != privateTmp && !strings.HasPrefix(path, privateTmp+"/") {
+	canonical, err := filepath.EvalSymlinks(path)
+	if err != nil {
 		return "", false
 	}
-	candidate := "/tmp" + strings.TrimPrefix(path, privateTmp)
-	if sameFilePath(path, candidate) {
-		return candidate, true
+	if canonical != privateTmp && !strings.HasPrefix(canonical, privateTmp+"/") {
+		return "", false
 	}
-	return "", false
-}
-
-func sameFilePath(left, right string) bool {
-	leftInfo, leftErr := os.Stat(left)
-	if leftErr != nil {
-		return false
-	}
-	rightInfo, rightErr := os.Stat(right)
-	if rightErr != nil {
-		return false
-	}
-	return os.SameFile(leftInfo, rightInfo)
+	return "/tmp" + strings.TrimPrefix(canonical, privateTmp), true
 }
 
 func resolveRegistryForImageBuilder(ctx context.Context, conn *grpcclient.AgentConnection, port int, builder string) (registryAddr string, cleanup func(), useMTLS bool, err error) {

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -37,6 +37,40 @@ import (
 // command execution and outputs.
 var neighborExecCommandContext = exec.CommandContext
 
+var (
+	imageBuilderCommandContext = exec.CommandContext
+	imageBuilderLookPath       = exec.LookPath
+	imageBuilderHostGOOS       = func() string { return runtime.GOOS }
+	imageBuilderHostGOARCH     = func() string { return runtime.GOARCH }
+)
+
+const (
+	imageBuilderDocker         = "docker"
+	imageBuilderAppleContainer = "apple-container"
+)
+
+func normalizeImageBuilder(builder string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(builder)) {
+	case "":
+		return imageBuilderDocker, nil
+	case imageBuilderDocker:
+		return imageBuilderDocker, nil
+	case imageBuilderAppleContainer:
+		return imageBuilderAppleContainer, nil
+	default:
+		return "", fmt.Errorf("invalid value %q for --builder: must be one of docker or apple-container", builder)
+	}
+}
+
+func imageBuilderDisplayName(builder string) string {
+	switch builder {
+	case imageBuilderAppleContainer:
+		return "Apple Container"
+	default:
+		return "Docker"
+	}
+}
+
 // requireRegistryAuth checks whether the device's registry requires mTLS
 // authentication and verifies the CLI has the necessary certs.
 // Returns an error if the device is provisioned but no CLI certs are available.
@@ -1190,6 +1224,160 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 		return fmt.Errorf("docker buildx build failed: %w", err)
 	}
 	return nil
+}
+
+func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {
+	normalized, err := normalizeImageBuilder(builder)
+	if err != nil {
+		return err
+	}
+	switch normalized {
+	case imageBuilderDocker:
+		return buildAndPushImage(ctx, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
+	case imageBuilderAppleContainer:
+		return buildAndPushImageWithAppleContainer(ctx, dir, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
+	default:
+		return fmt.Errorf("unsupported image builder %q", normalized)
+	}
+}
+
+func buildAndPushImageWithAppleContainer(ctx context.Context, dir, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {
+	if useMTLS {
+		return fmt.Errorf("Apple Container builder cannot push directly to an mTLS registry; use --builder docker or connect through a local registry proxy")
+	}
+	if err := checkAppleContainerBuilder(ctx); err != nil {
+		return err
+	}
+	if err := buildImageWithAppleContainer(ctx, dir, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput); err != nil {
+		return err
+	}
+
+	args := []string{"image", "push", "--scheme", "http", "--platform", platform, registryImage}
+	fmt.Fprintf(logOutput, "[apple-container] pushing image: container %s\n", strings.Join(args, " "))
+	cmd := imageBuilderCommandContext(ctx, "container", args...)
+	cmd.Stdout = streamOutput
+	cmd.Stderr = streamOutput
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("container image push failed: %w", err)
+	}
+	return nil
+}
+
+func buildImageWithAppleContainer(ctx context.Context, dir, imageName, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer) error {
+	buildContext, err := appleContainerBuildContextPath(dir)
+	if err != nil {
+		return fmt.Errorf("resolving project path: %w", err)
+	}
+	args := []string{"build", "--platform", platform, "-t", imageName}
+	if dockerfile != "" {
+		resolvedDockerfile, err := confinedDockerfilePath(dir, dockerfile)
+		if err != nil {
+			return err
+		}
+		args = append(args, "-f", resolvedDockerfile)
+	}
+	keys := make([]string, 0, len(buildArgs))
+	for k := range buildArgs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		args = append(args, "--build-arg", k+"="+buildArgs[k])
+	}
+	args = append(args, buildContext)
+
+	fmt.Fprintf(logOutput, "[apple-container] starting build: container %s\n", strings.Join(args, " "))
+	cmd := imageBuilderCommandContext(ctx, "container", args...)
+	cmd.Dir = buildContext
+	cmd.Stdout = streamOutput
+	cmd.Stderr = streamOutput
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("container build failed: %w", err)
+	}
+	return nil
+}
+
+func checkAppleContainerBuilder(ctx context.Context) error {
+	if imageBuilderHostGOOS() != "darwin" || imageBuilderHostGOARCH() != "arm64" {
+		return fmt.Errorf("Apple Container builder requires an Apple silicon Mac")
+	}
+	if _, err := imageBuilderLookPath("container"); err != nil {
+		return fmt.Errorf("container CLI is not installed or not in PATH")
+	}
+	if err := imageBuilderCommandContext(ctx, "container", "--version").Run(); err != nil {
+		return fmt.Errorf("container CLI is not usable: %w", err)
+	}
+	cmd := imageBuilderCommandContext(ctx, "container", "system", "status")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			msg = ": " + msg
+		}
+		return fmt.Errorf("Apple Container system is not running%s. Run 'container system start' and try again: %w", msg, err)
+	}
+	return nil
+}
+
+func appleContainerBuildContextPath(projectPath string) (string, error) {
+	buildContext, err := filepath.Abs(projectPath)
+	if err != nil {
+		return "", err
+	}
+	if imageBuilderHostGOOS() == "darwin" {
+		if normalized, ok := appleContainerTmpAlias(buildContext); ok {
+			return normalized, nil
+		}
+	}
+	return buildContext, nil
+}
+
+func appleContainerTmpAlias(path string) (string, bool) {
+	const privateTmp = "/private/tmp"
+	if path != privateTmp && !strings.HasPrefix(path, privateTmp+"/") {
+		return "", false
+	}
+	candidate := "/tmp" + strings.TrimPrefix(path, privateTmp)
+	if sameFilePath(path, candidate) {
+		return candidate, true
+	}
+	return "", false
+}
+
+func sameFilePath(left, right string) bool {
+	leftInfo, leftErr := os.Stat(left)
+	if leftErr != nil {
+		return false
+	}
+	rightInfo, rightErr := os.Stat(right)
+	if rightErr != nil {
+		return false
+	}
+	return os.SameFile(leftInfo, rightInfo)
+}
+
+func resolveRegistryForImageBuilder(ctx context.Context, conn *grpcclient.AgentConnection, port int, builder string) (registryAddr string, cleanup func(), useMTLS bool, err error) {
+	normalized, err := normalizeImageBuilder(builder)
+	if err != nil {
+		return "", nil, false, err
+	}
+	switch normalized {
+	case imageBuilderDocker:
+		registryAddr, cleanup, err = resolveRegistryForAgent(ctx, conn, port)
+		return registryAddr, cleanup, conn.IsMTLS, err
+	case imageBuilderAppleContainer:
+		var appleUseMTLS bool
+		registryAddr, appleUseMTLS, cleanup, err = resolveRegistryForSwiftAgent(ctx, conn, port)
+		if err != nil {
+			return "", nil, false, err
+		}
+		if appleUseMTLS {
+			cleanup()
+			return "", nil, false, fmt.Errorf("Apple Container builder cannot push directly to an mTLS registry over this connection; use --builder docker")
+		}
+		return registryAddr, cleanup, false, nil
+	default:
+		return "", nil, false, fmt.Errorf("unsupported image builder %q", normalized)
+	}
 }
 
 // registryHost formats a host:port for use in a registry image reference,

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -193,8 +193,9 @@ var validBuildArgNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // Build-arg values are passed to exec.Command as a single KEY=VALUE argument,
 // but keep a narrow allowlist so shell-like metacharacters, whitespace,
-// digests, and flag-looking values cannot cross into builder CLIs.
-var validBuildArgValueRe = regexp.MustCompile(`^[A-Za-z0-9_./:=,-]*$`)
+// digests, embedded key separators, and flag-looking values cannot cross into
+// builder CLIs.
+var validBuildArgValueRe = regexp.MustCompile(`^[A-Za-z0-9_./:,-]*$`)
 
 func isContainerBuildFileName(name string) bool {
 	if strings.HasSuffix(name, ".dockerignore") {
@@ -1487,7 +1488,12 @@ func appleContainerTmpAlias(path string) (string, bool) {
 	if canonical != privateTmp && !strings.HasPrefix(canonical, privateTmp+"/") {
 		return "", false
 	}
-	return "/tmp" + strings.TrimPrefix(canonical, privateTmp), true
+	candidate := "/tmp" + strings.TrimPrefix(canonical, privateTmp)
+	candidateCanonical, err := filepath.EvalSymlinks(candidate)
+	if err != nil || candidateCanonical != canonical {
+		return "", false
+	}
+	return candidate, true
 }
 
 func resolveRegistryForImageBuilder(ctx context.Context, conn *grpcclient.AgentConnection, port int, builder string) (registryAddr string, cleanup func(), useMTLS bool, err error) {

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -109,9 +109,7 @@ func registryAddrUsesLoopback(registry string) bool {
 		return false
 	}
 	addr = addr.Unmap()
-	// Unspecified addresses cover local proxy bind addresses such as
-	// 0.0.0.0:PORT or [::]:PORT when Wendy controls the proxy endpoint.
-	return addr.IsLoopback() || addr.IsUnspecified()
+	return addr.IsLoopback()
 }
 
 func appleContainerPushScheme(registryImage string) (string, error) {
@@ -192,7 +190,11 @@ func detectProjectType(dir string) (string, error) {
 // more safe characters.
 var validDockerfileNameRe = regexp.MustCompile(`^(Dockerfile|Containerfile)([.\-][a-zA-Z0-9][a-zA-Z0-9._-]*)?$`)
 var validBuildArgNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
-var validBuildArgValueRe = regexp.MustCompile(`^[A-Za-z0-9_./:=,@+-]*$`)
+
+// Build-arg values are passed to exec.Command as a single KEY=VALUE argument,
+// but keep a narrow allowlist so shell-like metacharacters, whitespace,
+// digests, and flag-looking values cannot cross into builder CLIs.
+var validBuildArgValueRe = regexp.MustCompile(`^[A-Za-z0-9_./:=,-]*$`)
 
 func isContainerBuildFileName(name string) bool {
 	if strings.HasSuffix(name, ".dockerignore") {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -825,6 +825,12 @@ func TestFilterBuildOptions_LocalProviderKeepsNativeOnly(t *testing.T) {
 }
 
 func TestEnsureProviderSupportsProjectType_LocalRejectsContainerProjects(t *testing.T) {
+	oldHintSupported := appleContainerLocalProviderHintSupported
+	t.Cleanup(func() {
+		appleContainerLocalProviderHintSupported = oldHintSupported
+	})
+	appleContainerLocalProviderHintSupported = func() bool { return true }
+
 	for _, projectType := range []string{"docker", "compose"} {
 		t.Run(projectType, func(t *testing.T) {
 			err := ensureProviderSupportsProjectType(&providers.LocalProvider{}, projectType, t.TempDir())
@@ -837,7 +843,29 @@ func TestEnsureProviderSupportsProjectType_LocalRejectsContainerProjects(t *test
 					t.Fatalf("error = %q, want substring %q", msg, want)
 				}
 			}
+			if projectType == "docker" && !strings.Contains(msg, "--device apple-container") {
+				t.Fatalf("docker error = %q, want Apple Container hint on supported hosts", msg)
+			}
+			if projectType == "compose" && strings.Contains(msg, "apple-container") {
+				t.Fatalf("compose error = %q, must not suggest Apple Container", msg)
+			}
 		})
+	}
+}
+
+func TestEnsureProviderSupportsProjectType_LocalOmitsAppleContainerHintWhenUnsupported(t *testing.T) {
+	oldHintSupported := appleContainerLocalProviderHintSupported
+	t.Cleanup(func() {
+		appleContainerLocalProviderHintSupported = oldHintSupported
+	})
+	appleContainerLocalProviderHintSupported = func() bool { return false }
+
+	err := ensureProviderSupportsProjectType(&providers.LocalProvider{}, "docker", t.TempDir())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "apple-container") {
+		t.Fatalf("error = %q, must not suggest Apple Container on unsupported hosts", err)
 	}
 }
 

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -1706,7 +1706,7 @@ func TestValidateDockerfileName(t *testing.T) {
 func TestValidateBuildArgPair(t *testing.T) {
 	valid := map[string]string{
 		"WENDY_PLATFORM":    "nvidia-jetson",
-		"_PRIVATE_ARG":      "value=with=equals",
+		"_PRIVATE_ARG":      "value-without-equals",
 		"WENDY_DEVICE_TYPE": "jetson-agx-orin",
 	}
 	for k, v := range valid {
@@ -1727,6 +1727,7 @@ func TestValidateBuildArgPair(t *testing.T) {
 		"SHELL":     "$(echo bad)",
 		"DIGEST":    "image@sha256:abc",
 		"PLUS":      "v1+metadata",
+		"EQUALS":    "value=with=equals",
 	}
 	for k, v := range invalid {
 		if err := validateBuildArgPair(k, v); err == nil {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -108,6 +108,32 @@ func TestBuildAndPushImageWithAppleContainerUsesContainerCLI(t *testing.T) {
 	}
 }
 
+func TestAppleContainerPushSchemeRequiresLoopbackRegistry(t *testing.T) {
+	for _, image := range []string{
+		"127.0.0.1:5000/test-app:latest",
+		"localhost:5000/test-app:latest",
+		"[::1]:5000/test-app:latest",
+	} {
+		scheme, err := appleContainerPushScheme(image)
+		if err != nil {
+			t.Fatalf("appleContainerPushScheme(%q): %v", image, err)
+		}
+		if scheme != "http" {
+			t.Fatalf("appleContainerPushScheme(%q) = %q, want http", image, scheme)
+		}
+	}
+
+	for _, image := range []string{
+		"192.168.1.20:5000/test-app:latest",
+		"my-wendy.local:5000/test-app:latest",
+		"host.docker.internal:5000/test-app:latest",
+	} {
+		if _, err := appleContainerPushScheme(image); err == nil {
+			t.Fatalf("appleContainerPushScheme(%q) = nil, want error", image)
+		}
+	}
+}
+
 func TestBuildDockerProjectWithBuilderDefaultsToAppleContainerOnAppleSilicon(t *testing.T) {
 	oldCommand := imageBuilderCommandContext
 	oldLookPath := imageBuilderLookPath

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -108,6 +108,110 @@ func TestBuildAndPushImageWithAppleContainerUsesContainerCLI(t *testing.T) {
 	}
 }
 
+func TestBuildDockerProjectWithBuilderDefaultsToAppleContainerOnAppleSilicon(t *testing.T) {
+	oldCommand := imageBuilderCommandContext
+	oldLookPath := imageBuilderLookPath
+	oldGOOS := imageBuilderHostGOOS
+	oldGOARCH := imageBuilderHostGOARCH
+	oldDockerBuild := buildDockerProjectWithDocker
+	t.Cleanup(func() {
+		imageBuilderCommandContext = oldCommand
+		imageBuilderLookPath = oldLookPath
+		imageBuilderHostGOOS = oldGOOS
+		imageBuilderHostGOARCH = oldGOARCH
+		buildDockerProjectWithDocker = oldDockerBuild
+	})
+
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+	imageBuilderCommandContext = fakeImageBuilderCommandContext(logFile)
+	imageBuilderLookPath = func(file string) (string, error) {
+		if file == "container" {
+			return "/usr/local/bin/container", nil
+		}
+		return "", errors.New("not found")
+	}
+	imageBuilderHostGOOS = func() string { return "darwin" }
+	imageBuilderHostGOARCH = func() string { return "arm64" }
+	buildDockerProjectWithDocker = func(dir, imageName, platform, dockerfile string) error {
+		t.Fatal("Docker fallback should not run when Apple Container succeeds")
+		return nil
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Containerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := buildDockerProjectWithBuilder(context.Background(), "", dir, "test-app:latest", "linux/arm64", "Containerfile"); err != nil {
+		t.Fatalf("buildDockerProjectWithBuilder: %v", err)
+	}
+
+	resolvedBuildFile, err := confinedDockerfilePath(dir, "Containerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	buildContext, err := appleContainerBuildContextPath(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "container\x00build\x00--platform\x00linux/arm64\x00-t\x00test-app:latest\x00-f\x00" + resolvedBuildFile + "\x00" + buildContext + "\n"
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("command log missing %q in:\n%s", want, string(data))
+	}
+}
+
+func TestBuildDockerProjectWithBuilderFallsBackToDockerWhenAutoAppleContainerFails(t *testing.T) {
+	oldCommand := imageBuilderCommandContext
+	oldLookPath := imageBuilderLookPath
+	oldGOOS := imageBuilderHostGOOS
+	oldGOARCH := imageBuilderHostGOARCH
+	oldDockerBuild := buildDockerProjectWithDocker
+	t.Cleanup(func() {
+		imageBuilderCommandContext = oldCommand
+		imageBuilderLookPath = oldLookPath
+		imageBuilderHostGOOS = oldGOOS
+		imageBuilderHostGOARCH = oldGOARCH
+		buildDockerProjectWithDocker = oldDockerBuild
+	})
+
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+	t.Setenv("IMAGE_BUILDER_FAIL_CONTAINER_BUILD", "1")
+	imageBuilderCommandContext = fakeImageBuilderCommandContext(logFile)
+	imageBuilderLookPath = func(file string) (string, error) {
+		if file == "container" {
+			return "/usr/local/bin/container", nil
+		}
+		return "", errors.New("not found")
+	}
+	imageBuilderHostGOOS = func() string { return "darwin" }
+	imageBuilderHostGOARCH = func() string { return "arm64" }
+
+	var dockerFallbackCalled bool
+	buildDockerProjectWithDocker = func(dir, imageName, platform, dockerfile string) error {
+		dockerFallbackCalled = true
+		if imageName != "test-app:latest" || platform != "linux/arm64" || dockerfile != "Dockerfile" {
+			t.Fatalf("fallback args = (%q, %q, %q), want image/platform/Dockerfile", imageName, platform, dockerfile)
+		}
+		return nil
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := buildDockerProjectWithBuilder(context.Background(), "", dir, "test-app:latest", "linux/arm64", "Dockerfile"); err != nil {
+		t.Fatalf("buildDockerProjectWithBuilder: %v", err)
+	}
+	if !dockerFallbackCalled {
+		t.Fatal("Docker fallback was not called")
+	}
+}
+
 func fakeImageBuilderCommandContext(logFile string) func(context.Context, string, ...string) *exec.Cmd {
 	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		cmdArgs := []string{"-test.run=TestImageBuilderHelperProcess", "--", name}
@@ -147,6 +251,9 @@ func TestImageBuilderHelperProcess(t *testing.T) {
 		os.Exit(0)
 	}
 	if len(args) >= 2 && args[0] == "container" && args[1] == "build" {
+		if os.Getenv("IMAGE_BUILDER_FAIL_CONTAINER_BUILD") == "1" {
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 	if len(args) >= 3 && args[0] == "container" && args[1] == "image" && args[2] == "push" {
@@ -378,6 +485,16 @@ func TestDetectProjectType_Dockerfile(t *testing.T) {
 	}
 }
 
+func TestDetectProjectType_Containerfile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Containerfile"), []byte("FROM alpine"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustDetectProjectType(t, dir); got != "docker" {
+		t.Errorf("detectProjectType = %q; want %q", got, "docker")
+	}
+}
+
 func TestDetectProjectType_PackageSwift(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "Package.swift"), []byte("// swift"), 0o644); err != nil {
@@ -505,6 +622,21 @@ func TestResolveDetectedBuildOption_PrefersDockerfileOverSwift(t *testing.T) {
 	}
 }
 
+func TestResolveDetectedBuildOption_PrefersContainerfileOverPython(t *testing.T) {
+	options := []BuildOption{
+		{Label: "Containerfile", Type: "docker", File: "Containerfile"},
+		{Label: "requirements.txt (Python)", Type: "python", File: "requirements.txt"},
+	}
+
+	got, err := resolveDetectedBuildOption(options, "", "")
+	if err != nil {
+		t.Fatalf("resolveDetectedBuildOption: %v", err)
+	}
+	if got == nil || got.Type != "docker" || got.File != "Containerfile" {
+		t.Fatalf("got %+v, want Containerfile docker option", got)
+	}
+}
+
 func TestResolveDetectedBuildOption_PrefersDockerfileOverPython(t *testing.T) {
 	options := []BuildOption{
 		{Label: "Dockerfile", Type: "docker", File: "Dockerfile"},
@@ -555,6 +687,7 @@ func TestBuildOptionForType_DockerUsesExactDockerfile(t *testing.T) {
 
 func TestResolveDetectedBuildOption_NonInteractiveMultipleDockerfilesPrefersBase(t *testing.T) {
 	options := []BuildOption{
+		{Label: "Containerfile", Type: "docker", File: "Containerfile"},
 		{Label: "Dockerfile", Type: "docker", File: "Dockerfile"},
 		{Label: "Dockerfile.dev", Type: "docker", File: "Dockerfile.dev"},
 		{Label: "Dockerfile.prod", Type: "docker", File: "Dockerfile.prod"},
@@ -566,6 +699,21 @@ func TestResolveDetectedBuildOption_NonInteractiveMultipleDockerfilesPrefersBase
 	}
 	if got == nil || got.File != "Dockerfile" {
 		t.Fatalf("got %+v, want base Dockerfile", got)
+	}
+}
+
+func TestResolveDetectedBuildOption_NonInteractiveContainerfileBase(t *testing.T) {
+	options := []BuildOption{
+		{Label: "Containerfile.dev", Type: "docker", File: "Containerfile.dev"},
+		{Label: "Containerfile", Type: "docker", File: "Containerfile"},
+	}
+
+	got, err := resolveDetectedBuildOption(options, "", "")
+	if err != nil {
+		t.Fatalf("resolveDetectedBuildOption: %v", err)
+	}
+	if got == nil || got.File != "Containerfile" {
+		t.Fatalf("got %+v, want base Containerfile", got)
 	}
 }
 
@@ -1462,9 +1610,23 @@ func TestResolveDockerfile_SingleVariant(t *testing.T) {
 	}
 }
 
+func TestResolveDockerfile_Containerfile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Containerfile"), []byte("FROM scratch"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveDockerfile(dir, "", false)
+	if err != nil {
+		t.Fatalf("resolveDockerfile: %v", err)
+	}
+	if got != "Containerfile" {
+		t.Fatalf("got %q, want Containerfile", got)
+	}
+}
+
 func TestResolveDockerfile_MultipleNonInteractivePrefersBase(t *testing.T) {
 	dir := t.TempDir()
-	for _, name := range []string{"Dockerfile", "Dockerfile.prod", "Dockerfile.dev"} {
+	for _, name := range []string{"Containerfile", "Dockerfile", "Dockerfile.prod", "Dockerfile.dev"} {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte("FROM scratch"), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -1495,13 +1657,13 @@ func TestResolveDockerfile_MultipleNonInteractiveVariantOnlyPrefersFirst(t *test
 }
 
 func TestValidateDockerfileName(t *testing.T) {
-	valid := []string{"Dockerfile", "Dockerfile.prod", "Dockerfile.dev", "Dockerfile-prod", "Dockerfile.my.variant", "./Dockerfile.prod"}
+	valid := []string{"Dockerfile", "Dockerfile.prod", "Dockerfile.dev", "Dockerfile-prod", "Dockerfile.my.variant", "./Dockerfile.prod", "Containerfile", "Containerfile.prod", "Containerfile-dev"}
 	for _, name := range valid {
 		if err := validateDockerfileName(name); err != nil {
 			t.Errorf("validateDockerfileName(%q) unexpected error: %v", name, err)
 		}
 	}
-	invalid := []string{"-flag", "dockerfile", "DOCKERFILE", "not-a-dockerfile", "Dockerfile/evil", "subdir/Dockerfile.prod", "../Dockerfile", ".hidden", "Dockerfile.dockerignore", "Dockerfile.prod.dockerignore", "Dockerfile.-prod", "Dockerfile..hidden", "Dockerfile-.prod"}
+	invalid := []string{"-flag", "dockerfile", "containerfile", "DOCKERFILE", "CONTAINERFILE", "not-a-dockerfile", "Dockerfile/evil", "subdir/Dockerfile.prod", "../Dockerfile", ".hidden", "Dockerfile.dockerignore", "Dockerfile.prod.dockerignore", "Containerfile.dockerignore", "Dockerfile.-prod", "Dockerfile..hidden", "Dockerfile-.prod", "Containerfile.-prod"}
 	for _, name := range invalid {
 		if err := validateDockerfileName(name); err == nil {
 			t.Errorf("validateDockerfileName(%q) expected error, got nil", name)

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -137,6 +138,18 @@ func TestAppleContainerPushSchemeRequiresLoopbackRegistry(t *testing.T) {
 		if _, err := appleContainerPushScheme(image); err == nil {
 			t.Fatalf("appleContainerPushScheme(%q) = nil, want error", image)
 		}
+	}
+}
+
+func TestLogAppleContainerFallbackOmitsRawError(t *testing.T) {
+	var buf bytes.Buffer
+	logAppleContainerFallback(&buf, errors.New("secret path /tmp/wendy/project"))
+	got := buf.String()
+	if !strings.Contains(got, "[WARN] Apple Container unavailable or failed; falling back to Docker") {
+		t.Fatalf("fallback log = %q, want warning", got)
+	}
+	if strings.Contains(got, "secret") || strings.Contains(got, "/tmp/wendy/project") {
+		t.Fatalf("fallback log leaked raw error details: %q", got)
 	}
 }
 
@@ -1728,6 +1741,10 @@ func TestValidateBuildArgPair(t *testing.T) {
 		"DIGEST":    "image@sha256:abc",
 		"PLUS":      "v1+metadata",
 		"EQUALS":    "value=with=equals",
+		"SLASH":     "linux/arm64",
+		"COLON":     "8080:80",
+		"COMMA":     "left,right",
+		"COMMAFLAG": ",--cache",
 	}
 	for k, v := range invalid {
 		if err := validateBuildArgPair(k, v); err == nil {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -32,6 +33,126 @@ func mustDetectProjectType(t *testing.T, dir string) string {
 		t.Fatalf("detectProjectType unexpected error: %v", err)
 	}
 	return got
+}
+
+func TestBuildAndPushImageWithAppleContainerUsesContainerCLI(t *testing.T) {
+	oldCommand := imageBuilderCommandContext
+	oldLookPath := imageBuilderLookPath
+	oldGOOS := imageBuilderHostGOOS
+	oldGOARCH := imageBuilderHostGOARCH
+	t.Cleanup(func() {
+		imageBuilderCommandContext = oldCommand
+		imageBuilderLookPath = oldLookPath
+		imageBuilderHostGOOS = oldGOOS
+		imageBuilderHostGOARCH = oldGOARCH
+	})
+
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+	imageBuilderCommandContext = fakeImageBuilderCommandContext(logFile)
+	imageBuilderLookPath = func(file string) (string, error) {
+		if file == "container" {
+			return "/usr/local/bin/container", nil
+		}
+		return "", errors.New("not found")
+	}
+	imageBuilderHostGOOS = func() string { return "darwin" }
+	imageBuilderHostGOARCH = func() string { return "arm64" }
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\nCOPY app.py .\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app.py"), []byte("print('hello')\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := buildAndPushImageWithBuilder(
+		context.Background(),
+		imageBuilderAppleContainer,
+		dir,
+		"127.0.0.1:5000",
+		"127.0.0.1:5000/test-app:latest",
+		"linux/arm64",
+		"Dockerfile",
+		map[string]string{"B": "2", "A": "1"},
+		io.Discard,
+		io.Discard,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("buildAndPushImageWithBuilder: %v", err)
+	}
+
+	resolvedDockerfile, err := confinedDockerfilePath(dir, "Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	buildContext, err := appleContainerBuildContextPath(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(data)
+	for _, want := range []string{
+		"container\x00--version\n",
+		"container\x00system\x00status\n",
+		"container\x00build\x00--platform\x00linux/arm64\x00-t\x00127.0.0.1:5000/test-app:latest\x00-f\x00" + resolvedDockerfile + "\x00--build-arg\x00A=1\x00--build-arg\x00B=2\x00" + buildContext + "\n",
+		"container\x00image\x00push\x00--scheme\x00http\x00--platform\x00linux/arm64\x00127.0.0.1:5000/test-app:latest\n",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("command log missing %q in:\n%s", want, log)
+		}
+	}
+}
+
+func fakeImageBuilderCommandContext(logFile string) func(context.Context, string, ...string) *exec.Cmd {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmdArgs := []string{"-test.run=TestImageBuilderHelperProcess", "--", name}
+		cmdArgs = append(cmdArgs, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_IMAGE_BUILDER_HELPER_PROCESS=1",
+			"IMAGE_BUILDER_HELPER_LOG="+logFile,
+		)
+		return cmd
+	}
+}
+
+func TestImageBuilderHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_IMAGE_BUILDER_HELPER_PROCESS") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) > 0 {
+		args = args[1:]
+	}
+	if logFile := os.Getenv("IMAGE_BUILDER_HELPER_LOG"); logFile != "" {
+		f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err == nil {
+			_, _ = f.WriteString(strings.Join(args, "\x00") + "\n")
+			_ = f.Close()
+		}
+	}
+	if len(args) >= 2 && args[0] == "container" && args[1] == "--version" {
+		_, _ = os.Stdout.WriteString("container 1.0.0\n")
+		os.Exit(0)
+	}
+	if len(args) >= 3 && args[0] == "container" && args[1] == "system" && args[2] == "status" {
+		os.Exit(0)
+	}
+	if len(args) >= 2 && args[0] == "container" && args[1] == "build" {
+		os.Exit(0)
+	}
+	if len(args) >= 3 && args[0] == "container" && args[1] == "image" && args[2] == "push" {
+		os.Exit(0)
+	}
+	os.Exit(1)
 }
 
 func TestEnsureDockerDaemon_DarwinUsesBundledCLIWhenRuntimeInstalledButDockerMissingFromPath(t *testing.T) {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -116,8 +116,6 @@ func TestAppleContainerPushSchemeRequiresLoopbackRegistry(t *testing.T) {
 		"[::1]:5000/test-app:latest",
 		"[::ffff:127.0.0.1]:5000/test-app:latest",
 		"[::ffff:7f00:1]:5000/test-app:latest",
-		"0.0.0.0:5000/test-app:latest",
-		"[::]:5000/test-app:latest",
 	} {
 		scheme, err := appleContainerPushScheme(image)
 		if err != nil {
@@ -131,6 +129,8 @@ func TestAppleContainerPushSchemeRequiresLoopbackRegistry(t *testing.T) {
 	for _, image := range []string{
 		"192.168.1.20:5000/test-app:latest",
 		"[::ffff:192.168.1.20]:5000/test-app:latest",
+		"0.0.0.0:5000/test-app:latest",
+		"[::]:5000/test-app:latest",
 		"my-wendy.local:5000/test-app:latest",
 		"host.docker.internal:5000/test-app:latest",
 	} {
@@ -1725,6 +1725,8 @@ func TestValidateBuildArgPair(t *testing.T) {
 		"ALSO_GOOD": "bad\x00value",
 		"LEADING":   "--flag-like",
 		"SHELL":     "$(echo bad)",
+		"DIGEST":    "image@sha256:abc",
+		"PLUS":      "v1+metadata",
 	}
 	for k, v := range invalid {
 		if err := validateBuildArgPair(k, v); err == nil {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -1717,6 +1717,8 @@ func TestValidateBuildArgPair(t *testing.T) {
 		"BAD\nKEY":  "value",
 		"GOOD":      "bad\nvalue",
 		"ALSO_GOOD": "bad\x00value",
+		"LEADING":   "--flag-like",
+		"SHELL":     "$(echo bad)",
 	}
 	for k, v := range invalid {
 		if err := validateBuildArgPair(k, v); err == nil {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -1671,6 +1671,34 @@ func TestValidateDockerfileName(t *testing.T) {
 	}
 }
 
+func TestValidateBuildArgPair(t *testing.T) {
+	valid := map[string]string{
+		"WENDY_PLATFORM":    "nvidia-jetson",
+		"_PRIVATE_ARG":      "value=with=equals",
+		"WENDY_DEVICE_TYPE": "jetson-agx-orin",
+	}
+	for k, v := range valid {
+		if err := validateBuildArgPair(k, v); err != nil {
+			t.Fatalf("validateBuildArgPair(%q, %q): %v", k, v, err)
+		}
+	}
+
+	invalid := map[string]string{
+		"":          "value",
+		"BAD-NAME":  "value",
+		"1BAD":      "value",
+		"BAD=NAME":  "value",
+		"BAD\nKEY":  "value",
+		"GOOD":      "bad\nvalue",
+		"ALSO_GOOD": "bad\x00value",
+	}
+	for k, v := range invalid {
+		if err := validateBuildArgPair(k, v); err == nil {
+			t.Fatalf("validateBuildArgPair(%q, %q) = nil, want error", k, v)
+		}
+	}
+}
+
 func TestConfinedDockerfilePath_Traversal(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := confinedDockerfilePath(dir, "../../etc/passwd"); err == nil {
@@ -1697,6 +1725,39 @@ func TestConfinedDockerfilePath_Valid(t *testing.T) {
 	}
 	if got == "" {
 		t.Fatal("expected non-empty resolved path")
+	}
+}
+
+func TestAppleContainerBuildFilePathUsesTmpAliasWhenAvailable(t *testing.T) {
+	oldGOOS := imageBuilderHostGOOS
+	t.Cleanup(func() {
+		imageBuilderHostGOOS = oldGOOS
+	})
+	imageBuilderHostGOOS = func() string { return "darwin" }
+
+	dir, err := os.MkdirTemp("/tmp", "wendy-apple-buildfile.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	privateDir := "/private" + dir
+	if !sameFilePath(dir, privateDir) {
+		t.Skip("/private/tmp is not an alias for /tmp on this host")
+	}
+
+	got, err := appleContainerBuildFilePath(privateDir, "Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "Dockerfile")
+	if got != want {
+		t.Fatalf("build file path = %q, want %q", got, want)
 	}
 }
 

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -111,8 +111,13 @@ func TestBuildAndPushImageWithAppleContainerUsesContainerCLI(t *testing.T) {
 func TestAppleContainerPushSchemeRequiresLoopbackRegistry(t *testing.T) {
 	for _, image := range []string{
 		"127.0.0.1:5000/test-app:latest",
+		"127.42.0.1:5000/test-app:latest",
 		"localhost:5000/test-app:latest",
 		"[::1]:5000/test-app:latest",
+		"[::ffff:127.0.0.1]:5000/test-app:latest",
+		"[::ffff:7f00:1]:5000/test-app:latest",
+		"0.0.0.0:5000/test-app:latest",
+		"[::]:5000/test-app:latest",
 	} {
 		scheme, err := appleContainerPushScheme(image)
 		if err != nil {
@@ -125,6 +130,7 @@ func TestAppleContainerPushSchemeRequiresLoopbackRegistry(t *testing.T) {
 
 	for _, image := range []string{
 		"192.168.1.20:5000/test-app:latest",
+		"[::ffff:192.168.1.20]:5000/test-app:latest",
 		"my-wendy.local:5000/test-app:latest",
 		"host.docker.internal:5000/test-app:latest",
 	} {
@@ -1775,7 +1781,9 @@ func TestAppleContainerBuildFilePathUsesTmpAliasWhenAvailable(t *testing.T) {
 	}
 
 	privateDir := "/private" + dir
-	if !sameFilePath(dir, privateDir) {
+	dirCanonical, dirErr := filepath.EvalSymlinks(dir)
+	privateCanonical, privateErr := filepath.EvalSymlinks(privateDir)
+	if dirErr != nil || privateErr != nil || dirCanonical != privateCanonical {
 		t.Skip("/private/tmp is not an alias for /tmp on this host")
 	}
 

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -96,7 +96,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	regPort := registryPort(agentOS)
-	registryAddr, proxyCleanup, err := resolveRegistryForAgent(ctx, conn, regPort)
+	registryAddr, proxyCleanup, useMTLS, err := resolveRegistryForImageBuilder(ctx, conn, regPort, opts.builder)
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Build all service images in parallel, then create and start containers.
-	if err := buildServicesParallel(ctx, cwd, appCfg.AppID, services, registryAddr, platform, buildArgs, conn.IsMTLS); err != nil {
+	if err := buildServicesParallel(ctx, cwd, appCfg.AppID, services, registryAddr, platform, buildArgs, opts.builder, useMTLS); err != nil {
 		return err
 	}
 
@@ -183,6 +183,7 @@ func buildServicesParallel(
 	services map[string]*appconfig.ServiceConfig,
 	registryAddr, platform string,
 	buildArgs map[string]string,
+	builder string,
 	useMTLS bool,
 ) error {
 	names := make([]string, 0, len(services))
@@ -240,7 +241,7 @@ func buildServicesParallel(
 			if prog == nil {
 				logOut = os.Stderr
 			}
-			err := buildAndPushImage(ctx, contextDir, registryAddr, imageName, platform, "", buildArgs, buildOut, logOut, useMTLS)
+			err := buildAndPushImageWithBuilder(ctx, builder, contextDir, registryAddr, imageName, platform, "", buildArgs, buildOut, logOut, useMTLS)
 			dur := time.Since(start)
 
 			if prog != nil {

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -96,11 +96,6 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	regPort := registryPort(agentOS)
-	registryAddr, proxyCleanup, useMTLS, err := resolveRegistryForImageBuilder(ctx, conn, regPort, opts.builder)
-	if err != nil {
-		return err
-	}
-	defer proxyCleanup()
 
 	buildArgs := map[string]string{
 		"WENDY_PLATFORM": wendyPlatform(versionResp.GetDeviceType()),
@@ -126,7 +121,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Build all service images in parallel, then create and start containers.
-	if err := buildServicesParallel(ctx, cwd, appCfg.AppID, services, registryAddr, platform, buildArgs, opts.builder, useMTLS); err != nil {
+	if err := buildServicesParallel(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder); err != nil {
 		return err
 	}
 
@@ -179,12 +174,13 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 // spinner in interactive terminals and via plain log lines otherwise.
 func buildServicesParallel(
 	ctx context.Context,
+	conn *grpcclient.AgentConnection,
+	regPort int,
 	cwd, appID string,
 	services map[string]*appconfig.ServiceConfig,
-	registryAddr, platform string,
+	platform string,
 	buildArgs map[string]string,
 	builder string,
-	useMTLS bool,
 ) error {
 	names := make([]string, 0, len(services))
 	for n := range services {
@@ -225,8 +221,8 @@ func buildServicesParallel(
 
 			start := time.Now()
 			contextDir := filepath.Join(cwd, svc.Context)
-			imageName := fmt.Sprintf("%s/%s-%s:latest",
-				registryAddr, strings.ToLower(appID), strings.ToLower(name))
+			repo := fmt.Sprintf("%s-%s", strings.ToLower(appID), strings.ToLower(name))
+			dockerfile, dockerfileErr := resolveDockerfile(contextDir, "", false)
 
 			var buildOut io.Writer
 			var logBuf bytes.Buffer
@@ -241,7 +237,10 @@ func buildServicesParallel(
 			if prog == nil {
 				logOut = os.Stderr
 			}
-			err := buildAndPushImageWithBuilder(ctx, builder, contextDir, registryAddr, imageName, platform, "", buildArgs, buildOut, logOut, useMTLS)
+			err := dockerfileErr
+			if err == nil {
+				err = buildAndPushImageForAgent(ctx, conn, regPort, builder, contextDir, repo, platform, dockerfile, buildArgs, buildOut, logOut)
+			}
 			dur := time.Since(start)
 
 			if prog != nil {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -730,7 +730,7 @@ func runComposeCommand(ctx context.Context, cwd string, opts runOptions) error {
 	}
 
 	if target.External != nil && target.Provider != nil {
-		// Docker provider: use docker compose directly.
+		// External providers handle local compose support themselves.
 		// Compose projects have no wendy.json, so entitlements are nil.
 		return runWithProvider(ctx, target.Provider, *target.External, cwd, filepath.Base(cwd), nil, opts)
 	}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -489,9 +489,9 @@ func newRunCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type to use when Dockerfile is present alongside Package.swift or Python project markers: docker, swift, or python")
-	cmd.Flags().StringVar(&opts.dockerfile, "dockerfile", "", "Dockerfile to build from (e.g. Dockerfile.prod); shows a selection menu when multiple Dockerfiles exist")
-	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to use for Dockerfile builds: docker or apple-container")
+	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type to use when Dockerfile/Containerfile is present alongside Package.swift or Python project markers: docker, swift, or python")
+	cmd.Flags().StringVar(&opts.dockerfile, "dockerfile", "", "Dockerfile or Containerfile to build from (e.g. Dockerfile.prod or Containerfile); shows a selection menu when multiple build files exist")
+	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to force for Dockerfile/Containerfile builds: docker or apple-container")
 	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Enable debug logging")
 	cmd.Flags().BoolVar(&opts.deploy, "deploy", false, "Create container but do not start it")
 	cmd.Flags().BoolVar(&opts.detach, "detach", false, "Start container but do not stream logs")
@@ -579,7 +579,7 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		return runComposeCommand(ctx, cwd, opts)
 	}
 
-	// For docker-type projects, resolve which Dockerfile to use before
+	// For docker-type projects, resolve which build file to use before
 	// connecting to the target — so the picker shows regardless of whether
 	// we end up on the agent path or a provider path (Docker, etc.).
 	if projectType == "docker" && opts.dockerfile == "" {
@@ -1075,14 +1075,16 @@ func resolveRunProjectType(dir, requestedType string) (string, error) {
 			}
 		}
 	case "docker":
-		// Accept the base Dockerfile or any Dockerfile.* / Dockerfile-* variant.
+		// Accept Dockerfile/Containerfile and dot/hyphen variants.
 		entries, readErr := os.ReadDir(dir)
 		if readErr != nil {
-			marker := filepath.Join(dir, "Dockerfile")
-			if _, err := os.Stat(marker); err == nil {
-				return "docker", nil
-			} else if !os.IsNotExist(err) {
-				return "", fmt.Errorf("checking for %s: %w", marker, err)
+			for _, base := range []string{"Dockerfile", "Containerfile"} {
+				marker := filepath.Join(dir, base)
+				if _, err := os.Stat(marker); err == nil {
+					return "docker", nil
+				} else if !os.IsNotExist(err) {
+					return "", fmt.Errorf("checking for %s: %w", marker, err)
+				}
 			}
 		} else {
 			for _, e := range entries {
@@ -1090,7 +1092,7 @@ func resolveRunProjectType(dir, requestedType string) (string, error) {
 					continue
 				}
 				name := e.Name()
-				if (name == "Dockerfile" || strings.HasPrefix(name, "Dockerfile.") || strings.HasPrefix(name, "Dockerfile-")) && !strings.HasSuffix(name, ".dockerignore") {
+				if isContainerBuildFileName(name) {
 					return "docker", nil
 				}
 			}
@@ -1132,7 +1134,7 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 	// Resolve Swift product name from Package.swift.
 	if projectType == "swift" {
 		if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-			return fmt.Errorf("`wendy run` for Swift packages is not supported on %s; provide a Dockerfile", runtime.GOOS)
+			return fmt.Errorf("`wendy run` for Swift packages is not supported on %s; provide a Dockerfile or Containerfile", runtime.GOOS)
 		}
 		if err := swifttoolchain.EnsureSwiftVersion(ctx, &dimWriter{}, os.Stderr); err != nil {
 			return err
@@ -1146,7 +1148,7 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 		}
 		product = swiftProduct
 	} else if p.CanBuild(projectPath) {
-		// Dockerfile exists — try to use Swift product name if Package.swift is also present.
+		// A container build file exists — try to use Swift product name if Package.swift is also present.
 		if swiftProduct, err := swifttoolchain.FindSwiftProductWithOptions(projectPath, opts.product, false); err == nil {
 			product = swiftProduct
 		}
@@ -1159,7 +1161,7 @@ func runWithProvider(ctx context.Context, p providers.DeviceProvider, device mod
 		return fmt.Errorf("Xcode projects are not supported by the %s provider; use 'wendy run' with a macOS target instead", p.DisplayName())
 	}
 
-	// Swift projects without a Dockerfile: cross-compile on the host and
+	// Swift projects without a container build file: cross-compile on the host and
 	// build a Docker image, bypassing the provider's normal Build method.
 	if projectType == "swift" {
 		if ib, ok := p.(providers.ImageBuilder); ok {
@@ -1249,7 +1251,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		return runMultiServiceWithAgent(ctx, conn, cwd, appCfg, opts)
 	}
 
-	// Detect project type and ensure a Dockerfile exists.
+	// Detect project type and ensure a build file exists when needed.
 	projectType, err := resolveRunProjectType(cwd, opts.buildType)
 	if err != nil {
 		return err
@@ -1284,28 +1286,31 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 
 	// Swift projects use a native darwin path for macOS targets and
 	// swift-container-plugin for Linux targets when --build-type=swift
-	// explicitly selects that path or when no Dockerfile is present.
+	// explicitly selects that path or when no Dockerfile/Containerfile is present.
 	// Both paths shell out to a host Swift toolchain:
 	//   - darwin target: `swift build` on the host. Requires a darwin host —
 	//     Linux's swift toolchain cannot cross-compile to macOS.
 	//   - linux target: swift-container-plugin via `swift package`. Requires
 	//     a darwin or linux host — swift-container-plugin does not yet ship
 	//     for Windows.
-	// On a Windows host with a Dockerfile the docker buildx path below
+	// On a Windows host with a Dockerfile/Containerfile the docker buildx path below
 	// handles the build, so the gates only trip when the host swift path
 	// would actually be taken.
 	if projectType == "swift" {
 		targetIsDarwin := platformOS(platform) == "darwin"
 		explicitSwift := normalizeBuildType(opts.buildType) == "swift"
-		_, dockerfileStatErr := os.Stat(filepath.Join(cwd, "Dockerfile"))
-		needsHostSwift := explicitSwift || os.IsNotExist(dockerfileStatErr)
+		resolvedBuildFile, dockerfileResolveErr := resolveDockerfile(cwd, "", false)
+		if dockerfileResolveErr != nil {
+			return dockerfileResolveErr
+		}
+		needsHostSwift := explicitSwift || resolvedBuildFile == ""
 
 		if needsHostSwift {
 			if targetIsDarwin && runtime.GOOS != "darwin" {
-				return fmt.Errorf("`wendy run` for Swift packages targeting darwin requires a darwin host (got %s); provide a Dockerfile to build a Linux image instead", runtime.GOOS)
+				return fmt.Errorf("`wendy run` for Swift packages targeting darwin requires a darwin host (got %s); provide a Dockerfile or Containerfile to build a Linux image instead", runtime.GOOS)
 			}
 			if !targetIsDarwin && runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-				return fmt.Errorf("`wendy run` for Swift packages is not supported on %s; provide a Dockerfile", runtime.GOOS)
+				return fmt.Errorf("`wendy run` for Swift packages is not supported on %s; provide a Dockerfile or Containerfile", runtime.GOOS)
 			}
 			if targetIsDarwin {
 				return runMacOSSwiftPMWithAgent(ctx, conn, cwd, appCfg, opts)
@@ -1316,7 +1321,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 
 	switch projectType {
 	case "docker":
-		// Dockerfile already exists.
+		// Dockerfile/Containerfile already exists.
 	case "compose":
 		return runComposeWithAgent(ctx, conn, cwd, opts)
 	case "python":
@@ -1331,11 +1336,11 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		}
 	case "swift":
 		if normalized, _ := normalizeImageBuilder(opts.builder); normalized == imageBuilderAppleContainer {
-			return fmt.Errorf("Apple Container builder is only supported for Dockerfile builds; provide a Dockerfile or omit --builder")
+			return fmt.Errorf("Apple Container builder is only supported for Dockerfile/Containerfile builds; provide a build file or omit --builder")
 		}
-		// Dockerfile exists; use the Docker build path.
+		// A container build file exists; use the image build path.
 	default:
-		return fmt.Errorf("unable to detect project type; ensure a Dockerfile, requirements.txt, or Package.swift is present")
+		return fmt.Errorf("unable to detect project type; ensure a Dockerfile/Containerfile, requirements.txt, or Package.swift is present")
 	}
 
 	deviceType := versionResp.GetDeviceType()
@@ -1371,20 +1376,8 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 
 	// Build and push the Docker image directly to the device's registry.
 	regPort := registryPort(agentOS)
-	// For link-local addresses (USB), a TCP proxy bridges the Docker VM
-	// to the host so buildx can reach the device.
-	registryAddr, proxyCleanup, useMTLS, err := resolveRegistryForImageBuilder(ctx, conn, regPort, opts.builder)
-	if err != nil {
-		return err
-	}
-	defer proxyCleanup()
-
 	repo := strings.ToLower(appCfg.AppID)
-	registryImage := fmt.Sprintf("%s/%s:latest", registryAddr, repo)
-
-	builder, _ := normalizeImageBuilder(opts.builder)
-	cliLogln("Building and pushing image with %s for %s...", imageBuilderDisplayName(builder), platform)
-	if err := buildAndPushImageWithBuilder(ctx, opts.builder, cwd, registryAddr, registryImage, platform, opts.dockerfile, buildArgs, os.Stdout, os.Stderr, useMTLS); err != nil {
+	if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, os.Stdout, os.Stderr); err != nil {
 		return fmt.Errorf("building and pushing image: %w", err)
 	}
 	cliLogln("Build and push completed.")

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -463,6 +463,7 @@ func createContainerWithProgress(ctx context.Context, svc agentpb.WendyContainer
 type runOptions struct {
 	buildType            string
 	dockerfile           string
+	builder              string
 	debug                bool
 	deploy               bool
 	detach               bool
@@ -490,6 +491,7 @@ func newRunCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type to use when Dockerfile is present alongside Package.swift or Python project markers: docker, swift, or python")
 	cmd.Flags().StringVar(&opts.dockerfile, "dockerfile", "", "Dockerfile to build from (e.g. Dockerfile.prod); shows a selection menu when multiple Dockerfiles exist")
+	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to use for Dockerfile builds: docker or apple-container")
 	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Enable debug logging")
 	cmd.Flags().BoolVar(&opts.deploy, "deploy", false, "Create container but do not start it")
 	cmd.Flags().BoolVar(&opts.detach, "detach", false, "Start container but do not stream logs")
@@ -543,6 +545,9 @@ func runCommand(ctx context.Context, opts runOptions) error {
 	cwd, err := resolveRunWorkingDir(opts)
 	if err != nil {
 		return fmt.Errorf("resolving working directory: %w", err)
+	}
+	if _, err := normalizeImageBuilder(opts.builder); err != nil {
+		return err
 	}
 
 	// --dockerfile implies a docker build; validate the file exists and ensure
@@ -730,6 +735,9 @@ func runComposeCommand(ctx context.Context, cwd string, opts runOptions) error {
 	}
 
 	if target.External != nil && target.Provider != nil {
+		if opts.builder != "" {
+			return fmt.Errorf("--builder is only used when --device selects a WendyOS device; use --device docker or --device apple-container for local provider runs")
+		}
 		// External providers handle local compose support themselves.
 		// Compose projects have no wendy.json, so entitlements are nil.
 		return runWithProvider(ctx, target.Provider, *target.External, cwd, filepath.Base(cwd), nil, opts)
@@ -1110,6 +1118,9 @@ func resolveRunProjectType(dir, requestedType string) (string, error) {
 
 // runWithProvider builds and runs via an external device provider.
 func runWithProvider(ctx context.Context, p providers.DeviceProvider, device models.ExternalDevice, projectPath, product string, entitlements []appconfig.Entitlement, opts runOptions) error {
+	if opts.builder != "" {
+		return fmt.Errorf("--builder is only used when --device selects a WendyOS device; use --device docker or --device apple-container for local provider runs")
+	}
 	projectType, err := resolveRunProjectType(projectPath, opts.buildType)
 	if err != nil {
 		return err
@@ -1319,6 +1330,9 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 			cliLogln("Note: --debug requires debugpy in the container image. Ensure your Dockerfile installs debugpy (e.g. RUN pip install debugpy).")
 		}
 	case "swift":
+		if normalized, _ := normalizeImageBuilder(opts.builder); normalized == imageBuilderAppleContainer {
+			return fmt.Errorf("Apple Container builder is only supported for Dockerfile builds; provide a Dockerfile or omit --builder")
+		}
 		// Dockerfile exists; use the Docker build path.
 	default:
 		return fmt.Errorf("unable to detect project type; ensure a Dockerfile, requirements.txt, or Package.swift is present")
@@ -1359,7 +1373,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	regPort := registryPort(agentOS)
 	// For link-local addresses (USB), a TCP proxy bridges the Docker VM
 	// to the host so buildx can reach the device.
-	registryAddr, proxyCleanup, err := resolveRegistryForAgent(ctx, conn, regPort)
+	registryAddr, proxyCleanup, useMTLS, err := resolveRegistryForImageBuilder(ctx, conn, regPort, opts.builder)
 	if err != nil {
 		return err
 	}
@@ -1368,9 +1382,10 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	repo := strings.ToLower(appCfg.AppID)
 	registryImage := fmt.Sprintf("%s/%s:latest", registryAddr, repo)
 
-	cliLogln("Building and pushing Docker image for %s...", platform)
-	if err := buildAndPushImage(ctx, cwd, registryAddr, registryImage, platform, opts.dockerfile, buildArgs, os.Stdout, os.Stderr, conn.IsMTLS); err != nil {
-		return fmt.Errorf("building and pushing Docker image: %w", err)
+	builder, _ := normalizeImageBuilder(opts.builder)
+	cliLogln("Building and pushing image with %s for %s...", imageBuilderDisplayName(builder), platform)
+	if err := buildAndPushImageWithBuilder(ctx, opts.builder, cwd, registryAddr, registryImage, platform, opts.dockerfile, buildArgs, os.Stdout, os.Stderr, useMTLS); err != nil {
+		return fmt.Errorf("building and pushing image: %w", err)
 	}
 	cliLogln("Build and push completed.")
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -736,7 +736,7 @@ func runComposeCommand(ctx context.Context, cwd string, opts runOptions) error {
 
 	if target.External != nil && target.Provider != nil {
 		if opts.builder != "" {
-			return fmt.Errorf("--builder is only used when --device selects a WendyOS device; use --device docker or --device apple-container for local provider runs")
+			return fmt.Errorf("--builder is only used when --device selects a WendyOS device; use --device docker for local Compose runs")
 		}
 		// External providers handle local compose support themselves.
 		// Compose projects have no wendy.json, so entitlements are nil.

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -141,6 +141,11 @@ func (p *AppleContainerProvider) BuildWithDockerfile(ctx context.Context, device
 		return nil, err
 	}
 
+	buildContext, err := appleContainerBuildContextPath(projectPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolving project path: %w", err)
+	}
+
 	imageName := strings.ToLower(product) + ":latest"
 	platform := "linux/arm64"
 	if device.CPUArchitecture != "" {
@@ -154,10 +159,10 @@ func (p *AppleContainerProvider) BuildWithDockerfile(ctx context.Context, device
 		}
 		args = append(args, "-f", resolved)
 	}
-	args = append(args, ".")
+	args = append(args, buildContext)
 
 	cmd := appleContainerCommandContext(ctx, "container", args...)
-	cmd.Dir = projectPath
+	cmd.Dir = buildContext
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -172,6 +177,45 @@ func (p *AppleContainerProvider) BuildWithDockerfile(ctx context.Context, device
 			ContainerName: product,
 		},
 	}, nil
+}
+
+func appleContainerBuildContextPath(projectPath string) (string, error) {
+	buildContext, err := filepath.Abs(projectPath)
+	if err != nil {
+		return "", err
+	}
+	// Apple Container 1.0.0 mishandles symlink-resolved /private/tmp build
+	// contexts. When macOS reports /private/tmp, pass the equivalent /tmp path.
+	if appleContainerHostGOOS() == "darwin" {
+		if normalized, ok := appleContainerTmpAlias(buildContext); ok {
+			return normalized, nil
+		}
+	}
+	return buildContext, nil
+}
+
+func appleContainerTmpAlias(path string) (string, bool) {
+	const privateTmp = "/private/tmp"
+	if path != privateTmp && !strings.HasPrefix(path, privateTmp+"/") {
+		return "", false
+	}
+	candidate := "/tmp" + strings.TrimPrefix(path, privateTmp)
+	if sameFilePath(path, candidate) {
+		return candidate, true
+	}
+	return "", false
+}
+
+func sameFilePath(left, right string) bool {
+	leftInfo, leftErr := os.Stat(left)
+	if leftErr != nil {
+		return false
+	}
+	rightInfo, rightErr := os.Stat(right)
+	if rightErr != nil {
+		return false
+	}
+	return os.SameFile(leftInfo, rightInfo)
 }
 
 func confinedProviderDockerfilePath(projectPath, dockerfile string) (string, error) {

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -23,8 +23,9 @@ var (
 )
 
 var (
-	appleContainerLabelKeyRe   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*(/[A-Za-z0-9][A-Za-z0-9_.-]*)?$`)
-	appleContainerLabelValueRe = regexp.MustCompile(`^[A-Za-z0-9_./:=,@+-]*$`)
+	appleContainerContainerNameRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+	appleContainerLabelKeyRe      = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*(/[A-Za-z0-9][A-Za-z0-9_.-]*)?$`)
+	appleContainerLabelValueRe    = regexp.MustCompile(`^[A-Za-z0-9_./:=,-]*$`)
 )
 
 type appleContainerBuildContext struct {
@@ -220,6 +221,20 @@ func validateAppleContainerKeyValueArg(kind, key, value string) error {
 	return nil
 }
 
+func validateAppleContainerContainerName(name string) error {
+	if !appleContainerContainerNameRe.MatchString(name) {
+		return fmt.Errorf("invalid Apple Container container name %q: must match [A-Za-z0-9][A-Za-z0-9_.-]*", name)
+	}
+	return nil
+}
+
+func appleContainerKeyValueArg(kind, key, value string) (string, error) {
+	if err := validateAppleContainerKeyValueArg(kind, key, value); err != nil {
+		return "", err
+	}
+	return key + "=" + value, nil
+}
+
 func confinedProviderDockerfilePath(projectPath, dockerfile string) (string, error) {
 	absProject, err := filepath.EvalSymlinks(projectPath)
 	if err != nil {
@@ -259,6 +274,9 @@ func (p *AppleContainerProvider) Run(ctx context.Context, app *BuiltApp, detach 
 	if !ok {
 		return fmt.Errorf("Apple Container provider: invalid build context")
 	}
+	if err := validateAppleContainerContainerName(bc.ContainerName); err != nil {
+		return err
+	}
 	if err := p.CheckRequirements(ctx); err != nil {
 		return err
 	}
@@ -266,12 +284,17 @@ func (p *AppleContainerProvider) Run(ctx context.Context, app *BuiltApp, detach 
 		return err
 	}
 
-	args := []string{"run", "--name", bc.ContainerName, "--label", "wendy.managed=true"}
+	managedLabel, err := appleContainerKeyValueArg("label", "wendy.managed", "true")
+	if err != nil {
+		return err
+	}
+	args := []string{"run", "--name", bc.ContainerName, "--label", managedLabel}
 	for k, v := range appconfig.BuildEntitlementAnnotations(app.Entitlements) {
-		if err := validateAppleContainerKeyValueArg("label", k, v); err != nil {
+		label, err := appleContainerKeyValueArg("label", k, v)
+		if err != nil {
 			return err
 		}
-		args = append(args, "--label", k+"="+v)
+		args = append(args, "--label", label)
 	}
 	if detach {
 		args = append(args, "--detach")
@@ -319,6 +342,9 @@ func (p *AppleContainerProvider) Stop(ctx context.Context, app *BuiltApp) error 
 	if !ok {
 		return fmt.Errorf("Apple Container provider: invalid build context")
 	}
+	if err := validateAppleContainerContainerName(bc.ContainerName); err != nil {
+		return err
+	}
 	cmd := appleContainerCommandContext(ctx, "container", "stop", bc.ContainerName)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("container stop: %s: %w", strings.TrimSpace(string(out)), err)
@@ -327,6 +353,9 @@ func (p *AppleContainerProvider) Stop(ctx context.Context, app *BuiltApp) error 
 }
 
 func (p *AppleContainerProvider) removeManagedContainer(ctx context.Context, name string) error {
+	if err := validateAppleContainerContainerName(name); err != nil {
+		return err
+	}
 	managed, err := p.containerHasManagedLabel(ctx, name)
 	if err != nil {
 		return err
@@ -342,6 +371,9 @@ func (p *AppleContainerProvider) removeManagedContainer(ctx context.Context, nam
 }
 
 func (p *AppleContainerProvider) containerHasManagedLabel(ctx context.Context, name string) (bool, error) {
+	if err := validateAppleContainerContainerName(name); err != nil {
+		return false, err
+	}
 	cmd := appleContainerCommandContext(ctx, "container", "inspect", name)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -490,6 +522,9 @@ func firstJSONMap(m map[string]any, keys ...string) map[string]any {
 }
 
 func (p *AppleContainerProvider) StartContainer(ctx context.Context, name string) error {
+	if err := validateAppleContainerContainerName(name); err != nil {
+		return err
+	}
 	cmd := appleContainerCommandContext(ctx, "container", "start", name)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("container start: %s: %w", strings.TrimSpace(string(out)), err)
@@ -498,6 +533,9 @@ func (p *AppleContainerProvider) StartContainer(ctx context.Context, name string
 }
 
 func (p *AppleContainerProvider) StopContainer(ctx context.Context, name string) error {
+	if err := validateAppleContainerContainerName(name); err != nil {
+		return err
+	}
 	cmd := appleContainerCommandContext(ctx, "container", "stop", name)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("container stop: %s: %w", strings.TrimSpace(string(out)), err)
@@ -506,6 +544,9 @@ func (p *AppleContainerProvider) StopContainer(ctx context.Context, name string)
 }
 
 func (p *AppleContainerProvider) RemoveContainer(ctx context.Context, name string) error {
+	if err := validateAppleContainerContainerName(name); err != nil {
+		return err
+	}
 	cmd := appleContainerCommandContext(ctx, "container", "delete", "--force", name)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("container delete: %s: %w", strings.TrimSpace(string(out)), err)

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -201,6 +201,19 @@ func sameFilePath(left, right string) bool {
 	return os.SameFile(leftInfo, rightInfo)
 }
 
+func validateAppleContainerKeyValueArg(kind, key, value string) error {
+	if key == "" {
+		return fmt.Errorf("invalid %s: key is empty", kind)
+	}
+	if strings.ContainsAny(key, "=\x00\r\n") {
+		return fmt.Errorf("invalid %s key %q: must not contain '=', NUL, or newline characters", kind, key)
+	}
+	if strings.ContainsAny(value, "\x00\r\n") {
+		return fmt.Errorf("invalid %s %q: value must not contain NUL or newline characters", kind, key)
+	}
+	return nil
+}
+
 func confinedProviderDockerfilePath(projectPath, dockerfile string) (string, error) {
 	absProject, err := filepath.EvalSymlinks(projectPath)
 	if err != nil {
@@ -225,6 +238,11 @@ func confinedProviderDockerfilePath(projectPath, dockerfile string) (string, err
 	if err != nil || escapes(rel) {
 		return "", fmt.Errorf("dockerfile %q must be within the project directory", dockerfile)
 	}
+	if appleContainerHostGOOS() == "darwin" {
+		if normalized, ok := appleContainerTmpAlias(resolved); ok {
+			return normalized, nil
+		}
+	}
 	return resolved, nil
 }
 
@@ -244,6 +262,9 @@ func (p *AppleContainerProvider) Run(ctx context.Context, app *BuiltApp, detach 
 
 	args := []string{"run", "--name", bc.ContainerName, "--label", "wendy.managed=true"}
 	for k, v := range appconfig.BuildEntitlementAnnotations(app.Entitlements) {
+		if err := validateAppleContainerKeyValueArg("label", k, v); err != nil {
+			return err
+		}
 		args = append(args, "--label", k+"="+v)
 	}
 	if detach {
@@ -293,12 +314,18 @@ func (p *AppleContainerProvider) Stop(ctx context.Context, app *BuiltApp) error 
 		return fmt.Errorf("Apple Container provider: invalid build context")
 	}
 	cmd := appleContainerCommandContext(ctx, "container", "stop", bc.ContainerName)
-	return cmd.Run()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("container stop: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
 }
 
 func (p *AppleContainerProvider) removeManagedContainer(ctx context.Context, name string) error {
 	managed, err := p.containerHasManagedLabel(ctx, name)
-	if err != nil || !managed {
+	if err != nil {
+		return err
+	}
+	if !managed {
 		return nil
 	}
 	cmd := appleContainerCommandContext(ctx, "container", "delete", "--force", name)
@@ -310,11 +337,25 @@ func (p *AppleContainerProvider) removeManagedContainer(ctx context.Context, nam
 
 func (p *AppleContainerProvider) containerHasManagedLabel(ctx context.Context, name string) (bool, error) {
 	cmd := appleContainerCommandContext(ctx, "container", "inspect", name)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return false, err
+		msg := strings.TrimSpace(string(out))
+		if appleContainerInspectNotFound(msg) {
+			return false, nil
+		}
+		if msg != "" {
+			return false, fmt.Errorf("container inspect: %s: %w", msg, err)
+		}
+		return false, fmt.Errorf("container inspect: %w", err)
 	}
 	return appleContainerInspectHasManagedLabel(out), nil
+}
+
+func appleContainerInspectNotFound(output string) bool {
+	s := strings.ToLower(output)
+	return strings.Contains(s, "not found") ||
+		strings.Contains(s, "no such container") ||
+		strings.Contains(s, "does not exist")
 }
 
 func appleContainerInspectHasManagedLabel(data []byte) bool {

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -19,6 +20,11 @@ var (
 	appleContainerLookPath       = exec.LookPath
 	appleContainerHostGOOS       = func() string { return runtime.GOOS }
 	appleContainerHostGOARCH     = func() string { return runtime.GOARCH }
+)
+
+var (
+	appleContainerLabelKeyRe   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*(/[A-Za-z0-9][A-Za-z0-9_.-]*)?$`)
+	appleContainerLabelValueRe = regexp.MustCompile(`^[A-Za-z0-9_./:=,@+-]*$`)
 )
 
 type appleContainerBuildContext struct {
@@ -205,11 +211,11 @@ func validateAppleContainerKeyValueArg(kind, key, value string) error {
 	if key == "" {
 		return fmt.Errorf("invalid %s: key is empty", kind)
 	}
-	if strings.ContainsAny(key, "=\x00\r\n") {
-		return fmt.Errorf("invalid %s key %q: must not contain '=', NUL, or newline characters", kind, key)
+	if !appleContainerLabelKeyRe.MatchString(key) {
+		return fmt.Errorf("invalid %s key %q: must contain only ASCII label characters and at most one '/' prefix separator", kind, key)
 	}
-	if strings.ContainsAny(value, "\x00\r\n") {
-		return fmt.Errorf("invalid %s %q: value must not contain NUL or newline characters", kind, key)
+	if !appleContainerLabelValueRe.MatchString(value) {
+		return fmt.Errorf("invalid %s %q: value must contain only safe ASCII label value characters", kind, key)
 	}
 	return nil
 }
@@ -361,8 +367,7 @@ func appleContainerInspectNotFound(output string) bool {
 func appleContainerInspectHasManagedLabel(data []byte) bool {
 	var v any
 	if err := json.Unmarshal(data, &v); err != nil {
-		s := string(data)
-		return strings.Contains(s, "wendy.managed") && strings.Contains(s, "true")
+		return false
 	}
 	return jsonContainsManagedLabel(v)
 }

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -26,6 +27,11 @@ var (
 	appleContainerContainerNameRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
 	appleContainerLabelKeyRe      = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*(/[A-Za-z0-9][A-Za-z0-9_.-]*)?$`)
 	appleContainerLabelValueRe    = regexp.MustCompile(`^[A-Za-z0-9_./:=,-]*$`)
+)
+
+const (
+	appleContainerMaxJSONDepth       = 32
+	appleContainerMaxJSONOutputBytes = 1 << 20
 )
 
 type appleContainerBuildContext struct {
@@ -186,26 +192,14 @@ func appleContainerBuildContextPath(projectPath string) (string, error) {
 
 func appleContainerTmpAlias(path string) (string, bool) {
 	const privateTmp = "/private/tmp"
-	if path != privateTmp && !strings.HasPrefix(path, privateTmp+"/") {
+	canonical, err := filepath.EvalSymlinks(path)
+	if err != nil {
 		return "", false
 	}
-	candidate := "/tmp" + strings.TrimPrefix(path, privateTmp)
-	if sameFilePath(path, candidate) {
-		return candidate, true
+	if canonical != privateTmp && !strings.HasPrefix(canonical, privateTmp+"/") {
+		return "", false
 	}
-	return "", false
-}
-
-func sameFilePath(left, right string) bool {
-	leftInfo, leftErr := os.Stat(left)
-	if leftErr != nil {
-		return false
-	}
-	rightInfo, rightErr := os.Stat(right)
-	if rightErr != nil {
-		return false
-	}
-	return os.SameFile(leftInfo, rightInfo)
+	return "/tmp" + strings.TrimPrefix(canonical, privateTmp), true
 }
 
 func validateAppleContainerKeyValueArg(kind, key, value string) error {
@@ -375,7 +369,10 @@ func (p *AppleContainerProvider) containerHasManagedLabel(ctx context.Context, n
 		return false, err
 	}
 	cmd := appleContainerCommandContext(ctx, "container", "inspect", name)
-	out, err := cmd.CombinedOutput()
+	out, truncated, err := appleContainerCombinedOutputLimited(cmd, appleContainerMaxJSONOutputBytes)
+	if truncated {
+		return false, fmt.Errorf("container inspect output exceeds %d bytes", appleContainerMaxJSONOutputBytes)
+	}
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
 		if appleContainerInspectNotFound(msg) {
@@ -397,6 +394,9 @@ func appleContainerInspectNotFound(output string) bool {
 }
 
 func appleContainerInspectHasManagedLabel(data []byte) bool {
+	if len(data) > appleContainerMaxJSONOutputBytes {
+		return false
+	}
 	var v any
 	if err := json.Unmarshal(data, &v); err != nil {
 		return false
@@ -405,10 +405,17 @@ func appleContainerInspectHasManagedLabel(data []byte) bool {
 }
 
 func jsonContainsManagedLabel(v any) bool {
+	return jsonContainsManagedLabelDepth(v, 0)
+}
+
+func jsonContainsManagedLabelDepth(v any, depth int) bool {
+	if depth > appleContainerMaxJSONDepth {
+		return false
+	}
 	switch value := v.(type) {
 	case []any:
 		for _, item := range value {
-			if jsonContainsManagedLabel(item) {
+			if jsonContainsManagedLabelDepth(item, depth+1) {
 				return true
 			}
 		}
@@ -417,7 +424,7 @@ func jsonContainsManagedLabel(v any) bool {
 			if k == "wendy.managed" && fmt.Sprint(item) == "true" {
 				return true
 			}
-			if jsonContainsManagedLabel(item) {
+			if jsonContainsManagedLabelDepth(item, depth+1) {
 				return true
 			}
 		}
@@ -427,7 +434,10 @@ func jsonContainsManagedLabel(v any) bool {
 
 func (p *AppleContainerProvider) ListContainers(ctx context.Context) ([]ContainerInfo, error) {
 	cmd := appleContainerCommandContext(ctx, "container", "list", "--all", "--format", "json")
-	out, err := cmd.Output()
+	out, truncated, err := appleContainerOutputLimited(cmd, appleContainerMaxJSONOutputBytes)
+	if truncated {
+		return nil, fmt.Errorf("container list output exceeds %d bytes", appleContainerMaxJSONOutputBytes)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("container list: %w", err)
 	}
@@ -446,6 +456,9 @@ func (p *AppleContainerProvider) ListContainers(ctx context.Context) ([]Containe
 }
 
 func appleContainerListInfos(data []byte) []ContainerInfo {
+	if len(data) > appleContainerMaxJSONOutputBytes {
+		return nil
+	}
 	var v any
 	if err := json.Unmarshal(data, &v); err != nil {
 		return nil
@@ -494,6 +507,48 @@ func appleContainerListInfos(data []byte) []ContainerInfo {
 		})
 	}
 	return containers
+}
+
+type limitedOutputBuffer struct {
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (b *limitedOutputBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buf.Len()
+	if remaining > 0 {
+		if len(p) <= remaining {
+			_, _ = b.buf.Write(p)
+		} else {
+			_, _ = b.buf.Write(p[:remaining])
+			b.truncated = true
+		}
+	} else if len(p) > 0 {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *limitedOutputBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+func appleContainerOutputLimited(cmd *exec.Cmd, limit int) ([]byte, bool, error) {
+	var stdout limitedOutputBuffer
+	stdout.limit = limit
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	return stdout.Bytes(), stdout.truncated, err
+}
+
+func appleContainerCombinedOutputLimited(cmd *exec.Cmd, limit int) ([]byte, bool, error) {
+	var combined limitedOutputBuffer
+	combined.limit = limit
+	cmd.Stdout = &combined
+	cmd.Stderr = &combined
+	err := cmd.Run()
+	return combined.Bytes(), combined.truncated, err
 }
 
 func firstJSONText(m map[string]any, keys ...string) string {

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -203,7 +203,12 @@ func appleContainerTmpAlias(path string) (string, bool) {
 	if canonical != privateTmp && !strings.HasPrefix(canonical, privateTmp+"/") {
 		return "", false
 	}
-	return "/tmp" + strings.TrimPrefix(canonical, privateTmp), true
+	candidate := "/tmp" + strings.TrimPrefix(canonical, privateTmp)
+	candidateCanonical, err := filepath.EvalSymlinks(candidate)
+	if err != nil || candidateCanonical != canonical {
+		return "", false
+	}
+	return candidate, true
 }
 
 func validateAppleContainerKeyValueArg(kind, key, value string) error {
@@ -234,26 +239,25 @@ func appleContainerKeyValueArg(kind, key, value string) (string, error) {
 }
 
 func confinedProviderDockerfilePath(projectPath, dockerfile string) (string, error) {
+	if err := validateContainerBuildFileName(dockerfile); err != nil {
+		return "", err
+	}
 	absProject, err := filepath.EvalSymlinks(projectPath)
 	if err != nil {
 		return "", fmt.Errorf("resolving project path: %w", err)
 	}
-	joined, err := filepath.Abs(filepath.Join(absProject, dockerfile))
-	if err != nil {
-		return "", fmt.Errorf("resolving dockerfile path: %w", err)
-	}
 	escapes := func(rel string) bool {
 		return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
 	}
-	rel, err := filepath.Rel(absProject, joined)
-	if err != nil || escapes(rel) {
-		return "", fmt.Errorf("dockerfile %q must be within the project directory", dockerfile)
-	}
-	resolved, err := filepath.EvalSymlinks(joined)
+	resolved, err := filepath.EvalSymlinks(filepath.Join(absProject, dockerfile))
 	if err != nil {
 		return "", fmt.Errorf("dockerfile %q: %w", dockerfile, err)
 	}
-	rel, err = filepath.Rel(absProject, resolved)
+	absProject, err = filepath.EvalSymlinks(projectPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving project path: %w", err)
+	}
+	rel, err := filepath.Rel(absProject, resolved)
 	if err != nil || escapes(rel) {
 		return "", fmt.Errorf("dockerfile %q must be within the project directory", dockerfile)
 	}

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -27,8 +27,8 @@ type appleContainerBuildContext struct {
 	cmd           *exec.Cmd
 }
 
-// AppleContainerProvider builds and runs Dockerfile projects with Apple's
-// container CLI on Apple silicon Macs.
+// AppleContainerProvider builds and runs Dockerfile/Containerfile projects
+// with Apple's container CLI on Apple silicon Macs.
 type AppleContainerProvider struct{}
 
 func (p *AppleContainerProvider) Key() string         { return ProviderKeyAppleContainer }
@@ -100,27 +100,7 @@ func (p *AppleContainerProvider) SupportedBuildTypes() []string {
 }
 
 func (p *AppleContainerProvider) CanBuild(projectPath string) bool {
-	return hasDockerfile(projectPath)
-}
-
-func hasDockerfile(projectPath string) bool {
-	entries, err := os.ReadDir(projectPath)
-	if err == nil {
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
-			}
-			name := e.Name()
-			if (name == "Dockerfile" || strings.HasPrefix(name, "Dockerfile.") || strings.HasPrefix(name, "Dockerfile-")) && !strings.HasSuffix(name, ".dockerignore") {
-				return true
-			}
-		}
-		return false
-	}
-	if _, statErr := os.Stat(filepath.Join(projectPath, "Dockerfile")); statErr == nil {
-		return true
-	}
-	return false
+	return hasContainerBuildFile(projectPath)
 }
 
 func (p *AppleContainerProvider) Build(ctx context.Context, device models.ExternalDevice, projectPath, product string, debug bool) (*BuiltApp, error) {
@@ -135,7 +115,7 @@ func (p *AppleContainerProvider) BuildWithDockerfile(ctx context.Context, device
 	switch strings.TrimSpace(strings.ToLower(buildType)) {
 	case "", "docker":
 	default:
-		return nil, fmt.Errorf("Apple Container supports Dockerfile builds only, not %s", buildType)
+		return nil, fmt.Errorf("Apple Container supports Dockerfile/Containerfile builds only, not %s", buildType)
 	}
 	if err := p.CheckRequirements(ctx); err != nil {
 		return nil, err
@@ -152,6 +132,9 @@ func (p *AppleContainerProvider) BuildWithDockerfile(ctx context.Context, device
 		platform = "linux/" + device.CPUArchitecture
 	}
 	args := []string{"build", "--platform", platform, "-t", imageName}
+	if dockerfile == "" {
+		dockerfile = defaultContainerBuildFile(projectPath)
+	}
 	if dockerfile != "" {
 		resolved, err := confinedProviderDockerfilePath(projectPath, dockerfile)
 		if err != nil {

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -405,11 +405,31 @@ func appleContainerListInfos(data []byte) []ContainerInfo {
 		if !ok {
 			continue
 		}
+		image := firstJSONText(m, "image", "Image")
+		if image == "" {
+			if cfg := firstJSONMap(m, "configuration", "Configuration"); cfg != nil {
+				if img := firstJSONMap(cfg, "image", "Image"); img != nil {
+					image = firstJSONText(img, "reference", "Reference")
+				}
+			}
+		}
+		state := firstJSONText(m, "state", "State")
+		status := firstJSONText(m, "status", "Status")
+		if statusMap := firstJSONMap(m, "status", "Status"); statusMap != nil {
+			if nestedState := firstJSONText(statusMap, "state", "State"); nestedState != "" {
+				if state == "" {
+					state = nestedState
+				}
+				if status == "" {
+					status = nestedState
+				}
+			}
+		}
 		containers = append(containers, ContainerInfo{
 			Name:   firstJSONText(m, "id", "ID", "name", "Name"),
-			Image:  firstJSONText(m, "image", "Image"),
-			State:  firstJSONText(m, "state", "State"),
-			Status: firstJSONText(m, "status", "Status"),
+			Image:  image,
+			State:  state,
+			Status: status,
 		})
 	}
 	return containers
@@ -418,10 +438,26 @@ func appleContainerListInfos(data []byte) []ContainerInfo {
 func firstJSONText(m map[string]any, keys ...string) string {
 	for _, key := range keys {
 		if value, ok := m[key]; ok {
-			return fmt.Sprint(value)
+			switch v := value.(type) {
+			case string:
+				return v
+			case json.Number:
+				return v.String()
+			case float64, bool:
+				return fmt.Sprint(v)
+			}
 		}
 	}
 	return ""
+}
+
+func firstJSONMap(m map[string]any, keys ...string) map[string]any {
+	for _, key := range keys {
+		if value, ok := m[key].(map[string]any); ok {
+			return value
+		}
+	}
+	return nil
 }
 
 func (p *AppleContainerProvider) StartContainer(ctx context.Context, name string) error {

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -455,7 +455,10 @@ func (p *AppleContainerProvider) ListContainers(ctx context.Context) ([]Containe
 		if info.Name == "" {
 			continue
 		}
-		managed, _ := p.containerHasManagedLabel(ctx, info.Name)
+		managed, err := p.containerHasManagedLabel(ctx, info.Name)
+		if err != nil {
+			return nil, err
+		}
 		if managed {
 			containers = append(containers, info)
 		}

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -1,0 +1,405 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+var (
+	appleContainerCommandContext = exec.CommandContext
+	appleContainerLookPath       = exec.LookPath
+	appleContainerHostGOOS       = func() string { return runtime.GOOS }
+	appleContainerHostGOARCH     = func() string { return runtime.GOARCH }
+)
+
+type appleContainerBuildContext struct {
+	ImageName     string
+	ContainerName string
+	cmd           *exec.Cmd
+}
+
+// AppleContainerProvider builds and runs Dockerfile projects with Apple's
+// container CLI on Apple silicon Macs.
+type AppleContainerProvider struct{}
+
+func (p *AppleContainerProvider) Key() string         { return ProviderKeyAppleContainer }
+func (p *AppleContainerProvider) DisplayName() string { return "Apple Container" }
+
+func (p *AppleContainerProvider) IsAvailable(ctx context.Context) bool {
+	if !appleContainerSupportedHost(appleContainerHostGOOS(), appleContainerHostGOARCH()) {
+		return false
+	}
+	if _, err := appleContainerLookPath("container"); err != nil {
+		return false
+	}
+	return appleContainerCommandContext(ctx, "container", "--version").Run() == nil
+}
+
+func appleContainerSupportedHost(goos, goarch string) bool {
+	return goos == "darwin" && goarch == "arm64"
+}
+
+func (p *AppleContainerProvider) CheckRequirements(ctx context.Context) error {
+	if !appleContainerSupportedHost(appleContainerHostGOOS(), appleContainerHostGOARCH()) {
+		return fmt.Errorf("Apple Container requires an Apple silicon Mac")
+	}
+	if _, err := appleContainerLookPath("container"); err != nil {
+		return fmt.Errorf("container CLI is not installed or not in PATH")
+	}
+	if err := appleContainerCommandContext(ctx, "container", "--version").Run(); err != nil {
+		return fmt.Errorf("container CLI is not usable: %w", err)
+	}
+	cmd := appleContainerCommandContext(ctx, "container", "system", "status")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			msg = ": " + msg
+		}
+		return fmt.Errorf("Apple Container system is not running%s. Run 'container system start' and try again: %w", msg, err)
+	}
+	return nil
+}
+
+func (p *AppleContainerProvider) DiscoverDevices(ctx context.Context) ([]models.ExternalDevice, error) {
+	if !p.IsAvailable(ctx) {
+		return nil, nil
+	}
+	version := appleContainerVersion(ctx)
+	return []models.ExternalDevice{
+		{
+			ID:              p.Key(),
+			DisplayName:     p.DisplayName(),
+			ProviderKey:     p.Key(),
+			IsWendyDevice:   false,
+			AgentVersion:    version,
+			OS:              "linux",
+			CPUArchitecture: "arm64",
+		},
+	}, nil
+}
+
+func appleContainerVersion(ctx context.Context) string {
+	out, err := appleContainerCommandContext(ctx, "container", "--version").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func (p *AppleContainerProvider) SupportedBuildTypes() []string {
+	return []string{"docker"}
+}
+
+func (p *AppleContainerProvider) CanBuild(projectPath string) bool {
+	return hasDockerfile(projectPath)
+}
+
+func hasDockerfile(projectPath string) bool {
+	entries, err := os.ReadDir(projectPath)
+	if err == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if (name == "Dockerfile" || strings.HasPrefix(name, "Dockerfile.") || strings.HasPrefix(name, "Dockerfile-")) && !strings.HasSuffix(name, ".dockerignore") {
+				return true
+			}
+		}
+		return false
+	}
+	if _, statErr := os.Stat(filepath.Join(projectPath, "Dockerfile")); statErr == nil {
+		return true
+	}
+	return false
+}
+
+func (p *AppleContainerProvider) Build(ctx context.Context, device models.ExternalDevice, projectPath, product string, debug bool) (*BuiltApp, error) {
+	return p.BuildWithDockerfile(ctx, device, projectPath, product, "", "", debug)
+}
+
+func (p *AppleContainerProvider) BuildWithType(ctx context.Context, device models.ExternalDevice, projectPath, product, buildType string, debug bool) (*BuiltApp, error) {
+	return p.BuildWithDockerfile(ctx, device, projectPath, product, buildType, "", debug)
+}
+
+func (p *AppleContainerProvider) BuildWithDockerfile(ctx context.Context, device models.ExternalDevice, projectPath, product, buildType, dockerfile string, debug bool) (*BuiltApp, error) {
+	switch strings.TrimSpace(strings.ToLower(buildType)) {
+	case "", "docker":
+	default:
+		return nil, fmt.Errorf("Apple Container supports Dockerfile builds only, not %s", buildType)
+	}
+	if err := p.CheckRequirements(ctx); err != nil {
+		return nil, err
+	}
+
+	imageName := strings.ToLower(product) + ":latest"
+	platform := "linux/arm64"
+	if device.CPUArchitecture != "" {
+		platform = "linux/" + device.CPUArchitecture
+	}
+	args := []string{"build", "--platform", platform, "-t", imageName}
+	if dockerfile != "" {
+		resolved, err := confinedProviderDockerfilePath(projectPath, dockerfile)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "-f", resolved)
+	}
+	args = append(args, ".")
+
+	cmd := appleContainerCommandContext(ctx, "container", args...)
+	cmd.Dir = projectPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("container build: %w", err)
+	}
+	return &BuiltApp{
+		ProviderKey: p.Key(),
+		Device:      device,
+		AppName:     product,
+		Context: &appleContainerBuildContext{
+			ImageName:     imageName,
+			ContainerName: product,
+		},
+	}, nil
+}
+
+func confinedProviderDockerfilePath(projectPath, dockerfile string) (string, error) {
+	absProject, err := filepath.EvalSymlinks(projectPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving project path: %w", err)
+	}
+	joined, err := filepath.Abs(filepath.Join(absProject, dockerfile))
+	if err != nil {
+		return "", fmt.Errorf("resolving dockerfile path: %w", err)
+	}
+	escapes := func(rel string) bool {
+		return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	}
+	rel, err := filepath.Rel(absProject, joined)
+	if err != nil || escapes(rel) {
+		return "", fmt.Errorf("dockerfile %q must be within the project directory", dockerfile)
+	}
+	resolved, err := filepath.EvalSymlinks(joined)
+	if err != nil {
+		return "", fmt.Errorf("dockerfile %q: %w", dockerfile, err)
+	}
+	rel, err = filepath.Rel(absProject, resolved)
+	if err != nil || escapes(rel) {
+		return "", fmt.Errorf("dockerfile %q must be within the project directory", dockerfile)
+	}
+	return resolved, nil
+}
+
+func (p *AppleContainerProvider) Run(ctx context.Context, app *BuiltApp, detach bool, output chan<- RunOutput) error {
+	defer close(output)
+
+	bc, ok := app.Context.(*appleContainerBuildContext)
+	if !ok {
+		return fmt.Errorf("Apple Container provider: invalid build context")
+	}
+	if err := p.CheckRequirements(ctx); err != nil {
+		return err
+	}
+	if err := p.removeManagedContainer(ctx, bc.ContainerName); err != nil {
+		return err
+	}
+
+	args := []string{"run", "--name", bc.ContainerName, "--label", "wendy.managed=true"}
+	for k, v := range appconfig.BuildEntitlementAnnotations(app.Entitlements) {
+		args = append(args, "--label", k+"="+v)
+	}
+	if detach {
+		args = append(args, "--detach")
+	}
+	args = append(args, bc.ImageName)
+
+	cmd := appleContainerCommandContext(ctx, "container", args...)
+	bc.cmd = cmd
+
+	if detach {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("container run: %w", err)
+		}
+		output <- RunOutput{Type: RunOutputStarted}
+		return nil
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("stderr pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("container run: %w", err)
+	}
+
+	output <- RunOutput{Type: RunOutputStarted}
+
+	done := make(chan struct{})
+	go scanLines(stdoutPipe, output, RunOutputStdout, done)
+	go scanLines(stderrPipe, output, RunOutputStderr, done)
+
+	<-done
+	<-done
+	return cmd.Wait()
+}
+
+func (p *AppleContainerProvider) Stop(ctx context.Context, app *BuiltApp) error {
+	bc, ok := app.Context.(*appleContainerBuildContext)
+	if !ok {
+		return fmt.Errorf("Apple Container provider: invalid build context")
+	}
+	cmd := appleContainerCommandContext(ctx, "container", "stop", bc.ContainerName)
+	return cmd.Run()
+}
+
+func (p *AppleContainerProvider) removeManagedContainer(ctx context.Context, name string) error {
+	managed, err := p.containerHasManagedLabel(ctx, name)
+	if err != nil || !managed {
+		return nil
+	}
+	cmd := appleContainerCommandContext(ctx, "container", "delete", "--force", name)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("container delete: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func (p *AppleContainerProvider) containerHasManagedLabel(ctx context.Context, name string) (bool, error) {
+	cmd := appleContainerCommandContext(ctx, "container", "inspect", name)
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	return appleContainerInspectHasManagedLabel(out), nil
+}
+
+func appleContainerInspectHasManagedLabel(data []byte) bool {
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		s := string(data)
+		return strings.Contains(s, "wendy.managed") && strings.Contains(s, "true")
+	}
+	return jsonContainsManagedLabel(v)
+}
+
+func jsonContainsManagedLabel(v any) bool {
+	switch value := v.(type) {
+	case []any:
+		for _, item := range value {
+			if jsonContainsManagedLabel(item) {
+				return true
+			}
+		}
+	case map[string]any:
+		for k, item := range value {
+			if k == "wendy.managed" && fmt.Sprint(item) == "true" {
+				return true
+			}
+			if jsonContainsManagedLabel(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (p *AppleContainerProvider) ListContainers(ctx context.Context) ([]ContainerInfo, error) {
+	cmd := appleContainerCommandContext(ctx, "container", "list", "--all", "--format", "json")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("container list: %w", err)
+	}
+
+	var containers []ContainerInfo
+	for _, info := range appleContainerListInfos(out) {
+		if info.Name == "" {
+			continue
+		}
+		managed, _ := p.containerHasManagedLabel(ctx, info.Name)
+		if managed {
+			containers = append(containers, info)
+		}
+	}
+	return containers, nil
+}
+
+func appleContainerListInfos(data []byte) []ContainerInfo {
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil
+	}
+	var entries []any
+	switch value := v.(type) {
+	case []any:
+		entries = value
+	case map[string]any:
+		if items, ok := value["items"].([]any); ok {
+			entries = items
+		}
+	}
+
+	containers := make([]ContainerInfo, 0, len(entries))
+	for _, entry := range entries {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		containers = append(containers, ContainerInfo{
+			Name:   firstJSONText(m, "id", "ID", "name", "Name"),
+			Image:  firstJSONText(m, "image", "Image"),
+			State:  firstJSONText(m, "state", "State"),
+			Status: firstJSONText(m, "status", "Status"),
+		})
+	}
+	return containers
+}
+
+func firstJSONText(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := m[key]; ok {
+			return fmt.Sprint(value)
+		}
+	}
+	return ""
+}
+
+func (p *AppleContainerProvider) StartContainer(ctx context.Context, name string) error {
+	cmd := appleContainerCommandContext(ctx, "container", "start", name)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("container start: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func (p *AppleContainerProvider) StopContainer(ctx context.Context, name string) error {
+	cmd := appleContainerCommandContext(ctx, "container", "stop", name)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("container stop: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func (p *AppleContainerProvider) RemoveContainer(ctx context.Context, name string) error {
+	cmd := appleContainerCommandContext(ctx, "container", "delete", "--force", name)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("container delete: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}

--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -26,7 +26,11 @@ var (
 var (
 	appleContainerContainerNameRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
 	appleContainerLabelKeyRe      = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*(/[A-Za-z0-9][A-Za-z0-9_.-]*)?$`)
-	appleContainerLabelValueRe    = regexp.MustCompile(`^[A-Za-z0-9_./:=,-]*$`)
+
+	// Label values intentionally permit only the characters emitted by Wendy's
+	// entitlement annotations: alphanumerics plus _ . / : = , and -. Shell
+	// metacharacters, whitespace, @ digests, quotes, and control bytes are rejected.
+	appleContainerLabelValueRe = regexp.MustCompile(`^[A-Za-z0-9_./:=,-]*$`)
 )
 
 const (

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -379,6 +379,22 @@ func TestRemoveManagedContainerInspectErrorHandling(t *testing.T) {
 	})
 }
 
+func TestAppleContainerListContainersReturnsInspectErrors(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+	oldCommand := appleContainerCommandContext
+	t.Cleanup(func() {
+		appleContainerCommandContext = oldCommand
+	})
+	t.Setenv("APPLE_CONTAINER_HELPER_LIST", "one")
+	t.Setenv("APPLE_CONTAINER_HELPER_INSPECT", "error")
+	appleContainerCommandContext = fakeAppleContainerCommandContext(logFile)
+
+	_, err := (&AppleContainerProvider{}).ListContainers(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("ListContainers error = %v, want inspect stderr context", err)
+	}
+}
+
 func TestAppleContainerCombinedOutputLimitedTruncates(t *testing.T) {
 	cmd := exec.Command(os.Args[0], "-test.run=TestAppleContainerHelperProcess", "--", "container", "inspect", "myapp")
 	cmd.Env = append(os.Environ(),
@@ -487,6 +503,13 @@ func TestAppleContainerHelperProcess(t *testing.T) {
 		case "large":
 			_, _ = os.Stdout.WriteString(strings.Repeat("x", appleContainerMaxJSONOutputBytes))
 			_, _ = os.Stdout.WriteString(strings.Repeat("x", appleContainerMaxJSONOutputBytes))
+			os.Exit(0)
+		}
+	}
+	if len(args) >= 5 && args[0] == "container" && args[1] == "list" {
+		switch os.Getenv("APPLE_CONTAINER_HELPER_LIST") {
+		case "one":
+			_, _ = os.Stdout.WriteString(`[{"id":"myapp","image":"myapp:latest","state":"running"}]`)
 			os.Exit(0)
 		}
 	}

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -45,6 +45,16 @@ func TestAppleContainerInspectHasManagedLabel(t *testing.T) {
 	if appleContainerInspectHasManagedLabel(malformed) {
 		t.Fatal("malformed inspect output must not be treated as managed")
 	}
+
+	deepManaged := []byte(strings.Repeat(`{"nested":`, appleContainerMaxJSONDepth+2) + `{"wendy.managed":"true"}` + strings.Repeat(`}`, appleContainerMaxJSONDepth+2))
+	if appleContainerInspectHasManagedLabel(deepManaged) {
+		t.Fatal("deeply nested inspect output must not be treated as managed")
+	}
+
+	oversized := []byte(strings.Repeat(" ", appleContainerMaxJSONOutputBytes+1))
+	if appleContainerInspectHasManagedLabel(oversized) {
+		t.Fatal("oversized inspect output must not be treated as managed")
+	}
 }
 
 func TestAppleContainerListInfos(t *testing.T) {
@@ -239,7 +249,9 @@ func TestAppleContainerBuildContextUsesTmpAliasWhenAvailable(t *testing.T) {
 	})
 
 	privateDir := "/private" + dir
-	if !sameFilePath(dir, privateDir) {
+	dirCanonical, dirErr := filepath.EvalSymlinks(dir)
+	privateCanonical, privateErr := filepath.EvalSymlinks(privateDir)
+	if dirErr != nil || privateErr != nil || dirCanonical != privateCanonical {
 		t.Skip("/private/tmp is not an alias for /tmp on this host")
 	}
 
@@ -268,7 +280,9 @@ func TestConfinedProviderDockerfilePathUsesTmpAliasWhenAvailable(t *testing.T) {
 	}
 
 	privateDir := "/private" + dir
-	if !sameFilePath(dir, privateDir) {
+	dirCanonical, dirErr := filepath.EvalSymlinks(dir)
+	privateCanonical, privateErr := filepath.EvalSymlinks(privateDir)
+	if dirErr != nil || privateErr != nil || dirCanonical != privateCanonical {
 		t.Skip("/private/tmp is not an alias for /tmp on this host")
 	}
 
@@ -328,6 +342,39 @@ func TestRemoveManagedContainerInspectErrorHandling(t *testing.T) {
 			t.Fatalf("removeManagedContainer error = %v, want inspect stderr context", err)
 		}
 	})
+
+	t.Run("oversized inspect output is rejected", func(t *testing.T) {
+		logFile := filepath.Join(t.TempDir(), "commands.log")
+		oldCommand := appleContainerCommandContext
+		t.Cleanup(func() {
+			appleContainerCommandContext = oldCommand
+		})
+		t.Setenv("APPLE_CONTAINER_HELPER_INSPECT", "large")
+		appleContainerCommandContext = fakeAppleContainerCommandContext(logFile)
+
+		err := (&AppleContainerProvider{}).removeManagedContainer(context.Background(), "myapp")
+		if err == nil || !strings.Contains(err.Error(), "output exceeds") {
+			t.Fatalf("removeManagedContainer error = %v, want output limit error", err)
+		}
+	})
+}
+
+func TestAppleContainerCombinedOutputLimitedTruncates(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestAppleContainerHelperProcess", "--", "container", "inspect", "myapp")
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_APPLE_CONTAINER_HELPER_PROCESS=1",
+		"APPLE_CONTAINER_HELPER_INSPECT=large",
+	)
+	out, truncated, err := appleContainerCombinedOutputLimited(cmd, 1024)
+	if err != nil {
+		t.Fatalf("appleContainerCombinedOutputLimited error = %v", err)
+	}
+	if !truncated {
+		t.Fatalf("truncated = false, want true; len(out) = %d", len(out))
+	}
+	if len(out) != 1024 {
+		t.Fatalf("len(out) = %d, want 1024", len(out))
+	}
 }
 
 func TestAppleContainerCheckRequirementsRejectsUnsupportedHost(t *testing.T) {
@@ -416,6 +463,10 @@ func TestAppleContainerHelperProcess(t *testing.T) {
 			os.Exit(1)
 		case "managed":
 			_, _ = os.Stdout.WriteString(`{"configuration":{"labels":{"wendy.managed":"true"}}}`)
+			os.Exit(0)
+		case "large":
+			_, _ = os.Stdout.WriteString(strings.Repeat("x", appleContainerMaxJSONOutputBytes))
+			_, _ = os.Stdout.WriteString(strings.Repeat("x", appleContainerMaxJSONOutputBytes))
 			os.Exit(0)
 		}
 	}

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -106,6 +106,12 @@ func TestValidateAppleContainerKeyValueArg(t *testing.T) {
 		"unicode.good": "snowman-☃",
 		"shell.good":   "$(echo bad)",
 		"digest.good":  "image@sha256:abc",
+		"plus.good":    "v1+metadata",
+		"pipe.good":    "left|right",
+		"semi.good":    "left;right",
+		"amp.good":     "left&right",
+		"quote.good":   `left"right`,
+		"back.good":    `left\right`,
 	}
 	for k, v := range invalid {
 		if err := validateAppleContainerKeyValueArg("label", k, v); err == nil {

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -66,6 +66,32 @@ func TestAppleContainerListInfos(t *testing.T) {
 	}
 }
 
+func TestValidateAppleContainerKeyValueArg(t *testing.T) {
+	valid := map[string]string{
+		"wendy.managed":                "true",
+		"sh.wendy/entitlement.network": "mode=host,ports=8080:80",
+	}
+	for k, v := range valid {
+		if err := validateAppleContainerKeyValueArg("label", k, v); err != nil {
+			t.Fatalf("validateAppleContainerKeyValueArg(%q, %q): %v", k, v, err)
+		}
+	}
+
+	invalid := map[string]string{
+		"":             "true",
+		"bad=key":      "true",
+		"bad\nkey":     "true",
+		"good.key":     "bad\nvalue",
+		"also.good":    "bad\rvalue",
+		"another.good": "bad\x00value",
+	}
+	for k, v := range invalid {
+		if err := validateAppleContainerKeyValueArg("label", k, v); err == nil {
+			t.Fatalf("validateAppleContainerKeyValueArg(%q, %q) = nil, want error", k, v)
+		}
+	}
+}
+
 func TestAppleContainerBuildWithDockerfileUsesContainerBuild(t *testing.T) {
 	restore := stubAppleContainerHost(t)
 	defer restore()
@@ -201,6 +227,84 @@ func TestAppleContainerBuildContextUsesTmpAliasWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestConfinedProviderDockerfilePathUsesTmpAliasWhenAvailable(t *testing.T) {
+	restore := stubAppleContainerHost(t)
+	defer restore()
+
+	dir, err := os.MkdirTemp("/tmp", "wendy-apple-dockerfile.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	privateDir := "/private" + dir
+	if !sameFilePath(dir, privateDir) {
+		t.Skip("/private/tmp is not an alias for /tmp on this host")
+	}
+
+	got, err := confinedProviderDockerfilePath(privateDir, "Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "Dockerfile")
+	if got != want {
+		t.Fatalf("dockerfile path = %q, want %q", got, want)
+	}
+}
+
+func TestAppleContainerStopIncludesStderr(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+	oldCommand := appleContainerCommandContext
+	t.Cleanup(func() {
+		appleContainerCommandContext = oldCommand
+	})
+	t.Setenv("APPLE_CONTAINER_HELPER_STOP_ERROR", "permission denied")
+	appleContainerCommandContext = fakeAppleContainerCommandContext(logFile)
+
+	err := (&AppleContainerProvider{}).Stop(context.Background(), &BuiltApp{
+		Context: &appleContainerBuildContext{ContainerName: "myapp"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("Stop error = %v, want stderr context", err)
+	}
+}
+
+func TestRemoveManagedContainerInspectErrorHandling(t *testing.T) {
+	t.Run("not found is ignored", func(t *testing.T) {
+		logFile := filepath.Join(t.TempDir(), "commands.log")
+		oldCommand := appleContainerCommandContext
+		t.Cleanup(func() {
+			appleContainerCommandContext = oldCommand
+		})
+		t.Setenv("APPLE_CONTAINER_HELPER_INSPECT", "missing")
+		appleContainerCommandContext = fakeAppleContainerCommandContext(logFile)
+
+		if err := (&AppleContainerProvider{}).removeManagedContainer(context.Background(), "myapp"); err != nil {
+			t.Fatalf("removeManagedContainer: %v", err)
+		}
+	})
+
+	t.Run("other inspect errors are returned", func(t *testing.T) {
+		logFile := filepath.Join(t.TempDir(), "commands.log")
+		oldCommand := appleContainerCommandContext
+		t.Cleanup(func() {
+			appleContainerCommandContext = oldCommand
+		})
+		t.Setenv("APPLE_CONTAINER_HELPER_INSPECT", "error")
+		appleContainerCommandContext = fakeAppleContainerCommandContext(logFile)
+
+		err := (&AppleContainerProvider{}).removeManagedContainer(context.Background(), "myapp")
+		if err == nil || !strings.Contains(err.Error(), "permission denied") {
+			t.Fatalf("removeManagedContainer error = %v, want inspect stderr context", err)
+		}
+	})
+}
+
 func TestAppleContainerCheckRequirementsRejectsUnsupportedHost(t *testing.T) {
 	oldGOOS := appleContainerHostGOOS
 	oldGOARCH := appleContainerHostGOARCH
@@ -268,6 +372,29 @@ func TestAppleContainerHelperProcess(t *testing.T) {
 		os.Exit(0)
 	}
 	if len(args) >= 2 && args[0] == "container" && args[1] == "build" {
+		os.Exit(0)
+	}
+	if len(args) >= 3 && args[0] == "container" && args[1] == "stop" {
+		if msg := os.Getenv("APPLE_CONTAINER_HELPER_STOP_ERROR"); msg != "" {
+			_, _ = os.Stderr.WriteString(msg + "\n")
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	if len(args) >= 3 && args[0] == "container" && args[1] == "inspect" {
+		switch os.Getenv("APPLE_CONTAINER_HELPER_INSPECT") {
+		case "missing":
+			_, _ = os.Stderr.WriteString("container not found\n")
+			os.Exit(1)
+		case "error":
+			_, _ = os.Stderr.WriteString("permission denied\n")
+			os.Exit(1)
+		case "managed":
+			_, _ = os.Stdout.WriteString(`{"configuration":{"labels":{"wendy.managed":"true"}}}`)
+			os.Exit(0)
+		}
+	}
+	if len(args) >= 3 && args[0] == "container" && args[1] == "delete" {
 		os.Exit(0)
 	}
 	os.Exit(1)

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -40,6 +40,11 @@ func TestAppleContainerInspectHasManagedLabel(t *testing.T) {
 	if appleContainerInspectHasManagedLabel(unmanaged) {
 		t.Fatal("unexpected managed label")
 	}
+
+	malformed := []byte(`container wendy.managed true`)
+	if appleContainerInspectHasManagedLabel(malformed) {
+		t.Fatal("malformed inspect output must not be treated as managed")
+	}
 }
 
 func TestAppleContainerListInfos(t *testing.T) {
@@ -68,8 +73,10 @@ func TestAppleContainerListInfos(t *testing.T) {
 
 func TestValidateAppleContainerKeyValueArg(t *testing.T) {
 	valid := map[string]string{
-		"wendy.managed":                "true",
-		"sh.wendy/entitlement.network": "mode=host,ports=8080:80",
+		"wendy.managed":                  "true",
+		"sh.wendy/entitlement.network":   "mode=host,ports=8080:80",
+		"sh.wendy/entitlement.persist.0": "name=data,path=/app/data",
+		"sh.wendy/entitlement.gpu":       "",
 	}
 	for k, v := range valid {
 		if err := validateAppleContainerKeyValueArg("label", k, v); err != nil {
@@ -81,9 +88,13 @@ func TestValidateAppleContainerKeyValueArg(t *testing.T) {
 		"":             "true",
 		"bad=key":      "true",
 		"bad\nkey":     "true",
+		"bad/key/part": "true",
+		"bad key":      "true",
 		"good.key":     "bad\nvalue",
 		"also.good":    "bad\rvalue",
 		"another.good": "bad\x00value",
+		"unicode.good": "snowman-☃",
+		"shell.good":   "$(echo bad)",
 	}
 	for k, v := range invalid {
 		if err := validateAppleContainerKeyValueArg("label", k, v); err == nil {

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -1,0 +1,185 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+func TestAppleContainerSupportedHost(t *testing.T) {
+	if !appleContainerSupportedHost("darwin", "arm64") {
+		t.Fatal("darwin/arm64 should support Apple Container")
+	}
+	for _, tc := range []struct {
+		goos   string
+		goarch string
+	}{
+		{"darwin", "amd64"},
+		{"linux", "arm64"},
+		{"windows", "arm64"},
+	} {
+		if appleContainerSupportedHost(tc.goos, tc.goarch) {
+			t.Fatalf("%s/%s should not support Apple Container", tc.goos, tc.goarch)
+		}
+	}
+}
+
+func TestAppleContainerInspectHasManagedLabel(t *testing.T) {
+	managed := []byte(`{"id":"app","configuration":{"labels":{"wendy.managed":"true"}}}`)
+	if !appleContainerInspectHasManagedLabel(managed) {
+		t.Fatal("expected managed label to be detected")
+	}
+
+	unmanaged := []byte(`{"id":"app","configuration":{"labels":{"other":"true"}}}`)
+	if appleContainerInspectHasManagedLabel(unmanaged) {
+		t.Fatal("unexpected managed label")
+	}
+}
+
+func TestAppleContainerListInfos(t *testing.T) {
+	got := appleContainerListInfos([]byte(`[
+		{"id":"app","image":"app:latest","state":"running"},
+		{"ID":"other","Image":"other:latest","State":"stopped","Status":"exited"}
+	]`))
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Name != "app" || got[0].Image != "app:latest" || got[0].State != "running" {
+		t.Fatalf("first entry = %+v", got[0])
+	}
+	if got[1].Name != "other" || got[1].Status != "exited" {
+		t.Fatalf("second entry = %+v", got[1])
+	}
+}
+
+func TestAppleContainerBuildWithDockerfileUsesContainerBuild(t *testing.T) {
+	restore := stubAppleContainerHost(t)
+	defer restore()
+
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+	oldCommand := appleContainerCommandContext
+	oldLookPath := appleContainerLookPath
+	t.Cleanup(func() {
+		appleContainerCommandContext = oldCommand
+		appleContainerLookPath = oldLookPath
+	})
+	appleContainerCommandContext = fakeAppleContainerCommandContext(logFile)
+	appleContainerLookPath = func(file string) (string, error) {
+		if file == "container" {
+			return "/usr/local/bin/container", nil
+		}
+		return "", errors.New("not found")
+	}
+
+	dir := t.TempDir()
+	dockerfile := filepath.Join(dir, "Dockerfile.prod")
+	if err := os.WriteFile(dockerfile, []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resolvedDockerfile, err := filepath.EvalSymlinks(dockerfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &AppleContainerProvider{}
+	app, err := p.BuildWithDockerfile(context.Background(), models.ExternalDevice{CPUArchitecture: "arm64"}, dir, "MyApp", "docker", "Dockerfile.prod", false)
+	if err != nil {
+		t.Fatalf("BuildWithDockerfile: %v", err)
+	}
+	if app.ProviderKey != ProviderKeyAppleContainer {
+		t.Fatalf("ProviderKey = %q", app.ProviderKey)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(data)
+	for _, want := range []string{
+		"container\x00--version\n",
+		"container\x00system\x00status\n",
+		"container\x00build\x00--platform\x00linux/arm64\x00-t\x00myapp:latest\x00-f\x00" + resolvedDockerfile + "\x00.\n",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("command log missing %q in:\n%s", want, log)
+		}
+	}
+}
+
+func TestAppleContainerCheckRequirementsRejectsUnsupportedHost(t *testing.T) {
+	oldGOOS := appleContainerHostGOOS
+	oldGOARCH := appleContainerHostGOARCH
+	t.Cleanup(func() {
+		appleContainerHostGOOS = oldGOOS
+		appleContainerHostGOARCH = oldGOARCH
+	})
+	appleContainerHostGOOS = func() string { return "linux" }
+	appleContainerHostGOARCH = func() string { return "arm64" }
+
+	err := (&AppleContainerProvider{}).CheckRequirements(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "Apple silicon Mac") {
+		t.Fatalf("CheckRequirements error = %v, want Apple silicon Mac diagnostic", err)
+	}
+}
+
+func stubAppleContainerHost(t *testing.T) func() {
+	t.Helper()
+	oldGOOS := appleContainerHostGOOS
+	oldGOARCH := appleContainerHostGOARCH
+	appleContainerHostGOOS = func() string { return "darwin" }
+	appleContainerHostGOARCH = func() string { return "arm64" }
+	return func() {
+		appleContainerHostGOOS = oldGOOS
+		appleContainerHostGOARCH = oldGOARCH
+	}
+}
+
+func fakeAppleContainerCommandContext(logFile string) func(context.Context, string, ...string) *exec.Cmd {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmdArgs := []string{"-test.run=TestAppleContainerHelperProcess", "--", name}
+		cmdArgs = append(cmdArgs, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_APPLE_CONTAINER_HELPER_PROCESS=1",
+			"APPLE_CONTAINER_HELPER_LOG="+logFile,
+		)
+		return cmd
+	}
+}
+
+func TestAppleContainerHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_APPLE_CONTAINER_HELPER_PROCESS") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) > 0 {
+		args = args[1:]
+	}
+	if logFile := os.Getenv("APPLE_CONTAINER_HELPER_LOG"); logFile != "" {
+		f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err == nil {
+			_, _ = f.WriteString(strings.Join(args, "\x00") + "\n")
+			_ = f.Close()
+		}
+	}
+	if len(args) >= 2 && args[0] == "container" && args[1] == "--version" {
+		_, _ = os.Stdout.WriteString("container 1.0.0\n")
+		os.Exit(0)
+	}
+	if len(args) >= 3 && args[0] == "container" && args[1] == "system" && args[2] == "status" {
+		os.Exit(0)
+	}
+	if len(args) >= 2 && args[0] == "container" && args[1] == "build" {
+		os.Exit(0)
+	}
+	os.Exit(1)
+}

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -302,6 +302,20 @@ func TestConfinedProviderDockerfilePathUsesTmpAliasWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestConfinedProviderDockerfilePathRejectsSubpaths(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := confinedProviderDockerfilePath(dir, filepath.Join("sub", "Dockerfile")); err == nil {
+		t.Fatal("expected subpath Dockerfile to be rejected")
+	}
+}
+
 func TestAppleContainerStopIncludesStderr(t *testing.T) {
 	logFile := filepath.Join(t.TempDir(), "commands.log")
 	oldCommand := appleContainerCommandContext

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -82,6 +82,10 @@ func TestAppleContainerBuildWithDockerfileUsesContainerBuild(t *testing.T) {
 	if err := os.WriteFile(dockerfile, []byte("FROM scratch\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	buildContext, err := appleContainerBuildContextPath(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	resolvedDockerfile, err := filepath.EvalSymlinks(dockerfile)
 	if err != nil {
 		t.Fatal(err)
@@ -104,11 +108,37 @@ func TestAppleContainerBuildWithDockerfileUsesContainerBuild(t *testing.T) {
 	for _, want := range []string{
 		"container\x00--version\n",
 		"container\x00system\x00status\n",
-		"container\x00build\x00--platform\x00linux/arm64\x00-t\x00myapp:latest\x00-f\x00" + resolvedDockerfile + "\x00.\n",
+		"container\x00build\x00--platform\x00linux/arm64\x00-t\x00myapp:latest\x00-f\x00" + resolvedDockerfile + "\x00" + buildContext + "\n",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("command log missing %q in:\n%s", want, log)
 		}
+	}
+}
+
+func TestAppleContainerBuildContextUsesTmpAliasWhenAvailable(t *testing.T) {
+	restore := stubAppleContainerHost(t)
+	defer restore()
+
+	dir, err := os.MkdirTemp("/tmp", "wendy-apple-context.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+
+	privateDir := "/private" + dir
+	if !sameFilePath(dir, privateDir) {
+		t.Skip("/private/tmp is not an alias for /tmp on this host")
+	}
+
+	got, err := appleContainerBuildContextPath(privateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != dir {
+		t.Fatalf("build context = %q, want %q", got, dir)
 	}
 }
 

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -95,10 +95,24 @@ func TestValidateAppleContainerKeyValueArg(t *testing.T) {
 		"another.good": "bad\x00value",
 		"unicode.good": "snowman-☃",
 		"shell.good":   "$(echo bad)",
+		"digest.good":  "image@sha256:abc",
 	}
 	for k, v := range invalid {
 		if err := validateAppleContainerKeyValueArg("label", k, v); err == nil {
 			t.Fatalf("validateAppleContainerKeyValueArg(%q, %q) = nil, want error", k, v)
+		}
+	}
+}
+
+func TestValidateAppleContainerContainerName(t *testing.T) {
+	for _, name := range []string{"myapp", "sh.wendy.app", "App_1-prod"} {
+		if err := validateAppleContainerContainerName(name); err != nil {
+			t.Fatalf("validateAppleContainerContainerName(%q): %v", name, err)
+		}
+	}
+	for _, name := range []string{"", "--flag", "bad/name", "bad name", "☃"} {
+		if err := validateAppleContainerContainerName(name); err == nil {
+			t.Fatalf("validateAppleContainerContainerName(%q) = nil, want error", name)
 		}
 	}
 }

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -45,16 +45,24 @@ func TestAppleContainerInspectHasManagedLabel(t *testing.T) {
 func TestAppleContainerListInfos(t *testing.T) {
 	got := appleContainerListInfos([]byte(`[
 		{"id":"app","image":"app:latest","state":"running"},
-		{"ID":"other","Image":"other:latest","State":"stopped","Status":"exited"}
+		{"ID":"other","Image":"other:latest","State":"stopped","Status":"exited"},
+		{
+			"id":"nested",
+			"configuration":{"image":{"reference":"nested:latest"}},
+			"status":{"state":"running"}
+		}
 	]`))
-	if len(got) != 2 {
-		t.Fatalf("len = %d, want 2", len(got))
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
 	}
 	if got[0].Name != "app" || got[0].Image != "app:latest" || got[0].State != "running" {
 		t.Fatalf("first entry = %+v", got[0])
 	}
 	if got[1].Name != "other" || got[1].Status != "exited" {
 		t.Fatalf("second entry = %+v", got[1])
+	}
+	if got[2].Name != "nested" || got[2].Image != "nested:latest" || got[2].State != "running" || got[2].Status != "running" {
+		t.Fatalf("third entry = %+v", got[2])
 	}
 }
 

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -124,6 +124,57 @@ func TestAppleContainerBuildWithDockerfileUsesContainerBuild(t *testing.T) {
 	}
 }
 
+func TestAppleContainerBuildWithContainerfileUsesContainerBuild(t *testing.T) {
+	restore := stubAppleContainerHost(t)
+	defer restore()
+
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+	oldCommand := appleContainerCommandContext
+	oldLookPath := appleContainerLookPath
+	t.Cleanup(func() {
+		appleContainerCommandContext = oldCommand
+		appleContainerLookPath = oldLookPath
+	})
+	appleContainerCommandContext = fakeAppleContainerCommandContext(logFile)
+	appleContainerLookPath = func(file string) (string, error) {
+		if file == "container" {
+			return "/usr/local/bin/container", nil
+		}
+		return "", errors.New("not found")
+	}
+
+	dir := t.TempDir()
+	containerfile := filepath.Join(dir, "Containerfile")
+	if err := os.WriteFile(containerfile, []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buildContext, err := appleContainerBuildContextPath(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedContainerfile, err := filepath.EvalSymlinks(containerfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &AppleContainerProvider{}
+	if !p.CanBuild(dir) {
+		t.Fatal("CanBuild = false, want true for Containerfile")
+	}
+	if _, err := p.Build(context.Background(), models.ExternalDevice{CPUArchitecture: "arm64"}, dir, "MyApp", false); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "container\x00build\x00--platform\x00linux/arm64\x00-t\x00myapp:latest\x00-f\x00" + resolvedContainerfile + "\x00" + buildContext + "\n"
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("command log missing %q in:\n%s", want, string(data))
+	}
+}
+
 func TestAppleContainerBuildContextUsesTmpAliasWhenAvailable(t *testing.T) {
 	restore := stubAppleContainerHost(t)
 	defer restore()

--- a/go/internal/cli/providers/buildfile.go
+++ b/go/internal/cli/providers/buildfile.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,6 +15,20 @@ func isContainerBuildFileName(name string) bool {
 		return false
 	}
 	return providerBuildFileNameRe.MatchString(name)
+}
+
+func validateContainerBuildFileName(name string) error {
+	cleaned := filepath.Clean(name)
+	if cleaned != filepath.Base(cleaned) {
+		return fmt.Errorf("invalid container build file name %q: path separators are not allowed", name)
+	}
+	if strings.HasSuffix(cleaned, ".dockerignore") {
+		return fmt.Errorf("invalid container build file name %q: .dockerignore files are not build files", cleaned)
+	}
+	if !providerBuildFileNameRe.MatchString(cleaned) {
+		return fmt.Errorf("invalid container build file name %q: must be Dockerfile, Containerfile, or a dot/hyphen variant of either", cleaned)
+	}
+	return nil
 }
 
 func hasContainerBuildFile(projectPath string) bool {

--- a/go/internal/cli/providers/buildfile.go
+++ b/go/internal/cli/providers/buildfile.go
@@ -1,0 +1,53 @@
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var providerBuildFileNameRe = regexp.MustCompile(`^(Dockerfile|Containerfile)([.\-][a-zA-Z0-9][a-zA-Z0-9._-]*)?$`)
+
+func isContainerBuildFileName(name string) bool {
+	if strings.HasSuffix(name, ".dockerignore") {
+		return false
+	}
+	return providerBuildFileNameRe.MatchString(name)
+}
+
+func hasContainerBuildFile(projectPath string) bool {
+	return defaultContainerBuildFile(projectPath) != ""
+}
+
+func defaultContainerBuildFile(projectPath string) string {
+	entries, err := os.ReadDir(projectPath)
+	if err == nil {
+		var firstVariant string
+		for _, preferred := range []string{"Dockerfile", "Containerfile"} {
+			for _, e := range entries {
+				if !e.IsDir() && e.Name() == preferred {
+					return preferred
+				}
+			}
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if isContainerBuildFileName(name) {
+				if firstVariant == "" {
+					firstVariant = name
+				}
+			}
+		}
+		return firstVariant
+	}
+	for _, preferred := range []string{"Dockerfile", "Containerfile"} {
+		if _, statErr := os.Stat(filepath.Join(projectPath, preferred)); statErr == nil {
+			return preferred
+		}
+	}
+	return ""
+}

--- a/go/internal/cli/providers/docker.go
+++ b/go/internal/cli/providers/docker.go
@@ -81,23 +81,8 @@ func (p *DockerProvider) SupportedBuildTypes() []string {
 }
 
 func (p *DockerProvider) CanBuild(projectPath string) bool {
-	entries, err := os.ReadDir(projectPath)
-	if err == nil {
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
-			}
-			name := e.Name()
-			if (name == "Dockerfile" || strings.HasPrefix(name, "Dockerfile.") || strings.HasPrefix(name, "Dockerfile-")) && !strings.HasSuffix(name, ".dockerignore") {
-				return true
-			}
-		}
-	} else {
-		// Fallback when ReadDir fails: Stat the base Dockerfile so CanBuild
-		// doesn't silently return false in permission-denied / transient-error cases.
-		if _, statErr := os.Stat(filepath.Join(projectPath, "Dockerfile")); statErr == nil {
-			return true
-		}
+	if hasContainerBuildFile(projectPath) {
+		return true
 	}
 	return composeFile(projectPath) != ""
 }
@@ -108,14 +93,15 @@ func (p *DockerProvider) Build(ctx context.Context, device models.ExternalDevice
 
 // BuildWithType is the typed-build entry point. When buildType is "compose" or
 // empty (auto), it uses the compose file if one is present. When buildType is
-// "docker", it builds the Dockerfile directly even if a compose file also
-// exists in the project root.
+// "docker", it builds the container build file directly even if a compose file
+// also exists in the project root.
 func (p *DockerProvider) BuildWithType(ctx context.Context, device models.ExternalDevice, projectPath, product, buildType string, debug bool) (*BuiltApp, error) {
 	return p.BuildWithDockerfile(ctx, device, projectPath, product, buildType, "", debug)
 }
 
-// BuildWithDockerfile builds with an explicit Dockerfile name (e.g. Dockerfile.prod).
-// An empty dockerfile falls back to Docker's default resolution (i.e. "Dockerfile").
+// BuildWithDockerfile builds with an explicit Dockerfile/Containerfile name
+// (e.g. Dockerfile.prod). An empty dockerfile falls back to the provider's
+// default build-file resolution.
 func (p *DockerProvider) BuildWithDockerfile(ctx context.Context, device models.ExternalDevice, projectPath, product, buildType, dockerfile string, debug bool) (*BuiltApp, error) {
 	useCompose := false
 	cf := composeFile(projectPath)
@@ -151,6 +137,9 @@ func (p *DockerProvider) BuildWithDockerfile(ctx context.Context, device models.
 
 	imageName := strings.ToLower(product) + ":latest"
 	args := []string{"build", "-t", imageName}
+	if dockerfile == "" {
+		dockerfile = defaultContainerBuildFile(projectPath)
+	}
 	if dockerfile != "" {
 		absProject, err := filepath.EvalSymlinks(projectPath)
 		if err != nil {

--- a/go/internal/cli/providers/local_test.go
+++ b/go/internal/cli/providers/local_test.go
@@ -26,20 +26,20 @@ func TestLocalProviderSupportsOnlyNativeBuildTypes(t *testing.T) {
 	}
 }
 
-func TestLocalProviderDoesNotClaimDockerfileProjects(t *testing.T) {
+func TestLocalProviderDoesNotClaimContainerBuildFileProjects(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "Containerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	p := &LocalProvider{}
 	if p.CanBuild(dir) {
-		t.Fatal("LocalProvider.CanBuild() = true for Dockerfile-only project, want false")
+		t.Fatal("LocalProvider.CanBuild() = true for container-build-file-only project, want false")
 	}
 
 	_, err := p.Build(context.Background(), models.ExternalDevice{ID: "local", ProviderKey: p.Key()}, dir, "app", false)
 	if err == nil {
-		t.Fatal("LocalProvider.Build() succeeded for Dockerfile-only project, want error")
+		t.Fatal("LocalProvider.Build() succeeded for container-build-file-only project, want error")
 	}
 	if !strings.Contains(err.Error(), "cannot determine build method") {
 		t.Fatalf("LocalProvider.Build() error = %q, want cannot determine build method", err)

--- a/go/internal/cli/providers/provider.go
+++ b/go/internal/cli/providers/provider.go
@@ -81,8 +81,8 @@ type TypedBuilder interface {
 }
 
 // DockerfileBuilder is optionally implemented by providers that support
-// building from a specific Dockerfile (e.g. Dockerfile.prod). When dockerfile
-// is empty, the provider uses its default Dockerfile resolution.
+// building from a specific Dockerfile/Containerfile (e.g. Dockerfile.prod).
+// When dockerfile is empty, the provider uses its default build-file resolution.
 type DockerfileBuilder interface {
 	BuildWithDockerfile(ctx context.Context, device models.ExternalDevice, projectPath, product, buildType, dockerfile string, debug bool) (*BuiltApp, error)
 }

--- a/go/internal/cli/providers/provider.go
+++ b/go/internal/cli/providers/provider.go
@@ -49,8 +49,9 @@ type RunOutputType int
 
 // Provider key constants for the built-in providers.
 const (
-	ProviderKeyDocker = "docker"
-	ProviderKeyLocal  = "local"
+	ProviderKeyAppleContainer = "apple-container"
+	ProviderKeyDocker         = "docker"
+	ProviderKeyLocal          = "local"
 )
 
 const (

--- a/go/internal/cli/providers/registry.go
+++ b/go/internal/cli/providers/registry.go
@@ -14,6 +14,7 @@ var (
 func init() {
 	allProviders = []DeviceProvider{
 		&LocalProvider{},
+		&AppleContainerProvider{},
 		&DockerProvider{},
 		&MicroWendyProvider{},
 	}


### PR DESCRIPTION
## Summary

Adds an `apple-container` local provider for Apple silicon macOS users who want to build and run Dockerfile projects with Apple's `container` CLI instead of Docker.

- Registers `--device apple-container` as a local provider on `darwin/arm64` when `container` is installed.
- Builds Dockerfile projects with `container build --platform linux/<arch>` and runs them with `container run` using Wendy-managed labels.
- Keeps Compose support on Docker and adds clearer local-target guidance in CLI docs and errors.
- Handles Apple Container 1.0.0's `/private/tmp` build-context behavior so `wendy init` projects created under `/tmp` build correctly.
- Parses Apple Container's nested list/inspect JSON shape for container-management metadata.

## Validation

- `CC=/usr/bin/clang go test ./go/internal/cli/providers`
- `CC=/usr/bin/clang go test ./go -count=1 -v`
- `CC=/usr/bin/clang go test ./... -count=1 -timeout 120s`
- `CC=/usr/bin/clang go vet ./...`
- Created a `simple-api` template under `/tmp` with `wendy init`, then verified `wendy --device apple-container build` uses Apple Container and succeeds.
- Verified `wendy --device apple-container run --detach` starts the generated simple-api container and applies the `wendy.managed=true` label, then cleaned up the container.
- Compared warm-cache build performance against Docker on the same simple-api project: Apple Container avg ~0.71s, Docker avg ~0.59s. Docker's first run was 7.52s because it pulled the base image.

## Notes

The hardware-backed CI integration script was attempted with `bash go/scripts/test-ci.sh -w /tmp/wendy-apple-container-perf/wendy -t python-hello`, but no WendyOS LAN device was discoverable in this environment, so that device deployment test could not run locally.