### PR TITLE
fix(ros2): config validation + schema for frameworks.ros2 (WDY-1700, WDY-1701, WDY-1706)

### DIFF
--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -784,8 +784,8 @@ func TestBuildROS2Env_AutoDomainID(t *testing.T) {
 		t.Fatalf("expected ROS_DOMAIN_ID in env, got %v", got)
 	}
 	id, err := strconv.Atoi(val)
-	if err != nil || id < 0 || id > 101 {
-		t.Errorf("auto domain ID = %q, want integer in [0,101]", val)
+	if err != nil || id < 0 || id > 232 {
+		t.Errorf("auto domain ID = %q, want integer in [0,232]", val)
 	}
 	// Stable: a second call for the same appId must produce the same ID.
 	again := buildROS2Env(cfg, "com.example.app", "")

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -432,6 +432,12 @@ func (c *AppConfig) Validate() error {
 		}
 	}
 
+	if c.Frameworks != nil {
+		if err := validateROS2Config("frameworks.ros2", c.Frameworks.ROS2); err != nil {
+			return err
+		}
+	}
+
 	for name, svc := range c.Services {
 		if svc == nil {
 			return fmt.Errorf("services[%q]: must not be null", name)
@@ -452,6 +458,11 @@ func (c *AppConfig) Validate() error {
 		}
 		if err := validateEntitlements(svc.Entitlements, fmt.Sprintf("services[%q].entitlement", name)); err != nil {
 			return err
+		}
+		if svc.Frameworks != nil {
+			if err := validateROS2Config(fmt.Sprintf("services[%q].frameworks.ros2", name), svc.Frameworks.ROS2); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -109,7 +109,7 @@ type RunConfig struct {
 // ROS2Config holds ROS 2 runtime configuration for a container.
 type ROS2Config struct {
 	// DomainID is the explicit ROS_DOMAIN_ID. When nil, a stable hash of
-	// the appId in the range 0–101 is injected instead (WDY-884).
+	// the appId in the range 0–232 is injected instead (WDY-884).
 	DomainID *int `json:"domainId,omitempty"`
 	// RMW selects the ROS middleware implementation. Accepts short names
 	// ("cyclonedds", "fastrtps") or full identifiers ("rmw_cyclonedds_cpp").

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -587,8 +587,9 @@ func ValidateJSON(data []byte) []string {
 	var warnings []string
 	warnings = append(warnings, validateEntitlementsJSON(raw["entitlements"], "entitlement")...)
 	warnings = append(warnings, validateHooksJSON(raw["hooks"])...)
+	warnings = append(warnings, validateFrameworksJSON(raw["frameworks"], "frameworks")...)
 
-	// Validate service-level entitlements when a services map is present.
+	// Validate service-level entitlements and frameworks when a services map is present.
 	// Unmarshal into map[string]json.RawMessage first so a null/invalid entry
 	// for one service doesn't silently drop warnings for all other services.
 	if servicesRaw, ok := raw["services"]; ok && len(servicesRaw) > 0 {
@@ -601,11 +602,44 @@ func ValidateJSON(data []byte) []string {
 				}
 				prefix := fmt.Sprintf("services[%q].entitlement", name)
 				warnings = append(warnings, validateEntitlementsJSON(svc["entitlements"], prefix)...)
+				warnings = append(warnings, validateFrameworksJSON(svc["frameworks"], fmt.Sprintf("services[%q].frameworks", name))...)
 			}
 		}
 	}
 
 	return warnings
+}
+
+// validateFrameworksJSON warns on unknown keys under frameworks.ros2 so a typo
+// like "domian_id" surfaces instead of being silently ignored (WDY-1706 M5).
+func validateFrameworksJSON(frameworksRaw json.RawMessage, prefix string) []string {
+	if len(frameworksRaw) == 0 {
+		return nil
+	}
+	var fw map[string]json.RawMessage
+	if err := json.Unmarshal(frameworksRaw, &fw); err != nil {
+		return nil
+	}
+	ros2Raw, ok := fw["ros2"]
+	if !ok || len(ros2Raw) == 0 {
+		return nil
+	}
+	var ros2 map[string]json.RawMessage
+	if err := json.Unmarshal(ros2Raw, &ros2); err != nil {
+		return nil
+	}
+	allowed := map[string]bool{"domainId": true, "rmw": true, "distro": true}
+	var unknown []string
+	for k := range ros2 {
+		if !allowed[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return []string{fmt.Sprintf("Unknown key(s) in %s.ros2: %s. Allowed keys are: distro, domainId, rmw", prefix, strings.Join(unknown, ", "))}
 }
 
 // validateEntitlementsJSON checks raw JSON entitlements for deprecated types

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -1022,6 +1022,17 @@ func TestValidateJSON_UnknownKeys(t *testing.T) {
 	}
 }
 
+func TestValidateJSON_UnknownROS2Keys(t *testing.T) {
+	data := []byte(`{
+		"appId": "com.example.app",
+		"frameworks": { "ros2": { "domainId": 42, "domian_id": 7, "rmw": "cyclonedds" } }
+	}`)
+	warnings := ValidateJSON(data)
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1 (for domian_id): %v", len(warnings), warnings)
+	}
+}
+
 func TestMCPEntitlementValid(t *testing.T) {
 	cfg := &AppConfig{
 		AppID: "test",

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -1033,6 +1033,13 @@ func TestValidateJSON_UnknownROS2Keys(t *testing.T) {
 	}
 }
 
+func TestValidateJSON_CleanROS2_NoWarnings(t *testing.T) {
+	data := []byte(`{"appId":"com.example.app","frameworks":{"ros2":{"domainId":0,"rmw":"cyclonedds","distro":"humble"}}}`)
+	if got := ValidateJSON(data); len(got) != 0 {
+		t.Errorf("clean ros2 config: got %d warnings, want 0: %v", len(got), got)
+	}
+}
+
 func TestMCPEntitlementValid(t *testing.T) {
 	cfg := &AppConfig{
 		AppID: "test",
@@ -1630,5 +1637,17 @@ func TestValidate_ROS2_PerServiceDomainID(t *testing.T) {
 	}
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("expected error for out-of-range per-service domainId, got nil")
+	}
+}
+
+func TestValidate_ROS2_PerServiceUnknownRMW(t *testing.T) {
+	cfg := &AppConfig{
+		AppID: "com.example.app",
+		Services: map[string]*ServiceConfig{
+			"talker": {Context: "./talker", Frameworks: &FrameworksConfig{ROS2: &ROS2Config{RMW: "rmw_bogus"}}},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for unknown per-service rmw, got nil")
 	}
 }

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -1585,3 +1585,39 @@ func TestValidateJSON_ServiceEntitlements(t *testing.T) {
 		}
 	})
 }
+
+func TestValidate_ROS2_RejectsBadDomainID(t *testing.T) {
+	bad := 500
+	cfg := &AppConfig{AppID: "com.example.app", Frameworks: &FrameworksConfig{ROS2: &ROS2Config{DomainID: &bad}}}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for out-of-range domainId, got nil")
+	}
+}
+
+func TestValidate_ROS2_RejectsUnknownRMW(t *testing.T) {
+	cfg := &AppConfig{AppID: "com.example.app", Frameworks: &FrameworksConfig{ROS2: &ROS2Config{RMW: "rmw_bogus"}}}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for unknown rmw, got nil")
+	}
+}
+
+func TestValidate_ROS2_AcceptsValid(t *testing.T) {
+	id := 42
+	cfg := &AppConfig{AppID: "com.example.app", Frameworks: &FrameworksConfig{ROS2: &ROS2Config{DomainID: &id, RMW: "cyclonedds", Distro: "humble"}}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid ros2 config rejected: %v", err)
+	}
+}
+
+func TestValidate_ROS2_PerServiceDomainID(t *testing.T) {
+	bad := -5
+	cfg := &AppConfig{
+		AppID: "com.example.app",
+		Services: map[string]*ServiceConfig{
+			"talker": {Context: "./talker", Frameworks: &FrameworksConfig{ROS2: &ROS2Config{DomainID: &bad}}},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for out-of-range per-service domainId, got nil")
+	}
+}

--- a/go/internal/shared/appconfig/ros2.go
+++ b/go/internal/shared/appconfig/ros2.go
@@ -20,13 +20,13 @@ const ROS2DefaultDistro = "humble"
 // specify one.
 const ROS2DefaultRMW = "rmw_cyclonedds_cpp"
 
-// ROS2DomainIDMin and ROS2DomainIDMax bound valid ROS_DOMAIN_ID values.
-// The ROS 2 spec defines 0–101 as the conservative portable range; some
-// platforms allow up to 232 but 101 covers all standard deployments
+// ROS2DomainIDMin and ROS2DomainIDMax bound valid ROS_DOMAIN_ID values to the
+// full ROS 2 range (0–232). RMW implementations map the domain ID to UDP ports;
+// 232 is the maximum the DDS port-mapping scheme supports
 // (SOC2-CC6, NIST-SI-10).
 const (
 	ROS2DomainIDMin = 0
-	ROS2DomainIDMax = 101
+	ROS2DomainIDMax = 232
 )
 
 // ros2RMWAliases maps wendy.json rmw values to full RMW implementation
@@ -71,7 +71,7 @@ func ROS2AutoDomainID(appID string) int {
 
 // ResolvedDomainID returns the effective ROS_DOMAIN_ID: the explicit
 // domainId when set, otherwise a stable hash of appID. It returns -1 when an
-// explicit domainId is outside the valid 0–101 range.
+// explicit domainId is outside the valid 0–232 range.
 func (r *ROS2Config) ResolvedDomainID(appID string) int {
 	if r.DomainID == nil {
 		return ROS2AutoDomainID(appID)

--- a/go/internal/shared/appconfig/ros2.go
+++ b/go/internal/shared/appconfig/ros2.go
@@ -1,6 +1,7 @@
 package appconfig
 
 import (
+	"fmt"
 	"hash/fnv"
 	"strconv"
 	"strings"
@@ -43,6 +44,24 @@ var ros2RMWAliases = map[string]string{
 	"rmw_fastrtps_cpp":   "rmw_fastrtps_cpp",
 	"rmw_connextdds":     "rmw_connextdds",
 	"rmw_gurumdds_cpp":   "rmw_gurumdds_cpp",
+}
+
+// validateROS2Config rejects an out-of-range domainId or an unknown rmw so a
+// typo fails fast at config-parse / `wendy run` time instead of silently
+// launching a container with no ROS_DOMAIN_ID/RMW_IMPLEMENTATION isolation
+// (WDY-1701). prefix labels the source, e.g. "frameworks.ros2" or
+// `services["talker"].frameworks.ros2`.
+func validateROS2Config(prefix string, r *ROS2Config) error {
+	if r == nil {
+		return nil
+	}
+	if r.DomainID != nil && (*r.DomainID < ROS2DomainIDMin || *r.DomainID > ROS2DomainIDMax) {
+		return fmt.Errorf("%s.domainId must be between %d and %d, got %d", prefix, ROS2DomainIDMin, ROS2DomainIDMax, *r.DomainID)
+	}
+	if r.RMW != "" && ros2RMWAliases[strings.ToLower(r.RMW)] == "" {
+		return fmt.Errorf("%s.rmw %q is not a supported RMW implementation", prefix, r.RMW)
+	}
+	return nil
 }
 
 // IsValidRMWImplementation reports whether s is a full RMW implementation

--- a/go/internal/shared/appconfig/ros2_test.go
+++ b/go/internal/shared/appconfig/ros2_test.go
@@ -21,7 +21,7 @@ func TestROS2Config_ResolvedDomainID(t *testing.T) {
 	if got := (&ROS2Config{DomainID: &explicit}).ResolvedDomainID("app"); got != 42 {
 		t.Errorf("explicit domain ID = %d, want 42", got)
 	}
-	invalid := 102
+	invalid := 233
 	if got := (&ROS2Config{DomainID: &invalid}).ResolvedDomainID("app"); got != -1 {
 		t.Errorf("out-of-range domain ID = %d, want -1", got)
 	}

--- a/go/internal/shared/appconfig/ros2_test.go
+++ b/go/internal/shared/appconfig/ros2_test.go
@@ -21,6 +21,13 @@ func TestROS2Config_ResolvedDomainID(t *testing.T) {
 	if got := (&ROS2Config{DomainID: &explicit}).ResolvedDomainID("app"); got != 42 {
 		t.Errorf("explicit domain ID = %d, want 42", got)
 	}
+	// Newly valid band (0–232): values above the old 101 cap resolve to themselves.
+	for _, valid := range []int{102, 150, 232} {
+		v := valid
+		if got := (&ROS2Config{DomainID: &v}).ResolvedDomainID("app"); got != valid {
+			t.Errorf("domain ID %d = %d, want %d", valid, got, valid)
+		}
+	}
 	invalid := 233
 	if got := (&ROS2Config{DomainID: &invalid}).ResolvedDomainID("app"); got != -1 {
 		t.Errorf("out-of-range domain ID = %d, want -1", got)

--- a/go/internal/shared/appconfig/schema_test.go
+++ b/go/internal/shared/appconfig/schema_test.go
@@ -58,4 +58,20 @@ func TestSchemaJSON_HasFrameworksAndServices(t *testing.T) {
 	if got, want := len(enumRaw), len(ros2RMWAliases); got != want {
 		t.Errorf("schema rmw enum has %d entries, want %d (keys of ros2RMWAliases)", got, want)
 	}
+
+	// Verify exact parity: each enum value must be a key in ros2RMWAliases, and vice versa.
+	want := make(map[string]bool, len(ros2RMWAliases))
+	for k := range ros2RMWAliases {
+		want[k] = true
+	}
+	for _, v := range enumRaw {
+		s, _ := v.(string)
+		if !want[s] {
+			t.Errorf("schema rmw enum value %q is not a key of ros2RMWAliases", s)
+		}
+		delete(want, s)
+	}
+	for k := range want {
+		t.Errorf("ros2RMWAliases key %q is missing from schema rmw enum", k)
+	}
 }

--- a/go/internal/shared/appconfig/schema_test.go
+++ b/go/internal/shared/appconfig/schema_test.go
@@ -1,0 +1,61 @@
+package appconfig
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSchemaJSON_HasFrameworksAndServices verifies that the embedded
+// wendy.schema.json contains top-level "frameworks" and "services" properties
+// and that the ros2 domainId maximum equals the Go constant ROS2DomainIDMax
+// (WDY-1700). This test acts as a sync guard: it fails when someone changes
+// ROS2DomainIDMax without updating the schema.
+func TestSchemaJSON_HasFrameworksAndServices(t *testing.T) {
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+
+	props, _ := schema["properties"].(map[string]any)
+	if _, ok := props["frameworks"]; !ok {
+		t.Error("schema missing top-level 'frameworks' property")
+	}
+	if _, ok := props["services"]; !ok {
+		t.Error("schema missing top-level 'services' property")
+	}
+
+	defs, _ := schema["$defs"].(map[string]any)
+	fw, _ := defs["frameworks"].(map[string]any)
+	if fw == nil {
+		t.Fatal("schema missing $defs.frameworks")
+	}
+
+	// Walk $defs.frameworks.properties.ros2.properties.domainId.maximum directly.
+	fwProps, _ := fw["properties"].(map[string]any)
+	ros2, _ := fwProps["ros2"].(map[string]any)
+	if ros2 == nil {
+		t.Fatal("$defs.frameworks missing ros2 property")
+	}
+	ros2Props, _ := ros2["properties"].(map[string]any)
+	domainId, _ := ros2Props["domainId"].(map[string]any)
+	if domainId == nil {
+		t.Fatal("$defs.frameworks.ros2 missing domainId property")
+	}
+	maxRaw, ok := domainId["maximum"]
+	if !ok {
+		t.Fatal("$defs.frameworks.ros2.domainId missing 'maximum'")
+	}
+	if got := int(maxRaw.(float64)); got != ROS2DomainIDMax {
+		t.Errorf("schema domainId maximum = %d, want %d (Go constant ROS2DomainIDMax)", got, ROS2DomainIDMax)
+	}
+
+	// Verify rmw enum length matches the number of keys in ros2RMWAliases.
+	rmw, _ := ros2Props["rmw"].(map[string]any)
+	if rmw == nil {
+		t.Fatal("$defs.frameworks.ros2 missing rmw property")
+	}
+	enumRaw, _ := rmw["enum"].([]any)
+	if got, want := len(enumRaw), len(ros2RMWAliases); got != want {
+		t.Errorf("schema rmw enum has %d entries, want %d (keys of ros2RMWAliases)", got, want)
+	}
+}

--- a/go/internal/shared/appconfig/schema_test.go
+++ b/go/internal/shared/appconfig/schema_test.go
@@ -2,6 +2,7 @@ package appconfig
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 )
 
@@ -73,5 +74,29 @@ func TestSchemaJSON_HasFrameworksAndServices(t *testing.T) {
 	}
 	for k := range want {
 		t.Errorf("ros2RMWAliases key %q is missing from schema rmw enum", k)
+	}
+}
+
+func TestSchemaJSON_DeclaresROS2ExampleKeys(t *testing.T) {
+	// The flagship ROS 2 example must validate against the schema (WDY-1700):
+	// every top-level key it uses must be a declared property, else
+	// additionalProperties:false rejects it in editors.
+	data, err := os.ReadFile("../../../../Examples/ROS2/wendy.json")
+	if err != nil {
+		t.Fatalf("reading ROS 2 example: %v", err)
+	}
+	var example map[string]any
+	if err := json.Unmarshal(data, &example); err != nil {
+		t.Fatalf("example is not valid JSON: %v", err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	props := schema["properties"].(map[string]any)
+	for k := range example {
+		if _, ok := props[k]; !ok {
+			t.Errorf("ROS 2 example uses top-level key %q not declared in schema properties (additionalProperties:false would reject it)", k)
+		}
 	}
 }

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -62,6 +62,10 @@
         "$ref": "#/$defs/fileSyncEntry"
       }
     },
+    "isolation": {
+      "type": "string",
+      "description": "Namespace isolation mode for multi-container deployments (e.g. shared-ipc, shared-network, isolated)."
+    },
     "frameworks": { "$ref": "#/$defs/frameworks" },
     "services": {
       "type": "object",

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -61,6 +61,12 @@
       "items": {
         "$ref": "#/$defs/fileSyncEntry"
       }
+    },
+    "frameworks": { "$ref": "#/$defs/frameworks" },
+    "services": {
+      "type": "object",
+      "description": "Per-service build and runtime configuration for a multi-service app.",
+      "additionalProperties": { "$ref": "#/$defs/service" }
     }
   },
   "$defs": {
@@ -334,6 +340,49 @@
             "type": "string"
           }
         }
+      }
+    },
+    "frameworks": {
+      "type": "object",
+      "description": "Optional framework-level configuration (e.g. ROS 2).",
+      "additionalProperties": false,
+      "properties": {
+        "ros2": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "ROS 2 runtime configuration injected into the container.",
+          "properties": {
+            "domainId": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 232,
+              "description": "ROS_DOMAIN_ID. When omitted, a stable hash of appId in [0,232] is used."
+            },
+            "rmw": {
+              "type": "string",
+              "enum": [
+                "cyclonedds", "fastrtps", "fastdds", "connextdds", "gurumdds",
+                "rmw_cyclonedds_cpp", "rmw_fastrtps_cpp", "rmw_connextdds", "rmw_gurumdds_cpp"
+              ],
+              "description": "RMW middleware. Short names or full identifiers. Defaults to rmw_cyclonedds_cpp."
+            },
+            "distro": {
+              "type": "string",
+              "description": "ROS 2 distribution (e.g. humble, jazzy). Defaults to humble."
+            }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "A single service within a multi-service app.",
+      "properties": {
+        "context": { "type": "string", "description": "Build context directory relative to wendy.json." },
+        "dependsOn": { "type": "array", "items": { "type": "string" }, "description": "Service names this service starts after." },
+        "entitlements": { "type": "array", "items": { "$ref": "#/$defs/entitlement" } },
+        "frameworks": { "$ref": "#/$defs/frameworks" }
       }
     }
   }


### PR DESCRIPTION
Closes the config/schema half of the ROS 2 bug cluster: ROS 2 configs were both **rejected by the JSON schema** (WDY-1700) and **never validated** by the Go config layer (WDY-1701), so a typo'd `domainId`/`rmw` silently launched a container with no DDS isolation. Also picks up WDY-1706 config polish (M5 unknown-key warnings, L2 full domain range).

## Changes
- **WDY-1706 L2 — domain range 0–232.** `ROS2DomainIDMax` 101 → 232 (ROS 2's real max). The FNV auto-domain modulo derives from the constant; prose/docs updated. Tests assert 102/150/232 now resolve valid and 233 is rejected.
- **WDY-1701 — `Validate()` checks `frameworks.ros2`.** New `validateROS2Config` rejects out-of-range `domainId` and unknown `rmw` (case-insensitive, via `ros2RMWAliases`) at **both** group and per-service level. An empty/unset `rmw` still defaults correctly.
- **WDY-1706 M5 — unknown-key warnings.** `ValidateJSON` now warns on unknown keys under `frameworks.ros2` (e.g. `domian_id`), group and per-service.
- **WDY-1700 — schema gains `frameworks` + `services`.** Added with `additionalProperties:false` defs mirroring the Go model; `domainId` `maximum:232`, `rmw` enum, `distro` string. Also declared the top-level `isolation` key (the ROS 2 example sets `isolation: shared-ipc` and was being rejected).

## Sync guarantees (tested)
- `schema_test.go` asserts the schema `rmw` enum **exactly** equals the keys of `ros2RMWAliases` (both directions) and that `domainId.maximum` equals the `ROS2DomainIDMax` constant — so schema/Go can't silently drift.
- A conformance test asserts every top-level key in `Examples/ROS2/wendy.json` is a declared schema property.

## Verification
- `go test ./internal/shared/appconfig/ ./internal/agent/containerd/` green; `gofmt` clean; schema JSON well-formed.
- No on-device verification needed — pure config-parse/schema logic, fully unit-tested.

## Follow-up (out of scope)
- The schema still omits `xcode` and `serviceName` from top-level properties — a pre-existing gap, not used by ROS 2; deferred.
- The schema `rmw` enum must be updated if a new RMW is ever added to `ros2RMWAliases` (the parity test enforces this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)