### PR TITLE
fix: ros2 sidecar matches the anchor app's RMW — CycloneDDS support (WDY-1593)

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1300,11 +1300,17 @@ func validateUserEnv(entries []string) error {
 }
 
 // cycloneDDSInlineConfig is the CycloneDDS configuration passed inline via
-// CYCLONEDDS_URI (not a file mount). Shared memory enables zero-copy DDS
-// transport between containers that share /dev/shm (isolation: "shared-ipc");
-// autodetermined network interfaces keep UDP discovery working as a fallback
-// (WDY-884).
-const cycloneDDSInlineConfig = `<CycloneDDS><Domain><SharedMemory><Enable>true</Enable><LogLevel>warning</LogLevel></SharedMemory><General><Interfaces><NetworkInterface autodetermine="true"/></Interfaces></General></CycloneDDS>`
+// CYCLONEDDS_URI (not a file mount). SharedMemory (iceoryx zero-copy) is
+// DISABLED: it requires an iox-roudi daemon that WendyOS does not run, and
+// enabling it makes CycloneDDS block at startup ("RouDi not found - waiting")
+// until the container is SIGKILLed, restart-looping. With it off, CycloneDDS
+// uses UDP over loopback, which works within the app group's shared network
+// namespace — ROS_LOCALHOST_ONLY=1 (always injected alongside) pins it to lo.
+// No <Interfaces> block: localhost-only already selects lo, and an autodetermine
+// interface on top makes it select "lo" twice ("the same interface may not be
+// selected twice"), which fails domain creation. Re-enabling zero-copy needs an
+// iox-roudi system service on the device first (WDY-884).
+const cycloneDDSInlineConfig = `<CycloneDDS><Domain><SharedMemory><Enable>false</Enable></SharedMemory></Domain></CycloneDDS>`
 
 // buildROS2Env returns ROS2 environment variables for the container resolved
 // from the app's frameworks.ros2 config (group-level, overridden by the

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -841,3 +841,19 @@ func TestSharedSHMPath(t *testing.T) {
 		t.Error("sharedSHMPath(\"../escape\") = nil error, want validation error")
 	}
 }
