### PR TITLE
fix(cli): clear progress hint on interrupt instead of lingering

### DIFF
--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -534,7 +534,7 @@ func buildDockerProject(dir, imageName, platform, dockerfile string) error {
 	}
 
 	s := tui.NewSpinner("Building Docker image...")
-	p := tea.NewProgram(s)
+	p := tui.NewProgressProgram(s)
 
 	go func() {
 		cmd.Stdout = os.Stdout

--- a/go/internal/cli/commands/buildprogress.go
+++ b/go/internal/cli/commands/buildprogress.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
 
@@ -64,7 +63,7 @@ func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure bo
 
 	// Interactive: run the steps model while the build streams events to it.
 	m := tui.NewBuildStepsModel(title)
-	prog := tea.NewProgram(m)
+	prog := tui.NewProgressProgram(m)
 	parser := tui.NewBuildParser(func(e tui.BuildStepEvent) {
 		prog.Send(tui.BuildStepMsg(e))
 	})

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -393,7 +393,7 @@ func pickCloudDevice(ctx context.Context, auth *config.AuthConfig, deviceName, b
 
 	var assets []*cloudpb.Asset
 	if isInteractiveTerminal() {
-		prog := tea.NewProgram(tui.NewSpinner("Fetching devices from cloud..."))
+		prog := tui.NewProgressProgram(tui.NewSpinner("Fetching devices from cloud..."))
 		var fetchErr error
 		go func() {
 			assets, fetchErr = fetchCloudAssets(ctx, auth)

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
@@ -1737,7 +1736,7 @@ func newDeviceUpdateCmd() *cobra.Command {
 
 			if isInteractiveTerminal() && !jsonOutput {
 				s := tui.NewSpinner("Uploading agent binary...")
-				p := tea.NewProgram(s)
+				p := tui.NewProgressProgram(s)
 
 				go func() {
 					uploadErr := deviceUpdateUpload(ctx, conn.AgentService, binaryData, sha256Hash)

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -163,7 +163,7 @@ func discoverOnce(ctx context.Context, opts discovery.DiscoveryOptions, includeL
 		return tui.SpinnerDoneMsg{Result: collection, Err: err}
 	}
 
-	p := tea.NewProgram(s)
+	p := tui.NewProgressProgram(s)
 	go func() {
 		p.Send(work())
 	}()

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -208,7 +208,7 @@ var runAgentConnectionSpinner = func(ctx context.Context, label string, fn func(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	prog := tea.NewProgram(tui.NewSpinner(label))
+	prog := tui.NewProgressProgram(tui.NewSpinner(label))
 
 	var (
 		conn   *grpcclient.AgentConnection

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"strings"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
@@ -549,7 +548,7 @@ func fetchRepoMetaWithUI(branch string) (*repoMeta, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	prog := tea.NewProgram(tui.NewSpinner("Fetching template registry..."))
+	prog := tui.NewProgressProgram(tui.NewSpinner("Fetching template registry..."))
 
 	var (
 		meta     *repoMeta
@@ -592,7 +591,7 @@ func downloadTemplateArchiveWithUI(language, tmpl, branch string) (map[string][]
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	prog := tea.NewProgram(tui.NewProgress(title).WithoutErrorView())
+	prog := tui.NewProgressProgram(tui.NewProgress(title).WithoutErrorView())
 
 	var (
 		files    map[string][]byte

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -434,7 +434,7 @@ func buildServicesParallel(
 	if isInteractiveTerminal() {
 		title := fmt.Sprintf("Building %d service(s)...", len(names))
 		m := tui.NewMultiSpinner(title, names)
-		prog = tea.NewProgram(m)
+		prog = tui.NewProgressProgram(m)
 	}
 
 	var wg sync.WaitGroup

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
@@ -239,7 +238,7 @@ so the device can download it directly.`,
 
 			if isInteractiveTerminal() {
 				spin := tui.NewSpinner("Downloading update...")
-				p := tea.NewProgram(spin)
+				p := tui.NewProgressProgram(spin)
 
 				go func() {
 					for {
@@ -439,7 +438,7 @@ func waitForDeviceOnline(ctx context.Context, host string) error {
 	}
 
 	spin := tui.NewSpinner("Waiting for device to come back online...")
-	p := tea.NewProgram(spin)
+	p := tui.NewProgressProgram(spin)
 	go func() {
 		if err := pollDeviceOnline(ctx, addr); err != nil {
 			p.Send(tui.SpinnerDoneMsg{Err: err})
@@ -677,7 +676,7 @@ func downloadArtifactToTemp(artifactURL string) (string, error) {
 
 	total := resp.ContentLength
 	prog := tui.NewProgress("Downloading artifact...")
-	p := tea.NewProgram(prog)
+	p := tui.NewProgressProgram(prog)
 
 	go func() {
 		var downloaded int64

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -542,7 +542,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		// bmap failures fall back silently; suppress the TUI error render
 		writeProg = writeProg.WithoutErrorView()
 	}
-	wp := tea.NewProgram(writeProg)
+	wp := tui.NewProgressProgram(writeProg)
 
 	go func() {
 		var writeErr error
@@ -610,7 +610,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		}
 		defer fallbackCloser.Close()
 		fallbackProg := tui.NewProgress(fmt.Sprintf("Writing to %s...", targetDrive.DevicePath))
-		fp := tea.NewProgram(fallbackProg)
+		fp := tui.NewProgressProgram(fallbackProg)
 		go func() {
 			fp.Send(tui.ProgressDoneMsg{Err: writeImageToDisk(fallbackReader, fallbackSize, targetDrive, func(written int64) {
 				if fallbackSize > 0 {
@@ -878,7 +878,7 @@ func downloadImage(img *imageInfo) (string, error) {
 	}
 
 	prog := tui.NewProgress(fmt.Sprintf("Downloading %s...", img.Version))
-	p := tea.NewProgram(prog)
+	p := tui.NewProgressProgram(prog)
 	sendProgress := throttledProgress(p, 33*time.Millisecond)
 
 	contentLength, supportsRanges := probeRangeSupport(client, img)
@@ -1282,7 +1282,7 @@ func measureGzipImage(path string, progress func(read, total int64)) (int64, err
 // the user quits the bar.
 func measureImageWithProgress(stream *imageStream) error {
 	prog := tui.NewProgress("Determining image size (one-time per image)...")
-	p := tea.NewProgram(prog)
+	p := tui.NewProgressProgram(prog)
 	sendProgress := throttledProgress(p, 33*time.Millisecond)
 
 	go func() {
@@ -2013,7 +2013,7 @@ func installESP32Firmware(ctx context.Context, nightly bool, chip string, wifi w
 	// Download with progress bar.
 
 	prog := tui.NewProgress(fmt.Sprintf("Downloading %s %s...", asset.Name, asset.Version))
-	p := tea.NewProgram(prog)
+	p := tui.NewProgressProgram(prog)
 
 	var fwPath string
 	var dlErr error
@@ -2065,7 +2065,7 @@ func installESP32Firmware(ctx context.Context, nightly bool, chip string, wifi w
 
 	fmt.Println()
 	flashProg := tui.NewProgress(fmt.Sprintf("Flashing to %s...", serialPort))
-	fp := tea.NewProgram(flashProg)
+	fp := tui.NewProgressProgram(flashProg)
 
 	go func() {
 		flashErr := flashFirmwareImage(serialPort, img, func(pct float64) {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -332,7 +332,7 @@ func progressModelUserCancelled(model tea.Model) bool {
 }
 
 func createContainerWithProgressTUI(cancel context.CancelFunc, stream agentpb.WendyContainerService_CreateContainerWithProgressClient) error {
-	prog := tea.NewProgram(tui.NewProgress("Pulling image on device...").WithoutErrorView())
+	prog := tui.NewProgressProgram(tui.NewProgress("Pulling image on device...").WithoutErrorView())
 
 	var (
 		createErr error

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/wendylabsinc/wendy/go/internal/cli/liteclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/swifttoolchain"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
@@ -224,7 +223,7 @@ func (p *MicroWendyProvider) Run(ctx context.Context, app *BuiltApp, detach bool
 	} else {
 		fmt.Println()
 		pushProg := tui.NewProgress("Pushing app...")
-		pp := tea.NewProgram(pushProg)
+		pp := tui.NewProgressProgram(pushProg)
 		go func() {
 			pushErr := client.PushApp(bc.WASMPath, func(written, total uint32) {
 				var pct float64

--- a/go/internal/cli/tui/interrupt.go
+++ b/go/internal/cli/tui/interrupt.go
@@ -1,0 +1,29 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// InterruptFilter routes Bubble Tea's InterruptMsg (raised by a SIGINT signal or
+// an explicitly sent interrupt) through the model's normal Ctrl+C handling.
+//
+// Bubble Tea's default interrupt handling is a "kill": it returns from the event
+// loop with ErrInterrupted *without* rendering the model's final View, and its
+// renderer only erases the bottom line on the way out. For a multi-line progress
+// frame — a spinner/bar plus the rotating hint line — that leaves everything
+// above the bottom line, including the hint, on screen. Translating the
+// interrupt into a Ctrl+C key press lets the model run its existing graceful
+// quit path (set its done/quitting state, return tea.Quit), so Bubble Tea draws
+// the cleared final frame and the hint does not linger.
+func InterruptFilter(_ tea.Model, msg tea.Msg) tea.Msg {
+	if _, ok := msg.(tea.InterruptMsg); ok {
+		return tea.KeyMsg{Type: tea.KeyCtrlC}
+	}
+	return msg
+}
+
+// NewProgressProgram builds a tea.Program for one of the progress models
+// (SpinnerModel, ProgressModel, MultiSpinnerModel, BuildStepsModel) with
+// InterruptFilter installed so the hint is cleared on interrupt instead of
+// lingering. Use it instead of tea.NewProgram when running those models.
+func NewProgressProgram(model tea.Model, opts ...tea.ProgramOption) *tea.Program {
+	return tea.NewProgram(model, append(opts, tea.WithFilter(InterruptFilter))...)
+}

--- a/go/internal/cli/tui/interrupt_test.go
+++ b/go/internal/cli/tui/interrupt_test.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const hintRune = "💡"
+
+// TestInterruptFilterConvertsInterruptToCtrlC verifies the filter rewrites an
+// InterruptMsg into a Ctrl+C key press (which every progress model already
+// handles as a graceful quit) and passes other messages through untouched.
+func TestInterruptFilterConvertsInterruptToCtrlC(t *testing.T) {
+	got := InterruptFilter(nil, tea.InterruptMsg{})
+	key, ok := got.(tea.KeyMsg)
+	if !ok || key.Type != tea.KeyCtrlC {
+		t.Fatalf("expected InterruptMsg to become Ctrl+C KeyMsg, got %#v", got)
+	}
+
+	passthrough := SpinnerUpdateMsg{Label: "x"}
+	if got := InterruptFilter(nil, passthrough); got != tea.Msg(passthrough) {
+		t.Fatalf("expected non-interrupt message to pass through unchanged, got %#v", got)
+	}
+}
+
+// quits reports whether a command (possibly a tea.Batch) resolves to tea.Quit.
+func quits(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	switch msg := cmd().(type) {
+	case tea.QuitMsg:
+		return true
+	case tea.BatchMsg:
+		return slices.ContainsFunc(msg, quits)
+	}
+	return false
+}
+
+// TestInterruptClearsHintForEveryProgressModel is the regression test for the
+// lingering-hint bug. On interrupt, NewProgressProgram routes the InterruptMsg
+// through the model's Ctrl+C handling. This asserts the mechanism the fix relies
+// on for each of the four hint-bearing models: feeding the filtered interrupt
+// message makes the model (a) quit and (b) render a final View that no longer
+// contains the rotating hint — so Bubble Tea's graceful path draws a cleared
+// frame instead of leaving the hint on screen.
+func TestInterruptClearsHintForEveryProgressModel(t *testing.T) {
+	cases := []struct {
+		name  string
+		model tea.Model
+	}{
+		{"spinner", NewSpinner("Connecting...")},
+		{"progress", NewProgress("Downloading...")},
+		{"multispinner", NewMultiSpinner("Building...", []string{"api", "web"})},
+		{"buildsteps", NewBuildStepsModel("Building image...")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Sanity: while running, the model shows a hint (otherwise the test
+			// would pass vacuously).
+			if !strings.Contains(tc.model.View(), hintRune) {
+				t.Fatalf("%s: expected a hint while running", tc.name)
+			}
+
+			filtered := InterruptFilter(tc.model, tea.InterruptMsg{})
+			updated, cmd := tc.model.Update(filtered)
+
+			if !quits(cmd) {
+				t.Fatalf("%s: interrupt should make the model quit gracefully", tc.name)
+			}
+			if strings.Contains(updated.View(), hintRune) {
+				t.Fatalf("%s: hint must be gone from the final View after interrupt", tc.name)
+			}
+		})
+	}
+}

--- a/specs/superpowers/2026-06-24-progress-hints-design.md
+++ b/specs/superpowers/2026-06-24-progress-hints-design.md
@@ -53,6 +53,30 @@ Each model gets the same four touch-points:
 4. `View()` appends `m.hints.view()` **only while the operation is running** —
    not on the done/error render paths — so final output stays clean.
 
+### Clearing the hint on interrupt
+
+Hiding the hint in `View()` is sufficient only on Bubble Tea's **graceful**
+shutdown path: when the model returns `tea.Quit`, Bubble Tea renders the final
+(hint-free) `View()` and its renderer emits `EraseScreenBelow` to clear the now
+shorter frame.
+
+On the **killed** path — `tea.InterruptMsg` (raised by SIGINT or an explicit
+interrupt), or any error returned from `Program.Run()` — Bubble Tea skips that
+final render entirely and its `kill()` erases only the bottom line. For a
+single-line spinner that was invisible; with the extra hint line it left the
+hint (and the spinner) lingering on screen above the next output.
+
+Fix (`tui.InterruptFilter` + `tui.NewProgressProgram` in `interrupt.go`): install
+a `tea.WithFilter` that rewrites `tea.InterruptMsg` into a `Ctrl+C` key press.
+Every progress model already treats `Ctrl+C` as a graceful quit (it sets its
+done/cancelled state and returns `tea.Quit`), so an interrupt now takes the
+proven graceful-clear path and the hint never lingers. This makes a SIGINT
+behave exactly like a `Ctrl+C` keypress, which a raw-mode terminal already
+delivers as a `KeyMsg` (never a signal); callers already detect cancellation via
+model state (`Done()` / `Err()`), not via the `Run()` error. All call sites that
+run a hint-bearing model construct their program with `tui.NewProgressProgram`
+instead of `tea.NewProgram`; picker/menu/non-hint models are left untouched.
+
 ## Testing
 
 `hints_test.go`:
@@ -63,6 +87,14 @@ Each model gets the same four touch-points:
   `""` for an empty one.
 - Each model's `View()` includes the hint line while running and omits it once
   `done`.
+
+`interrupt_test.go`:
+
+- `InterruptFilter` rewrites `tea.InterruptMsg` into a `Ctrl+C` `KeyMsg` and
+  passes other messages through unchanged.
+- For every hint-bearing model, feeding the filtered interrupt makes the model
+  quit (`tea.Quit`) and produces a final `View()` with no hint — so the
+  graceful-clear path runs and nothing lingers.
 
 ## Out of scope
 


### PR DESCRIPTION
## Problem

The rotating `💡 Tip:` line in the CLI progress indicators (spinner, progress bar, multi-spinner, build steps) lingered on screen after an operation ended via an **interrupt**.

All four hint-bearing models already drop the hint on Bubble Tea's **graceful** quit (it renders the final hint-free `View()` and the renderer erases the now-shorter frame). But on the **killed** path — `tea.InterruptMsg` (SIGINT or an explicit interrupt), or any error from `Program.Run()` — Bubble Tea skips that final render and its `kill()` only erases the bottom line, leaving the multi-line frame (spinner + hint) above it on screen.

## Fix

`go/internal/cli/tui/interrupt.go`:
- **`InterruptFilter`** — a `tea.WithFilter` that rewrites `tea.InterruptMsg` into a `Ctrl+C` key press. Every progress model already treats `Ctrl+C` as a graceful quit (sets its done/cancelled state, returns `tea.Quit`), so interrupts now take the proven graceful-clear path and the hint never lingers.
- **`NewProgressProgram`** — wraps `tea.NewProgram` with that filter.

This makes a SIGINT behave exactly like a `Ctrl+C` keypress (which a raw-mode terminal already delivers as a `KeyMsg`, never a signal). Callers detect cancellation via model state (`Done()` / `Err()`), not the `Run()` error, so their behavior is unchanged.

Migrated the ~20 call sites that run a hint-bearing model from `tea.NewProgram` to `tui.NewProgressProgram`; picker/menu/non-hint models are left untouched. Removed the now-unused `tea` import from 5 files.

## Tests

`interrupt_test.go` (deterministic, no timing skips):
- `InterruptFilter` rewrites `InterruptMsg` → `Ctrl+C` and passes other messages through.
- Table-driven across all four models: a filtered interrupt yields `tea.Quit` and a hint-free final `View()`.

Verified end-to-end under a real PTY (`pyte`): 0/20 tip-linger after the fix (was lingering before). `go build ./...`, `go vet`, `gofmt`, and `go test ./internal/cli/tui ./internal/cli/commands ./internal/cli/providers` all pass.

## Docs

Updated `specs/superpowers/2026-06-24-progress-hints-design.md` (the design doc for this feature) with a "Clearing the hint on interrupt" section and the new test coverage.

## Out of scope (pre-existing, noted by review)

`device.go` (`wendy device update`) and `os_cmd.go` (`waitForDeviceOnline`) check a spinner's `Result()` but not `Done()`, so a cancel is treated as success. Pre-existing for both keypress and signal; worth a separate follow-up with `Done()`-based guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)