### PR TITLE
fix(cli): isolate per-service buildx cache to fix ingest corruption race (WDY-1689)

### DIFF
--- a/go/internal/cli/commands/buildxcache_test.go
+++ b/go/internal/cli/commands/buildxcache_test.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildxLocalCacheDir(t *testing.T) {
+	const userCache = "/home/u/.cache"
+	base := filepath.Join(userCache, "wendy", "buildx")
+
+	tests := []struct {
+		name     string
+		cacheKey string
+		want     string
+	}{
+		{"empty key uses shared base dir", "", base},
+		{"service key gets isolated subdir", "myapp-gpu", filepath.Join(base, "myapp-gpu")},
+		{"distinct services get distinct dirs", "myapp-vui", filepath.Join(base, "myapp-vui")},
+		{"unsafe chars are sanitized", "My/App:1", filepath.Join(base, "my-app-1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildxLocalCacheDir(userCache, tt.cacheKey); got != tt.want {
+				t.Fatalf("buildxLocalCacheDir(%q) = %q, want %q", tt.cacheKey, got, tt.want)
+			}
+		})
+	}
+
+	// The core WDY-1689 invariant: two different concurrent service builds never
+	// resolve to the same local cache dir.
+	a := buildxLocalCacheDir(userCache, "app-a")
+	b := buildxLocalCacheDir(userCache, "app-b")
+	if a == b {
+		t.Fatalf("distinct cache keys collided on %q", a)
+	}
+}

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -653,7 +653,9 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		}
 
 		repo := fmt.Sprintf("%s-%s", projectName, name)
-		if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, ctxDir, repo, platform, dockerfile, allBuildArgs, os.Stdout, os.Stderr); err != nil {
+		// Compose builds run sequentially, so they share the local cache dir
+		// (empty cache key) — no concurrent cache-export race to isolate.
+		if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, ctxDir, repo, platform, dockerfile, allBuildArgs, "", os.Stdout, os.Stderr); err != nil {
 			return fmt.Errorf("building service %s: %w", name, err)
 		}
 		cliLogln("Service %s image built and pushed.", name)

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -546,7 +546,7 @@ func injectDebugpy(ctx context.Context, registryAddr, registryImage, platform st
 		return fmt.Errorf("writing debugpy Dockerfile: %w", err)
 	}
 
-	return buildAndPushImage(ctx, tmpDir, registryAddr, registryImage, platform, "", buildArgs, streamOutput, streamOutput, useMTLS)
+	return buildAndPushImage(ctx, tmpDir, registryAddr, registryImage, platform, "", buildArgs, "", streamOutput, streamOutput, useMTLS)
 }
 
 func generatePythonDockerfile(dir string, debug bool) (string, error) {
@@ -1323,7 +1323,22 @@ func updateBuilderConfig(ctx context.Context, builderName, config string, w io.W
 	return nil
 }
 
-func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {
+// buildxLocalCacheDir returns the local buildx cache directory
+// (--cache-to/--cache-from type=local) for a build. A non-empty cacheKey gives
+// the build its own isolated subdir so concurrent multi-service builds never
+// share one cache dir — BuildKit's local cache-export ingest store is not safe
+// for concurrent writers and parallel builds clobber each other's temp files
+// (WDY-1689). An empty cacheKey uses the shared base dir so single and
+// sequential builds keep their cross-run cache.
+func buildxLocalCacheDir(userCache, cacheKey string) string {
+	dir := filepath.Join(userCache, "wendy", "buildx")
+	if cacheKey != "" {
+		dir = filepath.Join(dir, sanitizeAppleContainerTag(cacheKey))
+	}
+	return dir
+}
+
+func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer, useMTLS bool) error {
 	// Serialize against other wendy processes: the buildx builder is shared, and
 	// reconfiguring or restarting it mid-build kills a concurrent build (#1017).
 	// Concurrent builds within this process share the lock via reference counting.
@@ -1350,7 +1365,7 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 	if err != nil {
 		return fmt.Errorf("finding user cache directory: %w", err)
 	}
-	cacheDir := filepath.Join(userCache, "wendy", "buildx")
+	cacheDir := buildxLocalCacheDir(userCache, cacheKey)
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return fmt.Errorf("creating cache directory: %w", err)
 	}
@@ -1458,14 +1473,14 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 	return nil
 }
 
-func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {
+func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer, useMTLS bool) error {
 	normalized, err := normalizeImageBuilder(builder)
 	if err != nil {
 		return err
 	}
 	switch normalized {
 	case imageBuilderDocker:
-		return buildAndPushImage(ctx, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
+		return buildAndPushImage(ctx, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput, useMTLS)
 	case imageBuilderAppleContainer:
 		return buildAndPushImageWithAppleContainer(ctx, dir, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
 	default:
@@ -1473,24 +1488,26 @@ func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAdd
 	}
 }
 
-func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer) error {
+func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer) error {
 	if _, err := normalizeImageBuilder(builder); err != nil {
 		return err
 	}
 	if imageBuilderWasExplicit(builder) {
-		return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, builder, dir, repo, platform, dockerfile, buildArgs, streamOutput, logOutput)
+		return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, builder, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput)
 	}
 	if shouldAutoAttemptAppleContainerBuilder() {
-		if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, streamOutput, logOutput); err == nil {
+		// Apple Container builds don't use buildx, so the local-cache key never
+		// applies; only the Docker fallback below consumes it.
+		if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, "", streamOutput, logOutput); err == nil {
 			return nil
 		} else {
 			logAppleContainerFallback(logOutput, err)
 		}
 	}
