### PR TITLE
perf(os install): pipeline seekable bmap writes, gate concurrency by storage type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	go.bug.st/serial v1.6.4
 	go.uber.org/zap v1.28.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.44.0
 	golang.org/x/term v0.43.0
 	google.golang.org/grpc v1.81.1
@@ -98,7 +99,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/go/internal/cli/commands/bmap.go
+++ b/go/internal/cli/commands/bmap.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
@@ -8,6 +9,9 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // BmapRange is one contiguous run of mapped blocks in a bmap file.
@@ -68,9 +72,24 @@ func parseBmap(data []byte) (*Bmap, error) {
 	return b, nil
 }
 
-// bmapChunkSize is the read granularity within a mapped range. Package-level
-// (not const) so tests can shrink it to exercise the multi-chunk path.
-var bmapChunkSize int64 = 1 << 20
+// bmapChunkSize is the read/write granularity within a mapped range. Larger
+// chunks mean fewer pwrite syscalls and bigger transfers to the device, which
+// matters on raw character devices (macOS /dev/rdiskN) and USB/SD media.
+// Package-level (not const) so tests can shrink it to exercise the multi-chunk
+// path.
+var bmapChunkSize int64 = 4 << 20
+
+// bmapWriteConcurrency is the number of writer goroutines applyBmapSeekable runs
+// concurrently. Decompression (CPU) and device writes (I/O) are pipelined, so
+// even a single writer keeps the device busy while the next chunk decompresses.
+// The default is 1 (strictly sequential) because that is the right policy for
+// SD/USB media: their flash translation layer is tuned for large sequential
+// writes, and scattering concurrent WriteAt calls across offsets triggers
+// erase-block read-modify-write and is slower, not faster. Only devices with
+// real write-queue depth (NVMe/SSD) benefit from >1 — see writersForStorage,
+// which the write paths use to raise this. Package-level so callers and tests
+// can override it.
+var bmapWriteConcurrency = 1
 
 // applyBmap reconstructs an image onto dst using the block map. It reads src
 // (the decompressed image) strictly sequentially — src may be a pipe — and
@@ -177,54 +196,116 @@ func mappedBytes(b *Bmap) int64 {
 	return total
 }
 
+// bmapWrite is one decompressed chunk handed from the reader goroutine to a
+// writer goroutine: the bytes and the device offset they belong at.
+type bmapWrite struct {
+	buf []byte
+	off int64
+}
+
 // applyBmapSeekable reconstructs an image onto dst using the block map, reading
 // only mapped ranges from a random-access source. It Seeks to each range's
 // start, so the underlying seekable decoder never decodes hole frames — this is
 // where the zero-block speedup comes from. Each range's SHA256 is verified
 // against the bmap; a mismatch aborts. progressFn reports cumulative mapped
