### PR TITLE
fix(cli): isolate parallel multi-service builds with a buildx builder pool (WDY-1554)

### DIFF
--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -653,7 +653,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		}
 
 		repo := fmt.Sprintf("%s-%s", projectName, name)
-		if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, ctxDir, repo, platform, dockerfile, allBuildArgs, os.Stdout, os.Stderr); err != nil {
+		if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, ctxDir, repo, platform, dockerfile, allBuildArgs, nil, os.Stdout, os.Stderr); err != nil {
 			return fmt.Errorf("building service %s: %w", name, err)
 		}
 		cliLogln("Service %s image built and pushed.", name)

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -546,7 +546,7 @@ func injectDebugpy(ctx context.Context, registryAddr, registryImage, platform st
 		return fmt.Errorf("writing debugpy Dockerfile: %w", err)
 	}
 
-	return buildAndPushImage(ctx, tmpDir, registryAddr, registryImage, platform, "", buildArgs, streamOutput, streamOutput, useMTLS)
+	return buildAndPushImage(ctx, tmpDir, registryAddr, registryImage, platform, "", buildArgs, nil, streamOutput, streamOutput, useMTLS)
 }
 
 func generatePythonDockerfile(dir string, debug bool) (string, error) {
@@ -954,10 +954,11 @@ func ensureBuildxBuilder(ctx context.Context, registryAddr string, useMTLS bool,
 	// buildx and buildkitd rejects ']' in table-header keys.
 	effectiveAddr, ipv6IP := splitIPv6RegistryAddr(registryAddr)
 
+	base := buildxBuilderBaseName()
 	if !useMTLS {
-		builderName, err = ensurePlaintextBuilder(ctx, configDir, effectiveAddr, w)
+		builderName, err = ensurePlaintextBuilder(ctx, base, configDir, effectiveAddr, w)
 	} else {
-		builderName, err = ensureMTLSBuilder(ctx, configDir, effectiveAddr, containerCertDir, w)
+		builderName, err = ensureMTLSBuilder(ctx, base+"-mtls", configDir, effectiveAddr, containerCertDir, w)
 	}
 	if err != nil {
 		return "", "", err
@@ -989,11 +990,7 @@ func ensureOCIExportBuilder(ctx context.Context, w io.Writer) (string, error) {
 	ensureBuildxBuilderMu.Lock()
 	defer ensureBuildxBuilderMu.Unlock()
 
-	base := os.Getenv("WENDY_BUILDX_BUILDER")
-	if base == "" {
-		base = "wendy"
-	}
-	builderName := base + "-oci"
+	builderName := buildxBuilderBaseName() + "-oci"
 
 	// Fast path: if the builder's buildkit container is already running, then the
 	// daemon is up, the builder exists, and it is bootstrapped — so we can skip
@@ -1032,6 +1029,134 @@ func ensureOCIExportBuilder(ctx context.Context, w io.Writer) (string, error) {
 		return "", fmt.Errorf("bootstrapping builder %q: %s: %w", builderName, string(out), err)
 	}
 	return builderName, nil
+}
+
+// buildxBuilderBaseName returns the base buildx builder name, honoring the
+// WENDY_BUILDX_BUILDER override (default "wendy"). Variant builders derive from
+// it by suffix: "<base>-mtls", "<base>-oci", "<base>-pool-<i>".
+func buildxBuilderBaseName() string {
+	base := os.Getenv("WENDY_BUILDX_BUILDER")
+	if base == "" {
+		base = "wendy"
+	}
+	return base
+}
+
+// poolBuilderName returns the buildx builder instance name for parallel-build
+// pool slot i. The "-pool-" infix keeps pool builders disjoint from the shared
+// "wendy"/"wendy-mtls"/"wendy-oci" builders so they never contend, and makes
+// leftover pool builders trivial to identify and prune (`docker buildx rm`).
+func poolBuilderName(base string, useMTLS bool, i int) string {
+	if useMTLS {
+		return fmt.Sprintf("%s-mtls-pool-%d", base, i)
+	}
+	return fmt.Sprintf("%s-pool-%d", base, i)
+}
+
+// buildxAssignment is one parallel-build slot's pre-warmed builder instance and
+// its isolated local cache dir. Handing each concurrent service build a distinct
+// builder + cache dir removes the shared buildkit ingest-store and shared local
+// cache races that made parallel multi-service builds flaky (WDY-1554).
+type buildxAssignment struct {
+	name     string // buildx builder instance, e.g. "wendy-pool-2"
+	cacheDir string // isolated --cache-to/--cache-from dir for this slot
+}
+
+// ensureBuilderPool creates (or reuses) a pool of `size` isolated buildx builders
+// for a parallel multi-service build and returns one assignment per slot.
+//
+// Every restart-capable operation — create, config injection, cert copy, restart,
+// bootstrap — happens HERE, up front, before the parallel fan-out. During the
+// fan-out each build only does a cheap "is my builder running" check
+// (ensurePoolBuilderRunning), so no build ever restarts a builder out from under
+// a sibling build. This preserves the #1017/#1018 guarantee while removing the
+// intra-process shared-ingest race the build lock was never meant to cover.
+//
+// Builders are persistent and reused across runs (like the shared builders); the
+// per-builder ".applied" marker makes re-ensure a no-op when the registry config
+// is unchanged. Callers should hold buildLock across this call and the fan-out so
+// a second wendy process can't reconfigure a pool builder mid-build.
+func ensureBuilderPool(ctx context.Context, size int, registryAddr string, useMTLS bool, w io.Writer) ([]buildxAssignment, error) {
+	ensureBuildxBuilderMu.Lock()
+	defer ensureBuildxBuilderMu.Unlock()
+
+	if err := ensureDockerDaemon(ctx); err != nil {
+		return nil, err
+	}
+
+	const containerCertDir = "/etc/buildkit/certs"
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("finding home directory: %w", err)
+	}
+	configDir := filepath.Join(home, ".cache", "wendy")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating config directory: %w", err)
+	}
+
+	userCache, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("finding user cache directory: %w", err)
+	}
+
+	// The IPv6 alias is identical for every slot (same registry); compute once.
+	effectiveAddr, ipv6IP := splitIPv6RegistryAddr(registryAddr)
+	base := buildxBuilderBaseName()
+
+	assignments := make([]buildxAssignment, 0, size)
+	for i := 0; i < size; i++ {
+		name := poolBuilderName(base, useMTLS, i)
+
+		// Create + configure each builder sequentially. ensure*Builder restarts the
+		// builder only when its ".applied" marker differs, so a warm pool is a
+		// no-op restart-wise; a cold pool pays the create/config cost once.
+		if useMTLS {
+			_, err = ensureMTLSBuilder(ctx, name, configDir, effectiveAddr, containerCertDir, w)
+		} else {
+			_, err = ensurePlaintextBuilder(ctx, name, configDir, effectiveAddr, w)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("preparing pool builder %q: %w", name, err)
+		}
+
+		// Each buildkitd container has its own /etc/hosts, so the IPv6 alias must
+		// be added per slot (mirrors the single-builder block in ensureBuildxBuilder).
+		if ipv6IP != "" {
+			containerName := "buildx_buildkit_" + name + "0"
+			hostsCmd := exec.CommandContext(ctx, "docker", "exec", containerName, "sh", "-c",
+				fmt.Sprintf("if grep -q ' wendy-registry' /etc/hosts; then sed -i 's/^[^#]* wendy-registry$/%s wendy-registry/' /etc/hosts; else printf '\\n%s wendy-registry\\n' >> /etc/hosts; fi", ipv6IP, ipv6IP))
+			if out, cmdErr := hostsCmd.CombinedOutput(); cmdErr != nil {
+				return nil, fmt.Errorf("adding hosts entry to pool builder %q: %s: %w", name, string(out), cmdErr)
+			}
+		}
+
+		cacheDir := filepath.Join(userCache, "wendy", "buildx-pool", strconv.Itoa(i))
+		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+			return nil, fmt.Errorf("creating pool cache directory: %w", err)
+		}
+
+		assignments = append(assignments, buildxAssignment{name: name, cacheDir: cacheDir})
+	}
+
+	return assignments, nil
+}
+
+// ensurePoolBuilderRunning is the cheap per-build check used inside the parallel
+// fan-out: it confirms a pre-warmed pool builder's buildkitd container is up
+// without ANY config injection or restart of a running container (a restart could
+// kill a sibling build). On the rare miss — the container died between pre-warm
+// and the build — it re-bootstraps, which is safe because each pool builder is
+// owned by exactly one concurrent build at a time.
+func ensurePoolBuilderRunning(ctx context.Context, builderName string) error {
+	containerName := "buildx_buildkit_" + builderName + "0"
+	if out, err := exec.CommandContext(ctx, "docker", "inspect", "-f", "{{.State.Running}}", containerName).Output(); err == nil && strings.TrimSpace(string(out)) == "true" {
+		return nil
+	}
+	if out, err := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName).CombinedOutput(); err != nil {
+		return fmt.Errorf("bootstrapping pool builder %q: %s: %w", builderName, string(out), err)
+	}
+	return nil
 }
 
 // buildkitRegistryConfig generates a buildkitd.toml snippet for the given
