### PR TITLE
[Agent] New feature: Expose GPU architecture in Device Info

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
@@ -187,6 +187,8 @@ message GetAgentVersionResponse {
     // are retained for backwards compatibility. Empty when the agent cannot
     // enumerate mounts.
     repeated DiskPartition partitions = 15;
+    // GPU architecture identifier. Format is vendor-specific (e.g. "sm_87" for NVIDIA).
+    optional string gpu_arch = 16;
 }
 
 // Usage information for a single mounted filesystem.

--- a/Proto/wendy/agent/services/v2/device_info_service.proto
+++ b/Proto/wendy/agent/services/v2/device_info_service.proto
@@ -28,6 +28,8 @@ message GetDeviceInfoResponse {
     // are retained for backwards compatibility. Empty when the agent cannot
     // enumerate mounts.
     repeated DiskPartition partitions = 14;
+    // GPU architecture identifier. Format is vendor-specific (e.g. "sm_87" for NVIDIA).
+    optional string gpu_arch = 15;
 }
 
 // Usage information for a single mounted filesystem.

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -87,6 +87,9 @@ func (s *AgentService) GetAgentVersion(_ context.Context, _ *agentpb.GetAgentVer
 	if gpuInfo.cudaVersion != "" {
 		resp.CudaVersion = &gpuInfo.cudaVersion
 	}
+	if gpuInfo.gpuArch != "" {
+		resp.GpuArch = &gpuInfo.gpuArch
+	}
 
 	if usage, ok := rootDiskUsage(); ok {
 		resp.DiskUsedBytes = &usage.usedBytes
@@ -111,6 +114,7 @@ type gpuInfo struct {
 	vendor         string
 	jetpackVersion string
 	cudaVersion    string
+	gpuArch        string
 }
 
 func detectGPUInfo() gpuInfo {
@@ -134,6 +138,7 @@ func detectGPUInfo() gpuInfo {
 	if info.vendor == "nvidia" {
 		info.jetpackVersion = detectJetPackVersion()
 		info.cudaVersion = detectCUDAVersion()
+		info.gpuArch = detectNvidiaGPUArch()
 	}
 
 	return info
@@ -212,6 +217,22 @@ func detectCUDAVersion() string {
 		}
 	}
 
+	return ""
+}
+
+var computeCapRe = regexp.MustCompile(`^\s*(\d+)\.(\d+)\s*$`)
+
+func detectNvidiaGPUArch() string {
+	if nvidiaSmi, err := exec.LookPath("nvidia-smi"); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		out, err := exec.CommandContext(ctx, nvidiaSmi, "--query-gpu=compute_cap", "--format=csv,noheader,nounits").Output()
+		if err == nil {
+			if m := computeCapRe.FindSubmatch(out); len(m) > 2 {
+				return "sm_" + string(m[1]) + string(m[2])
+			}
+		}
+	}
 	return ""
 }
 

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -182,7 +182,7 @@ func detectJetPackVersion() string {
 	if jp, ok := jetpack[key]; ok {
 		return jp
 	}
-	return "L4T " + major + "." + revision
+	return "L4T-" + major + "." + revision
 }
 
 var cudaVersionFileRe = regexp.MustCompile(`(?i)CUDA[^0-9]*([0-9]+\.[0-9]+(?:\.[0-9]+)?)`)

--- a/go/internal/agent/services/device_info_service.go
+++ b/go/internal/agent/services/device_info_service.go
@@ -52,6 +52,9 @@ func (s *DeviceInfoService) GetDeviceInfo(_ context.Context, _ *agentpbv2.GetDev
 	if gpuInfo.cudaVersion != "" {
 		resp.CudaVersion = &gpuInfo.cudaVersion
 	}
+	if gpuInfo.gpuArch != "" {
+		resp.GpuArch = &gpuInfo.gpuArch
+	}
 
 	if usage, ok := rootDiskUsage(); ok {
 		resp.DiskUsedBytes = &usage.usedBytes

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -121,7 +121,7 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 			}
 			defer target.Close()
 
-			var agentVersion, osName, osVersion, cpuArch, deviceType, storageMedium, gpuVendor, jetpackVersion, cudaVersion string
+			var agentVersion, osName, osVersion, cpuArch, deviceType, storageMedium, gpuVendor, jetpackVersion, cudaVersion, gpuArch string
 			var diskUsedBytes, diskTotalBytes *int64
 			var partitions []*agentpb.DiskPartition
 			var hasGPU bool
@@ -156,6 +156,7 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				gpuVendor = resp.GetGpuVendor()
 				jetpackVersion = resp.GetJetpackVersion()
 				cudaVersion = resp.GetCudaVersion()
+				gpuArch = resp.GetGpuArch()
 				diskUsedBytes = resp.DiskUsedBytes
 				diskTotalBytes = resp.DiskTotalBytes
 				partitions = resp.GetPartitions()
@@ -211,6 +212,9 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				if cudaVersion != "" {
 					out["cudaVersion"] = cudaVersion
 				}
+				if gpuArch != "" {
+					out["gpuArch"] = gpuArch
+				}
 				if checkUpdates {
 					out["latestVersion"] = latestVersion
 					out["updateAvailable"] = version.CompareVersions(latestVersion, agentVersion) > 0
@@ -248,6 +252,9 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				}
 				if cudaVersion != "" {
 					fmt.Printf("CUDA: %s\n", cudaVersion)
+				}
+				if gpuArch != "" {
+					fmt.Printf("GPU Arch: %s\n", gpuArch)
 				}
 			}
 			fmt.Printf("CLI Version: %s\n", version.Version)

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -307,6 +307,7 @@ func applyDeviceBuildArgHints(buildArgs map[string]string, versionResp *agentpb.
 	setHint("WENDY_GPU_VENDOR", versionResp.GetGpuVendor())
 	setHint("WENDY_JETPACK_VERSION", versionResp.GetJetpackVersion())
 	setHint("WENDY_CUDA_VERSION", versionResp.GetCudaVersion())
+	setHint("WENDY_GPU_ARCH", versionResp.GetGpuArch())
 }
 
 func sortedValidatedBuildArgKeys(buildArgs map[string]string) ([]string, error) {

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -174,6 +174,9 @@ func (s *mcpServer) handleDeviceInfo(ctx context.Context, _ mcpgo.CallToolReques
 	if resp.CudaVersion != nil {
 		info["cuda_version"] = resp.GetCudaVersion()
 	}
+	if resp.GpuArch != nil {
+		info["gpu_arch"] = resp.GetGpuArch()
+	}
 	b, _ := json.MarshalIndent(info, "", "  ")
 	return mcpgo.NewToolResultText(string(b)), nil
 }

--- a/go/proto/gen/agentpb/v2/device_info_service.pb.go
+++ b/go/proto/gen/agentpb/v2/device_info_service.pb.go
@@ -76,7 +76,9 @@ type GetDeviceInfoResponse struct {
 	// root filesystem is included here as well; disk_used_bytes/disk_total_bytes
 	// are retained for backwards compatibility. Empty when the agent cannot
 	// enumerate mounts.
-	Partitions    []*DiskPartition `protobuf:"bytes,14,rep,name=partitions,proto3" json:"partitions,omitempty"`
+	Partitions []*DiskPartition `protobuf:"bytes,14,rep,name=partitions,proto3" json:"partitions,omitempty"`
+	// GPU architecture identifier. Format is vendor-specific (e.g. "sm_87" for NVIDIA).
+	GpuArch       *string `protobuf:"bytes,15,opt,name=gpu_arch,json=gpuArch,proto3,oneof" json:"gpu_arch,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -207,6 +209,13 @@ func (x *GetDeviceInfoResponse) GetPartitions() []*DiskPartition {
 		return x.Partitions
 	}
 	return nil
+}
+
+func (x *GetDeviceInfoResponse) GetGpuArch() string {
+	if x != nil && x.GpuArch != nil {
+		return *x.GpuArch
+	}
+	return ""
 }
 
 // Usage information for a single mounted filesystem.
@@ -452,7 +461,7 @@ var File_wendy_agent_services_v2_device_info_service_proto protoreflect.FileDesc
 const file_wendy_agent_services_v2_device_info_service_proto_rawDesc = "" +
 	"\n" +
 	"1wendy/agent/services/v2/device_info_service.proto\x12\x17wendy.agent.services.v2\"\x16\n" +
-	"\x14GetDeviceInfoRequest\"\xcd\x05\n" +
+	"\x14GetDeviceInfoRequest\"\xfa\x05\n" +
 	"\x15GetDeviceInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\"\n" +
 	"\n" +
@@ -476,7 +485,8 @@ const file_wendy_agent_services_v2_device_info_service_proto_rawDesc = "" +
 	"\x10disk_total_bytes\x18\r \x01(\x03H\bR\x0ediskTotalBytes\x88\x01\x01\x12F\n" +
 	"\n" +
 	"partitions\x18\x0e \x03(\v2&.wendy.agent.services.v2.DiskPartitionR\n" +
-	"partitionsB\r\n" +
+	"partitions\x12\x1e\n" +
+	"\bgpu_arch\x18\x0f \x01(\tH\tR\agpuArch\x88\x01\x01B\r\n" +
 	"\v_os_versionB\r\n" +
 	"\v_public_keyB\x0e\n" +
 	"\f_device_typeB\n" +
@@ -486,7 +496,8 @@ const file_wendy_agent_services_v2_device_info_service_proto_rawDesc = "" +
 	"\x10_jetpack_versionB\x0f\n" +
 	"\r_cuda_versionB\x12\n" +
 	"\x10_disk_used_bytesB\x13\n" +
-	"\x11_disk_total_bytes\"\xa7\x01\n" +
+	"\x11_disk_total_bytesB\v\n" +
+	"\t_gpu_arch\"\xa7\x01\n" +
 	"\rDiskPartition\x12\x1e\n" +
 	"\n" +
 	"mountpoint\x18\x01 \x01(\tR\n" +

--- a/go/proto/gen/agentpb/wendy_agent_v1_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_service.pb.go
@@ -593,7 +593,9 @@ type GetAgentVersionResponse struct {
 	// root filesystem is included here as well; disk_used_bytes/disk_total_bytes
 	// are retained for backwards compatibility. Empty when the agent cannot
 	// enumerate mounts.
-	Partitions    []*DiskPartition `protobuf:"bytes,15,rep,name=partitions,proto3" json:"partitions,omitempty"`
+	Partitions []*DiskPartition `protobuf:"bytes,15,rep,name=partitions,proto3" json:"partitions,omitempty"`
+	// GPU architecture identifier. Format is vendor-specific (e.g. "sm_87" for NVIDIA).
+	GpuArch       *string `protobuf:"bytes,16,opt,name=gpu_arch,json=gpuArch,proto3,oneof" json:"gpu_arch,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -731,6 +733,13 @@ func (x *GetAgentVersionResponse) GetPartitions() []*DiskPartition {
 		return x.Partitions
 	}
 	return nil
+}
+
+func (x *GetAgentVersionResponse) GetGpuArch() string {
+	if x != nil && x.GpuArch != nil {
+		return *x.GpuArch
+	}
+	return ""
 }
 
 // Usage information for a single mounted filesystem.
@@ -3231,7 +3240,7 @@ const file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc = "" +
 	"\aupdated\x18\x01 \x01(\v24.wendy.agent.services.v1.UpdateAgentResponse.UpdatedH\x00R\aupdated\x1a\t\n" +
 	"\aUpdatedB\x0f\n" +
 	"\rresponse_type\"\x18\n" +
-	"\x16GetAgentVersionRequest\"\x8e\x06\n" +
+	"\x16GetAgentVersionRequest\"\xbb\x06\n" +
 	"\x17GetAgentVersionResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\"\n" +
 	"\n" +
@@ -3256,7 +3265,9 @@ const file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc = "" +
 	"\x10disk_total_bytes\x18\x0e \x01(\x03H\tR\x0ediskTotalBytes\x88\x01\x01\x12F\n" +
 	"\n" +
 	"partitions\x18\x0f \x03(\v2&.wendy.agent.services.v1.DiskPartitionR\n" +
-	"partitionsB\r\n" +
+	"partitions\x12\x1e\n" +
+	"\bgpu_arch\x18\x10 \x01(\tH\n" +
+	"R\agpuArch\x88\x01\x01B\r\n" +
 	"\v_os_versionB\r\n" +
 	"\v_public_keyB\x0e\n" +
 	"\f_device_typeB\n" +
@@ -3267,7 +3278,8 @@ const file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc = "" +
 	"\r_cuda_versionB\x11\n" +
 	"\x0f_storage_mediumB\x12\n" +
 	"\x10_disk_used_bytesB\x13\n" +
-	"\x11_disk_total_bytes\"\xa7\x01\n" +
+	"\x11_disk_total_bytesB\v\n" +
+	"\t_gpu_arch\"\xa7\x01\n" +
 	"\rDiskPartition\x12\x1e\n" +
 	"\n" +
 	"mountpoint\x18\x01 \x01(\tR\n" +


### PR DESCRIPTION
When we build a CUDA app, we want to know which GPU architecture we are targeting.
 This PR exposes this info in `wendy device info` and passes the info to the app build process.