### PR TITLE
fix(cli): retry transient registry pushes + throttle large groups (WDY-1690)

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1449,14 +1449,11 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 		".",
 	)
 
-	fmt.Fprintf(logOutput, "[buildx] starting build: docker %s\n", strings.Join(redactBuildArgsForLog(args), " "))
-	cmd := exec.CommandContext(ctx, "docker", args...)
-	cmd.Dir = dir
-	cmd.Stdout = streamOutput
-	cmd.Stderr = streamOutput
+	// Build the command environment once; it is reused across retry attempts.
 	// On macOS/Linux, override DOCKER_CONFIG so the buildx client does not
 	// call the host credential helper when setting up the build session.
 	// On Windows we leave DOCKER_CONFIG untouched (cleanDockerConfigDir == "").
+	var cmdEnv []string
 	if cleanDockerConfigDir != "" {
 		baseEnv := make([]string, 0, len(os.Environ()))
 		for _, e := range os.Environ() {
@@ -1464,14 +1461,91 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 				baseEnv = append(baseEnv, e)
 			}
 		}
-		cmd.Env = append(baseEnv, "DOCKER_CONFIG="+cleanDockerConfigDir)
+		cmdEnv = append(baseEnv, "DOCKER_CONFIG="+cleanDockerConfigDir)
 	}
 
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker buildx build failed: %w", err)
+	fmt.Fprintf(logOutput, "[buildx] starting build: docker %s\n", strings.Join(redactBuildArgsForLog(args), " "))
+
+	// Build and push, retrying transient registry/push failures. Images push to
+	// the device registry through one shared mTLS tunnel; under concurrent
+	// multi-service load it can briefly collapse (TLS handshake timeouts on even
+	// cheap blob HEADs) and buildkit reports the whole build as failed though the
+	// device is healthy (WDY-1690). A retry is cheap: the build is a cache hit and
+	// buildkit re-pushes only the blobs that did not make it.
+	var lastErr error
+	for attempt := 1; attempt <= maxBuildPushAttempts; attempt++ {
+		capture := &capturingWriter{w: streamOutput}
+		cmd := exec.CommandContext(ctx, "docker", args...)
+		cmd.Dir = dir
+		cmd.Stdout = capture
+		cmd.Stderr = capture
+		if cmdEnv != nil {
+			cmd.Env = cmdEnv
+		}
+
+		err := cmd.Run()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		// Don't retry on cancellation, on the final attempt, or for errors that
+		// don't look like a transient registry/push hiccup (a real build failure
+		// would just fail again and waste time).
+		if ctx.Err() != nil || attempt >= maxBuildPushAttempts || !isTransientPushError(capture.String()) {
+			break
+		}
+		backoff := buildPushRetryBackoff(attempt)
+		fmt.Fprintf(logOutput, "[buildx] transient registry/push error; retrying in %s (attempt %d/%d)\n", backoff, attempt+1, maxBuildPushAttempts)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("docker buildx build failed: %w", lastErr)
+		case <-time.After(backoff):
+		}
 	}
-	return nil
+	return fmt.Errorf("docker buildx build failed: %w", lastErr)
 }
