### PR TITLE
fix(cli): make mDNS .local resolution and USB-C work for Linux hosts

### DIFF
--- a/go/internal/cli/assets/docs/wendyos/networking/ipv4-dhcp.md
+++ b/go/internal/cli/assets/docs/wendyos/networking/ipv4-dhcp.md
@@ -54,7 +54,27 @@ In this mode the host receives an address from `10.42.0.2`–`10.42.0.5` and the
 
 ## Host-Side Setup
 
-### Mode 1 host setup — NetworkManager shared (recommended)
+### Easiest — `wendy device usb-setup` (Linux)
+
+On a Linux host, the CLI can do the host-side setup for you. It auto-detects the
+gadget interface, brings it up via NetworkManager, and installs a udev rule so
+ModemManager stops grabbing the gadget's serial console:
+
+```sh
+# Link-local (no DHCP server needed):
+sudo wendy device usb-setup
+
+# Or serve DHCP to the device (10.42.0.1/24) and share internet:
+sudo wendy device usb-setup --shared
+
+# Preview the changes first, or undo them:
+wendy device usb-setup --check
+sudo wendy device usb-setup --undo
+```
+
+The manual steps below are equivalent and remain available.
+
+### Mode 1 host setup — NetworkManager shared
 
 Run on the host once the NCM interface (`enxXXXXXXXXXXXX`) appears:
 

