### PR TITLE
refactor(agent): reduce external CLI usage (BlueZ D-Bus, drop pw-cli/lsusb)

### DIFF
--- a/go/internal/agent/bluetooth/manager_linux.go
+++ b/go/internal/agent/bluetooth/manager_linux.go
@@ -202,7 +202,7 @@ func (m *BlueZManager) Connect(ctx context.Context, address string, pair, trust 
 		// BlueZ rejects pairing requests unless an authentication agent is
 		// registered. Register a headless "just works" agent on this connection;
 		// it is unregistered automatically when the connection closes.
-		if err := registerPairingAgent(conn, m.logger); err != nil {
+		if err := registerPairingAgent(conn, m.logger, devicePath); err != nil {
 			m.logger.Warn("Failed to register pairing agent", zap.Error(err))
 		}
 		if call := device.CallWithContext(ctx, deviceIface+".Pair", 0); call.Err != nil && !isAlreadyExists(call.Err) {

--- a/go/internal/agent/bluetooth/manager_linux.go
+++ b/go/internal/agent/bluetooth/manager_linux.go
@@ -4,8 +4,8 @@ package bluetooth
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -156,45 +156,98 @@ func boolProp(props map[string]dbus.Variant, key string) bool {
 	return false
 }
 
-// Connect connects to a Bluetooth peripheral by address.
+// deviceObjectPath returns the BlueZ D-Bus object path for a device given its
+// adapter path and Bluetooth address. BlueZ encodes the address with colons
+// replaced by underscores and upper-cased hex, e.g.
+// /org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF.
+func deviceObjectPath(adapterPath, address string) dbus.ObjectPath {
+	encoded := strings.ToUpper(strings.ReplaceAll(address, ":", "_"))
+	return dbus.ObjectPath(adapterPath + "/dev_" + encoded)
+}
+
+// isAlreadyExists reports whether a BlueZ D-Bus error indicates the operation
+// was a no-op because the resource already exists (e.g. pairing a device that
+// is already paired). Such errors are safe to treat as success.
+func isAlreadyExists(err error) bool {
+	var dbusErr dbus.Error
+	if errors.As(err, &dbusErr) {
+		return dbusErr.Name == "org.bluez.Error.AlreadyExists"
+	}
+	return false
+}
+
+// Connect connects to a Bluetooth peripheral by address via BlueZ over D-Bus.
+// When pair is set it registers a headless pairing agent and pairs first; when
+// trust is set it marks the device trusted so BlueZ reconnects it automatically.
 func (m *BlueZManager) Connect(ctx context.Context, address string, pair, trust bool) error {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return fmt.Errorf("connecting to system bus: %w", err)
+	}
+	defer conn.Close()
+
+	devicePath := deviceObjectPath(bluezAdapterPath(), address)
+	device := conn.Object(bluezService, devicePath)
+
 	if trust {
-		if out, err := exec.CommandContext(ctx, "bluetoothctl", "trust", address).CombinedOutput(); err != nil {
-			m.logger.Warn("Failed to trust device", zap.Error(err), zap.String("output", string(out)))
+		if call := device.CallWithContext(ctx, "org.freedesktop.DBus.Properties.Set", 0,
+			deviceIface, "Trusted", dbus.MakeVariant(true)); call.Err != nil {
+			// Trust is best-effort: it improves reconnection but is not required
+			// for the connection itself to succeed.
+			m.logger.Warn("Failed to trust device", zap.String("address", address), zap.Error(call.Err))
 		}
 	}
 
 	if pair {
-		if out, err := exec.CommandContext(ctx, "bluetoothctl", "pair", address).CombinedOutput(); err != nil {
-			return fmt.Errorf("pairing with %s: %w (output: %s)", address, err, string(out))
+		// BlueZ rejects pairing requests unless an authentication agent is
+		// registered. Register a headless "just works" agent on this connection;
+		// it is unregistered automatically when the connection closes.
+		if err := registerPairingAgent(conn, m.logger); err != nil {
+			m.logger.Warn("Failed to register pairing agent", zap.Error(err))
+		}
+		if call := device.CallWithContext(ctx, deviceIface+".Pair", 0); call.Err != nil && !isAlreadyExists(call.Err) {
+			return fmt.Errorf("pairing with %s: %w", address, call.Err)
 		}
 	}
 
-	out, err := exec.CommandContext(ctx, "bluetoothctl", "connect", address).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("connecting to %s: %w (output: %s)", address, err, string(out))
+	if call := device.CallWithContext(ctx, deviceIface+".Connect", 0); call.Err != nil {
+		return fmt.Errorf("connecting to %s: %w", address, call.Err)
 	}
 
 	m.logger.Info("Connected to Bluetooth device", zap.String("address", address))
 	return nil
 }
 
-// Disconnect disconnects from a Bluetooth peripheral.
+// Disconnect disconnects from a Bluetooth peripheral via BlueZ over D-Bus.
 func (m *BlueZManager) Disconnect(ctx context.Context, address string) error {
-	out, err := exec.CommandContext(ctx, "bluetoothctl", "disconnect", address).CombinedOutput()
+	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
-		return fmt.Errorf("disconnecting from %s: %w (output: %s)", address, err, string(out))
+		return fmt.Errorf("connecting to system bus: %w", err)
+	}
+	defer conn.Close()
+
+	device := conn.Object(bluezService, deviceObjectPath(bluezAdapterPath(), address))
+	if call := device.CallWithContext(ctx, deviceIface+".Disconnect", 0); call.Err != nil {
+		return fmt.Errorf("disconnecting from %s: %w", address, call.Err)
 	}
 
 	m.logger.Info("Disconnected from Bluetooth device", zap.String("address", address))
 	return nil
 }
 
-// Forget removes a paired Bluetooth peripheral.
+// Forget removes a paired Bluetooth peripheral via BlueZ's Adapter1.RemoveDevice.
 func (m *BlueZManager) Forget(ctx context.Context, address string) error {
-	out, err := exec.CommandContext(ctx, "bluetoothctl", "remove", address).CombinedOutput()
+	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
-		return fmt.Errorf("removing device %s: %w (output: %s)", address, err, string(out))
+		return fmt.Errorf("connecting to system bus: %w", err)
+	}
+	defer conn.Close()
+
+	adapterPath := bluezAdapterPath()
+	devicePath := deviceObjectPath(adapterPath, address)
+	adapter := conn.Object(bluezService, dbus.ObjectPath(adapterPath))
+	if call := adapter.CallWithContext(ctx, adapterIface+".RemoveDevice", 0, devicePath); call.Err != nil {
+		return fmt.Errorf("removing device %s: %w", address, call.Err)
 	}
 
 	m.logger.Info("Forgot Bluetooth device", zap.String("address", address))

--- a/go/internal/agent/bluetooth/manager_linux.go
+++ b/go/internal/agent/bluetooth/manager_linux.go
@@ -9,9 +9,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/godbus/dbus/v5"
 	"go.uber.org/zap"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+const (
+	adapterIface = "org.bluez.Adapter1"
+	deviceIface  = "org.bluez.Device1"
+	// scanDuration is how long discovery runs before results are collected.
+	scanDuration = 8 * time.Second
 )
 
 type BlueZManager struct {
@@ -22,71 +30,52 @@ func newPlatformManager(logger *zap.Logger) Manager {
 	return &BlueZManager{logger: logger}
 }
 
-// Scan starts a Bluetooth scan and returns discovered devices on the channel.
+// Scan runs a Bluetooth discovery via BlueZ over D-Bus and returns the
+// discovered devices on the channel. It powers on the adapter, runs discovery
+// for scanDuration, then enumerates known devices through the BlueZ
+// ObjectManager so typed properties (RSSI, paired/connected/trusted, icon) are
+// read directly rather than parsed from bluetoothctl text output.
 func (m *BlueZManager) Scan(ctx context.Context) (<-chan []*agentpb.DiscoveredBluetoothPeripheral, error) {
 	ch := make(chan []*agentpb.DiscoveredBluetoothPeripheral, 10)
 
 	go func() {
 		defer close(ch)
 
-		// Start scanning via bluetoothctl.
-		scanCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-
-		// Power on the adapter.
-		if out, err := exec.CommandContext(scanCtx, "bluetoothctl", "power", "on").CombinedOutput(); err != nil {
-			m.logger.Warn("Failed to power on Bluetooth adapter", zap.Error(err), zap.String("output", string(out)))
-			return
-		}
-
-		// Start scan.
-		scanCmd := exec.CommandContext(scanCtx, "bluetoothctl", "--timeout", "8", "scan", "on")
-		if out, err := scanCmd.CombinedOutput(); err != nil {
-			m.logger.Debug("Bluetooth scan completed", zap.String("output", string(out)))
-		}
-
-		// List discovered devices.
-		listCmd := exec.CommandContext(ctx, "bluetoothctl", "devices")
-		output, err := listCmd.CombinedOutput()
+		conn, err := dbus.ConnectSystemBus()
 		if err != nil {
-			m.logger.Warn("Failed to list Bluetooth devices", zap.Error(err))
+			m.logger.Warn("Failed to connect to system bus for Bluetooth scan", zap.Error(err))
+			return
+		}
+		defer conn.Close()
+
+		adapterPath := bluezAdapterPath()
+		adapter := conn.Object(bluezService, dbus.ObjectPath(adapterPath))
+
+		// Power on the adapter. The call is a no-op if it is already on, but it
+		// also clears Command Disallowed state left over from a previous BLE
+		// connection that wasn't fully torn down at the HCI level.
+		if call := adapter.Call("org.freedesktop.DBus.Properties.Set", 0,
+			adapterIface, "Powered", dbus.MakeVariant(true)); call.Err != nil {
+			m.logger.Warn("Failed to power on Bluetooth adapter", zap.Error(call.Err))
 			return
 		}
 
-		var peripherals []*agentpb.DiscoveredBluetoothPeripheral
-		for _, line := range strings.Split(string(output), "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" {
-				continue
-			}
-			// Format: "Device XX:XX:XX:XX:XX:XX DeviceName"
-			parts := strings.SplitN(line, " ", 3)
-			if len(parts) < 3 || parts[0] != "Device" {
-				continue
-			}
-
-			address := parts[1]
-			name := parts[2]
-
-			peripheral := &agentpb.DiscoveredBluetoothPeripheral{
-				Address: address,
-				Name:    name,
-			}
-
-			// Check if paired/connected.
-			infoOutput, infoErr := exec.CommandContext(ctx, "bluetoothctl", "info", address).CombinedOutput()
-			if infoErr == nil {
-				info := string(infoOutput)
-				peripheral.Paired = strings.Contains(info, "Paired: yes")
-				peripheral.Connected = strings.Contains(info, "Connected: yes")
-				if strings.Contains(info, "Icon: audio") {
-					peripheral.DeviceType = "audio"
-				}
-			}
-
-			peripherals = append(peripherals, peripheral)
+		// Start discovery.
+		if call := adapter.Call(adapterIface+".StartDiscovery", 0); call.Err != nil {
+			m.logger.Warn("Failed to start Bluetooth discovery", zap.Error(call.Err))
+			return
 		}
 
+		// Let discovery run, then stop it (best-effort).
+		select {
+		case <-time.After(scanDuration):
+		case <-ctx.Done():
+		}
+		if call := adapter.Call(adapterIface+".StopDiscovery", 0); call.Err != nil {
+			m.logger.Debug("Failed to stop Bluetooth discovery", zap.Error(call.Err))
+		}
+
+		peripherals := m.collectPeripherals(conn, adapterPath)
 		if len(peripherals) > 0 {
 			select {
 			case ch <- peripherals:
@@ -96,6 +85,75 @@ func (m *BlueZManager) Scan(ctx context.Context) (<-chan []*agentpb.DiscoveredBl
 	}()
 
 	return ch, nil
+}
+
+// collectPeripherals enumerates devices known to BlueZ via the ObjectManager
+// and returns those belonging to the given adapter.
+func (m *BlueZManager) collectPeripherals(conn *dbus.Conn, adapterPath string) []*agentpb.DiscoveredBluetoothPeripheral {
+	var managed map[dbus.ObjectPath]map[string]map[string]dbus.Variant
+	root := conn.Object(bluezService, "/")
+	if err := root.Call("org.freedesktop.DBus.ObjectManager.GetManagedObjects", 0).Store(&managed); err != nil {
+		m.logger.Warn("Failed to enumerate Bluetooth devices", zap.Error(err))
+		return nil
+	}
+
+	// Device object paths are nested under the adapter, e.g.
+	// /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX.
+	prefix := adapterPath + "/"
+	var peripherals []*agentpb.DiscoveredBluetoothPeripheral
+	for path, ifaces := range managed {
+		props, ok := ifaces[deviceIface]
+		if !ok || !strings.HasPrefix(string(path), prefix) {
+			continue
+		}
+		peripherals = append(peripherals, deviceFromProps(props))
+	}
+	return peripherals
+}
+
+// deviceFromProps maps org.bluez.Device1 properties to the proto peripheral.
+func deviceFromProps(props map[string]dbus.Variant) *agentpb.DiscoveredBluetoothPeripheral {
+	p := &agentpb.DiscoveredBluetoothPeripheral{}
+
+	if s, ok := stringProp(props, "Address"); ok {
+		p.Address = s
+	}
+	// Alias is the user-facing name (falls back to Name when unset by BlueZ).
+	if s, ok := stringProp(props, "Alias"); ok && s != "" {
+		p.Name = s
+	} else if s, ok := stringProp(props, "Name"); ok {
+		p.Name = s
+	}
+	if v, ok := props["RSSI"]; ok {
+		if rssi, ok := v.Value().(int16); ok {
+			p.Rssi = int32(rssi)
+		}
+	}
+	// BlueZ icons for audio devices look like "audio-headset" / "audio-card".
+	if icon, ok := stringProp(props, "Icon"); ok && strings.HasPrefix(icon, "audio") {
+		p.DeviceType = "audio"
+	}
+	p.Paired = boolProp(props, "Paired")
+	p.Connected = boolProp(props, "Connected")
+	p.Trusted = boolProp(props, "Trusted")
+
+	return p
+}
+
+func stringProp(props map[string]dbus.Variant, key string) (string, bool) {
+	if v, ok := props[key]; ok {
+		s, ok := v.Value().(string)
+		return s, ok
+	}
+	return "", false
+}
+
+func boolProp(props map[string]dbus.Variant, key string) bool {
+	if v, ok := props[key]; ok {
+		b, _ := v.Value().(bool)
+		return b
+	}
+	return false
 }
 
 // Connect connects to a Bluetooth peripheral by address.

--- a/go/internal/agent/bluetooth/manager_linux_test.go
+++ b/go/internal/agent/bluetooth/manager_linux_test.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package bluetooth
+
+import "testing"
+
+func TestDeviceObjectPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		adapterPath string
+		address     string
+		want        string
+	}{
+		{
+			name:        "standard uppercase address",
+			adapterPath: "/org/bluez/hci0",
+			address:     "AA:BB:CC:DD:EE:FF",
+			want:        "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+		},
+		{
+			name:        "lowercase address is upper-cased",
+			adapterPath: "/org/bluez/hci0",
+			address:     "a1:b2:c3:d4:e5:f6",
+			want:        "/org/bluez/hci0/dev_A1_B2_C3_D4_E5_F6",
+		},
+		{
+			name:        "non-default adapter path",
+			adapterPath: "/org/bluez/hci1",
+			address:     "00:11:22:33:44:55",
+			want:        "/org/bluez/hci1/dev_00_11_22_33_44_55",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(deviceObjectPath(tt.adapterPath, tt.address)); got != tt.want {
+				t.Errorf("deviceObjectPath(%q, %q) = %q, want %q", tt.adapterPath, tt.address, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/agent/bluetooth/pairing_agent_linux.go
+++ b/go/internal/agent/bluetooth/pairing_agent_linux.go
@@ -24,11 +24,29 @@ const (
 // rejection lets the pairing attempt fail cleanly rather than hang.
 var errRejected = dbus.NewError("org.bluez.Error.Rejected", nil)
 
-// pairingAgent implements org.bluez.Agent1 as a headless auto-accepting agent.
-// It accepts pairing and service authorization requests without user
-// interaction, which is required for unattended pairing on an edge device.
+// pairingAgent implements org.bluez.Agent1 as a headless agent for a single
+// caller-initiated pairing. It auto-accepts pairing and service authorization
+// for the one device being paired (expected) and rejects requests from any
+// other device, so a nearby device cannot get itself bonded during the brief
+// window the agent is registered.
 type pairingAgent struct {
-	logger *zap.Logger
+	logger   *zap.Logger
+	expected dbus.ObjectPath
+}
+
+// accept auto-accepts an authorization callback when it is for the device this
+// agent was registered to pair (expected), and rejects it otherwise. Both
+// outcomes are logged at a level high enough to survive a production INFO log
+// configuration, giving an audit trail of established device relationships.
+func (a *pairingAgent) accept(device dbus.ObjectPath, action string, extra ...zap.Field) *dbus.Error {
+	fields := append([]zap.Field{zap.String("device", string(device))}, extra...)
+	if device != a.expected {
+		a.logger.Warn("Rejecting Bluetooth "+action+" from unexpected device",
+			append(fields, zap.String("expected", string(a.expected)))...)
+		return errRejected
+	}
+	a.logger.Info("Auto-accepting Bluetooth "+action, fields...)
+	return nil
 }
 
 // Release is called by BlueZ when the agent is unregistered.
@@ -53,32 +71,30 @@ func (a *pairingAgent) DisplayPasskey(device dbus.ObjectPath, passkey uint32, en
 	return nil
 }
 
-// RequestConfirmation / RequestAuthorization / AuthorizeService auto-accept,
-// completing "just works" pairing and service connections without prompting.
+// RequestConfirmation / RequestAuthorization / AuthorizeService complete "just
+// works" pairing and service connections without prompting, but only for the
+// device this agent was registered to pair (see accept).
 func (a *pairingAgent) RequestConfirmation(device dbus.ObjectPath, passkey uint32) *dbus.Error {
-	a.logger.Debug("Auto-confirming Bluetooth pairing", zap.String("device", string(device)))
-	return nil
+	return a.accept(device, "pairing confirmation", zap.Uint32("passkey", passkey))
 }
 
 func (a *pairingAgent) RequestAuthorization(device dbus.ObjectPath) *dbus.Error {
-	a.logger.Debug("Auto-authorizing Bluetooth pairing", zap.String("device", string(device)))
-	return nil
+	return a.accept(device, "pairing authorization")
 }
 
 func (a *pairingAgent) AuthorizeService(device dbus.ObjectPath, uuid string) *dbus.Error {
-	a.logger.Debug("Auto-authorizing Bluetooth service",
-		zap.String("device", string(device)), zap.String("uuid", uuid))
-	return nil
+	return a.accept(device, "service authorization", zap.String("uuid", uuid))
 }
 
 // Cancel is called by BlueZ when a request is cancelled (e.g. the remote aborts).
 func (a *pairingAgent) Cancel() *dbus.Error { return nil }
 
 // registerPairingAgent exports a headless pairing agent on conn and registers it
-// with BlueZ as the default agent. The agent stays registered for the lifetime
-// of conn; BlueZ unregisters it automatically when conn closes.
-func registerPairingAgent(conn *dbus.Conn, logger *zap.Logger) error {
-	agent := &pairingAgent{logger: logger}
+// with BlueZ as the default agent. The agent only auto-accepts pairing for
+// expected (the device being paired). It stays registered for the lifetime of
+// conn; BlueZ unregisters it automatically when conn closes.
+func registerPairingAgent(conn *dbus.Conn, logger *zap.Logger, expected dbus.ObjectPath) error {
+	agent := &pairingAgent{logger: logger, expected: expected}
 	if err := conn.Export(agent, agentObjectPath, agentIface); err != nil {
 		return fmt.Errorf("exporting pairing agent: %w", err)
 	}

--- a/go/internal/agent/bluetooth/pairing_agent_linux.go
+++ b/go/internal/agent/bluetooth/pairing_agent_linux.go
@@ -1,0 +1,97 @@
+//go:build linux
+
+package bluetooth
+
+import (
+	"fmt"
+
+	"github.com/godbus/dbus/v5"
+	"go.uber.org/zap"
+)
+
+const (
+	agentObjectPath   = dbus.ObjectPath("/org/wendy/btagent")
+	agentManagerIface = "org.bluez.AgentManager1"
+	agentIface        = "org.bluez.Agent1"
+	// agentCapability "NoInputNoOutput" selects "just works" pairing: BlueZ
+	// completes pairing without prompting for a PIN or passkey, which is the
+	// only viable mode on a headless device.
+	agentCapability = "NoInputNoOutput"
+)
+
+// errRejected is returned for agent callbacks that should never be reached under
+// NoInputNoOutput capability (PIN/passkey entry). Returning a BlueZ-recognised
+// rejection lets the pairing attempt fail cleanly rather than hang.
+var errRejected = dbus.NewError("org.bluez.Error.Rejected", nil)
+
+// pairingAgent implements org.bluez.Agent1 as a headless auto-accepting agent.
+// It accepts pairing and service authorization requests without user
+// interaction, which is required for unattended pairing on an edge device.
+type pairingAgent struct {
+	logger *zap.Logger
+}
+
+// Release is called by BlueZ when the agent is unregistered.
+func (a *pairingAgent) Release() *dbus.Error { return nil }
+
+// RequestPinCode / RequestPasskey are only invoked for capabilities that can
+// supply credentials. Under NoInputNoOutput they should not occur; reject them.
+func (a *pairingAgent) RequestPinCode(device dbus.ObjectPath) (string, *dbus.Error) {
+	return "", errRejected
+}
+
+func (a *pairingAgent) RequestPasskey(device dbus.ObjectPath) (uint32, *dbus.Error) {
+	return 0, errRejected
+}
+
+// Display* callbacks are no-ops: a headless device has nothing to display.
+func (a *pairingAgent) DisplayPinCode(device dbus.ObjectPath, pincode string) *dbus.Error {
+	return nil
+}
+
+func (a *pairingAgent) DisplayPasskey(device dbus.ObjectPath, passkey uint32, entered uint16) *dbus.Error {
+	return nil
+}
+
+// RequestConfirmation / RequestAuthorization / AuthorizeService auto-accept,
+// completing "just works" pairing and service connections without prompting.
+func (a *pairingAgent) RequestConfirmation(device dbus.ObjectPath, passkey uint32) *dbus.Error {
+	a.logger.Debug("Auto-confirming Bluetooth pairing", zap.String("device", string(device)))
+	return nil
+}
+
+func (a *pairingAgent) RequestAuthorization(device dbus.ObjectPath) *dbus.Error {
+	a.logger.Debug("Auto-authorizing Bluetooth pairing", zap.String("device", string(device)))
+	return nil
+}
+
+func (a *pairingAgent) AuthorizeService(device dbus.ObjectPath, uuid string) *dbus.Error {
+	a.logger.Debug("Auto-authorizing Bluetooth service",
+		zap.String("device", string(device)), zap.String("uuid", uuid))
+	return nil
+}
+
+// Cancel is called by BlueZ when a request is cancelled (e.g. the remote aborts).
+func (a *pairingAgent) Cancel() *dbus.Error { return nil }
+
+// registerPairingAgent exports a headless pairing agent on conn and registers it
+// with BlueZ as the default agent. The agent stays registered for the lifetime
+// of conn; BlueZ unregisters it automatically when conn closes.
+func registerPairingAgent(conn *dbus.Conn, logger *zap.Logger) error {
+	agent := &pairingAgent{logger: logger}
+	if err := conn.Export(agent, agentObjectPath, agentIface); err != nil {
+		return fmt.Errorf("exporting pairing agent: %w", err)
+	}
+
+	mgr := conn.Object(bluezService, "/org/bluez")
+	if call := mgr.Call(agentManagerIface+".RegisterAgent", 0, agentObjectPath, agentCapability); call.Err != nil {
+		return fmt.Errorf("registering pairing agent: %w", call.Err)
+	}
+	// Become the default agent so BlueZ routes authentication requests here even
+	// when other agents (e.g. a stray bluetoothctl) are present.
+	if call := mgr.Call(agentManagerIface+".RequestDefaultAgent", 0, agentObjectPath); call.Err != nil {
+		return fmt.Errorf("requesting default pairing agent: %w", call.Err)
+	}
+
+	return nil
+}

--- a/go/internal/agent/bluetooth/pairing_agent_linux_test.go
+++ b/go/internal/agent/bluetooth/pairing_agent_linux_test.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package bluetooth
+
+import (
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+	"go.uber.org/zap"
+)
+
+func TestPairingAgent_AcceptsOnlyExpectedDevice(t *testing.T) {
+	const expected = dbus.ObjectPath("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF")
+	const other = dbus.ObjectPath("/org/bluez/hci0/dev_11_22_33_44_55_66")
+
+	agent := &pairingAgent{logger: zap.NewNop(), expected: expected}
+
+	// The expected device is auto-accepted across all three callbacks.
+	if err := agent.RequestConfirmation(expected, 123456); err != nil {
+		t.Errorf("RequestConfirmation(expected) = %v, want nil", err)
+	}
+	if err := agent.RequestAuthorization(expected); err != nil {
+		t.Errorf("RequestAuthorization(expected) = %v, want nil", err)
+	}
+	if err := agent.AuthorizeService(expected, "0000110b-0000-1000-8000-00805f9b34fb"); err != nil {
+		t.Errorf("AuthorizeService(expected) = %v, want nil", err)
+	}
+
+	// Any other device in range during the pairing window is rejected.
+	if err := agent.RequestConfirmation(other, 123456); err != errRejected {
+		t.Errorf("RequestConfirmation(other) = %v, want errRejected", err)
+	}
+	if err := agent.RequestAuthorization(other); err != errRejected {
+		t.Errorf("RequestAuthorization(other) = %v, want errRejected", err)
+	}
+	if err := agent.AuthorizeService(other, "0000110b-0000-1000-8000-00805f9b34fb"); err != errRejected {
+		t.Errorf("AuthorizeService(other) = %v, want errRejected", err)
+	}
+}

--- a/go/internal/agent/services/audio_service.go
+++ b/go/internal/agent/services/audio_service.go
@@ -70,58 +70,6 @@ func (s *AudioService) ListAudioDevices(ctx context.Context, _ *agentpb.ListAudi
 	return &agentpb.ListAudioDevicesResponse{Devices: devices}, nil
 }
 
-// listPipeWireDevices uses pw-cli to list audio nodes.
-func (s *AudioService) listPipeWireDevices(ctx context.Context) ([]*agentpb.AudioDevice, error) {
-	cmd := exec.CommandContext(ctx, "pw-cli", "list-objects", "Node")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("pw-cli: %w", err)
-	}
-
-	var devices []*agentpb.AudioDevice
-	var current *agentpb.AudioDevice
-
-	scanner := bufio.NewScanner(strings.NewReader(string(output)))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-
-		if strings.HasPrefix(line, "id ") {
-			if current != nil {
-				devices = append(devices, current)
-			}
-			current = &agentpb.AudioDevice{}
-			parts := strings.Fields(line)
-			if len(parts) >= 2 {
-				if id, err := strconv.ParseUint(parts[1], 10, 32); err == nil {
-					current.Id = uint32(id)
-				}
-			}
-		}
-		if current == nil {
-			continue
-		}
-		if strings.Contains(line, "node.name") {
-			current.Name = extractQuotedValue(line)
-		}
-		if strings.Contains(line, "node.description") {
-			current.Description = extractQuotedValue(line)
-		}
-		if strings.Contains(line, "media.class") {
-			cls := extractQuotedValue(line)
-			if strings.Contains(cls, "Source") || strings.Contains(cls, "Input") {
-				current.Type = agentpb.AudioDeviceType_AUDIO_DEVICE_TYPE_INPUT
-			} else if strings.Contains(cls, "Sink") || strings.Contains(cls, "Output") {
-				current.Type = agentpb.AudioDeviceType_AUDIO_DEVICE_TYPE_OUTPUT
-			}
-		}
-	}
-	if current != nil {
-		devices = append(devices, current)
-	}
-
-	return devices, nil
-}
-
 // listALSADevices falls back to ALSA for audio device enumeration.
 func (s *AudioService) listALSADevices(ctx context.Context) ([]*agentpb.AudioDevice, error) {
 	var devices []*agentpb.AudioDevice
@@ -519,98 +467,6 @@ func (s *AudioService) SetDefaultAudioDevice(ctx context.Context, req *agentpb.S
 	return resp, nil
 }
 
-// listPulseAudioDevices uses pactl to enumerate sinks and sources.
-func (s *AudioService) listPulseAudioDevices(ctx context.Context) ([]*agentpb.AudioDevice, error) {
-	var devices []*agentpb.AudioDevice
-
-	// Collect sinks (output devices).
-	sinkDevices, err := s.parsePulseAudioDevices(ctx, "sink", agentpb.AudioDeviceType_AUDIO_DEVICE_TYPE_OUTPUT)
-	if err != nil {
-		return nil, fmt.Errorf("pactl list sinks: %w", err)
-	}
-	devices = append(devices, sinkDevices...)
-
-	// Collect sources (input devices).
-	sourceDevices, err := s.parsePulseAudioDevices(ctx, "source", agentpb.AudioDeviceType_AUDIO_DEVICE_TYPE_INPUT)
-	if err != nil {
-		return nil, fmt.Errorf("pactl list sources: %w", err)
-	}
-	devices = append(devices, sourceDevices...)
-
-	return devices, nil
-}
-
-// parsePulseAudioDevices parses "pactl list sinks short" and "pactl list sinks" for a device category.
-func (s *AudioService) parsePulseAudioDevices(ctx context.Context, category string, devType agentpb.AudioDeviceType) ([]*agentpb.AudioDevice, error) {
-	plural := category + "s"
-
-	// Get short listing for ID and name.
-	shortCmd := exec.CommandContext(ctx, "pactl", "list", plural, "short")
-	shortOutput, err := shortCmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("pactl list %s short: %w", plural, err)
-	}
-
-	type paDevice struct {
-		id   uint32
-		name string
-	}
-	var parsed []paDevice
-
-	scanner := bufio.NewScanner(strings.NewReader(string(shortOutput)))
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) < 2 {
-			continue
-		}
-		id, err := strconv.ParseUint(fields[0], 10, 32)
-		if err != nil {
-			continue
-		}
-		parsed = append(parsed, paDevice{id: uint32(id), name: fields[1]})
-	}
-
-	// Get long listing for descriptions.
-	longCmd := exec.CommandContext(ctx, "pactl", "list", plural)
-	longOutput, err := longCmd.Output()
-	if err != nil {
-		// Fall back to short-form only (no descriptions).
-		var devices []*agentpb.AudioDevice
-		for _, p := range parsed {
-			devices = append(devices, &agentpb.AudioDevice{
-				Id:   p.id,
-				Name: p.name,
-				Type: devType,
-			})
-		}
-		return devices, nil
-	}
-
-	// Parse descriptions from long output, indexed by order of appearance.
-	var descriptions []string
-	longScanner := bufio.NewScanner(strings.NewReader(string(longOutput)))
-	for longScanner.Scan() {
-		line := strings.TrimSpace(longScanner.Text())
-		if strings.HasPrefix(line, "Description:") {
-			descriptions = append(descriptions, strings.TrimSpace(strings.TrimPrefix(line, "Description:")))
-		}
-	}
-
-	var devices []*agentpb.AudioDevice
-	for i, p := range parsed {
-		dev := &agentpb.AudioDevice{
-			Id:   p.id,
-			Name: p.name,
-			Type: devType,
-		}
-		if i < len(descriptions) {
-			dev.Description = descriptions[i]
-		}
-		devices = append(devices, dev)
-	}
-	return devices, nil
-}
-
 // setPulseAudioDefaultByALSA resolves the given ALSA card/device to all
 // matching PulseAudio sinks and sources by matching ALSA properties, then sets
 // each as the system default. Both sink and source defaults are updated when a
@@ -849,22 +705,4 @@ func computeAudioLevels(data []byte) (peakDb, rmsDb float32) {
 	rmsDb = float32(20.0 * math.Log10(rmsVal/32768.0))
 
 	return peakDb, rmsDb
-}
-
-// extractQuotedValue extracts a value between quotes from a PipeWire property line.
-func extractQuotedValue(line string) string {
-	start := strings.Index(line, "\"")
-	if start < 0 {
-		// Try without quotes (some pw-cli formats use = value).
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) == 2 {
-			return strings.TrimSpace(parts[1])
-		}
-		return ""
-	}
-	end := strings.Index(line[start+1:], "\"")
-	if end < 0 {
-		return line[start+1:]
-	}
-	return line[start+1 : start+1+end]
 }

--- a/go/internal/shared/discovery/usb_linux.go
+++ b/go/internal/shared/discovery/usb_linux.go
@@ -3,75 +3,101 @@
 package discovery
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"os/exec"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 )
 
-// discoverUSB uses lsusb to find USB-connected Wendy devices on Linux.
-// lsusb output format: "Bus 001 Device 002: ID 1234:5678 Manufacturer Device Name"
-func discoverUSB(ctx context.Context) ([]models.USBDevice, error) {
-	cmd := exec.CommandContext(ctx, "lsusb")
-	out, err := cmd.Output()
+// usbSysfsRoot is the sysfs directory that enumerates USB devices. It is a
+// variable so tests can point it at a fixture tree.
+var usbSysfsRoot = "/sys/bus/usb/devices"
+
+// discoverUSB enumerates USB devices from sysfs and returns those that look like
+// a Wendy device (by name) or an Espressif ESP32-C6 (by VID:PID). Reading sysfs
+// directly avoids shelling out to lsusb and parsing its human-readable output.
+func discoverUSB(_ context.Context) ([]models.USBDevice, error) {
+	entries, err := os.ReadDir(usbSysfsRoot)
 	if err != nil {
-		return nil, fmt.Errorf("running lsusb: %w", err)
+		return nil, fmt.Errorf("reading %s: %w", usbSysfsRoot, err)
 	}
 
 	var devices []models.USBDevice
-	scanner := bufio.NewScanner(strings.NewReader(string(out)))
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		isWendy := strings.Contains(strings.ToLower(line), "wendy")
-		// Check for Espressif ESP32-C6 VID:PID.
-		esp32Match := strings.TrimPrefix(models.ESP32VendorID, "0x") + ":" + strings.TrimPrefix(models.ESP32ProductID, "0x")
-		isESP32 := strings.Contains(strings.ToLower(line), esp32Match)
-
-		if !isWendy && !isESP32 {
+	for _, entry := range entries {
+		name := entry.Name()
+		// Interface directories (e.g. "1-1:1.0") contain a colon and carry no
+		// idVendor/idProduct; only whole-device directories are of interest.
+		if strings.Contains(name, ":") {
 			continue
 		}
 
-		dev := models.USBDevice{
-			IsWendyDevice: isWendy || isESP32,
-			IsESP32:       isESP32,
+		dir := filepath.Join(usbSysfsRoot, name)
+		vid := readSysfsAttr(dir, "idVendor")
+		pid := readSysfsAttr(dir, "idProduct")
+		if vid == "" || pid == "" {
+			continue
 		}
 
-		// Extract "ID VVVV:PPPP"
-		idIdx := strings.Index(line, "ID ")
-		if idIdx >= 0 {
-			rest := line[idIdx+3:]
-			fields := strings.SplitN(rest, " ", 2)
-			if len(fields) >= 1 {
-				vidpid := strings.SplitN(fields[0], ":", 2)
-				if len(vidpid) == 2 {
-					dev.VendorID = fmt.Sprintf("0x%s", vidpid[0])
-					dev.ProductID = fmt.Sprintf("0x%s", vidpid[1])
-				}
-			}
-			if len(fields) >= 2 {
-				dev.Name = strings.TrimSpace(fields[1])
-				dev.DisplayName = dev.Name
-			}
+		dev, ok := usbDeviceFromSysfs(vid, pid,
+			readSysfsAttr(dir, "manufacturer"),
+			readSysfsAttr(dir, "product"))
+		if !ok {
+			continue
 		}
-
-		if dev.Name == "" {
-			if isESP32 {
-				dev.Name = "ESP32-C6"
-			} else {
-				dev.Name = "Wendy Device"
-			}
-			dev.DisplayName = dev.Name
-		}
-
-		if isESP32 {
-			dev.DisplayName = "ESP32-C6"
-		}
-
 		devices = append(devices, dev)
 	}
+
 	return devices, nil
+}
+
+// readSysfsAttr reads a single sysfs attribute file, returning its trimmed
+// contents or "" if the file is absent or unreadable.
+func readSysfsAttr(dir, attr string) string {
+	data, err := os.ReadFile(filepath.Join(dir, attr))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// usbDeviceFromSysfs builds a USBDevice from sysfs attribute values. vid and pid
+// are hex strings without the "0x" prefix (as exposed by sysfs). It reports
+// false when the device is neither a Wendy device (by name) nor an ESP32-C6 (by
+// VID:PID), matching the filtering previously performed on lsusb output.
+func usbDeviceFromSysfs(vid, pid, manufacturer, product string) (models.USBDevice, bool) {
+	vid = strings.ToLower(vid)
+	pid = strings.ToLower(pid)
+
+	isESP32 := vid == strings.TrimPrefix(models.ESP32VendorID, "0x") &&
+		pid == strings.TrimPrefix(models.ESP32ProductID, "0x")
+	name := strings.TrimSpace(manufacturer + " " + product)
+	isWendy := strings.Contains(strings.ToLower(name), "wendy")
+
+	if !isWendy && !isESP32 {
+		return models.USBDevice{}, false
+	}
+
+	dev := models.USBDevice{
+		IsWendyDevice: isWendy || isESP32,
+		IsESP32:       isESP32,
+		VendorID:      "0x" + vid,
+		ProductID:     "0x" + pid,
+		Name:          name,
+	}
+	if dev.Name == "" {
+		if isESP32 {
+			dev.Name = "ESP32-C6"
+		} else {
+			dev.Name = "Wendy Device"
+		}
+	}
+	dev.DisplayName = dev.Name
+	if isESP32 {
+		dev.DisplayName = "ESP32-C6"
+	}
+
+	return dev, true
 }

--- a/go/internal/shared/discovery/usb_linux.go
+++ b/go/internal/shared/discovery/usb_linux.go
@@ -12,17 +12,23 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 )
 
-// usbSysfsRoot is the sysfs directory that enumerates USB devices. It is a
-// variable so tests can point it at a fixture tree.
-var usbSysfsRoot = "/sys/bus/usb/devices"
+// defaultUSBSysfsRoot is the sysfs directory that enumerates USB devices.
+const defaultUSBSysfsRoot = "/sys/bus/usb/devices"
 
 // discoverUSB enumerates USB devices from sysfs and returns those that look like
 // a Wendy device (by name) or an Espressif ESP32-C6 (by VID:PID). Reading sysfs
 // directly avoids shelling out to lsusb and parsing its human-readable output.
 func discoverUSB(_ context.Context) ([]models.USBDevice, error) {
-	entries, err := os.ReadDir(usbSysfsRoot)
+	return discoverUSBAt(defaultUSBSysfsRoot)
+}
+
+// discoverUSBAt enumerates USB devices under an explicit sysfs root. The root is
+// trusted configuration (the kernel-controlled sysfs path in production); tests
+// pass a fixture tree directly rather than mutating shared state.
+func discoverUSBAt(root string) ([]models.USBDevice, error) {
+	entries, err := os.ReadDir(root)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", usbSysfsRoot, err)
+		return nil, fmt.Errorf("reading %s: %w", root, err)
 	}
 
 	var devices []models.USBDevice
@@ -33,8 +39,14 @@ func discoverUSB(_ context.Context) ([]models.USBDevice, error) {
 		if strings.Contains(name, ":") {
 			continue
 		}
+		// Defensive: os.ReadDir yields base names (never "." / ".." or a name
+		// with a separator), but guard anyway so a redirected root can never be
+		// escaped via filepath.Join.
+		if name == "." || name == ".." || strings.ContainsRune(name, filepath.Separator) {
+			continue
+		}
 
-		dir := filepath.Join(usbSysfsRoot, name)
+		dir := filepath.Join(root, name)
 		vid := readSysfsAttr(dir, "idVendor")
 		pid := readSysfsAttr(dir, "idProduct")
 		if vid == "" || pid == "" {

--- a/go/internal/shared/discovery/usb_linux_test.go
+++ b/go/internal/shared/discovery/usb_linux_test.go
@@ -3,7 +3,6 @@
 package discovery
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -115,13 +114,9 @@ func TestDiscoverUSB_FromSysfsTree(t *testing.T) {
 	// A bus root without idVendor/idProduct — must be skipped.
 	mkdev("usb3", map[string]string{})
 
-	prev := usbSysfsRoot
-	usbSysfsRoot = root
-	defer func() { usbSysfsRoot = prev }()
-
-	devices, err := discoverUSB(context.Background())
+	devices, err := discoverUSBAt(root)
 	if err != nil {
-		t.Fatalf("discoverUSB: %v", err)
+		t.Fatalf("discoverUSBAt: %v", err)
 	}
 
 	if len(devices) != 1 {

--- a/go/internal/shared/discovery/usb_linux_test.go
+++ b/go/internal/shared/discovery/usb_linux_test.go
@@ -1,0 +1,133 @@
+//go:build linux
+
+package discovery
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUSBDeviceFromSysfs(t *testing.T) {
+	tests := []struct {
+		name            string
+		vid, pid        string
+		mfr, product    string
+		wantOK          bool
+		wantName        string
+		wantDisplayName string
+		wantESP32       bool
+		wantVendorID    string
+	}{
+		{
+			name:            "esp32 by vid:pid with no strings",
+			vid:             "303a",
+			pid:             "1001",
+			wantOK:          true,
+			wantName:        "ESP32-C6",
+			wantDisplayName: "ESP32-C6",
+			wantESP32:       true,
+			wantVendorID:    "0x303a",
+		},
+		{
+			name:            "esp32 vid uppercased by sysfs is still matched",
+			vid:             "303A",
+			pid:             "1001",
+			wantOK:          true,
+			wantName:        "ESP32-C6",
+			wantDisplayName: "ESP32-C6",
+			wantESP32:       true,
+			wantVendorID:    "0x303a",
+		},
+		{
+			name:            "wendy device by name",
+			vid:             "1234",
+			pid:             "5678",
+			mfr:             "Wendy Labs",
+			product:         "Edge Device",
+			wantOK:          true,
+			wantName:        "Wendy Labs Edge Device",
+			wantDisplayName: "Wendy Labs Edge Device",
+			wantESP32:       false,
+			wantVendorID:    "0x1234",
+		},
+		{
+			name:    "unrelated device is filtered out",
+			vid:     "8086",
+			pid:     "0001",
+			mfr:     "Intel",
+			product: "Hub",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev, ok := usbDeviceFromSysfs(tt.vid, tt.pid, tt.mfr, tt.product)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if dev.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", dev.Name, tt.wantName)
+			}
+			if dev.DisplayName != tt.wantDisplayName {
+				t.Errorf("DisplayName = %q, want %q", dev.DisplayName, tt.wantDisplayName)
+			}
+			if dev.IsESP32 != tt.wantESP32 {
+				t.Errorf("IsESP32 = %v, want %v", dev.IsESP32, tt.wantESP32)
+			}
+			if !dev.IsWendyDevice {
+				t.Errorf("IsWendyDevice = false, want true")
+			}
+			if dev.VendorID != tt.wantVendorID {
+				t.Errorf("VendorID = %q, want %q", dev.VendorID, tt.wantVendorID)
+			}
+		})
+	}
+}
+
+func TestDiscoverUSB_FromSysfsTree(t *testing.T) {
+	root := t.TempDir()
+
+	// Helper to create a fake sysfs device directory with the given attributes.
+	mkdev := func(name string, attrs map[string]string) {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for k, v := range attrs {
+			if err := os.WriteFile(filepath.Join(dir, k), []byte(v+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// An ESP32-C6 whole-device directory.
+	mkdev("3-1", map[string]string{"idVendor": "303a", "idProduct": "1001"})
+	// An unrelated device that must be ignored.
+	mkdev("3-2", map[string]string{"idVendor": "8086", "idProduct": "0001", "manufacturer": "Intel"})
+	// An interface directory for the ESP32 — must be skipped (has a colon, no ids).
+	mkdev("3-1:1.0", map[string]string{})
+	// A bus root without idVendor/idProduct — must be skipped.
+	mkdev("usb3", map[string]string{})
+
+	prev := usbSysfsRoot
+	usbSysfsRoot = root
+	defer func() { usbSysfsRoot = prev }()
+
+	devices, err := discoverUSB(context.Background())
+	if err != nil {
+		t.Fatalf("discoverUSB: %v", err)
+	}
+
+	if len(devices) != 1 {
+		t.Fatalf("expected exactly 1 matched device, got %d: %+v", len(devices), devices)
+	}
+	if !devices[0].IsESP32 {
+		t.Errorf("expected the matched device to be the ESP32, got %+v", devices[0])
+	}
+}


### PR DESCRIPTION
Reduces wendy-agent's reliance on external CLIs by replacing them with native APIs / direct kernel interfaces.

## Bluetooth → BlueZ D-Bus
- **Scan/discovery** (original commit): enumerate peripherals via the BlueZ ObjectManager instead of parsing `bluetoothctl` text output.
- **Management ops** (new): `Connect` / `Disconnect` / `Forget` and trust/pair now use `Device1.Connect/Disconnect/Pair`, the `Trusted` property, and `Adapter1.RemoveDevice` — no more `bluetoothctl`.
- Pairing registers a headless `NoInputNoOutput` "just works" `Agent1`, **scoped to the connection** so it's only active during a caller-initiated pair and auto-unregistered when the connection closes (limits the auto-accept exposure).
- Adds a tested `deviceObjectPath` address→object-path helper.

## Audio — remove dead `pw-cli`/`pactl` enumeration
- Removes `listPipeWireDevices` (the only `pw-cli` caller) and its sole helper `extractQuotedValue`, eliminating `pw-cli` from the agent.
- Removes the dead `listPulseAudioDevices`/`parsePulseAudioDevices` helpers (never wired up). The live set-default path still uses `pactl`.

## USB discovery — sysfs instead of `lsusb`
- `discoverUSB` reads `/sys/bus/usb/devices` directly rather than shelling out to `lsusb` and regex-parsing its output. Adds a pure matcher with unit + fixture-tree tests.

## Validation
`go build ./go/...` and `go test` for `internal/agent/bluetooth`, `internal/shared/discovery`, and `internal/agent/services` — all pass (run in a `golang:1.26` Linux container, since the new tests are Linux-tagged). `gofmt` and `git diff --check` clean.

## Follow-up
`shared/discovery/bluetooth_linux.go` still uses `bluetoothctl` for BLE device *discovery*, so `bluez-utils` can't be dropped from the OS image until that path is migrated too (same D-Bus `Scan` pattern already used here).

> ⚠️ The D-Bus pairing path (auto-accept agent) hasn't been exercised on real BT hardware — worth a smoke test against an audio device on a Jetson/Pi before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)