### PR TITLE
fix(ros2): sidecar lifecycle + hardening (WDY-1702, WDY-1704, WDY-1706)

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -266,6 +266,12 @@ func main() {
 		}()
 	}
 
+	if ctrdClient != nil {
+		if err := ctrdClient.ReapOrphanedROS2Sidecars(ctx); err != nil {
+			logger.Warn("ROS 2 sidecar reap on boot failed", zap.Error(err))
+		}
+	}
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -79,6 +79,10 @@ type Client struct {
 	// (SOC2-CC6, NIST-AC-3, ISO27001-A.8).
 	appStopping map[string]bool
 
+	// ros2ExecRefs counts active ExecROS2 calls per sidecar name. Protected by mu.
+	// Teardown paths check this before SIGKILLing a sidecar (WDY-1702 H5).
+	ros2ExecRefs map[string]int
+
 	// chunkIndex maps CDC chunk hashes to byte ranges in uncompressed layer
 	// blobs (Model B). staging holds chunks received this session until the
 	// following AssembleLayerFromChunks consumes them.
@@ -112,6 +116,7 @@ func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) 
 		appIsolation: make(map[string]string),
 		serviceIPs:   make(map[string]map[string]string),
 		appStopping:  make(map[string]bool),
+		ros2ExecRefs: make(map[string]int),
 		chunkIndex:   idx,
 		staging:      newStaging(defaultChunkStagingDir),
 	}, nil

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -303,6 +303,7 @@ func (c *Client) ensureOneROS2Sidecar(ctx context.Context, anchor *services.ROS2
 	}
 
 	spec := localoci.DefaultSpec("rootfs", []string{"sleep", "infinity"})
