### PR TITLE
feat(os install): group device picker by WendyOS / Wendy Lite sections

### DIFF
--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -204,7 +204,6 @@ type pickerDevice struct {
 	Name       string
 	Version    string // display version (e.g. "0.10.5 (nightly)")
 	RawVersion string // exact version key for manifest lookup
-	Category   string // e.g. "Linux" or "Wendy Lite"
 	IsESP32    bool
 	ESP32Chip  string          // e.g. "esp32c6", "esp32c5"
 	Manifest   *deviceManifest // cached manifest for Linux devices
@@ -278,14 +277,15 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 			Name:       dev.Name,
 			Version:    displayVersion,
 			RawVersion: rawVersion,
-			Category:   "Linux",
 			Manifest:   dev.Manifest,
 		}
 		deviceMap[dev.Key] = pd
 
 		items = append(items, tui.PickerItem{
 			Name:        dev.Name,
-			Description: fmt.Sprintf("%s    %s", displayVersion, pd.Category),
+			Description: displayVersion,
+			Section:     "WendyOS",
+			SortKey:     "0_wendyos_" + strings.ToLower(dev.Name),
 			Value:       dev.Key,
 		})
 	}
@@ -302,13 +302,14 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 			deviceMap[esp.key] = pickerDevice{
 				Name:      esp.name,
 				Version:   espVersion,
-				Category:  "Wendy Lite",
 				IsESP32:   true,
 				ESP32Chip: esp.chip,
 			}
 			items = append(items, tui.PickerItem{
 				Name:        esp.name,
-				Description: fmt.Sprintf("%s    %s", espVersion, "Wendy Lite"),
+				Description: espVersion,
+				Section:     "Wendy Lite",
+				SortKey:     "1_lite_" + strings.ToLower(esp.name),
 				Value:       esp.key,
 			})
 		}

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -301,7 +301,6 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 var (
 	pickerTitle    = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary)
-	pickerSection  = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary)
 	pickerHint     = lipgloss.NewStyle().Foreground(ColorDim)
 	pickerScanning = lipgloss.NewStyle().Foreground(ColorPrimary)
 	pickerInsecure = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#ef4444"))
@@ -722,10 +721,17 @@ func withSectionHeaders(visible []PickerItem, itemRows []bubbleTable.Row, ncols 
 }
 
 // sectionHeaderRow builds a non-selectable header row whose first column shows
