### PR TITLE
fix: mask WiFi password input in os update/install prompt

### DIFF
--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1518,7 +1518,7 @@ func resolveWiFiCredentialsList(opts wifiCLIOptions) ([]wendyconf.WifiCredential
 			if pw, kerr := lookupKeychainPassword(c.SSID); kerr == nil && pw != "" {
 				c.Password = pw
 			} else if isInteractiveTerminal() {
-				pw, perr := tui.PromptText(fmt.Sprintf("WiFi password for %s", c.SSID), "(leave empty for open network)", nil)
+				pw, perr := tui.PromptPassword(fmt.Sprintf("WiFi password for %s", c.SSID), "(leave empty for open network)", nil)
 				if perr != nil {
 					return nil, fmt.Errorf("reading WiFi password: %w", perr)
 				}
@@ -1643,7 +1643,7 @@ var (
 		return tui.PromptText("WiFi SSID", "", nonEmptyValidator)
 	}
 	promptWifiPassword = func(ssid string) (string, error) {
-		return tui.PromptText(fmt.Sprintf("Password for %s", ssid), "(leave empty for open network)", nil)
+		return tui.PromptPassword(fmt.Sprintf("Password for %s", ssid), "(leave empty for open network)", nil)
 	}
 )
 

--- a/go/internal/cli/tui/textprompt.go
+++ b/go/internal/cli/tui/textprompt.go
@@ -47,6 +47,16 @@ func NewTextPrompt(prompt, hint, defaultValue string, validate ValidateFunc) Tex
 	}
 }
 
+// NewPasswordPrompt is like NewTextPrompt but masks the input (echoes '•') so
+// secrets such as WiFi passwords are never shown in plaintext. It takes no
+// default value — pre-filling a secret that can't be read back is pointless.
+func NewPasswordPrompt(prompt, hint string, validate ValidateFunc) TextPromptModel {
+	m := NewTextPrompt(prompt, hint, "", validate)
+	m.input.EchoMode = textinput.EchoPassword
+	m.input.EchoCharacter = '•'
+	return m
+}
+
 func (m TextPromptModel) Init() tea.Cmd {
 	return textinput.Blink
 }
@@ -126,7 +136,19 @@ func PromptText(prompt, hint string, validate ValidateFunc, programOpts ...tea.P
 // PromptTextWithDefault is like PromptText but pre-fills the input with a
 // default value that the user can accept (enter) or edit.
 func PromptTextWithDefault(prompt, hint, defaultValue string, validate ValidateFunc, programOpts ...tea.ProgramOption) (string, error) {
-	m := NewTextPrompt(prompt, hint, defaultValue, validate)
+	return runTextPrompt(NewTextPrompt(prompt, hint, defaultValue, validate), programOpts...)
+}
+
+// PromptPassword runs an interactive prompt whose input is masked (echoes '•'),
+// for secrets that must not appear on screen. Like PromptText, an empty value
+// is allowed unless validate rejects it.
+func PromptPassword(prompt, hint string, validate ValidateFunc, programOpts ...tea.ProgramOption) (string, error) {
+	return runTextPrompt(NewPasswordPrompt(prompt, hint, validate), programOpts...)
+}
+
+// runTextPrompt runs a prepared model to completion and returns its validated
+// value, ErrCancelled if the user quit, or a wrapped Bubble Tea error.
+func runTextPrompt(m TextPromptModel, programOpts ...tea.ProgramOption) (string, error) {
 	p := tea.NewProgram(m, programOpts...)
 	result, err := p.Run()
 	if err != nil {

--- a/go/internal/cli/tui/textprompt_test.go
+++ b/go/internal/cli/tui/textprompt_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -83,6 +84,33 @@ func TestTextPromptModel_DefaultValue(t *testing.T) {
 	m = updateTextPrompt(m, tkey("enter"))
 	if m.Value() != "/data" {
 		t.Fatalf("expected %q, got %q", "/data", m.Value())
+	}
+}
+
+func TestNewPasswordPrompt_MasksInput(t *testing.T) {
+	m := NewPasswordPrompt("Password", "", nil)
+	if m.input.EchoMode != textinput.EchoPassword {
+		t.Fatalf("expected EchoPassword, got %v", m.input.EchoMode)
+	}
+	if m.input.EchoCharacter != '•' {
+		t.Fatalf("expected mask char '•', got %q", m.input.EchoCharacter)
+	}
+
+	// Masking is display-only: the real value must still be captured.
+	for _, r := range "s3cret" {
+		m = updateTextPrompt(m, tkey(string(r)))
+	}
+	m = updateTextPrompt(m, tkey("enter"))
+	if m.Value() != "s3cret" {
+		t.Fatalf("expected captured value %q, got %q", "s3cret", m.Value())
+	}
+}
+
+func TestNewTextPrompt_DoesNotMask(t *testing.T) {
+	// Guard the non-secret path from regressing into masked echo.
+	m := NewTextPrompt("Name", "", "", nil)
+	if m.input.EchoMode != textinput.EchoNormal {
+		t.Fatalf("expected EchoNormal for text prompt, got %v", m.input.EchoMode)
 	}
 }
 


### PR DESCRIPTION
The flows read the password via PromptText, which left echo on. Add a masked PromptPassword variant (EchoPassword) and use it for both prompts.

Refs: WDY-1733