### PR TITLE
feat(notify): cloud push notifications via wendy notify start/stop/status

### DIFF
--- a/Proto/cloud/notifications.proto
+++ b/Proto/cloud/notifications.proto
@@ -12,6 +12,7 @@ service NotificationService {
   rpc DeleteNotification(DeleteNotificationRequest) returns (DeleteNotificationResponse);
   rpc MarkAsRead(MarkAsReadRequest) returns (MarkAsReadResponse);
   rpc GetUnreadCount(GetUnreadCountRequest) returns (GetUnreadCountResponse);
+  rpc SubscribeNotifications(SubscribeNotificationsRequest) returns (stream Notification);
 }
 
 enum NotificationSeverity {
@@ -84,4 +85,11 @@ message GetUnreadCountRequest {
 
 message GetUnreadCountResponse {
   int32 unread_count = 1;
+}
+
+message SubscribeNotificationsRequest {
+  int32  organization_id          = 1;
+  string user_id                  = 2;
+  optional NotificationSeverity min_severity = 3;
+  optional int32 after_id         = 4;
 }

--- a/go/internal/cli/commands/notify.go
+++ b/go/internal/cli/commands/notify.go
@@ -1,0 +1,96 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newNotifyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "notify",
+		Short: "Manage Wendy Cloud push notifications",
+	}
+
+	cmd.AddCommand(
+		newNotifyStartCmd(),
+		newNotifyStopCmd(),
+		newNotifyStatusCmd(),
+		newNotifyDaemonCmd(),
+	)
+	return cmd
+}
+
+func newNotifyStartCmd() *cobra.Command {
+	var cloudGRPC string
+
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Install and start the Wendy notification daemon",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			auth, err := pickAuthEntry(cloudGRPC)
+			if err != nil {
+				return err
+			}
+
+			if err := installNotifyService(auth.CloudGRPC); err != nil {
+				return fmt.Errorf("installing notification daemon: %w", err)
+			}
+
+			logPath, _ := notifyLogPath()
+			cmd.Printf("Wendy notification daemon started.\nLogs: %s\n", logPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (required when multiple auth sessions exist)")
+	return cmd
+}
+
+func newNotifyStopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop and uninstall the Wendy notification daemon",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := uninstallNotifyService(); err != nil {
+				return fmt.Errorf("uninstalling notification daemon: %w", err)
+			}
+			cmd.Println("Wendy notification daemon stopped.")
+			return nil
+		},
+	}
+}
+
+func newNotifyStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show the status of the Wendy notification daemon",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			status, err := notifyServiceStatus()
+			if err != nil {
+				return err
+			}
+			logPath, _ := notifyLogPath()
+			cmd.Printf("Notification daemon: %s\nLogs: %s\n", status, logPath)
+			return nil
+		},
+	}
+}
+
+func newNotifyDaemonCmd() *cobra.Command {
+	var cloudGRPC string
+
+	cmd := &cobra.Command{
+		Use:    "__daemon",
+		Short:  "Run the notification daemon (internal use by OS service manager)",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			auth, err := pickAuthEntry(cloudGRPC)
+			if err != nil {
+				return err
+			}
+			return runNotifyDaemon(cmd.Context(), auth, defaultNotifyDaemonDeps())
+		},
+	}
+	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (required when multiple auth sessions exist)")
+	return cmd
+}

--- a/go/internal/cli/commands/notify.go
+++ b/go/internal/cli/commands/notify.go
@@ -37,7 +37,10 @@ func newNotifyStartCmd() *cobra.Command {
 				return fmt.Errorf("installing notification daemon: %w", err)
 			}
 
-			logPath, _ := notifyLogPath()
+			logPath, err := notifyLogPath()
+			if err != nil {
+				logPath = "(log path unavailable)"
+			}
 			cmd.Printf("Wendy notification daemon started.\nLogs: %s\n", logPath)
 			return nil
 		},
@@ -69,7 +72,10 @@ func newNotifyStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			logPath, _ := notifyLogPath()
+			logPath, err := notifyLogPath()
+			if err != nil {
+				logPath = "(log path unavailable)"
+			}
 			cmd.Printf("Notification daemon: %s\nLogs: %s\n", status, logPath)
 			return nil
 		},

--- a/go/internal/cli/commands/notify_daemon.go
+++ b/go/internal/cli/commands/notify_daemon.go
@@ -1,0 +1,197 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+	"google.golang.org/grpc"
+)
+
+// notificationSubscriber is the narrow interface the daemon needs from the cloud client.
+type notificationSubscriber interface {
+	SubscribeNotifications(ctx context.Context, in *cloudpb.SubscribeNotificationsRequest, opts ...grpc.CallOption) (cloudpb.NotificationService_SubscribeNotificationsClient, error)
+}
+
+// notifyState maps cloud gRPC endpoints to per-endpoint state.
+type notifyState map[string]notifyEndpointState
+
+type notifyEndpointState struct {
+	LastSeenID int32 `json:"lastSeenId"`
+}
+
+// notifyDaemonDeps holds injectable dependencies for the daemon loop.
+type notifyDaemonDeps struct {
+	newClient    func(*config.AuthConfig) (notificationSubscriber, func(), error)
+	sendNotif    func(title, body string) error
+	sleep        func(ctx context.Context, d time.Duration) error
+	refreshCerts func(ctx context.Context, auth *config.AuthConfig) error
+	loadState    func() (notifyState, error)
+	saveState    func(notifyState) error
+}
+
+func defaultNotifyDaemonDeps() notifyDaemonDeps {
+	return notifyDaemonDeps{
+		newClient: func(auth *config.AuthConfig) (notificationSubscriber, func(), error) {
+			conn, err := dialCloudGRPC(auth)
+			if err != nil {
+				return nil, nil, err
+			}
+			return cloudpb.NewNotificationServiceClient(conn), func() { conn.Close() }, nil
+		},
+		sendNotif: sendOSNotification,
+		sleep: func(ctx context.Context, d time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(d):
+				return nil
+			}
+		},
+		refreshCerts: func(ctx context.Context, auth *config.AuthConfig) error {
+			return refreshCertsForAuth(ctx, auth)
+		},
+		loadState: loadNotifyState,
+		saveState: saveNotifyState,
+	}
+}
+
+// runNotifyDaemon streams notifications from Wendy Cloud and fires native OS
+// notifications. It reconnects with exponential backoff until ctx is cancelled.
+func runNotifyDaemon(ctx context.Context, auth *config.AuthConfig, deps notifyDaemonDeps) error {
+	state, err := deps.loadState()
+	if err != nil {
+		log.Printf("wendy notify: loading state: %v (starting fresh)", err)
+		state = make(notifyState)
+	}
+
+	backoff := time.Second
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		err := runNotifyStream(ctx, auth, state, deps)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if err != nil && isCertRefreshableError(err) {
+			log.Printf("wendy notify: cert error (%v), attempting refresh", err)
+			if rerr := deps.refreshCerts(ctx, auth); rerr != nil {
+				log.Printf("wendy notify: cert refresh failed: %v", rerr)
+			}
+		} else if err != nil && err != io.EOF {
+			log.Printf("wendy notify: stream error: %v", err)
+		}
+
+		if err := deps.sleep(ctx, backoff); err != nil {
+			return ctx.Err()
+		}
+		if backoff < 5*time.Minute {
+			backoff *= 2
+		}
+	}
+}
+
+func runNotifyStream(ctx context.Context, auth *config.AuthConfig, state notifyState, deps notifyDaemonDeps) error {
+	client, closeConn, err := deps.newClient(auth)
+	if err != nil {
+		return fmt.Errorf("connecting to cloud: %w", err)
+	}
+	defer closeConn()
+
+	ep := auth.CloudGRPC
+	epState := state[ep]
+
+	req := &cloudpb.SubscribeNotificationsRequest{
+		OrganizationId: int32(auth.Certificates[0].OrganizationID),
+		UserId:         auth.Certificates[0].UserID,
+	}
+	if epState.LastSeenID > 0 {
+		id := epState.LastSeenID
+		req.AfterId = &id
+	}
+
+	stream, err := client.SubscribeNotifications(ctx, req)
+	if err != nil {
+		return fmt.Errorf("subscribing: %w", err)
+	}
+
+	for {
+		n, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+
+		title := severityTitle(n.Severity)
+		if nerr := deps.sendNotif(title, n.Body); nerr != nil {
+			log.Printf("wendy notify: sending OS notification: %v", nerr)
+		}
+
+		state[ep] = notifyEndpointState{LastSeenID: n.Id}
+		if serr := deps.saveState(state); serr != nil {
+			log.Printf("wendy notify: saving state: %v", serr)
+		}
+	}
+}
+
+func severityTitle(sev cloudpb.NotificationSeverity) string {
+	switch sev {
+	case cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_WARNING:
+		return "Wendy — Warning"
+	case cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_ERROR:
+		return "Wendy — Error"
+	case cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_CRITICAL:
+		return "Wendy — Critical"
+	default:
+		return "Wendy"
+	}
+}
+
+func notifyStatePath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "notify-state.json"), nil
+}
+
+func loadNotifyState() (notifyState, error) {
+	path, err := notifyStatePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return make(notifyState), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var s notifyState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return make(notifyState), nil
+	}
+	return s, nil
+}
+
+func saveNotifyState(s notifyState) error {
+	path, err := notifyStatePath()
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}

