### PR TITLE
Harden `wendy project optimize`: path-traversal guard, --agentic secrets warning, stdout routing, docs

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/project/meta.json
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/project/meta.json
@@ -1,0 +1,6 @@
+{
+  "pages": [
+    "optimize",
+    "entitlements"
+  ]
+}

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/project/optimize.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/project/optimize.md
@@ -1,0 +1,41 @@
+`wendy project optimize` statically analyzes your project's build configuration — its Dockerfile(s), `requirements.txt`, and `wendy.json` — and reports missed build-speed and runtime optimizations.
+
+It runs locally and is read-only by default. It works on a single Dockerfile, a multi-service / Compose project (findings are grouped by service), and native Swift (`Package.swift`) or `Brewfile` projects.
+
+## What it checks
+
+- **Build caches** — compiled-language build/install steps (`cargo`, `go`, `swift`, `npm`/`yarn`/`pnpm`, `pip`) that run without a BuildKit `--mount=type=cache`, and so re-download or re-compile dependencies on every build.
+- **Release vs. debug** — debug builds shipped to production (`swift build` without `-c release`, `cargo build` without `--release`), and whether `WENDY_DEBUG` is wired to toggle the optimization level.
+- **CUDA / ML** — a CPU-only ML wheel (e.g. `torch==…+cpu`) paired with the `gpu` entitlement (or a CUDA wheel without it), and x86 `nvidia/cuda` base images on an arm64 (Jetson) target.
+- **Architecture & image** — an `amd64` base image on an arm64 device (which runs under slow QEMU emulation or fails), a missing `.dockerignore`, and single-stage builds that ship their full build toolchain.
+
+## Usage
+
+```bash
+wendy project optimize            # report findings (colorized in a terminal, JSON in CI)
+wendy project optimize --json     # machine-readable findings
+wendy project optimize --fix      # apply the safe, deterministic fixes
+wendy project optimize --agentic  # emit a context bundle for an AI agent
+```
+
+## Flags
+
+- `--fix` — apply the safe fixes only: add a build-cache mount, add the release flag (`swift`/`cargo`), and create a default `.dockerignore`. Fixes are idempotent; contextual changes (multi-stage refactors, choosing the right CUDA wheel) are left to you or the `--agentic` flow.
+- `--agentic` — instead of a report, emit a JSON bundle (static findings plus the verbatim project files and a prompt) designed to be piped into Claude Code or the Wendy MCP server.
+- `--severity <info|warning|error>` — the minimum severity that causes a non-zero exit. Defaults to `warning`.
+- `--arch <arch>` — override the target architecture (defaults to `arm64`).
+- `--json` — emit findings as JSON (also the default when output is not a terminal, e.g. in CI).
+
+## Exit codes
+
+- `0` — no findings at or above the severity threshold.
+- `1` — findings at or above the threshold (use this to gate CI).
+- `2` — execution error (no project found, parse failure).
+
+## At build time
+
+After a slow incremental build (one that reused cached layers and still took more than ~50s), `wendy run` / `wendy build` will run this scan automatically in an interactive terminal, show the findings, and offer to apply the safe fixes for your next build. This never runs in CI or non-interactive shells.
+
+## A note on `--agentic` and secrets
+
+The `--agentic` bundle includes the **verbatim contents** of your Dockerfile(s), `requirements.txt`, and `wendy.json` so the agent has full context. These files can contain secrets (`ARG`/`ENV` tokens, private registry URLs). The command prints a reminder to stderr; review the bundle before sending it to an external agent.

--- a/go/internal/cli/commands/optimize.go
+++ b/go/internal/cli/commands/optimize.go
@@ -109,7 +109,16 @@ func newOptimizeCmd() *cobra.Command {
 				if merr != nil {
 					return merr
 				}
-				cmd.Println(string(data))
+				// The bundle embeds verbatim file contents (Dockerfiles,
+				// requirements.txt, wendy.json) so an agent has full context.
+				// Warn on stderr — these may carry secrets (ARG/ENV tokens,
+				// private registry URLs) and the JSON is meant to be handed to
+				// an external agent. stderr keeps the warning out of the piped
+				// JSON on stdout.
+				cliNotice("note: this --agentic bundle contains the verbatim contents of your Dockerfile(s), requirements.txt, and wendy.json. Review it for secrets (ARG/ENV tokens, private registry URLs) before sending it to an external agent.")
+				// Bundle JSON goes to stdout so it can be piped to an agent;
+				// cmd.Println would route to stderr (cobra's OutOrStderr).
+				fmt.Println(string(data))
 				return nil
 			}
 
@@ -123,21 +132,23 @@ func newOptimizeCmd() *cobra.Command {
 				cliSuccess("Applied fixes:")
 				for _, a := range applied {
 					if a.Applied {
-						cmd.Printf("  %s — %s\n", a.Fix.File, a.Fix.Description)
+						fmt.Printf("  %s — %s\n", a.Fix.File, a.Fix.Description)
 					} else {
-						cmd.Printf("  %s — skipped (%s)\n", a.Fix.File, a.Reason)
+						fmt.Printf("  %s — skipped (%s)\n", a.Fix.File, a.Reason)
 					}
 				}
 			}
 
