### PR TITLE
Request client+server EKU for device-provisioning CSRs

### DIFF
--- a/go/internal/agent/services/provisioning_service.go
+++ b/go/internal/agent/services/provisioning_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -164,9 +165,12 @@ func (s *ProvisioningService) StartProvisioning(ctx context.Context, req *agentp
 		return nil, status.Errorf(codes.Internal, "failed to load or generate key pair: %v", err)
 	}
 
-	// Generate CSR using org and asset as common name.
+	// Generate CSR using org and asset as common name. The device identity acts
+	// as both a TLS client (to the cloud) and a TLS server (agent gRPC and tunnel
+	// endpoints), so request both EKUs.
 	commonName := fmt.Sprintf("sh/wendy/%d/%d", req.GetOrganizationId(), req.GetAssetId())
-	csrPEM, err := certs.GenerateCSR(keyPEM, commonName)
+	csrPEM, err := certs.GenerateCSR(keyPEM, commonName,
+		x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to generate CSR: %v", err)
 	}

--- a/go/internal/cli/commands/os_provision.go
+++ b/go/internal/cli/commands/os_provision.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -87,7 +88,10 @@ func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName st
 		return nil, fmt.Errorf("generating key pair: %w", err)
 	}
 
-	csrPEM, err := certs.GenerateCSR([]byte(keyPEM), fmt.Sprintf("sh/wendy/%d/%d", orgID, assetID))
+	// Device identity acts as both a TLS client (to the cloud) and a TLS server
+	// (agent gRPC and tunnel endpoints), so request both EKUs.
+	csrPEM, err := certs.GenerateCSR([]byte(keyPEM), fmt.Sprintf("sh/wendy/%d/%d", orgID, assetID),
+		x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth)
 	if err != nil {
 		return nil, fmt.Errorf("generating CSR: %w", err)
 	}