--- a/go/internal/cli/commands/notify_daemon.go
+++ b/go/internal/cli/commands/notify_daemon.go
@@ -48,10 +48,12 @@ func defaultNotifyDaemonDeps() notifyDaemonDeps {
 		},
 		sendNotif: sendOSNotification,
 		sleep: func(ctx context.Context, d time.Duration) error {
+			t := time.NewTimer(d)
+			defer t.Stop()
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(d):
+			case <-t.C:
 				return nil
 			}
 		},
@@ -111,6 +113,10 @@ func runNotifyStream(ctx context.Context, auth *config.AuthConfig, state notifyS
 
 	ep := auth.CloudGRPC
 	epState := state[ep]
+
+	if len(auth.Certificates) == 0 {
+		return fmt.Errorf("auth entry has no certificates; re-run 'wendy auth login'")
+	}
 
 	req := &cloudpb.SubscribeNotificationsRequest{
 		OrganizationId: int32(auth.Certificates[0].OrganizationID),

--- a/go/internal/cli/commands/notify_daemon_test.go
+++ b/go/internal/cli/commands/notify_daemon_test.go
@@ -1,0 +1,204 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// fakeNotifStream is a fake cloudpb.NotificationService_SubscribeNotificationsClient.
+type fakeNotifStream struct {
+	notifications []*cloudpb.Notification
+	index         int
+	finalErr      error
+}
+
+func (f *fakeNotifStream) Recv() (*cloudpb.Notification, error) {
+	if f.index < len(f.notifications) {
+		n := f.notifications[f.index]
+		f.index++
+		return n, nil
+	}
+	if f.finalErr != nil {
+		return nil, f.finalErr
+	}
+	return nil, io.EOF
+}
+
+func (f *fakeNotifStream) Header() (metadata.MD, error) { return nil, nil }
+func (f *fakeNotifStream) Trailer() metadata.MD         { return nil }
+func (f *fakeNotifStream) CloseSend() error             { return nil }
+func (f *fakeNotifStream) Context() context.Context     { return context.Background() }
+func (f *fakeNotifStream) SendMsg(m any) error          { return nil }
+func (f *fakeNotifStream) RecvMsg(m any) error          { return nil }
+
+// fakeNotifSubscriber implements notificationSubscriber.
+type fakeNotifSubscriber struct {
+	stream  cloudpb.NotificationService_SubscribeNotificationsClient
+	lastReq *cloudpb.SubscribeNotificationsRequest
+}
+
+func (f *fakeNotifSubscriber) SubscribeNotifications(ctx context.Context, req *cloudpb.SubscribeNotificationsRequest, _ ...grpc.CallOption) (cloudpb.NotificationService_SubscribeNotificationsClient, error) {
+	f.lastReq = req
+	return f.stream, nil
+}
+
+func TestRunNotifyDaemon_FiresNotificationsInOrder(t *testing.T) {
+	notifications := []*cloudpb.Notification{
+		{Id: 1, Body: "hello", Severity: cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_INFO},
+		{Id: 2, Body: "disk full", Severity: cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_WARNING},
+	}
+	sub := &fakeNotifSubscriber{stream: &fakeNotifStream{notifications: notifications, finalErr: io.EOF}}
+
+	var fired []string
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	state := make(notifyState)
+	deps := notifyDaemonDeps{
+		newClient:    func(*config.AuthConfig) (notificationSubscriber, func(), error) { return sub, func() {}, nil },
+		sendNotif:    func(title, body string) error { fired = append(fired, title+"|"+body); return nil },
+		sleep:        func(ctx context.Context, _ time.Duration) error { return ctx.Err() },
+		refreshCerts: func(context.Context, *config.AuthConfig) error { return nil },
+		loadState:    func() (notifyState, error) { return state, nil },
+		saveState:    func(s notifyState) error { state = s; return nil },
+	}
+
+	auth := &config.AuthConfig{
+		CloudGRPC:    "test:443",
+		Certificates: []config.CertificateInfo{{OrganizationID: 1, UserID: "u1"}},
+	}
+
+	// The daemon exits when all notifications are consumed (stream returns io.EOF)
+	// and the reconnect sleep is cancelled.
+	_ = runNotifyDaemon(ctx, auth, deps)
+
+	if len(fired) != 2 {
+		t.Fatalf("expected 2 notifications fired, got %d: %v", len(fired), fired)
+	}
+	if fired[0] != "Wendy|hello" {
+		t.Errorf("first notification: got %q, want %q", fired[0], "Wendy|hello")
+	}
+	if fired[1] != "Wendy — Warning|disk full" {
+		t.Errorf("second notification: got %q, want %q", fired[1], "Wendy — Warning|disk full")
+	}
+}
+
+func TestRunNotifyDaemon_PersistsLastSeenID(t *testing.T) {
+	notifications := []*cloudpb.Notification{
+		{Id: 5, Body: "ping", Severity: cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_INFO},
+	}
+	sub := &fakeNotifSubscriber{stream: &fakeNotifStream{notifications: notifications, finalErr: io.EOF}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var savedState notifyState
+	deps := notifyDaemonDeps{
+		newClient:    func(*config.AuthConfig) (notificationSubscriber, func(), error) { return sub, func() {}, nil },
+		sendNotif:    func(string, string) error { return nil },
+		sleep:        func(ctx context.Context, _ time.Duration) error { return ctx.Err() },
+		refreshCerts: func(context.Context, *config.AuthConfig) error { return nil },
+		loadState:    func() (notifyState, error) { return make(notifyState), nil },
+		saveState:    func(s notifyState) error { savedState = s; return nil },
+	}
+
+	auth := &config.AuthConfig{
+		CloudGRPC:    "cloud.example:443",
+		Certificates: []config.CertificateInfo{{OrganizationID: 2, UserID: "u2"}},
+	}
+
+	_ = runNotifyDaemon(ctx, auth, deps)
+
+	ep := savedState["cloud.example:443"]
+	if ep.LastSeenID != 5 {
+		t.Errorf("lastSeenID = %d, want 5", ep.LastSeenID)
+	}
+}
+
+func TestRunNotifyDaemon_PassesAfterIDOnSubscribe(t *testing.T) {
+	sub := &fakeNotifSubscriber{stream: &fakeNotifStream{finalErr: io.EOF}}
+	initialState := notifyState{
+		"resume:443": {LastSeenID: 42},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	deps := notifyDaemonDeps{
+		newClient:    func(*config.AuthConfig) (notificationSubscriber, func(), error) { return sub, func() {}, nil },
+		sendNotif:    func(string, string) error { return nil },
+		sleep:        func(ctx context.Context, _ time.Duration) error { return ctx.Err() },
+		refreshCerts: func(context.Context, *config.AuthConfig) error { return nil },
+		loadState:    func() (notifyState, error) { return initialState, nil },
+		saveState:    func(notifyState) error { return nil },
+	}
+
+	auth := &config.AuthConfig{
+		CloudGRPC:    "resume:443",
+		Certificates: []config.CertificateInfo{{OrganizationID: 1, UserID: "u1"}},
+	}
+
+	_ = runNotifyDaemon(ctx, auth, deps)
+
+	if sub.lastReq == nil {
+		t.Fatal("SubscribeNotifications was not called")
+	}
+	if sub.lastReq.AfterId == nil || *sub.lastReq.AfterId != 42 {
+		t.Errorf("AfterId = %v, want 42", sub.lastReq.AfterId)
+	}
+}
+
+func TestSeverityTitle(t *testing.T) {
+	cases := []struct {
+		sev  cloudpb.NotificationSeverity
+		want string
+	}{
+		{cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_INFO, "Wendy"},
+		{cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_WARNING, "Wendy — Warning"},
+		{cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_ERROR, "Wendy — Error"},
+		{cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_CRITICAL, "Wendy — Critical"},
+		{cloudpb.NotificationSeverity_NOTIFICATION_SEVERITY_UNSPECIFIED, "Wendy"},
+	}
+	for _, tc := range cases {
+		got := severityTitle(tc.sev)
+		if got != tc.want {
+			t.Errorf("severityTitle(%v) = %q, want %q", tc.sev, got, tc.want)
+		}
+	}
+}
+
+func TestLoadSaveNotifyState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	state, err := loadNotifyState()
+	if err != nil {
+		t.Fatalf("loadNotifyState (empty): %v", err)
+	}
+	if len(state) != 0 {
+		t.Errorf("expected empty state, got %v", state)
+	}
+
+	state["cloud.test:443"] = notifyEndpointState{LastSeenID: 99}
+	if err := saveNotifyState(state); err != nil {
+		t.Fatalf("saveNotifyState: %v", err)
+	}
+
+	loaded, err := loadNotifyState()
+	if err != nil {
+		t.Fatalf("loadNotifyState (after save): %v", err)
+	}
+	if loaded["cloud.test:443"].LastSeenID != 99 {
+		t.Errorf("loaded lastSeenID = %d, want 99", loaded["cloud.test:443"].LastSeenID)
+	}
+}
+
+// Ensure the errors import is used (it's included per task brief, suppress potential unused-import errors).
+var _ = errors.New

--- a/go/internal/cli/commands/notify_os_darwin.go
+++ b/go/internal/cli/commands/notify_os_darwin.go
@@ -1,0 +1,29 @@
+//go:build darwin
+
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+func sendOSNotification(title, body string) error {
+	script := fmt.Sprintf(
+		`display notification %s with title %s`,
+		quoteAppleScript(body),
+		quoteAppleScript(title),
+	)
+	cmd := execCommand("osascript", "-e", script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("osascript: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// quoteAppleScript wraps s in AppleScript double-quoted string literals,
+// escaping backslashes and double-quotes.
+func quoteAppleScript(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}

--- a/go/internal/cli/commands/notify_os_darwin_test.go
+++ b/go/internal/cli/commands/notify_os_darwin_test.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package commands
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestSendOSNotification_Darwin(t *testing.T) {
+	var capturedArgs []string
+	origCommand := execCommand
+	t.Cleanup(func() { execCommand = origCommand })
+
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		capturedArgs = append([]string{name}, args...)
+		return exec.Command("true")
+	}
+
+	err := sendOSNotification("Wendy — Warning", "disk is almost full")
+	if err != nil {
+		t.Fatalf("sendOSNotification: %v", err)
+	}
+
+	if len(capturedArgs) == 0 {
+		t.Fatal("expected exec.Command to be called")
+	}
+	if capturedArgs[0] != "osascript" {
+		t.Errorf("expected osascript, got %q", capturedArgs[0])
+	}
+	joined := strings.Join(capturedArgs, " ")
+	if !strings.Contains(joined, "Wendy — Warning") {
+		t.Errorf("title not in args: %q", joined)
+	}
+	if !strings.Contains(joined, "disk is almost full") {
+		t.Errorf("body not in args: %q", joined)
+	}
+}

--- a/go/internal/cli/commands/notify_os_linux.go
+++ b/go/internal/cli/commands/notify_os_linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package commands
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+func sendOSNotification(title, body string) error {
+	if _, err := execLookPath("notify-send"); err != nil {
+		log.Printf("wendy notify: notify-send not found, skipping OS notification: %v", err)
+		return nil
+	}
+	cmd := execCommand("notify-send", title, body)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("notify-send: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/go/internal/cli/commands/notify_os_linux_test.go
+++ b/go/internal/cli/commands/notify_os_linux_test.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package commands
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestSendOSNotification_Linux(t *testing.T) {
+	var capturedArgs []string
+	origLookPath := execLookPath
+	origCommand := execCommand
+	t.Cleanup(func() {
+		execLookPath = origLookPath
+		execCommand = origCommand
+	})
+
+	execLookPath = func(file string) (string, error) { return file, nil }
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		capturedArgs = append([]string{name}, args...)
+		return exec.Command("true")
+	}
+
+	err := sendOSNotification("Wendy — Error", "device offline")
+	if err != nil {
+		t.Fatalf("sendOSNotification: %v", err)
+	}
+
+	if capturedArgs[0] != "notify-send" {
+		t.Errorf("expected notify-send, got %q", capturedArgs[0])
+	}
+	joined := strings.Join(capturedArgs, " ")
+	if !strings.Contains(joined, "Wendy — Error") {
+		t.Errorf("title not in args: %q", joined)
+	}
+	if !strings.Contains(joined, "device offline") {
+		t.Errorf("body not in args: %q", joined)
+	}
+}
+
+func TestSendOSNotification_Linux_MissingNotifySend(t *testing.T) {
+	origLookPath := execLookPath
+	t.Cleanup(func() { execLookPath = origLookPath })
+
+	execLookPath = func(file string) (string, error) {
+		return "", &exec.Error{Name: file, Err: exec.ErrNotFound}
+	}
+
+	// Should not error — falls back silently.
+	err := sendOSNotification("Wendy", "hello")
+	if err != nil {
+		t.Fatalf("expected no error when notify-send is absent, got: %v", err)
+	}
+}

--- a/go/internal/cli/commands/notify_os_windows.go
+++ b/go/internal/cli/commands/notify_os_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+func sendOSNotification(title, body string) error {
+	// Use PowerShell Windows.UI.Notifications to display a toast.
+	script := fmt.Sprintf(`
+$null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]
+$template = [Windows.UI.Notifications.ToastTemplateType]::ToastText02
+$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent($template)
+$xml.GetElementsByTagName('text').Item(0).InnerText = %s
+$xml.GetElementsByTagName('text').Item(1).InnerText = %s
+$toast = [Windows.UI.Notifications.ToastNotification]::new($xml)
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Wendy').Show($toast)
+`, psPquote(title), psPquote(body))
+
+	cmd := execCommand("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("powershell toast: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// psPquote wraps s in PowerShell single-quoted string literals, escaping
+// single-quotes by doubling them.
+func psPquote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/go/internal/cli/commands/notify_os_windows_test.go
+++ b/go/internal/cli/commands/notify_os_windows_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package commands
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestSendOSNotification_Windows(t *testing.T) {
+	var capturedArgs []string
+	origCommand := execCommand
+	t.Cleanup(func() { execCommand = origCommand })
+
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		capturedArgs = append([]string{name}, args...)
+		return exec.Command("cmd", "/C", "exit 0")
+	}
+
+	err := sendOSNotification("Wendy — Critical", "system failure")
+	if err != nil {
+		t.Fatalf("sendOSNotification: %v", err)
+	}
+
+	if len(capturedArgs) == 0 {
+		t.Fatal("expected exec.Command to be called")
+	}
+	if !strings.Contains(capturedArgs[0], "powershell") && capturedArgs[0] != "powershell.exe" {
+		t.Errorf("expected powershell, got %q", capturedArgs[0])
+	}
+	joined := strings.Join(capturedArgs, " ")
+	if !strings.Contains(joined, "Wendy") {
+		t.Errorf("app name not in args: %q", joined)
+	}
+}

--- a/go/internal/cli/commands/notify_service_darwin.go
+++ b/go/internal/cli/commands/notify_service_darwin.go
@@ -100,7 +100,10 @@ func uninstallNotifyService() error {
 	cmd := execCommand("launchctl", "unload", plistPath)
 	_ = cmd.Run() // ignore: may already be stopped
 
-	return os.Remove(plistPath)
+	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func notifyServiceStatus() (string, error) {

--- a/go/internal/cli/commands/notify_service_darwin.go
+++ b/go/internal/cli/commands/notify_service_darwin.go
@@ -1,0 +1,116 @@
+//go:build darwin
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+const notifyPlistLabel = "sh.wendy.notify"
+
+var notifyPlistTmpl = template.Must(template.New("plist").Parse(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>{{.Label}}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{.BinaryPath}}</string>
+    <string>notify</string>
+    <string>__daemon</string>
+    <string>--cloud-grpc</string>
+    <string>{{.CloudGRPC}}</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>{{.LogPath}}</string>
+  <key>StandardErrorPath</key><string>{{.LogPath}}</string>
+</dict>
+</plist>
+`))
+
+func notifyPlistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", "sh.wendy.notify.plist"), nil
+}
+
+func notifyLogPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "notify.log"), nil
+}
+
+func installNotifyService(cloudGRPC string) error {
+	plistPath, err := notifyPlistPath()
+	if err != nil {
+		return err
+	}
+	logPath, err := notifyLogPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		return fmt.Errorf("creating LaunchAgents dir: %w", err)
+	}
+
+	f, err := os.Create(plistPath)
+	if err != nil {
+		return fmt.Errorf("writing plist: %w", err)
+	}
+	defer f.Close()
+
+	data := struct {
+		Label, BinaryPath, CloudGRPC, LogPath string
+	}{
+		Label:      notifyPlistLabel,
+		BinaryPath: wendyBinaryPath(),
+		CloudGRPC:  cloudGRPC,
+		LogPath:    logPath,
+	}
+	if err := notifyPlistTmpl.Execute(f, data); err != nil {
+		return fmt.Errorf("rendering plist template: %w", err)
+	}
+
+	cmd := execCommand("launchctl", "load", plistPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("launchctl load: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func uninstallNotifyService() error {
+	plistPath, err := notifyPlistPath()
+	if err != nil {
+		return err
+	}
+
+	cmd := execCommand("launchctl", "unload", plistPath)
+	_ = cmd.Run() // ignore: may already be stopped
+
+	return os.Remove(plistPath)
+}
+
+func notifyServiceStatus() (string, error) {
+	cmd := execCommand("launchctl", "list", notifyPlistLabel)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "stopped", nil
+	}
+	if strings.Contains(string(out), notifyPlistLabel) {
+		return "running", nil
+	}
+	return "stopped", nil
+}

--- a/go/internal/cli/commands/notify_service_darwin_test.go
+++ b/go/internal/cli/commands/notify_service_darwin_test.go
@@ -1,0 +1,91 @@
+//go:build darwin
+
+package commands
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallNotifyService_Darwin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	var launchctlArgs []string
+	origCommand := execCommand
+	t.Cleanup(func() { execCommand = origCommand })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "launchctl" {
+			launchctlArgs = append([]string{name}, args...)
+			return exec.Command("true")
+		}
+		return exec.Command(name, args...)
+	}
+
+	err := installNotifyService("cloud.example:443")
+	if err != nil {
+		t.Fatalf("installNotifyService: %v", err)
+	}
+
+	// Plist should exist.
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "sh.wendy.notify.plist")
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading plist: %v", err)
+	}
+	plist := string(data)
+	if !strings.Contains(plist, "sh.wendy.notify") {
+		t.Errorf("plist missing label: %s", plist)
+	}
+	if !strings.Contains(plist, "cloud.example:443") {
+		t.Errorf("plist missing cloud-grpc endpoint: %s", plist)
+	}
+	if !strings.Contains(plist, "__daemon") {
+		t.Errorf("plist missing __daemon subcommand: %s", plist)
+	}
+
+	// launchctl load should have been called.
+	if len(launchctlArgs) == 0 || launchctlArgs[1] != "load" {
+		t.Errorf("expected launchctl load, got %v", launchctlArgs)
+	}
+}
+
+func TestUninstallNotifyService_Darwin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create a fake plist.
+	plistDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(plistDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plistPath := filepath.Join(plistDir, "sh.wendy.notify.plist")
+	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var launchctlArgs []string
+	origCommand := execCommand
+	t.Cleanup(func() { execCommand = origCommand })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "launchctl" {
+			launchctlArgs = append([]string{name}, args...)
+			return exec.Command("true")
+		}
+		return exec.Command(name, args...)
+	}
+
+	if err := uninstallNotifyService(); err != nil {
+		t.Fatalf("uninstallNotifyService: %v", err)
+	}
+
+	if _, err := os.Stat(plistPath); !os.IsNotExist(err) {
+		t.Error("plist should have been removed")
+	}
+	if len(launchctlArgs) == 0 || launchctlArgs[1] != "unload" {
+		t.Errorf("expected launchctl unload, got %v", launchctlArgs)
+	}
+}

--- a/go/internal/cli/commands/notify_service_linux.go
+++ b/go/internal/cli/commands/notify_service_linux.go
@@ -85,7 +85,10 @@ func uninstallNotifyService() error {
 	cmd := execCommand("systemctl", "--user", "disable", "--now", "wendy-notify")
 	_ = cmd.Run() // ignore: may already be stopped
 
-	return os.Remove(unitPath)
+	if err := os.Remove(unitPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func notifyServiceStatus() (string, error) {

--- a/go/internal/cli/commands/notify_service_linux.go
+++ b/go/internal/cli/commands/notify_service_linux.go
@@ -83,7 +83,7 @@ func uninstallNotifyService() error {
 	}
 
 	cmd := execCommand("systemctl", "--user", "disable", "--now", "wendy-notify")
-	_ = cmd.Run()
+	_ = cmd.Run() // ignore: may already be stopped
 
 	return os.Remove(unitPath)
 }
@@ -98,5 +98,5 @@ func notifyServiceStatus() (string, error) {
 	if status == "active" {
 		return "running", nil
 	}
-	return status, nil
+	return "stopped", nil
 }

--- a/go/internal/cli/commands/notify_service_linux.go
+++ b/go/internal/cli/commands/notify_service_linux.go
@@ -1,0 +1,102 @@
+//go:build linux
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+var notifyUnitTmpl = template.Must(template.New("unit").Parse(`[Unit]
+Description=Wendy Cloud Notifications
+After=network-online.target
+
+[Service]
+ExecStart={{.BinaryPath}} notify __daemon --cloud-grpc {{.CloudGRPC}}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`))
+
+func notifyUnitPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "systemd", "user", "wendy-notify.service"), nil
+}
+
+func notifyLogPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "notify.log"), nil
+}
+
+func installNotifyService(cloudGRPC string) error {
+	unitPath, err := notifyUnitPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		return fmt.Errorf("creating systemd user dir: %w", err)
+	}
+
+	f, err := os.Create(unitPath)
+	if err != nil {
+		return fmt.Errorf("writing unit file: %w", err)
+	}
+	defer f.Close()
+
+	data := struct{ BinaryPath, CloudGRPC string }{
+		BinaryPath: wendyBinaryPath(),
+		CloudGRPC:  cloudGRPC,
+	}
+	if err := notifyUnitTmpl.Execute(f, data); err != nil {
+		return fmt.Errorf("rendering unit template: %w", err)
+	}
+
+	for _, args := range [][]string{
+		{"--user", "daemon-reload"},
+		{"--user", "enable", "--now", "wendy-notify"},
+	} {
+		cmd := execCommand("systemctl", args...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("systemctl %s: %w: %s", args[len(args)-1], err, strings.TrimSpace(string(out)))
+		}
+	}
+	return nil
+}
+
+func uninstallNotifyService() error {
+	unitPath, err := notifyUnitPath()
+	if err != nil {
+		return err
+	}
+
+	cmd := execCommand("systemctl", "--user", "disable", "--now", "wendy-notify")
+	_ = cmd.Run()
+
+	return os.Remove(unitPath)
+}
+
+func notifyServiceStatus() (string, error) {
+	cmd := execCommand("systemctl", "--user", "is-active", "wendy-notify")
+	out, err := cmd.Output()
+	if err != nil {
+		return "stopped", nil
+	}
+	status := strings.TrimSpace(string(out))
+	if status == "active" {
+		return "running", nil
+	}
+	return status, nil
+}

--- a/go/internal/cli/commands/notify_service_linux_test.go
+++ b/go/internal/cli/commands/notify_service_linux_test.go
@@ -1,0 +1,94 @@
+//go:build linux
+
+package commands
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallNotifyService_Linux(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var systemctlCalls [][]string
+	origCommand := execCommand
+	t.Cleanup(func() { execCommand = origCommand })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "systemctl" {
+			systemctlCalls = append(systemctlCalls, append([]string{name}, args...))
+			return exec.Command("true")
+		}
+		return exec.Command(name, args...)
+	}
+
+	err := installNotifyService("cloud.example:443")
+	if err != nil {
+		t.Fatalf("installNotifyService: %v", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "wendy-notify.service")
+	data, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("reading unit file: %v", err)
+	}
+	unit := string(data)
+	if !strings.Contains(unit, "__daemon") {
+		t.Errorf("unit missing __daemon: %s", unit)
+	}
+	if !strings.Contains(unit, "cloud.example:443") {
+		t.Errorf("unit missing cloud-grpc: %s", unit)
+	}
+
+	// Expect daemon-reload then enable --now.
+	if len(systemctlCalls) < 2 {
+		t.Fatalf("expected 2 systemctl calls, got %d: %v", len(systemctlCalls), systemctlCalls)
+	}
+	if !strings.Contains(strings.Join(systemctlCalls[0], " "), "daemon-reload") {
+		t.Errorf("first call not daemon-reload: %v", systemctlCalls[0])
+	}
+	if !strings.Contains(strings.Join(systemctlCalls[1], " "), "enable") {
+		t.Errorf("second call not enable: %v", systemctlCalls[1])
+	}
+}
+
+func TestUninstallNotifyService_Linux(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	_ = os.MkdirAll(unitDir, 0o755)
+	unitPath := filepath.Join(unitDir, "wendy-notify.service")
+	_ = os.WriteFile(unitPath, []byte("[Unit]"), 0o644)
+
+	var systemctlCalls [][]string
+	origCommand := execCommand
+	t.Cleanup(func() { execCommand = origCommand })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "systemctl" {
+			systemctlCalls = append(systemctlCalls, append([]string{name}, args...))
+			return exec.Command("true")
+		}
+		return exec.Command(name, args...)
+	}
+
+	if err := uninstallNotifyService(); err != nil {
+		t.Fatalf("uninstallNotifyService: %v", err)
+	}
+
+	if _, err := os.Stat(unitPath); !os.IsNotExist(err) {
+		t.Error("unit file should have been removed")
+	}
+	found := false
+	for _, call := range systemctlCalls {
+		if strings.Contains(strings.Join(call, " "), "disable") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected systemctl disable, got %v", systemctlCalls)
+	}
+}

--- a/go/internal/cli/commands/notify_service_windows.go
+++ b/go/internal/cli/commands/notify_service_windows.go
@@ -22,6 +22,9 @@ func notifyLogPath() (string, error) {
 
 func installNotifyService(cloudGRPC string) error {
 	bin := wendyBinaryPath()
+	if strings.Contains(bin, " ") {
+		bin = `"` + bin + `"`
+	}
 	action := fmt.Sprintf(`%s notify __daemon --cloud-grpc %s`, bin, cloudGRPC)
 
 	cmd := execCommand("schtasks",
@@ -39,7 +42,12 @@ func installNotifyService(cloudGRPC string) error {
 
 func uninstallNotifyService() error {
 	cmd := execCommand("schtasks", "/Delete", "/TN", notifyTaskName, "/F")
-	if out, err := cmd.CombinedOutput(); err != nil {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		outLower := strings.ToLower(string(out))
+		if strings.Contains(outLower, "cannot find") || strings.Contains(outLower, "does not exist") {
+			return nil
+		}
 		return fmt.Errorf("schtasks /Delete: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil

--- a/go/internal/cli/commands/notify_service_windows.go
+++ b/go/internal/cli/commands/notify_service_windows.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package commands
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+const notifyTaskName = "Wendy Notify"
+
+func notifyLogPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "notify.log"), nil
+}
+
+func installNotifyService(cloudGRPC string) error {
+	bin := wendyBinaryPath()
+	action := fmt.Sprintf(`%s notify __daemon --cloud-grpc %s`, bin, cloudGRPC)
+
+	cmd := execCommand("schtasks",
+		"/Create",
+		"/TN", notifyTaskName,
+		"/TR", action,
+		"/SC", "ONLOGON",
+		"/F",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("schtasks /Create: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func uninstallNotifyService() error {
+	cmd := execCommand("schtasks", "/Delete", "/TN", notifyTaskName, "/F")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("schtasks /Delete: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func notifyServiceStatus() (string, error) {
+	cmd := execCommand("schtasks", "/Query", "/TN", notifyTaskName, "/FO", "LIST")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "stopped", nil
+	}
+	outStr := string(out)
+	if strings.Contains(outStr, "Running") {
+		return "running", nil
+	}
+	if strings.Contains(outStr, notifyTaskName) {
+		return "installed (not running)", nil
+	}
+	return "stopped", nil
+}

--- a/go/internal/cli/commands/notify_service_windows_test.go
+++ b/go/internal/cli/commands/notify_service_windows_test.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package commands
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestInstallNotifyService_Windows(t *testing.T) {
+	var schtasksCalls [][]string
+	origCommand := execCommand
+	t.Cleanup(func() { execCommand = origCommand })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if strings.EqualFold(name, "schtasks") || strings.HasSuffix(strings.ToLower(name), "schtasks.exe") {
+			schtasksCalls = append(schtasksCalls, append([]string{name}, args...))
+			return exec.Command("cmd", "/C", "exit 0")
+		}
+		return exec.Command(name, args...)
+	}
+
+	err := installNotifyService("cloud.example:443")
+	if err != nil {
+		t.Fatalf("installNotifyService: %v", err)
+	}
+
+	if len(schtasksCalls) == 0 {
+		t.Fatal("expected schtasks to be called")
+	}
+	joined := strings.Join(schtasksCalls[0], " ")
+	if !strings.Contains(joined, "/Create") {
+		t.Errorf("expected /Create in schtasks call: %s", joined)
+	}
+	if !strings.Contains(joined, "cloud.example:443") {
+		t.Errorf("cloud-grpc not in schtasks call: %s", joined)
+	}
+	if !strings.Contains(joined, "__daemon") {
+		t.Errorf("__daemon not in schtasks call: %s", joined)
+	}
+}
+
+func TestUninstallNotifyService_Windows(t *testing.T) {
+	var schtasksCalls [][]string
+	origCommand := execCommand
+	t.Cleanup(func() { execCommand = origCommand })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if strings.EqualFold(name, "schtasks") || strings.HasSuffix(strings.ToLower(name), "schtasks.exe") {
+			schtasksCalls = append(schtasksCalls, append([]string{name}, args...))
+			return exec.Command("cmd", "/C", "exit 0")
+		}
+		return exec.Command(name, args...)
+	}
+
+	if err := uninstallNotifyService(); err != nil {
+		t.Fatalf("uninstallNotifyService: %v", err)
+	}
+
+	if len(schtasksCalls) == 0 {
+		t.Fatal("expected schtasks to be called")
+	}
+	joined := strings.Join(schtasksCalls[0], " ")
+	if !strings.Contains(joined, "/Delete") {
+		t.Errorf("expected /Delete in schtasks call: %s", joined)
+	}
+}

--- a/go/internal/cli/commands/notify_test.go
+++ b/go/internal/cli/commands/notify_test.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestNotifyCmd_HasSubcommands(t *testing.T) {
+	cmd := newNotifyCmd()
+
+	expected := map[string]bool{
+		"start":    false,
+		"stop":     false,
+		"status":   false,
+		"__daemon": false,
+	}
+	for _, sub := range cmd.Commands() {
+		if _, ok := expected[sub.Name()]; ok {
+			expected[sub.Name()] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestNotifyCmd_DaemonIsHidden(t *testing.T) {
+	cmd := newNotifyCmd()
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "__daemon" && !sub.Hidden {
+			t.Error("__daemon subcommand should be hidden")
+		}
+	}
+}
+
+func TestNotifyCmd_RegisteredInRoot(t *testing.T) {
+	root := NewRootCmd()
+	found := false
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == "notify" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("'notify' command not registered in root")
+	}
+}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -264,6 +264,7 @@ func NewRootCmd() *cobra.Command {
 		tourCmd,
 		mcpCmd,
 		completionCmd,
+		newNotifyCmd(),
 	)
 
 	root.SetHelpCommandGroupID("misc")

--- a/go/proto/gen/cloudpb/notifications.pb.go
+++ b/go/proto/gen/cloudpb/notifications.pb.go
@@ -722,6 +722,74 @@ func (x *GetUnreadCountResponse) GetUnreadCount() int32 {
 	return 0
 }
 
+type SubscribeNotificationsRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	OrganizationId int32                  `protobuf:"varint,1,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
+	UserId         string                 `protobuf:"bytes,2,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	MinSeverity    *NotificationSeverity  `protobuf:"varint,3,opt,name=min_severity,json=minSeverity,proto3,enum=wendycloud.v1.NotificationSeverity,oneof" json:"min_severity,omitempty"`
+	AfterId        *int32                 `protobuf:"varint,4,opt,name=after_id,json=afterId,proto3,oneof" json:"after_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SubscribeNotificationsRequest) Reset() {
+	*x = SubscribeNotificationsRequest{}
+	mi := &file_cloud_notifications_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SubscribeNotificationsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SubscribeNotificationsRequest) ProtoMessage() {}
+
+func (x *SubscribeNotificationsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cloud_notifications_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SubscribeNotificationsRequest.ProtoReflect.Descriptor instead.
+func (*SubscribeNotificationsRequest) Descriptor() ([]byte, []int) {
+	return file_cloud_notifications_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *SubscribeNotificationsRequest) GetOrganizationId() int32 {
+	if x != nil {
+		return x.OrganizationId
+	}
+	return 0
+}
+
+func (x *SubscribeNotificationsRequest) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *SubscribeNotificationsRequest) GetMinSeverity() NotificationSeverity {
+	if x != nil && x.MinSeverity != nil {
+		return *x.MinSeverity
+	}
+	return NotificationSeverity_NOTIFICATION_SEVERITY_UNSPECIFIED
+}
+
+func (x *SubscribeNotificationsRequest) GetAfterId() int32 {
+	if x != nil && x.AfterId != nil {
+		return *x.AfterId
+	}
+	return 0
+}
+
 var File_cloud_notifications_proto protoreflect.FileDescriptor
 
 const file_cloud_notifications_proto_rawDesc = "" +
@@ -774,13 +842,20 @@ const file_cloud_notifications_proto_rawDesc = "" +
 	"\x0forganization_id\x18\x01 \x01(\x05R\x0eorganizationId\x12\x17\n" +
 	"\auser_id\x18\x02 \x01(\tR\x06userId\";\n" +
 	"\x16GetUnreadCountResponse\x12!\n" +
-	"\funread_count\x18\x01 \x01(\x05R\vunreadCount*\xc5\x01\n" +
+	"\funread_count\x18\x01 \x01(\x05R\vunreadCount\"\xec\x01\n" +
+	"\x1dSubscribeNotificationsRequest\x12'\n" +
+	"\x0forganization_id\x18\x01 \x01(\x05R\x0eorganizationId\x12\x17\n" +
+	"\auser_id\x18\x02 \x01(\tR\x06userId\x12K\n" +
+	"\fmin_severity\x18\x03 \x01(\x0e2#.wendycloud.v1.NotificationSeverityH\x00R\vminSeverity\x88\x01\x01\x12\x1e\n" +
+	"\bafter_id\x18\x04 \x01(\x05H\x01R\aafterId\x88\x01\x01B\x0f\n" +
+	"\r_min_severityB\v\n" +
+	"\t_after_id*\xc5\x01\n" +
 	"\x14NotificationSeverity\x12%\n" +
 	"!NOTIFICATION_SEVERITY_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aNOTIFICATION_SEVERITY_INFO\x10\x01\x12!\n" +
 	"\x1dNOTIFICATION_SEVERITY_WARNING\x10\x02\x12\x1f\n" +
 	"\x1bNOTIFICATION_SEVERITY_ERROR\x10\x03\x12\"\n" +
-	"\x1eNOTIFICATION_SEVERITY_CRITICAL\x10\x042\xce\x04\n" +
+	"\x1eNOTIFICATION_SEVERITY_CRITICAL\x10\x042\xb5\x05\n" +
 	"\x13NotificationService\x12[\n" +
 	"\x12CreateNotification\x12(.wendycloud.v1.CreateNotificationRequest\x1a\x1b.wendycloud.v1.Notification\x12f\n" +
 	"\x11ListNotifications\x12'.wendycloud.v1.ListNotificationsRequest\x1a(.wendycloud.v1.ListNotificationsResponse\x12U\n" +
@@ -788,7 +863,8 @@ const file_cloud_notifications_proto_rawDesc = "" +
 	"\x12DeleteNotification\x12(.wendycloud.v1.DeleteNotificationRequest\x1a).wendycloud.v1.DeleteNotificationResponse\x12Q\n" +
 	"\n" +
 	"MarkAsRead\x12 .wendycloud.v1.MarkAsReadRequest\x1a!.wendycloud.v1.MarkAsReadResponse\x12]\n" +
-	"\x0eGetUnreadCount\x12$.wendycloud.v1.GetUnreadCountRequest\x1a%.wendycloud.v1.GetUnreadCountResponseb\x06proto3"
+	"\x0eGetUnreadCount\x12$.wendycloud.v1.GetUnreadCountRequest\x1a%.wendycloud.v1.GetUnreadCountResponse\x12e\n" +
+	"\x16SubscribeNotifications\x12,.wendycloud.v1.SubscribeNotificationsRequest\x1a\x1b.wendycloud.v1.Notification0\x01b\x06proto3"
 
 var (
 	file_cloud_notifications_proto_rawDescOnce sync.Once
@@ -803,49 +879,53 @@ func file_cloud_notifications_proto_rawDescGZIP() []byte {
 }
 
 var file_cloud_notifications_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_cloud_notifications_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_cloud_notifications_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_cloud_notifications_proto_goTypes = []any{
-	(NotificationSeverity)(0),          // 0: wendycloud.v1.NotificationSeverity
-	(*Notification)(nil),               // 1: wendycloud.v1.Notification
-	(*CreateNotificationRequest)(nil),  // 2: wendycloud.v1.CreateNotificationRequest
-	(*ListNotificationsRequest)(nil),   // 3: wendycloud.v1.ListNotificationsRequest
-	(*ListNotificationsResponse)(nil),  // 4: wendycloud.v1.ListNotificationsResponse
-	(*GetNotificationRequest)(nil),     // 5: wendycloud.v1.GetNotificationRequest
-	(*DeleteNotificationRequest)(nil),  // 6: wendycloud.v1.DeleteNotificationRequest
-	(*DeleteNotificationResponse)(nil), // 7: wendycloud.v1.DeleteNotificationResponse
-	(*MarkAsReadRequest)(nil),          // 8: wendycloud.v1.MarkAsReadRequest
-	(*MarkAsReadResponse)(nil),         // 9: wendycloud.v1.MarkAsReadResponse
-	(*GetUnreadCountRequest)(nil),      // 10: wendycloud.v1.GetUnreadCountRequest
-	(*GetUnreadCountResponse)(nil),     // 11: wendycloud.v1.GetUnreadCountResponse
-	(*structpb.Struct)(nil),            // 12: google.protobuf.Struct
-	(*timestamppb.Timestamp)(nil),      // 13: google.protobuf.Timestamp
+	(NotificationSeverity)(0),             // 0: wendycloud.v1.NotificationSeverity
+	(*Notification)(nil),                  // 1: wendycloud.v1.Notification
+	(*CreateNotificationRequest)(nil),     // 2: wendycloud.v1.CreateNotificationRequest
+	(*ListNotificationsRequest)(nil),      // 3: wendycloud.v1.ListNotificationsRequest
+	(*ListNotificationsResponse)(nil),     // 4: wendycloud.v1.ListNotificationsResponse
+	(*GetNotificationRequest)(nil),        // 5: wendycloud.v1.GetNotificationRequest
+	(*DeleteNotificationRequest)(nil),     // 6: wendycloud.v1.DeleteNotificationRequest
+	(*DeleteNotificationResponse)(nil),    // 7: wendycloud.v1.DeleteNotificationResponse
+	(*MarkAsReadRequest)(nil),             // 8: wendycloud.v1.MarkAsReadRequest
+	(*MarkAsReadResponse)(nil),            // 9: wendycloud.v1.MarkAsReadResponse
+	(*GetUnreadCountRequest)(nil),         // 10: wendycloud.v1.GetUnreadCountRequest
+	(*GetUnreadCountResponse)(nil),        // 11: wendycloud.v1.GetUnreadCountResponse
+	(*SubscribeNotificationsRequest)(nil), // 12: wendycloud.v1.SubscribeNotificationsRequest
+	(*structpb.Struct)(nil),               // 13: google.protobuf.Struct
+	(*timestamppb.Timestamp)(nil),         // 14: google.protobuf.Timestamp
 }
 var file_cloud_notifications_proto_depIdxs = []int32{
 	0,  // 0: wendycloud.v1.Notification.severity:type_name -> wendycloud.v1.NotificationSeverity
-	12, // 1: wendycloud.v1.Notification.related_entities:type_name -> google.protobuf.Struct
-	13, // 2: wendycloud.v1.Notification.created_at:type_name -> google.protobuf.Timestamp
-	13, // 3: wendycloud.v1.Notification.deleted_at:type_name -> google.protobuf.Timestamp
+	13, // 1: wendycloud.v1.Notification.related_entities:type_name -> google.protobuf.Struct
+	14, // 2: wendycloud.v1.Notification.created_at:type_name -> google.protobuf.Timestamp
+	14, // 3: wendycloud.v1.Notification.deleted_at:type_name -> google.protobuf.Timestamp
 	0,  // 4: wendycloud.v1.CreateNotificationRequest.severity:type_name -> wendycloud.v1.NotificationSeverity
-	12, // 5: wendycloud.v1.CreateNotificationRequest.related_entities:type_name -> google.protobuf.Struct
+	13, // 5: wendycloud.v1.CreateNotificationRequest.related_entities:type_name -> google.protobuf.Struct
 	0,  // 6: wendycloud.v1.ListNotificationsRequest.severity_filter:type_name -> wendycloud.v1.NotificationSeverity
 	1,  // 7: wendycloud.v1.ListNotificationsResponse.notifications:type_name -> wendycloud.v1.Notification
-	2,  // 8: wendycloud.v1.NotificationService.CreateNotification:input_type -> wendycloud.v1.CreateNotificationRequest
-	3,  // 9: wendycloud.v1.NotificationService.ListNotifications:input_type -> wendycloud.v1.ListNotificationsRequest
-	5,  // 10: wendycloud.v1.NotificationService.GetNotification:input_type -> wendycloud.v1.GetNotificationRequest
-	6,  // 11: wendycloud.v1.NotificationService.DeleteNotification:input_type -> wendycloud.v1.DeleteNotificationRequest
-	8,  // 12: wendycloud.v1.NotificationService.MarkAsRead:input_type -> wendycloud.v1.MarkAsReadRequest
-	10, // 13: wendycloud.v1.NotificationService.GetUnreadCount:input_type -> wendycloud.v1.GetUnreadCountRequest
-	1,  // 14: wendycloud.v1.NotificationService.CreateNotification:output_type -> wendycloud.v1.Notification
-	4,  // 15: wendycloud.v1.NotificationService.ListNotifications:output_type -> wendycloud.v1.ListNotificationsResponse
-	1,  // 16: wendycloud.v1.NotificationService.GetNotification:output_type -> wendycloud.v1.Notification
-	7,  // 17: wendycloud.v1.NotificationService.DeleteNotification:output_type -> wendycloud.v1.DeleteNotificationResponse
-	9,  // 18: wendycloud.v1.NotificationService.MarkAsRead:output_type -> wendycloud.v1.MarkAsReadResponse
-	11, // 19: wendycloud.v1.NotificationService.GetUnreadCount:output_type -> wendycloud.v1.GetUnreadCountResponse
-	14, // [14:20] is the sub-list for method output_type
-	8,  // [8:14] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	0,  // 8: wendycloud.v1.SubscribeNotificationsRequest.min_severity:type_name -> wendycloud.v1.NotificationSeverity
+	2,  // 9: wendycloud.v1.NotificationService.CreateNotification:input_type -> wendycloud.v1.CreateNotificationRequest
+	3,  // 10: wendycloud.v1.NotificationService.ListNotifications:input_type -> wendycloud.v1.ListNotificationsRequest
+	5,  // 11: wendycloud.v1.NotificationService.GetNotification:input_type -> wendycloud.v1.GetNotificationRequest
+	6,  // 12: wendycloud.v1.NotificationService.DeleteNotification:input_type -> wendycloud.v1.DeleteNotificationRequest
+	8,  // 13: wendycloud.v1.NotificationService.MarkAsRead:input_type -> wendycloud.v1.MarkAsReadRequest
+	10, // 14: wendycloud.v1.NotificationService.GetUnreadCount:input_type -> wendycloud.v1.GetUnreadCountRequest
+	12, // 15: wendycloud.v1.NotificationService.SubscribeNotifications:input_type -> wendycloud.v1.SubscribeNotificationsRequest
+	1,  // 16: wendycloud.v1.NotificationService.CreateNotification:output_type -> wendycloud.v1.Notification
+	4,  // 17: wendycloud.v1.NotificationService.ListNotifications:output_type -> wendycloud.v1.ListNotificationsResponse
+	1,  // 18: wendycloud.v1.NotificationService.GetNotification:output_type -> wendycloud.v1.Notification
+	7,  // 19: wendycloud.v1.NotificationService.DeleteNotification:output_type -> wendycloud.v1.DeleteNotificationResponse
+	9,  // 20: wendycloud.v1.NotificationService.MarkAsRead:output_type -> wendycloud.v1.MarkAsReadResponse
+	11, // 21: wendycloud.v1.NotificationService.GetUnreadCount:output_type -> wendycloud.v1.GetUnreadCountResponse
+	1,  // 22: wendycloud.v1.NotificationService.SubscribeNotifications:output_type -> wendycloud.v1.Notification
+	16, // [16:23] is the sub-list for method output_type
+	9,  // [9:16] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_cloud_notifications_proto_init() }
@@ -855,13 +935,14 @@ func file_cloud_notifications_proto_init() {
 	}
 	file_cloud_notifications_proto_msgTypes[0].OneofWrappers = []any{}
 	file_cloud_notifications_proto_msgTypes[2].OneofWrappers = []any{}
+	file_cloud_notifications_proto_msgTypes[11].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cloud_notifications_proto_rawDesc), len(file_cloud_notifications_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   11,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/cloudpb/notifications_grpc.pb.go
+++ b/go/proto/gen/cloudpb/notifications_grpc.pb.go
@@ -19,12 +19,13 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	NotificationService_CreateNotification_FullMethodName = "/wendycloud.v1.NotificationService/CreateNotification"
-	NotificationService_ListNotifications_FullMethodName  = "/wendycloud.v1.NotificationService/ListNotifications"
-	NotificationService_GetNotification_FullMethodName    = "/wendycloud.v1.NotificationService/GetNotification"
-	NotificationService_DeleteNotification_FullMethodName = "/wendycloud.v1.NotificationService/DeleteNotification"
-	NotificationService_MarkAsRead_FullMethodName         = "/wendycloud.v1.NotificationService/MarkAsRead"
-	NotificationService_GetUnreadCount_FullMethodName     = "/wendycloud.v1.NotificationService/GetUnreadCount"
+	NotificationService_CreateNotification_FullMethodName     = "/wendycloud.v1.NotificationService/CreateNotification"
+	NotificationService_ListNotifications_FullMethodName      = "/wendycloud.v1.NotificationService/ListNotifications"
+	NotificationService_GetNotification_FullMethodName        = "/wendycloud.v1.NotificationService/GetNotification"
+	NotificationService_DeleteNotification_FullMethodName     = "/wendycloud.v1.NotificationService/DeleteNotification"
+	NotificationService_MarkAsRead_FullMethodName             = "/wendycloud.v1.NotificationService/MarkAsRead"
+	NotificationService_GetUnreadCount_FullMethodName         = "/wendycloud.v1.NotificationService/GetUnreadCount"
+	NotificationService_SubscribeNotifications_FullMethodName = "/wendycloud.v1.NotificationService/SubscribeNotifications"
 )
 
 // NotificationServiceClient is the client API for NotificationService service.
@@ -37,6 +38,7 @@ type NotificationServiceClient interface {
 	DeleteNotification(ctx context.Context, in *DeleteNotificationRequest, opts ...grpc.CallOption) (*DeleteNotificationResponse, error)
 	MarkAsRead(ctx context.Context, in *MarkAsReadRequest, opts ...grpc.CallOption) (*MarkAsReadResponse, error)
 	GetUnreadCount(ctx context.Context, in *GetUnreadCountRequest, opts ...grpc.CallOption) (*GetUnreadCountResponse, error)
+	SubscribeNotifications(ctx context.Context, in *SubscribeNotificationsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Notification], error)
 }
 
 type notificationServiceClient struct {
@@ -107,6 +109,25 @@ func (c *notificationServiceClient) GetUnreadCount(ctx context.Context, in *GetU
 	return out, nil
 }
 
+func (c *notificationServiceClient) SubscribeNotifications(ctx context.Context, in *SubscribeNotificationsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Notification], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &NotificationService_ServiceDesc.Streams[0], NotificationService_SubscribeNotifications_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[SubscribeNotificationsRequest, Notification]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type NotificationService_SubscribeNotificationsClient = grpc.ServerStreamingClient[Notification]
+
 // NotificationServiceServer is the server API for NotificationService service.
 // All implementations must embed UnimplementedNotificationServiceServer
 // for forward compatibility.
@@ -117,6 +138,7 @@ type NotificationServiceServer interface {
 	DeleteNotification(context.Context, *DeleteNotificationRequest) (*DeleteNotificationResponse, error)
 	MarkAsRead(context.Context, *MarkAsReadRequest) (*MarkAsReadResponse, error)
 	GetUnreadCount(context.Context, *GetUnreadCountRequest) (*GetUnreadCountResponse, error)
+	SubscribeNotifications(*SubscribeNotificationsRequest, grpc.ServerStreamingServer[Notification]) error
 	mustEmbedUnimplementedNotificationServiceServer()
 }
 
@@ -144,6 +166,9 @@ func (UnimplementedNotificationServiceServer) MarkAsRead(context.Context, *MarkA
 }
 func (UnimplementedNotificationServiceServer) GetUnreadCount(context.Context, *GetUnreadCountRequest) (*GetUnreadCountResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetUnreadCount not implemented")
+}
+func (UnimplementedNotificationServiceServer) SubscribeNotifications(*SubscribeNotificationsRequest, grpc.ServerStreamingServer[Notification]) error {
+	return status.Error(codes.Unimplemented, "method SubscribeNotifications not implemented")
 }
 func (UnimplementedNotificationServiceServer) mustEmbedUnimplementedNotificationServiceServer() {}
 func (UnimplementedNotificationServiceServer) testEmbeddedByValue()                             {}
@@ -274,6 +299,17 @@ func _NotificationService_GetUnreadCount_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _NotificationService_SubscribeNotifications_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(SubscribeNotificationsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(NotificationServiceServer).SubscribeNotifications(m, &grpc.GenericServerStream[SubscribeNotificationsRequest, Notification]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type NotificationService_SubscribeNotificationsServer = grpc.ServerStreamingServer[Notification]
+
 // NotificationService_ServiceDesc is the grpc.ServiceDesc for NotificationService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -306,6 +342,12 @@ var NotificationService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _NotificationService_GetUnreadCount_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "SubscribeNotifications",
+			Handler:       _NotificationService_SubscribeNotifications_Handler,
+			ServerStreams: true,
+		},
+	},
 	Metadata: "cloud/notifications.proto",
 }


### PR DESCRIPTION
## Summary

- Adds `wendy notify start/stop/status` — installs a background OS service that streams Wendy Cloud notifications and surfaces them as native OS notifications (macOS toast via osascript, Linux via notify-send, Windows via PowerShell toast)
- Extends `NotificationService` proto with a `SubscribeNotifications` server-streaming RPC; daemon reconnects with exponential backoff and resumes from the last-seen notification ID across restarts
- Service management via launchd (macOS `~/Library/LaunchAgents/sh.wendy.notify.plist`), systemd user unit (Linux `~/.config/systemd/user/wendy-notify.service`), and Task Scheduler (Windows `ONLOGON` trigger); all three uninstall paths are idempotent

## Architecture

The hidden `wendy notify __daemon` subcommand is what the OS service manager invokes. `wendy notify start` writes the service file pointing at the current binary path and calls the platform service manager to install and start it. State is persisted to `~/.wendy/notify-state.json` (keyed by gRPC endpoint) so `AfterId` is passed on reconnect, preventing duplicate notifications.

## Test plan

- [ ] `cd go && go test ./internal/cli/commands/ -count=1 -timeout 90s` — full suite passes
- [ ] `GOOS=linux CGO_ENABLED=0 go build ./cmd/wendy` — Linux cross-compile clean
- [ ] `GOOS=windows CGO_ENABLED=0 go build ./cmd/wendy` — Windows cross-compile clean
- [ ] `wendy notify start` on macOS: check `~/Library/LaunchAgents/sh.wendy.notify.plist` written and `launchctl list sh.wendy.notify` shows running
- [ ] `wendy notify stop` when daemon not installed: exits 0 (idempotent)
- [ ] Trigger a cloud notification and verify native OS toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2PErUwYTDzfH4KvANRvNf