### PR TITLE
feat(cli): mic picker, virtual-device filtering, and lower-latency audio listen

### DIFF
--- a/go/internal/agent/services/audio_service.go
+++ b/go/internal/agent/services/audio_service.go
@@ -774,7 +774,8 @@ func (s *AudioService) StreamAudio(req *agentpb.StreamAudioRequest, stream grpc.
 		"-r", fmt.Sprintf("%d", sampleRate),
 		"-c", fmt.Sprintf("%d", channels),
 		"-t", "raw",
-		"--buffer-time=50000", // 50ms ALSA buffer to minimise capture latency
+		"--buffer-time=20000", // 20ms ALSA buffer to minimise capture latency
+		"--period-time=10000", // 10ms periods so data is delivered in small, frequent reads
 		"-",
 	)
 	var stderrBuf bytes.Buffer
@@ -788,8 +789,8 @@ func (s *AudioService) StreamAudio(req *agentpb.StreamAudioRequest, stream grpc.
 	}
 	defer func() { cmd.Process.Kill(); cmd.Wait() }() //nolint:errcheck
 
-	// Send ~20ms chunks of PCM data.
-	chunkSamples := sampleRate / 50 // 20ms worth of samples
+	// Send ~10ms chunks of PCM data to keep per-chunk latency low.
+	chunkSamples := sampleRate / 100 // 10ms worth of samples
 	chunkBytes := chunkSamples * channels * 2
 	buf := make([]byte, chunkBytes)
 

--- a/go/internal/cli/commands/audio.go
+++ b/go/internal/cli/commands/audio.go
@@ -2,11 +2,15 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -188,6 +192,8 @@ func newAudioListenCmd() *cobra.Command {
 	var sampleRate uint32
 	var channels uint32
 	var stdout bool
+	var all bool
+	var bufferMs uint32
 
 	cmd := &cobra.Command{
 		Use:   "listen",
@@ -199,6 +205,29 @@ func newAudioListenCmd() *cobra.Command {
 				return err
 			}
 			defer conn.Close()
+
+			// Resolve the device locally so we always send a concrete ID. The
+			// agent's auto-select (DeviceId == 0) would pick the first ALSA
+			// capture device, which on some platforms (e.g. Jetson Tegra) is a
+			// virtual routing endpoint that fails with an EIO on read.
+			if deviceID == 0 {
+				listResp, err := conn.AudioService.ListAudioDevices(ctx, &agentpb.ListAudioDevicesRequest{})
+				if err != nil {
+					return fmt.Errorf("listing audio devices: %w", err)
+				}
+				interactive := !stdout && term.IsTerminal(int(os.Stdin.Fd()))
+				id, chosen, err := resolveListenDeviceID(listResp.GetDevices(), deviceID, all, interactive, pickAudioDevice)
+				if err != nil {
+					if errors.Is(err, ErrUserCancelled) {
+						return nil
+					}
+					return err
+				}
+				deviceID = id
+				if chosen != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Using %s — %s\n", chosen.GetName(), chosen.GetDescription())
+				}
+			}
 
 			stream, err := conn.AudioService.StreamAudio(ctx, &agentpb.StreamAudioRequest{
 				DeviceId:   deviceID,
@@ -227,14 +256,16 @@ func newAudioListenCmd() *cobra.Command {
 				return nil
 			}
 
-			return playRealtimeAudio(ctx, stream, sampleRate, channels)
+			return playRealtimeAudio(ctx, stream, sampleRate, channels, bufferMs)
 		},
 	}
 
-	cmd.Flags().Uint32Var(&deviceID, "id", 0, "Audio device ID")
+	cmd.Flags().Uint32Var(&deviceID, "id", 0, "Audio device ID (default: auto-select or pick a microphone)")
 	cmd.Flags().Uint32Var(&sampleRate, "sample-rate", 16000, "Sample rate in Hz")
 	cmd.Flags().Uint32Var(&channels, "channels", 1, "Number of audio channels")
 	cmd.Flags().BoolVar(&stdout, "stdout", false, "Write raw PCM to stdout instead of playing")
+	cmd.Flags().BoolVar(&all, "all", false, "Include virtual/dummy capture devices when selecting a microphone")
+	cmd.Flags().Uint32Var(&bufferMs, "buffer-ms", 30, "Playback jitter-buffer target in ms; lower = less latency, more prone to dropouts")
 
 	return cmd
 }

