### PR TITLE
fix: forward --flags through `wendy device ros2 exec` (WDY-1553)

### DIFF
--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -938,8 +938,15 @@ func newROS2ExecCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exec [args...]",
 		Short: "Run a raw ros2 CLI command on the device",
-		Long:  "Run a raw ros2 CLI command inside the device's ROS 2 sidecar, e.g.\n  wendy device ros2 exec topic bw /scan",
-		Args:  cobra.MinimumNArgs(1),
+		Long: `Run a raw ros2 CLI command inside the device's ROS 2 sidecar.
+
+Everything after the ros2 command word is forwarded verbatim, so --flags
+work without escaping. Any wendy flags (--device, --domain) must come before
+the ros2 command; use -- to force the rest of the line through unparsed.`,
+		Example: `  wendy device ros2 exec topic echo /chatter --once
+  wendy device ros2 exec topic pub /cmd_vel geometry_msgs/msg/Twist --rate 10
+  wendy device ros2 exec --domain 5 node list`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
@@ -978,5 +985,9 @@ func newROS2ExecCmd() *cobra.Command {
 		},
 	}
 	ros2DomainFlag(cmd, &domain)
+	// Stop flag parsing at the first positional (the ros2 command word) so that
+	// --flags meant for ros2 (e.g. `topic echo /chatter --once`) forward verbatim
+	// instead of being rejected as unknown flags of this command (WDY-1553).
+	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -121,5 +122,32 @@ func TestROS2DomainPtr(t *testing.T) {
 	}
 	if got := ros2DomainPtr(42); got == nil || *got != 42 {
 		t.Errorf("ros2DomainPtr(42) = %v", got)
+	}
+}
+
+// TestROS2ExecForwardsFlags guards WDY-1553: the raw escape hatch must forward
+// --flags meant for ros2 verbatim instead of rejecting them as unknown flags,
+// while still parsing wendy's own flags when they precede the ros2 command.
+func TestROS2ExecForwardsFlags(t *testing.T) {
+	// --once belongs to ros2 and must survive as a positional, not error out.
+	cmd := newROS2ExecCmd()
+	args := []string{"topic", "echo", "/chatter", "--once"}
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags(%v) = %v, want nil (ros2 flags must forward verbatim)", args, err)
+	}
+	if got := cmd.Flags().Args(); !reflect.DeepEqual(got, args) {
+		t.Errorf("forwarded args = %v, want %v", got, args)
+	}
+
+	// A leading --domain is wendy's own flag: parse it, forward the rest verbatim.
+	cmd = newROS2ExecCmd()
+	if err := cmd.ParseFlags([]string{"--domain", "5", "topic", "echo", "--once"}); err != nil {
+		t.Fatalf("ParseFlags with leading --domain = %v, want nil", err)
+	}
+	if got, _ := cmd.Flags().GetInt32("domain"); got != 5 {
+		t.Errorf("--domain = %d, want 5", got)
+	}
+	if got, want := cmd.Flags().Args(), []string{"topic", "echo", "--once"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("forwarded args = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

`wendy device ros2 exec` is the raw-`ros2` escape hatch, but Cobra parsed any `--`-prefixed argument as a flag of `exec` itself, so most real ros2 commands couldn't run through it:

```
wendy device ros2 exec topic echo /chatter --once
→ ✗ unknown flag: --once
```

This fixes [WDY-1553](https://linear.app/wendylabsinc/issue/WDY-1553).

## Fix

Set `cmd.Flags().SetInterspersed(false)` on the `exec` command. Flag parsing now stops at the **first positional** — which for any ros2 command is always the verb (`topic`, `node`, `run`, …) — so everything after it forwards verbatim to `ros2`, including `--flags`. The agent's `Exec` RPC already runs `req.GetArgs()` verbatim, so no proto/agent change is needed.

### Why not `DisableFlagParsing: true` (the issue's primary suggestion)?

`--device`/`--json` are **root persistent flags** and `TraverseChildren` is off, so flags parse once at the leaf. `DisableFlagParsing: true` would swallow `--device`/`--json`/`--domain` and forward them to `ros2` — a regression in the core device selector. A `--`-only fix would leave the literal repro (no `--`) still broken.

`SetInterspersed(false)` keeps all wendy flags working (placed before the ros2 verb, the conventional position) **and** makes the exact repro work with no `--`:

```
wendy device ros2 exec topic echo /chatter --once            # works, no `--` needed
wendy --device d device ros2 exec --domain 5 topic pub --rate 10 ...
wendy device ros2 exec -- --help                             # `--` still forces passthrough
```

## Changes

- `go/internal/cli/commands/ros2.go` — `SetInterspersed(false)` + updated `Long`/`Example` help text documenting verbatim passthrough.
- `go/internal/cli/commands/ros2_test.go` — `TestROS2ExecForwardsFlags` covering `--once` forwarding and a leading `--domain 5` being consumed while the rest forwards verbatim.

## Testing

- `gofmt -l` clean; `go build ./...` OK; `go test ./internal/cli/commands/` passes (incl. new test).
- Repro command now gets past parsing to device resolution (`name resolver error`), with **zero** `unknown flag` errors.
- ⚠️ Not yet exercised against a live device with a running ROS 2 app — `topic echo … --once` should stream real output there.

## Notes

`ros2.go` exists only on the unmerged PR #1008 stack, so this is **stacked on `wdy-1593`** (→ `wdy-1555` → `jo.ros2-support`) and should merge after them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)