-// the styled section label and whose remaining columns are blank.
+// the section label and whose remaining columns are blank.
+//
+// The label is intentionally plain text, not a lipgloss-styled string: the
+// underlying bubbles table truncates every cell with runewidth.Truncate, which
+// is not ANSI-aware. A styled value's escape bytes count toward the column
+// width, so truncation cuts inside the escape sequence and the terminal renders
+// garbage. The "── " rule prefix keeps the row readable as a header without
+// embedding color.
 func sectionHeaderRow(label string, ncols int) bubbleTable.Row {
 	row := make(bubbleTable.Row, max(ncols, 1))
-	row[0] = pickerSection.Render("── " + label)
+	row[0] = "── " + label
 	return row
 }
 

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -25,6 +25,13 @@ type PickerItem struct {
 	Provisioned  string // "Provisioned" or "Unprovisioned" when known, empty otherwise
 	Hint         string // optional footer text shown when this item is highlighted
 
+	// Section, when non-empty, groups this item under a non-selectable header
+	// row bearing the section name. Sections are rendered in the order they
+	// first appear after sorting, so callers control grouping order via SortKey.
+	// When no visible item sets Section, the picker renders and navigates
+	// exactly as it does without sections.
+	Section string
+
 	// DedupKey is used for deduplication. If empty, Name is used.
 	// Items with the same DedupKey (case-insensitive) are merged via MergeItem.
 	DedupKey string
@@ -94,9 +101,14 @@ type PickerModel struct {
 	// whose items are free-form text (e.g. WiFi SSIDs).
 	Filterable bool
 
-	filter       string
-	items        []PickerItem
-	seenIdx      map[string]int // dedup key -> index in items
+	filter  string
+	items   []PickerItem
+	seenIdx map[string]int // dedup key -> index in items
+	// rowItem maps each table row to its index in the visible-items slice, or
+	// -1 when the row is a non-selectable section header. When no item sets a
+	// Section this is the identity mapping, so behavior matches the headerless
+	// picker exactly.
+	rowItem      []int
 	table        BubbleTable
 	columns      []pickerColumnDef
 	fixedColumns bool
@@ -170,17 +182,16 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case key == "enter":
 			visible := m.visibleItems()
-			cursor := m.table.Cursor()
-			if len(visible) > 0 && cursor >= 0 && cursor < len(visible) {
-				item := visible[cursor]
+			if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
+				item := visible[idx]
 				m.selected = &item
 				return m, tea.Quit
 			}
 		case key == "d" && !m.Filterable:
 			if m.OnSetDefault != nil {
-				cursor := m.table.Cursor()
-				if len(m.items) > 0 && cursor >= 0 && cursor < len(m.items) {
-					item := m.items[cursor]
+				visible := m.visibleItems()
+				if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
+					item := visible[idx]
 					key := strings.ToLower(item.DedupKey)
 					if key == "" {
 						key = strings.ToLower(item.Name)
@@ -232,8 +243,16 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		default:
+			prev := m.table.Cursor()
 			var cmd tea.Cmd
 			m.table, cmd = m.table.Update(msg)
+			// Skip over non-selectable section headers in the direction of
+			// travel so the cursor never rests on one.
+			dir := 1
+			if m.table.Cursor() < prev {
+				dir = -1
+			}
+			m.snapCursorToSelectable(dir)
 			return m, cmd
 		}
 
@@ -282,6 +301,7 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 var (
 	pickerTitle    = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary)
+	pickerSection  = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary)
 	pickerHint     = lipgloss.NewStyle().Foreground(ColorDim)
 	pickerScanning = lipgloss.NewStyle().Foreground(ColorPrimary)
 	pickerInsecure = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#ef4444"))
@@ -341,8 +361,7 @@ func (m PickerModel) View() string {
 		sb.WriteString(m.viewLine(pickerHint.Render("  "+m.legend)) + "\n")
 	}
 
-	cursor := m.table.Cursor()
-	if cursor >= 0 && cursor < len(visible) && visible[cursor].Insecure {
+	if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) && visible[idx].Insecure {
 		sb.WriteString(m.viewLine(pickerInsecure.Render("  ⚠  Connection is not secured with mTLS. PKI support is coming soon.")) + "\n")
 	}
 
@@ -362,11 +381,11 @@ func (m PickerModel) View() string {
 
 func (m PickerModel) selectedHint() string {
 	visible := m.visibleItems()
-	cursor := m.table.Cursor()
-	if cursor < 0 || cursor >= len(visible) {
+	idx := m.itemIndexForRow(m.table.Cursor())
+	if idx < 0 || idx >= len(visible) {
 		return ""
 	}
-	return strings.TrimSpace(visible[cursor].Hint)
+	return strings.TrimSpace(visible[idx].Hint)
 }
 
 func (m PickerModel) viewLine(line string) string {
@@ -538,10 +557,57 @@ func (m PickerModel) visibleItems() []PickerItem {
 
 func (m *PickerModel) currentCursorKey() string {
 	visible := m.visibleItems()
-	if cursor := m.table.Cursor(); cursor >= 0 && cursor < len(visible) {
-		return strings.ToLower(pickerItemKey(visible[cursor]))
+	if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
+		return strings.ToLower(pickerItemKey(visible[idx]))
 	}
 	return ""
+}
+
+// itemIndexForRow maps a table row index to its index in the visible-items
+// slice, or returns -1 when the row is a section header or out of range.
+func (m PickerModel) itemIndexForRow(row int) int {
+	if row < 0 || row >= len(m.rowItem) {
+		return -1
+	}
+	return m.rowItem[row]
+}
+
+// rowForItemIndex maps a visible-items index back to its table row, or -1 if
+// the item has no row (should not happen for in-range indices).
+func (m PickerModel) rowForItemIndex(itemIdx int) int {
+	for row, idx := range m.rowItem {
+		if idx == itemIdx {
+			return row
+		}
+	}
+	return -1
+}
+
+// snapCursorToSelectable nudges the cursor off a section-header row onto the
+// nearest selectable row, searching first in dir (+1 down, -1 up) and then the
+// other way when the list edge is reached. It is a no-op when the cursor is
+// already on a selectable row, which is always the case for headerless pickers.
+func (m *PickerModel) snapCursorToSelectable(dir int) {
+	n := len(m.rowItem)
+	if n == 0 {
+		return
+	}
+	cursor := m.table.Cursor()
+	if cursor >= 0 && cursor < n && m.rowItem[cursor] >= 0 {
+		return
+	}
+	for i := cursor; i >= 0 && i < n; i += dir {
+		if m.rowItem[i] >= 0 {
+			m.table.SetCursor(i)
+			return
+		}
+	}
+	for i := cursor; i >= 0 && i < n; i -= dir {
+		if m.rowItem[i] >= 0 {
+			m.table.SetCursor(i)
+			return
+		}
+	}
 }
 
 func (m *PickerModel) refreshTable() {
@@ -574,7 +640,9 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 
 	visible := m.visibleItems()
 	hasDefaultCol := m.OnSetDefault != nil
-	cols, rows := pickerTableDataForColumns(visible, m.DefaultKey, hasDefaultCol, m.columns, m.fixedColumns)
+	cols, itemRows := pickerTableDataForColumns(visible, m.DefaultKey, hasDefaultCol, m.columns, m.fixedColumns)
+	rows, rowItem := withSectionHeaders(visible, itemRows, len(cols))
+	m.rowItem = rowItem
 	m.table.SetRows(nil)
 	m.table.SetColumns(cols)
 	m.table.SetRows(rows)
@@ -592,12 +660,14 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 			}
 		}
 		if visIdx >= 0 {
-			m.table.SetCursor(visIdx)
+			m.table.SetCursor(m.rowForItemIndex(visIdx))
 		} else if m.table.Cursor() < 0 {
 			m.table.SetCursor(0)
 		} else if m.table.Cursor() >= len(rows) {
 			m.table.SetCursor(len(rows) - 1)
 		}
+		// Keep the cursor off a leading/inherited section header.
+		m.snapCursorToSelectable(1)
 	}
 
 	m.table.SetWidth(PickerTableWidth(m.table.Columns()))
@@ -609,6 +679,54 @@ func pickerItemKey(item PickerItem) string {
 		return item.DedupKey
 	}
 	return item.Name
+}
+
+// withSectionHeaders interleaves non-selectable section-header rows ahead of
+// the first item of each section. It returns the full row set (headers + item
+// rows) and a parallel rowItem slice mapping each row to its visible-items
+// index (-1 for headers). When no visible item sets a Section, the item rows
+// are returned unchanged with an identity mapping, preserving the headerless
+// picker's exact behavior.
+func withSectionHeaders(visible []PickerItem, itemRows []bubbleTable.Row, ncols int) ([]bubbleTable.Row, []int) {
+	hasSection := false
+	for _, item := range visible {
+		if item.Section != "" {
+			hasSection = true
+			break
+		}
+	}
+	if !hasSection {
+		rowItem := make([]int, len(itemRows))
+		for i := range rowItem {
+			rowItem[i] = i
+		}
+		return itemRows, rowItem
+	}
+
+	rows := make([]bubbleTable.Row, 0, len(itemRows)+2)
+	rowItem := make([]int, 0, len(itemRows)+2)
+	currentSection := ""
+	for i, item := range visible {
+		if i >= len(itemRows) {
+			break
+		}
+		if item.Section != "" && item.Section != currentSection {
+			currentSection = item.Section
+			rows = append(rows, sectionHeaderRow(currentSection, ncols))
+			rowItem = append(rowItem, -1)
+		}
+		rows = append(rows, itemRows[i])
+		rowItem = append(rowItem, i)
+	}
+	return rows, rowItem
+}
+
+// sectionHeaderRow builds a non-selectable header row whose first column shows
+// the styled section label and whose remaining columns are blank.
+func sectionHeaderRow(label string, ncols int) bubbleTable.Row {
+	row := make(bubbleTable.Row, max(ncols, 1))
+	row[0] = pickerSection.Render("── " + label)
+	return row
 }
 
 func pickerActiveColumnsForDefs(items []PickerItem, defs []pickerColumnDef, fixed bool) []pickerColumnDef {

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -639,6 +639,103 @@ func TestPickerModel_DXIgnoredWithoutCallbacks(t *testing.T) {
 	}
 }
 
+// ── Section headers ──────────────────────────────────────────────────
+
+// sectionedPicker builds a one-shot picker whose items belong to two ordered
+// sections: "WendyOS" (SortKey prefix 0_) before "Wendy Lite" (prefix 1_).
+// After sorting, the display order is:
+//
+//	── WendyOS      (header)
+//	Jetson Orin     (0_wendyos_jetson)
+//	Raspberry Pi 5  (0_wendyos_rpi5)
+//	── Wendy Lite   (header)
+//	ESP32-C5        (1_lite_c5)
+//	ESP32-C6        (1_lite_c6)
+func sectionedPicker(t *testing.T) PickerModel {
+	t.Helper()
+	m := NewPickerWithTitle("Select a device")
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "Raspberry Pi 5", Section: "WendyOS", SortKey: "0_wendyos_rpi5", Value: "rpi5"},
+		{Name: "Jetson Orin", Section: "WendyOS", SortKey: "0_wendyos_jetson", Value: "jetson"},
+		{Name: "ESP32-C6", Section: "Wendy Lite", SortKey: "1_lite_c6", Value: "c6"},
+		{Name: "ESP32-C5", Section: "Wendy Lite", SortKey: "1_lite_c5", Value: "c5"},
+	}})
+	return updated.(PickerModel)
+}
+
+func TestPickerModel_RendersSectionHeaders(t *testing.T) {
+	pm := sectionedPicker(t)
+
+	view := ansi.Strip(pm.View())
+	for _, want := range []string{"WendyOS", "Wendy Lite", "Jetson Orin", "Raspberry Pi 5", "ESP32-C5", "ESP32-C6"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected sectioned picker view to contain %q, got %q", want, view)
+		}
+	}
+	// The WendyOS header must appear before the Wendy Lite header.
+	if strings.Index(view, "WendyOS") > strings.Index(view, "Wendy Lite") {
+		t.Fatalf("expected WendyOS section before Wendy Lite section, got %q", view)
+	}
+}
+
+func TestPickerModel_SectionEnterSelectsDeviceNotHeader(t *testing.T) {
+	pm := sectionedPicker(t)
+
+	// The initial cursor must land on the first device, never the leading
+	// section header. Enter should select that device.
+	updated, cmd := pm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm = updated.(PickerModel)
+
+	if cmd == nil || pm.Selected() == nil {
+		t.Fatal("expected enter to select the first device, not a header row")
+	}
+	if got := pm.Selected().Value.(string); got != "jetson" {
+		t.Fatalf("selected %q, want jetson (first selectable row)", got)
+	}
+}
+
+func TestPickerModel_SectionDownSkipsHeader(t *testing.T) {
+	pm := sectionedPicker(t)
+
+	// From Jetson (first row), Down → Raspberry Pi 5, Down → must skip the
+	// Wendy Lite header and land on ESP32-C5.
+	for i := 0; i < 2; i++ {
+		updated, _ := pm.Update(tea.KeyMsg{Type: tea.KeyDown})
+		pm = updated.(PickerModel)
+	}
+	updated, _ := pm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm = updated.(PickerModel)
+
+	if pm.Selected() == nil {
+		t.Fatal("expected a device selection after navigating down, got none (cursor on header?)")
+	}
+	if got := pm.Selected().Value.(string); got != "c5" {
+		t.Fatalf("after 2× down selected %q, want c5 (first Wendy Lite device)", got)
+	}
+}
+
+func TestPickerModel_SectionUpSkipsHeader(t *testing.T) {
+	pm := sectionedPicker(t)
+
+	// Move down onto ESP32-C5, then Up must skip the Wendy Lite header back to
+	// Raspberry Pi 5 (last WendyOS device).
+	for i := 0; i < 2; i++ {
+		updated, _ := pm.Update(tea.KeyMsg{Type: tea.KeyDown})
+		pm = updated.(PickerModel)
+	}
+	updated, _ := pm.Update(tea.KeyMsg{Type: tea.KeyUp})
+	pm = updated.(PickerModel)
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm = updated.(PickerModel)
+
+	if pm.Selected() == nil {
+		t.Fatal("expected a device selection after navigating up, got none (cursor on header?)")
+	}
+	if got := pm.Selected().Value.(string); got != "rpi5" {
+		t.Fatalf("after down,down,up selected %q, want rpi5", got)
+	}
+}
+
 func hasColumn(cols []bubbleTable.Column, title string) bool {
 	for _, col := range cols {
 		if col.Title == title {

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -6,7 +6,9 @@ import (
 
 	bubbleTable "github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
 )
 
 func TestPickerModel_SelectsFromTable(t *testing.T) {
@@ -675,6 +677,26 @@ func TestPickerModel_RendersSectionHeaders(t *testing.T) {
 	// The WendyOS header must appear before the Wendy Lite header.
 	if strings.Index(view, "WendyOS") > strings.Index(view, "Wendy Lite") {
 		t.Fatalf("expected WendyOS section before Wendy Lite section, got %q", view)
+	}
+}
+
+// TestPickerModel_RendersSectionHeadersInColor guards against the section
+// header cell carrying lipgloss ANSI escapes into the table: the underlying
+// bubbles table truncates each cell with runewidth.Truncate, which counts the
+// escape bytes as visible width and cuts inside the escape sequence, leaving
+// mangled output (e.g. "…K") on a real color terminal. Tests default to the
+// Ascii profile (no escapes), so this forces truecolor to exercise that path.
+func TestPickerModel_RendersSectionHeadersInColor(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(termenv.Ascii)
+
+	pm := sectionedPicker(t)
+
+	view := ansi.Strip(pm.View())
+	for _, want := range []string{"WendyOS", "Wendy Lite"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected colorized sectioned picker to render header %q intact, got %q", want, view)
+		}
 	}
 }
 

--- a/specs/2026-06-25-os-install-section-headers-design.md
+++ b/specs/2026-06-25-os-install-section-headers-design.md
@@ -1,0 +1,120 @@
+# `wendy os install` device picker — section headers
+
+**Date:** 2026-06-25
+**Status:** Approved
+
+## Goal
+
+During `wendy os install`, group the interactive device list under
+non-selectable section headers — **WendyOS** first, then **Wendy Lite** — and
+have arrow-key navigation skip over the header rows. Rename the WendyOS group's
+displayed label from "Linux" to "WendyOS".
+
+WendyOS is the primary, more important target and therefore comes first.
+
+## Background
+
+The picker is a shared Bubble Tea component (`go/internal/cli/tui/picker.go`)
+backed by a single flat, keyboard-navigable `bubbleTable`. It has no native
+concept of section headers, and many existing call sites (device discovery,
+WiFi, project/model pickers) rely on the table cursor index mapping 1:1 to the
+visible item index. The `os install` picker is one-shot: it sends one
+`PickerAddMsg` followed by `PickerDoneMsg` (see `pickFromItems` in
+`go/internal/cli/commands/project.go`), so there is no live re-sorting to worry
+about.
+
+Today `runOSInstall` (`go/internal/cli/commands/os_install.go`) builds picker
+items for Linux devices (category `"Linux"`) and, when `--device-type` is not
+set, two ESP32 entries (category `"Wendy Lite"`). The category is shown as a
+suffix in the Description column. There are no headers and no enforced ordering
+between the two groups.
+
+## Design
+
+### Invariant: zero behavior change without sections
+
+A new `Section string` field is added to `PickerItem`. When **no** visible item
+sets `Section`, the picker renders and navigates exactly as before — same rows,
+same cursor↔item indexing, same output. Section behavior engages only when at
+least one visible item has a non-empty `Section`. This keeps every other picker
+(and all existing picker tests) untouched.
+
+### 1. `PickerItem.Section` (`tui/picker.go`)
+
+Add `Section string` to `PickerItem`. Items are grouped under a header bearing
+the section name. Section order follows the order each section first appears in
+the already-sorted item list, so callers control grouping order via `SortKey`.
+
+### 2. Interleaved header rows + cursor↔item mapping
+
+Add `rowItem []int` to `PickerModel`: one entry per table row, holding the index
+into the visible-items slice, or `-1` when the row is a section header.
+
+In `refreshTableWithCursorKey`, after the existing `SortKey` sort (which keeps
+items of the same section contiguous and ordered):
+
+- If any visible item has a `Section`, walk the visible items in order. When an
+  item's section differs from the previous emitted section, splice a header row
+  in front of it. Build `rowItem` in parallel (header → `-1`, item → its visible
+  index).
+- Otherwise, build rows exactly as today and set `rowItem` to the identity
+  mapping.
+
+The item rows themselves are still produced by the existing
+`pickerTableDataForColumns` path; header rows are spliced into the resulting row
+slice at the right positions so column widths still account for them.
+
+### 3. Navigation skips headers
+
+The cursor must never rest on a header row.
+
+- In the `default` key branch, record the cursor before forwarding the key to
+  the table, then after the table updates check whether the new cursor row is a
+  header (`rowItem[cursor] < 0`). If so, step one row in the direction of travel
+  (down if the cursor moved down or stayed, up otherwise) to the nearest
+  selectable row; if the edge is reached, reverse to find the first selectable
+  row.
+- Initial cursor and cursor-restore (`refreshTableWithCursorKey`) snap to the
+  first selectable row, never a header.
+- `enter`, `d`, `x`, the selected-item hint, and the insecure-mTLS warning all
+  resolve the highlighted item through `rowItem` instead of assuming
+  `cursor == visible index`. `enter`/`d`/`x` are no-ops if the cursor is somehow
+  on a header.
+
+### 4. Header styling
+
+The section label renders in the Name column as a bold `── WendyOS`-style cell
+(lipgloss styling embedded in the cell string; remaining columns blank). Because
+the cursor never lands on a header, it is never drawn with the selected-row
+highlight.
+
+### 5. `os_install.go`
+
+- WendyOS (Linux) devices: `Section: "WendyOS"`, `SortKey: "0_wendyos_<name>"`,
+  and the category label changes from `"Linux"` to `"WendyOS"`.
+- ESP32 devices: `Section: "Wendy Lite"`, `SortKey: "1_lite_<name>"`.
+- The Description column drops the redundant category suffix (the header now
+  states the group); it shows just the version.
+
+### 6. Edge cases
+
+- **One group only** (e.g. the Linux manifest fetch fails and only the two
+  ESP32 entries remain): the single section's header still renders. This is
+  simpler than conditionally suppressing it and remains accurate.
+- **`--device-type` set**: the interactive picker is never shown, so this path
+  is unaffected.
+- **Empty section**: a header is only emitted when an item introduces the
+  section, so a group with no devices produces no header.
+
+## Testing
+
+New unit tests in `tui/picker_test.go`:
+
+- Section headers render with their labels.
+- `KeyDown` from the last item of a section skips the following header and lands
+  on the next section's first item.
+- `enter` selects the correct item when a header precedes it.
+- A picker with no `Section` set behaves identically (cursor index == item
+  index), guarding the invariant above.
+
+All existing picker tests must remain green.


### PR DESCRIPTION
## What

During `wendy os install`, the interactive device picker now groups devices under section headers — **WendyOS** first, then **Wendy Lite** — instead of presenting a flat list with the platform crammed into the Description column. WendyOS is the primary target, so it leads.

```
Select a device (↑/↓ navigate, enter select, q quit)

 Name                Description
 ── WendyOS
 Jetson Orin Nano    (0.10.5)
 Raspberry Pi 5      (0.10.5)
 ── Wendy Lite
 ESP32-C5            (latest)
 ESP32-C6            (latest)
```

## How

**Shared picker component (`internal/cli/tui/picker.go`)**
- New `PickerItem.Section` field. When set, items render under a styled `── <name>` header row. Section order follows first appearance after the existing `SortKey` sort, so callers control grouping via `SortKey`.
- A `rowItem` mapping translates table rows → visible items, so a header row never shifts which device `enter`/`d`/`x`/the footer hint/the insecure-mTLS warning resolve to.
- Arrow-key navigation skips header rows (`snapCursorToSelectable`), and the initial/restored cursor never lands on a header.
- **Invariant:** when no visible item sets `Section`, rows and cursor indexing are identity-mapped — every other picker (device discovery, WiFi, project/model) behaves byte-for-byte as before.

**`internal/cli/commands/os_install.go`**
- WendyOS devices: `Section: "WendyOS"`, `SortKey: "0_wendyos_<name>"` (label changed from "Linux").
- ESP32 devices: `Section: "Wendy Lite"`, `SortKey: "1_lite_<name>"`.
- The redundant category suffix is dropped from the Description column (the header now conveys the group); removed the now-unused `pickerDevice.Category` field.

## Edge cases
- If only one group is present (e.g. the Linux manifest fetch fails, leaving only the ESP32 entries), its single header still renders.
- `--device-type` bypasses the interactive picker entirely and is unaffected.

## Testing
- New `tui/picker_test.go` cases: headers render in WendyOS→Wendy Lite order; `KeyDown` skips the inter-section header onto the next section's first device; `KeyUp` skips back; `enter` selects a device, never a header.
- All existing picker tests remain green (guarding the no-section invariant).
- `go build ./...`, `go vet`, and `go test ./internal/cli/tui/ ./internal/cli/commands/` pass.

Design doc: `specs/2026-06-25-os-install-section-headers-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)