### PR TITLE
Supply `WENDY_JETPACK_MAJOR` as docker build arg

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -52,6 +52,7 @@ Docker for local provider runs.
 | `WENDY_HAS_GPU` | `true` \| `false` | Absent on older agents |
 | `WENDY_GPU_VENDOR` | e.g. `nvidia`, `qualcomm` | Absent when no GPU is reported |
 | `WENDY_JETPACK_VERSION` | e.g. `6.0` | Jetson only |
+| `WENDY_JETPACK_MAJOR` | e.g. `6`, `7` | Jetson only; JetPack major for per-generation base-image selection |
 | `WENDY_CUDA_VERSION` | e.g. `12.6` | Jetson only |
 
 Example — selecting a base image by platform:

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -53,6 +53,7 @@ local runs, but compose service builds targeting a WendyOS device can use
 | `WENDY_HAS_GPU` | `true` \| `false` | Absent on older agents |
 | `WENDY_GPU_VENDOR` | e.g. `nvidia`, `qualcomm` | Absent when no GPU is reported |
 | `WENDY_JETPACK_VERSION` | e.g. `6.0` | Jetson only |
+| `WENDY_JETPACK_MAJOR` | e.g. `6`, `7` | Jetson only; JetPack major for per-generation base-image selection |
 | `WENDY_CUDA_VERSION` | e.g. `12.6` | Jetson only |
 
 `WENDY_PLATFORM` and `WENDY_DEBUG` are always set. The remaining args are only injected when the agent reports them, so Dockerfiles and Containerfiles can define their own `ARG` defaults for devices that predate the field.

--- a/go/internal/cli/commands/device_build_args_test.go
+++ b/go/internal/cli/commands/device_build_args_test.go
@@ -51,6 +51,23 @@ func TestApplyDeviceBuildArgHints_PassesMappedJetpackVersion(t *testing.T) {
 	}
 }
 
+// TestApplyDeviceBuildArgHints_DerivesJetpackMajor confirms the coarse
+// WENDY_JETPACK_MAJOR selector is derived from a clean version ("7.2" -> "7")
+// and omitted for an unmapped "L4T ..." fallback.
+func TestApplyDeviceBuildArgHints_DerivesJetpackMajor(t *testing.T) {
+	clean := map[string]string{}
+	applyDeviceBuildArgHints(clean, &agentpb.GetAgentVersionResponse{JetpackVersion: strptr("7.2")})
+	if got := clean["WENDY_JETPACK_MAJOR"]; got != "7" {
+		t.Fatalf("WENDY_JETPACK_MAJOR = %q, want %q", got, "7")
+	}
+
+	fallback := map[string]string{}
+	applyDeviceBuildArgHints(fallback, &agentpb.GetAgentVersionResponse{JetpackVersion: strptr("L4T 39.2.0")})
+	if got, ok := fallback["WENDY_JETPACK_MAJOR"]; ok {
+		t.Fatalf("expected WENDY_JETPACK_MAJOR omitted for L4T fallback, got %q", got)
+	}
+}
+
 // TestApplyDeviceBuildArgHints_OmitsUnreportedHints confirms older agents that
 // do not report a field leave the ARG default untouched (no empty value set).
 func TestApplyDeviceBuildArgHints_OmitsUnreportedHints(t *testing.T) {

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -280,13 +280,14 @@ func validateBuildArgPair(key, value string) error {
 
 // applyDeviceBuildArgHints injects the optional device/GPU build-arg hints the
 // agent reports (WENDY_DEVICE_TYPE, WENDY_HAS_GPU, WENDY_GPU_VENDOR,
-// WENDY_JETPACK_VERSION, WENDY_CUDA_VERSION) into buildArgs. Each hint is only
-// set when the agent reports it, so Dockerfiles keep their own ARG defaults on
-// older agents. These values are device-reported and feed straight into a
-// builder CLI, so any hint that fails build-arg validation is skipped with a
-// warning rather than failing the whole deploy — e.g. a Jetson running an L4T
-// release the agent's JetPack table doesn't map reports a fallback like
-// "L4T 38.2.0", whose space is rejected by validBuildArgValueRe.
+// WENDY_JETPACK_VERSION, WENDY_JETPACK_MAJOR, WENDY_CUDA_VERSION) into
+// buildArgs. Each hint is only set when the agent reports it, so Dockerfiles
+// keep their own ARG defaults on older agents. These values are device-reported
+// and feed straight into a builder CLI, so any hint that fails build-arg
+// validation is skipped with a warning rather than failing the whole deploy —
+// e.g. a Jetson running an L4T release the agent's JetPack table doesn't map
+// reports a fallback like "L4T 38.2.0", whose space is rejected by
+// validBuildArgValueRe.
 func applyDeviceBuildArgHints(buildArgs map[string]string, versionResp *agentpb.GetAgentVersionResponse) {
 	setHint := func(key, value string) {
 		if value == "" {
@@ -306,7 +307,17 @@ func applyDeviceBuildArgHints(buildArgs map[string]string, versionResp *agentpb.
 	}
 	setHint("WENDY_GPU_VENDOR", versionResp.GetGpuVendor())
 	setHint("WENDY_JETPACK_VERSION", versionResp.GetJetpackVersion())
+	// Coarse major ("7" from "7.2") to aid in per-generation image selection
+	setHint("WENDY_JETPACK_MAJOR", jetpackMajor(versionResp.GetJetpackVersion()))
 	setHint("WENDY_CUDA_VERSION", versionResp.GetCudaVersion())
+}
+
+func jetpackMajor(version string) string {
+	major, _, _ := strings.Cut(version, ".")
+	if _, err := strconv.Atoi(major); err != nil {
+		return "" // empty, or an unmapped "L4T 39.2.0" fallback — not a clean major
+	}
+	return major
 }
 
 func sortedValidatedBuildArgKeys(buildArgs map[string]string) ([]string, error) {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1681,8 +1681,9 @@ func startPostStartHook(ctx context.Context, appCfg *appconfig.AppConfig, hostna
 // jetson-agx-thor (tegra264 / JetPack 7 / CUDA 13) shares the "nvidia-jetson"
 // tier with the Orin boards (tegra234 / JetPack 6 / CUDA 12). The tier only says
 // "NVIDIA Jetson"; templates that ship a JetPack-pinned base image should branch
-// on the WENDY_JETPACK_VERSION / WENDY_CUDA_VERSION build args (also injected by
-// `wendy run`) to pick a Thor-compatible image where the JetPack 6 image differs.
+// on the WENDY_JETPACK_MAJOR build arg (a coarse "6"/"7", also injected by
+// `wendy run`) — or WENDY_JETPACK_VERSION / WENDY_CUDA_VERSION for finer pins —
+// to pick a Thor-compatible image where the JetPack 6 image differs.
 func wendyPlatform(deviceType string) string {
 	switch deviceType {
 	case "jetson-agx-orin", "jetson-orin-nano", "jetson-agx-thor":


### PR DESCRIPTION
For some apps it's useful to select a base image based on whether we're dealing with Jetpack 6 vs Jetpack 7. While we already have `WENDY_JETPACK_VERSION`, this is a value like `7.2` which is not easily used for conditional selection within a `Dockerfile`. If we provide `WENDY_JETPACK_MAJOR` (`7`) then this is straightforward.

Example usage in paired PR: https://github.com/wendylabsinc/samples/pull/14