--- a/go/internal/cli/assets/docs/wendyos/networking/troubleshooting.md
+++ b/go/internal/cli/assets/docs/wendyos/networking/troubleshooting.md
@@ -68,7 +68,14 @@ ip addr show enxXXXXXXXXXXXX    # should show 10.42.0.1/24 if NM sharing is acti
 nmcli connection show | grep -i usb
 ```
 
-If the host is not set up for sharing, run:
+If the host is not set up for sharing, the simplest fix on Linux is:
+```bash
+sudo wendy device usb-setup --shared    # serve DHCP to the device
+# or, without a DHCP server:
+sudo wendy device usb-setup             # link-local only
+```
+
+The equivalent manual steps:
 ```bash
 sudo ./scripts/setup-host-usb-link-local.sh install
 # Or for full internet sharing (NM):

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -81,6 +81,7 @@ func newDeviceCmd() *cobra.Command {
 		newAudioCmd(),
 		newCameraCmd(),
 		newHardwareCmd(),
+		newDeviceUSBSetupCmd(),
 	)
 	addToGroup("data",
 		newAppsCmd(),

--- a/go/internal/cli/commands/device_usbsetup.go
+++ b/go/internal/cli/commands/device_usbsetup.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// usbSetupOptions holds the flags for `wendy device usb-setup`.
+type usbSetupOptions struct {
+	iface  string // override the gadget interface; empty = auto-detect
+	shared bool   // NM "shared" (host serves DHCP) instead of link-local
+	dryRun bool   // print the plan, change nothing (also via --check)
+	undo   bool   // remove the NM profile + udev rule installed by this command
+}
+
+func newDeviceUSBSetupCmd() *cobra.Command {
+	var opts usbSetupOptions
+	cmd := &cobra.Command{
+		Use:   "usb-setup",
+		Short: "Configure this Linux host's USB-C link to a Wendy device",
+		Long: "Configure this Linux host so a USB-C-tethered Wendy device is reachable.\n\n" +
+			"It detects the gadget network interface, brings it up via NetworkManager\n" +
+			"(link-local by default, or --shared to serve DHCP to the device), and installs\n" +
+			"a udev rule so ModemManager stops grabbing the gadget's serial console.\n\n" +
+			"Modifies the system (NetworkManager + udev) and must run as root. Use --check\n" +
+			"to preview the changes first, and --undo to remove them.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return usbSetupRun(cmd, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.iface, "iface", "", "USB interface to configure (default: auto-detect)")
+	cmd.Flags().BoolVar(&opts.shared, "shared", false, "Serve DHCP to the device (NM shared) instead of link-local")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Print the planned changes without applying them")
+	cmd.Flags().BoolVar(&opts.dryRun, "check", false, "Alias for --dry-run")
+	cmd.Flags().BoolVar(&opts.undo, "undo", false, "Remove the NM profile and udev rule installed by this command")
+	return cmd
+}

--- a/go/internal/cli/commands/device_usbsetup_linux.go
+++ b/go/internal/cli/commands/device_usbsetup_linux.go
@@ -1,0 +1,187 @@
+//go:build linux
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
+	"github.com/wendylabsinc/wendy/go/internal/shared/nmcli"
+)
+
+const (
+	// usbSetupNMConnName is the NetworkManager profile name this command manages.
+	usbSetupNMConnName = "wendy-usb"
+	// usbSetupUdevPath is the host udev rule that keeps ModemManager off the gadget.
+	usbSetupUdevPath = "/etc/udev/rules.d/99-wendy-usb.rules"
+	// usbGadgetVID/PID identify the WendyOS USB-CDC composite gadget.
+	usbGadgetVID = "1d6b"
+	usbGadgetPID = "0104"
+)
+
+// usbSetupUdevRule tags the Wendy USB gadget so ModemManager leaves its CDC-ACM
+// serial console (/dev/ttyACM*) and CDC-NCM network port alone.
+const usbSetupUdevRule = `# Installed by 'wendy device usb-setup'.
+# Stop ModemManager from probing the Wendy USB gadget's serial console
+# (/dev/ttyACM*) and network port (VID:PID 1d6b:0104).
+ACTION=="add|change", SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d6b", ATTRS{idProduct}=="0104", ENV{ID_MM_DEVICE_IGNORE}="1"
+ACTION=="add|change", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d6b", ATTRS{idProduct}=="0104", ENV{ID_MM_DEVICE_IGNORE}="1"
+`
+
+// usbSetupSudoHint reproduces the relevant flags so a re-run-as-root suggestion
+// preserves the user's intent.
+func usbSetupSudoHint(opts usbSetupOptions) string {
+	var b strings.Builder
+	if opts.undo {
+		b.WriteString(" --undo")
+	}
+	if opts.shared {
+		b.WriteString(" --shared")
+	}
+	if opts.iface != "" {
+		fmt.Fprintf(&b, " --iface %s", opts.iface)
+	}
+	return b.String()
+}
+
+func usbSetupRun(cmd *cobra.Command, opts usbSetupOptions) error {
+	w := cmd.OutOrStdout()
+	ctx := cmd.Context()
+
+	if opts.undo {
+		return usbSetupUndo(ctx, w, opts)
+	}
+
+	iface, err := resolveUSBSetupInterface(opts.iface)
+	if err != nil {
+		return err
+	}
+
+	mode := "link-local"
+	modeNote := "device should use its on-device DHCP/link-local address"
+	if opts.shared {
+		mode = "shared"
+		modeNote = "host serves DHCP 10.42.0.1/24 to the device"
+	}
+
+	fmt.Fprintln(w, "Wendy USB-C host setup")
+	fmt.Fprintf(w, "  interface: %s\n", iface)
+	fmt.Fprintf(w, "  ipv4 mode: %s (%s)\n", mode, modeNote)
+	fmt.Fprintf(w, "  udev rule: %s (ModemManager-ignore for %s:%s)\n", usbSetupUdevPath, usbGadgetVID, usbGadgetPID)
+
+	addArgs := []string{"connection", "add", "type", "ethernet", "ifname", iface,
+		"con-name", usbSetupNMConnName, "connection.autoconnect", "yes"}
+	if opts.shared {
+		addArgs = append(addArgs, "ipv4.method", "shared")
+	} else {
+		addArgs = append(addArgs, "ipv4.method", "link-local", "ipv6.method", "link-local")
+	}
+
+	if opts.dryRun {
+		fmt.Fprintf(w, "\n[dry-run] would replace any existing '%s' profile, then run:\n", usbSetupNMConnName)
+		fmt.Fprintf(w, "  nmcli connection delete %s   # if present\n", usbSetupNMConnName)
+		fmt.Fprintf(w, "  nmcli %s\n", strings.Join(addArgs, " "))
+		fmt.Fprintf(w, "  nmcli connection up %s\n", usbSetupNMConnName)
+		fmt.Fprintf(w, "[dry-run] would write %s and run 'udevadm control --reload-rules && udevadm trigger'\n", usbSetupUdevPath)
+		return nil
+	}
+
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("this command modifies NetworkManager and udev and must run as root.\n"+
+			"  Re-run with: sudo wendy device usb-setup%s\n"+
+			"  Or preview the changes first with: wendy device usb-setup --check%s",
+			usbSetupSudoHint(opts), usbSetupSudoHint(opts))
+	}
+
+	nmcliPath, err := exec.LookPath("nmcli")
+	if err != nil {
+		return fmt.Errorf("nmcli not found; install NetworkManager or configure %s manually: %w", iface, err)
+	}
+
+	// Replace any stale profile with our name first (Scenario 5 in the
+	// networking troubleshooting docs). Ignore errors — it may not exist.
+	_ = nmcli.Command(ctx, nmcliPath, "connection", "delete", usbSetupNMConnName).Run()
+
+	if b, err := nmcli.Command(ctx, nmcliPath, addArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("nmcli connection add failed: %v: %s", err, strings.TrimSpace(string(b)))
+	}
+	if b, err := nmcli.Command(ctx, nmcliPath, "connection", "up", usbSetupNMConnName).CombinedOutput(); err != nil {
+		return fmt.Errorf("nmcli connection up failed: %v: %s", err, strings.TrimSpace(string(b)))
+	}
+	fmt.Fprintf(w, "✓ configured %s (%s)\n", iface, mode)
+
+	if err := os.WriteFile(usbSetupUdevPath, []byte(usbSetupUdevRule), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", usbSetupUdevPath, err)
+	}
+	if err := reloadUdev(ctx); err != nil {
+		return fmt.Errorf("reloading udev: %w", err)
+	}
+	fmt.Fprintf(w, "✓ installed ModemManager-ignore rule: %s\n", usbSetupUdevPath)
+	fmt.Fprintln(w, "\nDone. Re-plug the device if it was already connected, then run 'wendy discover'.")
+	return nil
+}
+
+// resolveUSBSetupInterface returns the gadget interface to configure, using the
+// override when given or auto-detecting otherwise.
+func resolveUSBSetupInterface(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	found, err := discovery.USBNetworkInterfaceNames()
+	if err != nil {
+		return "", fmt.Errorf("detecting USB interfaces: %w", err)
+	}
+	switch len(found) {
+	case 0:
+		return "", fmt.Errorf("no USB gadget interface found.\n" +
+			"  Connect the device with a data (not charge-only) USB-C cable, wait a few seconds, then retry.\n" +
+			"  If it is connected, pass it explicitly: wendy device usb-setup --iface <name> (see 'ip link').")
+	case 1:
+		return found[0], nil
+	default:
+		return "", fmt.Errorf("multiple USB interfaces found (%s); choose one with --iface <name>", strings.Join(found, ", "))
+	}
+}
+
+func usbSetupUndo(ctx context.Context, w io.Writer, opts usbSetupOptions) error {
+	if opts.dryRun {
+		fmt.Fprintf(w, "[dry-run] would delete NM profile '%s', remove %s, and reload udev\n", usbSetupNMConnName, usbSetupUdevPath)
+		return nil
+	}
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("--undo modifies NetworkManager and udev and must run as root.\n"+
+			"  Re-run with: sudo wendy device usb-setup%s", usbSetupSudoHint(opts))
+	}
+	if nmcliPath, err := exec.LookPath("nmcli"); err == nil {
+		_ = nmcli.Command(ctx, nmcliPath, "connection", "delete", usbSetupNMConnName).Run()
+	}
+	if err := os.Remove(usbSetupUdevPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing %s: %w", usbSetupUdevPath, err)
+	}
+	_ = reloadUdev(ctx)
+	fmt.Fprintf(w, "✓ removed '%s' NM profile and %s\n", usbSetupNMConnName, usbSetupUdevPath)
+	return nil
+}
+
+// reloadUdev reloads udev rules and re-triggers matching so the ModemManager
+// ignore tag applies to an already-connected device.
+func reloadUdev(ctx context.Context) error {
+	udevadm, err := exec.LookPath("udevadm")
+	if err != nil {
+		return fmt.Errorf("udevadm not found: %w", err)
+	}
+	if b, err := exec.CommandContext(ctx, udevadm, "control", "--reload-rules").CombinedOutput(); err != nil {
+		return fmt.Errorf("udevadm control: %v: %s", err, strings.TrimSpace(string(b)))
+	}
+	if b, err := exec.CommandContext(ctx, udevadm, "trigger").CombinedOutput(); err != nil {
+		return fmt.Errorf("udevadm trigger: %v: %s", err, strings.TrimSpace(string(b)))
+	}
+	return nil
+}