--- a/go/internal/shared/certs/certs.go
+++ b/go/internal/shared/certs/certs.go
@@ -37,15 +37,31 @@ func GenerateKeyPair() (privateKeyPEM string, err error) {
 // PEM-encoded private key (as bytes, so callers can zero the slice after use)
 // and common name. The CSR is returned as a PEM string.
 //
-// The CSR requests digitalSignature key usage and the clientAuth EKU so that
-// CAs honoring CSR extensions issue certs the wendy-agent mTLS interceptor
-// accepts (it requires an explicit clientAuth EKU). The Wendy cloud backends
-// set key usages server-side and ignore these, so this only matters for CAs
-// that derive extensions from the CSR.
-func GenerateCSR(privateKeyPEM []byte, commonName string) (csrPEM string, err error) {
+// The CSR requests digitalSignature key usage and the supplied extended key
+// usages so that CAs honoring CSR extensions issue certs the wendy-agent mTLS
+// interceptor accepts (it requires an explicit clientAuth EKU). When no EKUs
+// are supplied it defaults to clientAuth, keeping user/CLI certs scoped to
+// client authentication. Device-provisioning callers (device enroll, os
+// install) pass both clientAuth and serverAuth so the device identity can act
+// as a TLS client to the cloud and a TLS server for the agent's gRPC and tunnel
+// endpoints. The Wendy cloud backends set key usages server-side and ignore
+// these, so this only matters for CAs that derive extensions from the CSR.
+func GenerateCSR(privateKeyPEM []byte, commonName string, extKeyUsages ...x509.ExtKeyUsage) (csrPEM string, err error) {
 	key, err := parseECPrivateKey(privateKeyPEM)
 	if err != nil {
 		return "", err
+	}
+
+	if len(extKeyUsages) == 0 {
+		extKeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	ekuOIDs := make([]asn1.ObjectIdentifier, 0, len(extKeyUsages))
+	for _, eku := range extKeyUsages {
+		oid, ok := extKeyUsageOID(eku)
+		if !ok {
+			return "", fmt.Errorf("unsupported extended key usage: %d", eku)
+		}
+		ekuOIDs = append(ekuOIDs, oid)
 	}
 
 	// KeyUsage is a BIT STRING; digitalSignature is bit 0 (RFC 5280 4.2.1.3).
@@ -53,9 +69,7 @@ func GenerateCSR(privateKeyPEM []byte, commonName string) (csrPEM string, err er
 	if err != nil {
 		return "", fmt.Errorf("marshaling key usage: %w", err)
 	}
-	ekuValue, err := asn1.Marshal([]asn1.ObjectIdentifier{
-		{1, 3, 6, 1, 5, 5, 7, 3, 2}, // id-kp-clientAuth
-	})
+	ekuValue, err := asn1.Marshal(ekuOIDs)
 	if err != nil {
 		return "", fmt.Errorf("marshaling extended key usage: %w", err)
 	}
@@ -88,6 +102,20 @@ func GenerateCSR(privateKeyPEM []byte, commonName string) (csrPEM string, err er
 	}
 
 	return string(pem.EncodeToMemory(block)), nil
+}
+
+// extKeyUsageOID maps the extended key usages this package supports in CSRs to
+// their RFC 5280 object identifiers. Only the usages relevant to Wendy mTLS are
+// handled; unsupported values report ok=false so callers can fail loudly.
+func extKeyUsageOID(eku x509.ExtKeyUsage) (oid asn1.ObjectIdentifier, ok bool) {
+	switch eku {
+	case x509.ExtKeyUsageServerAuth:
+		return asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 1}, true // id-kp-serverAuth
+	case x509.ExtKeyUsageClientAuth:
+		return asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 2}, true // id-kp-clientAuth
+	default:
+		return nil, false
+	}
 }
 
 // ExtractPublicKey extracts the public key from a PEM-encoded EC private key

--- a/go/internal/shared/certs/certs_test.go
+++ b/go/internal/shared/certs/certs_test.go
@@ -318,4 +318,62 @@ func TestGenerateCSRRequestsClientAuthUsage(t *testing.T) {
 	if !found {
 		t.Errorf("CSR extended key usage missing clientAuth, got %v", ekus)
 	}
+
+	// The default (no explicit usages) must remain clientAuth-only so user/CLI
+	// certs stay scoped to client authentication.
+	serverAuthOID := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 1}
+	for _, oid := range ekus {
+		if oid.Equal(serverAuthOID) {
+			t.Errorf("default CSR extended key usage unexpectedly includes serverAuth, got %v", ekus)
+		}
+	}
+}
+
+func TestGenerateCSRRequestsClientAndServerAuthUsage(t *testing.T) {
+	keyPEM, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair() error = %v", err)
+	}
+
+	csrPEM, err := GenerateCSR([]byte(keyPEM), "sh/wendy/1/2",
+		x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth)
+	if err != nil {
+		t.Fatalf("GenerateCSR() error = %v", err)
+	}
+
+	block, _ := pem.Decode([]byte(csrPEM))
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatalf("parsing generated CSR: %v", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		t.Fatalf("CSR signature invalid: %v", err)
+	}
+
+	var ekus []asn1.ObjectIdentifier
+	for _, ext := range csr.Extensions {
+		if ext.Id.Equal(asn1.ObjectIdentifier{2, 5, 29, 37}) {
+			if _, err := asn1.Unmarshal(ext.Value, &ekus); err != nil {
+				t.Fatalf("unmarshaling extended key usage: %v", err)
+			}
+		}
+	}
+
+	clientAuthOID := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 2}
+	serverAuthOID := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 1}
+	var hasClient, hasServer bool
+	for _, oid := range ekus {
+		if oid.Equal(clientAuthOID) {
+			hasClient = true
+		}
+		if oid.Equal(serverAuthOID) {
+			hasServer = true
+		}
+	}
+	if !hasClient {
+		t.Errorf("CSR extended key usage missing clientAuth, got %v", ekus)
+	}
+	if !hasServer {
+		t.Errorf("CSR extended key usage missing serverAuth, got %v", ekus)
+	}
 }


### PR DESCRIPTION
## Summary

Device identities minted during `device enroll` and `os install` act as **both** a TLS client (connecting to the cloud) and a TLS server (the agent's gRPC and tunnel endpoints). Their CSRs should therefore request both `clientAuth` and `serverAuth` extended key usages, not just `clientAuth`.

## Changes

- **`certs.GenerateCSR`** now takes a variadic `extKeyUsages ...x509.ExtKeyUsage`. With none supplied it defaults to `clientAuth`-only, so existing user/CLI login and cert-refresh paths stay scoped to client authentication (least privilege). Added an `extKeyUsageOID` helper that maps the supported usages to their RFC 5280 OIDs and fails loudly on anything else.
- **Device-provisioning call sites** now pass `clientAuth` + `serverAuth`:
  - `agent/services/provisioning_service.go` — the `device enroll` flow (agent mints its own identity).
  - `cli/commands/os_provision.go` — the `os install` pre-enrollment flow.
- Tests: tightened the existing CSR test to assert the default stays `clientAuth`-only (no `serverAuth` leak into user certs) and added a test asserting both EKUs when requested.

## Caveat

`GenerateCSR`'s doc note still holds: the Wendy cloud backends set key usages server-side and **ignore** the CSR's requested EKUs. This change guarantees the dual EKU only for CAs that derive extensions from the CSR (e.g. the local-pki / local-enrollment path). For certs issued by production pki-core / Google CAS, the issuance profile must also include `serverAuth` — a separate, out-of-repo change.

## Validation

`go build ./...` clean; `certs`, `agent/services`, `agent/mtls`, `agent/interceptor`, and `cli/commands` test packages all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)