### PR TITLE
fix(cli): resolve saved .local default devices via mDNS browse (#1155)

### DIFF
--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
@@ -194,7 +195,7 @@ func TestNewDeviceCmd(t *testing.T) {
 		subNames[c.Name()] = true
 	}
 
-	expectedSubs := []string{"info", "version", "set-default", "unset-default", "setup", "update"}
+	expectedSubs := []string{"info", "version", "set-default", "get-default", "unset-default", "setup", "update"}
 	for _, name := range expectedSubs {
 		if !subNames[name] {
 			t.Errorf("device command missing subcommand %q", name)
@@ -223,6 +224,44 @@ func TestNewDeviceCmd(t *testing.T) {
 	}
 	if strings.Contains(help, "\n  version") {
 		t.Fatalf("device help should not list deprecated version command: %s", help)
+	}
+}
+
+func TestDeviceGetDefault_Set(t *testing.T) {
+	origJSON := jsonOutput
+	t.Cleanup(func() { jsonOutput = origJSON })
+	jsonOutput = false
+	setTempConfig(t, &config.Config{DefaultDevice: "wendy-thor.local"})
+
+	buf := new(bytes.Buffer)
+	cmd := newDeviceGetDefaultCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("get-default: %v", err)
+	}
+	if !strings.Contains(buf.String(), "wendy-thor.local") {
+		t.Fatalf("output %q missing default device", buf.String())
+	}
+}
+
+func TestDeviceGetDefault_NotSet(t *testing.T) {
+	origJSON := jsonOutput
+	t.Cleanup(func() { jsonOutput = origJSON })
+	jsonOutput = false
+	setTempConfig(t, &config.Config{})
+
+	buf := new(bytes.Buffer)
+	cmd := newDeviceGetDefaultCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("get-default: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(buf.String()), "no default") {
+		t.Fatalf("output %q should indicate no default device is set", buf.String())
 	}
 }
 

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -61,6 +61,7 @@ func newDeviceCmd() *cobra.Command {
 		newDeviceInfoCmd(),
 		newDeprecatedDeviceVersionCmd(),
 		newDeviceSetDefaultCmd(),
+		newDeviceGetDefaultCmd(),
 		newDeviceUnsetDefaultCmd(),
 		newDeviceSetupCmd(),
 		newDeviceEnrollCmd(),
@@ -313,6 +314,36 @@ func newDeviceSetDefaultCmd() *cobra.Command {
 			}
 
 			fmt.Printf("Default device set to: %s\n", device)
+			return nil
+		},
+	}
+}
+
+func newDeviceGetDefaultCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get-default",
+		Short: "Show the current default device",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			if jsonOutput {
+				data, err := json.MarshalIndent(map[string]string{"defaultDevice": cfg.DefaultDevice}, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), string(data))
+				return nil
+			}
+
+			if cfg.DefaultDevice == "" {
+				fmt.Fprintln(cmd.OutOrStdout(), "No default device set. Set one with 'wendy device set-default'.")
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Default device: %s\n", cfg.DefaultDevice)
 			return nil
 		},
 	}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -692,6 +692,8 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 					return nil, recErr
 				}
 				return connectFromSelectedDevice(target, cfg)
+			} else if isDefault {
+				return nil, defaultDeviceUnreachableError(hostname, connErr)
 			} else {
 				return nil, connErr
 			}
@@ -762,6 +764,20 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 	return conn, err
 }
 
+// mdnsBrowseTimeout bounds the mDNS fallback browse so an offline default device
+// does not stall a command for the full default discovery window.
+const mdnsBrowseTimeout = 4 * time.Second
+
+// osLookupHostFn resolves a hostname via the operating system resolver. It is a
+// package variable so tests can simulate a resolver that cannot see mDNS names.
+var osLookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// lanBrowseFn browses the LAN for WendyOS devices via mDNS. It is a package
+// variable so tests can substitute a fixture instead of a real network browse.
+var lanBrowseFn = discovery.DiscoverLAN
+
 // resolveAddrOnce resolves a host:port whose host is a DNS/mDNS name to an
 // IPv4-preferred IP:port, so the dials below target a literal IP. gRPC
 // otherwise resolves the name separately for every ClientConn we open (mTLS
