### PR TITLE
fix(ros2): mixed-RMW inspection correctness (WDY-1703, WDY-1710, WDY-1712)

### DIFF
--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 // TestROS2SidecarName maps each RMW to a distinct, prefix-scoped sidecar name
-// and collapses unknown/empty RMW to the stock-image (FastRTPS) default — the
-// basis for one persistent sidecar per RMW (WDY-1594).
+// and collapses empty RMW to the CycloneDDS (config-default) sidecar — the
+// basis for one persistent sidecar per RMW (WDY-1594, WDY-1703).
 func TestROS2SidecarName(t *testing.T) {
 	cyc := ros2SidecarName("rmw_cyclonedds_cpp")
 	fast := ros2SidecarName("rmw_fastrtps_cpp")
@@ -22,8 +22,8 @@ func TestROS2SidecarName(t *testing.T) {
 	if cyc == fast {
 		t.Errorf("distinct RMWs must map to distinct sidecars: %q == %q", cyc, fast)
 	}
-	if fast != def {
-		t.Errorf("empty RMW should map to the FastRTPS (image-default) sidecar: %q vs %q", def, fast)
+	if def != cyc {
+		t.Errorf("empty RMW should map to the CycloneDDS (config-default) sidecar (WDY-1703): %q vs %q", def, cyc)
 	}
 	if got := ros2SidecarName("rmw_bogus"); got != ros2SidecarPrefix+"-default" {
 		t.Errorf("unknown RMW = %q, want %q", got, ros2SidecarPrefix+"-default")

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -50,7 +50,10 @@ const (
 	// labelKeyROS2RMW records the anchor app's RMW implementation so each
 	// ExecROS2 can set RMW_IMPLEMENTATION to match — without it the sidecar's
 	// ros2 CLI falls to the image default and can't see apps on another RMW
-	// (WDY-1593). Empty means "use the image default" (FastRTPS).
+	// (WDY-1593). Empty means the app's RMW_IMPLEMENTATION was not set in its
+	// OCI spec env; Wendy's config layer defaults that to CycloneDDS
+	// (appconfig.ROS2DefaultRMW), so the sidecar layer treats empty as
+	// CycloneDDS too (WDY-1703).
 	labelKeyROS2RMW = "sh.wendy/ros2.rmw"
 
 	// rosImageDefaultRMW is the only RMW the stock docker.io/library/ros:<distro>
@@ -134,13 +137,15 @@ func rmwFromEnv(env []string) string {
 }
 
 // ros2SidecarSuffix maps an RMW to a short, containerd-ID-safe sidecar name
-// suffix (e.g. "rmw_cyclonedds_cpp" -> "cyclonedds"). Unknown/empty RMW -> the
-// stock-image default. One sidecar per suffix means one per distinct RMW.
+// suffix (e.g. "rmw_cyclonedds_cpp" -> "cyclonedds"). Empty RMW is treated as
+// CycloneDDS — the Wendy config-layer default (appconfig.ROS2DefaultRMW) — so
+// both layers agree on which sidecar serves an unset-RMW app (WDY-1703). One
+// sidecar per suffix means one per distinct RMW.
 func ros2SidecarSuffix(rmw string) string {
 	switch rmw {
-	case "rmw_cyclonedds_cpp":
+	case "rmw_cyclonedds_cpp", "":
 		return "cyclonedds"
-	case "rmw_fastrtps_cpp", "":
+	case "rmw_fastrtps_cpp":
 		return "fastrtps"
 	case "rmw_connextdds":
 		return "connext"
@@ -263,15 +268,21 @@ func (c *Client) ensureOneROS2Sidecar(ctx context.Context, anchor *services.ROS2
 		return services.ROS2Sidecar{}, fmt.Errorf("loading ROS 2 anchor container %q: %w", anchor.ContainerID, err)
 	}
 
-	// Pick the sidecar image. Stock ros:<distro> ships only FastRTPS, so for any
-	// other RMW (e.g. CycloneDDS, the Wendy default) reuse the anchor app's own
-	// image: it already has the matching RMW + ros2 CLI and is already pulled and
-	// unpacked on the device. FastRTPS (and empty/unknown) stay on the stock
-	// image — the verified path that does not depend on the app image carrying
-	// the ros2 CLI (WDY-1593).
+	// Pick the sidecar image.
+	//
+	// The stock docker.io/library/ros:<distro> image ships only FastRTPS
+	// (librmw_fastrtps_cpp; no CycloneDDS). It is used only for an explicit
+	// rmw_fastrtps_cpp anchor — the verified path that does not depend on the
+	// app image carrying the ros2 CLI (WDY-1593).
+	//
+	// For every other RMW — including empty (which Wendy's config layer
+	// resolves to CycloneDDS, appconfig.ROS2DefaultRMW, WDY-1703) — reuse the
+	// anchor app's own image: it already carries the matching RMW + ros2 CLI
+	// and is already pulled and unpacked on the device.
 	var image containerd.Image
 	reusedAnchorImage := false
-	if rmw == "" || rmw == rosImageDefaultRMW {
+	if rmw == rosImageDefaultRMW {
+		// stock docker.io/library/ros:<distro> ships only FastRTPS
 		imageName := "docker.io/library/ros:" + anchor.Distro
 		image, err = c.client.GetImage(ctx, imageName)
 		if err != nil {
@@ -287,14 +298,16 @@ func (c *Client) ensureOneROS2Sidecar(ctx context.Context, anchor *services.ROS2
 			}
 		}
 	} else {
-		// The anchor image is already pulled/unpacked (the anchor is running), so
-		// skip the pull/unpack dance entirely.
+		// CycloneDDS (incl. the empty/config default) and other RMWs reuse the
+		// anchor app's own image, which carries the matching RMW + ros2 CLI.
+		// The anchor image is already pulled/unpacked (the anchor is running),
+		// so skip the pull/unpack dance entirely.
 		image, err = anchorCtr.Image(ctx)
 		if err != nil {
 			return services.ROS2Sidecar{}, fmt.Errorf("resolving anchor image for %s sidecar (anchor %s): %w", rmw, anchor.ContainerID, err)
 		}
 		reusedAnchorImage = true
-		c.logger.Info("ROS 2 sidecar reusing anchor app image for non-default RMW",
+		c.logger.Info("ROS 2 sidecar reusing anchor app image",
 			zap.String("rmw", rmw), zap.String("image", image.Name()), zap.String("anchor", anchor.ContainerID))
 	}
 

--- a/go/internal/agent/services/ros2_service.go
+++ b/go/internal/agent/services/ros2_service.go
@@ -172,9 +172,15 @@ func (s *ROS2Service) ListNodes(ctx context.Context, req *agentpbv2.ListROS2Node
 		return nil, err
 	}
 	resp := &agentpbv2.ListROS2NodesResponse{}
+	seen := map[string]bool{}
 	for _, o := range outs {
 		for _, n := range parseROS2NodeList(o.out) {
 			n.Rmw = o.rmw
+			key := n.GetNamespace() + "/" + n.GetName() + "\x00" + o.rmw
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
 			resp.Nodes = append(resp.Nodes, n)
 		}
 	}
@@ -250,8 +256,14 @@ func (s *ROS2Service) ListServices(ctx context.Context, req *agentpbv2.ListROS2S
 		return nil, err
 	}
 	resp := &agentpbv2.ListROS2ServicesResponse{}
+	seen := map[string]bool{}
 	for _, o := range outs {
 		for _, t := range parseROS2TopicList(o.out) {
+			key := t.GetName() + "\x00" + o.rmw
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
 			resp.Services = append(resp.Services, &agentpbv2.ListROS2ServicesResponse_Service{
 				Name:  t.GetName(),
 				Types: t.GetTypes(),
@@ -363,6 +375,8 @@ func (s *ROS2Service) GetGraph(ctx context.Context, req *agentpbv2.GetROS2GraphR
 	resp := &agentpbv2.GetROS2GraphResponse{}
 	var lastErr error
 	any := false
+	seenNodes := map[string]bool{}
+	seenEdges := map[string]bool{}
 	for _, sc := range scs {
 		out, rerr := s.runIn(ctx, sc, "node", "list")
 		if rerr != nil {
@@ -372,18 +386,30 @@ func (s *ROS2Service) GetGraph(ctx context.Context, req *agentpbv2.GetROS2GraphR
 		any = true
 		for _, node := range parseROS2NodeList(out) {
 			node.Rmw = sc.rmw
-			resp.Nodes = append(resp.Nodes, node)
 			fqn := ros2NodeFQN(node)
+			nodeKey := fqn + "\x00" + sc.rmw
+			if !seenNodes[nodeKey] {
+				seenNodes[nodeKey] = true
+				resp.Nodes = append(resp.Nodes, node)
+			}
 			info, ierr := s.runIn(ctx, sc, "node", "info", fqn)
 			if ierr != nil {
 				continue // node may have exited between list and info
 			}
 			publishes, subscribes := parseROS2NodeInfo(info)
 			for _, topic := range publishes {
-				resp.Publishes = append(resp.Publishes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic, Rmw: sc.rmw})
+				edgeKey := fqn + "\x00" + topic + "\x00" + sc.rmw + "\x00pub"
+				if !seenEdges[edgeKey] {
+					seenEdges[edgeKey] = true
+					resp.Publishes = append(resp.Publishes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic, Rmw: sc.rmw})
+				}
 			}
 			for _, topic := range subscribes {
-				resp.Subscribes = append(resp.Subscribes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic, Rmw: sc.rmw})
+				edgeKey := fqn + "\x00" + topic + "\x00" + sc.rmw + "\x00sub"
+				if !seenEdges[edgeKey] {
+					seenEdges[edgeKey] = true
+					resp.Subscribes = append(resp.Subscribes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic, Rmw: sc.rmw})
+				}
 			}
 		}
 	}

--- a/go/internal/agent/services/ros2_service_test.go
+++ b/go/internal/agent/services/ros2_service_test.go
@@ -588,6 +588,89 @@ func TestROS2Service_RecordBag_UnexpectedExitWithHealthyAnchor(t *testing.T) {
 	}
 }
 
+// TestROS2Service_ListNodes_DedupsAcrossSidecars verifies that a node visible to
+// more than one sidecar appears only once per (namespace+name, rmw) pair
+// (WDY-1710). Two sidecars each on their own RMW both emit /talker → 2 nodes
+// kept (distinct RMWs). A sidecar that emits /talker twice in its stdout → only
+// 1 node kept (true duplicate).
+func TestROS2Service_ListNodes_DedupsAcrossSidecars(t *testing.T) {
+	rt := &fakeROS2Runtime{
+		sidecars: []ROS2Sidecar{
+			{Name: "sc-cyc", Distro: "humble", DomainID: 42, RMW: "rmw_cyclonedds_cpp"},
+			{Name: "sc-fast", Distro: "humble", DomainID: 42, RMW: "rmw_fastrtps_cpp"},
+		},
+		// Both sidecars emit /talker (different RMWs → 2 distinct entries kept).
+		// sc-cyc also emits /talker a second time via a duplicate stdout line to
+		// prove within-sidecar dedup (same name+rmw → collapsed to 1).
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			switch opts.SidecarName {
+			case "sc-cyc":
+				// Duplicate line simulates a sidecar reporting the same node twice.
+				io.WriteString(stdout, "/talker\n/talker\n")
+			case "sc-fast":
+				io.WriteString(stdout, "/talker\n")
+			}
+			return 0, nil
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	resp, err := svc.ListNodes(context.Background(), &agentpbv2.ListROS2NodesRequest{})
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	// /talker on rmw_cyclonedds_cpp and /talker on rmw_fastrtps_cpp are distinct
+	// (different RMW) → 2 entries. The duplicate /talker from sc-cyc is collapsed.
+	if len(resp.GetNodes()) != 2 {
+		t.Fatalf("got %d nodes, want 2 distinct (name,rmw) pairs", len(resp.GetNodes()))
+	}
+	// Verify both RMWs are represented.
+	rmws := map[string]bool{}
+	for _, n := range resp.GetNodes() {
+		rmws[n.GetRmw()] = true
+	}
+	if !rmws["rmw_cyclonedds_cpp"] || !rmws["rmw_fastrtps_cpp"] {
+		t.Errorf("RMW coverage = %v, want both cyclonedds and fastrtps", rmws)
+	}
+}
+
+// TestROS2Service_GetGraph_DedupsEdges verifies that a node's publish/subscribe
+// edges are deduplicated when a sidecar's node info stdout contains the same
+// topic twice (same (node, topic, rmw) → collapsed to 1 edge) (WDY-1710).
+func TestROS2Service_GetGraph_DedupsEdges(t *testing.T) {
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Name: "sc-cyc", Distro: "humble", DomainID: 0, RMW: "rmw_cyclonedds_cpp"},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			key := strings.Join(opts.Args, " ")
+			switch key {
+			case "node list":
+				io.WriteString(stdout, "/talker\n")
+			case "node info /talker":
+				// Duplicate publisher entry simulates noisy node info output.
+				io.WriteString(stdout, `/talker
+  Subscribers:
+  Publishers:
+    /chatter: std_msgs/msg/String
+    /chatter: std_msgs/msg/String
+`)
+			}
+			return 0, nil
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	resp, err := svc.GetGraph(context.Background(), &agentpbv2.GetROS2GraphRequest{})
+	if err != nil {
+		t.Fatalf("GetGraph: %v", err)
+	}
+	// The /talker→/chatter publish edge must appear exactly once despite the
+	// duplicate line in node info stdout.
+	if len(resp.GetPublishes()) != 1 {
+		t.Fatalf("got %d publish edges, want 1 (deduped)", len(resp.GetPublishes()))
+	}
+	if resp.GetPublishes()[0].GetNode() != "/talker" || resp.GetPublishes()[0].GetTopic() != "/chatter" {
+		t.Errorf("publish edge = %+v", resp.GetPublishes()[0])
+	}
+}
+
 func TestTailLines(t *testing.T) {
 	in := "a\nb\n\nc\nd\ne\n"
 	if got := tailLines(in, 3); got != "c\nd\ne" {

--- a/go/internal/cli/commands/ros2_graph.go
+++ b/go/internal/cli/commands/ros2_graph.go
@@ -37,21 +37,29 @@ func ros2GraphNodeLabel(node, rmw string, tagged bool) string {
 	return node
 }
 
-// ros2GraphEdges builds topic → publishers and topic → subscribers maps from
-// a graph response, skipping hidden infrastructure topics. Node labels carry an
-// RMW tag when the graph spans multiple RMWs.
-func ros2GraphEdges(graph *agentpbv2.GetROS2GraphResponse) (pubs, subs map[string][]string) {
+// ros2EdgeKey identifies a pub/sub bucket by both topic and RMW so that
+// publishers and subscribers are only paired within the same middleware
+// (WDY-1712). When the graph is single-RMW, all edges carry Rmw: "" and
+// therefore share the same key — identical to the pre-fix behaviour.
+type ros2EdgeKey struct{ topic, rmw string }
+
+// ros2GraphEdges builds (topic,rmw) → publishers and (topic,rmw) → subscribers
+// maps from a graph response, skipping hidden infrastructure topics. Node
+// labels carry an RMW tag when the graph spans multiple RMWs.
+func ros2GraphEdges(graph *agentpbv2.GetROS2GraphResponse) (pubs, subs map[ros2EdgeKey][]string) {
 	tagged := graphSpansMultipleRMWs(graph)
-	pubs = make(map[string][]string)
-	subs = make(map[string][]string)
+	pubs = make(map[ros2EdgeKey][]string)
+	subs = make(map[ros2EdgeKey][]string)
 	for _, e := range graph.GetPublishes() {
 		if !ros2HiddenGraphTopics[e.GetTopic()] {
-			pubs[e.GetTopic()] = append(pubs[e.GetTopic()], ros2GraphNodeLabel(e.GetNode(), e.GetRmw(), tagged))
+			k := ros2EdgeKey{e.GetTopic(), e.GetRmw()}
+			pubs[k] = append(pubs[k], ros2GraphNodeLabel(e.GetNode(), e.GetRmw(), tagged))
 		}
 	}
 	for _, e := range graph.GetSubscribes() {
 		if !ros2HiddenGraphTopics[e.GetTopic()] {
-			subs[e.GetTopic()] = append(subs[e.GetTopic()], ros2GraphNodeLabel(e.GetNode(), e.GetRmw(), tagged))
+			k := ros2EdgeKey{e.GetTopic(), e.GetRmw()}
+			subs[k] = append(subs[k], ros2GraphNodeLabel(e.GetNode(), e.GetRmw(), tagged))
 		}
 	}
 	return pubs, subs
@@ -63,23 +71,28 @@ func ros2GraphEdges(graph *agentpbv2.GetROS2GraphResponse) (pubs, subs map[strin
 func renderROS2GraphASCII(graph *agentpbv2.GetROS2GraphResponse) string {
 	pubs, subs := ros2GraphEdges(graph)
 
-	topics := make([]string, 0, len(pubs))
-	for topic := range pubs {
-		topics = append(topics, topic)
+	keys := make([]ros2EdgeKey, 0, len(pubs))
+	for k := range pubs {
+		keys = append(keys, k)
 	}
-	sort.Strings(topics)
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].topic != keys[j].topic {
+			return keys[i].topic < keys[j].topic
+		}
+		return keys[i].rmw < keys[j].rmw
+	})
 
 	var b strings.Builder
 	connected := make(map[string]bool)
-	for _, topic := range topics {
-		for _, pub := range pubs[topic] {
-			if len(subs[topic]) == 0 {
-				fmt.Fprintf(&b, "[%s] ──%s──▶ (no subscribers)\n", pub, topic)
+	for _, k := range keys {
+		for _, pub := range pubs[k] {
+			if len(subs[k]) == 0 {
+				fmt.Fprintf(&b, "[%s] ──%s──▶ (no subscribers)\n", pub, k.topic)
 				connected[pub] = true
 				continue
 			}
-			for _, sub := range subs[topic] {
-				fmt.Fprintf(&b, "[%s] ──%s──▶ [%s]\n", pub, topic, sub)
+			for _, sub := range subs[k] {
+				fmt.Fprintf(&b, "[%s] ──%s──▶ [%s]\n", pub, k.topic, sub)
 				connected[pub] = true
 				connected[sub] = true
 			}
@@ -123,15 +136,20 @@ func renderROS2GraphDOT(graph *agentpbv2.GetROS2GraphResponse) string {
 	for _, node := range graph.GetNodes() {
 		fmt.Fprintf(&b, "  %q;\n", ros2GraphNodeLabel(ros2GraphNodeFQN(node), node.GetRmw(), tagged))
 	}
-	topics := make([]string, 0, len(pubs))
-	for topic := range pubs {
-		topics = append(topics, topic)
+	keys := make([]ros2EdgeKey, 0, len(pubs))
+	for k := range pubs {
+		keys = append(keys, k)
 	}
-	sort.Strings(topics)
-	for _, topic := range topics {
-		for _, pub := range pubs[topic] {
-			for _, sub := range subs[topic] {
-				fmt.Fprintf(&b, "  %q -> %q [label=%q];\n", pub, sub, topic)
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].topic != keys[j].topic {
+			return keys[i].topic < keys[j].topic
+		}
+		return keys[i].rmw < keys[j].rmw
+	})
+	for _, k := range keys {
+		for _, pub := range pubs[k] {
+			for _, sub := range subs[k] {
+				fmt.Fprintf(&b, "  %q -> %q [label=%q];\n", pub, sub, k.topic)
 			}
 		}
 	}

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -113,6 +113,57 @@ func TestExtractROS2BagArchive_RejectsTraversal(t *testing.T) {
 	}
 }
 
+func testROS2GraphMixedRMW() *agentpbv2.GetROS2GraphResponse {
+	return &agentpbv2.GetROS2GraphResponse{
+		Nodes: []*agentpbv2.ROS2Node{
+			{Name: "talker", Namespace: "/", Rmw: "rmw_cyclonedds_cpp"},
+			{Name: "listener", Namespace: "/", Rmw: "rmw_cyclonedds_cpp"},
+			{Name: "talker", Namespace: "/", Rmw: "rmw_fastrtps_cpp"},
+			{Name: "listener", Namespace: "/", Rmw: "rmw_fastrtps_cpp"},
+		},
+		Publishes: []*agentpbv2.GetROS2GraphResponse_Edge{
+			{Node: "/talker", Topic: "/chatter", Rmw: "rmw_cyclonedds_cpp"},
+			{Node: "/talker", Topic: "/chatter", Rmw: "rmw_fastrtps_cpp"},
+		},
+		Subscribes: []*agentpbv2.GetROS2GraphResponse_Edge{
+			{Node: "/listener", Topic: "/chatter", Rmw: "rmw_cyclonedds_cpp"},
+			{Node: "/listener", Topic: "/chatter", Rmw: "rmw_fastrtps_cpp"},
+		},
+	}
+}
+
+func TestRenderROS2GraphASCII_NoCrossRMWEdges(t *testing.T) {
+	out := renderROS2GraphASCII(testROS2GraphMixedRMW())
+	// same-RMW edges present
+	if !strings.Contains(out, "[/talker [cyclonedds]] ──/chatter──▶ [/listener [cyclonedds]]") {
+		t.Errorf("missing cyclonedds edge:\n%s", out)
+	}
+	if !strings.Contains(out, "[/talker [fastrtps]] ──/chatter──▶ [/listener [fastrtps]]") {
+		t.Errorf("missing fastrtps edge:\n%s", out)
+	}
+	// cross-RMW edges must NOT appear
+	if strings.Contains(out, "[/talker [cyclonedds]] ──/chatter──▶ [/listener [fastrtps]]") ||
+		strings.Contains(out, "[/talker [fastrtps]] ──/chatter──▶ [/listener [cyclonedds]]") {
+		t.Errorf("cross-RMW edge drawn (WDY-1712):\n%s", out)
+	}
+}
+
+func TestRenderROS2GraphDOT_NoCrossRMWEdges(t *testing.T) {
+	out := renderROS2GraphDOT(testROS2GraphMixedRMW())
+	// same-RMW edges present
+	if !strings.Contains(out, `"/talker [cyclonedds]" -> "/listener [cyclonedds]" [label="/chatter"];`) {
+		t.Errorf("missing cyclonedds DOT edge:\n%s", out)
+	}
+	if !strings.Contains(out, `"/talker [fastrtps]" -> "/listener [fastrtps]" [label="/chatter"];`) {
+		t.Errorf("missing fastrtps DOT edge:\n%s", out)
+	}
+	// cross-RMW edges must NOT appear
+	if strings.Contains(out, `"/talker [cyclonedds]" -> "/listener [fastrtps]"`) ||
+		strings.Contains(out, `"/talker [fastrtps]" -> "/listener [cyclonedds]"`) {
+		t.Errorf("cross-RMW DOT edge drawn (WDY-1712):\n%s", out)
+	}
+}
+
 func TestROS2DomainPtr(t *testing.T) {
 	if got := ros2DomainPtr(-1); got != nil {
 		t.Errorf("ros2DomainPtr(-1) = %v, want nil", got)


### PR DESCRIPTION
Makes `wendy device ros2` correct on a mixed-RMW device. Three layers of the same data flow were each wrong; this fixes all three so RMW identity is handled consistently end-to-end (app env → sidecar → agent merge → CLI render).

## Changes
- **WDY-1703 — sidecar default RMW.** An app with no explicit `RMW_IMPLEMENTATION` resolved to **CycloneDDS** in the config layer (`ResolvedRMW`) but **FastRTPS** in the sidecar layer, so `wendy device ros2` showed an empty graph for a healthy CycloneDDS app. Now empty/unset RMW maps to the CycloneDDS sidecar suffix, and the stock `ros:<distro>` image is used **only** for an explicit `rmw_fastrtps_cpp` anchor — empty + CycloneDDS + other RMWs reuse the anchor app's own (matching) image.
- **WDY-1710 — duplicated entries.** `ListNodes`/`ListServices`/`GetGraph` now de-duplicate merged per-sidecar results by a stable key that includes RMW: `(name, rmw)` for nodes/services, `(fqn, rmw)` for graph nodes, `(node, topic, rmw)` for edges. Same name on two different RMWs is correctly kept as two; true duplicates collapse.
- **WDY-1712 — false cross-RMW edges.** The graph renderer keyed pub/sub on topic name alone, drawing physically-impossible CycloneDDS↔FastRTPS edges. Both the ASCII and DOT renderers now key on `(topic, rmw)`, connecting a publisher to a subscriber only when their RMW matches.

## Consistency (verified by whole-branch review)
The agent emits the canonical full RMW form (`rmw_cyclonedds_cpp`) on the wire; the CLI keys dedup/edge-matching on the same proto `Rmw` field (shortening only for display). So merge tags and render keys align. One-sidecar-per-RMW-suffix still holds (empty and `rmw_cyclonedds_cpp` share the `cyclonedds` suffix), so dedup is never reintroduced. The single-RMW path (`rmw == ""`) collapses to the old behavior unchanged.

## Verification
- `go test ./internal/cli/commands/ ./internal/agent/services/ ./internal/agent/containerd/` green; `gofmt` clean.
- New tests are real discriminators (fail against pre-fix code): no-cross-RMW-edge render, dedup-across-sidecars, empty→CycloneDDS sidecar.

## ⚠️ Needs on-device verification
Unit tests cover the logic; the end-to-end mixed-RMW behavior should be confirmed on a real device (the `wendyos-christos-new-jetson` / WDY-1554 ros2multi setup):
- Deploy a mixed-RMW app (CycloneDDS + FastRTPS talker/listener on the same topic).
- `wendy device ros2 nodes` → each node appears once (no 2× duplication).
- `wendy device ros2 graph` → no cross-RMW edges; same-RMW edges present.
- Deploy an app with no explicit `rmw` → `wendy device ros2 nodes` returns a non-empty graph (was empty before WDY-1703).

## Residual note
For a **non-Wendy** ros2-labeled container with no `RMW_IMPLEMENTATION` env and a stock FastRTPS-only image, the sidecar reuses that image (consistent with the image, but not CycloneDDS). Wendy-built apps always carry an explicit `rmw_cyclonedds_cpp` label, so this only affects externally-launched containers — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)