### PR TITLE
docs(overview): replace feature bullet list with USP card grid

### DIFF
--- a/go/internal/cli/assets/docs/components/docs/usp-grid.tsx
+++ b/go/internal/cli/assets/docs/components/docs/usp-grid.tsx
@@ -1,0 +1,75 @@
+type USP = {
+  flag: string;
+  title: string;
+  description: string;
+};
+
+const usps: USP[] = [
+  {
+    flag: '--deploy',
+    title: 'USB-C Deployment',
+    description:
+      'Plug in your Jetson or Pi and deploy in seconds. No SSH, no network config, no ceremony.',
+  },
+  {
+    flag: '--debug',
+    title: 'Remote Debugging',
+    description:
+      'Full VSCode debugger with breakpoints over USB or the internet — on any device, anywhere.',
+  },
+  {
+    flag: '--observe',
+    title: 'Observability',
+    description:
+      'Real-time logs, metrics, and distributed traces from every device in your fleet.',
+  },
+  {
+    flag: '--ros2',
+    title: 'ROS2 Support',
+    description:
+      'Run ROS2 nodes natively alongside WendyOS apps on the same hardware.',
+  },
+  {
+    flag: '--ota',
+    title: 'Atomic OTA Updates',
+    description:
+      'Push firmware to one device or ten thousand. Automatic rollback on failure.',
+  },
+  {
+    flag: '--editor',
+    title: 'VSCode & Cursor',
+    description:
+      'Deploy and debug without leaving your editor. Extensions for VSCode, Cursor, and Windsurf.',
+  },
+  {
+    flag: '--open-source',
+    title: 'Apache 2.0',
+    description:
+      'No black boxes, no lock-in. The full OS and toolchain are open source and auditable.',
+  },
+  {
+    flag: '--hardware',
+    title: 'NVIDIA & Raspberry Pi',
+    description:
+      'First-class support for Jetson Orin, AGX Thor, Raspberry Pi 5, and Pi Zero 2W.',
+  },
+];
+
+export function USPGrid() {
+  return (
+    <div className="not-prose my-8 grid gap-px bg-fd-border sm:grid-cols-2 lg:grid-cols-4">
+      {usps.map((usp) => (
+        <div
+          key={usp.flag}
+          className="flex flex-col gap-3 bg-fd-card p-5 transition-colors hover:bg-fd-accent"
+        >
+          <span className="font-mono text-[11px] font-medium tracking-wide text-fd-primary">
+            {usp.flag}
+          </span>
+          <h3 className="text-sm font-semibold text-fd-card-foreground">{usp.title}</h3>
+          <p className="text-xs leading-relaxed text-fd-muted-foreground">{usp.description}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/go/internal/cli/assets/docs/index.mdx
+++ b/go/internal/cli/assets/docs/index.mdx
@@ -6,18 +6,13 @@ full: true
 
 import { Database, Monitor, Box, Terminal, ArrowRight } from 'lucide-react';
 import { HardwareShowcase } from '@/components/docs/hardware-showcase';
+import { USPGrid } from '@/components/docs/usp-grid';
 
 ## Introduction
 
 **Wendy** is the open source (Apache 2.0) operating system and toolchain for robots, drones, and edge AI. Inspired by the mobile development experience, Wendy lets you plug in an NVIDIA Jetson or Raspberry Pi over USB and start coding instantly. [Wendy Agent for Mac](/docs/installation/wendy-agent-macos) is available in beta for teams that want to deploy and manage native macOS apps on Apple Silicon Mac targets.
 
-Key features include:
-
-- **USB-C deployment and debugging** — No internet or SSH needed. Just plug in and deploy.
-- **Remote Logging** — Real-time logs from devices anywhere in the world.
-- **Atomic OTA Updates** — Push updates to one or ten thousand devices without fear.
-- **VSCode Extension** — Modern development experience with full debugger support.
-- **Apache 2.0 Open Source** — No black boxes. Everything is open and hackable.
+<USPGrid />
 
 <a
   href="/docs/installation/developer-machine-setup"


### PR DESCRIPTION
## Summary

- Adds `USPGrid` component: 8 cards in a responsive 4→2→1 column grid, using the `gap-px bg-fd-border` technique for tight 1px dividers between cells
- Each card uses a CLI `--flag` label as the eyebrow — `--deploy`, `--debug`, `--ros2`, etc. — styled in `font-mono`, which anchors the design to the product's CLI identity
- Replaces the flat bullet list on the Overview page with the grid; all other page sections (CTA, Hardware Showcase, Core Components) unchanged

USPs covered: USB-C deployment, remote debugging, observability, ROS2 support, atomic OTA updates, VSCode/Cursor/Windsurf, Apache 2.0, NVIDIA Jetson + Raspberry Pi hardware.

## Test plan

- [ ] Verify docs build (`npm run build` in `go/internal/cli/assets/docs`)
- [ ] Check grid renders at desktop (4 col), tablet (2 col), and mobile (1 col)
- [ ] Confirm light/dark mode both look correct (all colors use `fd-*` tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnhPHaf2AU32tCH2mofYt6