### PR TITLE
test: add E2E scenario setup and cleanup hooks

### DIFF
--- a/swift/WendyE2ETests/README.md
+++ b/swift/WendyE2ETests/README.md
@@ -317,7 +317,21 @@ struct `'wendy device info'` {
 
 `CLIAndAgentScenario` creates CLI and agent sessions, attaches the recorder,
 installs the managed CLI on `PATH`, configures isolated `HOME` and `TMPDIR`, and
-copies the auth fixture for authenticated tests.
+copies the auth fixture for authenticated tests. For scenario-specific target
+setup or cleanup, pass `before` and/or `after` hooks to the scenario initializer;
+`after` runs even when setup or the test body fails, and the original failure is
+preserved unless cleanup is the only failure.
+
+```swift
+let scenario = CLIAndAgentScenario(
+    before: { _, agent in
+        try await agent.sh("brew uninstall --force hello || true")
+    },
+    after: { _, agent in
+        try await agent.sh("brew uninstall --force hello || true")
+    }
+)
+```
 
 ### Specification prose
 

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/CLIAndAgentScenario.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/CLIAndAgentScenario.swift
@@ -4,6 +4,16 @@ import WendyE2ETesting
 final class CLIAndAgentScenario: WendyE2EScenario, Sendable {
     // MARK: - Internal
 
+    typealias Hook = @Sendable (_ cli: WendyE2ESession, _ agent: WendyE2ESession) async throws -> Void
+
+    init(
+        before: Hook? = nil,
+        after: Hook? = nil
+    ) {
+        self.before = before
+        self.after = after
+    }
+
     func run<Result>(
         authenticated: Bool = true,
         filePath: String = #filePath,
@@ -18,25 +28,46 @@ final class CLIAndAgentScenario: WendyE2EScenario, Sendable {
             line: line
         )
 
-        let result: Result
+        var result: Result?
+        var primaryError: (any Error)?
+
         do {
+            if let before {
+                try await before(cli, agent)
+            }
             result = try await body(cli, agent)
         } catch {
-            try? await Self.tearDown(
+            primaryError = error
+        }
+
+        do {
+            if let after {
+                try await after(cli, agent)
+            }
+        } catch {
+            primaryError = primaryError ?? error
+        }
+
+        do {
+            try await Self.tearDown(
                 cli: cli,
                 agent: agent
             )
-            throw error
+        } catch {
+            primaryError = primaryError ?? error
         }
 
-        try await Self.tearDown(
-            cli: cli,
-            agent: agent
-        )
-        return result
+        if let primaryError {
+            throw primaryError
+        }
+
+        return result!
     }
 
     // MARK: - Private
+
+    private let before: Hook?
+    private let after: Hook?
 
     private func setUp(
         authenticated: Bool,


### PR DESCRIPTION
## Summary

Add optional `before` and `after` hooks to `CLIAndAgentScenario` so E2E specs can prepare and clean up CLI/agent state around each test.

This is a one-off PR cherry-picking `ea899f5c` from the Brewfile work branch so it can land independently.

## Behavior

- `before` runs after CLI and agent sessions are created.
- `after` runs even when `before` or the test body fails.
- The original failure is preserved unless cleanup is the only failure.
- Sessions are still torn down after hooks.

## Testing

- Attempted: `cd swift/WendyE2ETests && swift test --filter WendyDeviceVersionTests`
  - Build succeeded.
  - Runtime test failed because this environment does not have `WENDY_E2E_CLI_AUTH_CONFIG_PATH` / CLI auth fixture configured.
