### PR TITLE
test(cli): stress harness for the multi-service deploy fixes (WDY-1687)

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -2253,6 +2254,14 @@ func (p *registryProxy) serve(ctx context.Context) {
 func (p *registryProxy) forward(ctx context.Context, client net.Conn) {
 	defer client.Close()
 
+	// Test-only fault injection: with probability WENDY_REGISTRY_CHAOS, drop the
+	// connection before forwarding to simulate the device-registry tunnel
+	// hiccuping under load (connection reset / broken pipe). Used to exercise the
+	// build+push retry path (WDY-1690) on demand. Off (0) by default.
+	if chaosProxyShouldDrop() {
+		return
+	}
+
 	remote, err := p.dial(ctx)
 	if err != nil {
 		return
@@ -2263,6 +2272,21 @@ func (p *registryProxy) forward(ctx context.Context, client net.Conn) {
 	go func() { _, _ = io.Copy(remote, client); done <- struct{}{} }()
 	go func() { _, _ = io.Copy(client, remote); done <- struct{}{} }()
 	<-done
+}
+
+// chaosProxyShouldDrop reports whether this proxied connection should be dropped
+// for fault-injection testing, per the WENDY_REGISTRY_CHAOS probability (0..1).
+// Returns false (no chaos) when unset, unparseable, or <= 0.
+func chaosProxyShouldDrop() bool {
+	v := os.Getenv("WENDY_REGISTRY_CHAOS")
+	if v == "" {
+		return false
+	}
+	p, err := strconv.ParseFloat(v, 64)
+	if err != nil || p <= 0 {
+		return false
+	}
+	return rand.Float64() < p
 }
 
 // splitIPv6RegistryAddr checks if registryAddr is a bracketed IPv6 address

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -118,6 +118,11 @@ func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) ([]string, e
 	return appconfig.ServiceTopoOrder(services)
 }
 
+// buildServiceImage is the per-service build+push step. It is a package var so
+// stress/concurrency tests can substitute a fake builder and exercise the
+// parallel scheduling, skip handling, and failure-map collection without Docker.
+var buildServiceImage = buildAndPushImageForAgent
+
 // serviceFingerprintKey namespaces a deploy fingerprint per service within an
 // app group, so each service's build inputs are tracked independently.
 func serviceFingerprintKey(appID, service string) string {
@@ -482,7 +487,7 @@ func buildServicesParallel(
 				// Pass the per-service repo as the build's cache key so each concurrent
 				// build gets its own isolated local buildx cache dir (WDY-1689); sharing
 				// one dir corrupts BuildKit's cache-export ingest store under concurrency.
-				err = buildAndPushImageForAgent(ctx, conn, regPort, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOut)
+				err = buildServiceImage(ctx, conn, regPort, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOut)
 			}
 			dur := time.Since(start)
 

--- a/go/internal/cli/commands/stress_test.go
+++ b/go/internal/cli/commands/stress_test.go
@@ -1,0 +1,172 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// TestResolveDeployableServicesFuzz generates random acyclic dependency graphs
+// with random failures and checks resolveDeployableServices against an
+// independent reference: a service is deployable iff it did not fail and all its
+// dependencies are deployable. Also checks the dropped set is exactly the
+// non-failed, non-deployable services.
+func TestResolveDeployableServicesFuzz(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	for iter := 0; iter < 5000; iter++ {
+		n := 1 + r.Intn(12)
+		names := make([]string, n)
+		services := map[string]*appconfig.ServiceConfig{}
+		for i := 0; i < n; i++ {
+			names[i] = fmt.Sprintf("s%02d", i)
+		}
+		// Edges only to lower indices => acyclic.
+		deps := map[string][]string{}
+		for i := 0; i < n; i++ {
+			for j := 0; j < i; j++ {
+				if r.Intn(3) == 0 {
+					deps[names[i]] = append(deps[names[i]], names[j])
+				}
+			}
+			services[names[i]] = &appconfig.ServiceConfig{DependsOn: deps[names[i]]}
+		}
+		failed := map[string]error{}
+		for i := 0; i < n; i++ {
+			if r.Intn(4) == 0 {
+				failed[names[i]] = errors.New("boom")
+			}
+		}
+
+		// Reference: compute in index order (deps are all lower-indexed).
+		ref := map[string]bool{}
+		for i := 0; i < n; i++ {
+			name := names[i]
+			ok := failed[name] == nil
+			if ok {
+				for _, d := range deps[name] {
+					if !ref[d] {
+						ok = false
+						break
+					}
+				}
+			}
+			ref[name] = ok
+		}
+
+		gotDeployable, gotDropped := resolveDeployableServices(services, failed)
+
+		for _, name := range names {
+			_, inDeploy := gotDeployable[name]
+			if inDeploy != ref[name] {
+				t.Fatalf("iter %d: service %s deployable=%v, want %v (failed=%v deps=%v)",
+					iter, name, inDeploy, ref[name], failed[name] != nil, deps[name])
+			}
+			_, inDropped := gotDropped[name]
+			wantDropped := !ref[name] && failed[name] == nil
+			if inDropped != wantDropped {
+				t.Fatalf("iter %d: service %s dropped=%v, want %v", iter, name, inDropped, wantDropped)
+			}
+		}
+	}
+}
+
+// TestBuildServicesParallelStress hammers buildServicesParallel with a fake
+// builder under random skip/fail/concurrency settings, asserting that: skipped
+// services are never built, every non-skipped service is built exactly once, and
+// the returned failure map matches exactly the injected failures of non-skipped
+// services. Run with -race -count=N to stress the scheduling.
+func TestBuildServicesParallelStress(t *testing.T) {
+	root := t.TempDir()
+	const n = 24
+	services := map[string]*appconfig.ServiceConfig{}
+	names := make([]string, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("svc%02d", i)
+		names[i] = name
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		services[name] = &appconfig.ServiceConfig{Context: name}
+	}
+
+	r := rand.New(rand.NewSource(42))
+	skip := map[string]bool{}
+	failSet := map[string]bool{}
+	for _, name := range names {
+		if r.Intn(3) == 0 {
+			skip[name] = true
+		} else if r.Intn(3) == 0 {
+			failSet[name] = true
+		}
+	}
+
+	const appID = "app"
+	repoToName := func(repo string) string { return strings.TrimPrefix(repo, appID+"-") }
+
+	var mu sync.Mutex
+	built := map[string]int{}
+	orig := buildServiceImage
+	defer func() { buildServiceImage = orig }()
+	buildServiceImage = func(_ context.Context, _ *grpcclient.AgentConnection, _ int, _, _, repo, _, _ string, _ map[string]string, _ string, _, _ io.Writer) error {
+		name := repoToName(repo)
+		mu.Lock()
+		built[name]++
+		mu.Unlock()
+		if failSet[name] {
+			return fmt.Errorf("injected failure for %s", name)
+		}
+		return nil
+	}
+
+	maxConc := 1 + r.Intn(8)
+	failed, infraErr := buildServicesParallel(
+		context.Background(), nil, 5000, root, appID, services, "linux/arm64", nil, "docker", skip, maxConc)
+	if infraErr != nil {
+		t.Fatalf("unexpected infra error: %v", infraErr)
+	}
+
+	for _, name := range names {
+		mu.Lock()
+		c := built[name]
+		mu.Unlock()
+		switch {
+		case skip[name]:
+			if c != 0 {
+				t.Fatalf("skipped service %s was built %d times", name, c)
+			}
+		default:
+			if c != 1 {
+				t.Fatalf("service %s built %d times, want 1", name, c)
+			}
+		}
+	}
+
+	wantFailed := map[string]bool{}
+	for name := range failSet {
+		if !skip[name] {
+			wantFailed[name] = true
+		}
+	}
+	if len(failed) != len(wantFailed) {
+		t.Fatalf("failed set size %d, want %d (failed=%v)", len(failed), len(wantFailed), sortedServiceErrorKeys(failed))
+	}
+	for name := range wantFailed {
+		if failed[name] == nil {
+			t.Fatalf("expected %s in failed set; got %v", name, sortedServiceErrorKeys(failed))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Stress-test infrastructure for the WDY-1687 multi-service `wendy run` fixes (A–E). **Top of the stack: E (#1101) → C → D → B (#1098) → A (#1097).** Test-only + one tiny seam; no behavior change with the chaos hook off (the default).

## What's added
- **`buildServiceImage` seam** — `buildServicesParallel` now calls a package-var build function so concurrency/skip/failure handling can be exercised with a fake builder (no Docker).
- **`stress_test.go`**:
  - `TestResolveDeployableServicesFuzz` — 5000 random acyclic dependency graphs with random failures, checked against an independent reference (the partial-deploy/dependency-cascade math, Bug C/WDY-1691).
  - `TestBuildServicesParallelStress` — fake builder under random skip/fail/concurrency; asserts skipped services are never built, every other is built exactly once, and the failure map is exact. Run with `-race -count=N`.
- **Registry-proxy chaos mode** (`WENDY_REGISTRY_CHAOS`, default off) — randomly drops registry connections to fault-inject push failures and exercise the build+push retry path (Bug B/WDY-1690) on demand.

## Verified
- Fuzz: 5000 iterations clean.
- `TestBuildServicesParallelStress` + the logic suite: green under `-race -count=500`.
- On-device soak (random perturbations, 8 rounds): 26 assertions, 0 failures.
- Chaos at 85% drop: the retry-wrapper engages (`retrying in 2s… 4s`), 5/6 services recover, the rest fail honestly (no hang) — first live proof of the retry path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)