### PR TITLE
fix(agent): stop force-restarting healthy services-map apps (WDY-1552)

### DIFF
--- a/Proto/wendy/agent/services/v1/shared.proto
+++ b/Proto/wendy/agent/services/v1/shared.proto
@@ -19,8 +19,9 @@ enum AppRunningState {
     RUNNING = 1;
 }
 
-// ServiceEntry describes a single container within a multi-service app group.
-// Only present in AppContainer.services for multi-service apps.
+// ServiceEntry describes a single container within a services-map app group.
+// Present in AppContainer.services for any app that declares named services
+// (single- or multi-service); see AppContainer.services.
 message ServiceEntry {
     string name = 1;
     AppRunningState running_state = 2;
@@ -32,7 +33,8 @@ message AppContainer {
     AppRunningState running_state = 3;  // aggregate: RUNNING if any service is running
     uint32 failure_count = 4;
     uint32 mcp_port = 5;
-    // Non-empty for multi-service (compose) apps; one entry per service container.
-    // Empty for single-service apps.
+    // One entry per service container for apps that declare named services
+    // (single- or multi-service services-map apps). Empty for single-container
+    // apps and flattened single-service apps (those with no service name).
     repeated ServiceEntry services = 6;
 }

--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -169,10 +169,34 @@ func (m *ContainerMonitor) checkContainers(ctx context.Context) {
 		return
 	}
 
+	// Build the set of running container identities, keyed the same way the
+	// monitor registers state. Services-map apps are monitored per service under
+	// the "{appID}_{serviceName}" container name (see containerd.ContainerName /
+	// AppConfig.ContainerName), so key each service by that name using its own
+	// running state. Apps with no services (legacy single-container apps) are
+	// monitored under the bare appID. Keying only by bare appID — as before —
+	// meant running["{appID}_{serviceName}"] was never true, so the monitor
+	// force-restarted healthy services-map apps every tick (WDY-1552).
 	running := make(map[string]bool)
 	for _, c := range containers {
-		if c.GetRunningState() == agentpb.AppRunningState_RUNNING {
-			running[c.GetAppName()] = true
+		svcs := c.GetServices()
+		if len(svcs) == 0 {
+			if c.GetRunningState() == agentpb.AppRunningState_RUNNING {
+				running[c.GetAppName()] = true
+			}
+			continue
+		}
+		for _, s := range svcs {
+			if s.GetRunningState() != agentpb.AppRunningState_RUNNING {
+				continue
+			}
+			if s.GetName() == "" {
+				// Defensive: a serviceless entry maps to the bare appID.
+				running[c.GetAppName()] = true
+				continue
+			}
+			// Keep in sync with containerd.ContainerName.
+			running[c.GetAppName()+"_"+s.GetName()] = true
 		}
 	}
 

--- a/go/internal/agent/container/monitor_checkcontainers_test.go
+++ b/go/internal/agent/container/monitor_checkcontainers_test.go
@@ -1,0 +1,168 @@
+package container
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/services"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// fakeContainerd is a minimal services.ContainerdClient for exercising
+// checkContainers. ListContainers returns a fixed snapshot and StartContainer
+// records the identities the monitor tries to restart.
+type fakeContainerd struct {
+	containers []*agentpb.AppContainer
+
+	mu         sync.Mutex
+	startCalls []string
+	started    chan string // signalled (buffered) on each StartContainer
+}
+
+func (f *fakeContainerd) ListContainers(ctx context.Context) ([]*agentpb.AppContainer, error) {
+	return f.containers, nil
+}
+
+func (f *fakeContainerd) StartContainer(ctx context.Context, appName, _ string, _ *agentpb.RestartPolicy) (<-chan services.ContainerOutput, error) {
+	f.mu.Lock()
+	f.startCalls = append(f.startCalls, appName)
+	f.mu.Unlock()
+	if f.started != nil {
+		f.started <- appName
+	}
+	ch := make(chan services.ContainerOutput)
+	close(ch)
+	return ch, nil
+}
+
+func (f *fakeContainerd) startCallsSnapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.startCalls...)
+}
+
+// Remaining ContainerdClient methods are unused by checkContainers.
+func (f *fakeContainerd) ListLayers(ctx context.Context) ([]*agentpb.LayerHeader, error) {
+	return nil, nil
+}
+func (f *fakeContainerd) WriteLayer(ctx context.Context, digest string, reader io.Reader, size int64) error {
+	return nil
+}
+func (f *fakeContainerd) AssembleImage(ctx context.Context, imageName string, layers []*agentpb.RunContainerLayerHeader) error {
+	return nil
+}
+func (f *fakeContainerd) CreateContainer(ctx context.Context, req *agentpb.CreateContainerRequest, appCfg *appconfig.AppConfig) error {
+	return nil
+}
+func (f *fakeContainerd) CreateContainerWithProgress(ctx context.Context, req *agentpb.CreateContainerRequest, appCfg *appconfig.AppConfig, onProgress services.ProgressFunc) error {
+	return nil
+}
+func (f *fakeContainerd) StartContainerWithStdin(ctx context.Context, appName string, stdin io.Reader, postStartAgentCommand string, restartPolicy *agentpb.RestartPolicy) (<-chan services.ContainerOutput, error) {
+	return f.StartContainer(ctx, appName, postStartAgentCommand, restartPolicy)
+}
+func (f *fakeContainerd) StopContainer(ctx context.Context, appName string) error { return nil }
+func (f *fakeContainerd) DeleteContainer(ctx context.Context, appName string, deleteImage bool) error {
+	return nil
+}
+func (f *fakeContainerd) ContainerIDsForApp(ctx context.Context, appID string) ([]string, error) {
+	return nil, nil
+}
+func (f *fakeContainerd) GetContainerStats(ctx context.Context) ([]*agentpb.ContainerStats, error) {
+	return nil, nil
+}
+func (f *fakeContainerd) GetContainerMetrics(ctx context.Context, appName string) (services.ContainerMetrics, error) {
+	return services.ContainerMetrics{}, nil
+}
+func (f *fakeContainerd) GetContainerMCPPort(ctx context.Context, appName string) (uint32, error) {
+	return 0, nil
+}
+func (f *fakeContainerd) GetContainerRestartPolicyLabel(ctx context.Context, appName string) (string, error) {
+	return "", nil
+}
+
+func newMonitorWithClient(c services.ContainerdClient) *ContainerMonitor {
+	return NewContainerMonitor(zap.NewNop(), c, nil, time.Second)
+}
+
+// A healthy single-service services-map app is monitored under its
+// "{appID}_{serviceName}" container name. ListContainers reports the bare appID
+// as AppName but exposes the service via Services, so the monitor must NOT treat
+// the running service as stopped and restart it (WDY-1552).
+func TestCheckContainers_SingleServiceMapApp_NotRestarted(t *testing.T) {
+	fake := &fakeContainerd{
+		containers: []*agentpb.AppContainer{{
+			AppName:      "myapp",
+			RunningState: agentpb.AppRunningState_RUNNING,
+			Services: []*agentpb.ServiceEntry{
+				{Name: "web", RunningState: agentpb.AppRunningState_RUNNING},
+			},
+		}},
+	}
+	m := newMonitorWithClient(fake)
+	m.Register("myapp_web", RestartUnlessStopped, 0)
+
+	m.checkContainers(context.Background())
+
+	if calls := fake.startCallsSnapshot(); len(calls) != 0 {
+		t.Fatalf("StartContainer called for healthy service: %v", calls)
+	}
+	m.mu.Lock()
+	fc := m.states["myapp_web"].FailureCount
+	m.mu.Unlock()
+	if fc != 0 {
+		t.Fatalf("FailureCount = %d, want 0 (no spurious restart)", fc)
+	}
+}
+
+// A genuinely stopped service in a services-map app is still restarted under its
+// per-service container name.
+func TestCheckContainers_SingleServiceMapApp_RestartsWhenDown(t *testing.T) {
+	fake := &fakeContainerd{
+		started: make(chan string, 1),
+		containers: []*agentpb.AppContainer{{
+			AppName:      "myapp",
+			RunningState: agentpb.AppRunningState_STOPPED,
+			Services: []*agentpb.ServiceEntry{
+				{Name: "web", RunningState: agentpb.AppRunningState_STOPPED},
+			},
+		}},
+	}
+	m := newMonitorWithClient(fake)
+	m.Register("myapp_web", RestartUnlessStopped, 0) // LastRestart zero => backoff already elapsed
+
+	m.checkContainers(context.Background())
+
+	select {
+	case got := <-fake.started:
+		if got != "myapp_web" {
+			t.Fatalf("restarted %q, want %q", got, "myapp_web")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected StartContainer(myapp_web), got none")
+	}
+}
+
+// Legacy single-container apps (no Services) continue to match on the bare appID
+// and are not restarted while running.
+func TestCheckContainers_LegacySingleContainer_NotRestarted(t *testing.T) {
+	fake := &fakeContainerd{
+		containers: []*agentpb.AppContainer{{
+			AppName:      "legacyapp",
+			RunningState: agentpb.AppRunningState_RUNNING,
+		}},
+	}
+	m := newMonitorWithClient(fake)
+	m.Register("legacyapp", RestartUnlessStopped, 0)
+
+	m.checkContainers(context.Background())
+
+	if calls := fake.startCallsSnapshot(); len(calls) != 0 {
+		t.Fatalf("StartContainer called for healthy legacy app: %v", calls)
+	}
+}

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -2020,10 +2020,22 @@ func (c *Client) ListContainers(ctx context.Context) ([]*agentpb.AppContainer, e
 	for _, appID := range order {
 		e := grouped[appID]
 
-		// Populate per-service entries only for multi-service apps; single-service
-		// apps leave Services empty so callers can distinguish them cheaply.
+		// Populate per-service entries for any app that declares named services
+		// (single- or multi-service services-map apps). Single-container and
+		// flattened single-service apps have an empty service name and leave
+		// Services empty so callers can still distinguish them cheaply. Exposing
+		// the per-service identity for single-service apps is what lets the
+		// monitor reconcile them by their "{appID}_{serviceName}" container name
+		// instead of restart-looping a healthy app (WDY-1552).
 		var services []*agentpb.ServiceEntry
-		if len(e.services) > 1 {
+		hasNamedService := false
+		for _, s := range e.services {
+			if s.name != "" {
+				hasNamedService = true
+				break
+			}
+		}
+		if hasNamedService {
 			services = make([]*agentpb.ServiceEntry, len(e.services))
 			for i, s := range e.services {
 				services[i] = &agentpb.ServiceEntry{


### PR DESCRIPTION
## Summary

The container monitor force-killed (`exit 137`) and restarted **healthy** `services:`-map app containers on a ~15s loop. The container served traffic fine right up to each kill; the loop was invisible in `wendy device ps` / `container_list` (proto `failure_count` stays 0 — only the monitor's *internal* counter climbed), but users saw dropped connections (MJPEG/HTTP streams cut mid-response, `ERR_INCOMPLETE_CHUNKED_ENCODING`). Hit live on a Jetson Orin with `sh.wendy.examples.so101rig`.

## Root cause

A key-space mismatch in the monitor's reconcile loop:

- **Running set** was keyed by the **bare appID** — `checkContainers` builds it from `AppContainer.GetAppName()`, and `ListContainers` always sets `AppName` to the bare appID.
- **Monitored state** for a services-map app is keyed by the **container name** `{appID}_{serviceName}` (`ContainerName` / `AppConfig.ContainerName`), which is also what Stop/Delete mark via `ContainerIDsForApp`.

So `running["appID_serviceName"]` was never true even while the service ran → the monitor concluded the container was stopped → restarted it every tick past the 10s backoff (~15s cadence), bumping the internal `FailureCount`. Legacy single-container apps (`serviceName == ""` → bare container name) matched on both sides and were unaffected.

## Changes

- **`monitor.go`** — `checkContainers` now builds the running set **per service**, keyed by `{appID}_{serviceName}` using each service's *own* running state, falling back to the bare appID for serviceless (legacy) apps. This preserves per-service restart granularity: a multi-service app with one dead service still gets *that* service restarted.
- **`client.go` (`ListContainers`)** — populate `AppContainer.Services` for any app with **named** services (single- or multi-service), instead of only `len > 1`, so single-service services-map apps expose the per-service identity the monitor reconciles against. Single-container / flattened apps (empty service name) still leave `Services` empty, so existing `len > 1` group-rendering callers (`apps` table/picker/dashboard) are unaffected.
- **`shared.proto`** — doc-comment update only (no field changes → no codegen needed).
- **`monitor_checkcontainers_test.go`** — regression tests with a fake `ContainerdClient`.

## Note on the original ticket's single-vs-multi framing

The ticket states PR #1008 fixed the multi-service case and only single-service remained. The trace here shows `checkContainers`' running set was bare-appID-only (it never read `GetServices()`), so **any** app monitored under `appID_serviceName` would loop — including multi-service docker-compose apps. This fix covers single- **and** multi-service uniformly, so it is correct regardless.

## Testing

- `go build ./...` ✅ · `gofmt -l .` clean ✅
- `go test -race ./internal/agent/container/... ./internal/agent/containerd/... ./internal/agent/services/...` ✅
- **Regression proof:** with the `monitor.go` fix reverted, `TestCheckContainers_SingleServiceMapApp_NotRestarted` fails (`FailureCount = 1` — the spurious restart); with the fix, it passes.
- ⚠️ **On-device E2E still pending:** the test Jetson had no containers deployed, so the live loop wasn't observed. Before merge, deploy `sh.wendy.examples.so101rig` (default restart policy) and confirm via `telemetry_logs` that the `Restarting container` → `exit_code 137` → `Container started` cycle is gone and `failure_count` stays 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)