### PR TITLE
Show rotating educational hints in progress indicators

### DIFF
--- a/go/internal/cli/tui/hints.go
+++ b/go/internal/cli/tui/hints.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"math/rand"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// hintInterval is how often a running progress indicator rotates to a new hint.
+const hintInterval = 7 * time.Second
+
+// ProgressHints are short, educational "did you know" tips surfaced while a
+// progress indicator is running. They give users a heads-up on what the Wendy
+// CLI can do during otherwise-idle wait time. Edit this list freely.
+var ProgressHints = []string{
+	"Tip: Stream live app output with 'wendy device logs -f'",
+	"Tip: 'wendy run' rebuilds and redeploys automatically as you edit files",
+	"Tip: Inspect a device's hardware and capabilities with 'wendy device info'",
+	"Tip: Update the on-device agent with 'wendy device update'",
+	"Tip: Discover devices on your network with 'wendy device discover'",
+	"Tip: List and manage running apps with 'wendy device apps'",
+	"Tip: Scaffold a new project in seconds with 'wendy init'",
+	"Tip: Grant hardware access (GPU, camera, GPIO) via entitlements in wendy.json",
+	"Tip: Validate your wendy.json against the schema with 'wendy json'",
+	"Tip: View metrics, traces, and logs with the 'wendy telemetry' commands",
+	"Tip: Reach a device behind NAT with 'wendy cloud tunnel'",
+	"Tip: Let Claude drive your devices — set up the MCP server with 'wendy mcp setup'",
+}
+
+// hintTickMsg is emitted on each hint rotation tick.
+type hintTickMsg struct{}
+
+var hintStyle = lipgloss.NewStyle().Foreground(ColorDim)
+
+// hintRotator holds the currently displayed hint and rotates through a list.
+type hintRotator struct {
+	hints   []string
+	current string
+}
+
+// newHintRotator builds a rotator over ProgressHints with a random first hint.
+func newHintRotator() hintRotator {
+	r := hintRotator{hints: ProgressHints}
+	if len(r.hints) > 0 {
+		r.current = r.hints[rand.Intn(len(r.hints))]
+	}
+	return r
+}
+
+// tick returns a command that fires a hintTickMsg after hintInterval.
+func (r hintRotator) tick() tea.Cmd {
+	return tea.Tick(hintInterval, func(time.Time) tea.Msg {
+		return hintTickMsg{}
+	})
+}
+
+// next advances to a different random hint. It is a no-op when there are fewer
+// than two hints to choose from.
+func (r *hintRotator) next() {
+	if len(r.hints) < 2 {
+		return
+	}
+	for {
+		candidate := r.hints[rand.Intn(len(r.hints))]
+		if candidate != r.current {
+			r.current = candidate
+			return
+		}
+	}
+}
+
+// view renders the current hint as a dimmed line, or "" when there is no hint.
+func (r hintRotator) view() string {
+	if r.current == "" {
+		return ""
+	}
+	return hintStyle.Render("💡 " + r.current)
+}

--- a/go/internal/cli/tui/hints_models_test.go
+++ b/go/internal/cli/tui/hints_models_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+const hintMarker = "💡"
+
+func TestSpinnerShowsHintWhileRunning(t *testing.T) {
+	m := NewSpinner("Building...")
+	if !strings.Contains(m.View(), hintMarker) {
+		t.Fatal("expected running spinner View to include a hint")
+	}
+}
+
+func TestSpinnerHidesHintWhenDone(t *testing.T) {
+	m := NewSpinner("Building...")
+	updated, _ := m.Update(SpinnerDoneMsg{})
+	if strings.Contains(updated.View(), hintMarker) {
+		t.Fatal("expected completed spinner View to omit the hint")
+	}
+}
+
+func TestProgressShowsHintWhileRunning(t *testing.T) {
+	m := NewProgress("Downloading...")
+	if !strings.Contains(m.View(), hintMarker) {
+		t.Fatal("expected running progress View to include a hint")
+	}
+}
+
+func TestProgressHidesHintWhenDone(t *testing.T) {
+	m := NewProgress("Downloading...")
+	updated, _ := m.Update(ProgressDoneMsg{})
+	if strings.Contains(updated.View(), hintMarker) {
+		t.Fatal("expected completed progress View to omit the hint")
+	}
+}
+
+func TestMultiSpinnerShowsHintWhileRunning(t *testing.T) {
+	m := NewMultiSpinner("Building 2 services...", []string{"api", "web"})
+	if !strings.Contains(m.View(), hintMarker) {
+		t.Fatal("expected running multispinner View to include a hint")
+	}
+}
+
+func TestMultiSpinnerHidesHintWhenDone(t *testing.T) {
+	m := NewMultiSpinner("Building 2 services...", []string{"api", "web"})
+	updated, _ := m.Update(MultiSpinnerAllDoneMsg{})
+	if strings.Contains(updated.View(), hintMarker) {
+		t.Fatal("expected completed multispinner View to omit the hint")
+	}
+}
+
+func TestHintTickRotatesAndReschedules(t *testing.T) {
+	m := NewSpinner("Building...")
+	updated, cmd := m.Update(hintTickMsg{})
+	// A non-nil command is returned to reschedule the next rotation tick.
+	// (We don't invoke it: tea.Tick blocks for the full interval.)
+	if cmd == nil {
+		t.Fatal("expected hintTickMsg handling to reschedule another tick")
+	}
+	if !strings.Contains(updated.View(), hintMarker) {
+		t.Fatal("expected spinner to still show a hint after a tick")
+	}
+}

