### PR TITLE
feat(os): download & flash via bmap when available

### DIFF
--- a/Documentation/2026-06-15-seekable-zstd-flashing-design.md
+++ b/Documentation/2026-06-15-seekable-zstd-flashing-design.md
@@ -9,17 +9,22 @@ Status: Design — pending review
 Flashing a WendyOS image is slow on zero-heavy ("holey") images even when the
 block map (bmap) is engaged. bmap already eliminates the *write* I/O for holes:
 the writer only `WriteAt`s mapped ranges. But the parent process still
-gzip-decompresses the **entire** uncompressed image — holes included — because
-it streams the decompressed bytes through a pipe to the writer, and a gzip pipe
-is not seekable. To advance the stream to the next mapped range, every hole byte
-must be produced by the (single-threaded) gzip decoder and then discarded.
+decompresses the **entire** uncompressed image — holes included — because it
+streams the decompressed bytes through a pipe to the writer, and a deflate
+(zip/gzip) pipe is not seekable. To advance the stream to the next mapped range,
+every hole byte must be produced by the (single-threaded) decoder and discarded.
+
+(The OS images published to `wendyos-images-public` are currently `.zip`
+artifacts — `wendy-os-publisher` re-compresses the raw `.img`/`.wic` with
+`zip -6` — and the CLI also accepts `.gz` and raw for local files. All use
+single-threaded deflate, so the analysis is the same regardless of which.)
 
 For a typical Jetson image (~19 GB uncompressed, ~4 GB of real mapped data),
 that means decoding ~15 GB of zeros we immediately throw away. Single-threaded
-gzip decode (~150–250 MB/s) of the full image is the wall-clock bottleneck.
+deflate decode (~150–250 MB/s) of the full image is the wall-clock bottleneck.
 
-**Root cause:** holes cost decompression, not write I/O, and a gzip pipe cannot
-skip them.
+**Root cause:** holes cost decompression, not write I/O, and a deflate pipe
+cannot skip them.
 
 ## Goal
 
@@ -57,26 +62,46 @@ speed — roughly **15–20× faster wall-clock** on holey images. Download stay
 
 ## Architecture
 
-### Build side (meta-wendyos)
+### Build side (wendy-os-publisher, Go)
 
-- Compress each published image as seekable zstd → `<image>.img.zst`, frame size
-  **4 MiB uncompressed** (balances seek-table size against worst-case wasted
-  decode per range; tunable).
-- Continue publishing the existing `.bmap` unchanged.
-- The seek table is embedded in the `.zst` file (a trailing skippable frame), so
-  the artifact is self-contained — no separate index sidecar.
-- A small in-repo Go encoder (`cmd/`, reusing the same seekable library as the
-  reader so writer/reader cannot drift) produces the artifact; the Yocto
-  publish step invokes it. Build-side details (recipe wiring) are out of scope
-  for this CLI spec beyond "publish `.img.zst` + `.bmap`".
+The seekable-zstd artifact is produced in **`wendy-os-publisher`**, not in Yocto.
+Rationale: compression already lives there (it re-compresses raw `.img`/`.wic`
+→ `.zip`); it receives the **raw, uncompressed** image as input (exactly what a
+seekable encoder needs); and it is the single choke point that **both RPi
+(Yocto) and Jetson (NVIDIA L4T + bash)** funnel through, so one change covers
+both device families. It can also reuse the same `zstd-seekable-format-go`
+library as the CLI reader, so writer and reader cannot drift. Yocto and the
+Jetson scripts are unchanged.
+
+> Note: stock `zstd` (including `--long`) does **not** emit the seekable
+> container. Seekable zstd is a distinct format (independent frames + a trailing
+> skippable seek-table frame); it must be written by the seekable library.
+
+Publisher changes:
+
+- New `compressSeekableZstd()` path for OS images: read the raw image, write
+  `<image>.img.zst` in seekable format, frame size **4 MiB uncompressed**
+  (balances seek-table size against worst-case wasted decode per range; tunable).
+  The seek table is embedded in the `.zst` (trailing skippable frame), so the
+  artifact is self-contained — no separate index sidecar.
+- Upload `.img.zst` to GCS alongside the existing artifacts and populate a new
+  manifest field `zst_path` (+ `zst_checksum`, `zst_size_bytes`) on
+  `VersionMetadata`, mirroring how `path`/`checksum`/`size_bytes` are set.
+- The seekable artifact is produced for OS-image uploads only (not OTA/recovery).
+- **Prerequisite to verify, not assume:** the `.bmap` must be uploaded and
+  `bmap_path` set in the manifest. Production manifests already carry `bmap_path`
+  (bmap flashing is live), so this path exists; confirm it covers the device
+  families we target before relying on it. If a device has no bmap, the seekable
+  artifact still downloads but offers no hole-skipping benefit — the CLI uses the
+  legacy path (see fallback).
 
 ### Manifest
 
 - Add a per-version field `zst_path` (sibling to `path`/`bmap_path`). When
   present, the CLI derives `ZstURL = gcsBaseURL + "/" + zst_path`.
-- Absent `zst_path` → CLI uses the existing gzip + bmap/`dd` path unchanged.
-  This is the rollout/back-compat seam: old manifests and partially-published
-  versions keep working.
+- Absent `zst_path` → CLI uses the existing deflate (`.zip`/`.gz`) + bmap/`dd`
+  path unchanged. This is the rollout/back-compat seam: old manifests and
+  partially-published versions keep working.
 
 ### CLI side
 
@@ -96,14 +121,25 @@ silent fallback that would leave a half-written disk).
 
 ## Components / where the code lands
 
-All paths under `go/internal/cli/commands/` unless noted.
+CLI paths are under `go/internal/cli/commands/`. The build-side change lands in
+the separate `wendy-os-publisher` repo.
+
+**Publisher (`wendy-os-publisher`, separate repo):**
+
+- `cmd/upload_and_manifest.go`: add `compressSeekableZstd()`; upload `.img.zst`
+  for OS images; add `zst_path`/`zst_checksum`/`zst_size_bytes` to
+  `VersionMetadata` and populate them. Add the `zstd-seekable-format-go` dep.
+
+**CLI (`go/internal/cli/commands/`):**
 
 - `seekable_zstd.go` (new): the seekable reader — `ReaderAt`/`Size` over the
   decompressed image, plus frame iteration (`forEachFrame`/offset→frame lookup).
-- `bmap.go`: replace `applyBmap`'s stream-and-discard loop with the frame-walk
-  driven by an `io.ReaderAt` source. Keep `parseBmap` and per-range SHA256
-  verification. `discard()` becomes unused for this path and is removed if no
-  other caller remains.
+- `bmap.go`: add a new frame-walk writer (`applyBmapSeekable`, driven by an
+  `io.ReaderAt` source) **alongside** the existing streaming `applyBmap`. The
+  streaming version stays — it's still used by the legacy deflate+bmap fallback
+  path (which has only a sequential pipe, not a seekable source). Both share
+  `parseBmap` and the per-range SHA256 verification helper; factor that hashing
+  so the two writers can't diverge on the verification guarantee.
 - `bmap_writer.go` / `root.go`: `__bmap-write` gains `--source <.img.zst>`; the
   helper opens the seekable reader and runs the frame-walk itself as root,
   emitting a newline-delimited cumulative-bytes-written counter on stdout.
@@ -117,13 +153,19 @@ All paths under `go/internal/cli/commands/` unless noted.
 - `os_install.go`: prefer `zst_path`; thread the seekable source through;
   **skip the one-time gzip "measure size" pass when a bmap is present** — the
   bmap's `ImageSize` already gives the exact uncompressed total for the bar.
+  (This pass is gzip-specific: `.zip` entries and the new `.zst` reader both
+  report their size directly, so it only affects local `.gz` flashes. Minor,
+  independent win — included because it's cheap and removes a redundant full
+  decode on that path.)
 - `manifest.go`: add `zst_path` parsing and `ZstURL` on `imageInfo`.
 
 ### Dependency
 
 Add `github.com/SaveTheRbtz/zstd-seekable-format-go` (reader + writer), layered
-on the already-vendored `github.com/klauspost/compress`. Used by both the CLI
-reader and the in-repo build encoder.
+on the already-vendored `github.com/klauspost/compress`. Used by the CLI reader
+(`go.mod` in this repo) and by the publisher's writer (`go.mod` in
+`wendy-os-publisher`). Same library on both sides so the on-disk format cannot
+drift.
 
 ## Frame-walk algorithm
 
@@ -158,7 +200,8 @@ Properties:
 
 - Missing `zst_path`, seekable-open failure, or `Size()` ≠ bmap `ImageSize`
   *before* writing begins → print a `Note:` and fall back to the existing
-  gzip + bmap/`dd` path (consistent with current fallback style).
+  deflate (`.zip`/`.gz`) + bmap/`dd` path (consistent with current fallback
+  style).
 - `--no-bmap` forces the legacy path (a `.img.zst` with no usable bmap offers no
   benefit; we do not add a hole-less seekable mode).
 - Checksum mismatch, short write, decode error, or helper non-zero exit *during*
@@ -185,6 +228,8 @@ Properties:
 ## Rollout
 
 1. Land CLI support gated on `zst_path` (no-op until manifests carry it).
-2. Build publishes `.img.zst` for new image versions.
-3. CLI prefers `.img.zst` when present; older versions keep using gzip.
-No flag day; the manifest field is the switch.
+2. Land publisher support; it emits `.img.zst` + `zst_path` for new uploads.
+3. CLI prefers `.img.zst` when present; existing versions keep using the `.zip`
+   path. Yocto and the Jetson build scripts are unchanged.
+No flag day; the manifest field is the switch. Old CLIs ignore `zst_path` and
+keep downloading the `.zip`, so a published seekable artifact is backward-safe.

--- a/Documentation/2026-06-15-seekable-zstd-flashing-design.md
+++ b/Documentation/2026-06-15-seekable-zstd-flashing-design.md
@@ -30,6 +30,10 @@ cannot skip them.
 
 Make holes genuinely free on every flash (including the first) by decoding
 **only the bytes that bmap marks as mapped**, never materializing hole bytes.