+
+// maxBuildPushAttempts bounds how many times a fused buildx build+push is retried
+// on a transient registry/push failure (WDY-1690).
+const maxBuildPushAttempts = 3
+
+// buildPushRetryBackoff returns the wait before retry N+1 (2s, 4s). The tunnel
+// recovers quickly once concurrent push pressure drops, so a short linear backoff
+// is enough.
+func buildPushRetryBackoff(attempt int) time.Duration {
+	return time.Duration(attempt) * 2 * time.Second
+}
+
+// transientPushErrorRe matches buildkit output for registry/push failures that
+// are worth retrying — the device-registry tunnel collapsing under concurrent
+// pushes surfaces as TLS handshake timeouts and push failures, not as a genuine
+// build error (WDY-1690).
+var transientPushErrorRe = regexp.MustCompile(`(?i)(tls handshake timeout|failed to push|failed to do request|connection reset by peer|i/o timeout|unexpected eof|503 service unavailable|429 too many requests)`)
+
+func isTransientPushError(output string) bool {
+	return transientPushErrorRe.MatchString(output)
+}
+
+// capturingWriter tees writes to an underlying writer while retaining the last
+// maxCaptureBytes bytes, so a failed build's tail can be classified for the
+// push-retry path (WDY-1690) without buffering the entire (large) build log.
+type capturingWriter struct {
+	w   io.Writer
+	buf []byte
+}
+
+const maxCaptureBytes = 64 << 10
+
+func (c *capturingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.buf = append(c.buf, p[:n]...)
+	if len(c.buf) > maxCaptureBytes {
+		c.buf = append([]byte(nil), c.buf[len(c.buf)-maxCaptureBytes:]...)
+	}
+	return n, err
+}
+
+func (c *capturingWriter) String() string { return string(c.buf) }
 
 func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer, useMTLS bool) error {
 	normalized, err := normalizeImageBuilder(builder)

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1520,7 +1520,7 @@ func buildPushRetryBackoff(attempt int) time.Duration {
 // are worth retrying — the device-registry tunnel collapsing under concurrent
 // pushes surfaces as TLS handshake timeouts and push failures, not as a genuine
 // build error (WDY-1690).
-var transientPushErrorRe = regexp.MustCompile(`(?i)(tls handshake timeout|failed to push|failed to do request|connection reset by peer|i/o timeout|unexpected eof|503 service unavailable|429 too many requests)`)
+var transientPushErrorRe = regexp.MustCompile(`(?i)(tls handshake timeout|failed to push|failed to do request|connection reset by peer|i/o timeout|unexpected eof|broken pipe|write: connection timed out|503 service unavailable|429 too many requests)`)
 
 func isTransientPushError(output string) bool {
 	return transientPushErrorRe.MatchString(output)

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -24,7 +24,36 @@ import (
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
-const maxConcurrentBuilds = 4
+const (
+	maxConcurrentBuilds = 4
+
+	// Builds and pushes are fused in one buildx invocation, so build concurrency
+	// also bounds how many multi-GB images push through the single device-registry
+	// mTLS tunnel at once. Large groups (e.g. the 14-service go2 template, with a
+	// ~10 GB GPU image) collapse that tunnel under full fan-out, so groups at or
+	// above largeGroupThreshold are throttled to largeGroupConcurrency concurrent
+	// builds (WDY-1690). This is a heuristic default; an explicit --max-concurrency
+	// override is tracked separately (WDY-1693).
+	largeGroupThreshold   = 8
+	largeGroupConcurrency = 2
+)
+
+// multiBuildConcurrency returns how many service images to build+push at once for
+// a group of numServices, throttling large groups to protect the shared device
+// registry tunnel (WDY-1690).
+func multiBuildConcurrency(numServices int) int {
+	n := maxConcurrentBuilds
+	if numServices >= largeGroupThreshold {
+		n = largeGroupConcurrency
+	}
+	if n > numServices {
+		n = numServices
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
 
 func resolveServiceSubset(services map[string]*appconfig.ServiceConfig, only string) (map[string]*appconfig.ServiceConfig, error) {
 	if only == "" {
@@ -200,7 +229,12 @@ func buildServicesParallel(
 	}
 
 	results := make(chan result, len(names))
-	sem := make(chan struct{}, maxConcurrentBuilds)
+
+	concurrency := multiBuildConcurrency(len(names))
+	if concurrency < maxConcurrentBuilds && concurrency < len(names) {
+		cliLogln("Throttling to %d concurrent builds for %d services to protect the device registry tunnel (WDY-1690).", concurrency, len(names))
+	}
+	sem := make(chan struct{}, concurrency)
 
 	var prog *tea.Program
 	if isInteractiveTerminal() {

--- a/go/internal/cli/commands/pushretry_test.go
+++ b/go/internal/cli/commands/pushretry_test.go
@@ -9,6 +9,8 @@ func TestIsTransientPushError(t *testing.T) {
 		`error: read tcp 127.0.0.1->...: connection reset by peer`,
 		`dial tcp: i/o timeout`,
 		`unexpected EOF`,
+		`error: write tcp 127.0.0.1:50342->127.0.0.1:64880: write: broken pipe ; retrying in 1s`,
+		`write: connection timed out`,
 		`received unexpected HTTP status: 503 Service Unavailable`,
 		`429 Too Many Requests`,
 	}

--- a/go/internal/cli/commands/pushretry_test.go
+++ b/go/internal/cli/commands/pushretry_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import "testing"
+
+func TestIsTransientPushError(t *testing.T) {
+	transient := []string{
+		`Head "https://host.docker.internal:50342/v2/x/blobs/sha256:ab": net/http: TLS handshake timeout`,
+		`ERROR: failed to solve: failed to push host.docker.internal:50342/app:latest: failed to do request`,
+		`error: read tcp 127.0.0.1->...: connection reset by peer`,
+		`dial tcp: i/o timeout`,
+		`unexpected EOF`,
+		`received unexpected HTTP status: 503 Service Unavailable`,
+		`429 Too Many Requests`,
+	}
+	for _, s := range transient {
+		if !isTransientPushError(s) {
+			t.Errorf("expected transient for %q", s)
+		}
+	}
+
+	notTransient := []string{
+		``,
+		`ERROR: failed to solve: process "/bin/sh -c go build" did not complete successfully: exit code: 1`,
+		`Dockerfile:5: COPY failed: file not found`,
+		`undefined: someSymbol`,
+	}
+	for _, s := range notTransient {
+		if isTransientPushError(s) {
+			t.Errorf("did not expect transient for %q", s)
+		}
+	}
+}
+
+func TestMultiBuildConcurrency(t *testing.T) {
+	tests := []struct {
+		numServices int
+		want        int
+	}{
+		{0, 1},  // floor of 1
+		{1, 1},  // capped to numServices
+		{3, 3},  // small group, below default cap
+		{4, 4},  // at default cap
+		{7, 4},  // still default cap just under large threshold
+		{8, 2},  // large group -> throttled
+		{14, 2}, // the go2 template -> throttled
+	}
+	for _, tt := range tests {
+		if got := multiBuildConcurrency(tt.numServices); got != tt.want {
+			t.Errorf("multiBuildConcurrency(%d) = %d, want %d", tt.numServices, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [WDY-1690](https://linear.app/wendylabsinc/issue/WDY-1690) (Bug B of [WDY-1687](https://linear.app/wendylabsinc/issue/WDY-1687)).

**Stacked on #1097 (WDY-1689).** Base will retarget to `main` once #1097 merges.

Multi-service images push to the device registry through one shared `host.docker.internal:<port>` mTLS tunnel. Under full concurrent fan-out, large groups (the 14-service go2 template, with a ~10 GB GPU image) collapse the tunnel: even cheap blob `HEAD`s fail with `net/http: TLS handshake timeout`, buildkit's internal retry gives up, and the build is reported failed though the device is healthy.

## Fix

Two mitigations, both within the existing fused buildx build+push path:

- **Retry-with-backoff** (2s → 4s; 3 attempts) around the buildx invocation when the captured output matches a transient registry/push error (`TLS handshake timeout`, `failed to push`, `connection reset by peer`, `i/o timeout`, `503`/`429`, …). A retry is cheap: the build is a cache hit and buildkit re-pushes only the blobs that didn't make it. Genuine build failures and cancellation (Ctrl+C) are **not** retried. Output is captured via a capped (64 KB) tee so the large build log isn't buffered.
- **Auto-throttle**: groups at/above `largeGroupThreshold` (8) build at `largeGroupConcurrency` (2) instead of `maxConcurrentBuilds` (4), bounding how many multi-GB pushes hit the tunnel at once (the 14-service group → 2). Heuristic default; an explicit `--max-concurrency` override is tracked as [WDY-1693](https://linear.app/wendylabsinc/issue/WDY-1693).

Synergy with #1097: the cheap cached retries rely on each service having its own isolated local buildx cache (per-service cache dirs from the Bug A fix).

## Testing

- `go build`, `go vet`, `gofmt`, full `commands` package tests (incl. `-race`) — clean.
- New `pushretry_test.go`: transient-error classification (with a false-positive guard so real build failures aren't retried) and the concurrency-throttle table (≥8 services → 2; ≤7 → 4; floors/caps).
- Not yet exercised under a live tunnel collapse on hardware — that needs the heavy 14-service `gpu` load over the slow link; the retry/throttle logic itself is unit-covered.

Scope: Bug B only. A is #1097; C–E remain WDY-1691…1693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)