### PR TITLE
Add `wendy install` as surfaced alias for `wendy os install`

### DIFF
--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -182,6 +182,11 @@ func NewRootCmd() *cobra.Command {
 	initCmd.GroupID = "develop"
 	runCmd := newRunCmd()
 	runCmd.GroupID = "develop"
+	// `wendy install` is the surfaced alias for `wendy os install` (the `os`
+	// group is hidden). A fresh command instance is used because a cobra
+	// command can only be attached to one parent.
+	installCmd := newOSInstallCmd()
+	installCmd.GroupID = "develop"
 
 	// Manage
 	projectCmd := newProjectCmd()
@@ -263,6 +268,7 @@ func NewRootCmd() *cobra.Command {
 		// Develop & Deploy
 		initCmd,
 		runCmd,
+		installCmd,
 		// Manage
 		projectCmd,
 		deviceCmd,


### PR DESCRIPTION
## Summary

`wendy install` is now the new default entry point for installing WendyOS / Wendy Lite firmware on a device. It does exactly what `wendy os install` does.

- Adds a visible top-level `install` command in the **Develop & Deploy** group (alongside `init` and `run`).
- `wendy os install` continues to work unchanged for back-compat (the `os` group is hidden but fully functional).
- A fresh `newOSInstallCmd()` instance is used because a cobra command can only be attached to one parent — both paths share the same implementation, so all flags and behavior are identical.

## Testing

- `go build ./internal/cli/commands/` passes.
- `wendy --help` now lists `install` under Develop & Deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)