@@ -776,17 +792,69 @@ func resolveAddrOnce(ctx context.Context, addr string) string {
 		return addr // not host:port, or already a literal IP
 	}
 	rctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-	ips, err := net.DefaultResolver.LookupHost(rctx, host)
-	if err != nil || len(ips) == 0 {
-		return addr
+	ips, err := osLookupHostFn(rctx, host)
+	cancel()
+	if err == nil && len(ips) > 0 {
+		for _, ip := range ips { // prefer IPv4
+			if net.ParseIP(ip).To4() != nil {
+				return net.JoinHostPort(ip, port)
+			}
+		}
+		return net.JoinHostPort(ips[0], port)
 	}
-	for _, ip := range ips { // prefer IPv4
-		if net.ParseIP(ip).To4() != nil {
-			return net.JoinHostPort(ip, port)
+	// The OS resolver (and thus gRPC's) can't see mDNS ".local" names on
+	// Windows or on Linux hosts without nss-mdns/avahi — only macOS resolves
+	// them natively. Fall back to an mDNS browse so a saved default hostname
+	// still connects on those platforms (issue #1155).
+	if ip := resolveMDNSHost(ctx, host); ip != "" {
+		return net.JoinHostPort(ip, port)
+	}
+	return addr
+}
+
+// resolveMDNSHost browses the LAN via mDNS and returns the IP address advertised
+// by a device whose hostname matches host. It is the fallback used when the OS
+// resolver cannot resolve an mDNS ".local" name — mirroring the discover/picker
+// path, which already prefers discovered IPs for the same reason. Returns "" for
+// non-".local" hosts or when no advertised device matches.
+func resolveMDNSHost(ctx context.Context, host string) string {
+	normalized := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if !strings.HasSuffix(normalized, ".local") {
+		return ""
+	}
+	bctx, cancel := context.WithTimeout(ctx, mdnsBrowseTimeout)
+	defer cancel()
+	devices, err := lanBrowseFn(bctx, mdnsBrowseTimeout)
+	if err != nil {
+		return ""
+	}
+	want := normalizeMDNSHost(host)
+	for _, dev := range devices {
+		if dev.IPAddress == "" {
+			continue
+		}
+		if normalizeMDNSHost(dev.Hostname) == want {
+			return dev.IPAddress
 		}
 	}
-	return net.JoinHostPort(ips[0], port)
+	return ""
+}
+
+// normalizeMDNSHost lowercases a hostname and strips a trailing dot and ".local"
+// suffix so "Wendy-Thor.local." and "wendy-thor" compare equal.
+func normalizeMDNSHost(host string) string {
+	h := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	return strings.TrimSuffix(h, ".local")
+}
+
+// defaultDeviceUnreachableError wraps a connection failure for a saved default
+// device so the message makes clear the default IS persisted but could not be
+// reached — rather than letting the failure read as if set-default never took
+// effect (issue #1155).
+func defaultDeviceUnreachableError(hostname string, err error) error {
+	return fmt.Errorf("default device %q is set but could not be reached: %w\n"+
+		"  Confirm it with 'wendy device get-default'; change it with 'wendy device set-default' or clear it with 'wendy device unset-default'.",
+		hostname, err)
 }
 
 func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error, error) {
@@ -1391,6 +1459,8 @@ func resolveTarget(ctx context.Context, opts ...resolveOption) (*SelectedDevice,
 			} else if isDefault && !jsonOutput && !cfg.nonInteractive && isInteractiveTerminal() {
 				// Default device is unreachable — offer interactive recovery.
 				return handleDefaultDeviceRecovery(ctx, device, time.Since(startedAt), err, cfg.excludeProviderKeys, cfg.excludeBluetooth, cfg.suppressUpdateCheck)
+			} else if isDefault {
+				return nil, defaultDeviceUnreachableError(device, err)
 			} else {
 				return nil, err
 			}

--- a/go/internal/cli/commands/helpers_mdns_test.go
+++ b/go/internal/cli/commands/helpers_mdns_test.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+func TestNormalizeMDNSHost(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"wendy-thor.local", "wendy-thor"},
+		{"wendy-thor.local.", "wendy-thor"},
+		{"Wendy-Thor.LOCAL", "wendy-thor"},
+		{"  wendy-thor.local  ", "wendy-thor"},
+		{"wendy-thor", "wendy-thor"},
+	}
+	for _, c := range cases {
+		if got := normalizeMDNSHost(c.in); got != c.want {
+			t.Errorf("normalizeMDNSHost(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestResolveMDNSHost_MatchesByHostname(t *testing.T) {
+	orig := lanBrowseFn
+	defer func() { lanBrowseFn = orig }()
+	lanBrowseFn = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
+		return []models.LANDevice{
+			{Hostname: "other.local", IPAddress: "192.168.1.10"},
+			// Trailing dot and mixed case must still match the saved default.
+			{Hostname: "Wendy-Thor.local.", IPAddress: "192.168.1.50"},
+		}, nil
+	}
+
+	got := resolveMDNSHost(context.Background(), "wendy-thor.local")
+	if got != "192.168.1.50" {
+		t.Fatalf("resolveMDNSHost = %q, want %q", got, "192.168.1.50")
+	}
+}
+
+func TestResolveMDNSHost_NonLocalSkipsBrowse(t *testing.T) {
+	orig := lanBrowseFn
+	defer func() { lanBrowseFn = orig }()
+	called := false
+	lanBrowseFn = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
+		called = true
+		return nil, nil
+	}
+
+	if got := resolveMDNSHost(context.Background(), "example.com"); got != "" {
+		t.Fatalf("resolveMDNSHost(non-.local) = %q, want empty", got)
+	}
+	if called {
+		t.Fatal("expected no mDNS browse for a non-.local host")
+	}
+}
+
+func TestResolveMDNSHost_NoMatchReturnsEmpty(t *testing.T) {
+	orig := lanBrowseFn
+	defer func() { lanBrowseFn = orig }()
+	lanBrowseFn = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
+		return []models.LANDevice{{Hostname: "other.local", IPAddress: "192.168.1.10"}}, nil
+	}
+
+	if got := resolveMDNSHost(context.Background(), "wendy-thor.local"); got != "" {
+		t.Fatalf("resolveMDNSHost(no match) = %q, want empty", got)
+	}
+}
+
+func TestResolveAddrOnce_LiteralIPUnchanged(t *testing.T) {
+	if got := resolveAddrOnce(context.Background(), "192.168.1.50:50051"); got != "192.168.1.50:50051" {
+		t.Fatalf("resolveAddrOnce(IP) = %q, want unchanged", got)
+	}
+}
+
+func TestResolveAddrOnce_PrefersIPv4FromOSResolver(t *testing.T) {
+	orig := osLookupHostFn
+	defer func() { osLookupHostFn = orig }()
+	osLookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+		return []string{"fe80::1", "192.168.1.50"}, nil
+	}
+
+	if got := resolveAddrOnce(context.Background(), "wendy-thor.local:50051"); got != "192.168.1.50:50051" {
+		t.Fatalf("resolveAddrOnce = %q, want %q", got, "192.168.1.50:50051")
+	}
+}
+
+// When the OS resolver can't see the mDNS ".local" name (the Windows/Linux
+// failure mode behind issue #1155), resolveAddrOnce must fall back to an mDNS
+// browse rather than returning the unresolvable name.
+func TestResolveAddrOnce_FallsBackToMDNSWhenOSResolverFails(t *testing.T) {
+	origLookup := osLookupHostFn
+	origBrowse := lanBrowseFn
+	defer func() {
+		osLookupHostFn = origLookup
+		lanBrowseFn = origBrowse
+	}()
+
+	osLookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+		return nil, errors.New("no such host")
+	}
+	lanBrowseFn = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
+		return []models.LANDevice{{Hostname: "wendy-thor.local", IPAddress: "192.168.1.50"}}, nil
+	}
+
+	if got := resolveAddrOnce(context.Background(), "wendy-thor.local:50051"); got != "192.168.1.50:50051" {
+		t.Fatalf("resolveAddrOnce = %q, want %q", got, "192.168.1.50:50051")
+	}
+}
+
+func TestDefaultDeviceUnreachableError(t *testing.T) {
+	cause := errors.New("connection refused")
+	err := defaultDeviceUnreachableError("wendyos-workshop-16.local", cause)
+	if !errors.Is(err, cause) {
+		t.Fatal("expected wrapped error to unwrap to the underlying cause")
+	}
+	msg := err.Error()
+	for _, want := range []string{"wendyos-workshop-16.local", "set but could not be reached", "get-default"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q", msg, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Issue #1155 reports `wendy device set-default` "doesn't persist" on Windows, and possibly Linux: after `set-default <host>.local` succeeds, `wendy device info` re-prompts to pick a device and `wendy run` times out.

## Root cause

The default **is** persisted and read back correctly — `config.Load`/`config.Save` are symmetric and platform-independent (`os.UserHomeDir()` + `filepath.Join`). The reporter's "different config path" hypothesis is wrong.

The real failure is in the **connect path**. A saved `.local` default is resolved with the OS resolver (`net.DefaultResolver`, and thus gRPC's) in `resolveAddrOnce`:
- **macOS** resolves mDNS `.local` names natively → works (why we couldn't repro locally).
- **Windows** (especially with multiple virtual adapters — the reporter has Radmin VPN, Tailscale, WSL, USB NCM) → fails.
- **Linux** without `nss-mdns`/avahi → fails ("potentially Linux as well").

When the dial fails, the recovery flow added in WDY-739 (`dd622c75`) silently re-opens the device picker, which reads as "the default was ignored / never saved." The codebase already knows `.local` resolution is unreliable off-macOS — `lanAgentAddresses` prefers the discovered IP "so commands still work when .local hostname resolution is unavailable" — but that workaround only applied to freshly-discovered devices, not a stored default.

## Fix

- **mDNS-browse fallback** — `resolveAddrOnce` now falls back to an mDNS browse (the same `discovery.DiscoverLAN` the picker uses) when the OS resolver can't see a `.local` name, returning the advertised IP. Covers both stored defaults and explicit `--device foo.local`. macOS is unaffected (OS resolver succeeds, no browse); the browse only runs on the previously-broken failure path and is bounded to 4s.
- **Clearer messaging** — in non-interactive/JSON mode, an unreachable default now returns `default device "X" is set but could not be reached: …` instead of a bare connection error, so a *resolution* failure is never mistaken for a *persistence* failure.
- **`wendy device get-default`** — new command to confirm exactly what is persisted (mirrors into `wendy cloud device` automatically).

## Tests

The OS-resolver and mDNS-browse calls sit behind package-var seams (`osLookupHostFn`, `lanBrowseFn`) so the new logic is unit-tested without a network:
- `resolveMDNSHost`/`normalizeMDNSHost` matching (case + trailing-dot + `.local` normalization), non-`.local` skip, no-match.
- `resolveAddrOnce` IPv4 preference, literal-IP passthrough, and mDNS fallback when the OS resolver fails.
- `defaultDeviceUnreachableError` message + unwrap.
- `device get-default` set / not-set.

`go build ./...`, `go vet`, full `commands` package tests, and `gofmt -l` all clean.

## Verification still needed

This dev machine is a Mac, where `.local` already resolves, so the Windows/Linux failure path can't be exercised here. **On-device verification on Windows (and a no-avahi Linux host) is pending** — that's the main thing to confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)