### PR TITLE
feat(agent): export telemetry to cloud over OTLP gRPC

### DIFF
--- a/Documentation/2026-06-17-otlp-cloud-export-design.md
+++ b/Documentation/2026-06-17-otlp-cloud-export-design.md
@@ -1,0 +1,161 @@
+# Export agent telemetry to the cloud over OTLP gRPC
+
+**Date:** 2026-06-17
+**Status:** Approved (design)
+**Area:** `wendy-agent` — `go/internal/agent/services/cloud_flusher.go`
+
+## Problem
+
+The agent's `CloudFlusher` uploads buffered telemetry by converting OTLP log
+records into a custom `cloudpb.LogEntry` and calling the custom
+`wendycloud.v1.RemoteLoggingService/WriteLogEntries` RPC. The cloud no longer
+implements that route, so every flush fails:
+
+```
+cloud flusher: flush failed error=cloud flusher: WriteLogEntries (app=llm-app):
+  rpc error: code = Unimplemented desc = Requested RPC isn't implemented by this server.
+```
+
+The agent already *receives* native OTLP from apps (gRPC `:4317`, HTTP `:4318`)
+and buffers it as `ExportLogsServiceRequest` / `ExportMetricsServiceRequest` /
+`ExportTraceServiceRequest` with per-signal disk cursors. The fix is to stop
+converting and instead **re-export the buffered OTLP verbatim to the cloud's
+standard OTLP collector routes over gRPC**.
+
+Out of scope: the tunnel broker's `RegisterPresence` returning `Unimplemented`
+(tracked separately — OTLP has no broker/presence equivalent).
+
+## Goals
+
+- Replace the custom `WriteLogEntries` upload path with standard OTLP
+  `*Service/Export` gRPC calls.
+- Export all three signals (logs, metrics, traces). Today only logs are
+  uploaded; metrics/traces are buffered locally and never leave the device.
+- Preserve the existing device-side PII/size guards (deny-list, truncation,
+  label cap) by re-applying them to the OTLP records before export.
+- Preserve at-least-once delivery, per-signal cursors, and the 1s→60s
+  exponential backoff.
+
+## Non-goals
+
+- No fallback to `WriteLogEntries` on `Unimplemented`. The cloud is a single
+  centrally-deployed endpoint being upgraded in place — version-skew fallback
+  (as used for agent-vs-CLI) does not apply here.
+- No change to how telemetry is *received* or *buffered*.
+- No broker / tunnel changes.
+
+## Approach
+
+Re-export buffered OTLP per-signal. The dial stays the same (TLS 1.3 + mTLS
+device cert); only the RPC target changes. Each buffered frame is exported as
+one `Export` call to the matching cloud collector service.
+
+### Identity
+
+Org/asset are derived **server-side from the mTLS client certificate**, exactly
+as the current `WriteLogEntries` dial relies on. No `organization_id` /
+`asset_id` / `app_id` fields are sent. `app_id` continues to be carried as the
+`service.name` resource attribute already present in the OTLP payload. The
+`orgID`/`assetID` parameters on the constructors become unused in the export
+path (retained on the signature for caller/test compatibility).
+
+### Endpoint
+
+Same provisioned cloud host, port `:443`, mTLS — identical to today's dial.
+Standard OTLP gRPC service paths, via the already-generated `otelpb` client
+stubs:
+
+- `opentelemetry.proto.collector.logs.v1.LogsService/Export`
+- `opentelemetry.proto.collector.metrics.v1.MetricsService/Export`
+- `opentelemetry.proto.collector.trace.v1.TraceService/Export`
+
+### Dial & clients
+
+`dial` keeps `normalizeCloudHost`, the leaf+chain cert bundle, the system CA
+pool plus device chain, TLS 1.3, and the best-effort key zeroing. It now returns
+just the `*grpc.ClientConn`. The flusher builds all three OTLP clients from that
+single conn:
+
+```go
+logs := otelpb.NewLogsServiceClient(conn)
+metrics := otelpb.NewMetricsServiceClient(conn)
+traces := otelpb.NewTraceServiceClient(conn)
+```
+
+### Per-signal flush loop
+
+`runOnce` becomes signal-generic. For each signal in
+`{SignalLogs, SignalMetrics, SignalTraces}`:
+
+1. `cursor := buffer.LoadCursor(sig)`
+2. `frames, next := buffer.ReadFromCursor(sig, cursor, framesPerPass)` — frames
+   are freshly unmarshalled `Export*ServiceRequest` messages. `framesPerPass`
+   is a single constant (the count of buffered frames read per pass, reusing
+   the current value of 500) bounding how many frames a pass exports before
+   looping.
+3. For each frame: sanitize in place, then `client.Export(ctx, frame)` — **one
+   Export RPC per buffered frame**. Each frame was already bounded by the
+   receiver's body limits, so per-frame export avoids gRPC message-size math.
+4. After all frames in the batch succeed, `buffer.SaveCursor(sig, next)`.
+
+A failure on any frame aborts the pass without advancing that signal's cursor
+(at-least-once; the cloud tolerates duplicates) and triggers the shared
+backoff, matching current behavior. Signals are processed in a fixed order so
+retries re-send deterministically.
+
+### Sanitization — `go/internal/agent/services/cloud_telemetry_sanitize.go`
+
+The guards currently inline in `convertLogRecord` move into reusable in-place
+mutators:
+
+- `sanitizeLogs(*otelpb.ExportLogsServiceRequest)`
+- `sanitizeMetrics(*otelpb.ExportMetricsServiceRequest)`
+- `sanitizeTraces(*otelpb.ExportTraceServiceRequest)`
+
+Each walks Resource → Scope → record/datapoint/span attributes and applies the
+existing rules consistently across all three signals:
+
+- drop attributes whose key matches `sensitiveLabelDenyList`
+  (`isSensitiveLabelKey`),
+- truncate attribute keys to `maxLabelKeyLen`, values to `maxLabelValLen`,
+- truncate log-record bodies to `maxLogBodyBytes`,
+- cap attribute count at `maxLabels` per record.
+
+Frames returned by `ReadFromCursor` are freshly decoded per read, so in-place
+mutation is safe and does not touch the live in-memory broadcaster copies.
+
+### Removed
+
+`convertLogRecord`, `groupByApp`, `otelSeverityToCloud`, the per-app chunking
+logic and its `cloudFlusherMaxEntriesPerApp` constant (record-level chunking
+tied to `LogEntry`), and the `cloudpb` import in `cloud_flusher.go`. The
+read-batch constant is repurposed as `framesPerPass` (see above). `otelAnyValueString` is retained (moved
+to the sanitize file) since the sanitizer needs string coercion. `cloudpb`
+remains a package dependency via `tunnel_broker_client.go` and
+`provisioning_service.go`.
+
+## Risks / dependencies
+
+- **Rollout ordering:** the cloud must expose the three OTLP collector routes at
+  the provisioned host:443 and map the device cert → org/asset **before** this
+  agent ships. Until then the agent logs `Unimplemented` from the new routes
+  instead of the old one. This is the single hard external dependency.
+- **Volume increase:** metrics and traces now leave the device for the first
+  time. Existing buffer caps and backoff bound the rate; no new throttle is
+  added in this change.
+
+## Testing
+
+Rewrite `go/internal/agent/services/cloud_flusher_test.go`:
+
+- Stand up in-process fake `LogsService` / `MetricsService` / `TraceService`
+  gRPC servers that record received `Export` requests.
+- Seed the `TelemetryBuffer` with all three signals; assert each `Export` is
+  called with the expected payload and that per-signal cursors advance only
+  after success.
+- Retain the security assertions (deny-listed attributes dropped; oversized
+  body/labels truncated; label cap), now asserting against the exported OTLP
+  records rather than `cloudpb.LogEntry`.
+- Assert that a failing `Export` leaves the cursor unadvanced (retry safety).
+
+Run `go test ./internal/agent/services` and `gofmt -w` on touched files.

--- a/go/internal/agent/services/cloud_flusher.go
+++ b/go/internal/agent/services/cloud_flusher.go
@@ -4,20 +4,16 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/hex"
 	"fmt"
 	"math"
 	"net"
