### PR TITLE
Add `wendy project optimize` build-config analyzer

### DIFF
--- a/Examples/project-optimize-samples/README.md
+++ b/Examples/project-optimize-samples/README.md
@@ -1,0 +1,22 @@
+# `wendy project optimize` sample apps
+
+These are **intentionally un-optimized** sample projects. Each one trips a
+different set of `wendy project optimize` findings. They exist as demos and as
+manual-smoke fixtures — do **not** copy them as a starting point for a real app.
+
+Run from inside any sample directory:
+
+```bash
+wendy project optimize            # human report (interactive) / JSON (CI)
+wendy project optimize --json     # structured findings
+wendy project optimize --fix      # apply the safe fixes (cache mount, .dockerignore, release flag)
+wendy project optimize --agentic  # emit the context bundle for an AI agent
+```
+
+| Sample | Trips |
+|--------|-------|
+| `rust-debug-no-cache/` | arch-image (amd64-on-arm64 **error**), build-cache (cargo), release-debug (cargo debug build), arch-image (no `.dockerignore`, single-stage) |
+| `python-cuda-mismatch/` | cuda-ml (x86 `nvidia/cuda` base on arm64; CPU torch wheel with `gpu` entitlement), build-cache (pip), arch-image (no `.dockerignore`) |
+| `swift-debug-wendy-debug/` | release-debug (`swift build` missing `-c release`; `WENDY_DEBUG` declared but unused), build-cache (swift), arch-image (no `.dockerignore`, single-stage) |
+
+Each `EXPECTED.txt` lists the findings that sample is designed to produce.

--- a/Examples/project-optimize-samples/python-cuda-mismatch/Dockerfile
+++ b/Examples/project-optimize-samples/python-cuda-mismatch/Dockerfile
@@ -1,0 +1,11 @@
+# Intentionally un-optimized. See ../README.md.
+# - x86-first nvidia/cuda base image on an arm64 (Jetson) target
+# - pip install without a cache mount
+# - no .dockerignore alongside it
+FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+CMD ["python3", "main.py"]

--- a/Examples/project-optimize-samples/python-cuda-mismatch/EXPECTED.txt
+++ b/Examples/project-optimize-samples/python-cuda-mismatch/EXPECTED.txt
@@ -1,0 +1,5 @@
+Expected findings (wendy project optimize):
+  warning  cuda-ml         x86 CUDA base image on an arm64 target               (Dockerfile:5)
+  warning  cuda-ml         GPU entitlement set but a CPU-only ML wheel pinned   (requirements.txt:3)
+  warning  build-cache     pip install without --mount=type=cache              (Dockerfile:9) [fixable]
+  warning  arch-image      No .dockerignore                                     [fixable]

--- a/Examples/project-optimize-samples/python-cuda-mismatch/main.py
+++ b/Examples/project-optimize-samples/python-cuda-mismatch/main.py
@@ -1,0 +1,3 @@
+import torch
+
+print("cuda available:", torch.cuda.is_available())

--- a/Examples/project-optimize-samples/python-cuda-mismatch/requirements.txt
+++ b/Examples/project-optimize-samples/python-cuda-mismatch/requirements.txt
@@ -1,0 +1,4 @@
+# CPU-only torch wheel, but wendy.json declares the gpu entitlement.
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.3.0+cpu
+numpy>=1.26

--- a/Examples/project-optimize-samples/python-cuda-mismatch/wendy.json
+++ b/Examples/project-optimize-samples/python-cuda-mismatch/wendy.json
@@ -1,0 +1,7 @@
+{
+  "appId": "python-cuda-mismatch",
+  "platform": "wendyos",
+  "entitlements": [
+    { "type": "gpu" }
+  ]
+}

--- a/Examples/project-optimize-samples/rust-debug-no-cache/Dockerfile
+++ b/Examples/project-optimize-samples/rust-debug-no-cache/Dockerfile
@@ -1,0 +1,11 @@
+# Intentionally un-optimized. See ../README.md.
+# - forces amd64 on an arm64 device (QEMU / won't run)
+# - cargo build without a cache mount and without --release
+# - single stage, ships the full Rust toolchain
+# - no .dockerignore alongside it
+FROM --platform=linux/amd64 rust:1
+
+WORKDIR /app
+COPY . .
+RUN cargo build
+CMD ["/app/target/debug/app"]

--- a/Examples/project-optimize-samples/rust-debug-no-cache/EXPECTED.txt
+++ b/Examples/project-optimize-samples/rust-debug-no-cache/EXPECTED.txt
@@ -1,0 +1,6 @@
+Expected findings (wendy project optimize):
+  error    arch-image      amd64 base image on arm64 target          (Dockerfile:6)
+  warning  build-cache     cargo build without --mount=type=cache    (Dockerfile:10) [fixable]
+  warning  release-debug   cargo build is a debug build              (Dockerfile:10) [fixable]
+  warning  arch-image      No .dockerignore                          [fixable]
+  info     arch-image      Single-stage build ships its toolchain

--- a/Examples/project-optimize-samples/rust-debug-no-cache/wendy.json
+++ b/Examples/project-optimize-samples/rust-debug-no-cache/wendy.json
@@ -1,0 +1,4 @@
+{
+  "appId": "rust-debug-no-cache",
+  "platform": "wendyos"
+}

--- a/Examples/project-optimize-samples/swift-debug-wendy-debug/Dockerfile
+++ b/Examples/project-optimize-samples/swift-debug-wendy-debug/Dockerfile
@@ -1,0 +1,12 @@
+# Intentionally un-optimized. See ../README.md.
+# - swift build without -c release (debug binary shipped)
+# - WENDY_DEBUG is declared but never used to toggle the build
+# - swift build without a cache mount
+# - single stage, no .dockerignore
+FROM swift:6.0
+
+ARG WENDY_DEBUG=0
+WORKDIR /app
+COPY . .
+RUN swift build
+CMD ["/app/.build/debug/app"]

--- a/Examples/project-optimize-samples/swift-debug-wendy-debug/EXPECTED.txt
+++ b/Examples/project-optimize-samples/swift-debug-wendy-debug/EXPECTED.txt
@@ -1,0 +1,6 @@
+Expected findings (wendy project optimize):
+  warning  build-cache     swift build without --mount=type=cache      (Dockerfile:11) [fixable]
+  warning  release-debug   swift build is a debug build                (Dockerfile:11) [fixable]
+  info     release-debug   WENDY_DEBUG declared but never used to toggle the build
+  warning  arch-image      No .dockerignore                            [fixable]
+  info     arch-image      Single-stage build ships its toolchain

--- a/Examples/project-optimize-samples/swift-debug-wendy-debug/wendy.json
+++ b/Examples/project-optimize-samples/swift-debug-wendy-debug/wendy.json
@@ -1,0 +1,4 @@
+{
+  "appId": "swift-debug-wendy-debug",
+  "platform": "wendyos"
+}

--- a/go/internal/cli/commands/buildprogress.go
+++ b/go/internal/cli/commands/buildprogress.go
@@ -93,7 +93,9 @@ func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure bo
 		}
 		return buildErr
 	}
-	printBuildSummary(buildProgressOut, fm.Tally(), time.Since(start))
+	elapsed := time.Since(start)
+	printBuildSummary(buildProgressOut, fm.Tally(), elapsed)
+	maybeSuggestOptimizeAfterBuild(fm.Tally(), elapsed)
 	return nil
 }
 

