### PR TITLE
WDY-1558: Mark failed Swift E2E attempts without observations as failed

### DIFF
--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
@@ -16,3 +16,14 @@ func e2eAttemptArtifactsURL(in runURL: URL, targetName: String, attempt: String)
         .appendingPathComponent(targetName, isDirectory: true)
         .appendingPathComponent(attempt, isDirectory: true)
 }
+
+func e2eAttemptExitStatus(at attemptURL: URL) -> Int? {
+    let url = attemptURL.appendingPathComponent("attempt.json")
+    guard FileManager.default.fileExists(atPath: url.path),
+        let data = try? Data(contentsOf: url),
+        let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+        return nil
+    }
+    return object["exitStatus"] as? Int
+}

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -1067,8 +1067,10 @@ private func buildTargetOverview(
     files: [ReportTestFile]
 ) throws -> [ReportTargetOverviewRow] {
     var rowsByTarget: [String: ReportTargetOverviewAccumulator] = [:]
+    var observedAttemptsByTarget: [String: Set<String>] = [:]
+    let attemptURLsByTarget = try runAttemptArtifactURLsByTarget(in: runURL)
 
-    for (target, attemptURLs) in try runAttemptArtifactURLsByTarget(in: runURL) {
+    for (target, attemptURLs) in attemptURLsByTarget {
         var row = rowsByTarget[target] ?? ReportTargetOverviewAccumulator()
         row.attempts.formUnion(attemptURLs.map(\.lastPathComponent))
         if row.route == nil, let attemptURL = attemptURLs.first {
@@ -1083,8 +1085,24 @@ private func buildTargetOverview(
             var row = rowsByTarget[target] ?? ReportTargetOverviewAccumulator()
             row.route = row.route ?? observations.first?.route
             row.attempts.formUnion(observations.map(\.attempt))
+            observedAttemptsByTarget[target, default: []].formUnion(
+                observations.map(\.attempt)
+            )
             row.tests += 1
             row.counts.add(targetOutcome(for: observations.map(\.status)))
+            rowsByTarget[target] = row
+        }
+    }
+
+    for (target, attemptURLs) in attemptURLsByTarget {
+        let observedAttempts = observedAttemptsByTarget[target, default: []]
+        for attemptURL in attemptURLs
+        where !observedAttempts.contains(attemptURL.lastPathComponent) {
+            guard let exitStatus = e2eAttemptExitStatus(at: attemptURL), exitStatus != 0 else {
+                continue
+            }
+            var row = rowsByTarget[target] ?? ReportTargetOverviewAccumulator()
+            row.counts.failed += 1
             rowsByTarget[target] = row
         }
     }

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
@@ -160,6 +160,7 @@ private struct OverviewTargetAccumulator {
 
 private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
     var targetAccumulators: [String: OverviewTargetAccumulator] = [:]
+    var observedAttemptsByTarget: [String: Set<String>] = [:]
     var summaryCounts = OverviewOutcomeCounts()
     var uniqueTests = Set<String>()
     var testTargetCount = 0
@@ -224,6 +225,9 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
                     default: OverviewTargetAccumulator()
                 ]
                 targetAccumulator.attempts.formUnion(attempts.map(\.attempt))
+                observedAttemptsByTarget[targetName, default: []].formUnion(
+                    attempts.map(\.attempt)
+                )
                 targetAccumulator.tests += 1
                 targetAccumulator.counts.add(outcome)
                 targetAccumulators[targetName] = targetAccumulator
@@ -256,6 +260,29 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
                     uniqueTests.insert("\(suiteKey)/\(testKey)")
                 }
             }
+        }
+    }
+
+    for targetURL in try overviewDirectoryChildren(of: e2eAttemptArtifactsRootURL(in: runURL)) {
+        let targetName = targetURL.lastPathComponent
+        let observedAttempts = observedAttemptsByTarget[targetName, default: []]
+        for attemptURL in try overviewDirectoryChildren(of: targetURL) {
+            let attemptName = attemptURL.lastPathComponent
+            guard !observedAttempts.contains(attemptName),
+                let exitStatus = e2eAttemptExitStatus(at: attemptURL), exitStatus != 0
+            else {
+                continue
+            }
+
+            var targetAccumulator = targetAccumulators[
+                targetName,
+                default: OverviewTargetAccumulator()
+            ]
+            targetAccumulator.attempts.insert(attemptName)
+            targetAccumulator.counts.failed += 1
+            targetAccumulators[targetName] = targetAccumulator
+            summaryCounts.failed += 1
+            attemptResultCount += 1
         }
     }
 

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/ReportCommandTests.swift
@@ -105,6 +105,72 @@ struct `report command` {
         #expect(html.contains("title=\"macos-to-&lt;img src=x onerror=&quot;alert(1)&quot;&gt;\""))
         #expect(html.contains("macos-to-no-observations"))
     }