+	localoci.DropToMinimalCapabilities(spec)
 	spec.Process.Env = append(spec.Process.Env, "ROS_LOCALHOST_ONLY=1")
 	spec.Mounts = append(spec.Mounts, localoci.Mount{
 		Destination: ROS2BagDir,

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -602,8 +602,19 @@ func (c *Client) ReapOrphanedROS2Sidecars(ctx context.Context) error {
 		return fmt.Errorf("listing app containers for sidecar reap: %w", err)
 	}
 	for _, ctr := range appCtrs {
+		// WDY-1702 H4: distinguish definitive "anchor gone" from ambiguous errors.
+		// NotFound from Task() means the container has no task — it cleanly stopped
+		// or never started. That is precisely the orphan case: do NOT mark it
+		// unresolvable; omitting it from liveTasks lets its sidecar be reaped.
+		// Any other error (timeout, transient RPC) means liveness is genuinely
+		// unknown — mark unresolvable so its sidecar is kept (safety, WDY-1702 H4).
 		task, terr := ctr.Task(ctx, nil)
 		if terr != nil {
+			if errdefs.IsNotFound(terr) {
+				// Anchor definitively has no task (cleanly stopped/gone): reapable.
+				continue
+			}
+			// Liveness unknown: keep sidecar to avoid false-positive reap.
 			c.logger.Warn("ROS 2 sidecar reap: could not get task for app container, treating as unresolvable",
 				zap.String("container", ctr.ID()), zap.Error(terr))
 			unresolvable[ctr.ID()] = true
@@ -611,6 +622,11 @@ func (c *Client) ReapOrphanedROS2Sidecars(ctx context.Context) error {
 		}
 		st, serr := task.Status(ctx)
 		if serr != nil {
+			if errdefs.IsNotFound(serr) {
+				// Task record gone between Task() and Status(): definitively stopped.
+				continue
+			}
+			// Status unknown: keep sidecar to avoid false-positive reap.
 			c.logger.Warn("ROS 2 sidecar reap: could not get task status for app container, treating as unresolvable",
 				zap.String("container", ctr.ID()), zap.Error(serr))
 			unresolvable[ctr.ID()] = true

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -202,6 +202,11 @@ func (c *Client) EnsureROS2Sidecars(ctx context.Context) ([]services.ROS2Sidecar
 	if existing, lerr := c.listROS2Sidecars(ctx); lerr == nil {
 		for _, ctr := range existing {
 			if _, want := anchorByName[ctr.ID()]; !want {
+				if c.sidecarHasActiveExecsLocked(ctr.ID()) {
+					c.logger.Info("Deferring stale ROS 2 sidecar teardown: exec in flight",
+						zap.String("sidecar", ctr.ID()))
+					continue
+				}
 				_ = c.deleteROS2Sidecar(ctx, ctr)
 			}
 		}
@@ -252,6 +257,11 @@ func (c *Client) ensureOneROS2Sidecar(ctx context.Context, anchor *services.ROS2
 		}
 		c.logger.Info("Recreating stale ROS 2 sidecar",
 			zap.String("sidecar", name), zap.String("anchor", anchor.ContainerID), zap.Bool("anchor_alive", anchorAlive))
+		if c.sidecarHasActiveExecsLocked(name) {
+			c.logger.Info("Deferring stale ROS 2 sidecar recreation: exec in flight",
+				zap.String("sidecar", name))
+			return sidecar, nil
+		}
 		if derr := c.deleteROS2Sidecar(ctx, existing); derr != nil {
 			return services.ROS2Sidecar{}, fmt.Errorf("removing stale ROS 2 sidecar: %w", derr)
 		}
@@ -507,14 +517,20 @@ func (c *Client) StopROS2Sidecar(ctx context.Context) error {
 	return nil
 }
 
-// teardownAllROS2SidecarsLocked removes every sidecar container. Caller must
-// hold c.mu and pass a namespaced ctx.
+// teardownAllROS2SidecarsLocked removes every sidecar container that has no
+// active ExecROS2 calls. Sidecars with in-flight execs are skipped (logged).
+// Caller must hold c.mu and pass a namespaced ctx.
 func (c *Client) teardownAllROS2SidecarsLocked(ctx context.Context) {
 	sidecars, err := c.listROS2Sidecars(ctx)
 	if err != nil {
 		return
 	}
 	for _, ctr := range sidecars {
+		if c.sidecarHasActiveExecsLocked(ctr.ID()) {
+			c.logger.Info("Deferring ROS 2 sidecar teardown: exec in flight",
+				zap.String("sidecar", ctr.ID()))
+			continue
+		}
 		_ = c.deleteROS2Sidecar(ctx, ctr)
 	}
 }
@@ -528,6 +544,49 @@ func (c *Client) deleteROS2Sidecar(ctx context.Context, container containerd.Con
 		return err
 	}
 	return nil
+}
+
+// Locking order for ros2ExecRefs (WDY-1702 H5):
+//
+//   - acquireSidecarExec and releaseSidecarExec each take c.mu briefly only
+//     for the map mutation, then immediately release it.
+//   - ExecROS2 calls acquire/release around task.Exec+proc.Wait but does NOT
+//     hold c.mu for the full duration of the exec. This is intentional:
+//     EnsureROS2Sidecars and StopROS2Sidecar hold c.mu for their entire body,
+//     so if ExecROS2 also held c.mu across a long exec the two would serialize
+//     and risk deadlock.
+//   - Teardown callers (EnsureROS2Sidecars, teardownAllROS2SidecarsLocked)
+//     already hold c.mu when they need to test the refcount, so they use the
+//     sidecarHasActiveExecsLocked variant which skips the redundant lock.
+
+// acquireSidecarExec increments the active-exec refcount for the named sidecar.
+// It takes c.mu briefly; callers must NOT hold c.mu.
+func (c *Client) acquireSidecarExec(name string) {
+	c.mu.Lock()
+	if c.ros2ExecRefs == nil {
+		c.ros2ExecRefs = make(map[string]int)
+	}
+	c.ros2ExecRefs[name]++
+	c.mu.Unlock()
+}
+
+// releaseSidecarExec decrements the active-exec refcount for the named sidecar.
+// It takes c.mu briefly; callers must NOT hold c.mu.
+func (c *Client) releaseSidecarExec(name string) {
+	c.mu.Lock()
+	if c.ros2ExecRefs[name] > 0 {
+		c.ros2ExecRefs[name]--
+	}
+	if c.ros2ExecRefs[name] == 0 {
+		delete(c.ros2ExecRefs, name)
+	}
+	c.mu.Unlock()
+}
+
+// sidecarHasActiveExecsLocked reports whether name has any active ExecROS2
+// calls in flight. Caller must hold c.mu.
+func (c *Client) sidecarHasActiveExecsLocked(name string) bool {
+	return c.ros2ExecRefs[name] > 0
 }
 
 // ExecROS2 runs `ros2 <args...>` inside the CLI sidecar, streaming stdout and
@@ -596,6 +655,13 @@ func (c *Client) ExecROS2(ctx context.Context, opts services.ROS2ExecOptions, st
 			pspec.Env = append(pspec.Env, "CYCLONEDDS_URI="+cycloneDDSInlineConfig)
 		}
 	}
+
+	// Increment the per-sidecar exec refcount so that teardown (EnsureROS2Sidecars /
+	// StopROS2Sidecar) defers deletion while this exec is in flight. The acquire and
+	// release each take c.mu only briefly; c.mu is NOT held across task.Exec or
+	// proc.Wait (see locking-order comment above deleteROS2Sidecar).
+	c.acquireSidecarExec(name)
+	defer c.releaseSidecarExec(name)
 
 	execID := fmt.Sprintf("ros2-exec-%d-%d", time.Now().UnixNano(), ros2ExecCounter.Add(1))
 	proc, err := task.Exec(nctx, execID, pspec, cio.NewCreator(cio.WithStreams(nil, stdout, stderr)))

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -63,6 +64,12 @@ const (
 	// escalating to SIGKILL. `ros2 bag record` needs the grace period to
 	// finalize the bag on disk.
 	ros2ExecStopGrace = 10 * time.Second
+
+	// ros2MaxConcurrentExecs is the maximum number of simultaneous ExecROS2
+	// calls allowed against a single sidecar. Beyond this the exec is rejected
+	// with a clear error so a slow or hung command stream cannot exhaust the
+	// containerd exec table (L6, WDY-1706).
+	ros2MaxConcurrentExecs = 16
 )
 
 // ros2DistroPattern validates ROS 2 distro names read from container labels
@@ -212,13 +219,26 @@ func (c *Client) EnsureROS2Sidecars(ctx context.Context) ([]services.ROS2Sidecar
 		}
 	}
 
+	// Build sidecars for every RMW. On a per-RMW failure we log and continue so
+	// that a broken image for one RMW does not prevent commands against the
+	// remaining RMWs (L3, WDY-1706 partial-success). Only fail the whole call
+	// when every sidecar failed to ensure.
 	sidecars := make([]services.ROS2Sidecar, 0, len(order))
+	var errs []error
 	for _, name := range order {
 		sc, eerr := c.ensureOneROS2Sidecar(ctx, anchorByName[name], name)
 		if eerr != nil {
-			return nil, eerr
+			c.logger.Error("Failed to ensure ROS 2 sidecar; skipping RMW",
+				zap.String("sidecar", name),
+				zap.String("rmw", anchorByName[name].RMW),
+				zap.Error(eerr))
+			errs = append(errs, fmt.Errorf("sidecar %s: %w", name, eerr))
+			continue
 		}
 		sidecars = append(sidecars, sc)
+	}
+	if len(sidecars) == 0 {
+		return nil, fmt.Errorf("all ROS 2 sidecar builds failed: %w", errors.Join(errs...))
 	}
 	return sidecars, nil
 }
@@ -353,9 +373,12 @@ func (c *Client) ensureOneROS2Sidecar(ctx context.Context, anchor *services.ROS2
 			f.Close()
 		}
 	}()
-	// For shared-ipc, replace the sidecar's private tmpfs /dev/shm with the
-	// group's shared segment so it attaches to the same FastRTPS shm pool.
-	if isolation == "shared-ipc" {
+	// For shared-ipc groups using FastRTPS, replace the sidecar's private tmpfs
+	// /dev/shm with the group's shared segment so it attaches to the same
+	// FastRTPS shm pool. CycloneDDS has SharedMemory disabled in
+	// cycloneDDSInlineConfig so the bind would be a no-op for it; skip it to
+	// avoid unnecessary mount complexity (M1, WDY-1706).
+	if isolation == "shared-ipc" && anchor.RMW == "rmw_fastrtps_cpp" {
 		localoci.RemoveDefaultSHM(spec)
 		spec.Mounts = append(spec.Mounts, localoci.SharedSHMMount(sidecarSHM))
 	}
@@ -676,6 +699,22 @@ func (c *Client) acquireSidecarExec(name string) {
 	c.mu.Unlock()
 }
 
+// acquireSidecarExecCapped is like acquireSidecarExec but returns an error when
+// the per-sidecar exec count would exceed ros2MaxConcurrentExecs (L6, WDY-1706).
+// Callers must NOT hold c.mu.
+func (c *Client) acquireSidecarExecCapped(name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.ros2ExecRefs == nil {
+		c.ros2ExecRefs = make(map[string]int)
+	}
+	if c.ros2ExecRefs[name] >= ros2MaxConcurrentExecs {
+		return fmt.Errorf("too many concurrent ROS 2 execs on sidecar %q (limit %d); retry later", name, ros2MaxConcurrentExecs)
+	}
+	c.ros2ExecRefs[name]++
+	return nil
+}
+
 // releaseSidecarExec decrements the active-exec refcount for the named sidecar.
 // It takes c.mu briefly; callers must NOT hold c.mu.
 func (c *Client) releaseSidecarExec(name string) {
@@ -747,7 +786,10 @@ func (c *Client) ExecROS2(ctx context.Context, opts services.ROS2ExecOptions, st
 		fmt.Sprintf("source /opt/ros/%s/setup.bash >/dev/null 2>&1 && exec ros2 \"$@\"", distro),
 		"ros2",
 	}, opts.Args...)
-	pspec.Env = append(pspec.Env,
+	// Copy pspec.Env before appending to avoid mutating the slice header returned
+	// by container.Spec (future callers might cache the spec or share the backing
+	// array across execs — defensive copy prevents env bleed-over, L5, WDY-1706).
+	pspec.Env = append(append([]string(nil), pspec.Env...),
 		"ROS_DOMAIN_ID="+strconv.Itoa(opts.DomainID),
 		"ROS_LOCALHOST_ONLY=1",
 	)
@@ -766,7 +808,11 @@ func (c *Client) ExecROS2(ctx context.Context, opts services.ROS2ExecOptions, st
 	// StopROS2Sidecar) defers deletion while this exec is in flight. The acquire and
 	// release each take c.mu only briefly; c.mu is NOT held across task.Exec or
 	// proc.Wait (see locking-order comment above deleteROS2Sidecar).
-	c.acquireSidecarExec(name)
+	// acquireSidecarExecCapped rejects the call when the per-sidecar cap is reached
+	// (ros2MaxConcurrentExecs) to prevent exhausting the containerd exec table (L6, WDY-1706).
+	if err := c.acquireSidecarExecCapped(name); err != nil {
+		return -1, err
+	}
 	defer c.releaseSidecarExec(name)
 
 	execID := fmt.Sprintf("ros2-exec-%d-%d", time.Now().UnixNano(), ros2ExecCounter.Add(1))

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -545,6 +545,17 @@ func isOrphanedSidecar(anchorID string, anchorPID uint32, liveTasks map[uint32]s
 	return !ok || liveID != anchorID
 }
 
+// shouldReapSidecar decides whether a sidecar should be reaped. It is orphaned
+// only when its anchor is confirmably gone; if the anchor's liveness could not
+// be verified (anchorID in unresolvable), the sidecar is KEPT — a boot reaper
+// must never delete a sidecar whose anchor might still be alive (WDY-1702 H4).
+func shouldReapSidecar(anchorID string, anchorPID uint32, liveTasks map[uint32]string, unresolvable map[string]bool) bool {
+	if unresolvable[anchorID] {
+		return false
+	}
+	return isOrphanedSidecar(anchorID, anchorPID, liveTasks)
+}
+
 // ReapOrphanedROS2Sidecars deletes any ROS 2 CLI sidecar containers whose
 // anchor app task is no longer running. It is called once at agent boot after
 // the containerd client is ready, so sidecars orphaned by a prior agent crash
@@ -562,6 +573,7 @@ func (c *Client) ReapOrphanedROS2Sidecars(ctx context.Context) error {
 	// containers. Sidecars carry labelKeyROS2Sidecar (not labelKeyAppVersion),
 	// so they are naturally excluded from this set.
 	liveTasks := make(map[uint32]string)
+	unresolvable := make(map[string]bool)
 	appCtrs, err := c.client.Containers(ctx, fmt.Sprintf("labels.%q", labelKeyAppVersion))
 	if err != nil {
 		return fmt.Errorf("listing app containers for sidecar reap: %w", err)
@@ -569,10 +581,19 @@ func (c *Client) ReapOrphanedROS2Sidecars(ctx context.Context) error {
 	for _, ctr := range appCtrs {
 		task, terr := ctr.Task(ctx, nil)
 		if terr != nil {
+			c.logger.Warn("ROS 2 sidecar reap: could not get task for app container, treating as unresolvable",
+				zap.String("container", ctr.ID()), zap.Error(terr))
+			unresolvable[ctr.ID()] = true
 			continue
 		}
 		st, serr := task.Status(ctx)
-		if serr != nil || st.Status != containerd.Running {
+		if serr != nil {
+			c.logger.Warn("ROS 2 sidecar reap: could not get task status for app container, treating as unresolvable",
+				zap.String("container", ctr.ID()), zap.Error(serr))
+			unresolvable[ctr.ID()] = true
+			continue
+		}
+		if st.Status != containerd.Running {
 			continue
 		}
 		liveTasks[task.Pid()] = ctr.ID()
@@ -600,7 +621,7 @@ func (c *Client) ReapOrphanedROS2Sidecars(ctx context.Context) error {
 		}
 		anchorPID := uint32(anchorPID64)
 
-		if !isOrphanedSidecar(anchorID, anchorPID, liveTasks) {
+		if !shouldReapSidecar(anchorID, anchorPID, liveTasks, unresolvable) {
 			continue
 		}
 		if c.sidecarHasActiveExecsLocked(sc.ID()) {

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -535,6 +535,91 @@ func (c *Client) teardownAllROS2SidecarsLocked(ctx context.Context) {
 	}
 }
 
+// isOrphanedSidecar reports whether a sidecar is orphaned. A sidecar is
+// orphaned when its anchor PID is not present in the live-task set, or when
+// the live task at that PID belongs to a different container (PID recycled).
+// liveTasks maps running task PID → container ID.
+// This is a pure function so it can be unit-tested without containerd.
+func isOrphanedSidecar(anchorID string, anchorPID uint32, liveTasks map[uint32]string) bool {
+	liveID, ok := liveTasks[anchorPID]
+	return !ok || liveID != anchorID
+}
+
+// ReapOrphanedROS2Sidecars deletes any ROS 2 CLI sidecar containers whose
+// anchor app task is no longer running. It is called once at agent boot after
+// the containerd client is ready, so sidecars orphaned by a prior agent crash
+// or ungraceful shutdown are cleaned up before new workloads start.
+//
+// A sidecar is only deleted when its anchor container ID + PID no longer match
+// a live running task. Sidecars with active ExecROS2 calls in flight are
+// skipped (consistent with teardownAllROS2SidecarsLocked).
+func (c *Client) ReapOrphanedROS2Sidecars(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ctx = c.withNamespace(ctx)
+
+	// Build the live-task map: PID → container ID, for all running Wendy app
+	// containers. Sidecars carry labelKeyROS2Sidecar (not labelKeyAppVersion),
+	// so they are naturally excluded from this set.
+	liveTasks := make(map[uint32]string)
+	appCtrs, err := c.client.Containers(ctx, fmt.Sprintf("labels.%q", labelKeyAppVersion))
+	if err != nil {
+		return fmt.Errorf("listing app containers for sidecar reap: %w", err)
+	}
+	for _, ctr := range appCtrs {
+		task, terr := ctr.Task(ctx, nil)
+		if terr != nil {
+			continue
+		}
+		st, serr := task.Status(ctx)
+		if serr != nil || st.Status != containerd.Running {
+			continue
+		}
+		liveTasks[task.Pid()] = ctr.ID()
+	}
+
+	sidecars, err := c.listROS2Sidecars(ctx)
+	if err != nil {
+		return fmt.Errorf("listing ROS 2 sidecars for reap: %w", err)
+	}
+
+	for _, sc := range sidecars {
+		labels, lerr := sc.Labels(ctx)
+		if lerr != nil {
+			c.logger.Warn("ROS 2 sidecar reap: could not read labels, skipping",
+				zap.String("sidecar", sc.ID()), zap.Error(lerr))
+			continue
+		}
+		anchorID := labels[labelKeyROS2AnchorID]
+		anchorPIDStr := labels[labelKeyROS2AnchorPID]
+		anchorPID64, perr := strconv.ParseUint(anchorPIDStr, 10, 32)
+		if perr != nil {
+			c.logger.Warn("ROS 2 sidecar reap: invalid anchor PID label, treating as orphaned",
+				zap.String("sidecar", sc.ID()), zap.String("pid", anchorPIDStr))
+			// Fall through: isOrphanedSidecar with PID 0 will return true.
+		}
+		anchorPID := uint32(anchorPID64)
+
+		if !isOrphanedSidecar(anchorID, anchorPID, liveTasks) {
+			continue
+		}
+		if c.sidecarHasActiveExecsLocked(sc.ID()) {
+			c.logger.Info("ROS 2 sidecar reap: exec in flight, skipping",
+				zap.String("sidecar", sc.ID()))
+			continue
+		}
+		c.logger.Info("ROS 2 sidecar reap: deleting orphaned sidecar",
+			zap.String("sidecar", sc.ID()),
+			zap.String("anchor_id", anchorID),
+			zap.Uint32("anchor_pid", anchorPID))
+		if derr := c.deleteROS2Sidecar(ctx, sc); derr != nil {
+			c.logger.Warn("ROS 2 sidecar reap: delete failed",
+				zap.String("sidecar", sc.ID()), zap.Error(derr))
+		}
+	}
+	return nil
+}
+
 func (c *Client) deleteROS2Sidecar(ctx context.Context, container containerd.Container) error {
 	if task, err := container.Task(ctx, nil); err == nil {
 		_ = task.Kill(ctx, syscall.SIGKILL)

--- a/go/internal/agent/containerd/ros2_reap_test.go
+++ b/go/internal/agent/containerd/ros2_reap_test.go
@@ -2,6 +2,33 @@ package containerd
 
 import "testing"
 
+// TestShouldReapSidecar verifies the reap-decision helper that layers the
+// unresolvable-anchor safety check on top of isOrphanedSidecar. The critical
+// case is the third: when a container's liveness could not be determined, the
+// sidecar must be KEPT even though the anchor PID is absent from liveTasks.
+func TestShouldReapSidecar(t *testing.T) {
+	live := map[uint32]string{1234: "app-a"}
+	noUnresolvable := map[string]bool{}
+	withUnresolvable := map[string]bool{"app-a": true}
+
+	// Anchor is alive in liveTasks and not unresolvable → keep.
+	if shouldReapSidecar("app-a", 1234, live, noUnresolvable) {
+		t.Error("sidecar anchored to a live task should not be reaped")
+	}
+	// Anchor PID gone, not unresolvable → reap.
+	if !shouldReapSidecar("app-a", 9999, live, noUnresolvable) {
+		t.Error("sidecar whose anchor PID is gone (and resolvable) should be reaped")
+	}
+	// Anchor PID gone but container is unresolvable → keep (safety case, WDY-1702 H4).
+	if shouldReapSidecar("app-a", 9999, live, withUnresolvable) {
+		t.Error("sidecar whose anchor liveness is unverifiable must not be reaped")
+	}
+	// Anchor PID present but container is still marked unresolvable → keep.
+	if shouldReapSidecar("app-a", 1234, live, withUnresolvable) {
+		t.Error("sidecar whose anchor is unresolvable must not be reaped even if PID appears live")
+	}
+}
+
 // TestIsOrphanedSidecar verifies the pure orphan-detection predicate.
 // A sidecar is orphaned when its anchor PID is absent from the live-task set,
 // or when the live task at that PID belongs to a different container.

--- a/go/internal/agent/containerd/ros2_reap_test.go
+++ b/go/internal/agent/containerd/ros2_reap_test.go
@@ -1,0 +1,25 @@
+package containerd
+
+import "testing"
+
+// TestIsOrphanedSidecar verifies the pure orphan-detection predicate.
+// A sidecar is orphaned when its anchor PID is absent from the live-task set,
+// or when the live task at that PID belongs to a different container.
+func TestIsOrphanedSidecar(t *testing.T) {
+	live := map[uint32]string{1234: "app-a"}
+
+	if isOrphanedSidecar("app-a", 1234, live) {
+		t.Error("sidecar anchored to a live task is not orphaned")
+	}
+	if !isOrphanedSidecar("app-a", 9999, live) {
+		t.Error("sidecar whose anchor PID is gone is orphaned")
+	}
+	// PID exists but belongs to a different container (PID was recycled).
+	if !isOrphanedSidecar("app-a", 1234, map[uint32]string{1234: "app-b"}) {
+		t.Error("sidecar whose anchor PID now belongs to a different container is orphaned")
+	}
+	// Empty live set — all sidecars are orphaned.
+	if !isOrphanedSidecar("app-a", 1234, map[uint32]string{}) {
+		t.Error("sidecar with no live tasks at all is orphaned")
+	}
+}

--- a/go/internal/agent/containerd/ros2_refcount_test.go
+++ b/go/internal/agent/containerd/ros2_refcount_test.go
@@ -1,0 +1,84 @@
+package containerd
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestSidecarExecRefcount verifies that acquireSidecarExec/releaseSidecarExec
+// correctly guard sidecarHasActiveExecsLocked so teardown callers (which hold
+// c.mu) can check whether a sidecar is safe to delete.
+func TestSidecarExecRefcount(t *testing.T) {
+	c := &Client{ros2ExecRefs: map[string]int{}}
+
+	// Acquire increments the refcount; sidecar should be considered active.
+	c.acquireSidecarExec("sc-cyc")
+	c.mu.Lock()
+	active := c.sidecarHasActiveExecsLocked("sc-cyc")
+	c.mu.Unlock()
+	if !active {
+		t.Fatal("expected active exec after acquire")
+	}
+
+	// Release decrements back to zero; sidecar should now be safe to delete.
+	c.releaseSidecarExec("sc-cyc")
+	c.mu.Lock()
+	active = c.sidecarHasActiveExecsLocked("sc-cyc")
+	c.mu.Unlock()
+	if active {
+		t.Fatal("expected no active exec after release")
+	}
+}
+
+// TestSidecarExecRefcountMultiple checks that multiple concurrent acquires
+// require the same number of releases before the sidecar becomes deletable.
+func TestSidecarExecRefcountMultiple(t *testing.T) {
+	c := &Client{ros2ExecRefs: map[string]int{}}
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		c.acquireSidecarExec("sc-fast")
+	}
+	for i := 0; i < n-1; i++ {
+		c.releaseSidecarExec("sc-fast")
+		c.mu.Lock()
+		if !c.sidecarHasActiveExecsLocked("sc-fast") {
+			c.mu.Unlock()
+			t.Fatalf("sidecar should still be active after %d releases (want %d)", i+1, n)
+		}
+		c.mu.Unlock()
+	}
+	c.releaseSidecarExec("sc-fast")
+	c.mu.Lock()
+	active := c.sidecarHasActiveExecsLocked("sc-fast")
+	c.mu.Unlock()
+	if active {
+		t.Fatal("expected no active exec after all releases")
+	}
+}
+
+// TestSidecarExecRefcountConcurrent runs concurrent acquire/release pairs to
+// trigger the race detector. Each goroutine takes one exec slot; all complete
+// before the assertion.
+func TestSidecarExecRefcountConcurrent(t *testing.T) {
+	c := &Client{ros2ExecRefs: map[string]int{}}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			c.acquireSidecarExec("sc-concurrent")
+			c.releaseSidecarExec("sc-concurrent")
+		}()
+	}
+	wg.Wait()
+
+	c.mu.Lock()
+	active := c.sidecarHasActiveExecsLocked("sc-concurrent")
+	c.mu.Unlock()
+	if active {
+		t.Fatal("expected no active exec after all goroutines finished")
+	}
+}

--- a/go/internal/agent/containerd/ros2_refcount_test.go
+++ b/go/internal/agent/containerd/ros2_refcount_test.go
@@ -82,3 +82,27 @@ func TestSidecarExecRefcountConcurrent(t *testing.T) {
 		t.Fatal("expected no active exec after all goroutines finished")
 	}
 }
+
+// TestSidecarExecCapRejects verifies that the 17th concurrent exec on a single
+// sidecar is rejected and the 16th (at the cap boundary) is accepted.
+func TestSidecarExecCapRejects(t *testing.T) {
+	c := &Client{ros2ExecRefs: map[string]int{}}
+
+	// Acquire up to the cap — all must succeed.
+	for i := 0; i < ros2MaxConcurrentExecs; i++ {
+		if err := c.acquireSidecarExecCapped("sc-cap"); err != nil {
+			t.Fatalf("acquire %d (≤ cap) returned unexpected error: %v", i+1, err)
+		}
+	}
+
+	// The next acquire (17th) must fail.
+	if err := c.acquireSidecarExecCapped("sc-cap"); err == nil {
+		t.Fatal("expected error when acquiring beyond ros2MaxConcurrentExecs; got nil")
+	}
+
+	// After releasing one slot the cap is no longer exceeded; next acquire must succeed.
+	c.releaseSidecarExec("sc-cap")
+	if err := c.acquireSidecarExecCapped("sc-cap"); err != nil {
+		t.Fatalf("acquire after release should succeed; got: %v", err)
+	}
+}

--- a/go/internal/agent/oci/spec.go
+++ b/go/internal/agent/oci/spec.go
@@ -283,6 +283,21 @@ func defaultSeccomp() *LinuxSeccomp {
 	}
 }
 
+// DropToMinimalCapabilities strips the process capability set to empty. The ROS 2
+// CLI sidecar only execs `ros2` and needs none of the default caps
+// (CAP_NET_RAW/MKNOD/SETUID/...), so a network-joined helper should not carry
+// them (WDY-1704; least privilege, SOC2-CC6/NIST-AC-6).
+func DropToMinimalCapabilities(spec *Spec) {
+	empty := []string{}
+	spec.Process.Capabilities = &LinuxCapabilities{
+		Bounding:    empty,
+		Effective:   empty,
+		Inheritable: empty,
+		Permitted:   empty,
+		Ambient:     empty,
+	}
+}
+
 // InjectHostsMount adds a bind-mount that overlays /etc/hosts with the file at
 // hostsPath. Use this for isolated-mode containers so service names resolve.
 func InjectHostsMount(spec *Spec, hostsPath string) {

--- a/go/internal/agent/oci/spec_test.go
+++ b/go/internal/agent/oci/spec_test.go
@@ -161,6 +161,14 @@ func TestDropToMinimalCapabilities(t *testing.T) {
 	if caps == nil {
 		t.Fatal("Capabilities is nil after DropToMinimalCapabilities")
 	}
+	// Assert every capability class is fully empty — this is the primary invariant.
+	// The dangerous-cap loop below is vacuously true when sets are empty; this check
+	// catches regressions where a set is non-empty but happens to miss the short list.
+	for _, set := range [][]string{caps.Bounding, caps.Effective, caps.Permitted, caps.Inheritable, caps.Ambient} {
+		if len(set) != 0 {
+			t.Errorf("expected empty capability set, got %v", set)
+		}
+	}
 	dangerous := []string{"CAP_NET_RAW", "CAP_MKNOD", "CAP_SETUID", "CAP_SETPCAP"}
 	for _, set := range [][]string{caps.Bounding, caps.Effective, caps.Permitted, caps.Inheritable, caps.Ambient} {
 		for _, c := range set {

--- a/go/internal/agent/oci/spec_test.go
+++ b/go/internal/agent/oci/spec_test.go
@@ -154,6 +154,29 @@ func TestSpecNamespaces(t *testing.T) {
 	}
 }
 
+func TestDropToMinimalCapabilities(t *testing.T) {
+	spec := DefaultSpec("rootfs", []string{"sleep", "infinity"})
+	DropToMinimalCapabilities(spec)
+	caps := spec.Process.Capabilities
+	if caps == nil {
+		t.Fatal("Capabilities is nil after DropToMinimalCapabilities")
+	}
+	dangerous := []string{"CAP_NET_RAW", "CAP_MKNOD", "CAP_SETUID", "CAP_SETPCAP"}
+	for _, set := range [][]string{caps.Bounding, caps.Effective, caps.Permitted, caps.Inheritable, caps.Ambient} {
+		for _, c := range set {
+			for _, bad := range dangerous {
+				if c == bad {
+					t.Errorf("minimal caps must not include %s", c)
+				}
+			}
+		}
+	}
+	// Verify NoNewPrivileges is preserved.
+	if !spec.Process.NoNewPrivileges {
+		t.Error("NoNewPrivileges must remain true after DropToMinimalCapabilities")
+	}
+}
+
 func TestInjectHostsMount(t *testing.T) {
 	spec := DefaultSpec("rootfs", []string{"/bin/sh"})
 	InjectHostsMount(spec, "/run/wendy/hosts/com.example.app")


### PR DESCRIPTION
Hardens the `wendy device ros2` CLI-sidecar lifecycle: orphaned sidecars are now reaped, a running `ros2` exec can't be SIGKILLed by teardown, the sidecar runs least-privilege, and several robustness cleanups land.

## Changes
- **WDY-1704 — least privilege.** New `oci.DropToMinimalCapabilities` empties all five capability classes; the sidecar (which only `sleep infinity` + execs `ros2` over loopback) no longer carries `CAP_NET_RAW`/`CAP_MKNOD`/`CAP_SETUID`/etc. `NoNewPrivileges` stays true. (Non-root UID deferred — `ros2`/bag paths may need root reads; caps-drop is the high-value win.)
- **WDY-1702 H5 — exec/teardown race.** Per-sidecar active-exec refcount (`ros2ExecRefs`, guarded by `c.mu`). `ExecROS2` acquires before `task.Exec` (without holding `c.mu` across the blocking exec); teardown paths skip a sidecar with active execs via an unlocked `...Locked` variant. The increment and the teardown-check are both serialized under `c.mu`, so there's no TOCTOU — an in-flight `bag record`/`echo` can't be SIGKILLed mid-command.
- **WDY-1702 H4 — orphan reaper.** New boot-time `ReapOrphanedROS2Sidecars` deletes sidecars whose anchor app is gone, plus `StopROS2Sidecar` is wired into the no-running-app teardown. A pure `shouldReapSidecar`/`isOrphanedSidecar` decision **never deletes a live or unverifiable anchor**: a `NotFound` anchor is definitively gone (reapable), but an ambiguous `Task()` error marks the anchor "unresolvable" and keeps its sidecar (safety over completeness).
- **WDY-1706 polish.** M1: gate the shared `/dev/shm` bind on explicit `rmw_fastrtps_cpp` (CycloneDDS disables SharedMemory, so the bind was a no-op for it). L3: `EnsureROS2Sidecars` returns partial success (per-RMW errors aggregated; error only when all fail) instead of aborting the batch on first failure. L5: `ExecROS2` copies the spec env slice before appending. L6: cap concurrent execs per sidecar at 16.

## Concurrency (verified by whole-branch review)
Single mutex `c.mu`; the `...Locked` naming convention is honored at every call site (no self-deadlock, no lock-order inversion). The exec-vs-teardown TOCTOU is closed because increment-write and refcount-read are mutually exclusive under `c.mu`. `-race` green.

## Verification
- `go test ./internal/agent/oci/ ./internal/agent/containerd/ -race` green; `go build ./...` clean; `gofmt` clean.
- Unit-tested: cap drop (empty + NoNewPrivileges), refcount (incl. concurrent + over-cap reject), `isOrphanedSidecar`/`shouldReapSidecar` (alive/PID-gone/PID-recycled/unresolvable).

## ⚠️ Needs on-device verification
- A zero-capability sidecar can still: exec `ros2` over loopback, attach the shared FastRTPS `/dev/shm` segment in a shared-ipc group, and record a bag to the bind-mounted bag dir.
- The boot reaper deletes a sidecar orphaned by a prior ungraceful agent shutdown, and does NOT delete one whose anchor is still running.
- `ros2 bag record` survives a concurrent `wendy device ros2` / redeploy without SIGKILL (the H5 guard end-to-end).

## Follow-up (out of scope)
- Deferred teardown (a sidecar skipped because an exec is in flight) is collected by the next ensure/reap cycle, not retried immediately.
- Non-root sidecar UID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)