### PR TITLE
Revert "Wendy Lite: Temporarily disable EKU verifications on mTLS connection"

### DIFF
--- a/go/internal/cli/liteclient/client.go
+++ b/go/internal/cli/liteclient/client.go
@@ -71,7 +71,6 @@ func (c *WendyLiteClient) ConnectWithMutualAuthentication(address string, cert t
 			opts := x509.VerifyOptions{
 				Roots:         &rootCAs,
 				Intermediates: x509.NewCertPool(),
-				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny}, // Temporary workaround
 			}
 			for _, c := range certs[1:] {
 				opts.Intermediates.AddCert(c)


### PR DESCRIPTION
Bring back EKU verification

This reverts commit 4d83f02d8d98cb2a6a5b966247850d7308d534f2.