### PR TITLE
fix(ros2): CLI output/exec correctness (WDY-1705, WDY-1707, WDY-1708)

### DIFF
--- a/go/internal/agent/services/ros2_service.go
+++ b/go/internal/agent/services/ros2_service.go
@@ -457,7 +457,7 @@ func (s *ROS2Service) EchoTopic(req *agentpbv2.EchoROS2TopicRequest, stream grpc
 			DomainID:    sc.domainID,
 			SidecarName: sc.name,
 			Args:        []string{"topic", "echo", req.GetTopic()},
-		}, pw, pw)
+		}, pw, io.Discard)
 		pw.CloseWithError(execErr)
 		execDone <- execErr
 	}()
@@ -522,7 +522,7 @@ func (s *ROS2Service) MonitorHz(req *agentpbv2.MonitorROS2HzRequest, stream grpc
 			DomainID:    sc.domainID,
 			SidecarName: sc.name,
 			Args:        []string{"topic", "hz", req.GetTopic()},
-		}, pw, pw)
+		}, pw, io.Discard)
 		pw.CloseWithError(execErr)
 		execDone <- execErr
 	}()

--- a/go/internal/agent/services/ros2_service_test.go
+++ b/go/internal/agent/services/ros2_service_test.go
@@ -588,6 +588,28 @@ func TestROS2Service_RecordBag_UnexpectedExitWithHealthyAnchor(t *testing.T) {
 	}
 }
 
+func TestROS2Service_EchoTopic_StderrNotInPayload(t *testing.T) {
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Distro: "humble"},
+		execFn: func(_ context.Context, _ ROS2ExecOptions, stdout, stderr io.Writer) (int, error) {
+			io.WriteString(stderr, "selected interface \"lo\" is not multicast-capable: disabling multicast\n")
+			io.WriteString(stdout, "data: 'Hello World: 1'\n---\n")
+			return 0, nil
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2Message]{ctx: context.Background()}
+	if err := svc.EchoTopic(&agentpbv2.EchoROS2TopicRequest{Topic: "/chatter", Count: 1}, stream); err != nil {
+		t.Fatalf("EchoTopic: %v", err)
+	}
+	if len(stream.sent) != 1 {
+		t.Fatalf("got %d messages, want 1", len(stream.sent))
+	}
+	if strings.Contains(stream.sent[0].GetYaml(), "multicast") {
+		t.Errorf("stderr leaked into echo payload (WDY-1708): %q", stream.sent[0].GetYaml())
+	}
+}
+
 func TestTailLines(t *testing.T) {
 	in := "a\nb\n\nc\nd\ne\n"
 	if got := tailLines(in, 3); got != "c\nd\ne" {

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -842,6 +842,102 @@ func newROS2BagListCmd() *cobra.Command {
 	}
 }
 
+// bagRecvStream is the minimal interface consumed by downloadAndExtractBag,
+// satisfied by the gRPC grpc.ServerStreamingClient[agentpbv2.ROS2BagChunk]
+// returned by client.DownloadBag.
+type bagRecvStream interface {
+	Recv() (*agentpbv2.ROS2BagChunk, error)
+}
+
+// chunkResult carries the result of a single stream.Recv call.
+type chunkResult struct {
+	chunk *agentpbv2.ROS2BagChunk
+	err   error
+}
+
+// downloadAndExtractBag pumps chunks from stream into a pipe, extracts the
+// resulting tar archive to a temporary directory inside dest, then atomically
+// renames it into place. If extraction fails the pump goroutine is unblocked
+// via pr.CloseWithError and the context cancellation, and the temporary
+// directory is removed.
+func downloadAndExtractBag(ctx context.Context, stream bagRecvStream, dest string) error {
+	// Use a child context so we can signal the pump goroutine on extract error.
+	dlCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	pr, pw := io.Pipe()
+
+	go func() {
+		for {
+			// Run Recv in its own goroutine so we can also select on dlCtx.Done,
+			// allowing the extract-error path to unblock a streaming Recv call that
+			// may not itself inspect the parent context (e.g. in tests or when the
+			// underlying transport is slow to react to cancellation).
+			recv := make(chan chunkResult, 1)
+			go func() {
+				chunk, err := stream.Recv()
+				recv <- chunkResult{chunk, err}
+			}()
+
+			select {
+			case <-dlCtx.Done():
+				pw.CloseWithError(dlCtx.Err())
+				return
+			case r := <-recv:
+				if r.err == io.EOF {
+					pw.Close()
+					return
+				}
+				if r.err != nil {
+					pw.CloseWithError(r.err)
+					return
+				}
+				if _, werr := pw.Write(r.chunk.GetData()); werr != nil {
+					pw.CloseWithError(werr)
+					return
+				}
+			}
+		}
+	}()
+
+	// Extract to a temp directory inside dest so os.Rename is on the same FS.
+	tmpDir, err := os.MkdirTemp(dest, ".bag-download-*")
+	if err != nil {
+		pr.CloseWithError(err)
+		cancel()
+		return err
+	}
+
+	if err := extractROS2BagArchive(pr, tmpDir); err != nil {
+		// Unblock the pump goroutine and clean up the partial temp dir.
+		pr.CloseWithError(err)
+		cancel()
+		_ = os.RemoveAll(tmpDir)
+		return err
+	}
+
+	// Find the single top-level entry (bag directory) written by the extract.
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return fmt.Errorf("reading temp extract dir: %w", err)
+	}
+	if len(entries) != 1 {
+		_ = os.RemoveAll(tmpDir)
+		return fmt.Errorf("bag archive must contain exactly one top-level directory, got %d entries", len(entries))
+	}
+	bagName := entries[0].Name()
+	finalPath := filepath.Join(dest, bagName)
+
+	// Atomic rename: tmpDir/bagName → dest/bagName.
+	if err := os.Rename(filepath.Join(tmpDir, bagName), finalPath); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return fmt.Errorf("renaming bag into place: %w", err)
+	}
+	_ = os.Remove(tmpDir) // remove now-empty temp wrapper dir; ignore error
+	return nil
+}
+
 func newROS2BagDownloadCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "download [name] [dest]",