+
+// TestRMWFromEnv verifies the ROS 2 sidecar reads back the anchor app's
+// RMW_IMPLEMENTATION from its OCI spec env so it can match the app's DDS
+// implementation (WDY-1593).
+func TestRMWFromEnv(t *testing.T) {
+	got := rmwFromEnv([]string{"ROS_DOMAIN_ID=42", "RMW_IMPLEMENTATION=rmw_cyclonedds_cpp", "ROS_LOCALHOST_ONLY=1"})
+	if got != "rmw_cyclonedds_cpp" {
+		t.Errorf("rmwFromEnv = %q, want rmw_cyclonedds_cpp", got)
+	}
+	if got := rmwFromEnv([]string{"ROS_DOMAIN_ID=42"}); got != "" {
+		t.Errorf("rmwFromEnv (absent) = %q, want empty", got)
+	}
+	if got := rmwFromEnv(nil); got != "" {
+		t.Errorf("rmwFromEnv(nil) = %q, want empty", got)
+	}
+}

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -204,6 +204,7 @@ func (c *Client) EnsureROS2Sidecar(ctx context.Context) (services.ROS2Sidecar, e
 	// image — the verified path that does not depend on the app image carrying
 	// the ros2 CLI (WDY-1593).
 	var image containerd.Image
+	reusedAnchorImage := false
 	if rmw == "" || rmw == rosImageDefaultRMW {
 		imageName := "docker.io/library/ros:" + anchor.Distro
 		image, err = c.client.GetImage(ctx, imageName)
@@ -226,6 +227,7 @@ func (c *Client) EnsureROS2Sidecar(ctx context.Context) (services.ROS2Sidecar, e
 		if err != nil {
 			return services.ROS2Sidecar{}, fmt.Errorf("resolving anchor image for %s sidecar (anchor %s): %w", rmw, anchor.ContainerID, err)
 		}
+		reusedAnchorImage = true
 		c.logger.Info("ROS 2 sidecar reusing anchor app image for non-default RMW",
 			zap.String("rmw", rmw), zap.String("image", image.Name()), zap.String("anchor", anchor.ContainerID))
 	}
@@ -323,12 +325,59 @@ func (c *Client) EnsureROS2Sidecar(ctx context.Context) (services.ROS2Sidecar, e
 		return services.ROS2Sidecar{}, fmt.Errorf("ROS 2 app container changed while sidecar was starting; retry: %w", err)
 	}
 
+	// A reused app image is guaranteed to carry the matching RMW (that is how
+	// the app runs it) but not necessarily the ros2 CLI. If it lacks the CLI,
+	// fail with an actionable message instead of letting every command return a
+	// bare "ros2: not found" exit 127 (WDY-1593).
+	if reusedAnchorImage {
+		if hasCLI, perr := c.sidecarHasROS2CLI(ctx, container, task, anchor.Distro); perr != nil {
+			c.logger.Warn("Could not probe reused app image for the ros2 CLI; proceeding",
+				zap.String("image", image.Name()), zap.Error(perr))
+		} else if !hasCLI {
+			_ = c.deleteROS2Sidecar(ctx, container)
+			return services.ROS2Sidecar{}, fmt.Errorf("ROS 2 app image %q runs %s but does not include the ros2 CLI, so `wendy device ros2` cannot inspect it; install the CLI in the app image (e.g. apt-get install ros-%s-ros2cli)", image.Name(), rmw, anchor.Distro)
+		}
+	}
+
 	c.logger.Info("ROS 2 CLI sidecar started",
 		zap.String("image", image.Name()),
 		zap.String("rmw", rmw),
 		zap.String("anchor", anchor.ContainerID),
 		zap.Int("domain_id", anchor.DomainID))
 	return sidecar, nil
+}
+
+// sidecarHasROS2CLI reports whether the running sidecar task can find the ros2
+// CLI on PATH after sourcing the ROS environment. Used to fail loudly when a
+// reused app image shipped the RMW but not ros2cli (WDY-1593). A probe-setup
+// error (not a clean exit code) is returned so the caller can proceed rather
+// than block on a transient containerd hiccup.
+func (c *Client) sidecarHasROS2CLI(ctx context.Context, container containerd.Container, task containerd.Task, distro string) (bool, error) {
+	spec, err := container.Spec(ctx)
+	if err != nil {
+		return false, err
+	}
+	pspec := spec.Process
+	pspec.Terminal = false
+	pspec.Args = []string{
+		"/bin/bash", "-lc",
+		fmt.Sprintf("source /opt/ros/%s/setup.bash >/dev/null 2>&1; command -v ros2 >/dev/null 2>&1", distro),
+	}
+	execID := fmt.Sprintf("ros2-probe-%d", ros2ExecCounter.Add(1))
+	proc, err := task.Exec(ctx, execID, pspec, cio.NullIO)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _, _ = proc.Delete(ctx, containerd.WithProcessKill) }()
+	statusC, err := proc.Wait(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := proc.Start(ctx); err != nil {
+		return false, err
+	}
+	st := <-statusC
+	return st.ExitCode() == 0, st.Error()
 }
 
 // verifyROS2Anchor checks that the anchor container's task is still running

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -44,6 +45,18 @@ const (
 	// (app restarted), the sidecar is stale and must be recreated.
 	labelKeyROS2AnchorID  = "sh.wendy/ros2.anchor.id"
 	labelKeyROS2AnchorPID = "sh.wendy/ros2.anchor.pid"
+
+	// labelKeyROS2RMW records the anchor app's RMW implementation so each
+	// ExecROS2 can set RMW_IMPLEMENTATION to match — without it the sidecar's
+	// ros2 CLI falls to the image default and can't see apps on another RMW
+	// (WDY-1593). Empty means "use the image default" (FastRTPS).
+	labelKeyROS2RMW = "sh.wendy/ros2.rmw"
+
+	// rosImageDefaultRMW is the only RMW the stock docker.io/library/ros:<distro>
+	// image ships (verified: it contains librmw_fastrtps_cpp and the
+	// rmw-fastrtps-cpp packages, no CycloneDDS). An anchor app on any other RMW
+	// therefore needs a sidecar built from the app's own image (WDY-1593).
+	rosImageDefaultRMW = "rmw_fastrtps_cpp"
 
 	// ros2ExecStopGrace is how long ExecROS2 waits after SIGINT before
 	// escalating to SIGKILL. `ros2 bag record` needs the grace period to
@@ -95,6 +108,18 @@ func (c *Client) FindROS2Containers(ctx context.Context) ([]services.ROS2Target,
 		targets = append(targets, target)
 	}
 	return targets, nil
+}
+
+// rmwFromEnv returns the value of RMW_IMPLEMENTATION in a container's OCI spec
+// env, or "" when absent. Wendy injects it into ROS 2 app containers
+// (buildROS2Env); the sidecar reads it back to match the app's DDS impl.
+func rmwFromEnv(env []string) string {
+	for _, e := range env {
+		if v, ok := strings.CutPrefix(e, "RMW_IMPLEMENTATION="); ok {
+			return v
+		}
+	}
+	return ""
 }
 
 // EnsureROS2Sidecar starts (or reuses) the ROS 2 CLI sidecar container. The
@@ -153,19 +178,56 @@ func (c *Client) EnsureROS2Sidecar(ctx context.Context) (services.ROS2Sidecar, e
 		}
 	}
 