@@ -1074,12 +1199,7 @@ func removeBuilder(ctx context.Context, name string) {
 // HTTP registry config. The config is injected into the builder container via
 // docker cp (not --buildkitd-config) to avoid the host-side TOML parser which
 // cannot handle IPv6 brackets in registry addresses.
-func ensurePlaintextBuilder(ctx context.Context, configDir, registryAddr string, w io.Writer) (string, error) {
-	builderName := os.Getenv("WENDY_BUILDX_BUILDER")
-	if builderName == "" {
-		builderName = "wendy"
-	}
-
+func ensurePlaintextBuilder(ctx context.Context, builderName, configDir, registryAddr string, w io.Writer) (string, error) {
 	appliedPath := filepath.Join(configDir, builderName+".applied")
 
 	fullConfig := buildkitRegistryConfig(registryAddr, true, nil)
@@ -1137,14 +1257,8 @@ func ensurePlaintextBuilder(ctx context.Context, configDir, registryAddr string,
 
 // ensureMTLSBuilder ensures the "wendy-mtls" buildx builder exists with mTLS
 // client certs for the device registry.
-func ensureMTLSBuilder(ctx context.Context, configDir, registryAddr, containerCertDir string, w io.Writer) (string, error) {
-	base := os.Getenv("WENDY_BUILDX_BUILDER")
-	if base == "" {
-		base = "wendy"
-	}
-	builderName := base + "-mtls"
-
-	appliedPath := filepath.Join(configDir, base+"-mtls.applied")
+func ensureMTLSBuilder(ctx context.Context, builderName, configDir, registryAddr, containerCertDir string, w io.Writer) (string, error) {
+	appliedPath := filepath.Join(configDir, builderName+".applied")
 
 	certInfo := loadCLICert()
 	if certInfo == nil || certInfo.PemCertificate == "" || certInfo.PemPrivateKey == "" {
@@ -1323,7 +1437,7 @@ func updateBuilderConfig(ctx context.Context, builderName, config string, w io.W
 	return nil
 }
 
-func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {
+func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, asg *buildxAssignment, streamOutput, logOutput io.Writer, useMTLS bool) error {
 	// Serialize against other wendy processes: the buildx builder is shared, and
 	// reconfiguring or restarting it mid-build kills a concurrent build (#1017).
 	// Concurrent builds within this process share the lock via reference counting.
@@ -1333,9 +1447,23 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 	}
 	defer releaseLock()
 
-	builder, effectiveAddr, err := ensureBuildxBuilder(ctx, registryAddr, useMTLS, logOutput)
-	if err != nil {
-		return err
+	var builder, effectiveAddr string
+	if asg != nil {
+		// Parallel multi-service path: the pool builder was created, configured and
+		// bootstrapped up front (ensureBuilderPool), so here we only confirm it is
+		// running — never inject config or restart, which would kill a sibling build.
+		builder = asg.name
+		if err := ensurePoolBuilderRunning(ctx, builder); err != nil {
+			return err
+		}
+		// ensureBuilderPool applied the same IPv6 alias to every slot, so the image
+		// reference must be rewritten the same way (the recompute is a pure func).
+		effectiveAddr, _ = splitIPv6RegistryAddr(registryAddr)
+	} else {
+		builder, effectiveAddr, err = ensureBuildxBuilder(ctx, registryAddr, useMTLS, logOutput)
+		if err != nil {
+			return err
+		}
 	}
 
 	// When an IPv6 alias is in use, rewrite the image reference to match.
@@ -1350,7 +1478,12 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 	if err != nil {
 		return fmt.Errorf("finding user cache directory: %w", err)
 	}
+	// Single/shared builds use one shared cache dir; pooled parallel builds each
+	// use their own isolated dir so concurrent --cache-to/--cache-from never race.
 	cacheDir := filepath.Join(userCache, "wendy", "buildx")
+	if asg != nil {
+		cacheDir = asg.cacheDir
+	}
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return fmt.Errorf("creating cache directory: %w", err)
 	}
@@ -1458,14 +1591,14 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 	return nil
 }
 
-func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {
+func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, asg *buildxAssignment, streamOutput, logOutput io.Writer, useMTLS bool) error {
 	normalized, err := normalizeImageBuilder(builder)
 	if err != nil {
 		return err
 	}
 	switch normalized {
 	case imageBuilderDocker:
-		return buildAndPushImage(ctx, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
+		return buildAndPushImage(ctx, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, asg, streamOutput, logOutput, useMTLS)
 	case imageBuilderAppleContainer:
 		return buildAndPushImageWithAppleContainer(ctx, dir, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
 	default:
@@ -1473,24 +1606,26 @@ func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAdd
 	}
 }
 
-func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer) error {
+func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, asg *buildxAssignment, streamOutput, logOutput io.Writer) error {
 	if _, err := normalizeImageBuilder(builder); err != nil {
 		return err
 	}
 	if imageBuilderWasExplicit(builder) {
-		return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, builder, dir, repo, platform, dockerfile, buildArgs, streamOutput, logOutput)
+		return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, builder, dir, repo, platform, dockerfile, buildArgs, asg, streamOutput, logOutput)
 	}
 	if shouldAutoAttemptAppleContainerBuilder() {
-		if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, streamOutput, logOutput); err == nil {
+		// Apple Container builds don't use buildx, so the pool assignment never
+		// applies here; only the Docker fallback below consumes it.
+		if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, nil, streamOutput, logOutput); err == nil {
 			return nil
 		} else {
 			logAppleContainerFallback(logOutput, err)
 		}
 	}
-	return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderDocker, dir, repo, platform, dockerfile, buildArgs, streamOutput, logOutput)
+	return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderDocker, dir, repo, platform, dockerfile, buildArgs, asg, streamOutput, logOutput)
 }
 
-func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer) error {
+func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, asg *buildxAssignment, streamOutput, logOutput io.Writer) error {
 	normalized, err := normalizeImageBuilder(builder)
 	if err != nil {
 		return err
@@ -1503,7 +1638,7 @@ func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.
 
 	registryImage := fmt.Sprintf("%s/%s:latest", registryAddr, strings.ToLower(repo))
 	cliLogln("Building and pushing image with %s for %s...", imageBuilderDisplayName(normalized), platform)
-	return buildAndPushImageWithBuilder(ctx, normalized, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
+	return buildAndPushImageWithBuilder(ctx, normalized, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, asg, streamOutput, logOutput, useMTLS)
 }
 
 func buildAndPushImageWithAppleContainer(ctx context.Context, dir, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -76,6 +76,7 @@ func TestBuildAndPushImageWithAppleContainerUsesContainerCLI(t *testing.T) {
 		"linux/arm64",
 		"Dockerfile",
 		map[string]string{"B": "2", "A": "1"},
+		nil,
 		io.Discard,
 		io.Discard,
 		false,

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -26,6 +26,11 @@ import (
 
 const maxConcurrentBuilds = 4
 
+// buildServiceImage is the per-service build step. It's a package var so tests can
+// substitute it to exercise the parallel scheduling (assignment hand-off, builder
+// mutual-exclusion) without invoking docker.
+var buildServiceImage = buildAndPushImageForAgent
+
 func resolveServiceSubset(services map[string]*appconfig.ServiceConfig, only string) (map[string]*appconfig.ServiceConfig, error) {
 	if only == "" {
 		return services, nil
@@ -114,7 +119,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Build all service images in parallel, then create and start containers.
-	if err := buildServicesParallel(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder); err != nil {
+	if err := buildAllServiceImages(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder); err != nil {
 		return err
 	}
 
@@ -162,9 +167,69 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	return startAndStreamServices(ctx, conn, appCfg.AppID, ordered, opts)
 }
 
+// multiServiceUsesBuildxPool reports whether a multi-service run will build via
+// the Docker buildx path and should therefore use the isolated builder pool. It
+// returns false for Apple Container builds — including the macOS auto path that
+// tries Apple Container before falling back to Docker — since those don't use
+// buildx, and for the WENDY_BUILDX_POOL=0 opt-out.
+func multiServiceUsesBuildxPool(builder string) bool {
+	if os.Getenv("WENDY_BUILDX_POOL") == "0" {
+		return false
+	}
+	normalized, err := normalizeImageBuilder(builder)
+	if err != nil || normalized != imageBuilderDocker {
+		return false
+	}
+	if !imageBuilderWasExplicit(builder) && shouldAutoAttemptAppleContainerBuilder() {
+		return false
+	}
+	return true
+}
+
+// buildAllServiceImages builds every service image. On the parallel Docker path
+// it pre-warms an isolated builder pool (one buildkitd + cache dir per concurrent
+// build) so concurrent builds never race on a shared buildkit ingest store
+// (WDY-1554); otherwise it uses the shared builder exactly as before.
+//
+// For the pool path it holds the cross-process build lock across BOTH pre-warm
+// and the parallel fan-out, so another wendy process can't reconfigure/restart a
+// pool builder mid-build (#1017). The lock is released before this returns, so the
+// subsequent container create/start/stream phase does not block other builds.
+func buildAllServiceImages(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, cwd, appID string, services map[string]*appconfig.ServiceConfig, platform string, buildArgs map[string]string, builder string) error {
+	poolSize := min(maxConcurrentBuilds, len(services))
+	if poolSize <= 1 || !multiServiceUsesBuildxPool(builder) {
+		return buildServicesParallel(ctx, conn, regPort, cwd, appID, services, platform, buildArgs, builder, nil)
+	}
+
+	// Resolve the registry once so the dynamic proxy port is allocated and cached
+	// on conn before pre-warm. Every per-service build then reuses that same cached
+	// address, so the config it would compute matches each pool builder's ".applied"
+	// marker and no slot ever restarts mid-build.
+	registryAddr, cleanup, useMTLS, err := resolveRegistryForImageBuilder(ctx, conn, regPort, imageBuilderDocker)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	releaseLock, err := buildLock.acquire(ctx, os.Stderr)
+	if err != nil {
+		return err
+	}
+	defer releaseLock()
+
+	pool, err := ensureBuilderPool(ctx, poolSize, registryAddr, useMTLS, os.Stderr)
+	if err != nil {
+		return err
+	}
+	return buildServicesParallel(ctx, conn, regPort, cwd, appID, services, platform, buildArgs, builder, pool)
+}
+
 // buildServicesParallel builds all service images concurrently (up to
-// maxConcurrentBuilds at a time). Progress is shown via a Bubbletea multi-
-// spinner in interactive terminals and via plain log lines otherwise.
+// maxConcurrentBuilds at a time). When pool is non-empty each concurrent build is
+// handed a distinct, isolated builder + cache dir from the pool; when pool is nil
+// all builds share the default builder (unchanged behavior). Progress is shown via
+// a Bubbletea multi-spinner in interactive terminals and via plain log lines
+// otherwise.
 func buildServicesParallel(
 	ctx context.Context,
 	conn *grpcclient.AgentConnection,
@@ -174,6 +239,7 @@ func buildServicesParallel(
 	platform string,
 	buildArgs map[string]string,
 	builder string,
+	pool []buildxAssignment,
 ) error {
 	names := make([]string, 0, len(services))
 	for n := range services {
@@ -189,7 +255,24 @@ func buildServicesParallel(
 	}
 
 	results := make(chan result, len(names))
-	sem := make(chan struct{}, maxConcurrentBuilds)
+
+	// Gate concurrency with a channel of builder assignments: each goroutine takes
+	// one token (holding it for its whole build) and returns it on completion. With
+	// a pool every token is a distinct isolated builder + cache dir (WDY-1554);
+	// without one the tokens are nil and builds share the default builder, capped at
+	// maxConcurrentBuilds — exactly as before.
+	var assignments chan *buildxAssignment
+	if len(pool) > 0 {
+		assignments = make(chan *buildxAssignment, len(pool))
+		for i := range pool {
+			assignments <- &pool[i]
+		}
+	} else {
+		assignments = make(chan *buildxAssignment, maxConcurrentBuilds)
+		for i := 0; i < maxConcurrentBuilds; i++ {
+			assignments <- nil
+		}
+	}
 
 	var prog *tea.Program
 	if isInteractiveTerminal() {
@@ -203,8 +286,8 @@ func buildServicesParallel(
 		wg.Add(1)
 		go func(name string, svc *appconfig.ServiceConfig) {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
+			asg := <-assignments
+			defer func() { assignments <- asg }()
 
 			if prog != nil {
 				prog.Send(tui.MultiSpinnerStartMsg{Name: name})
@@ -232,7 +315,7 @@ func buildServicesParallel(
 			}
 			err := dockerfileErr
 			if err == nil {
-				err = buildAndPushImageForAgent(ctx, conn, regPort, builder, contextDir, repo, platform, dockerfile, buildArgs, buildOut, logOut)
+				err = buildServiceImage(ctx, conn, regPort, builder, contextDir, repo, platform, dockerfile, buildArgs, asg, buildOut, logOut)
 			}
 			dur := time.Since(start)
 

--- a/go/internal/cli/commands/multibuild_test.go
+++ b/go/internal/cli/commands/multibuild_test.go
@@ -1,0 +1,174 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func TestPoolBuilderName(t *testing.T) {
+	cases := []struct {
+		base string
+		mtls bool
+		i    int
+		want string
+	}{
+		{"wendy", false, 0, "wendy-pool-0"},
+		{"wendy", false, 3, "wendy-pool-3"},
+		{"wendy", true, 0, "wendy-mtls-pool-0"},
+		{"acme", true, 2, "acme-mtls-pool-2"},
+	}
+	for _, c := range cases {
+		if got := poolBuilderName(c.base, c.mtls, c.i); got != c.want {
+			t.Errorf("poolBuilderName(%q, %v, %d) = %q, want %q", c.base, c.mtls, c.i, got, c.want)
+		}
+	}
+}
+
+func TestMultiServiceUsesBuildxPool(t *testing.T) {
+	origGOOS, origGOARCH := imageBuilderHostGOOS, imageBuilderHostGOARCH
+	defer func() { imageBuilderHostGOOS, imageBuilderHostGOARCH = origGOOS, origGOARCH }()
+	t.Setenv("WENDY_BUILDX_POOL", "")
+
+	// Non-darwin host: the Docker buildx path is always taken.
+	imageBuilderHostGOOS = func() string { return "linux" }
+	imageBuilderHostGOARCH = func() string { return "amd64" }
+	if !multiServiceUsesBuildxPool("docker") {
+		t.Error("explicit docker builder should use the pool")
+	}
+	if !multiServiceUsesBuildxPool("") {
+		t.Error("default builder on a non-mac host should use the pool")
+	}
+	if multiServiceUsesBuildxPool("apple-container") {
+		t.Error("apple-container builder must not use the buildx pool")
+	}
+
+	// macOS arm64: the no-flag auto path tries Apple Container first, so skip the
+	// pool; an explicit --builder docker still uses it.
+	imageBuilderHostGOOS = func() string { return "darwin" }
+	imageBuilderHostGOARCH = func() string { return "arm64" }
+	if multiServiceUsesBuildxPool("") {
+		t.Error("auto Apple Container path (mac arm64, no flag) must skip the pool")
+	}
+	if !multiServiceUsesBuildxPool("docker") {
+		t.Error("explicit docker builder on mac should use the pool")
+	}
+
+	// Opt-out env disables the pool everywhere.
+	t.Setenv("WENDY_BUILDX_POOL", "0")
+	if multiServiceUsesBuildxPool("docker") {
+		t.Error("WENDY_BUILDX_POOL=0 should disable the pool")
+	}
+}
+
+// TestBuildServicesParallelAssignsDistinctBuilders verifies the core WDY-1554
+// invariant: with a builder pool, no two concurrent builds ever share a builder,
+// and concurrency reaches the pool size.
+func TestBuildServicesParallelAssignsDistinctBuilders(t *testing.T) {
+	pool := []buildxAssignment{
+		{name: "wendy-pool-0", cacheDir: "/c0"},
+		{name: "wendy-pool-1", cacheDir: "/c1"},
+		{name: "wendy-pool-2", cacheDir: "/c2"},
+	}
+	const numServices = 6
+	services := map[string]*appconfig.ServiceConfig{}
+	for i := 0; i < numServices; i++ {
+		services[fmt.Sprintf("svc%d", i)] = &appconfig.ServiceConfig{}
+	}
+
+	var (
+		mu        sync.Mutex
+		busy      = map[string]bool{}
+		usedCount = map[string]int{}
+		inFlight  int
+		gateOnce  sync.Once
+		gate      = make(chan struct{})
+	)
+
+	orig := buildServiceImage
+	defer func() { buildServiceImage = orig }()
+	buildServiceImage = func(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, asg *buildxAssignment, streamOutput, logOutput io.Writer) error {
+		if asg == nil {
+			t.Error("pooled build received a nil assignment")
+			return nil
+		}
+		mu.Lock()
+		if busy[asg.name] {
+			mu.Unlock()
+			t.Errorf("builder %s used by two concurrent builds", asg.name)
+			return nil
+		}
+		busy[asg.name] = true
+		usedCount[asg.name]++
+		inFlight++
+		reachedPoolSize := inFlight == len(pool)
+		mu.Unlock()
+
+		// The build that brings concurrency up to the pool size opens the gate; the
+		// others block on it. This deterministically forces pool-size concurrency
+		// (the first batch all hold the gate, proving distinct simultaneous builders).
+		if reachedPoolSize {
+			gateOnce.Do(func() { close(gate) })
+		}
+		select {
+		case <-gate:
+		case <-time.After(2 * time.Second):
+			t.Errorf("timed out before reaching pool-size concurrency (inFlight stuck below %d)", len(pool))
+		}
+
+		mu.Lock()
+		busy[asg.name] = false
+		inFlight--
+		mu.Unlock()
+		return nil
+	}
+
+	if err := buildServicesParallel(context.Background(), nil, 5000, t.TempDir(), "app", services, "linux/arm64", nil, imageBuilderDocker, pool); err != nil {
+		t.Fatalf("buildServicesParallel: %v", err)
+	}
+
+	if len(usedCount) != len(pool) {
+		t.Errorf("distinct builders used = %d, want %d", len(usedCount), len(pool))
+	}
+	total := 0
+	for _, c := range usedCount {
+		total += c
+	}
+	if total != numServices {
+		t.Errorf("total builds = %d, want %d", total, numServices)
+	}
+}
+
+// TestBuildServicesParallelNilPoolUsesNilAssignments verifies the unchanged
+// single-shared-builder path: every build gets a nil assignment.
+func TestBuildServicesParallelNilPoolUsesNilAssignments(t *testing.T) {
+	services := map[string]*appconfig.ServiceConfig{"a": {}, "b": {}, "c": {}}
+
+	var mu sync.Mutex
+	count := 0
+
+	orig := buildServiceImage
+	defer func() { buildServiceImage = orig }()
+	buildServiceImage = func(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, asg *buildxAssignment, streamOutput, logOutput io.Writer) error {
+		if asg != nil {
+			t.Errorf("expected nil assignment without a pool, got %q", asg.name)
+		}
+		mu.Lock()
+		count++
+		mu.Unlock()
+		return nil
+	}
+
+	if err := buildServicesParallel(context.Background(), nil, 5000, t.TempDir(), "app", services, "linux/arm64", nil, imageBuilderDocker, nil); err != nil {
+		t.Fatalf("buildServicesParallel: %v", err)
+	}
+	if count != len(services) {
+		t.Errorf("built %d services, want %d", count, len(services))
+	}
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1412,7 +1412,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// Build and push the Docker image directly to the device's registry.
 	regPort := registryPort(agentOS)
 	repo := strings.ToLower(appCfg.AppID)
-	if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, os.Stdout, os.Stderr); err != nil {
+	if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, nil, os.Stdout, os.Stderr); err != nil {
 		return fmt.Errorf("building and pushing image: %w", err)
 	}
 	cliLogln("Build and push completed.")


### PR DESCRIPTION
## Summary

Fixes [WDY-1554](https://linear.app/wendylabsinc/issue/WDY-1554). Multi-service `wendy run` builds up to `maxConcurrentBuilds`(=4) service images concurrently, all targeting **one** shared `wendy` buildkitd builder and **one** shared local cache dir. They race on the BuildKit ingest store, intermittently failing with:

```
rename /.../buildx/ingest/...: no such file or directory
```

(Most visible on the 4-service ROS2 `ros:humble` teleop example, where all four pull the same base layers at once.) On `main`, `maxConcurrentBuilds` is still 4, so the race is live.

> Note: recent perf PRs #1055/#1065 did **not** touch this path — neither modified `multibuild.go`; #1055 explicitly kept multi-service on the buildx→registry path and only added the separate `wendy-oci` builder for the single-service CDC path.

## Fix: isolated builder pool

`ensureBuilderPool` pre-warms `min(4, len(services))` isolated builders — `wendy-pool-<i>` (or `wendy-mtls-pool-<i>`) — each its **own** buildkitd container with its **own** cache dir `<UserCacheDir>/wendy/buildx-pool/<i>`. This removes both contention sources: the shared buildkit content/ingest store **and** the shared `--cache-to/--cache-from type=local` dir.

A nil-safe `*buildxAssignment` is threaded through `buildAndPushImageForAgent` → … → `buildAndPushImage`; `buildServicesParallel` hands each concurrent build a distinct pool token (a channel replaces the old semaphore). When there's no pool (single-service, compose, apple-container, macOS auto path, or `WENDY_BUILDX_POOL=0`), the assignment is `nil` and behavior is unchanged byte-for-byte.

## Preserving #1017 / #1018 (no mid-build builder restart)

A reconfigure/restart of a buildx builder mid-build kills a sibling build. The pool avoids this:

- **All** create / config-inject / cert-copy / restart / bootstrap happens **up front** in `ensureBuilderPool`, before the parallel fan-out. During the fan-out each build only does a cheap `docker inspect`-based running-check (`ensurePoolBuilderRunning`) — never a restart.
- `buildAllServiceImages` resolves the registry once (caching the proxy port on the connection so every slot's config is identical and stable) and holds `buildLock` across **both** pre-warm and the fan-out, so a second `wendy` process can't reconfigure a pool builder mid-build. The lock is released before container-create, so the deploy/stream phase doesn't block other builds.

## Edge cases

- 1 service / `--service` narrowed to 1 → no pool, no extra containers.
- apple-container (explicit or macOS auto) → no pool (doesn't use buildx).
- `WENDY_BUILDX_POOL=0` → opt out, falls back to the shared builder.
- Pool builders are persistent and reused across runs (like the existing builders); pruneable via `docker buildx rm <base>-pool-*`.

## Testing

- `go build ./go/...`, `go vet ./go/...`, `gofmt -l` — clean.
- Full `commands` package + all CLI package tests pass; new pool tests pass under `-race`.
- New unit tests: pool builder naming, the pool/no-pool decision matrix, and the parallel scheduling invariants (concurrency reaches pool size, no builder is ever used by two concurrent builds, nil-pool path stays nil).

### Still pending (needs hardware)

On-device repro + verification with the 4-service ROS2 example: clear the buildx cache, run cold ~10× on `main` to surface the intermittent failure, then confirm zero failures with the pool. That's the only true confirmation the ingest race is gone — hence draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)