### PR TITLE
fix(cli): prefer USB link-local over AP-isolated Wi-Fi IP

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -262,9 +262,17 @@ func lanAgentAddresses(dev models.LANDevice) []string {
 		port -= agentMTLSPortOffset // advertised port is mTLS; connectWithAutoTLS will add the offset back
 	}
 
+	hosts := []string{strings.TrimSpace(dev.IPAddress), strings.TrimSpace(dev.Hostname)}
+	if strings.TrimSpace(dev.USB) != "" {
+		// A USB-NCM path exists. The routed Wi-Fi IP (dev.IPAddress) may be
+		// black-holed by AP isolation on residential routers, so try the
+		// link-local .local hostname (reachable over USB) first.
+		hosts = []string{strings.TrimSpace(dev.Hostname), strings.TrimSpace(dev.IPAddress)}
+	}
+
 	var addresses []string
 	seen := make(map[string]bool)
-	for _, host := range []string{strings.TrimSpace(dev.IPAddress), strings.TrimSpace(dev.Hostname)} {
+	for _, host := range hosts {
 		if host == "" || seen[host] {
 			continue
 		}

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -701,6 +701,38 @@ func stubDiscoverLANDevices(t *testing.T, devices []models.LANDevice, err error)
 	})
 }
 
+func TestLanAgentAddressesPrefersUSBLinkLocal(t *testing.T) {
+	tests := []struct {
+		name string
+		dev  models.LANDevice
+		want []string
+	}{
+		{
+			name: "usb present orders link-local before routed wifi ip",
+			dev:  models.LANDevice{Hostname: "playful-reed.local", IPAddress: "192.168.1.50", USB: "en5 (USB Ethernet) 480 Mbps", Port: 50051},
+			want: []string{"playful-reed.local:50051", "192.168.1.50:50051"},
+		},
+		{
+			name: "no usb keeps ip-first ordering",
+			dev:  models.LANDevice{Hostname: "playful-reed.local", IPAddress: "192.168.1.50", Port: 50051},
+			want: []string{"192.168.1.50:50051", "playful-reed.local:50051"},
+		},
+		{
+			name: "usb present but no ip falls back to hostname only",
+			dev:  models.LANDevice{Hostname: "playful-reed.local", USB: "en5 (USB Ethernet) 480 Mbps", Port: 50051},
+			want: []string{"playful-reed.local:50051"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lanAgentAddresses(tt.dev)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("lanAgentAddresses() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsCertRejectionError(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Problem
From Andreas's Jun-14 bee-app field test (#2): with both Wi-Fi and USB-NCM up, the CLI dials the Wi-Fi IP first. On AP-isolated residential routers (Rogers/Shaw) that IP black-holes, and the sequential probe burns the full per-address timeout (~1.5s) before trying anything else.

## Change
`lanAgentAddresses` now orders the `.local` hostname (reachable over USB-NCM) **before** the routed Wi-Fi IP whenever a USB path exists (`dev.USB != ""`). When no USB path exists, ordering is unchanged (IP first). `dev.USB` was already populated by discovery but previously used only for display/dedup.

Pure client-side ordering change — no protocol change.

## Tests
`TestLanAgentAddressesPrefersUSBLinkLocal` covers USB-present (hostname first), no-USB (IP first), and USB-present-no-IP (hostname only). Full `internal/cli/commands` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)