### PR TITLE
Multi-service run: single-container UX + live build logs

### DIFF
--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -265,7 +265,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Build all service images in parallel, then create and start containers.
-	failed, buildErr := buildServicesParallel(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip, opts.maxConcurrency)
+	failed, buildErr := buildServicesParallel(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip, opts.maxConcurrency, opts.progress == progressPlain)
 	if buildErr != nil {
 		return buildErr
 	}
@@ -331,11 +331,19 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 			RestartPolicy: restartPolicy,
 		}
 
-		cliLogln("Creating container for service %s...", name)
+		if len(services) == 1 {
+			cliLogln("Creating container for %s...", tui.App(appCfg.AppID))
+		} else {
+			cliLogln("Creating container for service %s...", name)
+		}
 		if err := createContainerWithProgress(ctx, conn.ContainerService, createReq); err != nil {
 			return fmt.Errorf("creating container for service %s: %w", name, err)
 		}
-		cliLogln("Service %s container created.", name)
+		if len(services) == 1 {
+			cliLogln("Container %s created.", tui.App(appCfg.AppID))
+		} else {
+			cliLogln("Service %s container created.", name)
+		}
 		return nil
 	}
 
@@ -385,7 +393,9 @@ func droppedSummary(dropped map[string]string) string {
 // maxConcurrentBuilds at a time). Services in skip are already on the device with
 // unchanged inputs, so their build+push is skipped (WDY-1692). Progress is shown
 // via a Bubbletea multi-spinner in interactive terminals and via plain log lines
-// otherwise.
+// otherwise. When plainProgress is set the spinner is dropped and each service's
+// buildx output streams live (prefixed per service) so per-layer timings are
+// visible while the build runs (--progress=plain).
 func buildServicesParallel(
 	ctx context.Context,
 	conn *grpcclient.AgentConnection,
@@ -397,6 +407,7 @@ func buildServicesParallel(
 	builder string,
 	skip map[string]bool,
 	maxConcurrency int,
+	plainProgress bool,
 ) (map[string]error, error) {
 	names := make([]string, 0, len(services))
 	for n := range services {
@@ -430,12 +441,21 @@ func buildServicesParallel(
 	}
 	sem := make(chan struct{}, concurrency)
 
+	// --progress=plain streams each service's buildx output live, so it can't
+	// share the terminal with the multi-spinner; fall back to live prefixed logs.
 	var prog *tea.Program
-	if isInteractiveTerminal() {
+	if isInteractiveTerminal() && !plainProgress {
 		title := fmt.Sprintf("Building %d service(s)...", len(names))
 		m := tui.NewMultiSpinner(title, names)
 		prog = tea.NewProgram(m)
 	}
+	if plainProgress {
+		cliLogln("Streaming build logs (--progress=plain); per-layer timings appear inline.")
+	}
+
+	// streamMu serializes concurrent prefixWriter output so live buildx logs from
+	// different services never interleave mid-line.
+	var streamMu sync.Mutex
 
 	var wg sync.WaitGroup
 	for _, name := range names {
@@ -470,16 +490,26 @@ func buildServicesParallel(
 			dockerfile, dockerfileErr := resolveDockerfile(contextDir, "", false)
 
 			var buildOut io.Writer
+			var logOut io.Writer
 			var logBuf bytes.Buffer
-			if prog != nil {
-				// In interactive mode, buffer all output (setup logs + build output).
-				// On error the buffer is printed after the spinner exits.
+			switch {
+			case prog != nil:
+				// Spinner mode: buffer all output (setup logs + build output). On
+				// error the buffer is printed after the spinner exits.
 				buildOut = &logBuf
-			} else {
+				logOut = &logBuf
+			case plainProgress:
+				// Live mode: stream buildx output as it arrives, prefixed per
+				// service and serialized so concurrent builds stay readable.
+				prefix := serviceLogPrefix(name, len(names) == 1)
+				stdoutPW := &prefixWriter{mu: &streamMu, w: os.Stdout, prefix: prefix}
+				stderrPW := &prefixWriter{mu: &streamMu, w: os.Stderr, prefix: prefix}
+				defer stdoutPW.Flush()
+				defer stderrPW.Flush()
+				buildOut = stdoutPW
+				logOut = stderrPW
+			default:
 				buildOut = os.Stdout
-			}
-			logOut := buildOut
-			if prog == nil {
 				logOut = os.Stderr
 			}
 			err := dockerfileErr
@@ -608,6 +638,66 @@ func resolveDeployableServices(services map[string]*appconfig.ServiceConfig, fai
 
 var serviceLogStyle = lipgloss.NewStyle().Foreground(tui.ColorInfo)
 
+// serviceLogPrefix returns the per-line prefix used when multiplexing service
+// log output. A single-service group is treated as a plain single container —
+// "just do a docker run" — so its logs stream unprefixed; multi-service groups
+// keep the styled "[service] " prefix so interleaved lines stay attributable.
+func serviceLogPrefix(service string, single bool) string {
+	if single {
+		return ""
+	}
+	return serviceLogStyle.Render(fmt.Sprintf("[%s] ", service))
+}
+
+// prefixWriter forwards each complete (newline-terminated) line to w with prefix
+// prepended, serializing through the shared mu so concurrent service builds
+// streaming live buildx output never interleave mid-line. A trailing partial
+// line is held in buf until a later write completes it or Flush is called.
+type prefixWriter struct {
+	mu     *sync.Mutex
+	w      io.Writer
+	prefix string
+	buf    []byte
+}
+
+func (pw *prefixWriter) Write(p []byte) (int, error) {
+	pw.mu.Lock()
+	defer pw.mu.Unlock()
+	pw.buf = append(pw.buf, p...)
+	for {
+		i := bytes.IndexByte(pw.buf, '\n')
+		if i < 0 {
+			break
+		}
+		if err := pw.emitLocked(pw.buf[:i+1]); err != nil {
+			return len(p), err
+		}
+		pw.buf = pw.buf[i+1:]
+	}
+	return len(p), nil
+}
+
+func (pw *prefixWriter) emitLocked(line []byte) error {
+	if pw.prefix != "" {
+		if _, err := io.WriteString(pw.w, pw.prefix); err != nil {
+			return err
+		}
+	}
+	_, err := pw.w.Write(line)
+	return err
+}
+
+// Flush emits any buffered partial line. Call once after the build finishes so
+// a final line without a trailing newline isn't dropped.
+func (pw *prefixWriter) Flush() {
+	pw.mu.Lock()
+	defer pw.mu.Unlock()
+	if len(pw.buf) > 0 {
+		_ = pw.emitLocked(pw.buf)
+		pw.buf = nil
+	}
+}
+
 // multiServiceCreateConfig builds the per-service AppConfig transmitted to
 // the agent for a standalone multi-service app. The group identity and
 // runtime context (isolation, frameworks, shared entitlements) must travel
@@ -647,6 +737,11 @@ func multiServiceContainerName(appID, serviceName string) string {
 // the agent resolves a secondary's namespace join at container create time
 // against the primary's running task.
 func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnection, appID string, ordered []string, opts runOptions, createService func(name string) error) error {
+	// A group with exactly one service reads as a plain single container: stream
+	// its logs unprefixed and use single-container messaging ("just do a docker
+	// run") rather than the "App group (N services)" group lifecycle wording.
+	single := len(ordered) == 1
+
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
 
@@ -656,7 +751,11 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 	defer signal.Stop(sigCh)
 	go func() {
 		<-sigCh
-		cliLogln("\nStopping services...")
+		if single {
+			cliLogln("\nStopping container...")
+		} else {
+			cliLogln("\nStopping services...")
+		}
 		runCancel()
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer stopCancel()
@@ -689,7 +788,11 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 				return fmt.Errorf("waiting for service %s to start: %w", name, err)
 			}
 		}
-		cliLogln("App group %s running in detached mode.", appID)
+		if single {
+			cliLogln("Application %s running in detached mode.", tui.App(appID))
+		} else {
+			cliLogln("App group %s running in detached mode.", appID)
+		}
 		return nil
 	}
 
@@ -761,10 +864,14 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 		close(lines)
 	}()
 
-	cliLogln("App group %s started (%d services).", appID, len(ordered))
+	if single {
+		cliLogln("Application %s started.", tui.App(appID))
+	} else {
+		cliLogln("App group %s started (%d services).", appID, len(ordered))
+	}
 
 	for line := range lines {
-		prefix := serviceLogStyle.Render(fmt.Sprintf("[%s] ", line.service))
+		prefix := serviceLogPrefix(line.service, single)
 		if line.stdout {
 			fmt.Fprintf(os.Stdout, "%s%s", prefix, line.data)
 		} else {
@@ -772,10 +879,10 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 		}
 	}
 
-	if runCtx.Err() != nil {
+	if single {
+		cliLogln("\nApplication %s stopped.", tui.App(appID))
+	} else {
 		cliLogln("\nApp group %s stopped.", appID)
-		return nil
 	}
-	cliLogln("\nApp group %s stopped.", appID)
 	return nil
 }

--- a/go/internal/cli/commands/multibuild_test.go
+++ b/go/internal/cli/commands/multibuild_test.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"bytes"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
@@ -76,6 +79,59 @@ func TestMultiServiceCreateConfig_ServiceFrameworksOverride(t *testing.T) {
 	// Shared + per-service entitlements are merged.
 	if len(got.Entitlements) != 2 {
 		t.Errorf("listener entitlements = %+v, want shared bluetooth + gpu", got.Entitlements)
+	}
+}
+
+func TestPrefixWriter_PrefixesLinesAndBuffersPartial(t *testing.T) {
+	var mu sync.Mutex
+	var out bytes.Buffer
+	pw := &prefixWriter{mu: &mu, w: &out, prefix: "[svc] "}
+
+	// A partial line (no newline yet) is buffered, not emitted — so live buildx
+	// output never interleaves another service's line mid-way.
+	if _, err := pw.Write([]byte("hello")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("partial line should be buffered, got %q", out.String())
+	}
+
+	// Completing the line flushes it, prefixed; the trailing partial stays buffered.
+	if _, err := pw.Write([]byte(" world\nse")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got, want := out.String(), "[svc] hello world\n"; got != want {
+		t.Fatalf("after newline: got %q, want %q", got, want)
+	}
+
+	// Flush emits the buffered remainder so the last line isn't dropped.
+	pw.Flush()
+	if got, want := out.String(), "[svc] hello world\n[svc] se"; got != want {
+		t.Fatalf("after flush: got %q, want %q", got, want)
+	}
+}
+
+func TestPrefixWriter_EmptyPrefixPassesThrough(t *testing.T) {
+	var mu sync.Mutex
+	var out bytes.Buffer
+	pw := &prefixWriter{mu: &mu, w: &out, prefix: ""}
+	if _, err := pw.Write([]byte("line\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got, want := out.String(), "line\n"; got != want {
+		t.Fatalf("empty prefix: got %q, want %q", got, want)
+	}
+}
+
+func TestServiceLogPrefix_SingleServiceHasNoPrefix(t *testing.T) {
+	// A single-service group reads as a plain single container: its logs stream
+	// unprefixed, like a `docker run`. Multi-service groups keep the prefix so
+	// interleaved lines stay attributable.
+	if got := serviceLogPrefix("talker", true); got != "" {
+		t.Errorf("serviceLogPrefix(single) = %q, want empty", got)
+	}
+	if got := serviceLogPrefix("talker", false); !strings.Contains(got, "talker") {
+		t.Errorf("serviceLogPrefix(multi) = %q, want it to contain the service name", got)
 	}
 }
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -486,6 +486,11 @@ type runOptions struct {
 	// push on failure, chunkingForce uses chunk-diff with no fallback, and
 	// chunkingOff skips chunk-diff entirely (registry push only).
 	chunking string
+	// progress controls multi-service build output: progressAuto (default) shows
+	// a multi-spinner and surfaces buildx logs only on failure, while
+	// progressPlain drops the spinner and streams each service's buildx output
+	// live (prefixed per service) so per-layer timings are visible.
+	progress string
 }
 
 // Valid values for runOptions.chunking. An empty value is treated as
@@ -505,6 +510,24 @@ func validateChunkingMode(mode string) error {
 		return nil
 	default:
 		return fmt.Errorf("invalid --chunking value %q: must be auto, force, or off", mode)
+	}
+}
+
+// Valid values for runOptions.progress. An empty value is treated as
+// progressAuto so callers that build runOptions directly keep current behavior.
+const (
+	progressAuto  = "auto"
+	progressPlain = "plain"
+)
+
+// validateProgressMode rejects unknown --progress values. Empty is allowed and
+// means progressAuto.
+func validateProgressMode(mode string) error {
+	switch mode {
+	case "", progressAuto, progressPlain:
+		return nil
+	default:
+		return fmt.Errorf("invalid --progress value %q: must be auto or plain", mode)
 	}
 }
 
@@ -537,6 +560,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().IntVar(&opts.maxConcurrency, "max-concurrency", 0, "Multi-service: max service images to build+push at once (0 = auto-throttle large groups)")
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
 	cmd.Flags().StringVar(&opts.chunking, "chunking", chunkingAuto, "Content-defined chunking (CBC) deploy path: auto (try chunk-diff, fall back to registry push), force (chunk-diff only, no fallback), or off (registry push only)")
+	cmd.Flags().StringVar(&opts.progress, "progress", progressAuto, "Multi-service build output: auto (spinner; show buildx logs only on failure) or plain (stream each service's buildx output live with per-layer timings)")
 
 	return cmd
 }
@@ -588,6 +612,9 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		return fmt.Errorf("--max-concurrency must be >= 0 (0 = auto)")
 	}
 	if err := validateChunkingMode(opts.chunking); err != nil {
+		return err
+	}
+	if err := validateProgressMode(opts.progress); err != nil {
 		return err
 	}
 

--- a/go/internal/cli/commands/stress_test.go
+++ b/go/internal/cli/commands/stress_test.go
@@ -133,8 +133,11 @@ func TestBuildServicesParallelStress(t *testing.T) {
 	}
 
 	maxConc := 1 + r.Intn(8)
+	// Exercise both the spinner-buffered and the live prefixed-stream paths under
+	// the race detector so prefixWriter's shared-mutex serialization is covered.
+	plainProgress := r.Intn(2) == 0
 	failed, infraErr := buildServicesParallel(
-		context.Background(), nil, 5000, root, appID, services, "linux/arm64", nil, "docker", skip, maxConc)
+		context.Background(), nil, 5000, root, appID, services, "linux/arm64", nil, "docker", skip, maxConc, plainProgress)
 	if infraErr != nil {
 		t.Fatalf("unexpected infra error: %v", infraErr)
 	}


### PR DESCRIPTION
## What

Two related improvements to the multi-service `wendy run` path.

### 1. Single-service groups present as a single container
A `services` map with exactly one entry (or `--service X` narrowing to one) now reads like a plain single container instead of an "App group":
- logs stream **unprefixed** (no `[service]` prefix)
- create/start/stop/detach messaging uses single-container wording (`Application X started.` / `…stopped.`) instead of `App group (N services)`

Internal container/image naming is unchanged, so stop/restart addressing and build-skip fingerprints keep working.

### 2. `--progress` flag for real-time build logs
New flag on `wendy run`, mirroring docker's semantics:
- `auto` (default) — unchanged: multi-spinner, buildx logs surfaced only on failure.
- `plain` — drops the spinner and **streams each service's buildx output live**, prefixed per service and serialized through a shared mutex so concurrent builds never interleave mid-line.

This surfaces buildx's per-layer timings (`=> [stage] … DONE 12.3s`) in real time, which is what you need to debug slow layers.

```
wendy run --progress=plain
```

buildx already emits plain progress here — its stdout is a pipe, not a TTY, so `auto` falls back to plain — the spinner path was just buffering that output and discarding it on success. No `docker.go` change was needed.

## Testing
- New unit tests: `prefixWriter` (line buffering + prefix + flush) and `serviceLogPrefix`.
- The concurrency stress test now randomly exercises both the spinner and live-stream paths.
- Full `internal/cli/commands` suite passes with `-race`; `gofmt` clean; `git diff --check` clean.

## Out of scope
`wendy build` still has no multi-service path (it builds a single image and ignores the `services` array); this PR only touches the parallel builder used by `wendy run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)