### PR TITLE
Clean up the `wendy` --help pages and add `wendy run --watch`

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/login.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/login.md
@@ -1,3 +1,10 @@
+> **Tip:** [`wendy cloud login`](../cloud/login.md) is the recommended entry
+> point for authenticating with Wendy Cloud. This page documents
+> `wendy auth login`, which behaves identically and is kept for backward
+> compatibility but is no longer listed in the top-level help. The advanced
+> session commands (`use`, `default`, `refresh-certs`) remain under
+> `wendy auth`.
+
 Authenticates the CLI with Wendy Cloud. Opens a browser to the cloud dashboard, waits for the OAuth callback, generates a key pair and CSR, then issues and stores an mTLS certificate. Subsequent commands that connect to provisioned devices use this certificate automatically.
 
 After displaying the login URL, the CLI also prints a QR code in the terminal. You can scan this QR code with the **Wendy iOS app** to authenticate on your phone instead of (or in addition to) the browser flow.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/use.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/use.md
@@ -2,6 +2,12 @@
 
 Sets the default Wendy Cloud session used when several auth sessions are stored and no `--cloud-grpc` flag is given.
 
+> **Note:** The common auth flow — [`login`](../cloud/login.md),
+> [`logout`](../cloud/logout.md), and [`status`](../cloud/status.md) — is
+> surfaced under `wendy cloud`. Advanced session management (`use`, `default`,
+> `refresh-certs`) remains under `wendy auth`, which is hidden from the
+> top-level help but fully functional.
+
 ## Usage
 
 ```sh

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/login.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/login.md
@@ -1,0 +1,34 @@
+# `wendy cloud login`
+
+Authenticates the CLI with Wendy Cloud. This is the primary login entry point.
+
+## Usage
+
+```sh
+wendy cloud login
+wendy cloud login --cloud <dashboard-url> --cloud-grpc <grpc-endpoint>
+```
+
+## Description
+
+`wendy cloud login` is identical to [`wendy auth login`](../auth/login.md) — it
+reuses the same implementation. It opens a browser to the cloud dashboard, waits
+for the OAuth callback, generates a key pair and CSR, then issues and stores an
+mTLS certificate that subsequent commands use automatically.
+
+`wendy auth login` remains functional for backward compatibility but is no
+longer listed in the top-level help. See [`wendy auth login`](../auth/login.md)
+for the full flag reference and multi-session behaviour.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--cloud` | `""` | Dashboard URL of a non-default cloud instance. |
+| `--cloud-grpc` | `""` | gRPC endpoint of a non-default cloud instance. |
+
+## See also
+
+- [`wendy cloud logout`](./logout.md)
+- [`wendy cloud status`](./status.md)
+- [`wendy auth use`](../auth/use.md) — advanced multi-session management

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/logout.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/logout.md
@@ -1,0 +1,20 @@
+# `wendy cloud logout`
+
+Removes the stored Wendy Cloud auth session. Equivalent to `wendy auth logout`.
+
+## Usage
+
+```sh
+wendy cloud logout
+```
+
+## Description
+
+`wendy cloud logout` clears the stored mTLS session from `~/.wendy/config.json`.
+It reuses the same implementation as the (now hidden) `wendy auth logout` and
+remains the surfaced entry point for signing out.
+
+## See also
+
+- [`wendy cloud login`](./login.md)
+- [`wendy cloud status`](./status.md)

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/meta.json
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/meta.json
@@ -1,0 +1,9 @@
+{
+  "pages": [
+    "login",
+    "logout",
+    "status",
+    "discover",
+    "tunnel"
+  ]
+}

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/status.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/status.md
@@ -1,0 +1,24 @@
+# `wendy cloud status`
+
+Shows the currently active Wendy Cloud auth session. Equivalent to `wendy auth status`.
+
+## Usage
+
+```sh
+wendy cloud status
+```
+
+## Description
+
+`wendy cloud status` reports the stored Wendy Cloud session — the dashboard URL,
+gRPC endpoint, and certificate state. It reuses the same implementation as the
+(now hidden) `wendy auth status` and is the surfaced way to check who you are
+logged in as.
+
+When more than one session is stored, use [`wendy auth use`](../auth/use.md) to
+inspect and set the default.
+
+## See also
+
+- [`wendy cloud login`](./login.md)
+- [`wendy cloud logout`](./logout.md)

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/completion.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/completion.md
@@ -2,6 +2,10 @@
 
 Generates or installs shell completion scripts for the `wendy` CLI.
 
+> **Note:** `wendy completion` is not listed in `wendy --help` to keep the
+> top-level surface focused, but it is fully functional. Run
+> `wendy completion --help` directly to see its subcommands.
+
 ## Usage
 
 ```sh

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/enroll.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/enroll.md
@@ -2,6 +2,10 @@
 
 Enrolls the connected device with Wendy Cloud (or a local [pki-core](../../../../pki/)) and provisions it with mTLS certificates.
 
+> **Note:** `wendy device enroll` is an advanced command and is not listed in
+> `wendy device --help`. It remains fully functional. For most setups, use
+> [`wendy device setup`](./setup.md) instead.
+
 ## Usage
 
 ```sh
@@ -10,7 +14,7 @@ wendy device enroll [--name <name>] [--cloud-grpc <endpoint>] [flags]
 
 ## Description
 
-`wendy device enroll` creates an enrollment token using your stored auth session, then calls `StartProvisioning` on the connected agent so it fetches its certificate. Run [`wendy auth login`](../auth/login.md) first.
+`wendy device enroll` creates an enrollment token using your stored auth session, then calls `StartProvisioning` on the connected agent so it fetches its certificate. Run [`wendy cloud login`](../cloud/login.md) first.
 
 The enrolled device is registered in Wendy Cloud under a human-readable **name**. The name is fixed at enrollment time and cannot be changed afterward, so the command resolves it as follows:
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/get-default.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/get-default.md
@@ -1,4 +1,7 @@
 
+> **Note:** `wendy device get-default` is not listed in `wendy device --help`,
+> but it remains fully functional.
+
 Shows the current [default device](../../device-selection.md), if one is set.
 
 Use this to confirm what is persisted in the CLI configuration:

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/meta.json
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/meta.json
@@ -1,0 +1,21 @@
+{
+  "pages": [
+    "apps",
+    "logs",
+    "dashboard",
+    "info",
+    "set-default",
+    "unset-default",
+    "update",
+    "volumes",
+    "wifi",
+    "bluetooth",
+    "---Reference---",
+    "enroll",
+    "setup",
+    "get-default",
+    "provision",
+    "telemetry-stream",
+    "version"
+  ]
+}

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
@@ -1,3 +1,6 @@
+> **Note:** `wendy device set-default` is not listed in `wendy device --help`,
+> but it remains fully functional.
+
 Selects a device as the [default device](../../device-selection.md), so that other commands default to this device if available.
 
 The default can be a hostname, IP address, provider key, or explicit `host:port` value:

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
@@ -1,6 +1,3 @@
-> **Note:** `wendy device set-default` is not listed in `wendy device --help`,
-> but it remains fully functional.
-
 Selects a device as the [default device](../../device-selection.md), so that other commands default to this device if available.
 
 The default can be a hostname, IP address, provider key, or explicit `host:port` value:

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/setup.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/setup.md
@@ -1,3 +1,6 @@
+> **Note:** `wendy device setup` is an advanced command and is not listed in
+> `wendy device --help`. It remains fully functional.
+
 Interactive wizard that provisions the device, configures WiFi, and optionally updates the agent. Connects the device to [Wendy Cloud](../../../../cloud/) using the CLI's stored mTLS certificates.
 
 For provisioning against a self-hosted [pki-core](../../../../pki/) instead, use [`wendy device provision`](./provision.md).

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/telemetry-stream.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/telemetry-stream.md
@@ -1,3 +1,6 @@
+> **Note:** `wendy device telemetry-stream` is not listed in
+> `wendy device --help`, but it remains fully functional.
+
 Streams all OTel data as a custom JSONL format. This is used by the [VSCode extension](../../../../vscode/) to render the OTel traces, metrics and logs using only a single API call.
 
 ## Planned: runtime telemetry for embedded apps (not yet shipped)

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
@@ -41,12 +41,27 @@ succeeds, Mac agents appear under `lanDevices` in JSON output with
 `--device {hostname}:50051`, because discovery can be blocked by network policy
 or macOS permissions.
 
