### PR TITLE
WDY-1600: wait for agent after device update

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
@@ -1,4 +1,4 @@
-Updates the wendy-agent installation on the remote device. By default downloads the latest release binary from GitHub matching the device's CPU architecture. Pass `--binary <path>` to upload a locally built binary instead (e.g. a cross-compiled development build).
+Updates the wendy-agent installation on the remote device. By default downloads the latest release binary from GitHub matching the device's CPU architecture. Pass `--binary <path>` to upload a locally built binary instead (e.g. a cross-compiled development build). The command waits for the restarted agent to become reachable before reporting success.
 
 GitHub release lookups use the `GITHUB_TOKEN` environment variable for authentication when it is present, and fall back to unauthenticated requests otherwise.
 

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1828,7 +1828,7 @@ type agentRestartWaitOptions struct {
 const (
 	defaultAgentRestartInitialDelay = time.Second
 	defaultAgentRestartTimeout      = 20 * time.Second
-	defaultAgentRestartPollInterval = 250 * time.Millisecond
+	defaultAgentRestartPollInterval = time.Second
 )
 
 func deviceUpdateUpload(ctx context.Context, agentService agentpb.WendyAgentServiceClient, binaryData []byte, sha256Hash string) error {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1599,7 +1599,11 @@ func newDeviceUpdateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			defer conn.Close()
+			defer func() {
+				if conn != nil {
+					_ = conn.Close()
+				}
+			}()
 
 			var binaryData []byte
 
@@ -1712,6 +1716,34 @@ func newDeviceUpdateCmd() *cobra.Command {
 				}
 			}
 
+			reconnect := updatedAgentReconnectFunc(ctx, conn)
+			if conn != nil {
+				_ = conn.Close()
+				conn = nil
+			}
+			if isInteractiveTerminal() && !jsonOutput {
+				readyConn, err := runAgentConnectionSpinner(ctx, "Waiting for agent to restart...", func(spinCtx context.Context) (*grpcclient.AgentConnection, error) {
+					return waitForUpdatedAgentReady(spinCtx, reconnect, agentRestartWaitOptions{})
+				})
+				if err != nil {
+					return err
+				}
+				if readyConn != nil {
+					_ = readyConn.Close()
+				}
+			} else {
+				if !jsonOutput {
+					fmt.Println("Waiting for agent to restart...")
+				}
+				readyConn, err := waitForUpdatedAgentReady(ctx, reconnect, agentRestartWaitOptions{})
+				if err != nil {
+					return err
+				}
+				if readyConn != nil {
+					_ = readyConn.Close()
+				}
+			}
+
 			if jsonOutput {
 				resp := map[string]string{
 					"status":  "success",
@@ -1787,6 +1819,18 @@ func checkELFArchitecture(data []byte, deviceArch string) error {
 	return nil
 }
 
+type agentRestartWaitOptions struct {
+	InitialDelay time.Duration
+	Timeout      time.Duration
+	PollInterval time.Duration
+}
+
+const (
+	defaultAgentRestartInitialDelay = time.Second
+	defaultAgentRestartTimeout      = 20 * time.Second
+	defaultAgentRestartPollInterval = 250 * time.Millisecond
+)
+
 func deviceUpdateUpload(ctx context.Context, agentService agentpb.WendyAgentServiceClient, binaryData []byte, sha256Hash string) error {
 	stream, err := agentService.UpdateAgent(ctx)
 	if err != nil {
@@ -1846,4 +1890,93 @@ func deviceUpdateUpload(ctx context.Context, agentService agentpb.WendyAgentServ
 	}
 
 	return nil
+}
+
+func updatedAgentReconnectFunc(ctx context.Context, previous *grpcclient.AgentConnection) func(context.Context) (*grpcclient.AgentConnection, error) {
+	if cloudCfg, ok := cloudDeviceConfigFromContext(ctx); ok {
+		return func(waitCtx context.Context) (*grpcclient.AgentConnection, error) {
+			return connectToCloudAgent(waitCtx, cloudCfg.CloudGRPC, cloudCfg.DeviceName, cloudCfg.BrokerURL)
+		}
+	}
+
+	if addr, _, err := resolveDeviceAddress(); err == nil {
+		hostname := addr
+		if host, _, splitErr := net.SplitHostPort(addr); splitErr == nil {
+			hostname = host
+		}
+		return func(waitCtx context.Context) (*grpcclient.AgentConnection, error) {
+			return connectResolvedAgentWithProvisionedHint(waitCtx, hostname, addr, false, deferProvisionedMTLSCheck(waitCtx, addr))
+		}
+	}
+
+	if previous != nil && previous.Host != "" {
+		addr := hostPort(previous.Host, defaultAgentPort)
+		return func(waitCtx context.Context) (*grpcclient.AgentConnection, error) {
+			return connectResolvedAgentWithProvisionedHint(waitCtx, previous.Host, addr, false, func() bool { return false })
+		}
+	}
+
+	return func(waitCtx context.Context) (*grpcclient.AgentConnection, error) {
+		return connectToAgent(waitCtx,
+			ExcludeProviders("local", "docker", "wendy-lite"),
+			ExcludeBluetooth(),
+			SuppressUpdateCheck(),
+			SuppressProvisioningHint(),
+			NonInteractive(),
+		)
+	}
+}
+
+func waitForUpdatedAgentReady(ctx context.Context, reconnect func(context.Context) (*grpcclient.AgentConnection, error), opts agentRestartWaitOptions) (*grpcclient.AgentConnection, error) {
+	if opts.InitialDelay <= 0 {
+		opts.InitialDelay = defaultAgentRestartInitialDelay
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = defaultAgentRestartTimeout
+	}
+	if opts.PollInterval <= 0 {
+		opts.PollInterval = defaultAgentRestartPollInterval
+	}
+
+	if err := sleepContext(ctx, opts.InitialDelay); err != nil {
+		return nil, err
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	var lastErr error
+	for {
+		conn, err := reconnect(waitCtx)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+
+		if waitCtx.Err() != nil {
+			break
+		}
+		if err := sleepContext(waitCtx, opts.PollInterval); err != nil {
+			break
+		}
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("agent did not become reachable after update: %w", lastErr)
+	}
+	return nil, fmt.Errorf("agent did not become reachable after update: %w", waitCtx.Err())
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/go/internal/cli/commands/device_update_test.go
+++ b/go/internal/cli/commands/device_update_test.go
@@ -1,0 +1,87 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+)
+
+func TestWaitForUpdatedAgentReadyRetriesUntilReachable(t *testing.T) {
+	started := time.Now()
+	attempts := 0
+
+	conn, err := waitForUpdatedAgentReady(context.Background(), func(context.Context) (*grpcclient.AgentConnection, error) {
+		attempts++
+		if elapsed := time.Since(started); elapsed < 15*time.Millisecond {
+			t.Fatalf("reconnect attempted before initial restart delay: %s", elapsed)
+		}
+		if attempts < 3 {
+			return nil, errors.New("agent restarting")
+		}
+		return &grpcclient.AgentConnection{}, nil
+	}, agentRestartWaitOptions{
+		InitialDelay: 15 * time.Millisecond,
+		Timeout:      200 * time.Millisecond,
+		PollInterval: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("waitForUpdatedAgentReady() error = %v", err)
+	}
+	if conn == nil {
+		t.Fatal("waitForUpdatedAgentReady() returned nil connection")
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestWaitForUpdatedAgentReadyReturnsLastReconnectError(t *testing.T) {
+	wantErr := errors.New("connection refused")
+	attempts := 0
+
+	_, err := waitForUpdatedAgentReady(context.Background(), func(context.Context) (*grpcclient.AgentConnection, error) {
+		attempts++
+		return nil, wantErr
+	}, agentRestartWaitOptions{
+		InitialDelay: time.Millisecond,
+		Timeout:      20 * time.Millisecond,
+		PollInterval: 2 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("waitForUpdatedAgentReady() succeeded, want error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("waitForUpdatedAgentReady() error = %v, want wrapping %v", err, wantErr)
+	}
+	if !strings.Contains(err.Error(), "agent did not become reachable after update") {
+		t.Fatalf("waitForUpdatedAgentReady() error = %q, want restart readiness context", err.Error())
+	}
+	if attempts == 0 {
+		t.Fatal("reconnect was never attempted")
+	}
+}
+
+func TestWaitForUpdatedAgentReadyHonorsCanceledContextDuringInitialDelay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	attempts := 0
+	_, err := waitForUpdatedAgentReady(ctx, func(context.Context) (*grpcclient.AgentConnection, error) {
+		attempts++
+		return &grpcclient.AgentConnection{}, nil
+	}, agentRestartWaitOptions{
+		InitialDelay: 50 * time.Millisecond,
+		Timeout:      200 * time.Millisecond,
+		PollInterval: 5 * time.Millisecond,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForUpdatedAgentReady() error = %v, want context.Canceled", err)
+	}
+	if attempts != 0 {
+		t.Fatalf("reconnect attempts = %d, want 0", attempts)
+	}
+}


### PR DESCRIPTION
## Reproduction

- Built the local CLI and ARM64 agent, then ran the reported repro against `wendyos-jetson-orin-nano.local` before changing code.
- Reproduced the issue: `device update --binary` printed `{"message":"Agent updated successfully.","status":"success"}`, then the follow-up `device info --json` after `sleep 0.45` failed with `✗ Could not connect to device. Is it powered on and connected to the network?`.

## Summary

- Make `wendy device update` wait for a fresh connection to the restarted agent before reporting success.
- Preserve the existing `--json` success response shape; it is printed after readiness instead of immediately after the update RPC is accepted.
- Keep the retry/polling scoped to the update command and document the readiness behavior.

Closes WDY-1600

## Testing

- `cd go && go test ./internal/cli/commands ./internal/agent/services`
- Re-ran the reported one-liner after the fix against `wendyos-jetson-orin-nano.local`; the follow-up `device info --json` succeeded after `sleep 0.45`.