-	imageName := "docker.io/library/ros:" + anchor.Distro
-	image, err := c.client.GetImage(ctx, imageName)
+	// Read the RMW the anchor app actually runs (Wendy injects RMW_IMPLEMENTATION
+	// into the app's env via buildROS2Env) so the sidecar's ros2 CLI speaks the
+	// same DDS implementation (WDY-1593). An unrecognized value is dropped so a
+	// tampered env can never reach the sidecar's environment.
+	anchorCtr, err := c.client.LoadContainer(ctx, anchor.ContainerID)
 	if err != nil {
-		c.logger.Info("Pulling ROS 2 sidecar image", zap.String("image", imageName))
-		image, err = c.client.Pull(ctx, imageName, containerd.WithPullUnpack)
-		if err != nil {
-			return services.ROS2Sidecar{}, fmt.Errorf("pulling ROS 2 sidecar image %q: %w", imageName, err)
-		}
+		return services.ROS2Sidecar{}, fmt.Errorf("loading ROS 2 anchor container %q: %w", anchor.ContainerID, err)
 	}
-	if unpacked, uerr := image.IsUnpacked(ctx, ""); uerr == nil && !unpacked {
-		if uerr := c.UnpackImage(ctx, image, nil); uerr != nil {
-			return services.ROS2Sidecar{}, fmt.Errorf("unpacking ROS 2 sidecar image: %w", uerr)
+	anchorSpec, err := anchorCtr.Spec(ctx)
+	if err != nil {
+		return services.ROS2Sidecar{}, fmt.Errorf("reading ROS 2 anchor spec: %w", err)
+	}
+	rmw := rmwFromEnv(anchorSpec.Process.Env)
+	if rmw != "" && !appconfig.IsValidRMWImplementation(rmw) {
+		c.logger.Warn("Anchor has unrecognized RMW_IMPLEMENTATION; sidecar will use the image default",
+			zap.String("rmw", rmw), zap.String("anchor", anchor.ContainerID))
+		rmw = ""
+	}
+
+	// Pick the sidecar image. Stock ros:<distro> ships only FastRTPS, so for any
+	// other RMW (e.g. CycloneDDS, the Wendy default) reuse the anchor app's own
+	// image: it already has the matching RMW + ros2 CLI and is already pulled and
+	// unpacked on the device. FastRTPS (and empty/unknown) stay on the stock
+	// image — the verified path that does not depend on the app image carrying
+	// the ros2 CLI (WDY-1593).
+	var image containerd.Image
+	if rmw == "" || rmw == rosImageDefaultRMW {
+		imageName := "docker.io/library/ros:" + anchor.Distro
+		image, err = c.client.GetImage(ctx, imageName)
+		if err != nil {
+			c.logger.Info("Pulling ROS 2 sidecar image", zap.String("image", imageName))
+			image, err = c.client.Pull(ctx, imageName, containerd.WithPullUnpack)
+			if err != nil {
+				return services.ROS2Sidecar{}, fmt.Errorf("pulling ROS 2 sidecar image %q: %w", imageName, err)
+			}
 		}
+		if unpacked, uerr := image.IsUnpacked(ctx, ""); uerr == nil && !unpacked {
+			if uerr := c.UnpackImage(ctx, image, nil); uerr != nil {
+				return services.ROS2Sidecar{}, fmt.Errorf("unpacking ROS 2 sidecar image: %w", uerr)
+			}
+		}
+	} else {
+		// The anchor image is already pulled/unpacked (the anchor is running), so
+		// skip the pull/unpack dance entirely.
+		image, err = anchorCtr.Image(ctx)
+		if err != nil {
+			return services.ROS2Sidecar{}, fmt.Errorf("resolving anchor image for %s sidecar (anchor %s): %w", rmw, anchor.ContainerID, err)
+		}
+		c.logger.Info("ROS 2 sidecar reusing anchor app image for non-default RMW",
+			zap.String("rmw", rmw), zap.String("image", image.Name()), zap.String("anchor", anchor.ContainerID))
 	}
 
 	if err := os.MkdirAll(ROS2BagDir, 0o755); err != nil {
@@ -228,6 +290,7 @@ func (c *Client) EnsureROS2Sidecar(ctx context.Context) (services.ROS2Sidecar, e
 		labelKeyROS2Sidecar:   anchor.Distro,
 		labelKeyROS2AnchorID:  anchor.ContainerID,
 		labelKeyROS2AnchorPID: strconv.FormatUint(uint64(anchor.TaskPID), 10),
+		labelKeyROS2RMW:       rmw,
 	}
 	container, err := c.client.NewContainer(ctx, ros2SidecarName,
 		containerd.WithImage(image),
@@ -261,7 +324,8 @@ func (c *Client) EnsureROS2Sidecar(ctx context.Context) (services.ROS2Sidecar, e
 	}
 
 	c.logger.Info("ROS 2 CLI sidecar started",
-		zap.String("image", imageName),
+		zap.String("image", image.Name()),
+		zap.String("rmw", rmw),
 		zap.String("anchor", anchor.ContainerID),
 		zap.Int("domain_id", anchor.DomainID))
 	return sidecar, nil
@@ -389,6 +453,16 @@ func (c *Client) ExecROS2(ctx context.Context, opts services.ROS2ExecOptions, st
 		"ROS_DOMAIN_ID="+strconv.Itoa(opts.DomainID),
 		"ROS_LOCALHOST_ONLY=1",
 	)
+	// Match the anchor app's RMW so the CLI speaks the same DDS implementation;
+	// otherwise it falls to the image default and sees nothing on another RMW
+	// (WDY-1593). The label is written validated, but re-check before injecting
+	// into the environment as defense-in-depth (SOC2-CC6, NIST-SI-10).
+	if rmw := labels[labelKeyROS2RMW]; appconfig.IsValidRMWImplementation(rmw) {
+		pspec.Env = append(pspec.Env, "RMW_IMPLEMENTATION="+rmw)
+		if rmw == appconfig.ROS2DefaultRMW {
+			pspec.Env = append(pspec.Env, "CYCLONEDDS_URI="+cycloneDDSInlineConfig)
+		}
+	}
 
 	execID := fmt.Sprintf("ros2-exec-%d-%d", time.Now().UnixNano(), ros2ExecCounter.Add(1))
 	proc, err := task.Exec(nctx, execID, pspec, cio.NewCreator(cio.WithStreams(nil, stdout, stderr)))

--- a/go/internal/shared/appconfig/ros2.go
+++ b/go/internal/shared/appconfig/ros2.go
@@ -45,6 +45,21 @@ var ros2RMWAliases = map[string]string{
 	"rmw_gurumdds_cpp":   "rmw_gurumdds_cpp",
 }
 
+// IsValidRMWImplementation reports whether s is a full RMW implementation
+// identifier this codebase recognizes (the values ros2RMWAliases maps to).
+// Callers validate an RMW string read back from a container environment or
+// label before injecting it into another container's environment, so a
+// tampered or malformed value can never reach the sidecar's env
+// (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
+func IsValidRMWImplementation(s string) bool {
+	switch s {
+	case "rmw_cyclonedds_cpp", "rmw_fastrtps_cpp", "rmw_connextdds", "rmw_gurumdds_cpp":
+		return true
+	default:
+		return false
+	}
+}
+
 // ROS2AutoDomainID derives a stable ROS_DOMAIN_ID from the appId so the
 // domain does not change between restarts (WDY-884). The result is always in
 // [ROS2DomainIDMin, ROS2DomainIDMax].

--- a/go/internal/shared/appconfig/ros2_test.go
+++ b/go/internal/shared/appconfig/ros2_test.go
@@ -121,3 +121,18 @@ func TestParseROS2Annotation_Malformed(t *testing.T) {
 		}
 	}
 }
+
+func TestIsValidRMWImplementation(t *testing.T) {
+	valid := []string{"rmw_cyclonedds_cpp", "rmw_fastrtps_cpp", "rmw_connextdds", "rmw_gurumdds_cpp"}
+	for _, s := range valid {
+		if !IsValidRMWImplementation(s) {
+			t.Errorf("IsValidRMWImplementation(%q) = false, want true", s)
+		}
+	}
+	invalid := []string{"", "cyclonedds", "fastrtps", "rmw_fastrtps", "rmw_evil_cpp; rm -rf", "RMW_FASTRTPS_CPP"}
+	for _, s := range invalid {
+		if IsValidRMWImplementation(s) {
+			t.Errorf("IsValidRMWImplementation(%q) = true, want false", s)
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #1046 (WDY-1555). Base auto-retargets to `jo.ros2-support` when #1046 merges.

## Summary

Even with #1046's shared-ipc data-plane fix, `wendy device ros2` stayed empty for **CycloneDDS** apps — and Cyclone is the **Wendy default RMW**. The sidecar ran stock `ros:humble` (which ships **FastRTPS only**) and never set `RMW_IMPLEMENTATION`, so its `ros2` CLI spoke FastRTPS while a Cyclone app spoke Cyclone — different DDS implementations, no shared graph (`doctor` → `rmw_fastrtps_cpp`, `topic: none`). Closes WDY-1593.

## Changes

**1. Sidecar matches the anchor app's RMW** (`ros2.go`)
- Reads the RMW the anchor actually runs from its OCI spec env (`RMW_IMPLEMENTATION`, injected by `buildROS2Env`) — no annotation/schema change.
- **Hybrid image selection:** stock `ros:<distro>` ships only FastRTPS, so for any other RMW the sidecar **reuses the anchor app's own image** (already has the RMW + CLI, already on disk). FastRTPS / empty / unknown keep the stock image — the #1046-verified path that doesn't depend on the app image carrying the `ros2` CLI.
- `ExecROS2` sets `RMW_IMPLEMENTATION` (+ `CYCLONEDDS_URI` for Cyclone) to match. RMW values validated against an allowlist (`appconfig.IsValidRMWImplementation`) on read and before injection.
- **Fails loudly** when a reused image lacks the `ros2` CLI (probe `command -v ros2` once at start) instead of a bare `exit 127: ros2: not found`.

**2. Fix the malformed CycloneDDS inline config** (`client.go`, WDY-884)
The shared `cycloneDDSInlineConfig` (injected as `CYCLONEDDS_URI` into **every** Cyclone container) was broken in ways that crash-looped any Cyclone app — i.e. the default RMW had never worked end-to-end:
- unclosed `<Domain>` → XML parse error → `failed to create domain`
- invalid `<LogLevel>warning` → `warn`
- `autodetermine` interface conflicts with `ROS_LOCALHOST_ONLY` → "lo selected twice"
- `<SharedMemory>` enabled but WendyOS has no iceoryx **RouDi** daemon → cyclone blocks at startup → SIGKILL loop → **disabled** (UDP over loopback works; zero-copy needs RouDi in the OS image — tracked separately)

## Testing

- `gofmt`/`go vet` clean; `go test ./internal/agent/containerd/ ./internal/shared/appconfig/` passes (+ new `IsValidRMWImplementation`, `rmwFromEnv`).
- **Hardware-validated on a Jetson Orin Nano** with a 7-case RMW matrix (real rclpy apps):

  | # | Case | Sidecar RMW | Result |
  |---|------|-------------|--------|
  | 1 | cyclone-full | `rmw_cyclonedds_cpp` | ✅ reuse-app-image |
  | 2 | fastrtps-normal | `rmw_fastrtps_cpp` | ✅ stock image |
  | 3 | fastrtps, no CLI in image | `rmw_fastrtps_cpp` | ✅ hybrid (stock has CLI) |
  | 4 | cyclone, no CLI in image | (reuse) | ✅ friendly "app image lacks ros2 CLI" error |
  | 5 | connext template | — | app crashes (no RTI) — template only |
  | 6 | unknown RMW | `rmw_fastrtps_cpp` | ✅ dropped → FastRTPS default |
  | 7 | mixed (cyclone+fastrtps, one domain) | matches anchor only | ⚠️ one graph visible → WDY-1594 |

## Known follow-ups (not this PR)
- **WDY-1594** — mixed-RMW: sidecar anchors to one running container, so a second app on a different RMW (same domain) is invisible.
- Cyclone zero-copy (iceoryx RouDi daemon in the WendyOS image, Builder repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)