@@ -877,31 +973,15 @@ interactively.`,
 				}
 			}
 
-			stream, err := client.client.DownloadBag(cmd.Context(), &agentpbv2.DownloadROS2BagRequest{Name: name})
+			dlCtx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+
+			stream, err := client.client.DownloadBag(dlCtx, &agentpbv2.DownloadROS2BagRequest{Name: name})
 			if err != nil {
 				return ros2RPCError(err)
 			}
 
-			pr, pw := io.Pipe()
-			go func() {
-				for {
-					chunk, rerr := stream.Recv()
-					if rerr == io.EOF {
-						pw.Close()
-						return
-					}
-					if rerr != nil {
-						pw.CloseWithError(ros2RPCError(rerr))
-						return
-					}
-					if _, werr := pw.Write(chunk.GetData()); werr != nil {
-						pw.CloseWithError(werr)
-						return
-					}
-				}
-			}()
-
-			if err := extractROS2BagArchive(pr, dest); err != nil {
+			if err := downloadAndExtractBag(dlCtx, stream, dest); err != nil {
 				return err
 			}
 			cliSuccess("Downloaded bag %q to %s", name, filepath.Join(dest, name))

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -1089,18 +1089,23 @@ func extractROS2BagArchive(r io.Reader, dest string) error {
 // peels those flags out so they can select the target device without being
 // forwarded verbatim to ros2 (which would reject them as unknown flags).
 //
-// Only the exact forms --device <value> and --json are recognised; anything
-// else is left in the forwarded slice unchanged (WDY-1553 passthrough).
+// Only the exact forms --device <value>, --device=<value>, --json, and
+// --json=<ignored> are recognised; anything else is left in the forwarded
+// slice unchanged (WDY-1553 passthrough).
 func stripWendyExecGlobals(args []string) (device string, jsonFlag bool, forwarded []string) {
 	forwarded = make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "--device":
+		switch {
+		case strings.HasPrefix(args[i], "--device="):
+			device = strings.TrimPrefix(args[i], "--device=")
+		case args[i] == "--device":
 			if i+1 < len(args) {
 				device = args[i+1]
 				i++ // consume the value
+			} else {
+				forwarded = append(forwarded, args[i]) // no value — don't silently drop
 			}
-		case "--json":
+		case args[i] == "--json" || strings.HasPrefix(args[i], "--json="):
 			jsonFlag = true
 		default:
 			forwarded = append(forwarded, args[i])

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -1091,18 +1091,23 @@ type execRecvStream interface {
 //   - the last ExitCode frame reports a non-zero code.
 //
 // It never early-returns on a non-zero code — trailing output is drained first.
-func drainExecStream(stream execRecvStream, args []string, stdout, stderr io.Writer) error {
+// If ctx is cancelled (e.g. ctrl-c) and Recv returns any error, drainExecStream
+// returns nil — the same clean-stop behaviour as EchoTopic and MonitorHz.
+func drainExecStream(ctx context.Context, stream execRecvStream, args []string, stdout, stderr io.Writer) error {
 	var (
 		sawExitFrame bool
 		lastCode     int32
 	)
 	for {
-		msg, err := stream.Recv()
-		if err != nil {
-			if err == io.EOF {
-				break
+		msg, rerr := stream.Recv()
+		if rerr != nil {
+			if ctx.Err() != nil {
+				return nil // user cancelled (ctrl-c) — clean stop, like echo/hz
 			}
-			return ros2RPCError(err)
+			if rerr == io.EOF {
+				break // normal end — evaluate the exit-frame contract below
+			}
+			return ros2RPCError(rerr)
 		}
 		if len(msg.GetStdout()) > 0 {
 			stdout.Write(msg.GetStdout())
@@ -1155,7 +1160,7 @@ the ros2 command; use -- to force the rest of the line through unparsed.`,
 			if err != nil {
 				return ros2RPCError(err)
 			}
