### PR TITLE
WDY-1561: Fix macOS integration discovery empty matrix failure

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -149,9 +149,11 @@ jobs:
             fi
           }
 
+          DISCOVERED_COUNT=0
           HOSTS=()
           while IFS= read -r host; do
             [[ -z "$host" ]] && continue
+            DISCOVERED_COUNT=$((DISCOVERED_COUNT + 1))
             if ! validate_device_hostname "$host"; then
               echo "ERROR: invalid discovered device hostname: $host" >&2
               exit 1
@@ -174,13 +176,30 @@ jobs:
             exit 1
           fi
 
-          MATRIX=$(jq -cn --args '$ARGS.positional' "${HOSTS[@]}")
+          if [[ "$COUNT" -eq 0 ]]; then
+            MATRIX='[]'
+          else
+            MATRIX=$(jq -cn --args '$ARGS.positional' "${HOSTS[@]}")
+          fi
           [[ -n "$MATRIX" && "$MATRIX" != "null" ]] || { echo "ERROR: failed to build device matrix" >&2; exit 1; }
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
-          echo "Discovered $COUNT LAN device(s)."
-          if [[ "$INPUT_HOSTNAME" == '' && "$INPUT_JOBS" != 'discover' && "$COUNT" -eq 0 ]]; then
-            echo "ERROR: No LAN devices found via wendy discover"
+          echo "Discovered $DISCOVERED_COUNT LAN device(s); selected $COUNT allowlisted device(s)."
+          if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+            {
+              echo "### Wendy integration discovery"
+              echo
+              echo "- LAN devices discovered: $DISCOVERED_COUNT"
+              echo "- Allowlisted devices selected: $COUNT"
+              if [[ "$DISCOVERED_COUNT" -gt 0 && "$COUNT" -eq 0 ]]; then
+                echo
+                echo "No discovered LAN devices matched the integration allowlist, so downstream integration jobs will be skipped."
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [[ "$INPUT_HOSTNAME" == '' && "$INPUT_JOBS" != 'discover' && "$DISCOVERED_COUNT" -eq 0 ]]; then
+            echo "ERROR: No LAN devices found via wendy discover" >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Setup PR for WDY-1561.
- Implementation will fix the macOS integration discovery matrix path when discovery finds devices but none match the allowlist.
- The fix should avoid `set -u`/empty-array failures and make the zero-match outcome explicit.

Closes WDY-1561

## Testing

- Not run yet (setup-only draft).
