### PR TITLE
fix: inhibit agent auto-updater during OS update

### DIFF
--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -536,6 +536,46 @@ const osUpdateUnsupportedForHostMessage = "This setup cannot be updated with wen
 // "  10%" or "50% 5120 kB" or "Installing:  75%".
 var menderProgressRe = regexp.MustCompile(`(\d{1,3})%`)
 
+// systemctlFn runs systemctl; overridable in tests.
+var systemctlFn = func(ctx context.Context, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, "systemctl", args...).CombinedOutput()
+}
+
+const (
+	updaterTimerUnit   = "wendyos-agent-updater.timer"
+	updaterServiceUnit = "wendyos-agent-updater.service"
+)
+
+// inhibitAutoUpdater stops the agent auto-updater (timer+service) and returns a
+// defer-able restore func that re-enables the timer. The updater's "systemctl
+// stop wendyos-agent" would otherwise SIGTERM in-flight mender via the shared
+// service cgroup (default KillMode=control-group) and abort the OTA.
+// Best-effort: failures are logged, not fatal.
+func inhibitAutoUpdater(logger *zap.Logger) func() {
+	sysctl := func(args ...string) ([]byte, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return systemctlFn(ctx, args...)
+	}
+	run := func(args ...string) {
+		if out, err := sysctl(args...); err != nil {
+			logger.Warn("OTA updater-inhibit: systemctl failed",
+				zap.Strings("args", args), zap.Error(err),
+				zap.String("output", strings.TrimSpace(string(out))))
+		}
+	}
+	// Hosts without the auto-updater (Jetson/QEMU) have nothing to stop — no-op
+	// instead of logging a spurious failure on every OTA. `cat` exits non-zero
+	// when the unit is absent.
+	if _, err := sysctl("cat", updaterTimerUnit); err != nil {
+		return func() {}
+	}
+	run("stop", updaterTimerUnit, updaterServiceUnit)
+	// Restore only the timer: it re-triggers the oneshot service itself, and a
+	// stopped timer re-arms on the next boot regardless.
+	return func() { run("start", updaterTimerUnit) }
+}
+
 func defaultIsWendyOSHost() bool {
 	// Older WendyOS builds did not write /etc/wendyos/device-type, so keep the
 	// version file as a compatibility marker alongside the newer device type.
@@ -642,6 +682,11 @@ func (s *AgentService) UpdateOS(req *agentpb.UpdateOSRequest, stream grpc.Server
 			},
 		})
 	}
+
+	// Stop the auto-updater so it can't SIGTERM in-flight mender mid-OTA; see
+	// inhibitAutoUpdater. Restored on return.
+	restoreUpdater := inhibitAutoUpdater(s.logger)
+	defer restoreUpdater()
 
 	sendProgress := func(phase string, percent int32) {
 		_ = stream.Send(&agentpb.UpdateOSResponse{

--- a/go/internal/agent/services/inhibit_updater_test.go
+++ b/go/internal/agent/services/inhibit_updater_test.go
@@ -1,0 +1,86 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestInhibitAutoUpdater asserts inhibit probes for the updater, stops both
+// units, and restore re-starts the timer. Why this matters: see inhibitAutoUpdater.
+func TestInhibitAutoUpdater(t *testing.T) {
+	orig := systemctlFn
+	t.Cleanup(func() { systemctlFn = orig })
+
+	var calls [][]string
+	systemctlFn = func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		return nil, nil
+	}
+
+	inhibitAutoUpdater(zap.NewNop())()
+
+	if len(calls) != 3 {
+		t.Fatalf("expected cat, stop, start (3 calls), got %d: %v", len(calls), calls)
+	}
+	if calls[0][0] != "cat" || !strings.Contains(strings.Join(calls[0], " "), "wendyos-agent-updater.timer") {
+		t.Fatalf("first call must probe the updater timer, got %v", calls[0])
+	}
+	stop := strings.Join(calls[1], " ")
+	if calls[1][0] != "stop" ||
+		!strings.Contains(stop, "wendyos-agent-updater.timer") ||
+		!strings.Contains(stop, "wendyos-agent-updater.service") {
+		t.Fatalf("stop must target the updater timer and service, got %v", calls[1])
+	}
+	if calls[2][0] != "start" ||
+		!strings.Contains(strings.Join(calls[2], " "), "wendyos-agent-updater.timer") {
+		t.Fatalf("restore must re-start the updater timer, got %v", calls[2])
+	}
+}
+
+// Absent updater (Jetson/QEMU): the cat probe fails, so inhibit is a silent
+// no-op and restore touches nothing.
+func TestInhibitAutoUpdater_NoUpdaterUnit(t *testing.T) {
+	orig := systemctlFn
+	t.Cleanup(func() { systemctlFn = orig })
+
+	var calls [][]string
+	systemctlFn = func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		if args[0] == "cat" {
+			return []byte("No files found for wendyos-agent-updater.timer."), errors.New("exit status 1")
+		}
+		return nil, nil
+	}
+
+	inhibitAutoUpdater(zap.NewNop())()
+
+	if len(calls) != 1 || calls[0][0] != "cat" {
+		t.Fatalf("absent updater must probe once and do nothing else, got %v", calls)
+	}
+}
+
+// Best-effort: a failing stop must not panic and must still return a working
+// restore that attempts to re-start the timer.
+func TestInhibitAutoUpdater_StopFailureIsBestEffort(t *testing.T) {
+	orig := systemctlFn
+	t.Cleanup(func() { systemctlFn = orig })
+
+	var calls [][]string
+	systemctlFn = func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		if args[0] == "stop" {
+			return []byte("boom"), errors.New("exit status 1")
+		}
+		return nil, nil
+	}
+
+	inhibitAutoUpdater(zap.NewNop())() // must not panic
+
+	if len(calls) != 3 || calls[2][0] != "start" {
+		t.Fatalf("stop failure must still attempt restore, got %v", calls)
+	}
+}

--- a/go/internal/agent/services/os_update_service.go
+++ b/go/internal/agent/services/os_update_service.go
@@ -35,6 +35,11 @@ func (s *OSUpdateService) UpdateOS(req *agentpbv2.UpdateOSRequest, stream grpc.S
 		})
 	}
 
+	// Stop the auto-updater so it can't SIGTERM in-flight mender mid-OTA; see
+	// inhibitAutoUpdater. Restored on return.
+	restoreUpdater := inhibitAutoUpdater(s.logger)
+	defer restoreUpdater()
+
 	sendProgress := func(phase string, percent int32) {
 		_ = stream.Send(&agentpbv2.UpdateOSResponse{
 			ResponseType: &agentpbv2.UpdateOSResponse_Progress_{


### PR DESCRIPTION
The updater's "systemctl stop wendyos-agent" SIGTERMs in-flight mender via the shared service cgroup, aborting the OTA. Pause its timer for the update.

Refs: WDY-1611