--- a/go/internal/cli/commands/optimize.go
+++ b/go/internal/cli/commands/optimize.go
@@ -76,13 +76,19 @@ func newOptimizeCmd() *cobra.Command {
 		Use:   "optimize",
 		Short: "Analyze the project's build config for missed optimizations",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if agenticFlag && fixFlag {
+				fmt.Fprintln(os.Stderr, "error: --agentic and --fix cannot be combined; --agentic only emits an analysis bundle")
+				os.Exit(2)
+			}
 			cwd, err := os.Getwd()
 			if err != nil {
-				return err
+				fmt.Fprintln(os.Stderr, err.Error())
+				os.Exit(2)
 			}
 			threshold, err := optimize.ParseSeverity(severityFlag)
 			if err != nil {
-				return err
+				fmt.Fprintln(os.Stderr, err.Error())
+				os.Exit(2)
 			}
 			opts := optimizeOptions{Dir: cwd, Arch: archFlag, Fix: fixFlag, Agentic: agenticFlag}
 

--- a/go/internal/cli/commands/optimize.go
+++ b/go/internal/cli/commands/optimize.go
@@ -1,0 +1,149 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/optimize"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+type optimizeOptions struct {
+	Dir     string
+	Arch    string
+	Fix     bool
+	Agentic bool
+}
+
+// loadOptConfig loads wendy.json from dir, returning (nil, "") when absent.
+func loadOptConfig(dir string) (*appconfig.AppConfig, string) {
+	p := filepath.Join(dir, "wendy.json")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, ""
+	}
+	cfg, err := appconfig.LoadFromBytes(data)
+	if err != nil {
+		return nil, string(data)
+	}
+	return cfg, string(data)
+}
+
+// runOptimize is the testable core: no printing, no os.Exit.
+func runOptimize(opts optimizeOptions) (optimize.Report, []optimize.AppliedFix, error) {
+	arch := opts.Arch
+	if arch == "" {
+		arch = "arm64"
+	}
+	cfg, _ := loadOptConfig(opts.Dir)
+
+	targets, err := optimize.DiscoverTargets(opts.Dir, cfg, arch)
+	if err != nil {
+		return optimize.Report{}, nil, err
+	}
+	findings := optimize.Analyze(targets, optimize.DefaultAnalyzers())
+
+	var applied []optimize.AppliedFix
+	if opts.Fix {
+		applied, err = optimize.ApplyFixes(findings)
+		if err != nil {
+			return optimize.Report{}, applied, err
+		}
+		// Recompute post-fix so callers see the residual state.
+		targets, err = optimize.DiscoverTargets(opts.Dir, cfg, arch)
+		if err != nil {
+			return optimize.Report{}, applied, err
+		}
+		findings = optimize.Analyze(targets, optimize.DefaultAnalyzers())
+	}
+
+	return optimize.BuildReport(targets, findings), applied, nil
+}
+
+func newOptimizeCmd() *cobra.Command {
+	var (
+		archFlag     string
+		fixFlag      bool
+		agenticFlag  bool
+		severityFlag string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "optimize",
+		Short: "Analyze the project's build config for missed optimizations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			threshold, err := optimize.ParseSeverity(severityFlag)
+			if err != nil {
+				return err
+			}
+			opts := optimizeOptions{Dir: cwd, Arch: archFlag, Fix: fixFlag, Agentic: agenticFlag}
+
+			if agenticFlag {
+				arch := archFlag
+				if arch == "" {
+					arch = "arm64"
+				}
+				cfg, raw := loadOptConfig(cwd)
+				targets, derr := optimize.DiscoverTargets(cwd, cfg, arch)
+				if derr != nil {
+					fmt.Fprintln(os.Stderr, derr.Error())
+					os.Exit(2)
+				}
+				findings := optimize.Analyze(targets, optimize.DefaultAnalyzers())
+				bundle := optimize.BuildBundle(cwd, raw, targets, findings)
+				data, merr := json.MarshalIndent(bundle, "", "  ")
+				if merr != nil {
+					return merr
+				}
+				cmd.Println(string(data))
+				return nil
+			}
+
+			rep, applied, rerr := runOptimize(opts)
+			if rerr != nil {
+				fmt.Fprintln(os.Stderr, rerr.Error())
+				os.Exit(2)
+			}
+
+			if fixFlag {
+				cliSuccess("Applied fixes:")
+				for _, a := range applied {
+					if a.Applied {
+						cmd.Printf("  %s — %s\n", a.Fix.File, a.Fix.Description)
+					} else {
+						cmd.Printf("  %s — skipped (%s)\n", a.Fix.File, a.Reason)
+					}
+				}
+			}
+
+			if jsonOutput {
+				data, merr := json.MarshalIndent(rep, "", "  ")
+				if merr != nil {
+					return merr
+				}
+				cmd.Println(string(data))
+			} else {
+				cmd.Print(optimize.RenderHuman(rep))
+			}
+
+			if rep.MaxSeverity() >= threshold && len(rep.Findings) > 0 {
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&archFlag, "arch", "", "Target architecture (default arm64)")
+	cmd.Flags().BoolVar(&fixFlag, "fix", false, "Apply safe, deterministic fixes")
+	cmd.Flags().BoolVar(&agenticFlag, "agentic", false, "Emit an agent context bundle instead of a report")
+	cmd.Flags().StringVar(&severityFlag, "severity", "warning", "Minimum severity that triggers a non-zero exit (info|warning|error)")
+	return cmd
+}

--- a/go/internal/cli/commands/optimize_suggest.go
+++ b/go/internal/cli/commands/optimize_suggest.go
@@ -1,0 +1,129 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/optimize"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// slowIncrementalBuildThreshold is the wall-clock above which an incremental
+// build (one that reused cached layers) is slow enough to warrant surfacing an
+// optimize scan.
+const slowIncrementalBuildThreshold = 50 * time.Second
+
+// maybeSuggestOptimizeAfterBuild runs a static optimize scan and, if it finds
+// fixable issues, offers to apply them — but only after a slow incremental
+// build, and only on an interactive terminal. The fixes take effect on the
+// NEXT build; the current run continues unchanged. In CI / non-interactive
+// shells this is a no-op.
+func maybeSuggestOptimizeAfterBuild(tally tui.BuildTally, elapsed time.Duration) {
+	if !isInteractiveTerminal() {
+		return // CI / non-interactive: skip entirely.
+	}
+	// Only a slow build that actually reused cached layers (i.e. incremental).
+	if tally.Cached == 0 || elapsed < slowIncrementalBuildThreshold {
+		return
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	cfg, _ := loadOptConfig(cwd)
+	targets, err := optimize.DiscoverTargets(cwd, cfg, "arm64")
+	if err != nil || len(targets) == 0 {
+		return
+	}
+	findings := optimize.Analyze(targets, optimize.DefaultAnalyzers())
+	if len(findings) == 0 {
+		return
+	}
+	rep := optimize.BuildReport(targets, findings)
+	_, _, _, fixable := rep.Counts()
+
+	// Surfacing the scan counts as the day's optimize nudge for this project.
+	recordOptimizeTipShown(cwd)
+
+	cliNotice("\nThis incremental build took %s. A quick scan found %d build-config issue(s):",
+		elapsed.Round(time.Second), len(findings))
+	fmt.Fprint(os.Stderr, optimize.RenderHuman(rep))
+
+	if fixable == 0 {
+		return
+	}
+
+	confirmed, err := tui.ConfirmDefaultYes(
+		fmt.Sprintf("Apply %d safe fix(es) now? (takes effect on your next build)", fixable),
+		tea.WithOutput(os.Stderr),
+	)
+	if err != nil || !confirmed {
+		return
+	}
+
+	applied, err := optimize.ApplyFixes(findings)
+	if err != nil {
+		cliNotice("Could not apply fixes: %v", err)
+		return
+	}
+	n := 0
+	for _, a := range applied {
+		if a.Applied {
+			n++
+		}
+	}
+	cliSuccess("Applied %d fix(es) — they take effect on your next build.", n)
+}
+
+// maybeShowOptimizeTip surfaces a one-line, throttled tip pointing users at
+// `wendy project optimize` after a successful build/run. Once per day per
+// project, interactive only.
+func maybeShowOptimizeTip(cmd *cobra.Command) {
+	switch cmd.Name() {
+	case "run", "build":
+	default:
+		return
+	}
+	if jsonOutput || !isInteractiveTerminal() {
+		return
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	if optimizeTipShownToday(cwd) {
+		return
+	}
+	cliNotice("Tip: run `wendy project optimize` to check your Dockerfile and dependencies for build-speed and runtime wins.")
+	recordOptimizeTipShown(cwd)
+}
+
+func optimizeTipToday() string {
+	return time.Now().Format("2006-01-02")
+}
+
+func optimizeTipShownToday(projectKey string) bool {
+	cfg, err := config.Load()
+	if err != nil || cfg.OptimizeTipShownAt == nil {
+		return false
+	}
+	return cfg.OptimizeTipShownAt[projectKey] == optimizeTipToday()
+}
+
+func recordOptimizeTipShown(projectKey string) {
+	cfg, err := config.Load()
+	if err != nil {
+		return
+	}
+	if cfg.OptimizeTipShownAt == nil {
+		cfg.OptimizeTipShownAt = map[string]string{}
+	}
+	cfg.OptimizeTipShownAt[projectKey] = optimizeTipToday()
+	_ = config.Save(cfg)
+}

--- a/go/internal/cli/commands/optimize_suggest_test.go
+++ b/go/internal/cli/commands/optimize_suggest_test.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestOptimizeTipThrottle(t *testing.T) {
+	// Isolate the config dir to a temp HOME so we don't touch the real ~/.wendy.
+	t.Setenv("HOME", t.TempDir())
+
+	const key = "/some/project"
+
+	if optimizeTipShownToday(key) {
+		t.Fatalf("tip should not be marked shown before it is recorded")
+	}
+
+	recordOptimizeTipShown(key)
+
+	if !optimizeTipShownToday(key) {
+		t.Fatalf("tip should be marked shown for today after recording")
+	}
+
+	// A different project must not be throttled by the first one's record.
+	if optimizeTipShownToday("/other/project") {
+		t.Fatalf("throttle must be per-project, not global")
+	}
+}

--- a/go/internal/cli/commands/optimize_test.go
+++ b/go/internal/cli/commands/optimize_test.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeOptFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestRunOptimizeFindsAndFixes(t *testing.T) {
+	dir := t.TempDir()
+	writeOptFile(t, dir, "Dockerfile", "FROM rust:1\nRUN cargo build\n")
+
+	rep, _, err := runOptimize(optimizeOptions{Dir: dir})
+	if err != nil {
+		t.Fatalf("runOptimize: %v", err)
+	}
+	_, warn, _, fixable := rep.Counts()
+	if warn == 0 || fixable == 0 {
+		t.Fatalf("expected warnings and fixable findings, got counts: info=?, warn=%d, err=?, fixable=%d", warn, fixable)
+	}
+
+	// With --fix, the cache-mount + .dockerignore fixes apply, and a re-run drops fixable count.
+	repFixed, applied, err := runOptimize(optimizeOptions{Dir: dir, Fix: true})
+	if err != nil {
+		t.Fatalf("runOptimize fix: %v", err)
+	}
+	var anyApplied bool
+	for _, a := range applied {
+		if a.Applied {
+			anyApplied = true
+		}
+	}
+	if !anyApplied {
+		t.Fatalf("expected at least one applied fix")
+	}
+	// Re-running clean should report fewer fixable findings than the first pass.
+	_, _, _, fixableAfter := repFixed.Counts()
+	if fixableAfter >= fixable {
+		t.Fatalf("fixable did not decrease after --fix: before=%d after=%d", fixable, fixableAfter)
+	}
+}
+
+func TestRunOptimizeNoProject(t *testing.T) {
+	dir := t.TempDir()
+	rep, _, err := runOptimize(optimizeOptions{Dir: dir})
+	if err != nil {
+		t.Fatalf("runOptimize: %v", err)
+	}
+	if len(rep.Findings) != 0 {
+		t.Fatalf("expected no findings for empty dir, got %+v", rep.Findings)
+	}
+}

--- a/go/internal/cli/commands/project.go
+++ b/go/internal/cli/commands/project.go
@@ -38,6 +38,7 @@ func newProjectCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newEntitlementsCmd())
+	cmd.AddCommand(newOptimizeCmd())
 	return cmd
 }
 

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -82,6 +82,10 @@ func NewRootCmd() *cobra.Command {
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			// Surface a throttled tip about `wendy project optimize` after a
+			// successful build/run (no-op for other commands and in CI).
+			maybeShowOptimizeTip(cmd)
+
 			// Load fresh config so we see any value written by the background
 			// goroutine (possibly from a previous invocation).
 			cfg, err := config.Load()

--- a/go/internal/cli/optimize/analyzer.go
+++ b/go/internal/cli/optimize/analyzer.go
@@ -22,7 +22,10 @@ func Analyze(targets []Target, analyzers []Analyzer) []Finding {
 	for i := range targets {
 		t := &targets[i]
 		for _, a := range analyzers {
-			out = append(out, a.Analyze(t)...)
+			for _, f := range a.Analyze(t) {
+				f.Target = t.Name
+				out = append(out, f)
+			}
 		}
 	}
 	return out

--- a/go/internal/cli/optimize/analyzer.go
+++ b/go/internal/cli/optimize/analyzer.go
@@ -12,6 +12,7 @@ func DefaultAnalyzers() []Analyzer {
 		buildCacheAnalyzer{},
 		releaseDebugAnalyzer{},
 		cudaMLAnalyzer{},
+		archImageAnalyzer{},
 	}
 }
 

--- a/go/internal/cli/optimize/analyzer.go
+++ b/go/internal/cli/optimize/analyzer.go
@@ -11,6 +11,7 @@ func DefaultAnalyzers() []Analyzer {
 	return []Analyzer{
 		buildCacheAnalyzer{},
 		releaseDebugAnalyzer{},
+		cudaMLAnalyzer{},
 	}
 }
 

--- a/go/internal/cli/optimize/analyzer.go
+++ b/go/internal/cli/optimize/analyzer.go
@@ -9,7 +9,8 @@ type Analyzer interface {
 // DefaultAnalyzers returns all built-in analyzers. Each analyzer task appends here.
 func DefaultAnalyzers() []Analyzer {
 	return []Analyzer{
-		// appended by later tasks: buildCacheAnalyzer{}, releaseDebugAnalyzer{}, cudaMLAnalyzer{}, archImageAnalyzer{}
+		buildCacheAnalyzer{},
+		// appended by later tasks: releaseDebugAnalyzer{}, cudaMLAnalyzer{}, archImageAnalyzer{}
 	}
 }
 

--- a/go/internal/cli/optimize/analyzer.go
+++ b/go/internal/cli/optimize/analyzer.go
@@ -1,0 +1,26 @@
+package optimize
+
+// Analyzer inspects a Target and returns findings.
+type Analyzer interface {
+	ID() string
+	Analyze(t *Target) []Finding
+}
+
+// DefaultAnalyzers returns all built-in analyzers. Each analyzer task appends here.
+func DefaultAnalyzers() []Analyzer {
+	return []Analyzer{
+		// appended by later tasks: buildCacheAnalyzer{}, releaseDebugAnalyzer{}, cudaMLAnalyzer{}, archImageAnalyzer{}
+	}
+}
+
+// Analyze runs every analyzer over every target, in target-then-analyzer order.
+func Analyze(targets []Target, analyzers []Analyzer) []Finding {
+	var out []Finding
+	for i := range targets {
+		t := &targets[i]
+		for _, a := range analyzers {
+			out = append(out, a.Analyze(t)...)
+		}
+	}
+	return out
+}

--- a/go/internal/cli/optimize/analyzer.go
+++ b/go/internal/cli/optimize/analyzer.go
@@ -10,7 +10,7 @@ type Analyzer interface {
 func DefaultAnalyzers() []Analyzer {
 	return []Analyzer{
 		buildCacheAnalyzer{},
-		// appended by later tasks: releaseDebugAnalyzer{}, cudaMLAnalyzer{}, archImageAnalyzer{}
+		releaseDebugAnalyzer{},
 	}
 }
 

--- a/go/internal/cli/optimize/analyzer_test.go
+++ b/go/internal/cli/optimize/analyzer_test.go
@@ -1,0 +1,30 @@
+package optimize
+
+import "testing"
+
+type fakeAnalyzer struct{ id string }
+
+func (f fakeAnalyzer) ID() string { return f.id }
+func (f fakeAnalyzer) Analyze(t *Target) []Finding {
+	return []Finding{{Analyzer: f.id, Severity: SeverityWarning, Title: t.Name}}
+}
+
+func TestAnalyzeRunsAllAnalyzersOverAllTargets(t *testing.T) {
+	targets := []Target{{Name: "a", Kind: KindDockerfile}, {Name: "b", Kind: KindDockerfile}}
+	analyzers := []Analyzer{fakeAnalyzer{"x"}, fakeAnalyzer{"y"}}
+
+	findings := Analyze(targets, analyzers)
+	if len(findings) != 4 {
+		t.Fatalf("got %d findings, want 4", len(findings))
+	}
+	// target-then-analyzer order
+	if findings[0].Title != "a" || findings[0].Analyzer != "x" {
+		t.Fatalf("findings[0] = %+v", findings[0])
+	}
+	if findings[1].Analyzer != "y" {
+		t.Fatalf("findings[1] = %+v", findings[1])
+	}
+	if findings[2].Title != "b" {
+		t.Fatalf("findings[2] = %+v", findings[2])
+	}
+}

--- a/go/internal/cli/optimize/archimage.go
+++ b/go/internal/cli/optimize/archimage.go
@@ -1,0 +1,92 @@
+package optimize
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+type archImageAnalyzer struct{}
+
+func (archImageAnalyzer) ID() string { return "arch-image" }
+
+const defaultDockerignore = `.git
+**/.build
+**/.swiftpm
+node_modules
+target
+__pycache__
+*.pyc
+.venv
+dist
+build
+`
+
+func (a archImageAnalyzer) Analyze(t *Target) []Finding {
+	if t.Dockerfile == nil {
+		return nil
+	}
+	var out []Finding
+
+	fromCount := 0
+	hasStageName := false
+	installsToolchain := false
+
+	for _, inst := range t.Dockerfile.Instructions {
+		switch inst.Cmd {
+		case "FROM":
+			fromCount++
+			if strings.Contains(strings.ToUpper(" "+inst.Args+" "), " AS ") {
+				hasStageName = true
+			}
+			if t.Arch == "arm64" {
+				for _, fl := range inst.Flags {
+					if fl == "--platform=linux/amd64" || fl == "--platform=linux/x86_64" {
+						out = append(out, Finding{
+							Analyzer: a.ID(),
+							Severity: SeverityError,
+							Title:    "amd64 base image on arm64 target",
+							Detail:   "This FROM forces linux/amd64 but the target device is arm64. It will run under QEMU emulation (slow) or fail to start. Use an arm64/multi-arch base image.",
+							Location: &Loc{File: t.Dockerfile.Path, Line: inst.Line},
+						})
+					}
+				}
+			}
+		case "RUN":
+			if strings.Contains(inst.Args, "build-essential") ||
+				(strings.Contains(inst.Args, "apt-get install") && strings.Contains(inst.Args, "-dev")) ||
+				strings.Contains(inst.Args, "cargo build") ||
+				strings.Contains(inst.Args, "go build") ||
+				strings.Contains(inst.Args, "swift build") {
+				installsToolchain = true
+			}
+		}
+	}
+
+	if !fileExists(filepath.Join(t.Dir, ".dockerignore")) {
+		out = append(out, Finding{
+			Analyzer: a.ID(),
+			Severity: SeverityWarning,
+			Title:    "No .dockerignore",
+			Detail:   "Without a .dockerignore the whole context (including .git and build artifacts) is sent to the builder, slowing builds and bloating layers.",
+			Location: nil,
+			Fix: &Fix{
+				Description: "create a default .dockerignore",
+				Op:          FixCreateFile,
+				File:        filepath.Join(t.Dir, ".dockerignore"),
+				New:         defaultDockerignore,
+			},
+		})
+	}
+
+	if fromCount == 1 && !hasStageName && installsToolchain {
+		out = append(out, Finding{
+			Analyzer: a.ID(),
+			Severity: SeverityInfo,
+			Title:    "Single-stage build ships its build toolchain",
+			Detail:   "This image builds and runs in one stage, leaving compilers and -dev packages in the deployed image. A multi-stage build that copies only the final artifact into a slim runtime stage is much smaller.",
+			Location: nil,
+		})
+	}
+
+	return out
+}

--- a/go/internal/cli/optimize/archimage_test.go
+++ b/go/internal/cli/optimize/archimage_test.go
@@ -1,0 +1,56 @@
+package optimize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestArchAmd64OnArm(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM --platform=linux/amd64 python:3.12-slim\n")
+	tg.Dir = t.TempDir()
+	writeFile(t, tg.Dir, ".dockerignore", ".git\n")
+	got := archImageAnalyzer{}.Analyze(tg)
+	var sawErr bool
+	for _, f := range got {
+		if f.Severity == SeverityError {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Fatalf("expected an error finding for amd64-on-arm, got %+v", got)
+	}
+}
+
+func TestArchMissingDockerignoreFixable(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM python:3.12-slim\n")
+	tg.Dir = t.TempDir()
+	got := archImageAnalyzer{}.Analyze(tg)
+	var fix *Fix
+	for i := range got {
+		if got[i].Title == "No .dockerignore" {
+			fix = got[i].Fix
+		}
+	}
+	if fix == nil || fix.Op != FixCreateFile {
+		t.Fatalf("expected FixCreateFile for missing .dockerignore, got %+v", got)
+	}
+	if fix.File != filepath.Join(tg.Dir, ".dockerignore") {
+		t.Fatalf("fix.File = %q", fix.File)
+	}
+}
+
+func TestArchDockerignorePresentNoFinding(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM python:3.12-slim\n")
+	tg.Dir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(tg.Dir, ".dockerignore"), []byte(".git\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyzer := archImageAnalyzer{}
+	got := analyzer.Analyze(tg)
+	for _, f := range got {
+		if f.Title == "No .dockerignore" {
+			t.Fatalf("did not expect a .dockerignore finding")
+		}
+	}
+}

--- a/go/internal/cli/optimize/buildcache.go
+++ b/go/internal/cli/optimize/buildcache.go
@@ -1,0 +1,97 @@
+package optimize
+
+import (
+	"fmt"
+	"strings"
+)
+
+type buildCacheAnalyzer struct{}
+
+func (buildCacheAnalyzer) ID() string { return "build-cache" }
+
+// cacheRule maps a substring that signals a compiled-lang build to its cache mount target.
+type cacheRule struct {
+	match  string
+	target string
+}
+
+var cacheRules = []cacheRule{
+	{"cargo build", "/root/.cargo"},
+	{"cargo fetch", "/root/.cargo"},
+	{"go build", "/root/.cache/go-build"},
+	{"go mod download", "/root/.cache/go-build"},
+	{"swift build", "/root/.swiftpm"},
+	{"npm install", "/root/.npm"},
+	{"npm ci", "/root/.npm"},
+	{"yarn install", "/root/.npm"},
+	{"pnpm install", "/root/.npm"},
+	{"pip install", "/root/.cache/pip"},
+}
+
+func (a buildCacheAnalyzer) Analyze(t *Target) []Finding {
+	if t.Dockerfile == nil {
+		return nil
+	}
+	var out []Finding
+	for _, inst := range t.Dockerfile.Instructions {
+		if inst.Cmd != "RUN" {
+			continue
+		}
+		if hasCacheMount(inst.Flags) {
+			continue
+		}
+		rule, ok := matchCacheRule(inst.Args)
+		if !ok {
+			continue
+		}
+		raw := t.Dockerfile.Lines[inst.Line-1]
+		newLine := insertRunFlag(raw, fmt.Sprintf("--mount=type=cache,target=%s", rule.target))
+		out = append(out, Finding{
+			Analyzer: a.ID(),
+			Severity: SeverityWarning,
+			Title:    fmt.Sprintf("%q runs without a build cache mount", rule.match),
+			Detail: fmt.Sprintf("Add `--mount=type=cache,target=%s` to this RUN so %s reuses its cache across builds, "+
+				"cutting rebuild time substantially.", rule.target, rule.match),
+			Location: &Loc{File: t.Dockerfile.Path, Line: inst.Line},
+			Fix: &Fix{
+				Description: fmt.Sprintf("add cache mount for %s", rule.match),
+				Op:          FixReplaceLine,
+				File:        t.Dockerfile.Path,
+				Line:        inst.Line,
+				Old:         raw,
+				New:         newLine,
+			},
+		})
+	}
+	return out
+}
+
+func hasCacheMount(flags []string) bool {
+	for _, f := range flags {
+		if strings.HasPrefix(f, "--mount=") && strings.Contains(f, "type=cache") {
+			return true
+		}
+	}
+	return false
+}
+
+func matchCacheRule(args string) (cacheRule, bool) {
+	for _, r := range cacheRules {
+		if strings.Contains(args, r.match) {
+			return r, true
+		}
+	}
+	return cacheRule{}, false
+}
+
+// insertRunFlag inserts flag right after the leading RUN token of a raw line,
+// preserving the line's leading indentation.
+func insertRunFlag(raw, flag string) string {
+	indent := raw[:len(raw)-len(strings.TrimLeft(raw, " \t"))]
+	body := strings.TrimLeft(raw, " \t")
+	const run = "RUN "
+	if strings.HasPrefix(body, run) {
+		return indent + run + flag + " " + strings.TrimPrefix(body, run)
+	}
+	return raw // not a simple RUN line; leave unchanged
+}

--- a/go/internal/cli/optimize/buildcache_test.go
+++ b/go/internal/cli/optimize/buildcache_test.go
@@ -1,0 +1,46 @@
+package optimize
+
+import "testing"
+
+func dockerfileTarget(t *testing.T, src string) *Target {
+	t.Helper()
+	df := ParseDockerfile("Dockerfile", []byte(src))
+	return &Target{Name: "app", Kind: KindDockerfile, Dir: ".", Dockerfile: df, Arch: "arm64"}
+}
+
+func TestBuildCacheFlagsMissingMount(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM rust:1\nRUN cargo build --release\n")
+	got := buildCacheAnalyzer{}.Analyze(tg)
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1: %+v", len(got), got)
+	}
+	f := got[0]
+	if f.Analyzer != "build-cache" || f.Severity != SeverityWarning {
+		t.Fatalf("finding = %+v", f)
+	}
+	if f.Fix == nil || f.Fix.Op != FixReplaceLine {
+		t.Fatalf("expected FixReplaceLine, got %+v", f.Fix)
+	}
+	if f.Fix.Old != "RUN cargo build --release" {
+		t.Fatalf("fix.Old = %q", f.Fix.Old)
+	}
+	if f.Fix.New != "RUN --mount=type=cache,target=/root/.cargo cargo build --release" {
+		t.Fatalf("fix.New = %q", f.Fix.New)
+	}
+}
+
+func TestBuildCacheSilentWhenMountPresent(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM rust:1\nRUN --mount=type=cache,target=/root/.cargo cargo build\n")
+	got := buildCacheAnalyzer{}.Analyze(tg)
+	if len(got) != 0 {
+		t.Fatalf("got %d findings, want 0: %+v", len(got), got)
+	}
+}
+
+func TestBuildCacheIgnoresNonDockerTarget(t *testing.T) {
+	tg := &Target{Name: "app", Kind: KindNativeSwift, Arch: "arm64"}
+	got := buildCacheAnalyzer{}.Analyze(tg)
+	if len(got) != 0 {
+		t.Fatalf("got %d findings, want 0", len(got))
+	}
+}

--- a/go/internal/cli/optimize/bundle.go
+++ b/go/internal/cli/optimize/bundle.go
@@ -1,0 +1,66 @@
+package optimize
+
+import "strings"
+
+// BundleTarget is one target's verbatim inputs for the agent.
+type BundleTarget struct {
+	Name            string  `json:"name"`
+	Kind            string  `json:"kind"`
+	Dockerfile      string  `json:"dockerfile"`
+	RequirementsTxt *string `json:"requirements_txt"`
+}
+
+// BundleProject is project-level context for the agent.
+type BundleProject struct {
+	Dir      string `json:"dir"`
+	AppID    string `json:"app_id"`
+	Platform string `json:"platform"`
+	Arch     string `json:"arch"`
+}
+
+// Bundle is the --agentic output: static findings plus verbatim context.
+type Bundle struct {
+	Schema         int            `json:"schema"`
+	Project        BundleProject  `json:"project"`
+	Targets        []BundleTarget `json:"targets"`
+	WendyJSON      string         `json:"wendy_json"`
+	StaticFindings []Finding      `json:"static_findings"`
+	Instructions   string         `json:"instructions"`
+}
+
+const bundleInstructions = "You are optimizing a Wendy edge-device app build. " +
+	"The static_findings below were already detected by deterministic rules — do not just repeat them. " +
+	"Using the verbatim Dockerfile, requirements.txt, and wendy.json, look for the contextual optimizations rules cannot catch: " +
+	"converting to multi-stage builds, choosing the correct CUDA/PyTorch wheel for the device's JetPack/CUDA version, " +
+	"swapping to a slimmer or arch-correct base image, consolidating layers, and removing build-only deps from the runtime image. " +
+	"Propose concrete unified diffs against the files provided. The target architecture is given in project.arch."
+
+// BuildBundle assembles the agentic context bundle.
+func BuildBundle(dir, wendyJSON string, targets []Target, findings []Finding) Bundle {
+	b := Bundle{
+		Schema:         1,
+		Project:        BundleProject{Dir: dir},
+		WendyJSON:      wendyJSON,
+		StaticFindings: findings,
+		Instructions:   bundleInstructions,
+	}
+	if len(targets) > 0 {
+		b.Project.Arch = targets[0].Arch
+		if cfg := targets[0].Config; cfg != nil {
+			b.Project.AppID = cfg.AppID
+			b.Project.Platform = cfg.Platform
+		}
+	}
+	for _, t := range targets {
+		bt := BundleTarget{Name: t.Name, Kind: t.Kind.String()}
+		if t.Dockerfile != nil {
+			bt.Dockerfile = strings.Join(t.Dockerfile.Lines, "\n")
+		}
+		if t.Requirements != nil {
+			raw := t.Requirements.Raw
+			bt.RequirementsTxt = &raw
+		}
+		b.Targets = append(b.Targets, bt)
+	}
+	return b
+}

--- a/go/internal/cli/optimize/bundle_test.go
+++ b/go/internal/cli/optimize/bundle_test.go
@@ -1,0 +1,45 @@
+package optimize
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func TestBuildBundle(t *testing.T) {
+	df := ParseDockerfile("Dockerfile", []byte("FROM rust:1\nRUN cargo build\n"))
+	targets := []Target{{
+		Name:       "app",
+		Kind:       KindDockerfile,
+		Dir:        ".",
+		Dockerfile: df,
+		Arch:       "arm64",
+		Config:     &appconfig.AppConfig{AppID: "demo", Platform: "wendyos"},
+	}}
+	findings := []Finding{{Analyzer: "build-cache", Severity: SeverityWarning, Title: "no cache"}}
+
+	b := BuildBundle(".", "{\"appId\":\"demo\"}", targets, findings)
+
+	if b.Schema != 1 {
+		t.Fatalf("schema = %d, want 1", b.Schema)
+	}
+	if b.Project.AppID != "demo" || b.Project.Arch != "arm64" {
+		t.Fatalf("project = %+v", b.Project)
+	}
+	if len(b.Targets) != 1 || !strings.Contains(b.Targets[0].Dockerfile, "cargo build") {
+		t.Fatalf("targets = %+v", b.Targets)
+	}
+	if b.Targets[0].RequirementsTxt != nil {
+		t.Fatalf("expected nil RequirementsTxt")
+	}
+	if len(b.StaticFindings) != 1 || b.Instructions == "" {
+		t.Fatalf("findings/instructions missing")
+	}
+
+	// Must round-trip through JSON.
+	if _, err := json.Marshal(b); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+}

--- a/go/internal/cli/optimize/cudaml.go
+++ b/go/internal/cli/optimize/cudaml.go
@@ -1,0 +1,90 @@
+package optimize
+
+import (
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+type cudaMLAnalyzer struct{}
+
+func (cudaMLAnalyzer) ID() string { return "cuda-ml" }
+
+var mlPackages = map[string]bool{
+	"torch":           true,
+	"tensorflow":      true,
+	"onnxruntime":     true,
+	"onnxruntime-gpu": true,
+	"tensorflow-gpu":  true,
+}
+
+func hasGPUEntitlement(cfg *appconfig.AppConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, e := range cfg.Entitlements {
+		if e.Type == appconfig.EntitlementGPU {
+			return true
+		}
+	}
+	return false
+}
+
+func (a cudaMLAnalyzer) Analyze(t *Target) []Finding {
+	var out []Finding
+	gpu := hasGPUEntitlement(t.Config)
+
+	if t.Requirements != nil {
+		cpuIndex := false
+		for _, u := range t.Requirements.IndexURLs {
+			if strings.Contains(u, "/whl/cpu") {
+				cpuIndex = true
+			}
+		}
+		for _, p := range t.Requirements.Packages {
+			if !mlPackages[p.Name] {
+				continue
+			}
+			isCPU := p.LocalLabel == "cpu" || cpuIndex
+			isGPU := p.Name == "onnxruntime-gpu" || p.Name == "tensorflow-gpu" || strings.HasPrefix(p.LocalLabel, "cu")
+
+			if isCPU && gpu {
+				out = append(out, Finding{
+					Analyzer: a.ID(),
+					Severity: SeverityWarning,
+					Title:    "GPU entitlement set but a CPU-only ML wheel is pinned",
+					Detail: "wendy.json declares the gpu entitlement, but " + p.Name + " resolves to a CPU-only build. " +
+						"Pin a CUDA wheel matching the device's JetPack/CUDA version to actually use the GPU.",
+					Location: &Loc{File: t.Requirements.Path, Line: p.Line},
+				})
+			}
+			if isGPU && !gpu {
+				out = append(out, Finding{
+					Analyzer: a.ID(),
+					Severity: SeverityWarning,
+					Title:    "CUDA ML wheel pinned but no gpu entitlement declared",
+					Detail: p.Name + " is a CUDA build, but wendy.json does not declare the gpu entitlement, " +
+						"so the container will not get GPU access on the device.",
+					Location: &Loc{File: t.Requirements.Path, Line: p.Line},
+				})
+			}
+		}
+	}
+
+	if t.Dockerfile != nil && t.Arch == "arm64" {
+		for _, inst := range t.Dockerfile.Instructions {
+			if inst.Cmd == "FROM" && strings.Contains(inst.Args, "nvidia/cuda") {
+				out = append(out, Finding{
+					Analyzer: a.ID(),
+					Severity: SeverityWarning,
+					Title:    "x86 CUDA base image on an arm64 target",
+					Detail: "nvidia/cuda images are x86-first. On a Jetson (arm64) use an L4T base such as " +
+						"nvcr.io/nvidia/l4t-base or an l4t-* runtime image that matches the device JetPack.",
+					Location: &Loc{File: t.Dockerfile.Path, Line: inst.Line},
+				})
+			}
+		}
+	}
+
+	return out
+}

--- a/go/internal/cli/optimize/cudaml_test.go
+++ b/go/internal/cli/optimize/cudaml_test.go
@@ -1,0 +1,67 @@
+package optimize
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func gpuCfg() *appconfig.AppConfig {
+	return &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementGPU}}}
+}
+
+func TestCudaCPUWheelWithGPUEntitlement(t *testing.T) {
+	tg := &Target{
+		Name:         "app",
+		Kind:         KindDockerfile,
+		Arch:         "arm64",
+		Config:       gpuCfg(),
+		Requirements: ParseRequirements("requirements.txt", []byte("torch==2.3.0+cpu\n")),
+	}
+	got := cudaMLAnalyzer{}.Analyze(tg)
+	if len(got) != 1 || got[0].Severity != SeverityWarning {
+		t.Fatalf("want 1 warning, got %+v", got)
+	}
+	if got[0].Fix != nil {
+		t.Fatalf("cuda findings are report-only")
+	}
+}
+
+func TestCudaGPUWheelWithoutEntitlement(t *testing.T) {
+	cfg := &appconfig.AppConfig{}
+	tg := &Target{
+		Name:         "app",
+		Kind:         KindDockerfile,
+		Arch:         "arm64",
+		Config:       cfg,
+		Requirements: ParseRequirements("requirements.txt", []byte("onnxruntime-gpu\n")),
+	}
+	got := cudaMLAnalyzer{}.Analyze(tg)
+	if len(got) != 1 || got[0].Severity != SeverityWarning {
+		t.Fatalf("want 1 warning, got %+v", got)
+	}
+}
+
+func TestCudaX86BaseImageOnArm(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04\n")
+	cfg := &appconfig.AppConfig{}
+	tg.Config = cfg
+	got := cudaMLAnalyzer{}.Analyze(tg)
+	if len(got) != 1 || got[0].Severity != SeverityWarning {
+		t.Fatalf("want 1 warning for x86 cuda base, got %+v", got)
+	}
+}
+
+func TestCudaSilentWhenAligned(t *testing.T) {
+	tg := &Target{
+		Name:         "app",
+		Kind:         KindDockerfile,
+		Arch:         "arm64",
+		Config:       gpuCfg(),
+		Requirements: ParseRequirements("requirements.txt", []byte("numpy>=1.26\n")),
+	}
+	got := cudaMLAnalyzer{}.Analyze(tg)
+	if len(got) != 0 {
+		t.Fatalf("want 0, got %+v", got)
+	}
+}

--- a/go/internal/cli/optimize/cudaml_test.go
+++ b/go/internal/cli/optimize/cudaml_test.go
@@ -65,3 +65,17 @@ func TestCudaSilentWhenAligned(t *testing.T) {
 		t.Fatalf("want 0, got %+v", got)
 	}
 }
+
+func TestCudaCPUIndexURLEqualsFormWithGPUEntitlement(t *testing.T) {
+	tg := &Target{
+		Name:         "app",
+		Kind:         KindDockerfile,
+		Arch:         "arm64",
+		Config:       gpuCfg(),
+		Requirements: ParseRequirements("requirements.txt", []byte("--index-url=https://download.pytorch.org/whl/cpu\ntorch\n")),
+	}
+	got := cudaMLAnalyzer{}.Analyze(tg)
+	if len(got) != 1 || got[0].Severity != SeverityWarning {
+		t.Fatalf("want 1 warning for cpu-index + gpu entitlement, got %+v", got)
+	}
+}

--- a/go/internal/cli/optimize/dockerfile.go
+++ b/go/internal/cli/optimize/dockerfile.go
@@ -1,0 +1,69 @@
+package optimize
+
+import "strings"
+
+// Instruction is one parsed Dockerfile instruction.
+type Instruction struct {
+	Cmd   string   // upper-cased command, e.g. "RUN"
+	Args  string   // argument text with line continuations joined by single spaces
+	Flags []string // instruction flags, e.g. "--mount=type=cache,target=/x", "--platform=linux/amd64"
+	Line  int      // 1-based line where the instruction starts
+}
+
+// Dockerfile is a parsed Dockerfile.
+type Dockerfile struct {
+	Path         string
+	Lines        []string // raw lines, no trailing empty element
+	Instructions []Instruction
+}
+
+// ParseDockerfile parses Dockerfile bytes. It is lenient: malformed lines are
+// best-effort, never fatal.
+func ParseDockerfile(path string, data []byte) *Dockerfile {
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	rawLines := strings.Split(text, "\n")
+	// Drop a single trailing empty element from a final newline.
+	if n := len(rawLines); n > 0 && rawLines[n-1] == "" {
+		rawLines = rawLines[:n-1]
+	}
+
+	df := &Dockerfile{Path: path, Lines: rawLines}
+
+	i := 0
+	for i < len(rawLines) {
+		startLine := i + 1 // 1-based
+		line := rawLines[i]
+		trimmed := strings.TrimSpace(line)
+		i++
+
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Join continuation lines (current line ends with backslash).
+		joined := strings.TrimSpace(strings.TrimSuffix(strings.TrimRight(line, " \t"), "\\"))
+		for strings.HasSuffix(strings.TrimRight(line, " \t"), "\\") && i < len(rawLines) {
+			next := rawLines[i]
+			i++
+			joined += " " + strings.TrimSpace(strings.TrimSuffix(strings.TrimRight(next, " \t"), "\\"))
+			line = next
+		}
+		joined = strings.TrimSpace(joined)
+		if joined == "" {
+			continue
+		}
+
+		fields := strings.Fields(joined)
+		inst := Instruction{Cmd: strings.ToUpper(fields[0]), Line: startLine}
+		rest := fields[1:]
+		// Leading --flags belong to the instruction.
+		j := 0
+		for j < len(rest) && strings.HasPrefix(rest[j], "--") {
+			inst.Flags = append(inst.Flags, rest[j])
+			j++
+		}
+		inst.Args = strings.Join(rest[j:], " ")
+		df.Instructions = append(df.Instructions, inst)
+	}
+	return df
+}

--- a/go/internal/cli/optimize/dockerfile_test.go
+++ b/go/internal/cli/optimize/dockerfile_test.go
@@ -1,0 +1,40 @@
+package optimize
+
+import "testing"
+
+func TestParseDockerfile(t *testing.T) {
+	src := "# comment\n" +
+		"FROM --platform=linux/amd64 python:3.12-slim\n" +
+		"ARG WENDY_DEBUG=0\n" +
+		"RUN --mount=type=cache,target=/root/.cargo \\\n" +
+		"    cargo build --release\n" +
+		"COPY . .\n"
+
+	df := ParseDockerfile("Dockerfile", []byte(src))
+
+	if len(df.Instructions) != 4 {
+		t.Fatalf("got %d instructions, want 4: %+v", len(df.Instructions), df.Instructions)
+	}
+
+	from := df.Instructions[0]
+	if from.Cmd != "FROM" || from.Line != 2 {
+		t.Fatalf("FROM = %+v, want Cmd=FROM Line=2", from)
+	}
+	if len(from.Flags) != 1 || from.Flags[0] != "--platform=linux/amd64" {
+		t.Fatalf("FROM flags = %v, want [--platform=linux/amd64]", from.Flags)
+	}
+	if from.Args != "python:3.12-slim" {
+		t.Fatalf("FROM args = %q, want python:3.12-slim", from.Args)
+	}
+
+	run := df.Instructions[2]
+	if run.Cmd != "RUN" || run.Line != 4 {
+		t.Fatalf("RUN = %+v, want Cmd=RUN Line=4", run)
+	}
+	if len(run.Flags) != 1 || run.Flags[0] != "--mount=type=cache,target=/root/.cargo" {
+		t.Fatalf("RUN flags = %v", run.Flags)
+	}
+	if run.Args != "cargo build --release" {
+		t.Fatalf("RUN args = %q, want 'cargo build --release'", run.Args)
+	}
+}

--- a/go/internal/cli/optimize/finding.go
+++ b/go/internal/cli/optimize/finding.go
@@ -67,6 +67,7 @@ type Fix struct {
 // Finding is a single optimization issue.
 type Finding struct {
 	Analyzer string `json:"analyzer"`
+	Target   string `json:"target,omitempty"`
 	Severity Severity
 	Title    string `json:"title"`
 	Detail   string `json:"detail"`

--- a/go/internal/cli/optimize/finding.go
+++ b/go/internal/cli/optimize/finding.go
@@ -1,6 +1,9 @@
 package optimize
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 // Severity ranks how strongly a finding should be acted on.
 type Severity int
@@ -38,6 +41,25 @@ func ParseSeverity(s string) (Severity, error) {
 	}
 }
 
+// MarshalJSON encodes Severity as its lowercase string name.
+func (s Severity) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(s.String())), nil
+}
+
+// UnmarshalJSON decodes a Severity from its string name.
+func (s *Severity) UnmarshalJSON(data []byte) error {
+	str, err := strconv.Unquote(string(data))
+	if err != nil {
+		return err
+	}
+	v, err := ParseSeverity(str)
+	if err != nil {
+		return err
+	}
+	*s = v
+	return nil
+}
+
 // Loc points at a source location for a finding.
 type Loc struct {
 	File string `json:"file"`
@@ -66,11 +88,11 @@ type Fix struct {
 
 // Finding is a single optimization issue.
 type Finding struct {
-	Analyzer string `json:"analyzer"`
-	Target   string `json:"target,omitempty"`
-	Severity Severity
-	Title    string `json:"title"`
-	Detail   string `json:"detail"`
-	Location *Loc   `json:"location,omitempty"`
-	Fix      *Fix   `json:"fix,omitempty"`
+	Analyzer string   `json:"analyzer"`
+	Target   string   `json:"target,omitempty"`
+	Severity Severity `json:"severity"`
+	Title    string   `json:"title"`
+	Detail   string   `json:"detail"`
+	Location *Loc     `json:"location,omitempty"`
+	Fix      *Fix     `json:"fix,omitempty"`
 }

--- a/go/internal/cli/optimize/finding.go
+++ b/go/internal/cli/optimize/finding.go
@@ -1,0 +1,75 @@
+package optimize
+
+import "fmt"
+
+// Severity ranks how strongly a finding should be acted on.
+type Severity int
+
+const (
+	SeverityInfo Severity = iota
+	SeverityWarning
+	SeverityError
+)
+
+func (s Severity) String() string {
+	switch s {
+	case SeverityInfo:
+		return "info"
+	case SeverityWarning:
+		return "warning"
+	case SeverityError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseSeverity maps a CLI string to a Severity.
+func ParseSeverity(s string) (Severity, error) {
+	switch s {
+	case "info":
+		return SeverityInfo, nil
+	case "warning":
+		return SeverityWarning, nil
+	case "error":
+		return SeverityError, nil
+	default:
+		return SeverityInfo, fmt.Errorf("invalid severity %q (want info, warning, or error)", s)
+	}
+}
+
+// Loc points at a source location for a finding.
+type Loc struct {
+	File string `json:"file"`
+	Line int    `json:"line"`
+}
+
+// FixOp is the kind of edit a Fix performs.
+type FixOp int
+
+const (
+	// FixCreateFile creates File with New as its full contents (skipped if File exists).
+	FixCreateFile FixOp = iota
+	// FixReplaceLine replaces line Line of File: it must currently equal Old, and becomes New.
+	FixReplaceLine
+)
+
+// Fix is a deterministic, safe edit attached to a Finding. Nil means report-only.
+type Fix struct {
+	Description string `json:"description"`
+	Op          FixOp  `json:"op"`
+	File        string `json:"file"`
+	Line        int    `json:"line,omitempty"`
+	Old         string `json:"old,omitempty"`
+	New         string `json:"new"`
+}
+
+// Finding is a single optimization issue.
+type Finding struct {
+	Analyzer string `json:"analyzer"`
+	Severity Severity
+	Title    string `json:"title"`
+	Detail   string `json:"detail"`
+	Location *Loc   `json:"location,omitempty"`
+	Fix      *Fix   `json:"fix,omitempty"`
+}

--- a/go/internal/cli/optimize/finding_test.go
+++ b/go/internal/cli/optimize/finding_test.go
@@ -1,0 +1,34 @@
+package optimize
+
+import "testing"
+
+func TestSeverityString(t *testing.T) {
+	cases := []struct {
+		sev  Severity
+		want string
+	}{
+		{SeverityInfo, "info"},
+		{SeverityWarning, "warning"},
+		{SeverityError, "error"},
+	}
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			if got := c.sev.String(); got != c.want {
+				t.Fatalf("String() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseSeverity(t *testing.T) {
+	got, err := ParseSeverity("warning")
+	if err != nil {
+		t.Fatalf("ParseSeverity returned error: %v", err)
+	}
+	if got != SeverityWarning {
+		t.Fatalf("ParseSeverity = %v, want SeverityWarning", got)
+	}
+	if _, err := ParseSeverity("bogus"); err == nil {
+		t.Fatalf("ParseSeverity(\"bogus\") expected error, got nil")
+	}
+}

--- a/go/internal/cli/optimize/finding_test.go
+++ b/go/internal/cli/optimize/finding_test.go
@@ -1,6 +1,10 @@
 package optimize
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestSeverityString(t *testing.T) {
 	cases := []struct {
@@ -30,5 +34,30 @@ func TestParseSeverity(t *testing.T) {
 	}
 	if _, err := ParseSeverity("bogus"); err == nil {
 		t.Fatalf("ParseSeverity(\"bogus\") expected error, got nil")
+	}
+}
+
+func TestSeverityJSON(t *testing.T) {
+	b, err := json.Marshal(SeverityWarning)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != `"warning"` {
+		t.Fatalf("marshal = %s, want \"warning\"", b)
+	}
+	var s Severity
+	if err := json.Unmarshal([]byte(`"error"`), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s != SeverityError {
+		t.Fatalf("unmarshal = %v, want SeverityError", s)
+	}
+	// Finding marshals severity under the lowercase key with a string value.
+	fb, err := json.Marshal(Finding{Analyzer: "x", Severity: SeverityError, Title: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(fb), `"severity":"error"`) {
+		t.Fatalf("finding json = %s, want severity:\"error\"", fb)
 	}
 }

--- a/go/internal/cli/optimize/fix.go
+++ b/go/internal/cli/optimize/fix.go
@@ -1,0 +1,67 @@
+package optimize
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// AppliedFix records the outcome of applying one Fix.
+type AppliedFix struct {
+	Fix     Fix
+	Applied bool
+	Reason  string // populated when Applied is false
+}
+
+// ApplyFixes applies every finding's non-nil Fix. It is idempotent.
+func ApplyFixes(findings []Finding) ([]AppliedFix, error) {
+	var results []AppliedFix
+	for _, f := range findings {
+		if f.Fix == nil {
+			continue
+		}
+		fx := *f.Fix
+		switch fx.Op {
+		case FixCreateFile:
+			if fileExists(fx.File) {
+				results = append(results, AppliedFix{Fix: fx, Applied: false, Reason: "file already exists"})
+				continue
+			}
+			if err := os.WriteFile(fx.File, []byte(fx.New), 0o644); err != nil {
+				return results, fmt.Errorf("creating %s: %w", fx.File, err)
+			}
+			results = append(results, AppliedFix{Fix: fx, Applied: true})
+
+		case FixReplaceLine:
+			data, err := os.ReadFile(fx.File)
+			if err != nil {
+				return results, fmt.Errorf("reading %s: %w", fx.File, err)
+			}
+			text := strings.ReplaceAll(string(data), "\r\n", "\n")
+			trailingNL := strings.HasSuffix(text, "\n")
+			body := text
+			if trailingNL {
+				body = strings.TrimSuffix(text, "\n")
+			}
+			lines := strings.Split(body, "\n")
+			idx := fx.Line - 1
+			if idx < 0 || idx >= len(lines) || lines[idx] != fx.Old {
+				results = append(results, AppliedFix{Fix: fx, Applied: false, Reason: "already applied or line changed"})
+				continue
+			}
+			lines[idx] = fx.New
+			out := strings.Join(lines, "\n")
+			if trailingNL {
+				out += "\n"
+			}
+			if err := os.WriteFile(fx.File, []byte(out), 0o644); err != nil {
+				return results, fmt.Errorf("writing %s: %w", fx.File, err)
+			}
+			results = append(results, AppliedFix{Fix: fx, Applied: true})
+
+		default:
+			results = append(results, AppliedFix{Fix: fx, Applied: false, Reason: "unknown fix op"})
+		}
+	}
+	return results, nil
+}

--- a/go/internal/cli/optimize/fix_test.go
+++ b/go/internal/cli/optimize/fix_test.go
@@ -1,0 +1,61 @@
+package optimize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestApplyReplaceLineIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "Dockerfile")
+	if err := os.WriteFile(p, []byte("FROM rust:1\nRUN cargo build\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f := Finding{Fix: &Fix{
+		Op: FixReplaceLine, File: p, Line: 2,
+		Old: "RUN cargo build",
+		New: "RUN --mount=type=cache,target=/root/.cargo cargo build",
+	}}
+
+	applied, err := ApplyFixes([]Finding{f})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(applied) != 1 || !applied[0].Applied {
+		t.Fatalf("first apply = %+v", applied)
+	}
+	data, _ := os.ReadFile(p)
+	if string(data) != "FROM rust:1\nRUN --mount=type=cache,target=/root/.cargo cargo build\n" {
+		t.Fatalf("file after fix = %q", string(data))
+	}
+
+	// Re-running must not apply again.
+	applied2, err := ApplyFixes([]Finding{f})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied2[0].Applied {
+		t.Fatalf("second apply should be skipped, got %+v", applied2[0])
+	}
+}
+
+func TestApplyCreateFileSkipsExisting(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".dockerignore")
+	f := Finding{Fix: &Fix{Op: FixCreateFile, File: p, New: ".git\n"}}
+
+	if _, err := ApplyFixes([]Finding{f}); err != nil {
+		t.Fatal(err)
+	}
+	if !fileExists(p) {
+		t.Fatalf("file not created")
+	}
+	applied, err := ApplyFixes([]Finding{f})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied[0].Applied {
+		t.Fatalf("second create should skip existing file")
+	}
+}

--- a/go/internal/cli/optimize/releasedebug.go
+++ b/go/internal/cli/optimize/releasedebug.go
@@ -1,0 +1,79 @@
+package optimize
+
+import "strings"
+
+type releaseDebugAnalyzer struct{}
+
+func (releaseDebugAnalyzer) ID() string { return "release-debug" }
+
+func (a releaseDebugAnalyzer) Analyze(t *Target) []Finding {
+	if t.Dockerfile == nil {
+		return nil
+	}
+	var out []Finding
+
+	wendyDebugDefined := false
+	wendyDebugUsed := false
+
+	for _, inst := range t.Dockerfile.Instructions {
+		if (inst.Cmd == "ARG" || inst.Cmd == "ENV") && strings.Contains(inst.Args, "WENDY_DEBUG") {
+			wendyDebugDefined = true
+		}
+		if inst.Cmd == "RUN" && strings.Contains(inst.Args, "WENDY_DEBUG") {
+			wendyDebugUsed = true
+		}
+
+		if inst.Cmd != "RUN" {
+			continue
+		}
+		raw := t.Dockerfile.Lines[inst.Line-1]
+
+		if strings.Contains(inst.Args, "swift build") &&
+			!strings.Contains(inst.Args, "-c release") &&
+			!strings.Contains(inst.Args, "--configuration release") {
+			out = append(out, lineFlagFinding(a.ID(), t.Dockerfile.Path, inst.Line, raw,
+				"swift build", "swift build -c release",
+				"`swift build` defaults to a debug build. Add `-c release` so the shipped binary is optimized.",
+				"add -c release to swift build"))
+		}
+		if strings.Contains(inst.Args, "cargo build") && !strings.Contains(inst.Args, "--release") {
+			out = append(out, lineFlagFinding(a.ID(), t.Dockerfile.Path, inst.Line, raw,
+				"cargo build", "cargo build --release",
+				"`cargo build` defaults to a debug build. Add `--release` for an optimized binary.",
+				"add --release to cargo build"))
+		}
+	}
+
+	if wendyDebugDefined && !wendyDebugUsed {
+		out = append(out, Finding{
+			Analyzer: a.ID(),
+			Severity: SeverityInfo,
+			Title:    "WENDY_DEBUG is declared but never used to toggle the build",
+			Detail: "WENDY_DEBUG is defined but no RUN step branches on it. Gate the optimization level on it, " +
+				"e.g. release by default and a debug build only when WENDY_DEBUG=1.",
+			Location: nil,
+		})
+	}
+
+	return out
+}
+
+// lineFlagFinding builds a warning whose fix appends a flag to a build command on a raw line.
+func lineFlagFinding(analyzer, file string, line int, raw, oldCmd, newCmd, detail, fixDesc string) Finding {
+	newLine := strings.Replace(raw, oldCmd, newCmd, 1)
+	return Finding{
+		Analyzer: analyzer,
+		Severity: SeverityWarning,
+		Title:    oldCmd + " is a debug build",
+		Detail:   detail,
+		Location: &Loc{File: file, Line: line},
+		Fix: &Fix{
+			Description: fixDesc,
+			Op:          FixReplaceLine,
+			File:        file,
+			Line:        line,
+			Old:         raw,
+			New:         newLine,
+		},
+	}
+}

--- a/go/internal/cli/optimize/releasedebug_test.go
+++ b/go/internal/cli/optimize/releasedebug_test.go
@@ -1,0 +1,47 @@
+package optimize
+
+import "testing"
+
+func TestReleaseDebugSwiftMissingReleaseFlag(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM swift:6\nRUN swift build\n")
+	got := releaseDebugAnalyzer{}.Analyze(tg)
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1: %+v", len(got), got)
+	}
+	if got[0].Fix == nil {
+		t.Fatalf("expected fix, got nil")
+	}
+	if got[0].Fix.New != "RUN swift build -c release" {
+		t.Fatalf("fix.New = %q, want %q", got[0].Fix.New, "RUN swift build -c release")
+	}
+}
+
+func TestReleaseDebugSwiftSilentWithReleaseFlag(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM swift:6\nRUN swift build -c release\n")
+	got := releaseDebugAnalyzer{}.Analyze(tg)
+	if len(got) != 0 {
+		t.Fatalf("got %d, want 0: %+v", len(got), got)
+	}
+}
+
+func TestReleaseDebugWendyDebugDefinedButUnused(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM swift:6\nARG WENDY_DEBUG=0\nRUN swift build -c release\n")
+	got := releaseDebugAnalyzer{}.Analyze(tg)
+	if len(got) != 1 || got[0].Severity != SeverityInfo {
+		t.Fatalf("want 1 info finding for WENDY_DEBUG, got %+v", got)
+	}
+	if got[0].Fix != nil {
+		t.Fatalf("WENDY_DEBUG finding should be report-only")
+	}
+}
+
+func TestReleaseDebugWendyDebugUsed(t *testing.T) {
+	src := "FROM swift:6\nARG WENDY_DEBUG=0\nRUN if [ \"$WENDY_DEBUG\" = \"1\" ]; then swift build; else swift build -c release; fi\n"
+	tg := dockerfileTarget(t, src)
+	got := releaseDebugAnalyzer{}.Analyze(tg)
+	for _, f := range got {
+		if f.Severity == SeverityInfo {
+			t.Fatalf("did not expect WENDY_DEBUG info finding: %+v", f)
+		}
+	}
+}

--- a/go/internal/cli/optimize/report.go
+++ b/go/internal/cli/optimize/report.go
@@ -1,0 +1,88 @@
+package optimize
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ReportTarget is the lightweight target view embedded in a report.
+type ReportTarget struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}
+
+// Report is the rendered/serialized output of an optimize run.
+type Report struct {
+	Targets  []ReportTarget `json:"targets"`
+	Findings []Finding      `json:"findings"`
+}
+
+// BuildReport assembles a Report from targets and findings.
+func BuildReport(targets []Target, findings []Finding) Report {
+	rt := make([]ReportTarget, 0, len(targets))
+	for _, t := range targets {
+		rt = append(rt, ReportTarget{Name: t.Name, Kind: t.Kind.String()})
+	}
+	return Report{Targets: rt, Findings: findings}
+}
+
+// Counts returns finding counts by severity plus the number of fixable findings.
+func (r Report) Counts() (info, warning, errc, fixable int) {
+	for _, f := range r.Findings {
+		switch f.Severity {
+		case SeverityInfo:
+			info++
+		case SeverityWarning:
+			warning++
+		case SeverityError:
+			errc++
+		}
+		if f.Fix != nil {
+			fixable++
+		}
+	}
+	return
+}
+
+// MaxSeverity returns the highest severity in the report (SeverityInfo if empty).
+func (r Report) MaxSeverity() Severity {
+	max := SeverityInfo
+	for _, f := range r.Findings {
+		if f.Severity > max {
+			max = f.Severity
+		}
+	}
+	return max
+}
+
+// RenderHuman renders a plain-text report grouped by target Name.
+func RenderHuman(r Report) string {
+	var b strings.Builder
+
+	// Group findings by the target each was produced under. Findings carry no
+	// back-pointer, so render per target header then all findings (single-target
+	// is the common case; multi-target groups by Location file when present).
+	for _, t := range r.Targets {
+		fmt.Fprintf(&b, "%s (%s)\n", t.Name, t.Kind)
+	}
+	for _, f := range r.Findings {
+		loc := ""
+		if f.Location != nil {
+			loc = fmt.Sprintf(":%d", f.Location.Line)
+		}
+		fixable := ""
+		if f.Fix != nil {
+			fixable = "  (fixable)"
+		}
+		fmt.Fprintf(&b, "  %-7s  %s%s  %s%s\n", f.Severity.String(), f.Analyzer, loc, f.Title, fixable)
+	}
+
+	info, warn, errc, fixable := r.Counts()
+	total := info + warn + errc
+	fmt.Fprintf(&b, "\n%d findings (%d errors, %d warnings, %d info)", total, errc, warn, info)
+	if fixable > 0 {
+		fmt.Fprintf(&b, "  ·  %d fixable — run with --fix", fixable)
+	}
+	b.WriteString("\n")
+	return b.String()
+}

--- a/go/internal/cli/optimize/report.go
+++ b/go/internal/cli/optimize/report.go
@@ -3,6 +3,10 @@ package optimize
 import (
 	"fmt"
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
 
 // ReportTarget is the lightweight target view embedded in a report.
@@ -55,15 +59,42 @@ func (r Report) MaxSeverity() Severity {
 	return maxSev
 }
 
-// RenderHuman renders a plain-text report grouped by target Name.
+// Presentation styles. lipgloss disables color automatically on non-TTY
+// output (and under NO_COLOR), so the rendered text degrades to clean plain
+// text in pipes, CI, and tests — the tokens below stay intact either way.
+var (
+	headerStyle  = lipgloss.NewStyle().Bold(true).Foreground(tui.ColorPrimary)
+	titleStyle   = lipgloss.NewStyle().Bold(true)
+	refStyle     = lipgloss.NewStyle().Foreground(tui.ColorDim)
+	fixableStyle = lipgloss.NewStyle().Foreground(tui.ColorAccent)
+	footerStyle  = lipgloss.NewStyle().Foreground(tui.ColorDim)
+	nudgeStyle   = lipgloss.NewStyle().Bold(true).Foreground(tui.ColorAccent)
+
+	severityStyles = map[Severity]lipgloss.Style{
+		SeverityError:   lipgloss.NewStyle().Bold(true).Foreground(tui.ColorError),
+		SeverityWarning: lipgloss.NewStyle().Foreground(tui.ColorNotice),
+		SeverityInfo:    lipgloss.NewStyle().Foreground(tui.ColorInfo),
+	}
+	severityGlyphs = map[Severity]string{
+		SeverityError:   "✖",
+		SeverityWarning: "⚠",
+		SeverityInfo:    "ℹ",
+	}
+)
+
+// RenderHuman renders a report grouped by target. Output is colorized on a TTY
+// and plain (with identical text tokens) when piped or captured.
 func RenderHuman(r Report) string {
 	var b strings.Builder
 
+	refWidth := maxRefWidth(r.Findings)
+
 	for _, t := range r.Targets {
-		fmt.Fprintf(&b, "%s (%s)\n", t.Name, t.Kind)
+		b.WriteString(headerStyle.Render(fmt.Sprintf("%s (%s)", t.Name, t.Kind)))
+		b.WriteString("\n")
 		for _, f := range r.Findings {
 			if f.Target == t.Name {
-				writeFindingLine(&b, f)
+				writeFindingLine(&b, f, refWidth)
 			}
 		}
 	}
@@ -77,28 +108,53 @@ func RenderHuman(r Report) string {
 			}
 		}
 		if !matched {
-			writeFindingLine(&b, f)
+			writeFindingLine(&b, f, refWidth)
 		}
 	}
 
 	info, warn, errc, fixable := r.Counts()
 	total := info + warn + errc
-	fmt.Fprintf(&b, "\n%d findings (%d errors, %d warnings, %d info)", total, errc, warn, info)
+	b.WriteString("\n")
+	b.WriteString(footerStyle.Render(fmt.Sprintf("%d findings (%d errors, %d warnings, %d info)", total, errc, warn, info)))
 	if fixable > 0 {
-		fmt.Fprintf(&b, "  ·  %d fixable — run with --fix", fixable)
+		b.WriteString(footerStyle.Render("  ·  "))
+		b.WriteString(nudgeStyle.Render(fmt.Sprintf("%d fixable — run with --fix", fixable)))
 	}
 	b.WriteString("\n")
 	return b.String()
 }
 
-func writeFindingLine(b *strings.Builder, f Finding) {
-	loc := ""
+// findingRef is the "analyzer:line" (or just "analyzer") reference for a finding.
+func findingRef(f Finding) string {
 	if f.Location != nil {
-		loc = fmt.Sprintf(":%d", f.Location.Line)
+		return fmt.Sprintf("%s:%d", f.Analyzer, f.Location.Line)
 	}
-	fixable := ""
+	return f.Analyzer
+}
+
+// maxRefWidth returns the widest reference string, for column alignment.
+func maxRefWidth(findings []Finding) int {
+	w := 0
+	for _, f := range findings {
+		if n := len(findingRef(f)); n > w {
+			w = n
+		}
+	}
+	return w
+}
+
+func writeFindingLine(b *strings.Builder, f Finding, refWidth int) {
+	ref := findingRef(f)
+	glyph := severityGlyphs[f.Severity]
+	sevStyle := severityStyles[f.Severity]
+	// "<glyph> <severity>" padded so titles line up across severities.
+	marker := sevStyle.Render(fmt.Sprintf("%s %-7s", glyph, f.Severity.String()))
+	// Pad the reference to refWidth (plain-text width) so titles align.
+	paddedRef := refStyle.Render(ref) + strings.Repeat(" ", refWidth-len(ref))
+	line := fmt.Sprintf("  %s  %s  %s", marker, paddedRef, titleStyle.Render(f.Title))
 	if f.Fix != nil {
-		fixable = "  (fixable)"
+		line += "  " + fixableStyle.Render("(fixable)")
 	}
-	fmt.Fprintf(b, "  %-7s  %s%s  %s%s\n", f.Severity.String(), f.Analyzer, loc, f.Title, fixable)
+	b.WriteString(line)
+	b.WriteString("\n")
 }

--- a/go/internal/cli/optimize/report.go
+++ b/go/internal/cli/optimize/report.go
@@ -46,35 +46,39 @@ func (r Report) Counts() (info, warning, errc, fixable int) {
 
 // MaxSeverity returns the highest severity in the report (SeverityInfo if empty).
 func (r Report) MaxSeverity() Severity {
-	max := SeverityInfo
+	maxSev := SeverityInfo
 	for _, f := range r.Findings {
-		if f.Severity > max {
-			max = f.Severity
+		if f.Severity > maxSev {
+			maxSev = f.Severity
 		}
 	}
-	return max
+	return maxSev
 }
 
 // RenderHuman renders a plain-text report grouped by target Name.
 func RenderHuman(r Report) string {
 	var b strings.Builder
 
-	// Group findings by the target each was produced under. Findings carry no
-	// back-pointer, so render per target header then all findings (single-target
-	// is the common case; multi-target groups by Location file when present).
 	for _, t := range r.Targets {
 		fmt.Fprintf(&b, "%s (%s)\n", t.Name, t.Kind)
+		for _, f := range r.Findings {
+			if f.Target == t.Name {
+				writeFindingLine(&b, f)
+			}
+		}
 	}
+	// Defensive: any finding whose Target matches no listed target still gets shown.
 	for _, f := range r.Findings {
-		loc := ""
-		if f.Location != nil {
-			loc = fmt.Sprintf(":%d", f.Location.Line)
+		matched := false
+		for _, t := range r.Targets {
+			if f.Target == t.Name {
+				matched = true
+				break
+			}
 		}
-		fixable := ""
-		if f.Fix != nil {
-			fixable = "  (fixable)"
+		if !matched {
+			writeFindingLine(&b, f)
 		}
-		fmt.Fprintf(&b, "  %-7s  %s%s  %s%s\n", f.Severity.String(), f.Analyzer, loc, f.Title, fixable)
 	}
 
 	info, warn, errc, fixable := r.Counts()
@@ -85,4 +89,16 @@ func RenderHuman(r Report) string {
 	}
 	b.WriteString("\n")
 	return b.String()
+}
+
+func writeFindingLine(b *strings.Builder, f Finding) {
+	loc := ""
+	if f.Location != nil {
+		loc = fmt.Sprintf(":%d", f.Location.Line)
+	}
+	fixable := ""
+	if f.Fix != nil {
+		fixable = "  (fixable)"
+	}
+	fmt.Fprintf(b, "  %-7s  %s%s  %s%s\n", f.Severity.String(), f.Analyzer, loc, f.Title, fixable)
 }

--- a/go/internal/cli/optimize/report_test.go
+++ b/go/internal/cli/optimize/report_test.go
@@ -8,9 +8,9 @@ import (
 func sampleReport() Report {
 	targets := []Target{{Name: "app", Kind: KindDockerfile}}
 	findings := []Finding{
-		{Analyzer: "arch-image", Severity: SeverityError, Title: "amd64 base", Location: &Loc{File: "Dockerfile", Line: 1}},
-		{Analyzer: "build-cache", Severity: SeverityWarning, Title: "no cache", Location: &Loc{File: "Dockerfile", Line: 4}, Fix: &Fix{Op: FixReplaceLine}},
-		{Analyzer: "arch-image", Severity: SeverityWarning, Title: "No .dockerignore", Fix: &Fix{Op: FixCreateFile}},
+		{Analyzer: "arch-image", Target: "app", Severity: SeverityError, Title: "amd64 base", Location: &Loc{File: "Dockerfile", Line: 1}},
+		{Analyzer: "build-cache", Target: "app", Severity: SeverityWarning, Title: "no cache", Location: &Loc{File: "Dockerfile", Line: 4}, Fix: &Fix{Op: FixReplaceLine}},
+		{Analyzer: "arch-image", Target: "app", Severity: SeverityWarning, Title: "No .dockerignore", Fix: &Fix{Op: FixCreateFile}},
 	}
 	return BuildReport(targets, findings)
 }
@@ -36,5 +36,31 @@ func TestRenderHuman(t *testing.T) {
 	}
 	if strings.Contains(out, "arch-image:0") {
 		t.Fatalf("location-less finding should not print :0\n%s", out)
+	}
+	if !strings.Contains(out, "No .dockerignore") {
+		t.Fatalf("location-less finding missing from output:\n%s", out)
+	}
+}
+
+func TestRenderHumanGroupsByTarget(t *testing.T) {
+	targets := []Target{
+		{Name: "api", Kind: KindComposeService},
+		{Name: "web", Kind: KindComposeService},
+	}
+	findings := []Finding{
+		{Analyzer: "build-cache", Target: "web", Severity: SeverityWarning, Title: "web cache", Location: &Loc{File: "web/Dockerfile", Line: 3}},
+		{Analyzer: "build-cache", Target: "api", Severity: SeverityWarning, Title: "api cache", Location: &Loc{File: "api/Dockerfile", Line: 3}},
+	}
+	out := RenderHuman(BuildReport(targets, findings))
+	apiIdx := strings.Index(out, "api cache")
+	webIdx := strings.Index(out, "web cache")
+	apiHdr := strings.Index(out, "api (compose-service)")
+	webHdr := strings.Index(out, "web (compose-service)")
+	if apiHdr < 0 || webHdr < 0 || apiIdx < 0 || webIdx < 0 {
+		t.Fatalf("missing headers/findings:\n%s", out)
+	}
+	// api finding must appear under the api header (before the web header), web finding after the web header.
+	if !(apiHdr < apiIdx && apiIdx < webHdr && webHdr < webIdx) {
+		t.Fatalf("findings not grouped under their target headers:\n%s", out)
 	}
 }

--- a/go/internal/cli/optimize/report_test.go
+++ b/go/internal/cli/optimize/report_test.go
@@ -1,0 +1,40 @@
+package optimize
+
+import (
+	"strings"
+	"testing"
+)
+
+func sampleReport() Report {
+	targets := []Target{{Name: "app", Kind: KindDockerfile}}
+	findings := []Finding{
+		{Analyzer: "arch-image", Severity: SeverityError, Title: "amd64 base", Location: &Loc{File: "Dockerfile", Line: 1}},
+		{Analyzer: "build-cache", Severity: SeverityWarning, Title: "no cache", Location: &Loc{File: "Dockerfile", Line: 4}, Fix: &Fix{Op: FixReplaceLine}},
+		{Analyzer: "arch-image", Severity: SeverityWarning, Title: "No .dockerignore", Fix: &Fix{Op: FixCreateFile}},
+	}
+	return BuildReport(targets, findings)
+}
+
+func TestCountsAndMaxSeverity(t *testing.T) {
+	r := sampleReport()
+	info, warn, errc, fixable := r.Counts()
+	if info != 0 || warn != 2 || errc != 1 || fixable != 2 {
+		t.Fatalf("counts = info:%d warn:%d err:%d fixable:%d", info, warn, errc, fixable)
+	}
+	if r.MaxSeverity() != SeverityError {
+		t.Fatalf("MaxSeverity = %v, want error", r.MaxSeverity())
+	}
+}
+
+func TestRenderHuman(t *testing.T) {
+	out := RenderHuman(sampleReport())
+	if !strings.Contains(out, "app (dockerfile)") {
+		t.Fatalf("missing target header:\n%s", out)
+	}
+	if !strings.Contains(out, "build-cache:4") || !strings.Contains(out, "(fixable)") {
+		t.Fatalf("missing fixable build-cache line:\n%s", out)
+	}
+	if strings.Contains(out, "arch-image:0") {
+		t.Fatalf("location-less finding should not print :0\n%s", out)
+	}
+}

--- a/go/internal/cli/optimize/requirements.go
+++ b/go/internal/cli/optimize/requirements.go
@@ -40,9 +40,14 @@ func ParseRequirements(path string, data []byte) *Requirements {
 			line = strings.TrimSpace(line[:h])
 		}
 
-		if strings.HasPrefix(line, "--index-url") || strings.HasPrefix(line, "--extra-index-url") || strings.HasPrefix(line, "-i ") {
+		if strings.HasPrefix(line, "--index-url") || strings.HasPrefix(line, "--extra-index-url") || strings.HasPrefix(line, "-i ") || strings.HasPrefix(line, "-i=") {
 			fields := strings.Fields(line)
-			if len(fields) >= 2 {
+			first := fields[0]
+			if eq := strings.IndexByte(first, '='); eq >= 0 {
+				if url := first[eq+1:]; url != "" {
+					r.IndexURLs = append(r.IndexURLs, url)
+				}
+			} else if len(fields) >= 2 {
 				r.IndexURLs = append(r.IndexURLs, fields[len(fields)-1])
 			}
 			continue

--- a/go/internal/cli/optimize/requirements.go
+++ b/go/internal/cli/optimize/requirements.go
@@ -1,0 +1,85 @@
+package optimize
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Requirement is one parsed line of requirements.txt.
+type Requirement struct {
+	Name        string // lower-cased package name
+	VersionSpec string // e.g. "==2.3.0", ">=1.26", "" if none
+	LocalLabel  string // PEP 440 local label after '+', e.g. "cpu", "cu118"
+	Line        int
+}
+
+// Requirements is a parsed requirements.txt.
+type Requirements struct {
+	Path      string
+	Packages  []Requirement
+	IndexURLs []string
+}
+
+// namePattern matches the leading distribution name of a requirement line.
+var namePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*`)
+
+// ParseRequirements parses requirements.txt bytes leniently.
+func ParseRequirements(path string, data []byte) *Requirements {
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	r := &Requirements{Path: path}
+
+	for idx, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Strip inline comments.
+		if h := strings.Index(line, " #"); h >= 0 {
+			line = strings.TrimSpace(line[:h])
+		}
+
+		if strings.HasPrefix(line, "--index-url") || strings.HasPrefix(line, "--extra-index-url") || strings.HasPrefix(line, "-i ") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				r.IndexURLs = append(r.IndexURLs, fields[len(fields)-1])
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "-") {
+			continue // other pip options
+		}
+
+		name := namePattern.FindString(line)
+		if name == "" {
+			continue
+		}
+		rest := line[len(name):]
+		req := Requirement{Name: strings.ToLower(name), Line: idx + 1}
+
+		// Split off extras "[...]" if present.
+		if strings.HasPrefix(rest, "[") {
+			if end := strings.Index(rest, "]"); end >= 0 {
+				rest = rest[end+1:]
+			}
+		}
+		// Local label: "+label" appears within the version spec.
+		spec := rest
+		if plus := strings.Index(spec, "+"); plus >= 0 {
+			label := spec[plus+1:]
+			// label ends at first non [A-Za-z0-9.] char
+			labelEnd := len(label)
+			for k, c := range label {
+				if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.') {
+					labelEnd = k
+					break
+				}
+			}
+			req.LocalLabel = label[:labelEnd]
+			spec = spec[:plus]
+		}
+		req.VersionSpec = strings.TrimSpace(spec)
+		r.Packages = append(r.Packages, req)
+	}
+	return r
+}

--- a/go/internal/cli/optimize/requirements.go
+++ b/go/internal/cli/optimize/requirements.go
@@ -16,6 +16,7 @@ type Requirement struct {
 // Requirements is a parsed requirements.txt.
 type Requirements struct {
 	Path      string
+	Raw       string
 	Packages  []Requirement
 	IndexURLs []string
 }
@@ -25,9 +26,9 @@ var namePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*`)
 
 // ParseRequirements parses requirements.txt bytes leniently.
 func ParseRequirements(path string, data []byte) *Requirements {
+	r := &Requirements{Path: path, Raw: string(data)}
 	text := strings.ReplaceAll(string(data), "\r\n", "\n")
 	lines := strings.Split(text, "\n")
-	r := &Requirements{Path: path}
 
 	for idx, raw := range lines {
 		line := strings.TrimSpace(raw)

--- a/go/internal/cli/optimize/requirements_test.go
+++ b/go/internal/cli/optimize/requirements_test.go
@@ -26,3 +26,10 @@ func TestParseRequirements(t *testing.T) {
 		t.Fatalf("third pkg = %+v, want onnxruntime-gpu", r.Packages[2])
 	}
 }
+
+func TestParseRequirementsEqualsIndexURL(t *testing.T) {
+	r := ParseRequirements("requirements.txt", []byte("--index-url=https://download.pytorch.org/whl/cpu\ntorch\n"))
+	if len(r.IndexURLs) != 1 || r.IndexURLs[0] != "https://download.pytorch.org/whl/cpu" {
+		t.Fatalf("IndexURLs = %v, want one whl/cpu url", r.IndexURLs)
+	}
+}

--- a/go/internal/cli/optimize/requirements_test.go
+++ b/go/internal/cli/optimize/requirements_test.go
@@ -1,0 +1,28 @@
+package optimize
+
+import "testing"
+
+func TestParseRequirements(t *testing.T) {
+	src := "# deps\n" +
+		"--extra-index-url https://download.pytorch.org/whl/cpu\n" +
+		"torch==2.3.0+cpu\n" +
+		"numpy>=1.26\n" +
+		"onnxruntime-gpu\n"
+
+	r := ParseRequirements("requirements.txt", []byte(src))
+
+	if len(r.Packages) != 3 {
+		t.Fatalf("got %d packages, want 3: %+v", len(r.Packages), r.Packages)
+	}
+	if len(r.IndexURLs) != 1 || r.IndexURLs[0] != "https://download.pytorch.org/whl/cpu" {
+		t.Fatalf("IndexURLs = %v", r.IndexURLs)
+	}
+
+	torch := r.Packages[0]
+	if torch.Name != "torch" || torch.VersionSpec != "==2.3.0" || torch.LocalLabel != "cpu" || torch.Line != 3 {
+		t.Fatalf("torch = %+v", torch)
+	}
+	if r.Packages[2].Name != "onnxruntime-gpu" {
+		t.Fatalf("third pkg = %+v, want onnxruntime-gpu", r.Packages[2])
+	}
+}

--- a/go/internal/cli/optimize/target.go
+++ b/go/internal/cli/optimize/target.go
@@ -1,0 +1,159 @@
+package optimize
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// TargetKind is the kind of buildable unit being analyzed.
+type TargetKind int
+
+const (
+	KindDockerfile TargetKind = iota
+	KindComposeService
+	KindNativeSwift
+	KindNativeBrew
+)
+
+func (k TargetKind) String() string {
+	switch k {
+	case KindDockerfile:
+		return "dockerfile"
+	case KindComposeService:
+		return "compose-service"
+	case KindNativeSwift:
+		return "native-swift"
+	case KindNativeBrew:
+		return "native-brew"
+	default:
+		return "unknown"
+	}
+}
+
+// Target is one buildable unit to analyze.
+type Target struct {
+	Name         string
+	Kind         TargetKind
+	Dir          string
+	Dockerfile   *Dockerfile
+	Requirements *Requirements
+	Config       *appconfig.AppConfig
+	Arch         string
+}
+
+// resolveArch returns the override if set, else the offline default "arm64".
+func resolveArch(override string) string {
+	if override != "" {
+		return override
+	}
+	return "arm64"
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// loadDockerfile parses Dockerfile or Containerfile in dir, returning nil if neither exists.
+func loadDockerfile(dir string) *Dockerfile {
+	for _, name := range []string{"Dockerfile", "Containerfile"} {
+		p := filepath.Join(dir, name)
+		if fileExists(p) {
+			data, err := os.ReadFile(p)
+			if err == nil {
+				return ParseDockerfile(p, data)
+			}
+		}
+	}
+	return nil
+}
+
+// loadRequirements parses requirements.txt in dir, returning nil if absent.
+func loadRequirements(dir string) *Requirements {
+	p := filepath.Join(dir, "requirements.txt")
+	if fileExists(p) {
+		data, err := os.ReadFile(p)
+		if err == nil {
+			return ParseRequirements(p, data)
+		}
+	}
+	return nil
+}
+
+// DiscoverTargets decides what to analyze in dir.
+// arch is the already-resolved arch string.
+// It never errors on a missing Dockerfile; errors only when dir is unstat-able.
+func DiscoverTargets(dir string, cfg *appconfig.AppConfig, arch string) ([]Target, error) {
+	if _, err := os.Stat(dir); err != nil {
+		return nil, err
+	}
+
+	// Multi-service / compose: one target per service, sorted by name.
+	if cfg != nil && len(cfg.Services) > 0 {
+		names := make([]string, 0, len(cfg.Services))
+		for name := range cfg.Services {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		targets := make([]Target, 0, len(names))
+		for _, name := range names {
+			svcDir := dir
+			if svc := cfg.Services[name]; svc != nil && svc.Context != "" {
+				svcDir = filepath.Join(dir, svc.Context)
+			}
+			targets = append(targets, Target{
+				Name:         name,
+				Kind:         KindComposeService,
+				Dir:          svcDir,
+				Dockerfile:   loadDockerfile(svcDir),
+				Requirements: loadRequirements(svcDir),
+				Config:       cfg,
+				Arch:         arch,
+			})
+		}
+		return targets, nil
+	}
+
+	// Single Dockerfile or Containerfile.
+	if df := loadDockerfile(dir); df != nil {
+		return []Target{{
+			Name:         "app",
+			Kind:         KindDockerfile,
+			Dir:          dir,
+			Dockerfile:   df,
+			Requirements: loadRequirements(dir),
+			Config:       cfg,
+			Arch:         arch,
+		}}, nil
+	}
+
+	// Native Swift.
+	if fileExists(filepath.Join(dir, "Package.swift")) {
+		return []Target{{
+			Name:         "app",
+			Kind:         KindNativeSwift,
+			Dir:          dir,
+			Requirements: loadRequirements(dir),
+			Config:       cfg,
+			Arch:         arch,
+		}}, nil
+	}
+
+	// Native Brew.
+	if fileExists(filepath.Join(dir, "Brewfile")) {
+		return []Target{{
+			Name:         "app",
+			Kind:         KindNativeBrew,
+			Dir:          dir,
+			Requirements: loadRequirements(dir),
+			Config:       cfg,
+			Arch:         arch,
+		}}, nil
+	}
+
+	return []Target{}, nil
+}

--- a/go/internal/cli/optimize/target_test.go
+++ b/go/internal/cli/optimize/target_test.go
@@ -1,0 +1,73 @@
+package optimize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestResolveArch(t *testing.T) {
+	if got := resolveArch(""); got != "arm64" {
+		t.Fatalf("resolveArch(\"\") = %q, want arm64", got)
+	}
+	if got := resolveArch("amd64"); got != "amd64" {
+		t.Fatalf("resolveArch(\"amd64\") = %q, want amd64", got)
+	}
+}
+
+func TestDiscoverSingleDockerfile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM python:3.12-slim\n")
+	writeFile(t, dir, "requirements.txt", "torch==2.3.0+cpu\n")
+
+	targets, err := DiscoverTargets(dir, nil, "arm64")
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("got %d targets, want 1", len(targets))
+	}
+	tg := targets[0]
+	if tg.Kind != KindDockerfile {
+		t.Fatalf("kind = %v, want KindDockerfile", tg.Kind)
+	}
+	if tg.Dockerfile == nil || len(tg.Dockerfile.Instructions) == 0 {
+		t.Fatalf("Dockerfile not parsed")
+	}
+	if tg.Requirements == nil || len(tg.Requirements.Packages) != 1 {
+		t.Fatalf("requirements not attached")
+	}
+	if tg.Arch != "arm64" {
+		t.Fatalf("arch = %q, want arm64", tg.Arch)
+	}
+}
+
+func TestDiscoverNativeSwift(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Package.swift", "// swift-tools-version:6.0\n")
+	targets, err := DiscoverTargets(dir, nil, "arm64")
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	if len(targets) != 1 || targets[0].Kind != KindNativeSwift {
+		t.Fatalf("targets = %+v, want one KindNativeSwift", targets)
+	}
+}
+
+func TestDiscoverNothing(t *testing.T) {
+	dir := t.TempDir()
+	targets, err := DiscoverTargets(dir, nil, "arm64")
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("got %d targets, want 0", len(targets))
+	}
+}

--- a/go/internal/cli/optimize/target_test.go
+++ b/go/internal/cli/optimize/target_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
 
 func writeFile(t *testing.T, dir, name, content string) {
@@ -69,5 +71,39 @@ func TestDiscoverNothing(t *testing.T) {
 	}
 	if len(targets) != 0 {
 		t.Fatalf("got %d targets, want 0", len(targets))
+	}
+}
+
+func TestDiscoverComposeServices(t *testing.T) {
+	dir := t.TempDir()
+	svcDir := filepath.Join(dir, "api")
+	if err := os.MkdirAll(svcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, svcDir, "Dockerfile", "FROM golang:1.22\nRUN go build\n")
+	cfg := &appconfig.AppConfig{
+		Services: map[string]*appconfig.ServiceConfig{
+			"api": {Context: "api"},
+		},
+	}
+	targets, err := DiscoverTargets(dir, cfg, "arm64")
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("got %d targets, want 1", len(targets))
+	}
+	tg := targets[0]
+	if tg.Kind != KindComposeService {
+		t.Fatalf("kind = %v, want KindComposeService", tg.Kind)
+	}
+	if tg.Name != "api" {
+		t.Fatalf("name = %q, want api", tg.Name)
+	}
+	if tg.Dir != svcDir {
+		t.Fatalf("dir = %q, want %q", tg.Dir, svcDir)
+	}
+	if tg.Dockerfile == nil || len(tg.Dockerfile.Instructions) == 0 {
+		t.Fatalf("Dockerfile not parsed for compose service")
 	}
 }

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -24,6 +24,11 @@ type Config struct {
 	// the MCP server config and bundled skills. Empty means the user has never
 	// run setup, so auto-refresh stays off.
 	LastMCPSetupVersion string `json:"lastMCPSetupVersion,omitempty"`
+	// OptimizeTipShownAt throttles the `wendy project optimize` tip to once per
+	// day per project. Keyed by the project directory, value is an RFC3339 date
+	// (YYYY-MM-DD) of the last time the tip (or a build-time optimize scan) was
+	// surfaced for that project.
+	OptimizeTipShownAt map[string]string `json:"optimizeTipShownAt,omitempty"`
 }
 
 // AuthConfig holds authentication details for a cloud environment.

--- a/specs/2026-06-27-wendy-project-optimize-design.md
+++ b/specs/2026-06-27-wendy-project-optimize-design.md
@@ -1,0 +1,296 @@
+# `wendy project optimize` — Design
+
+**Date:** 2026-06-27
+**Status:** Approved (brainstorm), pending implementation plan
+
+## Summary
+
+A new `wendy project optimize` subcommand that analyzes a Wendy project's
+build configuration (Dockerfile, `requirements.txt`, `wendy.json`, and native
+build files) for missed deployment/runtime optimizations and reports
+actionable findings.
+
+The command is **static-by-default**: it runs fast, deterministic rule checks
+locally with no LLM dependency. An opt-in `--agentic` flag emits a structured
+context bundle (the same findings plus verbatim file contents and a prompt
+template) for an external agent — Claude Code or the `wendy` MCP server — to
+find the contextual optimizations that rules cannot. The Go CLI binary stays
+LLM-free.
+
+Findings are reported with severity, source location, and a suggested fix.
+Safe, deterministic fixes can be applied with `--fix`. `--json` and a non-zero
+exit code make the command a clean CI gate.
+
+## Decisions (from brainstorm)
+
+- **Path model:** static by default; `--agentic` is an opt-in flag, not a
+  separate command.
+- **Agentic engine:** the CLI does **not** call an LLM. `--agentic` emits a
+  context bundle to be piped into an external agent (Claude Code / `wendy` MCP).
+- **v1 check categories (all four):** build caches for compiled languages;
+  release-vs-debug / `WENDY_DEBUG`; CUDA/ML in `requirements.txt`; arch
+  mismatch + image size.
+- **Output:** report + opt-in `--fix` autofix (safe deterministic fixes only).
+- **Input surface:** single Dockerfile, Compose/multi-service, AND native
+  (Package.swift / Brewfile, no Docker).
+- **Arch:** auto-inferred (selected device's real arch via hardware
+  capabilities when a device is configured, else `arm64`). `--arch` is an
+  optional, never-required override.
+- **Engine architecture:** pluggable analyzer registry + structured `Fix`
+  objects in a standalone package (Approach A).
+
+## Architecture
+
+### Package layout
+
+New engine package `go/internal/cli/optimize/` (no Cobra dependency, fully
+unit-testable), plus thin command wiring in
+`go/internal/cli/commands/optimize.go` registered under `newProjectCmd()` in
+`go/internal/cli/commands/project.go`.
+
+```
+optimize/
+  target.go       // Target + DiscoverTargets
+  analyzer.go     // Analyzer interface, Finding, Fix, Severity, registry
+  dockerfile.go   // Dockerfile parse wrapper (moby/buildkit parser)
+  requirements.go // requirements.txt parse
+  report.go       // terminal + JSON reporter
+  fix.go          // apply safe fixes (idempotent)
+  bundle.go       // --agentic context bundle
+  checks/
+    buildcache.go
+    releasedebug.go
+    cudaml.go
+    archimage.go
+    testdata/
+```
+
+### Core types
+
+```go
+type Severity int // Info, Warning, Error
+
+type TargetKind int // Dockerfile, ComposeService, NativeSwift, NativeBrew
+
+type Target struct {
+    Name         string                // "app", or service name for compose/multi-service
+    Kind         TargetKind
+    Dir          string                // build context dir
+    Dockerfile   *Dockerfile           // parsed AST; nil for native targets
+    Requirements *Requirements         // parsed requirements.txt; nil if absent
+    Config       *appconfig.AppConfig  // shared wendy.json
+    Arch         string                // resolved target arch, default "arm64"
+}
+
+type Loc struct { File string; Line int }
+
+type Finding struct {
+    Analyzer string
+    Severity Severity
+    Title    string
+    Detail   string  // why it matters + recommendation
+    Location *Loc    // nil for project-level findings
+    Fix      *Fix    // nil => report-only
+}
+
+type FixOp int // CreateFile, AppendRunFlag, ReplaceLines
+
+type Fix struct {
+    Description string
+    Op          FixOp
+    File        string
+    Content     string // new content / appended flag / replacement text
+    // line range fields as needed for ReplaceLines
+}
+
+type Analyzer interface {
+    ID() string
+    Analyze(t *Target) []Finding
+}
+```
+
+The engine runs every registered `Analyzer` over every `Target` and flattens
+the results. The reporter and the agentic bundle both consume the same
+`[]Finding`, so they cannot drift.
+
+## Target discovery
+
+`DiscoverTargets(dir, cfg) ([]Target, error)` reuses the project-type detection
+already in `build.go` rather than reinventing it:
+
+1. **Multi-service / Compose** — if `wendy.json` has a `Services` map (or a
+   `docker-compose.y*ml` exists), emit one `Target` per service, resolving each
+   service's Dockerfile and context dir. The report groups findings by service.
+2. **Single Dockerfile** — `Dockerfile`/`Containerfile` (or the variant
+   `build.go` would select) in cwd → one `Target{Kind: Dockerfile}`.
+3. **Native** — no Dockerfile: `Package.swift` → `NativeSwift`; `Brewfile` →
+   `NativeBrew`. Compiled-lang/release checks run against build flags in those
+   files instead of `RUN` lines.
+4. **Nothing analyzable** — emit one `Info` finding ("no Dockerfile,
+   Package.swift, or Brewfile found") and exit 0.
+
+`requirements.txt` is attached to whichever target's context contains it, so
+the CUDA/ML analyzer fires for both Docker and native Python projects.
+
+**Arch resolution:** `wendy.json`'s `Platform` field gives the OS family, not
+CPU arch. Resolve arch by: (a) the selected/default device's real arch via
+hardware capabilities if a device is configured; else (b) `arm64`
+(Jetson/Pi/WendyOS are all ARM64). `--arch` overrides but is never required.
+
+## Analyzers
+
+For each: what it detects, severity, and whether the finding carries an
+auto-`Fix`. `--fix` only ever applies fixes from this list; everything else is
+report-only.
+
+### `buildcache` (Dockerfile / native)
+
+- Compiled-lang dependency/build steps in a `RUN` without
+  `--mount=type=cache`: `cargo build|fetch`, `go build|mod download`,
+  `swift build`, `npm|yarn|pnpm install`, `pip install`.
+  → **Warning**, `Fix: AppendRunFlag` (append the correct cache mount for that
+  tool — deterministic, safe; guarded against re-appending if already present).
+- Layer ordering: a full-context copy (`COPY . .`) appearing *before* the
+  dependency-manifest copy + install, busting the dependency cache every build.
+  → **Warning**, **report-only** (safe reordering is too context-dependent).
+
+### `releasedebug` (Dockerfile / native)
+
+- Debug-level build of a compiled lang shipped as the final artifact:
+  `swift build` without `-c release`; `cargo build` without `--release`;
+  `go build` with `-race` or without symbol stripping; C/C++ `-O0` / bare `-g`.
+  → **Warning**. `swift build` and `cargo build` get a `Fix: ReplaceLines` to
+  add the release flag; others report-only.
+- **`WENDY_DEBUG` wiring:** if `WENDY_DEBUG` appears as `ARG`/`ENV` but the
+  optimization level is not gated on it (or it is referenced nowhere)
+  → **Info** with a recommended pattern (release by default, debug only when
+  `WENDY_DEBUG=1`).
+
+### `cudaml` (requirements.txt + wendy.json + base image)
+
+- `requirements.txt` pulls `torch`/`tensorflow`/`onnxruntime`: detect CPU-only
+  wheel (`+cpu`, CPU index-url) while `wendy.json` declares the `gpu`
+  entitlement, or a GPU wheel with no `gpu` entitlement. → **Warning**.
+- CUDA/JetPack mismatch hints, and an x86 `nvidia/cuda` base image on an arm64
+  target (Jetson needs an L4T / `nvcr.io/.../l4t-*` base). → **Warning**.
+- All **report-only** — picking the correct wheel/base is exactly the
+  contextual judgment handed to the agentic path.
+
+### `archimage` (Dockerfile + wendy.json + arch)
+
+- `FROM --platform=linux/amd64` (or an amd64-only base) against an arm64 target
+  → emulation/won't-run. → **Error**, report-only.
+- Missing `.dockerignore` → **Warning**, `Fix: CreateFile` with sensible
+  defaults (`.git`, `**/.build`, `node_modules`, `target/`, `__pycache__`,
+  etc.) — safe autofix.
+- Single-stage build leaving a build toolchain (compiler, `-dev` packages) in
+  the final image → **Info**, report-only (multi-stage refactor is agentic
+  territory).
+
+**`--fix` touches only:** cache-mount append, release-flag add (swift/cargo),
+and `.dockerignore` create. Every subtle/contextual finding stays report-only.
+
+## Command surface
+
+Flags on `wendy project optimize`:
+
+- `--json` — reuse the existing persistent root flag; emits
+  `{targets, findings}`.
+- `--agentic` — emit the context bundle instead of the human report.
+- `--fix` — apply safe fixes; print a per-file summary of changes.
+- `--arch <arch>` — optional override of the auto-inferred target arch.
+- `--severity <info|warning|error>` — minimum severity that triggers a non-zero
+  exit (default `warning`).
+
+### Human report
+
+Grouped by target, using the existing lipgloss `tui` palette:
+
+```
+app (Dockerfile)
+  ✖ error    arch-image:9      amd64 base image on arm64 target — will run under QEMU
+  ⚠ warning  build-cache:14    cargo build without --mount=type=cache  [fixable]
+  ⚠ warning  release-debug:14  swift build missing -c release          [fixable]
+  ℹ info     arch-image        no .dockerignore                        [fixable]
+
+3 findings (1 error, 2 warnings)  ·  3 fixable — run with --fix
+```
+
+`[fixable]` tags findings carrying a `Fix`. The footer nudges toward `--fix` /
+`--agentic`.
+
+### `--fix` output
+
+Applies only `Fix`-bearing findings, writes files, and prints:
+
+```
+Fixed 3 issues:
+  Dockerfile:14  + --mount=type=cache,target=/root/.cargo
+  Dockerfile:14  swift build → swift build -c release
+  .dockerignore  created (7 entries)
+```
+
+Fixes are **idempotent**: re-running `--fix` makes no further change, and an
+already-present cache mount / release flag is never re-applied.
+
+### Exit codes
+
+- `0` — no findings at or above the severity threshold.
+- `1` — findings at or above threshold exist.
+- `2` — execution error (bad project, parse failure).
+
+With `--fix`, the exit code reflects findings *remaining* after fixing, making
+the command a clean CI gate.
+
+## `--agentic` bundle
+
+`--agentic` runs the full static analysis, then emits one structured bundle to
+stdout (or `--output <file>`) for an external agent:
+
+```jsonc
+{
+  "schema": 1,
+  "project": { "dir": "...", "app_id": "...", "platform": "wendyos", "arch": "arm64" },
+  "targets": [
+    { "name": "app", "kind": "Dockerfile",
+      "dockerfile": "<verbatim contents>",
+      "requirements_txt": "<contents or null>" }
+  ],
+  "wendy_json": "<verbatim contents>",
+  "static_findings": [ /* the same []Finding the reporter would show */ ],
+  "instructions": "<prompt template>"
+}
+```
+
+The `instructions` field tells the agent: here are the deterministic findings
+already caught — now look for the contextual optimizations rules cannot catch
+(multi-stage refactors, the right CUDA wheel for this JetPack, base-image swaps,
+layer consolidation) and propose concrete diffs. Static findings *seed* the
+agent rather than duplicating its work. The `schema` field is versioned so the
+MCP side can evolve independently.
+
+## Testing
+
+- **Analyzer unit tests** (the bulk): table-driven per check. Each case is a
+  small Dockerfile / requirements.txt / wendy.json fixture → assert the exact
+  `[]Finding` (analyzer id, severity, line, fixable-or-not). Covers positives
+  *and* negatives (e.g. a `RUN cargo build` that already has a cache mount
+  produces no finding). Fixtures in `optimize/checks/testdata/`.
+- **Dockerfile parser wrapper:** line numbers and `--mount` flag extraction
+  survive the moby parser round-trip.
+- **Discovery tests:** single-Dockerfile, compose/multi-service (N targets,
+  grouped), native Swift, native Brewfile, and the "nothing analyzable" path.
+- **Fix engine tests:** apply each safe fix to a fixture, assert resulting file
+  bytes, and assert **idempotency** (running `--fix` twice = no second change).
+- **Reporter/bundle golden tests:** a fixed `[]Finding` → assert the human
+  table, the `--json` shape, and the `--agentic` bundle JSON (schema-stable).
+- **Command integration test:** end-to-end on a temp project dir asserting exit
+  codes (0 / 1 / 2) and that `--fix` then a re-run drops to exit 0.
+
+## Out of scope (v1)
+
+- The LLM/agent itself — the CLI only emits the bundle.
+- Autofix for contextual findings (multi-stage refactor, CUDA wheel selection,
+  layer reordering) — report-only, deferred to the agentic path.
+- Reading a connected device's arch is best-effort; offline default is `arm64`.
+- Languages beyond Swift/Rust/Go/C-C++/Python/Node detection heuristics.

--- a/specs/superpowers/plans/2026-06-27-wendy-project-optimize.md
+++ b/specs/superpowers/plans/2026-06-27-wendy-project-optimize.md
@@ -1,0 +1,2506 @@
+# `wendy project optimize` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `wendy project optimize` subcommand that statically analyzes a Wendy project's build config (Dockerfile, requirements.txt, wendy.json, native build files) for missed optimizations, reports findings, applies safe `--fix`es, and can emit an `--agentic` context bundle.
+
+**Architecture:** A standalone, Cobra-free engine package `go/internal/cli/optimize/` holds parsers, the `Analyzer` registry, four analyzers, the reporter, the fix applier, and the agentic bundle. A thin command in `go/internal/cli/commands/optimize.go` wires flags and exit codes and registers under `newProjectCmd()`. Reporter and bundle both consume the same `[]Finding`.
+
+**Tech Stack:** Go 1.26.4, Cobra (spf13/cobra), lipgloss (charmbracelet/lipgloss) via the existing `tui` package. Stdlib `testing` + table tests only (no testify, no golden libs). No new third-party dependencies — Dockerfile parsing is an internal line-based parser.
+
+## Global Constraints
+
+- Module path: `github.com/wendylabsinc/wendy`. All internal imports use this prefix.
+- Go version: `go 1.26.4`.
+- No new third-party dependencies. Dockerfile/requirements parsing is internal stdlib code.
+- Engine package `optimize` must NOT import `spf13/cobra` (testable in isolation).
+- All analyzer files live in `package optimize` (single package, multiple files) — NOT a `checks/` sub-package — to avoid an import cycle between the registry and the analyzers. (Deviation from the spec's directory sketch; same package, same behavior.)
+- Tests use stdlib `testing` with table-driven subtests and `t.Fatalf`/`t.Errorf`. Use `t.TempDir()` for filesystem fixtures.
+- Persistent `--json` flag is read via the package-global `jsonOutput bool` in `package commands` (defined in `root.go`); do not add a second json flag.
+- Default target arch is `"arm64"`. `--arch` overrides. Device-based arch inference is out of scope for this plan.
+- Entitlement GPU constant: `appconfig.EntitlementGPU` (== `"gpu"`).
+- Exit codes: `0` no findings ≥ threshold; `1` findings ≥ threshold; `2` execution error.
+- Run `cd go && gofmt -w <files>` and `cd go && go test ./internal/cli/optimize/...` from the `go/` module dir (the module root is `go/`, module `github.com/wendylabsinc/wendy`).
+
+---
+
+## File Structure
+
+Engine package `go/internal/cli/optimize/`:
+- `finding.go` — `Severity`, `Loc`, `FixOp`, `Fix`, `Finding` types + helpers.
+- `dockerfile.go` — internal Dockerfile parser → `Dockerfile`, `Instruction`.
+- `requirements.go` — requirements.txt parser → `Requirements`, `Requirement`.
+- `target.go` — `Target`, `TargetKind`, `DiscoverTargets`, `resolveArch`.
+- `analyzer.go` — `Analyzer` interface, `DefaultAnalyzers()`, `Analyze()` engine driver.
+- `buildcache.go` — `buildCacheAnalyzer`.
+- `releasedebug.go` — `releaseDebugAnalyzer`.
+- `cudaml.go` — `cudaMLAnalyzer`.
+- `archimage.go` — `archImageAnalyzer`.
+- `fix.go` — `ApplyFixes`.
+- `report.go` — `RenderHuman`, `MarshalJSON` report shape.
+- `bundle.go` — `BuildBundle`.
+
+Command wiring:
+- `go/internal/cli/commands/optimize.go` — `newOptimizeCmd()`.
+- `go/internal/cli/commands/project.go:34-42` — register `newOptimizeCmd()`.
+
+---
+
+## Task 1: Core types (Severity, Finding, Fix)
+
+**Files:**
+- Create: `go/internal/cli/optimize/finding.go`
+- Test: `go/internal/cli/optimize/finding_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type Severity int` with `const (SeverityInfo Severity = iota; SeverityWarning; SeverityError)`.
+  - `func (s Severity) String() string` → `"info"|"warning"|"error"`.
+  - `func ParseSeverity(string) (Severity, error)`.
+  - `type Loc struct { File string; Line int }`.
+  - `type FixOp int` with `const (FixCreateFile FixOp = iota; FixReplaceLine)`.
+  - `type Fix struct { Description string; Op FixOp; File string; Line int; Old string; New string }`.
+  - `type Finding struct { Analyzer string; Severity Severity; Title string; Detail string; Location *Loc; Fix *Fix }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/finding_test.go
+package optimize
+
+import "testing"
+
+func TestSeverityString(t *testing.T) {
+	cases := []struct {
+		sev  Severity
+		want string
+	}{
+		{SeverityInfo, "info"},
+		{SeverityWarning, "warning"},
+		{SeverityError, "error"},
+	}
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			if got := c.sev.String(); got != c.want {
+				t.Fatalf("String() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseSeverity(t *testing.T) {
+	got, err := ParseSeverity("warning")
+	if err != nil {
+		t.Fatalf("ParseSeverity returned error: %v", err)
+	}
+	if got != SeverityWarning {
+		t.Fatalf("ParseSeverity = %v, want SeverityWarning", got)
+	}
+	if _, err := ParseSeverity("bogus"); err == nil {
+		t.Fatalf("ParseSeverity(\"bogus\") expected error, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestSeverity -v`
+Expected: FAIL — build error, `undefined: Severity`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/finding.go
+package optimize
+
+import "fmt"
+
+// Severity ranks how strongly a finding should be acted on.
+type Severity int
+
+const (
+	SeverityInfo Severity = iota
+	SeverityWarning
+	SeverityError
+)
+
+func (s Severity) String() string {
+	switch s {
+	case SeverityInfo:
+		return "info"
+	case SeverityWarning:
+		return "warning"
+	case SeverityError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseSeverity maps a CLI string to a Severity.
+func ParseSeverity(s string) (Severity, error) {
+	switch s {
+	case "info":
+		return SeverityInfo, nil
+	case "warning":
+		return SeverityWarning, nil
+	case "error":
+		return SeverityError, nil
+	default:
+		return SeverityInfo, fmt.Errorf("invalid severity %q (want info, warning, or error)", s)
+	}
+}
+
+// Loc points at a source location for a finding.
+type Loc struct {
+	File string `json:"file"`
+	Line int    `json:"line"`
+}
+
+// FixOp is the kind of edit a Fix performs.
+type FixOp int
+
+const (
+	// FixCreateFile creates File with New as its full contents (skipped if File exists).
+	FixCreateFile FixOp = iota
+	// FixReplaceLine replaces line Line of File: it must currently equal Old, and becomes New.
+	FixReplaceLine
+)
+
+// Fix is a deterministic, safe edit attached to a Finding. Nil means report-only.
+type Fix struct {
+	Description string `json:"description"`
+	Op          FixOp  `json:"op"`
+	File        string `json:"file"`
+	Line        int    `json:"line,omitempty"`
+	Old         string `json:"old,omitempty"`
+	New         string `json:"new"`
+}
+
+// Finding is a single optimization issue.
+type Finding struct {
+	Analyzer string `json:"analyzer"`
+	Severity Severity
+	Title    string `json:"title"`
+	Detail   string `json:"detail"`
+	Location *Loc   `json:"location,omitempty"`
+	Fix      *Fix   `json:"fix,omitempty"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestSeverity -v && go test ./internal/cli/optimize/ -run TestParseSeverity -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/finding.go internal/cli/optimize/finding_test.go
+git add go/internal/cli/optimize/finding.go go/internal/cli/optimize/finding_test.go
+git commit -m "feat(optimize): add core finding/severity/fix types"
+```
+
+---
+
+## Task 2: Dockerfile parser
+
+**Files:**
+- Create: `go/internal/cli/optimize/dockerfile.go`
+- Test: `go/internal/cli/optimize/dockerfile_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type Instruction struct { Cmd string; Args string; Flags []string; Line int }` — `Cmd` is upper-cased (e.g. `RUN`); `Args` is the full argument text with continuations joined by spaces; `Flags` holds instruction flags like `--mount=type=cache,...` and `--platform=...`; `Line` is the 1-based line where the instruction starts.
+  - `type Dockerfile struct { Path string; Lines []string; Instructions []Instruction }` — `Lines` is the raw file split by `\n` (no trailing newline element), used later by the fix applier.
+  - `func ParseDockerfile(path string, data []byte) *Dockerfile`.
+
+Parser rules: skip blank lines and `#`-comment lines; a line ending in `\` (after trimming trailing spaces) continues onto the next line; the first token of a logical line is the command (upper-cased); tokens of the form `--xxx` immediately following the command are flags; the remainder is `Args`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/dockerfile_test.go
+package optimize
+
+import "testing"
+
+func TestParseDockerfile(t *testing.T) {
+	src := "# comment\n" +
+		"FROM --platform=linux/amd64 python:3.12-slim\n" +
+		"ARG WENDY_DEBUG=0\n" +
+		"RUN --mount=type=cache,target=/root/.cargo \\\n" +
+		"    cargo build --release\n" +
+		"COPY . .\n"
+
+	df := ParseDockerfile("Dockerfile", []byte(src))
+
+	if len(df.Instructions) != 4 {
+		t.Fatalf("got %d instructions, want 4: %+v", len(df.Instructions), df.Instructions)
+	}
+
+	from := df.Instructions[0]
+	if from.Cmd != "FROM" || from.Line != 2 {
+		t.Fatalf("FROM = %+v, want Cmd=FROM Line=2", from)
+	}
+	if len(from.Flags) != 1 || from.Flags[0] != "--platform=linux/amd64" {
+		t.Fatalf("FROM flags = %v, want [--platform=linux/amd64]", from.Flags)
+	}
+	if from.Args != "python:3.12-slim" {
+		t.Fatalf("FROM args = %q, want python:3.12-slim", from.Args)
+	}
+
+	run := df.Instructions[2]
+	if run.Cmd != "RUN" || run.Line != 4 {
+		t.Fatalf("RUN = %+v, want Cmd=RUN Line=4", run)
+	}
+	if len(run.Flags) != 1 || run.Flags[0] != "--mount=type=cache,target=/root/.cargo" {
+		t.Fatalf("RUN flags = %v", run.Flags)
+	}
+	if run.Args != "cargo build --release" {
+		t.Fatalf("RUN args = %q, want 'cargo build --release'", run.Args)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestParseDockerfile -v`
+Expected: FAIL — `undefined: ParseDockerfile`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/dockerfile.go
+package optimize
+
+import "strings"
+
+// Instruction is one parsed Dockerfile instruction.
+type Instruction struct {
+	Cmd   string   // upper-cased command, e.g. "RUN"
+	Args  string   // argument text with line continuations joined by single spaces
+	Flags []string // instruction flags, e.g. "--mount=type=cache,target=/x", "--platform=linux/amd64"
+	Line  int      // 1-based line where the instruction starts
+}
+
+// Dockerfile is a parsed Dockerfile.
+type Dockerfile struct {
+	Path         string
+	Lines        []string // raw lines, no trailing empty element
+	Instructions []Instruction
+}
+
+// ParseDockerfile parses Dockerfile bytes. It is lenient: malformed lines are
+// best-effort, never fatal.
+func ParseDockerfile(path string, data []byte) *Dockerfile {
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	rawLines := strings.Split(text, "\n")
+	// Drop a single trailing empty element from a final newline.
+	if n := len(rawLines); n > 0 && rawLines[n-1] == "" {
+		rawLines = rawLines[:n-1]
+	}
+
+	df := &Dockerfile{Path: path, Lines: rawLines}
+
+	i := 0
+	for i < len(rawLines) {
+		startLine := i + 1 // 1-based
+		line := rawLines[i]
+		trimmed := strings.TrimSpace(line)
+		i++
+
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Join continuation lines (current line ends with backslash).
+		joined := strings.TrimSpace(strings.TrimSuffix(strings.TrimRight(line, " \t"), "\\"))
+		for strings.HasSuffix(strings.TrimRight(line, " \t"), "\\") && i < len(rawLines) {
+			next := rawLines[i]
+			i++
+			joined += " " + strings.TrimSpace(strings.TrimSuffix(strings.TrimRight(next, " \t"), "\\"))
+			line = next
+		}
+		joined = strings.TrimSpace(joined)
+		if joined == "" {
+			continue
+		}
+
+		fields := strings.Fields(joined)
+		inst := Instruction{Cmd: strings.ToUpper(fields[0]), Line: startLine}
+		rest := fields[1:]
+		// Leading --flags belong to the instruction.
+		j := 0
+		for j < len(rest) && strings.HasPrefix(rest[j], "--") {
+			inst.Flags = append(inst.Flags, rest[j])
+			j++
+		}
+		inst.Args = strings.Join(rest[j:], " ")
+		df.Instructions = append(df.Instructions, inst)
+	}
+	return df
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestParseDockerfile -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/dockerfile.go internal/cli/optimize/dockerfile_test.go
+git add go/internal/cli/optimize/dockerfile.go go/internal/cli/optimize/dockerfile_test.go
+git commit -m "feat(optimize): add internal Dockerfile parser"
+```
+
+---
+
+## Task 3: requirements.txt parser
+
+**Files:**
+- Create: `go/internal/cli/optimize/requirements.go`
+- Test: `go/internal/cli/optimize/requirements_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type Requirement struct { Name string; VersionSpec string; LocalLabel string; Line int }` — `Name` lower-cased package name; `VersionSpec` the version constraint text (e.g. `==2.3.0`); `LocalLabel` the PEP 440 local label after `+` (e.g. `cpu`, `cu118`), empty if none; `Line` 1-based.
+  - `type Requirements struct { Path string; Packages []Requirement; IndexURLs []string }` — `IndexURLs` collects values from `--index-url`/`--extra-index-url`/`-i` lines.
+  - `func ParseRequirements(path string, data []byte) *Requirements`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/requirements_test.go
+package optimize
+
+import "testing"
+
+func TestParseRequirements(t *testing.T) {
+	src := "# deps\n" +
+		"--extra-index-url https://download.pytorch.org/whl/cpu\n" +
+		"torch==2.3.0+cpu\n" +
+		"numpy>=1.26\n" +
+		"onnxruntime-gpu\n"
+
+	r := ParseRequirements("requirements.txt", []byte(src))
+
+	if len(r.Packages) != 3 {
+		t.Fatalf("got %d packages, want 3: %+v", len(r.Packages), r.Packages)
+	}
+	if len(r.IndexURLs) != 1 || r.IndexURLs[0] != "https://download.pytorch.org/whl/cpu" {
+		t.Fatalf("IndexURLs = %v", r.IndexURLs)
+	}
+
+	torch := r.Packages[0]
+	if torch.Name != "torch" || torch.VersionSpec != "==2.3.0" || torch.LocalLabel != "cpu" || torch.Line != 3 {
+		t.Fatalf("torch = %+v", torch)
+	}
+	if r.Packages[2].Name != "onnxruntime-gpu" {
+		t.Fatalf("third pkg = %+v, want onnxruntime-gpu", r.Packages[2])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestParseRequirements -v`
+Expected: FAIL — `undefined: ParseRequirements`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/requirements.go
+package optimize
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Requirement is one parsed line of requirements.txt.
+type Requirement struct {
+	Name        string // lower-cased package name
+	VersionSpec string // e.g. "==2.3.0", ">=1.26", "" if none
+	LocalLabel  string // PEP 440 local label after '+', e.g. "cpu", "cu118"
+	Line        int
+}
+
+// Requirements is a parsed requirements.txt.
+type Requirements struct {
+	Path      string
+	Packages  []Requirement
+	IndexURLs []string
+}
+
+// namePattern matches the leading distribution name of a requirement line.
+var namePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*`)
+
+// ParseRequirements parses requirements.txt bytes leniently.
+func ParseRequirements(path string, data []byte) *Requirements {
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	r := &Requirements{Path: path}
+
+	for idx, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Strip inline comments.
+		if h := strings.Index(line, " #"); h >= 0 {
+			line = strings.TrimSpace(line[:h])
+		}
+
+		if strings.HasPrefix(line, "--index-url") || strings.HasPrefix(line, "--extra-index-url") || strings.HasPrefix(line, "-i ") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				r.IndexURLs = append(r.IndexURLs, fields[len(fields)-1])
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "-") {
+			continue // other pip options
+		}
+
+		name := namePattern.FindString(line)
+		if name == "" {
+			continue
+		}
+		rest := line[len(name):]
+		req := Requirement{Name: strings.ToLower(name), Line: idx + 1}
+
+		// Split off extras "[...]" if present.
+		if strings.HasPrefix(rest, "[") {
+			if end := strings.Index(rest, "]"); end >= 0 {
+				rest = rest[end+1:]
+			}
+		}
+		// Local label: "+label" appears within the version spec.
+		spec := rest
+		if plus := strings.Index(spec, "+"); plus >= 0 {
+			label := spec[plus+1:]
+			// label ends at first non [A-Za-z0-9.] char
+			labelEnd := len(label)
+			for k, c := range label {
+				if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.') {
+					labelEnd = k
+					break
+				}
+			}
+			req.LocalLabel = label[:labelEnd]
+			spec = spec[:plus]
+		}
+		req.VersionSpec = strings.TrimSpace(spec)
+		r.Packages = append(r.Packages, req)
+	}
+	return r
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestParseRequirements -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/requirements.go internal/cli/optimize/requirements_test.go
+git add go/internal/cli/optimize/requirements.go go/internal/cli/optimize/requirements_test.go
+git commit -m "feat(optimize): add requirements.txt parser"
+```
+
+---
+
+## Task 4: Target discovery + arch resolution
+
+**Files:**
+- Create: `go/internal/cli/optimize/target.go`
+- Test: `go/internal/cli/optimize/target_test.go`
+
+**Interfaces:**
+- Consumes: `appconfig.AppConfig` (`github.com/wendylabsinc/wendy/go/internal/shared/appconfig`), `ParseDockerfile`, `ParseRequirements`.
+- Produces:
+  - `type TargetKind int` with `const (KindDockerfile TargetKind = iota; KindComposeService; KindNativeSwift; KindNativeBrew)`.
+  - `func (k TargetKind) String() string` → `"dockerfile"|"compose-service"|"native-swift"|"native-brew"`.
+  - `type Target struct { Name string; Kind TargetKind; Dir string; Dockerfile *Dockerfile; Requirements *Requirements; Config *appconfig.AppConfig; Arch string }`.
+  - `func resolveArch(override string) string` — returns `override` if non-empty, else `"arm64"`.
+  - `func DiscoverTargets(dir string, cfg *appconfig.AppConfig, arch string) ([]Target, error)` — `arch` is the already-resolved arch string; never errors on a missing Dockerfile (returns native or empty targets); errors only on unreadable dirs.
+
+Discovery order: if `cfg != nil && len(cfg.Services) > 0`, one `KindComposeService` target per service (sorted by service name), each resolving `<dir>/<service.Context or ".">` for a Dockerfile; else if a Dockerfile exists in `dir`, one `KindDockerfile`; else if `Package.swift` exists, one `KindNativeSwift`; else if `Brewfile` exists, one `KindNativeBrew`; else empty slice. A `requirements.txt` found in a target's `Dir` is attached. The Dockerfile filename is detected with the existing `isContainerBuildFileName` rules — for this task, match `Dockerfile` or `Containerfile` exactly (variants handled by reusing the helper is a follow-up).
+
+NOTE on `ServiceConfig`: the `appconfig.ServiceConfig` type has a context/dockerfile field. Read its actual field names from `go/internal/shared/appconfig/appconfig.go` during implementation; the test below uses only single-Dockerfile and native cases to stay independent of that struct's exact shape. Compose discovery is covered by the dedicated subtest using a synthesized `Services` map.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/target_test.go
+package optimize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestResolveArch(t *testing.T) {
+	if got := resolveArch(""); got != "arm64" {
+		t.Fatalf("resolveArch(\"\") = %q, want arm64", got)
+	}
+	if got := resolveArch("amd64"); got != "amd64" {
+		t.Fatalf("resolveArch(\"amd64\") = %q, want amd64", got)
+	}
+}
+
+func TestDiscoverSingleDockerfile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM python:3.12-slim\n")
+	writeFile(t, dir, "requirements.txt", "torch==2.3.0+cpu\n")
+
+	targets, err := DiscoverTargets(dir, nil, "arm64")
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("got %d targets, want 1", len(targets))
+	}
+	tg := targets[0]
+	if tg.Kind != KindDockerfile {
+		t.Fatalf("kind = %v, want KindDockerfile", tg.Kind)
+	}
+	if tg.Dockerfile == nil || len(tg.Dockerfile.Instructions) == 0 {
+		t.Fatalf("Dockerfile not parsed")
+	}
+	if tg.Requirements == nil || len(tg.Requirements.Packages) != 1 {
+		t.Fatalf("requirements not attached")
+	}
+	if tg.Arch != "arm64" {
+		t.Fatalf("arch = %q, want arm64", tg.Arch)
+	}
+}
+
+func TestDiscoverNativeSwift(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Package.swift", "// swift-tools-version:6.0\n")
+	targets, err := DiscoverTargets(dir, nil, "arm64")
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	if len(targets) != 1 || targets[0].Kind != KindNativeSwift {
+		t.Fatalf("targets = %+v, want one KindNativeSwift", targets)
+	}
+}
+
+func TestDiscoverNothing(t *testing.T) {
+	dir := t.TempDir()
+	targets, err := DiscoverTargets(dir, nil, "arm64")
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("got %d targets, want 0", len(targets))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestDiscover -v`
+Expected: FAIL — `undefined: DiscoverTargets`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/target.go
+package optimize
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// TargetKind is the kind of buildable unit being analyzed.
+type TargetKind int
+
+const (
+	KindDockerfile TargetKind = iota
+	KindComposeService
+	KindNativeSwift
+	KindNativeBrew
+)
+
+func (k TargetKind) String() string {
+	switch k {
+	case KindDockerfile:
+		return "dockerfile"
+	case KindComposeService:
+		return "compose-service"
+	case KindNativeSwift:
+		return "native-swift"
+	case KindNativeBrew:
+		return "native-brew"
+	default:
+		return "unknown"
+	}
+}
+
+// Target is one buildable unit to analyze.
+type Target struct {
+	Name         string
+	Kind         TargetKind
+	Dir          string
+	Dockerfile   *Dockerfile
+	Requirements *Requirements
+	Config       *appconfig.AppConfig
+	Arch         string
+}
+
+// resolveArch returns the override if set, else the offline default.
+func resolveArch(override string) string {
+	if override != "" {
+		return override
+	}
+	return "arm64"
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// loadDockerfile parses Dockerfile or Containerfile in dir, returning nil if neither exists.
+func loadDockerfile(dir string) *Dockerfile {
+	for _, name := range []string{"Dockerfile", "Containerfile"} {
+		p := filepath.Join(dir, name)
+		if fileExists(p) {
+			data, err := os.ReadFile(p)
+			if err == nil {
+				return ParseDockerfile(p, data)
+			}
+		}
+	}
+	return nil
+}
+
+// loadRequirements parses requirements.txt in dir, returning nil if absent.
+func loadRequirements(dir string) *Requirements {
+	p := filepath.Join(dir, "requirements.txt")
+	if fileExists(p) {
+		data, err := os.ReadFile(p)
+		if err == nil {
+			return ParseRequirements(p, data)
+		}
+	}
+	return nil
+}
+
+// DiscoverTargets decides what to analyze in dir.
+func DiscoverTargets(dir string, cfg *appconfig.AppConfig, arch string) ([]Target, error) {
+	if _, err := os.Stat(dir); err != nil {
+		return nil, err
+	}
+
+	// Multi-service / compose.
+	if cfg != nil && len(cfg.Services) > 0 {
+		names := make([]string, 0, len(cfg.Services))
+		for name := range cfg.Services {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		targets := make([]Target, 0, len(names))
+		for _, name := range names {
+			svcDir := dir // service context resolution refined during impl per ServiceConfig fields
+			targets = append(targets, Target{
+				Name:         name,
+				Kind:         KindComposeService,
+				Dir:          svcDir,
+				Dockerfile:   loadDockerfile(svcDir),
+				Requirements: loadRequirements(svcDir),
+				Config:       cfg,
+				Arch:         arch,
+			})
+		}
+		return targets, nil
+	}
+
+	// Single Dockerfile.
+	if df := loadDockerfile(dir); df != nil {
+		return []Target{{
+			Name:         "app",
+			Kind:         KindDockerfile,
+			Dir:          dir,
+			Dockerfile:   df,
+			Requirements: loadRequirements(dir),
+			Config:       cfg,
+			Arch:         arch,
+		}}, nil
+	}
+
+	// Native.
+	if fileExists(filepath.Join(dir, "Package.swift")) {
+		return []Target{{Name: "app", Kind: KindNativeSwift, Dir: dir, Requirements: loadRequirements(dir), Config: cfg, Arch: arch}}, nil
+	}
+	if fileExists(filepath.Join(dir, "Brewfile")) {
+		return []Target{{Name: "app", Kind: KindNativeBrew, Dir: dir, Requirements: loadRequirements(dir), Config: cfg, Arch: arch}}, nil
+	}
+
+	return []Target{}, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestResolveArch -v && go test ./internal/cli/optimize/ -run TestDiscover -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/target.go internal/cli/optimize/target_test.go
+git add go/internal/cli/optimize/target.go go/internal/cli/optimize/target_test.go
+git commit -m "feat(optimize): add target discovery and arch resolution"
+```
+
+---
+
+## Task 5: Analyzer interface + engine driver
+
+**Files:**
+- Create: `go/internal/cli/optimize/analyzer.go`
+- Test: `go/internal/cli/optimize/analyzer_test.go`
+
+**Interfaces:**
+- Consumes: `Target`, `Finding`.
+- Produces:
+  - `type Analyzer interface { ID() string; Analyze(t *Target) []Finding }`.
+  - `func DefaultAnalyzers() []Analyzer` — returns the registered analyzers. Starts empty; each later task appends its analyzer here.
+  - `func Analyze(targets []Target, analyzers []Analyzer) []Finding` — runs each analyzer over each target (analyzer takes `*Target`), concatenating results in target-then-analyzer order.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/analyzer_test.go
+package optimize
+
+import "testing"
+
+type fakeAnalyzer struct{ id string }
+
+func (f fakeAnalyzer) ID() string { return f.id }
+func (f fakeAnalyzer) Analyze(t *Target) []Finding {
+	return []Finding{{Analyzer: f.id, Severity: SeverityWarning, Title: t.Name}}
+}
+
+func TestAnalyzeRunsAllAnalyzersOverAllTargets(t *testing.T) {
+	targets := []Target{{Name: "a", Kind: KindDockerfile}, {Name: "b", Kind: KindDockerfile}}
+	analyzers := []Analyzer{fakeAnalyzer{"x"}, fakeAnalyzer{"y"}}
+
+	findings := Analyze(targets, analyzers)
+	if len(findings) != 4 {
+		t.Fatalf("got %d findings, want 4", len(findings))
+	}
+	// target-then-analyzer order
+	if findings[0].Title != "a" || findings[0].Analyzer != "x" {
+		t.Fatalf("findings[0] = %+v", findings[0])
+	}
+	if findings[1].Analyzer != "y" {
+		t.Fatalf("findings[1] = %+v", findings[1])
+	}
+	if findings[2].Title != "b" {
+		t.Fatalf("findings[2] = %+v", findings[2])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestAnalyzeRuns -v`
+Expected: FAIL — `undefined: Analyze` / `undefined: Analyzer`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/analyzer.go
+package optimize
+
+// Analyzer inspects a Target and returns findings.
+type Analyzer interface {
+	ID() string
+	Analyze(t *Target) []Finding
+}
+
+// DefaultAnalyzers returns all built-in analyzers. Each analyzer task appends here.
+func DefaultAnalyzers() []Analyzer {
+	return []Analyzer{
+		// appended by later tasks: buildCacheAnalyzer{}, releaseDebugAnalyzer{}, cudaMLAnalyzer{}, archImageAnalyzer{}
+	}
+}
+
+// Analyze runs every analyzer over every target, in target-then-analyzer order.
+func Analyze(targets []Target, analyzers []Analyzer) []Finding {
+	var out []Finding
+	for i := range targets {
+		t := &targets[i]
+		for _, a := range analyzers {
+			out = append(out, a.Analyze(t)...)
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestAnalyzeRuns -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/analyzer.go internal/cli/optimize/analyzer_test.go
+git add go/internal/cli/optimize/analyzer.go go/internal/cli/optimize/analyzer_test.go
+git commit -m "feat(optimize): add analyzer interface and engine driver"
+```
+
+---
+
+## Task 6: buildcache analyzer
+
+**Files:**
+- Create: `go/internal/cli/optimize/buildcache.go`
+- Modify: `go/internal/cli/optimize/analyzer.go` (append `buildCacheAnalyzer{}` to `DefaultAnalyzers()`)
+- Test: `go/internal/cli/optimize/buildcache_test.go`
+
+**Interfaces:**
+- Consumes: `Target`, `Instruction`, `Finding`, `Fix`.
+- Produces: `type buildCacheAnalyzer struct{}` implementing `Analyzer` with `ID() == "build-cache"`.
+
+Behavior: for each `RUN` instruction in the target's Dockerfile, if `Args` contains a known compiled-lang build/install command AND the instruction has no `--mount=type=cache` flag, emit a `SeverityWarning` finding with a `FixReplaceLine` that rewrites the whole line to add the appropriate cache mount right after `RUN`. Idempotency is enforced by the fix applier (Task 10) checking `Old`. Commands → cache targets:
+- `cargo build`, `cargo fetch` → `/root/.cargo`
+- `go build`, `go mod download` → `/root/.cache/go-build`
+- `swift build` → `/root/.swiftpm`
+- `npm install`, `npm ci`, `yarn install`, `pnpm install` → `/root/.npm`
+- `pip install` → `/root/.cache/pip`
+
+The fix's `Old` is the raw source line (`df.Lines[inst.Line-1]`); `New` inserts the mount flag after the leading `RUN` token of that raw line.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/buildcache_test.go
+package optimize
+
+import "testing"
+
+func dockerfileTarget(t *testing.T, src string) *Target {
+	t.Helper()
+	df := ParseDockerfile("Dockerfile", []byte(src))
+	return &Target{Name: "app", Kind: KindDockerfile, Dir: ".", Dockerfile: df, Arch: "arm64"}
+}
+
+func TestBuildCacheFlagsMissingMount(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM rust:1\nRUN cargo build --release\n")
+	got := buildCacheAnalyzer{}.Analyze(tg)
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1: %+v", len(got), got)
+	}
+	f := got[0]
+	if f.Analyzer != "build-cache" || f.Severity != SeverityWarning {
+		t.Fatalf("finding = %+v", f)
+	}
+	if f.Fix == nil || f.Fix.Op != FixReplaceLine {
+		t.Fatalf("expected FixReplaceLine, got %+v", f.Fix)
+	}
+	if f.Fix.Old != "RUN cargo build --release" {
+		t.Fatalf("fix.Old = %q", f.Fix.Old)
+	}
+	if f.Fix.New != "RUN --mount=type=cache,target=/root/.cargo cargo build --release" {
+		t.Fatalf("fix.New = %q", f.Fix.New)
+	}
+}
+
+func TestBuildCacheSilentWhenMountPresent(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM rust:1\nRUN --mount=type=cache,target=/root/.cargo cargo build\n")
+	if got := buildCacheAnalyzer{}.Analyze(tg); len(got) != 0 {
+		t.Fatalf("got %d findings, want 0: %+v", len(got), got)
+	}
+}
+
+func TestBuildCacheIgnoresNonDockerTarget(t *testing.T) {
+	tg := &Target{Name: "app", Kind: KindNativeSwift, Arch: "arm64"}
+	if got := buildCacheAnalyzer{}.Analyze(tg); len(got) != 0 {
+		t.Fatalf("got %d findings, want 0", len(got))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestBuildCache -v`
+Expected: FAIL — `undefined: buildCacheAnalyzer`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/buildcache.go
+package optimize
+
+import (
+	"fmt"
+	"strings"
+)
+
+type buildCacheAnalyzer struct{}
+
+func (buildCacheAnalyzer) ID() string { return "build-cache" }
+
+// cacheRule maps a substring that signals a compiled-lang build to its cache mount target.
+type cacheRule struct {
+	match  string
+	target string
+}
+
+var cacheRules = []cacheRule{
+	{"cargo build", "/root/.cargo"},
+	{"cargo fetch", "/root/.cargo"},
+	{"go build", "/root/.cache/go-build"},
+	{"go mod download", "/root/.cache/go-build"},
+	{"swift build", "/root/.swiftpm"},
+	{"npm install", "/root/.npm"},
+	{"npm ci", "/root/.npm"},
+	{"yarn install", "/root/.npm"},
+	{"pnpm install", "/root/.npm"},
+	{"pip install", "/root/.cache/pip"},
+}
+
+func (a buildCacheAnalyzer) Analyze(t *Target) []Finding {
+	if t.Dockerfile == nil {
+		return nil
+	}
+	var out []Finding
+	for _, inst := range t.Dockerfile.Instructions {
+		if inst.Cmd != "RUN" {
+			continue
+		}
+		if hasCacheMount(inst.Flags) {
+			continue
+		}
+		rule, ok := matchCacheRule(inst.Args)
+		if !ok {
+			continue
+		}
+		raw := t.Dockerfile.Lines[inst.Line-1]
+		newLine := insertRunFlag(raw, fmt.Sprintf("--mount=type=cache,target=%s", rule.target))
+		out = append(out, Finding{
+			Analyzer: a.ID(),
+			Severity: SeverityWarning,
+			Title:    fmt.Sprintf("%q runs without a build cache mount", rule.match),
+			Detail: fmt.Sprintf("Add `--mount=type=cache,target=%s` to this RUN so %s reuses its cache across builds, "+
+				"cutting rebuild time substantially.", rule.target, rule.match),
+			Location: &Loc{File: t.Dockerfile.Path, Line: inst.Line},
+			Fix: &Fix{
+				Description: fmt.Sprintf("add cache mount for %s", rule.match),
+				Op:          FixReplaceLine,
+				File:        t.Dockerfile.Path,
+				Line:        inst.Line,
+				Old:         raw,
+				New:         newLine,
+			},
+		})
+	}
+	return out
+}
+
+func hasCacheMount(flags []string) bool {
+	for _, f := range flags {
+		if strings.HasPrefix(f, "--mount=") && strings.Contains(f, "type=cache") {
+			return true
+		}
+	}
+	return false
+}
+
+func matchCacheRule(args string) (cacheRule, bool) {
+	for _, r := range cacheRules {
+		if strings.Contains(args, r.match) {
+			return r, true
+		}
+	}
+	return cacheRule{}, false
+}
+
+// insertRunFlag inserts flag right after the leading RUN token of a raw line,
+// preserving the line's leading indentation.
+func insertRunFlag(raw, flag string) string {
+	indent := raw[:len(raw)-len(strings.TrimLeft(raw, " \t"))]
+	body := strings.TrimLeft(raw, " \t")
+	const run = "RUN "
+	if strings.HasPrefix(body, run) {
+		return indent + run + flag + " " + strings.TrimPrefix(body, run)
+	}
+	return raw // not a simple RUN line; leave unchanged
+}
+```
+
+Then append to `DefaultAnalyzers()` in `analyzer.go`:
+
+```go
+func DefaultAnalyzers() []Analyzer {
+	return []Analyzer{
+		buildCacheAnalyzer{},
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestBuildCache -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/buildcache.go internal/cli/optimize/analyzer.go internal/cli/optimize/buildcache_test.go
+git add go/internal/cli/optimize/buildcache.go go/internal/cli/optimize/analyzer.go go/internal/cli/optimize/buildcache_test.go
+git commit -m "feat(optimize): add build-cache analyzer"
+```
+
+---
+
+## Task 7: releasedebug analyzer
+
+**Files:**
+- Create: `go/internal/cli/optimize/releasedebug.go`
+- Modify: `go/internal/cli/optimize/analyzer.go` (append `releaseDebugAnalyzer{}`)
+- Test: `go/internal/cli/optimize/releasedebug_test.go`
+
+**Interfaces:**
+- Consumes: `Target`, `Instruction`, `Finding`, `Fix`.
+- Produces: `type releaseDebugAnalyzer struct{}` with `ID() == "release-debug"`.
+
+Behavior over the Dockerfile:
+1. `RUN` with `swift build` lacking `-c release` (and not `--configuration release`) → `SeverityWarning` + `FixReplaceLine` appending ` -c release` to the `swift build` occurrence in the raw line.
+2. `RUN` with `cargo build` lacking `--release` → `SeverityWarning` + `FixReplaceLine` appending ` --release`.
+3. WENDY_DEBUG wiring: scan all instructions. If any `ARG`/`ENV` defines `WENDY_DEBUG` but no `RUN` line references `WENDY_DEBUG`, emit one `SeverityInfo` finding (no fix) recommending gating optimization on it. If `WENDY_DEBUG` is never mentioned at all, emit nothing (silence — projects need not adopt it).
+
+For the line-rewrite fixes, `Old` = raw source line; `New` = raw line with the flag inserted immediately after the build command token.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/releasedebug_test.go
+package optimize
+
+import "testing"
+
+func TestReleaseDebugSwiftMissingReleaseFlag(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM swift:6\nRUN swift build\n")
+	got := releaseDebugAnalyzer{}.Analyze(tg)
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1: %+v", len(got), got)
+	}
+	if got[0].Fix == nil || got[0].Fix.New != "RUN swift build -c release" {
+		t.Fatalf("fix = %+v", got[0].Fix)
+	}
+}
+
+func TestReleaseDebugSwiftSilentWithReleaseFlag(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM swift:6\nRUN swift build -c release\n")
+	if got := releaseDebugAnalyzer{}.Analyze(tg); len(got) != 0 {
+		t.Fatalf("got %d, want 0: %+v", len(got), got)
+	}
+}
+
+func TestReleaseDebugWendyDebugDefinedButUnused(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM swift:6\nARG WENDY_DEBUG=0\nRUN swift build -c release\n")
+	got := releaseDebugAnalyzer{}.Analyze(tg)
+	if len(got) != 1 || got[0].Severity != SeverityInfo {
+		t.Fatalf("want 1 info finding for WENDY_DEBUG, got %+v", got)
+	}
+	if got[0].Fix != nil {
+		t.Fatalf("WENDY_DEBUG finding should be report-only")
+	}
+}
+
+func TestReleaseDebugWendyDebugUsed(t *testing.T) {
+	src := "FROM swift:6\nARG WENDY_DEBUG=0\n" +
+		"RUN if [ \"$WENDY_DEBUG\" = \"1\" ]; then swift build; else swift build -c release; fi\n"
+	tg := dockerfileTarget(t, src)
+	for _, f := range releaseDebugAnalyzer{}.Analyze(tg) {
+		if f.Severity == SeverityInfo {
+			t.Fatalf("did not expect WENDY_DEBUG info finding: %+v", f)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestReleaseDebug -v`
+Expected: FAIL — `undefined: releaseDebugAnalyzer`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/releasedebug.go
+package optimize
+
+import "strings"
+
+type releaseDebugAnalyzer struct{}
+
+func (releaseDebugAnalyzer) ID() string { return "release-debug" }
+
+func (a releaseDebugAnalyzer) Analyze(t *Target) []Finding {
+	if t.Dockerfile == nil {
+		return nil
+	}
+	var out []Finding
+
+	wendyDebugDefined := false
+	wendyDebugUsed := false
+
+	for _, inst := range t.Dockerfile.Instructions {
+		joined := inst.Cmd + " " + inst.Args
+
+		if (inst.Cmd == "ARG" || inst.Cmd == "ENV") && strings.Contains(inst.Args, "WENDY_DEBUG") {
+			wendyDebugDefined = true
+		}
+		if inst.Cmd == "RUN" && strings.Contains(inst.Args, "WENDY_DEBUG") {
+			wendyDebugUsed = true
+		}
+
+		if inst.Cmd != "RUN" {
+			continue
+		}
+		raw := t.Dockerfile.Lines[inst.Line-1]
+
+		if strings.Contains(inst.Args, "swift build") &&
+			!strings.Contains(inst.Args, "-c release") &&
+			!strings.Contains(inst.Args, "--configuration release") {
+			out = append(out, lineFlagFinding(a.ID(), t.Dockerfile.Path, inst.Line, raw,
+				"swift build", "swift build -c release",
+				"`swift build` defaults to a debug build. Add `-c release` so the shipped binary is optimized.",
+				"add -c release to swift build"))
+		}
+		if strings.Contains(inst.Args, "cargo build") && !strings.Contains(inst.Args, "--release") {
+			out = append(out, lineFlagFinding(a.ID(), t.Dockerfile.Path, inst.Line, raw,
+				"cargo build", "cargo build --release",
+				"`cargo build` defaults to a debug build. Add `--release` for an optimized binary.",
+				"add --release to cargo build"))
+		}
+		_ = joined
+	}
+
+	if wendyDebugDefined && !wendyDebugUsed {
+		out = append(out, Finding{
+			Analyzer: a.ID(),
+			Severity: SeverityInfo,
+			Title:    "WENDY_DEBUG is declared but never used to toggle the build",
+			Detail: "WENDY_DEBUG is defined but no RUN step branches on it. Gate the optimization level on it, " +
+				"e.g. release by default and a debug build only when WENDY_DEBUG=1.",
+			Location: nil,
+		})
+	}
+
+	return out
+}
+
+// lineFlagFinding builds a warning whose fix appends a flag to a build command on a raw line.
+func lineFlagFinding(analyzer, file string, line int, raw, oldCmd, newCmd, detail, fixDesc string) Finding {
+	newLine := strings.Replace(raw, oldCmd, newCmd, 1)
+	return Finding{
+		Analyzer: analyzer,
+		Severity: SeverityWarning,
+		Title:    oldCmd + " is a debug build",
+		Detail:   detail,
+		Location: &Loc{File: file, Line: line},
+		Fix: &Fix{
+			Description: fixDesc,
+			Op:          FixReplaceLine,
+			File:        file,
+			Line:        line,
+			Old:         raw,
+			New:         newLine,
+		},
+	}
+}
+```
+
+Then append `releaseDebugAnalyzer{}` to `DefaultAnalyzers()`:
+
+```go
+func DefaultAnalyzers() []Analyzer {
+	return []Analyzer{
+		buildCacheAnalyzer{},
+		releaseDebugAnalyzer{},
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestReleaseDebug -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/releasedebug.go internal/cli/optimize/analyzer.go internal/cli/optimize/releasedebug_test.go
+git add go/internal/cli/optimize/releasedebug.go go/internal/cli/optimize/analyzer.go go/internal/cli/optimize/releasedebug_test.go
+git commit -m "feat(optimize): add release-debug analyzer"
+```
+
+---
+
+## Task 8: cudaml analyzer
+
+**Files:**
+- Create: `go/internal/cli/optimize/cudaml.go`
+- Modify: `go/internal/cli/optimize/analyzer.go` (append `cudaMLAnalyzer{}`)
+- Test: `go/internal/cli/optimize/cudaml_test.go`
+
+**Interfaces:**
+- Consumes: `Target`, `Requirements`, `Instruction`, `appconfig.AppConfig`, `appconfig.EntitlementGPU`.
+- Produces: `type cudaMLAnalyzer struct{}` with `ID() == "cuda-ml"`. All findings report-only (`Fix == nil`).
+
+Behavior:
+1. `hasGPUEntitlement(cfg)` = true if any `cfg.Entitlements[i].Type == appconfig.EntitlementGPU`.
+2. If `requirements.txt` lists a known ML package (`torch`, `tensorflow`, `onnxruntime`, `onnxruntime-gpu`) AND the wheel is CPU-only (package `LocalLabel == "cpu"`, OR any IndexURL contains `/whl/cpu`) AND `hasGPUEntitlement` → `SeverityWarning`: "GPU entitlement set but a CPU-only ML wheel is pinned."
+3. If a known GPU ML package (`onnxruntime-gpu`, or torch with `LocalLabel` starting `cu`) is present AND NOT `hasGPUEntitlement` → `SeverityWarning`: "CUDA wheel pinned but no gpu entitlement declared in wendy.json."
+4. Dockerfile `FROM` whose image arg contains `nvidia/cuda` while `t.Arch == "arm64"` → `SeverityWarning`: "x86 CUDA base image on an arm64 target; Jetson needs an L4T base (e.g. nvcr.io/nvidia/l4t-*)."
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/cudaml_test.go
+package optimize
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func gpuCfg() *appconfig.AppConfig {
+	return &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementGPU}}}
+}
+
+func TestCudaCPUWheelWithGPUEntitlement(t *testing.T) {
+	tg := &Target{
+		Name:         "app",
+		Kind:         KindDockerfile,
+		Arch:         "arm64",
+		Config:       gpuCfg(),
+		Requirements: ParseRequirements("requirements.txt", []byte("torch==2.3.0+cpu\n")),
+	}
+	got := cudaMLAnalyzer{}.Analyze(tg)
+	if len(got) != 1 || got[0].Severity != SeverityWarning {
+		t.Fatalf("want 1 warning, got %+v", got)
+	}
+	if got[0].Fix != nil {
+		t.Fatalf("cuda findings are report-only")
+	}
+}
+
+func TestCudaGPUWheelWithoutEntitlement(t *testing.T) {
+	tg := &Target{
+		Name:         "app",
+		Kind:         KindDockerfile,
+		Arch:         "arm64",
+		Config:       &appconfig.AppConfig{},
+		Requirements: ParseRequirements("requirements.txt", []byte("onnxruntime-gpu\n")),
+	}
+	got := cudaMLAnalyzer{}.Analyze(tg)
+	if len(got) != 1 || got[0].Severity != SeverityWarning {
+		t.Fatalf("want 1 warning, got %+v", got)
+	}
+}
+
+func TestCudaX86BaseImageOnArm(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04\n")
+	tg.Config = &appconfig.AppConfig{}
+	got := cudaMLAnalyzer{}.Analyze(tg)
+	if len(got) != 1 || got[0].Severity != SeverityWarning {
+		t.Fatalf("want 1 warning for x86 cuda base, got %+v", got)
+	}
+}
+
+func TestCudaSilentWhenAligned(t *testing.T) {
+	tg := &Target{
+		Name:         "app",
+		Kind:         KindDockerfile,
+		Arch:         "arm64",
+		Config:       gpuCfg(),
+		Requirements: ParseRequirements("requirements.txt", []byte("numpy>=1.26\n")),
+	}
+	if got := cudaMLAnalyzer{}.Analyze(tg); len(got) != 0 {
+		t.Fatalf("want 0, got %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestCuda -v`
+Expected: FAIL — `undefined: cudaMLAnalyzer`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/cudaml.go
+package optimize
+
+import (
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+type cudaMLAnalyzer struct{}
+
+func (cudaMLAnalyzer) ID() string { return "cuda-ml" }
+
+var mlPackages = map[string]bool{
+	"torch":            true,
+	"tensorflow":       true,
+	"onnxruntime":      true,
+	"onnxruntime-gpu":  true,
+	"tensorflow-gpu":   true,
+}
+
+func hasGPUEntitlement(cfg *appconfig.AppConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, e := range cfg.Entitlements {
+		if e.Type == appconfig.EntitlementGPU {
+			return true
+		}
+	}
+	return false
+}
+
+func (a cudaMLAnalyzer) Analyze(t *Target) []Finding {
+	var out []Finding
+	gpu := hasGPUEntitlement(t.Config)
+
+	if t.Requirements != nil {
+		cpuIndex := false
+		for _, u := range t.Requirements.IndexURLs {
+			if strings.Contains(u, "/whl/cpu") {
+				cpuIndex = true
+			}
+		}
+		for _, p := range t.Requirements.Packages {
+			if !mlPackages[p.Name] {
+				continue
+			}
+			isCPU := p.LocalLabel == "cpu" || cpuIndex
+			isGPU := p.Name == "onnxruntime-gpu" || p.Name == "tensorflow-gpu" || strings.HasPrefix(p.LocalLabel, "cu")
+
+			if isCPU && gpu {
+				out = append(out, Finding{
+					Analyzer: a.ID(),
+					Severity: SeverityWarning,
+					Title:    "GPU entitlement set but a CPU-only ML wheel is pinned",
+					Detail: "wendy.json declares the gpu entitlement, but " + p.Name + " resolves to a CPU-only build. " +
+						"Pin a CUDA wheel matching the device's JetPack/CUDA version to actually use the GPU.",
+					Location: &Loc{File: t.Requirements.Path, Line: p.Line},
+				})
+			}
+			if isGPU && !gpu {
+				out = append(out, Finding{
+					Analyzer: a.ID(),
+					Severity: SeverityWarning,
+					Title:    "CUDA ML wheel pinned but no gpu entitlement declared",
+					Detail: p.Name + " is a CUDA build, but wendy.json does not declare the gpu entitlement, " +
+						"so the container will not get GPU access on the device.",
+					Location: &Loc{File: t.Requirements.Path, Line: p.Line},
+				})
+			}
+		}
+	}
+
+	if t.Dockerfile != nil && t.Arch == "arm64" {
+		for _, inst := range t.Dockerfile.Instructions {
+			if inst.Cmd == "FROM" && strings.Contains(inst.Args, "nvidia/cuda") {
+				out = append(out, Finding{
+					Analyzer: a.ID(),
+					Severity: SeverityWarning,
+					Title:    "x86 CUDA base image on an arm64 target",
+					Detail: "nvidia/cuda images are x86-first. On a Jetson (arm64) use an L4T base such as " +
+						"nvcr.io/nvidia/l4t-base or an l4t-* runtime image that matches the device JetPack.",
+					Location: &Loc{File: t.Dockerfile.Path, Line: inst.Line},
+				})
+			}
+		}
+	}
+
+	return out
+}
+```
+
+Append `cudaMLAnalyzer{}` to `DefaultAnalyzers()`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestCuda -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/cudaml.go internal/cli/optimize/analyzer.go internal/cli/optimize/cudaml_test.go
+git add go/internal/cli/optimize/cudaml.go go/internal/cli/optimize/analyzer.go go/internal/cli/optimize/cudaml_test.go
+git commit -m "feat(optimize): add cuda-ml analyzer"
+```
+
+---
+
+## Task 9: archimage analyzer
+
+**Files:**
+- Create: `go/internal/cli/optimize/archimage.go`
+- Modify: `go/internal/cli/optimize/analyzer.go` (append `archImageAnalyzer{}`)
+- Test: `go/internal/cli/optimize/archimage_test.go`
+
+**Interfaces:**
+- Consumes: `Target`, `Instruction`, `Finding`, `Fix`.
+- Produces: `type archImageAnalyzer struct{}` with `ID() == "arch-image"`.
+
+Behavior:
+1. Any `FROM` with `--platform=linux/amd64` (or `--platform=linux/x86_64`) while `t.Arch == "arm64"` → `SeverityError`, report-only: "amd64 base image on arm64 target — runs under QEMU or fails."
+2. Missing `.dockerignore` in `t.Dir` (only for Dockerfile/compose targets) → `SeverityWarning` + `FixCreateFile` writing a default `.dockerignore`. Default contents constant `defaultDockerignore`.
+3. Single-stage build (exactly one `FROM` and no `AS` stage names) that also installs a build toolchain (a `RUN` whose Args contains `apt-get install` with a `-dev` package, or `build-essential`, or `cargo`/`go build`/`swift build`) → `SeverityInfo`, report-only: suggest multi-stage.
+
+`.dockerignore` existence is checked via `fileExists(filepath.Join(t.Dir, ".dockerignore"))`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/archimage_test.go
+package optimize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestArchAmd64OnArm(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM --platform=linux/amd64 python:3.12-slim\n")
+	tg.Dir = t.TempDir()
+	writeFile(t, tg.Dir, ".dockerignore", ".git\n") // present, so no .dockerignore finding
+	got := archImageAnalyzer{}.Analyze(tg)
+	var sawErr bool
+	for _, f := range got {
+		if f.Severity == SeverityError {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Fatalf("expected an error finding for amd64-on-arm, got %+v", got)
+	}
+}
+
+func TestArchMissingDockerignoreFixable(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM python:3.12-slim\n")
+	tg.Dir = t.TempDir() // no .dockerignore
+	got := archImageAnalyzer{}.Analyze(tg)
+	var fix *Fix
+	for i := range got {
+		if got[i].Title == "No .dockerignore" {
+			fix = got[i].Fix
+		}
+	}
+	if fix == nil || fix.Op != FixCreateFile {
+		t.Fatalf("expected FixCreateFile for missing .dockerignore, got %+v", got)
+	}
+	if fix.File != filepath.Join(tg.Dir, ".dockerignore") {
+		t.Fatalf("fix.File = %q", fix.File)
+	}
+}
+
+func TestArchDockerignorePresentNoFinding(t *testing.T) {
+	tg := dockerfileTarget(t, "FROM python:3.12-slim\n")
+	tg.Dir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(tg.Dir, ".dockerignore"), []byte(".git\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range archImageAnalyzer{}.Analyze(tg) {
+		if f.Title == "No .dockerignore" {
+			t.Fatalf("did not expect a .dockerignore finding")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestArch -v`
+Expected: FAIL — `undefined: archImageAnalyzer`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/archimage.go
+package optimize
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+type archImageAnalyzer struct{}
+
+func (archImageAnalyzer) ID() string { return "arch-image" }
+
+const defaultDockerignore = `.git
+**/.build
+**/.swiftpm
+node_modules
+target
+__pycache__
+*.pyc
+.venv
+dist
+build
+`
+
+func (a archImageAnalyzer) Analyze(t *Target) []Finding {
+	if t.Dockerfile == nil {
+		return nil
+	}
+	var out []Finding
+
+	fromCount := 0
+	hasStageName := false
+	installsToolchain := false
+
+	for _, inst := range t.Dockerfile.Instructions {
+		switch inst.Cmd {
+		case "FROM":
+			fromCount++
+			if strings.Contains(strings.ToUpper(" "+inst.Args+" "), " AS ") {
+				hasStageName = true
+			}
+			if t.Arch == "arm64" {
+				for _, fl := range inst.Flags {
+					if fl == "--platform=linux/amd64" || fl == "--platform=linux/x86_64" {
+						out = append(out, Finding{
+							Analyzer: a.ID(),
+							Severity: SeverityError,
+							Title:    "amd64 base image on arm64 target",
+							Detail: "This FROM forces linux/amd64 but the target device is arm64. It will run under " +
+								"QEMU emulation (slow) or fail to start. Use an arm64/multi-arch base image.",
+							Location: &Loc{File: t.Dockerfile.Path, Line: inst.Line},
+						})
+					}
+				}
+			}
+		case "RUN":
+			if strings.Contains(inst.Args, "build-essential") ||
+				(strings.Contains(inst.Args, "apt-get install") && strings.Contains(inst.Args, "-dev")) ||
+				strings.Contains(inst.Args, "cargo build") ||
+				strings.Contains(inst.Args, "go build") ||
+				strings.Contains(inst.Args, "swift build") {
+				installsToolchain = true
+			}
+		}
+	}
+
+	if !fileExists(filepath.Join(t.Dir, ".dockerignore")) {
+		out = append(out, Finding{
+			Analyzer: a.ID(),
+			Severity: SeverityWarning,
+			Title:    "No .dockerignore",
+			Detail: "Without a .dockerignore the whole context (including .git and build artifacts) is sent to the " +
+				"builder, slowing builds and bloating layers.",
+			Location: nil,
+			Fix: &Fix{
+				Description: "create a default .dockerignore",
+				Op:          FixCreateFile,
+				File:        filepath.Join(t.Dir, ".dockerignore"),
+				New:         defaultDockerignore,
+			},
+		})
+	}
+
+	if fromCount == 1 && !hasStageName && installsToolchain {
+		out = append(out, Finding{
+			Analyzer: a.ID(),
+			Severity: SeverityInfo,
+			Title:    "Single-stage build ships its build toolchain",
+			Detail: "This image builds and runs in one stage, leaving compilers and -dev packages in the deployed " +
+				"image. A multi-stage build that copies only the final artifact into a slim runtime stage is much smaller.",
+			Location: nil,
+		})
+	}
+
+	return out
+}
+```
+
+Append `archImageAnalyzer{}` to `DefaultAnalyzers()`. After this task `DefaultAnalyzers()` returns all four: `buildCacheAnalyzer{}, releaseDebugAnalyzer{}, cudaMLAnalyzer{}, archImageAnalyzer{}`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestArch -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/archimage.go internal/cli/optimize/analyzer.go internal/cli/optimize/archimage_test.go
+git add go/internal/cli/optimize/archimage.go go/internal/cli/optimize/analyzer.go go/internal/cli/optimize/archimage_test.go
+git commit -m "feat(optimize): add arch-image analyzer"
+```
+
+---
+
+## Task 10: Fix applier (idempotent)
+
+**Files:**
+- Create: `go/internal/cli/optimize/fix.go`
+- Test: `go/internal/cli/optimize/fix_test.go`
+
+**Interfaces:**
+- Consumes: `Finding`, `Fix`, `FixOp`.
+- Produces:
+  - `type AppliedFix struct { Fix Fix; Applied bool; Reason string }` — `Applied=false` with a `Reason` when skipped (already applied / line mismatch / file exists).
+  - `func ApplyFixes(findings []Finding) ([]AppliedFix, error)` — applies every finding's non-nil `Fix`. `FixCreateFile`: write `New` if file does not exist (else skip "file exists"). `FixReplaceLine`: read file, if line `Line` equals `Old` replace with `New` and write back (else skip "already applied or line changed"). Idempotent: re-running applies nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/fix_test.go
+package optimize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestApplyReplaceLineIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "Dockerfile")
+	if err := os.WriteFile(p, []byte("FROM rust:1\nRUN cargo build\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f := Finding{Fix: &Fix{
+		Op: FixReplaceLine, File: p, Line: 2,
+		Old: "RUN cargo build",
+		New: "RUN --mount=type=cache,target=/root/.cargo cargo build",
+	}}
+
+	applied, err := ApplyFixes([]Finding{f})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(applied) != 1 || !applied[0].Applied {
+		t.Fatalf("first apply = %+v", applied)
+	}
+	data, _ := os.ReadFile(p)
+	if string(data) != "FROM rust:1\nRUN --mount=type=cache,target=/root/.cargo cargo build\n" {
+		t.Fatalf("file after fix = %q", string(data))
+	}
+
+	// Re-running must not apply again.
+	applied2, err := ApplyFixes([]Finding{f})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied2[0].Applied {
+		t.Fatalf("second apply should be skipped, got %+v", applied2[0])
+	}
+}
+
+func TestApplyCreateFileSkipsExisting(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".dockerignore")
+	f := Finding{Fix: &Fix{Op: FixCreateFile, File: p, New: ".git\n"}}
+
+	if _, err := ApplyFixes([]Finding{f}); err != nil {
+		t.Fatal(err)
+	}
+	if !fileExists(p) {
+		t.Fatalf("file not created")
+	}
+	applied, err := ApplyFixes([]Finding{f})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied[0].Applied {
+		t.Fatalf("second create should skip existing file")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestApply -v`
+Expected: FAIL — `undefined: ApplyFixes`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/fix.go
+package optimize
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// AppliedFix records the outcome of applying one Fix.
+type AppliedFix struct {
+	Fix     Fix
+	Applied bool
+	Reason  string // populated when Applied is false
+}
+
+// ApplyFixes applies every finding's non-nil Fix. It is idempotent.
+func ApplyFixes(findings []Finding) ([]AppliedFix, error) {
+	var results []AppliedFix
+	for _, f := range findings {
+		if f.Fix == nil {
+			continue
+		}
+		fx := *f.Fix
+		switch fx.Op {
+		case FixCreateFile:
+			if fileExists(fx.File) {
+				results = append(results, AppliedFix{Fix: fx, Applied: false, Reason: "file already exists"})
+				continue
+			}
+			if err := os.WriteFile(fx.File, []byte(fx.New), 0o644); err != nil {
+				return results, fmt.Errorf("creating %s: %w", fx.File, err)
+			}
+			results = append(results, AppliedFix{Fix: fx, Applied: true})
+
+		case FixReplaceLine:
+			data, err := os.ReadFile(fx.File)
+			if err != nil {
+				return results, fmt.Errorf("reading %s: %w", fx.File, err)
+			}
+			text := strings.ReplaceAll(string(data), "\r\n", "\n")
+			trailingNL := strings.HasSuffix(text, "\n")
+			body := text
+			if trailingNL {
+				body = strings.TrimSuffix(text, "\n")
+			}
+			lines := strings.Split(body, "\n")
+			idx := fx.Line - 1
+			if idx < 0 || idx >= len(lines) || lines[idx] != fx.Old {
+				results = append(results, AppliedFix{Fix: fx, Applied: false, Reason: "already applied or line changed"})
+				continue
+			}
+			lines[idx] = fx.New
+			out := strings.Join(lines, "\n")
+			if trailingNL {
+				out += "\n"
+			}
+			if err := os.WriteFile(fx.File, []byte(out), 0o644); err != nil {
+				return results, fmt.Errorf("writing %s: %w", fx.File, err)
+			}
+			results = append(results, AppliedFix{Fix: fx, Applied: true})
+
+		default:
+			results = append(results, AppliedFix{Fix: fx, Applied: false, Reason: "unknown fix op"})
+		}
+	}
+	return results, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestApply -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/fix.go internal/cli/optimize/fix_test.go
+git add go/internal/cli/optimize/fix.go go/internal/cli/optimize/fix_test.go
+git commit -m "feat(optimize): add idempotent fix applier"
+```
+
+---
+
+## Task 11: Reporter (human + JSON shape)
+
+**Files:**
+- Create: `go/internal/cli/optimize/report.go`
+- Test: `go/internal/cli/optimize/report_test.go`
+
+**Interfaces:**
+- Consumes: `Target`, `Finding`, `Severity`.
+- Produces:
+  - `type Report struct { Targets []ReportTarget; Findings []Finding }` where `type ReportTarget struct { Name string; Kind string }`.
+  - `func BuildReport(targets []Target, findings []Finding) Report`.
+  - `func (r Report) Counts() (info, warning, errc, fixable int)`.
+  - `func (r Report) MaxSeverity() Severity` — highest severity present (defaults to `SeverityInfo` when empty).
+  - `func RenderHuman(r Report) string` — plain-text report grouped by target (no lipgloss color codes in the returned string, so it is testable; the command layer wraps lines in color). Each finding line: `  <sev>  <analyzer>:<line>  <title>[  (fixable)]`. Findings with no `Location` omit `:<line>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/report_test.go
+package optimize
+
+import (
+	"strings"
+	"testing"
+)
+
+func sampleReport() Report {
+	targets := []Target{{Name: "app", Kind: KindDockerfile}}
+	findings := []Finding{
+		{Analyzer: "arch-image", Severity: SeverityError, Title: "amd64 base", Location: &Loc{File: "Dockerfile", Line: 1}},
+		{Analyzer: "build-cache", Severity: SeverityWarning, Title: "no cache", Location: &Loc{File: "Dockerfile", Line: 4}, Fix: &Fix{Op: FixReplaceLine}},
+		{Analyzer: "arch-image", Severity: SeverityWarning, Title: "No .dockerignore", Fix: &Fix{Op: FixCreateFile}},
+	}
+	return BuildReport(targets, findings)
+}
+
+func TestCountsAndMaxSeverity(t *testing.T) {
+	r := sampleReport()
+	info, warn, errc, fixable := r.Counts()
+	if info != 0 || warn != 2 || errc != 1 || fixable != 2 {
+		t.Fatalf("counts = info:%d warn:%d err:%d fixable:%d", info, warn, errc, fixable)
+	}
+	if r.MaxSeverity() != SeverityError {
+		t.Fatalf("MaxSeverity = %v, want error", r.MaxSeverity())
+	}
+}
+
+func TestRenderHuman(t *testing.T) {
+	out := RenderHuman(sampleReport())
+	if !strings.Contains(out, "app (dockerfile)") {
+		t.Fatalf("missing target header:\n%s", out)
+	}
+	if !strings.Contains(out, "build-cache:4") || !strings.Contains(out, "(fixable)") {
+		t.Fatalf("missing fixable build-cache line:\n%s", out)
+	}
+	if strings.Contains(out, "arch-image:0") {
+		t.Fatalf("location-less finding should not print :0\n%s", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run 'TestCounts|TestRenderHuman' -v`
+Expected: FAIL — `undefined: BuildReport`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/report.go
+package optimize
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ReportTarget is the lightweight target view embedded in a report.
+type ReportTarget struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}
+
+// Report is the rendered/serialized output of an optimize run.
+type Report struct {
+	Targets  []ReportTarget `json:"targets"`
+	Findings []Finding      `json:"findings"`
+}
+
+// BuildReport assembles a Report from targets and findings.
+func BuildReport(targets []Target, findings []Finding) Report {
+	rt := make([]ReportTarget, 0, len(targets))
+	for _, t := range targets {
+		rt = append(rt, ReportTarget{Name: t.Name, Kind: t.Kind.String()})
+	}
+	return Report{Targets: rt, Findings: findings}
+}
+
+// Counts returns finding counts by severity plus the number of fixable findings.
+func (r Report) Counts() (info, warning, errc, fixable int) {
+	for _, f := range r.Findings {
+		switch f.Severity {
+		case SeverityInfo:
+			info++
+		case SeverityWarning:
+			warning++
+		case SeverityError:
+			errc++
+		}
+		if f.Fix != nil {
+			fixable++
+		}
+	}
+	return
+}
+
+// MaxSeverity returns the highest severity in the report (SeverityInfo if empty).
+func (r Report) MaxSeverity() Severity {
+	max := SeverityInfo
+	for _, f := range r.Findings {
+		if f.Severity > max {
+			max = f.Severity
+		}
+	}
+	return max
+}
+
+// RenderHuman renders a plain-text report grouped by target Name.
+func RenderHuman(r Report) string {
+	var b strings.Builder
+
+	// Group findings by the target each was produced under. Findings carry no
+	// back-pointer, so render per target header then all findings (single-target
+	// is the common case; multi-target groups by Location file when present).
+	for _, t := range r.Targets {
+		fmt.Fprintf(&b, "%s (%s)\n", t.Name, t.Kind)
+	}
+	for _, f := range r.Findings {
+		loc := ""
+		if f.Location != nil {
+			loc = fmt.Sprintf(":%d", f.Location.Line)
+		}
+		fixable := ""
+		if f.Fix != nil {
+			fixable = "  (fixable)"
+		}
+		fmt.Fprintf(&b, "  %-7s  %s%s  %s%s\n", f.Severity.String(), f.Analyzer, loc, f.Title, fixable)
+	}
+
+	info, warn, errc, fixable := r.Counts()
+	total := info + warn + errc
+	fmt.Fprintf(&b, "\n%d findings (%d errors, %d warnings, %d info)", total, errc, warn, info)
+	if fixable > 0 {
+		fmt.Fprintf(&b, "  ·  %d fixable — run with --fix", fixable)
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run 'TestCounts|TestRenderHuman' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/report.go internal/cli/optimize/report_test.go
+git add go/internal/cli/optimize/report.go go/internal/cli/optimize/report_test.go
+git commit -m "feat(optimize): add report builder and human renderer"
+```
+
+---
+
+## Task 12: Agentic bundle
+
+**Files:**
+- Create: `go/internal/cli/optimize/bundle.go`
+- Test: `go/internal/cli/optimize/bundle_test.go`
+
+**Interfaces:**
+- Consumes: `Target`, `Finding`, `Report` (for findings reuse).
+- Produces:
+  - `type BundleTarget struct { Name string; Kind string; Dockerfile string; RequirementsTxt *string }`.
+  - `type BundleProject struct { Dir string; AppID string; Platform string; Arch string }`.
+  - `type Bundle struct { Schema int; Project BundleProject; Targets []BundleTarget; WendyJSON string; StaticFindings []Finding; Instructions string }`.
+  - `func BuildBundle(dir, wendyJSON string, targets []Target, findings []Finding) Bundle` — `Schema = 1`; `WendyJSON` is the verbatim wendy.json text (empty if none); each target's `Dockerfile` is the raw source (joined `Lines`), `RequirementsTxt` is a pointer to the raw text or nil; `Project.AppID/Platform` come from the first target's `Config` if present; `Arch` from the first target; `Instructions` is the constant prompt template `bundleInstructions`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/optimize/bundle_test.go
+package optimize
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func TestBuildBundle(t *testing.T) {
+	df := ParseDockerfile("Dockerfile", []byte("FROM rust:1\nRUN cargo build\n"))
+	targets := []Target{{
+		Name:       "app",
+		Kind:       KindDockerfile,
+		Dir:        ".",
+		Dockerfile: df,
+		Arch:       "arm64",
+		Config:     &appconfig.AppConfig{AppID: "demo", Platform: "wendyos"},
+	}}
+	findings := []Finding{{Analyzer: "build-cache", Severity: SeverityWarning, Title: "no cache"}}
+
+	b := BuildBundle(".", "{\"appId\":\"demo\"}", targets, findings)
+
+	if b.Schema != 1 {
+		t.Fatalf("schema = %d, want 1", b.Schema)
+	}
+	if b.Project.AppID != "demo" || b.Project.Arch != "arm64" {
+		t.Fatalf("project = %+v", b.Project)
+	}
+	if len(b.Targets) != 1 || !strings.Contains(b.Targets[0].Dockerfile, "cargo build") {
+		t.Fatalf("targets = %+v", b.Targets)
+	}
+	if b.Targets[0].RequirementsTxt != nil {
+		t.Fatalf("expected nil RequirementsTxt")
+	}
+	if len(b.StaticFindings) != 1 || b.Instructions == "" {
+		t.Fatalf("findings/instructions missing")
+	}
+
+	// Must round-trip through JSON.
+	if _, err := json.Marshal(b); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestBuildBundle -v`
+Expected: FAIL — `undefined: BuildBundle`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/optimize/bundle.go
+package optimize
+
+import "strings"
+
+// BundleTarget is one target's verbatim inputs for the agent.
+type BundleTarget struct {
+	Name            string  `json:"name"`
+	Kind            string  `json:"kind"`
+	Dockerfile      string  `json:"dockerfile"`
+	RequirementsTxt *string `json:"requirements_txt"`
+}
+
+// BundleProject is project-level context for the agent.
+type BundleProject struct {
+	Dir      string `json:"dir"`
+	AppID    string `json:"app_id"`
+	Platform string `json:"platform"`
+	Arch     string `json:"arch"`
+}
+
+// Bundle is the --agentic output: static findings plus verbatim context.
+type Bundle struct {
+	Schema         int           `json:"schema"`
+	Project        BundleProject `json:"project"`
+	Targets        []BundleTarget `json:"targets"`
+	WendyJSON      string        `json:"wendy_json"`
+	StaticFindings []Finding     `json:"static_findings"`
+	Instructions   string        `json:"instructions"`
+}
+
+const bundleInstructions = "You are optimizing a Wendy edge-device app build. " +
+	"The static_findings below were already detected by deterministic rules — do not just repeat them. " +
+	"Using the verbatim Dockerfile, requirements.txt, and wendy.json, look for the contextual optimizations rules cannot catch: " +
+	"converting to multi-stage builds, choosing the correct CUDA/PyTorch wheel for the device's JetPack/CUDA version, " +
+	"swapping to a slimmer or arch-correct base image, consolidating layers, and removing build-only deps from the runtime image. " +
+	"Propose concrete unified diffs against the files provided. The target architecture is given in project.arch."
+
+// BuildBundle assembles the agentic context bundle.
+func BuildBundle(dir, wendyJSON string, targets []Target, findings []Finding) Bundle {
+	b := Bundle{
+		Schema:         1,
+		Project:        BundleProject{Dir: dir},
+		WendyJSON:      wendyJSON,
+		StaticFindings: findings,
+		Instructions:   bundleInstructions,
+	}
+	if len(targets) > 0 {
+		b.Project.Arch = targets[0].Arch
+		if cfg := targets[0].Config; cfg != nil {
+			b.Project.AppID = cfg.AppID
+			b.Project.Platform = cfg.Platform
+		}
+	}
+	for _, t := range targets {
+		bt := BundleTarget{Name: t.Name, Kind: t.Kind.String()}
+		if t.Dockerfile != nil {
+			bt.Dockerfile = strings.Join(t.Dockerfile.Lines, "\n")
+		}
+		if t.Requirements != nil {
+			raw := strings.Join(requirementLinesPlaceholder(t.Requirements), "\n")
+			_ = raw
+		}
+		b.Targets = append(b.Targets, bt)
+	}
+	return b
+}
+
+// requirementLinesPlaceholder exists only so the bundle can attach raw
+// requirements text. Requirements does not retain raw lines, so the command
+// layer passes raw file bytes via the target loader; here we return nil.
+func requirementLinesPlaceholder(_ *Requirements) []string { return nil }
+```
+
+NOTE during implementation: to populate `RequirementsTxt` with verbatim text, add a `Raw string` field to `Requirements` in Task 3's struct (set in `ParseRequirements` to the original text) and use it here instead of the placeholder helper. The placeholder keeps Task 12 self-contained; fold the `Raw` field addition into this task and delete `requirementLinesPlaceholder`. Updated `BuildBundle` requirements branch:
+
+```go
+		if t.Requirements != nil {
+			raw := t.Requirements.Raw
+			bt.RequirementsTxt = &raw
+		}
+```
+
+And in `requirements.go`, add `Raw string` to the `Requirements` struct and set `r.Raw = string(data)` at the top of `ParseRequirements`. Update the Task 3 test only if it asserts struct equality (it does not).
+
+- [ ] **Step 2b: Add the `Raw` field**
+
+Edit `go/internal/cli/optimize/requirements.go`: add `Raw string` field to `Requirements`, set `r := &Requirements{Path: path, Raw: string(data)}`. Remove `requirementLinesPlaceholder` and use the `Raw`-based branch above in `bundle.go`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go && go test ./internal/cli/optimize/ -run TestBuildBundle -v && go test ./internal/cli/optimize/ -v`
+Expected: PASS (all engine tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/optimize/bundle.go internal/cli/optimize/requirements.go internal/cli/optimize/bundle_test.go
+git add go/internal/cli/optimize/bundle.go go/internal/cli/optimize/requirements.go go/internal/cli/optimize/bundle_test.go
+git commit -m "feat(optimize): add agentic context bundle"
+```
+
+---
+
+## Task 13: Command wiring + exit codes (integration)
+
+**Files:**
+- Create: `go/internal/cli/commands/optimize.go`
+- Modify: `go/internal/cli/commands/project.go:34-42` (register `newOptimizeCmd()`)
+- Test: `go/internal/cli/commands/optimize_test.go`
+
+**Interfaces:**
+- Consumes: `optimize` package (`DiscoverTargets`, `DefaultAnalyzers`, `Analyze`, `BuildReport`, `RenderHuman`, `ApplyFixes`, `BuildBundle`, `ParseSeverity`, `resolveArch` is unexported — instead the command passes the `--arch` flag straight to `DiscoverTargets` after defaulting it inline), `appconfig.LoadFromFile`, global `jsonOutput`, `tui` colors, `cliSuccess`.
+- Produces: `func newOptimizeCmd() *cobra.Command`. Behavior: load wendy.json if present (nil if absent — optimize must work without it for native/dockerfile-only projects), resolve arch (`--arch` else `"arm64"`), discover targets, run analyzers, then branch on flags:
+  - `--agentic`: print `BuildBundle(...)` as indented JSON; exit 0.
+  - else build report; if `--json` print report JSON; else print `RenderHuman`.
+  - `--fix`: call `ApplyFixes(findings)`, print applied summary, then recompute findings by re-discovering + re-analyzing so the exit code reflects the post-fix state.
+  - Exit code: compare `report.MaxSeverity()` against the `--severity` threshold (default `warning`). At/above → return a non-zero-exit error via `newExitError(1)` style. Use Cobra's `SilenceUsage`/`SilenceErrors` already set on root; to force exit code 1 without a noisy error, set `cmd.SilenceErrors = true` and return a sentinel error whose message is empty, OR call `os.Exit`. Implementation detail: define `errFindings = errors.New("")` is ugly — instead the command sets a package var and `main.go` already maps errors to exit 1. Simplest correct approach: return a typed error `&exitCodeError{code: 1}` and check `main.go`. Since modifying main.go is out of scope, the command instead prints the report and calls `os.Exit(1)` directly after flushing output when findings ≥ threshold and not in `--json`/`--agentic` machine modes... 
+
+  DECISION (lock this in): the command returns `nil` always for output, and signals CI failure via `os.Exit`. Concretely: after rendering, if `!jsonOutput` and findings ≥ threshold, call `os.Exit(1)`. For `--json`/`--agentic`, still `os.Exit(1)` when findings ≥ threshold so CI works uniformly. Execution errors return a normal `error` (Cobra → exit 1 via main's handler, which is acceptable; reserve `os.Exit(2)` for them by calling `os.Exit(2)` on load/discovery failure). Because `os.Exit` bypasses test assertions, the testable core is extracted into `runOptimize(opts) (Report, []AppliedFix, error)` and the Cobra `RunE` is a thin wrapper that calls it and then decides exit code. Tests target `runOptimize`.
+
+So produce ALSO:
+  - `type optimizeOptions struct { Dir string; Arch string; Fix bool; Agentic bool }`.
+  - `func runOptimize(opts optimizeOptions) (optimize.Report, []optimize.AppliedFix, error)` — the testable core (no os.Exit, no printing). Loads config, discovers, analyzes; if `opts.Fix`, applies fixes then re-discovers+re-analyzes and returns the post-fix report plus the applied list.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// go/internal/cli/commands/optimize_test.go
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeOptFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestRunOptimizeFindsAndFixes(t *testing.T) {
+	dir := t.TempDir()
+	writeOptFile(t, dir, "Dockerfile", "FROM rust:1\nRUN cargo build\n")
+
+	rep, _, err := runOptimize(optimizeOptions{Dir: dir})
+	if err != nil {
+		t.Fatalf("runOptimize: %v", err)
+	}
+	_, warn, _, fixable := rep.Counts()
+	if warn == 0 || fixable == 0 {
+		t.Fatalf("expected warnings and fixable findings, got %+v", rep.Counts)
+	}
+
+	// With --fix, the cache-mount + .dockerignore fixes apply, and a re-run drops fixable count.
+	repFixed, applied, err := runOptimize(optimizeOptions{Dir: dir, Fix: true})
+	if err != nil {
+		t.Fatalf("runOptimize fix: %v", err)
+	}
+	var anyApplied bool
+	for _, a := range applied {
+		if a.Applied {
+			anyApplied = true
+		}
+	}
+	if !anyApplied {
+		t.Fatalf("expected at least one applied fix")
+	}
+	// Re-running clean should report fewer fixable findings than the first pass.
+	_, _, _, fixableAfter := repFixed.Counts()
+	if fixableAfter >= fixable {
+		t.Fatalf("fixable did not decrease after --fix: before=%d after=%d", fixable, fixableAfter)
+	}
+}
+
+func TestRunOptimizeNoProject(t *testing.T) {
+	dir := t.TempDir()
+	rep, _, err := runOptimize(optimizeOptions{Dir: dir})
+	if err != nil {
+		t.Fatalf("runOptimize: %v", err)
+	}
+	if len(rep.Findings) != 0 {
+		t.Fatalf("expected no findings for empty dir, got %+v", rep.Findings)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestRunOptimize -v`
+Expected: FAIL — `undefined: runOptimize`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// go/internal/cli/commands/optimize.go
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/optimize"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+type optimizeOptions struct {
+	Dir     string
+	Arch    string
+	Fix     bool
+	Agentic bool
+}
+
+// loadOptConfig loads wendy.json from dir, returning (nil, "") when absent.
+func loadOptConfig(dir string) (*appconfig.AppConfig, string) {
+	p := filepath.Join(dir, "wendy.json")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, ""
+	}
+	cfg, err := appconfig.LoadFromBytes(data)
+	if err != nil {
+		return nil, string(data)
+	}
+	return cfg, string(data)
+}
+
+// runOptimize is the testable core: no printing, no os.Exit.
+func runOptimize(opts optimizeOptions) (optimize.Report, []optimize.AppliedFix, error) {
+	arch := opts.Arch
+	if arch == "" {
+		arch = "arm64"
+	}
+	cfg, _ := loadOptConfig(opts.Dir)
+
+	targets, err := optimize.DiscoverTargets(opts.Dir, cfg, arch)
+	if err != nil {
+		return optimize.Report{}, nil, err
+	}
+	findings := optimize.Analyze(targets, optimize.DefaultAnalyzers())
+
+	var applied []optimize.AppliedFix
+	if opts.Fix {
+		applied, err = optimize.ApplyFixes(findings)
+		if err != nil {
+			return optimize.Report{}, applied, err
+		}
+		// Recompute post-fix so callers see the residual state.
+		targets, err = optimize.DiscoverTargets(opts.Dir, cfg, arch)
+		if err != nil {
+			return optimize.Report{}, applied, err
+		}
+		findings = optimize.Analyze(targets, optimize.DefaultAnalyzers())
+	}
+
+	return optimize.BuildReport(targets, findings), applied, nil
+}
+
+func newOptimizeCmd() *cobra.Command {
+	var (
+		archFlag     string
+		fixFlag      bool
+		agenticFlag  bool
+		severityFlag string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "optimize",
+		Short: "Analyze the project's build config for missed optimizations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			threshold, err := optimize.ParseSeverity(severityFlag)
+			if err != nil {
+				return err
+			}
+			opts := optimizeOptions{Dir: cwd, Arch: archFlag, Fix: fixFlag, Agentic: agenticFlag}
+
+			if agenticFlag {
+				arch := archFlag
+				if arch == "" {
+					arch = "arm64"
+				}
+				cfg, raw := loadOptConfig(cwd)
+				targets, derr := optimize.DiscoverTargets(cwd, cfg, arch)
+				if derr != nil {
+					os.Exit(2)
+				}
+				findings := optimize.Analyze(targets, optimize.DefaultAnalyzers())
+				bundle := optimize.BuildBundle(cwd, raw, targets, findings)
+				data, merr := json.MarshalIndent(bundle, "", "  ")
+				if merr != nil {
+					return merr
+				}
+				cmd.Println(string(data))
+				return nil
+			}
+
+			rep, applied, rerr := runOptimize(opts)
+			if rerr != nil {
+				cmd.PrintErrln(rerr.Error())
+				os.Exit(2)
+			}
+
+			if fixFlag {
+				cliSuccess("Applied fixes:")
+				for _, a := range applied {
+					if a.Applied {
+						cmd.Printf("  %s — %s\n", a.Fix.File, a.Fix.Description)
+					} else {
+						cmd.Printf("  %s — skipped (%s)\n", a.Fix.File, a.Reason)
+					}
+				}
+			}
+
+			if jsonOutput {
+				data, merr := json.MarshalIndent(rep, "", "  ")
+				if merr != nil {
+					return merr
+				}
+				cmd.Println(string(data))
+			} else {
+				cmd.Print(optimize.RenderHuman(rep))
+			}
+
+			if rep.MaxSeverity() >= threshold && len(rep.Findings) > 0 {
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&archFlag, "arch", "", "Target architecture (default arm64)")
+	cmd.Flags().BoolVar(&fixFlag, "fix", false, "Apply safe, deterministic fixes")
+	cmd.Flags().BoolVar(&agenticFlag, "agentic", false, "Emit an agent context bundle instead of a report")
+	cmd.Flags().StringVar(&severityFlag, "severity", "warning", "Minimum severity that triggers a non-zero exit (info|warning|error)")
+	return cmd
+}
+```
+
+Then register in `project.go`:
+
+```go
+func newProjectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Manage Wendy project configuration",
+	}
+
+	cmd.AddCommand(newEntitlementsCmd())
+	cmd.AddCommand(newOptimizeCmd())
+	return cmd
+}
+```
+
+NOTE: confirm `appconfig.LoadFromBytes` is exported (the explorer reported `LoadFromFile` calls `LoadFromBytes`). If it is unexported, use `appconfig.LoadFromFile(filepath.Join(dir, "wendy.json"))` inside `loadOptConfig` and read the raw bytes separately with `os.ReadFile`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestRunOptimize -v && go test ./internal/cli/optimize/... && go build ./...`
+Expected: PASS, build clean.
+
+- [ ] **Step 5: Manual smoke (optional but recommended)**
+
+```bash
+cd go && go run ./cmd/wendy project optimize --help
+# In a project dir with a Dockerfile that runs `cargo build`:
+#   wendy project optimize            -> warnings + (fixable)
+#   wendy project optimize --fix      -> applies cache mount + .dockerignore
+#   wendy project optimize --agentic  -> JSON bundle
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd go && gofmt -w internal/cli/commands/optimize.go internal/cli/commands/project.go internal/cli/commands/optimize_test.go
+git add go/internal/cli/commands/optimize.go go/internal/cli/commands/project.go go/internal/cli/commands/optimize_test.go
+git commit -m "feat(optimize): wire wendy project optimize command"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- Static-by-default + `--agentic` bundle → Tasks 12, 13. ✓
+- Four analyzers (buildcache, releasedebug, cudaml, archimage) → Tasks 6–9. ✓
+- Three project shapes (Dockerfile, compose, native) → Task 4 discovery. ✓ (compose service-context resolution is flagged for refinement against the real `ServiceConfig` fields during Task 4.)
+- Report + `--json` + exit codes → Tasks 11, 13. ✓
+- Safe `--fix` (cache mount, release flag, .dockerignore), idempotent → Tasks 6, 7, 9, 10. ✓
+- Arch auto-infer + `--arch` override (offline default arm64; device inference deferred) → Tasks 4, 13. ✓
+
+**Known follow-ups (documented, not gaps):**
+- Compose `ServiceConfig` context/dockerfile field wiring (Task 4 NOTE).
+- Dockerfile-name variants (`Dockerfile.prod`) beyond `Dockerfile`/`Containerfile` — reuse `isContainerBuildFileName` later.
+- Device-based arch inference.
+- Exit-code mechanism uses `os.Exit` from `RunE` after flushing output; core logic is tested via `runOptimize` to keep it assertable.
+
+**Type consistency:** `Finding`/`Fix`/`Severity`/`FixOp`/`Loc` defined in Task 1 and used unchanged through Tasks 6–13. `Requirements.Raw` field added in Task 12 (Step 2b) and back-referenced to Task 3. `DefaultAnalyzers()` grows by one entry per analyzer task (6→9).


### PR DESCRIPTION
## What

Adds `wendy project optimize` — a static analyzer for a Wendy project's build configuration that reports missed deployment/runtime optimizations, can auto-apply safe fixes, and can emit a context bundle for an AI agent.

Static-by-default (fast, deterministic, no LLM). `--agentic` emits a structured bundle for Claude Code / the wendy MCP server. The Go binary stays LLM-free.

## Checks (four analyzers)

- **build-cache** — compiled-lang build/install RUN steps missing `--mount=type=cache` (cargo/go/swift/npm/pip).
- **release-debug** — debug builds shipped to prod (`swift build` w/o `-c release`, `cargo build` w/o `--release`); `WENDY_DEBUG` declared but not wired to toggle optimization.
- **cuda-ml** — CPU-only ML wheel with a `gpu` entitlement (or vice-versa); x86 `nvidia/cuda` base image on an arm64 (Jetson) target.
- **arch-image** — amd64 base image on arm64 (error), missing `.dockerignore`, single-stage build shipping its toolchain.

## Surface

- `wendy project optimize` — human report (interactive) / JSON (non-TTY/CI).
- `--fix` — applies safe deterministic fixes (cache mount, release flag, `.dockerignore`), idempotent.
- `--agentic` — emits a schema-versioned context bundle.
- `--json`, `--severity <info|warning|error>`, `--arch` (auto-infers arm64). Exit codes: 0 none / 1 findings ≥ threshold / 2 error.
- Handles single Dockerfile, Compose/multi-service (findings grouped by service), and native Swift/Brewfile projects.

## Architecture

New Cobra-free engine package `go/internal/cli/optimize/` (parsers, analyzer registry, fix applier, reporter, bundle), wired via `go/internal/cli/commands/optimize.go` under `wendy project`. No new third-party dependencies — the Dockerfile parser is internal.

## Tests & samples

Each analyzer + parser + the fix applier (incl. idempotency) + discovery + reporter + command core are unit-tested. Three intentionally un-optimized sample apps under `Examples/project-optimize-samples/` (Rust, Python/CUDA, Swift) demonstrate the findings.

Spec and implementation plan: `specs/2026-06-27-wendy-project-optimize-design.md`, `specs/superpowers/plans/2026-06-27-wendy-project-optimize.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Follow-up enhancements (in this PR)

- **Colorized, aligned human report** — severity glyphs + color (error/warning/info), bold target headers and titles, aligned reference column. lipgloss degrades to plain text on non-TTY/CI, so JSON/CI output and tests are unaffected.
- **Build-time auto-scan** — after a *slow incremental* build (cached layers reused, >50s) on an interactive terminal, `wendy run`/`build` runs a quick optimize scan, prints the findings, and offers a `[Y/n]` to apply the safe fixes (they take effect on the next build; the current run continues). Skipped entirely in CI / non-TTY.
- **Throttled tip** — a once-per-day-per-project tip points users at `wendy project optimize` after a successful build/run (interactive only). Throttle state lives in `~/.wendy` config.
