### PR TITLE
feat(cloud): make cloud devices addressable (id match, ids in discover, hostname default)

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/discover.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/discover.md
@@ -44,6 +44,29 @@ The TUI displays a table with the following columns for each device:
 
 Pressing `u` on a highlighted device downloads the latest agent release from GitHub, uploads it to the device via the broker tunnel, and waits for the agent to restart (up to 60 seconds). A status message is shown during the update and the version column refreshes automatically on completion.
 
+## JSON output
+
+When run non-interactively (output is piped) or with `--json`, a JSON array is written to stdout. Each element contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Stable numeric asset ID. Pass this value to [`wendy cloud tunnel --device <id>`](./tunnel.md) to target unnamed or ambiguously named devices. Omitted when zero. |
+| `name` | string | Device name (may be empty for devices enrolled without a name). |
+| `type` | string | Human-readable hardware device type. |
+| `address` | string | IP address reported by the cloud. |
+| `version` | string | Running agent version. Omitted when it could not be determined. |
+
+Example:
+
+```json
+[
+  {"id": 42, "name": "playful-reed", "type": "Raspberry Pi 5", "address": "192.168.1.10", "version": "0.10.4"},
+  {"id": 43, "name": "", "type": "Raspberry Pi 5", "address": "192.168.1.11"}
+]
+```
+
+The `id` field is the primary mechanism for addressing a device that was enrolled without a name — pass it to `wendy cloud tunnel --device <id>`.
+
 ## Flags
 
 | Flag | Default | Description |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/tunnel.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/tunnel.md
@@ -10,20 +10,53 @@ wendy cloud tunnel [flags]
 
 ## Description
 
-`wendy cloud tunnel` fetches the list of **online** compute devices from Wendy Cloud (using `OnlineOnly = true`) and either prompts you to choose one interactively or connects directly when only one device is available.
+`wendy cloud tunnel` fetches the list of **online** compute devices from Wendy Cloud (using `OnlineOnly = true`) and either connects directly when only one device is available, selects the device named or identified by `--device`, or prompts you to choose one interactively.
 
 The device list is retrieved via a server-streaming `AssetService.ListAssets` gRPC call so the CLI receives assets incrementally without a separate pagination loop.
+
+### Selecting a device
+
+`--device` resolves a device in two steps:
+
+1. **By name** — a case-insensitive exact match against device names. If the value matches more than one device, the command errors with `multiple devices match …; use a more specific name`.
+2. **By numeric asset ID** — if no name matches and the value is a plain integer, it is treated as the device's numeric asset ID. This is how you target a device that was enrolled without a name. Run [`wendy cloud discover --json`](./discover.md) to list IDs.
+
+If neither matches, the command errors with `no device named or with id "<value>" found; run 'wendy cloud discover --json' to list ids`.
+
+When `--device` is omitted and multiple devices are online:
+
+- In an **interactive terminal**, the cloud discover TUI opens in picker mode.
+- In a **non-interactive environment** (pipe/CI), the command exits with an error that enumerates the candidates as `id=name` pairs (unnamed devices show as `(unnamed)`), so you can re-run with a working `--device`:
+
+  ```
+  multiple cloud devices found; rerun with --device <id|name> (42=playful-reed, 43=(unnamed))
+  ```
 
 ## Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--cloud-grpc` | `""` | Cloud gRPC endpoint. Required when multiple auth sessions exist. |
+| `--device` | `""` | Target a specific cloud device by **name** (case-insensitive exact match) or **numeric asset ID**. When omitted with multiple online devices, an interactive terminal shows the picker and a non-interactive environment errors with the available `id=name` pairs. |
 
 ## Examples
 
