### PR TITLE
Update JetPack version reported by the agent

### DIFF
--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -161,6 +161,7 @@ func detectJetPackVersion() string {
 	// L4T → JetPack version table.
 	// https://developer.nvidia.com/embedded/jetpack-archive
 	jetpack := map[string]string{
+		"39.2": "7.2",
 		"36.4": "6.1",
 		"36.3": "6.0",
 		"36.2": "6.0",

--- a/go/internal/agent/services/ros2_service.go
+++ b/go/internal/agent/services/ros2_service.go
@@ -486,6 +486,7 @@ func (s *ROS2Service) EchoTopic(req *agentpbv2.EchoROS2TopicRequest, stream grpc
 		sent++
 		if req.GetCount() > 0 && sent >= req.GetCount() {
 			cancel()
+			pr.CloseWithError(context.Canceled) // unblock goroutine stuck writing to pw
 			<-execDone
 			return nil
 		}


### PR DESCRIPTION
WENDY_JETPACK_VERSION is not correctly set.

When compiling the app with `wendy run`, we get this warning: 
```
Warning: ignoring device-reported build arg WENDY_JETPACK_VERSION="L4T 39.2.0": invalid build arg "WENDY_JETPACK_VERSION": value must contain only safe ASCII characters
```
