### PR TITLE
fix(cli): normalize agent OS to a valid OCI platform (WDY-1723)

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1905,16 +1905,33 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 // Rules:
 //   - If cfgPlatform is a full "os/arch" string, use it as-is.
 //   - If cfgPlatform is OS-only (e.g., "linux" or "darwin"), append the agent arch.
-//   - If cfgPlatform is empty, default to the agent's OS and architecture.
+//   - If cfgPlatform is empty, default to the agent's OS (normalized to a valid
+//     OCI platform OS) and architecture.
 func resolveAgentPlatform(cfgPlatform, agentOS, agentArch string) string {
 	if cfgPlatform == "" {
-		return agentOS + "/" + agentArch
+		return ociOS(agentOS) + "/" + agentArch
 	}
 	if strings.Contains(cfgPlatform, "/") {
 		return cfgPlatform
 	}
 	// OS-only: append agent architecture.
 	return cfgPlatform + "/" + agentArch
+}
+
+// ociOS maps the agent-reported OS to a valid OCI image platform OS. The agent
+// reports the Linux distribution ID (e.g. "ubuntu", "debian") as its OS for
+// human-facing device info, but OCI image manifests only use "linux"/"darwin"/
+// "windows". Feeding a distro ID into the buildx --platform produces an invalid
+// platform like "ubuntu/arm64" and every build fails with "no match for
+// platform in manifest", so anything that isn't darwin/windows is treated as
+// linux (WDY-1723).
+func ociOS(agentOS string) string {
+	switch strings.ToLower(agentOS) {
+	case "darwin", "windows":
+		return strings.ToLower(agentOS)
+	default:
+		return "linux"
+	}
 }
 
 func registryPort(agentOS string) int {

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1905,10 +1905,11 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 // Rules:
 //   - If cfgPlatform is a full "os/arch" string, use it as-is.
 //   - If cfgPlatform is OS-only (e.g., "linux" or "darwin"), append the agent arch.
-//   - If cfgPlatform is empty, default to the agent's OS (normalized to a valid
-//     OCI platform OS) and architecture.
+//   - If cfgPlatform is empty, or a wendy target family ("wendyos"/"wendy-lite")
+//     that `wendy init` writes by default, derive the platform from the agent's
+//     OS (normalized to a valid OCI platform OS) and architecture.
 func resolveAgentPlatform(cfgPlatform, agentOS, agentArch string) string {
-	if cfgPlatform == "" {
+	if cfgPlatform == "" || isWendyTargetFamily(cfgPlatform) {
 		return ociOS(agentOS) + "/" + agentArch
 	}
 	if strings.Contains(cfgPlatform, "/") {
@@ -1916,6 +1917,20 @@ func resolveAgentPlatform(cfgPlatform, agentOS, agentArch string) string {
 	}
 	// OS-only: append agent architecture.
 	return cfgPlatform + "/" + agentArch
+}
+
+// isWendyTargetFamily reports whether the wendy.json platform value is a wendy
+// target family ("wendyos"/"wendy-lite") — the default `wendy init` writes —
+// rather than an OCI "os" or "os/arch". These are placeholders for "auto-derive
+// the OCI platform from the connected agent", not OCI OS strings, so feeding
+// them to buildx --platform yields an invalid platform like "wendyos/arm64"
+// and every build fails (WDY-1723).
+func isWendyTargetFamily(p string) bool {
+	switch strings.ToLower(p) {
+	case appconfig.PlatformWendyOS, appconfig.PlatformWendyLite:
+		return true
+	}
+	return false
 }
 
 // ociOS maps the agent-reported OS to a valid OCI image platform OS. The agent

--- a/go/internal/cli/commands/platform_test.go
+++ b/go/internal/cli/commands/platform_test.go
@@ -21,6 +21,16 @@ func TestResolveAgentPlatform(t *testing.T) {
 		{"windows preserved", "", "windows", "amd64", "windows/amd64"},
 		{"mixed-case distro normalized", "", "Ubuntu", "arm64", "linux/arm64"},
 
+		// wendy target families ("wendyos"/"wendy-lite") are what `wendy init`
+		// writes by default — they are auto-targets, not OCI OS strings, so they
+		// must derive from the (normalized) agent OS, not pass through as
+		// "wendyos/arm64" (WDY-1723).
+		{"wendyos default, wendyos agent", "wendyos", "wendyos", "arm64", "linux/arm64"},
+		{"wendyos default, ubuntu agent", "wendyos", "ubuntu", "arm64", "linux/arm64"},
+		{"wendyos default, darwin agent", "wendyos", "darwin", "arm64", "darwin/arm64"},
+		{"wendy-lite default normalized", "wendy-lite", "ubuntu", "amd64", "linux/amd64"},
+		{"mixed-case wendyos normalized", "WendyOS", "ubuntu", "arm64", "linux/arm64"},
+
 		// Explicit full cfgPlatform is trusted as-is (user override / workaround).
 		{"explicit full platform as-is", "linux/arm64", "ubuntu", "arm64", "linux/arm64"},
 		{"explicit full platform amd64", "linux/amd64", "ubuntu", "arm64", "linux/amd64"},

--- a/go/internal/cli/commands/platform_test.go
+++ b/go/internal/cli/commands/platform_test.go
@@ -1,0 +1,58 @@
+package commands
+
+import "testing"
+
+func TestResolveAgentPlatform(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfgPlatform string
+		agentOS     string
+		agentArch   string
+		want        string
+	}{
+		// Empty cfgPlatform: agent OS is normalized to a valid OCI OS. A distro
+		// ID reported by a stock-Ubuntu agent must not leak into the platform
+		// (WDY-1723).
+		{"distro os normalized to linux", "", "ubuntu", "arm64", "linux/arm64"},
+		{"debian normalized to linux", "", "debian", "arm64", "linux/arm64"},
+		{"rhel normalized to linux", "", "rhel", "amd64", "linux/amd64"},
+		{"linux passes through", "", "linux", "arm64", "linux/arm64"},
+		{"darwin preserved", "", "darwin", "arm64", "darwin/arm64"},
+		{"windows preserved", "", "windows", "amd64", "windows/amd64"},
+		{"mixed-case distro normalized", "", "Ubuntu", "arm64", "linux/arm64"},
+
+		// Explicit full cfgPlatform is trusted as-is (user override / workaround).
+		{"explicit full platform as-is", "linux/arm64", "ubuntu", "arm64", "linux/arm64"},
+		{"explicit full platform amd64", "linux/amd64", "ubuntu", "arm64", "linux/amd64"},
+
+		// OS-only cfgPlatform: user-specified OS + agent arch.
+		{"os-only cfg appends arch", "linux", "ubuntu", "arm64", "linux/arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAgentPlatform(tt.cfgPlatform, tt.agentOS, tt.agentArch); got != tt.want {
+				t.Errorf("resolveAgentPlatform(%q, %q, %q) = %q, want %q",
+					tt.cfgPlatform, tt.agentOS, tt.agentArch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOciOS(t *testing.T) {
+	tests := map[string]string{
+		"ubuntu":  "linux",
+		"debian":  "linux",
+		"rhel":    "linux",
+		"linux":   "linux",
+		"":        "linux",
+		"darwin":  "darwin",
+		"DARWIN":  "darwin",
+		"windows": "windows",
+	}
+	for in, want := range tests {
+		if got := ociOS(in); got != want {
+			t.Errorf("ociOS(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`wendy run` failed to build **any** service for a device whose agent reports its OS as a Linux **distro ID** (e.g. `"ubuntu"`) instead of `"linux"`. The CLI fed that straight into the buildx `--platform`, producing an invalid OCI platform like `ubuntu/arm64`, so every build died with:

```
ERROR: failed to solve: python:3.11-slim: ... no match for platform in manifest: not found
```

This broke all deploys to stock Ubuntu arm64 devices that got the agent via `install.wendy.sh` (e.g. a MyBotShop Go2 onboard Orin, JP5.1.1).

## Root cause

The agent **deliberately** reports the distro ID as its OS for human-facing device info (`agent/services/distro_linux.go` → `detectOS()`). The bug is the CLI conflating that *display* string with a *machine* OCI platform OS:

```go
// helpers.go  resolveAgentPlatform
if cfgPlatform == "" {
    return agentOS + "/" + agentArch   // "ubuntu" + "/arm64" → "ubuntu/arm64"
}
```

OCI image manifests only ever use `linux`/`darwin`/`windows`, so `ubuntu` matches nothing.

## Fix

Normalize at the single platform-construction chokepoint — all five build paths (`run` ×2, `build`, `compose`, `multibuild`) go through `resolveAgentPlatform`. Add `ociOS()` and apply it in the empty-`cfgPlatform` branch (anything not `darwin`/`windows` → `linux`). Explicit `cfgPlatform` values are still trusted as-is.

This fixes **every already-deployed agent** without changing what the agent reports (CLI-only; no agent update needed). The macOS/Windows agent-as-target paths still get `darwin`/`windows`.

## Testing

- New `platform_test.go`: `resolveAgentPlatform`/`ociOS` table tests — `ubuntu`/`debian`/`rhel`/mixed-case → `linux`, `darwin`/`windows` preserved, explicit + OS-only `cfgPlatform` unchanged. All pass; `go vet` clean; CLI builds.
- ⏳ **On-device check pending:** `wendy run --debug` against the Ubuntu-reporting Go2 should now show `--platform linux/arm64` and deploy.

Fixes WDY-1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)