### PR TITLE
Jo/device table connecting state

### DIFF
--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	bubbleTable "github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -220,6 +221,14 @@ type btScanMsg struct {
 }
 type extScanMsg struct{ devices []models.ExternalDevice }
 
+// lanProbeMsg carries the result of an async agent version/OS probe for one LAN
+// device. dev holds the resolved metadata when err is nil.
+type lanProbeMsg struct {
+	name string
+	dev  models.LANDevice
+	err  error
+}
+
 // discoverDeviceInfo is the JSON structure copied to the clipboard.
 type discoverDeviceInfo struct {
 	ID          int32  `json:"id,omitempty"`
@@ -272,7 +281,9 @@ type discoverModel struct {
 	bleWarning         string
 	flashMessage       string
 	flashIsError       bool
-	updatingDeviceName string // non-empty while a background update is running
+	updatingDeviceName string                    // non-empty while a background update is running
+	spinner            spinner.Model             // animates Agent/OS cells while LAN probes run
+	probe              map[string]tui.ProbeState // LAN display name (lowercased) -> probe state
 }
 
 func newDiscoverModel(ctx context.Context, opts discovery.DiscoveryOptions) discoverModel {
@@ -283,6 +294,10 @@ func newDiscoverModel(ctx context.Context, opts discovery.DiscoveryOptions) disc
 		bleSeen:         make(map[string]time.Time),
 		table:           newDiscoverTable(true),
 		includeExternal: shouldIncludeExternal(opts),
+		// Empty style so View() yields a bare frame rune for the plain table
+		// cells (matches tui.newProbeSpinner).
+		spinner: spinner.New(spinner.WithSpinner(spinner.Dot)),
+		probe:   make(map[string]tui.ProbeState),
 	}
 	m.refreshTable()
 	return m
@@ -316,10 +331,22 @@ func (m discoverModel) scanEthernet() tea.Cmd {
 
 func (m discoverModel) scanLAN() tea.Cmd {
 	return func() tea.Msg {
+		// Discover devices only; version/OS are resolved asynchronously per
+		// device (see probeLANCmd) so rows appear immediately with a
+		// "connecting" spinner instead of blocking on the probe.
 		devices, _ := discovery.DiscoverLAN(m.ctx, m.opts.Timeout)
-		devices = resolveLANVersions(m.ctx, devices)
 		sortLANDevicesForDiscover(devices)
 		return lanScanMsg{devices: devices}
+	}
+}
+
+// probeLANCmd resolves a single LAN device's agent version/OS in the background
+// and reports the result as a lanProbeMsg.
+func (m discoverModel) probeLANCmd(dev models.LANDevice) tea.Cmd {
+	ctx := m.ctx
+	return func() tea.Msg {
+		resolved, _, err := resolveLANVersion(ctx, dev)
+		return lanProbeMsg{name: dev.DisplayName, dev: resolved, err: err}
 	}
 }
 
@@ -354,6 +381,7 @@ func (m discoverModel) Init() tea.Cmd {
 	if m.includeExternal {
 		cmds = append(cmds, m.scanExternal())
 	}
+	cmds = append(cmds, m.spinner.Tick)
 	return tea.Batch(cmds...)
 }
 
@@ -479,8 +507,54 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.collection.LANDevices = msg.devices
 		m.hasResults = true
+
+		// Assign a probe state to each device and kick off a background probe
+		// for any whose version isn't known yet. nextProbeState keeps resolved
+		// rows sticky and avoids flipping a failed row back to the spinner.
+		cmds := []tea.Cmd{m.scanLAN()}
+		for i := range m.collection.LANDevices {
+			d := &m.collection.LANDevices[i]
+			key := strings.ToLower(d.DisplayName)
+			if d.AgentVersion != "" {
+				m.probe[key] = nextProbeState(m.probe[key], tui.ProbeOK)
+				continue
+			}
+			prev := m.probe[key]
+			m.probe[key] = nextProbeState(prev, tui.ProbePending)
+			if prev != tui.ProbePending {
+				cmds = append(cmds, m.probeLANCmd(*d))
+			}
+		}
 		m.refreshTable()
-		return m, m.scanLAN()
+		return m, tea.Batch(cmds...)
+	case lanProbeMsg:
+		key := strings.ToLower(msg.name)
+		for i := range m.collection.LANDevices {
+			d := &m.collection.LANDevices[i]
+			if !strings.EqualFold(d.DisplayName, msg.name) {
+				continue
+			}
+			if msg.err == nil {
+				d.AgentVersion = msg.dev.AgentVersion
+				d.DeviceType = msg.dev.DeviceType
+				d.OS = msg.dev.OS
+				d.OSVersion = msg.dev.OSVersion
+				d.CPUArchitecture = msg.dev.CPUArchitecture
+				m.probe[key] = nextProbeState(m.probe[key], tui.ProbeOK)
+			} else {
+				m.probe[key] = nextProbeState(m.probe[key], tui.ProbeFailed)
+			}
+			break
+		}
+		m.refreshTable()
+		return m, nil
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		if m.anyProbePending() {
+			m.refreshTable()
+		}
+		return m, cmd
 	case btScanMsg:
 		now := time.Now()
 
@@ -594,7 +668,7 @@ func (m discoverModel) View() string {
 	}
 
 	if !m.collection.IsEmpty() {
-		sb.WriteString(m.tableView() + "\n")
+		sb.WriteString(tui.ColorizeProbeGlyphs(m.tableView()) + "\n")
 		sb.WriteString(m.viewLine(dimStyle.Render("  "+tui.DeviceTableLegend)) + "\n")
 		if hint := m.selectedHint(); hint != "" {
 			sb.WriteString(m.viewLine(hintWarnStyle.Render("  ⚠  "+hint)) + "\n")
@@ -616,8 +690,34 @@ func (m discoverModel) View() string {
 	return sb.String()
 }
 
+// anyProbePending reports whether any LAN device still has a probe in flight.
+func (m discoverModel) anyProbePending() bool {
+	for _, st := range m.probe {
+		if st == tui.ProbePending {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *discoverModel) refreshTable() {
 	m.tableItems = discoverTableItems(m.collection)
+	// Stamp each LAN row with its probe state (and the current spinner frame
+	// while connecting) so the Agent/OS columns animate / show the error glyph.
+	frame := m.spinner.View()
+	for i := range m.tableItems {
+		name := m.tableItems[i].lanName
+		if name == "" {
+			continue
+		}
+		st := m.probe[strings.ToLower(name)]
+		m.tableItems[i].picker.Probe = st
+		if st == tui.ProbePending {
+			m.tableItems[i].picker.ProbeFrame = frame
+			// Still connecting: don't show the no-access hint yet.
+			m.tableItems[i].picker.Hint = ""
+		}
+	}
 	pickerItems := discoverPickerItems(m.tableItems)
 	cols, rows := tui.PickerDeviceTableData(pickerItems, discoverDefaultKey(), true)
 	m.table.SetColumns(cols)

--- a/go/internal/cli/commands/discover_probe_test.go
+++ b/go/internal/cli/commands/discover_probe_test.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// discoverAgentCell returns the Agent-column cell of the single table row.
+func discoverAgentCell(t *testing.T, m discoverModel) string {
+	t.Helper()
+	agentIdx := -1
+	for i, c := range m.table.Columns() {
+		if c.Title == "Agent" {
+			agentIdx = i
+		}
+	}
+	if agentIdx < 0 {
+		t.Fatalf("no Agent column; columns=%v", m.table.Columns())
+	}
+	rows := m.table.Rows()
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d; want 1", len(rows))
+	}
+	return rows[0][agentIdx]
+}
+
+func TestDiscoverModel_LANProbePendingThenOK(t *testing.T) {
+	m := newDiscoverModel(context.Background(), defaultOpts())
+
+	// A LAN device discovered without a version is "connecting": probe state is
+	// pending and the Agent cell shows a (non-empty) spinner frame, not blank.
+	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{DisplayName: "alpha"}}})
+	dm := updated.(discoverModel)
+	if dm.probe["alpha"] != tui.ProbePending {
+		t.Fatalf("probe state = %v; want pending", dm.probe["alpha"])
+	}
+	if cell := discoverAgentCell(t, dm); cell == "" {
+		t.Fatal("pending device Agent cell should show a spinner frame, got blank")
+	}
+
+	// The probe resolves: the version appears and the state becomes OK.
+	updated, _ = dm.Update(lanProbeMsg{name: "alpha", dev: models.LANDevice{
+		DisplayName: "alpha", AgentVersion: "0.10.4", OSVersion: "WendyOS-0.10.4",
+	}})
+	dm = updated.(discoverModel)
+	if dm.probe["alpha"] != tui.ProbeOK {
+		t.Fatalf("probe state = %v; want ok", dm.probe["alpha"])
+	}
+	if cell := discoverAgentCell(t, dm); cell != "0.10.4" {
+		t.Fatalf("resolved Agent cell = %q; want 0.10.4", cell)
+	}
+}
+
+func TestDiscoverModel_LANProbeFailedShowsGlyph(t *testing.T) {
+	m := newDiscoverModel(context.Background(), defaultOpts())
+	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{DisplayName: "beta"}}})
+	dm := updated.(discoverModel)
+
+	updated, _ = dm.Update(lanProbeMsg{name: "beta", err: context.DeadlineExceeded})
+	dm = updated.(discoverModel)
+	if dm.probe["beta"] != tui.ProbeFailed {
+		t.Fatalf("probe state = %v; want failed", dm.probe["beta"])
+	}
+	if cell := discoverAgentCell(t, dm); cell != tui.ProbeFailedGlyph {
+		t.Fatalf("failed Agent cell = %q; want %q", cell, tui.ProbeFailedGlyph)
+	}
+}
+
+func TestDiscoverModel_LANProbeOKSurvivesTransientFailure(t *testing.T) {
+	m := newDiscoverModel(context.Background(), defaultOpts())
+	updated, _ := m.Update(lanScanMsg{devices: []models.LANDevice{{DisplayName: "gamma"}}})
+	dm := updated.(discoverModel)
+	updated, _ = dm.Update(lanProbeMsg{name: "gamma", dev: models.LANDevice{DisplayName: "gamma", AgentVersion: "1.2.3"}})
+	dm = updated.(discoverModel)
+
+	// A later failed probe must not erase a known version.
+	updated, _ = dm.Update(lanProbeMsg{name: "gamma", err: context.DeadlineExceeded})
+	dm = updated.(discoverModel)
+	if dm.probe["gamma"] != tui.ProbeOK {
+		t.Fatalf("probe state = %v; want ok (sticky)", dm.probe["gamma"])
+	}
+	if cell := discoverAgentCell(t, dm); cell != "1.2.3" {
+		t.Fatalf("Agent cell = %q; want 1.2.3 retained", cell)
+	}
+}

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -538,6 +538,16 @@ func TestDiscoverModelViewShowsNoAccessHintForHighlightedDevice(t *testing.T) {
 	}}})
 	dm := updated.(discoverModel)
 
