### PR TITLE
fix(agent): bluetooth entitlement fails multi-service containers (WDY-1688)

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -608,12 +608,20 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}
 	}
 
-	// Start D-Bus proxy if bluetooth entitlement is present.
+	// Start D-Bus proxy if bluetooth entitlement is present. The returned
+	// socket directory is keyed by containerName (which includes the service
+	// name for multi-service apps), so it must be threaded through to the
+	// bluetooth entitlement verbatim — reconstructing it from appID alone would
+	// drop the service suffix and runc would fail with a missing bind-mount
+	// source.
 	var dbusProxyStarted bool
+	var dbusProxySocketDir string
 	if c.proxyManager != nil && hasBluetooth(appCfg) {
-		if _, err := c.proxyManager.Start(ctx, containerName); err != nil {
+		dir, err := c.proxyManager.Start(ctx, containerName)
+		if err != nil {
 			return fmt.Errorf("starting D-Bus proxy for %q: %w", containerName, err)
 		}
+		dbusProxySocketDir = dir
 		dbusProxyStarted = true
 		defer func() {
 			if dbusProxyStarted {
@@ -708,7 +716,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	}
 
 	opts := localoci.ApplyOptions{
-		DBusProxyAvailable: c.proxyManager != nil,
+		DBusProxySocketDir: dbusProxySocketDir,
 	}
 	// Pass a shallow copy of appCfg with AppID and ServiceName set to the
 	// derived (validated) values. This ensures ApplyEntitlements always receives

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -34,11 +34,17 @@ const (
 
 // ApplyOptions configures optional behavior for entitlement application.
 type ApplyOptions struct {
-	// DBusProxyAvailable indicates that xdg-dbus-proxy is available and the
-	// caller will set up a filtered proxy socket for Bluetooth containers.
-	// When true, the bluetooth entitlement mounts from the proxy socket
-	// directory instead of the host D-Bus socket directly.
-	DBusProxyAvailable bool
+	// DBusProxySocketDir is the host directory holding the xdg-dbus-proxy
+	// filtered socket prepared for this container — the path returned by
+	// dbusproxy.Manager.Start. When non-empty, the bluetooth entitlement
+	// bind-mounts it at /var/run/dbus so the container sees an org.bluez-only
+	// D-Bus. It must be the exact directory the proxy created (which is keyed
+	// by the container name, not the bare app ID); reconstructing it from the
+	// app ID alone drops the per-service suffix and the mount source won't
+	// exist. When empty, the bluetooth entitlement adds no mount and only sets
+	// DBUS_SYSTEM_BUS_ADDRESS — mounting the raw host D-Bus socket directly
+	// would expose every system service, so it is never done.
+	DBusProxySocketDir string
 }
 
 // ApplyEntitlements modifies an OCI spec in-place based on app config entitlements.
@@ -74,7 +80,7 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 		case appconfig.EntitlementPersist:
 			applyPersist(spec, ent, cfg.AppID)
 		case appconfig.EntitlementBluetooth:
-			applyBluetooth(spec, cfg.AppID, opts.DBusProxyAvailable)
+			applyBluetooth(spec, opts.DBusProxySocketDir)
 		case appconfig.EntitlementUSB:
 			applyUSB(spec)
 		case appconfig.EntitlementI2C:
@@ -609,16 +615,18 @@ func applyPersist(spec *Spec, ent appconfig.Entitlement, appID string) {
 }
 
 // applyBluetooth adds D-Bus socket mounts for Bluetooth access.
-// When proxyAvailable is true, it mounts from the xdg-dbus-proxy filtered
-// socket directory (only org.bluez allowed). Otherwise, it falls back to
-// mounting the host D-Bus sockets directly (unrestricted access).
-func applyBluetooth(spec *Spec, appID string, proxyAvailable bool) {
-	if proxyAvailable {
+// When proxySocketDir is non-empty, it mounts that xdg-dbus-proxy filtered
+// socket directory (only org.bluez allowed) at /var/run/dbus. The directory
+// is supplied by the caller (the value dbusproxy.Manager.Start returned for
+// this container) rather than reconstructed here, so the mount source always
+// matches what the proxy actually created. When empty, it adds no mount and
+// never falls back to the raw host D-Bus sockets.
+func applyBluetooth(spec *Spec, proxySocketDir string) {
+	if proxySocketDir != "" {
 		// Mount the filtered proxy socket directory.
-		proxyDir := filepath.Join("/run/wendy/dbus-proxy", appID)
 		spec.Mounts = append(spec.Mounts, Mount{
 			Destination: "/var/run/dbus",
-			Source:      proxyDir,
+			Source:      proxySocketDir,
 			Type:        "bind",
 			Options:     []string{"rbind", "nosuid", "noexec"},
 		})

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -462,7 +462,7 @@ func TestApplyEntitlements_Bluetooth_NoProxy(t *testing.T) {
 		},
 	}
 
-	if err := ApplyEntitlements(spec, cfg, ApplyOptions{DBusProxyAvailable: false}); err != nil {
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{DBusProxySocketDir: ""}); err != nil {
 		t.Fatalf("ApplyEntitlements() error = %v", err)
 	}
 
@@ -490,7 +490,12 @@ func TestApplyEntitlements_Bluetooth_Proxy(t *testing.T) {
 		},
 	}
 
-	if err := ApplyEntitlements(spec, cfg, ApplyOptions{DBusProxyAvailable: true}); err != nil {
+	// The caller (containerd client) passes the exact directory the proxy
+	// created, keyed by container name. Here a multi-service container name is
+	// used to guard against the regression where the mount source was rebuilt
+	// from the bare app ID and dropped the service suffix (WDY-1688).
+	const proxyDir = "/run/wendy/dbus-proxy/bt-app_btscan"
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{DBusProxySocketDir: proxyDir}); err != nil {
 		t.Fatalf("ApplyEntitlements() error = %v", err)
 	}
 
@@ -504,12 +509,11 @@ func TestApplyEntitlements_Bluetooth_Proxy(t *testing.T) {
 		t.Error("bluetooth proxy should not add /run/dbus mount")
 	}
 
-	// Verify source points to proxy directory.
+	// Verify source points to the exact directory the caller supplied.
 	for _, m := range spec.Mounts {
 		if m.Destination == "/var/run/dbus" {
-			expected := "/run/wendy/dbus-proxy/bt-app"
-			if m.Source != expected {
-				t.Errorf("proxy /var/run/dbus source = %q, want %q", m.Source, expected)
+			if m.Source != proxyDir {
+				t.Errorf("proxy /var/run/dbus source = %q, want %q", m.Source, proxyDir)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

The `bluetooth` entitlement made any **multi-service** container fail to start: runc aborted init with `bind mount source stat /run/wendy/dbus-proxy/<appId>: no such file or directory`.

**Root cause — a path mismatch:**
- The dbus-proxy creates its socket dir keyed by the **container name** → `/run/wendy/dbus-proxy/<appId>_<serviceName>`.
- But `applyBluetooth` rebuilt the bind-mount source from the **appId alone** → `/run/wendy/dbus-proxy/<appId>`.

For multi-service apps those diverge, so the mount source never exists and runc fails. Single-container apps worked by accident (the two names are identical).

## Fix

Stop re-deriving the path. `dbusproxy.Manager.Start` already returns the exact dir it created; the containerd client now captures that and threads it through `ApplyOptions.DBusProxySocketDir` to the bluetooth entitlement. No more guessing → no more mismatch.

- `oci/entitlements.go` — `ApplyOptions.DBusProxyAvailable bool` → `DBusProxySocketDir string`; `applyBluetooth` mounts the supplied dir (still never falls back to the raw host D-Bus socket).
- `containerd/client.go` — capture the dir from `proxyManager.Start` and pass it through.
- `oci/entitlements_test.go` — bluetooth tests updated; proxy test now uses a service-suffixed dir (`bt-app_btscan`) as a regression guard.

## Scope

Only the bluetooth entitlement was affected — it's the only one whose mount source is provisioned by a *separate* component (the proxy) while the path was rebuilt independently. Other entitlements either create their own source inline (`persist`) or mount host paths/devices that already exist.

## Testing

- `go build`, `go vet`, and the `oci` / `containerd` / `dbusproxy` test packages all pass.
- ⏳ **Not yet verified on-device.** Needs the Linux arm64 agent side-loaded on the Jetson Orin Nano and a multi-service bluetooth app (e.g. `go2-initial-test`'s `btscan`) deployed to confirm the container starts.

Fixes WDY-1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)