### PR TITLE
Clean up Swift E2E setup scripts

### DIFF
--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: lan
   setup:
-    description: Run the platform Swift E2E setup script before tests.
+    description: Run the platform Swift E2E per-run setup/preflight script before tests.
     required: false
     default: 'false'
   managed_agent:

--- a/swift/Scripts/E2ESetup.macOS.sh
+++ b/swift/Scripts/E2ESetup.macOS.sh
@@ -1,23 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ENABLE_REMOTE_LOGIN=false
+
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Prepare macOS for WendyAgent Swift E2E tests.
+Preflight macOS for WendyAgent Swift E2E tests.
 
-The setup asks for sudo access, installs Homebrew if needed, installs required
-developer tools, installs Swift via swiftly if needed, and configures
-passwordless SSH loopback for the current user.
+This is a per-run helper for ephemeral E2E runs. It does not install Homebrew,
+install Swift, or otherwise bootstrap a macOS host. The runner is expected to be
+provisioned once with the required developer tools and Remote Login/sshd.
+
+Per run, this script:
+  - verifies the required tools are already on PATH;
+  - prepares the current user's ~/.ssh key and authorized_keys; and
+  - verifies passwordless SSH to localhost for the E2E command executor.
 
 Options:
-  --help, -h  Show this help message.
+  --enable-remote-login  If SSH loopback is not ready, try to enable macOS
+                         Remote Login using sudo. This is an explicit
+                         provisioning opt-in and is never attempted by default.
+  --help, -h             Show this help message.
 EOF
 }
 
 logStep() {
   printf '==> %s\n' "$1"
+}
+
+printProvisioningHint() {
+  cat >&2 <<'EOF'
+
+Provision this macOS runner once before running Swift E2E tests:
+  - install Xcode or the Xcode command line tools;
+  - install bash, curl, git, go, make, Swift, zip, ssh, and ssh-keygen;
+  - enable Remote Login/sshd for the runner user; and
+  - allow the runner user to SSH to localhost with keys in ~/.ssh/authorized_keys.
+
+The per-run setup intentionally does not install packages or require sudo.
+EOF
+}
+
+failWithProvisioningHint() {
+  echo "ERROR: $1" >&2
+  printProvisioningHint
+  exit 1
 }
 
 checkCommand() {
@@ -29,25 +58,18 @@ checkCommand() {
     printf '\033[32mYes\033[0m\n'
   else
     printf 'No\n' >&2
-    echo "ERROR: Missing required tool: $label" >&2
-    exit 1
+    failWithProvisioningHint "Missing required tool: $label"
   fi
 }
 
-requireSudo() {
-  logStep "Requesting sudo access"
-  sudo -v
-}
-
-installHomebrewIfNeeded() {
-  if command -v brew >/dev/null 2>&1; then
-    return 0
+checkXcodebuild() {
+  printf 'Checking `Xcode command line tools` available ... '
+  if command -v xcodebuild >/dev/null 2>&1 && xcodebuild -version >/dev/null 2>&1; then
+    printf '\033[32mYes\033[0m\n'
+  else
+    printf 'No\n' >&2
+    failWithProvisioningHint "Xcode command line tools are missing or not usable"
   fi
-
-  logStep "Installing Homebrew"
-  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  sourceHomebrewEnvironment
-  hash -r
 }
 
 sourceHomebrewEnvironment() {
@@ -71,58 +93,11 @@ sourceHomebrewEnvironment() {
   fi
 }
 
-installHomebrewPackages() {
-  logStep "Installing Homebrew E2E dependencies"
-  sourceHomebrewEnvironment
-  brew update
-  brew install bash curl git go make zip
-}
-
 sourceSwiftlyEnvironment() {
   local env_file="${SWIFTLY_HOME_DIR:-$HOME/.swiftly}/env.sh"
   if [ -f "$env_file" ]; then
     # shellcheck disable=SC1090
     . "$env_file"
-  fi
-}
-
-installSwiftlyMacOSIfNeeded() {
-  sourceSwiftlyEnvironment
-  if command -v swiftly >/dev/null 2>&1; then
-    return 0
-  fi
-
-  logStep "Installing swiftly"
-  local temporary_dir
-  temporary_dir="$(mktemp -d)"
-  trap 'rm -rf "$temporary_dir"' EXIT
-
-  (
-    cd "$temporary_dir"
-    curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg
-    installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
-    ~/.swiftly/bin/swiftly init --quiet-shell-followup
-  )
-
-  rm -rf "$temporary_dir"
-  trap - EXIT
-  sourceSwiftlyEnvironment
-  hash -r
-}
-
-installSwiftMacOSIfNeeded() {
-  sourceSwiftlyEnvironment
-  if command -v swift >/dev/null 2>&1; then
-    return 0
-  fi
-
-  installSwiftlyMacOSIfNeeded
-  sourceSwiftlyEnvironment
-  if ! command -v swift >/dev/null 2>&1; then
-    logStep "Installing Swift with swiftly"
-    swiftly install --use latest --assume-yes
-    sourceSwiftlyEnvironment
-    hash -r
   fi
 }
 
@@ -136,23 +111,18 @@ sshLoopbackWorks() {
     localhost true >/dev/null 2>&1
 }
 
-startSSHServiceIfPossible() {
-  if sshLoopbackWorks; then
-    return 0
-  fi
-
-  sudo /usr/sbin/systemsetup -setremotelogin on >/dev/null 2>&1
-  sudo /bin/launchctl kickstart -k system/com.openssh.sshd >/dev/null 2>&1 || true
-}
-
-setupSSHLoopback() {
-  logStep "Setting up SSH loopback for E2E sessions"
+prepareSSHLoopbackCredentials() {
+  logStep "Preparing SSH loopback credentials for E2E sessions"
 
   mkdir -p "$HOME/.ssh"
   chmod 700 "$HOME/.ssh"
 
   if [ ! -f "$HOME/.ssh/id_ed25519" ]; then
     ssh-keygen -q -t ed25519 -N "" -C "${USER:-wendy-e2e}@$(hostname)" -f "$HOME/.ssh/id_ed25519"
+  fi
+
+  if [ ! -f "$HOME/.ssh/id_ed25519.pub" ]; then
+    ssh-keygen -y -f "$HOME/.ssh/id_ed25519" > "$HOME/.ssh/id_ed25519.pub"
   fi
 
   touch "$HOME/.ssh/authorized_keys"
@@ -163,24 +133,52 @@ setupSSHLoopback() {
   if ! grep -qxF "$public_key" "$HOME/.ssh/authorized_keys"; then
     printf '%s\n' "$public_key" >> "$HOME/.ssh/authorized_keys"
   fi
+}
 
-  startSSHServiceIfPossible
+enableRemoteLoginIfRequested() {
+  if [ "$ENABLE_REMOTE_LOGIN" != "true" ] || sshLoopbackWorks; then
+    return 0
+  fi
 
-  if ! sshLoopbackWorks; then
-    echo "ERROR: Could not establish passwordless SSH to localhost." >&2
-    echo "Swift E2E sessions execute local commands through SSH; verify Remote Login/sshd and ~/.ssh/authorized_keys." >&2
+  logStep "Enabling macOS Remote Login for SSH loopback"
+  if ! sudo -n true >/dev/null 2>&1; then
+    failWithProvisioningHint "--enable-remote-login requires non-interactive sudo access"
+  fi
+
+  sudo /usr/sbin/systemsetup -setremotelogin on >/dev/null
+  sudo /bin/launchctl kickstart -k system/com.openssh.sshd >/dev/null 2>&1 || true
+}
+
+checkSSHLoopback() {
+  prepareSSHLoopbackCredentials
+  enableRemoteLoginIfRequested
+
+  printf 'Checking passwordless SSH to localhost ... '
+  if sshLoopbackWorks; then
+    printf '\033[32mYes\033[0m\n'
+  else
+    printf 'No\n' >&2
+    cat >&2 <<'EOF'
+ERROR: Passwordless SSH to localhost is not ready.
+Swift E2E sessions execute local commands through SSH. This per-run setup
+prepared the current user's SSH credentials, but it does not enable macOS Remote
+Login by default because that is a privileged host-provisioning operation.
+
+Enable Remote Login once for the runner user, or run this script with
+--enable-remote-login on a machine where non-interactive sudo is intentionally
+available.
+EOF
+    printProvisioningHint
     exit 1
   fi
 }
 
 setupE2EMacOS() {
-  logStep "Setting up Swift E2E dependencies for macOS"
+  logStep "Preflighting Swift E2E dependencies for macOS"
 
-  requireSudo
-  installHomebrewIfNeeded
-  installHomebrewPackages
-  installSwiftMacOSIfNeeded
-  setupSSHLoopback
+  sourceHomebrewEnvironment
+  sourceSwiftlyEnvironment
+  hash -r
 
   checkCommand bash
   checkCommand curl
@@ -191,11 +189,16 @@ setupE2EMacOS() {
   checkCommand zip
   checkCommand ssh "openssh-client"
   checkCommand ssh-keygen
-  checkCommand xcodebuild "Xcode command line tools"
+  checkXcodebuild
+  checkSSHLoopback
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --enable-remote-login)
+      ENABLE_REMOTE_LOGIN=true
+      shift
+      ;;
     --help|-h)
       usage
       exit 0

--- a/swift/Scripts/E2ESetup.sh
+++ b/swift/Scripts/E2ESetup.sh
@@ -8,30 +8,27 @@ usage() {
 Usage: $(basename "$0") [OPTIONS]
 
 Prepare the current host for WendyAgent Swift E2E tests by dispatching to the
-platform-specific setup script.
+platform-specific setup/preflight script.
 
 Options:
   --help, -h  Show this help message.
+
+Other options are forwarded to the platform-specific script.
 EOF
 }
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
+for argument in "$@"; do
+  case "$argument" in
     --help|-h)
       usage
       exit 0
-      ;;
-    *)
-      echo "Unknown option: $1" >&2
-      usage >&2
-      exit 64
       ;;
   esac
 done
 
 case "$(uname -s)" in
   Darwin)
-    exec bash "$SCRIPT_DIR/E2ESetup.macOS.sh"
+    exec bash "$SCRIPT_DIR/E2ESetup.macOS.sh" "$@"
     ;;
   Linux)
     if command -v lsb_release >/dev/null 2>&1; then
@@ -42,7 +39,7 @@ case "$(uname -s)" in
 
     case "${distribution,,}" in
       ubuntu)