-			return drainExecStream(stream, args, os.Stdout, os.Stderr)
+			return drainExecStream(ctx, stream, args, os.Stdout, os.Stderr)
 		},
 	}
 	ros2DomainFlag(cmd, &domain)

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -982,7 +982,7 @@ interactively.`,
 			}
 
 			if err := downloadAndExtractBag(dlCtx, stream, dest); err != nil {
-				return err
+				return ros2RPCError(err)
 			}
 			cliSuccess("Downloaded bag %q to %s", name, filepath.Join(dest, name))
 			return nil

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -1122,6 +1122,10 @@ func stripWendyExecGlobals(args []string) (device string, jsonFlag bool, forward
 	forwarded = make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		switch {
+		case args[i] == "--":
+			// Honor the -- escape: forward the rest verbatim
+			forwarded = append(forwarded, args[i:]...)
+			return
 		case strings.HasPrefix(args[i], "--device="):
 			device = strings.TrimPrefix(args[i], "--device=")
 		case args[i] == "--device":

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -545,6 +545,48 @@ func newROS2DoctorCmd() *cobra.Command {
 
 // ── streaming commands ──────────────────────────────────────────────
 
+// echoRecvStream is the minimal interface consumed by drainEchoStream,
+// satisfied by grpc.ServerStreamingClient[agentpbv2.ROS2Message].
+type echoRecvStream interface {
+	Recv() (*agentpbv2.ROS2Message, error)
+}
+
+// drainEchoStream reads messages from stream until io.EOF or ctx cancellation,
+// printing each message to stdout.  When the stream ends having delivered zero
+// messages, it writes a stderr notice so the user isn't left with silent output.
+//
+// WDY-1708 (claim b): exit 0 is intentional — in ROS 2, "no active publishers
+// yet" is not a hard error; topics are dynamic and a streaming echo on an idle
+// or absent topic legitimately produces no output.  However, silence without
+// feedback is confusing, so we emit a single notice on stderr.  At least one
+// message received → no notice.
+func drainEchoStream(ctx context.Context, stream echoRecvStream, topic string, useJSON bool, stderr io.Writer) error {
+	received := 0
+	for {
+		msg, rerr := stream.Recv()
+		if rerr != nil {
+			if rerr == io.EOF || ctx.Err() != nil {
+				// WDY-1708: keep exit 0, but surface a notice when no messages
+				// arrived so the user knows the topic had no active publishers.
+				if received == 0 {
+					fmt.Fprintf(stderr, "Notice: No messages received on %s — the topic may have no active publishers.\n", topic)
+				}
+				return nil
+			}
+			return ros2RPCError(rerr)
+		}
+		received++
+		if useJSON {
+			if jerr := printROS2JSON(map[string]string{"topic": msg.GetTopic(), "yaml": msg.GetYaml()}); jerr != nil {
+				return jerr
+			}
+			continue
+		}
+		fmt.Print(msg.GetYaml())
+		fmt.Println("---")
+	}
+}
+
 func newROS2EchoCmd() *cobra.Command {
 	var domain int32
 	var count int32
@@ -570,23 +612,7 @@ func newROS2EchoCmd() *cobra.Command {
 			if err != nil {
 				return ros2RPCError(err)
 			}
-			for {
-				msg, rerr := stream.Recv()
-				if rerr != nil {
-					if rerr == io.EOF || ctx.Err() != nil {
-						return nil
-					}
-					return ros2RPCError(rerr)
-				}
-				if jsonOutput {
-					if jerr := printROS2JSON(map[string]string{"topic": msg.GetTopic(), "yaml": msg.GetYaml()}); jerr != nil {
-						return jerr
-					}
-					continue
-				}
-				fmt.Print(msg.GetYaml())
-				fmt.Println("---")
-			}
+			return drainEchoStream(ctx, stream, args[0], jsonOutput, os.Stderr)
 		},
 	}
 	ros2DomainFlag(cmd, &domain)

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -159,7 +159,7 @@ func newROS2NodesCmd() *cobra.Command {
 				return printROS2JSON(nodes)
 			}
 			if len(resp.GetNodes()) == 0 {
-				cliLogln("No ROS 2 nodes found.")
+				cliNotice("No ROS 2 nodes found.")
 				return nil
 			}
 			rmws := make([]string, 0, len(resp.GetNodes()))
@@ -223,7 +223,7 @@ func newROS2TopicsCmd() *cobra.Command {
 				return printROS2JSON(topics)
 			}
 			if len(resp.GetTopics()) == 0 {
-				cliLogln("No ROS 2 topics found.")
+				cliNotice("No ROS 2 topics found.")
 				return nil
 			}
 			rmws := make([]string, 0, len(resp.GetTopics()))
@@ -334,7 +334,7 @@ func newROS2ServicesCmd() *cobra.Command {
 				return printROS2JSON(svcs)
 			}
 			if len(resp.GetServices()) == 0 {
-				cliLogln("No ROS 2 services found.")
+				cliNotice("No ROS 2 services found.")
 				return nil
 			}
 			rmws := make([]string, 0, len(resp.GetServices()))
@@ -825,7 +825,7 @@ func newROS2BagListCmd() *cobra.Command {
 				return printROS2JSON(bags)
 			}
 			if len(resp.GetBags()) == 0 {
-				cliLogln("No bags recorded on the device.")
+				cliNotice("No bags recorded on the device.")
 				return nil
 			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -1078,6 +1078,52 @@ func extractROS2BagArchive(r io.Reader, dest string) error {
 
 // ── escape hatch ────────────────────────────────────────────────────
 
+// execRecvStream is the minimal interface consumed by drainExecStream, matching
+// grpc.ServerStreamingClient[agentpbv2.ROS2ExecOutput].
+type execRecvStream interface {
+	Recv() (*agentpbv2.ROS2ExecOutput, error)
+}
+
+// drainExecStream reads all messages from stream until io.EOF, forwarding
+// stdout chunks to stdout and stderr chunks to stderr.  It returns an error if:
+//   - the stream closes without a terminal ExitCode frame ("stream ended before
+//     exit status"), which indicates a truncated or aborted stream; or
+//   - the last ExitCode frame reports a non-zero code.
+//
+// It never early-returns on a non-zero code — trailing output is drained first.
+func drainExecStream(stream execRecvStream, args []string, stdout, stderr io.Writer) error {
+	var (
+		sawExitFrame bool
+		lastCode     int32
+	)
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return ros2RPCError(err)
+		}
+		if len(msg.GetStdout()) > 0 {
+			stdout.Write(msg.GetStdout())
+		}
+		if len(msg.GetStderr()) > 0 {
+			stderr.Write(msg.GetStderr())
+		}
+		if msg.ExitCode != nil {
+			sawExitFrame = true
+			lastCode = *msg.ExitCode
+		}
+	}
+	if !sawExitFrame {
+		return fmt.Errorf("ros2 %s: stream ended before exit status", strings.Join(args, " "))
+	}
+	if lastCode != 0 {
+		return fmt.Errorf("ros2 %s exited with code %d", strings.Join(args, " "), lastCode)
+	}
+	return nil
+}
+
 func newROS2ExecCmd() *cobra.Command {
 	var domain int32
 	cmd := &cobra.Command{
@@ -1109,24 +1155,7 @@ the ros2 command; use -- to force the rest of the line through unparsed.`,
 			if err != nil {
 				return ros2RPCError(err)
 			}