+
+    @Test
+    func `renders failed target for failed attempt artifact without observations`() throws {
+        let rootURL = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let packageURL = rootURL.appendingPathComponent("Package", isDirectory: true)
+        let testsURL = packageURL.appendingPathComponent("Tests", isDirectory: true)
+        let supportURL = packageURL.appendingPathComponent("Support", isDirectory: true)
+        let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
+        let attemptURL =
+            runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent("macos-jetson-orin-nano", isDirectory: true)
+            .appendingPathComponent("0001", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: testsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: supportURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: attemptURL, withIntermediateDirectories: true)
+        try """
+        {
+          "exitStatus": 1
+        }
+        """.write(
+            to: attemptURL.appendingPathComponent("attempt.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        <!doctype html>
+        <html>
+          <body>
+            {{TARGET_OVERVIEW}}
+            <!-- Repeat this .card section once per test file. -->
+            <footer></footer>
+          </body>
+        </html>
+        """.write(
+            to: supportURL.appendingPathComponent("e2e-report.template.html"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        var command = try ReportCommand.parse([
+            "--package-dir", packageURL.path,
+            "--run-dir", runURL.path,
+        ])
+        try command.run()
+
+        let html = try String(
+            contentsOf: runURL.appendingPathComponent("index.html"),
+            encoding: .utf8
+        )
+
+        #expect(html.contains("macos-jetson-orin-nano"))
+        #expect(html.contains("<td><span class=\"badge fail\">Failed</span></td>"))
+        #expect(html.contains("""
+          <td class="numeric">1</td>
+          <td class="numeric">0</td>
+          <td class="numeric">0</td>
+          <td class="numeric">0</td>
+          <td class="numeric">1</td>
+          <td class="numeric">0</td>
+          <td class="numeric">0</td>
+        """))
+    }
 }
 
 private func writeReportTestMetadata(to observationURL: URL) throws {

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -88,6 +88,48 @@ struct `run overview` {
     }
 
     @Test
+    func `marks failed attempt artifacts without observations as failed targets`() throws {
+        let rootURL = e2eTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
+        let attemptURL =
+            runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent("macos-jetson-orin-nano", isDirectory: true)
+            .appendingPathComponent("0001", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: attemptURL, withIntermediateDirectories: true)
+        try """
+        {
+          "exitStatus": 1
+        }
+        """.write(
+            to: attemptURL.appendingPathComponent("attempt.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let overview = try writeRunOverview(in: runURL)
+
+        #expect(overview.summary.tests == 0)
+        #expect(overview.summary.testTargets == 0)
+        #expect(overview.summary.attemptResults == 1)
+        #expect(overview.summary.failed == 1)
+        #expect(overview.summary.unknown == 0)
+        #expect(overview.targets.count == 1)
+
+        let target = try #require(overview.targets.first)
+        #expect(target.name == "macos-jetson-orin-nano")
+        #expect(target.outcome == .failed)
+        #expect(target.attempts == 1)
+        #expect(target.tests == 0)
+        #expect(target.failed == 1)
+        #expect(target.unknown == 0)
+        #expect(overview.noteworthy.deterministicFailures.isEmpty)
+    }
+
+    @Test
     func `uses test metadata to distinguish duplicate test names`() throws {
         let rootURL = e2eTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: rootURL) }


### PR DESCRIPTION
## Summary

- Setup PR for WDY-1558.
- Implementation will classify failed Swift E2E attempt-level artifacts with no per-test observations as failed in run overview/report output.
- Regression coverage should use an attempt with non-zero `attempt.json.exitStatus` and no `observations` entries.

Closes WDY-1558

## Testing

- Not run yet (setup-only draft).