+## Local run targets
+
+By default `wendy discover` hides **local run targets** — this machine,
+Docker/OrbStack, and Apple Container — so the table shows only separate WendyOS
+devices. Pass `--all` to include them:
+
+```sh
+wendy discover --all
+```
+
+> **Note:** JSON output (`wendy discover --json`) always includes local run
+> targets regardless of `--all`, so scripts and MCP callers continue to receive
+> the full set.
+
 ## Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--timeout` | `5s` | How long to wait for mDNS responses |
 | `--json` | `false` | Output results as a JSON array instead of a table |
+| `--all` | `false` | Include local run targets (this machine, Docker/OrbStack, Apple Container) in the table. JSON output always includes them regardless of this flag. |
 
 ## Interactive table
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/meta.json
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/meta.json
@@ -1,0 +1,20 @@
+{
+  "pages": [
+    "init",
+    "run",
+    "project",
+    "device",
+    "cloud",
+    "analytics",
+    "cache",
+    "---Reference---",
+    "auth",
+    "build",
+    "completion",
+    "discover",
+    "json",
+    "os",
+    "tour",
+    "utils"
+  ]
+}

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -129,6 +129,30 @@ On a **Windows host**, `wendy run` returns an actionable error for Swift project
 | `--max-concurrency <n>` | Max service images to build+push at once in multi-service projects. 0 = auto-throttle large groups (default). |
 | `--user-args <args>` | Extra arguments to pass to the container at runtime. |
 | `--chunking <mode>` | Controls the content-based chunking (CBC) chunk-diff deploy path: `auto` (default), `force`, or `off`. See [Deploy path: `--chunking`](#deploy-path---chunking). |
+| `--all` | Include local run targets (this machine, Docker/OrbStack, Apple Container) in the device picker. Hidden by default so the picker lists WendyOS devices first. |
+| `--watch` | Watch the project directory and redeploy on every change. Runs detached and non-interactive. See [Watch mode](#watch-mode). |
+| `--debounce <ms>` | Watch mode only: quiet period in milliseconds after the last change before redeploying (default `400`). |
+| `--verbose` | Watch mode only: always show build output. By default build output is hidden unless a build fails. |
+
+## Watch mode
+
+Pass `--watch` to rebuild and redeploy automatically whenever source files in the
+project directory change:
+
+```sh
+wendy run --watch
+wendy run --watch --debounce 800 --verbose
+```
+
+In watch mode the deployment is always **detached** and **non-interactive**
+(equivalent to `--detach --yes`), so the watch loop never blocks on a prompt. A
+rapid sequence of saves is coalesced by the debounce window (default 400 ms) so a
+single redeploy runs after edits settle. Build output is hidden unless a build
+fails; pass `--verbose` to always show it, or `--debounce <ms>` to tune the quiet
+period.
+
+> **Note:** `wendy watch` is kept as a hidden alias for `wendy run --watch` for
+> backward compatibility, but `wendy run --watch` is the supported entry point.
 
 ## Deploy path: `--chunking`
 

--- a/go/internal/cli/commands/apps.go
+++ b/go/internal/cli/commands/apps.go
@@ -595,9 +595,10 @@ func newAppsRemoveCmd() *cobra.Command {
 
 func newPsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "ps",
-		Short: "List running containers (alias for 'apps list')",
-		RunE:  newAppsListCmd().RunE,
+		Use:    "ps",
+		Short:  "List running containers (alias for 'apps list')",
+		Hidden: true,
+		RunE:   newAppsListCmd().RunE,
 	}
 }
 

--- a/go/internal/cli/commands/cloud.go
+++ b/go/internal/cli/commands/cloud.go
@@ -21,6 +21,13 @@ func newCloudCmd() *cobra.Command {
 		Short: "Manage Wendy Cloud resources",
 	}
 
+	// Surface the common Wendy Cloud auth flow under `wendy cloud`. These reuse
+	// the same constructors as the (now hidden) top-level `wendy auth` command;
+	// the advanced session commands (refresh-certs, use, default) remain
+	// reachable only via `wendy auth`.
+	cmd.AddCommand(newAuthLoginCmd())
+	cmd.AddCommand(newAuthLogoutCmd())
+	cmd.AddCommand(newAuthStatusCmd())
 	cmd.AddCommand(newCloudEnrollDeviceCmd())
 	cmd.AddCommand(newCloudDiscoverCmd())
 	cmd.AddCommand(newCloudRunCmd())

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -298,6 +298,9 @@ func TestNewDeviceCmd(t *testing.T) {
 	if versionCmd, _, err := cmd.Find([]string{"version"}); err != nil || !versionCmd.Hidden {
 		t.Errorf("device version should be hidden; cmd=%v err=%v", versionCmd, err)
 	}
+	if setDefaultCmd, _, err := cmd.Find([]string{"set-default"}); err != nil || setDefaultCmd.Hidden {
+		t.Errorf("device set-default should be visible; cmd=%v err=%v", setDefaultCmd, err)
+	}
 
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -84,11 +85,84 @@ func TestNewRunCmd(t *testing.T) {
 	}
 
 	// Verify expected flags exist.
-	expectedFlags := []string{"build-type", "builder", "debug", "deploy", "detach", "restart-unless-stopped", "restart-on-failure", "no-restart", "prefix", "user-args"}
+	expectedFlags := []string{"build-type", "builder", "debug", "deploy", "detach", "restart-unless-stopped", "restart-on-failure", "no-restart", "prefix", "user-args", "watch", "debounce", "verbose"}
 	for _, name := range expectedFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("missing flag %q", name)
 		}
+	}
+}
+
+// TestWithWatchInvariants verifies the watch loop's required invariants are
+// applied: it must run detached and never prompt, so a rapid series of saves
+// can't block on log streaming or an interactive confirmation.
+func TestWithWatchInvariants(t *testing.T) {
+	got := withWatchInvariants(runOptions{})
+	if !got.detach {
+		t.Error("detach should be forced true in watch mode")
+	}
+	if !got.yes {
+		t.Error("yes should be forced true in watch mode")
+	}
+
+	// Other options must be preserved.
+	in := runOptions{product: "demo", prefix: "apps/demo", chunking: chunkingForce}
+	out := withWatchInvariants(in)
+	if out.product != "demo" || out.prefix != "apps/demo" || out.chunking != chunkingForce {
+		t.Errorf("watch invariants clobbered unrelated options: %+v", out)
+	}
+}
+
+// TestRunCmdWatchFlagAlias verifies `wendy run --watch` parses and that the
+// debounce/verbose flags carry the same defaults as the standalone `wendy watch`
+// command they mirror.
+func TestRunCmdWatchFlagAlias(t *testing.T) {
+	cmd := newRunCmd()
+	if err := cmd.Flags().Parse([]string{"--watch"}); err != nil {
+		t.Fatalf("parse --watch: %v", err)
+	}
+	if debounce := cmd.Flags().Lookup("debounce"); debounce == nil || debounce.DefValue != "400" {
+		t.Fatalf("debounce flag default = %v; want 400", debounce)
+	}
+}
+
+// TestRunResolveOptions_ExcludesLocalByDefault verifies that, without --all,
+// `wendy run`'s interactive picker hides the on-machine run targets.
+func TestRunResolveOptions_ExcludesLocalByDefault(t *testing.T) {
+	cfg := resolveConfig{excludeProviderKeys: map[string]bool{}}
+	for _, o := range runResolveOptions(runOptions{}) {
+		o(&cfg)
+	}
+	for _, k := range providers.LocalProviderKeys() {
+		if !cfg.excludeProviderKeys[k] {
+			t.Errorf("provider %q should be excluded from the picker by default", k)
+		}
+	}
+}
+
+// TestRunResolveOptions_AllShowsLocal verifies that --all surfaces the local
+// run targets in the picker again.
+func TestRunResolveOptions_AllShowsLocal(t *testing.T) {
+	cfg := resolveConfig{excludeProviderKeys: map[string]bool{}}
+	for _, o := range runResolveOptions(runOptions{allTargets: true}) {
+		o(&cfg)
+	}
+	for _, k := range providers.LocalProviderKeys() {
+		if cfg.excludeProviderKeys[k] {
+			t.Errorf("--all should not exclude provider %q", k)
+		}
+	}
+}
+
+// TestRunResolveOptions_YesIsNonInteractive verifies --yes keeps suppressing the
+// interactive picker (preserved while refactoring the option builder).
+func TestRunResolveOptions_YesIsNonInteractive(t *testing.T) {
+	cfg := resolveConfig{excludeProviderKeys: map[string]bool{}}
+	for _, o := range runResolveOptions(runOptions{yes: true}) {
+		o(&cfg)
+	}
+	if !cfg.nonInteractive {
+		t.Error("--yes should set non-interactive resolve")
 	}
 }
 
