### PR TITLE
feat: ros2 inspection merges across RMWs — mixed-RMW devices (WDY-1594)

### DIFF
--- a/Proto/wendy/agent/services/v2/ros2_service.proto
+++ b/Proto/wendy/agent/services/v2/ros2_service.proto
@@ -39,6 +39,9 @@ service ROS2Service {
 message ROS2Node {
     string name = 1;
     string namespace = 2;
+    // rmw identifies which RMW graph this node came from when a device runs
+    // apps on more than one RMW (WDY-1594). Empty on single-RMW devices.
+    string rmw = 3;
 }
 
 message ROS2Topic {
@@ -46,6 +49,9 @@ message ROS2Topic {
     repeated string types = 2; // a topic can have multiple publisher types
     int32 publisher_count = 3;
     int32 subscriber_count = 4;
+    // rmw identifies which RMW graph this topic came from (WDY-1594). Empty on
+    // single-RMW devices.
+    string rmw = 5;
 }
 
 message ListROS2NodesRequest {
@@ -86,6 +92,8 @@ message ListROS2ServicesResponse {
     message Service {
         string name = 1;
         repeated string types = 2;
+        // rmw identifies which RMW graph this service came from (WDY-1594).
+        string rmw = 3;
     }
     repeated Service services = 1;
 }
@@ -145,6 +153,7 @@ message GetROS2GraphResponse {
     message Edge {
         string node = 1;  // fully-qualified node name
         string topic = 2;
+        string rmw = 3;   // RMW graph this edge belongs to (WDY-1594); "" single-RMW
     }
     repeated ROS2Node nodes = 1;
     repeated Edge publishes = 2;  // node publishes to topic

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -12,6 +12,29 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+// TestROS2SidecarName maps each RMW to a distinct, prefix-scoped sidecar name
+// and collapses unknown/empty RMW to the stock-image (FastRTPS) default — the
+// basis for one persistent sidecar per RMW (WDY-1594).
+func TestROS2SidecarName(t *testing.T) {
+	cyc := ros2SidecarName("rmw_cyclonedds_cpp")
+	fast := ros2SidecarName("rmw_fastrtps_cpp")
+	def := ros2SidecarName("")
+	if cyc == fast {
+		t.Errorf("distinct RMWs must map to distinct sidecars: %q == %q", cyc, fast)
+	}
+	if fast != def {
+		t.Errorf("empty RMW should map to the FastRTPS (image-default) sidecar: %q vs %q", def, fast)
+	}
+	if got := ros2SidecarName("rmw_bogus"); got != ros2SidecarPrefix+"-default" {
+		t.Errorf("unknown RMW = %q, want %q", got, ros2SidecarPrefix+"-default")
+	}
+	for _, n := range []string{cyc, fast, def} {
+		if !strings.HasPrefix(n, ros2SidecarPrefix+"-") {
+			t.Errorf("sidecar name %q lacks the expected prefix", n)
+		}
+	}
+}
+
 func TestCreateContainerProgressMappingUsesApplyPhase(t *testing.T) {
 	progress := UnpackProgress{
 		Phase:       "layer",

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	// ros2SidecarName is the fixed containerd ID of the ROS 2 CLI sidecar.
-	// A single well-known name makes the sidecar idempotent: every
-	// `wendy device ros2` command reuses the same container (WDY-1332).
-	ros2SidecarName = "wendy-ros2-cli-sidecar"
+	// ros2SidecarPrefix is the containerd ID prefix of the ROS 2 CLI sidecars.
+	// A device runs one sidecar per distinct RMW (WDY-1594), each named
+	// "<prefix>-<rmw-suffix>" by ros2SidecarName, so commands can reach the
+	// right DDS graph. Listing by this prefix enumerates them all.
+	ros2SidecarPrefix = "wendy-ros2-cli-sidecar"
 
 	// ROS2BagDir is the host directory where rosbag2 recordings are stored.
 	// It is bind-mounted into the sidecar at the same path so the agent can
@@ -99,6 +100,16 @@ func (c *Client) FindROS2Containers(ctx context.Context) ([]services.ROS2Target,
 			Distro:      distro,
 			DomainID:    domainID,
 		}
+		// Resolve the RMW the app actually runs (Wendy injects RMW_IMPLEMENTATION
+		// via buildROS2Env) so callers can group apps by RMW — a device runs one
+		// sidecar per RMW (WDY-1593, WDY-1594). Drop an unrecognized value to ""
+		// (the image default) so it can never reach a sidecar environment and so
+		// naming/grouping stays consistent.
+		if spec, serr := ctr.Spec(ctx); serr == nil && spec.Process != nil {
+			if rmw := rmwFromEnv(spec.Process.Env); rmw == "" || appconfig.IsValidRMWImplementation(rmw) {
+				target.RMW = rmw
+			}
+		}
 		if task, terr := ctr.Task(ctx, nil); terr == nil {
 			if st, serr := task.Status(ctx); serr == nil && st.Status == containerd.Running {
 				target.Running = true
@@ -122,44 +133,112 @@ func rmwFromEnv(env []string) string {
 	return ""
 }
 
-// EnsureROS2Sidecar starts (or reuses) the ROS 2 CLI sidecar container. The
-// sidecar runs the official ros:<distro> image and joins the first running
-// ROS 2 app container's namespace topology — its network namespace always, and
-// for shared-ipc app groups also the IPC namespace plus the group's shared
-// /dev/shm — so it sees every node in the DDS domain over both UDP discovery
-// and the shared-memory data plane. It idles on `sleep infinity` while commands
-// are exec'd into it.
-func (c *Client) EnsureROS2Sidecar(ctx context.Context) (services.ROS2Sidecar, error) {
+// ros2SidecarSuffix maps an RMW to a short, containerd-ID-safe sidecar name
+// suffix (e.g. "rmw_cyclonedds_cpp" -> "cyclonedds"). Unknown/empty RMW -> the
+// stock-image default. One sidecar per suffix means one per distinct RMW.
+func ros2SidecarSuffix(rmw string) string {
+	switch rmw {
+	case "rmw_cyclonedds_cpp":
+		return "cyclonedds"
+	case "rmw_fastrtps_cpp", "":
+		return "fastrtps"
+	case "rmw_connextdds":
+		return "connext"
+	case "rmw_gurumdds_cpp":
+		return "gurum"
+	default:
+		return "default"
+	}
+}
+
+// ros2SidecarName is the containerd ID of the sidecar for a given RMW.
+func ros2SidecarName(rmw string) string {
+	return ros2SidecarPrefix + "-" + ros2SidecarSuffix(rmw)
+}
+
+// listROS2Sidecars returns all sidecar containers (those carrying the sidecar
+// label), across every RMW. ctx must already be namespaced.
+func (c *Client) listROS2Sidecars(ctx context.Context) ([]containerd.Container, error) {
+	return c.client.Containers(ctx, fmt.Sprintf("labels.%q", labelKeyROS2Sidecar))
+}
+
+// EnsureROS2Sidecars starts or reuses one CLI sidecar per distinct RMW used by
+// the running ROS 2 apps, tears down sidecars whose RMW is gone, and returns one
+// entry per live RMW graph (WDY-1594). Each sidecar runs an RMW-matched image
+// and joins its anchor app's namespace topology (network always; for shared-ipc
+// groups also the IPC namespace + shared /dev/shm — WDY-1555/1593), idling on
+// `sleep infinity` while commands are exec'd into it.
+func (c *Client) EnsureROS2Sidecars(ctx context.Context) ([]services.ROS2Sidecar, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	ctx = c.withNamespace(ctx)
 
 	targets, err := c.FindROS2Containers(ctx)
 	if err != nil {
-		return services.ROS2Sidecar{}, err
+		return nil, err
 	}
-	var anchor *services.ROS2Target
+	// One anchor per distinct RMW (first running wins), in stable listing order.
+	var order []string // sidecar names, deduped, first-seen order
+	anchorByName := map[string]*services.ROS2Target{}
 	for i := range targets {
-		if targets[i].Running {
-			anchor = &targets[i]
-			break
+		t := &targets[i]
+		if !t.Running {
+			continue
+		}
+		name := ros2SidecarName(t.RMW)
+		if _, dup := anchorByName[name]; dup {
+			continue
+		}
+		anchorByName[name] = t
+		order = append(order, name)
+	}
+	if len(order) == 0 {
+		// No running ROS 2 apps: tear down every leftover sidecar and fail.
+		c.teardownAllROS2SidecarsLocked(ctx)
+		return nil, fmt.Errorf("no running ROS 2 containers found; deploy an app with a frameworks.ros2 config first")
+	}
+
+	// Tear down sidecars whose RMW is no longer running.
+	if existing, lerr := c.listROS2Sidecars(ctx); lerr == nil {
+		for _, ctr := range existing {
+			if _, want := anchorByName[ctr.ID()]; !want {
+				_ = c.deleteROS2Sidecar(ctx, ctr)
+			}
 		}
 	}
-	if anchor == nil {
-		// Lazily satisfy the "sidecar stops when all ROS2 containers stop"
-		// lifecycle: tear down any leftover sidecar before failing.
-		_ = c.stopROS2SidecarLocked(ctx)
-		return services.ROS2Sidecar{}, fmt.Errorf("no running ROS 2 containers found; deploy an app with a frameworks.ros2 config first")
+
+	sidecars := make([]services.ROS2Sidecar, 0, len(order))
+	for _, name := range order {
+		sc, eerr := c.ensureOneROS2Sidecar(ctx, anchorByName[name], name)
+		if eerr != nil {
+			return nil, eerr
+		}
+		sidecars = append(sidecars, sc)
 	}
+	return sidecars, nil
+}
+
+// ensureOneROS2Sidecar starts or reuses the sidecar container named `name`,
+// anchored to `anchor` and matching anchor.RMW. Caller holds c.mu and passes a
+// namespaced ctx.
+func (c *Client) ensureOneROS2Sidecar(ctx context.Context, anchor *services.ROS2Target, name string) (services.ROS2Sidecar, error) {
 	if !ros2DistroPattern.MatchString(anchor.Distro) {
 		return services.ROS2Sidecar{}, fmt.Errorf("invalid ROS 2 distro %q in container label", anchor.Distro)
 	}
+	// anchor.RMW is already validated to a known identifier or "" by
+	// FindROS2Containers, so it's safe to inject and to use for naming.
+	rmw := anchor.RMW
 
-	sidecar := services.ROS2Sidecar{Distro: anchor.Distro, DomainID: anchor.DomainID}
+	sidecar := services.ROS2Sidecar{
+		Name:     name,
+		Distro:   anchor.Distro,
+		DomainID: anchor.DomainID,
+		RMW:      rmw,
+	}
 
-	// Reuse the existing sidecar when it is running and still anchored to the
-	// current network namespace of a live ROS 2 container.
-	if existing, lerr := c.client.LoadContainer(ctx, ros2SidecarName); lerr == nil {
+	// Reuse the existing sidecar when it is running and still anchored to this
+	// RMW's live ROS 2 container.
+	if existing, lerr := c.client.LoadContainer(ctx, name); lerr == nil {
 		labels, _ := existing.Labels(ctx)
 		anchorAlive := labels[labelKeyROS2AnchorID] == anchor.ContainerID &&
 			labels[labelKeyROS2AnchorPID] == strconv.FormatUint(uint64(anchor.TaskPID), 10) &&
@@ -172,29 +251,16 @@ func (c *Client) EnsureROS2Sidecar(ctx context.Context) (services.ROS2Sidecar, e
 			}
 		}
 		c.logger.Info("Recreating stale ROS 2 sidecar",
-			zap.String("anchor", anchor.ContainerID), zap.Bool("anchor_alive", anchorAlive))
+			zap.String("sidecar", name), zap.String("anchor", anchor.ContainerID), zap.Bool("anchor_alive", anchorAlive))
 		if derr := c.deleteROS2Sidecar(ctx, existing); derr != nil {
 			return services.ROS2Sidecar{}, fmt.Errorf("removing stale ROS 2 sidecar: %w", derr)
 		}
 	}
 
-	// Read the RMW the anchor app actually runs (Wendy injects RMW_IMPLEMENTATION
-	// into the app's env via buildROS2Env) so the sidecar's ros2 CLI speaks the
-	// same DDS implementation (WDY-1593). An unrecognized value is dropped so a
-	// tampered env can never reach the sidecar's environment.
+	// Load the anchor container for the anchor-image reuse path below.
 	anchorCtr, err := c.client.LoadContainer(ctx, anchor.ContainerID)
 	if err != nil {
 		return services.ROS2Sidecar{}, fmt.Errorf("loading ROS 2 anchor container %q: %w", anchor.ContainerID, err)
-	}
-	anchorSpec, err := anchorCtr.Spec(ctx)
-	if err != nil {
-		return services.ROS2Sidecar{}, fmt.Errorf("reading ROS 2 anchor spec: %w", err)
-	}
-	rmw := rmwFromEnv(anchorSpec.Process.Env)
-	if rmw != "" && !appconfig.IsValidRMWImplementation(rmw) {
-		c.logger.Warn("Anchor has unrecognized RMW_IMPLEMENTATION; sidecar will use the image default",
-			zap.String("rmw", rmw), zap.String("anchor", anchor.ContainerID))
-		rmw = ""
 	}
 
 	// Pick the sidecar image. Stock ros:<distro> ships only FastRTPS, so for any
@@ -294,9 +360,9 @@ func (c *Client) EnsureROS2Sidecar(ctx context.Context) (services.ROS2Sidecar, e
 		labelKeyROS2AnchorPID: strconv.FormatUint(uint64(anchor.TaskPID), 10),
 		labelKeyROS2RMW:       rmw,
 	}
-	container, err := c.client.NewContainer(ctx, ros2SidecarName,
+	container, err := c.client.NewContainer(ctx, name,
 		containerd.WithImage(image),
-		containerd.WithNewSnapshot(ros2SidecarName, image),
+		containerd.WithNewSnapshot(name, image),
 		containerd.WithContainerLabels(labels),
 		containerd.WithNewSpec(oci.WithSpecFromBytes(specJSON)),
 	)
@@ -400,48 +466,56 @@ func (c *Client) verifyROS2Anchor(ctx context.Context, anchor *services.ROS2Targ
 	return nil
 }
 
-// VerifyROS2Sidecar reports whether the sidecar is still anchored to a live
-// ROS 2 app container. A stopped or replaced anchor (app redeploy) tears
-// down the network namespace the sidecar joined, invalidating any in-flight
-// command — most visibly a bag recording session.
+// VerifyROS2Sidecar reports whether every running sidecar is still anchored to a
+// live ROS 2 app container. A stopped or replaced anchor (app redeploy) tears
+// down the namespace the sidecar joined, invalidating any in-flight command —
+// most visibly a bag recording session.
 func (c *Client) VerifyROS2Sidecar(ctx context.Context) error {
 	ctx = c.withNamespace(ctx)
-	sidecar, err := c.client.LoadContainer(ctx, ros2SidecarName)
+	sidecars, err := c.listROS2Sidecars(ctx)
 	if err != nil {
-		return fmt.Errorf("sidecar not found: %w", err)
+		return fmt.Errorf("listing ROS 2 sidecars: %w", err)
 	}
-	labels, err := sidecar.Labels(ctx)
-	if err != nil {
-		return fmt.Errorf("reading sidecar labels: %w", err)
+	if len(sidecars) == 0 {
+		return fmt.Errorf("sidecar not found")
 	}
-	anchorPID, err := strconv.ParseUint(labels[labelKeyROS2AnchorPID], 10, 32)
-	if err != nil {
-		return fmt.Errorf("sidecar has no valid anchor PID label")
+	for _, sc := range sidecars {
+		labels, lerr := sc.Labels(ctx)
+		if lerr != nil {
+			return fmt.Errorf("reading sidecar labels: %w", lerr)
+		}
+		anchorPID, perr := strconv.ParseUint(labels[labelKeyROS2AnchorPID], 10, 32)
+		if perr != nil {
+			return fmt.Errorf("sidecar %s has no valid anchor PID label", sc.ID())
+		}
+		if verr := c.verifyROS2Anchor(ctx, &services.ROS2Target{
+			ContainerID: labels[labelKeyROS2AnchorID],
+			TaskPID:     uint32(anchorPID),
+		}); verr != nil {
+			return verr
+		}
 	}
-	return c.verifyROS2Anchor(ctx, &services.ROS2Target{
-		ContainerID: labels[labelKeyROS2AnchorID],
-		TaskPID:     uint32(anchorPID),
-	})
+	return nil
 }
 
-// StopROS2Sidecar stops and removes the ROS 2 CLI sidecar if present.
+// StopROS2Sidecar stops and removes all ROS 2 CLI sidecars if present.
 func (c *Client) StopROS2Sidecar(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.stopROS2SidecarLocked(c.withNamespace(ctx))
+	c.teardownAllROS2SidecarsLocked(c.withNamespace(ctx))
+	return nil
 }
 
-// stopROS2SidecarLocked removes the sidecar. Caller must hold c.mu and pass a
-// namespaced ctx.
-func (c *Client) stopROS2SidecarLocked(ctx context.Context) error {
-	container, err := c.client.LoadContainer(ctx, ros2SidecarName)
+// teardownAllROS2SidecarsLocked removes every sidecar container. Caller must
+// hold c.mu and pass a namespaced ctx.
+func (c *Client) teardownAllROS2SidecarsLocked(ctx context.Context) {
+	sidecars, err := c.listROS2Sidecars(ctx)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("loading ROS 2 sidecar: %w", err)
+		return
 	}
-	return c.deleteROS2Sidecar(ctx, container)
+	for _, ctr := range sidecars {
+		_ = c.deleteROS2Sidecar(ctx, ctr)
+	}
 }
 
 func (c *Client) deleteROS2Sidecar(ctx context.Context, container containerd.Container) error {
@@ -463,7 +537,16 @@ func (c *Client) deleteROS2Sidecar(ctx context.Context, container containerd.Con
 func (c *Client) ExecROS2(ctx context.Context, opts services.ROS2ExecOptions, stdout, stderr io.Writer) (int, error) {
 	nctx := c.withNamespace(context.WithoutCancel(ctx))
 
-	container, err := c.client.LoadContainer(nctx, ros2SidecarName)
+	name := opts.SidecarName
+	if name == "" {
+		// No specific sidecar requested: use any running one (single-RMW case).
+		if scs, lerr := c.listROS2Sidecars(nctx); lerr == nil && len(scs) > 0 {
+			name = scs[0].ID()
+		} else {
+			name = ros2SidecarName("")
+		}
+	}
+	container, err := c.client.LoadContainer(nctx, name)
 	if err != nil {
 		return -1, fmt.Errorf("ROS 2 sidecar not available: %w", err)
 	}

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -132,20 +132,26 @@ type ROS2Target struct {
 	AppID       string
 	Distro      string // e.g. "humble"
 	DomainID    int    // resolved ROS_DOMAIN_ID
+	RMW         string // resolved RMW_IMPLEMENTATION (e.g. "rmw_cyclonedds_cpp"); "" if unset
 	Running     bool
 	TaskPID     uint32 // pid of the container's init process; 0 when not running
 }
 
-// ROS2Sidecar describes the running ROS 2 CLI sidecar container.
+// ROS2Sidecar describes one running ROS 2 CLI sidecar container. A device with
+// apps on multiple RMWs runs one sidecar per RMW (WDY-1594); each inspects the
+// graph of its own RMW.
 type ROS2Sidecar struct {
+	Name     string // sidecar container ID (per-RMW)
 	Distro   string
-	DomainID int // default DDS domain, taken from the anchor app container
+	DomainID int    // default DDS domain, taken from the anchor app container
+	RMW      string // the RMW this sidecar speaks (e.g. "rmw_cyclonedds_cpp"); "" = image default
 }
 
 // ROS2ExecOptions configures a single `ros2` invocation inside the sidecar.
 type ROS2ExecOptions struct {
-	DomainID int      // ROS_DOMAIN_ID for this invocation
-	Args     []string // arguments after `ros2`, passed without shell interpretation
+	DomainID    int      // ROS_DOMAIN_ID for this invocation
+	Args        []string // arguments after `ros2`, passed without shell interpretation
+	SidecarName string   // which per-RMW sidecar to exec in; empty = the default/first
 }
 
 // ROS2Runtime abstracts the containerd-side ROS 2 sidecar plumbing used by
@@ -153,9 +159,11 @@ type ROS2ExecOptions struct {
 type ROS2Runtime interface {
 	// FindROS2Containers returns all containers labelled with a ros2 config.
 	FindROS2Containers(ctx context.Context) ([]ROS2Target, error)
-	// EnsureROS2Sidecar starts or reuses the CLI sidecar and returns its
-	// distro and the default DDS domain.
-	EnsureROS2Sidecar(ctx context.Context) (ROS2Sidecar, error)
+	// EnsureROS2Sidecars starts or reuses one CLI sidecar per distinct RMW in
+	// use by the running ROS 2 apps, and tears down sidecars whose RMW is no
+	// longer present. Returns one entry per live RMW graph (WDY-1594). Returns
+	// an error when no ROS 2 app is running.
+	EnsureROS2Sidecars(ctx context.Context) ([]ROS2Sidecar, error)
 	// StopROS2Sidecar stops and removes the sidecar if present.
 	StopROS2Sidecar(ctx context.Context) error
 	// VerifyROS2Sidecar reports whether the sidecar is still anchored to a

--- a/go/internal/agent/services/ros2_service.go
+++ b/go/internal/agent/services/ros2_service.go
@@ -48,29 +48,46 @@ func NewROS2Service(logger *zap.Logger, runtime ROS2Runtime, bagDir string) *ROS
 	return &ROS2Service{logger: logger, runtime: runtime, bagDir: bagDir}
 }
 
-// resolveDomain ensures the sidecar is running and returns the effective DDS
-// domain: the request override when present, otherwise the domain from the
-// app container's ros2 label.
-func (s *ROS2Service) resolveDomain(ctx context.Context, override *int32) (int, error) {
-	sidecar, err := s.runtime.EnsureROS2Sidecar(ctx)
-	if err != nil {
-		return 0, status.Error(codes.FailedPrecondition, err.Error())
-	}
-	if override == nil {
-		return sidecar.DomainID, nil
-	}
-	id := int(*override)
-	if id < appconfig.ROS2DomainIDMin || id > appconfig.ROS2DomainIDMax {
-		return 0, status.Errorf(codes.InvalidArgument, "domain ID %d out of range [%d,%d]", id, appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax)
-	}
-	return id, nil
+// ros2SC is a resolved per-RMW sidecar plus the DDS domain to use for a call.
+type ros2SC struct {
+	name     string
+	rmw      string
+	domainID int
 }
 
-// run executes `ros2 <args>` in the sidecar and returns its stdout. A
+// resolveSidecars ensures one sidecar per running RMW (WDY-1594) and returns
+// them with the effective domain: the --domain override when set, else each
+// sidecar's own default. Discovery commands run in all and merge; targeted
+// commands route to one.
+func (s *ROS2Service) resolveSidecars(ctx context.Context, override *int32) ([]ros2SC, error) {
+	sidecars, err := s.runtime.EnsureROS2Sidecars(ctx)
+	if err != nil {
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
+	ovr := -1
+	if override != nil {
+		id := int(*override)
+		if id < appconfig.ROS2DomainIDMin || id > appconfig.ROS2DomainIDMax {
+			return nil, status.Errorf(codes.InvalidArgument, "domain ID %d out of range [%d,%d]", id, appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax)
+		}
+		ovr = id
+	}
+	out := make([]ros2SC, 0, len(sidecars))
+	for _, sc := range sidecars {
+		d := sc.DomainID
+		if ovr >= 0 {
+			d = ovr
+		}
+		out = append(out, ros2SC{name: sc.Name, rmw: sc.RMW, domainID: d})
+	}
+	return out, nil
+}
+
+// runIn executes `ros2 <args>` in a specific sidecar and returns its stdout. A
 // non-zero exit code is reported as an error carrying stderr.
-func (s *ROS2Service) run(ctx context.Context, domainID int, args ...string) (string, error) {
+func (s *ROS2Service) runIn(ctx context.Context, sc ros2SC, args ...string) (string, error) {
 	var stdout, stderr bytes.Buffer
-	code, err := s.runtime.ExecROS2(ctx, ROS2ExecOptions{DomainID: domainID, Args: args}, &stdout, &stderr)
+	code, err := s.runtime.ExecROS2(ctx, ROS2ExecOptions{DomainID: sc.domainID, Args: args, SidecarName: sc.name}, &stdout, &stderr)
 	if err != nil {
 		return "", status.Errorf(codes.Internal, "ros2 %s: %v", strings.Join(args, " "), err)
 	}
@@ -84,51 +101,130 @@ func (s *ROS2Service) run(ctx context.Context, domainID int, args ...string) (st
 	return stdout.String(), nil
 }
 
+// ros2Out is one sidecar's stdout for a merged command, tagged with its RMW.
+type ros2Out struct {
+	rmw string
+	out string
+}
+
+// runMerged runs args in every sidecar and returns each one's tagged output.
+// A sidecar that errors is skipped so one broken RMW graph doesn't hide the
+// others; if every sidecar errors, the last error is returned.
+func (s *ROS2Service) runMerged(ctx context.Context, scs []ros2SC, args ...string) ([]ros2Out, error) {
+	var outs []ros2Out
+	var lastErr error
+	for _, sc := range scs {
+		out, err := s.runIn(ctx, sc, args...)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		outs = append(outs, ros2Out{rmw: sc.rmw, out: out})
+	}
+	if len(outs) == 0 && lastErr != nil {
+		return nil, lastErr
+	}
+	return outs, nil
+}
+
+// pickSidecarForTopic routes a topic-targeted command (echo/hz/info) to the
+// sidecar whose graph carries the topic — a topic lives in exactly one RMW
+// graph. Falls back to the first sidecar when ownership can't be determined.
+func (s *ROS2Service) pickSidecarForTopic(ctx context.Context, scs []ros2SC, topic string) ros2SC {
+	for _, sc := range scs {
+		out, err := s.runIn(ctx, sc, "topic", "list")
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(out, "\n") {
+			if strings.TrimSpace(line) == topic {
+				return sc
+			}
+		}
+	}
+	return scs[0]
+}
+
+// runFirst runs args in each sidecar and returns the first successful output —
+// used for node/service-targeted commands whose target lives in exactly one RMW
+// graph (the others error cleanly). Returns the last error if all fail.
+func (s *ROS2Service) runFirst(ctx context.Context, scs []ros2SC, args ...string) (string, error) {
+	var lastErr error
+	for _, sc := range scs {
+		out, err := s.runIn(ctx, sc, args...)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = status.Error(codes.Internal, "no ROS 2 sidecar available")
+	}
+	return "", lastErr
+}
+
 func (s *ROS2Service) ListNodes(ctx context.Context, req *agentpbv2.ListROS2NodesRequest) (*agentpbv2.ListROS2NodesResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
-	out, err := s.run(ctx, domainID, "node", "list")
+	outs, err := s.runMerged(ctx, scs, "node", "list")
 	if err != nil {
 		return nil, err
 	}
-	return &agentpbv2.ListROS2NodesResponse{Nodes: parseROS2NodeList(out)}, nil
+	resp := &agentpbv2.ListROS2NodesResponse{}
+	for _, o := range outs {
+		for _, n := range parseROS2NodeList(o.out) {
+			n.Rmw = o.rmw
+			resp.Nodes = append(resp.Nodes, n)
+		}
+	}
+	return resp, nil
 }
 
 func (s *ROS2Service) ListTopics(ctx context.Context, req *agentpbv2.ListROS2TopicsRequest) (*agentpbv2.ListROS2TopicsResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
-	out, err := s.run(ctx, domainID, "topic", "list", "-t")
-	if err != nil {
-		return nil, err
-	}
-	topics := parseROS2TopicList(out)
-	if req.GetIncludeCounts() {
-		for _, t := range topics {
-			info, ierr := s.run(ctx, domainID, "topic", "info", t.GetName())
-			if ierr != nil {
-				continue // topic may have disappeared between list and info
+	resp := &agentpbv2.ListROS2TopicsResponse{}
+	var lastErr error
+	any := false
+	for _, sc := range scs {
+		out, rerr := s.runIn(ctx, sc, "topic", "list", "-t")
+		if rerr != nil {
+			lastErr = rerr
+			continue
+		}
+		any = true
+		for _, t := range parseROS2TopicList(out) {
+			t.Rmw = sc.rmw
+			if req.GetIncludeCounts() {
+				if info, ierr := s.runIn(ctx, sc, "topic", "info", t.GetName()); ierr == nil {
+					_, pubs, subs := parseROS2TopicInfo(info)
+					t.PublisherCount = pubs
+					t.SubscriberCount = subs
+				}
 			}
-			_, pubs, subs := parseROS2TopicInfo(info)
-			t.PublisherCount = pubs
-			t.SubscriberCount = subs
+			resp.Topics = append(resp.Topics, t)
 		}
 	}
-	return &agentpbv2.ListROS2TopicsResponse{Topics: topics}, nil
+	if !any && lastErr != nil {
+		return nil, lastErr
+	}
+	return resp, nil
 }
 
 func (s *ROS2Service) GetTopicInfo(ctx context.Context, req *agentpbv2.GetROS2TopicInfoRequest) (*agentpbv2.GetROS2TopicInfoResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
 	if err := validateROS2GraphName(req.GetTopic()); err != nil {
 		return nil, err
 	}
-	out, err := s.run(ctx, domainID, "topic", "info", "-v", req.GetTopic())
+	sc := s.pickSidecarForTopic(ctx, scs, req.GetTopic())
+	out, err := s.runIn(ctx, sc, "topic", "info", "-v", req.GetTopic())
 	if err != nil {
 		return nil, err
 	}
@@ -139,32 +235,36 @@ func (s *ROS2Service) GetTopicInfo(ctx context.Context, req *agentpbv2.GetROS2To
 			Types:           types,
 			PublisherCount:  pubs,
 			SubscriberCount: subs,
+			Rmw:             sc.rmw,
 		},
 		Verbose: out,
 	}, nil
 }
 
 func (s *ROS2Service) ListServices(ctx context.Context, req *agentpbv2.ListROS2ServicesRequest) (*agentpbv2.ListROS2ServicesResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
-	out, err := s.run(ctx, domainID, "service", "list", "-t")
+	outs, err := s.runMerged(ctx, scs, "service", "list", "-t")
 	if err != nil {
 		return nil, err
 	}
 	resp := &agentpbv2.ListROS2ServicesResponse{}
-	for _, t := range parseROS2TopicList(out) {
-		resp.Services = append(resp.Services, &agentpbv2.ListROS2ServicesResponse_Service{
-			Name:  t.GetName(),
-			Types: t.GetTypes(),
-		})
+	for _, o := range outs {
+		for _, t := range parseROS2TopicList(o.out) {
+			resp.Services = append(resp.Services, &agentpbv2.ListROS2ServicesResponse_Service{
+				Name:  t.GetName(),
+				Types: t.GetTypes(),
+				Rmw:   o.rmw,
+			})
+		}
 	}
 	return resp, nil
 }
 
 func (s *ROS2Service) ListParams(ctx context.Context, req *agentpbv2.ListROS2ParamsRequest) (*agentpbv2.ListROS2ParamsResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
@@ -175,15 +275,29 @@ func (s *ROS2Service) ListParams(ctx context.Context, req *agentpbv2.ListROS2Par
 		}
 		args = append(args, req.GetNode())
 	}
-	out, err := s.run(ctx, domainID, args...)
+	resp := &agentpbv2.ListROS2ParamsResponse{}
+	if req.GetNode() != "" {
+		// Node-targeted: it lives in one RMW graph; use the sidecar that has it.
+		out, err := s.runFirst(ctx, scs, args...)
+		if err != nil {
+			return nil, err
+		}
+		resp.Nodes = parseROS2ParamList(out, req.GetNode())
+		return resp, nil
+	}
+	// All-nodes: merge across every RMW graph.
+	outs, err := s.runMerged(ctx, scs, args...)
 	if err != nil {
 		return nil, err
 	}
-	return &agentpbv2.ListROS2ParamsResponse{Nodes: parseROS2ParamList(out, req.GetNode())}, nil
+	for _, o := range outs {
+		resp.Nodes = append(resp.Nodes, parseROS2ParamList(o.out, "")...)
+	}
+	return resp, nil
 }
 
 func (s *ROS2Service) GetParam(ctx context.Context, req *agentpbv2.GetROS2ParamRequest) (*agentpbv2.GetROS2ParamResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +307,7 @@ func (s *ROS2Service) GetParam(ctx context.Context, req *agentpbv2.GetROS2ParamR
 	if err := validateROS2ParamName(req.GetParam()); err != nil {
 		return nil, err
 	}
-	out, err := s.run(ctx, domainID, "param", "get", req.GetNode(), req.GetParam())
+	out, err := s.runFirst(ctx, scs, "param", "get", req.GetNode(), req.GetParam())
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +315,7 @@ func (s *ROS2Service) GetParam(ctx context.Context, req *agentpbv2.GetROS2ParamR
 }
 
 func (s *ROS2Service) SetParam(ctx context.Context, req *agentpbv2.SetROS2ParamRequest) (*agentpbv2.SetROS2ParamResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +325,7 @@ func (s *ROS2Service) SetParam(ctx context.Context, req *agentpbv2.SetROS2ParamR
 	if err := validateROS2ParamName(req.GetParam()); err != nil {
 		return nil, err
 	}
-	out, err := s.run(ctx, domainID, "param", "set", req.GetNode(), req.GetParam(), req.GetValue())
+	out, err := s.runFirst(ctx, scs, "param", "set", req.GetNode(), req.GetParam(), req.GetValue())
 	if err != nil {
 		// `ros2 param set` reports failures both via exit code and text.
 		return &agentpbv2.SetROS2ParamResponse{Success: false, Message: err.Error()}, nil
@@ -220,7 +334,7 @@ func (s *ROS2Service) SetParam(ctx context.Context, req *agentpbv2.SetROS2ParamR
 }
 
 func (s *ROS2Service) CallService(ctx context.Context, req *agentpbv2.CallROS2ServiceRequest) (*agentpbv2.CallROS2ServiceResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +345,7 @@ func (s *ROS2Service) CallService(ctx context.Context, req *agentpbv2.CallROS2Se
 	if req.GetRequest() != "" {
 		args = append(args, req.GetRequest())
 	}
-	out, err := s.run(ctx, domainID, args...)
+	out, err := s.runFirst(ctx, scs, args...)
 	if err != nil {
 		return &agentpbv2.CallROS2ServiceResponse{Success: false, Response: err.Error()}, nil
 	}
@@ -239,60 +353,87 @@ func (s *ROS2Service) CallService(ctx context.Context, req *agentpbv2.CallROS2Se
 }
 
 func (s *ROS2Service) GetGraph(ctx context.Context, req *agentpbv2.GetROS2GraphRequest) (*agentpbv2.GetROS2GraphResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
-	out, err := s.run(ctx, domainID, "node", "list")
-	if err != nil {
-		return nil, err
+	resp := &agentpbv2.GetROS2GraphResponse{}
+	var lastErr error
+	any := false
+	for _, sc := range scs {
+		out, rerr := s.runIn(ctx, sc, "node", "list")
+		if rerr != nil {
+			lastErr = rerr
+			continue
+		}
+		any = true
+		for _, node := range parseROS2NodeList(out) {
+			node.Rmw = sc.rmw
+			resp.Nodes = append(resp.Nodes, node)
+			fqn := ros2NodeFQN(node)
+			info, ierr := s.runIn(ctx, sc, "node", "info", fqn)
+			if ierr != nil {
+				continue // node may have exited between list and info
+			}
+			publishes, subscribes := parseROS2NodeInfo(info)
+			for _, topic := range publishes {
+				resp.Publishes = append(resp.Publishes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic, Rmw: sc.rmw})
+			}
+			for _, topic := range subscribes {
+				resp.Subscribes = append(resp.Subscribes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic, Rmw: sc.rmw})
+			}
+		}
 	}
-	resp := &agentpbv2.GetROS2GraphResponse{Nodes: parseROS2NodeList(out)}
-	for _, node := range resp.Nodes {
-		fqn := ros2NodeFQN(node)
-		info, ierr := s.run(ctx, domainID, "node", "info", fqn)
-		if ierr != nil {
-			continue // node may have exited between list and info
-		}
-		publishes, subscribes := parseROS2NodeInfo(info)
-		for _, topic := range publishes {
-			resp.Publishes = append(resp.Publishes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic})
-		}
-		for _, topic := range subscribes {
-			resp.Subscribes = append(resp.Subscribes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic})
-		}
+	if !any && lastErr != nil {
+		return nil, lastErr
 	}
 	return resp, nil
 }
 
 func (s *ROS2Service) Doctor(ctx context.Context, req *agentpbv2.ROS2DoctorRequest) (*agentpbv2.ROS2DoctorResponse, error) {
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return nil, err
 	}
-	// `ros2 doctor` exits non-zero when checks fail, but the report is still
-	// the useful output — capture both streams and return whatever we got.
-	var stdout, stderr bytes.Buffer
-	_, execErr := s.runtime.ExecROS2(ctx, ROS2ExecOptions{DomainID: domainID, Args: []string{"doctor", "--report"}}, &stdout, &stderr)
-	if execErr != nil {
-		return nil, status.Errorf(codes.Internal, "ros2 doctor: %v", execErr)
+	// One report per RMW graph, each headed by its RMW when more than one runs.
+	var sb strings.Builder
+	for _, sc := range scs {
+		// `ros2 doctor` exits non-zero when checks fail, but the report is still
+		// the useful output — capture both streams and return whatever we got.
+		var stdout, stderr bytes.Buffer
+		_, execErr := s.runtime.ExecROS2(ctx, ROS2ExecOptions{DomainID: sc.domainID, Args: []string{"doctor", "--report"}, SidecarName: sc.name}, &stdout, &stderr)
+		if execErr != nil {
+			return nil, status.Errorf(codes.Internal, "ros2 doctor: %v", execErr)
+		}
+		report := stdout.String()
+		if strings.TrimSpace(report) == "" {
+			report = stderr.String()
+		}
+		if len(scs) > 1 {
+			label := sc.rmw
+			if label == "" {
+				label = "default"
+			}
+			sb.WriteString("=== RMW: " + label + " ===\n")
+		}
+		sb.WriteString(report)
+		if !strings.HasSuffix(report, "\n") {
+			sb.WriteString("\n")
+		}
 	}
-	report := stdout.String()
-	if strings.TrimSpace(report) == "" {
-		report = stderr.String()
-	}
-	return &agentpbv2.ROS2DoctorResponse{Report: report}, nil
+	return &agentpbv2.ROS2DoctorResponse{Report: sb.String()}, nil
 }
 
 func (s *ROS2Service) EchoTopic(req *agentpbv2.EchoROS2TopicRequest, stream grpc.ServerStreamingServer[agentpbv2.ROS2Message]) error {
 	ctx := stream.Context()
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return err
 	}
 	if err := validateROS2GraphName(req.GetTopic()); err != nil {
 		return err
 	}
+	sc := s.pickSidecarForTopic(ctx, scs, req.GetTopic())
 
 	execCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -301,8 +442,9 @@ func (s *ROS2Service) EchoTopic(req *agentpbv2.EchoROS2TopicRequest, stream grpc
 	execDone := make(chan error, 1)
 	go func() {
 		_, execErr := s.runtime.ExecROS2(execCtx, ROS2ExecOptions{
-			DomainID: domainID,
-			Args:     []string{"topic", "echo", req.GetTopic()},
+			DomainID:    sc.domainID,
+			SidecarName: sc.name,
+			Args:        []string{"topic", "echo", req.GetTopic()},
 		}, pw, pw)
 		pw.CloseWithError(execErr)
 		execDone <- execErr
@@ -348,13 +490,14 @@ func (s *ROS2Service) EchoTopic(req *agentpbv2.EchoROS2TopicRequest, stream grpc
 
 func (s *ROS2Service) MonitorHz(req *agentpbv2.MonitorROS2HzRequest, stream grpc.ServerStreamingServer[agentpbv2.ROS2HzSample]) error {
 	ctx := stream.Context()
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return err
 	}
 	if err := validateROS2GraphName(req.GetTopic()); err != nil {
 		return err
 	}
+	sc := s.pickSidecarForTopic(ctx, scs, req.GetTopic())
 
 	execCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -363,8 +506,9 @@ func (s *ROS2Service) MonitorHz(req *agentpbv2.MonitorROS2HzRequest, stream grpc
 	execDone := make(chan error, 1)
 	go func() {
 		_, execErr := s.runtime.ExecROS2(execCtx, ROS2ExecOptions{
-			DomainID: domainID,
-			Args:     []string{"topic", "hz", req.GetTopic()},
+			DomainID:    sc.domainID,
+			SidecarName: sc.name,
+			Args:        []string{"topic", "hz", req.GetTopic()},
 		}, pw, pw)
 		pw.CloseWithError(execErr)
 		execDone <- execErr
@@ -414,7 +558,7 @@ func (s *ROS2Service) RecordBag(stream grpc.BidiStreamingServer[agentpbv2.Record
 		return status.Error(codes.InvalidArgument, "first RecordBag message must be a start command")
 	}
 
-	domainID, err := s.resolveDomain(ctx, start.DomainId)
+	scs, err := s.resolveSidecars(ctx, start.DomainId)
 	if err != nil {
 		return err
 	}
@@ -439,6 +583,13 @@ func (s *ROS2Service) RecordBag(stream grpc.BidiStreamingServer[agentpbv2.Record
 		args = append(args, "-a")
 	}
 
+	// Recording captures a single RMW graph; route to the sidecar that owns the
+	// first requested topic, else the first sidecar.
+	sc := scs[0]
+	if len(start.GetTopics()) > 0 {
+		sc = s.pickSidecarForTopic(ctx, scs, start.GetTopics()[0])
+	}
+
 	execCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -449,7 +600,7 @@ func (s *ROS2Service) RecordBag(stream grpc.BidiStreamingServer[agentpbv2.Record
 	var output bytes.Buffer
 	execDone := make(chan execResult, 1)
 	go func() {
-		code, execErr := s.runtime.ExecROS2(execCtx, ROS2ExecOptions{DomainID: domainID, Args: args}, &output, &output)
+		code, execErr := s.runtime.ExecROS2(execCtx, ROS2ExecOptions{DomainID: sc.domainID, SidecarName: sc.name, Args: args}, &output, &output)
 		execDone <- execResult{code: code, err: execErr}
 	}()
 
@@ -681,7 +832,7 @@ func (w *ros2ChunkWriter) send(data []byte) error {
 
 func (s *ROS2Service) Exec(req *agentpbv2.ROS2ExecRequest, stream grpc.ServerStreamingServer[agentpbv2.ROS2ExecOutput]) error {
 	ctx := stream.Context()
-	domainID, err := s.resolveDomain(ctx, req.DomainId)
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
 	if err != nil {
 		return err
 	}
@@ -689,9 +840,12 @@ func (s *ROS2Service) Exec(req *agentpbv2.ROS2ExecRequest, stream grpc.ServerStr
 		return status.Error(codes.InvalidArgument, "ros2 exec requires at least one argument")
 	}
 
+	// Raw passthrough can't be RMW-routed (the args are opaque); run it in the
+	// first sidecar. Use `--rmw`-aware commands for per-graph inspection.
+	sc := scs[0]
 	stdout := &ros2ExecStreamWriter{stream: stream, stderr: false}
 	stderr := &ros2ExecStreamWriter{stream: stream, stderr: true}
-	code, execErr := s.runtime.ExecROS2(ctx, ROS2ExecOptions{DomainID: domainID, Args: req.GetArgs()}, stdout, stderr)
+	code, execErr := s.runtime.ExecROS2(ctx, ROS2ExecOptions{DomainID: sc.domainID, SidecarName: sc.name, Args: req.GetArgs()}, stdout, stderr)
 	if ctx.Err() != nil {
 		return nil
 	}

--- a/go/internal/agent/services/ros2_service.go
+++ b/go/internal/agent/services/ros2_service.go
@@ -127,17 +127,22 @@ func (s *ROS2Service) runMerged(ctx context.Context, scs []ros2SC, args ...strin
 	return outs, nil
 }
 
-// pickSidecarForTopic routes a topic-targeted command (echo/hz/info) to the
-// sidecar whose graph carries the topic — a topic lives in exactly one RMW
-// graph. Falls back to the first sidecar when ownership can't be determined.
-func (s *ROS2Service) pickSidecarForTopic(ctx context.Context, scs []ros2SC, topic string) ros2SC {
+// pickSidecarOwning routes a target-specific command to the sidecar whose graph
+// carries `target`, found by matching a line of `ros2 <listKind> list` (a
+// topic/node/service lives in exactly one RMW graph). This avoids running the
+// command in the wrong sidecar — where a node/service-targeted call (param get,
+// service call) would block on DDS discovery until timeout before failing.
+// Falls back to the first sidecar when ownership can't be determined; if the
+// same name exists in more than one RMW graph (genuinely ambiguous), the
+// first-running RMW deterministically wins.
+func (s *ROS2Service) pickSidecarOwning(ctx context.Context, scs []ros2SC, listKind, target string) ros2SC {
 	for _, sc := range scs {
-		out, err := s.runIn(ctx, sc, "topic", "list")
+		out, err := s.runIn(ctx, sc, listKind, "list")
 		if err != nil {
 			continue
 		}
 		for _, line := range strings.Split(out, "\n") {
-			if strings.TrimSpace(line) == topic {
+			if strings.TrimSpace(line) == target {
 				return sc
 			}
 		}
@@ -145,22 +150,16 @@ func (s *ROS2Service) pickSidecarForTopic(ctx context.Context, scs []ros2SC, top
 	return scs[0]
 }
 
-// runFirst runs args in each sidecar and returns the first successful output —
-// used for node/service-targeted commands whose target lives in exactly one RMW
-// graph (the others error cleanly). Returns the last error if all fail.
-func (s *ROS2Service) runFirst(ctx context.Context, scs []ros2SC, args ...string) (string, error) {
-	var lastErr error
-	for _, sc := range scs {
-		out, err := s.runIn(ctx, sc, args...)
-		if err == nil {
-			return out, nil
-		}
-		lastErr = err
-	}
-	if lastErr == nil {
-		lastErr = status.Error(codes.Internal, "no ROS 2 sidecar available")
-	}
-	return "", lastErr
+func (s *ROS2Service) pickSidecarForTopic(ctx context.Context, scs []ros2SC, topic string) ros2SC {
+	return s.pickSidecarOwning(ctx, scs, "topic", topic)
+}
+
+func (s *ROS2Service) pickSidecarForNode(ctx context.Context, scs []ros2SC, node string) ros2SC {
+	return s.pickSidecarOwning(ctx, scs, "node", node)
+}
+
+func (s *ROS2Service) pickSidecarForService(ctx context.Context, scs []ros2SC, service string) ros2SC {
+	return s.pickSidecarOwning(ctx, scs, "service", service)
 }
 
 func (s *ROS2Service) ListNodes(ctx context.Context, req *agentpbv2.ListROS2NodesRequest) (*agentpbv2.ListROS2NodesResponse, error) {
@@ -277,8 +276,9 @@ func (s *ROS2Service) ListParams(ctx context.Context, req *agentpbv2.ListROS2Par
 	}
 	resp := &agentpbv2.ListROS2ParamsResponse{}
 	if req.GetNode() != "" {
-		// Node-targeted: it lives in one RMW graph; use the sidecar that has it.
-		out, err := s.runFirst(ctx, scs, args...)
+		// Node-targeted: it lives in one RMW graph; route to the sidecar that has it.
+		sc := s.pickSidecarForNode(ctx, scs, req.GetNode())
+		out, err := s.runIn(ctx, sc, args...)
 		if err != nil {
 			return nil, err
 		}
@@ -307,7 +307,8 @@ func (s *ROS2Service) GetParam(ctx context.Context, req *agentpbv2.GetROS2ParamR
 	if err := validateROS2ParamName(req.GetParam()); err != nil {
 		return nil, err
 	}
-	out, err := s.runFirst(ctx, scs, "param", "get", req.GetNode(), req.GetParam())
+	sc := s.pickSidecarForNode(ctx, scs, req.GetNode())
+	out, err := s.runIn(ctx, sc, "param", "get", req.GetNode(), req.GetParam())
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +326,8 @@ func (s *ROS2Service) SetParam(ctx context.Context, req *agentpbv2.SetROS2ParamR
 	if err := validateROS2ParamName(req.GetParam()); err != nil {
 		return nil, err
 	}
-	out, err := s.runFirst(ctx, scs, "param", "set", req.GetNode(), req.GetParam(), req.GetValue())
+	sc := s.pickSidecarForNode(ctx, scs, req.GetNode())
+	out, err := s.runIn(ctx, sc, "param", "set", req.GetNode(), req.GetParam(), req.GetValue())
 	if err != nil {
 		// `ros2 param set` reports failures both via exit code and text.
 		return &agentpbv2.SetROS2ParamResponse{Success: false, Message: err.Error()}, nil
@@ -345,7 +347,8 @@ func (s *ROS2Service) CallService(ctx context.Context, req *agentpbv2.CallROS2Se
 	if req.GetRequest() != "" {
 		args = append(args, req.GetRequest())
 	}
-	out, err := s.runFirst(ctx, scs, args...)
+	sc := s.pickSidecarForService(ctx, scs, req.GetService())
+	out, err := s.runIn(ctx, sc, args...)
 	if err != nil {
 		return &agentpbv2.CallROS2ServiceResponse{Success: false, Response: err.Error()}, nil
 	}
@@ -397,14 +400,20 @@ func (s *ROS2Service) Doctor(ctx context.Context, req *agentpbv2.ROS2DoctorReque
 	}
 	// One report per RMW graph, each headed by its RMW when more than one runs.
 	var sb strings.Builder
+	var lastErr error
+	any := false
 	for _, sc := range scs {
 		// `ros2 doctor` exits non-zero when checks fail, but the report is still
-		// the useful output — capture both streams and return whatever we got.
+		// the useful output — capture both streams and return whatever we got. A
+		// sidecar whose exec genuinely fails is skipped so one broken RMW graph
+		// doesn't hide the others (matches the other merge commands).
 		var stdout, stderr bytes.Buffer
 		_, execErr := s.runtime.ExecROS2(ctx, ROS2ExecOptions{DomainID: sc.domainID, Args: []string{"doctor", "--report"}, SidecarName: sc.name}, &stdout, &stderr)
 		if execErr != nil {
-			return nil, status.Errorf(codes.Internal, "ros2 doctor: %v", execErr)
+			lastErr = status.Errorf(codes.Internal, "ros2 doctor: %v", execErr)
+			continue
 		}
+		any = true
 		report := stdout.String()
 		if strings.TrimSpace(report) == "" {
 			report = stderr.String()
@@ -420,6 +429,9 @@ func (s *ROS2Service) Doctor(ctx context.Context, req *agentpbv2.ROS2DoctorReque
 		if !strings.HasSuffix(report, "\n") {
 			sb.WriteString("\n")
 		}
+	}
+	if !any && lastErr != nil {
+		return nil, lastErr
 	}
 	return &agentpbv2.ROS2DoctorResponse{Report: sb.String()}, nil
 }
@@ -590,6 +602,14 @@ func (s *ROS2Service) RecordBag(stream grpc.BidiStreamingServer[agentpbv2.Record
 		sc = s.pickSidecarForTopic(ctx, scs, start.GetTopics()[0])
 	}
 
+	// A rosbag can't span DDS implementations: on a mixed-RMW device, `-a`
+	// records only this sidecar's RMW graph. Warn so missing topics from other
+	// RMWs aren't a surprise (WDY-1594).
+	var startMsg string
+	if len(start.GetTopics()) == 0 && len(scs) > 1 {
+		startMsg = fmt.Sprintf("recording the %s graph only; -a does not span RMWs (this device also runs other RMWs)", sc.rmw)
+	}
+
 	execCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -607,6 +627,7 @@ func (s *ROS2Service) RecordBag(stream grpc.BidiStreamingServer[agentpbv2.Record
 	if err := stream.Send(&agentpbv2.RecordROS2BagResponse{
 		State:   agentpbv2.RecordROS2BagResponse_STATE_RECORDING,
 		BagName: bagName,
+		Message: startMsg,
 	}); err != nil {
 		cancel()
 		<-execDone

--- a/go/internal/agent/services/ros2_service_test.go
+++ b/go/internal/agent/services/ros2_service_test.go
@@ -23,6 +23,7 @@ import (
 // fakeROS2Runtime scripts ExecROS2 responses keyed by the joined args.
 type fakeROS2Runtime struct {
 	sidecar   ROS2Sidecar
+	sidecars  []ROS2Sidecar // when set, EnsureROS2Sidecars returns these (mixed-RMW tests)
 	ensureErr error
 	verifyErr error
 	// outputs maps "node list" → stdout. Missing keys exit 1.
@@ -36,11 +37,14 @@ func (f *fakeROS2Runtime) FindROS2Containers(context.Context) ([]ROS2Target, err
 	return nil, nil
 }
 
-func (f *fakeROS2Runtime) EnsureROS2Sidecar(context.Context) (ROS2Sidecar, error) {
+func (f *fakeROS2Runtime) EnsureROS2Sidecars(context.Context) ([]ROS2Sidecar, error) {
 	if f.ensureErr != nil {
-		return ROS2Sidecar{}, f.ensureErr
+		return nil, f.ensureErr
 	}
-	return f.sidecar, nil
+	if len(f.sidecars) > 0 {
+		return f.sidecars, nil
+	}
+	return []ROS2Sidecar{f.sidecar}, nil
 }
 
 func (f *fakeROS2Runtime) StopROS2Sidecar(context.Context) error { return nil }
@@ -82,6 +86,41 @@ func TestROS2Service_ListNodes(t *testing.T) {
 	}
 	if rt.calls[0].DomainID != 7 {
 		t.Errorf("exec domain = %d, want sidecar default 7", rt.calls[0].DomainID)
+	}
+}
+
+// TestROS2Service_ListNodes_MergesPerRMW verifies a mixed-RMW device merges the
+// nodes from every RMW sidecar and tags each with its RMW (WDY-1594).
+func TestROS2Service_ListNodes_MergesPerRMW(t *testing.T) {
+	rt := &fakeROS2Runtime{
+		sidecars: []ROS2Sidecar{
+			{Name: "sc-cyc", Distro: "humble", DomainID: 42, RMW: "rmw_cyclonedds_cpp"},
+			{Name: "sc-fast", Distro: "humble", DomainID: 42, RMW: "rmw_fastrtps_cpp"},
+		},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			switch opts.SidecarName {
+			case "sc-cyc":
+				io.WriteString(stdout, "/talker\n")
+			case "sc-fast":
+				io.WriteString(stdout, "/listener\n")
+			}
+			return 0, nil
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	resp, err := svc.ListNodes(context.Background(), &agentpbv2.ListROS2NodesRequest{})
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(resp.GetNodes()) != 2 {
+		t.Fatalf("got %d nodes, want 2 (merged across RMWs)", len(resp.GetNodes()))
+	}
+	byRMW := map[string]string{}
+	for _, n := range resp.GetNodes() {
+		byRMW[n.GetRmw()] = n.GetName()
+	}
+	if byRMW["rmw_cyclonedds_cpp"] != "talker" || byRMW["rmw_fastrtps_cpp"] != "listener" {
+		t.Errorf("merged nodes not tagged by RMW: %+v", byRMW)
 	}
 }
 

--- a/go/internal/agent/services/ros2_service_test.go
+++ b/go/internal/agent/services/ros2_service_test.go
@@ -124,6 +124,73 @@ func TestROS2Service_ListNodes_MergesPerRMW(t *testing.T) {
 	}
 }
 
+// twoSidecarRuntime is a fake with one CycloneDDS and one FastRTPS sidecar.
+func twoSidecarRuntime(execFn func(context.Context, ROS2ExecOptions, io.Writer, io.Writer) (int, error)) *fakeROS2Runtime {
+	return &fakeROS2Runtime{
+		sidecars: []ROS2Sidecar{
+			{Name: "sc-cyc", Distro: "humble", DomainID: 42, RMW: "rmw_cyclonedds_cpp"},
+			{Name: "sc-fast", Distro: "humble", DomainID: 42, RMW: "rmw_fastrtps_cpp"},
+		},
+		execFn: execFn,
+	}
+}
+
+// TestROS2Service_GetParam_RoutesToOwningRMW verifies a node-targeted command
+// runs only in the sidecar whose graph has the node (found via `node list`),
+// never in the wrong RMW where it would block on discovery (WDY-1594).
+func TestROS2Service_GetParam_RoutesToOwningRMW(t *testing.T) {
+	rt := twoSidecarRuntime(func(_ context.Context, opts ROS2ExecOptions, stdout, stderr io.Writer) (int, error) {
+		key := strings.Join(opts.Args, " ")
+		switch {
+		case key == "node list" && opts.SidecarName == "sc-cyc":
+			io.WriteString(stdout, "/other\n") // /talker is NOT here
+			return 0, nil
+		case key == "node list" && opts.SidecarName == "sc-fast":
+			io.WriteString(stdout, "/talker\n")
+			return 0, nil
+		case strings.HasPrefix(key, "param get") && opts.SidecarName == "sc-fast":
+			io.WriteString(stdout, "Boolean value is: True\n")
+			return 0, nil
+		default:
+			fmt.Fprint(stderr, "node not found") // param get in the wrong sidecar
+			return 1, nil
+		}
+	})
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	got, err := svc.GetParam(context.Background(), &agentpbv2.GetROS2ParamRequest{Node: "/talker", Param: "use_sim_time"})
+	if err != nil {
+		t.Fatalf("GetParam: %v", err)
+	}
+	if got.GetValue() != "Boolean value is: True" {
+		t.Errorf("value = %q", got.GetValue())
+	}
+	for _, c := range rt.calls {
+		if strings.HasPrefix(strings.Join(c.Args, " "), "param get") && c.SidecarName != "sc-fast" {
+			t.Errorf("param get ran in %q; must route to the owning sidecar sc-fast", c.SidecarName)
+		}
+	}
+}
+
+// TestROS2Service_Doctor_SkipsFailedSidecar verifies one sidecar's exec failure
+// doesn't hide the others' reports (WDY-1594).
+func TestROS2Service_Doctor_SkipsFailedSidecar(t *testing.T) {
+	rt := twoSidecarRuntime(func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+		if opts.SidecarName == "sc-cyc" {
+			return 0, errors.New("exec failed") // genuine exec error, not a check failure
+		}
+		io.WriteString(stdout, "FASTRTPS REPORT OK\n")
+		return 0, nil
+	})
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	resp, err := svc.Doctor(context.Background(), &agentpbv2.ROS2DoctorRequest{})
+	if err != nil {
+		t.Fatalf("Doctor should skip the failing sidecar, got error: %v", err)
+	}
+	if !strings.Contains(resp.GetReport(), "FASTRTPS REPORT OK") {
+		t.Errorf("report missing the healthy sidecar's output: %q", resp.GetReport())
+	}
+}
+
 func TestROS2Service_DomainOverride(t *testing.T) {
 	rt := &fakeROS2Runtime{
 		sidecar: ROS2Sidecar{Distro: "humble", DomainID: 7},

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -110,6 +110,25 @@ func printROS2JSON(v any) error {
 
 // ── inspection commands ─────────────────────────────────────────────
 
+// ros2RMWShort renders an RMW identifier compactly for display, e.g.
+// "rmw_cyclonedds_cpp" -> "cyclonedds".
+func ros2RMWShort(rmw string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(rmw, "rmw_"), "_cpp")
+}
+
+// ros2ShowRMWTags reports whether the results span more than one RMW, so the
+// per-result "[rmw]" tag is shown only on mixed-RMW devices and never clutters
+// the common single-RMW case (WDY-1594).
+func ros2ShowRMWTags(rmws ...string) bool {
+	seen := map[string]struct{}{}
+	for _, r := range rmws {
+		if r != "" {
+			seen[r] = struct{}{}
+		}
+	}
+	return len(seen) > 1
+}
+
 func newROS2NodesCmd() *cobra.Command {
 	var domain int32
 	cmd := &cobra.Command{
@@ -131,10 +150,11 @@ func newROS2NodesCmd() *cobra.Command {
 				type node struct {
 					Name      string `json:"name"`
 					Namespace string `json:"namespace"`
+					RMW       string `json:"rmw,omitempty"`
 				}
 				nodes := make([]node, 0, len(resp.GetNodes()))
 				for _, n := range resp.GetNodes() {
-					nodes = append(nodes, node{Name: n.GetName(), Namespace: n.GetNamespace()})
+					nodes = append(nodes, node{Name: n.GetName(), Namespace: n.GetNamespace(), RMW: n.GetRmw()})
 				}
 				return printROS2JSON(nodes)
 			}
@@ -142,8 +162,17 @@ func newROS2NodesCmd() *cobra.Command {
 				cliLogln("No ROS 2 nodes found.")
 				return nil
 			}
+			rmws := make([]string, 0, len(resp.GetNodes()))
 			for _, n := range resp.GetNodes() {
-				fmt.Println(ros2GraphNodeFQN(n))
+				rmws = append(rmws, n.GetRmw())
+			}
+			showTags := ros2ShowRMWTags(rmws...)
+			for _, n := range resp.GetNodes() {
+				line := ros2GraphNodeFQN(n)
+				if showTags && n.GetRmw() != "" {
+					line += "  [" + ros2RMWShort(n.GetRmw()) + "]"
+				}
+				fmt.Println(line)
 			}
 			return nil
 		},
@@ -179,6 +208,7 @@ func newROS2TopicsCmd() *cobra.Command {
 					Types       []string `json:"types"`
 					Publishers  int32    `json:"publishers,omitempty"`
 					Subscribers int32    `json:"subscribers,omitempty"`
+					RMW         string   `json:"rmw,omitempty"`
 				}
 				topics := make([]topic, 0, len(resp.GetTopics()))
 				for _, t := range resp.GetTopics() {
@@ -187,6 +217,7 @@ func newROS2TopicsCmd() *cobra.Command {
 						Types:       t.GetTypes(),
 						Publishers:  t.GetPublisherCount(),
 						Subscribers: t.GetSubscriberCount(),
+						RMW:         t.GetRmw(),
 					})
 				}
 				return printROS2JSON(topics)
@@ -195,13 +226,29 @@ func newROS2TopicsCmd() *cobra.Command {
 				cliLogln("No ROS 2 topics found.")
 				return nil
 			}
+			rmws := make([]string, 0, len(resp.GetTopics()))
+			for _, t := range resp.GetTopics() {
+				rmws = append(rmws, t.GetRmw())
+			}
+			rmwCol := ros2ShowRMWTags(rmws...)
 			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-			if all {
+			switch {
+			case all && rmwCol:
+				fmt.Fprintln(w, "TOPIC\tTYPE\tPUBS\tSUBS\tRMW")
+				for _, t := range resp.GetTopics() {
+					fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\n", t.GetName(), strings.Join(t.GetTypes(), ", "), t.GetPublisherCount(), t.GetSubscriberCount(), ros2RMWShort(t.GetRmw()))
+				}
+			case all:
 				fmt.Fprintln(w, "TOPIC\tTYPE\tPUBS\tSUBS")
 				for _, t := range resp.GetTopics() {
 					fmt.Fprintf(w, "%s\t%s\t%d\t%d\n", t.GetName(), strings.Join(t.GetTypes(), ", "), t.GetPublisherCount(), t.GetSubscriberCount())
 				}
-			} else {
+			case rmwCol:
+				fmt.Fprintln(w, "TOPIC\tTYPE\tRMW")
+				for _, t := range resp.GetTopics() {
+					fmt.Fprintf(w, "%s\t%s\t%s\n", t.GetName(), strings.Join(t.GetTypes(), ", "), ros2RMWShort(t.GetRmw()))
+				}
+			default:
 				fmt.Fprintln(w, "TOPIC\tTYPE")
 				for _, t := range resp.GetTopics() {
 					fmt.Fprintf(w, "%s\t%s\n", t.GetName(), strings.Join(t.GetTypes(), ", "))
@@ -278,10 +325,11 @@ func newROS2ServicesCmd() *cobra.Command {
 				type svc struct {
 					Name  string   `json:"name"`
 					Types []string `json:"types"`
+					RMW   string   `json:"rmw,omitempty"`
 				}
 				svcs := make([]svc, 0, len(resp.GetServices()))
 				for _, s := range resp.GetServices() {
-					svcs = append(svcs, svc{Name: s.GetName(), Types: s.GetTypes()})
+					svcs = append(svcs, svc{Name: s.GetName(), Types: s.GetTypes(), RMW: s.GetRmw()})
 				}
 				return printROS2JSON(svcs)
 			}
@@ -289,10 +337,22 @@ func newROS2ServicesCmd() *cobra.Command {
 				cliLogln("No ROS 2 services found.")
 				return nil
 			}
-			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "SERVICE\tTYPE")
+			rmws := make([]string, 0, len(resp.GetServices()))
 			for _, s := range resp.GetServices() {
-				fmt.Fprintf(w, "%s\t%s\n", s.GetName(), strings.Join(s.GetTypes(), ", "))
+				rmws = append(rmws, s.GetRmw())
+			}
+			rmwCol := ros2ShowRMWTags(rmws...)
+			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			if rmwCol {
+				fmt.Fprintln(w, "SERVICE\tTYPE\tRMW")
+				for _, s := range resp.GetServices() {
+					fmt.Fprintf(w, "%s\t%s\t%s\n", s.GetName(), strings.Join(s.GetTypes(), ", "), ros2RMWShort(s.GetRmw()))
+				}
+			} else {
+				fmt.Fprintln(w, "SERVICE\tTYPE")
+				for _, s := range resp.GetServices() {
+					fmt.Fprintf(w, "%s\t%s\n", s.GetName(), strings.Join(s.GetTypes(), ", "))
+				}
 			}
 			return w.Flush()
 		},

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -743,6 +743,9 @@ func newROS2BagRecordCmd() *cobra.Command {
 				topicsDesc = strings.Join(args, ", ")
 			}
 			cliLogln("Recording %s to bag %q on the device. Press ctrl-c to stop.", topicsDesc, first.GetBagName())
+			if m := first.GetMessage(); m != "" {
+				cliLogln("Note: %s", m)
+			}
 
 			// Wait for ctrl-c or an unsolicited terminal message (recorder error).
 			recvCh := make(chan *agentpbv2.RecordROS2BagResponse, 1)

--- a/go/internal/cli/commands/ros2_graph.go
+++ b/go/internal/cli/commands/ros2_graph.go
@@ -15,19 +15,43 @@ var ros2HiddenGraphTopics = map[string]bool{
 	"/parameter_events": true,
 }
 
+// graphSpansMultipleRMWs reports whether the graph carries nodes from more than
+// one RMW, so node labels are RMW-tagged only on mixed-RMW devices (WDY-1594).
+func graphSpansMultipleRMWs(graph *agentpbv2.GetROS2GraphResponse) bool {
+	seen := map[string]struct{}{}
+	for _, n := range graph.GetNodes() {
+		if n.GetRmw() != "" {
+			seen[n.GetRmw()] = struct{}{}
+		}
+	}
+	return len(seen) > 1
+}
+
+// ros2GraphNodeLabel renders a node label, appending its RMW tag when the graph
+// spans multiple RMWs so identically-named nodes in different graphs are
+// distinguishable.
+func ros2GraphNodeLabel(node, rmw string, tagged bool) string {
+	if tagged && rmw != "" {
+		return node + " [" + ros2RMWShort(rmw) + "]"
+	}
+	return node
+}
+
 // ros2GraphEdges builds topic → publishers and topic → subscribers maps from
-// a graph response, skipping hidden infrastructure topics.
+// a graph response, skipping hidden infrastructure topics. Node labels carry an
+// RMW tag when the graph spans multiple RMWs.
 func ros2GraphEdges(graph *agentpbv2.GetROS2GraphResponse) (pubs, subs map[string][]string) {
+	tagged := graphSpansMultipleRMWs(graph)
 	pubs = make(map[string][]string)
 	subs = make(map[string][]string)
 	for _, e := range graph.GetPublishes() {
 		if !ros2HiddenGraphTopics[e.GetTopic()] {
-			pubs[e.GetTopic()] = append(pubs[e.GetTopic()], e.GetNode())
+			pubs[e.GetTopic()] = append(pubs[e.GetTopic()], ros2GraphNodeLabel(e.GetNode(), e.GetRmw(), tagged))
 		}
 	}
 	for _, e := range graph.GetSubscribes() {
 		if !ros2HiddenGraphTopics[e.GetTopic()] {
-			subs[e.GetTopic()] = append(subs[e.GetTopic()], e.GetNode())
+			subs[e.GetTopic()] = append(subs[e.GetTopic()], ros2GraphNodeLabel(e.GetNode(), e.GetRmw(), tagged))
 		}
 	}
 	return pubs, subs
@@ -62,11 +86,12 @@ func renderROS2GraphASCII(graph *agentpbv2.GetROS2GraphResponse) string {
 		}
 	}
 
+	tagged := graphSpansMultipleRMWs(graph)
 	var isolated []string
 	for _, node := range graph.GetNodes() {
-		fqn := ros2GraphNodeFQN(node)
-		if !connected[fqn] {
-			isolated = append(isolated, fqn)
+		label := ros2GraphNodeLabel(ros2GraphNodeFQN(node), node.GetRmw(), tagged)
+		if !connected[label] {
+			isolated = append(isolated, label)
 		}
 	}
 	sort.Strings(isolated)
@@ -94,8 +119,9 @@ func renderROS2GraphDOT(graph *agentpbv2.GetROS2GraphResponse) string {
 	b.WriteString("digraph ros2 {\n")
 	b.WriteString("  rankdir=LR;\n")
 	b.WriteString("  node [shape=box];\n")
+	tagged := graphSpansMultipleRMWs(graph)
 	for _, node := range graph.GetNodes() {
-		fmt.Fprintf(&b, "  %q;\n", ros2GraphNodeFQN(node))
+		fmt.Fprintf(&b, "  %q;\n", ros2GraphNodeLabel(ros2GraphNodeFQN(node), node.GetRmw(), tagged))
 	}
 	topics := make([]string, 0, len(pubs))
 	for topic := range pubs {

--- a/go/proto/gen/agentpb/v2/ros2_service.pb.go
+++ b/go/proto/gen/agentpb/v2/ros2_service.pb.go
@@ -74,9 +74,12 @@ func (RecordROS2BagResponse_State) EnumDescriptor() ([]byte, []int) {
 }
 
 type ROS2Node struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Namespace     string                 `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Name      string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace string                 `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// rmw identifies which RMW graph this node came from when a device runs
+	// apps on more than one RMW (WDY-1594). Empty on single-RMW devices.
+	Rmw           string `protobuf:"bytes,3,opt,name=rmw,proto3" json:"rmw,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -125,14 +128,24 @@ func (x *ROS2Node) GetNamespace() string {
 	return ""
 }
 
+func (x *ROS2Node) GetRmw() string {
+	if x != nil {
+		return x.Rmw
+	}
+	return ""
+}
+
 type ROS2Topic struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	Name            string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Types           []string               `protobuf:"bytes,2,rep,name=types,proto3" json:"types,omitempty"` // a topic can have multiple publisher types
 	PublisherCount  int32                  `protobuf:"varint,3,opt,name=publisher_count,json=publisherCount,proto3" json:"publisher_count,omitempty"`
 	SubscriberCount int32                  `protobuf:"varint,4,opt,name=subscriber_count,json=subscriberCount,proto3" json:"subscriber_count,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// rmw identifies which RMW graph this topic came from (WDY-1594). Empty on
+	// single-RMW devices.
+	Rmw           string `protobuf:"bytes,5,opt,name=rmw,proto3" json:"rmw,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ROS2Topic) Reset() {
@@ -191,6 +204,13 @@ func (x *ROS2Topic) GetSubscriberCount() int32 {
 		return x.SubscriberCount
 	}
 	return 0
+}
+
+func (x *ROS2Topic) GetRmw() string {
+	if x != nil {
+		return x.Rmw
+	}
+	return ""
 }
 
 type ListROS2NodesRequest struct {
@@ -1867,9 +1887,11 @@ func (x *ROS2ExecOutput) GetExitCode() int32 {
 }
 
 type ListROS2ServicesResponse_Service struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Types         []string               `protobuf:"bytes,2,rep,name=types,proto3" json:"types,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Types []string               `protobuf:"bytes,2,rep,name=types,proto3" json:"types,omitempty"`
+	// rmw identifies which RMW graph this service came from (WDY-1594).
+	Rmw           string `protobuf:"bytes,3,opt,name=rmw,proto3" json:"rmw,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1916,6 +1938,13 @@ func (x *ListROS2ServicesResponse_Service) GetTypes() []string {
 		return x.Types
 	}
 	return nil
+}
+
+func (x *ListROS2ServicesResponse_Service) GetRmw() string {
+	if x != nil {
+		return x.Rmw
+	}
+	return ""
 }
 
 type ListROS2ParamsResponse_NodeParams struct {
@@ -1974,6 +2003,7 @@ type GetROS2GraphResponse_Edge struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Node          string                 `protobuf:"bytes,1,opt,name=node,proto3" json:"node,omitempty"` // fully-qualified node name
 	Topic         string                 `protobuf:"bytes,2,opt,name=topic,proto3" json:"topic,omitempty"`
+	Rmw           string                 `protobuf:"bytes,3,opt,name=rmw,proto3" json:"rmw,omitempty"` // RMW graph this edge belongs to (WDY-1594); "" single-RMW
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2018,6 +2048,13 @@ func (x *GetROS2GraphResponse_Edge) GetNode() string {
 func (x *GetROS2GraphResponse_Edge) GetTopic() string {
 	if x != nil {
 		return x.Topic
+	}
+	return ""
+}
+
+func (x *GetROS2GraphResponse_Edge) GetRmw() string {
+	if x != nil {
+		return x.Rmw
 	}
 	return ""
 }
@@ -2190,15 +2227,17 @@ var File_wendy_agent_services_v2_ros2_service_proto protoreflect.FileDescriptor
 
 const file_wendy_agent_services_v2_ros2_service_proto_rawDesc = "" +
 	"\n" +
-	"*wendy/agent/services/v2/ros2_service.proto\x12\x17wendy.agent.services.v2\"<\n" +
+	"*wendy/agent/services/v2/ros2_service.proto\x12\x17wendy.agent.services.v2\"N\n" +
 	"\bROS2Node\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
-	"\tnamespace\x18\x02 \x01(\tR\tnamespace\"\x89\x01\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x10\n" +
+	"\x03rmw\x18\x03 \x01(\tR\x03rmw\"\x9b\x01\n" +
 	"\tROS2Topic\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05types\x18\x02 \x03(\tR\x05types\x12'\n" +
 	"\x0fpublisher_count\x18\x03 \x01(\x05R\x0epublisherCount\x12)\n" +
-	"\x10subscriber_count\x18\x04 \x01(\x05R\x0fsubscriberCount\"F\n" +
+	"\x10subscriber_count\x18\x04 \x01(\x05R\x0fsubscriberCount\x12\x10\n" +
+	"\x03rmw\x18\x05 \x01(\tR\x03rmw\"F\n" +
 	"\x14ListROS2NodesRequest\x12 \n" +
 	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01B\f\n" +
 	"\n" +
@@ -2223,12 +2262,13 @@ const file_wendy_agent_services_v2_ros2_service_proto_rawDesc = "" +
 	"\x17ListROS2ServicesRequest\x12 \n" +
 	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01B\f\n" +
 	"\n" +
-	"_domain_id\"\xa6\x01\n" +
+	"_domain_id\"\xb8\x01\n" +
 	"\x18ListROS2ServicesResponse\x12U\n" +
-	"\bservices\x18\x01 \x03(\v29.wendy.agent.services.v2.ListROS2ServicesResponse.ServiceR\bservices\x1a3\n" +
+	"\bservices\x18\x01 \x03(\v29.wendy.agent.services.v2.ListROS2ServicesResponse.ServiceR\bservices\x1aE\n" +
 	"\aService\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
-	"\x05types\x18\x02 \x03(\tR\x05types\"[\n" +
+	"\x05types\x18\x02 \x03(\tR\x05types\x12\x10\n" +
+	"\x03rmw\x18\x03 \x01(\tR\x03rmw\"[\n" +
 	"\x15ListROS2ParamsRequest\x12 \n" +
 	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01\x12\x12\n" +
 	"\x04node\x18\x02 \x01(\tR\x04nodeB\f\n" +
@@ -2271,16 +2311,17 @@ const file_wendy_agent_services_v2_ros2_service_proto_rawDesc = "" +
 	"\x13GetROS2GraphRequest\x12 \n" +
 	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01B\f\n" +
 	"\n" +
-	"_domain_id\"\xa7\x02\n" +
+	"_domain_id\"\xb9\x02\n" +
 	"\x14GetROS2GraphResponse\x127\n" +
 	"\x05nodes\x18\x01 \x03(\v2!.wendy.agent.services.v2.ROS2NodeR\x05nodes\x12P\n" +
 	"\tpublishes\x18\x02 \x03(\v22.wendy.agent.services.v2.GetROS2GraphResponse.EdgeR\tpublishes\x12R\n" +
 	"\n" +
 	"subscribes\x18\x03 \x03(\v22.wendy.agent.services.v2.GetROS2GraphResponse.EdgeR\n" +
-	"subscribes\x1a0\n" +
+	"subscribes\x1aB\n" +
 	"\x04Edge\x12\x12\n" +
 	"\x04node\x18\x01 \x01(\tR\x04node\x12\x14\n" +
-	"\x05topic\x18\x02 \x01(\tR\x05topic\"C\n" +
+	"\x05topic\x18\x02 \x01(\tR\x05topic\x12\x10\n" +
+	"\x03rmw\x18\x03 \x01(\tR\x03rmw\"C\n" +
 	"\x11ROS2DoctorRequest\x12 \n" +
 	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01B\f\n" +
 	"\n" +


### PR DESCRIPTION
Builds on #1046/#1050 (WDY-1555/1593), now merged into `jo.ros2-support`; this targets that branch directly.

## Summary

`wendy device ros2` could inspect only one RMW graph at a time. On a device running both a CycloneDDS app and a FastRTPS app (different DDS implementations don't share a graph), it showed one and **silently hid the other**. It now inspects **both at once**, with each result tagged by its RMW. Closes WDY-1594.

This implements the issue's **Option 1 (per-RMW sidecars + merge)** — the full fix — superseding the WDY-1593-era single-sidecar advisory (showing both graphs makes the "other RMW hidden" note unnecessary).

## Changes

**Agent — one persistent sidecar per RMW** (`containerd/ros2.go`)
- Replaces the single `wendy-ros2-cli-sidecar` with one per distinct RMW in use (`…-cyclonedds`, `…-fastrtps`), each image/RMW-matched and anchored to an app of that RMW. Full lifecycle: create/reuse/teardown keyed off the running RMW set.
- `EnsureROS2Sidecar` → `EnsureROS2Sidecars`; `ExecROS2` targets a named sidecar.

**Agent — merge vs route** (`services/ros2_service.go`)
- Discovery (`nodes`/`topics`/`services`/`graph`/`doctor`): run in every sidecar, **merge**, tag each result with its RMW. A broken RMW graph is skipped, not fatal.
- Targeted (`topic info`/`echo`/`hz`/`param`/`call`/`bag`): **route** to the RMW graph that owns the topic/node.

**Proto:** `rmw` field on `ROS2Node`, `ROS2Topic`, services `Service`, and graph `Edge` (regenerated with the pinned protoc 34.0 — no churn).

**CLI:** renders an RMW tag/column, but only when results span >1 RMW so single-RMW devices stay clean. `--json` carries a structured `rmw` field.

## Testing

- Unit tests: per-RMW merge (`ListNodes` across two sidecars, tagged), sidecar naming, existing single-RMW behavior; `gofmt`/`vet` clean; agent + CLI build.
- **Hardware-verified on a Jetson Orin Nano** running CycloneDDS + FastRTPS apps on the same domain:

  | Command | Before | After |
  |---|---|---|
  | `ros2 nodes` | one `wendy_talker` | `wendy_talker [cyclonedds]` **and** `[fastrtps]` |
  | `ros2 topics` | one `/chatter` | both `/chatter`, with an RMW column |
  | `ros2 graph` | two indistinguishable lines | `[/wendy_talker [cyclonedds]]` / `[…[fastrtps]]` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)