-        exec bash "$SCRIPT_DIR/E2ESetup.ubuntu.sh"
+        exec bash "$SCRIPT_DIR/E2ESetup.ubuntu.sh" "$@"
         ;;
       *)
         echo "ERROR: Unsupported Linux distribution for E2E setup: ${distribution:-unknown}" >&2


### PR DESCRIPTION
## Summary

- Make the macOS Swift E2E setup path a per-run preflight instead of a host bootstrapper.
- Remove default Homebrew/Swift installation and unconditional sudo from macOS setup; Remote Login can only be enabled with an explicit `--enable-remote-login` opt-in.
- Document the macOS runner contract in setup output: tools and Remote Login/sshd must be pre-provisioned, while the per-run helper only checks tools, prepares user SSH keys, and verifies SSH loopback.
- Keep Ubuntu setup behavior intact and preserve setup-failure attempt artifact generation in the composite action.

Closes WDY-1724

## Notes

Hosted local macOS still uses `setup: true`, but that now means preflight-only setup with no sudo by default. If a runner lacks Remote Login/sshd, the job will fail with a provisioning message instead of trying to mutate the host.

## Testing

- `bash -n swift/Scripts/E2ESetup.sh`
- `bash -n swift/Scripts/E2ESetup.macOS.sh`
- `bash -n swift/Scripts/E2ESetup.ubuntu.sh`
- `bash swift/Scripts/E2ESetup.sh --help`
- `bash swift/Scripts/E2ESetup.macOS.sh --help`
- `bash swift/Scripts/E2ESetup.ubuntu.sh --help`
- `git diff --check`
- Simulated the macOS setup path with a fake Darwin environment, failing SSH loopback, and a fake `sudo`; confirmed the script exits with the SSH provisioning error without invoking `sudo`.