-// bytes written.
+// bytes written; calls are serialized and monotonic.
+//
+// Decompression (CPU) and device writes (I/O) run in separate goroutines linked
+// by a bounded buffer pool, so the device is never idle waiting for the next
+// chunk to decompress and vice versa. bmapWriteConcurrency writer goroutines
+// drain the pipeline, keeping the write queue deep on media that benefits. The
+// seekable decoder is touched only by the single reader goroutine, honoring its
+// "not safe for concurrent use" contract.
 func applyBmapSeekable(src io.ReadSeeker, dst io.WriterAt, b *Bmap, progressFn func(int64)) error {
-	buf := make([]byte, bmapChunkSize)
-	var written int64
-	for _, r := range b.Ranges {
-		start := r.First * b.BlockSize
-		end := (r.Last + 1) * b.BlockSize
-		if end > b.ImageSize {
-			end = b.ImageSize
-		}
-		if end <= start {
-			continue
-		}
-		if _, err := src.Seek(start, io.SeekStart); err != nil {
-			return fmt.Errorf("seeking to %d: %w", start, err)
-		}
-		h := sha256.New()
-		off := start
-		for off < end {
-			n := int64(len(buf))
-			if rem := end - off; rem < n {
-				n = rem
-			}
-			if _, err := io.ReadFull(src, buf[:n]); err != nil {
-				return fmt.Errorf("reading mapped range at %d: %w", off, err)
-			}
-			if _, err := dst.WriteAt(buf[:n], off); err != nil {
-				return fmt.Errorf("writing at %d: %w", off, err)
-			}
-			h.Write(buf[:n])
-			off += n
-			written += n
-			progressFn(written)
-		}
-		if r.Checksum != "" {
-			got := hex.EncodeToString(h.Sum(nil))
-			if !strings.EqualFold(got, r.Checksum) {
-				return fmt.Errorf("bmap: checksum mismatch for blocks %d-%d (got %s, want %s)",
-					r.First, r.Last, got, r.Checksum)
-			}
-		}
+	workers := bmapWriteConcurrency
+	if workers < 1 {
+		workers = 1
 	}
-	return nil
+	// One reusable buffer per worker plus slack so the reader can run a couple
+	// of chunks ahead. A buffer only returns to free once its WriteAt completes,
+	// so the reader can never overwrite bytes still in flight.
+	poolSize := workers + 2
+	free := make(chan []byte, poolSize)
+	for i := 0; i < poolSize; i++ {
+		free <- make([]byte, bmapChunkSize)
+	}
+	jobs := make(chan bmapWrite, workers)
+
+	var progMu sync.Mutex
+	var written int64
+	report := func(n int) {
+		progMu.Lock()
+		written += int64(n)
+		progressFn(written)
+		progMu.Unlock()
+	}
+
+	g, ctx := errgroup.WithContext(context.Background())
+
+	for i := 0; i < workers; i++ {
+		g.Go(func() error {
+			for job := range jobs {
+				if _, err := dst.WriteAt(job.buf, job.off); err != nil {
+					return fmt.Errorf("writing at %d: %w", job.off, err)
+				}
+				report(len(job.buf))
+				free <- job.buf[:cap(job.buf)]
+			}
+			return nil
+		})
+	}
+
+	g.Go(func() error {
+		defer close(jobs)
+		for _, r := range b.Ranges {
+			start := r.First * b.BlockSize
+			end := (r.Last + 1) * b.BlockSize
+			if end > b.ImageSize {
+				end = b.ImageSize
+			}
+			if end <= start {
+				continue
+			}
+			if _, err := src.Seek(start, io.SeekStart); err != nil {
+				return fmt.Errorf("seeking to %d: %w", start, err)
+			}
+			h := sha256.New()
+			off := start
+			for off < end {
+				n := bmapChunkSize
+				if rem := end - off; rem < n {
+					n = rem
+				}
+				var buf []byte
+				select {
+				case buf = <-free:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				buf = buf[:n]
+				if _, err := io.ReadFull(src, buf); err != nil {
+					return fmt.Errorf("reading mapped range at %d: %w", off, err)
+				}
+				h.Write(buf) // hash on the reader goroutine, off the write path
+				select {
+				case jobs <- bmapWrite{buf: buf, off: off}:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				off += n
+			}
+			if r.Checksum != "" {
+				got := hex.EncodeToString(h.Sum(nil))
+				if !strings.EqualFold(got, r.Checksum) {
+					return fmt.Errorf("bmap: checksum mismatch for blocks %d-%d (got %s, want %s)",
+						r.First, r.Last, got, r.Checksum)
+				}
+			}
+		}
+		return nil
+	})
+
+	return g.Wait()
 }
 
 // parseRange parses a bmap range token: either "N" or "N-M".

--- a/go/internal/cli/commands/bmap_test.go
+++ b/go/internal/cli/commands/bmap_test.go
@@ -226,6 +226,73 @@ func TestApplyBmapSeekableWritesOnlyMappedRanges(t *testing.T) {
 	}
 }
 
+// TestApplyBmapSeekableConcurrentWriters stresses the pipelined writer path:
+// tiny chunks force many buffers to cycle through the pool while multiple
+// writer goroutines drain them out of order. A buffer-aliasing bug (the reader
+// overwriting a buffer still queued for write) would corrupt the output, and a
+// non-monotonic/racy progress counter would surface here under -race.
+func TestApplyBmapSeekableConcurrentWriters(t *testing.T) {
+	oldChunk, oldWorkers := bmapChunkSize, bmapWriteConcurrency
+	bmapChunkSize = 13       // tiny: many chunks per range, forces pool cycling
+	bmapWriteConcurrency = 4 // exercise multiple writer goroutines
+	defer func() { bmapChunkSize, bmapWriteConcurrency = oldChunk, oldWorkers }()
+
+	const bs = 4096
+	const blocks = 64
+	img := make([]byte, bs*blocks)
+	for i := range img {
+		img[i] = byte((i*7 + 3) % 256)
+	}
+	// Three mapped ranges separated by holes.
+	b := &Bmap{
+		BlockSize: bs,
+		ImageSize: int64(len(img)),
+		Ranges: []BmapRange{
+			{First: 0, Last: 3, Checksum: blockChecksum(img[0 : bs*4])},
+			{First: 10, Last: 20, Checksum: blockChecksum(img[bs*10 : bs*21])},
+			{First: 60, Last: 63, Checksum: blockChecksum(img[bs*60 : bs*64])},
+		},
+	}
+	comp := encodeSeekable(t, img, bs)
+	si, err := openSeekableZstdFromReader(bytes.NewReader(comp))
+	if err != nil {
+		t.Fatalf("open seekable: %v", err)
+	}
+	defer si.Close()
+
+	dst := newMemWriterAt(b.ImageSize)
+	var progress int64 // safe: applyBmapSeekable serializes progressFn calls
+	if err := applyBmapSeekable(si, dst, b, func(n int64) { progress = n }); err != nil {
+		t.Fatalf("applyBmapSeekable: %v", err)
+	}
+	for _, r := range b.Ranges {
+		s, e := r.First*bs, (r.Last+1)*bs
+		if !bytes.Equal(dst.buf[s:e], img[s:e]) {
+			t.Fatalf("range %d-%d not reconstructed correctly", r.First, r.Last)
+		}
+	}
+	for _, off := range []int{bs * 4, bs*10 - 1, bs * 21, bs*60 - 1} {
+		if dst.written[off] {
+			t.Fatalf("hole byte at offset %d was written", off)
+		}
+	}
+	if progress != mappedBytes(b) {
+		t.Fatalf("progress = %d, want %d", progress, mappedBytes(b))
+	}
+}
+
+func TestWritersForStorage(t *testing.T) {
+	if got := writersForStorage(StorageNVMe); got != 4 {
+		t.Errorf("NVMe writers = %d, want 4", got)
+	}
+	// SD/USB and unknown devices must stay strictly sequential.
+	for _, st := range []StorageType{StorageUSB, StorageUnknown} {
+		if got := writersForStorage(st); got != 1 {
+			t.Errorf("writers for %v = %d, want 1 (sequential)", st, got)
+		}
+	}
+}
+
 func TestApplyBmapSeekableDetectsCorruption(t *testing.T) {
 	img, b := buildSparseImage()
 	img[10] = 0xff // corrupt mapped block 0 before compression

--- a/go/internal/cli/commands/bmap_writer.go
+++ b/go/internal/cli/commands/bmap_writer.go
@@ -105,8 +105,13 @@ func validateDeviceTarget(path string) error {
 // runBmapWriteSeekable is the body of `__bmap-write` when --source is given. It
 // opens the seekable image and writes only mapped ranges to the raw device,
 // emitting cumulative bytes written on stdout (one decimal per line) so the
-// parent can drive the progress bar. Runs as root; no stdin pipe.
-func runBmapWriteSeekable(devicePath, bmapPath, sourcePath string, stdout io.Writer) (retErr error) {
+// parent can drive the progress bar. Runs as root; no stdin pipe. writers > 0
+// overrides the writer concurrency (the parent picks it from the storage type);
+// 0 keeps the sequential default that is correct for SD/USB media.
+func runBmapWriteSeekable(devicePath, bmapPath, sourcePath string, writers int, stdout io.Writer) (retErr error) {
+	if writers > 0 {
+		bmapWriteConcurrency = writers
+	}
 	if err := validateDeviceTarget(devicePath); err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/disklister_darwin.go
+++ b/go/internal/cli/commands/disklister_darwin.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -249,7 +250,8 @@ func writeImageWithBmapSeekable(sourcePath, bmapPath string, d drive, progressFn
 		return fmt.Errorf("locating wendy binary: %w", err)
 	}
 	cmd := exec.Command("sudo", self, "__bmap-write",
-		"--device", d.RawPath, "--bmap", bmapPath, "--source", sourcePath)
+		"--device", d.RawPath, "--bmap", bmapPath, "--source", sourcePath,
+		"--writers", strconv.Itoa(writersForStorage(d.StorageType)))
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("stdout pipe: %w", err)

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/dustin/go-humanize"
@@ -294,7 +295,8 @@ func writeImageWithBmapSeekable(sourcePath, bmapPath string, d drive, progressFn
 		return fmt.Errorf("locating wendy binary: %w", err)
 	}
 	cmd := exec.Command("sudo", self, "__bmap-write",
-		"--device", d.DevicePath, "--bmap", bmapPath, "--source", sourcePath)
+		"--device", d.DevicePath, "--bmap", bmapPath, "--source", sourcePath,
+		"--writers", strconv.Itoa(writersForStorage(d.StorageType)))
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("stdout pipe: %w", err)

--- a/go/internal/cli/commands/disklister_storage.go
+++ b/go/internal/cli/commands/disklister_storage.go
@@ -8,3 +8,15 @@ const (
 	StorageNVMe
 	StorageUSB
 )
+
+// writersForStorage returns how many concurrent writer goroutines the seekable
+// bmap writer should use for a given storage type. NVMe/SSD has real write-queue
+// depth and benefits from parallel WriteAt; SD/USB media (and unknown devices,
+// which are usually card readers) are serial and get slower under scattered
+// concurrent writes, so they write strictly sequentially.
+func writersForStorage(t StorageType) int {
+	if t == StorageNVMe {
+		return 4
+	}
+	return 1
+}

--- a/go/internal/cli/commands/disklister_windows.go
+++ b/go/internal/cli/commands/disklister_windows.go
@@ -538,6 +538,10 @@ func writeImageWithBmapSeekable(sourcePath, bmapPath string, d drive, progressFn
 		return err
 	}
 	defer ld.close()
+	// In-process on Windows (no helper subprocess), so set the writer
+	// concurrency directly from the storage type: parallel for NVMe, sequential
+	// for SD/USB media whose FTL is hurt by scattered concurrent writes.
+	bmapWriteConcurrency = writersForStorage(d.StorageType)
 	return applyBmapSeekable(si, handleWriterAt{h: ld.handle}, b, progressFn)
 }
 

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -152,12 +152,13 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	var bmapDevice, bmapFile, bmapSource string
+	var bmapWriters int
 	bmapWriteCmd := &cobra.Command{
 		Use:    "__bmap-write",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if bmapSource != "" {
-				return runBmapWriteSeekable(bmapDevice, bmapFile, bmapSource, cmd.OutOrStdout())
+				return runBmapWriteSeekable(bmapDevice, bmapFile, bmapSource, bmapWriters, cmd.OutOrStdout())
 			}
 			return runBmapWrite(bmapDevice, bmapFile, cmd.InOrStdin())
 		},
@@ -165,6 +166,7 @@ func NewRootCmd() *cobra.Command {
 	bmapWriteCmd.Flags().StringVar(&bmapDevice, "device", "", "Raw device path to write")
 	bmapWriteCmd.Flags().StringVar(&bmapFile, "bmap", "", "Path to the .bmap file")
 	bmapWriteCmd.Flags().StringVar(&bmapSource, "source", "", "Path to the seekable .img.zst source")
+	bmapWriteCmd.Flags().IntVar(&bmapWriters, "writers", 0, "Concurrent writer goroutines (0 = sequential default)")
 
 	root.AddCommand(
 		bleCheckCmd,


### PR DESCRIPTION
## What

Optimizes the seekable-zstd bmap write path used by `wendy os install`.

The old `applyBmapSeekable` loop did `decompress → write → hash` serially in a single goroutine, so the device sat idle during CPU work and the CPU sat idle during the device write — they never overlapped. This splits the loop into:

- a **reader** goroutine: `Seek` + decompress + SHA256, handing filled buffers over a bounded buffer pool, and
- **writer** goroutine(s): drain the pool and `WriteAt`.

So chunk N+1 decompresses while chunk N is still being written; the device is never blocked waiting on the CPU.

## Storage-aware writer concurrency

Writer count is now picked from the drive's `StorageType`:

- **NVMe/SSD** → 4 writers (real write-queue depth).
- **SD/USB/unknown** → **1 writer, strictly sequential.** Scattering concurrent `WriteAt` across offsets on SD/USB media triggers erase-block read-modify-write and is *slower*, not faster.

Default is `1` (safe everywhere); only the NVMe path opts up. Plumbed via a `--writers` flag on the hidden `__bmap-write` helper (Linux/macOS re-exec) and set in-process on Windows — mirroring how the `dd` path already branches `bs=4M`/`bs=64M` on storage type.

## Also

- Chunk size 1 MiB → 4 MiB (fewer `pwrite` syscalls, bigger transfers; matters on macOS raw `/dev/rdiskN`).
- SHA256 moved off the write path onto the reader goroutine.
- Progress reporting serialized under a mutex so it stays monotonic across parallel writers (production emits cumulative bytes to the parent's progress bar).
- Holes are still skipped (seek past them) — empty space stays free.

## Scope note

Only touches the **seekable** path (`applyBmapSeekable`). Images published as gzip+bmap without a `.zst` (currently all Raspberry Pi builds) take the separate `applyBmap` path and are unaffected by this PR.

## Tests

- `go test -race ./internal/cli/commands` passes.
- New `TestApplyBmapSeekableConcurrentWriters` (tiny chunks + 4 writers stresses buffer-pool reuse and parallel out-of-order writes, `-race`-clean).
- New `TestWritersForStorage` locks the NVMe=4 / SD=USB=unknown=1 policy.
- Builds for darwin, linux/arm64, windows/amd64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)