--- a/go/internal/cli/commands/device_usbsetup_linux_test.go
+++ b/go/internal/cli/commands/device_usbsetup_linux_test.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestUSBSetupSudoHint(t *testing.T) {
+	cases := []struct {
+		opts usbSetupOptions
+		want string
+	}{
+		{usbSetupOptions{}, ""},
+		{usbSetupOptions{shared: true}, " --shared"},
+		{usbSetupOptions{iface: "usb0"}, " --iface usb0"},
+		{usbSetupOptions{undo: true, shared: true, iface: "enx1"}, " --undo --shared --iface enx1"},
+	}
+	for _, c := range cases {
+		if got := usbSetupSudoHint(c.opts); got != c.want {
+			t.Errorf("usbSetupSudoHint(%+v) = %q, want %q", c.opts, got, c.want)
+		}
+	}
+}
+
+func TestResolveUSBSetupInterface_Override(t *testing.T) {
+	got, err := resolveUSBSetupInterface("usb7")
+	if err != nil || got != "usb7" {
+		t.Fatalf("resolveUSBSetupInterface(override) = %q, %v; want usb7, nil", got, err)
+	}
+}
+
+// Dry-run must print the plan, require no root, and change nothing.
+func TestUSBSetupRun_DryRun(t *testing.T) {
+	newCmd := func(buf *bytes.Buffer) *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.SetOut(buf)
+		cmd.SetContext(context.Background())
+		return cmd
+	}
+
+	var buf bytes.Buffer
+	if err := usbSetupRun(newCmd(&buf), usbSetupOptions{iface: "usb0", dryRun: true}); err != nil {
+		t.Fatalf("dry-run (link-local) returned error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"[dry-run]", "usb0", "ipv4.method link-local", usbSetupUdevPath} {
+		if !strings.Contains(out, want) {
+			t.Errorf("link-local dry-run output missing %q\n%s", want, out)
+		}
+	}
+
+	buf.Reset()
+	if err := usbSetupRun(newCmd(&buf), usbSetupOptions{iface: "usb0", shared: true, dryRun: true}); err != nil {
+		t.Fatalf("dry-run (shared) returned error: %v", err)
+	}
+	if out := buf.String(); !strings.Contains(out, "ipv4.method shared") {
+		t.Errorf("shared dry-run output missing 'ipv4.method shared'\n%s", out)
+	}
+
+	buf.Reset()
+	if err := usbSetupRun(newCmd(&buf), usbSetupOptions{undo: true, dryRun: true}); err != nil {
+		t.Fatalf("dry-run (undo) returned error: %v", err)
+	}
+	if out := buf.String(); !strings.Contains(out, usbSetupNMConnName) || !strings.Contains(out, "[dry-run]") {
+		t.Errorf("undo dry-run output unexpected\n%s", out)
+	}
+}

--- a/go/internal/cli/commands/device_usbsetup_other.go
+++ b/go/internal/cli/commands/device_usbsetup_other.go
@@ -1,0 +1,26 @@
+//go:build !linux
+
+package commands
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// usbSetupRun is unsupported off Linux. macOS brings up the USB-C gadget link
+// automatically; Windows users configure the gadget network adapter manually.
+func usbSetupRun(cmd *cobra.Command, opts usbSetupOptions) error {
+	_ = opts
+	switch runtime.GOOS {
+	case "darwin":
+		fmt.Fprintln(cmd.OutOrStdout(),
+			"macOS brings up the USB-C link to a Wendy device automatically — no setup needed.\n"+
+				"If the device isn't found, check System Settings ▸ Network for the USB adapter, then run 'wendy discover'.")
+		return nil
+	default:
+		return fmt.Errorf("'wendy device usb-setup' configures a Linux host's USB-C link and is not supported on %s.\n"+
+			"  Configure the USB gadget network adapter manually, then run 'wendy discover'.", runtime.GOOS)
+	}
+}

