### PR TITLE
CLI: stream host WiFi scan into the picker + don't offer updates for dev agents

### DIFF
--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -251,7 +251,7 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 			fmt.Printf("CLI Version: %s\n", version.Version)
 
 			warn := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
-			if cmp := version.CompareVersions(version.Version, agentVersion); cmp > 0 {
+			if cmp := version.CompareVersions(version.Version, agentVersion); cmp > 0 && agentVersion != "dev" {
 				fmt.Println(warn.Render("\nAgent is behind the CLI — run 'wendy device update' to update."))
 			} else if cmp < 0 {
 				fmt.Println(warn.Render("\nCLI is behind the agent — consider updating the CLI."))
@@ -440,7 +440,7 @@ func newDeviceSetupCmd() *cobra.Command {
 				fmt.Printf("Unable to check agent version: %v\n", err)
 			} else {
 				fmt.Printf("Agent version: %s\n", versionResp.GetVersion())
-				if cmp := version.CompareVersions(version.Version, versionResp.GetVersion()); cmp > 0 {
+				if cmp := version.CompareVersions(version.Version, versionResp.GetVersion()); cmp > 0 && versionResp.GetVersion() != "dev" {
 					fmt.Println("Agent is behind the CLI — consider running 'wendy device update'.")
 				}
 			}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -853,6 +853,11 @@ func checkAndOfferUpdate(ctx context.Context, conn *grpcclient.AgentConnection) 
 	if version.Version == "dev" {
 		return conn, nil
 	}
+	// A dev agent build is running intentionally — never offer to replace it
+	// with a stable release (CompareVersions treats "dev" as always-behind).
+	if agentVer == "dev" {
+		return conn, nil
+	}
 	// Unknown agent version — skip to avoid spurious update prompts.
 	if agentVer == "" {
 		return conn, nil

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1440,15 +1440,21 @@ func selectWifiNetworkStreaming() (wifiScanSelection, error) {
 	var mu sync.Mutex
 	go func() {
 		defer p.Send(tui.PickerDoneMsg{})
-		nets, err := scanLocalWifiNetworks()
+		// Stream the host scan: cached results paint the picker instantly, then
+		// the fresh rescan fills it in — so SSIDs trickle in rather than the
+		// picker sitting on "Scanning..." until the whole scan completes
+		// (matching the device-side picker in pickWifiNetwork).
+		hadNetworks := false
+		err := streamLocalWifiScan(func(batch []localWifiNetwork) {
+			if len(batch) > 0 {
+				hadNetworks = true
+			}
+			p.Send(tui.PickerAddMsg{Items: localWifiPickerItems(batch)})
+		})
 		mu.Lock()
 		sel.ScanErr = err
-		sel.HadNetworks = len(nets) > 0
+		sel.HadNetworks = hadNetworks
 		mu.Unlock()
-		if err != nil {
-			return
-		}
-		p.Send(tui.PickerAddMsg{Items: localWifiPickerItems(nets)})
 	}()
 	fmt.Println()
 	finalModel, runErr := p.Run()

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -701,15 +701,16 @@ func pickWifiNetwork(ctx context.Context, target *SelectedDevice) (string, error
 
 	switch {
 	case target.Bluetooth != nil && !target.Bluetooth.IsWendyAgent():
-		// Wendy Lite — scan from the host machine (one-shot).
+		// Wendy Lite — scan from the host machine. Cached results paint the
+		// picker instantly, then the fresh rescan fills it in, so SSIDs trickle
+		// in rather than appearing all at once when the scan completes.
 		go func() {
 			defer p.Send(tui.PickerDoneMsg{})
-			nets, err := scanLocalWifiNetworks()
-			if err != nil {
+			if err := streamLocalWifiScan(func(batch []localWifiNetwork) {
+				p.Send(tui.PickerAddMsg{Items: localWifiPickerItems(batch)})
+			}); err != nil {
 				recordScanErr(fmt.Errorf("scanning local WiFi networks: %w", err))
-				return
 			}
-			p.Send(tui.PickerAddMsg{Items: localWifiPickerItems(nets)})
 		}()
 
 	case target.Bluetooth != nil || target.Agent != nil:

--- a/go/internal/cli/commands/wifi_scan_darwin.go
+++ b/go/internal/cli/commands/wifi_scan_darwin.go
@@ -19,7 +19,10 @@ import (
 // a synchronous fresh scan, so the returned set is current.
 const wifiScanCacheHint = ""
 
-const corewlanScanScript = `
+// corewlanPreamble opens the shared CoreWLAN interface and defines the
+// security-label helper. The two obtain snippets below append a `networks`
+// binding; corewlanPrintLoop then emits the tab-delimited rows.
+const corewlanPreamble = `
 import CoreWLAN
 let client = CWWiFiClient.shared()
 guard let iface = client.interface() else {
@@ -38,30 +41,70 @@ func securityLabel(_ net: CWNetwork) -> String {
     if net.supportsSecurity(.none) || net.supportsSecurity(.OWE) || net.supportsSecurity(.oweTransition) { return "Open" }
     return ""
 }
+`
+
+// corewlanFreshObtain performs a synchronous on-demand scan (several seconds).
+const corewlanFreshObtain = `
+let networks: [CWNetwork]
 do {
-    let networks = try iface.scanForNetworks(withSSID: nil)
-    for net in networks.sorted(by: { $0.rssiValue > $1.rssiValue }) {
-        guard let ssid = net.ssid, !ssid.isEmpty else { continue }
-        // Strip C0/DEL/C1 control characters before printing: SSIDs come
-        // from beacon frames, and a tab would shift the tab-delimited
-        // fields, letting attacker bytes land in the security column.
-        let clean = String(ssid.unicodeScalars.filter {
-            $0.value >= 0x20 && $0.value != 0x7F && !(0x80...0x9F).contains($0.value)
-        }.map { Character($0) })
-        guard !clean.isEmpty else { continue }
-        print("\(clean)\t\(net.rssiValue)\t\(securityLabel(net))")
-    }
+    networks = try iface.scanForNetworks(withSSID: nil)
 } catch {
     fputs("scan failed: \(error)\n", stderr)
     exit(1)
 }
 `
 
-// scanLocalWifiNetworks uses CoreWLAN (via a small Swift script) to list WiFi
-// networks visible to the host machine.
+// corewlanCachedObtain returns the most recent scan results without scanning,
+// so it returns instantly (and is empty until the OS has scanned at least once).
+const corewlanCachedObtain = `
+let networks = Array(iface.cachedScanResults() ?? [])
+`
+
+const corewlanPrintLoop = `
+for net in networks.sorted(by: { $0.rssiValue > $1.rssiValue }) {
+    guard let ssid = net.ssid, !ssid.isEmpty else { continue }
+    // Strip C0/DEL/C1 control characters before printing: SSIDs come
+    // from beacon frames, and a tab would shift the tab-delimited
+    // fields, letting attacker bytes land in the security column.
+    let clean = String(ssid.unicodeScalars.filter {
+        $0.value >= 0x20 && $0.value != 0x7F && !(0x80...0x9F).contains($0.value)
+    }.map { Character($0) })
+    guard !clean.isEmpty else { continue }
+    print("\(clean)\t\(net.rssiValue)\t\(securityLabel(net))")
+}
+`
+
+// scanLocalWifiNetworks uses CoreWLAN (via a small Swift script) to perform a
+// fresh on-demand scan of WiFi networks visible to the host machine.
 func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
+	nets, err := runCorewlanScan(corewlanPreamble + corewlanFreshObtain + corewlanPrintLoop)
+	if err != nil {
+		if errors.Is(err, errNoWifiAdapter) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("scanning WiFi networks: %w", err)
+	}
+	return nets, nil
+}
+
+// cachedLocalWifiNetworks returns CoreWLAN's most recent scan results without
+// triggering a fresh scan, so a streaming picker can paint instantly while
+// scanLocalWifiNetworks runs the slower on-demand scan. Best-effort: any
+// failure yields no networks rather than an error.
+func cachedLocalWifiNetworks() []localWifiNetwork {
+	nets, err := runCorewlanScan(corewlanPreamble + corewlanCachedObtain + corewlanPrintLoop)
+	if err != nil {
+		return nil
+	}
+	return nets
+}
+
+// runCorewlanScan runs the given Swift program and parses its tab-delimited
+// "SSID\tRSSI\tSecurity" output. A "no wifi interface" failure is reported as
+// errNoWifiAdapter; other exec failures pass through (with captured stderr).
+func runCorewlanScan(script string) ([]localWifiNetwork, error) {
 	cmd := exec.Command("/usr/bin/swift", "-")
-	cmd.Stdin = strings.NewReader(corewlanScanScript)
+	cmd.Stdin = strings.NewReader(script)
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -69,7 +112,7 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 		if errors.As(err, &ee) && strings.Contains(string(ee.Stderr), "no wifi interface") {
 			return nil, errNoWifiAdapter
 		}
-		return nil, fmt.Errorf("scanning WiFi networks: %w", exitErrWithStderr(err))
+		return nil, exitErrWithStderr(err)
 	}
 
 	seen := make(map[string]bool)

--- a/go/internal/cli/commands/wifi_scan_linux.go
+++ b/go/internal/cli/commands/wifi_scan_linux.go
@@ -39,7 +39,33 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	// Trigger a rescan first (may fail if already scanning).
 	_ = nmcli.Command(context.Background(), nmcliPath, "device", "wifi", "rescan").Run()
 
-	cmd := nmcli.Command(context.Background(), nmcliPath, "-t", "-f", "SSID,SIGNAL,SECURITY", "device", "wifi", "list")
+	return nmcliListWifi(nmcliPath)
+}
+
+// cachedLocalWifiNetworks reads nmcli's current scan cache without forcing a
+// rescan, so a streaming picker can paint instantly while scanLocalWifiNetworks
+// runs the slower `device wifi rescan`. `--rescan no` keeps the list call from
+// blocking on a fresh scan when the cache is stale. Best-effort: any failure
+// (including no nmcli on PATH, or an nmcli too old to know `--rescan`) yields
+// no networks rather than an error — the authoritative scan still runs after.
+func cachedLocalWifiNetworks() []localWifiNetwork {
+	nmcliPath, err := exec.LookPath("nmcli")
+	if err != nil {
+		return nil
+	}
+	nets, err := nmcliListWifi(nmcliPath, "--rescan", "no")
+	if err != nil {
+		return nil
+	}
+	return nets
+}
+
+// nmcliListWifi lists the WiFi networks nmcli currently knows about and parses
+// the result. It does not trigger a rescan itself; extraArgs (e.g. "--rescan",
+// "no") are appended to the list command.
+func nmcliListWifi(nmcliPath string, extraArgs ...string) ([]localWifiNetwork, error) {
+	args := append([]string{"-t", "-f", "SSID,SIGNAL,SECURITY", "device", "wifi", "list"}, extraArgs...)
+	cmd := nmcli.Command(context.Background(), nmcliPath, args...)
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("scanning WiFi networks: %w", exitErrWithStderr(err))

--- a/go/internal/cli/commands/wifi_scan_shared.go
+++ b/go/internal/cli/commands/wifi_scan_shared.go
@@ -26,6 +26,32 @@ func exitErrWithStderr(err error) error {
 	return err
 }
 
+// streamLocalWifiScan emits host WiFi scan results into emit as they become
+// available, so an interactive picker paints immediately instead of sitting on
+// "Scanning..." for the full duration of a fresh rescan. It first emits the
+// instant cached set (cachedLocalWifiNetworks), then the authoritative fresh
+// set once the platform rescan completes (scanLocalWifiNetworks). This mirrors
+// the trickle-in behavior of the device-side picker (pickWifiNetwork), where
+// SSIDs appear while the rescan runs rather than all at once at the end.
+//
+// emit may be called zero, one, or two times with cumulative batches; callers
+// feed each into the picker, which dedups by SSID. The returned error is the
+// fresh scan's error (errNoWifiAdapter, a transient failure, or nil) — the
+// cached pre-paint is best-effort and never surfaces an error.
+func streamLocalWifiScan(emit func([]localWifiNetwork)) error {
+	if cached := cachedLocalWifiNetworks(); len(cached) > 0 {
+		emit(cached)
+	}
+	nets, err := scanLocalWifiNetworks()
+	if err != nil {
+		return err
+	}
+	if len(nets) > 0 {
+		emit(nets)
+	}
+	return nil
+}
+
 // wifiScanFailureNotice renders the user-facing message shown when a host
 // WiFi scan produced no usable networks. scanErr == nil means the scan
 // succeeded but found nothing.

--- a/go/internal/cli/commands/wifi_scan_windows.go
+++ b/go/internal/cli/commands/wifi_scan_windows.go
@@ -30,6 +30,14 @@ func scanLocalWifiNetworks() ([]localWifiNetwork, error) {
 	return parseNetshNetworks(string(output)), nil
 }
 
+// cachedLocalWifiNetworks returns no networks on Windows: netsh already reads
+// the WLAN service's cached scan list (see scanLocalWifiNetworks), so the
+// single scan is effectively instant and a separate cached pre-paint would
+// just run netsh twice. streamLocalWifiScan falls through to the fresh scan.
+func cachedLocalWifiNetworks() []localWifiNetwork {
+	return nil
+}
+
 // wifiScanCacheHint is appended to empty-scan messages on Windows because
 // netsh reads cached results — see scanLocalWifiNetworks for details.
 const wifiScanCacheHint = "Windows scans for nearby networks periodically; if your network is missing, wait a few seconds and try again, or pass --ssid to specify it directly"


### PR DESCRIPTION
Two small, independent CLI improvements split out of the MCP Apps branch (#1015) so each lands on its own.

## 1. Stream host WiFi scan results into the picker (`e7b444fa`)
Adds `streamLocalWifiScan`, which emits the instant **cached** SSID set first, then the authoritative **fresh** rescan. The host WiFi picker (Wendy Lite `wendy device setup` and `os install` network selection) now paints immediately and trickles in SSIDs instead of sitting on "Scanning…" for the full rescan — matching the device-side picker (`pickWifiNetwork`). Touches `wifi.go`, `wifi_scan_{shared,darwin,linux,windows}.go`, `os_install.go`.

## 2. Don't flag/offer updates for a dev agent (`b8c7d39f`)
A device intentionally running a `dev` agent build should not be told it's "behind the CLI" or offered a downgrade to a stable release (`CompareVersions` treats `dev` as always-behind). Skip the behind-warning (`device info`) and the update offer (`checkAndOfferUpdate`) when the agent reports `dev`. Touches `device.go`, `helpers.go`.

## Test plan
- [x] `go build ./internal/cli/commands/` clean
- [x] `go test ./internal/cli/commands/` passes
- [ ] Manual: host WiFi picker trickles in SSIDs; a `dev`-agent device shows no update prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)