### PR TITLE
fix(os): pick OS image variant from published artifacts, not USB bus type

### DIFF
--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -86,6 +86,10 @@ type imageInfo struct {
 	Version     string
 	BmapURL     string
 	ZstURL      string
+	// Storage is the resolved manifest variant ("sd"/"nvme"/""), used to keep
+	// the on-disk cache keyed per variant so an SD download and an NVMe download
+	// of the same device+version never collide on one cache file.
+	Storage string
 }
 
 func fetchMainManifest() (*mainManifest, error) {
@@ -193,6 +197,7 @@ func getImageInfo(dm *deviceManifest, ver, storage string) (*imageInfo, error) {
 		DownloadURL: gcsBaseURL + "/" + t.imagePath,
 		ImageSize:   t.imageSize,
 		Version:     ver,
+		Storage:     storage,
 	}
 	if t.bmapPath != "" {
 		info.BmapURL = gcsBaseURL + "/" + t.bmapPath

--- a/go/internal/cli/commands/os_download.go
+++ b/go/internal/cli/commands/os_download.go
@@ -44,21 +44,30 @@ func runOSDownload(flagVersion string, overwrite bool) error {
 		}
 	}
 
+	// download has no target drive to probe, so default to the device's natural
+	// removable image (SD for Raspberry Pi, NVMe for Jetson) rather than the
+	// legacy field, which for dual-variant devices like RPi 5 is the NVMe image.
+	v, ok := dev.Manifest.Versions[version]
+	if !ok {
+		return fmt.Errorf("version %s not found in device manifest", version)
+	}
+	storage := defaultManifestStorage(v)
+
 	// Validate version exists in manifest before touching the filesystem.
-	imgInfo, err := getImageInfo(dev.Manifest, version, "")
+	imgInfo, err := getImageInfo(dev.Manifest, version, storage)
 	if err != nil {
 		return fmt.Errorf("getting image info: %w", err)
 	}
 
 	// Check if already cached — zip format (new) or legacy extracted img.
 	cached := ""
-	if zipPath, zpErr := osCachedZipPath(selectedKey, version); zpErr == nil {
+	if zipPath, zpErr := osCachedZipPath(selectedKey, version, storage); zpErr == nil {
 		if info, statErr := os.Stat(zipPath); statErr == nil && info.Size() > 0 {
 			cached = zipPath
 		}
 	}
 	if cached == "" {
-		if imgPath, ipErr := osCachedImagePath(selectedKey, version); ipErr == nil {
+		if imgPath, ipErr := osCachedImagePath(selectedKey, version, storage); ipErr == nil {
 			if info, statErr := os.Stat(imgPath); statErr == nil && info.Size() > 0 {
 				cached = imgPath
 			}

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -122,7 +122,7 @@ Flags can be provided progressively — omitted values trigger interactive picke
 	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use nightly/prerelease builds")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&noBmap, "no-bmap", false, "Disable bmap-accelerated flashing even when a block map is available")
-	cmd.Flags().StringVar(&storageOverride, "storage", "", "Force image storage variant: nvme or sd (default: auto-detect from the target drive)")
+	cmd.Flags().StringVar(&storageOverride, "storage", "", "Force image storage variant: nvme or sd (default: auto-detect — real NVMe drives use nvme; a USB-attached drive uses the device's published image, SD for Raspberry Pi / NVMe for Jetson SSD enclosures)")
 	cmd.Flags().BoolVar(&yesOverwriteInternal, "yes-overwrite-internal", false, "Required to wipe an internal (non-removable) drive in non-interactive mode")
 	cmd.Flags().StringVar(&deviceType, "device-type", "", "Device type from manifest (e.g. raspberry-pi-5)")
 	cmd.Flags().StringVar(&versionFlag, "version", "", "WendyOS version to install (interactive if omitted)")
@@ -455,9 +455,18 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		}
 	}
 
-	// Step 5: Resolve image metadata for the target storage.
+	// Step 5: Resolve image metadata for the target storage. A USB-attached
+	// drive is ambiguous (SD card in a reader vs NVMe SSD in an enclosure), so
+	// the variant is chosen from what this manifest version publishes — see
+	// manifestStorage. Pass --storage to override.
+	ver, ok := device.Manifest.Versions[selectedVersion]
+	if !ok {
+		return fmt.Errorf("version %s not found in device manifest", selectedVersion)
+	}
+	storage := manifestStorage(ver, targetDrive.StorageType, storageOverride)
+
 	fmt.Printf("\nPreparing %s %s image...\n", device.Name, selectedVersion)
-	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, manifestStorage(targetDrive, storageOverride))
+	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, storage)
 	if err != nil {
 		return fmt.Errorf("getting image info: %w", err)
 	}
@@ -469,8 +478,8 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	var seekableZst, seekableBmap string
 	var seekableTotal int64
 	if !noBmap && imgInfo.ZstURL != "" && imgInfo.BmapURL != "" {
-		zstPath, zerr := resolveSeekableZst(deviceKey, selectedVersion, imgInfo.ZstURL)
-		bmapCandidate, berr := osCachedBmapPath(deviceKey, selectedVersion)
+		zstPath, zerr := resolveSeekableZst(deviceKey, selectedVersion, storage, imgInfo.ZstURL)
+		bmapCandidate, berr := osCachedBmapPath(deviceKey, selectedVersion, storage)
 		switch {
 		case zerr != nil:
 			fmt.Printf("Note: could not fetch seekable image (%v); flashing the full image.\n", zerr)
@@ -510,7 +519,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		}
 
 		if !noBmap && imgInfo.BmapURL != "" {
-			candidate, derr := osCachedBmapPath(deviceKey, selectedVersion)
+			candidate, derr := osCachedBmapPath(deviceKey, selectedVersion, storage)
 			if derr != nil {
 				fmt.Printf("Note: cannot resolve block-map cache path (%v); flashing the full image.\n", derr)
 			} else if derr := downloadBmap(imgInfo.BmapURL, candidate); derr != nil {
@@ -914,87 +923,103 @@ func readFileOrNil(path string) []byte {
 	return data
 }
 
-func osCachedImagePath(deviceKey, version string) (string, error) {
-	// Sanitize to prevent path traversal from user-supplied --version flag.
+// osCachedPath builds a cache file path for deviceKey+version, keyed by the
+// storage variant ("sd"/"nvme") when one is given so an SD image and an NVMe
+// image of the same device+version never share one file. ext includes the dot
+// (e.g. ".img", ".zip", ".bmap", ".img.zst"). Inputs are sanitized to prevent
+// path traversal from the user-supplied --version flag and the storage key.
+func osCachedPath(deviceKey, version, storage, ext string) (string, error) {
 	safeDevice := filepath.Base(deviceKey)
 	safeVersion := filepath.Base(version)
 	if safeDevice != deviceKey || safeVersion != version ||
 		strings.Contains(deviceKey, "..") || strings.Contains(version, "..") {
 		return "", fmt.Errorf("invalid device key or version: %q / %q", deviceKey, version)
 	}
-
-	dir, err := osCacheDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, fmt.Sprintf("%s-%s.img", safeDevice, safeVersion)), nil
-}
-
-func osCachedZipPath(deviceKey, version string) (string, error) {
-	safeDevice := filepath.Base(deviceKey)
-	safeVersion := filepath.Base(version)
-	if safeDevice != deviceKey || safeVersion != version ||
-		strings.Contains(deviceKey, "..") || strings.Contains(version, "..") {
-		return "", fmt.Errorf("invalid device key or version: %q / %q", deviceKey, version)
+	if storage != "" {
+		safeStorage := filepath.Base(storage)
+		if safeStorage != storage || strings.Contains(storage, "..") {
+			return "", fmt.Errorf("invalid storage key: %q", storage)
+		}
 	}
 
 	dir, err := osCacheDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, fmt.Sprintf("%s-%s.zip", safeDevice, safeVersion)), nil
+	name := safeVersion
+	if storage != "" {
+		name = fmt.Sprintf("%s-%s", safeVersion, storage)
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s-%s%s", safeDevice, name, ext)), nil
 }
 
-func osCachedBmapPath(deviceKey, version string) (string, error) {
-	safeDevice := filepath.Base(deviceKey)
-	safeVersion := filepath.Base(version)
-	if safeDevice != deviceKey || safeVersion != version ||
-		strings.Contains(deviceKey, "..") || strings.Contains(version, "..") {
-		return "", fmt.Errorf("invalid device key or version: %q / %q", deviceKey, version)
-	}
-
-	dir, err := osCacheDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, fmt.Sprintf("%s-%s.bmap", safeDevice, safeVersion)), nil
+func osCachedImagePath(deviceKey, version, storage string) (string, error) {
+	return osCachedPath(deviceKey, version, storage, ".img")
 }
 
-// manifestStorage maps a target drive's protocol to the manifest storage key,
-// honoring an explicit override. USB-attached drives default to nvme (e.g. a
-// Jetson NVMe in a USB enclosure); built-in SD readers and unknown buses → sd.
-func manifestStorage(d drive, override string) string {
+func osCachedZipPath(deviceKey, version, storage string) (string, error) {
+	return osCachedPath(deviceKey, version, storage, ".zip")
+}
+
+func osCachedBmapPath(deviceKey, version, storage string) (string, error) {
+	return osCachedPath(deviceKey, version, storage, ".bmap")
+}
+
+// manifestStorage picks the manifest storage key ("sd"/"nvme") for a target
+// drive, honoring an explicit override.
+//
+// A real NVMe controller is unambiguous → nvme. A USB-attached drive is NOT:
+// an SD card in a USB reader and an NVMe SSD in a USB enclosure both enumerate
+// as USB on every platform (the StorageType enum has no SD value), so bus type
+// alone can't tell them apart. We disambiguate from the variants this manifest
+// version actually publishes via defaultManifestStorage: prefer the SD image
+// when the device ships one (Raspberry Pi), else the NVMe image (a Jetson SSD
+// enclosure), else legacy/sd. Unknown buses (built-in card readers) → sd.
+//
+// Assumption: a device that publishes BOTH an sd and an nvme variant is
+// SD-natural for an ambiguous USB target (true for the only dual-variant device
+// today, Raspberry Pi 5). Pass --storage to override.
+func manifestStorage(v deviceVersion, st StorageType, override string) string {
 	switch override {
 	case "nvme", "sd":
 		return override
 	}
-	switch d.StorageType {
-	case StorageNVMe, StorageUSB:
+	switch st {
+	case StorageNVMe:
+		return "nvme"
+	case StorageUSB:
+		return defaultManifestStorage(v)
+	default:
+		return "sd"
+	}
+}
+
+// defaultManifestStorage returns the device's natural removable image variant
+// based on which artifacts the manifest version publishes: an SD variant when
+// present (the common Raspberry Pi case), otherwise an NVMe variant (a Jetson
+// NVMe SSD), otherwise "sd" so resolveTriple falls back to the legacy image.
+// Used when there is no target-drive protocol to consult (wendy os download)
+// and as the ambiguous-USB tiebreaker for manifestStorage.
+func defaultManifestStorage(v deviceVersion) string {
+	switch {
+	case v.SDPath != "":
+		return "sd"
+	case v.NVMEPath != "":
 		return "nvme"
 	default:
 		return "sd"
 	}
 }
 
-func osCachedZstPath(deviceKey, version string) (string, error) {
-	safeDevice := filepath.Base(deviceKey)
-	safeVersion := filepath.Base(version)
-	if safeDevice != deviceKey || safeVersion != version ||
-		strings.Contains(deviceKey, "..") || strings.Contains(version, "..") {
-		return "", fmt.Errorf("invalid device key or version: %q / %q", deviceKey, version)
-	}
-	dir, err := osCacheDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, fmt.Sprintf("%s-%s.img.zst", safeDevice, safeVersion)), nil
+func osCachedZstPath(deviceKey, version, storage string) (string, error) {
+	return osCachedPath(deviceKey, version, storage, ".img.zst")
 }
 
 // resolveSeekableZst downloads (or cache-hits) the seekable .img.zst for
 // deviceKey+version from zstURL, returning the cached path. Reuses downloadImage
 // (streams to a temp file with progress) then renames into the cache.
-func resolveSeekableZst(deviceKey, version, zstURL string) (string, error) {
-	cached, err := osCachedZstPath(deviceKey, version)
+func resolveSeekableZst(deviceKey, version, storage, zstURL string) (string, error) {
+	cached, err := osCachedZstPath(deviceKey, version, storage)
 	if err != nil {
 		return "", err
 	}
@@ -1079,7 +1104,7 @@ func resolveOSImage(deviceKey string, img *imageInfo) (string, error) {
 	isZip := strings.HasSuffix(strings.ToLower(img.DownloadURL), ".zip")
 
 	// Legacy .img cache hit (backward compat with pre-streaming caches).
-	imgCached, err := osCachedImagePath(deviceKey, img.Version)
+	imgCached, err := osCachedImagePath(deviceKey, img.Version, img.Storage)
 	if err != nil {
 		return "", err
 	}
@@ -1090,7 +1115,7 @@ func resolveOSImage(deviceKey string, img *imageInfo) (string, error) {
 
 	if isZip {
 		// Zip cache hit.
-		zipCached, zipErr := osCachedZipPath(deviceKey, img.Version)
+		zipCached, zipErr := osCachedZipPath(deviceKey, img.Version, img.Storage)
 		if zipErr != nil {
 			return "", zipErr
 		}

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -134,7 +134,7 @@ func TestPickManifestVersion_SemverOrdering(t *testing.T) {
 
 func TestOsCachedImagePath_Sanitization(t *testing.T) {
 	// Valid inputs should produce a valid path.
-	path, err := osCachedImagePath("raspberry-pi-5", "0.10.4")
+	path, err := osCachedImagePath("raspberry-pi-5", "0.10.4", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -143,20 +143,26 @@ func TestOsCachedImagePath_Sanitization(t *testing.T) {
 	}
 
 	// Path traversal in version should be rejected.
-	_, err = osCachedImagePath("raspberry-pi-5", "../../../etc/passwd")
+	_, err = osCachedImagePath("raspberry-pi-5", "../../../etc/passwd", "")
 	if err == nil {
 		t.Fatal("expected error for path traversal in version")
 	}
 
 	// Path traversal in device key should be rejected.
-	_, err = osCachedImagePath("../evil", "0.10.4")
+	_, err = osCachedImagePath("../evil", "0.10.4", "")
 	if err == nil {
 		t.Fatal("expected error for path traversal in device key")
+	}
+
+	// Path traversal in storage key should be rejected.
+	_, err = osCachedImagePath("raspberry-pi-5", "0.10.4", "../evil")
+	if err == nil {
+		t.Fatal("expected error for path traversal in storage key")
 	}
 }
 
 func TestOsCachedZipPath_Sanitization(t *testing.T) {
-	path, err := osCachedZipPath("raspberry-pi-5", "0.10.4")
+	path, err := osCachedZipPath("raspberry-pi-5", "0.10.4", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,14 +170,45 @@ func TestOsCachedZipPath_Sanitization(t *testing.T) {
 		t.Fatalf("expected .zip suffix, got %q", path)
 	}
 
-	_, err = osCachedZipPath("raspberry-pi-5", "../../../etc/passwd")
+	_, err = osCachedZipPath("raspberry-pi-5", "../../../etc/passwd", "")
 	if err == nil {
 		t.Fatal("expected error for path traversal in version")
 	}
 
-	_, err = osCachedZipPath("../evil", "0.10.4")
+	_, err = osCachedZipPath("../evil", "0.10.4", "")
 	if err == nil {
 		t.Fatal("expected error for path traversal in device key")
+	}
+}
+
+// The storage key, when set, becomes part of the cache filename so an SD image
+// and an NVMe image of the same device+version never collide on one file.
+func TestOsCachedPath_StorageKeyed(t *testing.T) {
+	sd, err := osCachedZipPath("raspberry-pi-5", "0.16.0", "sd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	nvme, err := osCachedZipPath("raspberry-pi-5", "0.16.0", "nvme")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sd == nvme {
+		t.Fatalf("sd and nvme cache paths must differ, both = %q", sd)
+	}
+	if !strings.HasSuffix(sd, "raspberry-pi-5-0.16.0-sd.zip") {
+		t.Errorf("unexpected sd cache path: %q", sd)
+	}
+	if !strings.HasSuffix(nvme, "raspberry-pi-5-0.16.0-nvme.zip") {
+		t.Errorf("unexpected nvme cache path: %q", nvme)
+	}
+
+	// Empty storage keeps the legacy (unsuffixed) name for backward compat.
+	legacy, err := osCachedZipPath("raspberry-pi-5", "0.16.0", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasSuffix(legacy, "raspberry-pi-5-0.16.0.zip") {
+		t.Errorf("unexpected legacy cache path: %q", legacy)
 	}
 }
 
@@ -878,7 +915,7 @@ func TestResolveOSImage_ZipCacheHit(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
 	content := []byte("fake image bytes")
-	zipPath, err := osCachedZipPath("test-device", "9.9.9")
+	zipPath, err := osCachedZipPath("test-device", "9.9.9", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -916,7 +953,7 @@ func TestResolveOSImage_LegacyImgCacheHit(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
-	imgPath, err := osCachedImagePath("test-device", "8.8.8")
+	imgPath, err := osCachedImagePath("test-device", "8.8.8", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -940,7 +977,7 @@ func TestOpenOSImageStream_ZipCacheHit(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
 	content := []byte("stream me please")
-	zipPath, err := osCachedZipPath("stream-device", "7.7.7")
+	zipPath, err := osCachedZipPath("stream-device", "7.7.7", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -988,7 +1025,7 @@ func TestOpenOSImageStream_LegacyImgCacheHit(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
 	content := []byte("old img cache data")
-	imgPath, err := osCachedImagePath("legacy-device", "6.6.6")
+	imgPath, err := osCachedImagePath("legacy-device", "6.6.6", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/internal/cli/commands/storage_select_test.go
+++ b/go/internal/cli/commands/storage_select_test.go
@@ -2,52 +2,144 @@
 
 package commands
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestManifestStorage(t *testing.T) {
+	// Variant shapes mirroring what each device publishes today.
+	rpi5 := deviceVersion{ // dual-variant; legacy path = the nvme image
+		Path: "img/nvme.img.gz", NVMEPath: "img/nvme.img.gz", SDPath: "img/sd.img.gz",
+	}
+	jetson := deviceVersion{ // nvme-only; legacy path = the nvme image
+		Path: "img/nvme.img.zip", NVMEPath: "img/nvme.img.zip",
+	}
+	legacyOnly := deviceVersion{ // RPi 3/4: only the legacy (SD) image
+		Path: "img/sd.img.gz", BmapPath: "img/sd.bmap",
+	}
+
 	tests := []struct {
 		name     string
-		d        drive
+		v        deviceVersion
+		st       StorageType
 		override string
 		want     string
 	}{
 		{
 			name:     "override nvme wins regardless of storage type",
-			d:        drive{StorageType: StorageUnknown},
+			v:        rpi5,
+			st:       StorageUnknown,
 			override: "nvme",
 			want:     "nvme",
 		},
 		{
 			name:     "override sd wins regardless of storage type",
-			d:        drive{StorageType: StorageNVMe},
+			v:        jetson,
+			st:       StorageNVMe,
 			override: "sd",
 			want:     "sd",
 		},
 		{
-			name:     "USB-attached drive defaults to nvme",
-			d:        drive{StorageType: StorageUSB},
-			override: "",
-			want:     "nvme",
+			name: "real NVMe controller returns nvme without consulting manifest",
+			v:    deviceVersion{}, // empty: proves StorageNVMe short-circuits
+			st:   StorageNVMe,
+			want: "nvme",
 		},
 		{
-			name:     "NVMe drive without override returns nvme",
-			d:        drive{StorageType: StorageNVMe},
-			override: "",
-			want:     "nvme",
+			name: "unknown storage type (built-in SD reader) returns sd",
+			v:    rpi5,
+			st:   StorageUnknown,
+			want: "sd",
 		},
 		{
-			name:     "unknown storage type returns sd",
-			d:        drive{StorageType: StorageUnknown},
-			override: "",
-			want:     "sd",
+			// The regression: an RPi 5 SD card in a USB reader enumerates as USB.
+			// It must resolve to the SD image, not the NVMe image.
+			name: "USB drive + device publishes an SD variant returns sd (RPi 5)",
+			v:    rpi5,
+			st:   StorageUSB,
+			want: "sd",
+		},
+		{
+			// Preserves commit 95d63153: a Jetson NVMe SSD in a USB enclosure has
+			// no SD variant, so the ambiguous USB case falls through to nvme.
+			name: "USB drive + device publishes only an NVMe variant returns nvme (Jetson)",
+			v:    jetson,
+			st:   StorageUSB,
+			want: "nvme",
+		},
+		{
+			name: "USB drive + legacy-only device returns sd (RPi 3/4)",
+			v:    legacyOnly,
+			st:   StorageUSB,
+			want: "sd",
+		},
+		{
+			name:     "override beats the ambiguous-USB default",
+			v:        rpi5,
+			st:       StorageUSB,
+			override: "nvme",
+			want:     "nvme",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := manifestStorage(tc.d, tc.override)
+			got := manifestStorage(tc.v, tc.st, tc.override)
 			if got != tc.want {
-				t.Errorf("manifestStorage(%+v, %q) = %q; want %q", tc.d, tc.override, got, tc.want)
+				t.Errorf("manifestStorage(%+v, %v, %q) = %q; want %q", tc.v, tc.st, tc.override, got, tc.want)
+			}
+		})
+	}
+}
+
+// End-to-end guard for the boot bug: an RPi 5 (dual-variant) target on a USB
+// reader must resolve to the SD image URL, never the NVMe one.
+func TestManifestStorage_RPi5USBResolvesSDImage(t *testing.T) {
+	dm := &deviceManifest{
+		DeviceID: "raspberry-pi-5",
+		Versions: map[string]deviceVersion{
+			"nightly": {
+				Path:     "images/rpi5/nightly/wendyos-nvme.sdimg.gz",
+				NVMEPath: "images/rpi5/nightly/wendyos-nvme.sdimg.gz",
+				SDPath:   "images/rpi5/nightly/wendyos-sd.sdimg.gz",
+			},
+		},
+	}
+	v := dm.Versions["nightly"]
+
+	storage := manifestStorage(v, StorageUSB, "")
+	if storage != "sd" {
+		t.Fatalf("manifestStorage for RPi5 USB = %q; want sd", storage)
+	}
+
+	info, err := getImageInfo(dm, "nightly", storage)
+	if err != nil {
+		t.Fatalf("getImageInfo: %v", err)
+	}
+	if !strings.HasSuffix(info.DownloadURL, "wendyos-sd.sdimg.gz") {
+		t.Errorf("resolved image = %q; want the sd image", info.DownloadURL)
+	}
+	if info.Storage != "sd" {
+		t.Errorf("imageInfo.Storage = %q; want sd", info.Storage)
+	}
+}
+
+// defaultManifestStorage drives `wendy os download`, which has no target drive.
+func TestDefaultManifestStorage(t *testing.T) {
+	cases := []struct {
+		name string
+		v    deviceVersion
+		want string
+	}{
+		{"prefers sd when an sd variant exists", deviceVersion{SDPath: "s", NVMEPath: "n"}, "sd"},
+		{"nvme when only an nvme variant exists", deviceVersion{NVMEPath: "n"}, "nvme"},
+		{"sd for legacy-only devices", deviceVersion{Path: "p"}, "sd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := defaultManifestStorage(tc.v); got != tc.want {
+				t.Errorf("defaultManifestStorage(%+v) = %q; want %q", tc.v, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

`wendy os install` could flash the **wrong image variant** onto a target drive. `manifestStorage` mapped **any USB-attached drive → the `nvme` image variant**. An SD card in a USB card reader enumerates as `StorageUSB` on every platform (the `StorageType` enum has no SD value), so an **RPi 5 SD card flashed through a USB reader** received the **NVMe image** — whose Mender u-boot env targets the `nvme` interface and `root=/dev/nvme0n1p2` — and could not boot from the SD card, even though flashing and bmap checksums succeeded.

Regressing change: `95d63153` (added `StorageUSB → "nvme"` for the Jetson-NVMe-in-USB-enclosure case).

## Fix

Resolve the ambiguous USB case from the variants the manifest version **actually publishes**, via a new `defaultManifestStorage(v)`:

- device publishes an **SD** variant → `sd` (Raspberry Pi)
- else an **NVMe** variant → `nvme` (Jetson NVMe SSD in a USB enclosure — preserves `95d63153`)
- else → `sd` (legacy single-image devices fall back to the legacy image)

A real NVMe controller (`StorageNVMe`) still resolves to `nvme`; `--storage` still overrides everything.

### Also in this PR
- **`wendy os download`** had the same defect (`storage=""` → legacy field = the NVMe image for RPi 5). It now defaults to `defaultManifestStorage`.
- **Storage-aware image cache key** (`{device}-{version}-{storage}`), so an SD and an NVMe download of the same device+version no longer collide on one cache file.

## Blast radius
- **Raspberry Pi 5** — the only device publishing both `sd` and `nvme` variants — was the one user-visibly affected.
- **RPi 3/4** publish SD-only and were correct via legacy fallback; now explicitly `sd`.
- **Jetson** (Orin Nano / AGX Orin / AGX Thor) publish NVMe-only for the dd-able flow; USB→nvme was correct and is preserved. Their eMMC/SD variants flash via tegraflash recovery, not this path.

> Note: a built-in SD reader reports `Protocol: Secure Digital` → `StorageUnknown` → `sd`, so it was already correct; this fix targets **USB card readers**, which are indistinguishable from NVMe enclosures by bus type alone.

## Tests
- `TestManifestStorage`: RPi5+USB→sd (regression), Jetson+USB→nvme (preserved), legacy-only→sd, override-wins, NVMe→nvme, Unknown→sd
- `TestManifestStorage_RPi5USBResolvesSDImage`: end-to-end — USB target resolves the **sd** image URL
- `TestDefaultManifestStorage`, storage-keyed cache-path tests
- `go build ./...`, `go vet`, `gofmt -l` all clean; full `internal/cli/commands` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)