### PR TITLE
fix(agent): discover LE advertising adapter instead of assuming hci0

### DIFF
--- a/go/internal/agent/bluetooth/advertiser_linux.go
+++ b/go/internal/agent/bluetooth/advertiser_linux.go
@@ -29,6 +29,52 @@ func bluezAdapterPath() string {
 	return defaultBluezAdapter
 }
 
+// advertisingAdapterPath selects the BlueZ adapter to advertise on. If
+// WENDY_BT_ADAPTER is set, that path is trusted verbatim. Otherwise it
+// enumerates BlueZ's managed objects and returns the first adapter that
+// implements org.bluez.LEAdvertisingManager1 — the interface that exposes
+// RegisterAdvertisement.
+//
+// The default /org/bluez/hci0 is not always the advertising-capable
+// controller: the onboard radio can enumerate as a higher hciN, or a USB
+// dongle may be the only LE-capable adapter. Calling RegisterAdvertisement on
+// an adapter that lacks the interface surfaces as a confusing
+// "RegisterAdvertisement ... doesn't exist" D-Bus error, so discover the right
+// adapter up front and fail fast with a clear message when none supports it.
+func advertisingAdapterPath(conn *dbus.Conn) (string, error) {
+	if p := os.Getenv("WENDY_BT_ADAPTER"); p != "" {
+		return p, nil
+	}
+
+	var managed map[dbus.ObjectPath]map[string]map[string]dbus.Variant
+	root := conn.Object(bluezService, "/")
+	if err := root.Call("org.freedesktop.DBus.ObjectManager.GetManagedObjects", 0).Store(&managed); err != nil {
+		return "", fmt.Errorf("enumerate bluez objects: %w", err)
+	}
+
+	if p := findAdvertisingAdapter(managed); p != "" {
+		return p, nil
+	}
+	return "", fmt.Errorf("no bluetooth adapter implements %s (LE advertising unsupported)", advManagerIface)
+}
+
+// findAdvertisingAdapter returns the path of the adapter implementing
+// org.bluez.LEAdvertisingManager1, or "" if none do. When several adapters
+// qualify it returns the lexicographically lowest path so selection is stable
+// across runs despite Go's randomised map iteration order.
+func findAdvertisingAdapter(managed map[dbus.ObjectPath]map[string]map[string]dbus.Variant) string {
+	var best string
+	for path, ifaces := range managed {
+		if _, ok := ifaces[advManagerIface]; !ok {
+			continue
+		}
+		if s := string(path); best == "" || s < best {
+			best = s
+		}
+	}
+	return best
+}
+
 // advertisement implements org.bluez.LEAdvertisement1 on D-Bus.
 type advertisement struct{}
 
@@ -68,7 +114,12 @@ func startAdvertising(ctx context.Context, logger *zap.Logger) error {
 		return fmt.Errorf("export advertisement properties: %w", err)
 	}
 
-	hci := conn.Object(bluezService, dbus.ObjectPath(bluezAdapterPath()))
+	adapterPath, err := advertisingAdapterPath(conn)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+	hci := conn.Object(bluezService, dbus.ObjectPath(adapterPath))
 
 	// Ensure the adapter is powered on. The call is a no-op if it already is,
 	// but it also clears Command Disallowed state that lingers after a previous
@@ -116,7 +167,10 @@ func startAdvertising(ctx context.Context, logger *zap.Logger) error {
 		return fmt.Errorf("register advertisement: %w", regErr)
 	}
 
-	logger.Info("BLE advertisement registered", zap.String("uuid", wendyServiceUUID), zap.String("name", hostname))
+	logger.Info("BLE advertisement registered",
+		zap.String("adapter", adapterPath),
+		zap.String("uuid", wendyServiceUUID),
+		zap.String("name", hostname))
 
 	// Wait for context cancellation, then unregister.
 	go func() {

--- a/go/internal/agent/bluetooth/advertiser_linux_test.go
+++ b/go/internal/agent/bluetooth/advertiser_linux_test.go
@@ -1,0 +1,60 @@
+//go:build linux
+
+package bluetooth
+
+import (
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+func TestFindAdvertisingAdapter(t *testing.T) {
+	advMgr := map[string]map[string]dbus.Variant{advManagerIface: {}}
+	adapterOnly := map[string]map[string]dbus.Variant{adapterIface: {}}
+
+	tests := []struct {
+		name    string
+		managed map[dbus.ObjectPath]map[string]map[string]dbus.Variant
+		want    string
+	}{
+		{
+			name: "advertising-capable adapter at hci0",
+			managed: map[dbus.ObjectPath]map[string]map[string]dbus.Variant{
+				"/org/bluez/hci0": advMgr,
+			},
+			want: "/org/bluez/hci0",
+		},
+		{
+			name: "advertising-capable adapter at hci1 while hci0 lacks the interface",
+			managed: map[dbus.ObjectPath]map[string]map[string]dbus.Variant{
+				"/org/bluez/hci0": adapterOnly,
+				"/org/bluez/hci1": advMgr,
+			},
+			want: "/org/bluez/hci1",
+		},
+		{
+			name: "no adapter implements LEAdvertisingManager1",
+			managed: map[dbus.ObjectPath]map[string]map[string]dbus.Variant{
+				"/org/bluez/hci0": adapterOnly,
+			},
+			want: "",
+		},
+		{
+			name: "multiple capable adapters returns the lowest path deterministically",
+			managed: map[dbus.ObjectPath]map[string]map[string]dbus.Variant{
+				"/org/bluez/hci2": advMgr,
+				"/org/bluez/hci0": advMgr,
+				"/org/bluez/hci1": advMgr,
+			},
+			want: "/org/bluez/hci0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findAdvertisingAdapter(tt.managed); got != tt.want {
+				t.Errorf("findAdvertisingAdapter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

BLE advertising fails on some devices with:

```
BLE advertising unavailable error=register advertisement: Method "RegisterAdvertisement" with signature "oa{sv}" on interface "org.bluez.LEAdvertisingManager1" doesn't exist
```

Our D-Bus call is correct (`RegisterAdvertisement(o, a{sv})` → `oa{sv}` matches BlueZ's API). The "doesn't exist" error means the `org.bluez.LEAdvertisingManager1` interface isn't present on the object we call.

`startAdvertising` hardcoded `/org/bluez/hci0`. That object only exposes `LEAdvertisingManager1` when the LE-capable controller backs `hci0`. When the onboard radio enumerates as a higher `hciN`, or the only LE-capable adapter is a USB dongle, `hci0` lacks the interface — the call returns `UnknownMethod`, and the code then retried it 30 times over 30 seconds before giving up with a confusing error.

## Fix

Discover the adapter that actually implements `org.bluez.LEAdvertisingManager1` via BlueZ's `ObjectManager.GetManagedObjects` (the same enumeration pattern already used by device scanning in `manager_linux.go`), instead of assuming `hci0`:

- Found → advertise on that adapter (lowest path chosen deterministically when several qualify).
- None → fail fast with `no bluetooth adapter implements org.bluez.LEAdvertisingManager1 (LE advertising unsupported)` instead of 30s of cryptic retries.
- `WENDY_BT_ADAPTER` still overrides the choice verbatim.

The selected adapter is now included in the "BLE advertisement registered" log.

## Tests

Added `TestFindAdvertisingAdapter` covering: capable adapter at hci0, capable adapter at hci1 while hci0 lacks the interface, none capable, and deterministic selection among multiple. Ran the full `internal/agent/bluetooth` suite under a Linux toolchain (the package is `//go:build linux`); all pass. `GOOS=linux go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)