### PR TITLE
fix(os-install): cap device name at 55 chars for valid hostname

### DIFF
--- a/go/internal/agent/configpartition/apply.go
+++ b/go/internal/agent/configpartition/apply.go
@@ -238,10 +238,16 @@ func applyWendyConf(logger *zap.Logger, cfgDir string) {
 	}
 }
 
+// maxDeviceNameLen caps the device name so the hostname this package derives as
+// "wendyos-<name>" (via generate-hostname.sh in applyDeviceName) stays within the
+// 63-octet RFC 1035 label limit. The 8-character "wendyos-" prefix leaves 55
+// characters for the name; longer names produce an invalid hostname label.
+const maxDeviceNameLen = 55
+
 // validDeviceName reports whether name satisfies the WendyOS device name rules:
-// starts with a lowercase letter, followed by 2–63 lowercase letters, digits, or hyphens.
+// starts with a lowercase letter, followed by 2–54 lowercase letters, digits, or hyphens.
 func validDeviceName(name string) bool {
-	if len(name) < 3 || len(name) > 64 {
+	if len(name) < 3 || len(name) > maxDeviceNameLen {
 		return false
 	}
 	for i, c := range name {
@@ -261,7 +267,7 @@ func validDeviceName(name string) bool {
 
 func applyDeviceName(logger *zap.Logger, name string) error {
 	if !validDeviceName(name) {
-		return fmt.Errorf("invalid device name %q: must match ^[a-z][a-z0-9-]{2,63}$", name)
+		return fmt.Errorf("invalid device name %q: must match ^[a-z][a-z0-9-]{2,54}$", name)
 	}
 
 	const deviceNamePath = "/etc/wendyos/device-name"

--- a/go/internal/agent/configpartition/apply_test.go
+++ b/go/internal/agent/configpartition/apply_test.go
@@ -277,6 +277,7 @@ func TestValidDeviceName(t *testing.T) {
 		"brave-dolphin",
 		"my-device-1",
 		"a23",
+		strings.Repeat("a", maxDeviceNameLen), // at the length cap
 	}
 	for _, name := range valid {
 		if !validDeviceName(name) {
@@ -286,18 +287,27 @@ func TestValidDeviceName(t *testing.T) {
 
 	invalid := []string{
 		"",
-		"ab",                    // too short
-		"1abc",                  // starts with digit
-		"-abc",                  // starts with hyphen
-		"ABC",                   // uppercase
-		"has space",             // space
-		strings.Repeat("a", 65), // too long
-		"valid_but_underscore",  // underscore not allowed
+		"ab",                                    // too short
+		"1abc",                                  // starts with digit
+		"-abc",                                  // starts with hyphen
+		"ABC",                                   // uppercase
+		"has space",                             // space
+		strings.Repeat("a", maxDeviceNameLen+1), // one over the cap
+		"valid_but_underscore",                  // underscore not allowed
 	}
 	for _, name := range invalid {
 		if validDeviceName(name) {
 			t.Errorf("expected %q to be invalid", name)
 		}
+	}
+
+	// The cap exists so the derived "wendyos-<name>" hostname stays within the
+	// 63-octet RFC 1035 label limit (WDY-1518).
+	if maxDeviceNameLen != 55 {
+		t.Errorf("maxDeviceNameLen = %d; want 55", maxDeviceNameLen)
+	}
+	if got := len("wendyos-" + strings.Repeat("a", maxDeviceNameLen)); got > 63 {
+		t.Errorf("derived hostname label is %d octets; exceeds the RFC 1035 limit of 63", got)
 	}
 }
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -151,7 +151,7 @@ Requires an active `wendy auth login` session. The CLI creates an enrollment tok
 | `--wifi-password` | — | Password for `--wifi-ssid` |
 | `--wifi` | — | Pre-configure one WiFi network; repeatable |
 | `--no-wifi` | false | Skip WiFi setup entirely |
-| `--device-name` | interactive | Set device name on first boot (lowercase letters, digits, hyphens; must start with a letter, 3–64 chars) |
+| `--device-name` | interactive | Set device name on first boot (lowercase letters, digits, hyphens; must start with a letter, 3–55 chars) |
 | `--pre-enroll` | auto | Pre-enroll with Wendy Cloud during imaging |
 
 > **TODO**: Post-flashing Linux devices still need certificate provisioning and Wendy Cloud enrollment if `--pre-enroll` was not used. See [`wendy device setup`](../device/setup.md), [PKI](../../../../pki/), and [Wendy Cloud](../../../../cloud/).

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1542,9 +1542,16 @@ func nonEmptyValidator(v string) error {
 	return nil
 }
 
+// maxDeviceNameLen caps the device name so the derived hostname stays a valid
+// DNS label. The agent builds the hostname as "wendyos-<name>" (see
+// generate-hostname.sh / configpartition.applyDeviceName); with the 8-character
+// "wendyos-" prefix, a 55-character name yields a 63-octet label — the RFC 1035
+// maximum. Longer names produce an invalid hostname label on the device.
+const maxDeviceNameLen = 55
+
 func validateDeviceName(name string) error {
-	if len(name) < 3 || len(name) > 64 {
-		return fmt.Errorf("device name must be 3–64 characters")
+	if len(name) < 3 || len(name) > maxDeviceNameLen {
+		return fmt.Errorf("device name must be 3–%d characters", maxDeviceNameLen)
 	}
 	for i, c := range name {
 		switch {
@@ -1586,7 +1593,7 @@ func resolveDeviceName(flagName string) (string, error) {
 	fmt.Println()
 	name, err := promptDeviceName(
 		"Device name",
-		"(a-z, 0-9 and hyphens, starts with a letter, 3–64 chars; empty = auto-generate)",
+		fmt.Sprintf("(a-z, 0-9 and hyphens, starts with a letter, 3–%d chars; empty = auto-generate)", maxDeviceNameLen),
 		optionalDeviceNameValidator,
 	)
 	if err != nil {

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -815,8 +815,8 @@ func TestResolveDeviceNameFlagValidation(t *testing.T) {
 		in      string
 		wantErr string
 	}{
-		{"too short", "ab", "3–64 characters"},
-		{"too long", strings.Repeat("a", 65), "3–64 characters"},
+		{"too short", "ab", "3–55 characters"},
+		{"too long", strings.Repeat("a", 56), "3–55 characters"},
 		{"starts with number", "1device", "start with a lowercase letter"},
 		{"uppercase", "Wendy", "lowercase letters, digits, and hyphens"},
 		{"underscore", "wendy_pi", "lowercase letters, digits, and hyphens"},
@@ -834,6 +834,27 @@ func TestResolveDeviceNameFlagValidation(t *testing.T) {
 				t.Fatalf("error %q should contain %q", err.Error(), tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestValidateDeviceNameLengthBoundary pins the device-name length cap to the
+// value that keeps the agent-derived "wendyos-<name>" hostname within the
+// 63-octet RFC 1035 label limit (WDY-1518).
+func TestValidateDeviceNameLengthBoundary(t *testing.T) {
+	if maxDeviceNameLen != 55 {
+		t.Fatalf("maxDeviceNameLen = %d; want 55 so wendyos-<name> stays a valid DNS label", maxDeviceNameLen)
+	}
+
+	maxName := strings.Repeat("a", maxDeviceNameLen)
+	if err := validateDeviceName(maxName); err != nil {
+		t.Fatalf("name of max length %d should be valid: %v", maxDeviceNameLen, err)
+	}
+	if got := len("wendyos-" + maxName); got > 63 {
+		t.Fatalf("derived hostname label is %d octets; exceeds the RFC 1035 limit of 63", got)
+	}
+
+	if err := validateDeviceName(strings.Repeat("a", maxDeviceNameLen+1)); err == nil {
+		t.Fatalf("name longer than %d should be rejected", maxDeviceNameLen)
 	}
 }
 
@@ -1230,7 +1251,7 @@ func TestResolveDeviceNamePromptStatesConstraints(t *testing.T) {
 	}
 
 	// The hint must surface the naming constraints inline (WDY-1475).
-	for _, want := range []string{"a-z", "3–64", "auto-generate"} {
+	for _, want := range []string{"a-z", "3–55", "auto-generate"} {
 		if !strings.Contains(gotHint, want) {
 			t.Errorf("hint %q should mention %q", gotHint, want)
 		}

--- a/go/internal/cli/commands/tour.go
+++ b/go/internal/cli/commands/tour.go
@@ -1839,8 +1839,8 @@ func deviceUsesNVMe(key string) bool {
 
 // validateDeviceNameTour checks that a name is a valid device hostname.
 func validateDeviceNameTour(name string) error {
-	if len(name) < 3 || len(name) > 64 {
-		return fmt.Errorf("must be 3–64 characters")
+	if len(name) < 3 || len(name) > maxDeviceNameLen {
+		return fmt.Errorf("must be 3–%d characters", maxDeviceNameLen)
 	}
 	for i, c := range name {
 		if c >= 'a' && c <= 'z' {


### PR DESCRIPTION
## Summary

The CLI device-name validators allowed **3–64 characters**, but on the device the agent derives the hostname as `wendyos-<name>` (via `/usr/sbin/generate-hostname.sh`, invoked from `configpartition.applyDeviceName`). With the 8-character `wendyos-` prefix, any name longer than **55** characters produces a hostname label exceeding the **63-octet RFC 1035 limit** — yielding an invalid `/etc/hostname` and broken mDNS/avahi advertising.

This is the "likely fix" called out in WDY-1518: tighten the validators' max to 55 and update the prompt hint/docs.

## Changes

- **`os_install.go`** — `validateDeviceName` cap 64→55; error message and interactive prompt hint updated; introduces a documented `maxDeviceNameLen` constant explaining the RFC 1035 derivation.
- **`tour.go`** — `validateDeviceNameTour` (the interactive tour's device-name entry) tightened to the same cap.
- **`configpartition/apply.go`** — `validDeviceName`, the agent-side backstop that actually runs `generate-hostname.sh`, tightened 64→55 so an over-long name can never reach hostname generation regardless of where it originated (CLI, tour, or pre-enrollment).
- **`os/install.md`** — `--device-name` doc updated to `3–55 chars`.
- **Tests** — boundary tests in both packages pin the cap to the value that keeps `wendyos-<name>` ≤ 63 octets (55-char name valid, 56 rejected), and assert `len("wendyos-"+maxName) ≤ 63`.

## Notes / open questions from the ticket

- `generate-hostname.sh` lives in the WendyOS image build (meta layer), not this repo, so its truncation behavior isn't changed here — the validators prevent the over-long name from reaching it in the first place.
- Cloud-side validation for `CreateAssetEnrollmentToken` lives in the cloud repo (only the client stub is here) and is out of scope for this PR; it may want the same 55 limit.
- **Compat:** a tightened validator would reject re-provisioning of any existing device named in the 56–64 range. Given the cap produces an invalid hostname anyway, rejecting at provisioning time is the safer behavior.

## Test plan

- `go build ./...` — clean
- `go vet ./internal/cli/commands/ ./internal/agent/configpartition/` — clean
- `go test ./internal/cli/commands/ ./internal/agent/configpartition/` — pass

Fixes WDY-1518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)