-	return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderDocker, dir, repo, platform, dockerfile, buildArgs, streamOutput, logOutput)
+	return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderDocker, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput)
 }
 
-func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer) error {
+func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer) error {
 	normalized, err := normalizeImageBuilder(builder)
 	if err != nil {
 		return err
@@ -1503,7 +1520,7 @@ func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.
 
 	registryImage := fmt.Sprintf("%s/%s:latest", registryAddr, strings.ToLower(repo))
 	cliLogln("Building and pushing image with %s for %s...", imageBuilderDisplayName(normalized), platform)
-	return buildAndPushImageWithBuilder(ctx, normalized, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
+	return buildAndPushImageWithBuilder(ctx, normalized, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput, useMTLS)
 }
 
 func buildAndPushImageWithAppleContainer(ctx context.Context, dir, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -76,6 +76,7 @@ func TestBuildAndPushImageWithAppleContainerUsesContainerCLI(t *testing.T) {
 		"linux/arm64",
 		"Dockerfile",
 		map[string]string{"B": "2", "A": "1"},
+		"",
 		io.Discard,
 		io.Discard,
 		false,

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -243,7 +243,10 @@ func buildServicesParallel(
 			}
 			err := dockerfileErr
 			if err == nil {
-				err = buildAndPushImageForAgent(ctx, conn, regPort, builder, contextDir, repo, platform, dockerfile, buildArgs, buildOut, logOut)
+				// Pass the per-service repo as the build's cache key so each concurrent
+				// build gets its own isolated local buildx cache dir (WDY-1689); sharing
+				// one dir corrupts BuildKit's cache-export ingest store under concurrency.
+				err = buildAndPushImageForAgent(ctx, conn, regPort, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOut)
 			}
 			dur := time.Since(start)
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1412,7 +1412,9 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// Build and push the Docker image directly to the device's registry.
 	regPort := registryPort(agentOS)
 	repo := strings.ToLower(appCfg.AppID)
-	if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, os.Stdout, os.Stderr); err != nil {
+	// Single-service build: no concurrency, so keep the shared local cache dir
+	// (empty cache key) for cross-run cache reuse.
+	if err := buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, "", os.Stdout, os.Stderr); err != nil {
 		return fmt.Errorf("building and pushing image: %w", err)
 	}
 	cliLogln("Build and push completed.")


### PR DESCRIPTION
## Summary

Fixes [WDY-1689](https://linear.app/wendylabsinc/issue/WDY-1689) (Bug A of [WDY-1687](https://linear.app/wendylabsinc/issue/WDY-1687)).

Concurrent multi-service `wendy run` builds all pointed buildx at the **same** local cache dir (`~/Library/Caches/wendy/buildx`) for `--cache-to`/`--cache-from`. BuildKit's local cache-export ingest store is **not safe for concurrent writers**, so parallel builds (up to `maxConcurrentBuilds`=4) clobber each other's temp files and fail intermittently — a different service each run:

```
ERROR: error writing layer blob: rename .../buildx/ingest/<hash>/startedat.tmp .../startedat: no such file or directory
```

## Fix

Thread a `cacheKey` through the build/push chain (`buildAndPushImage` → `…WithBuilder` → `…ForAgent` → `…ForAgentWithBuilder`). The parallel multibuild path passes each service's `repo` as the key, so every concurrent build gets its **own** isolated cache subdir (`…/buildx/<service>`). Single-service (`run.go`) and sequential Compose (`compose.go`) builds pass an empty key and keep the shared base dir for cross-run cache reuse.

The single buildkitd **content store stays shared**, so common base layers (e.g. the 10 GB `gpu` image) are still pulled once — no per-builder duplication.

## Why not the builder pool (#1073)?

#1073 (WDY-1554) solves the same race with a pool of fully isolated buildkitd containers + caches. That removes both the shared ingest store and the shared cache dir, but forces every concurrent build to pull/store base layers independently (the 10 GB `gpu` image stored up to 4×) and adds significant lifecycle machinery. The proven error path points squarely at the local **cache-export** dir, so this lighter, ~60-line fix targets the actual cause while keeping base-layer reuse. #1073 remains the documented fallback if buildkitd's internal store also turns out to race.

## Testing

- `go build`, `go vet`, `gofmt`, full `commands` package tests (incl. `-race`) — clean.
- New unit test (`buildxcache_test.go`) covering the cache-dir helper and the core invariant: distinct services never resolve to the same cache dir.
- **Verified end-to-end on a real Jetson Orin Nano (WendyOS-0.15.2, arm64).** Deployed an identical 4-service group with both binaries:
  - **main:** one shared `buildx/ingest/` dir (the raced resource).
  - **this branch:** four per-service dirs, each with its **own** `ingest/` — `…cachecheck-{alpha,bravo,charlie,delta}/`.
  Both deploys completed with zero ingest/rename errors; the per-service layout is the structural guarantee the shared-ingest race is eliminated.

Scope: Bug A only. Bugs B–E are tracked separately (WDY-1690…1693).

🤖 Generated with [Claude Code](https://claude.com/claude-code)