### PR TITLE
feat(cli): --max-concurrency flag to override build+push throttle (WDY-1693)

### DIFF
--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -32,15 +32,15 @@ const (
 	// mTLS tunnel at once. Large groups (e.g. the 14-service go2 template, with a
 	// ~10 GB GPU image) collapse that tunnel under full fan-out, so groups at or
 	// above largeGroupThreshold are throttled to largeGroupConcurrency concurrent
-	// builds (WDY-1690). This is a heuristic default; an explicit --max-concurrency
-	// override is tracked separately (WDY-1693).
+	// builds (WDY-1690). This is the heuristic default; users can override it with
+	// --max-concurrency (WDY-1693).
 	largeGroupThreshold   = 8
 	largeGroupConcurrency = 2
 )
 
-// multiBuildConcurrency returns how many service images to build+push at once for
-// a group of numServices, throttling large groups to protect the shared device
-// registry tunnel (WDY-1690).
+// multiBuildConcurrency returns the auto (heuristic) number of service images to
+// build+push at once for a group of numServices, throttling large groups to
+// protect the shared device registry tunnel (WDY-1690).
 func multiBuildConcurrency(numServices int) int {
 	n := maxConcurrentBuilds
 	if numServices >= largeGroupThreshold {
@@ -48,6 +48,27 @@ func multiBuildConcurrency(numServices int) int {
 	}
 	if n > numServices {
 		n = numServices
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// resolveBuildConcurrency returns the effective build+push concurrency for
+// buildCount services. A positive override (--max-concurrency, WDY-1693) takes
+// precedence over the auto heuristic; either way the result is clamped to
+// [1, buildCount].
+func resolveBuildConcurrency(buildCount, override int) int {
+	if buildCount < 1 {
+		return 1
+	}
+	n := multiBuildConcurrency(buildCount)
+	if override > 0 {
+		n = override
+	}
+	if n > buildCount {
+		n = buildCount
 	}
 	if n < 1 {
 		n = 1
@@ -239,7 +260,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Build all service images in parallel, then create and start containers.
-	failed, buildErr := buildServicesParallel(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip)
+	failed, buildErr := buildServicesParallel(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip, opts.maxConcurrency)
 	if buildErr != nil {
 		return buildErr
 	}
@@ -370,6 +391,7 @@ func buildServicesParallel(
 	buildArgs map[string]string,
 	builder string,
 	skip map[string]bool,
+	maxConcurrency int,
 ) (map[string]error, error) {
 	names := make([]string, 0, len(services))
 	for n := range services {
@@ -394,9 +416,12 @@ func buildServicesParallel(
 			buildCount++
 		}
 	}
-	concurrency := multiBuildConcurrency(buildCount)
-	if concurrency < maxConcurrentBuilds && concurrency < buildCount {
-		cliLogln("Throttling to %d concurrent builds for %d services to protect the device registry tunnel (WDY-1690).", concurrency, buildCount)
+	concurrency := resolveBuildConcurrency(buildCount, maxConcurrency)
+	switch {
+	case maxConcurrency > 0 && concurrency < buildCount:
+		cliLogln("Building up to %d service(s) at a time (--max-concurrency).", concurrency)
+	case maxConcurrency <= 0 && concurrency < maxConcurrentBuilds && concurrency < buildCount:
+		cliLogln("Throttling to %d concurrent builds for %d services to protect the device registry tunnel (WDY-1690); override with --max-concurrency.", concurrency, buildCount)
 	}
 	sem := make(chan struct{}, concurrency)
 

--- a/go/internal/cli/commands/pushretry_test.go
+++ b/go/internal/cli/commands/pushretry_test.go
@@ -52,3 +52,26 @@ func TestMultiBuildConcurrency(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveBuildConcurrency(t *testing.T) {
+	tests := []struct {
+		buildCount int
+		override   int
+		want       int
+	}{
+		// override = 0 -> auto heuristic (multiBuildConcurrency)
+		{0, 0, 1},  // nothing to build -> floor 1
+		{4, 0, 4},  // small group, default cap
+		{14, 0, 2}, // large group -> auto-throttled
+		// override > 0 -> use it, clamped to [1, buildCount]
+		{14, 1, 1}, // explicit serialization
+		{14, 6, 6}, // explicit higher than auto
+		{3, 10, 3}, // override capped to buildCount
+		{5, 0, 4},  // 5 services, below large threshold -> default cap 4
+	}
+	for _, tt := range tests {
+		if got := resolveBuildConcurrency(tt.buildCount, tt.override); got != tt.want {
+			t.Errorf("resolveBuildConcurrency(%d, %d) = %d, want %d", tt.buildCount, tt.override, got, tt.want)
+		}
+	}
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -476,6 +476,7 @@ type runOptions struct {
 	product              string
 	service              string
 	keepGoing            bool
+	maxConcurrency       int
 	userArgs             []string
 	// quietBuild suppresses the image build (buildx) output, surfacing it only
 	// when the build fails. Set by `wendy watch` to keep the redeploy loop quiet.
@@ -508,6 +509,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.product, "product", "", "Swift Package Manager product to build and run")
 	cmd.Flags().StringVar(&opts.service, "service", "", "Build and run only the named service and its dependencies (multi-service projects)")
 	cmd.Flags().BoolVar(&opts.keepGoing, "keep-going", false, "Multi-service: deploy services that build successfully instead of aborting the whole group on the first build/push failure")
+	cmd.Flags().IntVar(&opts.maxConcurrency, "max-concurrency", 0, "Multi-service: max service images to build+push at once (0 = auto-throttle large groups)")
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
 
 	return cmd
@@ -555,6 +557,9 @@ func runCommand(ctx context.Context, opts runOptions) error {
 	}
 	if _, err := normalizeImageBuilder(opts.builder); err != nil {
 		return err
+	}
+	if opts.maxConcurrency < 0 {
+		return fmt.Errorf("--max-concurrency must be >= 0 (0 = auto)")
 	}
 
 	// --dockerfile implies a docker build; validate the file exists and ensure


### PR DESCRIPTION
## Summary
Fixes [WDY-1693](https://linear.app/wendylabsinc/issue/WDY-1693) (Bug E of [WDY-1687](https://linear.app/wendylabsinc/issue/WDY-1687)). **Top of the stack: C → D → #1098 (B) → #1097 (A).**

Build/push concurrency was a hardcoded heuristic (`multiBuildConcurrency`: 4 normally, 2 for large groups, added in Bug B). Expose it.

## Fix
New **`--max-concurrency`** flag (multi-service). `resolveBuildConcurrency` applies the override when `> 0` (clamped to `[1, buildCount]`) and otherwise uses the auto heuristic. `0` = auto (unchanged default); negative values are rejected in `runCommand`. The build log distinguishes an explicit limit from auto-throttling.

Use `--max-concurrency 1` to fully serialize on a fragile tunnel, or raise it on a fast link.

## Testing
build/vet/gofmt/`-race` clean; `resolveBuildConcurrency` table tests (override vs auto, clamping); flag verified in `wendy run --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)