+Secondary goal, required to deliver the speedup on multi-storage devices: make
+the image/bmap/zst artifacts **storage-keyed** (NVMe vs SD), fixing the existing
+cross-storage clobber that forces Jetson NVMe flashes onto the slow `dd` path
+(see "Storage variants").
 
 Non-goals: changing the bmap format; changing the non-bmap (`dd`) path; keeping
 the published image flashable by generic third-party tools (Etcher/dd/RPi
@@ -95,13 +99,57 @@ Publisher changes:
   artifact still downloads but offers no hole-skipping benefit — the CLI uses the
   legacy path (see fallback).
 
+### Storage variants (NVMe / SD) — and an existing bug this fixes
+
+Multi-storage devices (e.g. Jetson orin-nano) publish **two different images**
+for one version: an NVMe image and an SD image, with different partition layouts
+and therefore different bmaps. Today the CLI's install path reads a **single**
+`path` + **single** `bmap_path`, and the publisher clobbers both on every
+storage publish (last write wins). The result: `path` and `bmap_path` can
+describe different storages, the per-range checksum fails on block 0, and the
+size-mismatch guard (commit `e7271aa1`) falls back to `dd`. So the ~19 GB Jetson
+NVMe images — where this optimization matters most — currently get **no** bmap
+benefit at all.
+
+This design makes image + bmap + zst **storage-keyed**, which both fixes that
+bug and lets the seekable path engage on multi-storage devices.
+
+**Selector:** the target drive's `StorageType` is known before image resolution
+(it's chosen at `os_install.go` ~L374–397, before `getImageInfo` at L445). The
+enum is only `StorageNVMe` vs `StorageUnknown` (everything else), mapping to:
+
+- `StorageNVMe` → `nvme` variant
+- otherwise → `sd` variant (the default / removable-card image)
+
+(eMMC is not a removable flash target on this drive-writing path, so it is out of
+scope here even though the publisher may carry eMMC fields for OTA.)
+
 ### Manifest
 
-- Add a per-version field `zst_path` (sibling to `path`/`bmap_path`). When
-  present, the CLI derives `ZstURL = gcsBaseURL + "/" + zst_path`.
-- Absent `zst_path` → CLI uses the existing deflate (`.zip`/`.gz`) + bmap/`dd`
-  path unchanged. This is the rollout/back-compat seam: old manifests and
-  partially-published versions keep working.
+Add storage-keyed fields to the CLI's `deviceVersion` and the publisher's
+`VersionMetadata`, each a triple of image + bmap + zst (path/checksum/size):
+
+- `nvme_path` / `nvme_bmap_path` / `nvme_zst_path` (+ `*_checksum`, `*_size_bytes`)
+- `sd_path` / `sd_bmap_path` / `sd_zst_path` (+ `*_checksum`, `*_size_bytes`)
+- Legacy `path` / `bmap_path` / `zst_path` remain as the **fallback** triple.
+
+Resolution rule in `getImageInfo(dm, ver, storage)` (new `storage` arg derived
+from `targetDrive.StorageType`):
+
+1. Prefer the triple for the selected storage (`nvme_*` or `sd_*`).
+2. If that storage's triple is absent, fall back to the legacy `path` /
+   `bmap_path` / `zst_path` (covers single-storage devices like RPi and older
+   manifests).
+3. Within the chosen triple, `zst_path` present and `--no-bmap` unset → seekable
+   path; else deflate (`.zip`/`.gz`) + bmap/`dd`, unchanged.
+
+Crucially the image, bmap, and zst now come from the **same** storage triple, so
+they always describe the same image — the block-0 mismatch that forced `dd` can
+no longer happen from cross-storage clobbering.
+
+**Publisher back-compat:** keep writing the legacy `path`/`bmap_path` (point them
+at a sensible default storage) so old CLIs still flash; new CLIs prefer the
+storage-keyed triple. New publisher additionally writes the `*_zst_*` fields.
 
 ### CLI side
 
@@ -127,8 +175,11 @@ the separate `wendy-os-publisher` repo.
 **Publisher (`wendy-os-publisher`, separate repo):**
 
 - `cmd/upload_and_manifest.go`: add `compressSeekableZstd()`; upload `.img.zst`
-  for OS images; add `zst_path`/`zst_checksum`/`zst_size_bytes` to
-  `VersionMetadata` and populate them. Add the `zstd-seekable-format-go` dep.
+  for OS images; add the storage-keyed `*_zst_path`/`*_zst_checksum`/
+  `*_zst_size_bytes` fields (and ensure `*_bmap_path` is storage-keyed too) to
+  `VersionMetadata` and populate the triple for the storage being published;
+  keep writing legacy `path`/`bmap_path` for old CLIs. Add the
+  `zstd-seekable-format-go` dep.
 
 **CLI (`go/internal/cli/commands/`):**
 
@@ -150,7 +201,12 @@ the separate `wendy-os-publisher` repo.
   stdin.
 - `disklister_windows.go`: no helper — run the frame-walk in-process against the
   locked disk handle, source = seekable reader over the cached `.img.zst`.
-- `os_install.go`: prefer `zst_path`; thread the seekable source through;
+- `manifest.go`: add the storage-keyed `nvme_*`/`sd_*` image+bmap+zst fields to
+  `deviceVersion` and `ZstURL` to `imageInfo`; change `getImageInfo` to take a
+  `storage` arg (from `targetDrive.StorageType`) and apply the resolution rule
+  (storage triple → legacy fallback) from the Manifest section.
+- `os_install.go`: pass the target drive's storage into `getImageInfo`; prefer
+  the selected triple's `zst_path`; thread the seekable source through;
   **skip the one-time gzip "measure size" pass when a bmap is present** — the
   bmap's `ImageSize` already gives the exact uncompressed total for the bar.
   (This pass is gzip-specific: `.zip` entries and the new `.zst` reader both
@@ -220,7 +276,12 @@ Properties:
 - `seekable_zstd_test.go` (new): round-trip — encode a known buffer seekable,
   then `ReadAt` random offsets/lengths and assert bytes; frame-boundary reads;
   `Size()` correctness.
-- Manifest test: `zst_path` present → `ZstURL` set; absent → empty, legacy path.
+- Manifest test: storage resolution — `getImageInfo(.., "nvme")` picks the
+  `nvme_*` triple; `"sd"` picks `sd_*`; missing storage triple falls back to
+  legacy `path`/`bmap_path`/`zst_path`; `zst_path` present → `ZstURL` set, absent
+  → empty (legacy path). A regression case mirroring the Jetson clobber: NVMe and
+  SD triples present with different bmaps → NVMe target resolves NVMe bmap (no
+  cross-storage mismatch, no `dd` fallback).
 - An end-to-end test that flashes a small synthetic holey image to a temp file
   (not a real device) via the frame-walk and byte-compares against the expected
   reconstruction.

--- a/Documentation/2026-06-15-seekable-zstd-flashing-design.md
+++ b/Documentation/2026-06-15-seekable-zstd-flashing-design.md
@@ -1,0 +1,190 @@
+# Seekable-zstd flashing: skip holes without decompressing them
+
+Date: 2026-06-15
+Branch: `jo/bmap-flash` (PR #1036)
+Status: Design — pending review
+
+## Problem
+
+Flashing a WendyOS image is slow on zero-heavy ("holey") images even when the
+block map (bmap) is engaged. bmap already eliminates the *write* I/O for holes:
+the writer only `WriteAt`s mapped ranges. But the parent process still
+gzip-decompresses the **entire** uncompressed image — holes included — because
+it streams the decompressed bytes through a pipe to the writer, and a gzip pipe
+is not seekable. To advance the stream to the next mapped range, every hole byte
+must be produced by the (single-threaded) gzip decoder and then discarded.
+
+For a typical Jetson image (~19 GB uncompressed, ~4 GB of real mapped data),
+that means decoding ~15 GB of zeros we immediately throw away. Single-threaded
+gzip decode (~150–250 MB/s) of the full image is the wall-clock bottleneck.
+
+**Root cause:** holes cost decompression, not write I/O, and a gzip pipe cannot
+skip them.
+
+## Goal
+
+Make holes genuinely free on every flash (including the first) by decoding
+**only the bytes that bmap marks as mapped**, never materializing hole bytes.
+
+Non-goals: changing the bmap format; changing the non-bmap (`dd`) path; keeping
+the published image flashable by generic third-party tools (Etcher/dd/RPi
+Imager) — the optimized artifact is wendy-specific.
+
+## Approach: seekable zstd
+
+Publish the image compressed with **zstd in the seekable format** (a sequence of
+independent ~4 MB-uncompressed frames plus an embedded seek table). The seek
+table makes the *decompressed* image randomly addressable via `io.ReaderAt`. The
+CLI then decodes only the frames that overlap mapped ranges and skips pure-hole
+frames entirely.
+
+Why this and not alternatives (recorded for posterity):
+
+- **Plain zstd, keep streaming:** ~4× faster decode but still decodes holes.
+  Rejected as the end state (kept conceptually as the codec half of this work).
+- **Raw decompressed cache + `ReadAt`:** makes holes free on *repeat* flashes
+  only, costs a full ~16–20 GB/image on disk, first flash unchanged. Rejected.
+- **Drop compression (raw artifact):** decode of the *mapped* data is only ~5 s;
+  shipping it raw multiplies download (~4 GB vs ~1.5 GB) and cache disk (~10×)
+  to save those seconds. Net slower once download/disk are counted. Rejected.
+- **Raw + bmap-driven HTTP Range GETs:** simpler (no codec), skips holes on the
+  network too, but downloads mapped data uncompressed; a win only on fast/LAN
+  links. Rejected as default; noted as a possible future option.
+
+Expected result for the example image: decode ~4 GB instead of ~19 GB, at zstd
+speed — roughly **15–20× faster wall-clock** on holey images. Download stays
+~1.5 GB; cache disk stays ~1.5 GB.
+
+## Architecture
+
+### Build side (meta-wendyos)
+
+- Compress each published image as seekable zstd → `<image>.img.zst`, frame size
+  **4 MiB uncompressed** (balances seek-table size against worst-case wasted
+  decode per range; tunable).
+- Continue publishing the existing `.bmap` unchanged.
+- The seek table is embedded in the `.zst` file (a trailing skippable frame), so
+  the artifact is self-contained — no separate index sidecar.
+- A small in-repo Go encoder (`cmd/`, reusing the same seekable library as the
+  reader so writer/reader cannot drift) produces the artifact; the Yocto
+  publish step invokes it. Build-side details (recipe wiring) are out of scope
+  for this CLI spec beyond "publish `.img.zst` + `.bmap`".
+
+### Manifest
+
+- Add a per-version field `zst_path` (sibling to `path`/`bmap_path`). When
+  present, the CLI derives `ZstURL = gcsBaseURL + "/" + zst_path`.
+- Absent `zst_path` → CLI uses the existing gzip + bmap/`dd` path unchanged.
+  This is the rollout/back-compat seam: old manifests and partially-published
+  versions keep working.
+
+### CLI side
+
+Data flow when `zst_path` is present and `--no-bmap` is not set:
+
+1. Download `.img.zst` and `.bmap` (existing atomic-download + traversal-safe
+   cache machinery; `.img.zst` cached like other images).
+2. Open a **seekable reader** exposing `ReadAt(p, off)` and `Size()` over the
+   decompressed image (wrapping `klauspost/compress/zstd` + the seekable seek
+   table). `Size()` and the bmap's `ImageSize` must agree; mismatch → fall back
+   (same spirit as the existing size-mismatch guard).
+3. Run the **frame-walk** (below) to write only mapped ranges.
+
+If `zst_path` is absent, or any step fails before writing begins, fall back to
+the current path. Once writing to the device has begun, a failure is fatal (no
+silent fallback that would leave a half-written disk).
+
+## Components / where the code lands
+
+All paths under `go/internal/cli/commands/` unless noted.
+
+- `seekable_zstd.go` (new): the seekable reader — `ReaderAt`/`Size` over the
+  decompressed image, plus frame iteration (`forEachFrame`/offset→frame lookup).
+- `bmap.go`: replace `applyBmap`'s stream-and-discard loop with the frame-walk
+  driven by an `io.ReaderAt` source. Keep `parseBmap` and per-range SHA256
+  verification. `discard()` becomes unused for this path and is removed if no
+  other caller remains.
+- `bmap_writer.go` / `root.go`: `__bmap-write` gains `--source <.img.zst>`; the
+  helper opens the seekable reader and runs the frame-walk itself as root,
+  emitting a newline-delimited cumulative-bytes-written counter on stdout.
+  The stdin pipe for this path is removed. **Add path validation** for
+  `--device` and `--source` (the defense-in-depth item now load-bearing).
+- `disklister_{linux,darwin}.go`: `writeImageWithBmap` re-execs the helper with
+  `--source` and scans the helper's stdout for progress instead of feeding
+  stdin.
+- `disklister_windows.go`: no helper — run the frame-walk in-process against the
+  locked disk handle, source = seekable reader over the cached `.img.zst`.
+- `os_install.go`: prefer `zst_path`; thread the seekable source through;
+  **skip the one-time gzip "measure size" pass when a bmap is present** — the
+  bmap's `ImageSize` already gives the exact uncompressed total for the bar.
+- `manifest.go`: add `zst_path` parsing and `ZstURL` on `imageInfo`.
+
+### Dependency
+
+Add `github.com/SaveTheRbtz/zstd-seekable-format-go` (reader + writer), layered
+on the already-vendored `github.com/klauspost/compress`. Used by both the CLI
+reader and the in-repo build encoder.
+
+## Frame-walk algorithm
+
+Input: ordered mapped ranges from the bmap (byte offsets, derived from
+block-index ranges × block size, clamped to `ImageSize`); an `io.ReaderAt`
+seekable source; the device `io.WriterAt`; `progressFn`.
+
+```
+for each frame [fstart, fend) in increasing offset order:
+    if frame overlaps no mapped range:
+        skip            # never decode — the hole savings
+        continue
+    decode frame once into buf
+    for each mapped sub-span [s, e) within this frame:
+        dst.WriteAt(buf[s-fstart : e-fstart], s)
+        feed buf[s-fstart : e-fstart] into the current range's SHA256
+        progressFn(cumulative mapped bytes written)
+    finalize SHA256 for any range that ends within this frame; mismatch -> abort
+```
+
+Properties:
+
+- Each needed frame is decoded exactly once, in order (no redundant re-decodes
+  from many small seeks); pure-hole frames are never decoded.
+- A bmap range may span multiple frames; its running hash carries across frame
+  boundaries and is finalized when the range completes — preserving today's
+  per-range verification guarantee exactly.
+- Progress reflects cumulative mapped bytes written (matches the existing bar's
+  semantics; total = sum of mapped range sizes, known up front from the bmap).
+
+## Error handling & fallback
+
+- Missing `zst_path`, seekable-open failure, or `Size()` ≠ bmap `ImageSize`
+  *before* writing begins → print a `Note:` and fall back to the existing
+  gzip + bmap/`dd` path (consistent with current fallback style).
+- `--no-bmap` forces the legacy path (a `.img.zst` with no usable bmap offers no
+  benefit; we do not add a hole-less seekable mode).
+- Checksum mismatch, short write, decode error, or helper non-zero exit *during*
+  writing → fatal, surfaced with the helper's stderr (as today). No silent
+  fallback mid-flash.
+- Helper path validation: reject a `--device` that is not a block/char device
+  and a `--source` that escapes the expected cache root.
+
+## Testing
+
+- `bmap_test.go`: extend with frame-walk cases against an in-memory
+  `ReaderAt` — holes at start/middle/end, ranges spanning frame boundaries,
+  range exactly on a frame boundary, single-block ranges, checksum-mismatch
+  abort, full-hole image, fully-mapped image. Shrink frame size in tests to
+  exercise multi-frame ranges (mirrors the existing `bmapChunkSize` test hook).
+- `seekable_zstd_test.go` (new): round-trip — encode a known buffer seekable,
+  then `ReadAt` random offsets/lengths and assert bytes; frame-boundary reads;
+  `Size()` correctness.
+- Manifest test: `zst_path` present → `ZstURL` set; absent → empty, legacy path.
+- An end-to-end test that flashes a small synthetic holey image to a temp file
+  (not a real device) via the frame-walk and byte-compares against the expected
+  reconstruction.
+
+## Rollout
+
+1. Land CLI support gated on `zst_path` (no-op until manifests carry it).
+2. Build publishes `.img.zst` for new image versions.
+3. CLI prefers `.img.zst` when present; older versions keep using gzip.
+No flag day; the manifest field is the switch.

--- a/Documentation/2026-06-15-seekable-zstd-flashing-plan.md
+++ b/Documentation/2026-06-15-seekable-zstd-flashing-plan.md
@@ -1,0 +1,1283 @@
+# Seekable-zstd Flashing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make zeroed/hole blocks free to flash by publishing images as seekable zstd and decoding only bmap-mapped ranges, and make image/bmap/zst storage-keyed (NVMe vs SD) so multi-storage devices stop falling back to `dd`.
+
+**Architecture:** The build publisher emits a seekable-zstd image (`.img.zst`, embedded seek table). The CLI opens it as a random-access `io.ReadSeeker` over the decompressed image and writes only the bmap's mapped ranges, seeking past holes so hole frames are never decoded. The privileged `__bmap-write` helper reads the source itself (no stdin pipe) and reports progress on stdout. Manifest fields for image+bmap+zst become storage-keyed; the target drive's `StorageType` selects the variant.
+
+**Tech Stack:** Go; `github.com/SaveTheRbtz/zstd-seekable-format-go/pkg` (seekable container) over the already-vendored `github.com/klauspost/compress/zstd`; cobra; standard `testing`.
+
+**Spec:** `Documentation/2026-06-15-seekable-zstd-flashing-design.md`
+
+---
+
+## Shared contract (read first — both repos depend on it)
+
+- **Format:** seekable zstd. Writer = `seekable.NewWriter(dst, enc)`; each `Write([]byte)` emits one frame, so the publisher writes the raw image in **4 MiB chunks** to get ~4 MiB frames. `Writer.Close()` writes the seek table. Reader = `seekable.NewReader(src io.ReadSeeker, dec)`; it implements `io.ReaderAt`, `io.Seeker`, `io.Closer`.
+- **Manifest JSON tags** (must be byte-identical in `wendy-os-publisher` `VersionMetadata` and the CLI `deviceVersion`):
+  - `nvme_path`, `nvme_checksum`, `nvme_size_bytes`, `nvme_bmap_path`, `nvme_zst_path`, `nvme_zst_checksum`, `nvme_zst_size_bytes`
+  - `sd_path`, `sd_checksum`, `sd_size_bytes`, `sd_bmap_path`, `sd_zst_path`, `sd_zst_checksum`, `sd_zst_size_bytes`
+  - Legacy fallback (already exist): `path`, `checksum`, `size_bytes`, `bmap_path`; plus new legacy `zst_path`, `zst_checksum`, `zst_size_bytes`.
+- **Storage selector:** `StorageNVMe` → `nvme` variant; anything else (`StorageUnknown`) → `sd` variant. Missing variant → legacy fields.
+
+## File structure
+
+**Part A — CLI (`go/internal/cli/commands/`, this repo):**
+- Create `seekable_zstd.go` — open a seekable-zstd file as a decompressed `io.ReadSeeker` + `Size()`; one responsibility: the codec wrapper.
+- Modify `bmap.go` — add `applyBmapSeekable` (seek-based writer) beside streaming `applyBmap`; factor shared per-range hashing.
+- Modify `root.go` — add `--source` flag to `__bmap-write`.
+- Modify `bmap_writer.go` — `runBmapWriteSeekable`; `--device`/`--source` path validation.
+- Modify `disklister_linux.go`, `disklister_darwin.go` — re-exec helper with `--source`, scan stdout for progress.
+- Modify `disklister_windows.go` — in-process seekable frame-walk.
+- Modify `manifest.go` — storage-keyed fields, `ZstURL`, `getImageInfo(dm, ver, storage)`.
+- Modify `os_install.go` — pass storage, prefer zst triple, mapped-bytes progress total, skip measure pass when bmap present.
+
+**Part B — Publisher (`wendy-os-publisher/cmd/upload_and_manifest.go`, separate repo):**
+- Storage-keyed `*_zst_*`/`*_bmap_*` fields on `VersionMetadata`; `compressSeekableZstd`; upload + populate.
+
+---
+
+# Part A — CLI (run in this repo / worktree)
+
+## Task 1: Add the seekable-zstd dependency
+
+**Files:**
+- Modify: `go.mod`, `go.sum` (repo root)
+
+- [ ] **Step 1: Add the module**
+
+Run:
+```bash
+cd go && go get github.com/SaveTheRbtz/zstd-seekable-format-go@latest
+```
+Expected: `go.mod` gains a `require github.com/SaveTheRbtz/zstd-seekable-format-go vX.Y.Z` line; `klauspost/compress` may move from `// indirect` to direct.
+
+- [ ] **Step 2: Verify it resolves and builds**
+
+Run:
+```bash
+cd go && go build ./... 2>&1 | head
+```
+Expected: no output (build clean). If `klauspost/compress` version is bumped, that's fine.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go/go.mod go/go.sum
+git commit -m "build(os): add zstd-seekable-format-go dependency"
+```
+
+---
+
+## Task 2: Seekable-zstd reader wrapper
+
+**Files:**
+- Create: `go/internal/cli/commands/seekable_zstd.go`
+- Test: `go/internal/cli/commands/seekable_zstd_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package commands
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+	"github.com/klauspost/compress/zstd"
+)
+
+// encodeSeekable compresses data into the seekable-zstd container using
+// frameSize-byte frames, returning the compressed bytes. Test-only helper.
+func encodeSeekable(t *testing.T, data []byte, frameSize int) []byte {
+	t.Helper()
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatalf("zstd.NewWriter: %v", err)
+	}
+	defer enc.Close()
+	var buf bytes.Buffer
+	w, err := seekable.NewWriter(&buf, enc)
+	if err != nil {
+		t.Fatalf("seekable.NewWriter: %v", err)
+	}
+	for off := 0; off < len(data); off += frameSize {
+		end := off + frameSize
+		if end > len(data) {
+			end = len(data)
+		}
+		if _, err := w.Write(data[off:end]); err != nil {
+			t.Fatalf("seekable write: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("seekable close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestSeekableImageReadAtAndSize(t *testing.T) {
+	data := make([]byte, 10_000)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	comp := encodeSeekable(t, data, 1024)
+
+	si, err := openSeekableZstdFromReader(bytes.NewReader(comp))
+	if err != nil {
+		t.Fatalf("openSeekableZstdFromReader: %v", err)
+	}
+	defer si.Close()
+
+	if si.Size() != int64(len(data)) {
+		t.Fatalf("Size() = %d, want %d", si.Size(), len(data))
+	}
+	// Random ReadAt across frame boundaries.
+	for _, tc := range []struct{ off, n int }{{0, 100}, {1000, 2048}, {5000, 4000}, {9990, 10}} {
+		got := make([]byte, tc.n)
+		if _, err := si.ReadAt(got, int64(tc.off)); err != nil && err != io.EOF {
+			t.Fatalf("ReadAt(%d,%d): %v", tc.off, tc.n, err)
+		}
+		if !bytes.Equal(got, data[tc.off:tc.off+tc.n]) {
+			t.Fatalf("ReadAt(%d,%d) mismatch", tc.off, tc.n)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestSeekableImage -v`
+Expected: FAIL — `undefined: openSeekableZstdFromReader`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+	"github.com/klauspost/compress/zstd"
+)
+
+// seekableImage is a random-access view over the decompressed bytes of a
+// seekable-zstd image. It is NOT safe for concurrent use: callers drive it from
+// a single goroutine (the flash loop). Close releases the decoder and file.
+type seekableImage struct {
+	r    seekable.Reader
+	dec  *zstd.Decoder
+	f    *os.File // nil when constructed from an in-memory ReadSeeker (tests)
+	size int64
+}
+
+// openSeekableZstd opens a seekable-zstd file on disk.
+func openSeekableZstd(path string) (*seekableImage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening seekable image: %w", err)
+	}
+	si, err := newSeekableImage(f)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	si.f = f
+	return si, nil
+}
+
+// openSeekableZstdFromReader builds a seekableImage over an in-memory source.
+func openSeekableZstdFromReader(rs io.ReadSeeker) (*seekableImage, error) {
+	return newSeekableImage(rs)
+}
+
+func newSeekableImage(rs io.ReadSeeker) (*seekableImage, error) {
+	dec, err := zstd.NewReader(nil)
+	if err != nil {
+		return nil, fmt.Errorf("zstd decoder: %w", err)
+	}
+	r, err := seekable.NewReader(rs, dec)
+	if err != nil {
+		dec.Close()
+		return nil, fmt.Errorf("seekable reader: %w", err)
+	}
+	table, err := r.SeekTable()
+	if err != nil {
+		r.Close()
+		dec.Close()
+		return nil, fmt.Errorf("seek table: %w", err)
+	}
+	return &seekableImage{r: r, dec: dec, size: int64(table.DecompressedSize())}, nil
+}
+
+func (s *seekableImage) Size() int64 { return s.size }
+
+func (s *seekableImage) ReadAt(p []byte, off int64) (int, error) { return s.r.ReadAt(p, off) }
+
+func (s *seekableImage) Seek(off int64, whence int) (int64, error) { return s.r.Seek(off, whence) }
+
+func (s *seekableImage) Read(p []byte) (int, error) { return s.r.Read(p) }
+
+func (s *seekableImage) Close() error {
+	err := s.r.Close()
+	s.dec.Close()
+	if s.f != nil {
+		if e := s.f.Close(); err == nil {
+			err = e
+		}
+	}
+	return err
+}
+```
+
+> Implementation note: `table.DecompressedSize()` is the expected accessor. If the installed library version names it differently (e.g. a field or `Size()`), adjust this one line — the test pins the behavior.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestSeekableImage -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/seekable_zstd.go go/internal/cli/commands/seekable_zstd_test.go
+git commit -m "feat(os): seekable-zstd reader over decompressed image"
+```
+
+---
+
+## Task 3: `applyBmapSeekable` — write only mapped ranges, seek past holes
+
+**Files:**
+- Modify: `go/internal/cli/commands/bmap.go`
+- Test: `go/internal/cli/commands/bmap_test.go` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `bmap_test.go` (reuses `buildSparseImage`, `newMemWriterAt`, `encodeSeekable` from Task 2):
+
+```go
+func TestApplyBmapSeekableWritesOnlyMappedRanges(t *testing.T) {
+	img, b := buildSparseImage() // blocks 0-1 and 4-5 mapped, bs=4096
+	comp := encodeSeekable(t, img, 4096)
+	si, err := openSeekableZstdFromReader(bytes.NewReader(comp))
+	if err != nil {
+		t.Fatalf("open seekable: %v", err)
+	}
+	defer si.Close()
+
+	dst := newMemWriterAt(b.ImageSize)
+	var progress int64
+	mapped := mappedBytes(b)
+	if err := applyBmapSeekable(si, dst, b, func(n int64) { progress = n }); err != nil {
+		t.Fatalf("applyBmapSeekable: %v", err)
+	}
+	const bs = 4096
+	if !bytes.Equal(dst.buf[0:bs*2], img[0:bs*2]) || !bytes.Equal(dst.buf[bs*4:bs*6], img[bs*4:bs*6]) {
+		t.Fatal("mapped ranges not written correctly")
+	}
+	for _, off := range []int{bs * 2, bs*4 - 1, bs * 6, bs*8 - 1} {
+		if dst.written[off] {
+			t.Fatalf("hole byte at offset %d was written", off)
+		}
+	}
+	if progress != mapped {
+		t.Fatalf("progress = %d, want mapped total %d", progress, mapped)
+	}
+}
+
+func TestApplyBmapSeekableDetectsCorruption(t *testing.T) {
+	img, b := buildSparseImage()
+	img[10] = 0xff // corrupt mapped block 0 before compression
+	comp := encodeSeekable(t, img, 4096)
+	si, err := openSeekableZstdFromReader(bytes.NewReader(comp))
+	if err != nil {
+		t.Fatalf("open seekable: %v", err)
+	}
+	defer si.Close()
+	dst := newMemWriterAt(b.ImageSize)
+	if err := applyBmapSeekable(si, dst, b, func(int64) {}); err == nil {
+		t.Fatal("expected checksum mismatch error, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestApplyBmapSeekable -v`
+Expected: FAIL — `undefined: applyBmapSeekable` / `undefined: mappedBytes`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `bmap.go`:
+
+```go
+// mappedBytes returns the total number of mapped (non-hole) bytes the block map
+// describes — the exact amount applyBmapSeekable will write. Used to size the
+// progress bar for the seekable path.
+func mappedBytes(b *Bmap) int64 {
+	var total int64
+	for _, r := range b.Ranges {
+		start := r.First * b.BlockSize
+		end := (r.Last + 1) * b.BlockSize
+		if end > b.ImageSize {
+			end = b.ImageSize
+		}
+		if end > start {
+			total += end - start
+		}
+	}
+	return total
+}
+
+// applyBmapSeekable reconstructs an image onto dst using the block map, reading
+// only mapped ranges from a random-access source. It Seeks to each range's
+// start, so the underlying seekable decoder never decodes hole frames — this is
+// where the zero-block speedup comes from. Each range's SHA256 is verified
+// against the bmap; a mismatch aborts. progressFn reports cumulative mapped
+// bytes written.
+func applyBmapSeekable(src io.ReadSeeker, dst io.WriterAt, b *Bmap, progressFn func(int64)) error {
+	buf := make([]byte, bmapChunkSize)
+	var written int64
+	for _, r := range b.Ranges {
+		start := r.First * b.BlockSize
+		end := (r.Last + 1) * b.BlockSize
+		if end > b.ImageSize {
+			end = b.ImageSize
+		}
+		if end <= start {
+			continue
+		}
+		if _, err := src.Seek(start, io.SeekStart); err != nil {
+			return fmt.Errorf("seeking to %d: %w", start, err)
+		}
+		h := sha256.New()
+		off := start
+		for off < end {
+			n := int64(len(buf))
+			if rem := end - off; rem < n {
+				n = rem
+			}
+			if _, err := io.ReadFull(src, buf[:n]); err != nil {
+				return fmt.Errorf("reading mapped range at %d: %w", off, err)
+			}
+			if _, err := dst.WriteAt(buf[:n], off); err != nil {
+				return fmt.Errorf("writing at %d: %w", off, err)
+			}
+			h.Write(buf[:n])
+			off += n
+			written += n
+			progressFn(written)
+		}
+		if r.Checksum != "" {
+			got := hex.EncodeToString(h.Sum(nil))
+			if !strings.EqualFold(got, r.Checksum) {
+				return fmt.Errorf("bmap: checksum mismatch for blocks %d-%d (got %s, want %s)",
+					r.First, r.Last, got, r.Checksum)
+			}
+		}
+	}
+	return nil
+}
+```
+
+(No new imports needed: `io`, `crypto/sha256`, `encoding/hex`, `fmt`, `strings` are already imported by `bmap.go`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd go && go test ./internal/cli/commands/ -run 'TestApplyBmap' -v`
+Expected: PASS (both new seekable tests and the existing streaming ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/bmap.go go/internal/cli/commands/bmap_test.go
+git commit -m "feat(os): applyBmapSeekable writes mapped ranges, seeks past holes"
+```
+
+---
+
+## Task 4: Storage-keyed manifest resolution
+
+**Files:**
+- Modify: `go/internal/cli/commands/manifest.go`
+- Test: `go/internal/cli/commands/manifest_test.go` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/append `manifest_test.go`:
+
+```go
+package commands
+
+import "testing"
+
+func newTestManifest() *deviceManifest {
+	return &deviceManifest{
+		DeviceID: "jetson-orin-nano",
+		Versions: map[string]deviceVersion{
+			"1.0.0": {
+				// legacy fields (clobbered in the wild) point at SD
+				Path: "img/sd.img.zip", BmapPath: "img/sd.bmap",
+				// storage-keyed triples
+				NVMEPath: "img/nvme.img.zip", NVMEBmapPath: "img/nvme.bmap",
+				NVMEZstPath: "img/nvme.img.zst", NVMEZstSizeBytes: 111,
+				SDPath: "img/sd.img.zip", SDBmapPath: "img/sd.bmap",
+				SDZstPath: "img/sd.img.zst", SDZstSizeBytes: 222,
+			},
+		},
+	}
+}
+
+func TestGetImageInfoNVMePicksNVMeTriple(t *testing.T) {
+	info, err := getImageInfo(newTestManifest(), "1.0.0", "nvme")
+	if err != nil {
+		t.Fatalf("getImageInfo: %v", err)
+	}
+	if info.DownloadURL != gcsBaseURL+"/img/nvme.img.zip" {
+		t.Errorf("DownloadURL = %q", info.DownloadURL)
+	}
+	if info.BmapURL != gcsBaseURL+"/img/nvme.bmap" {
+		t.Errorf("BmapURL = %q", info.BmapURL)
+	}
+	if info.ZstURL != gcsBaseURL+"/img/nvme.img.zst" {
+		t.Errorf("ZstURL = %q", info.ZstURL)
+	}
+}
+
+func TestGetImageInfoSDPicksSDTriple(t *testing.T) {
+	info, err := getImageInfo(newTestManifest(), "1.0.0", "sd")
+	if err != nil {
+		t.Fatalf("getImageInfo: %v", err)
+	}
+	if info.ZstURL != gcsBaseURL+"/img/sd.img.zst" || info.BmapURL != gcsBaseURL+"/img/sd.bmap" {
+		t.Errorf("SD triple not selected: %+v", info)
+	}
+}
+
+func TestGetImageInfoFallsBackToLegacy(t *testing.T) {
+	dm := &deviceManifest{Versions: map[string]deviceVersion{
+		"1.0.0": {Path: "img/legacy.img.zip", BmapPath: "img/legacy.bmap"},
+	}}
+	info, err := getImageInfo(dm, "1.0.0", "nvme")
+	if err != nil {
+		t.Fatalf("getImageInfo: %v", err)
+	}
+	if info.DownloadURL != gcsBaseURL+"/img/legacy.img.zip" || info.BmapURL != gcsBaseURL+"/img/legacy.bmap" {
+		t.Errorf("legacy fallback not used: %+v", info)
+	}
+	if info.ZstURL != "" {
+		t.Errorf("ZstURL should be empty when no zst published, got %q", info.ZstURL)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestGetImageInfo -v`
+Expected: FAIL — unknown fields `NVMEPath`/`NVMEBmapPath`/`NVMEZstPath`/`SDPath`/… and `getImageInfo` takes 2 args, not 3; `imageInfo.ZstURL` undefined.
+
+- [ ] **Step 3: Add fields + rewrite `getImageInfo`**
+
+In `manifest.go`, add to the `deviceVersion` struct (after `BmapPath`):
+
+```go
+	BmapPath               string `json:"bmap_path"`
+	ZstPath                string `json:"zst_path"`
+	ZstChecksum            string `json:"zst_checksum"`
+	ZstSizeBytes           int64  `json:"zst_size_bytes"`
+
+	// Storage-keyed image+bmap+zst triples (NVMe).
+	NVMEPath         string `json:"nvme_path"`
+	NVMEChecksum     string `json:"nvme_checksum"`
+	NVMESizeBytes    int64  `json:"nvme_size_bytes"`
+	NVMEBmapPath     string `json:"nvme_bmap_path"`
+	NVMEZstPath      string `json:"nvme_zst_path"`
+	NVMEZstChecksum  string `json:"nvme_zst_checksum"`
+	NVMEZstSizeBytes int64  `json:"nvme_zst_size_bytes"`
+
+	// Storage-keyed image+bmap+zst triples (SD / removable card; the default).
+	SDPath         string `json:"sd_path"`
+	SDChecksum     string `json:"sd_checksum"`
+	SDSizeBytes    int64  `json:"sd_size_bytes"`
+	SDBmapPath     string `json:"sd_bmap_path"`
+	SDZstPath      string `json:"sd_zst_path"`
+	SDZstChecksum  string `json:"sd_zst_checksum"`
+	SDZstSizeBytes int64  `json:"sd_zst_size_bytes"`
+```
+
+Add `ZstURL` to `imageInfo`:
+
+```go
+type imageInfo struct {
+	DownloadURL string
+	ImageSize   int64
+	Version     string
+	BmapURL     string
+	ZstURL      string
+}
+```
+
+Replace the existing `getImageInfo` with:
+
+```go
+// imageTriple is the resolved (image, bmap, zst) path set for one storage.
+type imageTriple struct {
+	imagePath string
+	imageSize int64
+	bmapPath  string
+	zstPath   string
+}
+
+// getImageInfo resolves the download URLs for ver on dm, preferring the triple
+// matching storage ("nvme" or "sd") and falling back to the legacy fields when
+// that storage has no dedicated artifacts. Keeping image+bmap+zst from one
+// triple guarantees they describe the same image (no cross-storage mismatch).
+func getImageInfo(dm *deviceManifest, ver, storage string) (*imageInfo, error) {
+	v, ok := dm.Versions[ver]
+	if !ok {
+		return nil, fmt.Errorf("version %s not found in device manifest", ver)
+	}
+	t := resolveTriple(v, storage)
+
+	info := &imageInfo{
+		DownloadURL: gcsBaseURL + "/" + t.imagePath,
+		ImageSize:   t.imageSize,
+		Version:     ver,
+	}
+	if t.bmapPath != "" {
+		info.BmapURL = gcsBaseURL + "/" + t.bmapPath
+	}
+	if t.zstPath != "" {
+		info.ZstURL = gcsBaseURL + "/" + t.zstPath
+	}
+	return info, nil
+}
+
+func resolveTriple(v deviceVersion, storage string) imageTriple {
+	switch storage {
+	case "nvme":
+		if v.NVMEPath != "" {
+			return imageTriple{v.NVMEPath, v.NVMESizeBytes, v.NVMEBmapPath, v.NVMEZstPath}
+		}
+	case "sd":
+		if v.SDPath != "" {
+			return imageTriple{v.SDPath, v.SDSizeBytes, v.SDBmapPath, v.SDZstPath}
+		}
+	}
+	// Legacy fallback.
+	return imageTriple{v.Path, v.SizeBytes, v.BmapPath, v.ZstPath}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestGetImageInfo -v`
+Expected: PASS. (Build will fail to link until Task 8 updates the `getImageInfo` callers — that's expected; the `-run` test compiles the package, so if other callers break compilation, do Step 5 of Task 8's caller edits together. To keep this task self-contained, update the two existing callers' arity now:)
+
+In `os_install.go` change the two call sites that read `getImageInfo(device.Manifest, X)` to pass a storage string. For the **pre-flight validation** call (around L367) where no drive is chosen yet, pass `""` (legacy/any): `getImageInfo(device.Manifest, flagVersion, "")`. The real selection call (L445) is rewired in Task 8; temporarily pass `""` there too so the package compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/manifest.go go/internal/cli/commands/manifest_test.go go/internal/cli/commands/os_install.go
+git commit -m "feat(os): storage-keyed manifest resolution (nvme/sd) with legacy fallback"
+```
+
+---
+
+## Task 5: `__bmap-write --source` + path validation
+
+**Files:**
+- Modify: `go/internal/cli/commands/root.go:154-163`
+- Modify: `go/internal/cli/commands/bmap_writer.go`
+- Test: `go/internal/cli/commands/bmap_writer_test.go` (create)
+
+- [ ] **Step 1: Write the failing validation test**
+
+Create `bmap_writer_test.go`:
+
+```go
+package commands
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateBmapSourceRejectsOutsideCache(t *testing.T) {
+	if err := validateBmapSource("/etc/passwd"); err == nil {
+		t.Fatal("expected rejection of path outside cache root")
+	}
+}
+
+func TestValidateBmapSourceAcceptsInsideCache(t *testing.T) {
+	dir, err := osCacheDir()
+	if err != nil {
+		t.Skipf("no cache dir: %v", err)
+	}
+	p := filepath.Join(dir, "jetson", "1.0.0", "image.img.zst")
+	if err := validateBmapSource(p); err != nil {
+		t.Fatalf("expected acceptance inside cache root, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestValidateBmapSource -v`
+Expected: FAIL — `undefined: validateBmapSource`.
+
+- [ ] **Step 3: Implement validation + seekable helper body**
+
+Add to `bmap_writer.go` (imports: add `path/filepath`, `strings`):
+
+```go
+// validateBmapSource rejects a --source that is not a regular file beneath the
+// OS image cache root. The helper runs as root, so this prevents a caller from
+// pointing it at an arbitrary path via sudo.
+func validateBmapSource(path string) error {
+	root, err := osCacheDir()
+	if err != nil {
+		return fmt.Errorf("resolving cache root: %w", err)
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+	if abs != absRoot && !strings.HasPrefix(abs, absRoot+string(filepath.Separator)) {
+		return fmt.Errorf("source %s is outside the image cache", path)
+	}
+	return nil
+}
+
+// validateDeviceTarget rejects a --device that is not a block/character device.
+func validateDeviceTarget(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat device: %w", err)
+	}
+	if info.Mode()&os.ModeDevice == 0 {
+		return fmt.Errorf("%s is not a device", path)
+	}
+	return nil
+}
+
+// runBmapWriteSeekable is the body of `__bmap-write` when --source is given. It
+// opens the seekable image and writes only mapped ranges to the raw device,
+// emitting cumulative bytes written on stdout (one decimal per line) so the
+// parent can drive the progress bar. Runs as root; no stdin pipe.
+func runBmapWriteSeekable(devicePath, bmapPath, sourcePath string, stdout io.Writer) error {
+	if err := validateDeviceTarget(devicePath); err != nil {
+		return err
+	}
+	if err := validateBmapSource(sourcePath); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(bmapPath)
+	if err != nil {
+		return fmt.Errorf("reading bmap: %w", err)
+	}
+	b, err := parseBmap(data)
+	if err != nil {
+		return err
+	}
+	si, err := openSeekableZstd(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer si.Close()
+	if si.Size() != b.ImageSize {
+		return fmt.Errorf("seekable image size %d != bmap image size %d", si.Size(), b.ImageSize)
+	}
+	dev, err := os.OpenFile(devicePath, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("opening device %s: %w", devicePath, err)
+	}
+	defer dev.Close()
+	emit := func(n int64) { fmt.Fprintf(stdout, "%d\n", n) }
+	if err := applyBmapSeekable(si, dev, b, emit); err != nil {
+		return err
+	}
+	if err := dev.Sync(); err != nil && !errors.Is(err, syscall.ENOTTY) {
+		return fmt.Errorf("syncing device %s: %w", devicePath, err)
+	}
+	return nil
+}
+```
+
+In `root.go`, extend the `__bmap-write` command (replace the `bmapDevice, bmapFile` block at L154-163):
+
+```go
+	var bmapDevice, bmapFile, bmapSource string
+	bmapWriteCmd := &cobra.Command{
+		Use:    "__bmap-write",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if bmapSource != "" {
+				return runBmapWriteSeekable(bmapDevice, bmapFile, bmapSource, cmd.OutOrStdout())
+			}
+			return runBmapWrite(bmapDevice, bmapFile, cmd.InOrStdin())
+		},
+	}
+	bmapWriteCmd.Flags().StringVar(&bmapDevice, "device", "", "Raw device path to write")
+	bmapWriteCmd.Flags().StringVar(&bmapFile, "bmap", "", "Path to the .bmap file")
+	bmapWriteCmd.Flags().StringVar(&bmapSource, "source", "", "Path to the seekable .img.zst source")
+```
+
+- [ ] **Step 4: Run test + build**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestValidateBmapSource -v && go build ./...`
+Expected: PASS, clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/root.go go/internal/cli/commands/bmap_writer.go go/internal/cli/commands/bmap_writer_test.go
+git commit -m "feat(os): __bmap-write --source seekable path with path validation"
+```
+
+---
+
+## Task 6: Wire Linux + macOS to re-exec the helper with `--source`
+
+**Files:**
+- Modify: `go/internal/cli/commands/disklister_linux.go:235-280`
+- Modify: `go/internal/cli/commands/disklister_darwin.go:189-235`
+
+These are integration points against a privileged subprocess; they're verified by build + a unit test of the stdout progress scanner (the device write itself needs hardware and is covered by manual verification).
+
+- [ ] **Step 1: Add a progress scanner + new bmap entrypoint (test first)**
+
+Create `go/internal/cli/commands/bmap_progress_test.go`:
+
+```go
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanBmapProgress(t *testing.T) {
+	var last int64
+	scanBmapProgress(strings.NewReader("100\n2048\n65536\n"), func(n int64) { last = n })
+	if last != 65536 {
+		t.Fatalf("last progress = %d, want 65536", last)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestScanBmapProgress -v`
+Expected: FAIL — `undefined: scanBmapProgress`.
+
+- [ ] **Step 3: Implement the scanner (shared, in `bmap_writer.go`)**
+
+```go
+// scanBmapProgress reads the helper's stdout (one cumulative decimal byte count
+// per line) and forwards each value to progressFn.
+func scanBmapProgress(r io.Reader, progressFn func(int64)) {
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		if n, err := strconv.ParseInt(line, 10, 64); err == nil {
+			progressFn(n)
+		}
+	}
+}
+```
+
+(Add imports `bufio`, `strconv` to `bmap_writer.go`.)
+
+- [ ] **Step 4: Add `writeImageWithBmapSeekable` to each platform file**
+
+In `disklister_linux.go` add (mirrors `writeImageWithBmap` but no stdin; uses `d.DevicePath`):
+
+```go
+// writeImageWithBmapSeekable flashes via the seekable source: it re-execs
+// `sudo wendy __bmap-write --source <zst> --bmap <bmap> --device <dev>`; the
+// helper reads the source itself and writes mapped ranges as root. progressFn
+// receives cumulative mapped bytes (scanned from the helper's stdout).
+func writeImageWithBmapSeekable(sourcePath, bmapPath string, d drive, progressFn func(int64)) error {
+	if err := unmountDisk(d.DevicePath); err != nil {
+		return err
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locating wendy binary: %w", err)
+	}
+	cmd := exec.Command("sudo", self, "__bmap-write",
+		"--device", d.DevicePath, "--bmap", bmapPath, "--source", sourcePath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting bmap helper: %w", err)
+	}
+	scanBmapProgress(stdout, progressFn)
+	if err := cmd.Wait(); err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("bmap write failed: %w\n%s", err, stderr.String())
+		}
+		return fmt.Errorf("bmap write failed: %w", err)
+	}
+	exec.Command("sync").Run() //nolint:errcheck
+	return nil
+}
+```
+
+In `disklister_darwin.go` add the same function but with `d.RawPath` instead of `d.DevicePath` in the `--device` arg (matching the existing `writeImageWithBmap` on darwin).
+
+- [ ] **Step 5: Run test + build (both GOOS)**
+
+Run:
+```bash
+cd go && go test ./internal/cli/commands/ -run TestScanBmapProgress -v
+GOOS=linux go build ./... && GOOS=darwin go build ./...
+```
+Expected: PASS; both builds clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go/internal/cli/commands/bmap_writer.go go/internal/cli/commands/bmap_progress_test.go go/internal/cli/commands/disklister_linux.go go/internal/cli/commands/disklister_darwin.go
+git commit -m "feat(os): re-exec bmap helper with --source on linux/darwin"
+```
+
+---
+
+## Task 7: Wire Windows in-process seekable frame-walk
+
+**Files:**
+- Modify: `go/internal/cli/commands/disklister_windows.go:486-508`
+
+Windows has no privileged helper; it runs `applyBmapSeekable` directly against the locked disk handle.
+
+- [ ] **Step 1: Add `writeImageWithBmapSeekable` (Windows)**
+
+Replace/extend the Windows bmap writer to add:
+
+```go
+// writeImageWithBmapSeekable opens the seekable source and writes only mapped
+// ranges to the locked disk handle in-process (no helper on Windows).
+func writeImageWithBmapSeekable(sourcePath, bmapPath string, d drive, progressFn func(int64)) error {
+	data, err := os.ReadFile(bmapPath)
+	if err != nil {
+		return fmt.Errorf("reading bmap: %w", err)
+	}
+	b, err := parseBmap(data)
+	if err != nil {
+		return err
+	}
+	si, err := openSeekableZstd(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer si.Close()
+	if si.Size() != b.ImageSize {
+		return fmt.Errorf("seekable image size %d != bmap image size %d", si.Size(), b.ImageSize)
+	}
+	ld, err := lockAndOpenDisk(d) // existing Windows locked-handle helper used by writeImageWithBmap
+	if err != nil {
+		return err
+	}
+	defer ld.close()
+	return applyBmapSeekable(si, handleWriterAt{h: ld.handle}, b, progressFn)
+}
+```
+
+> Match the existing Windows lock/open/close helper names used by the current `writeImageWithBmap` (see `disklister_windows.go:484-508` — `handleWriterAt` already exists; reuse the same lock acquisition call it uses).
+
+- [ ] **Step 2: Build for Windows**
+
+Run: `cd go && GOOS=windows go build ./...`
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go/internal/cli/commands/disklister_windows.go
+git commit -m "feat(os): in-process seekable bmap writer on windows"
+```
+
+---
+
+## Task 8: Wire the install flow — select storage, prefer zst, fix progress + measure
+
+**Files:**
+- Modify: `go/internal/cli/commands/os_install.go` (image resolution ~L443-493; write dispatch ~L500-512; measure guard ~L461)
+
+- [ ] **Step 1: Map drive storage → manifest storage key**
+
+Add to `os_install.go`:
+
+```go
+// manifestStorage maps a target drive's protocol to the manifest storage key.
+func manifestStorage(d drive) string {
+	if d.StorageType == StorageNVMe {
+		return "nvme"
+	}
+	return "sd"
+}
+```
+
+- [ ] **Step 2: Resolve the image for the chosen storage**
+
+Change the resolution call (was temporarily `""` in Task 4) at ~L445 to use the selected drive:
+
+```go
+	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, manifestStorage(targetDrive))
+	if err != nil {
+		return fmt.Errorf("getting image info: %w", err)
+	}
+```
+
+- [ ] **Step 3: Add cache-path + resolve helpers for the `.zst`**
+
+The existing helpers are `osCachedImagePath` (`.img`), `osCachedZipPath` (`.zip`), `osCachedBmapPath` (`.bmap`), and `downloadImage(img *imageInfo) (string, error)` (atomic temp download with progress) + `resolveOSImage` (download→rename into cache). Add a sibling for the `.zst`, modeled exactly on `osCachedZipPath` and `resolveOSImage`'s non-zip branch:
+
+```go
+func osCachedZstPath(deviceKey, version string) (string, error) {
+	safeDevice := filepath.Base(deviceKey)
+	safeVersion := filepath.Base(version)
+	if safeDevice != deviceKey || safeVersion != version ||
+		strings.Contains(deviceKey, "..") || strings.Contains(version, "..") {
+		return "", fmt.Errorf("invalid device key or version: %q / %q", deviceKey, version)
+	}
+	dir, err := osCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s-%s.img.zst", safeDevice, safeVersion)), nil
+}
+
+// resolveSeekableZst downloads (or cache-hits) the seekable .img.zst for
+// deviceKey+version from zstURL, returning the cached path. Reuses downloadImage
+// (which streams to a temp file with progress) then renames into the cache.
+func resolveSeekableZst(deviceKey, version, zstURL string) (string, error) {
+	cached, err := osCachedZstPath(deviceKey, version)
+	if err != nil {
+		return "", err
+	}
+	if info, statErr := os.Stat(cached); statErr == nil && info.Size() > 0 {
+		fmt.Printf("Using cached seekable image (%s)\n", cached)
+		return cached, nil
+	}
+	downloadPath, err := downloadImage(&imageInfo{DownloadURL: zstURL, Version: version})
+	if err != nil {
+		return "", fmt.Errorf("downloading seekable image: %w", err)
+	}
+	os.Remove(cached) // clear stale/0-byte so Rename succeeds on Windows
+	if err := os.Rename(downloadPath, cached); err != nil {
+		os.Remove(downloadPath)
+		return "", fmt.Errorf("caching seekable image: %w", err)
+	}
+	return cached, nil
+}
+```
+
+- [ ] **Step 4: Compute the seekable plan in Step 5b**
+
+In the Step 5b block (~L470-493), declare the seekable plan vars and try them first; on success the legacy `bmapPath` stays empty so the streaming path is skipped:
+
+```go
+	// Step 5b: prefer the seekable-zstd fast path when the manifest advertises a
+	// zst for this storage and a usable bmap, and the user didn't pass --no-bmap.
+	var seekableZst, seekableBmap string
+	var seekableTotal int64
+	if !noBmap && imgInfo.ZstURL != "" && imgInfo.BmapURL != "" {
+		zstPath, zerr := resolveSeekableZst(deviceKey, selectedVersion, imgInfo.ZstURL)
+		bmapCandidate, berr := osCachedBmapPath(deviceKey, selectedVersion)
+		if zerr == nil && berr == nil && downloadBmap(imgInfo.BmapURL, bmapCandidate) == nil {
+			if parsed, perr := parseBmap(readFileOrNil(bmapCandidate)); perr == nil {
+				seekableZst, seekableBmap, seekableTotal = zstPath, bmapCandidate, mappedBytes(parsed)
+			} else {
+				fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
+			}
+		} else if zerr != nil {
+			fmt.Printf("Note: could not fetch seekable image (%v); flashing the full image.\n", zerr)
+		}
+	}
+	// (the existing .zip + legacy-bmap preparation that sets `bmapPath` follows,
+	// unchanged; it only runs to set `bmapPath` when seekableZst == "")
+```
+
+- [ ] **Step 5: Add the seekable branch to the write goroutine**
+
+In the Step 6 dispatch goroutine (L500-517), add a first branch:
+
+```go
+	go func() {
+		var writeErr error
+		switch {
+		case seekableZst != "":
+			fmt.Println("Using seekable block map for faster flashing.")
+			writeErr = writeImageWithBmapSeekable(seekableZst, seekableBmap, targetDrive, func(written int64) {
+				wp.Send(tui.ProgressUpdateMsg{
+					Percent: float64(written) / float64(seekableTotal),
+					Written: written,
+					Total:   seekableTotal,
+				})
+			})
+		case bmapPath != "":
+			fmt.Println("Using block map for faster flashing.")
+			writeErr = writeImageWithBmap(stream, stream.uncompressedSize, targetDrive, bmapPath, func(written int64) {
+				if msg, ok := stream.writeProgressMsg(written); ok {
+					wp.Send(msg)
+				}
+			})
+		default:
+			writeErr = writeImageToDisk(stream, stream.uncompressedSize, targetDrive, func(written int64) {
+				if msg, ok := stream.writeProgressMsg(written); ok {
+					wp.Send(msg)
+				}
+			})
+		}
+		wp.Send(tui.ProgressDoneMsg{Err: writeErr})
+	}()
+```
+
+The existing `wp.Run()` / error handling (L519-527) and provisioning (L529+) are unchanged.
+
+- [ ] **Step 6: Skip the measure pass when a bmap is present**
+
+At the measure guard (~L461), add the bmap short-circuit:
+
+```go
+	if stream.uncompressedSize == 0 && stream.sourcePath != "" && imgInfo.BmapURL == "" {
+		// bmap's ImageSize already gives the exact total; only measure when no bmap.
+		if err := measureImageWithProgress(stream); err != nil {
+```
+
+- [ ] **Step 7: Build + full package test**
+
+Run: `cd go && go build ./... && go test ./internal/cli/commands/ -v 2>&1 | tail -20`
+Expected: clean build; tests PASS.
+
+- [ ] **Step 8: Manual verification (record result)**
+
+Flash a real holey image to a USB/SD target and confirm: output shows "Using seekable block map for faster flashing.", the bar reaches 100%, the device boots. Note wall-clock vs the previous `.zip` path.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add go/internal/cli/commands/os_install.go
+git commit -m "feat(os): prefer seekable-zstd flash path, storage-aware, skip measure with bmap"
+```
+
+---
+
+# Part B — Publisher (run in the `wendy-os-publisher` repo)
+
+> These tasks are executed in `/Users/joannisorlandos/git/wendy/wendy-os-publisher`, not this worktree. The JSON tags MUST match the Shared Contract above.
+
+## Task 9: Storage-keyed zst/bmap fields on `VersionMetadata`
+
+**Files:**
+- Modify: `cmd/upload_and_manifest.go` (`VersionMetadata` struct, ~L84-115)
+
+- [ ] **Step 1: Add fields**
+
+Add to `VersionMetadata` (mirroring the CLI `deviceVersion` tags exactly):
+
+```go
+	// Legacy seekable-zstd (fallback triple).
+	ZstPath      string `json:"zst_path,omitempty"`
+	ZstChecksum  string `json:"zst_checksum,omitempty"`
+	ZstSizeBytes int64  `json:"zst_size_bytes,omitempty"`
+
+	// NVMe triple.
+	NVMEBmapPath     string `json:"nvme_bmap_path,omitempty"`
+	NVMEZstPath      string `json:"nvme_zst_path,omitempty"`
+	NVMEZstChecksum  string `json:"nvme_zst_checksum,omitempty"`
+	NVMEZstSizeBytes int64  `json:"nvme_zst_size_bytes,omitempty"`
+
+	// SD triple.
+	SDPath         string `json:"sd_path,omitempty"`
+	SDChecksum     string `json:"sd_checksum,omitempty"`
+	SDSizeBytes    int64  `json:"sd_size_bytes,omitempty"`
+	SDBmapPath     string `json:"sd_bmap_path,omitempty"`
+	SDZstPath      string `json:"sd_zst_path,omitempty"`
+	SDZstChecksum  string `json:"sd_zst_checksum,omitempty"`
+	SDZstSizeBytes int64  `json:"sd_zst_size_bytes,omitempty"`
+```
+
+(`NVMEPath`/`NVMEChecksum`/`NVMESizeBytes` already exist on the publisher side per exploration; reuse them.)
+
+- [ ] **Step 2: Build**
+
+Run: `go build ./...`
+Expected: clean.
+
+- [ ] **Step 3: Commit (in publisher repo)**
+
+```bash
+git add cmd/upload_and_manifest.go
+git commit -m "feat: storage-keyed zst/bmap manifest fields"
+```
+
+---
+
+## Task 10: Produce + upload the seekable-zstd artifact
+
+**Files:**
+- Modify: `cmd/upload_and_manifest.go` (compression + upload + manifest population)
+- Modify: `go.mod` (add `github.com/SaveTheRbtz/zstd-seekable-format-go`)
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `go get github.com/SaveTheRbtz/zstd-seekable-format-go@latest && go build ./...`
+
+- [ ] **Step 2: Add the encoder (test first)**
+
+Create `cmd/seekable_test.go`:
+
+```go
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+	"github.com/klauspost/compress/zstd"
+)
+
+func TestCompressSeekableZstdRoundTrips(t *testing.T) {
+	src := make([]byte, 9000)
+	for i := range src {
+		src[i] = byte(i % 251)
+	}
+	dir := t.TempDir()
+	in := filepath.Join(dir, "image.img")
+	out := filepath.Join(dir, "image.img.zst")
+	if err := os.WriteFile(in, src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := compressSeekableZstd(in, out); err != nil {
+		t.Fatalf("compressSeekableZstd: %v", err)
+	}
+	comp, _ := os.ReadFile(out)
+	dec, _ := zstd.NewReader(nil)
+	defer dec.Close()
+	r, err := seekable.NewReader(bytes.NewReader(comp), dec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	got := make([]byte, len(src))
+	if _, err := r.ReadAt(got, 0); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("round-trip mismatch")
+	}
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `go test ./cmd/ -run TestCompressSeekableZstd -v`
+Expected: FAIL — `undefined: compressSeekableZstd`.
+
+- [ ] **Step 4: Implement the encoder**
+
+Add to `cmd/upload_and_manifest.go`:
+
+```go
+const seekableFrameSize = 4 << 20 // 4 MiB uncompressed per frame
+
+// compressSeekableZstd writes the raw image at srcPath into a seekable-zstd
+// container at dstPath, one frame per seekableFrameSize chunk.
+func compressSeekableZstd(srcPath, dstPath string) error {
+	in, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("opening image: %w", err)
+	}
+	defer in.Close()
+	out, err := os.Create(dstPath)
+	if err != nil {
+		return fmt.Errorf("creating zst: %w", err)
+	}
+	defer out.Close()
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		return err
+	}
+	defer enc.Close()
+	w, err := seekable.NewWriter(out, enc)
+	if err != nil {
+		return err
+	}
+	buf := make([]byte, seekableFrameSize)
+	for {
+		n, rerr := io.ReadFull(in, buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				w.Close()
+				return werr
+			}
+		}
+		if rerr == io.EOF || rerr == io.ErrUnexpectedEOF {
+			break
+		}
+		if rerr != nil {
+			w.Close()
+			return rerr
+		}
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	return out.Close()
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./cmd/ -run TestCompressSeekableZstd -v`
+Expected: PASS.
+
+- [ ] **Step 6: Wire into the OS-image upload path**
+
+In the OS-image branch of the upload flow (where `.zip` is produced and `VersionMetadata` populated, ~L1760-1815): after the raw image is available, call `compressSeekableZstd(rawPath, rawPath+".zst")`, upload it via the existing `uploadFile`, compute its checksum/size with the existing `calculateChecksum`, and set the fields for the storage being published — `NVMEZstPath`/`NVMEZstChecksum`/`NVMEZstSizeBytes` for `--storage nvme`, the `SD*` equivalents otherwise, and the legacy `ZstPath` set to the same default storage you already mirror into legacy `Path`. Ensure `NVMEBmapPath`/`SDBmapPath` are also set from the uploaded bmap so each triple is self-consistent. Keep writing legacy `Path`/`BmapPath` unchanged for old CLIs.
+
+- [ ] **Step 7: Build + test**
+
+Run: `go build ./... && go test ./cmd/ -v 2>&1 | tail -20`
+Expected: clean build; tests PASS.
+
+- [ ] **Step 8: Commit (in publisher repo)**
+
+```bash
+git add cmd/upload_and_manifest.go cmd/seekable_test.go go.mod go.sum
+git commit -m "feat: produce + upload seekable-zstd image, populate storage-keyed manifest"
+```
+
+---
+
+## Final verification
+
+- [ ] CLI: `cd go && go build ./... && GOOS=windows go build ./... && GOOS=darwin go build ./... && go test ./internal/cli/commands/ -v`
+- [ ] Publisher: re-publish one multi-storage version (e.g. jetson-orin-nano) for both `--storage nvme` and `--storage sd`; confirm the manifest carries both triples with distinct `*_bmap_path`/`*_zst_path`.
+- [ ] End-to-end: `wendy os install` to an NVMe target uses the NVMe triple + seekable path (no `dd` fallback) and to an SD target uses the SD triple; both boot. Record wall-clock improvement on a holey image.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20251212221603-3adeb8663819
 	github.com/BurntSushi/toml v1.6.0
+	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -21,6 +22,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/mdns v1.0.6
+	github.com/klauspost/compress v1.18.6
 	github.com/mark3labs/mcp-go v0.54.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -38,7 +40,6 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 // indirect
 	github.com/Microsoft/hcsshim v0.15.0-rc.1 // indirect
-	github.com/SaveTheRbtz/zstd-seekable-format-go v0.7.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -65,7 +66,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 // indirect
 	github.com/Microsoft/hcsshim v0.15.0-rc.1 // indirect
+	github.com/SaveTheRbtz/zstd-seekable-format-go v0.7.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 h1:0kQAzHq8vL
 github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29/go.mod h1:ZWa7ssZJT30CCDGJ7fk/2SBTq9BIQrrVjrcss0UW2s0=
 github.com/Microsoft/hcsshim v0.15.0-rc.1 h1:FbbwtQmiD+BVHynGkx5S65JkLyhkEiiTP8nrpmg2SZw=
 github.com/Microsoft/hcsshim v0.15.0-rc.1/go.mod h1:HWvvUPIy9HF6LotILj1G4VyS065rcLQ6tqj6tMUdOfI=
-github.com/SaveTheRbtz/zstd-seekable-format-go v0.7.1 h1:26fXh2eGDAFd3RL+RngsyKw6BPwrdULYJQI46Azcidw=
-github.com/SaveTheRbtz/zstd-seekable-format-go v0.7.1/go.mod h1:cvUQDGY8Zt1hfS8ygvqcDYkOyJeM/cw/orgNlvMv/KQ=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0 h1:LvK7+C6qgz8BPnmn7xGekf8vTkcqTvyBBHaLYIMxx0g=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0/go.mod h1:I28hc9eaiqKCoOB+9Wh/P1IOScfm0xCgyWC6DAo0lmo=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -49,12 +49,8 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6dyLYXQ=
 github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
-github.com/containerd/containerd/api v1.11.0 h1:smv4e74S/wwIx0Sj7lhwO1t3M/oi+mSzk2VXqHq8aO0=
-github.com/containerd/containerd/api v1.11.0/go.mod h1:CaQFRu+N1MtbgL6JDOJLUB1hCKESU1lD6MuTJhgtdlw=
 github.com/containerd/containerd/api v1.11.1 h1:h8nfoDW9+fNsC/9TwiAHj8B1GzXKtR4eFtkhi/X5RLU=
 github.com/containerd/containerd/api v1.11.1/go.mod h1:CaQFRu+N1MtbgL6JDOJLUB1hCKESU1lD6MuTJhgtdlw=
-github.com/containerd/containerd/v2 v2.3.0 h1:qpB5dyToxPqea1OdedyAiAnnor5wxTM+Py9nWt5CnWY=
-github.com/containerd/containerd/v2 v2.3.0/go.mod h1:+chyhxLNeqUVOcTJGgaSu/IbDGX6p3+d8AJjAaerAS8=
 github.com/containerd/containerd/v2 v2.3.1 h1:4dVXBdlvotRBlaP2TmNbY/EGc06KJrMDDUqQdxX/HOk=
 github.com/containerd/containerd/v2 v2.3.1/go.mod h1:xVoxGPWZBwwph8DF2IbDhriLKdHfjdpO0b3wFP9wQ1I=
 github.com/containerd/continuity v0.5.0 h1:7a85HZpCSs+1Zps0Ee3DPSuAWY+0SJM1JNM51nlEVDg=
@@ -151,8 +147,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
-github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 h1:0kQAzHq8vL
 github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29/go.mod h1:ZWa7ssZJT30CCDGJ7fk/2SBTq9BIQrrVjrcss0UW2s0=
 github.com/Microsoft/hcsshim v0.15.0-rc.1 h1:FbbwtQmiD+BVHynGkx5S65JkLyhkEiiTP8nrpmg2SZw=
 github.com/Microsoft/hcsshim v0.15.0-rc.1/go.mod h1:HWvvUPIy9HF6LotILj1G4VyS065rcLQ6tqj6tMUdOfI=
+github.com/SaveTheRbtz/zstd-seekable-format-go v0.7.1 h1:26fXh2eGDAFd3RL+RngsyKw6BPwrdULYJQI46Azcidw=
+github.com/SaveTheRbtz/zstd-seekable-format-go v0.7.1/go.mod h1:cvUQDGY8Zt1hfS8ygvqcDYkOyJeM/cw/orgNlvMv/KQ=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/go/internal/cli/commands/bmap.go
+++ b/go/internal/cli/commands/bmap.go
@@ -1,8 +1,11 @@
 package commands
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 )
@@ -63,6 +66,94 @@ func parseBmap(data []byte) (*Bmap, error) {
 		})
 	}
 	return b, nil
+}
+
+// applyBmap reconstructs an image onto dst using the block map. It reads src
+// (the decompressed image) strictly sequentially — src may be a pipe — and
+// writes only mapped ranges via WriteAt, discarding bytes that fall in holes.
+// Each mapped range's SHA256 is verified against the bmap; a mismatch aborts.
+// progressFn is called with the cumulative number of uncompressed bytes
+// consumed from src.
+func applyBmap(src io.Reader, dst io.WriterAt, b *Bmap, progressFn func(int64)) error {
+	const chunk = 1 << 20 // 1 MiB read granularity within a range
+	buf := make([]byte, chunk)
+	var consumed int64
+
+	pos := int64(0) // next uncompressed byte offset we will read
+	for _, r := range b.Ranges {
+		start := r.First * b.BlockSize
+		end := (r.Last + 1) * b.BlockSize
+		if end > b.ImageSize {
+			end = b.ImageSize
+		}
+
+		// Skip the hole before this range by reading and discarding.
+		if start > pos {
+			if err := discard(src, start-pos, buf, &consumed, progressFn); err != nil {
+				return err
+			}
+			pos = start
+		}
+
+		// Stream the range to dst while hashing it.
+		h := sha256.New()
+		off := start
+		for off < end {
+			n := int64(len(buf))
+			if rem := end - off; rem < n {
+				n = rem
+			}
+			if _, err := io.ReadFull(src, buf[:n]); err != nil {
+				return fmt.Errorf("reading mapped range at %d: %w", off, err)
+			}
+			if _, err := dst.WriteAt(buf[:n], off); err != nil {
+				return fmt.Errorf("writing at %d: %w", off, err)
+			}
+			h.Write(buf[:n])
+			off += n
+			consumed += n
+			progressFn(consumed)
+		}
+		pos = end
+
+		if r.Checksum != "" {
+			got := hex.EncodeToString(h.Sum(nil))
+			if !strings.EqualFold(got, r.Checksum) {
+				return fmt.Errorf("bmap: checksum mismatch for blocks %d-%d (got %s, want %s)",
+					r.First, r.Last, got, r.Checksum)
+			}
+		}
+	}
+
+	// Drain any trailing holes so src is fully consumed (keeps the upstream
+	// decompressor/pipe happy and makes progress reach 100%).
+	if b.ImageSize > pos {
+		if err := discard(src, b.ImageSize-pos, buf, &consumed, progressFn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// discard reads exactly n bytes from src and throws them away, updating the
+// running consumed counter and progress.
+func discard(src io.Reader, n int64, buf []byte, consumed *int64, progressFn func(int64)) error {
+	for n > 0 {
+		m := int64(len(buf))
+		if n < m {
+			m = n
+		}
+		read, err := io.ReadFull(src, buf[:m])
+		if read > 0 {
+			*consumed += int64(read)
+			progressFn(*consumed)
+			n -= int64(read)
+		}
+		if err != nil {
+			return fmt.Errorf("reading hole: %w", err)
+		}
+	}
+	return nil
 }
 
 // parseRange parses a bmap range token: either "N" or "N-M".

--- a/go/internal/cli/commands/bmap.go
+++ b/go/internal/cli/commands/bmap.go
@@ -159,6 +159,74 @@ func discard(src io.Reader, n int64, buf []byte, consumed *int64, progressFn fun
 	return nil
 }
 
+// mappedBytes returns the total number of mapped (non-hole) bytes the block map
+// describes — the exact amount applyBmapSeekable will write. Used to size the
+// progress bar for the seekable path.
+func mappedBytes(b *Bmap) int64 {
+	var total int64
+	for _, r := range b.Ranges {
+		start := r.First * b.BlockSize
+		end := (r.Last + 1) * b.BlockSize
+		if end > b.ImageSize {
+			end = b.ImageSize
+		}
+		if end > start {
+			total += end - start
+		}
+	}
+	return total
+}
+
+// applyBmapSeekable reconstructs an image onto dst using the block map, reading
+// only mapped ranges from a random-access source. It Seeks to each range's
+// start, so the underlying seekable decoder never decodes hole frames — this is
+// where the zero-block speedup comes from. Each range's SHA256 is verified
+// against the bmap; a mismatch aborts. progressFn reports cumulative mapped
+// bytes written.
+func applyBmapSeekable(src io.ReadSeeker, dst io.WriterAt, b *Bmap, progressFn func(int64)) error {
+	buf := make([]byte, bmapChunkSize)
+	var written int64
+	for _, r := range b.Ranges {
+		start := r.First * b.BlockSize
+		end := (r.Last + 1) * b.BlockSize
+		if end > b.ImageSize {
+			end = b.ImageSize
+		}
+		if end <= start {
+			continue
+		}
+		if _, err := src.Seek(start, io.SeekStart); err != nil {
+			return fmt.Errorf("seeking to %d: %w", start, err)
+		}
+		h := sha256.New()
+		off := start
+		for off < end {
+			n := int64(len(buf))
+			if rem := end - off; rem < n {
+				n = rem
+			}
+			if _, err := io.ReadFull(src, buf[:n]); err != nil {
+				return fmt.Errorf("reading mapped range at %d: %w", off, err)
+			}
+			if _, err := dst.WriteAt(buf[:n], off); err != nil {
+				return fmt.Errorf("writing at %d: %w", off, err)
+			}
+			h.Write(buf[:n])
+			off += n
+			written += n
+			progressFn(written)
+		}
+		if r.Checksum != "" {
+			got := hex.EncodeToString(h.Sum(nil))
+			if !strings.EqualFold(got, r.Checksum) {
+				return fmt.Errorf("bmap: checksum mismatch for blocks %d-%d (got %s, want %s)",
+					r.First, r.Last, got, r.Checksum)
+			}
+		}
+	}
+	return nil
+}
+
 // parseRange parses a bmap range token: either "N" or "N-M".
 func parseRange(s string) (first, last int64, err error) {
 	if s == "" {

--- a/go/internal/cli/commands/bmap.go
+++ b/go/internal/cli/commands/bmap.go
@@ -1,0 +1,93 @@
+package commands
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// BmapRange is one contiguous run of mapped blocks in a bmap file.
+// First and Last are inclusive block indices.
+type BmapRange struct {
+	First    int64
+	Last     int64
+	Checksum string // hex-encoded SHA256 of the range's bytes
+}
+
+// Bmap is the parsed subset of a bmaptool v2.0 block-map file that we need to
+// reconstruct an image: the block size, total image size, and the mapped
+// ranges with their per-range checksums.
+type Bmap struct {
+	BlockSize int64
+	ImageSize int64
+	Ranges    []BmapRange
+}
+
+// xmlBmap mirrors the on-disk bmaptool XML format for unmarshalling.
+type xmlBmap struct {
+	ImageSize    int64  `xml:"ImageSize"`
+	BlockSize    int64  `xml:"BlockSize"`
+	ChecksumType string `xml:"ChecksumType"`
+	Ranges       []struct {
+		Checksum string `xml:"chksum,attr"`
+		Value    string `xml:",chardata"`
+	} `xml:"BlockMap>Range"`
+}
+
+// parseBmap decodes a bmaptool v2.0 block-map file. It rejects checksum types
+// other than sha256 (the only type the build emits) so callers fall back to dd
+// rather than skipping verification.
+func parseBmap(data []byte) (*Bmap, error) {
+	var x xmlBmap
+	if err := xml.Unmarshal(data, &x); err != nil {
+		return nil, fmt.Errorf("parsing bmap: %w", err)
+	}
+	if x.BlockSize <= 0 || x.ImageSize <= 0 {
+		return nil, fmt.Errorf("bmap: invalid block size %d or image size %d", x.BlockSize, x.ImageSize)
+	}
+	if t := strings.ToLower(strings.TrimSpace(x.ChecksumType)); t != "sha256" {
+		return nil, fmt.Errorf("bmap: unsupported checksum type %q", x.ChecksumType)
+	}
+
+	b := &Bmap{BlockSize: x.BlockSize, ImageSize: x.ImageSize}
+	for _, r := range x.Ranges {
+		first, last, err := parseRange(strings.TrimSpace(r.Value))
+		if err != nil {
+			return nil, err
+		}
+		b.Ranges = append(b.Ranges, BmapRange{
+			First:    first,
+			Last:     last,
+			Checksum: strings.TrimSpace(r.Checksum),
+		})
+	}
+	return b, nil
+}
+
+// parseRange parses a bmap range token: either "N" or "N-M".
+func parseRange(s string) (first, last int64, err error) {
+	if s == "" {
+		return 0, 0, fmt.Errorf("bmap: empty range")
+	}
+	dash := strings.IndexByte(s, '-')
+	if dash < 0 {
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("bmap: bad block number %q: %w", s, err)
+		}
+		return n, n, nil
+	}
+	first, err = strconv.ParseInt(s[:dash], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("bmap: bad range start %q: %w", s, err)
+	}
+	last, err = strconv.ParseInt(s[dash+1:], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("bmap: bad range end %q: %w", s, err)
+	}
+	if last < first {
+		return 0, 0, fmt.Errorf("bmap: range end %d before start %d", last, first)
+	}
+	return first, last, nil
+}

--- a/go/internal/cli/commands/bmap.go
+++ b/go/internal/cli/commands/bmap.go
@@ -68,6 +68,10 @@ func parseBmap(data []byte) (*Bmap, error) {
 	return b, nil
 }
 
+// bmapChunkSize is the read granularity within a mapped range. Package-level
+// (not const) so tests can shrink it to exercise the multi-chunk path.
+var bmapChunkSize int64 = 1 << 20
+
 // applyBmap reconstructs an image onto dst using the block map. It reads src
 // (the decompressed image) strictly sequentially — src may be a pipe — and
 // writes only mapped ranges via WriteAt, discarding bytes that fall in holes.
@@ -75,8 +79,7 @@ func parseBmap(data []byte) (*Bmap, error) {
 // progressFn is called with the cumulative number of uncompressed bytes
 // consumed from src.
 func applyBmap(src io.Reader, dst io.WriterAt, b *Bmap, progressFn func(int64)) error {
-	const chunk = 1 << 20 // 1 MiB read granularity within a range
-	buf := make([]byte, chunk)
+	buf := make([]byte, bmapChunkSize)
 	var consumed int64
 
 	pos := int64(0) // next uncompressed byte offset we will read

--- a/go/internal/cli/commands/bmap_progress_test.go
+++ b/go/internal/cli/commands/bmap_progress_test.go
@@ -1,0 +1,14 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanBmapProgress(t *testing.T) {
+	var last int64
+	scanBmapProgress(strings.NewReader("100\n2048\n65536\n"), func(n int64) { last = n })
+	if last != 65536 {
+		t.Fatalf("last progress = %d, want 65536", last)
+	}
+}

--- a/go/internal/cli/commands/bmap_test.go
+++ b/go/internal/cli/commands/bmap_test.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseBmap(t *testing.T) {
+	data, err := os.ReadFile("testdata/sample.bmap")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	b, err := parseBmap(data)
+	if err != nil {
+		t.Fatalf("parseBmap: %v", err)
+	}
+	if b.BlockSize != 4096 {
+		t.Errorf("BlockSize = %d, want 4096", b.BlockSize)
+	}
+	if b.ImageSize != 32768 {
+		t.Errorf("ImageSize = %d, want 32768", b.ImageSize)
+	}
+	if len(b.Ranges) != 2 {
+		t.Fatalf("len(Ranges) = %d, want 2", len(b.Ranges))
+	}
+	if b.Ranges[0].First != 0 || b.Ranges[0].Last != 1 {
+		t.Errorf("Ranges[0] = %d-%d, want 0-1", b.Ranges[0].First, b.Ranges[0].Last)
+	}
+	if b.Ranges[1].First != 4 || b.Ranges[1].Last != 5 {
+		t.Errorf("Ranges[1] = %d-%d, want 4-5", b.Ranges[1].First, b.Ranges[1].Last)
+	}
+}
+
+func TestParseBmapSingleBlockRange(t *testing.T) {
+	const x = `<bmap version="2.0"><ImageSize>4096</ImageSize><BlockSize>4096</BlockSize>` +
+		`<ChecksumType>sha256</ChecksumType><BlockMap><Range chksum="ab">3</Range></BlockMap></bmap>`
+	b, err := parseBmap([]byte(x))
+	if err != nil {
+		t.Fatalf("parseBmap: %v", err)
+	}
+	if len(b.Ranges) != 1 || b.Ranges[0].First != 3 || b.Ranges[0].Last != 3 {
+		t.Fatalf("range = %+v, want single block 3", b.Ranges)
+	}
+}
+
+func TestParseBmapRejectsNonSHA256(t *testing.T) {
+	const x = `<bmap version="2.0"><ImageSize>1</ImageSize><BlockSize>1</BlockSize>` +
+		`<ChecksumType>crc32</ChecksumType><BlockMap></BlockMap></bmap>`
+	if _, err := parseBmap([]byte(x)); err == nil {
+		t.Fatal("expected error for non-sha256 checksum type")
+	}
+}
+
+func TestParseBmapRejectsGarbage(t *testing.T) {
+	if _, err := parseBmap([]byte("not xml")); err == nil {
+		t.Fatal("expected error for invalid XML")
+	}
+}

--- a/go/internal/cli/commands/bmap_test.go
+++ b/go/internal/cli/commands/bmap_test.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"testing"
 )
@@ -54,5 +57,80 @@ func TestParseBmapRejectsNonSHA256(t *testing.T) {
 func TestParseBmapRejectsGarbage(t *testing.T) {
 	if _, err := parseBmap([]byte("not xml")); err == nil {
 		t.Fatal("expected error for invalid XML")
+	}
+}
+
+// memWriterAt is an in-memory io.WriterAt that records exactly which offsets
+// were written, so tests can assert holes are left untouched.
+type memWriterAt struct {
+	buf     []byte
+	written []bool // per-byte: true if written
+}
+
+func newMemWriterAt(size int64) *memWriterAt {
+	return &memWriterAt{buf: make([]byte, size), written: make([]bool, size)}
+}
+
+func (m *memWriterAt) WriteAt(p []byte, off int64) (int, error) {
+	copy(m.buf[off:], p)
+	for i := range p {
+		m.written[off+int64(i)] = true
+	}
+	return len(p), nil
+}
+
+func blockChecksum(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// buildSparseImage returns an 8-block image (block size 4096) where blocks 0-1
+// are zeros and blocks 4-5 are 0x01; blocks 2-3 and 6-7 are "holes" (zeros) we
+// expect applyBmap NOT to write.
+func buildSparseImage() ([]byte, *Bmap) {
+	const bs = 4096
+	img := make([]byte, bs*8)
+	for i := bs * 4; i < bs*6; i++ {
+		img[i] = 0x01
+	}
+	b := &Bmap{
+		BlockSize: bs,
+		ImageSize: int64(len(img)),
+		Ranges: []BmapRange{
+			{First: 0, Last: 1, Checksum: blockChecksum(img[0 : bs*2])},
+			{First: 4, Last: 5, Checksum: blockChecksum(img[bs*4 : bs*6])},
+		},
+	}
+	return img, b
+}
+
+func TestApplyBmapWritesOnlyMappedRanges(t *testing.T) {
+	img, b := buildSparseImage()
+	dst := newMemWriterAt(b.ImageSize)
+	var progress int64
+	if err := applyBmap(bytes.NewReader(img), dst, b, func(n int64) { progress = n }); err != nil {
+		t.Fatalf("applyBmap: %v", err)
+	}
+	const bs = 4096
+	if !bytes.Equal(dst.buf[0:bs*2], img[0:bs*2]) || !bytes.Equal(dst.buf[bs*4:bs*6], img[bs*4:bs*6]) {
+		t.Fatal("mapped ranges not written correctly")
+	}
+	for _, off := range []int{bs * 2, bs*4 - 1, bs * 6, bs*8 - 1} {
+		if dst.written[off] {
+			t.Fatalf("hole byte at offset %d was written", off)
+		}
+	}
+	if progress != b.ImageSize {
+		t.Fatalf("progress = %d, want %d", progress, b.ImageSize)
+	}
+}
+
+func TestApplyBmapDetectsCorruption(t *testing.T) {
+	img, b := buildSparseImage()
+	img[10] = 0xff // corrupt a byte inside mapped block 0
+	dst := newMemWriterAt(b.ImageSize)
+	err := applyBmap(bytes.NewReader(img), dst, b, func(int64) {})
+	if err == nil {
+		t.Fatal("expected checksum mismatch error, got nil")
 	}
 }

--- a/go/internal/cli/commands/bmap_test.go
+++ b/go/internal/cli/commands/bmap_test.go
@@ -134,3 +134,65 @@ func TestApplyBmapDetectsCorruption(t *testing.T) {
 		t.Fatal("expected checksum mismatch error, got nil")
 	}
 }
+
+func TestApplyBmapMultiChunkRange(t *testing.T) {
+	old := bmapChunkSize
+	bmapChunkSize = 7 // tiny, to force many inner-loop iterations per range
+	defer func() { bmapChunkSize = old }()
+
+	img, b := buildSparseImage() // blocks 0-1 and 4-5 mapped, bs=4096
+	dst := newMemWriterAt(b.ImageSize)
+	if err := applyBmap(bytes.NewReader(img), dst, b, func(int64) {}); err != nil {
+		t.Fatalf("applyBmap: %v", err)
+	}
+	const bs = 4096
+	if !bytes.Equal(dst.buf[0:bs*2], img[0:bs*2]) || !bytes.Equal(dst.buf[bs*4:bs*6], img[bs*4:bs*6]) {
+		t.Fatal("mapped ranges not reconstructed correctly across chunk boundaries")
+	}
+}
+
+func TestApplyBmapPartialFinalBlock(t *testing.T) {
+	const bs = 4096
+	const size = bs + 100 // block 0 full, block 1 only 100 bytes
+	img := make([]byte, size)
+	for i := range img {
+		img[i] = byte(i % 251)
+	}
+	b := &Bmap{
+		BlockSize: bs,
+		ImageSize: size,
+		Ranges:    []BmapRange{{First: 0, Last: 1, Checksum: blockChecksum(img[:size])}},
+	}
+	dst := newMemWriterAt(size)
+	if err := applyBmap(bytes.NewReader(img), dst, b, func(int64) {}); err != nil {
+		t.Fatalf("applyBmap: %v", err)
+	}
+	if !bytes.Equal(dst.buf, img) {
+		t.Fatal("partial final block not written correctly")
+	}
+	if dst.written[size-1] != true {
+		t.Fatal("last byte should be written")
+	}
+}
+
+func TestApplyBmapEmptyChecksumSkipsVerify(t *testing.T) {
+	img, b := buildSparseImage()
+	img[10] = 0xff            // corrupt mapped block 0
+	b.Ranges[0].Checksum = "" // but disable its verification
+	b.Ranges[1].Checksum = "" // and the other, so neither aborts
+	dst := newMemWriterAt(b.ImageSize)
+	if err := applyBmap(bytes.NewReader(img), dst, b, func(int64) {}); err != nil {
+		t.Fatalf("applyBmap with empty checksums should not verify: %v", err)
+	}
+}
+
+func TestParseBmapRejectsZeroSizes(t *testing.T) {
+	for _, x := range []string{
+		`<bmap version="2.0"><ImageSize>0</ImageSize><BlockSize>4096</BlockSize><ChecksumType>sha256</ChecksumType><BlockMap></BlockMap></bmap>`,
+		`<bmap version="2.0"><ImageSize>4096</ImageSize><BlockSize>0</BlockSize><ChecksumType>sha256</ChecksumType><BlockMap></BlockMap></bmap>`,
+	} {
+		if _, err := parseBmap([]byte(x)); err == nil {
+			t.Fatalf("expected error for zero size in %q", x)
+		}
+	}
+}

--- a/go/internal/cli/commands/bmap_test.go
+++ b/go/internal/cli/commands/bmap_test.go
@@ -196,3 +196,47 @@ func TestParseBmapRejectsZeroSizes(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyBmapSeekableWritesOnlyMappedRanges(t *testing.T) {
+	img, b := buildSparseImage() // blocks 0-1 and 4-5 mapped, bs=4096
+	comp := encodeSeekable(t, img, 4096)
+	si, err := openSeekableZstdFromReader(bytes.NewReader(comp))
+	if err != nil {
+		t.Fatalf("open seekable: %v", err)
+	}
+	defer si.Close()
+
+	dst := newMemWriterAt(b.ImageSize)
+	var progress int64
+	mapped := mappedBytes(b)
+	if err := applyBmapSeekable(si, dst, b, func(n int64) { progress = n }); err != nil {
+		t.Fatalf("applyBmapSeekable: %v", err)
+	}
+	const bs = 4096
+	if !bytes.Equal(dst.buf[0:bs*2], img[0:bs*2]) || !bytes.Equal(dst.buf[bs*4:bs*6], img[bs*4:bs*6]) {
+		t.Fatal("mapped ranges not written correctly")
+	}
+	for _, off := range []int{bs * 2, bs*4 - 1, bs * 6, bs*8 - 1} {
+		if dst.written[off] {
+			t.Fatalf("hole byte at offset %d was written", off)
+		}
+	}
+	if progress != mapped {
+		t.Fatalf("progress = %d, want mapped total %d", progress, mapped)
+	}
+}
+
+func TestApplyBmapSeekableDetectsCorruption(t *testing.T) {
+	img, b := buildSparseImage()
+	img[10] = 0xff // corrupt mapped block 0 before compression
+	comp := encodeSeekable(t, img, 4096)
+	si, err := openSeekableZstdFromReader(bytes.NewReader(comp))
+	if err != nil {
+		t.Fatalf("open seekable: %v", err)
+	}
+	defer si.Close()
+	dst := newMemWriterAt(b.ImageSize)
+	if err := applyBmapSeekable(si, dst, b, func(int64) {}); err == nil {
+		t.Fatal("expected checksum mismatch error, got nil")
+	}
+}

--- a/go/internal/cli/commands/bmap_writer.go
+++ b/go/internal/cli/commands/bmap_writer.go
@@ -1,11 +1,15 @@
 package commands
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -62,6 +66,98 @@ func (c *countingWriter) Write(p []byte) (int, error) {
 		c.progressFn(c.n)
 	}
 	return written, err
+}
+
+// validateBmapSource rejects a --source that is not beneath the OS image cache
+// root. The helper runs as root, so this prevents a caller from pointing it at
+// an arbitrary path via sudo.
+func validateBmapSource(path string) error {
+	root, err := osCacheDir()
+	if err != nil {
+		return fmt.Errorf("resolving cache root: %w", err)
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+	if abs != absRoot && !strings.HasPrefix(abs, absRoot+string(filepath.Separator)) {
+		return fmt.Errorf("source %s is outside the image cache", path)
+	}
+	return nil
+}
+
+// validateDeviceTarget rejects a --device that is not a block/character device.
+func validateDeviceTarget(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat device: %w", err)
+	}
+	if info.Mode()&os.ModeDevice == 0 {
+		return fmt.Errorf("%s is not a device", path)
+	}
+	return nil
+}
+
+// runBmapWriteSeekable is the body of `__bmap-write` when --source is given. It
+// opens the seekable image and writes only mapped ranges to the raw device,
+// emitting cumulative bytes written on stdout (one decimal per line) so the
+// parent can drive the progress bar. Runs as root; no stdin pipe.
+func runBmapWriteSeekable(devicePath, bmapPath, sourcePath string, stdout io.Writer) error {
+	if err := validateDeviceTarget(devicePath); err != nil {
+		return err
+	}
+	if err := validateBmapSource(sourcePath); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(bmapPath)
+	if err != nil {
+		return fmt.Errorf("reading bmap: %w", err)
+	}
+	b, err := parseBmap(data)
+	if err != nil {
+		return err
+	}
+	si, err := openSeekableZstd(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer si.Close()
+	if si.Size() != b.ImageSize {
+		return fmt.Errorf("seekable image size %d != bmap image size %d", si.Size(), b.ImageSize)
+	}
+	dev, err := os.OpenFile(devicePath, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("opening device %s: %w", devicePath, err)
+	}
+	defer dev.Close()
+	emit := func(n int64) { fmt.Fprintf(stdout, "%d\n", n) }
+	if err := applyBmapSeekable(si, dev, b, emit); err != nil {
+		return err
+	}
+	if err := dev.Sync(); err != nil && !errors.Is(err, syscall.ENOTTY) {
+		return fmt.Errorf("syncing device %s: %w", devicePath, err)
+	}
+	return nil
+}
+
+// scanBmapProgress reads the helper's stdout (one cumulative decimal byte count
+// per line) and forwards each value to progressFn. Used by the parent process
+// in writeImageWithBmapSeekable (added in a later task).
+func scanBmapProgress(r io.Reader, progressFn func(int64)) {
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		if n, err := strconv.ParseInt(line, 10, 64); err == nil {
+			progressFn(n)
+		}
+	}
 }
 
 // runBmapWrite is the body of the hidden __bmap-write helper subcommand

--- a/go/internal/cli/commands/bmap_writer.go
+++ b/go/internal/cli/commands/bmap_writer.go
@@ -106,7 +106,7 @@ func validateDeviceTarget(path string) error {
 // opens the seekable image and writes only mapped ranges to the raw device,
 // emitting cumulative bytes written on stdout (one decimal per line) so the
 // parent can drive the progress bar. Runs as root; no stdin pipe.
-func runBmapWriteSeekable(devicePath, bmapPath, sourcePath string, stdout io.Writer) error {
+func runBmapWriteSeekable(devicePath, bmapPath, sourcePath string, stdout io.Writer) (retErr error) {
 	if err := validateDeviceTarget(devicePath); err != nil {
 		return err
 	}
@@ -133,7 +133,11 @@ func runBmapWriteSeekable(devicePath, bmapPath, sourcePath string, stdout io.Wri
 	if err != nil {
 		return fmt.Errorf("opening device %s: %w", devicePath, err)
 	}
-	defer dev.Close()
+	defer func() {
+		if cerr := dev.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("closing device %s: %w", devicePath, cerr)
+		}
+	}()
 	emit := func(n int64) { fmt.Fprintf(stdout, "%d\n", n) }
 	if err := applyBmapSeekable(si, dev, b, emit); err != nil {
 		return err

--- a/go/internal/cli/commands/bmap_writer.go
+++ b/go/internal/cli/commands/bmap_writer.go
@@ -10,7 +10,9 @@ import (
 
 // downloadBmap fetches a (small) .bmap XML file to dst. The bmap is tiny, so a
 // single GET with a short timeout is sufficient. Any failure is the caller's
-// cue to fall back to dd.
+// cue to fall back to dd. The download is atomic: data is written to a
+// temporary file and renamed into place only on success, so an interrupted
+// download never leaves a corrupt file for a later run to parse.
 func downloadBmap(url, dst string) error {
 	client := &http.Client{Timeout: 60 * time.Second}
 	resp, err := client.Get(url)
@@ -21,13 +23,24 @@ func downloadBmap(url, dst string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("bmap returned status %d", resp.StatusCode)
 	}
-	f, err := os.Create(dst)
+
+	tmp := dst + ".tmp"
+	f, err := os.Create(tmp)
 	if err != nil {
 		return fmt.Errorf("creating bmap file: %w", err)
 	}
-	defer f.Close()
 	if _, err := io.Copy(f, io.LimitReader(resp.Body, 64<<20)); err != nil {
+		f.Close()
+		os.Remove(tmp)
 		return fmt.Errorf("writing bmap file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("closing bmap file: %w", err)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("finalizing bmap file: %w", err)
 	}
 	return nil
 }

--- a/go/internal/cli/commands/bmap_writer.go
+++ b/go/internal/cli/commands/bmap_writer.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"syscall"
 	"time"
 )
 
@@ -84,5 +86,12 @@ func runBmapWrite(devicePath, bmapPath string, image io.Reader) error {
 	if err := applyBmap(image, dev, b, func(int64) {}); err != nil {
 		return err
 	}
-	return dev.Sync()
+	// Flush to media. fsync works on Linux block devices, but macOS raw
+	// character devices (/dev/rdiskN) reject it with ENOTTY — there the parent
+	// runs sync(8) after we exit, so a missing fsync is harmless. Treat ENOTTY
+	// as success rather than failing a flash whose data already landed.
+	if err := dev.Sync(); err != nil && !errors.Is(err, syscall.ENOTTY) {
+		return fmt.Errorf("syncing device %s: %w", devicePath, err)
+	}
+	return nil
 }

--- a/go/internal/cli/commands/bmap_writer.go
+++ b/go/internal/cli/commands/bmap_writer.go
@@ -32,6 +32,23 @@ func downloadBmap(url, dst string) error {
 	return nil
 }
 
+// countingWriter wraps an io.Writer and reports cumulative bytes written via
+// progressFn. Used to drive the flash progress bar from bytes fed to the helper.
+type countingWriter struct {
+	w          io.Writer
+	n          int64
+	progressFn func(int64)
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	written, err := c.w.Write(p)
+	c.n += int64(written)
+	if c.progressFn != nil {
+		c.progressFn(c.n)
+	}
+	return written, err
+}
+
 // runBmapWrite is the body of the hidden __bmap-write helper subcommand
 // (Linux/macOS). It opens the raw device, reads the decompressed image from
 // the supplied reader (stdin in production), and applies the bmap. It runs as

--- a/go/internal/cli/commands/bmap_writer.go
+++ b/go/internal/cli/commands/bmap_writer.go
@@ -165,7 +165,7 @@ func scanBmapProgress(r io.Reader, progressFn func(int64)) {
 // the supplied reader (stdin in production), and applies the bmap. It runs as
 // root (re-exec'd under sudo by the parent), so it does not prompt or print
 // TUI — progress is tracked by the parent counting bytes fed to stdin.
-func runBmapWrite(devicePath, bmapPath string, image io.Reader) error {
+func runBmapWrite(devicePath, bmapPath string, image io.Reader) (retErr error) {
 	data, err := os.ReadFile(bmapPath)
 	if err != nil {
 		return fmt.Errorf("reading bmap: %w", err)
@@ -178,7 +178,11 @@ func runBmapWrite(devicePath, bmapPath string, image io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("opening device %s: %w", devicePath, err)
 	}
-	defer dev.Close()
+	defer func() {
+		if closeErr := dev.Close(); closeErr != nil && retErr == nil {
+			retErr = fmt.Errorf("closing device %s: %w", devicePath, closeErr)
+		}
+	}()
 	if err := applyBmap(image, dev, b, func(int64) {}); err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/bmap_writer.go
+++ b/go/internal/cli/commands/bmap_writer.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// downloadBmap fetches a (small) .bmap XML file to dst. The bmap is tiny, so a
+// single GET with a short timeout is sufficient. Any failure is the caller's
+// cue to fall back to dd.
+func downloadBmap(url, dst string) error {
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("fetching bmap: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bmap returned status %d", resp.StatusCode)
+	}
+	f, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("creating bmap file: %w", err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, io.LimitReader(resp.Body, 64<<20)); err != nil {
+		return fmt.Errorf("writing bmap file: %w", err)
+	}
+	return nil
+}
+
+// runBmapWrite is the body of the hidden __bmap-write helper subcommand
+// (Linux/macOS). It opens the raw device, reads the decompressed image from
+// the supplied reader (stdin in production), and applies the bmap. It runs as
+// root (re-exec'd under sudo by the parent), so it does not prompt or print
+// TUI — progress is tracked by the parent counting bytes fed to stdin.
+func runBmapWrite(devicePath, bmapPath string, image io.Reader) error {
+	data, err := os.ReadFile(bmapPath)
+	if err != nil {
+		return fmt.Errorf("reading bmap: %w", err)
+	}
+	b, err := parseBmap(data)
+	if err != nil {
+		return err
+	}
+	dev, err := os.OpenFile(devicePath, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("opening device %s: %w", devicePath, err)
+	}
+	defer dev.Close()
+	if err := applyBmap(image, dev, b, func(int64) {}); err != nil {
+		return err
+	}
+	return dev.Sync()
+}

--- a/go/internal/cli/commands/bmap_writer_test.go
+++ b/go/internal/cli/commands/bmap_writer_test.go
@@ -6,8 +6,26 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 )
+
+func TestValidateBmapSourceRejectsOutsideCache(t *testing.T) {
+	if err := validateBmapSource("/etc/passwd"); err == nil {
+		t.Fatal("expected rejection of path outside cache root")
+	}
+}
+
+func TestValidateBmapSourceAcceptsInsideCache(t *testing.T) {
+	dir, err := osCacheDir()
+	if err != nil {
+		t.Skipf("no cache dir: %v", err)
+	}
+	p := filepath.Join(dir, "jetson", "1.0.0", "image.img.zst")
+	if err := validateBmapSource(p); err != nil {
+		t.Fatalf("expected acceptance inside cache root, got %v", err)
+	}
+}
 
 func TestDownloadBmap(t *testing.T) {
 	const body = `<bmap version="2.0"></bmap>`

--- a/go/internal/cli/commands/bmap_writer_test.go
+++ b/go/internal/cli/commands/bmap_writer_test.go
@@ -59,6 +59,17 @@ func TestRunBmapWriteToFile(t *testing.T) {
 	}
 }
 
+func TestBmapWriteCommandIsHidden(t *testing.T) {
+	root := NewRootCmd()
+	c, _, err := root.Find([]string{"__bmap-write"})
+	if err != nil {
+		t.Fatalf("find __bmap-write: %v", err)
+	}
+	if c.Name() != "__bmap-write" || !c.Hidden {
+		t.Fatalf("__bmap-write should be a hidden command; got name=%q hidden=%v", c.Name(), c.Hidden)
+	}
+}
+
 // bmapXML renders a minimal valid bmap document for b (sha256, blocks in order).
 func bmapXML(b *Bmap) string {
 	var sb bytes.Buffer

--- a/go/internal/cli/commands/bmap_writer_test.go
+++ b/go/internal/cli/commands/bmap_writer_test.go
@@ -1,0 +1,73 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestDownloadBmap(t *testing.T) {
+	const body = `<bmap version="2.0"></bmap>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	dst := t.TempDir() + "/x.bmap"
+	if err := downloadBmap(srv.URL, dst); err != nil {
+		t.Fatalf("downloadBmap: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body = %q, want %q", got, body)
+	}
+}
+
+func TestDownloadBmapHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	if err := downloadBmap(srv.URL, t.TempDir()+"/x.bmap"); err == nil {
+		t.Fatal("expected error on 404")
+	}
+}
+
+func TestRunBmapWriteToFile(t *testing.T) {
+	img, b := buildSparseImage() // from bmap_test.go (same package)
+	dir := t.TempDir()
+	bmapPath := dir + "/img.bmap"
+	if err := os.WriteFile(bmapPath, []byte(bmapXML(b)), 0o644); err != nil {
+		t.Fatalf("write bmap: %v", err)
+	}
+	devPath := dir + "/device.img"
+	if err := os.WriteFile(devPath, make([]byte, b.ImageSize), 0o644); err != nil {
+		t.Fatalf("seed device: %v", err)
+	}
+	if err := runBmapWrite(devPath, bmapPath, bytes.NewReader(img)); err != nil {
+		t.Fatalf("runBmapWrite: %v", err)
+	}
+	got, _ := os.ReadFile(devPath)
+	if !bytes.Equal(got, img) {
+		t.Fatal("device content does not match image")
+	}
+}
+
+// bmapXML renders a minimal valid bmap document for b (sha256, blocks in order).
+func bmapXML(b *Bmap) string {
+	var sb bytes.Buffer
+	fmt.Fprintf(&sb, `<bmap version="2.0"><ImageSize>%d</ImageSize><BlockSize>%d</BlockSize>`,
+		b.ImageSize, b.BlockSize)
+	sb.WriteString(`<ChecksumType>sha256</ChecksumType><BlockMap>`)
+	for _, r := range b.Ranges {
+		fmt.Fprintf(&sb, `<Range chksum="%s">%d-%d</Range>`, r.Checksum, r.First, r.Last)
+	}
+	sb.WriteString(`</BlockMap></bmap>`)
+	return sb.String()
+}

--- a/go/internal/cli/commands/disklister_darwin.go
+++ b/go/internal/cli/commands/disklister_darwin.go
@@ -234,6 +234,40 @@ func writeImageWithBmap(r io.Reader, totalSize int64, d drive, bmapPath string, 
 	return nil
 }
 
+// writeImageWithBmapSeekable flashes via the seekable source: it re-execs
+// `sudo wendy __bmap-write --source <zst> --bmap <bmap> --device <dev>`; the
+// helper reads the source itself and writes mapped ranges as root. progressFn
+// receives cumulative mapped bytes (scanned from the helper's stdout).
+func writeImageWithBmapSeekable(sourcePath, bmapPath string, d drive, progressFn func(int64)) error {
+	if err := unmountDisk(d.DevicePath); err != nil {
+		return err
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locating wendy binary: %w", err)
+	}
+	cmd := exec.Command("sudo", self, "__bmap-write",
+		"--device", d.RawPath, "--bmap", bmapPath, "--source", sourcePath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting bmap helper: %w", err)
+	}
+	scanBmapProgress(stdout, progressFn)
+	if err := cmd.Wait(); err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("bmap write failed: %w\n%s", err, stderr.String())
+		}
+		return fmt.Errorf("bmap write failed: %w", err)
+	}
+	exec.Command("sync").Run() //nolint:errcheck
+	return nil
+}
+
 func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(written int64)) error {
 	if err := unmountDisk(d.DevicePath); err != nil {
 		return err

--- a/go/internal/cli/commands/disklister_darwin.go
+++ b/go/internal/cli/commands/disklister_darwin.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -178,6 +179,52 @@ func unmountDisk(devPath string) error {
 			return fmt.Errorf("unmounting %s: %s\nClose Finder windows, Disk Utility, or any apps using the disk, then retry", devPath, string(forceOut)+string(out))
 		}
 	}
+	return nil
+}
+
+// writeImageWithBmap flashes the image to d using the block map. It re-execs
+// this binary as `sudo wendy __bmap-write`, streaming the decompressed image to
+// the helper's stdin; the helper seeks and writes only mapped ranges as root.
+// progressFn receives cumulative uncompressed bytes fed to the helper.
+func writeImageWithBmap(r io.Reader, totalSize int64, d drive, bmapPath string, progressFn func(written int64)) error {
+	if err := unmountDisk(d.DevicePath); err != nil {
+		return err
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locating wendy binary: %w", err)
+	}
+	cmd := exec.Command("sudo", self, "__bmap-write", "--device", d.RawPath, "--bmap", bmapPath)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting bmap helper: %w", err)
+	}
+
+	cw := &countingWriter{w: stdin, progressFn: progressFn}
+	copyErr := func() error {
+		defer stdin.Close()
+		_, err := io.Copy(cw, r)
+		return err
+	}()
+
+	waitErr := cmd.Wait()
+	if waitErr != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("bmap write failed: %w\n%s", waitErr, stderr.String())
+		}
+		return fmt.Errorf("bmap write failed: %w", waitErr)
+	}
+	if copyErr != nil {
+		return fmt.Errorf("streaming image to bmap helper: %w", copyErr)
+	}
+	_ = totalSize
+	exec.Command("sync").Run() //nolint:errcheck
 	return nil
 }
 

--- a/go/internal/cli/commands/disklister_darwin.go
+++ b/go/internal/cli/commands/disklister_darwin.go
@@ -103,6 +103,8 @@ func parseDiskutilOutput(out []byte, seen map[string]bool, isExternal bool) []dr
 			}
 			if strings.EqualFold(info.protocol, "nvme") {
 				storageType = StorageNVMe
+			} else if strings.EqualFold(info.protocol, "usb") {
+				storageType = StorageUSB
 			}
 		}
 

--- a/go/internal/cli/commands/disklister_darwin.go
+++ b/go/internal/cli/commands/disklister_darwin.go
@@ -214,14 +214,20 @@ func writeImageWithBmap(r io.Reader, totalSize int64, d drive, bmapPath string, 
 	}()
 
 	waitErr := cmd.Wait()
+	if copyErr != nil {
+		// A failure copying the (decompressed) image into the helper is the
+		// root cause; the helper's non-zero exit is just the downstream effect
+		// of its stdin closing early. Surface the copy error first.
+		if waitErr != nil {
+			return fmt.Errorf("streaming image to bmap helper: %w (helper: %v; %s)", copyErr, waitErr, stderr.String())
+		}
+		return fmt.Errorf("streaming image to bmap helper: %w", copyErr)
+	}
 	if waitErr != nil {
 		if stderr.Len() > 0 {
 			return fmt.Errorf("bmap write failed: %w\n%s", waitErr, stderr.String())
 		}
 		return fmt.Errorf("bmap write failed: %w", waitErr)
-	}
-	if copyErr != nil {
-		return fmt.Errorf("streaming image to bmap helper: %w", copyErr)
 	}
 	_ = totalSize
 	exec.Command("sync").Run() //nolint:errcheck

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -3,9 +3,11 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -224,6 +226,51 @@ func unmountLsblkDevice(dev lsblkDevice) error {
 		}
 	}
 	return firstErr
+}
+
+// writeImageWithBmap flashes the image to d using the block map. It re-execs
+// this binary as `sudo wendy __bmap-write`, streaming the decompressed image to
+// the helper's stdin; the helper seeks and writes only mapped ranges as root.
+// progressFn receives cumulative uncompressed bytes fed to the helper.
+func writeImageWithBmap(r io.Reader, totalSize int64, d drive, bmapPath string, progressFn func(written int64)) error {
+	if err := unmountDisk(d.DevicePath); err != nil {
+		return err
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locating wendy binary: %w", err)
+	}
+	cmd := exec.Command("sudo", self, "__bmap-write", "--device", d.DevicePath, "--bmap", bmapPath)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting bmap helper: %w", err)
+	}
+
+	cw := &countingWriter{w: stdin, progressFn: progressFn}
+	copyErr := func() error {
+		defer stdin.Close()
+		_, err := io.Copy(cw, r)
+		return err
+	}()
+
+	waitErr := cmd.Wait()
+	if waitErr != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("bmap write failed: %w\n%s", waitErr, stderr.String())
+		}
+		return fmt.Errorf("bmap write failed: %w", waitErr)
+	}
+	if copyErr != nil {
+		return fmt.Errorf("streaming image to bmap helper: %w", copyErr)
+	}
+	_ = totalSize
+	return nil
 }
 
 func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(written int64)) error {

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -279,6 +279,40 @@ func writeImageWithBmap(r io.Reader, totalSize int64, d drive, bmapPath string, 
 	return nil
 }
 
+// writeImageWithBmapSeekable flashes via the seekable source: it re-execs
+// `sudo wendy __bmap-write --source <zst> --bmap <bmap> --device <dev>`; the
+// helper reads the source itself and writes mapped ranges as root. progressFn
+// receives cumulative mapped bytes (scanned from the helper's stdout).
+func writeImageWithBmapSeekable(sourcePath, bmapPath string, d drive, progressFn func(int64)) error {
+	if err := unmountDisk(d.DevicePath); err != nil {
+		return err
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locating wendy binary: %w", err)
+	}
+	cmd := exec.Command("sudo", self, "__bmap-write",
+		"--device", d.DevicePath, "--bmap", bmapPath, "--source", sourcePath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting bmap helper: %w", err)
+	}
+	scanBmapProgress(stdout, progressFn)
+	if err := cmd.Wait(); err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("bmap write failed: %w\n%s", err, stderr.String())
+		}
+		return fmt.Errorf("bmap write failed: %w", err)
+	}
+	exec.Command("sync").Run() //nolint:errcheck
+	return nil
+}
+
 func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(written int64)) error {
 	if err := unmountDisk(d.DevicePath); err != nil {
 		return err

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -260,14 +260,20 @@ func writeImageWithBmap(r io.Reader, totalSize int64, d drive, bmapPath string, 
 	}()
 
 	waitErr := cmd.Wait()
+	if copyErr != nil {
+		// A failure copying the (decompressed) image into the helper is the
+		// root cause; the helper's non-zero exit is just the downstream effect
+		// of its stdin closing early. Surface the copy error first.
+		if waitErr != nil {
+			return fmt.Errorf("streaming image to bmap helper: %w (helper: %v; %s)", copyErr, waitErr, stderr.String())
+		}
+		return fmt.Errorf("streaming image to bmap helper: %w", copyErr)
+	}
 	if waitErr != nil {
 		if stderr.Len() > 0 {
 			return fmt.Errorf("bmap write failed: %w\n%s", waitErr, stderr.String())
 		}
 		return fmt.Errorf("bmap write failed: %w", waitErr)
-	}
-	if copyErr != nil {
-		return fmt.Errorf("streaming image to bmap helper: %w", copyErr)
 	}
 	_ = totalSize
 	return nil

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -109,6 +109,8 @@ func listDrivesLinux() ([]drive, error) {
 		storageType := StorageUnknown
 		if dev.Transport == "nvme" {
 			storageType = StorageNVMe
+		} else if dev.Transport == "usb" {
+			storageType = StorageUSB
 		}
 		drives = append(drives, drive{
 			DevicePath: devPath,

--- a/go/internal/cli/commands/disklister_storage.go
+++ b/go/internal/cli/commands/disklister_storage.go
@@ -6,4 +6,5 @@ type StorageType int
 const (
 	StorageUnknown StorageType = iota
 	StorageNVMe
+	StorageUSB
 )

--- a/go/internal/cli/commands/disklister_windows.go
+++ b/go/internal/cli/commands/disklister_windows.go
@@ -457,12 +457,25 @@ func (hw handleWriterAt) WriteAt(p []byte, off int64) (int, error) {
 	if _, err := syscall.Seek(hw.h, off, 0 /* FILE_BEGIN */); err != nil {
 		return 0, err
 	}
-	var done uint32
-	if err := syscall.WriteFile(hw.h, p, &done, nil); err != nil {
-		return int(done), err
+	// Raw physical-drive writes must be a multiple of the sector size. Pad the
+	// final sub-sector chunk with zeros (matches writeImageToDisk's behavior).
+	const sector = 512
+	buf := p
+	if rem := len(p) % sector; rem != 0 {
+		padded := make([]byte, len(p)+(sector-rem))
+		copy(padded, p)
+		buf = padded
 	}
-	if int(done) < len(p) {
-		return int(done), fmt.Errorf("short write at offset %d: wrote %d of %d bytes", off, done, len(p))
+	var done uint32
+	if err := syscall.WriteFile(hw.h, buf, &done, nil); err != nil {
+		return 0, err
+	}
+	if int(done) < len(buf) {
+		return 0, fmt.Errorf("short write at offset %d: wrote %d of %d bytes", off, done, len(buf))
+	}
+	// Report only the caller's requested byte count, not the padding.
+	if len(p) < int(done) {
+		return len(p), nil
 	}
 	return int(done), nil
 }

--- a/go/internal/cli/commands/disklister_windows.go
+++ b/go/internal/cli/commands/disklister_windows.go
@@ -312,12 +312,43 @@ func (ld *lockedDisk) close() {
 	flushFileBuffers := kernel32.NewProc("FlushFileBuffers")
 	flushFileBuffers.Call(uintptr(ld.handle)) //nolint:errcheck
 
-	// os.NewFile owns the HANDLE; close through diskFile to avoid double-close.
+	// Release all our locks (physical drive + volume handles) and then
+	// immediately set the disk offline. When locks are released Windows
+	// rescans the partition table and auto-assigns drive letters to every
+	// partition it finds (EFI, rootfs, recovery, etc.), flooding Explorer
+	// with phantom drives. Setting the disk offline right after prevents this.
+	//
+	// os.NewFile took ownership of the underlying Windows HANDLE (it installs
+	// a finalizer that calls CloseHandle), so we close exclusively through
+	// diskFile.Close() — calling syscall.CloseHandle separately would
+	// double-close once the finalizer ran, with undefined behavior if Windows
+	// reused the handle value.
 	if cerr := ld.diskFile.Close(); cerr != nil {
 		fmt.Fprintf(os.Stderr, "warning: closing %s: %v\n", ld.devPath, cerr)
 	}
 	ld.closeVolumeHandles()
 
+	// Remove any auto-assigned drive letters, then (for non-removable
+	// disks) take the disk offline. Set-Disk -IsOffline alone doesn't
+	// remove letters that Windows already assigned during the brief window
+	// between releasing locks and going offline.
+	//
+	// Get-Partition -ErrorAction SilentlyContinue: right after Clear-Disk the
+	// partition table re-read may not have completed and the cmdlet emits a
+	// non-terminating "no MSFT_Partition objects" error we don't want fatal.
+	// Set-Disk: no -Confirm (legacy Storage module rejects it; -IsOffline
+	// doesn't prompt) and no -ErrorAction Stop (we log exit status below).
+	//
+	// Skip Set-Disk -IsOffline for removable targets — Windows rejects it
+	// on USB / SD / MMC and on the PCIE card readers that report as SCSI
+	// but are flagged removable by looksLikeCardReader, with "Not
+	// Supported: Removable media cannot be set to offline." (WDY-1178).
+	// Gating in Go on the same drive.IsRemovable predicate used to select
+	// the install target keeps the cleanup predicate in lockstep with
+	// selection. Removing the partition access paths above is what
+	// actually prevents phantom drive letters; the offline step is only
+	// meaningful on fixed disks (where Windows would otherwise auto-mount
+	// partitions on the next rescan).
 	cleanupScript := fmt.Sprintf(
 		"Get-Partition -DiskNumber %d -ErrorAction SilentlyContinue | "+
 			"Where-Object { $_.DriveLetter } | "+
@@ -346,14 +377,24 @@ func openLockedDisk(d drive) (*lockedDisk, error) {
 		return nil, err
 	}
 
-	// Ensure the disk is online before clearing partitions.
+	// Ensure the disk is online before clearing partitions — a previous
+	// write may have left it offline. Set-Disk -IsOffline doesn't prompt, so
+	// no -Confirm switch is required (and the legacy Storage module rejects
+	// it outright).
 	onlineScript := fmt.Sprintf("Set-Disk -Number %d -IsOffline $false", diskNum)
 	_ = exec.Command(powershellExe, "-NoProfile", "-NonInteractive", "-Command", onlineScript).Run()
 
+	// Clear all partitions on the disk first. This is necessary because
+	// disks (e.g. from a prior Jetson flash) may contain many partitions
+	// without drive letters that getVolumesForDisk cannot enumerate. Those
+	// hidden volumes stay mounted and cause "Access is denied" on write.
 	if err := clearDiskPartitions(diskNum); err != nil {
 		return nil, err
 	}
 
+	// Lock and dismount any remaining lettered volumes on this disk. We
+	// must keep the volume handles open for the entire duration of the
+	// write — closing them would release the lock and let Windows re-mount.
 	letters, err := getVolumesForDisk(diskNum)
 	if err != nil {
 		return nil, fmt.Errorf("enumerating volumes: %w", err)
@@ -374,6 +415,7 @@ func openLockedDisk(d drive) (*lockedDisk, error) {
 		ld.volumeHs = append(ld.volumeHs, h)
 	}
 
+	// Open the raw physical drive for writing.
 	devPathUTF16, err := syscall.UTF16PtrFromString(d.DevicePath)
 	if err != nil {
 		ld.closeVolumeHandles()
@@ -397,7 +439,10 @@ func openLockedDisk(d drive) (*lockedDisk, error) {
 	ld.diskFile = os.NewFile(uintptr(handle), d.DevicePath)
 
 	var bytesReturned uint32
+	// Allow writes beyond the reported partition layout. Without this,
+	// Windows may reject writes that extend past existing partitions.
 	_ = syscall.DeviceIoControl(handle, fsctlAllowExtendedDASDIO, nil, 0, nil, 0, &bytesReturned, nil)
+	// Lock the physical drive itself for exclusive access.
 	_ = syscall.DeviceIoControl(handle, fsctlLockVolume, nil, 0, nil, 0, &bytesReturned, nil)
 
 	return ld, nil
@@ -415,6 +460,9 @@ func (hw handleWriterAt) WriteAt(p []byte, off int64) (int, error) {
 	var done uint32
 	if err := syscall.WriteFile(hw.h, p, &done, nil); err != nil {
 		return int(done), err
+	}
+	if int(done) < len(p) {
+		return int(done), fmt.Errorf("short write at offset %d: wrote %d of %d bytes", off, done, len(p))
 	}
 	return int(done), nil
 }

--- a/go/internal/cli/commands/disklister_windows.go
+++ b/go/internal/cli/commands/disklister_windows.go
@@ -62,6 +62,7 @@ type drive struct {
 	Size        string // human-readable size
 	SizeBytes   int64  // size in bytes
 	IsRemovable bool
+	StorageType StorageType // underlying storage protocol
 }
 
 // psDisk is the JSON structure returned by the joined Get-Disk / Get-PhysicalDisk query.
@@ -136,6 +137,10 @@ func listDrivesWindows(externalOnly bool) ([]drive, error) {
 		}
 
 		devPath := fmt.Sprintf(`\\.\PhysicalDrive%d`, d.Number)
+		storageType := StorageUnknown
+		if strings.EqualFold(d.BusType, "NVMe") {
+			storageType = StorageNVMe
+		}
 		drives = append(drives, drive{
 			DevicePath:  devPath,
 			RawPath:     devPath,
@@ -143,6 +148,7 @@ func listDrivesWindows(externalOnly bool) ([]drive, error) {
 			Size:        humanize.Bytes(uint64(d.Size)),
 			SizeBytes:   d.Size,
 			IsRemovable: external || looksLikeCardReader(d),
+			StorageType: storageType,
 		})
 	}
 

--- a/go/internal/cli/commands/disklister_windows.go
+++ b/go/internal/cli/commands/disklister_windows.go
@@ -506,6 +506,33 @@ func writeImageWithBmap(r io.Reader, totalSize int64, d drive, bmapPath string, 
 	return nil
 }
 
+// writeImageWithBmapSeekable opens the seekable source and writes only mapped
+// ranges to the locked disk handle in-process (no helper on Windows).
+func writeImageWithBmapSeekable(sourcePath, bmapPath string, d drive, progressFn func(int64)) error {
+	data, err := os.ReadFile(bmapPath)
+	if err != nil {
+		return fmt.Errorf("reading bmap: %w", err)
+	}
+	b, err := parseBmap(data)
+	if err != nil {
+		return err
+	}
+	si, err := openSeekableZstd(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer si.Close()
+	if si.Size() != b.ImageSize {
+		return fmt.Errorf("seekable image size %d != bmap image size %d", si.Size(), b.ImageSize)
+	}
+	ld, err := openLockedDisk(d)
+	if err != nil {
+		return err
+	}
+	defer ld.close()
+	return applyBmapSeekable(si, handleWriterAt{h: ld.handle}, b, progressFn)
+}
+
 func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(written int64)) error {
 	ld, err := openLockedDisk(d)
 	if err != nil {

--- a/go/internal/cli/commands/disklister_windows.go
+++ b/go/internal/cli/commands/disklister_windows.go
@@ -140,6 +140,8 @@ func listDrivesWindows(externalOnly bool) ([]drive, error) {
 		storageType := StorageUnknown
 		if strings.EqualFold(d.BusType, "NVMe") {
 			storageType = StorageNVMe
+		} else if strings.EqualFold(d.BusType, "USB") {
+			storageType = StorageUSB
 		}
 		drives = append(drives, drive{
 			DevicePath:  devPath,

--- a/go/internal/cli/commands/disklister_windows.go
+++ b/go/internal/cli/commands/disklister_windows.go
@@ -284,56 +284,100 @@ func clearDiskPartitions(diskNum int) error {
 	return nil
 }
 
-func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(written int64)) error {
+// lockedDisk holds the resources acquired to write to a physical drive on
+// Windows. Call close() when done to flush, release locks, and set the disk
+// offline.
+type lockedDisk struct {
+	handle      syscall.Handle
+	diskFile    *os.File
+	volumeHs    []syscall.Handle
+	diskNum     int
+	isRemovable bool
+	devPath     string
+}
+
+func (ld *lockedDisk) closeVolumeHandles() {
+	for _, h := range ld.volumeHs {
+		syscall.CloseHandle(h)
+	}
+	ld.volumeHs = nil
+}
+
+// close flushes file buffers, releases all locks, and sets the disk offline
+// (for non-removable disks). Mirrors the cleanup sequence at the end of the
+// original writeImageToDisk.
+func (ld *lockedDisk) close() {
+	// Flush the file buffers.
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	flushFileBuffers := kernel32.NewProc("FlushFileBuffers")
+	flushFileBuffers.Call(uintptr(ld.handle)) //nolint:errcheck
+
+	// os.NewFile owns the HANDLE; close through diskFile to avoid double-close.
+	if cerr := ld.diskFile.Close(); cerr != nil {
+		fmt.Fprintf(os.Stderr, "warning: closing %s: %v\n", ld.devPath, cerr)
+	}
+	ld.closeVolumeHandles()
+
+	cleanupScript := fmt.Sprintf(
+		"Get-Partition -DiskNumber %d -ErrorAction SilentlyContinue | "+
+			"Where-Object { $_.DriveLetter } | "+
+			"ForEach-Object { Remove-PartitionAccessPath -DiskNumber $_.DiskNumber -PartitionNumber $_.PartitionNumber -AccessPath \"$($_.DriveLetter):\\\" -ErrorAction SilentlyContinue }",
+		ld.diskNum,
+	)
+	if !ld.isRemovable {
+		cleanupScript += fmt.Sprintf("; Set-Disk -Number %d -IsOffline $true", ld.diskNum)
+	}
+	if output, err := exec.Command(powershellExe, "-NoProfile", "-NonInteractive", "-Command", cleanupScript).CombinedOutput(); err != nil {
+		msg := strings.TrimSpace(string(output))
+		if msg != "" {
+			fmt.Fprintf(os.Stderr, "warning: failed to set disk %d offline: %v: %s\n", ld.diskNum, err, msg)
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: failed to set disk %d offline: %v\n", ld.diskNum, err)
+		}
+	}
+}
+
+// openLockedDisk brings d online, clears its partitions, locks any lettered
+// volumes, opens the raw physical drive handle, and applies the DASD / lock
+// IOCTLs. The caller must call close() on the returned lockedDisk.
+func openLockedDisk(d drive) (*lockedDisk, error) {
 	diskNum, err := parseDiskNumber(d.DevicePath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// Ensure the disk is online before clearing partitions — a previous
-	// write may have left it offline. Set-Disk -IsOffline doesn't prompt, so
-	// no -Confirm switch is required (and the legacy Storage module rejects
-	// it outright).
+	// Ensure the disk is online before clearing partitions.
 	onlineScript := fmt.Sprintf("Set-Disk -Number %d -IsOffline $false", diskNum)
 	_ = exec.Command(powershellExe, "-NoProfile", "-NonInteractive", "-Command", onlineScript).Run()
 
-	// Clear all partitions on the disk first. This is necessary because
-	// disks (e.g. from a prior Jetson flash) may contain many partitions
-	// without drive letters that getVolumesForDisk cannot enumerate. Those
-	// hidden volumes stay mounted and cause "Access is denied" on write.
 	if err := clearDiskPartitions(diskNum); err != nil {
-		return err
+		return nil, err
 	}
 
-	// Lock and dismount any remaining lettered volumes on this disk. We
-	// must keep the volume handles open for the entire duration of the
-	// write — closing them would release the lock and let Windows re-mount.
 	letters, err := getVolumesForDisk(diskNum)
 	if err != nil {
-		return fmt.Errorf("enumerating volumes: %w", err)
+		return nil, fmt.Errorf("enumerating volumes: %w", err)
 	}
 
-	var volumeHandles []syscall.Handle
-	closeAllHandles := func() {
-		for _, h := range volumeHandles {
-			syscall.CloseHandle(h)
-		}
-		volumeHandles = nil
+	ld := &lockedDisk{
+		diskNum:     diskNum,
+		isRemovable: d.IsRemovable,
+		devPath:     d.DevicePath,
 	}
-	defer closeAllHandles()
 
 	for _, letter := range letters {
 		h, err := lockAndDismountVolume(letter)
 		if err != nil {
-			return fmt.Errorf("preparing volume %s: %w", letter, err)
+			ld.closeVolumeHandles()
+			return nil, fmt.Errorf("preparing volume %s: %w", letter, err)
 		}
-		volumeHandles = append(volumeHandles, h)
+		ld.volumeHs = append(ld.volumeHs, h)
 	}
 
-	// Open the raw physical drive for writing.
 	devPathUTF16, err := syscall.UTF16PtrFromString(d.DevicePath)
 	if err != nil {
-		return fmt.Errorf("encoding device path: %w", err)
+		ld.closeVolumeHandles()
+		return nil, fmt.Errorf("encoding device path: %w", err)
 	}
 
 	handle, err := syscall.CreateFile(
@@ -346,18 +390,67 @@ func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(wri
 		0,
 	)
 	if err != nil {
-		return fmt.Errorf("opening %s for writing (are you running as Administrator?): %w", d.DevicePath, err)
+		ld.closeVolumeHandles()
+		return nil, fmt.Errorf("opening %s for writing (are you running as Administrator?): %w", d.DevicePath, err)
 	}
+	ld.handle = handle
+	ld.diskFile = os.NewFile(uintptr(handle), d.DevicePath)
 
-	// Allow writes beyond the reported partition layout. Without this,
-	// Windows may reject writes that extend past existing partitions.
 	var bytesReturned uint32
 	_ = syscall.DeviceIoControl(handle, fsctlAllowExtendedDASDIO, nil, 0, nil, 0, &bytesReturned, nil)
-
-	// Lock the physical drive itself for exclusive access.
 	_ = syscall.DeviceIoControl(handle, fsctlLockVolume, nil, 0, nil, 0, &bytesReturned, nil)
 
-	diskFile := os.NewFile(uintptr(handle), d.DevicePath)
+	return ld, nil
+}
+
+// handleWriterAt adapts a Windows disk handle to io.WriterAt by seeking to off
+// then writing. applyBmap calls WriteAt sequentially, so the shared file
+// pointer is safe.
+type handleWriterAt struct{ h syscall.Handle }
+
+func (hw handleWriterAt) WriteAt(p []byte, off int64) (int, error) {
+	if _, err := syscall.Seek(hw.h, off, 0 /* FILE_BEGIN */); err != nil {
+		return 0, err
+	}
+	var done uint32
+	if err := syscall.WriteFile(hw.h, p, &done, nil); err != nil {
+		return int(done), err
+	}
+	return int(done), nil
+}
+
+// writeImageWithBmap flashes the image to d using the block map. It acquires
+// the same locked disk handle as writeImageToDisk and calls applyBmap to write
+// only the mapped ranges. progress is driven directly by applyBmap.
+func writeImageWithBmap(r io.Reader, totalSize int64, d drive, bmapPath string, progressFn func(written int64)) error {
+	data, err := os.ReadFile(bmapPath)
+	if err != nil {
+		return fmt.Errorf("reading bmap: %w", err)
+	}
+	b, err := parseBmap(data)
+	if err != nil {
+		return err
+	}
+
+	ld, err := openLockedDisk(d)
+	if err != nil {
+		return err
+	}
+	defer ld.close()
+
+	if err := applyBmap(r, handleWriterAt{h: ld.handle}, b, progressFn); err != nil {
+		return err
+	}
+	_ = totalSize
+	return nil
+}
+
+func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(written int64)) error {
+	ld, err := openLockedDisk(d)
+	if err != nil {
+		return err
+	}
+	defer ld.close()
 
 	buf := make([]byte, 4*1024*1024) // 4 MiB
 	var totalWritten int64
@@ -374,7 +467,7 @@ func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(wri
 					buf[i] = 0
 				}
 			}
-			if _, writeErr := diskFile.Write(buf[:writeLen]); writeErr != nil {
+			if _, writeErr := ld.diskFile.Write(buf[:writeLen]); writeErr != nil {
 				return fmt.Errorf("writing to disk: %w", writeErr)
 			}
 			totalWritten += int64(n)
@@ -387,66 +480,6 @@ func writeImageToDisk(r io.Reader, totalSize int64, d drive, progressFn func(wri
 		}
 		if readErr != nil {
 			return fmt.Errorf("reading image: %w", readErr)
-		}
-	}
-
-	// Flush the file buffers.
-	kernel32 := syscall.NewLazyDLL("kernel32.dll")
-	flushFileBuffers := kernel32.NewProc("FlushFileBuffers")
-	flushFileBuffers.Call(uintptr(handle)) //nolint:errcheck
-
-	// Release all our locks (physical drive + volume handles) and then
-	// immediately set the disk offline. When locks are released Windows
-	// rescans the partition table and auto-assigns drive letters to every
-	// partition it finds (EFI, rootfs, recovery, etc.), flooding Explorer
-	// with phantom drives. Setting the disk offline right after prevents this.
-	//
-	// os.NewFile took ownership of the underlying Windows HANDLE (it installs
-	// a finalizer that calls CloseHandle), so we close exclusively through
-	// diskFile.Close() — calling syscall.CloseHandle separately would
-	// double-close once the finalizer ran, with undefined behavior if Windows
-	// reused the handle value.
-	if cerr := diskFile.Close(); cerr != nil {
-		fmt.Fprintf(os.Stderr, "warning: closing %s: %v\n", d.DevicePath, cerr)
-	}
-	closeAllHandles()
-
-	// Remove any auto-assigned drive letters, then (for non-removable
-	// disks) take the disk offline. Set-Disk -IsOffline alone doesn't
-	// remove letters that Windows already assigned during the brief window
-	// between releasing locks and going offline.
-	//
-	// Get-Partition -ErrorAction SilentlyContinue: right after Clear-Disk the
-	// partition table re-read may not have completed and the cmdlet emits a
-	// non-terminating "no MSFT_Partition objects" error we don't want fatal.
-	// Set-Disk: no -Confirm (legacy Storage module rejects it; -IsOffline
-	// doesn't prompt) and no -ErrorAction Stop (we log exit status below).
-	//
-	// Skip Set-Disk -IsOffline for removable targets — Windows rejects it
-	// on USB / SD / MMC and on the PCIE card readers that report as SCSI
-	// but are flagged removable by looksLikeCardReader, with "Not
-	// Supported: Removable media cannot be set to offline." (WDY-1178).
-	// Gating in Go on the same drive.IsRemovable predicate used to select
-	// the install target keeps the cleanup predicate in lockstep with
-	// selection. Removing the partition access paths above is what
-	// actually prevents phantom drive letters; the offline step is only
-	// meaningful on fixed disks (where Windows would otherwise auto-mount
-	// partitions on the next rescan).
-	cleanupScript := fmt.Sprintf(
-		"Get-Partition -DiskNumber %d -ErrorAction SilentlyContinue | "+
-			"Where-Object { $_.DriveLetter } | "+
-			"ForEach-Object { Remove-PartitionAccessPath -DiskNumber $_.DiskNumber -PartitionNumber $_.PartitionNumber -AccessPath \"$($_.DriveLetter):\\\" -ErrorAction SilentlyContinue }",
-		diskNum,
-	)
-	if !d.IsRemovable {
-		cleanupScript += fmt.Sprintf("; Set-Disk -Number %d -IsOffline $true", diskNum)
-	}
-	if output, err := exec.Command(powershellExe, "-NoProfile", "-NonInteractive", "-Command", cleanupScript).CombinedOutput(); err != nil {
-		msg := strings.TrimSpace(string(output))
-		if msg != "" {
-			fmt.Fprintf(os.Stderr, "warning: failed to set disk %d offline: %v: %s\n", diskNum, err, msg)
-		} else {
-			fmt.Fprintf(os.Stderr, "warning: failed to set disk %d offline: %v\n", diskNum, err)
 		}
 	}
 

--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -45,6 +45,28 @@ type deviceVersion struct {
 	NVMEOTAUpdateChecksum  string `json:"nvme_ota_update_checksum"`
 	NVMEOTAUpdateSizeBytes int64  `json:"nvme_ota_update_size_bytes"`
 	BmapPath               string `json:"bmap_path"`
+
+	ZstPath      string `json:"zst_path"`
+	ZstChecksum  string `json:"zst_checksum"`
+	ZstSizeBytes int64  `json:"zst_size_bytes"`
+
+	// Storage-keyed image+bmap+zst triples (NVMe).
+	NVMEPath         string `json:"nvme_path"`
+	NVMEChecksum     string `json:"nvme_checksum"`
+	NVMESizeBytes    int64  `json:"nvme_size_bytes"`
+	NVMEBmapPath     string `json:"nvme_bmap_path"`
+	NVMEZstPath      string `json:"nvme_zst_path"`
+	NVMEZstChecksum  string `json:"nvme_zst_checksum"`
+	NVMEZstSizeBytes int64  `json:"nvme_zst_size_bytes"`
+
+	// Storage-keyed image+bmap+zst triples (SD / removable card; the default).
+	SDPath         string `json:"sd_path"`
+	SDChecksum     string `json:"sd_checksum"`
+	SDSizeBytes    int64  `json:"sd_size_bytes"`
+	SDBmapPath     string `json:"sd_bmap_path"`
+	SDZstPath      string `json:"sd_zst_path"`
+	SDZstChecksum  string `json:"sd_zst_checksum"`
+	SDZstSizeBytes int64  `json:"sd_zst_size_bytes"`
 }
 
 // deviceInfo is the aggregated info shown in the picker for one device.
@@ -63,6 +85,7 @@ type imageInfo struct {
 	ImageSize   int64
 	Version     string
 	BmapURL     string
+	ZstURL      string
 }
 
 func fetchMainManifest() (*mainManifest, error) {
@@ -147,21 +170,52 @@ func getAvailableDevices() ([]deviceInfo, error) {
 	return devices, nil
 }
 
-func getImageInfo(dm *deviceManifest, ver string) (*imageInfo, error) {
+// imageTriple is the resolved (image, bmap, zst) path set for one storage.
+type imageTriple struct {
+	imagePath string
+	imageSize int64
+	bmapPath  string
+	zstPath   string
+}
+
+// getImageInfo resolves the download URLs for ver on dm, preferring the triple
+// matching storage ("nvme" or "sd") and falling back to the legacy fields when
+// that storage has no dedicated artifacts. Keeping image+bmap+zst from one
+// triple guarantees they describe the same image (no cross-storage mismatch).
+func getImageInfo(dm *deviceManifest, ver, storage string) (*imageInfo, error) {
 	v, ok := dm.Versions[ver]
 	if !ok {
 		return nil, fmt.Errorf("version %s not found in device manifest", ver)
 	}
+	t := resolveTriple(v, storage)
 
 	info := &imageInfo{
-		DownloadURL: gcsBaseURL + "/" + v.Path,
-		ImageSize:   v.SizeBytes,
+		DownloadURL: gcsBaseURL + "/" + t.imagePath,
+		ImageSize:   t.imageSize,
 		Version:     ver,
 	}
-	if v.BmapPath != "" {
-		info.BmapURL = gcsBaseURL + "/" + v.BmapPath
+	if t.bmapPath != "" {
+		info.BmapURL = gcsBaseURL + "/" + t.bmapPath
+	}
+	if t.zstPath != "" {
+		info.ZstURL = gcsBaseURL + "/" + t.zstPath
 	}
 	return info, nil
+}
+
+func resolveTriple(v deviceVersion, storage string) imageTriple {
+	switch storage {
+	case "nvme":
+		if v.NVMEPath != "" {
+			return imageTriple{v.NVMEPath, v.NVMESizeBytes, v.NVMEBmapPath, v.NVMEZstPath}
+		}
+	case "sd":
+		if v.SDPath != "" {
+			return imageTriple{v.SDPath, v.SDSizeBytes, v.SDBmapPath, v.SDZstPath}
+		}
+	}
+	// Legacy fallback.
+	return imageTriple{v.Path, v.SizeBytes, v.BmapPath, v.ZstPath}
 }
 
 func getOTAUpdateURL(dm *deviceManifest, ver string, storageMedium string) (string, error) {

--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -44,6 +44,7 @@ type deviceVersion struct {
 	NVMEOTAUpdatePath      string `json:"nvme_ota_update_path"`
 	NVMEOTAUpdateChecksum  string `json:"nvme_ota_update_checksum"`
 	NVMEOTAUpdateSizeBytes int64  `json:"nvme_ota_update_size_bytes"`
+	BmapPath               string `json:"bmap_path"`
 }
 
 // deviceInfo is the aggregated info shown in the picker for one device.
@@ -61,6 +62,7 @@ type imageInfo struct {
 	DownloadURL string
 	ImageSize   int64
 	Version     string
+	BmapURL     string
 }
 
 func fetchMainManifest() (*mainManifest, error) {
@@ -151,11 +153,15 @@ func getImageInfo(dm *deviceManifest, ver string) (*imageInfo, error) {
 		return nil, fmt.Errorf("version %s not found in device manifest", ver)
 	}
 
-	return &imageInfo{
+	info := &imageInfo{
 		DownloadURL: gcsBaseURL + "/" + v.Path,
 		ImageSize:   v.SizeBytes,
 		Version:     ver,
-	}, nil
+	}
+	if v.BmapPath != "" {
+		info.BmapURL = gcsBaseURL + "/" + v.BmapPath
+	}
+	return info, nil
 }
 
 func getOTAUpdateURL(dm *deviceManifest, ver string, storageMedium string) (string, error) {

--- a/go/internal/cli/commands/manifest_bmap_test.go
+++ b/go/internal/cli/commands/manifest_bmap_test.go
@@ -21,7 +21,7 @@ func TestGetImageInfoResolvesBmapURL(t *testing.T) {
 	if err := json.Unmarshal([]byte(body), &dm); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	info, err := getImageInfo(&dm, "0.11.0")
+	info, err := getImageInfo(&dm, "0.11.0", "")
 	if err != nil {
 		t.Fatalf("getImageInfo: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestGetImageInfoNoBmap(t *testing.T) {
 	dm := deviceManifest{Versions: map[string]deviceVersion{
 		"1.0.0": {Path: "p/x.img", SizeBytes: 1},
 	}}
-	info, err := getImageInfo(&dm, "1.0.0")
+	info, err := getImageInfo(&dm, "1.0.0", "")
 	if err != nil {
 		t.Fatalf("getImageInfo: %v", err)
 	}

--- a/go/internal/cli/commands/manifest_bmap_test.go
+++ b/go/internal/cli/commands/manifest_bmap_test.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGetImageInfoResolvesBmapURL(t *testing.T) {
+	const body = `{
+		"device_id": "raspberry-pi-5",
+		"versions": {
+			"0.11.0": {
+				"path": "images/rpi5/0.11.0/wendyos.img.gz",
+				"size_bytes": 123,
+				"checksum": "abc",
+				"bmap_path": "images/rpi5/0.11.0/wendyos.img.bmap"
+			}
+		}
+	}`
+	var dm deviceManifest
+	if err := json.Unmarshal([]byte(body), &dm); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	info, err := getImageInfo(&dm, "0.11.0")
+	if err != nil {
+		t.Fatalf("getImageInfo: %v", err)
+	}
+	want := gcsBaseURL + "/images/rpi5/0.11.0/wendyos.img.bmap"
+	if info.BmapURL != want {
+		t.Fatalf("BmapURL = %q, want %q", info.BmapURL, want)
+	}
+}
+
+func TestGetImageInfoNoBmap(t *testing.T) {
+	dm := deviceManifest{Versions: map[string]deviceVersion{
+		"1.0.0": {Path: "p/x.img", SizeBytes: 1},
+	}}
+	info, err := getImageInfo(&dm, "1.0.0")
+	if err != nil {
+		t.Fatalf("getImageInfo: %v", err)
+	}
+	if info.BmapURL != "" {
+		t.Fatalf("BmapURL = %q, want empty", info.BmapURL)
+	}
+}

--- a/go/internal/cli/commands/manifest_test.go
+++ b/go/internal/cli/commands/manifest_test.go
@@ -1,0 +1,62 @@
+package commands
+
+import "testing"
+
+func newTestManifest() *deviceManifest {
+	return &deviceManifest{
+		DeviceID: "jetson-orin-nano",
+		Versions: map[string]deviceVersion{
+			"1.0.0": {
+				// legacy fields (clobbered in the wild) point at SD
+				Path: "img/sd.img.zip", BmapPath: "img/sd.bmap",
+				// storage-keyed triples
+				NVMEPath: "img/nvme.img.zip", NVMEBmapPath: "img/nvme.bmap",
+				NVMEZstPath: "img/nvme.img.zst", NVMEZstSizeBytes: 111,
+				SDPath: "img/sd.img.zip", SDBmapPath: "img/sd.bmap",
+				SDZstPath: "img/sd.img.zst", SDZstSizeBytes: 222,
+			},
+		},
+	}
+}
+
+func TestGetImageInfoNVMePicksNVMeTriple(t *testing.T) {
+	info, err := getImageInfo(newTestManifest(), "1.0.0", "nvme")
+	if err != nil {
+		t.Fatalf("getImageInfo: %v", err)
+	}
+	if info.DownloadURL != gcsBaseURL+"/img/nvme.img.zip" {
+		t.Errorf("DownloadURL = %q", info.DownloadURL)
+	}
+	if info.BmapURL != gcsBaseURL+"/img/nvme.bmap" {
+		t.Errorf("BmapURL = %q", info.BmapURL)
+	}
+	if info.ZstURL != gcsBaseURL+"/img/nvme.img.zst" {
+		t.Errorf("ZstURL = %q", info.ZstURL)
+	}
+}
+
+func TestGetImageInfoSDPicksSDTriple(t *testing.T) {
+	info, err := getImageInfo(newTestManifest(), "1.0.0", "sd")
+	if err != nil {
+		t.Fatalf("getImageInfo: %v", err)
+	}
+	if info.ZstURL != gcsBaseURL+"/img/sd.img.zst" || info.BmapURL != gcsBaseURL+"/img/sd.bmap" {
+		t.Errorf("SD triple not selected: %+v", info)
+	}
+}
+
+func TestGetImageInfoFallsBackToLegacy(t *testing.T) {
+	dm := &deviceManifest{Versions: map[string]deviceVersion{
+		"1.0.0": {Path: "img/legacy.img.zip", BmapPath: "img/legacy.bmap"},
+	}}
+	info, err := getImageInfo(dm, "1.0.0", "nvme")
+	if err != nil {
+		t.Fatalf("getImageInfo: %v", err)
+	}
+	if info.DownloadURL != gcsBaseURL+"/img/legacy.img.zip" || info.BmapURL != gcsBaseURL+"/img/legacy.bmap" {
+		t.Errorf("legacy fallback not used: %+v", info)
+	}
+	if info.ZstURL != "" {
+		t.Errorf("ZstURL should be empty when no zst published, got %q", info.ZstURL)
+	}
+}

--- a/go/internal/cli/commands/os_download.go
+++ b/go/internal/cli/commands/os_download.go
@@ -45,7 +45,7 @@ func runOSDownload(flagVersion string, overwrite bool) error {
 	}
 
 	// Validate version exists in manifest before touching the filesystem.
-	imgInfo, err := getImageInfo(dev.Manifest, version)
+	imgInfo, err := getImageInfo(dev.Manifest, version, "")
 	if err != nil {
 		return fmt.Errorf("getting image info: %w", err)
 	}

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -456,14 +456,19 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	if !noBmap && imgInfo.ZstURL != "" && imgInfo.BmapURL != "" {
 		zstPath, zerr := resolveSeekableZst(deviceKey, selectedVersion, imgInfo.ZstURL)
 		bmapCandidate, berr := osCachedBmapPath(deviceKey, selectedVersion)
-		if zerr == nil && berr == nil && downloadBmap(imgInfo.BmapURL, bmapCandidate) == nil {
-			if parsed, perr := parseBmap(readFileOrNil(bmapCandidate)); perr == nil {
-				seekableZst, seekableBmap, seekableTotal = zstPath, bmapCandidate, mappedBytes(parsed)
-			} else {
-				fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
-			}
-		} else if zerr != nil {
+		switch {
+		case zerr != nil:
 			fmt.Printf("Note: could not fetch seekable image (%v); flashing the full image.\n", zerr)
+		case berr != nil:
+			fmt.Printf("Note: cannot resolve block-map cache path (%v); flashing the full image.\n", berr)
+		default:
+			if derr := downloadBmap(imgInfo.BmapURL, bmapCandidate); derr != nil {
+				fmt.Printf("Note: could not fetch block map (%v); flashing the full image.\n", derr)
+			} else if parsed, perr := parseBmap(readFileOrNil(bmapCandidate)); perr != nil {
+				fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
+			} else {
+				seekableZst, seekableBmap, seekableTotal = zstPath, bmapCandidate, mappedBytes(parsed)
+			}
 		}
 	}
 
@@ -516,8 +521,12 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		case seekableZst != "":
 			fmt.Println("Using seekable block map for faster flashing.")
 			writeErr = writeImageWithBmapSeekable(seekableZst, seekableBmap, targetDrive, func(written int64) {
+				var pct float64
+				if seekableTotal > 0 {
+					pct = float64(written) / float64(seekableTotal)
+				}
 				wp.Send(tui.ProgressUpdateMsg{
-					Percent: float64(written) / float64(seekableTotal),
+					Percent: pct,
 					Written: written,
 					Total:   seekableTotal,
 				})

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -475,8 +475,18 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 			fmt.Printf("Note: cannot resolve block-map cache path (%v); flashing the full image.\n", derr)
 		} else if derr := downloadBmap(imgInfo.BmapURL, candidate); derr != nil {
 			fmt.Printf("Note: could not fetch block map (%v); flashing the full image.\n", derr)
-		} else if _, perr := parseBmap(readFileOrNil(candidate)); perr != nil {
+		} else if parsed, perr := parseBmap(readFileOrNil(candidate)); perr != nil {
 			fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
+		} else if stream.uncompressedSize > 0 && parsed.ImageSize != stream.uncompressedSize {
+			// The manifest can advertise a bmap that does not describe this
+			// image. Multi-storage Jetson builds (e.g. orin-nano) publish both
+			// an NVMe and an SD image but share a single bmap_path: the SD
+			// publish runs last and overwrites it, while `path` stays the NVMe
+			// image. Flashing the NVMe image against the SD block map fails
+			// per-range checksum verification on the very first block. The bmap
+			// records the full image size, so a size mismatch is a cheap, sure
+			// signal that the map is for a different image — fall back to dd.
+			fmt.Printf("Note: block map is for a %d-byte image but this image is %d bytes; flashing the full image.\n", parsed.ImageSize, stream.uncompressedSize)
 		} else {
 			bmapPath = candidate
 		}

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -440,55 +440,68 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		}
 	}
 
-	// Step 5: Resolve image (cached or download) and open streaming reader.
+	// Step 5: Resolve image metadata for the target storage.
 	fmt.Printf("\nPreparing %s %s image...\n", device.Name, selectedVersion)
-	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, "")
+	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, manifestStorage(targetDrive))
 	if err != nil {
 		return fmt.Errorf("getting image info: %w", err)
 	}
 
-	stream, err := openOSImageStream(deviceKey, imgInfo)
-	if err != nil {
-		return fmt.Errorf("opening OS image: %w", err)
-	}
-	defer stream.Close()
-
-	// One-time sizing pass for compressed images that cannot report their
-	// decompressed size (gzip). Without it the write bar has no usable total.
-	// The result is cached in a sidecar, so this only runs on the first flash
-	// of a given image. Failure is non-fatal: the bar falls back to
-	// compressed-consumption progress.
-	if stream.uncompressedSize == 0 && stream.sourcePath != "" {
-		if err := measureImageWithProgress(stream); err != nil {
-			if errors.Is(err, context.Canceled) {
-				return err
+	// Step 5a: Prefer the seekable-zstd fast path. When the manifest advertises a
+	// .zst for this storage plus a usable bmap (and --no-bmap wasn't passed), we
+	// download only the .zst + bmap and write mapped ranges, skipping holes —
+	// and crucially we do NOT download the full .zip image at all.
+	var seekableZst, seekableBmap string
+	var seekableTotal int64
+	if !noBmap && imgInfo.ZstURL != "" && imgInfo.BmapURL != "" {
+		zstPath, zerr := resolveSeekableZst(deviceKey, selectedVersion, imgInfo.ZstURL)
+		bmapCandidate, berr := osCachedBmapPath(deviceKey, selectedVersion)
+		if zerr == nil && berr == nil && downloadBmap(imgInfo.BmapURL, bmapCandidate) == nil {
+			if parsed, perr := parseBmap(readFileOrNil(bmapCandidate)); perr == nil {
+				seekableZst, seekableBmap, seekableTotal = zstPath, bmapCandidate, mappedBytes(parsed)
+			} else {
+				fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
 			}
-			fmt.Printf("Could not determine image size: %v\n", err)
+		} else if zerr != nil {
+			fmt.Printf("Note: could not fetch seekable image (%v); flashing the full image.\n", zerr)
 		}
 	}
 
-	// Step 5b: Download and validate block map for accelerated flashing.
+	// Step 5b: Fallback path — resolve the .zip/.img stream only when NOT using
+	// the seekable path (so the seekable path never downloads the .zip). For
+	// compressed images, measure the size (skipped when a bmap is present, since
+	// the bmap's ImageSize is the exact total) and prepare the legacy block map.
+	var stream *imageStream
 	var bmapPath string
-	if !noBmap && imgInfo.BmapURL != "" {
-		candidate, derr := osCachedBmapPath(deviceKey, selectedVersion)
-		if derr != nil {
-			fmt.Printf("Note: cannot resolve block-map cache path (%v); flashing the full image.\n", derr)
-		} else if derr := downloadBmap(imgInfo.BmapURL, candidate); derr != nil {
-			fmt.Printf("Note: could not fetch block map (%v); flashing the full image.\n", derr)
-		} else if parsed, perr := parseBmap(readFileOrNil(candidate)); perr != nil {
-			fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
-		} else if stream.uncompressedSize > 0 && parsed.ImageSize != stream.uncompressedSize {
-			// The manifest can advertise a bmap that does not describe this
-			// image. Multi-storage Jetson builds (e.g. orin-nano) publish both
-			// an NVMe and an SD image but share a single bmap_path: the SD
-			// publish runs last and overwrites it, while `path` stays the NVMe
-			// image. Flashing the NVMe image against the SD block map fails
-			// per-range checksum verification on the very first block. The bmap
-			// records the full image size, so a size mismatch is a cheap, sure
-			// signal that the map is for a different image — fall back to dd.
-			fmt.Printf("Note: block map is for a %d-byte image but this image is %d bytes; flashing the full image.\n", parsed.ImageSize, stream.uncompressedSize)
-		} else {
-			bmapPath = candidate
+	if seekableZst == "" {
+		stream, err = openOSImageStream(deviceKey, imgInfo)
+		if err != nil {
+			return fmt.Errorf("opening OS image: %w", err)
+		}
+		defer stream.Close()
+
+		if stream.uncompressedSize == 0 && stream.sourcePath != "" && imgInfo.BmapURL == "" {
+			if err := measureImageWithProgress(stream); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return err
+				}
+				fmt.Printf("Could not determine image size: %v\n", err)
+			}
+		}
+
+		if !noBmap && imgInfo.BmapURL != "" {
+			candidate, derr := osCachedBmapPath(deviceKey, selectedVersion)
+			if derr != nil {
+				fmt.Printf("Note: cannot resolve block-map cache path (%v); flashing the full image.\n", derr)
+			} else if derr := downloadBmap(imgInfo.BmapURL, candidate); derr != nil {
+				fmt.Printf("Note: could not fetch block map (%v); flashing the full image.\n", derr)
+			} else if parsed, perr := parseBmap(readFileOrNil(candidate)); perr != nil {
+				fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
+			} else if stream.uncompressedSize > 0 && parsed.ImageSize != stream.uncompressedSize {
+				fmt.Printf("Note: block map is for a %d-byte image but this image is %d bytes; flashing the full image.\n", parsed.ImageSize, stream.uncompressedSize)
+			} else {
+				bmapPath = candidate
+			}
 		}
 	}
 
@@ -499,14 +512,24 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 
 	go func() {
 		var writeErr error
-		if bmapPath != "" {
+		switch {
+		case seekableZst != "":
+			fmt.Println("Using seekable block map for faster flashing.")
+			writeErr = writeImageWithBmapSeekable(seekableZst, seekableBmap, targetDrive, func(written int64) {
+				wp.Send(tui.ProgressUpdateMsg{
+					Percent: float64(written) / float64(seekableTotal),
+					Written: written,
+					Total:   seekableTotal,
+				})
+			})
+		case bmapPath != "":
 			fmt.Println("Using block map for faster flashing.")
 			writeErr = writeImageWithBmap(stream, stream.uncompressedSize, targetDrive, bmapPath, func(written int64) {
 				if msg, ok := stream.writeProgressMsg(written); ok {
 					wp.Send(msg)
 				}
 			})
-		} else {
+		default:
 			writeErr = writeImageToDisk(stream, stream.uncompressedSize, targetDrive, func(written int64) {
 				if msg, ok := stream.writeProgressMsg(written); ok {
 					wp.Send(msg)
@@ -911,6 +934,52 @@ func osCachedBmapPath(deviceKey, version string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, fmt.Sprintf("%s-%s.bmap", safeDevice, safeVersion)), nil
+}
+
+// manifestStorage maps a target drive's protocol to the manifest storage key.
+func manifestStorage(d drive) string {
+	if d.StorageType == StorageNVMe {
+		return "nvme"
+	}
+	return "sd"
+}
+
+func osCachedZstPath(deviceKey, version string) (string, error) {
+	safeDevice := filepath.Base(deviceKey)
+	safeVersion := filepath.Base(version)
+	if safeDevice != deviceKey || safeVersion != version ||
+		strings.Contains(deviceKey, "..") || strings.Contains(version, "..") {
+		return "", fmt.Errorf("invalid device key or version: %q / %q", deviceKey, version)
+	}
+	dir, err := osCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s-%s.img.zst", safeDevice, safeVersion)), nil
+}
+
+// resolveSeekableZst downloads (or cache-hits) the seekable .img.zst for
+// deviceKey+version from zstURL, returning the cached path. Reuses downloadImage
+// (streams to a temp file with progress) then renames into the cache.
+func resolveSeekableZst(deviceKey, version, zstURL string) (string, error) {
+	cached, err := osCachedZstPath(deviceKey, version)
+	if err != nil {
+		return "", err
+	}
+	if info, statErr := os.Stat(cached); statErr == nil && info.Size() > 0 {
+		fmt.Printf("Using cached seekable image (%s)\n", cached)
+		return cached, nil
+	}
+	downloadPath, err := downloadImage(&imageInfo{DownloadURL: zstURL, Version: version})
+	if err != nil {
+		return "", fmt.Errorf("downloading seekable image: %w", err)
+	}
+	os.Remove(cached) // clear stale/0-byte so Rename succeeds on Windows
+	if err := os.Rename(downloadPath, cached); err != nil {
+		os.Remove(downloadPath)
+		return "", fmt.Errorf("caching seekable image: %w", err)
+	}
+	return cached, nil
 }
 
 type zipReadCloser struct {

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -470,15 +470,15 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	// Step 5b: Download and validate block map for accelerated flashing.
 	var bmapPath string
 	if !noBmap && imgInfo.BmapURL != "" {
-		if cacheDir, derr := osCacheDir(); derr == nil {
-			candidate := filepath.Join(cacheDir, fmt.Sprintf("%s-%s.bmap", deviceKey, selectedVersion))
-			if derr := downloadBmap(imgInfo.BmapURL, candidate); derr != nil {
-				fmt.Printf("Note: could not fetch block map (%v); flashing the full image.\n", derr)
-			} else if _, perr := parseBmap(readFileOrNil(candidate)); perr != nil {
-				fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
-			} else {
-				bmapPath = candidate
-			}
+		candidate, derr := osCachedBmapPath(deviceKey, selectedVersion)
+		if derr != nil {
+			fmt.Printf("Note: cannot resolve block-map cache path (%v); flashing the full image.\n", derr)
+		} else if derr := downloadBmap(imgInfo.BmapURL, candidate); derr != nil {
+			fmt.Printf("Note: could not fetch block map (%v); flashing the full image.\n", derr)
+		} else if _, perr := parseBmap(readFileOrNil(candidate)); perr != nil {
+			fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
+		} else {
+			bmapPath = candidate
 		}
 	}
 
@@ -886,6 +886,21 @@ func osCachedZipPath(deviceKey, version string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, fmt.Sprintf("%s-%s.zip", safeDevice, safeVersion)), nil
+}
+
+func osCachedBmapPath(deviceKey, version string) (string, error) {
+	safeDevice := filepath.Base(deviceKey)
+	safeVersion := filepath.Base(version)
+	if safeDevice != deviceKey || safeVersion != version ||
+		strings.Contains(deviceKey, "..") || strings.Contains(version, "..") {
+		return "", fmt.Errorf("invalid device key or version: %q / %q", deviceKey, version)
+	}
+
+	dir, err := osCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s-%s.bmap", safeDevice, safeVersion)), nil
 }
 
 type zipReadCloser struct {

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -42,6 +42,7 @@ const (
 func newOSInstallCmd() *cobra.Command {
 	var nightly bool
 	var force bool
+	var noBmap bool
 	var yesOverwriteInternal bool
 	var preEnroll bool
 	var deviceType string
@@ -109,12 +110,13 @@ Flags can be provided progressively — omitted values trigger interactive picke
 					mode = preEnrollSkip
 				}
 			}
-			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, opts, deviceName, preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC})
+			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, noBmap, opts, deviceName, preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC})
 		},
 	}
 
 	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use nightly/prerelease builds")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&noBmap, "no-bmap", false, "Disable bmap-accelerated flashing even when a block map is available")
 	cmd.Flags().BoolVar(&yesOverwriteInternal, "yes-overwrite-internal", false, "Required to wipe an internal (non-removable) drive in non-interactive mode")
 	cmd.Flags().StringVar(&deviceType, "device-type", "", "Device type from manifest (e.g. raspberry-pi-5)")
 	cmd.Flags().StringVar(&versionFlag, "version", "", "WendyOS version to install (interactive if omitted)")
@@ -239,7 +241,7 @@ func pickLinuxDevice() (string, deviceInfo, error) {
 	return key, deviceMap[key], nil
 }
 
-func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
+func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap bool, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
 	fmt.Println("Fetching available devices...")
 
 	// Fetch Linux devices from GCS manifest.
@@ -338,12 +340,12 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	if device.IsESP32 {
 		return installESP32Firmware(ctx, nightly, device.ESP32Chip)
 	}
-	return installLinuxImage(ctx, selected, device, nightly, flagVersion, flagDrive, force, yesOverwriteInternal, wifi, deviceName, preOpts)
+	return installLinuxImage(ctx, selected, device, nightly, flagVersion, flagDrive, force, yesOverwriteInternal, noBmap, wifi, deviceName, preOpts)
 }
 
 // installLinuxImage handles the Linux device path: pick version → pick drive → download → write.
 // nightly, flagVersion, flagDrive, and force allow skipping the corresponding interactive prompts.
-func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, nightly bool, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
+func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, nightly bool, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap bool, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
 	// Authenticate elevation up front so we don't pay for the multi-hundred-MB
 	// image download just to discover the user can't write to a raw disk. On
 	// Windows this offers a UAC re-launch when not elevated; on Unix it
@@ -465,17 +467,42 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		}
 	}
 
+	// Step 5b: Download and validate block map for accelerated flashing.
+	var bmapPath string
+	if !noBmap && imgInfo.BmapURL != "" {
+		if cacheDir, derr := osCacheDir(); derr == nil {
+			candidate := filepath.Join(cacheDir, fmt.Sprintf("%s-%s.bmap", deviceKey, selectedVersion))
+			if derr := downloadBmap(imgInfo.BmapURL, candidate); derr != nil {
+				fmt.Printf("Note: could not fetch block map (%v); flashing the full image.\n", derr)
+			} else if _, perr := parseBmap(readFileOrNil(candidate)); perr != nil {
+				fmt.Printf("Note: block map unusable (%v); flashing the full image.\n", perr)
+			} else {
+				bmapPath = candidate
+			}
+		}
+	}
+
 	// Step 6: Write image to drive with progress bar.
 	fmt.Printf("Writing image to %s...\n", targetDrive.DevicePath)
 	writeProg := tui.NewProgress(fmt.Sprintf("Writing to %s...", targetDrive.DevicePath))
 	wp := tea.NewProgram(writeProg)
 
 	go func() {
-		writeErr := writeImageToDisk(stream, stream.uncompressedSize, targetDrive, func(written int64) {
-			if msg, ok := stream.writeProgressMsg(written); ok {
-				wp.Send(msg)
-			}
-		})
+		var writeErr error
+		if bmapPath != "" {
+			fmt.Println("Using block map for faster flashing.")
+			writeErr = writeImageWithBmap(stream, stream.uncompressedSize, targetDrive, bmapPath, func(written int64) {
+				if msg, ok := stream.writeProgressMsg(written); ok {
+					wp.Send(msg)
+				}
+			})
+		} else {
+			writeErr = writeImageToDisk(stream, stream.uncompressedSize, targetDrive, func(written int64) {
+				if msg, ok := stream.writeProgressMsg(written); ok {
+					wp.Send(msg)
+				}
+			})
+		}
 		wp.Send(tui.ProgressDoneMsg{Err: writeErr})
 	}()
 
@@ -818,6 +845,16 @@ func osCacheDir() (string, error) {
 		return "", fmt.Errorf("creating OS cache directory: %w", err)
 	}
 	return dir, nil
+}
+
+// readFileOrNil reads path, returning nil on error (used for best-effort bmap
+// validation where failure just disables the bmap fast path).
+func readFileOrNil(path string) []byte {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	return data
 }
 
 func osCachedImagePath(deviceKey, version string) (string, error) {

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -43,6 +43,7 @@ func newOSInstallCmd() *cobra.Command {
 	var nightly bool
 	var force bool
 	var noBmap bool
+	var storageOverride string
 	var yesOverwriteInternal bool
 	var preEnroll bool
 	var deviceType string
@@ -110,13 +111,14 @@ Flags can be provided progressively — omitted values trigger interactive picke
 					mode = preEnrollSkip
 				}
 			}
-			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, noBmap, opts, deviceName, preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC})
+			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, noBmap, storageOverride, opts, deviceName, preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC})
 		},
 	}
 
 	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use nightly/prerelease builds")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&noBmap, "no-bmap", false, "Disable bmap-accelerated flashing even when a block map is available")
+	cmd.Flags().StringVar(&storageOverride, "storage", "", "Force image storage variant: nvme or sd (default: auto-detect from the target drive)")
 	cmd.Flags().BoolVar(&yesOverwriteInternal, "yes-overwrite-internal", false, "Required to wipe an internal (non-removable) drive in non-interactive mode")
 	cmd.Flags().StringVar(&deviceType, "device-type", "", "Device type from manifest (e.g. raspberry-pi-5)")
 	cmd.Flags().StringVar(&versionFlag, "version", "", "WendyOS version to install (interactive if omitted)")
@@ -241,7 +243,10 @@ func pickLinuxDevice() (string, deviceInfo, error) {
 	return key, deviceMap[key], nil
 }
 
-func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap bool, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
+func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap bool, storageOverride string, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
+	if storageOverride != "" && storageOverride != "nvme" && storageOverride != "sd" {
+		return fmt.Errorf("invalid --storage %q: must be \"nvme\" or \"sd\"", storageOverride)
+	}
 	fmt.Println("Fetching available devices...")
 
 	// Fetch Linux devices from GCS manifest.
@@ -340,12 +345,12 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	if device.IsESP32 {
 		return installESP32Firmware(ctx, nightly, device.ESP32Chip)
 	}
-	return installLinuxImage(ctx, selected, device, nightly, flagVersion, flagDrive, force, yesOverwriteInternal, noBmap, wifi, deviceName, preOpts)
+	return installLinuxImage(ctx, selected, device, nightly, flagVersion, flagDrive, force, yesOverwriteInternal, noBmap, storageOverride, wifi, deviceName, preOpts)
 }
 
 // installLinuxImage handles the Linux device path: pick version → pick drive → download → write.
 // nightly, flagVersion, flagDrive, and force allow skipping the corresponding interactive prompts.
-func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, nightly bool, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap bool, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
+func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevice, nightly bool, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap bool, storageOverride string, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
 	// Authenticate elevation up front so we don't pay for the multi-hundred-MB
 	// image download just to discover the user can't write to a raw disk. On
 	// Windows this offers a UAC re-launch when not elevated; on Unix it
@@ -442,7 +447,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 
 	// Step 5: Resolve image metadata for the target storage.
 	fmt.Printf("\nPreparing %s %s image...\n", device.Name, selectedVersion)
-	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, manifestStorage(targetDrive))
+	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, manifestStorage(targetDrive, storageOverride))
 	if err != nil {
 		return fmt.Errorf("getting image info: %w", err)
 	}
@@ -945,12 +950,20 @@ func osCachedBmapPath(deviceKey, version string) (string, error) {
 	return filepath.Join(dir, fmt.Sprintf("%s-%s.bmap", safeDevice, safeVersion)), nil
 }
 
-// manifestStorage maps a target drive's protocol to the manifest storage key.
-func manifestStorage(d drive) string {
-	if d.StorageType == StorageNVMe {
-		return "nvme"
+// manifestStorage maps a target drive's protocol to the manifest storage key,
+// honoring an explicit override. USB-attached drives default to nvme (e.g. a
+// Jetson NVMe in a USB enclosure); built-in SD readers and unknown buses → sd.
+func manifestStorage(d drive, override string) string {
+	switch override {
+	case "nvme", "sd":
+		return override
 	}
-	return "sd"
+	switch d.StorageType {
+	case StorageNVMe, StorageUSB:
+		return "nvme"
+	default:
+		return "sd"
+	}
 }
 
 func osCachedZstPath(deviceKey, version string) (string, error) {

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -364,7 +364,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	selectedVersion := device.RawVersion // default: latest (or nightly if --nightly)
 	if flagVersion != "" {
 		// Validate the requested version exists in the manifest.
-		if _, err := getImageInfo(device.Manifest, flagVersion); err != nil {
+		if _, err := getImageInfo(device.Manifest, flagVersion, ""); err != nil {
 			return fmt.Errorf("version %q not found for %s", flagVersion, device.Name)
 		}
 		selectedVersion = flagVersion
@@ -442,7 +442,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 
 	// Step 5: Resolve image (cached or download) and open streaming reader.
 	fmt.Printf("\nPreparing %s %s image...\n", device.Name, selectedVersion)
-	imgInfo, err := getImageInfo(device.Manifest, selectedVersion)
+	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, "")
 	if err != nil {
 		return fmt.Errorf("getting image info: %w", err)
 	}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -151,16 +151,20 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
-	var bmapDevice, bmapFile string
+	var bmapDevice, bmapFile, bmapSource string
 	bmapWriteCmd := &cobra.Command{
 		Use:    "__bmap-write",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if bmapSource != "" {
+				return runBmapWriteSeekable(bmapDevice, bmapFile, bmapSource, cmd.OutOrStdout())
+			}
 			return runBmapWrite(bmapDevice, bmapFile, cmd.InOrStdin())
 		},
 	}
 	bmapWriteCmd.Flags().StringVar(&bmapDevice, "device", "", "Raw device path to write")
 	bmapWriteCmd.Flags().StringVar(&bmapFile, "bmap", "", "Path to the .bmap file")
+	bmapWriteCmd.Flags().StringVar(&bmapSource, "source", "", "Path to the seekable .img.zst source")
 
 	root.AddCommand(
 		bleCheckCmd,

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -151,8 +151,20 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
+	var bmapDevice, bmapFile string
+	bmapWriteCmd := &cobra.Command{
+		Use:    "__bmap-write",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runBmapWrite(bmapDevice, bmapFile, cmd.InOrStdin())
+		},
+	}
+	bmapWriteCmd.Flags().StringVar(&bmapDevice, "device", "", "Raw device path to write")
+	bmapWriteCmd.Flags().StringVar(&bmapFile, "bmap", "", "Path to the .bmap file")
+
 	root.AddCommand(
 		bleCheckCmd,
+		bmapWriteCmd,
 		runCmd,
 		buildCmd,
 		initCmd,

--- a/go/internal/cli/commands/seekable_zstd.go
+++ b/go/internal/cli/commands/seekable_zstd.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+	"github.com/klauspost/compress/zstd"
+)
+
+// seekableImage is a random-access view over the decompressed bytes of a
+// seekable-zstd image. It is NOT safe for concurrent use: callers drive it from
+// a single goroutine (the flash loop). Close releases the decoder and file.
+type seekableImage struct {
+	r    *seekable.Reader
+	dec  *zstd.Decoder
+	f    *os.File // nil when constructed from an in-memory ReadSeeker (tests)
+	size int64
+}
+
+// openSeekableZstd opens a seekable-zstd file on disk.
+func openSeekableZstd(path string) (*seekableImage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening seekable image: %w", err)
+	}
+	si, err := newSeekableImage(f)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	si.f = f
+	return si, nil
+}
+
+// openSeekableZstdFromReader builds a seekableImage over an in-memory source.
+func openSeekableZstdFromReader(rs io.ReadSeeker) (*seekableImage, error) {
+	return newSeekableImage(rs)
+}
+
+func newSeekableImage(rs io.ReadSeeker) (*seekableImage, error) {
+	dec, err := zstd.NewReader(nil)
+	if err != nil {
+		return nil, fmt.Errorf("zstd decoder: %w", err)
+	}
+	r, err := seekable.NewReader(rs, dec)
+	if err != nil {
+		dec.Close()
+		return nil, fmt.Errorf("seekable reader: %w", err)
+	}
+	table, err := r.SeekTable()
+	if err != nil {
+		r.Close()
+		dec.Close()
+		return nil, fmt.Errorf("seek table: %w", err)
+	}
+	return &seekableImage{r: r, dec: dec, size: int64(table.Size())}, nil
+}
+
+func (s *seekableImage) Size() int64 { return s.size }
+
+func (s *seekableImage) ReadAt(p []byte, off int64) (int, error) { return s.r.ReadAt(p, off) }
+
+func (s *seekableImage) Seek(off int64, whence int) (int64, error) { return s.r.Seek(off, whence) }
+
+func (s *seekableImage) Read(p []byte) (int, error) { return s.r.Read(p) }
+
+func (s *seekableImage) Close() error {
+	err := s.r.Close()
+	s.dec.Close()
+	if s.f != nil {
+		if e := s.f.Close(); err == nil {
+			err = e
+		}
+	}
+	return err
+}

--- a/go/internal/cli/commands/seekable_zstd_test.go
+++ b/go/internal/cli/commands/seekable_zstd_test.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+	"github.com/klauspost/compress/zstd"
+)
+
+// encodeSeekable compresses data into the seekable-zstd container using
+// frameSize-byte frames, returning the compressed bytes. Test-only helper.
+func encodeSeekable(t *testing.T, data []byte, frameSize int) []byte {
+	t.Helper()
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatalf("zstd.NewWriter: %v", err)
+	}
+	defer enc.Close()
+	var buf bytes.Buffer
+	w, err := seekable.NewWriter(&buf, enc)
+	if err != nil {
+		t.Fatalf("seekable.NewWriter: %v", err)
+	}
+	for off := 0; off < len(data); off += frameSize {
+		end := off + frameSize
+		if end > len(data) {
+			end = len(data)
+		}
+		if _, err := w.Write(data[off:end]); err != nil {
+			t.Fatalf("seekable write: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("seekable close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestSeekableImageReadAtAndSize(t *testing.T) {
+	data := make([]byte, 10_000)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	comp := encodeSeekable(t, data, 1024)
+
+	si, err := openSeekableZstdFromReader(bytes.NewReader(comp))
+	if err != nil {
+		t.Fatalf("openSeekableZstdFromReader: %v", err)
+	}
+	defer si.Close()
+
+	if si.Size() != int64(len(data)) {
+		t.Fatalf("Size() = %d, want %d", si.Size(), len(data))
+	}
+	for _, tc := range []struct{ off, n int }{{0, 100}, {1000, 2048}, {5000, 4000}, {9990, 10}} {
+		got := make([]byte, tc.n)
+		if _, err := si.ReadAt(got, int64(tc.off)); err != nil && err != io.EOF {
+			t.Fatalf("ReadAt(%d,%d): %v", tc.off, tc.n, err)
+		}
+		if !bytes.Equal(got, data[tc.off:tc.off+tc.n]) {
+			t.Fatalf("ReadAt(%d,%d) mismatch", tc.off, tc.n)
+		}
+	}
+}

--- a/go/internal/cli/commands/storage_select_test.go
+++ b/go/internal/cli/commands/storage_select_test.go
@@ -1,0 +1,54 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import "testing"
+
+func TestManifestStorage(t *testing.T) {
+	tests := []struct {
+		name     string
+		d        drive
+		override string
+		want     string
+	}{
+		{
+			name:     "override nvme wins regardless of storage type",
+			d:        drive{StorageType: StorageUnknown},
+			override: "nvme",
+			want:     "nvme",
+		},
+		{
+			name:     "override sd wins regardless of storage type",
+			d:        drive{StorageType: StorageNVMe},
+			override: "sd",
+			want:     "sd",
+		},
+		{
+			name:     "USB-attached drive defaults to nvme",
+			d:        drive{StorageType: StorageUSB},
+			override: "",
+			want:     "nvme",
+		},
+		{
+			name:     "NVMe drive without override returns nvme",
+			d:        drive{StorageType: StorageNVMe},
+			override: "",
+			want:     "nvme",
+		},
+		{
+			name:     "unknown storage type returns sd",
+			d:        drive{StorageType: StorageUnknown},
+			override: "",
+			want:     "sd",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := manifestStorage(tc.d, tc.override)
+			if got != tc.want {
+				t.Errorf("manifestStorage(%+v, %q) = %q; want %q", tc.d, tc.override, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/testdata/sample.bmap
+++ b/go/internal/cli/commands/testdata/sample.bmap
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<bmap version="2.0">
+    <ImageSize>32768</ImageSize>
+    <BlockSize>4096</BlockSize>
+    <BlocksCount>8</BlocksCount>
+    <MappedBlocksCount>4</MappedBlocksCount>
+    <ChecksumType>sha256</ChecksumType>
+    <BmapFileChecksum>0000000000000000000000000000000000000000000000000000000000000000</BmapFileChecksum>
+    <BlockMap>
+        <Range chksum="5fd6c2a1d24f3c2c1e6b1c0a0e1c4d5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d">0-1</Range>
+        <Range chksum="1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b">4-5</Range>
+    </BlockMap>
+</bmap>


### PR DESCRIPTION
## Summary

Adds bmap-accelerated flashing to `wendy os install`. When the device manifest advertises a `bmap_path` (the publisher side landed in [WendyOS-Builder#106](https://github.com/wendylabsinc/WendyOS-Builder/pull/106)), the CLI downloads the `.bmap` block-map and flashes by writing **only the mapped block ranges** with per-range SHA256 verification, instead of a full `dd`. Falls back transparently to the existing `dd` path when no bmap is available, the download/parse fails, or `--no-bmap` is passed.

- **Manifest:** `deviceVersion.bmap_path` → resolved `imageInfo.BmapURL`
- **`bmap.go`:** `parseBmap` (bmaptool v2.0 XML) + `applyBmap` — sequential read of the decompressed stream (works on a non-seekable pipe), seeking `WriteAt` of mapped ranges, per-range SHA256 verify, holes skipped
- **`bmap_writer.go`:** atomic `downloadBmap` (tmp + rename), `runBmapWrite` helper body, `countingWriter` for progress
- **Hidden `__bmap-write` subcommand** (mirrors `__ble-check`): on Linux/macOS the device write is re-exec'd under `sudo`, streaming the image to its stdin — preserving today's "elevate only the write" model. Windows writes in-process over the existing privileged disk handle (the working `writeImageToDisk` was refactored to share `openLockedDisk`).
- **Install wiring:** `--no-bmap` flag; prints "Using block map for faster flashing"; provisioning (config partition / WiFi / pre-enroll) is unchanged and still runs after the write

Scope notes: bmap is generated by the builder only for NVMe/SD/RPi images, not eMMC/tegraflash (those keep the `dd` path). Input-seek optimization for raw images is intentionally out of scope — the win here is reduced device write I/O + free integrity verification.

## Test Plan

- [x] Unit: `parseBmap` (fixture, single-block, non-sha256, garbage, zero-size); `applyBmap` (mapped-only writes, hole untouched, corruption detected, multi-chunk range, partial final block, empty-checksum skip); `downloadBmap` (success, 404); `runBmapWrite` parse→apply→device round trip; hidden subcommand registration
- [x] `go build ./...` + `go test ./internal/cli/commands/` green; cross-builds clean for linux/arm64, darwin/arm64, windows/amd64
- [ ] **Manual:** flash a bmap-enabled image (NVMe Jetson or RPi build) to a real target — confirm "Using block map" prints, completes with no checksum error, device boots
- [ ] **Manual:** `--no-bmap` (and an eMMC device) falls back to `dd` and boots
- [ ] **Manual:** `--wifi`/`--device-name` still provision the config partition after a bmap flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)