### PR TITLE
feat(cli): --keep-going partial group deploy instead of all-or-nothing (WDY-1691)

### DIFF
--- a/go/internal/cli/commands/deploypartial_test.go
+++ b/go/internal/cli/commands/deploypartial_test.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func keysOf(m map[string]*appconfig.ServiceConfig) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestResolveDeployableServices(t *testing.T) {
+	// a -> b -> c (a depends on b depends on c); d standalone.
+	services := map[string]*appconfig.ServiceConfig{
+		"a": {DependsOn: []string{"b"}},
+		"b": {DependsOn: []string{"c"}},
+		"c": {},
+		"d": {},
+	}
+
+	t.Run("no failures: all deployable", func(t *testing.T) {
+		dep, dropped := resolveDeployableServices(services, map[string]error{})
+		if got := keysOf(dep); !reflect.DeepEqual(got, []string{"a", "b", "c", "d"}) {
+			t.Fatalf("deployable = %v", got)
+		}
+		if len(dropped) != 0 {
+			t.Fatalf("dropped = %v", dropped)
+		}
+	})
+
+	t.Run("leaf failure cascades to dependents", func(t *testing.T) {
+		// c failed -> b and a can't deploy (dependency); d unaffected.
+		dep, dropped := resolveDeployableServices(services, map[string]error{"c": errors.New("boom")})
+		if got := keysOf(dep); !reflect.DeepEqual(got, []string{"d"}) {
+			t.Fatalf("deployable = %v, want [d]", got)
+		}
+		// a and b are dropped due to dependency; c is failed (not in dropped).
+		if _, ok := dropped["a"]; !ok {
+			t.Errorf("expected a dropped (failed dependency)")
+		}
+		if _, ok := dropped["b"]; !ok {
+			t.Errorf("expected b dropped (failed dependency)")
+		}
+		if _, ok := dropped["c"]; ok {
+			t.Errorf("c failed itself; must not appear in dropped: %v", dropped)
+		}
+	})
+
+	t.Run("independent failure does not affect others", func(t *testing.T) {
+		dep, dropped := resolveDeployableServices(services, map[string]error{"d": errors.New("boom")})
+		if got := keysOf(dep); !reflect.DeepEqual(got, []string{"a", "b", "c"}) {
+			t.Fatalf("deployable = %v, want [a b c]", got)
+		}
+		if len(dropped) != 0 {
+			t.Fatalf("dropped = %v, want none", dropped)
+		}
+	})
+}
+
+func TestJoinServiceErrorsStableOrder(t *testing.T) {
+	failed := map[string]error{
+		"zeta":  errors.New("z"),
+		"alpha": errors.New("a"),
+	}
+	if got := sortedServiceErrorKeys(failed); !reflect.DeepEqual(got, []string{"alpha", "zeta"}) {
+		t.Fatalf("sortedServiceErrorKeys = %v", got)
+	}
+	if joinServiceErrors(failed) == nil {
+		t.Fatal("expected non-nil joined error")
+	}
+}

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -239,14 +239,16 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Build all service images in parallel, then create and start containers.
-	if err := buildServicesParallel(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip); err != nil {
-		return err
+	failed, buildErr := buildServicesParallel(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip)
+	if buildErr != nil {
+		return buildErr
 	}
 
 	// Record fingerprints for the services we actually built+pushed, so the next
-	// run can skip them. Skipped services already have a matching fingerprint.
+	// run can skip them. Skipped services already have a matching fingerprint;
+	// failed services must not be recorded (their image isn't on the device).
 	for name := range services {
-		if skip[name] {
+		if skip[name] || failed[name] != nil {
 			continue
 		}
 		if h, ok := hashes[name]; ok {
@@ -254,8 +256,33 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 		}
 	}
 
+	// Default (all-or-nothing): any build/push failure aborts the whole group so
+	// no half-deployed group is left behind. --keep-going deploys what built and
+	// reports the rest (WDY-1691).
+	if len(failed) > 0 && !opts.keepGoing {
+		return joinServiceErrors(failed)
+	}
+
+	// Determine which services can actually be deployed: those that built and
+	// whose dependencies all built too. partialErr is surfaced at the end so the
+	// command still exits non-zero after deploying the healthy subset.
+	deployServices := services
+	var partialErr error
+	if len(failed) > 0 {
+		deployable, dropped := resolveDeployableServices(services, failed)
+		deployServices = deployable
+		cliNotice("Partial deploy: %d deploying, %d failed (%s)%s.",
+			len(deployable), len(failed), strings.Join(sortedServiceErrorKeys(failed), ", "),
+			droppedSummary(dropped))
+		partialErr = joinServiceErrors(failed)
+		if len(deployable) == 0 {
+			cliNotice("No services left to deploy.")
+			return partialErr
+		}
+	}
+
 	// Create (and start) containers in dependency order.
-	ordered, err := serviceTopoOrder(services)
+	ordered, err := serviceTopoOrder(deployServices)
 	if err != nil {
 		return err
 	}
@@ -297,7 +324,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 			}
 		}
 		cliLogln("App group %s created (not started, --deploy).", appCfg.AppID)