+Connect, choosing interactively when more than one device is online:
+
 ```sh
 wendy cloud tunnel
+```
+
+Target a device by name:
+
+```sh
+wendy cloud tunnel --device playful-reed
+```
+
+Target an unnamed device by its numeric asset ID (from `wendy cloud discover --json`):
+
+```sh
+wendy cloud tunnel --device 43
 ```
 
 ## See also

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/enroll.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/enroll.md
@@ -1,0 +1,59 @@
+# `wendy device enroll`
+
+Enrolls the connected device with Wendy Cloud (or a local [pki-core](../../../../pki/)) and provisions it with mTLS certificates.
+
+## Usage
+
+```sh
+wendy device enroll [--name <name>] [--cloud-grpc <endpoint>] [flags]
+```
+
+## Description
+
+`wendy device enroll` creates an enrollment token using your stored auth session, then calls `StartProvisioning` on the connected agent so it fetches its certificate. Run [`wendy auth login`](../auth/login.md) first.
+
+The enrolled device is registered in Wendy Cloud under a human-readable **name**. The name is fixed at enrollment time and cannot be changed afterward, so the command resolves it as follows:
+
+1. **`--name <name>`** — always wins when provided.
+2. **Hostname default** — when `--name` is omitted and the device is reachable by hostname (e.g. `playful-reed.local`), the name defaults to that hostname with any `.local` suffix stripped (so `playful-reed.local` → `playful-reed`).
+3. **Interactive prompt** — in a terminal, when no `--name` is given the command prompts for a name. When a hostname default is available it is shown in brackets and used if you press Enter without typing anything:
+
+   ```
+   Device name [playful-reed]:
+   ```
+4. **Bare IP / no hostname** — when the device is addressed by a bare IP (no resolvable hostname) and `--name` is omitted, there is no default. In a non-interactive environment this fails with:
+
+   ```
+   device name is required; pass --name when not running interactively
+   ```
+
+   In an interactive terminal it prompts for a name with no default and errors if you leave it blank.
+
+> **Naming an unnamed device:** A device enrolled without a usable name shows up with an empty name in [`wendy cloud discover`](../cloud/discover.md). You can still address it by its numeric asset ID — see [`wendy cloud tunnel --device <id>`](../cloud/tunnel.md).
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--name` | hostname (`.local` stripped) | Human-readable device name. Defaults to the device hostname when omitted; required when the device is reachable only by a bare IP address in a non-interactive environment. |
+| `--cloud-grpc` | `""` | Cloud / pki-core gRPC endpoint to use. Required when multiple auth sessions exist. |
+
+## Examples
+
+Enroll, defaulting the name to the device hostname:
+
+```sh
+wendy device enroll --device playful-reed.local
+```
+
+Enroll with an explicit name:
+
+```sh
+wendy device enroll --device 192.168.1.11 --name lab-pi-01
+```
+
+## Related
+
+- [`wendy device setup`](./setup.md) — interactive wizard that provisions, configures WiFi, and enrolls in one flow.
+- `wendy cloud enroll-device` — alias for this command, reachable through the cloud tunnel.
+- [`wendy device provision`](./provision.md) — enroll against a self-hosted pki-core instead of Wendy Cloud.

--- a/go/internal/cli/assets/docs/cloud/tunnel.md
+++ b/go/internal/cli/assets/docs/cloud/tunnel.md
@@ -10,22 +10,28 @@ The `wendy cloud tunnel` command opens a secure gRPC tunnel from your developer 
 ## Usage
 
 ```sh
