### PR TITLE
fix(agent): Raspberry Pi camera fixes — list cleanup + v4l2h264enc H.264 level (WDY-1603)

### DIFF
--- a/go/internal/agent/camera/transport.go
+++ b/go/internal/agent/camera/transport.go
@@ -82,11 +82,37 @@ var csiDriverPrefixes = []string{
 	"nvcsi",
 	"unicam",
 	"bcm2835-unicam",
-	"bcm2835-isp",
 	"rkisp1",
 	"rzg2l-cru",
 	"imx",
 	"ov",
+}
+
+// nonCameraDriverPrefixes are kernel driver names that bind V4L2 memory-to-memory
+// devices which advertise VIDEO_CAPTURE but are NOT capture sources — the legacy
+// Raspberry Pi 0-4 ISP (bcm2835-isp, exposed as bcm2835-isp-capture0/1) and the
+// H.264 codec (bcm2835-codec). Without this denylist they would surface in
+// `camera list` as phantom CSI cameras (WDY-1603). Pi 5 (rp1-cfe/pispbe) and
+// Jetson (tegra-*) use different drivers and are unaffected.
+var nonCameraDriverPrefixes = []string{
+	"bcm2835-isp",
+	"bcm2835-codec",
+}
+
+// IsNonCameraDriver reports whether driver binds a non-camera V4L2 m2m device
+// (ISP/codec) that should be excluded from camera enumeration. Matching is
+// case-insensitive prefix semantics, consistent with the transport classifiers.
+func IsNonCameraDriver(driver string) bool {
+	if driver == "" {
+		return false
+	}
+	lower := strings.ToLower(driver)
+	for _, p := range nonCameraDriverPrefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // Classify returns the transport for /dev/<base> (e.g. base == "video0").
@@ -97,6 +123,12 @@ func Classify(base string) (Transport, string) {
 	driver := ""
 	if err == nil {
 		driver = filepath.Base(target)
+	}
+	// Non-camera m2m devices (ISP/codec) advertise VIDEO_CAPTURE and may carry an
+	// of_node; exclude them up front so neither the prefix match nor the of_node
+	// fallback below misclassifies them as a CSI camera.
+	if IsNonCameraDriver(driver) {
+		return TransportUnknown, driver
 	}
 	if t := transportFromDriver(driver); t != TransportUnknown {
 		return t, driver

--- a/go/internal/agent/camera/transport_test.go
+++ b/go/internal/agent/camera/transport_test.go
@@ -76,6 +76,51 @@ func TestClassify_CSI_SensorDriverImx(t *testing.T) {
 	}
 }
 
+func TestClassify_NonCamera_Bcm2835Isp(t *testing.T) {
+	// The bcm2835-isp m2m capture nodes (bcm2835-isp-capture0/1) advertise
+	// VIDEO_CAPTURE but are the legacy Pi 0-4 ISP output, not a sensor capture
+	// source. They must NOT be classified as CSI cameras.
+	withFakeSysfs(t, map[string]string{"video14": "bcm2835-isp"}, nil)
+	got, drv := Classify("video14")
+	if got != TransportUnknown || drv != "bcm2835-isp" {
+		t.Fatalf("got (%v, %q), want (Unknown, bcm2835-isp)", got, drv)
+	}
+}
+
+func TestClassify_NonCamera_Bcm2835Codec(t *testing.T) {
+	// The bcm2835-codec H.264 encode/decode m2m nodes are not cameras either.
+	withFakeSysfs(t, map[string]string{"video10": "bcm2835-codec"}, nil)
+	got, drv := Classify("video10")
+	if got != TransportUnknown || drv != "bcm2835-codec" {
+		t.Fatalf("got (%v, %q), want (Unknown, bcm2835-codec)", got, drv)
+	}
+}
+
+func TestClassify_NonCamera_IspNotReclassifiedByOfNode(t *testing.T) {
+	// Even when the ISP platform device carries a device-tree of_node, the
+	// non-camera denylist must win over the of_node CSI fallback.
+	withFakeSysfs(t, map[string]string{"video14": "bcm2835-isp"}, map[string]bool{"video14": true})
+	got, drv := Classify("video14")
+	if got != TransportUnknown || drv != "bcm2835-isp" {
+		t.Fatalf("got (%v, %q), want (Unknown, bcm2835-isp)", got, drv)
+	}
+}
+
+func TestIsNonCameraDriver(t *testing.T) {
+	nonCamera := []string{"bcm2835-isp", "bcm2835-codec"}
+	for _, drv := range nonCamera {
+		if !IsNonCameraDriver(drv) {
+			t.Errorf("IsNonCameraDriver(%q) = false, want true", drv)
+		}
+	}
+	camera := []string{"bcm2835-unicam", "unicam", "imx477", "ov5647", "uvcvideo", "tegra-capture-vi", ""}
+	for _, drv := range camera {
+		if IsNonCameraDriver(drv) {
+			t.Errorf("IsNonCameraDriver(%q) = true, want false", drv)
+		}
+	}
+}
+
 func TestClassify_CSI_OfNodeImpliesCSI(t *testing.T) {
 	// Unknown driver but a device-tree node present → still CSI.
 	withFakeSysfs(t, map[string]string{"video0": "mystery-driver"}, map[string]bool{"video0": true})

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -347,6 +347,11 @@ func (s *VideoService) listV4L2Devices(ctx context.Context) ([]*agentpb.VideoDev
 			name = base
 		}
 		transport, driver := s.classifyTransport(base)
+		// Skip non-camera m2m nodes (Pi 0-4 bcm2835-isp/codec) that advertise
+		// VIDEO_CAPTURE but are not capture sources (WDY-1603).
+		if camera.IsNonCameraDriver(driver) {
+			continue
+		}
 		dev := &agentpb.VideoDevice{
 			Id:        uint32(id),
 			Name:      name,

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -1445,7 +1445,12 @@ func encoderSegment(encoder string, hasH264Parse bool, gop int) string {
 		// Jetson L4T hardware encoder; NV12 is its preferred input format.
 		enc = "videoconvert ! video/x-raw,format=NV12 ! nvv4l2h264enc" + kf
 	case "v4l2h264enc":
-		enc = "videoconvert ! video/x-raw,format=I420 ! v4l2h264enc" + kf + " ! video/x-h264,profile=baseline"
+		// The Raspberry Pi bcm2835-codec rejects frames ("Failed to process
+		// frame") unless the output H.264 level is pinned — a bare or
+		// profile-only capsfilter lets it negotiate a level the driver can't
+		// process. level 4 covers up to 1080p30, the encoder's ceiling
+		// (verified on a Pi 4, WDY-1603).
+		enc = "videoconvert ! video/x-raw,format=I420 ! v4l2h264enc" + kf + " ! video/x-h264,profile=baseline,level=(string)4"
 	case "x264enc":
 		enc = "videoconvert ! video/x-raw,format=I420 ! x264enc tune=zerolatency" + kf + " ! video/x-h264,profile=high"
 	case "openh264enc":

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -345,6 +345,19 @@ func TestBuildGStreamerArgs_V4L2HardwareEncoder(t *testing.T) {
 	}
 }
 
+func TestBuildGStreamerArgs_V4L2PinsH264Level(t *testing.T) {
+	// On the Raspberry Pi bcm2835-codec, a bare v4l2h264enc (even with a
+	// profile-only capsfilter) negotiates an H.264 level the driver then rejects
+	// at QBUF time ("Failed to process frame"). Pinning an explicit level in the
+	// output caps is required for the encoder to run (verified on a Pi 4, WDY-1603).
+	req := &agentpb.StreamVideoRequest{}
+	args := mustBuildGStreamerArgs(t, "/usr/bin/gst-launch-1.0", "/dev/video0", req, "v4l2h264enc", true)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "level=(string)4") {
+		t.Errorf("v4l2h264enc output caps must pin an H.264 level: %v", args)
+	}
+}
+
 func TestBuildGStreamerArgs_NVV4L2HardwareEncoder(t *testing.T) {
 	req := &agentpb.StreamVideoRequest{}
 	args := mustBuildGStreamerArgs(t, "/usr/bin/gst-launch-1.0", "/dev/video0", req, "nvv4l2h264enc", true)

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -76,6 +76,50 @@ func TestListV4L2Devices_TwoDevices(t *testing.T) {
 	}
 }
 
+func TestListV4L2Devices_ExcludesNonCameraDrivers(t *testing.T) {
+	// On Raspberry Pi 3/4 the bcm2835-isp and bcm2835-codec m2m nodes advertise
+	// VIDEO_CAPTURE and would otherwise pollute `camera list` as fake cameras.
+	// Only the real unicam capture node should be listed.
+	svc := newTestVideoService(
+		func() ([]string, error) {
+			return []string{"/dev/video0", "/dev/video10", "/dev/video14", "/dev/video15"}, nil
+		},
+		func(base string) (string, error) {
+			names := map[string]string{
+				"video0":  "unicam",
+				"video10": "bcm2835-codec-decode",
+				"video14": "bcm2835-isp-capture0",
+				"video15": "bcm2835-isp-capture1",
+			}
+			return names[base], nil
+		},
+	)
+	svc.classifyTransport = func(base string) (camera.Transport, string) {
+		drivers := map[string]string{
+			"video0":  "bcm2835-unicam",
+			"video10": "bcm2835-codec",
+			"video14": "bcm2835-isp",
+			"video15": "bcm2835-isp",
+		}
+		drv := drivers[base]
+		if camera.IsNonCameraDriver(drv) {
+			return camera.TransportUnknown, drv
+		}
+		return camera.TransportCSI, drv
+	}
+
+	devices, err := svc.listV4L2Devices(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("expected only the unicam node, got %d: %v", len(devices), devices)
+	}
+	if devices[0].GetPath() != "/dev/video0" || devices[0].GetName() != "unicam" {
+		t.Errorf("expected /dev/video0 unicam, got path=%q name=%q", devices[0].GetPath(), devices[0].GetName())
+	}
+}
+
 func TestListV4L2Devices_NoDevices(t *testing.T) {
 	svc := newTestVideoService(
 		func() ([]string, error) { return nil, nil },


### PR DESCRIPTION
## Context

WDY-1603: `wendy device camera view` fails on Raspberry Pi 3/4. Two agent-side issues, both verified on a Pi 4 with the OS fix (wendylabsinc/WendyOS-Builder#133) applied.

## 1. `v4l2h264enc` rejects every frame unless the H.264 level is pinned

The Raspberry Pi `bcm2835-codec` hardware encoder fails with `Failed to process frame. Maybe be due to not enough memory or failing driver` when its output H.264 level is unconstrained — a bare or **profile-only** capsfilter lets it negotiate a level the driver then refuses at QBUF time. Isolated on-device:

| pipeline tail | result |
|---|---|
| `v4l2h264enc` (bare) | ❌ fails |
| `v4l2h264enc ! video/x-h264,profile=baseline` (old code) | ❌ fails |
| `v4l2h264enc ! video/x-h264,profile=baseline,level=(string)4` | ✅ streams |

Fix: pin `level=(string)4` (covers up to 1080p30, the encoder's ceiling) in `encoderSegment`. **This path went untested until now because Pi 4 is the first device that actually uses `v4l2h264enc`** — Pi 5 has no HW H.264 encoder (uses `x264enc`) and Jetson uses `nvv4l2h264enc`.

## 2. `camera list` showed phantom ISP/codec nodes

The legacy Pi 0–4 `bcm2835-isp` (`bcm2835-isp-capture0/1`) and `bcm2835-codec` V4L2 m2m nodes advertise `VIDEO_CAPTURE` but aren't capture sources. `bcm2835-isp` was in `csiDriverPrefixes`, so they were listed as phantom `csi` cameras.

> `listV4L2Devices` lists every node that passes `hasVideoCapture` regardless of transport, so removing the prefix alone would only relabel them — an explicit skip is required.

Fix: remove `bcm2835-isp` from `csiDriverPrefixes`; add a `nonCameraDriverPrefixes` denylist (`bcm2835-isp`, `bcm2835-codec`) + `IsNonCameraDriver()`; `Classify` short-circuits these to `Unknown` before the `of_node` fallback; `listV4L2Devices` skips them. The real camera is the `bcm2835-unicam` node, which still classifies as CSI.

## Scope / safety

Pi 5 (`rp1-cfe`/`pispbe`, `x264enc`) and Jetson (`tegra-*`, `nvv4l2h264enc`) use different drivers/encoders and are unaffected.

## Tests (TDD)

- `transport_test.go`: +4 — `bcm2835-isp`/`bcm2835-codec` → Unknown (incl. with of_node present); `IsNonCameraDriver` truth table; `unicam`/`imx477`/`ov5647` stay CSI.
- `video_service_test.go`: +2 — list excludes the ISP/codec nodes; `v4l2h264enc` caps pin an H.264 level.

`go test ./internal/agent/...` green; gofmt + go vet clean.

## Verified end-to-end on a Pi 4

With the deployed agent: `camera list` returns only the real unicam node (driver `unicam`, `libcamera_id` = the imx477); `camera view --stdout` streams valid **H.264 1280×1080 @ 30fps**.

Pairs with wendylabsinc/WendyOS-Builder#133 (the OS `dtoverlay=imx477`). **Both are required** for Pi 4 camera streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)