-		return nil
+		return partialErr
 	}
 
 	// Create and start each service in dependency order, multiplexing log
@@ -306,7 +333,26 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	// namespace join is resolved at container create time against the
 	// primary's running task, so the primary must be started before the
 	// next service is created.
-	return startAndStreamServices(ctx, conn, appCfg.AppID, ordered, opts, createService)
+	if err := startAndStreamServices(ctx, conn, appCfg.AppID, ordered, opts, createService); err != nil {
+		return err
+	}
+	// In --keep-going mode, exit non-zero after deploying the healthy subset so
+	// callers/CI still see that some services failed.
+	return partialErr
+}
+
+// droppedSummary formats the services skipped because a dependency failed, for
+// the partial-deploy notice. Returns "" when nothing was dropped.
+func droppedSummary(dropped map[string]string) string {
+	if len(dropped) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(dropped))
+	for n := range dropped {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return fmt.Sprintf(", %d skipped (failed dependency: %s)", len(names), strings.Join(names, ", "))
 }
 
 // buildServicesParallel builds all service images concurrently (up to
@@ -324,7 +370,7 @@ func buildServicesParallel(
 	buildArgs map[string]string,
 	builder string,
 	skip map[string]bool,
-) error {
+) (map[string]error, error) {
 	names := make([]string, 0, len(services))
 	for n := range services {
 		names = append(names, n)
@@ -438,25 +484,96 @@ func buildServicesParallel(
 
 	if prog != nil {
 		if _, runErr := prog.Run(); runErr != nil {
-			return fmt.Errorf("build progress TUI: %w", runErr)
+			return nil, fmt.Errorf("build progress TUI: %w", runErr)
 		}
 	}
 
-	// Collect errors. For failed services, print their buffered output now that
-	// the spinner has exited and the terminal is clean.
-	var errs []error
+	// Collect per-service failures. For failed services, print their buffered
+	// output now that the spinner has exited and the terminal is clean. The caller
+	// decides whether any failure aborts the group (default) or only its own
+	// service is dropped (--keep-going, WDY-1691).
+	failed := map[string]error{}
 	for r := range results {
 		if r.err != nil {
-			errs = append(errs, fmt.Errorf("service %s: %w", r.name, r.err))
+			failed[r.name] = r.err
 			if r.log != "" {
 				fmt.Fprintf(os.Stderr, "\n[%s] build log:\n%s", r.name, r.log)
 			}
 		}
 	}
-	if len(errs) > 0 {
-		return errors.Join(errs...)
+	return failed, nil
+}
+
+// sortedServiceErrorKeys returns the service names in failed, sorted, for stable
+// error/report output.
+func sortedServiceErrorKeys(failed map[string]error) []string {
+	names := make([]string, 0, len(failed))
+	for n := range failed {
+		names = append(names, n)
 	}
-	return nil
+	sort.Strings(names)
+	return names
+}
+
+// joinServiceErrors builds a single error from a per-service failure map, in
+// stable order.
+func joinServiceErrors(failed map[string]error) error {
+	var errs []error
+	for _, n := range sortedServiceErrorKeys(failed) {
+		errs = append(errs, fmt.Errorf("service %s: %w", n, failed[n]))
+	}
+	return errors.Join(errs...)
+}
+
+// resolveDeployableServices returns the subset of services that can be deployed:
+// those that built successfully and whose (transitive) dependencies all built
+// successfully too. dropped maps each service that is skipped *because of a failed
+// dependency* (not its own failure) to a human-readable reason. Failed services
+// are reported separately via the failed map. A dependency cycle is treated as
+// not deployable (serviceTopoOrder reports the cycle itself).
+func resolveDeployableServices(services map[string]*appconfig.ServiceConfig, failed map[string]error) (deployable map[string]*appconfig.ServiceConfig, dropped map[string]string) {
+	deployable = map[string]*appconfig.ServiceConfig{}
+	dropped = map[string]string{}
+
+	const (
+		unknown  = 0
+		yes      = 1
+		no       = 2
+		visiting = 3
+	)
+	state := map[string]int{}
+
+	var canDeploy func(name string) bool
+	canDeploy = func(name string) bool {
+		switch state[name] {
+		case yes:
+			return true
+		case no, visiting:
+			return false
+		}
+		state[name] = visiting
+		svc, ok := services[name]
+		if !ok || svc == nil || failed[name] != nil {
+			state[name] = no
+			return false
+		}
+		for _, dep := range svc.DependsOn {
+			if !canDeploy(dep) {
+				state[name] = no
+				dropped[name] = fmt.Sprintf("dependency %q was not deployed", dep)
+				return false
+			}
+		}
+		state[name] = yes
+		return true
+	}
+
+	for name := range services {
+		if canDeploy(name) {
+			deployable[name] = services[name]
+		}
+	}
+	return deployable, dropped
 }
 
 var serviceLogStyle = lipgloss.NewStyle().Foreground(tui.ColorInfo)

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -475,6 +475,7 @@ type runOptions struct {
 	prefix               string
 	product              string
 	service              string
+	keepGoing            bool
 	userArgs             []string
 	// quietBuild suppresses the image build (buildx) output, surfacing it only
 	// when the build fails. Set by `wendy watch` to keep the redeploy loop quiet.
@@ -506,6 +507,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.prefix, "prefix", "", "Project directory to run from instead of the current working directory")
 	cmd.Flags().StringVar(&opts.product, "product", "", "Swift Package Manager product to build and run")
 	cmd.Flags().StringVar(&opts.service, "service", "", "Build and run only the named service and its dependencies (multi-service projects)")
+	cmd.Flags().BoolVar(&opts.keepGoing, "keep-going", false, "Multi-service: deploy services that build successfully instead of aborting the whole group on the first build/push failure")
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
 
 	return cmd


### PR DESCRIPTION
## Summary
Fixes [WDY-1691](https://linear.app/wendylabsinc/issue/WDY-1691) (Bug C of [WDY-1687](https://linear.app/wendylabsinc/issue/WDY-1687)). **Stacked on #1092-D → #1098 (B) → #1097 (A).**

A single service build/push failure aborted the entire multi-service group — none of the healthy services started, even when most built fine.

## Fix
New **`--keep-going`** flag. `buildServicesParallel` now returns a per-service failure map (plus a separate infra error) instead of a joined error, so the caller decides:
- **Default** (unchanged): any failure returns the joined error and nothing deploys.
- **`--keep-going`**: deploy the services that built, and skip any whose (transitive) dependency failed (`resolveDeployableServices`). A partial-deploy notice reports failed + dependency-skipped services. The command still exits non-zero after deploying the healthy subset, so CI/scripts see the failure.

Fingerprints (Bug D) are saved only for services that actually built. Scope: build/push failures; create/start failures still abort (namespace-join ordering is load-bearing).

## Testing
build/vet/gofmt/`-race` clean; unit tests for `resolveDeployableServices` (no-failure, cascade-to-dependents, independent-failure) and error ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)