### PR TITLE
style(cli): group wendy cloud subcommands in help output

### DIFF
--- a/go/internal/cli/commands/cloud.go
+++ b/go/internal/cli/commands/cloud.go
@@ -21,18 +21,41 @@ func newCloudCmd() *cobra.Command {
 		Short: "Manage Wendy Cloud resources",
 	}
 
-	// Surface the common Wendy Cloud auth flow under `wendy cloud`. These reuse
-	// the same constructors as the (now hidden) top-level `wendy auth` command;
-	// the advanced session commands (refresh-certs, use, default) remain
-	// reachable only via `wendy auth`.
-	cmd.AddCommand(newAuthLoginCmd())
-	cmd.AddCommand(newAuthLogoutCmd())
-	cmd.AddCommand(newAuthStatusCmd())
-	cmd.AddCommand(newCloudEnrollDeviceCmd())
-	cmd.AddCommand(newCloudDiscoverCmd())
-	cmd.AddCommand(newCloudRunCmd())
-	cmd.AddCommand(newCloudTunnelCmd())
-	cmd.AddCommand(newCloudDeviceCmd())
+	cmd.AddGroup(
+		&cobra.Group{ID: "auth", Title: "Authentication:"},
+		&cobra.Group{ID: "devices", Title: "Devices:"},
+		&cobra.Group{ID: "connectivity", Title: "Connectivity:"},
+	)
+
+	addToGroup := func(groupID string, cmds ...*cobra.Command) {
+		for _, c := range cmds {
+			c.GroupID = groupID
+			cmd.AddCommand(c)
+		}
+	}
+
+	// Authentication: the common Wendy Cloud auth flow surfaced under
+	// `wendy cloud`. These reuse the same constructors as the (now hidden)
+	// top-level `wendy auth` command; the advanced session commands
+	// (refresh-certs, use, default) remain reachable only via `wendy auth`.
+	addToGroup("auth",
+		newAuthLoginCmd(),
+		newAuthLogoutCmd(),
+		newAuthStatusCmd(),
+	)
+	// Devices: enroll, discover, and operate cloud-connected devices. The
+	// hidden `run` command stays registered (and runnable) but off the help
+	// menu; it is hidden via its own constructor.
+	addToGroup("devices",
+		newCloudEnrollDeviceCmd(),
+		newCloudDiscoverCmd(),
+		newCloudDeviceCmd(),
+		newCloudRunCmd(),
+	)
+	// Connectivity: networking helpers that reach a device through the cloud.
+	addToGroup("connectivity",
+		newCloudTunnelCmd(),
+	)
 	return cmd
 }
 


### PR DESCRIPTION
## What

Organize `wendy cloud --help` into titled groups, matching the existing `wendy device` pattern. Previously the subcommands were a flat, registration-ordered list.

```
Authentication:
  login         Log in to Wendy Cloud or a local pki-core instance
  logout        Log out from Wendy Cloud
  status        Show current authentication status

Devices:
  enroll-device Enroll the connected device with Wendy Cloud or a local pki-core
  discover      List enrolled devices in Wendy Cloud
  device        Manage WendyOS devices through Wendy Cloud

Connectivity:
  tunnel        Forward a local TCP port to a port on a cloud-enrolled device
```

## How

- Added three `cobra.Group`s (`auth` / `devices` / `connectivity`) and assigned each subcommand via a local `addToGroup` helper — the same idiom `newDeviceCmd()` already uses.
- The hidden, deprecated `run` command stays registered and runnable but remains off the help menu.

Pure presentation change — no command names or behavior change.

## Testing

- `gofmt` clean, `git diff --check` clean
- `go test ./internal/cli/commands` passes
- Verified `wendy cloud --help` renders the grouped output above

🤖 Generated with [Claude Code](https://claude.com/claude-code)