+	// While the probe is still in flight the row is "connecting" (spinner), so
+	// the no-access hint is suppressed.
+	if view := ansi.Strip(dm.View()); strings.Contains(view, "does not have access") {
+		t.Fatalf("no-access hint should be suppressed while connecting, got %q", view)
+	}
+
+	// Once the probe fails, the provisioned device shows the no-access hint.
+	updated, _ = dm.Update(lanProbeMsg{name: "wendy-locked", err: context.DeadlineExceeded})
+	dm = updated.(discoverModel)
+
 	view := ansi.Strip(dm.View())
 	if !strings.Contains(view, "does not have access") {
 		t.Fatalf("expected no-access hint in view, got %q", view)

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1617,6 +1617,30 @@ type pickerEntry struct {
 // mergePickerItem merges a newly discovered transport into an existing picker
 // item for the same physical device. It combines connection types, prefers
 // LAN addresses, and merges the underlying DiscoveredDevice fields.
+// nextProbeState resolves the probe state for a merged picker row. A succeeded
+// probe (ProbeOK) is sticky: it survives a later transient failure and is never
+// reset to the spinner when the device is rediscovered. A failed probe stays
+// failed until a retry succeeds, and is not flipped back to the spinner on
+// rediscovery. ProbeNone (non-LAN transports) never overrides a real state.
+func nextProbeState(existing, incoming tui.ProbeState) tui.ProbeState {
+	switch incoming {
+	case tui.ProbeOK:
+		return tui.ProbeOK
+	case tui.ProbeFailed:
+		if existing == tui.ProbeOK {
+			return tui.ProbeOK
+		}
+		return tui.ProbeFailed
+	case tui.ProbePending:
+		if existing == tui.ProbeNone {
+			return tui.ProbePending
+		}
+		return existing
+	default:
+		return existing
+	}
+}
+
 func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 	e, eOK := existing.Value.(*pickerEntry)
 	n, nOK := incoming.Value.(*pickerEntry)
@@ -1698,6 +1722,8 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 	if existing.AgentVersion != "" && existing.Hint == discoverNoAccessHint {
 		existing.Hint = ""
 	}
+
+	existing.Probe = nextProbeState(existing.Probe, incoming.Probe)
 }
 
 func usbFirstSortKey(name, usb string) string {
@@ -1747,8 +1773,15 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 	// Continuous LAN discovery — devices appear as they're found.
 	lanCh := make(chan models.LANDevice, 16)
 	go discovery.DiscoverLANContinuous(discoverCtx, lanCh)
-	sendLANItem := func(dev models.LANDevice, insecure bool) {
+	sendLANItem := func(dev models.LANDevice, insecure bool, probe tui.ProbeState) {
 		devCopy := dev
+		// While the probe is still in flight the Agent/OS columns show a
+		// spinner, so suppress the no-access hint until we actually know the
+		// probe failed.
+		hint := ""
+		if probe != tui.ProbePending {
+			hint = lanNoAccessHint(&devCopy, dev.AgentVersion)
+		}
 		p.Send(tui.PickerAddMsg{Items: []tui.PickerItem{{
 			Name:         dev.DisplayName,
 			Type:         "LAN",
@@ -1757,7 +1790,8 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 			AgentVersion: dev.AgentVersion,
 			OSVersion:    dev.OSVersion,
 			Provisioned:  lanProvisionedDisplay(&devCopy),
-			Hint:         lanNoAccessHint(&devCopy, dev.AgentVersion),
+			Hint:         hint,
+			Probe:        probe,
 			DedupKey:     dev.DisplayName,
 			SortKey:      usbFirstSortKey(dev.DisplayName, dev.USB),
 			Insecure:     insecure,
@@ -1773,26 +1807,31 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 	}
 	go func() {
 		for rawDev := range lanCh {
+			// Show the device immediately with a "connecting" spinner, then
+			// resolve its version/OS and update the row in place.
+			sendLANItem(rawDev, false, tui.ProbePending)
 			resolved, isMTLS, err := resolveLANVersion(discoverCtx, rawDev)
-			sendLANItem(resolved, err == nil && !isMTLS)
-			if err != nil {
-				// Version probe failed on first attempt. Retry in background so
-				// the version appears once the device becomes responsive, without
-				// requiring it to be rediscovered via mDNS.
-				go func(d models.LANDevice) {
-					for attempt := 0; attempt < 5; attempt++ {
-						select {
-						case <-discoverCtx.Done():
-							return
-						case <-time.After(2 * time.Second):
-						}
-						if updated, isMTLS, retryErr := resolveLANVersion(discoverCtx, d); retryErr == nil {
-							sendLANItem(updated, !isMTLS)
-							return
-						}
-					}
-				}(rawDev)
+			if err == nil {
+				sendLANItem(resolved, !isMTLS, tui.ProbeOK)
+				continue
 			}
+			// Version probe failed on first attempt: mark the row failed (red
+			// triangle) and retry in the background so the version appears once
+			// the device becomes responsive, without requiring rediscovery.
+			sendLANItem(rawDev, false, tui.ProbeFailed)
+			go func(d models.LANDevice) {
+				for attempt := 0; attempt < 5; attempt++ {
+					select {
+					case <-discoverCtx.Done():
+						return
+					case <-time.After(2 * time.Second):
+					}
+					if updated, isMTLS, retryErr := resolveLANVersion(discoverCtx, d); retryErr == nil {
+						sendLANItem(updated, !isMTLS, tui.ProbeOK)
+						return
+					}
+				}
+			}(rawDev)
 		}
 	}()
 

--- a/go/internal/cli/commands/picker_probe_test.go
+++ b/go/internal/cli/commands/picker_probe_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+func TestNextProbeState(t *testing.T) {
+	cases := []struct {
+		name                     string
+		existing, incoming, want tui.ProbeState
+	}{
+		{"first probe starts pending", tui.ProbeNone, tui.ProbePending, tui.ProbePending},
+		{"pending resolves to ok", tui.ProbePending, tui.ProbeOK, tui.ProbeOK},
+		{"pending resolves to failed", tui.ProbePending, tui.ProbeFailed, tui.ProbeFailed},
+		{"ok survives transient failure", tui.ProbeOK, tui.ProbeFailed, tui.ProbeOK},
+		{"ok not reset to pending on rediscovery", tui.ProbeOK, tui.ProbePending, tui.ProbeOK},
+		{"failed recovers on retry success", tui.ProbeFailed, tui.ProbeOK, tui.ProbeOK},
+		{"failed not flipped to spinner on rediscovery", tui.ProbeFailed, tui.ProbePending, tui.ProbeFailed},
+		{"none stays none", tui.ProbeNone, tui.ProbeNone, tui.ProbeNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nextProbeState(tc.existing, tc.incoming); got != tc.want {
+				t.Errorf("nextProbeState(%v,%v) = %v; want %v", tc.existing, tc.incoming, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -4,10 +4,68 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	bubbleTable "github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
+
+// newProbeSpinner builds the spinner that animates the Agent/OS columns while a
+// device probe is in flight. Its Style is intentionally empty so View() returns
+// a bare frame rune: the frame is written into plain table cells, which the
+// bubbles table truncates without ANSI awareness, so it must carry no escapes.
+func newProbeSpinner() spinner.Model {
+	return spinner.New(spinner.WithSpinner(spinner.Dot))
+}
+
+// ProbeState describes whether an agent version/OS probe for a device row is in
+// flight, succeeded, or failed. The zero value (ProbeNone) renders the version
+// columns exactly as before, so non-probing pickers are unaffected.
+type ProbeState int
+
+const (
+	ProbeNone    ProbeState = iota // no probe semantics: show version text as-is
+	ProbePending                   // probe in flight: show an animated spinner
+	ProbeOK                        // probe succeeded: show the version
+	ProbeFailed                    // probe failed: show the error glyph
+)
+
+// ProbeFailedGlyph marks a row whose agent probe failed and for which no version
+// is cached. It is rendered red by the view layer (see ColorizeProbeGlyphs); the
+// cell value itself is kept as a plain glyph so the table's non-ANSI-aware
+// truncation stays correct.
+const ProbeFailedGlyph = "▲"
+
+// probeFailedColored wraps the failure glyph in a red foreground that resets
+// only the foreground (\x1b[39m), not the whole SGR state. A full reset would
+// clear a selected row's background for the rest of the line; resetting just the
+// foreground keeps the highlight intact. 196 matches the red used elsewhere in
+// the device tables.
+const probeFailedColored = "\x1b[38;5;196m" + ProbeFailedGlyph + "\x1b[39m"
+
+// ColorizeProbeGlyphs colors the (plain-text) failure glyph red in an
+// already-rendered table view. The glyph is kept plain inside table cells so the
+// table's non-ANSI-aware truncation stays correct; color is applied here, after
+// layout, so it never affects column widths.
+func ColorizeProbeGlyphs(view string) string {
+	return strings.ReplaceAll(view, ProbeFailedGlyph, probeFailedColored)
+}
+
+// probeColumnValue renders an Agent/OS cell for the given probe state. While
+// pending it shows the current spinner frame; on failure with no cached version
+// it shows the error glyph; otherwise it shows the version text (a cached
+// version is preserved even after a later transient failure).
+func probeColumnValue(state ProbeState, version, frame string) string {
+	switch state {
+	case ProbePending:
+		return frame
+	case ProbeFailed:
+		if version == "" {
+			return ProbeFailedGlyph
+		}
+	}
+	return version
+}
 
 // PickerItem represents a selectable row in the device picker.
 type PickerItem struct {
@@ -24,6 +82,15 @@ type PickerItem struct {
 	OSVersion    string
 	Provisioned  string // "Provisioned" or "Unprovisioned" when known, empty otherwise
 	Hint         string // optional footer text shown when this item is highlighted
+
+	// Probe reflects whether the agent version/OS probe for this row is in
+	// flight (ProbePending), done (ProbeOK), or failed (ProbeFailed). The zero
+	// value (ProbeNone) renders the version columns verbatim.
+	Probe ProbeState
+	// ProbeFrame is the spinner frame shown in the Agent/OS columns while
+	// Probe == ProbePending. The owning model refreshes it on every spinner
+	// tick; it is ignored for every other probe state.
+	ProbeFrame string
 
 	// Section, when non-empty, groups this item under a non-selectable header
 	// row bearing the section name. Sections are rendered in the order they
@@ -110,6 +177,7 @@ type PickerModel struct {
 	// picker exactly.
 	rowItem      []int
 	table        BubbleTable
+	spinner      spinner.Model // animates Agent/OS cells while probes are pending
 	columns      []pickerColumnDef
 	fixedColumns bool
 	legend       string // optional glyph legend rendered under the table
@@ -133,6 +201,7 @@ func NewPicker() PickerModel {
 		Title:        "Select a device",
 		seenIdx:      make(map[string]int),
 		table:        newPickerTable(),
+		spinner:      newProbeSpinner(),
 		columns:      pickerDeviceColumnDefs,
 		fixedColumns: true,
 		legend:       DeviceTableLegend,
@@ -147,6 +216,7 @@ func NewPickerWithTitle(title string) PickerModel {
 		Title:    title,
 		seenIdx:  make(map[string]int),
 		table:    newPickerTable(),
+		spinner:  newProbeSpinner(),
 		scanning: true,
 	}
 	m.refreshTable()
@@ -166,10 +236,30 @@ func NewPickerWithTitleAndColumns(title string, columns []PickerColumn) PickerMo
 	return m
 }
 
-func (m PickerModel) Init() tea.Cmd { return nil }
+func (m PickerModel) Init() tea.Cmd { return m.spinner.Tick }
+
+// anyProbePending reports whether any item still has a probe in flight, i.e.
+// whether the spinner has anything to animate.
+func (m PickerModel) anyProbePending() bool {
+	for i := range m.items {
+		if m.items[i].Probe == ProbePending {
+			return true
+		}
+	}
+	return false
+}
 
 func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		// Re-render so pending rows pick up the new frame; skip the rebuild
+		// when nothing is animating, but keep the tick loop alive cheaply.
+		if m.anyProbePending() {
+			m.refreshTable()
+		}
+		return m, cmd
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -354,7 +444,7 @@ func (m PickerModel) View() string {
 		return sb.String()
 	}
 
-	sb.WriteString(m.tableView() + "\n")
+	sb.WriteString(ColorizeProbeGlyphs(m.tableView()) + "\n")
 
 	if m.legend != "" {
 		sb.WriteString(m.viewLine(pickerHint.Render("  "+m.legend)) + "\n")
@@ -513,14 +603,14 @@ var pickerDeviceColumnDefs = []pickerColumnDef{
 		title:    "Agent",
 		minWidth: 7,
 		value: func(item PickerItem) string {
-			return item.AgentVersion
+			return probeColumnValue(item.Probe, item.AgentVersion, item.ProbeFrame)
 		},
 	},
 	{
 		title:    "OS",
 		minWidth: 4,
 		value: func(item PickerItem) string {
-			return item.OSVersion
+			return probeColumnValue(item.Probe, item.OSVersion, item.ProbeFrame)
 		},
 	},
 	{
@@ -614,6 +704,15 @@ func (m *PickerModel) refreshTable() {
 }
 
 func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
+	// Stamp the current spinner frame onto pending rows so the Agent/OS columns
+	// animate as the table is rebuilt.
+	frame := m.spinner.View()
+	for i := range m.items {
+		if m.items[i].Probe == ProbePending {
+			m.items[i].ProbeFrame = frame
+		}
+	}
+
 	// Sort items for a stable, predictable display order. When SortKey is set,
 	// it takes precedence; otherwise sort by name (using DedupKey if present).
 	sort.SliceStable(m.items, func(i, j int) bool {

--- a/go/internal/cli/tui/picker_probe_model_test.go
+++ b/go/internal/cli/tui/picker_probe_model_test.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+)
+
+func agentColumnIndex(t *testing.T, m PickerModel) int {
+	t.Helper()
+	for i, c := range m.table.Columns() {
+		if c.Title == "Agent" {
+			return i
+		}
+	}
+	t.Fatalf("no Agent column; columns=%v", m.table.Columns())
+	return -1
+}
+
+func TestPickerModel_StartsSpinner(t *testing.T) {
+	if NewPicker().Init() == nil {
+		t.Fatal("Init should start the probe spinner (non-nil command)")
+	}
+}
+
+func TestPickerModel_PendingRowShowsSpinnerFrame(t *testing.T) {
+	m := NewPicker()
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{
+		Name: "dev", Type: "LAN", Address: "dev.local:50052",
+		DedupKey: "dev", Probe: ProbePending,
+	}}})
+	pm := updated.(PickerModel)
+
+	rows := pm.table.Rows()
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d; want 1", len(rows))
+	}
+	if cell := rows[0][agentColumnIndex(t, pm)]; cell == "" {
+		t.Fatal("pending row Agent cell should show a spinner frame, got empty")
+	}
+}
+
+func TestPickerModel_SpinnerTickAdvancesFrame(t *testing.T) {
+	m := NewPicker()
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{
+		Name: "dev", Type: "LAN", Address: "dev.local:50052",
+		DedupKey: "dev", Probe: ProbePending,
+	}}})
+	pm := updated.(PickerModel)
+	agentIdx := agentColumnIndex(t, pm)
+	first := pm.table.Rows()[0][agentIdx]
+
+	// Drive several ticks; the spinner frame must change at least once.
+	changed := false
+	for i := 0; i < 12; i++ {
+		u, cmd := pm.Update(spinner.TickMsg{})
+		pm = u.(PickerModel)
+		if cmd == nil {
+			t.Fatal("spinner tick should schedule the next tick")
+		}
+		if pm.table.Rows()[0][agentIdx] != first {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		t.Fatalf("spinner frame never changed across ticks (stuck on %q)", first)
+	}
+}
+
+func TestPickerModel_ViewColorizesFailedGlyph(t *testing.T) {
+	m := NewPicker()
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{
+		Name: "dev", Type: "LAN", Address: "dev.local:50052",
+		DedupKey: "dev", Probe: ProbeFailed,
+	}}})
+	pm := updated.(PickerModel)
+
+	view := pm.View()
+	if !strings.Contains(view, probeFailedColored) {
+		t.Fatalf("View should render the failed glyph in red; view=%q", view)
+	}
+}

--- a/go/internal/cli/tui/picker_probe_test.go
+++ b/go/internal/cli/tui/picker_probe_test.go
@@ -1,0 +1,91 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestColorizeProbeGlyphs(t *testing.T) {
+	t.Run("no glyph is unchanged", func(t *testing.T) {
+		in := "alpha  0.10.4  WendyOS-0.10.4"
+		if got := ColorizeProbeGlyphs(in); got != in {
+			t.Errorf("got %q; want unchanged %q", got, in)
+		}
+	})
+
+	t.Run("glyph is colored but width preserved", func(t *testing.T) {
+		in := "failed  ▲  ▲"
+		got := ColorizeProbeGlyphs(in)
+		if !strings.Contains(got, "\x1b[") {
+			t.Errorf("expected ANSI color escapes in %q", got)
+		}
+		// Coloring must not change the visible text/width: stripping ANSI must
+		// return exactly the original string.
+		if stripped := ansi.Strip(got); stripped != in {
+			t.Errorf("stripped = %q; want original %q", stripped, in)
+		}
+		// Must not emit a full reset (\x1b[0m), which would clear a selected
+		// row's background; only the foreground is reset.
+		if strings.Contains(got, "\x1b[0m") {
+			t.Errorf("colorized glyph should not emit a full reset: %q", got)
+		}
+	})
+}
+
+func TestProbeColumnValue(t *testing.T) {
+	const frame = "⠙"
+	cases := []struct {
+		name    string
+		state   ProbeState
+		version string
+		want    string
+	}{
+		{"none keeps version", ProbeNone, "0.10.4", "0.10.4"},
+		{"none empty stays empty", ProbeNone, "", ""},
+		{"pending shows spinner frame", ProbePending, "", frame},
+		{"pending ignores stale version", ProbePending, "0.10.4", frame},
+		{"ok shows version", ProbeOK, "0.10.4", "0.10.4"},
+		{"failed without version shows triangle", ProbeFailed, "", ProbeFailedGlyph},
+		{"failed with cached version keeps it", ProbeFailed, "0.10.4", "0.10.4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := probeColumnValue(tc.state, tc.version, frame)
+			if got != tc.want {
+				t.Errorf("probeColumnValue(%v, %q, %q) = %q; want %q", tc.state, tc.version, frame, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPickerDeviceTableData_ProbeStates(t *testing.T) {
+	const frame = "⠹"
+	items := []PickerItem{
+		{Name: "pending", Type: "LAN", Address: "p.local:50052", Probe: ProbePending, ProbeFrame: frame},
+		{Name: "failed", Type: "LAN", Address: "f.local:50052", Probe: ProbeFailed},
+		{Name: "ok", Type: "LAN", Address: "o.local:50052", Probe: ProbeOK, AgentVersion: "0.10.4", OSVersion: "WendyOS-0.10.4"},
+	}
+
+	_, rows := PickerDeviceTableData(items, "", false)
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d; want 3", len(rows))
+	}
+	for i, row := range rows {
+		if len(row) < 5 {
+			t.Fatalf("row %d has %d cells; want >= 5 (Name,Type,Address,Agent,OS)", i, len(row))
+		}
+	}
+
+	// Agent cell is index 3, OS cell index 4 (no marker/default column here).
+	if rows[0][3] != frame || rows[0][4] != frame {
+		t.Errorf("pending row agent/os = %q/%q; want spinner frame %q", rows[0][3], rows[0][4], frame)
+	}
+	if rows[1][3] != ProbeFailedGlyph || rows[1][4] != ProbeFailedGlyph {
+		t.Errorf("failed row agent/os = %q/%q; want %q", rows[1][3], rows[1][4], ProbeFailedGlyph)
+	}
+	if rows[2][3] != "0.10.4" || rows[2][4] != "WendyOS-0.10.4" {
+		t.Errorf("ok row agent/os = %q/%q; want versions", rows[2][3], rows[2][4])
+	}
+}

--- a/specs/2026-06-27-agent-probe-connecting-state-design.md
+++ b/specs/2026-06-27-agent-probe-connecting-state-design.md
@@ -1,0 +1,173 @@
+# Design: "Connecting" + failure states for Agent/OS columns
+
+**Date:** 2026-06-27
+**Status:** Approved (design)
+
+## Problem
+
+Interactive device tables (`wendy discover` and the live device picker used by
+`wendy run` and the device commands) show **Agent** (version) and **OS** columns
+sourced from `tui.PickerItem.AgentVersion` / `OSVersion`. These values come from a
+per-device gRPC probe (`GetAgentVersion`, ~1.5s timeout) wrapped by
+`resolveLANVersions` / `resolveLANVersion`.
+
+Today the probe is **bundled into the discovery scan and blocks**:
+
+- In `wendy discover`, `scanLAN` runs `DiscoverLAN` and then `resolveLANVersions`
+  in a single command, so a LAN device only appears in the table once its probe
+  has finished. On failure the Agent/OS cells are simply **blank** (with a footer
+  hint for the no-access case only).
+- In the live device picker (`helpers.go`), a LAN device is added to the picker
+  **only after** `resolveLANVersion` returns, so it pops in late with no
+  intermediate feedback.
+
+There is no visible "in-flight" state. Users cannot tell the difference between
+"still connecting", "no version reported", and "probe failed".
+
+## Goal
+
+While an agent's version + OS are being fetched, show an animated **"connecting"
+progress indicator** in the Agent/OS cells. When the probe **fails**, show a red
+error triangle (`▲`). Apply this consistently across all interactive tables that
+probe agent version/OS.
+
+## Non-goals
+
+- Changing the probe transport, timeout, or retry counts.
+- Changing JSON / non-interactive output.
+- Adding connecting/failure states to pickers that do not probe agents (apps,
+  build, init, entitlements, drive selection, etc.).
+
+## Design
+
+### 1. Shared probe-state model
+
+Add a probe-state field to `tui.PickerItem`:
+
+```go
+type ProbeState int
+
+const (
+    ProbeNone    ProbeState = iota // zero value: render version text as today
+    ProbePending                   // probe in flight: show spinner
+    ProbeOK                        // probe succeeded: show version
+    ProbeFailed                    // probe failed: show red triangle
+)
+
+type PickerItem struct {
+    // ... existing fields ...
+    Probe ProbeState
+}
+```
+
+`ProbeNone` is the zero value, so **every existing non-agent picker is unchanged**
+— they never set `Probe`, and the renderer falls through to today's behavior.
+Only the LAN/agent-probing call sites set `ProbePending` / `ProbeOK` /
+`ProbeFailed`.
+
+### 2. Shared cell renderer
+
+A single helper in the `tui` package decides what the **Agent** and **OS** cells
+render, given the item's probe state, its cached version text, and the current
+spinner frame:
+
+| Probe state | Agent cell | OS cell |
+|---|---|---|
+| `ProbePending` | spinner frame (dim) | spinner frame (dim) |
+| `ProbeFailed` (no cached version) | red `▲` | red `▲` |
+| `ProbeOK` | `AgentVersion` (incl. outdated `⚠`) | `OSVersion` |
+| `ProbeNone` | `AgentVersion` | `OSVersion` |
+
+The indicator is rendered in **both** Agent and OS cells (a single probe populates
+both). The existing outdated-agent `⚠` suffix continues to apply in the `ProbeOK`
+/ `ProbeNone` cases via `discoverAgentVersionDisplay`.
+
+The renderer must receive the **current spinner frame** because the frame is
+dynamic and lives in the model, not the item:
+
+- The standalone `PickerDeviceTableData` (used by `wendy discover`) takes the
+  current frame as a parameter.
+- The interactive `PickerModel` (used by the live device picker) holds its own
+  `spinner.Model` and substitutes the frame when it builds rows from `m.items`.
+
+### 3. Spinner / tick loop
+
+Each interactive model gains one `spinner.Model`, following the existing
+`MultiSpinnerModel` precedent (`bubbles/spinner`, `spinner.Dot`,
+`ColorPrimary`):
+
+- `Init` starts the spinner `Tick` only when there is work to animate.
+- On `spinner.TickMsg`, advance the spinner, redraw the table, and re-tick
+  **only while at least one row is `ProbePending`**. When nothing is connecting,
+  ticking stops so there are no idle redraws.
+
+### 4. Per-surface wiring
+
+#### `wendy discover` table (`discover.go`)
+
+Decouple the probe from the scan:
+
+- `scanLAN` returns discovered devices **immediately** (no `resolveLANVersions`
+  call), each marked `ProbePending`.
+- For each discovered device, spawn a probe command that returns a new
+  `lanProbeMsg{ key, resp, isMTLS, err }`.
+- The model tracks probe state per device (keyed by display name / address). On
+  `lanProbeMsg`:
+  - success → populate `AgentVersion`, `DeviceType`, `OS`, `OSVersion`,
+    `CPUArchitecture`; set `ProbeOK`.
+  - failure with **no** previously known version → set `ProbeFailed`.
+  - failure **after** a prior success → keep the last-known version and stay
+    `ProbeOK` (anti-flicker; preserves the current "preserve last known agent
+    metadata" behavior at `discover.go` lines ~479–493).
+- `refreshTable` injects the current spinner frame for `ProbePending` rows when
+  calling `PickerDeviceTableData`.
+
+#### Live device picker (`helpers.go`)
+
+- Send the LAN `PickerItem` with `ProbePending` **before** calling
+  `resolveLANVersion`, so the row appears immediately with a spinner.
+- After the probe resolves, send the same `DedupKey` again with `ProbeOK`
+  (+version/OS) or `ProbeFailed`; the picker's `MergeItem` callback updates the
+  existing row in place.
+- The existing background retry loop is unchanged; a later successful retry sends
+  `ProbeOK`, flipping `Failed → OK`.
+- BLE and external-provider items carry version from the scan directly (no
+  separate probe), so they remain `ProbeNone`.
+
+#### Refreshing picker (`picker_refresh.go`)
+
+Used for drive selection in `os install`, which does not probe agents. Items stay
+`ProbeNone`; no change beyond inheriting the new field's zero value.
+
+### 5. Failure semantics
+
+- A failed probe — unreachable, timeout, **or** no-access (provisioned device
+  whose certificate this CLI cannot satisfy) — renders red `▲`.
+- The existing footer hint (`discoverNoAccessHint`) still appears on highlight to
+  explain the no-access variant specifically. The triangle signals "probe
+  failed"; the footer explains the most common recoverable cause.
+- A transient failure after a prior success does **not** downgrade to `▲`; the
+  last-known version stays visible.
+
+## Testing
+
+- **Cell renderer (tui):** unit tests for each `ProbeState` — pending → spinner
+  frame, failed → red `▲`, ok → version (with and without outdated `⚠`), none →
+  version/blank.
+- **discover model:** a device appears as `ProbePending` before its probe
+  resolves, then flips to `ProbeOK` (version shown) or `ProbeFailed` (`▲`) on
+  `lanProbeMsg`; a transient failure after success keeps the version.
+- **Live picker:** a pending item is added, then merged to resolved/failed via
+  `MergeItem` on the same `DedupKey`.
+- **Regression guard:** non-agent pickers (apps, build, init) render identically
+  (all `ProbeNone`).
+
+## Affected files (anticipated)
+
+- `go/internal/cli/tui/picker.go` — `ProbeState`, `Probe` field, cell renderer,
+  spinner in `PickerModel`, `PickerDeviceTableData` frame parameter.
+- `go/internal/cli/commands/discover.go` — decoupled probe, `lanProbeMsg`,
+  spinner/tick, `refreshTable` frame injection, item construction.
+- `go/internal/cli/commands/helpers.go` — live picker pending/resolved sends,
+  `MergeItem` handling of probe state.
+- Tests alongside each.


### PR DESCRIPTION
## Device table connecting state

Adds asynchronous "connecting" / "failed" probe states to the Agent and OS columns in both `wendy discover` and the live device picker.

Previously, LAN discovery blocked on each device's agent version/OS probe before the row appeared. Now rows show immediately with a spinner while the probe runs asynchronously, resolving to the version (success) or a red ▲ (failure). Failed probes are retried in the background so a device that becomes responsive populates without needing rediscovery.

### Changes
- `tui`: `ProbeState` (pending/ok/failed) with a connecting spinner and red ▲ glyph for the Agent/OS columns.
- `wendy discover`: decoupled the version/OS probe from the initial scan; rows render immediately and probe state is tracked per device.
- Live device picker: same connecting/failed probe behavior with bounded background retry.

Merged latest `main` (includes the `includeLocal` discover flag); resolved conflicts in `discover.go` and updated `discover_probe_test.go` for the new `newDiscoverModel` signature.