-			for {
-				msg, rerr := stream.Recv()
-				if rerr != nil {
-					if rerr == io.EOF || ctx.Err() != nil {
-						return nil
-					}
-					return ros2RPCError(rerr)
-				}
-				if len(msg.GetStdout()) > 0 {
-					os.Stdout.Write(msg.GetStdout())
-				}
-				if len(msg.GetStderr()) > 0 {
-					os.Stderr.Write(msg.GetStderr())
-				}
-				if msg.ExitCode != nil && *msg.ExitCode != 0 {
-					return fmt.Errorf("ros2 %s exited with code %d", strings.Join(args, " "), *msg.ExitCode)
-				}
-			}
+			return drainExecStream(stream, args, os.Stdout, os.Stderr)
 		},
 	}
 	ros2DomainFlag(cmd, &domain)

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -1078,6 +1078,37 @@ func extractROS2BagArchive(r io.Reader, dest string) error {
 
 // ── escape hatch ────────────────────────────────────────────────────
 
+// stripWendyExecGlobals scans args (the post-positional slice captured by
+// SetInterspersed(false)) for --device and --json flags that belong to wendy,
+// removes them from the slice, and returns their values alongside the
+// remaining args that should be forwarded to the remote ros2 process.
+//
+// Because SetInterspersed(false) stops cobra's flag parser at the first
+// positional, any --device/--json placed after the ros2 command word lands in
+// args rather than being parsed by the persistent root flags.  This function
+// peels those flags out so they can select the target device without being
+// forwarded verbatim to ros2 (which would reject them as unknown flags).
+//
+// Only the exact forms --device <value> and --json are recognised; anything
+// else is left in the forwarded slice unchanged (WDY-1553 passthrough).
+func stripWendyExecGlobals(args []string) (device string, jsonFlag bool, forwarded []string) {
+	forwarded = make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--device":
+			if i+1 < len(args) {
+				device = args[i+1]
+				i++ // consume the value
+			}
+		case "--json":
+			jsonFlag = true
+		default:
+			forwarded = append(forwarded, args[i])
+		}
+	}
+	return device, jsonFlag, forwarded
+}
+
 // execRecvStream is the minimal interface consumed by drainExecStream, matching
 // grpc.ServerStreamingClient[agentpbv2.ROS2ExecOutput].
 type execRecvStream interface {
@@ -1147,6 +1178,20 @@ the ros2 command; use -- to force the rest of the line through unparsed.`,
 			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
 
+			// SetInterspersed(false) stops cobra's flag parser at the first
+			// positional, so --device/--json placed after the ros2 command word
+			// (e.g. `exec node info /talker --device host.local`) land in args
+			// instead of being parsed by the root persistent flags.  Strip them
+			// here and propagate into the package globals before resolveTarget
+			// runs inside newROS2Client (WDY-1707).
+			localDevice, localJSON, fwdArgs := stripWendyExecGlobals(args)
+			if localDevice != "" {
+				deviceFlag = localDevice
+			}
+			if localJSON {
+				jsonOutput = true
+			}
+
 			client, err := newROS2Client(ctx)
 			if err != nil {
 				return err
@@ -1155,12 +1200,12 @@ the ros2 command; use -- to force the rest of the line through unparsed.`,
 
 			stream, err := client.client.Exec(ctx, &agentpbv2.ROS2ExecRequest{
 				DomainId: ros2DomainPtr(domain),
-				Args:     args,
+				Args:     fwdArgs,
 			})
 			if err != nil {
 				return ros2RPCError(err)
 			}
-			return drainExecStream(ctx, stream, args, os.Stdout, os.Stderr)
+			return drainExecStream(ctx, stream, fwdArgs, os.Stdout, os.Stderr)
 		},
 	}
 	ros2DomainFlag(cmd, &domain)

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -461,6 +461,12 @@ func TestROS2ExecDeviceFlagNotForwarded(t *testing.T) {
 			wantDevice: "",
 			wantFwd:    []string{"node", "list", "--device"},
 		},
