### PR TITLE
fix(cdi): prefer /var/run/cdi over /etc/cdi for NVIDIA spec lookup

### DIFF
--- a/go/internal/agent/cdi/generate.go
+++ b/go/internal/agent/cdi/generate.go
@@ -12,8 +12,8 @@ import (
 )
 
 var cdiSpecPaths = []string{
-	"/etc/cdi/nvidia.yaml",
 	"/var/run/cdi/nvidia.yaml",
+	"/etc/cdi/nvidia.yaml",
 }
 
 const cdiOutputDir = "/var/run/cdi"

--- a/go/internal/agent/cdi/manager.go
+++ b/go/internal/agent/cdi/manager.go
@@ -99,8 +99,8 @@ func (m *Manager) GetCDIDevices(categories []string) ([]CDIDeviceInfo, error) {
 // It tries /etc/cdi/nvidia.yaml first, then /var/run/cdi/nvidia.yaml.
 func (m *Manager) LoadNVIDIACDISpec() (*CDISpecification, error) {
 	possiblePaths := []string{
-		filepath.Join(m.specPath, "nvidia.yaml"),
 		"/var/run/cdi/nvidia.yaml",
+		filepath.Join(m.specPath, "nvidia.yaml"),
 	}
 
 	var specPath string


### PR DESCRIPTION
## Summary

- Inverts the CDI spec search order in both `EnsureNVIDIACDISpec` and `LoadNVIDIACDISpec`
- `/var/run/cdi/nvidia.yaml` is now checked before `/etc/cdi/nvidia.yaml`
- The runtime path is written by `nvidia-ctk` and reflects live device state; it should take precedence over static config under `/etc`

## Test plan

- [ ] `go test ./internal/agent/cdi/...` passes (verified locally)
- [ ] On a device with NVIDIA/Jetson hardware, confirm agent picks up the runtime-generated spec at `/var/run/cdi/nvidia.yaml` when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6emK6PFWA6HwsF4JmyVkh