### PR TITLE
Map jetson-agx-thor to the nvidia-jetson platform tier

### DIFF
--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -743,6 +743,7 @@ var deviceTypeNames = map[string]string{
 	"raspberry-pi-5":   "Raspberry Pi 5",
 	"jetson-agx-orin":  "Jetson AGX Orin",
 	"jetson-orin-nano": "Jetson Orin Nano",
+	"jetson-agx-thor":  "Jetson AGX Thor",
 	"x86_64":           "x86-64",
 }
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1634,9 +1634,15 @@ func startPostStartHook(ctx context.Context, appCfg *appconfig.AppConfig, hostna
 // Dockerfile base stage selection. Adding a new device only requires adding
 // a case here; templates need no changes until a new platform tier is introduced.
 // Unknown device types fall back to "generic" (CPU-only).
+//
+// jetson-agx-thor (tegra264 / JetPack 7 / CUDA 13) shares the "nvidia-jetson"
+// tier with the Orin boards (tegra234 / JetPack 6 / CUDA 12). The tier only says
+// "NVIDIA Jetson"; templates that ship a JetPack-pinned base image should branch
+// on the WENDY_JETPACK_VERSION / WENDY_CUDA_VERSION build args (also injected by
+// `wendy run`) to pick a Thor-compatible image where the JetPack 6 image differs.
 func wendyPlatform(deviceType string) string {
 	switch deviceType {
-	case "jetson-agx-orin", "jetson-orin-nano":
+	case "jetson-agx-orin", "jetson-orin-nano", "jetson-agx-thor":
 		return "nvidia-jetson"
 	default:
 		return "generic"

--- a/go/internal/cli/commands/run_test.go
+++ b/go/internal/cli/commands/run_test.go
@@ -16,6 +16,7 @@ func TestWendyPlatform(t *testing.T) {
 	}{
 		{"jetson-agx-orin", "nvidia-jetson"},
 		{"jetson-orin-nano", "nvidia-jetson"},
+		{"jetson-agx-thor", "nvidia-jetson"},
 		{"raspberrypi5", "generic"},
 		{"unknown-device", "generic"},
 		{"", "generic"},


### PR DESCRIPTION
## What

`wendyPlatform()` (used by `wendy run` / `wendy compose` to inject the `WENDY_PLATFORM` build arg) recognized only the Orin boards. A **Jetson AGX Thor** device (`jetson-agx-thor`) fell through to `generic`, so any Dockerfile that selects its base stage via `FROM base-${WENDY_PLATFORM}` got the **CPU** stage — no GPU acceleration on Thor.

This adds `jetson-agx-thor` to the `nvidia-jetson` case (plus the `wendy discover` display-name map and the `TestWendyPlatform` table).

## Why this tier, and the JetPack caveat

Thor is tegra264 / JetPack 7 / CUDA 13; the Orin boards are tegra234 / JetPack 6 / CUDA 12. They share the **coarse `nvidia-jetson` tier** ("this is an NVIDIA Jetson"), but their base images are not interchangeable.

I kept the single tier deliberately: the 5 `camera-feed-yolo` templates do `FROM base-${WENDY_PLATFORM}` with only `base-generic` / `base-nvidia-jetson` stages, so a *new* tier (e.g. `nvidia-jetson-thor`) would break their builds on Thor (missing stage). The doc comment now records that templates shipping a JetPack-pinned base image should branch on the injected `WENDY_JETPACK_VERSION` / `WENDY_CUDA_VERSION` args to pick a Thor-compatible image — those templates currently use a JetPack-6 (dustynv r36/cu128) image that won't GPU-accelerate on Thor. That image refinement is a per-template follow-up, not part of this CLI change.

## Relation to templates#46

Companion to wendylabsinc/templates#46, which makes the `llm` template select NVIDIA's CUDA Ollama image. That template keys on `WENDY_GPU_VENDOR` (which already covers Thor), so it does **not** depend on this change — this fixes the `WENDY_PLATFORM`-keyed templates (camera-feed-yolo) and the device display name.

## Testing

- `go test ./go/internal/cli/commands/` — pass (incl. new `TestWendyPlatform` case).
- `go vet ./go/internal/cli/commands/` — clean.
- `gofmt -l` clean; `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)