### PR TITLE
fix(agent): GPU entitlement works on JetPack 5 (L4T r35) via L4T CSV fallback (WDY-1716)

### DIFF
--- a/go/internal/agent/cdi/csv.go
+++ b/go/internal/agent/cdi/csv.go
@@ -1,0 +1,195 @@
+package cdi
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/oci"
+)
+
+// l4tCSVDir is the directory the NVIDIA Container Runtime "CSV mode" uses to
+// list the host driver files and device nodes that must be exposed to a
+// container on Tegra/L4T (Jetson). Behind a var so tests can point it at a
+// tempdir.
+var l4tCSVDir = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+// statDevice returns the major/minor of the device node at p. Behind a var so
+// tests can inject device numbers without creating real device nodes (which
+// requires root + mknod). Mirrors the dev_t decoding used in the oci package.
+var statDevice = func(p string) (major, minor int64, err error) {
+	var st syscall.Stat_t
+	if err := syscall.Stat(p, &st); err != nil {
+		return 0, 0, err
+	}
+	rdev := uint64(st.Rdev)
+	return int64(unix.Major(rdev)), int64(unix.Minor(rdev)), nil
+}
+
+type csvEntryKind string
+
+const (
+	csvLib csvEntryKind = "lib"
+	csvSym csvEntryKind = "sym"
+	csvDir csvEntryKind = "dir"
+	csvDev csvEntryKind = "dev"
+)
+
+type l4tCSVEntry struct {
+	kind csvEntryKind
+	path string
+}
+
+// ApplyL4TCSV provisions Tegra/L4T GPU access on a Jetson by translating the
+// NVIDIA Container Runtime "CSV mode" file lists
+// (/etc/nvidia-container-runtime/host-files-for-container.d/*.csv) into OCI
+// mounts and device nodes.
+//
+// It is the fallback used when no nvidia-ctk-generated CDI spec is available —
+// e.g. on JetPack 5 (L4T r35) devices whose nvidia-container-toolkit (≤1.11)
+// predates `nvidia-ctk cdi generate`. Without it the container's 0-byte
+// libcuda.so.1 stub is never overlaid with the host driver and the Tegra iGPU
+// device nodes (/dev/nvmap, /dev/nvhost-*, /dev/nvgpu/igpu0/*) are missing, so
+// CUDA is unavailable inside the container (WDY-1716).
+//
+// CSV entries:
+//   - lib / sym / dir → read-only bind-mount the host path at the same path in
+//     the container, overlaying any stub the image ships.
+//   - dev → add the device node (mknod'd by runc) plus a cgroup allow rule.
+//
+// Missing sources are skipped (never fatal) so a stale CSV entry cannot stop a
+// container from starting. Entries whose destination is already present in the
+// spec are skipped to avoid duplicates. Returns the number of mounts + device
+// nodes applied.
+func ApplyL4TCSV(spec *oci.Spec) (int, error) {
+	entries, err := loadL4TCSVEntries(l4tCSVDir)
+	if err != nil {
+		return 0, err
+	}
+	if len(entries) == 0 {
+		return 0, nil
+	}
+
+	if spec.Linux == nil {
+		spec.Linux = &oci.Linux{}
+	}
+	if spec.Linux.Resources == nil {
+		spec.Linux.Resources = &oci.LinuxResources{}
+	}
+
+	existingMounts := make(map[string]bool, len(spec.Mounts))
+	for _, m := range spec.Mounts {
+		existingMounts[m.Destination] = true
+	}
+	existingDevs := make(map[string]bool, len(spec.Linux.Devices))
+	for _, d := range spec.Linux.Devices {
+		existingDevs[d.Path] = true
+	}
+
+	applied := 0
+	for _, e := range entries {
+		switch e.kind {
+		case csvLib, csvSym, csvDir:
+			// Bind-mount the host file/dir read-only at the same path. ro +
+			// nosuid + nodev keep it least-privilege; noexec is deliberately NOT
+			// set — shared libraries must be mmap'd executable by the loader.
+			// Skip missing sources so a stale entry can't block container start.
+			if _, err := os.Lstat(e.path); err != nil {
+				continue
+			}
+			if existingMounts[e.path] {
+				continue
+			}
+			existingMounts[e.path] = true
+			spec.Mounts = append(spec.Mounts, oci.Mount{
+				Destination: e.path,
+				Source:      e.path,
+				Type:        "bind",
+				Options:     []string{"rbind", "ro", "nosuid", "nodev"},
+			})
+			applied++
+		case csvDev:
+			if existingDevs[e.path] {
+				continue
+			}
+			major, minor, err := statDevice(e.path)
+			if err != nil {
+				continue
+			}
+			existingDevs[e.path] = true
+			spec.Linux.Devices = append(spec.Linux.Devices, oci.LinuxDevice{
+				Path:  e.path,
+				Type:  "c",
+				Major: major,
+				Minor: minor,
+			})
+			// "rw", not "rwm": runc creates the node above, so the container only
+			// opens it and the mknod bit is withheld as least privilege (matches
+			// the gpu/camera entitlement convention).
+			mj, mn := major, minor
+			spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, oci.LinuxDeviceCgroup{
+				Allow:  true,
+				Type:   "c",
+				Major:  &mj,
+				Minor:  &mn,
+				Access: "rw",
+			})
+			applied++
+		}
+	}
+
+	return applied, nil
+}
+
+// loadL4TCSVEntries reads every *.csv under dir and returns the parsed,
+// de-duplicated entries. Each line is "<kind>, <path>" where kind is one of
+// lib/sym/dir/dev; blank lines, comments, malformed lines, and unknown kinds
+// are skipped. Unreadable files are skipped rather than failing the whole load.
+func loadL4TCSVEntries(dir string) ([]l4tCSVEntry, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.csv"))
+	if err != nil {
+		return nil, err
+	}
+
+	var entries []l4tCSVEntry
+	seen := make(map[string]bool)
+	for _, f := range matches {
+		file, err := os.Open(f)
+		if err != nil {
+			continue
+		}
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			parts := strings.SplitN(line, ",", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			kind := csvEntryKind(strings.ToLower(strings.TrimSpace(parts[0])))
+			switch kind {
+			case csvLib, csvSym, csvDir, csvDev:
+			default:
+				continue
+			}
+			path := strings.TrimSpace(parts[1])
+			if path == "" {
+				continue
+			}
+			key := string(kind) + "\x00" + path
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			entries = append(entries, l4tCSVEntry{kind: kind, path: path})
+		}
+		file.Close()
+	}
+	return entries, nil
+}

