### PR TITLE
Add --chunking flag to control CBC deploy path

### DIFF
--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -11,6 +11,20 @@ import (
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
+func TestValidateChunkingMode(t *testing.T) {
+	valid := []string{"", chunkingAuto, chunkingForce, chunkingOff}
+	for _, m := range valid {
+		if err := validateChunkingMode(m); err != nil {
+			t.Errorf("validateChunkingMode(%q) = %v; want nil", m, err)
+		}
+	}
+	for _, m := range []string{"auto ", "AUTO", "yes", "true", "none"} {
+		if err := validateChunkingMode(m); err == nil {
+			t.Errorf("validateChunkingMode(%q) = nil; want error", m)
+		}
+	}
+}
+
 func TestResolveRestartPolicy_Default(t *testing.T) {
 	opts := runOptions{}
 	rp := resolveRestartPolicy(opts)

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -481,6 +481,31 @@ type runOptions struct {
 	// quietBuild suppresses the image build (buildx) output, surfacing it only
 	// when the build fails. Set by `wendy watch` to keep the redeploy loop quiet.
 	quietBuild bool
+	// chunking controls the content-defined chunking (CBC) deploy path:
+	// chunkingAuto (default/empty) tries chunk-diff and falls back to a registry
+	// push on failure, chunkingForce uses chunk-diff with no fallback, and
+	// chunkingOff skips chunk-diff entirely (registry push only).
+	chunking string
+}
+
+// Valid values for runOptions.chunking. An empty value is treated as
+// chunkingAuto so callers that build runOptions directly (e.g. wendy watch)
+// keep the default behavior.
+const (
+	chunkingAuto  = "auto"
+	chunkingForce = "force"
+	chunkingOff   = "off"
+)
+
+// validateChunkingMode rejects unknown --chunking values. Empty is allowed and
+// means chunkingAuto.
+func validateChunkingMode(mode string) error {
+	switch mode {
+	case "", chunkingAuto, chunkingForce, chunkingOff:
+		return nil
+	default:
+		return fmt.Errorf("invalid --chunking value %q: must be auto, force, or off", mode)
+	}
 }
 
 func newRunCmd() *cobra.Command {
@@ -511,6 +536,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.keepGoing, "keep-going", false, "Multi-service: deploy services that build successfully instead of aborting the whole group on the first build/push failure")
 	cmd.Flags().IntVar(&opts.maxConcurrency, "max-concurrency", 0, "Multi-service: max service images to build+push at once (0 = auto-throttle large groups)")
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
+	cmd.Flags().StringVar(&opts.chunking, "chunking", chunkingAuto, "Content-defined chunking (CBC) deploy path: auto (try chunk-diff, fall back to registry push), force (chunk-diff only, no fallback), or off (registry push only)")
 
 	return cmd
 }
@@ -560,6 +586,9 @@ func runCommand(ctx context.Context, opts runOptions) error {
 	}
 	if opts.maxConcurrency < 0 {
 		return fmt.Errorf("--max-concurrency must be >= 0 (0 = auto)")
+	}
+	if err := validateChunkingMode(opts.chunking); err != nil {
+		return err
 	}
 
 	// --dockerfile implies a docker build; validate the file exists and ensure
@@ -1418,7 +1447,10 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// detached (--detach) runs. Deploy-only (--deploy) is excluded because it
 	// must create the container WITHOUT starting it, whereas RunContainer always
 	// starts; that mode stays on the registry path via startAndStreamContainer.
-	if !opts.deploy {
+	//
+	// --chunking gates this path: "off" skips it entirely (registry push only),
+	// while "force" uses it with no registry-push fallback on failure.
+	if !opts.deploy && opts.chunking != chunkingOff {
 		if err := deployByChunkDiff(ctx, conn, cwd, appCfg, platform, opts.dockerfile, buildArgs, opts); err == nil {
 			if hashErr == nil {
 				saveDeployFingerprint(appCfg.AppID, deviceKey, deployFingerprint{InputHash: inputHash, AppVersion: appCfg.Version})
@@ -1429,6 +1461,10 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 			// newer change, or the user hit Ctrl-C). Don't fall back to a full
 			// registry push — just surface the cancellation.
 			return err
+		} else if opts.chunking == chunkingForce {
+			// --chunking=force opts out of the registry-push fallback so the
+			// failure is surfaced instead of silently masked by a slower path.
+			return fmt.Errorf("chunk-diff deploy failed and --chunking=force disables the registry-push fallback: %w", err)
 		} else {
 			cliLogln("Fast layer-diff deploy failed (%v); falling back to registry push.", err)
 		}


### PR DESCRIPTION
## What

Adds a tri-state `--chunking` flag to `wendy run` to control the content-based chunking (CBC) chunk-diff deploy path.

Until now `wendy run` always attempted the CBC chunk-diff path and silently fell back to a slower registry push if it failed, with no way to force or disable it.

## Behavior

```
wendy run                  # auto — try CBC, fall back to registry push (current behavior)
wendy run --chunking force # CBC only, fail loudly (no fallback)
wendy run --chunking off   # registry push only, skip CBC
```

- **auto** (default): unchanged — try chunk-diff, fall back to registry push on failure.
- **force**: use chunk-diff and, on failure, return the error instead of silently falling back. Cancellation still returns cleanly.
- **off**: skip `deployByChunkDiff` entirely, go straight to the registry push.

An empty value is treated as `auto`, so callers that build `runOptions` directly (`wendy watch`, the deprecated `cloud run`) keep current behavior.

Note: with `--deploy`, both `force` and `off` are no-ops since `--deploy` already bypasses the chunk-diff path (it must create the container without starting it).

## Changes

- `run.go`: `chunking` field + `chunkingAuto`/`chunkingForce`/`chunkingOff` constants, `validateChunkingMode` helper, flag registration, early validation, and gating of the fast-path block.
- `commands_test.go`: `TestValidateChunkingMode` covering valid (incl. empty) and rejected values.

## Validation

- `gofmt` clean
- `go test ./internal/cli/commands/` passes
- `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)