--- a/go/internal/cli/tui/hints_test.go
+++ b/go/internal/cli/tui/hints_test.go
@@ -1,0 +1,69 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewHintRotatorPicksHintFromList(t *testing.T) {
+	r := newHintRotator()
+	if r.current == "" {
+		t.Fatal("expected newHintRotator to pick a non-empty starting hint")
+	}
+	found := false
+	for _, h := range ProgressHints {
+		if h == r.current {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("starting hint %q is not in ProgressHints", r.current)
+	}
+}
+
+func TestHintRotatorNextAvoidsImmediateRepeat(t *testing.T) {
+	r := hintRotator{hints: []string{"a", "b", "c"}, current: "a"}
+	prev := r.current
+	for i := 0; i < 50; i++ {
+		r.next()
+		if r.current == prev {
+			t.Fatalf("next() repeated hint %q on iteration %d", r.current, i)
+		}
+		prev = r.current
+	}
+}
+
+func TestHintRotatorNextNoopForSingleHint(t *testing.T) {
+	r := hintRotator{hints: []string{"only"}, current: "only"}
+	r.next()
+	if r.current != "only" {
+		t.Fatalf("expected single-hint rotator to stay %q, got %q", "only", r.current)
+	}
+}
+
+func TestHintRotatorNextNoopForEmpty(t *testing.T) {
+	r := hintRotator{} // must not panic
+	r.next()
+	if r.current != "" {
+		t.Fatalf("expected empty rotator to stay empty, got %q", r.current)
+	}
+}
+
+func TestHintRotatorViewRendersHint(t *testing.T) {
+	r := hintRotator{hints: []string{"do a thing"}, current: "do a thing"}
+	v := r.view()
+	if !strings.Contains(v, "do a thing") {
+		t.Fatalf("view %q does not contain the hint text", v)
+	}
+	if !strings.Contains(v, "💡") {
+		t.Fatalf("view %q does not contain the hint marker", v)
+	}
+}
+
+func TestHintRotatorViewEmptyForNoHint(t *testing.T) {
+	r := hintRotator{}
+	if v := r.view(); v != "" {
+		t.Fatalf("expected empty view for empty rotator, got %q", v)
+	}
+}

--- a/go/internal/cli/tui/multispinner.go
+++ b/go/internal/cli/tui/multispinner.go
@@ -58,6 +58,7 @@ type MultiSpinnerModel struct {
 	rows    []multiSpinnerRow
 	byName  map[string]int
 	spinner spinner.Model
+	hints   hintRotator
 	done    bool
 	err     error
 }
@@ -79,12 +80,13 @@ func NewMultiSpinner(title string, names []string) MultiSpinnerModel {
 		rows:    rows,
 		byName:  byName,
 		spinner: s,
+		hints:   newHintRotator(),
 	}
 }
 
 // Init implements tea.Model.
 func (m MultiSpinnerModel) Init() tea.Cmd {
-	return m.spinner.Tick
+	return tea.Batch(m.spinner.Tick, m.hints.tick())
 }
 
 // Update implements tea.Model.
@@ -101,6 +103,10 @@ func (m MultiSpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
 		return m, cmd
+
+	case hintTickMsg:
+		m.hints.next()
+		return m, m.hints.tick()
 
 	case MultiSpinnerStartMsg:
 		if i, ok := m.byName[msg.Name]; ok {
@@ -191,6 +197,11 @@ func (m MultiSpinnerModel) View() string {
 				msErrorStyle.Render("failed"),
 			))
 		}