--- a/go/internal/cli/commands/device_usbsetup_test.go
+++ b/go/internal/cli/commands/device_usbsetup_test.go
@@ -1,0 +1,15 @@
+package commands
+
+import "testing"
+
+func TestNewDeviceUSBSetupCmd_Flags(t *testing.T) {
+	cmd := newDeviceUSBSetupCmd()
+	if cmd.Use != "usb-setup" {
+		t.Fatalf("Use = %q, want usb-setup", cmd.Use)
+	}
+	for _, f := range []string{"iface", "shared", "dry-run", "check", "undo"} {
+		if cmd.Flags().Lookup(f) == nil {
+			t.Errorf("missing flag --%s", f)
+		}
+	}
+}

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -165,11 +165,30 @@ func discoverOnce(ctx context.Context, opts discovery.DiscoveryOptions) error {
 	collection, ok := result.(*models.DevicesCollection)
 	if !ok || collection == nil || collection.IsEmpty() {
 		fmt.Println("No devices found.")
+		fmt.Println(noDevicesHint())
 		return nil
 	}
 
 	fmt.Print(renderDeviceTable(collection))
 	return nil
+}
+
+// noDevicesHint returns short, OS-appropriate guidance shown when discovery
+// finds nothing. mDNS discovery needs multicast on the path; on Linux the
+// browse uses Avahi (or raw multicast) and is commonly defeated by a stopped
+// avahi-daemon or a firewall blocking UDP 5353.
+func noDevicesHint() string {
+	if runtime.GOOS == "linux" {
+		return "Hints:\n" +
+			"  • Is avahi-daemon running?   systemctl status avahi-daemon\n" +
+			"  • Firewall blocking mDNS?    sudo ufw allow 5353/udp   (if ufw is active)\n" +
+			"  • USB-C tethered device?     sudo wendy device usb-setup\n" +
+			"  • Or connect directly by IP: wendy device connect <ip>:50051"
+	}
+	return "Hints:\n" +
+		"  • Device powered on and on the same network (or USB-C tethered).\n" +
+		"  • mDNS uses UDP 5353 — make sure a firewall isn't blocking it.\n" +
+		"  • Or connect directly by IP: wendy device connect <ip>:50051"
 }
 
 // discoverContinuous runs scans in a loop, refreshing the table until Ctrl+C.

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -2354,7 +2354,14 @@ func resolveRegistryIP(host string) string {
 func resolveHostPreferRoutable(hostname string) string {
 	addrs, err := net.LookupHost(hostname)
 	if err != nil || len(addrs) == 0 {
-		return ""
+		// The shipped CGO_ENABLED=0 binary can't resolve ".local" via the OS
+		// resolver; fall back to an mDNS browse so a device reached by its
+		// ".local" name still resolves for registry use (issue #1155).
+		if ip := resolveMDNSHost(context.Background(), hostname); ip != "" {
+			addrs = []string{ip}
+		} else {
+			return ""
+		}
 	}
 
 	// Scan all addresses before returning — IPv4 may appear after global IPv6

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -263,38 +263,6 @@ func hostPort(host string, port int) string {
 	return fmt.Sprintf("%s:%d", host, port)
 }
 
-// resolveHostPreferIPv4 resolves a hostname to a concrete IP address,
-// preferring IPv4 over global IPv6. If the input is already an IP address
-// or resolution fails, it returns the input unchanged.
-func resolveHostPreferIPv4(host string) string {
-	if _, err := netip.ParseAddr(host); err == nil {
-		return host // already an IP
-	}
-
-	addrs, err := net.LookupHost(host)
-	if err != nil || len(addrs) == 0 {
-		return host
-	}
-
-	var globalIPv6 string
-	for _, a := range addrs {
-		addr, parseErr := netip.ParseAddr(a)
-		if parseErr != nil {
-			continue
-		}
-		if addr.Is4() {
-			return a
-		}
-		if !addr.IsLinkLocalUnicast() && globalIPv6 == "" {
-			globalIPv6 = addr.WithZone("").String()
-		}
-	}
-	if globalIPv6 != "" {
-		return globalIPv6
-	}
-	return host // only link-local IPv6 found — keep hostname for zone-aware dial
-}
-
 // lanAgentAddresses returns candidate gRPC addresses for a LAN device.
 // Prefer the discovered IP address so commands still work when .local
 // hostname resolution is unavailable on the host machine.
@@ -768,6 +736,19 @@ func connectWithAutoTLS(ctx context.Context, plaintextAddr string) (*grpcclient.
 // does not stall a command for the full default discovery window.
 const mdnsBrowseTimeout = 4 * time.Second
 
+// mdnsBrowseTimeoutValue returns the mDNS fallback browse timeout, allowing
+// WENDY_MDNS_TIMEOUT (a Go duration like "8s") to raise it for slow networks
+// where the default window is too short to hear a response. Values outside
+// [1s, 30s] are ignored in favour of the default.
+func mdnsBrowseTimeoutValue() time.Duration {
+	if v := os.Getenv("WENDY_MDNS_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d >= time.Second && d <= 30*time.Second {
+			return d
+		}
+	}
+	return mdnsBrowseTimeout
+}
+
 // osLookupHostFn resolves a hostname via the operating system resolver. It is a
 // package variable so tests can simulate a resolver that cannot see mDNS names.
 var osLookupHostFn = func(ctx context.Context, host string) ([]string, error) {
@@ -777,6 +758,33 @@ var osLookupHostFn = func(ctx context.Context, host string) ([]string, error) {
 // lanBrowseFn browses the LAN for WendyOS devices via mDNS. It is a package
 // variable so tests can substitute a fixture instead of a real network browse.
 var lanBrowseFn = discovery.DiscoverLAN
+
+// resolveHostMDNSFallback resolves a bare hostname to a single IP, preferring
+// IPv4. It tries the OS resolver first, then falls back to an mDNS browse for
+// ".local" names. The OS resolver (and thus gRPC's) can't see mDNS ".local"
+// names on Windows or on Linux hosts without nss-mdns/avahi — and the shipped
+// binaries are built CGO_ENABLED=0, so they use Go's pure resolver which
+// ignores nss-mdns entirely. Only macOS resolves ".local" natively. The
+// mDNS-browse fallback keeps ".local" names working on those platforms (issue
+// #1155). A bare IP literal is returned unchanged; "" is returned when the
+// name cannot be resolved and no advertised mDNS device matches.
+func resolveHostMDNSFallback(ctx context.Context, host string) string {
+	if net.ParseIP(host) != nil {
+		return host
+	}
+	rctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ips, err := osLookupHostFn(rctx, host)
+	cancel()
+	if err == nil && len(ips) > 0 {
+		for _, ip := range ips { // prefer IPv4
+			if net.ParseIP(ip).To4() != nil {
+				return ip
+			}
+		}
+		return ips[0]
+	}
+	return resolveMDNSHost(ctx, host) // "" for non-".local" names or no match
+}
 
 // resolveAddrOnce resolves a host:port whose host is a DNS/mDNS name to an
 // IPv4-preferred IP:port, so the dials below target a literal IP. gRPC
@@ -791,22 +799,7 @@ func resolveAddrOnce(ctx context.Context, addr string) string {
 	if err != nil || net.ParseIP(host) != nil {
 		return addr // not host:port, or already a literal IP
 	}
-	rctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	ips, err := osLookupHostFn(rctx, host)
-	cancel()
-	if err == nil && len(ips) > 0 {
-		for _, ip := range ips { // prefer IPv4
-			if net.ParseIP(ip).To4() != nil {
-				return net.JoinHostPort(ip, port)
-			}
-		}
-		return net.JoinHostPort(ips[0], port)
-	}
-	// The OS resolver (and thus gRPC's) can't see mDNS ".local" names on
-	// Windows or on Linux hosts without nss-mdns/avahi — only macOS resolves
-	// them natively. Fall back to an mDNS browse so a saved default hostname
-	// still connects on those platforms (issue #1155).
-	if ip := resolveMDNSHost(ctx, host); ip != "" {
+	if ip := resolveHostMDNSFallback(ctx, host); ip != "" {
 		return net.JoinHostPort(ip, port)
 	}
 	return addr
@@ -822,9 +815,10 @@ func resolveMDNSHost(ctx context.Context, host string) string {
 	if !strings.HasSuffix(normalized, ".local") {
 		return ""
 	}
-	bctx, cancel := context.WithTimeout(ctx, mdnsBrowseTimeout)
+	timeout := mdnsBrowseTimeoutValue()
+	bctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	devices, err := lanBrowseFn(bctx, mdnsBrowseTimeout)
+	devices, err := lanBrowseFn(bctx, timeout)
 	if err != nil {
 		return ""
 	}
@@ -847,14 +841,28 @@ func normalizeMDNSHost(host string) string {
 	return strings.TrimSuffix(h, ".local")
 }
 
+// mdnsLocalHint returns guidance for ".local" mDNS resolution failures. The
+// shipped CLI is built CGO_ENABLED=0, so it can't see ".local" names via the OS
+// resolver (nss-mdns) and relies on an mDNS browse (avahi/raw multicast)
+// instead; that browse needs multicast on the path. Returns "" for
+// non-".local" hosts.
+func mdnsLocalHint(host string) string {
+	h := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if !strings.HasSuffix(h, ".local") {
+		return ""
+	}
+	return "\n  Resolving a .local name needs mDNS: ensure avahi-daemon is running and" +
+		" UDP 5353 isn't firewalled (e.g. 'sudo ufw allow 5353/udp'), or connect by IP."
+}
+
 // defaultDeviceUnreachableError wraps a connection failure for a saved default
 // device so the message makes clear the default IS persisted but could not be
 // reached — rather than letting the failure read as if set-default never took
 // effect (issue #1155).
 func defaultDeviceUnreachableError(hostname string, err error) error {
 	return fmt.Errorf("default device %q is set but could not be reached: %w\n"+
-		"  Confirm it with 'wendy device get-default'; change it with 'wendy device set-default' or clear it with 'wendy device unset-default'.",
-		hostname, err)
+		"  Confirm it with 'wendy device get-default'; change it with 'wendy device set-default' or clear it with 'wendy device unset-default'.%s",
+		hostname, err, mdnsLocalHint(hostname))
 }
 
 func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error, error) {

--- a/go/internal/cli/commands/helpers_mdns_test.go
+++ b/go/internal/cli/commands/helpers_mdns_test.go
@@ -124,4 +124,89 @@ func TestDefaultDeviceUnreachableError(t *testing.T) {
 			t.Errorf("error %q missing %q", msg, want)
 		}
 	}
+	// A ".local" target carries the mDNS troubleshooting hint.
+	if !strings.Contains(msg, "5353") {
+		t.Errorf("expected mDNS hint for a .local default, got %q", msg)
+	}
+
+	// A non-".local" target must not carry the mDNS hint.
+	if msg := defaultDeviceUnreachableError("192.168.1.50", cause).Error(); strings.Contains(msg, "5353") {
+		t.Errorf("did not expect mDNS hint for an IP default, got %q", msg)
+	}
+}
+
+func TestMDNSBrowseTimeoutValue(t *testing.T) {
+	cases := []struct {
+		env  string
+		want time.Duration
+	}{
+		{"", mdnsBrowseTimeout},
+		{"8s", 8 * time.Second},
+		{"500ms", mdnsBrowseTimeout}, // below floor → default
+		{"60s", mdnsBrowseTimeout},   // above ceiling → default
+		{"garbage", mdnsBrowseTimeout},
+	}
+	for _, c := range cases {
+		t.Setenv("WENDY_MDNS_TIMEOUT", c.env)
+		if got := mdnsBrowseTimeoutValue(); got != c.want {
+			t.Errorf("WENDY_MDNS_TIMEOUT=%q → %v, want %v", c.env, got, c.want)
+		}
+	}
+}
+
+func TestMDNSLocalHint(t *testing.T) {
+	if got := mdnsLocalHint("wendy-thor.local"); !strings.Contains(got, "5353") || !strings.Contains(got, "mDNS") {
+		t.Errorf("mdnsLocalHint(.local) = %q, want mDNS/5353 guidance", got)
+	}
+	for _, h := range []string{"example.com", "192.168.1.50", "wendy-thor"} {
+		if got := mdnsLocalHint(h); got != "" {
+			t.Errorf("mdnsLocalHint(%q) = %q, want empty", h, got)
+		}
+	}
+}
+
+func TestResolveHostMDNSFallback(t *testing.T) {
+	origLookup := osLookupHostFn
+	origBrowse := lanBrowseFn
+	defer func() {
+		osLookupHostFn = origLookup
+		lanBrowseFn = origBrowse
+	}()
+
+	// IP literal passes through untouched (no resolver calls).
+	osLookupHostFn = func(context.Context, string) ([]string, error) {
+		t.Fatal("OS resolver should not be called for an IP literal")
+		return nil, nil
+	}
+	if got := resolveHostMDNSFallback(context.Background(), "192.168.1.50"); got != "192.168.1.50" {
+		t.Fatalf("resolveHostMDNSFallback(IP) = %q, want unchanged", got)
+	}
+
+	// OS resolver result prefers IPv4 over IPv6.
+	osLookupHostFn = func(context.Context, string) ([]string, error) {
+		return []string{"fe80::1", "192.168.1.50"}, nil
+	}
+	if got := resolveHostMDNSFallback(context.Background(), "wendy-thor.local"); got != "192.168.1.50" {
+		t.Fatalf("resolveHostMDNSFallback(OS) = %q, want 192.168.1.50", got)
+	}
+
+	// OS resolver failure on a ".local" name falls back to the mDNS browse.
+	osLookupHostFn = func(context.Context, string) ([]string, error) {
+		return nil, errors.New("no such host")
+	}
+	lanBrowseFn = func(context.Context, time.Duration) ([]models.LANDevice, error) {
+		return []models.LANDevice{{Hostname: "wendy-thor.local", IPAddress: "10.0.0.7"}}, nil
+	}
+	if got := resolveHostMDNSFallback(context.Background(), "wendy-thor.local"); got != "10.0.0.7" {
+		t.Fatalf("resolveHostMDNSFallback(mDNS) = %q, want 10.0.0.7", got)
+	}
+
+	// OS failure on a non-".local" name yields "" (no browse attempted).
+	lanBrowseFn = func(context.Context, time.Duration) ([]models.LANDevice, error) {
+		t.Fatal("mDNS browse should not run for a non-.local host")
+		return nil, nil
+	}
+	if got := resolveHostMDNSFallback(context.Background(), "example.com"); got != "" {
+		t.Fatalf("resolveHostMDNSFallback(non-.local fail) = %q, want empty", got)
+	}
 }

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -475,25 +475,24 @@ func localIPForHost(host string) (string, error) {
 	}
 
 	if parsedIP == nil {
-		// Not an IP literal — resolve via DNS.
-		ips, err := net.LookupHost(host)
-		if err != nil {
-			return "", fmt.Errorf("resolving %s: %w", host, err)
+		// Not an IP literal — resolve via DNS, falling back to an mDNS browse
+		// for ".local" names. The shipped CGO_ENABLED=0 binary can't resolve
+		// ".local" via the OS resolver, so without this fallback `wendy os`
+		// commands targeting a ".local" host fail on Linux/Windows (issue #1155).
+		ip := resolveHostMDNSFallback(context.Background(), host)
+		if ip == "" {
+			return "", fmt.Errorf("resolving %s: no addresses found%s", host, mdnsLocalHint(host))
 		}
-		// Prefer IPv4; fall back to the first result.
-		for _, ip := range ips {
-			if p := net.ParseIP(ip); p != nil && p.To4() != nil {
-				parsedIP = p
-				dialHost = ip
-				break
-			}
+		// An mDNS-discovered IPv6 link-local address carries a zone (e.g.
+		// fe80::1%en0): keep it for dialing but strip it before ParseIP.
+		dialHost = ip
+		ipForParse := ip
+		if i := strings.Index(ip, "%"); i != -1 {
+			ipForParse = ip[:i]
 		}
-		if parsedIP == nil && len(ips) > 0 {
-			dialHost = ips[0]
-			parsedIP = net.ParseIP(ips[0])
-		}
+		parsedIP = net.ParseIP(ipForParse)
 		if parsedIP == nil {
-			return "", fmt.Errorf("no addresses found for %s", host)
+			return "", fmt.Errorf("resolving %s: invalid address %q", host, ip)
 		}
 	}
 

--- a/go/internal/shared/discovery/discovery.go
+++ b/go/internal/shared/discovery/discovery.go
@@ -3,13 +3,25 @@ package discovery
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 )
+
+// logMDNSQueryErr reports an mDNS query failure to stderr when WENDY_MDNS_DEBUG
+// is set. It is a no-op for nil errors or when debugging is off, so callers can
+// wrap the query directly: logMDNSQueryErr(iface, mdns.Query(params)).
+func logMDNSQueryErr(iface string, err error) {
+	if err == nil || os.Getenv("WENDY_MDNS_DEBUG") == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "wendy: mDNS query on %s failed: %v\n", iface, err)
+}
 
 const (
 	// wendyServiceType is the mDNS service type advertised by WendyOS devices.

--- a/go/internal/shared/discovery/discovery_linux.go
+++ b/go/internal/shared/discovery/discovery_linux.go
@@ -308,7 +308,7 @@ func queryInterface(ctx context.Context, iface *net.Interface, timeout time.Dura
 	params.Timeout = timeout
 	params.Logger = silentLogger
 
-	_ = mdns.Query(params)
+	logMDNSQueryErr(iface.Name, mdns.Query(params))
 	close(entriesCh)
 	<-done
 

--- a/go/internal/shared/discovery/mdns_linux.go
+++ b/go/internal/shared/discovery/mdns_linux.go
@@ -200,7 +200,7 @@ func queryInterfaceMDNS(_ context.Context, iface *net.Interface, serviceType str
 	params.Timeout = timeout
 	params.Logger = silentLogger
 
-	_ = mdns.Query(params)
+	logMDNSQueryErr(iface.Name, mdns.Query(params))
 	close(entriesCh)
 	<-done
 

--- a/go/internal/shared/discovery/usb_connection.go
+++ b/go/internal/shared/discovery/usb_connection.go
@@ -2,11 +2,34 @@ package discovery
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 )
+
+// USBNetworkInterfaceNames returns the names of non-loopback network interfaces
+// that appear to be USB-attached (USB-CDC gadget links), using the same
+// heuristics as device discovery (name patterns plus, on Linux, a sysfs
+// device-path check). It is used by the CLI's `wendy device usb-setup` command
+// to locate the host's gadget interface.
+func USBNetworkInterfaceNames() ([]string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("listing interfaces: %w", err)
+	}
+	var out []string
+	for i := range ifaces {
+		if ifaces[i].Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if looksLikeUSBConnection(ifaces[i].Name, "") {
+			out = append(out, ifaces[i].Name)
+		}
+	}
+	return out, nil
+}
 
 // ansiEscapeRE matches ANSI/VT100 escape sequences (e.g. colour codes).
 var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
@@ -88,7 +111,11 @@ func looksLikeUSBConnection(interfaceName, displayName string) bool {
 	case linuxUSBInterfaceNameRE.MatchString(name):
 		return true
 	default:
-		return false
+		// Fall back to sysfs: an interface whose real device path traverses the
+		// USB bus is USB-backed regardless of its name. This keeps gadget
+		// detection working under net.ifnames=0 / classic naming (eth0, usb0),
+		// where none of the name heuristics above match. No-op off Linux.
+		return interfaceIsUSBBacked(strings.TrimSpace(interfaceName))
 	}
 }
 

--- a/go/internal/shared/discovery/usb_iface_linux.go
+++ b/go/internal/shared/discovery/usb_iface_linux.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+package discovery
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// netClassRoot is the sysfs directory that enumerates network interfaces. It is
+// a var so tests can point it at a fixture tree.
+var netClassRoot = "/sys/class/net"
+
+// interfaceIsUSBBacked reports whether the named network interface is backed by
+// a USB device. It resolves the interface's sysfs symlink to its real device
+// path and checks whether that path traverses the USB bus (a "usb*" path
+// component). This catches USB-CDC gadget interfaces even when predictable
+// naming is disabled (net.ifnames=0) and the interface is a plain name like
+// "eth0"/"usb0" that the name heuristics in looksLikeUSBConnection would miss.
+func interfaceIsUSBBacked(name string) bool {
+	if name == "" {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Join(netClassRoot, name))
+	if err != nil {
+		return false
+	}
+	return pathHasUSBComponent(resolved)
+}
+
+// pathHasUSBComponent reports whether any path segment names a USB bus/device
+// (sysfs uses components like "usb1", "usb2", ...).
+func pathHasUSBComponent(p string) bool {
+	for _, seg := range strings.Split(p, string(filepath.Separator)) {
+		if strings.HasPrefix(seg, "usb") {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/shared/discovery/usb_iface_linux_test.go
+++ b/go/internal/shared/discovery/usb_iface_linux_test.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildNetFixture creates a fake /sys/class/net tree where each interface name
+// is a symlink to a device directory under devicesRoot. It returns the path to
+// use as netClassRoot.
+func buildNetFixture(t *testing.T, ifaces map[string]string) string {
+	t.Helper()
+	base := t.TempDir()
+	classRoot := filepath.Join(base, "class", "net")
+	if err := os.MkdirAll(classRoot, 0o755); err != nil {
+		t.Fatalf("mkdir class root: %v", err)
+	}
+	for iface, devRel := range ifaces {
+		devAbs := filepath.Join(base, devRel)
+		if err := os.MkdirAll(devAbs, 0o755); err != nil {
+			t.Fatalf("mkdir device dir %s: %v", devAbs, err)
+		}
+		if err := os.Symlink(devAbs, filepath.Join(classRoot, iface)); err != nil {
+			t.Fatalf("symlink %s: %v", iface, err)
+		}
+	}
+	return classRoot
+}
+
+func TestInterfaceIsUSBBacked(t *testing.T) {
+	orig := netClassRoot
+	defer func() { netClassRoot = orig }()
+
+	netClassRoot = buildNetFixture(t, map[string]string{
+		// USB-CDC gadget: device path traverses a usb1 bus component.
+		"usb0": "devices/platform/soc/usb1/1-1/1-1:1.0/net/usb0",
+		// Predictable-name gadget, same USB topology.
+		"enp0s20u1": "devices/pci0000:00/0000:00:14.0/usb2/2-1/2-1:1.0/net/enp0s20u1",
+		// On-board PCI ethernet: no usb component.
+		"eth0": "devices/pci0000:00/0000:00:1f.6/net/eth0",
+	})
+
+	tests := []struct {
+		iface string
+		want  bool
+	}{
+		{"usb0", true},
+		{"enp0s20u1", true},
+		{"eth0", false},
+		{"missing0", false}, // no such interface
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := interfaceIsUSBBacked(tt.iface); got != tt.want {
+			t.Errorf("interfaceIsUSBBacked(%q) = %v, want %v", tt.iface, got, tt.want)
+		}
+	}
+}
+
+// looksLikeUSBConnection must classify a USB-backed interface as USB even when
+// its name (classic eth0 under net.ifnames=0) matches none of the name rules.
+func TestLooksLikeUSBConnection_SysfsFallback(t *testing.T) {
+	orig := netClassRoot
+	defer func() { netClassRoot = orig }()
+	netClassRoot = buildNetFixture(t, map[string]string{
+		"eth0": "devices/platform/soc/usb1/1-1/1-1:1.0/net/eth0",
+		"eth1": "devices/pci0000:00/0000:00:1f.6/net/eth1",
+	})
+
+	if !looksLikeUSBConnection("eth0", "") {
+		t.Error("expected USB-backed eth0 to be detected as a USB connection")
+	}
+	if looksLikeUSBConnection("eth1", "") {
+		t.Error("did not expect on-board eth1 to be detected as a USB connection")
+	}
+}

--- a/go/internal/shared/discovery/usb_iface_other.go
+++ b/go/internal/shared/discovery/usb_iface_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package discovery
+
+// interfaceIsUSBBacked is a no-op on non-Linux platforms; USB-vs-LAN labelling
+// there relies on the interface/display-name heuristics in
+// looksLikeUSBConnection.
+func interfaceIsUSBBacked(string) bool { return false }


### PR DESCRIPTION
## Why

Reports of mDNS and USB-C failures on Ubuntu 24.04 (and older) prompted a deep investigation of the host-facing CLI/agent. The reported symptoms turn out to be **structural and Linux-wide**, not specific to one Ubuntu release — the networking/peripheral stack changes between Ubuntu versions are *not* the cause.

Key findings (all verified against the code):
- **Shipped Linux/Windows binaries are `CGO_ENABLED=0`** (`.github/workflows/build.yml:122`; macOS CLI is the lone CGO=1 exception). CGO=0 forces Go's pure resolver, which **ignores `nss-mdns`**, so `.local` can't resolve via the OS regardless of distro. systemd-resolved also has mDNS off by default.
- The #1155 mDNS-browse fallback (`resolveAddrOnce` → `resolveMDNSHost`) covered the main connect path but **not** `wendy os` / registry resolution.
- USB-C: the device is a DHCP **client** expecting the **host** to serve DHCP; a stock Linux host is left unconfigured (no IPv4 over USB-C), and ModemManager can grab the gadget's CDC-ACM serial console. The host helper + udev rule referenced in docs are **not shipped in the CLI**.
- The device USB gadget is **CDC NCM/ECM (not RNDIS)**, so the kernel RNDIS removal is a non-issue.

## What changed

**mDNS / `.local` resolution**
- Extracted a shared `resolveHostMDNSFallback` (OS resolver → IPv4-preferred → mDNS browse) and routed the bypass sites (`os_cmd.go localIPForHost`, `docker.go resolveHostPreferRoutable`) through it.
- Removed dead `resolveHostPreferIPv4`; added a `.local`-specific hint to the unreachable-default error.

**Discovery diagnostics**
- Linux-specific hints when `wendy discover` finds nothing (avahi-daemon, `ufw allow 5353/udp`, `usb-setup`, connect-by-IP).
- `WENDY_MDNS_DEBUG` surfaces previously-discarded mDNS query errors; `WENDY_MDNS_TIMEOUT` overrides the browse window.

**New `wendy device usb-setup` (Linux; macOS/Windows stub)**
- Auto-detects the gadget interface, brings it up via NetworkManager (link-local default, `--shared` for DHCP), and installs a ModemManager-ignore udev rule. Supports `--check`/`--dry-run`, `--undo`, `--iface`; requires sudo with a clear re-run hint.

**USB detection robustness**
- sysfs `device`-path check so gadget detection survives `net.ifnames=0`; exported `discovery.USBNetworkInterfaceNames()` (reused by the command).

**Docs** — networking troubleshooting / ipv4-dhcp point at the new command.

## Testing

- `gofmt` clean; **`go test ./...` → 41 packages ok, 0 failures.**
- darwin build + tests; **linux & windows cross-`vet`** clean; **linux test binaries cross-compile/link** (Linux-only tests can't run on macOS but compile).
- New tests: shared resolver + hint + timeout; sysfs USB detection; command flags + Linux dry-run/sudo-hint.

> ⚠️ **On-device verification on Ubuntu 26 is still pending.** Repro must use the **shipped `CGO_ENABLED=0` binary** — a local `go build` defaults to CGO=1 and resolves `.local` via nss-mdns, masking the bug.

## Out of scope (flagged for the WendyOS image repo)
- Consider defaulting USB networking to on-device DHCP/link-local so a stock host needs no setup.
- Keep the device udev/ModemManager rules in sync with the new command.
- Fix the `WENDYOS_USB_NET_MODE` value-name inconsistency between `ipv4-dhcp.md` and `configuration-files.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