-	"sort"
 	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
-	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
 )
 
@@ -30,16 +26,17 @@ func normalizeCloudHost(host string) string {
 }
 
 const (
-	cloudFlusherMaxBackoff       = 60 * time.Second
-	cloudFlusherBatchSize        = 500
-	cloudFlusherDefaultApp       = "device"
-	cloudFlusherCollector        = "wendy-agent"
-	cloudFlusherMaxEntriesPerApp = 5000 // per-RPC cap to stay under gRPC message size limits
+	cloudFlusherMaxBackoff = 60 * time.Second
+	// cloudFlusherFramesPerPass bounds how many buffered OTLP frames a single
+	// flush pass reads (and exports, one Export RPC each) before looping.
+	cloudFlusherFramesPerPass = 500
 )
 
-// CloudFlusher reads log segments from TelemetryBuffer via ReadFromCursor,
-// converts OTLP LogRecords to cloud LogEntry values, and calls WriteLogEntries.
-// Metrics and traces are not uploaded in this iteration.
+// CloudFlusher reads buffered OTLP frames from TelemetryBuffer via ReadFromCursor
+// and re-exports them to the cloud's standard OTLP collector routes
+// (Logs/Metrics/Trace Service Export) over mTLS gRPC. PII/size guards are
+// applied per frame before export. Identity is derived server-side from the
+// client certificate.
 type CloudFlusher struct {
 	logger          *zap.Logger
 	buffer          *TelemetryBuffer
@@ -76,12 +73,11 @@ func (f *CloudFlusher) Run(ctx context.Context) {
 	}
 
 	var cloudHost string
-	var orgID, assetID int32
 
 	// Poll until provisioned.
 	for {
 		var enrolled bool
-		cloudHost, orgID, assetID, enrolled = f.provisioningSvc.ProvisioningInfo()
+		cloudHost, _, _, enrolled = f.provisioningSvc.ProvisioningInfo()
 		if enrolled {
 			break
 		}
@@ -105,7 +101,7 @@ func (f *CloudFlusher) Run(ctx context.Context) {
 		}
 
 		certPEM, chainPEM, keyData := f.provisioningSvc.ProvisioningCerts()
-		conn, client, err := f.dial(ctx, cloudHost, certPEM, chainPEM, keyData)
+		conn, err := f.dial(ctx, cloudHost, certPEM, chainPEM, keyData)
 		if err != nil {
 			f.logger.Warn("cloud flusher: dial failed", zap.Error(err))
 			f.sleep(ctx, attempt)
@@ -113,7 +109,11 @@ func (f *CloudFlusher) Run(ctx context.Context) {
 			continue
 		}
 
-		err = f.runOnce(ctx, client, orgID, assetID)
+		err = f.runOnce(ctx,
+			otelpb.NewLogsServiceClient(conn),
+			otelpb.NewMetricsServiceClient(conn),
+			otelpb.NewTraceServiceClient(conn),
+		)
 		conn.Close()
 
 		if err != nil {
@@ -147,7 +147,7 @@ func (f *CloudFlusher) sleep(ctx context.Context, attempt int) {
 
 // dial establishes a TLS 1.3 gRPC connection. keyData is zeroed on return as
 // best-effort protection; crypto/tls may retain additional internal copies.
-func (f *CloudFlusher) dial(ctx context.Context, host, certPEM, chainPEM string, keyData []byte) (*grpc.ClientConn, cloudpb.RemoteLoggingServiceClient, error) {
+func (f *CloudFlusher) dial(ctx context.Context, host, certPEM, chainPEM string, keyData []byte) (*grpc.ClientConn, error) {
 	host = normalizeCloudHost(host)
 	defer func() {
 		for i := range keyData {
@@ -163,7 +163,7 @@ func (f *CloudFlusher) dial(ctx context.Context, host, certPEM, chainPEM string,
 	}
 	cert, err := tls.X509KeyPair(certBundle, keyData)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cloud flusher: parse key pair: %w", err)
+		return nil, fmt.Errorf("cloud flusher: parse key pair: %w", err)
 	}
 
 	caPool, err := x509.SystemCertPool()
@@ -182,225 +182,65 @@ func (f *CloudFlusher) dial(ctx context.Context, host, certPEM, chainPEM string,
 
 	conn, err := grpc.NewClient(host, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return conn, cloudpb.NewRemoteLoggingServiceClient(conn), nil
+	return conn, nil
 }
 
-// runOnce performs a single read-convert-upload pass. It does not advance the
-// cursor if WriteLogEntries returns an error (ensuring retry safety).
-func (f *CloudFlusher) runOnce(ctx context.Context, client cloudpb.RemoteLoggingServiceClient, orgID, assetID int32) error {
+// runOnce performs a single flush pass over all three OTLP signals. For each
+// signal it reads a batch of buffered frames, sanitizes each, and exports it
+// via the matching OTLP collector route. A signal's cursor advances only after
+// every frame in its batch is exported successfully (at-least-once delivery;
+// the cloud tolerates duplicates). Org/asset identity is derived server-side
+// from the mTLS client certificate, so no identifiers are sent in the request.
+func (f *CloudFlusher) runOnce(ctx context.Context, logs otelpb.LogsServiceClient, metrics otelpb.MetricsServiceClient, traces otelpb.TraceServiceClient) error {
 	if f.buffer == nil {
 		return nil
 	}
-	// cursor.json is HMAC-SHA256 integrity-protected via a device-local key
-	// stored in cursor.key. Any tampering or corruption is detected by
-	// LoadCursor, which resets the offset to zero rather than trusting a
-	// manipulated value.
-	cursor := f.buffer.LoadCursor(SignalLogs)
-	msgs, next, err := f.buffer.ReadFromCursor(SignalLogs, cursor, cloudFlusherBatchSize)
+	if err := f.flushSignal(ctx, SignalLogs, func(msg proto.Message) error {
+		req := msg.(*otelpb.ExportLogsServiceRequest)
+		sanitizeLogs(req)
+		_, err := logs.Export(ctx, req)
+		return err
+	}); err != nil {
+		return err
+	}
+	if err := f.flushSignal(ctx, SignalMetrics, func(msg proto.Message) error {
+		req := msg.(*otelpb.ExportMetricsServiceRequest)
+		sanitizeMetrics(req)
+		_, err := metrics.Export(ctx, req)
+		return err
+	}); err != nil {
+		return err
+	}
+	return f.flushSignal(ctx, SignalTraces, func(msg proto.Message) error {
+		req := msg.(*otelpb.ExportTraceServiceRequest)
+		sanitizeTraces(req)
+		_, err := traces.Export(ctx, req)
+		return err
+	})
+}
+
+// flushSignal reads one batch of buffered frames for sig, exports each via the
+// provided callback, and advances the signal's cursor only if all exports
+// succeed. On any export error the cursor is left untouched so the batch is
+// retried (already-exported frames may be re-sent).
+func (f *CloudFlusher) flushSignal(ctx context.Context, sig SignalType, export func(proto.Message) error) error {
+	cursor := f.buffer.LoadCursor(sig)
+	msgs, next, err := f.buffer.ReadFromCursor(sig, cursor, cloudFlusherFramesPerPass)
 	if err != nil {
-		return fmt.Errorf("cloud flusher: read from cursor: %w", err)
+		return fmt.Errorf("cloud flusher: read %s from cursor: %w", sig, err)
 	}
 	if len(msgs) == 0 {
 		return nil
 	}
-
-	// Group entries by app ID (service.name resource attribute).
-	appEntries := f.groupByApp(msgs)
-
-	// Sort app IDs for deterministic iteration order so that partial-failure
-	// retries always re-send apps in the same sequence.
-	appIDs := make([]string, 0, len(appEntries))
-	for appID := range appEntries {
-		appIDs = append(appIDs, appID)
-	}
-	sort.Strings(appIDs)
-
-	// Each app's entries are sent in one or more RPCs, chunked to at most
-	// cloudFlusherMaxEntriesPerApp entries to stay within gRPC message size limits.
-	// On any failure, the cursor is NOT advanced and the entire batch is retried —
-	// already-uploaded entries will be re-sent. This is intentional at-least-once
-	// delivery; the cloud accepts duplicates.
-	collectorStr := cloudFlusherCollector
-	var sentAny bool
-	for _, appID := range appIDs {
-		allEntries := appEntries[appID]
-		for start := 0; start < len(allEntries); start += cloudFlusherMaxEntriesPerApp {
-			end := start + cloudFlusherMaxEntriesPerApp
-			if end > len(allEntries) {
-				end = len(allEntries)
-			}
-			req := &cloudpb.WriteLogEntriesRequest{
-				OrganizationId: orgID,
-				AssetId:        assetID,
-				AppId:          appID,
-				Collector:      &collectorStr,
-				Entries:        allEntries[start:end],
-			}
-			if _, err := client.WriteLogEntries(ctx, req); err != nil {
-				if sentAny {
-					// Warn operators that already-uploaded entries will be re-sent on retry.
-					f.logger.Warn("cloud flusher: partial batch failure; prior entries will be re-sent on retry",
-						zap.String("failed_app", appID),
-					)
-				}
-				// Do NOT advance cursor; caller will retry.
-				return fmt.Errorf("cloud flusher: WriteLogEntries (app=%s): %w", appID, err)
-			}
-			sentAny = true
+	for _, msg := range msgs {
+		if err := export(msg); err != nil {
+			return fmt.Errorf("cloud flusher: export %s: %w", sig, err)
 		}
 	}
-
-	// All batches succeeded — advance the cursor.
-	if err := f.buffer.SaveCursor(SignalLogs, next); err != nil {
-		f.logger.Warn("cloud flusher: failed to save cursor", zap.Error(err))
-		return fmt.Errorf("saving cursor: %w", err)
+	if err := f.buffer.SaveCursor(sig, next); err != nil {
+		return fmt.Errorf("cloud flusher: save %s cursor: %w", sig, err)
 	}
 	return nil
-}
-
-// groupByApp converts OTLP log messages to cloud LogEntry values grouped by
-// the service.name resource attribute. Entries without a service.name are
-// grouped under "device".
-func (f *CloudFlusher) groupByApp(msgs []proto.Message) map[string][]*cloudpb.LogEntry {
-	result := make(map[string][]*cloudpb.LogEntry)
-
-	for _, msg := range msgs {
-		req, ok := msg.(*otelpb.ExportLogsServiceRequest)
-		if !ok {
-			continue
-		}
-		for _, rl := range req.GetResourceLogs() {
-			appID := cloudFlusherDefaultApp
-			if res := rl.GetResource(); res != nil {
-				for _, kv := range res.GetAttributes() {
-					if kv.GetKey() == "service.name" {
-						if s := kv.GetValue().GetStringValue(); s != "" {
-							appID = s
-						}
-						break
-					}
-				}
-			}
-
-			for _, sl := range rl.GetScopeLogs() {
-				for _, lr := range sl.GetLogRecords() {
-					entry := convertLogRecord(lr)
-					result[appID] = append(result[appID], entry)
-				}
-			}
-		}
-	}
-	return result
-}
-
-// convertLogRecord converts a single OTLP LogRecord to a cloud LogEntry.
-func convertLogRecord(lr *otelpb.LogRecord) *cloudpb.LogEntry {
-	entry := &cloudpb.LogEntry{
-		Severity: otelSeverityToCloud(lr.GetSeverityNumber()),
-	}
-
-	// Timestamp.
-	if ns := lr.GetTimeUnixNano(); ns != 0 {
-		entry.Timestamp = timestamppb.New(time.Unix(0, int64(ns)))
-	}
-	if ns := lr.GetObservedTimeUnixNano(); ns != 0 {
-		entry.ObservedAt = timestamppb.New(time.Unix(0, int64(ns)))
-	}
-
-	// Trace/span IDs as hex strings.
-	if traceID := lr.GetTraceId(); len(traceID) == 16 {
-		entry.TraceId = hex.EncodeToString(traceID)
-	}
-	if spanID := lr.GetSpanId(); len(spanID) == 8 {
-		entry.SpanId = hex.EncodeToString(spanID)
-	}
-
-	// Body → text payload. Truncated to maxLogBodyBytes to prevent oversized
-	// entries from reaching the cloud and to guard against data-exfiltration
-	// via abnormally large log bodies.
-	if body := lr.GetBody(); body != nil {
-		text := otelAnyValueString(body)
-		if len(text) > maxLogBodyBytes {
-			text = text[:maxLogBodyBytes]
-		}
-		entry.Payload = &cloudpb.LogEntry_TextPayload{
-			TextPayload: text,
-		}
-	}
-
-	// Copy log-record attributes into labels, applying PII / size guards:
-	//   • keys matching the credential/PII deny-list are dropped entirely
-	//   • keys and values are truncated to avoid excessive data transfer
-	//   • total label count is capped at maxLabels
-	if attrs := lr.GetAttributes(); len(attrs) > 0 {
-		labels := make(map[string]string, min(len(attrs), maxLabels))
-		for _, kv := range attrs {
-			if len(labels) >= maxLabels {
-				break
-			}
-			k := kv.GetKey()
-			if isSensitiveLabelKey(k) {
-				continue
-			}
-			if len(k) > maxLabelKeyLen {
-				k = k[:maxLabelKeyLen]
-			}
-			v := otelAnyValueString(kv.GetValue())
-			if len(v) > maxLabelValLen {
-				v = v[:maxLabelValLen]
-			}
-			labels[k] = v
-		}
-		entry.Labels = labels
-	}
-
-	return entry
-}
-
-// otelAnyValueString converts an OTLP AnyValue to a human-readable string.
-func otelAnyValueString(v *otelpb.AnyValue) string {
-	if v == nil {
-		return ""
-	}
-	switch val := v.GetValue().(type) {
-	case *otelpb.AnyValue_StringValue:
-		return val.StringValue
-	case *otelpb.AnyValue_BoolValue:
-		if val.BoolValue {
-			return "true"
-		}
-		return "false"
-	case *otelpb.AnyValue_IntValue:
-		return fmt.Sprintf("%d", val.IntValue)
-	case *otelpb.AnyValue_DoubleValue:
-		return fmt.Sprintf("%g", val.DoubleValue)
-	case *otelpb.AnyValue_BytesValue:
-		return hex.EncodeToString(val.BytesValue)
-	default:
-		return fmt.Sprintf("%v", v)
-	}
-}
-
-// otelSeverityToCloud maps an OTLP SeverityNumber to a cloud LogSeverity.
-func otelSeverityToCloud(sev otelpb.SeverityNumber) cloudpb.LogSeverity {
-	switch {
-	case sev == otelpb.SeverityNumber_SEVERITY_NUMBER_UNSPECIFIED:
-		return cloudpb.LogSeverity_LOG_SEVERITY_UNSPECIFIED
-	case sev >= otelpb.SeverityNumber_SEVERITY_NUMBER_TRACE && sev <= otelpb.SeverityNumber_SEVERITY_NUMBER_TRACE4:
-		return cloudpb.LogSeverity_LOG_SEVERITY_DEBUG
-	case sev >= otelpb.SeverityNumber_SEVERITY_NUMBER_DEBUG && sev <= otelpb.SeverityNumber_SEVERITY_NUMBER_DEBUG4:
-		return cloudpb.LogSeverity_LOG_SEVERITY_DEBUG
-	case sev >= otelpb.SeverityNumber_SEVERITY_NUMBER_INFO && sev <= otelpb.SeverityNumber_SEVERITY_NUMBER_INFO4:
-		return cloudpb.LogSeverity_LOG_SEVERITY_INFO
-	case sev >= otelpb.SeverityNumber_SEVERITY_NUMBER_WARN && sev <= otelpb.SeverityNumber_SEVERITY_NUMBER_WARN4:
-		return cloudpb.LogSeverity_LOG_SEVERITY_WARNING
-	case sev >= otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR && sev <= otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR4:
-		return cloudpb.LogSeverity_LOG_SEVERITY_ERROR
-	case sev >= otelpb.SeverityNumber_SEVERITY_NUMBER_FATAL && sev <= otelpb.SeverityNumber_SEVERITY_NUMBER_FATAL4:
-		return cloudpb.LogSeverity_LOG_SEVERITY_CRITICAL
-	default:
-		return cloudpb.LogSeverity_LOG_SEVERITY_UNSPECIFIED
-	}
 }

--- a/go/internal/agent/services/cloud_flusher.go
+++ b/go/internal/agent/services/cloud_flusher.go
@@ -45,7 +45,8 @@ type CloudFlusher struct {
 
 // NewCloudFlusher creates a CloudFlusher for tests. The explicit org/asset ID
 // parameters are preserved for compatibility with existing callers, but the
-// flusher does not store them on the struct.
+// flusher does not store them on the struct. They are ignored entirely because
+// device identity is derived from the mTLS client certificate.
 func NewCloudFlusher(logger *zap.Logger, buffer *TelemetryBuffer, orgID, assetID int32) *CloudFlusher {
 	return &CloudFlusher{
 		logger: logger,
@@ -197,7 +198,7 @@ func (f *CloudFlusher) runOnce(ctx context.Context, logs otelpb.LogsServiceClien
 	if f.buffer == nil {
 		return nil
 	}
-	if err := f.flushSignal(ctx, SignalLogs, func(msg proto.Message) error {
+	if err := f.flushSignal(SignalLogs, func(msg proto.Message) error {
 		req := msg.(*otelpb.ExportLogsServiceRequest)
 		sanitizeLogs(req)
 		_, err := logs.Export(ctx, req)
@@ -205,7 +206,7 @@ func (f *CloudFlusher) runOnce(ctx context.Context, logs otelpb.LogsServiceClien
 	}); err != nil {
 		return err
 	}
-	if err := f.flushSignal(ctx, SignalMetrics, func(msg proto.Message) error {
+	if err := f.flushSignal(SignalMetrics, func(msg proto.Message) error {
 		req := msg.(*otelpb.ExportMetricsServiceRequest)
 		sanitizeMetrics(req)
 		_, err := metrics.Export(ctx, req)
@@ -213,7 +214,7 @@ func (f *CloudFlusher) runOnce(ctx context.Context, logs otelpb.LogsServiceClien
 	}); err != nil {
 		return err
 	}
-	return f.flushSignal(ctx, SignalTraces, func(msg proto.Message) error {
+	return f.flushSignal(SignalTraces, func(msg proto.Message) error {
 		req := msg.(*otelpb.ExportTraceServiceRequest)
 		sanitizeTraces(req)
 		_, err := traces.Export(ctx, req)
@@ -225,7 +226,10 @@ func (f *CloudFlusher) runOnce(ctx context.Context, logs otelpb.LogsServiceClien
 // provided callback, and advances the signal's cursor only if all exports
 // succeed. On any export error the cursor is left untouched so the batch is
 // retried (already-exported frames may be re-sent).
-func (f *CloudFlusher) flushSignal(ctx context.Context, sig SignalType, export func(proto.Message) error) error {
+func (f *CloudFlusher) flushSignal(sig SignalType, export func(proto.Message) error) error {
+	if f.buffer == nil {
+		return nil
+	}
 	cursor := f.buffer.LoadCursor(sig)
 	msgs, next, err := f.buffer.ReadFromCursor(sig, cursor, cloudFlusherFramesPerPass)
 	if err != nil {

--- a/go/internal/agent/services/cloud_flusher.go
+++ b/go/internal/agent/services/cloud_flusher.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"net"
 	"sort"
-	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -36,33 +35,7 @@ const (
 	cloudFlusherDefaultApp       = "device"
 	cloudFlusherCollector        = "wendy-agent"
 	cloudFlusherMaxEntriesPerApp = 5000 // per-RPC cap to stay under gRPC message size limits
-
-	// PII / payload size guards applied in convertLogRecord before cloud upload.
-	maxLogBodyBytes = 65536 // 64 KiB — prevents oversized payloads
-	maxLabelKeyLen  = 256
-	maxLabelValLen  = 1024
-	maxLabels       = 64
 )
-
-// sensitiveLabelDenyList contains substrings that, when found in a label key
-// (case-insensitive), indicate the value may contain credentials or PII.
-// Such labels are dropped before upload to prevent accidental exposure.
-var sensitiveLabelDenyList = []string{
-	"password", "passwd", "secret", "token", "authorization",
-	"api_key", "apikey", "private_key", "credential", "auth",
-	"cookie", "session",
-}
-
-// isSensitiveLabelKey reports whether key contains a deny-listed substring.
-func isSensitiveLabelKey(key string) bool {
-	lower := strings.ToLower(key)
-	for _, denied := range sensitiveLabelDenyList {
-		if strings.Contains(lower, denied) {
-			return true
-		}
-	}
-	return false
-}
 
 // CloudFlusher reads log segments from TelemetryBuffer via ReadFromCursor,
 // converts OTLP LogRecords to cloud LogEntry values, and calls WriteLogEntries.

--- a/go/internal/agent/services/cloud_flusher_test.go
+++ b/go/internal/agent/services/cloud_flusher_test.go
@@ -9,19 +9,17 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
 )
 
-// fakeRemoteLogging implements cloudpb.RemoteLoggingServiceClient for testing.
-type fakeRemoteLogging struct {
-	mu       sync.Mutex
-	calls    []*cloudpb.WriteLogEntriesRequest
-	errOnce  error // returned on first call then cleared
-	tailFunc func(ctx context.Context, in *cloudpb.TailLogEntriesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[cloudpb.TailLogEntriesResponse], error)
+// fakeLogsClient implements otelpb.LogsServiceClient.
+type fakeLogsClient struct {
+	mu      sync.Mutex
+	calls   []*otelpb.ExportLogsServiceRequest
+	errOnce error
 }
 
-func (f *fakeRemoteLogging) WriteLogEntries(ctx context.Context, in *cloudpb.WriteLogEntriesRequest, opts ...grpc.CallOption) (*cloudpb.WriteLogEntriesResponse, error) {
+func (f *fakeLogsClient) Export(ctx context.Context, in *otelpb.ExportLogsServiceRequest, opts ...grpc.CallOption) (*otelpb.ExportLogsServiceResponse, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.errOnce != nil {
@@ -30,75 +28,104 @@ func (f *fakeRemoteLogging) WriteLogEntries(ctx context.Context, in *cloudpb.Wri
 		return nil, err
 	}
 	f.calls = append(f.calls, in)
-	return &cloudpb.WriteLogEntriesResponse{AcceptedCount: int32(len(in.GetEntries()))}, nil
+	return &otelpb.ExportLogsServiceResponse{}, nil
 }
 
-func (f *fakeRemoteLogging) TailLogEntries(ctx context.Context, in *cloudpb.TailLogEntriesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[cloudpb.TailLogEntriesResponse], error) {
-	if f.tailFunc != nil {
-		return f.tailFunc(ctx, in, opts...)
-	}
-	return nil, errors.New("TailLogEntries not implemented in fake")
+func (f *fakeLogsClient) count() int { f.mu.Lock(); defer f.mu.Unlock(); return len(f.calls) }
+
+// fakeMetricsClient implements otelpb.MetricsServiceClient.
+type fakeMetricsClient struct {
+	mu    sync.Mutex
+	calls []*otelpb.ExportMetricsServiceRequest
 }
 
-func (f *fakeRemoteLogging) totalEntries() int {
+func (f *fakeMetricsClient) Export(ctx context.Context, in *otelpb.ExportMetricsServiceRequest, opts ...grpc.CallOption) (*otelpb.ExportMetricsServiceResponse, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	n := 0
-	for _, c := range f.calls {
-		n += len(c.GetEntries())
-	}
-	return n
+	f.calls = append(f.calls, in)
+	return &otelpb.ExportMetricsServiceResponse{}, nil
 }
 
-// makeLogReqWithService creates a log request with a service.name resource attribute.
-func makeLogReqWithService(body, serviceName string) *otelpb.ExportLogsServiceRequest {
-	attrs := []*otelpb.KeyValue{}
-	if serviceName != "" {
-		attrs = append(attrs, &otelpb.KeyValue{
-			Key:   "service.name",
-			Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: serviceName}},
-		})
-	}
+func (f *fakeMetricsClient) count() int { f.mu.Lock(); defer f.mu.Unlock(); return len(f.calls) }
+
+// fakeTraceClient implements otelpb.TraceServiceClient.
+type fakeTraceClient struct {
+	mu    sync.Mutex
+	calls []*otelpb.ExportTraceServiceRequest
+}
+
+func (f *fakeTraceClient) Export(ctx context.Context, in *otelpb.ExportTraceServiceRequest, opts ...grpc.CallOption) (*otelpb.ExportTraceServiceResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, in)
+	return &otelpb.ExportTraceServiceResponse{}, nil
+}
+
+func (f *fakeTraceClient) count() int { f.mu.Lock(); defer f.mu.Unlock(); return len(f.calls) }
+
+// logReqWithSensitive builds a log request whose record carries a deny-listed
+// attribute, used to assert export-time scrubbing.
+func logReqWithSensitive(body string) *otelpb.ExportLogsServiceRequest {
 	return &otelpb.ExportLogsServiceRequest{
 		ResourceLogs: []*otelpb.ResourceLogs{{
-			Resource: &otelpb.Resource{Attributes: attrs},
 			ScopeLogs: []*otelpb.ScopeLogs{{
 				LogRecords: []*otelpb.LogRecord{{
 					Body: &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: body}},
+					Attributes: []*otelpb.KeyValue{
+						{Key: "password", Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: "hunter2"}}},
+						{Key: "ok", Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: "1"}}},
+					},
 				}},
 			}},
 		}},
 	}
 }
 
-func TestCloudFlusher_FlushesEntries(t *testing.T) {
+func TestCloudFlusher_ExportsAllSignals(t *testing.T) {
 	buf, _ := makeTestBuffer(t, 10*1024*1024, 1*1024*1024)
-
-	// Write 5 log entries.
-	for i := 0; i < 5; i++ {
-		buf.PublishLogs(makeLogReq("entry"))
+	for i := 0; i < 3; i++ {
+		buf.PublishLogs(makeLogReq("log"))
 	}
+	buf.PublishMetrics(makeMetricReq("m"))
+	buf.PublishMetrics(makeMetricReq("m2"))
+	buf.PublishTraces(makeTraceReq("s"))
 
-	fake := &fakeRemoteLogging{}
+	logs, metrics, traces := &fakeLogsClient{}, &fakeMetricsClient{}, &fakeTraceClient{}
 	flusher := NewCloudFlusher(zap.NewNop(), buf, 1, 2)
 
-	ctx := context.Background()
-
-	// First pass: should read all 5 entries and upload them.
-	if err := flusher.runOnce(ctx, fake, 0, 0); err != nil {
+	if err := flusher.runOnce(context.Background(), logs, metrics, traces); err != nil {
 		t.Fatalf("runOnce: %v", err)
 	}
-	if got := fake.totalEntries(); got != 5 {
-		t.Errorf("first pass: want 5 entries uploaded, got %d", got)
+	if logs.count() != 3 {
+		t.Errorf("want 3 log exports, got %d", logs.count())
 	}
+	if metrics.count() != 2 {
+		t.Errorf("want 2 metric exports, got %d", metrics.count())
+	}
+	if traces.count() != 1 {
+		t.Errorf("want 1 trace export, got %d", traces.count())
+	}
+}
 
-	// Cursor should have advanced: second pass should upload nothing.
-	prevCalls := len(fake.calls)
-	if err := flusher.runOnce(ctx, fake, 0, 0); err != nil {
-		t.Fatalf("runOnce second: %v", err)
+func TestCloudFlusher_AdvancesCursorPerSignal(t *testing.T) {
+	buf, _ := makeTestBuffer(t, 10*1024*1024, 1*1024*1024)
+	buf.PublishLogs(makeLogReq("log"))
+
+	logs, metrics, traces := &fakeLogsClient{}, &fakeMetricsClient{}, &fakeTraceClient{}
+	flusher := NewCloudFlusher(zap.NewNop(), buf, 1, 2)
+
+	if err := flusher.runOnce(context.Background(), logs, metrics, traces); err != nil {
+		t.Fatalf("first runOnce: %v", err)
 	}
-	if len(fake.calls) != prevCalls {
-		t.Errorf("second pass: expected no new RPC calls, but got %d more", len(fake.calls)-prevCalls)
+	if logs.count() != 1 {
+		t.Fatalf("want 1 export, got %d", logs.count())
+	}
+	// Second pass: cursor advanced, nothing new to export.
+	if err := flusher.runOnce(context.Background(), logs, metrics, traces); err != nil {
+		t.Fatalf("second runOnce: %v", err)
+	}
+	if logs.count() != 1 {
+		t.Errorf("cursor did not advance: want 1 total export, got %d", logs.count())
 	}
 }
 
@@ -106,65 +133,53 @@ func TestCloudFlusher_RetryOnError(t *testing.T) {
 	buf, _ := makeTestBuffer(t, 10*1024*1024, 1*1024*1024)
 	buf.PublishLogs(makeLogReq("retry-me"))
 
-	fake := &fakeRemoteLogging{errOnce: errors.New("transient error")}
+	logs := &fakeLogsClient{errOnce: errors.New("transient error")}
+	metrics, traces := &fakeMetricsClient{}, &fakeTraceClient{}
 	flusher := NewCloudFlusher(zap.NewNop(), buf, 1, 2)
 
-	ctx := context.Background()
-
-	// First pass: should fail, cursor must NOT advance.
-	if err := flusher.runOnce(ctx, fake, 0, 0); err == nil {
+	if err := flusher.runOnce(context.Background(), logs, metrics, traces); err == nil {
 		t.Fatal("expected error on first pass, got nil")
 	}
-
-	// No entries should have been recorded.
-	if got := fake.totalEntries(); got != 0 {
-		t.Errorf("want 0 entries after error, got %d", got)
+	if logs.count() != 0 {
+		t.Errorf("want 0 successful exports after error, got %d", logs.count())
 	}
-
-	// Second pass: error cleared, should succeed and upload the entry.
-	if err := flusher.runOnce(ctx, fake, 0, 0); err != nil {
+	// Second pass: error cleared, cursor was not advanced, entry re-sent.
+	if err := flusher.runOnce(context.Background(), logs, metrics, traces); err != nil {
 		t.Fatalf("second runOnce: %v", err)
 	}
-	if got := fake.totalEntries(); got != 1 {
-		t.Errorf("want 1 entry after retry, got %d", got)
+	if logs.count() != 1 {
+		t.Errorf("want 1 export after retry, got %d", logs.count())
 	}
 }
 
 func TestCloudFlusher_EmptyBuffer(t *testing.T) {
 	buf, _ := makeTestBuffer(t, 10*1024*1024, 1*1024*1024)
-	fake := &fakeRemoteLogging{}
+	logs, metrics, traces := &fakeLogsClient{}, &fakeMetricsClient{}, &fakeTraceClient{}
 	flusher := NewCloudFlusher(zap.NewNop(), buf, 1, 2)
 
-	// runOnce on an empty buffer should return nil and make no RPC calls.
-	if err := flusher.runOnce(context.Background(), fake, 0, 0); err != nil {
+	if err := flusher.runOnce(context.Background(), logs, metrics, traces); err != nil {
 		t.Fatalf("expected nil on empty buffer, got %v", err)
 	}
-	if len(fake.calls) != 0 {
-		t.Errorf("expected no RPC calls on empty buffer, got %d", len(fake.calls))
+	if logs.count()+metrics.count()+traces.count() != 0 {
+		t.Errorf("expected no exports on empty buffer")
 	}
 }
 
-func TestCloudFlusher_GroupsByApp(t *testing.T) {
+func TestCloudFlusher_ScrubsBeforeExport(t *testing.T) {
 	buf, _ := makeTestBuffer(t, 10*1024*1024, 1*1024*1024)
+	buf.PublishLogs(logReqWithSensitive("body"))
 
-	// Two requests with different service names.
-	buf.PublishLogs(makeLogReqWithService("log-a", "app-a"))
-	buf.PublishLogs(makeLogReqWithService("log-b", "app-b"))
-	// One without service.name → goes to "device"
-	buf.PublishLogs(makeLogReq("no-service"))
-
-	fake := &fakeRemoteLogging{}
+	logs, metrics, traces := &fakeLogsClient{}, &fakeMetricsClient{}, &fakeTraceClient{}
 	flusher := NewCloudFlusher(zap.NewNop(), buf, 1, 2)
 
-	if err := flusher.runOnce(context.Background(), fake, 0, 0); err != nil {
+	if err := flusher.runOnce(context.Background(), logs, metrics, traces); err != nil {
 		t.Fatalf("runOnce: %v", err)
 	}
-
-	// Should be 3 separate RPC calls (one per app/device group).
-	if len(fake.calls) != 3 {
-		t.Errorf("want 3 RPC calls (one per app group), got %d", len(fake.calls))
+	if logs.count() != 1 {
+		t.Fatalf("want 1 export, got %d", logs.count())
 	}
-	if fake.totalEntries() != 3 {
-		t.Errorf("want 3 total entries, got %d", fake.totalEntries())
+	attrs := logs.calls[0].GetResourceLogs()[0].GetScopeLogs()[0].GetLogRecords()[0].GetAttributes()
+	if len(attrs) != 1 || attrs[0].GetKey() != "ok" {
+		t.Errorf("sensitive attr not scrubbed before export: %+v", attrs)
 	}
 }

--- a/go/internal/agent/services/cloud_flusher_test.go
+++ b/go/internal/agent/services/cloud_flusher_test.go
@@ -150,6 +150,10 @@ func TestCloudFlusher_RetryOnError(t *testing.T) {
 	if logs.count() != 1 {
 		t.Errorf("want 1 export after retry, got %d", logs.count())
 	}
+	got := logs.calls[0].GetResourceLogs()[0].GetScopeLogs()[0].GetLogRecords()[0].GetBody().GetStringValue()
+	if got != "retry-me" {
+		t.Errorf("re-sent frame body: want %q, got %q", "retry-me", got)
+	}
 }
 
 func TestCloudFlusher_EmptyBuffer(t *testing.T) {

--- a/go/internal/agent/services/cloud_telemetry_sanitize.go
+++ b/go/internal/agent/services/cloud_telemetry_sanitize.go
@@ -42,18 +42,18 @@ func sanitizeAttributes(attrs []*otelpb.KeyValue) []*otelpb.KeyValue {
 		return attrs
 	}
 	out := make([]*otelpb.KeyValue, 0, min(len(attrs), maxLabels))
-	for _, kv := range attrs {
+	for _, attr := range attrs {
 		if len(out) >= maxLabels {
 			break
 		}
-		k := kv.GetKey()
+		k := attr.GetKey()
 		if isSensitiveLabelKey(k) {
 			continue
 		}
 		if len(k) > maxLabelKeyLen {
 			k = k[:maxLabelKeyLen]
 		}
-		v := kv.GetValue()
+		v := attr.GetValue()
 		if s := v.GetStringValue(); len(s) > maxLabelValLen {
 			v = &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: s[:maxLabelValLen]}}
 		}

--- a/go/internal/agent/services/cloud_telemetry_sanitize.go
+++ b/go/internal/agent/services/cloud_telemetry_sanitize.go
@@ -1,0 +1,155 @@
+package services
+
+import (
+	"strings"
+
+	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
+)
+
+const (
+	// PII / payload size guards applied to OTLP records before cloud export.
+	maxLogBodyBytes = 65536 // 64 KiB — prevents oversized payloads
+	maxLabelKeyLen  = 256
+	maxLabelValLen  = 1024
+	maxLabels       = 64
+)
+
+// sensitiveLabelDenyList contains substrings that, when found in an attribute
+// key (case-insensitive), indicate the value may contain credentials or PII.
+// Such attributes are dropped before export to prevent accidental exposure.
+var sensitiveLabelDenyList = []string{
+	"password", "passwd", "secret", "token", "authorization",
+	"api_key", "apikey", "private_key", "credential", "auth",
+	"cookie", "session",
+}
+
+// isSensitiveLabelKey reports whether key contains a deny-listed substring.
+func isSensitiveLabelKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, denied := range sensitiveLabelDenyList {
+		if strings.Contains(lower, denied) {
+			return true
+		}
+	}
+	return false
+}
+
+// sanitizeAttributes returns a new attribute slice with deny-listed keys
+// removed, keys and string values truncated, and the total count capped at
+// maxLabels. The input slice and its elements are not modified.
+func sanitizeAttributes(attrs []*otelpb.KeyValue) []*otelpb.KeyValue {
+	if len(attrs) == 0 {
+		return attrs
+	}
+	out := make([]*otelpb.KeyValue, 0, min(len(attrs), maxLabels))
+	for _, kv := range attrs {
+		if len(out) >= maxLabels {
+			break
+		}
+		k := kv.GetKey()
+		if isSensitiveLabelKey(k) {
+			continue
+		}
+		if len(k) > maxLabelKeyLen {
+			k = k[:maxLabelKeyLen]
+		}
+		v := kv.GetValue()
+		if s := v.GetStringValue(); len(s) > maxLabelValLen {
+			v = &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: s[:maxLabelValLen]}}
+		}
+		out = append(out, &otelpb.KeyValue{Key: k, Value: v})
+	}
+	return out
+}
+
+// sanitizeLogs scrubs resource and log-record attributes and truncates oversized
+// log bodies, mutating req in place.
+func sanitizeLogs(req *otelpb.ExportLogsServiceRequest) {
+	if req == nil {
+		return
+	}
+	for _, rl := range req.GetResourceLogs() {
+		if res := rl.GetResource(); res != nil {
+			res.Attributes = sanitizeAttributes(res.GetAttributes())
+		}
+		for _, sl := range rl.GetScopeLogs() {
+			for _, lr := range sl.GetLogRecords() {
+				lr.Attributes = sanitizeAttributes(lr.GetAttributes())
+				if body := lr.GetBody(); body != nil {
+					if s := body.GetStringValue(); len(s) > maxLogBodyBytes {
+						lr.Body = &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: s[:maxLogBodyBytes]}}
+					}
+				}
+			}
+		}
+	}
+}
+
+// sanitizeMetrics scrubs resource attributes and every data-point's attributes
+// across all metric data types, mutating req in place.
+func sanitizeMetrics(req *otelpb.ExportMetricsServiceRequest) {
+	if req == nil {
+		return
+	}
+	for _, rm := range req.GetResourceMetrics() {
+		if res := rm.GetResource(); res != nil {
+			res.Attributes = sanitizeAttributes(res.GetAttributes())
+		}
+		for _, sm := range rm.GetScopeMetrics() {
+			for _, m := range sm.GetMetrics() {
+				sanitizeMetricDataPoints(m)
+			}
+		}
+	}
+}
+
+// sanitizeMetricDataPoints scrubs the attributes on each data point of m,
+// dispatching on the metric's data type.
+func sanitizeMetricDataPoints(m *otelpb.Metric) {
+	switch data := m.GetData().(type) {
+	case *otelpb.Metric_Gauge:
+		for _, dp := range data.Gauge.GetDataPoints() {
+			dp.Attributes = sanitizeAttributes(dp.GetAttributes())
+		}
+	case *otelpb.Metric_Sum:
+		for _, dp := range data.Sum.GetDataPoints() {
+			dp.Attributes = sanitizeAttributes(dp.GetAttributes())
+		}
+	case *otelpb.Metric_Histogram:
+		for _, dp := range data.Histogram.GetDataPoints() {
+			dp.Attributes = sanitizeAttributes(dp.GetAttributes())
+		}
+	case *otelpb.Metric_ExponentialHistogram:
+		for _, dp := range data.ExponentialHistogram.GetDataPoints() {
+			dp.Attributes = sanitizeAttributes(dp.GetAttributes())
+		}
+	case *otelpb.Metric_Summary:
+		for _, dp := range data.Summary.GetDataPoints() {
+			dp.Attributes = sanitizeAttributes(dp.GetAttributes())
+		}
+	}
+}
+
+// sanitizeTraces scrubs resource, span, span-event, and span-link attributes,
+// mutating req in place.
+func sanitizeTraces(req *otelpb.ExportTraceServiceRequest) {
+	if req == nil {
+		return
+	}
+	for _, rs := range req.GetResourceSpans() {
+		if res := rs.GetResource(); res != nil {
+			res.Attributes = sanitizeAttributes(res.GetAttributes())
+		}
+		for _, ss := range rs.GetScopeSpans() {
+			for _, sp := range ss.GetSpans() {
+				sp.Attributes = sanitizeAttributes(sp.GetAttributes())
+				for _, ev := range sp.GetEvents() {
+					ev.Attributes = sanitizeAttributes(ev.GetAttributes())
+				}
+				for _, ln := range sp.GetLinks() {
+					ln.Attributes = sanitizeAttributes(ln.GetAttributes())
+				}
+			}
+		}
+	}
+}

--- a/go/internal/agent/services/cloud_telemetry_sanitize_test.go
+++ b/go/internal/agent/services/cloud_telemetry_sanitize_test.go
@@ -1,0 +1,120 @@
+package services
+
+import (
+	"strings"
+	"testing"
+
+	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
+)
+
+func kv(key, val string) *otelpb.KeyValue {
+	return &otelpb.KeyValue{
+		Key:   key,
+		Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: val}},
+	}
+}
+
+func TestSanitizeAttributes_DropsSensitiveAndTruncates(t *testing.T) {
+	in := []*otelpb.KeyValue{
+		kv("user", "alice"),
+		kv("password", "hunter2"),       // dropped by deny-list
+		kv("auth_header", "Bearer xyz"), // dropped (contains "auth")
+		kv(strings.Repeat("k", maxLabelKeyLen+10), "v"),
+		kv("big", strings.Repeat("v", maxLabelValLen+10)),
+	}
+	out := sanitizeAttributes(in)
+
+	for _, a := range out {
+		if isSensitiveLabelKey(a.GetKey()) {
+			t.Errorf("sensitive key survived: %q", a.GetKey())
+		}
+		if len(a.GetKey()) > maxLabelKeyLen {
+			t.Errorf("key not truncated: len=%d", len(a.GetKey()))
+		}
+		if len(a.GetValue().GetStringValue()) > maxLabelValLen {
+			t.Errorf("value not truncated: len=%d", len(a.GetValue().GetStringValue()))
+		}
+	}
+	if len(out) != 3 { // user, truncated-key, big
+		t.Fatalf("want 3 surviving attrs, got %d", len(out))
+	}
+}
+
+func TestSanitizeAttributes_CapsCount(t *testing.T) {
+	in := make([]*otelpb.KeyValue, 0, maxLabels+10)
+	for i := 0; i < maxLabels+10; i++ {
+		in = append(in, kv("k", "v"))
+	}
+	if got := len(sanitizeAttributes(in)); got != maxLabels {
+		t.Fatalf("want %d (capped), got %d", maxLabels, got)
+	}
+}
+
+func TestSanitizeLogs_TruncatesBodyAndScrubsAttrs(t *testing.T) {
+	req := &otelpb.ExportLogsServiceRequest{
+		ResourceLogs: []*otelpb.ResourceLogs{{
+			Resource: &otelpb.Resource{Attributes: []*otelpb.KeyValue{kv("token", "abc")}},
+			ScopeLogs: []*otelpb.ScopeLogs{{
+				LogRecords: []*otelpb.LogRecord{{
+					Body:       &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: strings.Repeat("x", maxLogBodyBytes+100)}},
+					Attributes: []*otelpb.KeyValue{kv("secret", "s"), kv("ok", "1")},
+				}},
+			}},
+		}},
+	}
+	sanitizeLogs(req)
+
+	rl := req.GetResourceLogs()[0]
+	if len(rl.GetResource().GetAttributes()) != 0 {
+		t.Errorf("resource token attr should be dropped")
+	}
+	lr := rl.GetScopeLogs()[0].GetLogRecords()[0]
+	if len(lr.GetBody().GetStringValue()) != maxLogBodyBytes {
+		t.Errorf("body not truncated to %d, got %d", maxLogBodyBytes, len(lr.GetBody().GetStringValue()))
+	}
+	if len(lr.GetAttributes()) != 1 || lr.GetAttributes()[0].GetKey() != "ok" {
+		t.Errorf("record attrs not scrubbed correctly: %+v", lr.GetAttributes())
+	}
+}
+
+func TestSanitizeMetrics_ScrubsDataPointAttrs(t *testing.T) {
+	req := &otelpb.ExportMetricsServiceRequest{
+		ResourceMetrics: []*otelpb.ResourceMetrics{{
+			ScopeMetrics: []*otelpb.ScopeMetrics{{
+				Metrics: []*otelpb.Metric{{
+					Name: "m",
+					Data: &otelpb.Metric_Gauge{Gauge: &otelpb.Gauge{
+						DataPoints: []*otelpb.NumberDataPoint{{
+							Attributes: []*otelpb.KeyValue{kv("api_key", "k"), kv("region", "us")},
+						}},
+					}},
+				}},
+			}},
+		}},
+	}
+	sanitizeMetrics(req)
+
+	dp := req.GetResourceMetrics()[0].GetScopeMetrics()[0].GetMetrics()[0].GetGauge().GetDataPoints()[0]
+	if len(dp.GetAttributes()) != 1 || dp.GetAttributes()[0].GetKey() != "region" {
+		t.Errorf("datapoint attrs not scrubbed: %+v", dp.GetAttributes())
+	}
+}
+
+func TestSanitizeTraces_ScrubsSpanAttrs(t *testing.T) {
+	req := &otelpb.ExportTraceServiceRequest{
+		ResourceSpans: []*otelpb.ResourceSpans{{
+			ScopeSpans: []*otelpb.ScopeSpans{{
+				Spans: []*otelpb.Span{{
+					Name:       "s",
+					Attributes: []*otelpb.KeyValue{kv("credential", "c"), kv("route", "/x")},
+				}},
+			}},
+		}},
+	}
+	sanitizeTraces(req)
+
+	sp := req.GetResourceSpans()[0].GetScopeSpans()[0].GetSpans()[0]
+	if len(sp.GetAttributes()) != 1 || sp.GetAttributes()[0].GetKey() != "route" {
+		t.Errorf("span attrs not scrubbed: %+v", sp.GetAttributes())
+	}
+}

--- a/go/internal/agent/services/cloud_telemetry_sanitize_test.go
+++ b/go/internal/agent/services/cloud_telemetry_sanitize_test.go
@@ -78,25 +78,103 @@ func TestSanitizeLogs_TruncatesBodyAndScrubsAttrs(t *testing.T) {
 }
 
 func TestSanitizeMetrics_ScrubsDataPointAttrs(t *testing.T) {
-	req := &otelpb.ExportMetricsServiceRequest{
-		ResourceMetrics: []*otelpb.ResourceMetrics{{
-			ScopeMetrics: []*otelpb.ScopeMetrics{{
-				Metrics: []*otelpb.Metric{{
-					Name: "m",
-					Data: &otelpb.Metric_Gauge{Gauge: &otelpb.Gauge{
-						DataPoints: []*otelpb.NumberDataPoint{{
-							Attributes: []*otelpb.KeyValue{kv("api_key", "k"), kv("region", "us")},
-						}},
+	denyAttr := kv("api_key", "k")
+	safeAttr := kv("region", "us")
+
+	tests := []struct {
+		name   string
+		metric *otelpb.Metric
+		getDP  func(m *otelpb.Metric) []*otelpb.KeyValue
+	}{
+		{
+			name: "Gauge",
+			metric: &otelpb.Metric{
+				Name: "gauge",
+				Data: &otelpb.Metric_Gauge{Gauge: &otelpb.Gauge{
+					DataPoints: []*otelpb.NumberDataPoint{{
+						Attributes: []*otelpb.KeyValue{denyAttr, safeAttr},
 					}},
 				}},
-			}},
-		}},
+			},
+			getDP: func(m *otelpb.Metric) []*otelpb.KeyValue {
+				return m.GetGauge().GetDataPoints()[0].GetAttributes()
+			},
+		},
+		{
+			name: "Sum",
+			metric: &otelpb.Metric{
+				Name: "sum",
+				Data: &otelpb.Metric_Sum{Sum: &otelpb.Sum{
+					DataPoints: []*otelpb.NumberDataPoint{{
+						Attributes: []*otelpb.KeyValue{denyAttr, safeAttr},
+					}},
+				}},
+			},
+			getDP: func(m *otelpb.Metric) []*otelpb.KeyValue {
+				return m.GetSum().GetDataPoints()[0].GetAttributes()
+			},
+		},
+		{
+			name: "Histogram",
+			metric: &otelpb.Metric{
+				Name: "histogram",
+				Data: &otelpb.Metric_Histogram{Histogram: &otelpb.Histogram{
+					DataPoints: []*otelpb.HistogramDataPoint{{
+						Attributes: []*otelpb.KeyValue{denyAttr, safeAttr},
+					}},
+				}},
+			},
+			getDP: func(m *otelpb.Metric) []*otelpb.KeyValue {
+				return m.GetHistogram().GetDataPoints()[0].GetAttributes()
+			},
+		},
+		{
+			name: "ExponentialHistogram",
+			metric: &otelpb.Metric{
+				Name: "exp_histogram",
+				Data: &otelpb.Metric_ExponentialHistogram{ExponentialHistogram: &otelpb.ExponentialHistogram{
+					DataPoints: []*otelpb.ExponentialHistogramDataPoint{{
+						Attributes: []*otelpb.KeyValue{denyAttr, safeAttr},
+					}},
+				}},
+			},
+			getDP: func(m *otelpb.Metric) []*otelpb.KeyValue {
+				return m.GetExponentialHistogram().GetDataPoints()[0].GetAttributes()
+			},
+		},
+		{
+			name: "Summary",
+			metric: &otelpb.Metric{
+				Name: "summary",
+				Data: &otelpb.Metric_Summary{Summary: &otelpb.Summary{
+					DataPoints: []*otelpb.SummaryDataPoint{{
+						Attributes: []*otelpb.KeyValue{denyAttr, safeAttr},
+					}},
+				}},
+			},
+			getDP: func(m *otelpb.Metric) []*otelpb.KeyValue {
+				return m.GetSummary().GetDataPoints()[0].GetAttributes()
+			},
+		},
 	}
-	sanitizeMetrics(req)
 
-	dp := req.GetResourceMetrics()[0].GetScopeMetrics()[0].GetMetrics()[0].GetGauge().GetDataPoints()[0]
-	if len(dp.GetAttributes()) != 1 || dp.GetAttributes()[0].GetKey() != "region" {
-		t.Errorf("datapoint attrs not scrubbed: %+v", dp.GetAttributes())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &otelpb.ExportMetricsServiceRequest{
+				ResourceMetrics: []*otelpb.ResourceMetrics{{
+					ScopeMetrics: []*otelpb.ScopeMetrics{{
+						Metrics: []*otelpb.Metric{tc.metric},
+					}},
+				}},
+			}
+			sanitizeMetrics(req)
+
+			m := req.GetResourceMetrics()[0].GetScopeMetrics()[0].GetMetrics()[0]
+			attrs := tc.getDP(m)
+			if len(attrs) != 1 || attrs[0].GetKey() != "region" {
+				t.Errorf("datapoint attrs not scrubbed correctly: %+v", attrs)
+			}
+		})
 	}
 }
 
@@ -107,6 +185,13 @@ func TestSanitizeTraces_ScrubsSpanAttrs(t *testing.T) {
 				Spans: []*otelpb.Span{{
 					Name:       "s",
 					Attributes: []*otelpb.KeyValue{kv("credential", "c"), kv("route", "/x")},
+					Events: []*otelpb.Span_Event{{
+						Name:       "e",
+						Attributes: []*otelpb.KeyValue{kv("api_key", "secret"), kv("event_type", "click")},
+					}},
+					Links: []*otelpb.Span_Link{{
+						Attributes: []*otelpb.KeyValue{kv("token", "t"), kv("link_kind", "parent")},
+					}},
 				}},
 			}},
 		}},
@@ -116,5 +201,13 @@ func TestSanitizeTraces_ScrubsSpanAttrs(t *testing.T) {
 	sp := req.GetResourceSpans()[0].GetScopeSpans()[0].GetSpans()[0]
 	if len(sp.GetAttributes()) != 1 || sp.GetAttributes()[0].GetKey() != "route" {
 		t.Errorf("span attrs not scrubbed: %+v", sp.GetAttributes())
+	}
+	evAttrs := sp.GetEvents()[0].GetAttributes()
+	if len(evAttrs) != 1 || evAttrs[0].GetKey() != "event_type" {
+		t.Errorf("event attrs not scrubbed: %+v", evAttrs)
+	}
+	lnAttrs := sp.GetLinks()[0].GetAttributes()
+	if len(lnAttrs) != 1 || lnAttrs[0].GetKey() != "link_kind" {
+		t.Errorf("link attrs not scrubbed: %+v", lnAttrs)
 	}
 }


### PR DESCRIPTION
## Problem

The agent's `CloudFlusher` uploaded buffered telemetry by converting OTLP log records into a custom `cloudpb.LogEntry` and calling `wendycloud.v1.RemoteLoggingService/WriteLogEntries`. The cloud no longer implements that route, so every flush failed:

```
cloud flusher: flush failed error=cloud flusher: WriteLogEntries (app=llm-app):
  rpc error: code = Unimplemented desc = Requested RPC isn't implemented by this server.
```

## What this does

Stops converting and instead **re-exports the buffered native OTLP verbatim to the cloud's standard OTLP collector routes over gRPC** (`LogsService` / `MetricsService` / `TraceService` `Export`), over the existing mTLS connection.

- **All three signals** are now exported (logs, metrics, traces). Previously only logs were uploaded; metrics/traces were buffered locally and never left the device.
- **Identity** is derived server-side from the mTLS device client certificate — no `organization_id` / `asset_id` / `app_id` fields are sent. `app_id` continues to ride along as the `service.name` resource attribute already in the OTLP payload.
- **One `Export` RPC per buffered frame**; a signal's cursor advances only after all of that signal's frames in a pass succeed (at-least-once delivery; the cloud tolerates duplicates). The 1s→60s backoff and per-signal cursors are preserved.
- **PII / size guards preserved**: the deny-list, attribute key/value truncation, log-body truncation, and label cap moved into a reusable `sanitize{Logs,Metrics,Traces}` module applied to each frame before export — now covering all five metric data-point types and span/event/link attributes.
- The custom conversion path (`convertLogRecord`, `groupByApp`, `otelSeverityToCloud`, `WriteLogEntries`) and the `cloudpb`/`timestamppb`/`hex`/`sort` imports are removed from `cloud_flusher.go`. No fallback to the old route — the cloud is the single endpoint being upgraded.

The tunnel broker's separate `RegisterPresence` `Unimplemented` (also visible in the logs) is **out of scope** — OTLP has no broker/presence equivalent; tracked separately.

## ⚠️ Rollout dependency

The cloud must expose the OTLP collector routes (`opentelemetry.proto.collector.{logs,metrics,trace}.v1.*Service/Export`) at the provisioned host:443 and map the device cert → org/asset **before** this agent ships. Until then the agent will log `Unimplemented` from the new routes (benign, backed off) instead of the old one.

## Testing

- New `cloud_telemetry_sanitize_test.go`: deny-list drop, key/value/body truncation, label cap, all five metric data types, span+event+link attrs.
- Rewritten `cloud_flusher_test.go`: in-process fake OTLP `Logs/Metrics/Trace` clients assert all three signals export, sanitization runs before export, per-signal cursor advances only on success, and a failed `Export` leaves the cursor unadvanced (frame re-sent with body intact).
- `go test ./internal/agent/services`, `go build ./cmd/wendy-agent`, `go vet`, `gofmt` all clean.

Design: `Documentation/2026-06-17-otlp-cloud-export-design.md`

## Follow-ups (non-blocking)

- Scope-level `InstrumentationScope.Attributes` are not sanitized (library-populated name/version, not user PII).
- Add per-signal export-failure tests for metrics/traces (logic is shared; logs path is covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)