+	}
+
+	if hint := m.hints.view(); hint != "" {
+		sb.WriteString(hint)
+		sb.WriteString("\n")
 	}
 
 	return sb.String()

--- a/go/internal/cli/tui/progress.go
+++ b/go/internal/cli/tui/progress.go
@@ -33,6 +33,7 @@ type ProgressModel struct {
 	progress progress.Model
 	title    string
 	details  []string
+	hints    hintRotator
 	percent  float64
 	written  int64
 	total    int64
@@ -47,6 +48,7 @@ func NewProgress(title string) ProgressModel {
 	return ProgressModel{
 		progress: p,
 		title:    title,
+		hints:    newHintRotator(),
 		showErr:  true,
 	}
 }
@@ -61,7 +63,7 @@ func (m ProgressModel) WithoutErrorView() ProgressModel {
 
 // Init implements tea.Model.
 func (m ProgressModel) Init() tea.Cmd {
-	return nil
+	return m.hints.tick()
 }
 
 // Update implements tea.Model.
@@ -93,6 +95,10 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.err = msg.Err
 		m.percent = 1.0
 		return m, tea.Quit
+
+	case hintTickMsg:
+		m.hints.next()
+		return m, m.hints.tick()
 
 	case progress.FrameMsg:
 		progressModel, cmd := m.progress.Update(msg)
@@ -132,7 +138,11 @@ func (m ProgressModel) View() string {
 		}
 		return fmt.Sprintf("%s\n%s%s%s\n", m.title, details, m.progress.ViewAs(1.0), byteInfo)
 	}
-	return fmt.Sprintf("%s\n%s%s%s\n", m.title, details, m.progress.ViewAs(m.percent), byteInfo)
+	out := fmt.Sprintf("%s\n%s%s%s\n", m.title, details, m.progress.ViewAs(m.percent), byteInfo)
+	if hint := m.hints.view(); hint != "" {
+		out += hint + "\n"
+	}
+	return out
 }
 
 func appendProgressDetail(details []string, detail string) []string {

--- a/go/internal/cli/tui/spinner.go
+++ b/go/internal/cli/tui/spinner.go
@@ -24,6 +24,7 @@ type SpinnerUpdateMsg struct {
 type SpinnerModel struct {
 	spinner  spinner.Model
 	title    string
+	hints    hintRotator
 	done     bool
 	err      error
 	result   interface{}
@@ -37,12 +38,13 @@ func NewSpinner(title string) SpinnerModel {
 	return SpinnerModel{
 		spinner: s,
 		title:   title,
+		hints:   newHintRotator(),
 	}
 }
 
 // Init implements tea.Model.
 func (m SpinnerModel) Init() tea.Cmd {
-	return m.spinner.Tick
+	return tea.Batch(m.spinner.Tick, m.hints.tick())
 }
 
 // Update implements tea.Model.
@@ -65,6 +67,10 @@ func (m SpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.title = msg.Label
 		return m, nil
 
+	case hintTickMsg:
+		m.hints.next()
+		return m, m.hints.tick()
+
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
@@ -85,7 +91,11 @@ func (m SpinnerModel) View() string {
 		}
 		return ""
 	}
-	return fmt.Sprintf("%s %s\n", m.spinner.View(), m.title)
+	out := fmt.Sprintf("%s %s\n", m.spinner.View(), m.title)
+	if hint := m.hints.view(); hint != "" {
+		out += hint + "\n"
+	}
+	return out
 }
 
 func (m SpinnerModel) Result() (interface{}, error) {

--- a/go/internal/cli/tui/spinner_test.go
+++ b/go/internal/cli/tui/spinner_test.go
@@ -170,9 +170,10 @@ func TestBubbleTable_CropsWideViewAndScrolls(t *testing.T) {
 func TestProgressModel_Init(t *testing.T) {
 	p := NewProgress("Downloading...")
 	cmd := p.Init()
-	// ProgressModel.Init returns nil since there's no initial tick needed.
-	if cmd != nil {
-		t.Error("expected nil Init cmd for progress model")
+	// ProgressModel.Init returns the hint rotation tick so educational hints
+	// rotate while the bar is running.
+	if cmd == nil {
+		t.Error("expected non-nil Init cmd to start hint rotation")
 	}
 }
 

--- a/specs/superpowers/2026-06-24-progress-hints-design.md
+++ b/specs/superpowers/2026-06-24-progress-hints-design.md
@@ -1,0 +1,71 @@
+# Progress indicator hints — design
+
+**Date:** 2026-06-24
+**Status:** Approved
+
+## Goal
+
+While any progress indicator is running, show a random "did you know" tip about
+what the Wendy CLI can do, rotating to a new tip every ~7 seconds. The intent is
+educational: give users a heads-up on features they might not know about during
+otherwise-idle wait time (builds, deploys, downloads, flashes, multi-service
+builds).
+
+## Scope
+
+All three Bubble Tea progress models in `go/internal/cli/tui/`:
+
+- `SpinnerModel` (`spinner.go`) — single indeterminate operations
+- `ProgressModel` (`progress.go`) — determinate progress bar
+- `MultiSpinnerModel` (`multispinner.go`) — concurrent per-service builds
+
+## Design
+
+### Shared component: `hints.go` (new file)
+
+A single reusable piece so all three models behave identically.
+
+- `var ProgressHints []string` — editable list of ~12 tips, each phrased as
+  `Tip: <something you can do>`, referencing real Wendy CLI commands.
+- `hintTickMsg` — internal Bubble Tea message emitted on each rotation tick.
+- `hintInterval` — rotation cadence (~7s).
+- `hintRotator` struct — `{ hints []string; current string }` with methods:
+  - `newHintRotator() hintRotator` — picks a random starting hint.
+  - `tick() tea.Cmd` — `tea.Tick(hintInterval, …)` returning `hintTickMsg`.
+  - `next()` — advances to a *different* random hint (no immediate repeat).
+  - `view() string` — renders `💡 <hint>` dimmed via `ColorDim`, or `""` when
+    the list is empty.
+
+Randomness uses `math/rand` (Go auto-seeds the global source). A single-element
+or empty list degrades gracefully: `next()` is a no-op when fewer than two hints
+exist, `view()` returns `""` for an empty list.
+
+### Wiring into each model
+
+Each model gets the same four touch-points:
+
+1. Add a `hints hintRotator` field; initialize it in the constructor with
+   `newHintRotator()`.
+2. `Init()` batches the existing tick command with `m.hints.tick()` via
+   `tea.Batch`.
+3. `Update()` gains `case hintTickMsg:` → call `m.hints.next()`, then re-issue
+   `m.hints.tick()`.
+4. `View()` appends `m.hints.view()` **only while the operation is running** —
+   not on the done/error render paths — so final output stays clean.
+
+## Testing
+
+`hints_test.go`:
+
+- `next()` returns a hint different from the current one (multi-element list).
+- `next()` is a no-op for single-element / empty lists (no panic).
+- `view()` renders a line containing the hint text for a non-empty rotator and
+  `""` for an empty one.
+- Each model's `View()` includes the hint line while running and omits it once
+  `done`.
+
+## Out of scope
+
+- Per-operation hint filtering (e.g. build-only vs download-only lists). One
+  shared list for now; can be revisited later.
+- Configurable rotation interval or disabling hints via a flag.


### PR DESCRIPTION
## What

All three Wendy CLI progress indicators now display a random educational tip while running, rotating to a new one every ~7s and clearing once the operation completes. The intent is to give users a heads-up on features they might not know about during otherwise-idle wait time (builds, deploys, downloads, flashes).

```
⣾  Building Docker image...
💡 Tip: Validate your wendy.json against the schema with 'wendy json'
```

## How

New shared component `go/internal/cli/tui/hints.go`:
- `ProgressHints` — an editable list of ~12 "did you know" tips referencing real `wendy` commands. Exported so the list lives in one place and is easy to edit.
- `hintRotator` — picks a random starting hint, rotates to a *different* random hint each tick (no immediate repeats), and renders a dimmed `💡 <tip>` line using the existing `ColorDim`. Empty/single-element lists degrade gracefully.

Wiring into `SpinnerModel`, `ProgressModel`, and `MultiSpinnerModel` (same four touch-points each):
1. constructor seeds a `hintRotator`
2. `Init()` starts the rotation tick (batched with the spinner tick)
3. `Update()` handles `hintTickMsg` → advance + reschedule via `tea.Tick`
4. `View()` appends the hint **only on the running path**, so done/error output stays clean

## Testing

- TDD throughout: `hints_test.go` and `hints_models_test.go` cover the random picker, immediate-repeat avoidance, single/empty no-op edge cases, view rendering, per-model show-while-running / hide-when-done, and tick rescheduling.
- `spinner_test.go`: updated the `ProgressModel.Init` assertion, which now returns the hint tick rather than nil.
- CI-equivalent checks pass locally: `go vet ./...`, `gofmt -l -s .`, `go test -race`. Full module builds.

Design spec: `specs/superpowers/2026-06-24-progress-hints-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163whbvSCCP3X2hMQrMHnu4
