### PR TITLE
cli/dashboard: sanitize log bodies and split multiline records

### DIFF
--- a/go/internal/cli/commands/dashboard.go
+++ b/go/internal/cli/commands/dashboard.go
@@ -204,8 +204,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 
 	case dashboardLogMsg:
-		line := formatLogLine(msg.service, msg.record)
-		m.logs = append(m.logs, line)
+		m.logs = append(m.logs, formatLogLines(msg.service, msg.record)...)
 		if m.autoScroll {
 			maxOff := len(m.logs) - m.logViewHeight()
 			if maxOff < 0 {
@@ -612,35 +611,120 @@ func extractMetricValue(m *otelpb.Metric) (string, time.Time) {
 	}
 }
 
-func formatLogLine(service string, lr *otelpb.LogRecord) string {
+// sanitizeLogText strips terminal control sequences from untrusted log content
+// so they cannot corrupt the dashboard's stdout grid. BubbleTea writes View()
+// verbatim to stdout and treats each '\n' as a row boundary it owns; a raw '\r',
+// cursor-movement/erase escape (e.g. from a `pulling manifest` spinner), or
+// other control byte embedded in a log body would otherwise move the real
+// terminal cursor and bleed across the pane separator.
+//
+// Newlines are preserved so the caller can split a multiline body into separate
+// rows. Tabs become spaces; carriage returns, ESC-introduced sequences, and all
+// other C0/C1/DEL control bytes are dropped.
+func sanitizeLogText(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	inEscape := false
+	for _, r := range s {
+		if inEscape {
+			// Mirror truncateVisible: an escape sequence ends at its first
+			// ASCII letter (final byte of CSI/SGR/cursor sequences).
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEscape = false
+			}
+			continue
+		}
+		switch {
+		case r == '\x1b':
+			inEscape = true
+		case r == '\n':
+			b.WriteRune('\n')
+		case r == '\t':
+			b.WriteByte(' ')
+		case r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f):
+			// C0 controls (incl. '\r'), DEL, and C1 controls: drop.
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// visibleWidth counts rendered columns, skipping ANSI escape sequences.
+func visibleWidth(s string) int {
+	visible := 0
+	inEscape := false
+	for _, r := range s {
+		if r == '\x1b' {
+			inEscape = true
+			continue
+		}
+		if inEscape {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEscape = false
+			}
+			continue
+		}
+		visible++
+	}
+	return visible
+}
+
+// formatLogLines renders one log record into one or more display rows. A
+// multiline body is split into separate rows; continuation rows are indented to
+// align under the body so the timestamp/severity prefix stays readable.
+// Attributes are appended to the final row.
+func formatLogLines(service string, lr *otelpb.LogRecord) []string {
 	ts := time.Unix(0, int64(lr.GetTimeUnixNano())).Local().Format("15:04:05")
 	label, style := severityLabel(lr.GetSeverityNumber())
 
-	var b strings.Builder
-	b.WriteString(logTimeStyle.Render(ts))
-	b.WriteByte(' ')
-	b.WriteString(style.Render(label))
+	var pb strings.Builder
+	pb.WriteString(logTimeStyle.Render(ts))
+	pb.WriteByte(' ')
+	pb.WriteString(style.Render(label))
 	if service != "" {
-		b.WriteByte(' ')
-		b.WriteString(logAppStyle.Render("[" + service + "]"))
+		pb.WriteByte(' ')
+		pb.WriteString(logAppStyle.Render("[" + service + "]"))
 	}
+	pb.WriteByte(' ')
+	prefix := pb.String()
+	indent := strings.Repeat(" ", visibleWidth(prefix))
 
-	body := lr.GetBody()
-	if body != nil {
-		b.WriteByte(' ')
-		b.WriteString(body.GetStringValue())
-	}
-
-	attrs := lr.GetAttributes()
-	if len(attrs) > 0 {
-		b.WriteByte(' ')
-		for i, kv := range attrs {
-			if i > 0 {
-				b.WriteByte(' ')
-			}
-			b.WriteString(logMetaStyle.Render(kv.GetKey() + "=" + anyValueString(kv.GetValue())))
+	var bodyLines []string
+	if body := lr.GetBody(); body != nil {
+		bodyLines = strings.Split(sanitizeLogText(body.GetStringValue()), "\n")
+		// Drop trailing blank lines (container output usually ends in '\n').
+		for len(bodyLines) > 0 && strings.TrimSpace(bodyLines[len(bodyLines)-1]) == "" {
+			bodyLines = bodyLines[:len(bodyLines)-1]
 		}
 	}
 
-	return b.String()
+	var attrStr string
+	if attrs := lr.GetAttributes(); len(attrs) > 0 {
+		var ab strings.Builder
+		for i, kv := range attrs {
+			if i > 0 {
+				ab.WriteByte(' ')
+			}
+			ab.WriteString(logMetaStyle.Render(sanitizeLogText(kv.GetKey()) + "=" + sanitizeLogText(anyValueString(kv.GetValue()))))
+		}
+		attrStr = ab.String()
+	}
+
+	var rows []string
+	for i, bl := range bodyLines {
+		if i == 0 {
+			rows = append(rows, prefix+bl)
+		} else {
+			rows = append(rows, indent+bl)
+		}
+	}
+	if len(rows) == 0 {
+		// No body: keep the prefix (trimmed of its trailing space) on its own row.
+		rows = append(rows, strings.TrimRight(prefix, " "))
+	}
+	if attrStr != "" {
+		rows[len(rows)-1] += " " + attrStr
+	}
+	return rows
 }

--- a/go/internal/cli/commands/dashboard.go
+++ b/go/internal/cli/commands/dashboard.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -621,30 +622,87 @@ func extractMetricValue(m *otelpb.Metric) (string, time.Time) {
 // Newlines are preserved so the caller can split a multiline body into separate
 // rows. Tabs become spaces; carriage returns, ESC-introduced sequences, and all
 // other C0/C1/DEL control bytes are dropped.
+//
+// The escape grammar is parsed by class rather than "drop until the next ASCII
+// letter", so an attacker-controlled OSC payload (e.g. `ESC ] 0 ; title BEL`,
+// as emitted by `pulling manifest` style spinners) cannot leak its tail, and a
+// two-character escape (e.g. `ESC 7`) cannot swallow the printable text that
+// follows it. Raw ESC and all control bytes are dropped unconditionally, so no
+// escape or control byte ever reaches stdout regardless of sequence shape.
 func sanitizeLogText(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
-	inEscape := false
-	for _, r := range s {
-		if inEscape {
-			// Mirror truncateVisible: an escape sequence ends at its first
-			// ASCII letter (final byte of CSI/SGR/cursor sequences).
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEscape = false
-			}
-			continue
+
+	const (
+		stNormal    = iota // ordinary text
+		stEscStart         // saw ESC (or an 8-bit C1 introducer); classify next rune
+		stCSI              // CSI sequence; ends at a final byte 0x40-0x7e
+		stString           // OSC/DCS/PM/APC/SOS string; ends at BEL or ST (ESC \)
+		stStringEsc        // saw ESC inside a string; ST iff the next rune is '\'
+	)
+	state := stNormal
+
+	// Decode runes explicitly rather than ranging: a raw 8-bit C1 control byte
+	// (e.g. the 0x9b CSI introducer) is not valid UTF-8, so `range` would yield
+	// RuneError and hide it. Unifying the raw byte value with the decoded rune
+	// lets the control/introducer checks see C1 controls in either form while
+	// still preserving valid multi-byte UTF-8 (e.g. braille spinner glyphs).
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			r = rune(s[i]) // invalid byte: treat by its raw value
 		}
-		switch {
-		case r == '\x1b':
-			inEscape = true
-		case r == '\n':
-			b.WriteRune('\n')
-		case r == '\t':
-			b.WriteByte(' ')
-		case r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f):
-			// C0 controls (incl. '\r'), DEL, and C1 controls: drop.
-		default:
-			b.WriteRune(r)
+		i += size
+
+		switch state {
+		case stEscStart:
+			switch {
+			case r == '[':
+				state = stCSI
+			case r == ']' || r == 'P' || r == 'X' || r == '^' || r == '_':
+				state = stString
+			default:
+				// Two-character escape (ESC 7, ESC =, ESC M, ...): complete.
+				state = stNormal
+			}
+		case stCSI:
+			// CSI parameter/intermediate bytes precede a final byte in 0x40-0x7e.
+			if r >= 0x40 && r <= 0x7e {
+				state = stNormal
+			}
+		case stString:
+			switch r {
+			case '\x07': // BEL terminator
+				state = stNormal
+			case '\x1b': // possible ST (ESC \)
+				state = stStringEsc
+			}
+		case stStringEsc:
+			// ST is ESC '\'; otherwise the ESC began a fresh sequence inside the
+			// string, so stay in the string and reinterpret the rune there.
+			if r == '\\' {
+				state = stNormal
+			} else {
+				state = stString
+			}
+		default: // stNormal
+			switch {
+			case r == '\x1b':
+				state = stEscStart
+			case r == 0x9b: // 8-bit CSI introducer
+				state = stCSI
+			case r == 0x9d || r == 0x90 || r == 0x9e || r == 0x9f || r == 0x98:
+				// 8-bit OSC/DCS/PM/APC/SOS introducers.
+				state = stString
+			case r == '\n':
+				b.WriteRune('\n')
+			case r == '\t':
+				b.WriteByte(' ')
+			case r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f):
+				// C0 controls (incl. '\r'), DEL, and other C1 controls: drop.
+			default:
+				b.WriteRune(r)
+			}
 		}
 	}
 	return b.String()
@@ -693,9 +751,11 @@ func formatLogLines(service string, lr *otelpb.LogRecord) []string {
 	var bodyLines []string
 	if body := lr.GetBody(); body != nil {
 		bodyLines = strings.Split(sanitizeLogText(body.GetStringValue()), "\n")
-		// Drop trailing blank lines (container output usually ends in '\n').
-		for len(bodyLines) > 0 && strings.TrimSpace(bodyLines[len(bodyLines)-1]) == "" {
-			bodyLines = bodyLines[:len(bodyLines)-1]
+		// Drop only the single empty element produced by a terminating '\n'
+		// (container output usually ends in one); intentional interior or
+		// trailing blank lines are preserved so records render in full.
+		if n := len(bodyLines); n > 0 && bodyLines[n-1] == "" {
+			bodyLines = bodyLines[:n-1]
 		}
 	}
 

--- a/go/internal/cli/commands/dashboard_test.go
+++ b/go/internal/cli/commands/dashboard_test.go
@@ -1,0 +1,134 @@
+package commands
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
+)
+
+// ansiRE strips SGR color codes (and any other escape sequences) so tests can
+// assert on the visible content of a rendered row.
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }
+
+func strBody(s string) *otelpb.AnyValue {
+	return &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: s}}
+}
+
+func strAttr(key, val string) *otelpb.KeyValue {
+	return &otelpb.KeyValue{Key: key, Value: strBody(val)}
+}
+
+func TestSanitizeLogText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "hello world", "hello world"},
+		{"carriage return dropped", "abc\rdef", "abcdef"},
+		{"cursor erase escape removed", "pulling manifest ⠋\x1b[2K", "pulling manifest ⠋"},
+		{"cursor up escape removed", "x\x1b[1Ay", "xy"},
+		{"sgr color removed", "\x1b[31mred\x1b[0m", "red"},
+		{"tab becomes space", "a\tb", "a b"},
+		{"nul and bell dropped", "a\x00\x07b", "ab"},
+		{"newline preserved", "line1\nline2", "line1\nline2"},
+		{"spinner braille preserved", "⠋⠙⠹", "⠋⠙⠹"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeLogText(tc.in); got != tc.want {
+				t.Fatalf("sanitizeLogText(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// noRowContainsControlBytes asserts the layout-breaking bytes never survive into
+// a rendered row. Raw newline/carriage-return and cursor-movement/erase escapes
+// would corrupt the BubbleTea stdout grid.
+func noRowContainsControlBytes(t *testing.T, rows []string) {
+	t.Helper()
+	for i, row := range rows {
+		if strings.ContainsAny(row, "\n\r") {
+			t.Fatalf("row %d contains raw newline/carriage return: %q", i, row)
+		}
+		// After stripping SGR color codes, no escape byte should remain.
+		if strings.ContainsRune(stripANSI(row), '\x1b') {
+			t.Fatalf("row %d contains a non-color escape sequence: %q", i, row)
+		}
+	}
+}
+
+func TestFormatLogLinesMultilineSplitsIntoRows(t *testing.T) {
+	lr := &otelpb.LogRecord{Body: strBody("line1\nline2\nline3")}
+	rows := formatLogLines("svc", lr)
+
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d: %#v", len(rows), rows)
+	}
+	noRowContainsControlBytes(t, rows)
+
+	if !strings.HasSuffix(stripANSI(rows[0]), "line1") {
+		t.Errorf("row 0 should end with body line1, got %q", stripANSI(rows[0]))
+	}
+	// Continuation rows are indented under the prefix and carry only body text.
+	for i, want := range []string{"line2", "line3"} {
+		row := stripANSI(rows[i+1])
+		if !strings.HasPrefix(row, " ") {
+			t.Errorf("continuation row %d should be indented, got %q", i+1, row)
+		}
+		if strings.TrimLeft(row, " ") != want {
+			t.Errorf("continuation row %d = %q, want indented %q", i+1, row, want)
+		}
+	}
+}
+
+func TestFormatLogLinesStripsProgressControlSequences(t *testing.T) {
+	// A spinner line as produced by `ollama pull`: trailing erase + carriage return.
+	lr := &otelpb.LogRecord{Body: strBody("pulling manifest ⠋\x1b[2K\r")}
+	rows := formatLogLines("llm-app", lr)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row (trailing empty dropped), got %d: %#v", len(rows), rows)
+	}
+	noRowContainsControlBytes(t, rows)
+	if !strings.Contains(stripANSI(rows[0]), "pulling manifest ⠋") {
+		t.Errorf("row should retain visible body, got %q", stripANSI(rows[0]))
+	}
+}
+
+func TestFormatLogLinesAttributesOnLastRow(t *testing.T) {
+	lr := &otelpb.LogRecord{
+		Body:       strBody("a\nb"),
+		Attributes: []*otelpb.KeyValue{strAttr("stream", "stderr")},
+	}
+	rows := formatLogLines("svc", lr)
+
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d: %#v", len(rows), rows)
+	}
+	noRowContainsControlBytes(t, rows)
+	last := stripANSI(rows[len(rows)-1])
+	if !strings.Contains(last, "stream=stderr") {
+		t.Errorf("attributes should be appended to the last row, got %q", last)
+	}
+	if strings.Contains(stripANSI(rows[0]), "stream=stderr") {
+		t.Errorf("attributes should not appear on the first row, got %q", stripANSI(rows[0]))
+	}
+}
+
+func TestFormatLogLinesNilBody(t *testing.T) {
+	lr := &otelpb.LogRecord{Attributes: []*otelpb.KeyValue{strAttr("k", "v")}}
+	rows := formatLogLines("svc", lr)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row for body-less record, got %d: %#v", len(rows), rows)
+	}
+	noRowContainsControlBytes(t, rows)
+	if !strings.Contains(stripANSI(rows[0]), "k=v") {
+		t.Errorf("expected attributes on the single row, got %q", stripANSI(rows[0]))
+	}
+}