--- a/go/internal/agent/cdi/csv_test.go
+++ b/go/internal/agent/cdi/csv_test.go
@@ -1,0 +1,185 @@
+package cdi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/oci"
+)
+
+// writeCSV creates dir and writes a single csv file with the given content,
+// then points l4tCSVDir at dir for the duration of the test.
+func useCSVDir(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "l4t.csv"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+	orig := l4tCSVDir
+	l4tCSVDir = dir
+	t.Cleanup(func() { l4tCSVDir = orig })
+	return dir
+}
+
+func mountForDest(spec *oci.Spec, dest string) (oci.Mount, bool) {
+	for _, m := range spec.Mounts {
+		if m.Destination == dest {
+			return m, true
+		}
+	}
+	return oci.Mount{}, false
+}
+
+func deviceForPath(spec *oci.Spec, path string) (oci.LinuxDevice, bool) {
+	for _, d := range spec.Linux.Devices {
+		if d.Path == path {
+			return d, true
+		}
+	}
+	return oci.LinuxDevice{}, false
+}
+
+func hasCgroupRule(spec *oci.Spec, major, minor int64) bool {
+	for _, r := range spec.Linux.Resources.Devices {
+		if r.Major != nil && r.Minor != nil && *r.Major == major && *r.Minor == minor && r.Allow {
+			return true
+		}
+	}
+	return false
+}
+
+func newSpec() *oci.Spec {
+	return &oci.Spec{Linux: &oci.Linux{Resources: &oci.LinuxResources{}}}
+}
+
+func TestApplyL4TCSV_MountsLibsAndDevices(t *testing.T) {
+	// Real lib file + dir on disk so the bind-mount sources exist; a missing lib
+	// that must be skipped; and two device entries (one resolvable, one not).
+	libDir := t.TempDir()
+	libFile := filepath.Join(libDir, "libcuda.so.1")
+	if err := os.WriteFile(libFile, []byte("ELF"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fwDir := filepath.Join(libDir, "firmware")
+	if err := os.MkdirAll(fwDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	missingLib := filepath.Join(libDir, "nope.so")
+
+	content := "# comment line\n" +
+		"\n" +
+		"lib, " + libFile + "\n" +
+		"sym, " + libFile + "\n" + // duplicate path, different kind: still one mount dest
+		"dir, " + fwDir + "\n" +
+		"lib, " + missingLib + "\n" + // missing source -> skipped
+		"dev, /dev/nvmap\n" +
+		"dev, /dev/missing\n" + // statDevice errors -> skipped
+		"garbage line without comma\n" +
+		"weird, /tmp/x\n" // unknown kind -> skipped
+
+	useCSVDir(t, content)
+
+	orig := statDevice
+	statDevice = func(p string) (int64, int64, error) {
+		if p == "/dev/nvmap" {
+			return 10, 55, nil
+		}
+		return 0, 0, os.ErrNotExist
+	}
+	t.Cleanup(func() { statDevice = orig })
+
+	spec := newSpec()
+	applied, err := ApplyL4TCSV(spec)
+	if err != nil {
+		t.Fatalf("ApplyL4TCSV: %v", err)
+	}
+
+	// libFile (once, deduped across lib+sym), fwDir, /dev/nvmap = 3 applied.
+	if applied != 3 {
+		t.Errorf("applied = %d, want 3", applied)
+	}
+
+	if m, ok := mountForDest(spec, libFile); !ok {
+		t.Error("libcuda mount missing")
+	} else if m.Source != libFile || m.Type != "bind" {
+		t.Errorf("libcuda mount = %+v", m)
+	}
+	if _, ok := mountForDest(spec, fwDir); !ok {
+		t.Error("firmware dir mount missing")
+	}
+	if _, ok := mountForDest(spec, missingLib); ok {
+		t.Error("missing lib should not be mounted")
+	}
+
+	if d, ok := deviceForPath(spec, "/dev/nvmap"); !ok {
+		t.Error("/dev/nvmap device node missing")
+	} else if d.Major != 10 || d.Minor != 55 || d.Type != "c" {
+		t.Errorf("/dev/nvmap device = %+v", d)
+	}
+	if !hasCgroupRule(spec, 10, 55) {
+		t.Error("/dev/nvmap cgroup rule missing")
+	}
+	if _, ok := deviceForPath(spec, "/dev/missing"); ok {
+		t.Error("unresolvable device should be skipped")
+	}
+
+	// Lib mounts must remain executable-capable: no "noexec".
+	if m, _ := mountForDest(spec, libFile); contains(m.Options, "noexec") {
+		t.Error("lib mount must not set noexec (loader needs PROT_EXEC mmap)")
+	}
+}
+
+func TestApplyL4TCSV_NoFiles(t *testing.T) {
+	orig := l4tCSVDir
+	l4tCSVDir = t.TempDir() // empty dir, no *.csv
+	t.Cleanup(func() { l4tCSVDir = orig })
+
+	spec := newSpec()
+	applied, err := ApplyL4TCSV(spec)
+	if err != nil {
+		t.Fatalf("ApplyL4TCSV: %v", err)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0 when no CSV files present", applied)
+	}
+}
+
+func TestApplyL4TCSV_SkipsDuplicateOfExistingSpecEntry(t *testing.T) {
+	libDir := t.TempDir()
+	libFile := filepath.Join(libDir, "lib.so")
+	if err := os.WriteFile(libFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	useCSVDir(t, "lib, "+libFile+"\n")
+
+	spec := newSpec()
+	// Pre-seed the same destination (e.g. another entitlement already mounted it).
+	spec.Mounts = append(spec.Mounts, oci.Mount{Destination: libFile, Source: "/other"})
+
+	applied, err := ApplyL4TCSV(spec)
+	if err != nil {
+		t.Fatalf("ApplyL4TCSV: %v", err)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0 (dest already present)", applied)
+	}
+	var count int
+	for _, m := range spec.Mounts {
+		if m.Destination == libFile {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("duplicate mount destination created: %d entries", count)
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -880,6 +880,12 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}
 	}
 
+	// Remove duplicate device nodes before handing the spec to runc: independent
+	// provisioners (CDI/L4T-CSV GPU setup and the gpu entitlement) can add the
+	// same node, and runc mknod()s each entry, so a duplicate path would fail
+	// container creation with EEXIST.
+	localoci.DedupeDevices(spec)
+
 	// Serialize our custom OCI spec to JSON for WithSpecFromBytes.
 	specJSON, err := json.Marshal(spec)
 	if err != nil {
@@ -943,7 +949,20 @@ func (c *Client) applyCDIGPU(spec *localoci.Spec) {
 	mgr := cdi.NewManager()
 	cdiSpec, err := mgr.LoadNVIDIACDISpec()
 	if err != nil {
-		c.logger.Warn("No NVIDIA CDI spec found, GPU library mounts may be incomplete", zap.Error(err))
+		// No nvidia-ctk-generated CDI spec. On Tegra/L4T this is expected when the
+		// device's nvidia-container-toolkit predates `nvidia-ctk cdi generate`
+		// (JetPack 5 / r35, toolkit ≤1.11). Fall back to the NVIDIA Container
+		// Runtime CSV-mode file lists, which still ship on those images and list
+		// the real libcuda.so.1 plus the Tegra iGPU device nodes (WDY-1716).
+		if applied, csvErr := cdi.ApplyL4TCSV(spec); csvErr != nil {
+			c.logger.Warn("L4T CSV GPU fallback failed; GPU mounts may be incomplete", zap.Error(csvErr))
+		} else if applied > 0 {
+			c.logger.Info("Applied L4T CSV GPU provisioning (no CDI spec; nvidia-ctk predates CDI)",
+				zap.Int("count", applied))
+			return
+		}
+		c.logger.Warn("No NVIDIA CDI spec and no usable L4T CSV files; GPU library mounts may be incomplete",
+			zap.Error(err))
 		return
 	}
 

--- a/go/internal/agent/oci/dedupe_test.go
+++ b/go/internal/agent/oci/dedupe_test.go
@@ -1,0 +1,32 @@
+package oci
+
+import "testing"
+
+func TestDedupeDevices(t *testing.T) {
+	spec := &Spec{Linux: &Linux{Devices: []LinuxDevice{
+		{Path: "/dev/nvidiactl", Major: 195, Minor: 255},
+		{Path: "/dev/nvmap", Major: 10, Minor: 55},
+		{Path: "/dev/nvidiactl", Major: 195, Minor: 255}, // dup from a second provisioner
+		{Path: "/dev/nvgpu/igpu0/ctrl", Major: 234, Minor: 1},
+	}}}
+
+	DedupeDevices(spec)
+
+	if got := len(spec.Linux.Devices); got != 3 {
+		t.Fatalf("device count = %d, want 3", got)
+	}
+	// First occurrence is kept and order is otherwise preserved.
+	want := []string{"/dev/nvidiactl", "/dev/nvmap", "/dev/nvgpu/igpu0/ctrl"}
+	for i, w := range want {
+		if spec.Linux.Devices[i].Path != w {
+			t.Errorf("device[%d] = %q, want %q", i, spec.Linux.Devices[i].Path, w)
+		}
+	}
+}
+
+func TestDedupeDevices_NoLinuxOrEmpty(t *testing.T) {
+	// Must not panic on nil Linux or short slices.
+	DedupeDevices(&Spec{})
+	DedupeDevices(&Spec{Linux: &Linux{}})
+	DedupeDevices(&Spec{Linux: &Linux{Devices: []LinuxDevice{{Path: "/dev/x"}}}})
+}

--- a/go/internal/agent/oci/spec.go
+++ b/go/internal/agent/oci/spec.go
@@ -174,6 +174,31 @@ type POSIXRlimit struct {
 	Soft uint64 `json:"soft"`
 }
 
+// DedupeDevices removes duplicate device-node entries (same Path) from
+// spec.Linux.Devices, keeping the first occurrence. runc mknod()s each device
+// entry, so a duplicate path makes container creation fail with EEXIST. Several
+// independent provisioners can add the same node — e.g. the NVIDIA CDI spec (or
+// the L4T CSV fallback) and the gpu entitlement both add /dev/nvidiactl — so the
+// finalized spec is deduped once before it is handed to runc. The cgroup allow
+// rules are intentionally left untouched: duplicate allow rules are harmless
+// (purely additive) and a whole-major rule is not redundant with a major:minor
+// one.
+func DedupeDevices(spec *Spec) {
+	if spec.Linux == nil || len(spec.Linux.Devices) < 2 {
+		return
+	}
+	seen := make(map[string]bool, len(spec.Linux.Devices))
+	deduped := spec.Linux.Devices[:0]
+	for _, d := range spec.Linux.Devices {
+		if seen[d.Path] {
+			continue
+		}
+		seen[d.Path] = true
+		deduped = append(deduped, d)
+	}
+	spec.Linux.Devices = deduped
+}
+
 func DefaultSpec(rootfsPath string, args []string) *Spec {
 	return &Spec{
 		OCIVersion: "1.0.2",


### PR DESCRIPTION
## Summary

The `gpu` entitlement was unusable on **JetPack 5 / L4T r35** Jetsons (worked on JP6). Inside the container `libcuda.so.1` was a 0-byte stub (host driver never bind-mounted) and the Tegra iGPU device nodes were missing → `torch.cuda.is_available() == False`.

**Root cause:** the device's `nvidia-container-toolkit` (≤1.11 — `1.11.0-rc.1` on the Go2 Orin) predates `nvidia-ctk cdi generate`, so the agent's CDI generation fails and **no CDI spec is ever produced**. `applyCDIGPU` then mounts nothing and the container falls back to discrete-GPU device nodes only — no `libcuda.so.1` mount, no iGPU nodes. JP6 works because its newer toolkit produces a real CDI spec.

## Fix

Add an in-agent **L4T "CSV mode" fallback**. When no `nvidia-ctk` CDI spec is available, translate the device's own NVIDIA Container Runtime CSV file lists (`/etc/nvidia-container-runtime/host-files-for-container.d/*.csv`) directly into OCI mounts and device nodes:

- `lib` / `sym` / `dir` → read-only bind-mount at the same path (overlays the image's 0-byte `libcuda.so.1` stub with the real 23 MB host driver). `noexec` is deliberately omitted so the loader can mmap libraries executable.
- `dev` → device node + cgroup allow rule (`/dev/nvmap`, `/dev/nvhost-*`, the full `/dev/nvgpu/igpu0/*` set).
- Missing sources are skipped so a stale CSV entry can't block container start.

These CSVs already ship on the affected images, so GPU works on the device **as-is — no toolkit upgrade, no reflash**. JP6 keeps using its real CDI spec (fallback only triggers when none exists).

Also adds `oci.DedupeDevices`, run before the spec is serialized: the GPU setup (CDI or CSV) and the `gpu` entitlement can both add the same node (e.g. `/dev/nvidiactl`), and runc `mknod()`s each entry, so a duplicate path would fail container creation with `EEXIST`. This also hardens the pre-existing CDI path.

## Files

- `go/internal/agent/cdi/csv.go` (+ `csv_test.go`) — `ApplyL4TCSV` and CSV parsing
- `go/internal/agent/containerd/client.go` — wire the fallback into `applyCDIGPU`; dedup before serialize
- `go/internal/agent/oci/spec.go` (+ `dedupe_test.go`) — `DedupeDevices`

## Testing

- Unit: `oci` + `cdi` packages pass (incl. `-race`); `gofmt`/`go vet` clean; linux/arm64 agent builds.
- **Verified end-to-end on a real JetPack-5 Go2** (WendyOS, JP5.1.1) — side-loaded the agent, recreated the gpu container:

| Check | Before | After |
|---|---|---|
| `…/tegra/libcuda.so.1` | 0 bytes (stub) | **23,217,008 bytes** (real driver) |
| `/dev/nvmap`, `/dev/nvhost-gpu`, `/dev/nvgpu` | missing | **present** |
| `torch.cuda.is_available()` | False | **True — "Orin"** |
| go2-initial-test **gpu** tile | FAIL | **PASS** — `Orin · CUDA 11.4 · 2k×2k matmul 50.8 ms` |
| go2-initial-test **jetson** tile | FAIL (TensorRT ImportError) | **PASS** — `TensorRT 8.5.2.2` |

Fixes WDY-1716

🤖 Generated with [Claude Code](https://claude.com/claude-code)