--- a/go/internal/cli/commands/audio_devices.go
+++ b/go/internal/cli/commands/audio_devices.go
@@ -1,0 +1,209 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// minBufferMs is the floor for the --buffer-ms latency knob. Below this the
+// playback jitter buffer is too shallow to absorb any network jitter.
+const minBufferMs uint32 = 10
+
+// defaultAgentChunkMs is the approximate duration of each PCM chunk the agent
+// emits for StreamAudio (see StreamAudio in the agent's audio_service.go). The
+// playback jitter buffer depth is derived from it.
+const defaultAgentChunkMs uint32 = 10
+
+// virtualCapturePatterns are case-insensitive substrings that mark an INPUT
+// device as a virtual/dummy endpoint rather than a usable microphone. This is a
+// denylist on purpose: anything unrecognised (USB mics, onboard codecs, named
+// I2S mics) is treated as real, so an unusual real microphone is never silently
+// hidden. Users can still reach hidden devices with --all or an explicit --id.
+var virtualCapturePatterns = []string{
+	"admaif",   // Tegra APE DMA routing FIFOs; nothing routed in by default (EIO on read)
+	"hdmi",     // display audio, not a microphone
+	"dummy",    // snd-dummy driver
+	"loopback", // ALSA loopback
+	"aloop",    // snd-aloop
+	"null",     // null sink/source
+	"virtual",  // PipeWire/Pulse virtual nodes
+}
+
+// isLikelyVirtualCapture reports whether an INPUT device is a virtual/dummy
+// endpoint that cannot serve as a real microphone.
+func isLikelyVirtualCapture(d *agentpb.AudioDevice) bool {
+	hay := strings.ToLower(d.GetName() + " " + d.GetDescription())
+	for _, p := range virtualCapturePatterns {
+		if strings.Contains(hay, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// inputDevices returns the INPUT (capture) devices, preserving order.
+func inputDevices(devs []*agentpb.AudioDevice) []*agentpb.AudioDevice {
+	var out []*agentpb.AudioDevice
+	for _, d := range devs {
+		if d.GetType() == agentpb.AudioDeviceType_AUDIO_DEVICE_TYPE_INPUT {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// realCaptureDevices returns INPUT devices that are not likely-virtual,
+// preserving order.
+func realCaptureDevices(devs []*agentpb.AudioDevice) []*agentpb.AudioDevice {
+	var out []*agentpb.AudioDevice
+	for _, d := range inputDevices(devs) {
+		if !isLikelyVirtualCapture(d) {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func findAudioDeviceByID(devs []*agentpb.AudioDevice, id uint32) *agentpb.AudioDevice {
+	for _, d := range devs {
+		if d.GetId() == id {
+			return d
+		}
+	}
+	return nil
+}
+
+// listenDevicePicker runs an interactive picker over the candidate devices and
+// returns the chosen device ID, or ErrUserCancelled if the user aborted. It is
+// injected into resolveListenDeviceID so the resolver stays unit-testable.
+type listenDevicePicker func(candidates []*agentpb.AudioDevice) (uint32, error)
+
+// resolveListenDeviceID selects the capture device ID for `audio listen`.
+//
+// Precedence:
+//  1. idFlag != 0 -> use it verbatim (explicit always wins; no filtering).
+//  2. candidate pool = real capture devices (or all INPUT devices when all).
+//  3. empty pool   -> actionable error.
+//  4. one device   -> use it.
+//  5. 2+ devices    -> picker when interactive, else the first one.
+//
+// The returned *agentpb.AudioDevice is the chosen device when known (for
+// logging); it may be nil when idFlag points at a device not present in devs.
+func resolveListenDeviceID(
+	devs []*agentpb.AudioDevice,
+	idFlag uint32,
+	all, interactive bool,
+	pick listenDevicePicker,
+) (uint32, *agentpb.AudioDevice, error) {
+	if idFlag != 0 {
+		return idFlag, findAudioDeviceByID(devs, idFlag), nil
+	}
+
+	pool := realCaptureDevices(devs)
+	if all {
+		pool = inputDevices(devs)
+	}
+
+	switch len(pool) {
+	case 0:
+		if all {
+			return 0, nil, fmt.Errorf("no capture devices found on the target device")
+		}
+		return 0, nil, fmt.Errorf(
+			"no microphone detected; re-run with --all to include virtual/loopback devices, " +
+				"or pass --id (see `wendy device audio list`)")
+	case 1:
+		return pool[0].GetId(), pool[0], nil
+	default:
+		if !interactive {
+			return pool[0].GetId(), pool[0], nil
+		}
+		id, err := pick(pool)
+		if err != nil {
+			return 0, nil, err
+		}
+		return id, findAudioDeviceByID(pool, id), nil
+	}
+}
+
+// jitterDepthChunks returns the playback jitter-buffer depth (in chunks) for a
+// given target latency and per-chunk duration, with a floor of one chunk.
+func jitterDepthChunks(bufferMs, chunkMs uint32) int {
+	if chunkMs == 0 {
+		chunkMs = 1
+	}
+	if d := int(bufferMs / chunkMs); d >= 1 {
+		return d
+	}
+	return 1
+}
+
+// audioPickerItems builds the picker rows for the candidate capture devices.
+// PickerItem.Value carries the *agentpb.AudioDevice so the column closures and
+// the selection handler can read the device ID without a side table.
+func audioPickerItems(candidates []*agentpb.AudioDevice) []tui.PickerItem {
+	items := make([]tui.PickerItem, 0, len(candidates))
+	for _, d := range candidates {
+		items = append(items, tui.PickerItem{
+			Name:        d.GetName(),
+			Description: d.GetDescription(),
+			DedupKey:    fmt.Sprintf("%d", d.GetId()),
+			Value:       d,
+		})
+	}
+	return items
+}
+
+func audioPickerColumns() []tui.PickerColumn {
+	devOf := func(it tui.PickerItem) *agentpb.AudioDevice {
+		d, _ := it.Value.(*agentpb.AudioDevice)
+		return d
+	}
+	return []tui.PickerColumn{
+		{Title: "ID", MinWidth: 6, Required: true, Value: func(it tui.PickerItem) string {
+			if d := devOf(it); d != nil {
+				return fmt.Sprintf("%d", d.GetId())
+			}
+			return ""
+		}},
+		{Title: "Name", MinWidth: 12, Required: true, Value: func(it tui.PickerItem) string { return it.Name }},
+		{Title: "Description", MinWidth: 20, Value: func(it tui.PickerItem) string { return it.Description }},
+	}
+}
+
+// pickAudioDevice presents the interactive microphone picker and returns the
+// chosen device ID. It returns ErrUserCancelled if the user quits.
+func pickAudioDevice(candidates []*agentpb.AudioDevice) (uint32, error) {
+	picker := tui.NewPickerWithTitleAndColumns("Select a microphone", audioPickerColumns())
+	p := tea.NewProgram(picker)
+
+	go func() {
+		p.Send(tui.PickerAddMsg{Items: audioPickerItems(candidates)})
+		p.Send(tui.PickerDoneMsg{})
+	}()
+
+	finalModel, err := p.Run()
+	if err != nil {
+		return 0, fmt.Errorf("microphone picker: %w", err)
+	}
+	pm, ok := finalModel.(tui.PickerModel)
+	if !ok {
+		return 0, fmt.Errorf("microphone picker: unexpected model type")
+	}
+	if pm.Cancelled() {
+		return 0, ErrUserCancelled
+	}
+	sel := pm.Selected()
+	if sel == nil {
+		return 0, ErrUserCancelled
+	}
+	d, ok := sel.Value.(*agentpb.AudioDevice)
+	if !ok || d == nil {
+		return 0, fmt.Errorf("microphone picker: invalid selection")
+	}
+	return d.GetId(), nil
+}

--- a/go/internal/cli/commands/audio_devices_test.go
+++ b/go/internal/cli/commands/audio_devices_test.go
@@ -1,0 +1,166 @@
+package commands
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func mkDev(id uint32, name, desc string, t agentpb.AudioDeviceType) *agentpb.AudioDevice {
+	return &agentpb.AudioDevice{Id: id, Name: name, Description: desc, Type: t}
+}
+
+const (
+	inT  = agentpb.AudioDeviceType_AUDIO_DEVICE_TYPE_INPUT
+	outT = agentpb.AudioDeviceType_AUDIO_DEVICE_TYPE_OUTPUT
+)
+
+func TestIsLikelyVirtualCapture(t *testing.T) {
+	cases := []struct {
+		name string
+		dev  *agentpb.AudioDevice
+		want bool
+	}{
+		{"tegra admaif", mkDev(257, "hw:1,0", "APE [NVIDIA Jetson Thor AGX APE], device 0: fe.admaif@9610000.ADMAIF1 (*) []", inT), true},
+		{"hdmi capture", mkDev(4, "hw:0,3", "HDA [NVIDIA Jetson Thor AGX HDA], device 3: HDMI 0 [HDMI 0]", inT), true},
+		{"dummy", mkDev(99, "hw:9,0", "Dummy [Dummy], device 0: Dummy PCM", inT), true},
+		{"loopback", mkDev(98, "hw:8,0", "Loopback [Loopback], device 0: Loopback PCM", inT), true},
+		{"usb webcam mic", mkDev(513, "hw:2,0", "C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio]", inT), false},
+		{"realtek onboard", mkDev(1, "hw:0,0", "HDA Intel PCH [HDA Intel PCH], device 0: ALC892 Analog [ALC892 Analog]", inT), false},
+		{"named i2s mic", mkDev(770, "hw:3,1", "tegrasndt210ref [tegra-snd-t210ref-mobile-rt5640], device 1: ICM-43434 Mic", inT), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isLikelyVirtualCapture(c.dev); got != c.want {
+				t.Fatalf("isLikelyVirtualCapture(%q) = %v, want %v", c.dev.GetDescription(), got, c.want)
+			}
+		})
+	}
+}
+
+// thorDevices mirrors the real `wendy device audio list` output on a Jetson Thor:
+// 32 APE ADMAIF capture FIFOs, the C920 USB mic, and HDMI outputs.
+func thorDevices() []*agentpb.AudioDevice {
+	var devs []*agentpb.AudioDevice
+	for i := uint32(0); i < 32; i++ {
+		devs = append(devs, mkDev(257+i, "hw:1,"+itoa(i),
+			"APE [NVIDIA Jetson Thor AGX APE], device "+itoa(i)+": fe.admaif@9610000.ADMAIF"+itoa(i+1)+" (*) []", inT))
+	}
+	devs = append(devs, mkDev(513, "hw:2,0", "C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio]", inT))
+	devs = append(devs, mkDev(4, "hw:0,3", "HDA [NVIDIA Jetson Thor AGX HDA], device 3: HDMI 0 [HDMI 0]", outT))
+	return devs
+}
+
+func itoa(n uint32) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func TestRealCaptureDevices_Thor(t *testing.T) {
+	real := realCaptureDevices(thorDevices())
+	if len(real) != 1 {
+		t.Fatalf("expected exactly 1 real capture device, got %d", len(real))
+	}
+	if real[0].GetId() != 513 {
+		t.Fatalf("expected C920 (id 513), got id %d (%s)", real[0].GetId(), real[0].GetName())
+	}
+}
+
+func TestResolveListenDeviceID(t *testing.T) {
+	usb := mkDev(513, "hw:2,0", "C920 USB Audio", inT)
+	usb2 := mkDev(514, "hw:4,0", "Blue Yeti USB Audio", inT)
+	admaif := mkDev(257, "hw:1,0", "APE ADMAIF1", inT)
+
+	neverPick := func([]*agentpb.AudioDevice) (uint32, error) {
+		t.Helper()
+		t.Fatal("picker should not have been called")
+		return 0, nil
+	}
+
+	t.Run("--id wins, no pick, no list needed", func(t *testing.T) {
+		id, _, err := resolveListenDeviceID([]*agentpb.AudioDevice{admaif}, 999, false, true, neverPick)
+		if err != nil || id != 999 {
+			t.Fatalf("got id=%d err=%v, want 999/nil", id, err)
+		}
+	})
+
+	t.Run("single real device used silently", func(t *testing.T) {
+		id, chosen, err := resolveListenDeviceID([]*agentpb.AudioDevice{usb, admaif}, 0, false, true, neverPick)
+		if err != nil || id != 513 || chosen.GetId() != 513 {
+			t.Fatalf("got id=%d chosen=%v err=%v", id, chosen, err)
+		}
+	})
+
+	t.Run("multiple real, non-interactive picks first", func(t *testing.T) {
+		id, chosen, err := resolveListenDeviceID([]*agentpb.AudioDevice{usb, usb2, admaif}, 0, false, false, neverPick)
+		if err != nil || id != 513 || chosen.GetId() != 513 {
+			t.Fatalf("got id=%d chosen=%v err=%v", id, chosen, err)
+		}
+	})
+
+	t.Run("multiple real, interactive uses picker", func(t *testing.T) {
+		pick := func(cands []*agentpb.AudioDevice) (uint32, error) {
+			if len(cands) != 2 {
+				t.Fatalf("expected 2 candidates, got %d", len(cands))
+			}
+			return 514, nil
+		}
+		id, chosen, err := resolveListenDeviceID([]*agentpb.AudioDevice{usb, usb2, admaif}, 0, false, true, pick)
+		if err != nil || id != 514 || chosen.GetId() != 514 {
+			t.Fatalf("got id=%d chosen=%v err=%v", id, chosen, err)
+		}
+	})
+
+	t.Run("picker cancel propagates ErrUserCancelled", func(t *testing.T) {
+		pick := func([]*agentpb.AudioDevice) (uint32, error) { return 0, ErrUserCancelled }
+		_, _, err := resolveListenDeviceID([]*agentpb.AudioDevice{usb, usb2}, 0, false, true, pick)
+		if !errors.Is(err, ErrUserCancelled) {
+			t.Fatalf("want ErrUserCancelled, got %v", err)
+		}
+	})
+
+	t.Run("no real device without --all errors and mentions --all", func(t *testing.T) {
+		_, _, err := resolveListenDeviceID([]*agentpb.AudioDevice{admaif}, 0, false, true, neverPick)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "--all") {
+			t.Fatalf("error should mention --all: %v", err)
+		}
+	})
+
+	t.Run("--all includes virtual devices", func(t *testing.T) {
+		// Only virtual inputs present; --all makes them eligible.
+		id, _, err := resolveListenDeviceID([]*agentpb.AudioDevice{admaif}, 0, true, false, neverPick)
+		if err != nil || id != 257 {
+			t.Fatalf("got id=%d err=%v, want 257/nil", id, err)
+		}
+	})
+}
+
+func TestJitterDepthChunks(t *testing.T) {
+	cases := []struct {
+		bufferMs, chunkMs uint32
+		want              int
+	}{
+		{30, 10, 3},
+		{10, 10, 1},
+		{5, 10, 1}, // floor at 1
+		{50, 20, 2},
+		{30, 0, 30}, // guard against div-by-zero (chunkMs treated as 1)
+	}
+	for _, c := range cases {
+		if got := jitterDepthChunks(c.bufferMs, c.chunkMs); got != c.want {
+			t.Fatalf("jitterDepthChunks(%d,%d) = %d, want %d", c.bufferMs, c.chunkMs, got, c.want)
+		}
+	}
+}

--- a/go/internal/cli/commands/audio_playback_oto.go
+++ b/go/internal/cli/commands/audio_playback_oto.go
@@ -13,22 +13,27 @@ import (
 )
 
 // playRealtimeAudio plays the gRPC audio stream through the local speakers.
-// Chunks are fed into a small ring buffer so stale data is dropped rather
-// than accumulating lag.
+// Chunks are fed into a small jitter buffer so stale data is dropped rather
+// than accumulating lag. bufferMs sets the target playback latency: it sizes
+// both the oto output buffer and the jitter-buffer depth. Lower values reduce
+// latency but make playback more prone to dropouts on a jittery link.
 func playRealtimeAudio(ctx context.Context, stream interface {
 	Recv() (*agentpb.AudioChunk, error)
-}, sampleRate, channels uint32) error {
+}, sampleRate, channels, bufferMs uint32) error {
 	if sampleRate == 0 {
 		sampleRate = 48000
 	}
 	if channels == 0 {
 		channels = 1
 	}
+	if bufferMs < minBufferMs {
+		bufferMs = minBufferMs
+	}
 	otoCtx, readyCh, err := oto.NewContext(&oto.NewContextOptions{
 		SampleRate:   int(sampleRate),
 		ChannelCount: int(channels),
 		Format:       oto.FormatSignedInt16LE,
-		BufferSize:   50 * time.Millisecond,
+		BufferSize:   time.Duration(bufferMs) * time.Millisecond,
 	})
 	if err != nil {
 		return fmt.Errorf("initialising audio output: %w", err)
@@ -39,8 +44,7 @@ func playRealtimeAudio(ctx context.Context, stream interface {
 		return ctx.Err()
 	}
 
-	const ringSize = 4
-	ring := make(chan []byte, ringSize)
+	ring := make(chan []byte, jitterDepthChunks(bufferMs, defaultAgentChunkMs))
 
 	recvErr := make(chan error, 1)
 	go func() {

--- a/go/internal/cli/commands/audio_playback_unsupported.go
+++ b/go/internal/cli/commands/audio_playback_unsupported.go
@@ -11,6 +11,6 @@ import (
 
 func playRealtimeAudio(_ context.Context, _ interface {
 	Recv() (*agentpb.AudioChunk, error)
-}, _, _ uint32) error {
+}, _, _, _ uint32) error {
 	return fmt.Errorf("audio playback is not available in this CLI build; use --stdout to write raw PCM audio")
 }


### PR DESCRIPTION
## Problem

`wendy device audio listen` with no `--id` sends `DeviceId=0`, so the agent auto-selects the *first* ALSA capture device. On a Jetson Thor that is an APE **ADMAIF** routing FIFO (`hw:1,0`) — it opens but fails on the first read with `arecord: pcm_read:2285: read error: Input/output error` (EIO). The only real mic (a USB C920, `hw:2,0`) sorts last and was never chosen. There was also no way to pick a mic interactively, and replay latency was high.

Verified on `wendyos-thor.local`: `--id 513` (C920) captures cleanly; the default auto-select EIOs.

## Changes

**Device selection (CLI-side, fixes the bug):**
- New `audio_devices.go`: denylist classification (`isLikelyVirtualCapture`) hides virtual/dummy capture endpoints — Tegra `ADMAIF`, `HDMI`, `dummy`, `loopback`/`aloop`, `null`, `virtual`. Denylist (not allowlist) so an unknown real mic is never silently hidden.
- `resolveListenDeviceID` precedence: `--id` wins → real-capture pool (or **all** INPUT with `--all`) → empty = actionable error → exactly one = use it → 2+ = interactive picker, else first device (non-interactive). The CLI always sends a concrete ID, so the agent's EIO-prone auto-select is never hit for `listen`.
- New `--all` flag (reveal virtual devices) and `--buffer-ms` flag (latency knob, default 30, floor 10).

**Latency (aggressive, tunable):**
- `--buffer-ms` drives the oto output buffer **and** the playback jitter-buffer depth (`jitterDepthChunks`), replacing the fixed ring-of-4.
- Agent-side: arecord `--buffer-time` 50ms→20ms + `--period-time=10ms`, and ~10ms chunks (was 20ms).

`audio list` is intentionally left as a full, unfiltered inventory (it's the ID-lookup command). No proto/gRPC-API changes.

## Tests
- Classification incl. the real Thor device list (32× ADMAIF + HDMI + C920 → only C920 survives) and USB/Realtek/I2S positives.
- `resolveListenDeviceID` state machine: 0/1/2+ real, `--all`, `--id`, interactive vs. not, picker-cancel.
- `jitterDepthChunks` math.

`go build ./...`, `go vet`, `gofmt`, and the affected test packages all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)