--- a/go/internal/cli/commands/dashboard_test.go
+++ b/go/internal/cli/commands/dashboard_test.go
@@ -37,6 +37,12 @@ func TestSanitizeLogText(t *testing.T) {
 		{"nul and bell dropped", "a\x00\x07b", "ab"},
 		{"newline preserved", "line1\nline2", "line1\nline2"},
 		{"spinner braille preserved", "⠋⠙⠹", "⠋⠙⠹"},
+		{"osc title with bel terminator dropped", "\x1b]0;evil title\x07after", "after"},
+		{"osc title with st terminator dropped", "\x1b]0;evil title\x1b\\after", "after"},
+		{"dcs sequence dropped", "\x1bPq#payload\x1b\\done", "done"},
+		{"8-bit csi dropped", "before\x9b2Kafter", "beforeafter"},
+		{"two-char escape does not swallow following text", "x\x1b7y", "xy"},
+		{"two-char keypad escape dropped", "a\x1b=b", "ab"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -118,6 +124,24 @@ func TestFormatLogLinesAttributesOnLastRow(t *testing.T) {
 	}
 	if strings.Contains(stripANSI(rows[0]), "stream=stderr") {
 		t.Errorf("attributes should not appear on the first row, got %q", stripANSI(rows[0]))
+	}
+}
+
+func TestFormatLogLinesPreservesInteriorBlankLines(t *testing.T) {
+	// A body with an intentional interior blank line and a single terminating
+	// newline: the interior blank is kept, only the terminator empty is dropped.
+	lr := &otelpb.LogRecord{Body: strBody("a\n\nb\n")}
+	rows := formatLogLines("svc", lr)
+
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows (interior blank kept, terminator dropped), got %d: %#v", len(rows), rows)
+	}
+	noRowContainsControlBytes(t, rows)
+	if got := strings.TrimSpace(stripANSI(rows[1])); got != "" {
+		t.Errorf("row 1 should be the preserved blank line, got %q", got)
+	}
+	if !strings.HasSuffix(stripANSI(rows[2]), "b") {
+		t.Errorf("row 2 should carry body line b, got %q", stripANSI(rows[2]))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Untrusted log content rendered in the live dashboard could corrupt the terminal: a raw `\r`, cursor-movement/erase escape (e.g. an `ollama`/`pulling manifest` progress spinner), or other control byte in a log body would move the real terminal cursor and bleed across the pane separator, because BubbleTea writes `View()` verbatim to stdout and treats each `\n` as a row boundary it owns.
- Add `sanitizeLogText`, which drops C0/C1/DEL control bytes and ESC-introduced escape sequences, converts tabs to spaces, and preserves newlines.
- Replace `formatLogLine` with `formatLogLines`: it sanitizes the body, splits a multiline body into separate rows (continuation rows indented under the prefix), and appends attributes to the final row. Attribute keys/values are sanitized too.

## Test plan
- New `dashboard_test.go` covers sanitization cases (CR, cursor erase/up, SGR, tab, NUL/BEL, newline, braille spinner), multiline row splitting, progress-sequence stripping, attribute placement on the last row, and the nil-body case.
- `go test ./internal/cli/commands/` → ok
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)