### PR TITLE
feat(cli): hide the Address column in `wendy cloud discover`

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/discover.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/cloud/discover.md
@@ -27,8 +27,11 @@ The TUI displays a table with the following columns for each device:
 |--------|-------------|
 | Name | Device name |
 | Type | Hardware device type |
-| Address | IP address reported by the cloud |
 | Version | Running agent version (fetched live; `—` while loading) |
+
+The device's IP address is not shown as a column — cloud devices are reached by
+name/ID through the broker tunnel. The address is still included in the
+clipboard/JSON output (see below).
 
 ### Keyboard shortcuts
 

--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -327,10 +327,6 @@ func (m cloudDiscoverModel) viewLine(line string) string {
 func cloudDiscoverTableRows(assets []*cloudpb.Asset, versions map[int32]*agentpb.GetAgentVersionResponse) []bubbleTable.Row {
 	rows := make([]bubbleTable.Row, 0, len(assets))
 	for _, a := range assets {
-		addr := a.GetIpAddress()
-		if addr == "" {
-			addr = "—"
-		}
 		devType := humanReadableDeviceType(a.GetDeviceType())
 		ver := "—"
 		if v := versions[a.GetId()]; v != nil {
@@ -339,7 +335,7 @@ func cloudDiscoverTableRows(assets []*cloudpb.Asset, versions map[int32]*agentpb
 				devType = humanReadableDeviceType(v.GetDeviceType())
 			}
 		}
-		rows = append(rows, bubbleTable.Row{"", a.GetName(), devType, addr, ver})
+		rows = append(rows, bubbleTable.Row{"", a.GetName(), devType, ver})
 	}
 	return rows
 }

--- a/go/internal/cli/commands/cloud_discover_address_test.go
+++ b/go/internal/cli/commands/cloud_discover_address_test.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func TestCloudDiscoverTableRows_OmitsAddress(t *testing.T) {
+	devType, ip := "raspberry-pi-5", "192.168.1.50"
+	a := &cloudpb.Asset{Id: 1, Name: "alpha", DeviceType: &devType, IpAddress: &ip}
+	rows := cloudDiscoverTableRows([]*cloudpb.Asset{a}, nil)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d; want 1", len(rows))
+	}
+	row := rows[0]
+	// Columns are: marker, Name, Type, Version — no Address.
+	if len(row) != 4 {
+		t.Fatalf("row has %d cells; want 4 (marker, Name, Type, Version): %v", len(row), row)
+	}
+	for _, cell := range row {
+		if cell == "192.168.1.50" {
+			t.Fatalf("address must be omitted from the cloud discover row: %v", row)
+		}
+	}
+	if row[1] != "alpha" {
+		t.Errorf("name cell = %q; want alpha", row[1])
+	}
+}
+
+func TestDiscoverTableHeaders_OmitAddress(t *testing.T) {
+	for _, h := range discoverTableHeaders {
+		if h == "Address" {
+			t.Fatalf("cloud discover headers should not include Address: %v", discoverTableHeaders)
+		}
+	}
+	if got, want := len(discoverTableHeaders), len(discoverTableMinWidths); got != want {
+		t.Fatalf("headers (%d) and min widths (%d) length mismatch", got, want)
+	}
+	if got, want := len(discoverTableHeaders), len(discoverTableMaxWidths); got != want {
+		t.Fatalf("headers (%d) and max widths (%d) length mismatch", got, want)
+	}
+}

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -755,10 +755,14 @@ func newDiscoverTable(interactive bool) tui.BubbleTable {
 	return tui.NewBubbleTable(interactive, nil)
 }
 
+// These back the `wendy cloud discover` table. The Address column is omitted:
+// cloud devices are addressed by name/ID via the broker tunnel, so the IP adds
+// noise. (The interactive `wendy discover` table uses tui.PickerDeviceTableData,
+// not these.) The full address is still available in the clipboard JSON.
 var (
-	discoverTableHeaders   = []string{"", "Name", "Type", "Address", "Version"}
-	discoverTableMinWidths = []int{3, 12, 10, 14, 10}
-	discoverTableMaxWidths = []int{3, 33, 20, 28, 16}
+	discoverTableHeaders   = []string{"", "Name", "Type", "Version"}
+	discoverTableMinWidths = []int{3, 12, 10, 10}
+	discoverTableMaxWidths = []int{3, 33, 20, 16}
 )
 
 var deviceTypeNames = map[string]string{


### PR DESCRIPTION
Cloud devices are reached by name/ID through the broker tunnel, so the IP column added noise. Drop it from the cloud discover table (and its shared column defs, which only back that table); the address is still included in the clipboard/JSON output. Docs updated to match.


Claude-Session: https://claude.ai/code/session_019zmdqCEDdLa2UTMyTae2se