-wendy cloud tunnel [--cloud-grpc <endpoint>]
+wendy cloud tunnel [--cloud-grpc <endpoint>] [--device <id|name>]
 ```
 
 The CLI:
 1. Calls `AssetService.ListAssets` with `IsComputeDevice = true` and `OnlineOnly = true` via a **server-streaming** gRPC connection.
 2. Collects streamed assets up to a hard cap of **10 000 devices** (to prevent unbounded memory growth from a misbehaving backend). If the backend returns more, the command exits with an error: `cloud returned more than 10000 devices`.
-3. When more than one device is available, presents the interactive **cloud discover TUI** in picker mode (`↑/↓` to navigate, `enter` to select, `u` to update a device before connecting, `q` to cancel).
+3. Selects the target device:
+   - When `--device` is set, matches it against device names (case-insensitive exact match) and falls back to treating a plain integer as the numeric asset ID — letting you target a device enrolled without a name.
+   - When `--device` is unset and exactly one device is online, connects to it directly.
+   - When `--device` is unset and more than one device is online:
+     - In an **interactive terminal**, presents the cloud discover TUI in picker mode (`↑/↓` to navigate, `enter` to select, `u` to update a device before connecting, `q` to cancel).
+     - In a **non-interactive environment**, exits with an error that enumerates available devices as `id=name` pairs (unnamed devices show as `(unnamed)`). Pass `--device <id|name>` to select one directly.
 4. Opens a tunnel to the selected device.
 
-Only online devices (those with an active broker presence) are shown. If you need to inspect enrolled-but-offline devices, use [`wendy cloud discover --all`](../clients/wendy-cli/commands/cloud/discover.md).
+Only online devices (those with an active broker presence) are shown. If you need to inspect enrolled-but-offline devices, use [`wendy cloud discover --all`](../clients/wendy-cli/commands/cloud/discover.md). Run [`wendy cloud discover --json`](../clients/wendy-cli/commands/cloud/discover.md) to list the numeric asset IDs you can pass to `--device`.
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
 | `--cloud-grpc` | Override the cloud gRPC endpoint (required when multiple auth sessions exist). |
+| `--device` | Target a specific device by name (case-insensitive exact match) or numeric asset ID. When omitted in a non-interactive context with multiple devices, the command exits with an error listing `id=name` pairs. |
 
 ## Related
 

--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -350,6 +350,7 @@ func cloudDiscoverTableRows(assets []*cloudpb.Asset, versions map[int32]*agentpb
 
 func cloudDeviceInfoFromAsset(a *cloudpb.Asset, ver *agentpb.GetAgentVersionResponse) discoverDeviceInfo {
 	info := discoverDeviceInfo{
+		ID:      a.GetId(),
 		Name:    a.GetName(),
 		Type:    humanReadableDeviceType(a.GetDeviceType()),
 		Address: a.GetIpAddress(),

--- a/go/internal/cli/commands/cloud_discover_test.go
+++ b/go/internal/cli/commands/cloud_discover_test.go
@@ -1,0 +1,15 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func TestCloudDeviceInfoIncludesID(t *testing.T) {
+	a := &cloudpb.Asset{Id: 77}
+	info := cloudDeviceInfoFromAsset(a, nil)
+	if info.ID != 77 {
+		t.Fatalf("expected ID 77, got %d", info.ID)
+	}
+}

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -348,12 +349,31 @@ func resolveCloudAsset(assets []*cloudpb.Asset, deviceName string) (*cloudpb.Ass
 		if matched != nil {
 			return matched, nil
 		}
-		return nil, fmt.Errorf("no device named %q found; omit --device to choose from a list", deviceName)
+		// Numeric asset-id fallback: allows targeting unnamed devices.
+		if id, err := strconv.Atoi(strings.TrimSpace(deviceName)); err == nil {
+			for _, a := range assets {
+				if a.GetId() == int32(id) {
+					return a, nil
+				}
+			}
+		}
+		return nil, fmt.Errorf("no device named or with id %q found; run 'wendy cloud discover --json' to list ids", deviceName)
 	}
 	if len(assets) == 1 {
 		return assets[0], nil
 	}
-	return nil, nil // multiple devices — show picker
+	var b strings.Builder
+	for i, a := range assets {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		name := a.GetName()
+		if name == "" {
+			name = "(unnamed)"
+		}
+		fmt.Fprintf(&b, "%d=%s", a.GetId(), name)
+	}
+	return nil, fmt.Errorf("multiple cloud devices found; rerun with --device <id|name> (%s)", b.String())
 }
 
 func pickCloudDevice(ctx context.Context, auth *config.AuthConfig, deviceName, brokerURL string) (*cloudpb.Asset, error) {
@@ -387,13 +407,16 @@ func pickCloudDevice(ctx context.Context, auth *config.AuthConfig, deviceName, b
 		}
 	}
 
-	asset, err := resolveCloudAsset(assets, deviceName)
-	if err != nil || asset != nil {
-		return asset, err
-	}
-
-	if !isInteractiveTerminal() {
-		return nil, fmt.Errorf("multiple cloud devices found; rerun with --device in a non-interactive environment")
+	// When running interactively with no --device and multiple assets, skip
+	// resolveCloudAsset (which now returns an enumerated error) and fall
+	// straight through to the interactive picker.
+	if isInteractiveTerminal() && deviceName == "" && len(assets) > 1 {
+		// fall through to picker below
+	} else {
+		asset, err := resolveCloudAsset(assets, deviceName)
+		if err != nil || asset != nil {
+			return asset, err
+		}
 	}
 
 	m := newCloudDiscoverModel(ctx, auth, brokerURL, false, true, assets)

--- a/go/internal/cli/commands/cloud_tunnel_test.go
+++ b/go/internal/cli/commands/cloud_tunnel_test.go
@@ -1,7 +1,10 @@
 package commands
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 )
 
 func TestParseTunnelArg(t *testing.T) {
@@ -37,5 +40,39 @@ func TestParseTunnelArg(t *testing.T) {
 				t.Errorf("parseTunnelArg(%q) = (%d, %d), want (%d, %d)", tt.arg, local, remote, tt.wantLocal, tt.wantRemote)
 			}
 		})
+	}
+}
+
+func cloudAssetFixture(id int32, name string) *cloudpb.Asset {
+	a := &cloudpb.Asset{Id: id}
+	if name != "" {
+		a.Name = name
+	}
+	return a
+}
+
+func TestResolveCloudAssetByNameAndID(t *testing.T) {
+	assets := []*cloudpb.Asset{cloudAssetFixture(41, "playful-reed"), cloudAssetFixture(42, "")}
+	got, err := resolveCloudAsset(assets, "playful-reed")
+	if err != nil || got.GetId() != 41 {
+		t.Fatalf("by name: got %v, err %v", got, err)
+	}
+	got, err = resolveCloudAsset(assets, "42")
+	if err != nil || got.GetId() != 42 {
+		t.Fatalf("by id: got %v, err %v", got, err)
+	}
+	if _, err = resolveCloudAsset(assets, "nope"); err == nil {
+		t.Fatal("expected error for unknown device")
+	}
+}
+
+func TestResolveCloudAssetAmbiguousListsIDs(t *testing.T) {
+	assets := []*cloudpb.Asset{cloudAssetFixture(41, "a"), cloudAssetFixture(42, "b")}
+	_, err := resolveCloudAsset(assets, "")
+	if err == nil {
+		t.Fatal("expected ambiguity error with no --device")
+	}
+	if !strings.Contains(err.Error(), "41") || !strings.Contains(err.Error(), "42") {
+		t.Fatalf("error should list candidate IDs, got: %v", err)
 	}
 }

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -539,21 +540,44 @@ func promptWifiIfNeeded(ctx context.Context, conn *grpcclient.AgentConnection) {
 	}
 }
 
+// defaultEnrollmentName derives a device name from the connected host,
+// stripping a .local suffix. Returns "" for bare IP addresses (no usable name).
+func defaultEnrollmentName(host string) string {
+	h := strings.TrimSpace(host)
+	if h == "" || net.ParseIP(h) != nil {
+		return ""
+	}
+	return strings.TrimSuffix(h, ".local")
+}
+
 func runEnrollDevice(ctx context.Context, conn *grpcclient.AgentConnection, auth *config.AuthConfig, name string) error {
 	if len(auth.Certificates) == 0 {
 		return fmt.Errorf("selected auth entry has no certificates; re-run 'wendy auth login'")
 	}
 
 	if name == "" {
+		defaultName := defaultEnrollmentName(conn.Host)
 		if !isInteractiveTerminal() {
-			return fmt.Errorf("device name is required; pass --name when not running interactively")
-		}
-		fmt.Print("Device name: ")
-		reader := bufio.NewReader(os.Stdin)
-		line, _ := reader.ReadString('\n')
-		name = strings.TrimSpace(line)
-		if name == "" {
-			return fmt.Errorf("device name is required")
+			if defaultName != "" {
+				name = defaultName
+			} else {
+				return fmt.Errorf("device name is required; pass --name when not running interactively")
+			}
+		} else {
+			prompt := "Device name"
+			if defaultName != "" {
+				prompt = fmt.Sprintf("Device name [%s]", defaultName)
+			}
+			fmt.Printf("%s: ", prompt)
+			reader := bufio.NewReader(os.Stdin)
+			line, _ := reader.ReadString('\n')
+			name = strings.TrimSpace(line)
+			if name == "" {
+				name = defaultName
+			}
+			if name == "" {
+				return fmt.Errorf("device name is required")
+			}
 		}
 	}
 

--- a/go/internal/cli/commands/device_test.go
+++ b/go/internal/cli/commands/device_test.go
@@ -17,3 +17,17 @@ func TestDeviceCmd_HasPs(t *testing.T) {
 		t.Error("expected 'ps' subcommand on device command")
 	}
 }
+
+func TestDefaultEnrollmentName(t *testing.T) {
+	cases := map[string]string{
+		"playful-reed.local": "playful-reed",
+		"playful-reed":       "playful-reed",
+		"192.168.1.50":       "",
+		"":                   "",
+	}
+	for in, want := range cases {
+		if got := defaultEnrollmentName(in); got != want {
+			t.Errorf("defaultEnrollmentName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -198,6 +198,7 @@ type extScanMsg struct{ devices []models.ExternalDevice }
 
 // discoverDeviceInfo is the JSON structure copied to the clipboard.
 type discoverDeviceInfo struct {
+	ID          int32  `json:"id,omitempty"`
 	Name        string `json:"name"`
 	Type        string `json:"type"`
 	USB         string `json:"usb,omitempty"`


### PR DESCRIPTION
## Problem
From Andreas's Jun-14 bee-app field test (#3): a provisioned device showed up in `wendy cloud discover` with an empty name. `cloud tunnel --device <x>` matched by name only, so an unnamed device was unaddressable; without `--device` it errored "multiple devices found" with no usable selector. Dead end.

## Change (3 commits)
- **Default enrollment name to hostname** — `wendy device enroll` without `--name` now defaults the cloud asset name to the WendyOS hostname (e.g. `playful-reed` from `playful-reed.local`) instead of prompting/failing. Explicit `--name` still wins.
- **Expose asset ID in discover JSON** — `discoverDeviceInfo` gains `id`; `cloud discover --json` now carries the stable asset id.
- **`--device` matches name OR numeric asset id** — and the non-interactive multi-device error now enumerates `id=name` pairs so you can re-run with a working `--device`.

`--device` semantics widen (name then id fallback) but stay backward compatible. The interactive multi-device picker path is preserved (verified in review).

## Tests
`TestResolveCloudAssetByNameAndID`, `TestResolveCloudAssetAmbiguousListsIDs`, `TestCloudDeviceInfoIncludesID`, `TestDefaultEnrollmentName`. Full `internal/cli/commands` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)