+		{
+			name:       "double dash escapes remaining args verbatim",
+			args:       []string{"run", "mypkg", "--", "--device", "/dev/ttyUSB0"},
+			wantDevice: "",
+			wantFwd:    []string{"run", "mypkg", "--", "--device", "/dev/ttyUSB0"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -267,6 +267,121 @@ func (f *fakeEOFStream) Recv() (*agentpbv2.ROS2BagChunk, error) {
 	return nil, io.EOF
 }
 
+// ── drainExecStream tests (WDY-1705 M7) ────────────────────────────────────
+
+// fakeExecStream simulates a grpc.ServerStreamingClient[ROS2ExecOutput].
+// msgs is consumed in order; after all msgs are exhausted, Recv returns io.EOF.
+type fakeExecStream struct {
+	msgs []*agentpbv2.ROS2ExecOutput
+	errs []error // parallel slice; non-nil entry returns that error instead
+	pos  int
+}
+
+func (f *fakeExecStream) Recv() (*agentpbv2.ROS2ExecOutput, error) {
+	if f.pos >= len(f.msgs) {
+		return nil, io.EOF
+	}
+	i := f.pos
+	f.pos++
+	if f.errs != nil && i < len(f.errs) && f.errs[i] != nil {
+		return nil, f.errs[i]
+	}
+	return f.msgs[i], nil
+}
+
+func int32ptr(v int32) *int32 { return &v }
+
+// TestDrainExecStream_ExitZero: stream ends with ExitCode=0 → nil error.
+func TestDrainExecStream_ExitZero(t *testing.T) {
+	stream := &fakeExecStream{
+		msgs: []*agentpbv2.ROS2ExecOutput{
+			{ExitCode: int32ptr(0)},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	if err := drainExecStream(stream, []string{"node", "list"}, &stdout, &stderr); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+// TestDrainExecStream_ExitNonZero: stream ends with ExitCode=2 → error mentioning the code.
+func TestDrainExecStream_ExitNonZero(t *testing.T) {
+	stream := &fakeExecStream{
+		msgs: []*agentpbv2.ROS2ExecOutput{
+			{ExitCode: int32ptr(2)},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	err := drainExecStream(stream, []string{"node", "list"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error for exit code 2, got nil")
+	}
+	if !strings.Contains(err.Error(), "2") {
+		t.Errorf("error %q does not mention exit code 2", err.Error())
+	}
+}
+
+// TestDrainExecStream_NoExitFrame: stream EOFs with no exit-code frame → error about truncation.
+func TestDrainExecStream_NoExitFrame(t *testing.T) {
+	// Stream sends a stdout chunk but never sends an ExitCode frame.
+	stream := &fakeExecStream{
+		msgs: []*agentpbv2.ROS2ExecOutput{
+			{Stdout: []byte("hello\n")},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	err := drainExecStream(stream, []string{"topic", "echo", "/chatter"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error when no exit-code frame received, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "exit") {
+		t.Errorf("error %q does not mention exit status", err.Error())
+	}
+}
+
+// TestDrainExecStream_OutputBeforeExit: stdout/stderr chunks before the exit frame are forwarded.
+func TestDrainExecStream_OutputBeforeExit(t *testing.T) {
+	stream := &fakeExecStream{
+		msgs: []*agentpbv2.ROS2ExecOutput{
+			{Stdout: []byte("out1")},
+			{Stderr: []byte("err1")},
+			{Stdout: []byte("out2")},
+			{ExitCode: int32ptr(0)},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	if err := drainExecStream(stream, []string{"node", "list"}, &stdout, &stderr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := stdout.String(); got != "out1out2" {
+		t.Errorf("stdout = %q, want %q", got, "out1out2")
+	}
+	if got := stderr.String(); got != "err1" {
+		t.Errorf("stderr = %q, want %q", got, "err1")
+	}
+}
+
+// TestDrainExecStream_DrainsAfterNonZero: trailing output chunks after a non-zero
+// exit code in a single frame are still forwarded (exit frame is the last message).
+func TestDrainExecStream_DrainsAfterNonZero(t *testing.T) {
+	// The agent sends stdout/stderr before the exit frame; this test confirms
+	// we don't early-return before draining all output.
+	stream := &fakeExecStream{
+		msgs: []*agentpbv2.ROS2ExecOutput{
+			{Stdout: []byte("before exit")},
+			{ExitCode: int32ptr(1)},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	err := drainExecStream(stream, []string{"node", "list"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error for exit code 1, got nil")
+	}
+	if got := stdout.String(); got != "before exit" {
+		t.Errorf("stdout = %q, want %q — output was dropped before drain", got, "before exit")
+	}
+}
+
 // TestROS2ExecForwardsFlags guards WDY-1553: the raw escape hatch must forward
 // --flags meant for ros2 verbatim instead of rejecting them as unknown flags,
 // while still parsing wendy's own flags when they precede the ros2 command.

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func testROS2Graph() *agentpbv2.GetROS2GraphResponse {
@@ -500,5 +502,70 @@ func TestROS2ExecForwardsFlags(t *testing.T) {
 	}
 	if got, want := cmd.Flags().Args(), []string{"topic", "echo", "--once"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("forwarded args = %v, want %v", got, want)
+	}
+}
+
+// ── ros2RPCError regression tests (WDY-1708) ───────────────────────────────
+//
+// These tests lock the exit-code contract: hard CLI failures must propagate a
+// non-nil error so the entrypoint can call os.Exit(1). The "app image does not
+// include the ros2 CLI" FailedPrecondition is the canonical hard-failure path
+// reported in WDY-1708.
+
+// TestROS2RPCError_FailedPreconditionIsNonNil guards against any future change
+// that silently swallows FailedPrecondition errors. A non-nil return is required
+// so RunE → cobra → main.go → os.Exit(1) fires correctly (WDY-1708 regression).
+func TestROS2RPCError_FailedPreconditionIsNonNil(t *testing.T) {
+	// Simulate "app image does not include the ros2 CLI" coming from the agent.
+	agentErr := status.Error(codes.FailedPrecondition,
+		`ROS 2 app image "myapp:latest" runs rmw_fastrtps_cpp but does not include the ros2 CLI, `+
+			`so 'wendy device ros2' cannot inspect it; install the CLI in the app image`)
+
+	got := ros2RPCError(agentErr)
+	if got == nil {
+		t.Fatal("ros2RPCError(FailedPrecondition) = nil, want non-nil error (WDY-1708: must produce non-zero exit)")
+	}
+	// The message from the agent must be preserved so the user sees it.
+	if !strings.Contains(got.Error(), "does not include the ros2 CLI") {
+		t.Errorf("ros2RPCError message = %q; should preserve the agent's description", got.Error())
+	}
+}
+
+// TestROS2RPCError_UnimplementedIsNonNil ensures an agent that is too old to
+// support ROS 2 inspection still causes a non-zero exit.
+func TestROS2RPCError_UnimplementedIsNonNil(t *testing.T) {
+	agentErr := status.Error(codes.Unimplemented, "unknown service agentpb.v2.ROS2Service")
+
+	got := ros2RPCError(agentErr)
+	if got == nil {
+		t.Fatal("ros2RPCError(Unimplemented) = nil, want non-nil error (WDY-1708: must produce non-zero exit)")
+	}
+}
+
+// TestROS2RPCError_OtherGRPCCodeIsNonNil verifies that transport errors
+// (Unavailable, Internal, etc.) are not swallowed.
+func TestROS2RPCError_OtherGRPCCodeIsNonNil(t *testing.T) {
+	for _, code := range []codes.Code{
+		codes.Unavailable,
+		codes.Internal,
+		codes.DeadlineExceeded,
+		codes.Unknown,
+	} {
+		err := ros2RPCError(status.Error(code, "some transport error"))
+		if err == nil {
+			t.Errorf("ros2RPCError(%v) = nil, want non-nil (WDY-1708)", code)
+		}
+	}
+}
+
+// TestROS2RPCError_PlainErrorPassesThrough verifies that a non-gRPC error is
+// returned as-is (non-nil).
+func TestROS2RPCError_PlainErrorPassesThrough(t *testing.T) {
+	plain := errors.New("connection refused")
+	if got := ros2RPCError(plain); got == nil {
+		t.Fatal("ros2RPCError(plain error) = nil, want non-nil")
+	}
+	if got := ros2RPCError(plain); got != plain {
+		t.Errorf("ros2RPCError(plain) = %v, want same error identity", got)
 	}
 }

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -406,6 +406,64 @@ type errOnFirstRecv struct{ err error }
 
 func (e *errOnFirstRecv) Recv() (*agentpbv2.ROS2ExecOutput, error) { return nil, e.err }
 
+// TestROS2ExecDeviceFlagNotForwarded guards WDY-1707: --device (and --json)
+// appearing after the ros2 command word must be stripped from the forwarded
+// args and the extracted value returned so it can select the target device —
+// not forwarded to the remote ros2 process which rejects unknown flags.
+//
+// Implementation note: cobra's SetInterspersed(false) stops all flag parsing
+// at the first positional, so post-positional --device always lands in
+// Flags().Args() regardless of whether --device is registered locally.
+// The fix uses stripWendyExecGlobals to peel off --device/--json in RunE.
+func TestROS2ExecDeviceFlagNotForwarded(t *testing.T) {
+	cases := []struct {
+		name       string
+		args       []string
+		wantDevice string
+		wantJSON   bool
+		wantFwd    []string
+	}{
+		{
+			name:       "device after command",
+			args:       []string{"node", "info", "/talker", "--device", "host"},
+			wantDevice: "host",
+			wantFwd:    []string{"node", "info", "/talker"},
+		},
+		{
+			name:       "device before command (pre-positional, no strip needed)",
+			args:       []string{"node", "info", "/talker"},
+			wantDevice: "",
+			wantFwd:    []string{"node", "info", "/talker"},
+		},
+		{
+			name:     "json after command",
+			args:     []string{"node", "list", "--json"},
+			wantJSON: true,
+			wantFwd:  []string{"node", "list"},
+		},
+		{
+			name:       "device and ros2 flags coexist",
+			args:       []string{"topic", "echo", "/chatter", "--once", "--device", "edge.local"},
+			wantDevice: "edge.local",
+			wantFwd:    []string{"topic", "echo", "/chatter", "--once"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotDevice, gotJSON, gotFwd := stripWendyExecGlobals(tc.args)
+			if gotDevice != tc.wantDevice {
+				t.Errorf("device = %q, want %q", gotDevice, tc.wantDevice)
+			}
+			if gotJSON != tc.wantJSON {
+				t.Errorf("json = %v, want %v", gotJSON, tc.wantJSON)
+			}
+			if !reflect.DeepEqual(gotFwd, tc.wantFwd) {
+				t.Errorf("forwarded args = %v, want %v", gotFwd, tc.wantFwd)
+			}
+		})
+	}
+}
+
 // TestROS2ExecForwardsFlags guards WDY-1553: the raw escape hatch must forward
 // --flags meant for ros2 verbatim instead of rejecting them as unknown flags,
 // while still parsing wendy's own flags when they precede the ros2 command.

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -299,7 +300,7 @@ func TestDrainExecStream_ExitZero(t *testing.T) {
 		},
 	}
 	var stdout, stderr bytes.Buffer
-	if err := drainExecStream(stream, []string{"node", "list"}, &stdout, &stderr); err != nil {
+	if err := drainExecStream(context.Background(), stream, []string{"node", "list"}, &stdout, &stderr); err != nil {
 		t.Errorf("expected nil, got %v", err)
 	}
 }
@@ -312,7 +313,7 @@ func TestDrainExecStream_ExitNonZero(t *testing.T) {
 		},
 	}
 	var stdout, stderr bytes.Buffer
-	err := drainExecStream(stream, []string{"node", "list"}, &stdout, &stderr)
+	err := drainExecStream(context.Background(), stream, []string{"node", "list"}, &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected error for exit code 2, got nil")
 	}
@@ -330,7 +331,7 @@ func TestDrainExecStream_NoExitFrame(t *testing.T) {
 		},
 	}
 	var stdout, stderr bytes.Buffer
-	err := drainExecStream(stream, []string{"topic", "echo", "/chatter"}, &stdout, &stderr)
+	err := drainExecStream(context.Background(), stream, []string{"topic", "echo", "/chatter"}, &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected error when no exit-code frame received, got nil")
 	}
@@ -350,7 +351,7 @@ func TestDrainExecStream_OutputBeforeExit(t *testing.T) {
 		},
 	}
 	var stdout, stderr bytes.Buffer
-	if err := drainExecStream(stream, []string{"node", "list"}, &stdout, &stderr); err != nil {
+	if err := drainExecStream(context.Background(), stream, []string{"node", "list"}, &stdout, &stderr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := stdout.String(); got != "out1out2" {
@@ -373,7 +374,7 @@ func TestDrainExecStream_DrainsAfterNonZero(t *testing.T) {
 		},
 	}
 	var stdout, stderr bytes.Buffer
-	err := drainExecStream(stream, []string{"node", "list"}, &stdout, &stderr)
+	err := drainExecStream(context.Background(), stream, []string{"node", "list"}, &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected error for exit code 1, got nil")
 	}
@@ -381,6 +382,29 @@ func TestDrainExecStream_DrainsAfterNonZero(t *testing.T) {
 		t.Errorf("stdout = %q, want %q — output was dropped before drain", got, "before exit")
 	}
 }
+
+// TestDrainExecStream_ContextCancelledReturnsNil: ctrl-c cancels the ctx; Recv
+// returns a gRPC Canceled error (or any error) while ctx.Err() != nil.
+// drainExecStream must return nil — NOT an error — even though no exit frame
+// was seen.  This locks the ctrl-c clean-stop behaviour (WDY-1705 regression).
+func TestDrainExecStream_ContextCancelledReturnsNil(t *testing.T) {
+	cancelErr := fmt.Errorf("rpc error: code = Canceled desc = context canceled")
+	// errOnFirstRecv is a minimal execRecvStream that always returns an error.
+	// This simulates gRPC returning Canceled when the context is cancelled.
+	stream := &errOnFirstRecv{err: cancelErr}
+	// Pre-cancel the context, exactly as signal.NotifyContext does on ctrl-c.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var stdout, stderr bytes.Buffer
+	if err := drainExecStream(ctx, stream, []string{"topic", "echo", "/chatter"}, &stdout, &stderr); err != nil {
+		t.Errorf("drainExecStream with cancelled ctx returned %v, want nil (ctrl-c must be a clean stop)", err)
+	}
+}
+
+// errOnFirstRecv is an execRecvStream that returns a fixed error on every Recv.
+type errOnFirstRecv struct{ err error }
+
+func (e *errOnFirstRecv) Recv() (*agentpbv2.ROS2ExecOutput, error) { return nil, e.err }
 
 // TestROS2ExecForwardsFlags guards WDY-1553: the raw escape hatch must forward
 // --flags meant for ros2 verbatim instead of rejecting them as unknown flags,

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -424,8 +424,14 @@ func TestROS2ExecDeviceFlagNotForwarded(t *testing.T) {
 		wantFwd    []string
 	}{
 		{
-			name:       "device after command",
+			name:       "device after command (space form)",
 			args:       []string{"node", "info", "/talker", "--device", "host"},
+			wantDevice: "host",
+			wantFwd:    []string{"node", "info", "/talker"},
+		},
+		{
+			name:       "device after command (equals form)",
+			args:       []string{"node", "info", "/talker", "--device=host"},
 			wantDevice: "host",
 			wantFwd:    []string{"node", "info", "/talker"},
 		},
@@ -446,6 +452,12 @@ func TestROS2ExecDeviceFlagNotForwarded(t *testing.T) {
 			args:       []string{"topic", "echo", "/chatter", "--once", "--device", "edge.local"},
 			wantDevice: "edge.local",
 			wantFwd:    []string{"topic", "echo", "/chatter", "--once"},
+		},
+		{
+			name:       "trailing bare --device (no value) not dropped",
+			args:       []string{"node", "list", "--device"},
+			wantDevice: "",
+			wantFwd:    []string{"node", "list", "--device"},
 		},
 	}
 	for _, tc := range cases {

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -3,11 +3,15 @@ package commands
 import (
 	"archive/tar"
 	"bytes"
+	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 )
@@ -123,6 +127,144 @@ func TestROS2DomainPtr(t *testing.T) {
 	if got := ros2DomainPtr(42); got == nil || *got != 42 {
 		t.Errorf("ros2DomainPtr(42) = %v", got)
 	}
+}
+
+// fakeBlockingStream is a bagRecvStream that first returns a fixed payload then
+// blocks until its context is cancelled, simulating a live gRPC stream.
+type fakeBlockingStream struct {
+	ctx     context.Context
+	chunks  [][]byte
+	sent    int
+	blocked chan struct{} // closed when the stream reaches the blocking phase
+}
+
+func (f *fakeBlockingStream) Recv() (*agentpbv2.ROS2BagChunk, error) {
+	if f.sent < len(f.chunks) {
+		chunk := &agentpbv2.ROS2BagChunk{}
+		chunk.Data = f.chunks[f.sent]
+		f.sent++
+		return chunk, nil
+	}
+	// signal that we are now blocking
+	select {
+	case <-f.blocked:
+	default:
+		close(f.blocked)
+	}
+	// block until context is done
+	<-f.ctx.Done()
+	return nil, f.ctx.Err()
+}
+
+// TestDownloadAndExtractBag_ExtractErrorUnblocksStream verifies WDY-1705 M6:
+// when extractROS2BagArchive fails mid-stream the pump goroutine is unblocked
+// (call returns, doesn't hang) and no partial directory is left at dest.
+func TestDownloadAndExtractBag_ExtractErrorUnblocksStream(t *testing.T) {
+	// Build a syntactically valid tar whose first entry has a path-traversal
+	// name so that extractROS2BagArchive rejects it immediately after reading
+	// the (complete) 512-byte tar header — before requesting more data from the
+	// stream. This lets the test stream block on its second Recv while the
+	// extractor has already returned an error, proving the pump is unblocked.
+	var badTar bytes.Buffer
+	tw := tar.NewWriter(&badTar)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "../escape.txt",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := &fakeBlockingStream{
+		ctx:     ctx,
+		chunks:  [][]byte{badTar.Bytes()},
+		blocked: make(chan struct{}),
+	}
+
+	dest := t.TempDir()
+	finalPath := filepath.Join(dest, "mybag")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- downloadAndExtractBag(ctx, stream, dest)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error from corrupt tar, got nil")
+		}
+		// Ensure no partial directory was left at the final path.
+		if _, statErr := os.Stat(finalPath); !errors.Is(statErr, os.ErrNotExist) {
+			t.Errorf("partial bag directory left at %s after extract error", finalPath)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("downloadAndExtractBag blocked forever — pump goroutine leaked (WDY-1705)")
+	}
+}
+
+// TestDownloadAndExtractBag_Success verifies the happy path: a valid tar is
+// extracted to dest and the final bag directory appears at the correct path.
+func TestDownloadAndExtractBag_Success(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	content := []byte("yaml: data")
+	headers := []tar.Header{
+		{Name: "mybag", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "mybag/metadata.yaml", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(content))},
+	}
+	if err := tw.WriteHeader(&headers[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.WriteHeader(&headers[1]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap the buffer as a single-chunk stream that then returns EOF.
+	stream := &fakeEOFStream{data: buf.Bytes()}
+
+	dest := t.TempDir()
+	ctx := context.Background()
+
+	if err := downloadAndExtractBag(ctx, stream, dest); err != nil {
+		t.Fatalf("downloadAndExtractBag: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "mybag", "metadata.yaml"))
+	if err != nil {
+		t.Fatalf("reading extracted file: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("content = %q, want %q", got, content)
+	}
+}
+
+// fakeEOFStream sends its entire payload as one chunk then returns io.EOF.
+type fakeEOFStream struct {
+	data []byte
+	sent bool
+}
+
+func (f *fakeEOFStream) Recv() (*agentpbv2.ROS2BagChunk, error) {
+	if !f.sent {
+		f.sent = true
+		chunk := &agentpbv2.ROS2BagChunk{}
+		chunk.Data = f.data
+		return chunk, nil
+	}
+	return nil, io.EOF
 }
 
 // TestROS2ExecForwardsFlags guards WDY-1553: the raw escape hatch must forward

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -569,3 +569,83 @@ func TestROS2RPCError_PlainErrorPassesThrough(t *testing.T) {
 		t.Errorf("ros2RPCError(plain) = %v, want same error identity", got)
 	}
 }
+
+// ── drainEchoStream tests (WDY-1708 claim b) ───────────────────────────────
+
+// fakeEchoStream is an echoRecvStream that returns a fixed set of messages
+// then io.EOF.
+type fakeEchoStream struct {
+	msgs []*agentpbv2.ROS2Message
+	pos  int
+}
+
+func (f *fakeEchoStream) Recv() (*agentpbv2.ROS2Message, error) {
+	if f.pos >= len(f.msgs) {
+		return nil, io.EOF
+	}
+	m := f.msgs[f.pos]
+	f.pos++
+	return m, nil
+}
+
+// TestDrainEchoStream_ZeroMessages: stream immediately EOFs → exit 0 AND
+// stderr notice containing the topic name (WDY-1708 claim b).
+func TestDrainEchoStream_ZeroMessages(t *testing.T) {
+	stream := &fakeEchoStream{} // no messages, Recv returns io.EOF immediately
+	var stderr bytes.Buffer
+	err := drainEchoStream(context.Background(), stream, "/does_not_exist", false, &stderr)
+	if err != nil {
+		t.Errorf("drainEchoStream zero-messages = %v, want nil (exit 0 is intentional per WDY-1708)", err)
+	}
+	notice := stderr.String()
+	if !strings.Contains(notice, "/does_not_exist") {
+		t.Errorf("stderr notice %q does not mention the topic name", notice)
+	}
+	if notice == "" {
+		t.Error("stderr was empty — user would receive no feedback on a silent echo (WDY-1708)")
+	}
+}
+
+// TestDrainEchoStream_MessagesReceived: stream delivers messages → exit 0,
+// no stderr notice emitted.
+func TestDrainEchoStream_MessagesReceived(t *testing.T) {
+	stream := &fakeEchoStream{
+		msgs: []*agentpbv2.ROS2Message{
+			{Topic: "/chatter", Yaml: "data: hello\n"},
+			{Topic: "/chatter", Yaml: "data: world\n"},
+		},
+	}
+	var stderr bytes.Buffer
+	err := drainEchoStream(context.Background(), stream, "/chatter", false, &stderr)
+	if err != nil {
+		t.Errorf("drainEchoStream with messages = %v, want nil", err)
+	}
+	if notice := stderr.String(); notice != "" {
+		t.Errorf("unexpected stderr output %q — notice must not appear when messages were received", notice)
+	}
+}
+
+// TestDrainEchoStream_CtxCancelZeroMessages: ctrl-c with zero messages received
+// → exit 0 and notice is still emitted (acceptable; user stopped a silent topic).
+func TestDrainEchoStream_CtxCancelZeroMessages(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel, simulating ctrl-c
+	// Stream returns a context error on Recv (simulates gRPC honouring ctx).
+	stream := &errOnFirstEchoRecv{err: ctx.Err()}
+	var stderr bytes.Buffer
+	err := drainEchoStream(ctx, stream, "/idle_topic", false, &stderr)
+	if err != nil {
+		t.Errorf("drainEchoStream ctx-cancel = %v, want nil", err)
+	}
+	// Notice is acceptable (and expected) when ctrl-c fires after zero messages.
+	if notice := stderr.String(); !strings.Contains(notice, "/idle_topic") {
+		t.Errorf("stderr %q should mention the topic on ctrl-c with zero messages", notice)
+	}
+}
+
+// errOnFirstEchoRecv is an echoRecvStream that always returns a fixed error.
+type errOnFirstEchoRecv struct{ err error }
+
+func (e *errOnFirstEchoRecv) Recv() (*agentpbv2.ROS2Message, error) {
+	return nil, e.err
+}


### PR DESCRIPTION
Fixes a cluster of `wendy device ros2` CLI output/exec correctness bugs found by live testing. Each stream-draining path was extracted into a unit-testable helper.

## Changes
- **WDY-1705 L1 — stdout pollution.** "No X found" notices on `nodes`/`topics`/`services`/`bag list` now go to **stderr** (`cliNotice`) so scripted/`--json` consumers get clean stdout.
- **WDY-1705 M6 — bag-download leak.** `bag download` now uses a cancelable context, extracts into a temp dir and atomically renames into place, and on extract error calls `pr.CloseWithError` + `cancel()` so the pump goroutine can't leak and no partial bag dir is left. (`downloadAndExtractBag` helper; `ros2RPCError` wrapping preserved.)
- **WDY-1705 M7 — exec exit code.** `exec` now reads to EOF and returns a non-zero error if the stream ends without a terminal exit-code frame or the last code was non-zero (no early-return that drops trailing output). Ctrl-c of a long-running `exec` still exits cleanly (regression-tested). (`drainExecStream` helper.)
- **WDY-1707 — exec swallows `--device`.** `exec node info /talker --device host` now selects the device instead of forwarding `--device` to the remote ros2. `SetInterspersed(false)` precludes parsing local flags post-positional, so wendy's own globals (`--device`/`--device=`/`--json`) are stripped from the forwarded args (`stripWendyExecGlobals`); a user-supplied `--` is honored (everything after it forwards verbatim). The WDY-1553 passthrough is preserved (`TestROS2ExecForwardsFlags` green).
- **WDY-1708 #1 — echo stderr leak.** The agent's `EchoTopic`/`MonitorHz` no longer pass the same pipe for stdout+stderr (`pw, io.Discard`), so DDS init warnings no longer contaminate the deserialized message `yaml` payload.
- **WDY-1708 #2 — exit codes on failure.** Investigated: the entrypoint already `os.Exit(1)`s on non-nil errors and `ros2RPCError` is non-nil for all gRPC codes (incl. the no-ros2-CLI `FailedPrecondition`) — locked with regression tests. The one real gap was `echo` on an absent/idle topic exiting 0 *silently*: it now emits a stderr notice.

## echo exit-0 decision (intentional)
`wendy device ros2 echo` on an absent/idle topic exits 0 by design — in ROS 2, topics are dynamic and "no active publisher yet" is not a hard error. But silent exit-0 was confusing, so the echo loop now writes a stderr notice (`No messages received on <topic> — the topic may have no active publishers.`) when the stream ends with zero messages. The notice goes to stderr only, so `--json`/piped stdout consumers are unaffected. Hard failures remain non-zero via `ros2RPCError`.

## Verification
- `go test ./internal/cli/commands/ ./internal/agent/services/` green; `go build ./...` clean; `gofmt` clean.
- New unit tests: bag extract-error unblocks stream + no partial dir; exec exit-frame contract (5 cases) + ctrl-c→nil; device strip (space/equals/bare/`--`-escape, 7 cases) + WDY-1553 passthrough; echo stderr-not-in-payload; echo zero-message notice; `ros2RPCError` non-nil contract (4 codes).

## ⚠️ Needs on-device verification
- Real ctrl-c (SIGINT through gRPC transport) on `exec` and `echo` against a live agent (tests simulate ctx-cancel).
- `bag download` extract-error path against a real `DownloadBag` stream (tests use fakes).
- `exec node info /talker --device <dev>` selects the device end-to-end; `echo` payload has no stderr line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)