@@ -383,7 +457,7 @@ func TestNewCloudDeviceCmd(t *testing.T) {
 	}
 }
 
-func TestPublicDeviceAliasesRemainVisible(t *testing.T) {
+func TestPsAliasIsHiddenButRunnable(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		cmd  *cobra.Command
@@ -392,12 +466,14 @@ func TestPublicDeviceAliasesRemainVisible(t *testing.T) {
 		{name: "cloud device", cmd: newCloudDeviceCmd()},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			// ps is hidden from help but must remain resolvable so the alias
+			// keeps working for anyone who already relies on it.
 			psCmd, _, err := tc.cmd.Find([]string{"ps"})
 			if err != nil {
 				t.Fatalf("Find(ps): %v", err)
 			}
-			if psCmd.Name() != "ps" || psCmd.Hidden {
-				t.Fatalf("ps should be a visible command; cmd=%v hidden=%v", psCmd.Name(), psCmd.Hidden)
+			if psCmd.Name() != "ps" || !psCmd.Hidden {
+				t.Fatalf("ps should be a hidden (but runnable) command; cmd=%v hidden=%v", psCmd.Name(), psCmd.Hidden)
 			}
 			if !strings.Contains(psCmd.Short, "alias for 'apps list'") {
 				t.Fatalf("ps help should point at apps list, got %q", psCmd.Short)
@@ -410,8 +486,8 @@ func TestPublicDeviceAliasesRemainVisible(t *testing.T) {
 			if err := tc.cmd.Execute(); err != nil {
 				t.Fatalf("help: %v", err)
 			}
-			if !strings.Contains(buf.String(), "ps") {
-				t.Fatalf("parent help should list visible ps alias: %s", buf.String())
+			if strings.Contains(buf.String(), "\n  ps ") {
+				t.Fatalf("parent help should not list hidden ps alias: %s", buf.String())
 			}
 		})
 	}

--- a/go/internal/cli/commands/completion_test.go
+++ b/go/internal/cli/commands/completion_test.go
@@ -64,8 +64,8 @@ func TestCompletion_HasInstallSubcommand(t *testing.T) {
 	if compCmd == nil {
 		t.Fatal("expected `completion` subcommand on root")
 	}
-	if compCmd.GroupID != "misc" {
-		t.Errorf("completion.GroupID = %q; want %q", compCmd.GroupID, "misc")
+	if compCmd.GroupID != "settings" {
+		t.Errorf("completion.GroupID = %q; want %q", compCmd.GroupID, "settings")
 	}
 	want := map[string]bool{"bash": true, "zsh": true, "fish": true, "powershell": true, "install": true}
 	have := []string{}

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -299,10 +299,9 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 
 func newDeviceSetDefaultCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "set-default [hostname]",
-		Short:  "Set the default device hostname",
-		Hidden: true,
-		Args:   cobra.MaximumNArgs(1),
+		Use:   "set-default [hostname]",
+		Short: "Set the default device hostname",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var device string
 			if len(args) > 0 {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -44,10 +44,9 @@ func newDeviceCmd() *cobra.Command {
 	}
 
 	cmd.AddGroup(
+		&cobra.Group{ID: "common", Title: "Common Commands:"},
 		&cobra.Group{ID: "manage", Title: "Device Management:"},
-		&cobra.Group{ID: "monitor", Title: "Monitoring:"},
 		&cobra.Group{ID: "hardware", Title: "Hardware:"},
-		&cobra.Group{ID: "data", Title: "Apps & Storage:"},
 	)
 
 	addToGroup := func(groupID string, cmds ...*cobra.Command) {
@@ -57,6 +56,14 @@ func newDeviceCmd() *cobra.Command {
 		}
 	}
 
+	// Common Commands: the subcommands used in everyday workflows, surfaced at
+	// the top in rough order of usefulness.
+	addToGroup("common",
+		newAppsCmd(),
+		newDeviceLogsCmd(),
+		newROS2Cmd(),
+		newDeviceDashboardCmd(),
+	)
 	addToGroup("manage",
 		newDeviceInfoCmd(),
 		newDeprecatedDeviceVersionCmd(),
@@ -68,12 +75,7 @@ func newDeviceCmd() *cobra.Command {
 		newDeviceUnenrollCmd(),
 		newDeviceUpdateCmd(),
 		newDeviceSyncTimeCmd(),
-	)
-	addToGroup("monitor",
-		newDeviceLogsCmd(),
-		newDeviceDashboardCmd(),
-		newDeviceTelemetryStreamCmd(),
-		newROS2Cmd(),
+		newVolumesCmd(),
 	)
 	addToGroup("hardware",
 		newWifiCmd(),
@@ -82,9 +84,10 @@ func newDeviceCmd() *cobra.Command {
 		newCameraCmd(),
 		newHardwareCmd(),
 	)
-	addToGroup("data",
-		newAppsCmd(),
-		newVolumesCmd(),
+	// Hidden commands stay registered (and runnable) but are kept off the help
+	// menu; they are hidden via their own constructors.
+	addToGroup("manage",
+		newDeviceTelemetryStreamCmd(),
 		newPsCmd(),
 	)
 
@@ -296,9 +299,10 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 
 func newDeviceSetDefaultCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "set-default [hostname]",
-		Short: "Set the default device hostname",
-		Args:  cobra.MaximumNArgs(1),
+		Use:    "set-default [hostname]",
+		Short:  "Set the default device hostname",
+		Hidden: true,
+		Args:   cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var device string
 			if len(args) > 0 {
@@ -329,9 +333,10 @@ func newDeviceSetDefaultCmd() *cobra.Command {
 
 func newDeviceGetDefaultCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "get-default",
-		Short: "Show the current default device",
-		Args:  cobra.NoArgs,
+		Use:    "get-default",
+		Short:  "Show the current default device",
+		Hidden: true,
+		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
@@ -398,9 +403,10 @@ func newDeviceUnsetDefaultCmd() *cobra.Command {
 
 func newDeviceSetupCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "setup",
-		Short: "Interactive device setup: enroll, name, and configure WiFi",
-		Long:  "Walks through enrollment (with device naming) and WiFi configuration for a new device.",
+		Use:    "setup",
+		Short:  "Interactive device setup: enroll, name, and configure WiFi",
+		Long:   "Walks through enrollment (with device naming) and WiFi configuration for a new device.",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			conn, err := connectToAgent(ctx, SuppressProvisioningHint())
@@ -505,9 +511,10 @@ func newDeviceEnrollCmd() *cobra.Command {
 	var cloudGRPC string
 
 	cmd := &cobra.Command{
-		Use:   "enroll",
-		Short: "Enroll this device with Wendy Cloud or a local pki-core",
-		Long:  "Creates an enrollment token using your stored auth session and provisions the connected device with mTLS certificates. Run 'wendy auth login' first.",
+		Use:    "enroll",
+		Short:  "Enroll this device with Wendy Cloud or a local pki-core",
+		Long:   "Creates an enrollment token using your stored auth session and provisions the connected device with mTLS certificates. Run 'wendy cloud login' first.",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -1138,8 +1145,9 @@ func newDeviceTelemetryStreamCmd() *cobra.Command {
 	var enableTraces bool
 
 	cmd := &cobra.Command{
-		Use:   "telemetry-stream",
-		Short: "Stream telemetry data (logs, metrics, traces) as JSONL",
+		Use:    "telemetry-stream",
+		Short:  "Stream telemetry data (logs, metrics, traces) as JSONL",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no flags were explicitly set, enable all streams.
 			if !cmd.Flags().Changed("logs") && !cmd.Flags().Changed("metrics") && !cmd.Flags().Changed("traces") {

--- a/go/internal/cli/commands/device_sync_time.go
+++ b/go/internal/cli/commands/device_sync_time.go
@@ -10,8 +10,9 @@ import (
 
 func newDeviceSyncTimeCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "sync-time",
-		Short: "Sync the clock on nearby WendyOS devices via Roughtime multicast",
+		Use:    "sync-time",
+		Hidden: true,
+		Short:  "Sync the clock on nearby WendyOS devices via Roughtime multicast",
 		Long: `Queries a Roughtime server for a cryptographically signed timestamp,
 then multicasts the signed proof to all WendyOS devices on the local network.
 Devices verify the Roughtime signature themselves — the Mac is an untrusted relay.`,

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -30,6 +30,7 @@ import (
 func newDiscoverCmd() *cobra.Command {
 	var discoverType string
 	var timeout time.Duration
+	var all bool
 
 	cmd := &cobra.Command{
 		Use:   "discover",
@@ -65,29 +66,37 @@ func newDiscoverCmd() *cobra.Command {
 					timeout = 5 * time.Second
 				}
 				opts.Timeout = timeout
+				// JSON output always lists every target so scripts/MCP keep the
+				// full set regardless of --all.
 				return discoverJSON(cmd.Context(), opts)
 			}
 
 			if timeoutSet {
 				opts.Timeout = timeout
-				return discoverOnce(cmd.Context(), opts)
+				return discoverOnce(cmd.Context(), opts, all)
 			}
-			return discoverContinuous(cmd.Context(), opts)
+			return discoverContinuous(cmd.Context(), opts, all)
 		},
 	}
 
 	cmd.Flags().StringVar(&discoverType, "type", "all", "Discovery type: usb, lan, bluetooth, external, all")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "Scan once for this duration then exit")
+	cmd.Flags().BoolVar(&all, "all", false, "Include local run targets (this machine, Docker/OrbStack, Apple Container) in the results; hidden by default")
 
 	return cmd
 }
 
-// discoverExternalDevices queries all registered providers for their devices.
-// This uses AllProviders (not just available ones) so devices are discoverable
-// even when the build toolchain isn't installed.
-func discoverExternalDevices(ctx context.Context) []models.ExternalDevice {
+// discoverExternalDevices queries registered providers for their devices. This
+// uses AllProviders (not just available ones) so devices are discoverable even
+// when the build toolchain isn't installed. Unless includeLocal is set, local
+// run targets (this machine, Docker/OrbStack, Apple Container) are skipped so
+// the table lists separate WendyOS devices by default.
+func discoverExternalDevices(ctx context.Context, includeLocal bool) []models.ExternalDevice {
 	var all []models.ExternalDevice
 	for _, p := range providers.AllProviders() {
+		if !includeLocal && providers.IsLocalProviderKey(p.Key()) {
+			continue
+		}
 		devices, err := p.DiscoverDevices(ctx)
 		if err != nil {
 			continue
@@ -121,7 +130,8 @@ func discoverJSON(ctx context.Context, opts discovery.DiscoveryOptions) error {
 	sortLANDevicesForDiscover(collection.LANDevices)
 
 	if shouldIncludeExternal(opts) {
-		collection.ExternalDevices = discoverExternalDevices(ctx)
+		// JSON output always includes local run targets (see newDiscoverCmd).
+		collection.ExternalDevices = discoverExternalDevices(ctx, true)
 	}
 
 	data, err := json.MarshalIndent(collection, "", "  ")
@@ -133,7 +143,8 @@ func discoverJSON(ctx context.Context, opts discovery.DiscoveryOptions) error {
 }
 
 // discoverOnce runs a single scan with the given timeout and prints results.
-func discoverOnce(ctx context.Context, opts discovery.DiscoveryOptions) error {
+// includeLocal surfaces local run targets that are hidden by default.
+func discoverOnce(ctx context.Context, opts discovery.DiscoveryOptions, includeLocal bool) error {
 	s := tui.NewSpinner("Scanning for WendyOS devices...")
 
 	includeExternal := shouldIncludeExternal(opts)
@@ -145,7 +156,7 @@ func discoverOnce(ctx context.Context, opts discovery.DiscoveryOptions) error {
 			annotateLANUSBFromEthernet(collection)
 			sortLANDevicesForDiscover(collection.LANDevices)
 			if includeExternal {
-				collection.ExternalDevices = discoverExternalDevices(ctx)
+				collection.ExternalDevices = discoverExternalDevices(ctx, includeLocal)
 			}
 		}
 		return tui.SpinnerDoneMsg{Result: collection, Err: err}
@@ -197,9 +208,10 @@ func noDevicesHint() string {
 }
 
 // discoverContinuous runs scans in a loop, refreshing the table until Ctrl+C.
-func discoverContinuous(ctx context.Context, opts discovery.DiscoveryOptions) error {
+// includeLocal surfaces local run targets that are hidden by default.
+func discoverContinuous(ctx context.Context, opts discovery.DiscoveryOptions, includeLocal bool) error {
 	opts.Timeout = 3 * time.Second // per-scan timeout
-	m := newDiscoverModel(ctx, opts)
+	m := newDiscoverModel(ctx, opts, includeLocal)
 	p := tea.NewProgram(m)
 	if _, err := p.Run(); err != nil {
 		return fmt.Errorf("TUI error: %w", err)
@@ -273,9 +285,10 @@ type discoverModel struct {
 	flashMessage       string
 	flashIsError       bool
 	updatingDeviceName string // non-empty while a background update is running
+	includeLocal       bool   // surface local run targets hidden by default
 }
 
-func newDiscoverModel(ctx context.Context, opts discovery.DiscoveryOptions) discoverModel {
+func newDiscoverModel(ctx context.Context, opts discovery.DiscoveryOptions, includeLocal bool) discoverModel {
 	m := discoverModel{
 		ctx:             ctx,
 		opts:            opts,
@@ -283,6 +296,7 @@ func newDiscoverModel(ctx context.Context, opts discovery.DiscoveryOptions) disc
 		bleSeen:         make(map[string]time.Time),
 		table:           newDiscoverTable(true),
 		includeExternal: shouldIncludeExternal(opts),
+		includeLocal:    includeLocal,
 	}
 	m.refreshTable()
 	return m
@@ -333,7 +347,7 @@ func (m discoverModel) scanBluetooth() tea.Cmd {
 
 func (m discoverModel) scanExternal() tea.Cmd {
 	return func() tea.Msg {
-		return extScanMsg{devices: discoverExternalDevices(m.ctx)}
+		return extScanMsg{devices: discoverExternalDevices(m.ctx, m.includeLocal)}
 	}
 }
 

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -86,7 +86,7 @@ func TestDiscoverModel_UpdateReturnsDelayedCmd(t *testing.T) {
 	t.Setenv("WENDY_DISCOVER_ETHERNET_INTERVAL", "1ms")
 	t.Setenv("WENDY_DISCOVER_EXTERNAL_INTERVAL", "1ms")
 
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 
 	// Each scan message type should return a non-nil command (the delayed rescan).
 	cases := []struct {
@@ -115,7 +115,7 @@ func TestDiscoverModel_UpdateReturnsDelayedCmd(t *testing.T) {
 func TestDiscoverModel_UpdateRampsRescanIntervals(t *testing.T) {
 	t.Setenv("WENDY_DISCOVER_USB_INTERVAL", "3s")
 
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 	updated, _ := m.Update(usbScanMsg{devices: []models.USBDevice{{DisplayName: "test"}}})
 	m = updated.(discoverModel)
 	if m.usbInterval.next != time.Second {
@@ -130,7 +130,7 @@ func TestDiscoverModel_UpdateRampsRescanIntervals(t *testing.T) {
 }
 
 func TestDiscoverModel_QuitOnKeyMsg(t *testing.T) {
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	um := updated.(discoverModel)
@@ -143,7 +143,7 @@ func TestDiscoverModel_QuitOnKeyMsg(t *testing.T) {
 }
 
 func TestDiscoverModel_Init(t *testing.T) {
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 	cmd := m.Init()
 	if cmd == nil {
 		t.Error("expected non-nil Init cmd (batch of scan commands)")
@@ -151,7 +151,7 @@ func TestDiscoverModel_Init(t *testing.T) {
 }
 
 func TestDiscoverModel_TableNavigation(t *testing.T) {
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 
 	updated, _ := m.Update(usbScanMsg{devices: []models.USBDevice{
 		{DisplayName: "alpha"},
@@ -172,7 +172,7 @@ func TestDiscoverModel_TableNavigation(t *testing.T) {
 }
 
 func TestDiscoverModel_WindowWidthCropsViewLines(t *testing.T) {
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 20})
 	m = updated.(discoverModel)
@@ -201,7 +201,7 @@ func TestDiscoverModel_WindowWidthCropsViewLines(t *testing.T) {
 }
 
 func TestDiscoverModel_LeftRightScrollsWithoutBreakingVerticalNavigation(t *testing.T) {
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
 	m = updated.(discoverModel)
@@ -255,7 +255,7 @@ func TestDiscoverModel_LeftRightScrollsWithoutBreakingVerticalNavigation(t *test
 func TestDiscoverModel_DKeySetsDefaultAndMarksSelectedDevice(t *testing.T) {
 	setTempConfig(t, &config.Config{})
 
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{
 		DisplayName: "ubuntu",
 		Hostname:    "ubuntu.local",
@@ -303,7 +303,7 @@ func TestDiscoverTableItemsHidesAddressForDockerAndLocal(t *testing.T) {
 }
 
 func TestDiscoverModel_ViewShowsLegendWithDevices(t *testing.T) {
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 
 	if strings.Contains(m.View(), tui.DeviceTableLegend) {
 		t.Fatalf("expected no legend before any device is found, got %q", m.View())
@@ -530,7 +530,7 @@ func TestMergePickerItemClearsNoAccessHintWhenVersionKnown(t *testing.T) {
 }
 
 func TestDiscoverModelViewShowsNoAccessHintForHighlightedDevice(t *testing.T) {
-	m := newDiscoverModel(context.Background(), discovery.DiscoveryOptions{})
+	m := newDiscoverModel(context.Background(), discovery.DiscoveryOptions{}, true)
 	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{
 		DisplayName: "wendy-locked",
 		IPAddress:   "192.168.1.30",
@@ -548,7 +548,7 @@ func TestDiscoverModelViewShowsNoAccessHintForHighlightedDevice(t *testing.T) {
 }
 
 func TestDiscoverModelViewOmitsHintForAccessibleDevice(t *testing.T) {
-	m := newDiscoverModel(context.Background(), discovery.DiscoveryOptions{})
+	m := newDiscoverModel(context.Background(), discovery.DiscoveryOptions{}, true)
 	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{
 		DisplayName:  "wendy-mine",
 		IPAddress:    "192.168.1.31",
@@ -649,7 +649,7 @@ func TestDiscoverModel_EnterCopiesSelectedDevice(t *testing.T) {
 		return nil
 	}
 
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 	updated0, _ := m.Update(usbScanMsg{devices: []models.USBDevice{
 		{DisplayName: "wendyos-test", Hostname: "192.168.1.5"},
 	}})
@@ -685,7 +685,7 @@ func TestDiscoverModel_ACopiesAllDevices(t *testing.T) {
 		return nil
 	}
 
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 	updated0, _ := m.Update(usbScanMsg{devices: []models.USBDevice{
 		{DisplayName: "device-1", Hostname: "10.0.0.1"},
 		{DisplayName: "device-2", Hostname: "10.0.0.2"},
@@ -719,7 +719,7 @@ func TestDiscoverModel_EnterShowsErrorOnClipboardFailure(t *testing.T) {
 		return fmt.Errorf("xclip not found")
 	}
 
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 	updated0, _ := m.Update(usbScanMsg{devices: []models.USBDevice{
 		{DisplayName: "test-device", Hostname: "10.0.0.1"},
 	}})
@@ -734,7 +734,7 @@ func TestDiscoverModel_EnterShowsErrorOnClipboardFailure(t *testing.T) {
 }
 
 func TestDiscoverModel_FlashClearMsg(t *testing.T) {
-	m := newDiscoverModel(context.Background(), defaultOpts())
+	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 	m.flashMessage = "test flash"
 
 	updated, _ := m.Update(flashClearMsg{})
@@ -865,5 +865,18 @@ func TestCopyToClipboard_NoToolsFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "install one of") {
 		t.Errorf("error should suggest installation, got: %v", err)
+	}
+}
+
+// TestDiscoverCmdHasAllFlag verifies `wendy discover --all` exists and defaults
+// to off, so local run targets are hidden unless explicitly requested.
+func TestDiscoverCmdHasAllFlag(t *testing.T) {
+	cmd := newDiscoverCmd()
+	flag := cmd.Flags().Lookup("all")
+	if flag == nil {
+		t.Fatal("discover is missing the --all flag")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("--all default = %q; want false", flag.DefValue)
 	}
 }

--- a/go/internal/cli/commands/json_cmd.go
+++ b/go/internal/cli/commands/json_cmd.go
@@ -11,8 +11,9 @@ import (
 
 func newJSONCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "json",
-		Short: "Inspect and validate wendy.json",
+		Use:    "json",
+		Short:  "Inspect and validate wendy.json",
+		Hidden: true,
 	}
 
 	cmd.AddCommand(newJSONSchemaCmd())

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -166,55 +166,67 @@ func NewRootCmd() *cobra.Command {
 	root.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	root.PersistentFlags().StringVar(&deviceFlag, "device", "", "Target device hostname")
 
+	// Render the top-level command groups in the deliberate order below rather
+	// than alphabetically, so e.g. "project" lists before "device".
+	cobra.EnableCommandSorting = false
+
 	root.AddGroup(
-		&cobra.Group{ID: "project", Title: "Project Commands:"},
-		&cobra.Group{ID: "cloud", Title: "Manage Your Cloud:"},
-		&cobra.Group{ID: "devices", Title: "Manage Your Devices:"},
-		&cobra.Group{ID: "misc", Title: "Misc.:"},
+		&cobra.Group{ID: "develop", Title: "Develop & Deploy:"},
+		&cobra.Group{ID: "manage", Title: "Manage:"},
+		&cobra.Group{ID: "cloud", Title: "Cloud:"},
+		&cobra.Group{ID: "settings", Title: "Settings:"},
 	)
 
-	// Project Commands
-	runCmd := newRunCmd()
-	runCmd.GroupID = "project"
-	watchCmd := newWatchCmd()
-	watchCmd.GroupID = "project"
-	buildCmd := newBuildCmd()
-	buildCmd.GroupID = "project"
+	// Develop & Deploy
 	initCmd := newInitCmd()
-	initCmd.GroupID = "project"
-	projectCmd := newProjectCmd()
-	projectCmd.GroupID = "project"
-	jsonCmd := newJSONCmd()
-	jsonCmd.GroupID = "project"
+	initCmd.GroupID = "develop"
+	runCmd := newRunCmd()
+	runCmd.GroupID = "develop"
 
-	// Cloud Commands
-	authCmd := newAuthCmd()
-	authCmd.GroupID = "cloud"
+	// Manage
+	projectCmd := newProjectCmd()
+	projectCmd.GroupID = "manage"
+	deviceCmd := newDeviceCmd()
+	deviceCmd.GroupID = "manage"
+
+	// Cloud
 	cloudCmd := newCloudCmd()
 	cloudCmd.GroupID = "cloud"
 
-	// Device Commands
-	deviceCmd := newDeviceCmd()
-	deviceCmd.GroupID = "devices"
-	discoverCmd := newDiscoverCmd()
-	discoverCmd.GroupID = "devices"
-	osCmd := newOSCmd()
-	osCmd.GroupID = "devices"
-	// Misc Commands
-	cacheCmd := newCacheCmd()
-	cacheCmd.GroupID = "misc"
-	infoCmd := newInfoCmd()
-	infoCmd.GroupID = "misc"
+	// Settings
 	analyticsCmd := newAnalyticsCmd()
-	analyticsCmd.GroupID = "misc"
+	analyticsCmd.GroupID = "settings"
+	cacheCmd := newCacheCmd()
+	cacheCmd.GroupID = "settings"
+
+	// Hidden commands: still fully functional, just omitted from `wendy --help`
+	// to keep the top-level surface focused on the common workflow. `auth`
+	// remains a working command for back-compat ('wendy cloud login' is the
+	// surfaced entry point); 'json' is already hidden in its constructor.
+	buildCmd := newBuildCmd()
+	buildCmd.Hidden = true
+	watchCmd := newWatchCmd()
+	watchCmd.Hidden = true
+	jsonCmd := newJSONCmd()
+	authCmd := newAuthCmd()
+	authCmd.Hidden = true
+	discoverCmd := newDiscoverCmd()
+	discoverCmd.Hidden = true
+	osCmd := newOSCmd()
+	osCmd.Hidden = true
+	infoCmd := newInfoCmd()
+	infoCmd.Hidden = true
 	utilsCmd := newUtilsCmd()
-	utilsCmd.GroupID = "misc"
+	utilsCmd.Hidden = true
 	tourCmd := newTourCmd()
-	tourCmd.GroupID = "misc"
+	tourCmd.Hidden = true
 	mcpCmd := newMCPCmd()
-	mcpCmd.GroupID = "misc"
+	mcpCmd.Hidden = true
 	completionCmd := newCompletionCmd()
-	completionCmd.GroupID = "misc"
+	completionCmd.Hidden = true
+	// Keep a valid group on the (hidden) completion command so the help/
+	// completion group wiring below stays consistent.
+	completionCmd.GroupID = "settings"
 
 	// Hidden command used by a subprocess to test CoreBluetooth access.
 	// The main process spawns a child process that runs this command so
@@ -245,32 +257,39 @@ func NewRootCmd() *cobra.Command {
 	bmapWriteCmd.Flags().StringVar(&bmapSource, "source", "", "Path to the seekable .img.zst source")
 	bmapWriteCmd.Flags().IntVar(&bmapWriters, "writers", 0, "Concurrent writer goroutines (0 = sequential default)")
 
+	// Visible commands are added in display order (command sorting is disabled
+	// above); hidden commands follow and never appear in help.
 	root.AddCommand(
+		// Develop & Deploy
+		initCmd,
+		runCmd,
+		// Manage
+		projectCmd,
+		deviceCmd,
+		// Cloud
+		cloudCmd,
+		// Settings
+		analyticsCmd,
+		cacheCmd,
+		// Hidden
 		bleCheckCmd,
 		bmapWriteCmd,
 		newUSBSetupHiddenCmd(),
-		runCmd,
 		watchCmd,
 		buildCmd,
-		initCmd,
-		projectCmd,
 		jsonCmd,
 		authCmd,
-		cloudCmd,
-		deviceCmd,
 		discoverCmd,
 		osCmd,
-		cacheCmd,
 		infoCmd,
-		analyticsCmd,
 		utilsCmd,
 		tourCmd,
 		mcpCmd,
 		completionCmd,
 	)
 
-	root.SetHelpCommandGroupID("misc")
-	root.SetCompletionCommandGroupID("misc")
+	root.SetHelpCommandGroupID("settings")
+	root.SetCompletionCommandGroupID("settings")
 
 	root.Version = version.Version
 	return root

--- a/go/internal/cli/commands/root_test.go
+++ b/go/internal/cli/commands/root_test.go
@@ -82,13 +82,23 @@ func TestRootCommand_Help(t *testing.T) {
 	expectedTexts := []string{
 		"Wendy",
 		"edge computing",
-		"Project Commands",
-		"Manage Your Devices",
+		"Develop & Deploy",
+		"Manage",
+		"Cloud",
+		"Settings",
 		"Flags",
 	}
 	for _, text := range expectedTexts {
 		if !strings.Contains(strings.ToLower(output), strings.ToLower(text)) {
 			t.Errorf("help output missing %q", text)
+		}
+	}
+
+	// Commands that were demoted to hidden must not appear in top-level help,
+	// even though they remain registered and runnable.
+	for _, hidden := range []string{"build", "watch", "discover", "os", "utils", "info", "mcp", "tour", "auth", "completion"} {
+		if strings.Contains(output, "\n  "+hidden+" ") {
+			t.Errorf("help output should not list hidden command %q:\n%s", hidden, output)
 		}
 	}
 }

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -486,6 +486,25 @@ type runOptions struct {
 	// push on failure, chunkingForce uses chunk-diff with no fallback, and
 	// chunkingOff skips chunk-diff entirely (registry push only).
 	chunking string
+	// allTargets shows local run targets (the local machine, Docker/OrbStack,
+	// Apple Container) in the interactive device picker. They are hidden by
+	// default so the picker lists WendyOS devices first.
+	allTargets bool
+}
+
+// runResolveOptions builds the resolveTarget options shared by every `wendy run`
+// device-selection path. By default the interactive picker hides local run
+// targets (LocalProviderKeys); --all (opts.allTargets) surfaces them again.
+// --yes suppresses the picker entirely.
+func runResolveOptions(opts runOptions) []resolveOption {
+	var resolveOpts []resolveOption
+	if opts.yes {
+		resolveOpts = append(resolveOpts, NonInteractive())
+	}
+	if !opts.allTargets {
+		resolveOpts = append(resolveOpts, ExcludeProviders(providers.LocalProviderKeys()...))
+	}
+	return resolveOpts
 }
 
 // Valid values for runOptions.chunking. An empty value is treated as
@@ -510,12 +529,22 @@ func validateChunkingMode(mode string) error {
 
 func newRunCmd() *cobra.Command {
 	var opts runOptions
+	var watch bool
+	var debounceMS int
+	var verbose bool
 
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Build and run application on a WendyOS device",
 		Long:  "Reads wendy.json from the current directory or --prefix directory, builds a container image, and deploys it to the target device.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if watch {
+				// In watch mode, hide build output unless a build fails (unless
+				// --verbose); detached + non-interactive are enforced by
+				// watchCommand. This mirrors `wendy watch`.
+				opts.quietBuild = !verbose
+				return watchCommand(cmd.Context(), opts, time.Duration(debounceMS)*time.Millisecond)
+			}
 			return runCommand(cmd.Context(), opts)
 		},
 	}
@@ -537,6 +566,10 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().IntVar(&opts.maxConcurrency, "max-concurrency", 0, "Multi-service: max service images to build+push at once (0 = auto-throttle large groups)")
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
 	cmd.Flags().StringVar(&opts.chunking, "chunking", chunkingAuto, "Content-defined chunking (CBC) deploy path: auto (try chunk-diff, fall back to registry push), force (chunk-diff only, no fallback), or off (registry push only)")
+	cmd.Flags().BoolVar(&opts.allTargets, "all", false, "Include local run targets (this machine, Docker/OrbStack, Apple Container) in the device picker; hidden by default")
+	cmd.Flags().BoolVar(&watch, "watch", false, "Watch the project directory and redeploy on every change (runs detached; same as 'wendy watch')")
+	cmd.Flags().IntVar(&debounceMS, "debounce", 400, "Watch mode (--watch): quiet period in milliseconds after the last change before redeploying")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Watch mode (--watch): always show build output (default: hidden unless the build fails)")
 
 	return cmd
 }
@@ -649,11 +682,7 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		}
 	}()
 	if cfgMissing {
-		var resolveOpts []resolveOption
-		if opts.yes {
-			resolveOpts = append(resolveOpts, NonInteractive())
-		}
-		target, err = resolveRunTarget(ctx, resolveOpts...)
+		target, err = resolveRunTarget(ctx, runResolveOptions(opts)...)
 		if err != nil {
 			return err
 		}
@@ -697,11 +726,7 @@ func runCommand(ctx context.Context, opts runOptions) error {
 
 	// Step 2: Resolve the target device.
 	if target == nil {
-		var resolveOpts []resolveOption
-		if opts.yes {
-			resolveOpts = append(resolveOpts, NonInteractive())
-		}
-		target, err = resolveRunTarget(ctx, resolveOpts...)
+		target, err = resolveRunTarget(ctx, runResolveOptions(opts)...)
 		if err != nil {
 			return err
 		}
@@ -769,11 +794,7 @@ func preflightMissingAppConfigForMacTarget(ctx context.Context, target *Selected
 // runComposeCommand handles the full device-selection + execution flow for
 // docker-compose projects, bypassing the wendy.json requirement.
 func runComposeCommand(ctx context.Context, cwd string, opts runOptions) error {
-	var resolveOpts []resolveOption
-	if opts.yes {
-		resolveOpts = append(resolveOpts, NonInteractive())
-	}
-	target, err := resolveRunTarget(ctx, resolveOpts...)
+	target, err := resolveRunTarget(ctx, runResolveOptions(opts)...)
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/watch.go
+++ b/go/internal/cli/commands/watch.go
@@ -31,10 +31,8 @@ func newWatchCmd() *cobra.Command {
 			"Runs detached (does not stream logs); use 'wendy device logs' to tail output. " +
 			"Build output is hidden unless a build fails; pass --verbose to always show it.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// The watch loop must never block on logs or prompt between cycles.
-			opts.detach = true
-			opts.yes = true
 			// Keep the loop quiet: hide build output unless a build fails.
+			// Detached + non-interactive are enforced by watchCommand itself.
 			opts.quietBuild = !verbose
 			return watchCommand(cmd.Context(), opts, time.Duration(debounceMS)*time.Millisecond)
 		},
@@ -56,10 +54,22 @@ func newWatchCmd() *cobra.Command {
 	return cmd
 }
 
+// withWatchInvariants returns opts with the settings the watch loop requires:
+// it must run detached and never prompt, so a rapid series of saves can't block
+// on log streaming or an interactive confirmation between redeploy cycles. Both
+// entry points (`wendy watch` and `wendy run --watch`) route through
+// watchCommand, so enforcing the invariants here keeps them from drifting.
+func withWatchInvariants(opts runOptions) runOptions {
+	opts.detach = true
+	opts.yes = true
+	return opts
+}
+
 func watchCommand(ctx context.Context, opts runOptions, debounce time.Duration) error {
 	if debounce <= 0 {
 		debounce = 400 * time.Millisecond
 	}
+	opts = withWatchInvariants(opts)
 	root, err := resolveRunWorkingDir(opts)
 	if err != nil {
 		return err

--- a/go/internal/cli/providers/local_provider_keys_test.go
+++ b/go/internal/cli/providers/local_provider_keys_test.go
@@ -1,0 +1,44 @@
+package providers
+
+import "testing"
+
+// TestLocalProviderKeys verifies the local-target classification used by
+// `wendy run`/`wendy discover` to hide on-machine run targets unless --all.
+// The local container runtimes and the local machine are in; real external
+// hardware (android phone, wendy-lite MCU) is out.
+func TestLocalProviderKeys(t *testing.T) {
+	want := map[string]bool{
+		ProviderKeyLocal:          true,
+		ProviderKeyDocker:         true,
+		ProviderKeyAppleContainer: true,
+	}
+
+	got := map[string]bool{}
+	for _, k := range LocalProviderKeys() {
+		got[k] = true
+	}
+	for k := range want {
+		if !got[k] {
+			t.Errorf("LocalProviderKeys() missing %q", k)
+		}
+	}
+	for _, k := range []string{"android", "wendy-lite"} {
+		if got[k] {
+			t.Errorf("LocalProviderKeys() should not contain external hardware key %q", k)
+		}
+	}
+}
+
+func TestIsLocalProviderKey(t *testing.T) {
+	local := []string{ProviderKeyLocal, ProviderKeyDocker, ProviderKeyAppleContainer}
+	for _, k := range local {
+		if !IsLocalProviderKey(k) {
+			t.Errorf("IsLocalProviderKey(%q) = false; want true", k)
+		}
+	}
+	for _, k := range []string{"android", "wendy-lite", "", "unknown"} {
+		if IsLocalProviderKey(k) {
+			t.Errorf("IsLocalProviderKey(%q) = true; want false", k)
+		}
+	}
+}

--- a/go/internal/cli/providers/provider.go
+++ b/go/internal/cli/providers/provider.go
@@ -4,6 +4,7 @@ package providers
 
 import (
 	"context"
+	"slices"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
@@ -53,6 +54,22 @@ const (
 	ProviderKeyDocker         = "docker"
 	ProviderKeyLocal          = "local"
 )
+
+// LocalProviderKeys are the providers whose "devices" are really this computer
+// or a local container runtime (the local machine, Docker/OrbStack, Apple
+// Container) rather than a separate WendyOS device. `wendy run` and
+// `wendy discover` hide these from the default device list unless --all is
+// given. Real external hardware providers (e.g. android, wendy-lite) are not
+// local and are always shown.
+func LocalProviderKeys() []string {
+	return []string{ProviderKeyLocal, ProviderKeyDocker, ProviderKeyAppleContainer}
+}
+
+// IsLocalProviderKey reports whether key names a local run target (see
+// LocalProviderKeys).
+func IsLocalProviderKey(key string) bool {
+	return slices.Contains(LocalProviderKeys(), key)
+}
 
 const (
 	RunOutputStarted RunOutputType = iota

--- a/go/internal/cli/tui/progress_test.go
+++ b/go/internal/cli/tui/progress_test.go
@@ -32,7 +32,10 @@ func TestProgressViewByteInfo(t *testing.T) {
 		if !strings.Contains(view, "(50.0 MiB)") {
 			t.Errorf("View() = %q; want it to contain %q", view, "(50.0 MiB)")
 		}
-		if strings.Contains(view, "/") {
+		// A total renders as "(written / total)"; match the separator
+		// specifically so an unrelated "/" in a rotating hint (e.g.
+		// "Claude/Codex") doesn't trip this check.
+		if strings.Contains(view, " / ") {
 			t.Errorf("View() = %q; must not render a total when none is known", view)
 		}
 	})

--- a/specs/2026-06-27-build-progress-view-design.md
+++ b/specs/2026-06-27-build-progress-view-design.md
@@ -1,0 +1,171 @@
+# Cleaner build progress for `wendy run` / `cloud run`
+
+Date: 2026-06-27
+Branch: `jo/improve-cli`
+Status: Approved (design)
+
+## Problem
+
+`wendy run` / `wendy cloud run` pipes the raw `docker buildx` stream straight to
+stdout. A single-service deploy produces dozens of lines of low-signal noise
+(`#6 sha256:… 2.10MB / 14.36MB`, `[buildx] bootstrapping builder …`,
+`exporting layers … pushing layers …`), and the user cannot quickly see which
+build step is running, whether layers were cached, or how long the build took.
+
+We want a quiet, live view that still surfaces the essentials:
+
+- the current build step / phase (which Dockerfile layer),
+- caching (which steps were cache hits vs rebuilt),
+- timing (per-step and total build duration),
+
+and the same information in the multi-service build view. We must not hide real
+errors.
+
+## Chosen presentation
+
+A **live, collapsing step list** for single-service builds:
+
+```
+Building image for linux/amd64...
+  ✓ load build definition          0.0s
+  ✓ load metadata python:3.11      2.0s
+  ⚡ [1/6] FROM python:3.11-slim   cached
+  ⚡ [2/6] WORKDIR /app            cached
+  ⚡ [3/6] COPY requirements.txt   cached
+  ⠙ [4/6] RUN pip install ...      8s
+  · [5/6] COPY app.py
+  · [6/6] RUN useradd ...
+  exporting + pushing layers
+```
+
+On success it collapses to a one-line summary:
+
+```
+✓ Built & pushed (4 cached, 2 rebuilt) in 21.3s
+```
+
+## Architecture
+
+Three pieces, with a pure, testable parser at the core.
+
+### 1. `buildprogress.Parser` — pure core
+
+An `io.Writer` that the buildx `stdout`/`stderr` is piped into. The build is
+invoked with `--progress=plain` so the format is deterministic. `plain` is
+chosen over `rawjson` because it is universally supported (rawjson needs
+buildx ≥ 0.13 and errors out on older clients), and it is already the format
+buildx emits when its output is not a TTY — so we have a real sample to test
+against.
+
+The parser recognises the buildkit plain grammar:
+
+- `#N <name>` → step started. The name carries the meaningful label:
+  `[4/6] RUN …`, `[internal] load build definition`, `[1/6] FROM …`,
+  `exporting to image`, etc.
+- `#N CACHED` → step was a cache hit.
+- `#N DONE 4.3s` → step finished, with duration.
+- `#N ERROR …` and the trailing `------` … `------` error block → step failed.
+- export / push vertices (`exporting layers`, `pushing layers`,
+  `pushing manifest …`) → collapsed into a single "exporting + pushing" phase.
+
+It maintains:
+
+- ordered list of steps with status (pending / running / cached / done / failed)
+  and duration,
+- the currently-active step,
+- cached vs rebuilt tallies,
+- total elapsed time,
+- a capped raw buffer (same idea as the existing `capturingWriter`) for failure
+  replay and transient-push-error classification.
+
+`Write([]byte)` parses newly-arrived lines and invokes an `onEvent(StepEvent)`
+callback. No rendering, no terminal access → unit-testable as
+`bytes-in → events-out`.
+
+### 2. Single-service renderer — `BuildStepsModel` (Bubble Tea)
+
+Mirrors the lifecycle of the existing `tui.MultiSpinnerModel`:
+
+- the build runs in a goroutine, writing to the parser;
+- the parser `prog.Send()`s step events to the Bubble Tea program;
+- the main goroutine runs `prog.Run()`, which quits on an all-done message.
+
+It renders the collapsing step list above (spinner on the active step, `✓` for
+built, `⚡` for cached, `·` for pending), and on success replaces the block with
+the one-line summary. On failure it prints the captured raw buildx log so the
+underlying error (e.g. a failed `pip install`) is fully visible.
+
+### 3. Multi-service adapter
+
+The multi-service path already runs a `tui.MultiSpinnerModel` with a per-row
+detail string and an **unused** `MultiSpinnerDetailMsg`. Each concurrent
+service build gets its own `buildprogress.Parser`; its events map to:
+
+- `MultiSpinnerDetailMsg{Name, Detail}` for the active step
+  (e.g. `[4/6] RUN pip install`), and
+- the cached/rebuilt tallies, surfaced in the done row:
+  `✓ api  built (4 cached, 2 rebuilt) 21.3s`.
+
+No change to the MultiSpinner lifecycle — we only start sending the detail
+messages that the model already understands, plus extend the done message with
+the tallies.
+
+## Integration points
+
+Least-invasive: wrap the existing `streamOutput` `io.Writer` at each call site.
+A helper owns TUI setup/teardown and the summary line so call sites stay a
+one-liner:
+
+```go
+err := buildprogress.RunSingle(ctx, title, interactive, func(w io.Writer) error {
+    return buildAndPushImageForAgent(ctx, conn, regPort, builder, cwd, repo,
+        platform, dockerfile, buildArgs, "", w, logSink)
+})
+```
+
+Call sites:
+
+- `deployByChunkDiff` → `buildImageToOCILayout` (run.go ~1878, OCI fast path)
+- single-service registry push path (run.go ~1504)
+- multi-service `buildServiceImage` (multibuild.go ~490) — via the adapter
+- compose build path (compose.go)
+
+## Fallbacks
+
+- **Non-TTY / CI** (`!isInteractiveTerminal()`): no Bubble Tea program. The
+  parser drives one concise line per completed step
+  (`✓ [4/6] RUN … 8s` / `⚡ [1/6] FROM … cached`) so logs stay readable and
+  greppable.
+- **Failure**: the full raw buildx log is printed (never hidden), exactly as
+  today, after the TUI tears down cleanly.
+- **Quiet setup logs**: `[buildx] bootstrapping / inject / restart` chatter and
+  the `Fast layer-diff deploy failed … falling back to registry push` /
+  `Apple Container unavailable … falling back to Docker` messages route to a
+  buffer flushed only on error. The fallback chain collapses to a single short
+  status line rather than multi-line bootstrap noise. These already go to the
+  separate `logOutput` writer, distinct from the build `streamOutput`, so this
+  is a routing change, not a parsing one.
+- **Apple Container builder** (different output format): best-effort. If the
+  parser sees no recognisable buildx steps it falls back to streaming the raw
+  output rather than mis-parsing.
+
+No new CLI flag. Raw output is available via the existing `--verbose` flag
+(watch mode) and is always shown on failure.
+
+## Testing
+
+- **Parser**: unit tests against the real `cloud run` log captured in the task
+  as a fixture — cached path, full-rebuild path, failure path (`pip install`
+  error), and export/push phase. Assert the emitted `StepEvent` sequence and the
+  final tallies/durations.
+- **Plain (non-TTY) renderer**: golden-output tests.
+- **TUI models**: lightweight `Update`-message tests in the style of the
+  existing `multispinner_test` / `spinner_test`.
+
+## Out of scope
+
+- Switching the build data source to `--progress=rawjson` (considered; rejected
+  for compatibility).
+- Reworking the device-side "Unpacking image" progress bar, which is already
+  clean.
+- Changing build concurrency, caching, or the push/retry logic.


### PR DESCRIPTION
## Summary

Reorganizes the `wendy` CLI command surface so the top-level and `wendy device` help pages lead with the commands people actually use, and merges `wendy watch` into `wendy run --watch`.

### Top-level `wendy --help`
Regrouped into four focused sections and trimmed the surface:
- **Develop & Deploy:** `init`, `run`
- **Manage:** `project`, `device`
- **Cloud:** `cloud`
- **Settings:** `analytics`, `cache`, `help`

Demoted to hidden (still fully runnable): `build`, `watch`, `discover`, `os`, `utils`, `info`, `mcp`, `tour`, `completion`, and `auth`. Command sorting is disabled so groups render in deliberate order (e.g. `project` before `device`).

### Cloud auth
- Surfaced `wendy cloud login` / `logout` / `status`, reusing the existing auth constructors. `wendy auth` stays hidden-but-working for back-compat; advanced session commands (`refresh-certs`, `use`, `default`) remain under it.

### `wendy device --help`
- New **Common Commands:** group on top: `apps`, `logs`, `ros2`, `dashboard`.
- Folded `volumes` into **Device Management**; dropped the now-empty Monitoring / Apps & Storage groups.
- Hidden (still runnable): `set-default`, `get-default`, `enroll`, `setup`, `sync-time`, `telemetry-stream`, `ps`.

### `wendy run --watch`
- Merged `wendy watch` into `wendy run --watch` (with `--debounce` / `--verbose`); both entry points route through a shared `withWatchInvariants` helper so detached/non-interactive behavior can't drift. `wendy watch` is kept hidden as an alias.

### Discover
- `wendy discover` (and the device picker) now hide local run targets by default behind a `--all` flag.

## Testing
- `go test ./internal/cli/commands ./internal/cli/providers`
- `gofmt -l` clean; `git diff --check` clean
- Manually verified `wendy --help`, `wendy device --help`, `wendy cloud --help`, and that hidden commands (`auth`, `ps`, etc.) still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbMN8SsFoNKPSwr8cE2BBV