### PR TITLE
Set up Claude/Codex at the start of the tour

### DIFF
--- a/go/internal/cli/commands/tour.go
+++ b/go/internal/cli/commands/tour.go
@@ -353,14 +353,19 @@ func (m tourWizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyc
 			m.phase = phaseError
 			return m, nil
 		}
-		m.phase = phaseAICheck
-		return m, m.cmdCheckAITools()
+		m.phase = phaseCloud
+		return m, nil
 
 	case tourAICheckDoneMsg:
 		m.claudePath = msg.claudePath
 		m.codexPath = msg.codexPath
-		m.phase = phaseAICheck
-		return m, nil
+		if m.claudePath != "" || m.codexPath != "" {
+			m.phase = phaseAICheck
+			return m, nil
+		}
+		// No AI CLI installed — skip the AI step entirely.
+		m.phase = phaseLoadDevices
+		return m, loadDevicesCmd()
 
 	case tourMCPSetupDoneMsg:
 		m.mcpSetupResult = msg.results
@@ -429,8 +434,7 @@ func (m tourWizardModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case phaseWelcome:
 		switch key {
 		case "enter", " ":
-			m.phase = phaseLoadDevices
-			return m, loadDevicesCmd()
+			return m, m.cmdCheckAITools()
 		case "q", "ctrl+c":
 			return m, tea.Quit
 		}
@@ -787,10 +791,11 @@ func (m tourWizardModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.wifiCursor++
 			}
 		case "enter", " ":
-			if m.claudePath != "" && m.wifiCursor == 0 {
+			if (m.claudePath != "" || m.codexPath != "") && m.wifiCursor == 0 {
 				return m, runMCPSetupCmd()
 			}
-			m.phase = phaseCloud
+			m.phase = phaseLoadDevices
+			return m, loadDevicesCmd()
 		case "q", "ctrl+c":
 			return m, tea.Quit
 		}
@@ -798,7 +803,8 @@ func (m tourWizardModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case phaseAIMCPSetup:
 		switch key {
 		case "enter", " ":
-			m.phase = phaseCloud
+			m.phase = phaseLoadDevices
+			return m, loadDevicesCmd()
 		case "q", "ctrl+c":
 			return m, tea.Quit
 		}

--- a/go/internal/cli/commands/tour.go
+++ b/go/internal/cli/commands/tour.go
@@ -971,9 +971,10 @@ func (m tourWizardModel) viewWelcome(w int) string {
 	sb.WriteString(wizSubStyle.Render("Let's get you set up from scratch — takes about 5 minutes.") + "\n\n")
 	sb.WriteString(wizBodyStyle.Width(w).Render(
 		"This wizard will:\n"+
-			"  1. Flash WendyOS onto your device\n"+
-			"  2. Boot it and connect over the network\n"+
-			"  3. Deploy a sample Python app\n\n"+
+			"  1. Connect your AI coding assistant (if installed)\n"+
+			"  2. Flash WendyOS onto your device\n"+
+			"  3. Boot it and connect over the network\n"+
+			"  4. Deploy a sample Python app\n\n"+
 			"If anything goes wrong you can restart at any time with:\n") + "\n")
 	sb.WriteString("  " + wizCodeStyle.Render("wendy tour") + "\n\n")
 	sb.WriteString(wizHintStyle.Render("Press Enter to begin"))
@@ -1431,39 +1432,29 @@ func (m tourWizardModel) viewCreateProject(w int) string {
 
 func (m tourWizardModel) viewAICheck(w int) string {
 	var sb strings.Builder
-	sb.WriteString(wizTitleStyle.Render("Step 9 — Continue development") + "\n\n")
+	sb.WriteString(wizTitleStyle.Render("Connect your AI coding assistant") + "\n\n")
 
+	var detected []string
 	if m.claudePath != "" {
-		sb.WriteString(wizSuccessStyle.Render("Claude Code detected") + "\n")
-		sb.WriteString(wizBodyStyle.Width(w).Render(
-			"You can continue developing with Claude Code. Open your project in it:") + "\n\n")
-		sb.WriteString("  " + wizCodeStyle.Render(fmt.Sprintf("cd %s && claude", m.projectPath)) + "\n\n")
-		sb.WriteString(wizBodyStyle.Width(w).Render(
-			"Set up the Wendy MCP server so Claude can access your device directly?") + "\n\n")
-		opts := []string{"Yes, set up MCP now", "No, skip"}
-		for i, opt := range opts {
-			if i == m.wifiCursor {
-				sb.WriteString(wizSelectedStyle.Render("▶ "+opt) + "\n")
-			} else {
-				sb.WriteString(wizNormalStyle.Render("  "+opt) + "\n")
-			}
-		}
-		sb.WriteString("\n" + wizHintStyle.Render("↑/↓ navigate  ·  Enter select"))
-	} else if m.codexPath != "" {
-		sb.WriteString(wizSuccessStyle.Render("Codex detected") + "\n")
-		sb.WriteString(wizBodyStyle.Width(w).Render(
-			"Continue development with Codex from your project directory:") + "\n\n")
-		sb.WriteString("  " + wizCodeStyle.Render(fmt.Sprintf("cd %s && codex", m.projectPath)) + "\n\n")
-		sb.WriteString(wizHintStyle.Render("Enter to continue"))
-	} else {
-		sb.WriteString(wizBodyStyle.Width(w).Render(
-			"To get AI-assisted development for Wendy apps, install Claude Code:") + "\n\n")
-		sb.WriteString("  " + wizCodeStyle.Render("npm install -g @anthropic-ai/claude-code") + "\n\n")
-		sb.WriteString(wizBodyStyle.Width(w).Render(
-			"Then open your project and run:") + "\n\n")
-		sb.WriteString("  " + wizCodeStyle.Render(fmt.Sprintf("cd %s && claude", m.projectPath)) + "\n\n")
-		sb.WriteString(wizHintStyle.Render("Enter to continue"))
+		detected = append(detected, "Claude Code")
 	}
+	if m.codexPath != "" {
+		detected = append(detected, "Codex")
+	}
+	sb.WriteString(wizSuccessStyle.Render("Detected: "+strings.Join(detected, ", ")) + "\n\n")
+	sb.WriteString(wizBodyStyle.Width(w).Render(
+		"Set up the Wendy MCP server so your assistant can talk to your devices "+
+			"directly — list devices, manage containers, read telemetry, and more?") + "\n\n")
+
+	opts := []string{"Yes, set up MCP now", "No, skip"}
+	for i, opt := range opts {
+		if i == m.wifiCursor {
+			sb.WriteString(wizSelectedStyle.Render("▶ "+opt) + "\n")
+		} else {
+			sb.WriteString(wizNormalStyle.Render("  "+opt) + "\n")
+		}
+	}
+	sb.WriteString("\n" + wizHintStyle.Render("↑/↓ navigate  ·  Enter select"))
 	return sb.String()
 }
 
@@ -1482,8 +1473,8 @@ func (m tourWizardModel) viewAIMCPSetup(w int) string {
 		}
 		sb.WriteString("\n")
 		sb.WriteString(wizBodyStyle.Width(w).Render(
-			"Restart Claude Code to activate the Wendy MCP server.\n"+
-				"Claude will now have tools to list devices, manage containers,\n"+
+			"Restart your AI assistant to activate the Wendy MCP server.\n"+
+				"It will then have tools to list devices, manage containers,\n"+
 				"read telemetry, and more.") + "\n\n")
 		sb.WriteString(wizHintStyle.Render("Enter to continue"))
 	}

--- a/go/internal/cli/commands/tour_test.go
+++ b/go/internal/cli/commands/tour_test.go
@@ -1,6 +1,104 @@
 package commands
 
-import "testing"
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// stepTour runs one Update and returns the resulting model + command.
+func stepTour(t *testing.T, m tourWizardModel, msg tea.Msg) (tourWizardModel, tea.Cmd) {
+	t.Helper()
+	next, cmd := m.Update(msg)
+	tm, ok := next.(tourWizardModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want tourWizardModel", next)
+	}
+	return tm, cmd
+}
+
+func TestTourAICheckRouting(t *testing.T) {
+	t.Run("claude detected goes to AI step", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseWelcome
+		m, _ = stepTour(t, m, tourAICheckDoneMsg{claudePath: "/usr/bin/claude"})
+		if m.phase != phaseAICheck {
+			t.Fatalf("phase = %v, want phaseAICheck", m.phase)
+		}
+	})
+
+	t.Run("codex detected goes to AI step", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseWelcome
+		m, _ = stepTour(t, m, tourAICheckDoneMsg{codexPath: "/usr/bin/codex"})
+		if m.phase != phaseAICheck {
+			t.Fatalf("phase = %v, want phaseAICheck", m.phase)
+		}
+	})
+
+	t.Run("neither detected skips to device load", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseWelcome
+		m, cmd := stepTour(t, m, tourAICheckDoneMsg{})
+		if m.phase != phaseLoadDevices {
+			t.Fatalf("phase = %v, want phaseLoadDevices", m.phase)
+		}
+		if cmd == nil {
+			t.Fatal("expected loadDevicesCmd, got nil")
+		}
+	})
+}
+
+func TestTourAIStepTransitions(t *testing.T) {
+	t.Run("skip leads to device load", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseAICheck
+		m.codexPath = "/usr/bin/codex"
+		m.wifiCursor = 1 // "No, skip"
+		m, cmd := stepTour(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+		if m.phase != phaseLoadDevices {
+			t.Fatalf("phase = %v, want phaseLoadDevices", m.phase)
+		}
+		if cmd == nil {
+			t.Fatal("expected loadDevicesCmd, got nil")
+		}
+	})
+
+	t.Run("yes with codex only triggers MCP setup", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseAICheck
+		m.codexPath = "/usr/bin/codex" // no claude
+		m.wifiCursor = 0               // "Yes, set up MCP"
+		m, cmd := stepTour(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+		if cmd == nil {
+			t.Fatal("expected runMCPSetupCmd, got nil") // not executed — would write config
+		}
+		if m.phase != phaseAICheck {
+			t.Fatalf("phase = %v, want phaseAICheck (waiting for setup result)", m.phase)
+		}
+	})
+
+	t.Run("mcp results screen leads to device load", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseAIMCPSetup
+		m, cmd := stepTour(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+		if m.phase != phaseLoadDevices {
+			t.Fatalf("phase = %v, want phaseLoadDevices", m.phase)
+		}
+		if cmd == nil {
+			t.Fatal("expected loadDevicesCmd, got nil")
+		}
+	})
+}
+
+func TestTourDeployGoesToCloud(t *testing.T) {
+	m := newTourWizardModel()
+	m.phase = phaseRunProject
+	m, _ = stepTour(t, m, tourRunDoneMsg{})
+	if m.phase != phaseCloud {
+		t.Fatalf("phase = %v, want phaseCloud", m.phase)
+	}
+}
 
 func TestParseNetshSSID(t *testing.T) {
 	cases := []struct {

--- a/specs/2026-06-27-tour-ai-setup-first-design.md
+++ b/specs/2026-06-27-tour-ai-setup-first-design.md
@@ -1,0 +1,115 @@
+# Set up Claude/Codex at the start of the tour
+
+**Date:** 2026-06-27
+**Status:** Approved, ready for implementation
+
+## Problem
+
+`wendy tour` (the hidden interactive onboarding wizard in
+`go/internal/cli/commands/tour.go`) already detects installed AI coding CLIs
+(`claude`, `codex`) and offers to wire up the Wendy MCP server — but it does so
+as the **very last step** (`phaseAICheck` → `phaseAIMCPSetup`, "Step 9"), after
+the user has flashed WendyOS, booted the device, and deployed a sample app.
+
+That ordering buries the single most valuable thing for a developer: getting
+their AI assistant connected to Wendy. The flash + boot + deploy phases are slow
+and mostly idle waiting; if the MCP server were configured up front, the user
+could already be coding against Wendy (and querying it through Claude/Codex)
+while the device comes up.
+
+## Goal
+
+Promote AI-assistant setup to run **immediately after the welcome screen**,
+before device selection — but only when at least one supported CLI is installed.
+
+## Decisions (settled during brainstorming)
+
+- **Move to start only.** The AI setup runs once, at the front. The existing
+  end-of-tour AI step is removed (not duplicated).
+- **Skip silently when neither CLI is installed.** No install-instructions
+  screen up front — that would be noise before the user has even picked a
+  device. (The previous end-of-tour step showed install hints; we drop that.)
+- **Offer MCP setup for Codex too**, not just Claude. Today a Codex-only user
+  gets a bare "cd && codex" hint with no MCP wiring; `setupMCPForAllTools()`
+  already configures Codex, so we close that gap.
+- **The early AI screen is unnumbered** ("Connect your AI coding assistant").
+  Renumbering the 16 existing "Step N" labels would be needless churn, and the
+  AI step is an optional pre-step that sits before "Step 1 — Select your device".
+
+## Flow
+
+```
+Welcome
+  → cmdCheckAITools()                    (exec.LookPath claude/codex — instant, local)
+       ├─ claude and/or codex found → phaseAICheck (Connect your AI assistant)
+       │        ├─ "Yes, set up MCP" → runMCPSetupCmd() → phaseAIMCPSetup (results) → loadDevices
+       │        └─ "No, skip"        → loadDevices
+       └─ neither found             → loadDevices   (silent skip)
+  → Step 1: Select device → … → flash → boot → deploy sample app
+  → "You're all set!" (phaseCloud — no AI step at the end)
+```
+
+## Code changes (all in `go/internal/cli/commands/tour.go`)
+
+The supporting machinery is reused unchanged: `cmdCheckAITools`,
+`runMCPSetupCmd`, and `setupMCPForAllTools()` (in `mcp_setup.go`, already covers
+Claude Code, Claude Desktop, Cursor, Windsurf, Codex). No enum reordering — flow
+is driven by transitions, not by `iota` order.
+
+1. **`phaseWelcome` enter handler** (`handleKey`, ~L431): instead of
+   `m.phase = phaseLoadDevices; return m, loadDevicesCmd()`, fire
+   `return m, m.cmdCheckAITools()` (phase stays `phaseWelcome` for the
+   sub-millisecond LookPath round-trip).
+
+2. **`tourAICheckDoneMsg` handler** (~L359): route on result.
+   - If `claudePath != "" || codexPath != ""` → `m.phase = phaseAICheck`.
+   - Else → `m.phase = phaseLoadDevices; return m, loadDevicesCmd()`.
+
+3. **`viewAICheck`** (~L1426): reframe as a pre-step.
+   - Title → `"Connect your AI coding assistant"` (drop "Step 9 —").
+   - Remove all `m.projectPath` references (no project exists yet).
+   - List detected tools (e.g. "Detected: Claude Code, Codex").
+   - Show the Yes/No MCP-setup menu whenever **claude or codex** is detected
+     (today the menu only appears for claude; codex-only falls through to a
+     bare hint).
+
+4. **`phaseAICheck` key handler** (~L779): on "No"/skip, transition to
+   `phaseLoadDevices` + `loadDevicesCmd()` instead of `phaseCloud`. The
+   "Yes → runMCPSetupCmd()" path is unchanged.
+
+5. **`phaseAIMCPSetup` key handler** (~L798): after showing results, continue to
+   `phaseLoadDevices` + `loadDevicesCmd()` instead of `phaseCloud`.
+   `viewAIMCPSetup` text needs no project-specific edits (its "restart Claude to
+   activate" message is still accurate up front).
+
+6. **`tourRunDoneMsg` handler** (~L350): after the deploy completes, go straight
+   to `phaseCloud`. Remove the `phaseAICheck` + `cmdCheckAITools()` detour.
+
+7. **`viewWelcome`** (~L962): add a line to the "This wizard will:" list noting
+   it connects the AI coding assistant.
+
+## Testing
+
+The tour is a `tea.Model`, so its `Update` can be driven directly in unit tests
+without a terminal. Add tests (new `tour_test.go` or extend existing) that
+construct `newTourWizardModel()` and assert the new routing:
+
+1. **claude detected → welcome leads to AI step.** Feed `tourAICheckDoneMsg{claudePath: "/x/claude"}`;
+   assert `m.phase == phaseAICheck`.
+2. **neither detected → welcome skips to device load.** Feed
+   `tourAICheckDoneMsg{}`; assert `m.phase == phaseLoadDevices`.
+3. **skip from AI step → device load.** From `phaseAICheck`, send the "No" key
+   path; assert `m.phase == phaseLoadDevices`.
+4. **MCP results screen → device load.** From `phaseAIMCPSetup`, press Enter;
+   assert `m.phase == phaseLoadDevices`.
+5. **deploy completion → cloud, not AI.** Feed `tourRunDoneMsg{}`; assert
+   `m.phase == phaseCloud`.
+
+LookPath itself is not stubbed — tests drive the message handlers directly,
+which is where the routing logic lives.
+
+## Out of scope
+
+- No change to `setupMCPForAllTools()` or any MCP config writer.
+- No change to the device/flash/boot/deploy phases.
+- No renumbering of existing step labels.

--- a/specs/superpowers/plans/2026-06-27-tour-ai-setup-first.md
+++ b/specs/superpowers/plans/2026-06-27-tour-ai-setup-first.md
@@ -1,0 +1,477 @@
+# Tour AI-Setup-First Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the `wendy tour` wizard's Claude/Codex detection and Wendy MCP setup from the final step to immediately after the welcome screen, skipping silently when no AI CLI is installed.
+
+**Architecture:** The tour is a single Bubble Tea `tourWizardModel` in `go/internal/cli/commands/tour.go`. Flow is driven by phase transitions inside `Update`/`handleKey`, not by enum order. We re-point a handful of transitions so the existing `phaseAICheck` → `phaseAIMCPSetup` screens run right after `phaseWelcome` and lead into `phaseLoadDevices`, and so the post-deploy path goes straight to `phaseCloud`. The supporting commands (`cmdCheckAITools`, `runMCPSetupCmd`, `setupMCPForAllTools`) are reused unchanged.
+
+**Tech Stack:** Go, charmbracelet/bubbletea, standard `testing`.
+
+## Global Constraints
+
+- All code changes live in `go/internal/cli/commands/tour.go`; tests in `go/internal/cli/commands/tour_test.go`. Package `commands`.
+- Do NOT reorder the `tourPhase` `iota` enum — flow is transition-driven.
+- Do NOT modify `setupMCPForAllTools()` or any MCP config writer in `mcp_setup.go`.
+- Do NOT execute the `tea.Cmd` returned by `runMCPSetupCmd()` in tests — it writes real user config files. Assert it is non-nil instead.
+- `tourWizardModel.Update` has a value receiver and returns `tea.Model`; type-assert the result back to `tourWizardModel` to read `.phase`.
+
+---
+
+### Task 1: Reposition the AI-setup routing
+
+Re-point the four transitions that currently place AI setup at the end so it runs after welcome and flows into device loading, and broaden the MCP-setup offer to cover Codex (not just Claude). Drive with unit tests against `Update`.
+
+**Files:**
+- Modify: `go/internal/cli/commands/tour.go` (handlers in `Update` ~L350-363 and `handleKey` ~L429-436, ~L779-804)
+- Test: `go/internal/cli/commands/tour_test.go`
+
+**Interfaces:**
+- Consumes (existing, unchanged signatures):
+  - `newTourWizardModel() tourWizardModel`
+  - `func (m tourWizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd)`
+  - `tourAICheckDoneMsg struct{ claudePath, codexPath string }`
+  - `tourMCPSetupDoneMsg struct{ results []mcpSetupResult }`
+  - `tourRunDoneMsg struct{ err error }`
+  - `loadDevicesCmd() tea.Cmd`, `runMCPSetupCmd() tea.Cmd`, `func (m tourWizardModel) cmdCheckAITools() tea.Cmd`
+  - phase constants: `phaseWelcome`, `phaseAICheck`, `phaseAIMCPSetup`, `phaseLoadDevices`, `phaseCloud`
+- Produces: the new routing behavior asserted by the tests below.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `go/internal/cli/commands/tour_test.go`. The file currently has a single-line `import "testing"` — replace it with the block below (merge, do not add a second import block):
+
+```go
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// phaseOf runs one Update and returns the resulting model + command.
+func stepTour(t *testing.T, m tourWizardModel, msg tea.Msg) (tourWizardModel, tea.Cmd) {
+	t.Helper()
+	next, cmd := m.Update(msg)
+	tm, ok := next.(tourWizardModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want tourWizardModel", next)
+	}
+	return tm, cmd
+}
+
+func TestTourAICheckRouting(t *testing.T) {
+	t.Run("claude detected goes to AI step", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseWelcome
+		m, _ = stepTour(t, m, tourAICheckDoneMsg{claudePath: "/usr/bin/claude"})
+		if m.phase != phaseAICheck {
+			t.Fatalf("phase = %v, want phaseAICheck", m.phase)
+		}
+	})
+
+	t.Run("codex detected goes to AI step", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseWelcome
+		m, _ = stepTour(t, m, tourAICheckDoneMsg{codexPath: "/usr/bin/codex"})
+		if m.phase != phaseAICheck {
+			t.Fatalf("phase = %v, want phaseAICheck", m.phase)
+		}
+	})
+
+	t.Run("neither detected skips to device load", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseWelcome
+		m, cmd := stepTour(t, m, tourAICheckDoneMsg{})
+		if m.phase != phaseLoadDevices {
+			t.Fatalf("phase = %v, want phaseLoadDevices", m.phase)
+		}
+		if cmd == nil {
+			t.Fatal("expected loadDevicesCmd, got nil")
+		}
+	})
+}
+
+func TestTourAIStepTransitions(t *testing.T) {
+	t.Run("skip leads to device load", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseAICheck
+		m.codexPath = "/usr/bin/codex"
+		m.wifiCursor = 1 // "No, skip"
+		m, cmd := stepTour(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+		if m.phase != phaseLoadDevices {
+			t.Fatalf("phase = %v, want phaseLoadDevices", m.phase)
+		}
+		if cmd == nil {
+			t.Fatal("expected loadDevicesCmd, got nil")
+		}
+	})
+
+	t.Run("yes with codex only triggers MCP setup", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseAICheck
+		m.codexPath = "/usr/bin/codex" // no claude
+		m.wifiCursor = 0               // "Yes, set up MCP"
+		m, cmd := stepTour(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+		if cmd == nil {
+			t.Fatal("expected runMCPSetupCmd, got nil") // not executed — would write config
+		}
+		if m.phase != phaseAICheck {
+			t.Fatalf("phase = %v, want phaseAICheck (waiting for setup result)", m.phase)
+		}
+	})
+
+	t.Run("mcp results screen leads to device load", func(t *testing.T) {
+		m := newTourWizardModel()
+		m.phase = phaseAIMCPSetup
+		m, cmd := stepTour(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+		if m.phase != phaseLoadDevices {
+			t.Fatalf("phase = %v, want phaseLoadDevices", m.phase)
+		}
+		if cmd == nil {
+			t.Fatal("expected loadDevicesCmd, got nil")
+		}
+	})
+}
+
+func TestTourDeployGoesToCloud(t *testing.T) {
+	m := newTourWizardModel()
+	m.phase = phaseRunProject
+	m, _ = stepTour(t, m, tourRunDoneMsg{})
+	if m.phase != phaseCloud {
+		t.Fatalf("phase = %v, want phaseCloud", m.phase)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd go && go test ./internal/cli/commands/ -run 'TestTourAICheckRouting|TestTourAIStepTransitions|TestTourDeployGoesToCloud' -v`
+Expected: FAIL — `neither detected` lands on `phaseAICheck` (current code routes unconditionally), `skip`/`mcp results` land on `phaseCloud`, `codex only` does not trigger MCP setup, and deploy routes to `phaseAICheck`.
+
+- [ ] **Step 3: Re-point the `tourAICheckDoneMsg` handler**
+
+In `tour.go`, replace:
+
+```go
+	case tourAICheckDoneMsg:
+		m.claudePath = msg.claudePath
+		m.codexPath = msg.codexPath
+		m.phase = phaseAICheck
+		return m, nil
+```
+
+with:
+
+```go
+	case tourAICheckDoneMsg:
+		m.claudePath = msg.claudePath
+		m.codexPath = msg.codexPath
+		if m.claudePath != "" || m.codexPath != "" {
+			m.phase = phaseAICheck
+			return m, nil
+		}
+		// No AI CLI installed — skip the AI step entirely.
+		m.phase = phaseLoadDevices
+		return m, loadDevicesCmd()
+```
+
+- [ ] **Step 4: Send the deploy-completion path straight to the cloud screen**
+
+Replace:
+
+```go
+	case tourRunDoneMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			m.phase = phaseError
+			return m, nil
+		}
+		m.phase = phaseAICheck
+		return m, m.cmdCheckAITools()
+```
+
+with:
+
+```go
+	case tourRunDoneMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			m.phase = phaseError
+			return m, nil
+		}
+		m.phase = phaseCloud
+		return m, nil
+```
+
+- [ ] **Step 5: Fire the AI check from the welcome screen**
+
+In `handleKey`, replace the `phaseWelcome` enter branch:
+
+```go
+	case phaseWelcome:
+		switch key {
+		case "enter", " ":
+			m.phase = phaseLoadDevices
+			return m, loadDevicesCmd()
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		}
+```
+
+with:
+
+```go
+	case phaseWelcome:
+		switch key {
+		case "enter", " ":
+			return m, m.cmdCheckAITools()
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		}
+```
+
+- [ ] **Step 6: Update the AI-step key handler (Codex offer + continue to device load)**
+
+Replace the `phaseAICheck` branch:
+
+```go
+	case phaseAICheck:
+		switch key {
+		case "up", "k":
+			if m.wifiCursor > 0 {
+				m.wifiCursor--
+			}
+		case "down", "j":
+			if m.wifiCursor < 1 {
+				m.wifiCursor++
+			}
+		case "enter", " ":
+			if m.claudePath != "" && m.wifiCursor == 0 {
+				return m, runMCPSetupCmd()
+			}
+			m.phase = phaseCloud
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		}
+```
+
+with:
+
+```go
+	case phaseAICheck:
+		switch key {
+		case "up", "k":
+			if m.wifiCursor > 0 {
+				m.wifiCursor--
+			}
+		case "down", "j":
+			if m.wifiCursor < 1 {
+				m.wifiCursor++
+			}
+		case "enter", " ":
+			if (m.claudePath != "" || m.codexPath != "") && m.wifiCursor == 0 {
+				return m, runMCPSetupCmd()
+			}
+			m.phase = phaseLoadDevices
+			return m, loadDevicesCmd()
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		}
+```
+
+- [ ] **Step 7: Continue from the MCP results screen into device load**
+
+Replace the `phaseAIMCPSetup` branch:
+
+```go
+	case phaseAIMCPSetup:
+		switch key {
+		case "enter", " ":
+			m.phase = phaseCloud
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		}
+```
+
+with:
+
+```go
+	case phaseAIMCPSetup:
+		switch key {
+		case "enter", " ":
+			m.phase = phaseLoadDevices
+			return m, loadDevicesCmd()
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		}
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `cd go && go test ./internal/cli/commands/ -run 'TestTourAICheckRouting|TestTourAIStepTransitions|TestTourDeployGoesToCloud' -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add go/internal/cli/commands/tour.go go/internal/cli/commands/tour_test.go
+git commit -m "feat: run tour AI/MCP setup right after welcome"
+```
+
+---
+
+### Task 2: Reframe the AI and welcome copy for the front of the tour
+
+The screens now render before any device or project exists. Remove the project-path references from `viewAICheck`, give it a front-of-tour title and a detected-tools line, make the offer cover both assistants, and add an AI line to the welcome blurb. Verified by build + `go vet` (these are presentation strings with no branching logic to unit-test).
+
+**Files:**
+- Modify: `go/internal/cli/commands/tour.go` (`viewWelcome` ~L962, `viewAICheck` ~L1426, `viewAIMCPSetup` ~L1464)
+
+**Interfaces:**
+- Consumes: `m.claudePath`, `m.codexPath`, `m.wifiCursor`, and the `wiz*Style` lipgloss styles (all existing).
+- Produces: no new symbols; presentation only.
+
+- [ ] **Step 1: Reframe `viewAICheck`**
+
+Replace the entire `viewAICheck` function:
+
+```go
+func (m tourWizardModel) viewAICheck(w int) string {
+	var sb strings.Builder
+	sb.WriteString(wizTitleStyle.Render("Step 9 — Continue development") + "\n\n")
+
+	if m.claudePath != "" {
+		sb.WriteString(wizSuccessStyle.Render("Claude Code detected") + "\n")
+		sb.WriteString(wizBodyStyle.Width(w).Render(
+			"You can continue developing with Claude Code. Open your project in it:") + "\n\n")
+		sb.WriteString("  " + wizCodeStyle.Render(fmt.Sprintf("cd %s && claude", m.projectPath)) + "\n\n")
+		sb.WriteString(wizBodyStyle.Width(w).Render(
+			"Set up the Wendy MCP server so Claude can access your device directly?") + "\n\n")
+		opts := []string{"Yes, set up MCP now", "No, skip"}
+		for i, opt := range opts {
+			if i == m.wifiCursor {
+				sb.WriteString(wizSelectedStyle.Render("▶ "+opt) + "\n")
+			} else {
+				sb.WriteString(wizNormalStyle.Render("  "+opt) + "\n")
+			}
+		}
+		sb.WriteString("\n" + wizHintStyle.Render("↑/↓ navigate  ·  Enter select"))
+	} else if m.codexPath != "" {
+		sb.WriteString(wizSuccessStyle.Render("Codex detected") + "\n")
+		sb.WriteString(wizBodyStyle.Width(w).Render(
+			"Continue development with Codex from your project directory:") + "\n\n")
+		sb.WriteString("  " + wizCodeStyle.Render(fmt.Sprintf("cd %s && codex", m.projectPath)) + "\n\n")
+		sb.WriteString(wizHintStyle.Render("Enter to continue"))
+	} else {
+		sb.WriteString(wizBodyStyle.Width(w).Render(
+			"To get AI-assisted development for Wendy apps, install Claude Code:") + "\n\n")
+		sb.WriteString("  " + wizCodeStyle.Render("npm install -g @anthropic-ai/claude-code") + "\n\n")
+		sb.WriteString(wizBodyStyle.Width(w).Render(
+			"Then open your project and run:") + "\n\n")
+		sb.WriteString("  " + wizCodeStyle.Render(fmt.Sprintf("cd %s && claude", m.projectPath)) + "\n\n")
+		sb.WriteString(wizHintStyle.Render("Enter to continue"))
+	}
+	return sb.String()
+}
+```
+
+with:
+
+```go
+func (m tourWizardModel) viewAICheck(w int) string {
+	var sb strings.Builder
+	sb.WriteString(wizTitleStyle.Render("Connect your AI coding assistant") + "\n\n")
+
+	var detected []string
+	if m.claudePath != "" {
+		detected = append(detected, "Claude Code")
+	}
+	if m.codexPath != "" {
+		detected = append(detected, "Codex")
+	}
+	sb.WriteString(wizSuccessStyle.Render("Detected: "+strings.Join(detected, ", ")) + "\n\n")
+	sb.WriteString(wizBodyStyle.Width(w).Render(
+		"Set up the Wendy MCP server so your assistant can talk to your devices "+
+			"directly — list devices, manage containers, read telemetry, and more?") + "\n\n")
+
+	opts := []string{"Yes, set up MCP now", "No, skip"}
+	for i, opt := range opts {
+		if i == m.wifiCursor {
+			sb.WriteString(wizSelectedStyle.Render("▶ "+opt) + "\n")
+		} else {
+			sb.WriteString(wizNormalStyle.Render("  "+opt) + "\n")
+		}
+	}
+	sb.WriteString("\n" + wizHintStyle.Render("↑/↓ navigate  ·  Enter select"))
+	return sb.String()
+}
+```
+
+- [ ] **Step 2: Make the MCP-results copy assistant-agnostic**
+
+In `viewAIMCPSetup`, replace:
+
+```go
+		sb.WriteString(wizBodyStyle.Width(w).Render(
+			"Restart Claude Code to activate the Wendy MCP server.\n"+
+				"Claude will now have tools to list devices, manage containers,\n"+
+				"read telemetry, and more.") + "\n\n")
+```
+
+with:
+
+```go
+		sb.WriteString(wizBodyStyle.Width(w).Render(
+			"Restart your AI assistant to activate the Wendy MCP server.\n"+
+				"It will then have tools to list devices, manage containers,\n"+
+				"read telemetry, and more.") + "\n\n")
+```
+
+- [ ] **Step 3: Add the AI line to the welcome blurb**
+
+In `viewWelcome`, replace:
+
+```go
+	sb.WriteString(wizBodyStyle.Width(w).Render(
+		"This wizard will:\n"+
+			"  1. Flash WendyOS onto your device\n"+
+			"  2. Boot it and connect over the network\n"+
+			"  3. Deploy a sample Python app\n\n"+
+			"If anything goes wrong you can restart at any time with:\n") + "\n")
+```
+
+with:
+
+```go
+	sb.WriteString(wizBodyStyle.Width(w).Render(
+		"This wizard will:\n"+
+			"  1. Connect your AI coding assistant (if installed)\n"+
+			"  2. Flash WendyOS onto your device\n"+
+			"  3. Boot it and connect over the network\n"+
+			"  4. Deploy a sample Python app\n\n"+
+			"If anything goes wrong you can restart at any time with:\n") + "\n")
+```
+
+- [ ] **Step 4: Build, vet, and run the package tests**
+
+Run: `cd go && go build ./internal/cli/... && go vet ./internal/cli/commands/ && go test ./internal/cli/commands/ -run Tour -v`
+Expected: build succeeds, vet is clean (no unused `fmt` import — `fmt` is still used elsewhere in the file), Tour tests PASS.
+
+- [ ] **Step 5: Manually verify the rendered screens (optional but recommended)**
+
+Run: `cd go && go run ./cmd/wendy tour` (requires an interactive terminal). Confirm: welcome lists "Connect your AI coding assistant" first; pressing Enter shows the AI screen when `claude`/`codex` is on PATH (or jumps straight to device selection when neither is); choosing "No, skip" lands on device selection.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go/internal/cli/commands/tour.go
+git commit -m "feat: reframe tour AI screen as a front-of-tour pre-step"
+```
+
+---
+
+## Notes for the implementer
+
+- After Task 1, `m.projectPath` is no longer read by `viewAICheck` once Task 2 lands; it is still set and used by other phases (`createPythonProject`, `viewCreateProject`), so leave the field in place.
+- The `fmt` import remains required by other view functions; do not remove it when deleting the `fmt.Sprintf` calls from `viewAICheck`.
+- Run the full package suite once at the end: `cd go && go test ./internal/cli/commands/`.


### PR DESCRIPTION
## What

Moves the `wendy tour` wizard's AI-assistant setup (claude/codex detection + Wendy MCP server wiring) from the **final** step to **immediately after the welcome screen** — before the slow flash → boot → deploy phases.

The goal: get the user's AI coding assistant connected to Wendy *immediately*, so they can start coding against the device while it comes up, instead of being offered it only at the very end.

## Flow

```
Welcome
  → detect claude/codex (exec.LookPath — instant)
       ├─ claude and/or codex found → "Connect your AI coding assistant" → optional MCP setup → results
       └─ neither found            → skip silently
  → Step 1: Select device → flash → boot → deploy sample app
  → "You're all set!"   (no AI step at the end anymore)
```

## Changes

- **Welcome → AI check first.** Pressing Enter on the welcome screen now runs the AI detection, then routes to the AI step (if a CLI is found) or straight to device selection (if not).
- **Skip silently when nothing is installed.** No up-front install-instructions screen — that would be noise before the user has even picked a device.
- **Codex gets MCP setup too.** Previously a Codex-only user got a bare hint with no MCP wiring; the offer now covers Claude *and* Codex (`setupMCPForAllTools()` already configured Codex).
- **AI screen reframed as a front-of-tour pre-step.** Dropped the `projectPath` references (no project exists yet), added a "Detected: …" line, and unnumbered the screen so the existing "Step 1…8" labels are untouched.
- **Post-deploy** now goes straight to the "You're all set!" cloud screen.

No changes to `setupMCPForAllTools()` or any MCP config writer — all reused.

## Tests

New model-level tests drive `Update` through the routing:
- claude/codex detected → AI step; neither → device load (silent skip)
- "skip" and the MCP-results screen → device load
- "Yes" with Codex-only → triggers MCP setup
- deploy completion → cloud screen (not the old AI step)

Full `internal/cli/commands` package suite passes; build + `go vet` clean.

Design + plan: `specs/2026-06-27-tour-ai-setup-first-design.md`, `specs/superpowers/plans/2026-06-27-tour-ai-setup-first.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)