+			// Emit on stdout (fmt, not cmd.Println) so --json/report output can
+			// be captured and piped, consistent with the rest of the CLI.
 			if jsonOutput {
 				data, merr := json.MarshalIndent(rep, "", "  ")
 				if merr != nil {
 					return merr
 				}
-				cmd.Println(string(data))
+				fmt.Println(string(data))
 			} else {
-				cmd.Print(optimize.RenderHuman(rep))
+				fmt.Print(optimize.RenderHuman(rep))
 			}
 
 			if rep.MaxSeverity() >= threshold && len(rep.Findings) > 0 {

--- a/go/internal/cli/optimize/target.go
+++ b/go/internal/cli/optimize/target.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
@@ -50,6 +51,16 @@ func resolveArch(override string) string {
 		return override
 	}
 	return "arm64"
+}
+
+// isWithinDir reports whether target is base itself or a descendant of it,
+// guarding against path-traversal (e.g. a "../../etc" build context).
+func isWithinDir(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func fileExists(path string) bool {
@@ -103,7 +114,15 @@ func DiscoverTargets(dir string, cfg *appconfig.AppConfig, arch string) ([]Targe
 		for _, name := range names {
 			svcDir := dir
 			if svc := cfg.Services[name]; svc != nil && svc.Context != "" {
-				svcDir = filepath.Join(dir, svc.Context)
+				candidate := filepath.Join(dir, svc.Context)
+				// Refuse to read a build context that escapes the project tree.
+				// A malicious wendy.json could otherwise point Context at
+				// "../../etc" and have us read (and, via --agentic, surface)
+				// arbitrary files. Skip such services entirely.
+				if !isWithinDir(dir, candidate) {
+					continue
+				}
+				svcDir = candidate
 			}
 			targets = append(targets, Target{
 				Name:         name,

--- a/go/internal/cli/optimize/target_test.go
+++ b/go/internal/cli/optimize/target_test.go
@@ -15,6 +15,43 @@ func writeFile(t *testing.T, dir, name, content string) {
 	}
 }
 
+func TestDiscoverComposeServiceRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	// A malicious context that escapes the project tree must not be analyzed.
+	cfg := &appconfig.AppConfig{
+		Services: map[string]*appconfig.ServiceConfig{
+			"evil": {Context: "../../../../../../etc"},
+		},
+	}
+	targets, err := DiscoverTargets(dir, cfg, "arm64")
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("traversal context must be skipped, got %d targets: %+v", len(targets), targets)
+	}
+}
+
+func TestIsWithinDir(t *testing.T) {
+	base := t.TempDir()
+	cases := []struct {
+		target string
+		want   bool
+	}{
+		{base, true},
+		{filepath.Join(base, "svc"), true},
+		{filepath.Join(base, "a", "b"), true},
+		{filepath.Join(base, ".."), false},
+		{filepath.Join(base, "..", "sibling"), false},
+		{filepath.Join(base, "..", "..", "etc"), false},
+	}
+	for _, c := range cases {
+		if got := isWithinDir(base, c.target); got != c.want {
+			t.Errorf("isWithinDir(%q, %q) = %v, want %v", base, c.target, got, c.want)
+		}
+	}
+}
+
 func TestResolveArch(t *testing.T) {
 	if got := resolveArch(""); got != "arm64" {
 		t.Fatalf("resolveArch(\"\") = %q, want arm64", got)


### PR DESCRIPTION
Follow-up to #1202 (merged) — addresses the HIGH findings from the AI security review on that PR, fixes an output-stream bug, and adds the missing command docs.

## Security fixes

- **Path traversal in compose discovery (HIGH).** `DiscoverTargets` joined the project dir with a service's `Context` from `wendy.json` without validating it stayed in-tree. A malicious `wendy.json` (`"context": "../../etc"`) could make the analyzer read arbitrary files and surface them via `--agentic`. Added `isWithinDir` and now skip any service whose context escapes the project tree. Covered by `TestDiscoverComposeServiceRejectsTraversal` and `TestIsWithinDir`.
- **`--agentic` secret disclosure (HIGH).** The bundle embeds the verbatim contents of Dockerfile(s), `requirements.txt`, and `wendy.json`, which can carry secrets (`ARG`/`ENV` tokens, private registry URLs). The command now prints a clear reminder to **stderr** before emitting the bundle, and the behavior is documented.

## Output-stream fix

- `--json` and `--agentic` output went to **stderr** (`cmd.Println` → cobra's `OutOrStderr`), so `wendy project optimize --agentic | <agent>` and `--json > file` captured nothing. Routed both to **stdout** via `fmt.Println`, matching every other command. The `--agentic` secrets warning correctly stays on stderr so it never pollutes the piped JSON.

## Docs

- Added the `wendy project optimize` command page (`commands/project/optimize.md`) and `project/meta.json`, including the `--agentic` secrets caveat.

Remaining review items (MEDIUM/LOW: TOCTOU on `.dockerignore` create, file-mode hardening, storing project paths in config, toolchain-heuristic false positives) are noted for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
