### PR TITLE
perf(cli): skip CBC chunking for layers already on device

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.proto
@@ -23,6 +23,11 @@ service WendyContainerService {
     rpc StreamMCP(stream MCPChunk) returns (stream MCPChunk);
     rpc QueryChunks(QueryChunksRequest) returns (QueryChunksResponse);
     rpc WriteChunks(stream WriteChunksRequest) returns (WriteChunksResponse);
+    // QueryLayers reports which uncompressed layers (by diff ID) the device
+    // already has in its content store, with their sizes. The CLI uses this to
+    // skip decompressing and content-chunking layers the device can reuse as-is
+    // — for those layers no dedup is possible, so chunking would be pure waste.
+    rpc QueryLayers(QueryLayersRequest) returns (QueryLayersResponse);
 }
 
 message ListContainersRequest {}
@@ -57,6 +62,27 @@ message WriteChunksRequest {
 }
 
 message WriteChunksResponse {}
+
+message QueryLayersRequest {
+    // Uncompressed layer digests (diff IDs, "sha256:<hex>") to check for
+    // presence in the device's content store.
+    repeated string diff_ids = 1;
+}
+
+message QueryLayersResponse {
+    // The subset of the requested layers the device already has. Layers absent
+    // from this list are not present and must be pushed.
+    repeated PresentLayer present = 1;
+}
+
+message PresentLayer {
+    // The uncompressed layer digest (diff ID) that the device has.
+    string diff_id = 1;
+    // Uncompressed blob size as stored in the content store. The CLI puts this
+    // in the reassembly header so AssembleImage references the layer correctly
+    // without the CLI having to decompress it to learn its size.
+    int64 size = 2;
+}
 
 message LayerHeader {
     // The hash identity of the layer.

--- a/go/integration_test.go
+++ b/go/integration_test.go
@@ -242,6 +242,10 @@ func (m *statefulContainerdClient) MissingChunks(_ context.Context, hashes [][32
 	return hashes, nil
 }
 
+func (m *statefulContainerdClient) PresentLayers(_ context.Context, _ []string) (map[string]int64, error) {
+	return nil, nil
+}
+
 func (m *statefulContainerdClient) StageChunk(_ context.Context, _ [32]byte, _ []byte) error {
 	return nil
 }

--- a/go/internal/agent/container/monitor_checkcontainers_test.go
+++ b/go/internal/agent/container/monitor_checkcontainers_test.go
@@ -96,6 +96,10 @@ func (f *fakeContainerd) MissingChunks(_ context.Context, hashes [][32]byte) ([]
 	return hashes, nil
 }
 
+func (f *fakeContainerd) PresentLayers(_ context.Context, _ []string) (map[string]int64, error) {
+	return nil, nil
+}
+
 func (f *fakeContainerd) StageChunk(_ context.Context, _ [32]byte, _ []byte) error {
 	return nil
 }

--- a/go/internal/agent/containerd/chunkstore.go
+++ b/go/internal/agent/containerd/chunkstore.go
@@ -161,6 +161,32 @@ func (c *Client) MissingChunks(_ context.Context, hashes [][32]byte) ([][32]byte
 	return out, nil
 }
 
+// PresentLayers reports which of the given uncompressed layer digests (diff IDs)
+// already exist in the content store, mapping each present diff ID to its blob
+// size. Layers the device does not have are simply absent from the result. The
+// CLI uses this to skip decompressing and chunking layers it can reuse as-is.
+// Malformed digests are skipped rather than failing the whole query.
+func (c *Client) PresentLayers(ctx context.Context, diffIDs []string) (map[string]int64, error) {
+	nsCtx := c.withNamespace(ctx)
+	cs := c.client.ContentStore()
+	present := make(map[string]int64, len(diffIDs))
+	for _, d := range diffIDs {
+		dgst, err := digest.Parse(d)
+		if err != nil {
+			continue
+		}
+		info, err := cs.Info(nsCtx, dgst)
+		if err != nil {
+			if errdefs.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		present[d] = info.Size
+	}
+	return present, nil
+}
+
 func (c *Client) StageChunk(_ context.Context, h [32]byte, data []byte) error {
 	if len(data) > maxStagedChunkBytes {
 		return status.Errorf(codes.ResourceExhausted, "chunk too large: %d > %d bytes", len(data), maxStagedChunkBytes)

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -241,6 +241,18 @@ func (s *ContainerService) QueryChunks(ctx context.Context, req *agentpb.QueryCh
 	return &agentpb.QueryChunksResponse{MissingHashes: out}, nil
 }
 
+func (s *ContainerService) QueryLayers(ctx context.Context, req *agentpb.QueryLayersRequest) (*agentpb.QueryLayersResponse, error) {
+	present, err := s.containerd.PresentLayers(ctx, req.GetDiffIds())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "querying layers: %v", err)
+	}
+	out := make([]*agentpb.PresentLayer, 0, len(present))
+	for diffID, size := range present {
+		out = append(out, &agentpb.PresentLayer{DiffId: diffID, Size: size})
+	}
+	return &agentpb.QueryLayersResponse{Present: out}, nil
+}
+
 func (s *ContainerService) WriteChunks(stream grpc.ClientStreamingServer[agentpb.WriteChunksRequest, agentpb.WriteChunksResponse]) error {
 	ctx := stream.Context()
 	for {

--- a/go/internal/agent/services/container_service_chunks_test.go
+++ b/go/internal/agent/services/container_service_chunks_test.go
@@ -18,6 +18,7 @@ import (
 type fakeContainerd struct {
 	mockContainerdClient
 	missingFn    func(ctx context.Context, hashes [][32]byte) ([][32]byte, error)
+	presentFn    func(ctx context.Context, diffIDs []string) (map[string]int64, error)
 	stageChunkFn func(ctx context.Context, h [32]byte, data []byte) error
 	stagedChunks []stagedChunk
 }
@@ -37,6 +38,14 @@ func (f *fakeContainerd) MissingChunks(ctx context.Context, hashes [][32]byte) (
 		return f.missingFn(ctx, hashes)
 	}
 	return hashes, nil
+}
+
+// PresentLayers delegates to presentFn when set; otherwise reports nothing present.
+func (f *fakeContainerd) PresentLayers(ctx context.Context, diffIDs []string) (map[string]int64, error) {
+	if f.presentFn != nil {
+		return f.presentFn(ctx, diffIDs)
+	}
+	return nil, nil
 }
 
 // StageChunk records the (hash, data) pair and delegates to stageChunkFn when set.
@@ -72,6 +81,31 @@ func TestQueryChunksReturnsMissing(t *testing.T) {
 	}
 	if len(resp.GetMissingHashes()) != 1 || !bytes.Equal(resp.GetMissingHashes()[0], h1) {
 		t.Fatalf("expected only h1 missing, got %v", resp.GetMissingHashes())
+	}
+}
+
+func TestQueryLayersReportsPresent(t *testing.T) {
+	fake := newFakeContainerd()
+	fake.presentFn = func(_ context.Context, diffIDs []string) (map[string]int64, error) {
+		// Pretend only the first requested layer is present, with a known size.
+		if len(diffIDs) == 0 {
+			return nil, nil
+		}
+		return map[string]int64{diffIDs[0]: 4096}, nil
+	}
+	svc := NewContainerService(zap.NewNop(), fake)
+
+	resp, err := svc.QueryLayers(context.Background(), &agentpb.QueryLayersRequest{
+		DiffIds: []string{"sha256:aaa", "sha256:bbb"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.GetPresent()) != 1 {
+		t.Fatalf("expected 1 present layer, got %d", len(resp.GetPresent()))
+	}
+	if got := resp.GetPresent()[0]; got.GetDiffId() != "sha256:aaa" || got.GetSize() != 4096 {
+		t.Fatalf("present layer mismatch: got %q size %d", got.GetDiffId(), got.GetSize())
 	}
 }
 

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -129,6 +129,10 @@ func (m *mockContainerdClient) MissingChunks(_ context.Context, hashes [][32]byt
 	return hashes, nil
 }
 
+func (m *mockContainerdClient) PresentLayers(_ context.Context, _ []string) (map[string]int64, error) {
+	return nil, nil
+}
+
 func (m *mockContainerdClient) StageChunk(_ context.Context, _ [32]byte, _ []byte) error {
 	return nil
 }

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -44,6 +44,10 @@ type ContainerdClient interface {
 	WriteLayer(ctx context.Context, digest string, reader io.Reader, size int64) error
 	AssembleImage(ctx context.Context, imageName string, layers []*agentpb.RunContainerLayerHeader, imageConfig []byte) error
 	MissingChunks(ctx context.Context, hashes [][32]byte) ([][32]byte, error)
+	// PresentLayers reports which uncompressed layer diff IDs the device already
+	// has, mapping each to its blob size. Used by QueryLayers so the CLI can skip
+	// chunking layers the device can reuse as-is.
+	PresentLayers(ctx context.Context, diffIDs []string) (map[string]int64, error)
 	StageChunk(ctx context.Context, h [32]byte, data []byte) error
 	AssembleLayerFromChunks(ctx context.Context, diffID string, hashes [][32]byte) error
 	CreateContainer(ctx context.Context, req *agentpb.CreateContainerRequest, appCfg *appconfig.AppConfig) error

--- a/go/internal/cli/commands/chunkpush.go
+++ b/go/internal/cli/commands/chunkpush.go
@@ -2,10 +2,12 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/chunk"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -33,16 +35,65 @@ const maxConcurrentLayerPush = 4
 //
 // The common case — an unchanged layer whose chunks the device already has —
 // resolves from cache and finds nothing missing, so the layer is never
-// decompressed or re-chunked.
+// decompressed or re-chunked. A layer the device already holds in full (reported
+// by the QueryLayers pre-check) is skipped entirely: it is never decompressed,
+// chunked, or transferred.
 func pushLayersByChunks(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer) ([]*agentpb.RunContainerLayerHeader, error) {
 	headers := make([]*agentpb.RunContainerLayerHeader, len(layers))
+
+	// Capability probe: a single empty QueryChunks tells us whether the agent
+	// supports chunk-diff at all BEFORE we decompress and chunk the first layer.
+	// An old agent returns Unimplemented, which bubbles up so deployByChunkDiff
+	// falls back to a registry push instead of wasting a layer's worth of work.
+	if _, err := cs.QueryChunks(ctx, &agentpb.QueryChunksRequest{}); err != nil {
+		return nil, err
+	}
+
+	// Layer pre-check: ask which layers the device already has by diff ID so we
+	// can skip them entirely. A layer the device already holds yields no dedup, so
+	// decompressing and content-chunking it would be pure waste. Degrades to
+	// chunking every layer when the agent is too old or the query fails.
+	present := queryPresentLayers(ctx, cs, layers)
+
+	// Build the present-layer headers up front and collect the indices that still
+	// need a chunk-diff push. A present-layer header carries no chunk hashes, so
+	// the agent skips reassembly and reuses the blob already in its content store.
+	// We trust that blob for the rest of the deploy: unlike the always-send-chunks
+	// path (where QueryChunks would re-report bytes the device lost mid-deploy),
+	// nothing re-sends a skipped layer. The window is safe in practice — the blob
+	// stays referenced by the app's current image until this deploy replaces it,
+	// so containerd GC will not reclaim it underneath us.
+	var toPush []int
+	skipped := 0
+	for i, l := range layers {
+		if l.DiffID != "" {
+			if size, ok := present[l.DiffID]; ok {
+				headers[i] = &agentpb.RunContainerLayerHeader{
+					Digest:      l.DiffID,
+					DiffId:      l.DiffID,
+					Size:        size,
+					Compression: agentpb.RunContainerLayerHeader_COMPRESSION_NONE,
+				}
+				skipped++
+				continue
+			}
+		}
+		toPush = append(toPush, i)
+	}
+	if skipped > 0 {
+		cliLogln("Reusing %s layer(s) already on device; chunking %s.",
+			tui.Value(fmt.Sprintf("%d", skipped)), tui.Value(fmt.Sprintf("%d", len(toPush))))
+	}
+	if len(toPush) == 0 {
+		return headers, nil
+	}
 
 	limit := maxConcurrentLayerPush
 	if n := runtime.GOMAXPROCS(0); n < limit {
 		limit = n
 	}
-	if limit > len(layers) {
-		limit = len(layers)
+	if limit > len(toPush) {
+		limit = len(toPush)
 	}
 	if limit < 1 {
 		limit = 1
@@ -50,14 +101,14 @@ func pushLayersByChunks(ctx context.Context, cs agentpb.WendyContainerServiceCli
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(limit)
-	for i, l := range layers {
-		i, l := i, l
+	for _, idx := range toPush {
+		idx, l := idx, layers[idx]
 		g.Go(func() error {
 			h, err := pushLayerByChunks(ctx, cs, l)
 			if err != nil {
 				return err
 			}
-			headers[i] = h // distinct index per goroutine — preserves layer order
+			headers[idx] = h // distinct index per goroutine — preserves layer order
 			return nil
 		})
 	}
@@ -65,6 +116,38 @@ func pushLayersByChunks(ctx context.Context, cs agentpb.WendyContainerServiceCli
 		return nil, err
 	}
 	return headers, nil
+}
+
+// queryPresentLayers asks the device which of these layers it already has, keyed
+// by diff ID, returning each present diff ID's uncompressed size. Layers with no
+// known diff ID are not queried. The pre-check is a pure optimization: an agent
+// too old to implement QueryLayers (Unimplemented), or any query error, yields a
+// nil map so the caller chunks every layer as before.
+func queryPresentLayers(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer) map[string]int64 {
+	diffIDs := make([]string, 0, len(layers))
+	for _, l := range layers {
+		if l.DiffID != "" {
+			diffIDs = append(diffIDs, l.DiffID)
+		}
+	}
+	if len(diffIDs) == 0 {
+		return nil
+	}
+	resp, err := cs.QueryLayers(ctx, &agentpb.QueryLayersRequest{DiffIds: diffIDs})
+	if err != nil {
+		if !isUnimplementedRPCError(err) {
+			// The agent supports chunk-diff (the probe succeeded) but the layer
+			// pre-check failed for another reason; chunk everything rather than
+			// abort the deploy over a missed optimization.
+			cliLogln("Layer pre-check unavailable (%v); chunking all layers.", err)
+		}
+		return nil
+	}
+	out := make(map[string]int64, len(resp.GetPresent()))
+	for _, p := range resp.GetPresent() {
+		out[p.GetDiffId()] = p.GetSize()
+	}
+	return out
 }
 
 // pushLayerByChunks runs the chunk-diff push for a single layer and returns its

--- a/go/internal/cli/commands/chunkpush_test.go
+++ b/go/internal/cli/commands/chunkpush_test.go
@@ -3,24 +3,39 @@ package commands
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/chunk"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // fakeContainerClient satisfies agentpb.WendyContainerServiceClient via the
-// embedded-interface trick. Only QueryChunks and WriteChunks are overridden;
-// all other methods panic (they must not be called by pushLayersByChunks).
+// embedded-interface trick. Only QueryChunks, QueryLayers, and WriteChunks are
+// overridden; all other methods panic (they must not be called by
+// pushLayersByChunks).
 type fakeContainerClient struct {
 	agentpb.WendyContainerServiceClient // embedded nil — satisfies interface
 	queryFn                             func(*agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse
+	queryLayersFn                       func(*agentpb.QueryLayersRequest) *agentpb.QueryLayersResponse
 	chunksWritten                       int
 }
 
 func (f *fakeContainerClient) QueryChunks(_ context.Context, in *agentpb.QueryChunksRequest, _ ...grpc.CallOption) (*agentpb.QueryChunksResponse, error) {
 	return f.queryFn(in), nil
+}
+
+// QueryLayers delegates to queryLayersFn when set; otherwise it reports
+// Unimplemented, mirroring an agent too old for the layer pre-check so the push
+// degrades to chunking every layer.
+func (f *fakeContainerClient) QueryLayers(_ context.Context, in *agentpb.QueryLayersRequest, _ ...grpc.CallOption) (*agentpb.QueryLayersResponse, error) {
+	if f.queryLayersFn == nil {
+		return nil, status.Error(codes.Unimplemented, "QueryLayers not implemented")
+	}
+	return f.queryLayersFn(in), nil
 }
 
 func (f *fakeContainerClient) WriteChunks(_ context.Context, _ ...grpc.CallOption) (grpc.ClientStreamingClient[agentpb.WriteChunksRequest, agentpb.WriteChunksResponse], error) {
@@ -99,4 +114,90 @@ func TestPushLayersByChunksWritesOnlyMissing(t *testing.T) {
 	if headers[0].GetCompression() != agentpb.RunContainerLayerHeader_COMPRESSION_NONE {
 		t.Fatalf("layer must be uncompressed, got %v", headers[0].GetCompression())
 	}
+}
+
+// TestPushLayersByChunksSkipsPresentLayer verifies that a layer the device
+// already has (reported by QueryLayers) is never decompressed, chunked, or
+// transferred — its header is built from the diff ID and the device-reported
+// size alone.
+func TestPushLayersByChunksSkipsPresentLayer(t *testing.T) {
+	manifestCacheTestDir = t.TempDir()
+	t.Cleanup(func() { manifestCacheTestDir = "" })
+
+	diffID := "sha256:" + strings.Repeat("ab", 32)
+	const presentSize int64 = 4096
+
+	fake := &fakeContainerClient{
+		queryFn: func(req *agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse {
+			// The only legitimate QueryChunks here is the empty capability probe.
+			if len(req.GetChunkHashes()) != 0 {
+				t.Errorf("QueryChunks called with %d hashes; a present layer must not be chunked", len(req.GetChunkHashes()))
+			}
+			return &agentpb.QueryChunksResponse{}
+		},
+		queryLayersFn: func(req *agentpb.QueryLayersRequest) *agentpb.QueryLayersResponse {
+			return &agentpb.QueryLayersResponse{
+				Present: []*agentpb.PresentLayer{{DiffId: diffID, Size: presentSize}},
+			}
+		},
+	}
+
+	// The blob is intentionally NOT valid gzip: if the push tried to decompress
+	// this layer it would fail, proving the present layer was skipped.
+	headers, err := pushLayersByChunks(context.Background(), fake, []localLayer{{
+		Digest:    "sha256:" + sha256Hex([]byte("compressed-bytes")),
+		DiffID:    diffID,
+		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+		Blob:      []byte("this is not gzip"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.chunksWritten != 0 {
+		t.Fatalf("expected 0 chunks written for a present layer, got %d", fake.chunksWritten)
+	}
+	if len(headers) != 1 {
+		t.Fatalf("expected 1 header, got %d", len(headers))
+	}
+	h := headers[0]
+	if h.GetDiffId() != diffID || h.GetDigest() != diffID {
+		t.Fatalf("present-layer header digest/diffID mismatch: digest=%q diffID=%q want %q", h.GetDigest(), h.GetDiffId(), diffID)
+	}
+	if h.GetSize() != presentSize {
+		t.Fatalf("present-layer header size = %d, want %d (device-reported)", h.GetSize(), presentSize)
+	}
+	if len(h.GetChunkHashes()) != 0 {
+		t.Fatalf("present-layer header must carry no chunk hashes, got %d", len(h.GetChunkHashes()))
+	}
+	if h.GetCompression() != agentpb.RunContainerLayerHeader_COMPRESSION_NONE {
+		t.Fatalf("present-layer header must be uncompressed, got %v", h.GetCompression())
+	}
+}
+
+// TestPushLayersByChunksProbeUnimplemented verifies that an agent which does not
+// support chunk-diff at all (QueryChunks returns Unimplemented) surfaces the
+// error before any layer work, so the caller can fall back to a registry push.
+func TestPushLayersByChunksProbeUnimplemented(t *testing.T) {
+	manifestCacheTestDir = t.TempDir()
+	t.Cleanup(func() { manifestCacheTestDir = "" })
+
+	fake := &probeUnsupportedClient{}
+	_, err := pushLayersByChunks(context.Background(), fake, []localLayer{{
+		Digest:    "sha256:" + sha256Hex([]byte("x")),
+		MediaType: "application/vnd.oci.image.layer.v1.tar",
+		Blob:      []byte("not gzip either"),
+	}})
+	if !isUnimplementedRPCError(err) {
+		t.Fatalf("expected Unimplemented error from the capability probe, got %v", err)
+	}
+}
+
+// probeUnsupportedClient fails QueryChunks with Unimplemented, modelling an agent
+// too old for any chunk-diff support.
+type probeUnsupportedClient struct {
+	agentpb.WendyContainerServiceClient
+}
+
+func (probeUnsupportedClient) QueryChunks(_ context.Context, _ *agentpb.QueryChunksRequest, _ ...grpc.CallOption) (*agentpb.QueryChunksResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "QueryChunks not implemented")
 }

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -28,6 +28,7 @@ import (
 // read or decompress it. Blob is an in-memory fallback used by tests.
 type localLayer struct {
 	Digest    string // compressed OCI layer blob digest ("sha256:<hex>") — stable cache key
+	DiffID    string // uncompressed layer digest from the image config's rootfs.diff_ids; "" when unavailable
 	MediaType string // OCI/Docker layer media type (drives decompression)
 
 	Blob []byte // compressed bytes, when held in memory (tests / small blobs)
@@ -272,8 +273,12 @@ func readOCILayoutLayers(ociTarPath, platform string) ([]localLayer, []byte, err
 	}
 
 	// Fetch the image config blob so the runtime config (Cmd/Entrypoint/Env/
-	// WorkingDir/User) survives reassembly on the device.
+	// WorkingDir/User) survives reassembly on the device. It also carries
+	// rootfs.diff_ids — the uncompressed digest of each layer, in layer order —
+	// which lets the push pre-check layer presence on the device WITHOUT
+	// decompressing anything.
 	var imageConfig []byte
+	var diffIDs []string
 	if manifest.Config.Digest != "" {
 		configHex, err := digestToHex(manifest.Config.Digest)
 		if err != nil {
@@ -283,7 +288,23 @@ func readOCILayoutLayers(ociTarPath, platform string) ([]localLayer, []byte, err
 		if err != nil {
 			return nil, nil, fmt.Errorf("config blob %s: %w", manifest.Config.Digest, err)
 		}
+		var cfg struct {
+			RootFS struct {
+				DiffIDs []string `json:"diff_ids"`
+			} `json:"rootfs"`
+		}
+		// A malformed/absent rootfs just leaves diffIDs empty: the push falls back
+		// to deriving each diff ID by decompressing, so this is a pure optimization.
+		if err := json.Unmarshal(imageConfig, &cfg); err == nil {
+			diffIDs = cfg.RootFS.DiffIDs
+		}
 	}
+
+	// diff_ids align 1:1 with manifest layers (both bottom-to-top, empty layers
+	// excluded) per the OCI image-config spec. Only trust them to label layers
+	// when the counts match; otherwise leave DiffID empty and let the push derive
+	// it the slow way rather than risk mislabelling a layer.
+	diffIDsAligned := len(diffIDs) == len(manifest.Layers)
 
 	layers := make([]localLayer, 0, len(manifest.Layers))
 	for i, desc := range manifest.Layers {
@@ -295,11 +316,16 @@ func readOCILayoutLayers(ociTarPath, platform string) ([]localLayer, []byte, err
 		if !ok {
 			return nil, nil, fmt.Errorf("layer %d blob %s not found in OCI tar", i, desc.Digest)
 		}
+		var diffID string
+		if diffIDsAligned {
+			diffID = diffIDs[i]
+		}
 		// Reference the compressed blob by its range in the on-disk tar; it is
 		// streamed (never fully buffered) during the push, and decompression is
 		// deferred so cache-resolved layers are never read at all.
 		layers = append(layers, localLayer{
 			Digest:    desc.Digest,
+			DiffID:    diffID,
 			MediaType: desc.MediaType,
 			TarPath:   ociTarPath,
 			Offset:    loc.off,

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -259,6 +259,42 @@ func TestReadOCILayoutLayersGzip(t *testing.T) {
 	}
 }
 
+// TestReadOCILayoutLayersPopulatesDiffID verifies the uncompressed diff ID is
+// read from the image config's rootfs.diff_ids — without decompressing — and is
+// distinct from the compressed layer digest for a gzip layer.
+func TestReadOCILayoutLayersPopulatesDiffID(t *testing.T) {
+	dir := t.TempDir()
+	ociTar := filepath.Join(dir, "image.tar")
+	want := []byte("diffid-probe-payload")
+
+	var compressed bytes.Buffer
+	gw := gzip.NewWriter(&compressed)
+	if _, err := gw.Write(want); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	compressedBytes := compressed.Bytes()
+
+	writeMinimalOCILayout(t, ociTar, compressedBytes, "application/vnd.oci.image.layer.v1.tar+gzip", want)
+
+	layers, _, err := readOCILayoutLayers(ociTar, "linux/arm64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(layers) != 1 {
+		t.Fatalf("expected 1 layer, got %d", len(layers))
+	}
+	wantDiffID := "sha256:" + sha256Hex(want)
+	if layers[0].DiffID != wantDiffID {
+		t.Fatalf("DiffID = %q, want %q (from config rootfs.diff_ids)", layers[0].DiffID, wantDiffID)
+	}
+	if layers[0].DiffID == layers[0].Digest {
+		t.Fatal("DiffID must differ from the compressed Digest for a gzip layer")
+	}
+}
+
 // imageManifestBytes builds a single-layer image manifest (+ its config and
 // layer blobs) for the given architecture, returning the manifest JSON and the
 // blob entries to embed in an OCI tar.

--- a/go/proto/gen/agentpb/wendy_agent_v1_container_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_container_service.pb.go
@@ -73,7 +73,7 @@ func (x CreateContainerProgress_Phase) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CreateContainerProgress_Phase.Descriptor instead.
 func (CreateContainerProgress_Phase) EnumDescriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{13, 0}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{16, 0}
 }
 
 type RunContainerLayerHeader_CompressionType int32
@@ -122,7 +122,7 @@ func (x RunContainerLayerHeader_CompressionType) Number() protoreflect.EnumNumbe
 
 // Deprecated: Use RunContainerLayerHeader_CompressionType.Descriptor instead.
 func (RunContainerLayerHeader_CompressionType) EnumDescriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{17, 0}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{20, 0}
 }
 
 type ListContainersRequest struct {
@@ -507,6 +507,154 @@ func (*WriteChunksResponse) Descriptor() ([]byte, []int) {
 	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{8}
 }
 
+type QueryLayersRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Uncompressed layer digests (diff IDs, "sha256:<hex>") to check for
+	// presence in the device's content store.
+	DiffIds       []string `protobuf:"bytes,1,rep,name=diff_ids,json=diffIds,proto3" json:"diff_ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryLayersRequest) Reset() {
+	*x = QueryLayersRequest{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryLayersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryLayersRequest) ProtoMessage() {}
+
+func (x *QueryLayersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryLayersRequest.ProtoReflect.Descriptor instead.
+func (*QueryLayersRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *QueryLayersRequest) GetDiffIds() []string {
+	if x != nil {
+		return x.DiffIds
+	}
+	return nil
+}
+
+type QueryLayersResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The subset of the requested layers the device already has. Layers absent
+	// from this list are not present and must be pushed.
+	Present       []*PresentLayer `protobuf:"bytes,1,rep,name=present,proto3" json:"present,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryLayersResponse) Reset() {
+	*x = QueryLayersResponse{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryLayersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryLayersResponse) ProtoMessage() {}
+
+func (x *QueryLayersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryLayersResponse.ProtoReflect.Descriptor instead.
+func (*QueryLayersResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *QueryLayersResponse) GetPresent() []*PresentLayer {
+	if x != nil {
+		return x.Present
+	}
+	return nil
+}
+
+type PresentLayer struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The uncompressed layer digest (diff ID) that the device has.
+	DiffId string `protobuf:"bytes,1,opt,name=diff_id,json=diffId,proto3" json:"diff_id,omitempty"`
+	// Uncompressed blob size as stored in the content store. The CLI puts this
+	// in the reassembly header so AssembleImage references the layer correctly
+	// without the CLI having to decompress it to learn its size.
+	Size          int64 `protobuf:"varint,2,opt,name=size,proto3" json:"size,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PresentLayer) Reset() {
+	*x = PresentLayer{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PresentLayer) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PresentLayer) ProtoMessage() {}
+
+func (x *PresentLayer) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PresentLayer.ProtoReflect.Descriptor instead.
+func (*PresentLayer) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *PresentLayer) GetDiffId() string {
+	if x != nil {
+		return x.DiffId
+	}
+	return ""
+}
+
+func (x *PresentLayer) GetSize() int64 {
+	if x != nil {
+		return x.Size
+	}
+	return 0
+}
+
 type LayerHeader struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The hash identity of the layer.
@@ -518,7 +666,7 @@ type LayerHeader struct {
 
 func (x *LayerHeader) Reset() {
 	*x = LayerHeader{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[9]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -530,7 +678,7 @@ func (x *LayerHeader) String() string {
 func (*LayerHeader) ProtoMessage() {}
 
 func (x *LayerHeader) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[9]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -543,7 +691,7 @@ func (x *LayerHeader) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LayerHeader.ProtoReflect.Descriptor instead.
 func (*LayerHeader) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{9}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *LayerHeader) GetDigest() string {
@@ -587,7 +735,7 @@ type RunContainerLayersRequest struct {
 
 func (x *RunContainerLayersRequest) Reset() {
 	*x = RunContainerLayersRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[10]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -599,7 +747,7 @@ func (x *RunContainerLayersRequest) String() string {
 func (*RunContainerLayersRequest) ProtoMessage() {}
 
 func (x *RunContainerLayersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[10]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -612,7 +760,7 @@ func (x *RunContainerLayersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunContainerLayersRequest.ProtoReflect.Descriptor instead.
 func (*RunContainerLayersRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{10}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *RunContainerLayersRequest) GetImageName() string {
@@ -697,7 +845,7 @@ type CreateContainerRequest struct {
 
 func (x *CreateContainerRequest) Reset() {
 	*x = CreateContainerRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[11]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -709,7 +857,7 @@ func (x *CreateContainerRequest) String() string {
 func (*CreateContainerRequest) ProtoMessage() {}
 
 func (x *CreateContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[11]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -722,7 +870,7 @@ func (x *CreateContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateContainerRequest.ProtoReflect.Descriptor instead.
 func (*CreateContainerRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{11}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CreateContainerRequest) GetImageName() string {
@@ -789,7 +937,7 @@ type CreateContainerResponse struct {
 
 func (x *CreateContainerResponse) Reset() {
 	*x = CreateContainerResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[12]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -801,7 +949,7 @@ func (x *CreateContainerResponse) String() string {
 func (*CreateContainerResponse) ProtoMessage() {}
 
 func (x *CreateContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[12]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -814,7 +962,7 @@ func (x *CreateContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateContainerResponse.ProtoReflect.Descriptor instead.
 func (*CreateContainerResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{12}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{15}
 }
 
 type CreateContainerProgress struct {
@@ -830,7 +978,7 @@ type CreateContainerProgress struct {
 
 func (x *CreateContainerProgress) Reset() {
 	*x = CreateContainerProgress{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[13]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -842,7 +990,7 @@ func (x *CreateContainerProgress) String() string {
 func (*CreateContainerProgress) ProtoMessage() {}
 
 func (x *CreateContainerProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[13]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -855,7 +1003,7 @@ func (x *CreateContainerProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateContainerProgress.ProtoReflect.Descriptor instead.
 func (*CreateContainerProgress) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{13}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CreateContainerProgress) GetPhase() CreateContainerProgress_Phase {
@@ -906,7 +1054,7 @@ type CreateContainerProgressResponse struct {
 
 func (x *CreateContainerProgressResponse) Reset() {
 	*x = CreateContainerProgressResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[14]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -918,7 +1066,7 @@ func (x *CreateContainerProgressResponse) String() string {
 func (*CreateContainerProgressResponse) ProtoMessage() {}
 
 func (x *CreateContainerProgressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[14]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -931,7 +1079,7 @@ func (x *CreateContainerProgressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateContainerProgressResponse.ProtoReflect.Descriptor instead.
 func (*CreateContainerProgressResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{14}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CreateContainerProgressResponse) GetResponseType() isCreateContainerProgressResponse_ResponseType {
@@ -986,7 +1134,7 @@ type StartContainerRequest struct {
 
 func (x *StartContainerRequest) Reset() {
 	*x = StartContainerRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[15]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -998,7 +1146,7 @@ func (x *StartContainerRequest) String() string {
 func (*StartContainerRequest) ProtoMessage() {}
 
 func (x *StartContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[15]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1011,7 +1159,7 @@ func (x *StartContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartContainerRequest.ProtoReflect.Descriptor instead.
 func (*StartContainerRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{15}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *StartContainerRequest) GetAppName() string {
@@ -1043,7 +1191,7 @@ type AttachContainerRequest struct {
 
 func (x *AttachContainerRequest) Reset() {
 	*x = AttachContainerRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[16]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1055,7 +1203,7 @@ func (x *AttachContainerRequest) String() string {
 func (*AttachContainerRequest) ProtoMessage() {}
 
 func (x *AttachContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[16]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1068,7 +1216,7 @@ func (x *AttachContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachContainerRequest.ProtoReflect.Descriptor instead.
 func (*AttachContainerRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{16}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *AttachContainerRequest) GetRequestType() isAttachContainerRequest_RequestType {
@@ -1135,7 +1283,7 @@ type RunContainerLayerHeader struct {
 
 func (x *RunContainerLayerHeader) Reset() {
 	*x = RunContainerLayerHeader{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[17]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1147,7 +1295,7 @@ func (x *RunContainerLayerHeader) String() string {
 func (*RunContainerLayerHeader) ProtoMessage() {}
 
 func (x *RunContainerLayerHeader) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[17]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1160,7 +1308,7 @@ func (x *RunContainerLayerHeader) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunContainerLayerHeader.ProtoReflect.Descriptor instead.
 func (*RunContainerLayerHeader) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{17}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *RunContainerLayerHeader) GetDigest() string {
@@ -1219,7 +1367,7 @@ type RunContainerLayersResponse struct {
 
 func (x *RunContainerLayersResponse) Reset() {
 	*x = RunContainerLayersResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[18]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1231,7 +1379,7 @@ func (x *RunContainerLayersResponse) String() string {
 func (*RunContainerLayersResponse) ProtoMessage() {}
 
 func (x *RunContainerLayersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[18]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1244,7 +1392,7 @@ func (x *RunContainerLayersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunContainerLayersResponse.ProtoReflect.Descriptor instead.
 func (*RunContainerLayersResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{18}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *RunContainerLayersResponse) GetResponseType() isRunContainerLayersResponse_ResponseType {
@@ -1312,7 +1460,7 @@ type StopContainerRequest struct {
 
 func (x *StopContainerRequest) Reset() {
 	*x = StopContainerRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[19]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1324,7 +1472,7 @@ func (x *StopContainerRequest) String() string {
 func (*StopContainerRequest) ProtoMessage() {}
 
 func (x *StopContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[19]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1337,7 +1485,7 @@ func (x *StopContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopContainerRequest.ProtoReflect.Descriptor instead.
 func (*StopContainerRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{19}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *StopContainerRequest) GetAppName() string {
@@ -1355,7 +1503,7 @@ type StopContainerResponse struct {
 
 func (x *StopContainerResponse) Reset() {
 	*x = StopContainerResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[20]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1367,7 +1515,7 @@ func (x *StopContainerResponse) String() string {
 func (*StopContainerResponse) ProtoMessage() {}
 
 func (x *StopContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[20]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1380,7 +1528,7 @@ func (x *StopContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopContainerResponse.ProtoReflect.Descriptor instead.
 func (*StopContainerResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{20}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{23}
 }
 
 type DeleteContainerRequest struct {
@@ -1396,7 +1544,7 @@ type DeleteContainerRequest struct {
 
 func (x *DeleteContainerRequest) Reset() {
 	*x = DeleteContainerRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[21]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1408,7 +1556,7 @@ func (x *DeleteContainerRequest) String() string {
 func (*DeleteContainerRequest) ProtoMessage() {}
 
 func (x *DeleteContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[21]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1421,7 +1569,7 @@ func (x *DeleteContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteContainerRequest.ProtoReflect.Descriptor instead.
 func (*DeleteContainerRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{21}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *DeleteContainerRequest) GetAppName() string {
@@ -1453,7 +1601,7 @@ type DeleteContainerResponse struct {
 
 func (x *DeleteContainerResponse) Reset() {
 	*x = DeleteContainerResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[22]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1465,7 +1613,7 @@ func (x *DeleteContainerResponse) String() string {
 func (*DeleteContainerResponse) ProtoMessage() {}
 
 func (x *DeleteContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[22]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1478,7 +1626,7 @@ func (x *DeleteContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteContainerResponse.ProtoReflect.Descriptor instead.
 func (*DeleteContainerResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{22}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{25}
 }
 
 type ListVolumesRequest struct {
@@ -1489,7 +1637,7 @@ type ListVolumesRequest struct {
 
 func (x *ListVolumesRequest) Reset() {
 	*x = ListVolumesRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[23]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1501,7 +1649,7 @@ func (x *ListVolumesRequest) String() string {
 func (*ListVolumesRequest) ProtoMessage() {}
 
 func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[23]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1514,7 +1662,7 @@ func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesRequest.ProtoReflect.Descriptor instead.
 func (*ListVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{23}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{26}
 }
 
 type VolumeInfo struct {
@@ -1531,7 +1679,7 @@ type VolumeInfo struct {
 
 func (x *VolumeInfo) Reset() {
 	*x = VolumeInfo{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[24]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1543,7 +1691,7 @@ func (x *VolumeInfo) String() string {
 func (*VolumeInfo) ProtoMessage() {}
 
 func (x *VolumeInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[24]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1556,7 +1704,7 @@ func (x *VolumeInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeInfo.ProtoReflect.Descriptor instead.
 func (*VolumeInfo) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{24}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *VolumeInfo) GetName() string {
@@ -1603,7 +1751,7 @@ type ListVolumesResponse struct {
 
 func (x *ListVolumesResponse) Reset() {
 	*x = ListVolumesResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[25]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1615,7 +1763,7 @@ func (x *ListVolumesResponse) String() string {
 func (*ListVolumesResponse) ProtoMessage() {}
 
 func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[25]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1628,7 +1776,7 @@ func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesResponse.ProtoReflect.Descriptor instead.
 func (*ListVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{25}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ListVolumesResponse) GetVolumes() []*VolumeInfo {
@@ -1647,7 +1795,7 @@ type RemoveVolumeRequest struct {
 
 func (x *RemoveVolumeRequest) Reset() {
 	*x = RemoveVolumeRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[26]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1659,7 +1807,7 @@ func (x *RemoveVolumeRequest) String() string {
 func (*RemoveVolumeRequest) ProtoMessage() {}
 
 func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[26]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1672,7 +1820,7 @@ func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeRequest.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{26}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *RemoveVolumeRequest) GetName() string {
@@ -1690,7 +1838,7 @@ type RemoveVolumeResponse struct {
 
 func (x *RemoveVolumeResponse) Reset() {
 	*x = RemoveVolumeResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[27]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1702,7 +1850,7 @@ func (x *RemoveVolumeResponse) String() string {
 func (*RemoveVolumeResponse) ProtoMessage() {}
 
 func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[27]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1715,7 +1863,7 @@ func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeResponse.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{27}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{30}
 }
 
 type ContainerStats struct {
@@ -1729,7 +1877,7 @@ type ContainerStats struct {
 
 func (x *ContainerStats) Reset() {
 	*x = ContainerStats{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[28]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1741,7 +1889,7 @@ func (x *ContainerStats) String() string {
 func (*ContainerStats) ProtoMessage() {}
 
 func (x *ContainerStats) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[28]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1754,7 +1902,7 @@ func (x *ContainerStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerStats.ProtoReflect.Descriptor instead.
 func (*ContainerStats) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{28}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ContainerStats) GetAppName() string {
@@ -1786,7 +1934,7 @@ type ListContainerStatsRequest struct {
 
 func (x *ListContainerStatsRequest) Reset() {
 	*x = ListContainerStatsRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[29]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1798,7 +1946,7 @@ func (x *ListContainerStatsRequest) String() string {
 func (*ListContainerStatsRequest) ProtoMessage() {}
 
 func (x *ListContainerStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[29]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1811,7 +1959,7 @@ func (x *ListContainerStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListContainerStatsRequest.ProtoReflect.Descriptor instead.
 func (*ListContainerStatsRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{29}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{32}
 }
 
 type ListContainerStatsResponse struct {
@@ -1823,7 +1971,7 @@ type ListContainerStatsResponse struct {
 
 func (x *ListContainerStatsResponse) Reset() {
 	*x = ListContainerStatsResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[30]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1835,7 +1983,7 @@ func (x *ListContainerStatsResponse) String() string {
 func (*ListContainerStatsResponse) ProtoMessage() {}
 
 func (x *ListContainerStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[30]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1848,7 +1996,7 @@ func (x *ListContainerStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListContainerStatsResponse.ProtoReflect.Descriptor instead.
 func (*ListContainerStatsResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{30}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ListContainerStatsResponse) GetStats() []*ContainerStats {
@@ -1866,7 +2014,7 @@ type GetResourceStatsRequest struct {
 
 func (x *GetResourceStatsRequest) Reset() {
 	*x = GetResourceStatsRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[31]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1878,7 +2026,7 @@ func (x *GetResourceStatsRequest) String() string {
 func (*GetResourceStatsRequest) ProtoMessage() {}
 
 func (x *GetResourceStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[31]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1891,7 +2039,7 @@ func (x *GetResourceStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetResourceStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetResourceStatsRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{31}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{34}
 }
 
 type GetResourceStatsResponse struct {
@@ -1904,7 +2052,7 @@ type GetResourceStatsResponse struct {
 
 func (x *GetResourceStatsResponse) Reset() {
 	*x = GetResourceStatsResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[32]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1916,7 +2064,7 @@ func (x *GetResourceStatsResponse) String() string {
 func (*GetResourceStatsResponse) ProtoMessage() {}
 
 func (x *GetResourceStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[32]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1929,7 +2077,7 @@ func (x *GetResourceStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetResourceStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetResourceStatsResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{32}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetResourceStatsResponse) GetHost() *HostStats {
@@ -1962,7 +2110,7 @@ type HostStats struct {
 
 func (x *HostStats) Reset() {
 	*x = HostStats{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[33]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1974,7 +2122,7 @@ func (x *HostStats) String() string {
 func (*HostStats) ProtoMessage() {}
 
 func (x *HostStats) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[33]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1987,7 +2135,7 @@ func (x *HostStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostStats.ProtoReflect.Descriptor instead.
 func (*HostStats) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{33}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *HostStats) GetCpuTotalJiffies() uint64 {
@@ -2047,7 +2195,7 @@ type GpuStats struct {
 
 func (x *GpuStats) Reset() {
 	*x = GpuStats{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[34]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2059,7 +2207,7 @@ func (x *GpuStats) String() string {
 func (*GpuStats) ProtoMessage() {}
 
 func (x *GpuStats) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[34]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2072,7 +2220,7 @@ func (x *GpuStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GpuStats.ProtoReflect.Descriptor instead.
 func (*GpuStats) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{34}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GpuStats) GetIndex() uint32 {
@@ -2137,7 +2285,7 @@ type ResourceContainerStats struct {
 
 func (x *ResourceContainerStats) Reset() {
 	*x = ResourceContainerStats{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[35]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2149,7 +2297,7 @@ func (x *ResourceContainerStats) String() string {
 func (*ResourceContainerStats) ProtoMessage() {}
 
 func (x *ResourceContainerStats) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[35]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2162,7 +2310,7 @@ func (x *ResourceContainerStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceContainerStats.ProtoReflect.Descriptor instead.
 func (*ResourceContainerStats) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{35}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ResourceContainerStats) GetAppName() string {
@@ -2195,7 +2343,7 @@ type GetContainerPortsRequest struct {
 
 func (x *GetContainerPortsRequest) Reset() {
 	*x = GetContainerPortsRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[36]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2207,7 +2355,7 @@ func (x *GetContainerPortsRequest) String() string {
 func (*GetContainerPortsRequest) ProtoMessage() {}
 
 func (x *GetContainerPortsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[36]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2220,7 +2368,7 @@ func (x *GetContainerPortsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetContainerPortsRequest.ProtoReflect.Descriptor instead.
 func (*GetContainerPortsRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{36}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetContainerPortsRequest) GetAppName() string {
@@ -2239,7 +2387,7 @@ type GetContainerPortsResponse struct {
 
 func (x *GetContainerPortsResponse) Reset() {
 	*x = GetContainerPortsResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[37]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2251,7 +2399,7 @@ func (x *GetContainerPortsResponse) String() string {
 func (*GetContainerPortsResponse) ProtoMessage() {}
 
 func (x *GetContainerPortsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[37]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2264,7 +2412,7 @@ func (x *GetContainerPortsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetContainerPortsResponse.ProtoReflect.Descriptor instead.
 func (*GetContainerPortsResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{37}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetContainerPortsResponse) GetPorts() []*PortEntry {
@@ -2285,7 +2433,7 @@ type PortEntry struct {
 
 func (x *PortEntry) Reset() {
 	*x = PortEntry{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[38]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2297,7 +2445,7 @@ func (x *PortEntry) String() string {
 func (*PortEntry) ProtoMessage() {}
 
 func (x *PortEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[38]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2310,7 +2458,7 @@ func (x *PortEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PortEntry.ProtoReflect.Descriptor instead.
 func (*PortEntry) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{38}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *PortEntry) GetProtocol() string {
@@ -2343,7 +2491,7 @@ type MCPChunk struct {
 
 func (x *MCPChunk) Reset() {
 	*x = MCPChunk{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[39]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2355,7 +2503,7 @@ func (x *MCPChunk) String() string {
 func (*MCPChunk) ProtoMessage() {}
 
 func (x *MCPChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[39]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2368,7 +2516,7 @@ func (x *MCPChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MCPChunk.ProtoReflect.Descriptor instead.
 func (*MCPChunk) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{39}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *MCPChunk) GetData() []byte {
@@ -2386,7 +2534,7 @@ type RunContainerLayersResponse_Started struct {
 
 func (x *RunContainerLayersResponse_Started) Reset() {
 	*x = RunContainerLayersResponse_Started{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[40]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2398,7 +2546,7 @@ func (x *RunContainerLayersResponse_Started) String() string {
 func (*RunContainerLayersResponse_Started) ProtoMessage() {}
 
 func (x *RunContainerLayersResponse_Started) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[40]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2411,7 +2559,7 @@ func (x *RunContainerLayersResponse_Started) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use RunContainerLayersResponse_Started.ProtoReflect.Descriptor instead.
 func (*RunContainerLayersResponse_Started) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{18, 0}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{21, 0}
 }
 
 type RunContainerLayersResponse_ConsoleOutput struct {
@@ -2423,7 +2571,7 @@ type RunContainerLayersResponse_ConsoleOutput struct {
 
 func (x *RunContainerLayersResponse_ConsoleOutput) Reset() {
 	*x = RunContainerLayersResponse_ConsoleOutput{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[41]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2435,7 +2583,7 @@ func (x *RunContainerLayersResponse_ConsoleOutput) String() string {
 func (*RunContainerLayersResponse_ConsoleOutput) ProtoMessage() {}
 
 func (x *RunContainerLayersResponse_ConsoleOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[41]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2448,7 +2596,7 @@ func (x *RunContainerLayersResponse_ConsoleOutput) ProtoReflect() protoreflect.M
 
 // Deprecated: Use RunContainerLayersResponse_ConsoleOutput.ProtoReflect.Descriptor instead.
 func (*RunContainerLayersResponse_ConsoleOutput) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{18, 1}
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{21, 1}
 }
 
 func (x *RunContainerLayersResponse_ConsoleOutput) GetData() []byte {
@@ -2478,7 +2626,14 @@ const file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDes
 	"\x12WriteChunksRequest\x12\x12\n" +
 	"\x04hash\x18\x01 \x01(\fR\x04hash\x12\x12\n" +
 	"\x04data\x18\x02 \x01(\fR\x04data\"\x15\n" +
-	"\x13WriteChunksResponse\"9\n" +
+	"\x13WriteChunksResponse\"/\n" +
+	"\x12QueryLayersRequest\x12\x19\n" +
+	"\bdiff_ids\x18\x01 \x03(\tR\adiffIds\"V\n" +
+	"\x13QueryLayersResponse\x12?\n" +
+	"\apresent\x18\x01 \x03(\v2%.wendy.agent.services.v1.PresentLayerR\apresent\";\n" +
+	"\fPresentLayer\x12\x17\n" +
+	"\adiff_id\x18\x01 \x01(\tR\x06diffId\x12\x12\n" +
+	"\x04size\x18\x02 \x01(\x03R\x04size\"9\n" +
 	"\vLayerHeader\x12\x16\n" +
 	"\x06digest\x18\x01 \x01(\tR\x06digest\x12\x12\n" +
 	"\x04size\x18\x02 \x01(\x03R\x04size\"\x80\x03\n" +
@@ -2623,7 +2778,7 @@ const file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDes
 	"\x04port\x18\x02 \x01(\rR\x04port\x12\x18\n" +
 	"\aaddress\x18\x03 \x01(\tR\aaddress\"\x1e\n" +
 	"\bMCPChunk\x12\x12\n" +
-	"\x04data\x18\x01 \x01(\fR\x04data2\xab\x10\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data2\x95\x11\n" +
 	"\x15WendyContainerService\x12`\n" +
 	"\n" +
 	"ListLayers\x12*.wendy.agent.services.v1.ListLayersRequest\x1a$.wendy.agent.services.v1.LayerHeader0\x01\x12i\n" +
@@ -2644,7 +2799,8 @@ const file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDes
 	"\x11GetContainerPorts\x121.wendy.agent.services.v1.GetContainerPortsRequest\x1a2.wendy.agent.services.v1.GetContainerPortsResponse\x12U\n" +
 	"\tStreamMCP\x12!.wendy.agent.services.v1.MCPChunk\x1a!.wendy.agent.services.v1.MCPChunk(\x010\x01\x12h\n" +
 	"\vQueryChunks\x12+.wendy.agent.services.v1.QueryChunksRequest\x1a,.wendy.agent.services.v1.QueryChunksResponse\x12j\n" +
-	"\vWriteChunks\x12+.wendy.agent.services.v1.WriteChunksRequest\x1a,.wendy.agent.services.v1.WriteChunksResponse(\x01b\x06proto3"
+	"\vWriteChunks\x12+.wendy.agent.services.v1.WriteChunksRequest\x1a,.wendy.agent.services.v1.WriteChunksResponse(\x01\x12h\n" +
+	"\vQueryLayers\x12+.wendy.agent.services.v1.QueryLayersRequest\x1a,.wendy.agent.services.v1.QueryLayersResponseb\x06proto3"
 
 var (
 	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescOnce sync.Once
@@ -2659,7 +2815,7 @@ func file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDesc
 }
 
 var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
 var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_goTypes = []any{
 	(CreateContainerProgress_Phase)(0),               // 0: wendy.agent.services.v1.CreateContainerProgress.Phase
 	(RunContainerLayerHeader_CompressionType)(0),     // 1: wendy.agent.services.v1.RunContainerLayerHeader.CompressionType
@@ -2672,102 +2828,108 @@ var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_goTypes 
 	(*QueryChunksResponse)(nil),                      // 8: wendy.agent.services.v1.QueryChunksResponse
 	(*WriteChunksRequest)(nil),                       // 9: wendy.agent.services.v1.WriteChunksRequest
 	(*WriteChunksResponse)(nil),                      // 10: wendy.agent.services.v1.WriteChunksResponse
-	(*LayerHeader)(nil),                              // 11: wendy.agent.services.v1.LayerHeader
-	(*RunContainerLayersRequest)(nil),                // 12: wendy.agent.services.v1.RunContainerLayersRequest
-	(*CreateContainerRequest)(nil),                   // 13: wendy.agent.services.v1.CreateContainerRequest
-	(*CreateContainerResponse)(nil),                  // 14: wendy.agent.services.v1.CreateContainerResponse
-	(*CreateContainerProgress)(nil),                  // 15: wendy.agent.services.v1.CreateContainerProgress
-	(*CreateContainerProgressResponse)(nil),          // 16: wendy.agent.services.v1.CreateContainerProgressResponse
-	(*StartContainerRequest)(nil),                    // 17: wendy.agent.services.v1.StartContainerRequest
-	(*AttachContainerRequest)(nil),                   // 18: wendy.agent.services.v1.AttachContainerRequest
-	(*RunContainerLayerHeader)(nil),                  // 19: wendy.agent.services.v1.RunContainerLayerHeader
-	(*RunContainerLayersResponse)(nil),               // 20: wendy.agent.services.v1.RunContainerLayersResponse
-	(*StopContainerRequest)(nil),                     // 21: wendy.agent.services.v1.StopContainerRequest
-	(*StopContainerResponse)(nil),                    // 22: wendy.agent.services.v1.StopContainerResponse
-	(*DeleteContainerRequest)(nil),                   // 23: wendy.agent.services.v1.DeleteContainerRequest
-	(*DeleteContainerResponse)(nil),                  // 24: wendy.agent.services.v1.DeleteContainerResponse
-	(*ListVolumesRequest)(nil),                       // 25: wendy.agent.services.v1.ListVolumesRequest
-	(*VolumeInfo)(nil),                               // 26: wendy.agent.services.v1.VolumeInfo
-	(*ListVolumesResponse)(nil),                      // 27: wendy.agent.services.v1.ListVolumesResponse
-	(*RemoveVolumeRequest)(nil),                      // 28: wendy.agent.services.v1.RemoveVolumeRequest
-	(*RemoveVolumeResponse)(nil),                     // 29: wendy.agent.services.v1.RemoveVolumeResponse
-	(*ContainerStats)(nil),                           // 30: wendy.agent.services.v1.ContainerStats
-	(*ListContainerStatsRequest)(nil),                // 31: wendy.agent.services.v1.ListContainerStatsRequest
-	(*ListContainerStatsResponse)(nil),               // 32: wendy.agent.services.v1.ListContainerStatsResponse
-	(*GetResourceStatsRequest)(nil),                  // 33: wendy.agent.services.v1.GetResourceStatsRequest
-	(*GetResourceStatsResponse)(nil),                 // 34: wendy.agent.services.v1.GetResourceStatsResponse
-	(*HostStats)(nil),                                // 35: wendy.agent.services.v1.HostStats
-	(*GpuStats)(nil),                                 // 36: wendy.agent.services.v1.GpuStats
-	(*ResourceContainerStats)(nil),                   // 37: wendy.agent.services.v1.ResourceContainerStats
-	(*GetContainerPortsRequest)(nil),                 // 38: wendy.agent.services.v1.GetContainerPortsRequest
-	(*GetContainerPortsResponse)(nil),                // 39: wendy.agent.services.v1.GetContainerPortsResponse
-	(*PortEntry)(nil),                                // 40: wendy.agent.services.v1.PortEntry
-	(*MCPChunk)(nil),                                 // 41: wendy.agent.services.v1.MCPChunk
-	(*RunContainerLayersResponse_Started)(nil),       // 42: wendy.agent.services.v1.RunContainerLayersResponse.Started
-	(*RunContainerLayersResponse_ConsoleOutput)(nil), // 43: wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
-	(*AppContainer)(nil),                             // 44: AppContainer
-	(*RestartPolicy)(nil),                            // 45: RestartPolicy
+	(*QueryLayersRequest)(nil),                       // 11: wendy.agent.services.v1.QueryLayersRequest
+	(*QueryLayersResponse)(nil),                      // 12: wendy.agent.services.v1.QueryLayersResponse
+	(*PresentLayer)(nil),                             // 13: wendy.agent.services.v1.PresentLayer
+	(*LayerHeader)(nil),                              // 14: wendy.agent.services.v1.LayerHeader
+	(*RunContainerLayersRequest)(nil),                // 15: wendy.agent.services.v1.RunContainerLayersRequest
+	(*CreateContainerRequest)(nil),                   // 16: wendy.agent.services.v1.CreateContainerRequest
+	(*CreateContainerResponse)(nil),                  // 17: wendy.agent.services.v1.CreateContainerResponse
+	(*CreateContainerProgress)(nil),                  // 18: wendy.agent.services.v1.CreateContainerProgress
+	(*CreateContainerProgressResponse)(nil),          // 19: wendy.agent.services.v1.CreateContainerProgressResponse
+	(*StartContainerRequest)(nil),                    // 20: wendy.agent.services.v1.StartContainerRequest
+	(*AttachContainerRequest)(nil),                   // 21: wendy.agent.services.v1.AttachContainerRequest
+	(*RunContainerLayerHeader)(nil),                  // 22: wendy.agent.services.v1.RunContainerLayerHeader
+	(*RunContainerLayersResponse)(nil),               // 23: wendy.agent.services.v1.RunContainerLayersResponse
+	(*StopContainerRequest)(nil),                     // 24: wendy.agent.services.v1.StopContainerRequest
+	(*StopContainerResponse)(nil),                    // 25: wendy.agent.services.v1.StopContainerResponse
+	(*DeleteContainerRequest)(nil),                   // 26: wendy.agent.services.v1.DeleteContainerRequest
+	(*DeleteContainerResponse)(nil),                  // 27: wendy.agent.services.v1.DeleteContainerResponse
+	(*ListVolumesRequest)(nil),                       // 28: wendy.agent.services.v1.ListVolumesRequest
+	(*VolumeInfo)(nil),                               // 29: wendy.agent.services.v1.VolumeInfo
+	(*ListVolumesResponse)(nil),                      // 30: wendy.agent.services.v1.ListVolumesResponse
+	(*RemoveVolumeRequest)(nil),                      // 31: wendy.agent.services.v1.RemoveVolumeRequest
+	(*RemoveVolumeResponse)(nil),                     // 32: wendy.agent.services.v1.RemoveVolumeResponse
+	(*ContainerStats)(nil),                           // 33: wendy.agent.services.v1.ContainerStats
+	(*ListContainerStatsRequest)(nil),                // 34: wendy.agent.services.v1.ListContainerStatsRequest
+	(*ListContainerStatsResponse)(nil),               // 35: wendy.agent.services.v1.ListContainerStatsResponse
+	(*GetResourceStatsRequest)(nil),                  // 36: wendy.agent.services.v1.GetResourceStatsRequest
+	(*GetResourceStatsResponse)(nil),                 // 37: wendy.agent.services.v1.GetResourceStatsResponse
+	(*HostStats)(nil),                                // 38: wendy.agent.services.v1.HostStats
+	(*GpuStats)(nil),                                 // 39: wendy.agent.services.v1.GpuStats
+	(*ResourceContainerStats)(nil),                   // 40: wendy.agent.services.v1.ResourceContainerStats
+	(*GetContainerPortsRequest)(nil),                 // 41: wendy.agent.services.v1.GetContainerPortsRequest
+	(*GetContainerPortsResponse)(nil),                // 42: wendy.agent.services.v1.GetContainerPortsResponse
+	(*PortEntry)(nil),                                // 43: wendy.agent.services.v1.PortEntry
+	(*MCPChunk)(nil),                                 // 44: wendy.agent.services.v1.MCPChunk
+	(*RunContainerLayersResponse_Started)(nil),       // 45: wendy.agent.services.v1.RunContainerLayersResponse.Started
+	(*RunContainerLayersResponse_ConsoleOutput)(nil), // 46: wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
+	(*AppContainer)(nil),                             // 47: AppContainer
+	(*RestartPolicy)(nil),                            // 48: RestartPolicy
 }
 var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_depIdxs = []int32{
-	44, // 0: wendy.agent.services.v1.ListContainersResponse.container:type_name -> AppContainer
-	19, // 1: wendy.agent.services.v1.RunContainerLayersRequest.layers:type_name -> wendy.agent.services.v1.RunContainerLayerHeader
-	45, // 2: wendy.agent.services.v1.RunContainerLayersRequest.restart_policy:type_name -> RestartPolicy
-	45, // 3: wendy.agent.services.v1.CreateContainerRequest.restart_policy:type_name -> RestartPolicy
-	0,  // 4: wendy.agent.services.v1.CreateContainerProgress.phase:type_name -> wendy.agent.services.v1.CreateContainerProgress.Phase
-	15, // 5: wendy.agent.services.v1.CreateContainerProgressResponse.progress:type_name -> wendy.agent.services.v1.CreateContainerProgress
-	14, // 6: wendy.agent.services.v1.CreateContainerProgressResponse.completed:type_name -> wendy.agent.services.v1.CreateContainerResponse
-	45, // 7: wendy.agent.services.v1.StartContainerRequest.restart_policy:type_name -> RestartPolicy
-	1,  // 8: wendy.agent.services.v1.RunContainerLayerHeader.compression:type_name -> wendy.agent.services.v1.RunContainerLayerHeader.CompressionType
-	42, // 9: wendy.agent.services.v1.RunContainerLayersResponse.started:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.Started
-	43, // 10: wendy.agent.services.v1.RunContainerLayersResponse.stdout_output:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
-	43, // 11: wendy.agent.services.v1.RunContainerLayersResponse.stderr_output:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
-	26, // 12: wendy.agent.services.v1.ListVolumesResponse.volumes:type_name -> wendy.agent.services.v1.VolumeInfo
-	30, // 13: wendy.agent.services.v1.ListContainerStatsResponse.stats:type_name -> wendy.agent.services.v1.ContainerStats
-	35, // 14: wendy.agent.services.v1.GetResourceStatsResponse.host:type_name -> wendy.agent.services.v1.HostStats
-	37, // 15: wendy.agent.services.v1.GetResourceStatsResponse.containers:type_name -> wendy.agent.services.v1.ResourceContainerStats
-	36, // 16: wendy.agent.services.v1.HostStats.gpus:type_name -> wendy.agent.services.v1.GpuStats
-	40, // 17: wendy.agent.services.v1.GetContainerPortsResponse.ports:type_name -> wendy.agent.services.v1.PortEntry
-	4,  // 18: wendy.agent.services.v1.WendyContainerService.ListLayers:input_type -> wendy.agent.services.v1.ListLayersRequest
-	5,  // 19: wendy.agent.services.v1.WendyContainerService.WriteLayer:input_type -> wendy.agent.services.v1.WriteLayerRequest
-	13, // 20: wendy.agent.services.v1.WendyContainerService.CreateContainer:input_type -> wendy.agent.services.v1.CreateContainerRequest
-	13, // 21: wendy.agent.services.v1.WendyContainerService.CreateContainerWithProgress:input_type -> wendy.agent.services.v1.CreateContainerRequest
-	12, // 22: wendy.agent.services.v1.WendyContainerService.RunContainer:input_type -> wendy.agent.services.v1.RunContainerLayersRequest
-	17, // 23: wendy.agent.services.v1.WendyContainerService.StartContainer:input_type -> wendy.agent.services.v1.StartContainerRequest
-	18, // 24: wendy.agent.services.v1.WendyContainerService.AttachContainer:input_type -> wendy.agent.services.v1.AttachContainerRequest
-	21, // 25: wendy.agent.services.v1.WendyContainerService.StopContainer:input_type -> wendy.agent.services.v1.StopContainerRequest
-	23, // 26: wendy.agent.services.v1.WendyContainerService.DeleteContainer:input_type -> wendy.agent.services.v1.DeleteContainerRequest
-	2,  // 27: wendy.agent.services.v1.WendyContainerService.ListContainers:input_type -> wendy.agent.services.v1.ListContainersRequest
-	25, // 28: wendy.agent.services.v1.WendyContainerService.ListVolumes:input_type -> wendy.agent.services.v1.ListVolumesRequest
-	28, // 29: wendy.agent.services.v1.WendyContainerService.RemoveVolume:input_type -> wendy.agent.services.v1.RemoveVolumeRequest
-	31, // 30: wendy.agent.services.v1.WendyContainerService.ListContainerStats:input_type -> wendy.agent.services.v1.ListContainerStatsRequest
-	33, // 31: wendy.agent.services.v1.WendyContainerService.GetResourceStats:input_type -> wendy.agent.services.v1.GetResourceStatsRequest
-	38, // 32: wendy.agent.services.v1.WendyContainerService.GetContainerPorts:input_type -> wendy.agent.services.v1.GetContainerPortsRequest
-	41, // 33: wendy.agent.services.v1.WendyContainerService.StreamMCP:input_type -> wendy.agent.services.v1.MCPChunk
-	7,  // 34: wendy.agent.services.v1.WendyContainerService.QueryChunks:input_type -> wendy.agent.services.v1.QueryChunksRequest
-	9,  // 35: wendy.agent.services.v1.WendyContainerService.WriteChunks:input_type -> wendy.agent.services.v1.WriteChunksRequest
-	11, // 36: wendy.agent.services.v1.WendyContainerService.ListLayers:output_type -> wendy.agent.services.v1.LayerHeader
-	6,  // 37: wendy.agent.services.v1.WendyContainerService.WriteLayer:output_type -> wendy.agent.services.v1.WriteLayerResponse
-	14, // 38: wendy.agent.services.v1.WendyContainerService.CreateContainer:output_type -> wendy.agent.services.v1.CreateContainerResponse
-	16, // 39: wendy.agent.services.v1.WendyContainerService.CreateContainerWithProgress:output_type -> wendy.agent.services.v1.CreateContainerProgressResponse
-	20, // 40: wendy.agent.services.v1.WendyContainerService.RunContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
-	20, // 41: wendy.agent.services.v1.WendyContainerService.StartContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
-	20, // 42: wendy.agent.services.v1.WendyContainerService.AttachContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
-	22, // 43: wendy.agent.services.v1.WendyContainerService.StopContainer:output_type -> wendy.agent.services.v1.StopContainerResponse
-	24, // 44: wendy.agent.services.v1.WendyContainerService.DeleteContainer:output_type -> wendy.agent.services.v1.DeleteContainerResponse
-	3,  // 45: wendy.agent.services.v1.WendyContainerService.ListContainers:output_type -> wendy.agent.services.v1.ListContainersResponse
-	27, // 46: wendy.agent.services.v1.WendyContainerService.ListVolumes:output_type -> wendy.agent.services.v1.ListVolumesResponse
-	29, // 47: wendy.agent.services.v1.WendyContainerService.RemoveVolume:output_type -> wendy.agent.services.v1.RemoveVolumeResponse
-	32, // 48: wendy.agent.services.v1.WendyContainerService.ListContainerStats:output_type -> wendy.agent.services.v1.ListContainerStatsResponse
-	34, // 49: wendy.agent.services.v1.WendyContainerService.GetResourceStats:output_type -> wendy.agent.services.v1.GetResourceStatsResponse
-	39, // 50: wendy.agent.services.v1.WendyContainerService.GetContainerPorts:output_type -> wendy.agent.services.v1.GetContainerPortsResponse
-	41, // 51: wendy.agent.services.v1.WendyContainerService.StreamMCP:output_type -> wendy.agent.services.v1.MCPChunk
-	8,  // 52: wendy.agent.services.v1.WendyContainerService.QueryChunks:output_type -> wendy.agent.services.v1.QueryChunksResponse
-	10, // 53: wendy.agent.services.v1.WendyContainerService.WriteChunks:output_type -> wendy.agent.services.v1.WriteChunksResponse
-	36, // [36:54] is the sub-list for method output_type
-	18, // [18:36] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	47, // 0: wendy.agent.services.v1.ListContainersResponse.container:type_name -> AppContainer
+	13, // 1: wendy.agent.services.v1.QueryLayersResponse.present:type_name -> wendy.agent.services.v1.PresentLayer
+	22, // 2: wendy.agent.services.v1.RunContainerLayersRequest.layers:type_name -> wendy.agent.services.v1.RunContainerLayerHeader
+	48, // 3: wendy.agent.services.v1.RunContainerLayersRequest.restart_policy:type_name -> RestartPolicy
+	48, // 4: wendy.agent.services.v1.CreateContainerRequest.restart_policy:type_name -> RestartPolicy
+	0,  // 5: wendy.agent.services.v1.CreateContainerProgress.phase:type_name -> wendy.agent.services.v1.CreateContainerProgress.Phase
+	18, // 6: wendy.agent.services.v1.CreateContainerProgressResponse.progress:type_name -> wendy.agent.services.v1.CreateContainerProgress
+	17, // 7: wendy.agent.services.v1.CreateContainerProgressResponse.completed:type_name -> wendy.agent.services.v1.CreateContainerResponse
+	48, // 8: wendy.agent.services.v1.StartContainerRequest.restart_policy:type_name -> RestartPolicy
+	1,  // 9: wendy.agent.services.v1.RunContainerLayerHeader.compression:type_name -> wendy.agent.services.v1.RunContainerLayerHeader.CompressionType
+	45, // 10: wendy.agent.services.v1.RunContainerLayersResponse.started:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.Started
+	46, // 11: wendy.agent.services.v1.RunContainerLayersResponse.stdout_output:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
+	46, // 12: wendy.agent.services.v1.RunContainerLayersResponse.stderr_output:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
+	29, // 13: wendy.agent.services.v1.ListVolumesResponse.volumes:type_name -> wendy.agent.services.v1.VolumeInfo
+	33, // 14: wendy.agent.services.v1.ListContainerStatsResponse.stats:type_name -> wendy.agent.services.v1.ContainerStats
+	38, // 15: wendy.agent.services.v1.GetResourceStatsResponse.host:type_name -> wendy.agent.services.v1.HostStats
+	40, // 16: wendy.agent.services.v1.GetResourceStatsResponse.containers:type_name -> wendy.agent.services.v1.ResourceContainerStats
+	39, // 17: wendy.agent.services.v1.HostStats.gpus:type_name -> wendy.agent.services.v1.GpuStats
+	43, // 18: wendy.agent.services.v1.GetContainerPortsResponse.ports:type_name -> wendy.agent.services.v1.PortEntry
+	4,  // 19: wendy.agent.services.v1.WendyContainerService.ListLayers:input_type -> wendy.agent.services.v1.ListLayersRequest
+	5,  // 20: wendy.agent.services.v1.WendyContainerService.WriteLayer:input_type -> wendy.agent.services.v1.WriteLayerRequest
+	16, // 21: wendy.agent.services.v1.WendyContainerService.CreateContainer:input_type -> wendy.agent.services.v1.CreateContainerRequest
+	16, // 22: wendy.agent.services.v1.WendyContainerService.CreateContainerWithProgress:input_type -> wendy.agent.services.v1.CreateContainerRequest
+	15, // 23: wendy.agent.services.v1.WendyContainerService.RunContainer:input_type -> wendy.agent.services.v1.RunContainerLayersRequest
+	20, // 24: wendy.agent.services.v1.WendyContainerService.StartContainer:input_type -> wendy.agent.services.v1.StartContainerRequest
+	21, // 25: wendy.agent.services.v1.WendyContainerService.AttachContainer:input_type -> wendy.agent.services.v1.AttachContainerRequest
+	24, // 26: wendy.agent.services.v1.WendyContainerService.StopContainer:input_type -> wendy.agent.services.v1.StopContainerRequest
+	26, // 27: wendy.agent.services.v1.WendyContainerService.DeleteContainer:input_type -> wendy.agent.services.v1.DeleteContainerRequest
+	2,  // 28: wendy.agent.services.v1.WendyContainerService.ListContainers:input_type -> wendy.agent.services.v1.ListContainersRequest
+	28, // 29: wendy.agent.services.v1.WendyContainerService.ListVolumes:input_type -> wendy.agent.services.v1.ListVolumesRequest
+	31, // 30: wendy.agent.services.v1.WendyContainerService.RemoveVolume:input_type -> wendy.agent.services.v1.RemoveVolumeRequest
+	34, // 31: wendy.agent.services.v1.WendyContainerService.ListContainerStats:input_type -> wendy.agent.services.v1.ListContainerStatsRequest
+	36, // 32: wendy.agent.services.v1.WendyContainerService.GetResourceStats:input_type -> wendy.agent.services.v1.GetResourceStatsRequest
+	41, // 33: wendy.agent.services.v1.WendyContainerService.GetContainerPorts:input_type -> wendy.agent.services.v1.GetContainerPortsRequest
+	44, // 34: wendy.agent.services.v1.WendyContainerService.StreamMCP:input_type -> wendy.agent.services.v1.MCPChunk
+	7,  // 35: wendy.agent.services.v1.WendyContainerService.QueryChunks:input_type -> wendy.agent.services.v1.QueryChunksRequest
+	9,  // 36: wendy.agent.services.v1.WendyContainerService.WriteChunks:input_type -> wendy.agent.services.v1.WriteChunksRequest
+	11, // 37: wendy.agent.services.v1.WendyContainerService.QueryLayers:input_type -> wendy.agent.services.v1.QueryLayersRequest
+	14, // 38: wendy.agent.services.v1.WendyContainerService.ListLayers:output_type -> wendy.agent.services.v1.LayerHeader
+	6,  // 39: wendy.agent.services.v1.WendyContainerService.WriteLayer:output_type -> wendy.agent.services.v1.WriteLayerResponse
+	17, // 40: wendy.agent.services.v1.WendyContainerService.CreateContainer:output_type -> wendy.agent.services.v1.CreateContainerResponse
+	19, // 41: wendy.agent.services.v1.WendyContainerService.CreateContainerWithProgress:output_type -> wendy.agent.services.v1.CreateContainerProgressResponse
+	23, // 42: wendy.agent.services.v1.WendyContainerService.RunContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
+	23, // 43: wendy.agent.services.v1.WendyContainerService.StartContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
+	23, // 44: wendy.agent.services.v1.WendyContainerService.AttachContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
+	25, // 45: wendy.agent.services.v1.WendyContainerService.StopContainer:output_type -> wendy.agent.services.v1.StopContainerResponse
+	27, // 46: wendy.agent.services.v1.WendyContainerService.DeleteContainer:output_type -> wendy.agent.services.v1.DeleteContainerResponse
+	3,  // 47: wendy.agent.services.v1.WendyContainerService.ListContainers:output_type -> wendy.agent.services.v1.ListContainersResponse
+	30, // 48: wendy.agent.services.v1.WendyContainerService.ListVolumes:output_type -> wendy.agent.services.v1.ListVolumesResponse
+	32, // 49: wendy.agent.services.v1.WendyContainerService.RemoveVolume:output_type -> wendy.agent.services.v1.RemoveVolumeResponse
+	35, // 50: wendy.agent.services.v1.WendyContainerService.ListContainerStats:output_type -> wendy.agent.services.v1.ListContainerStatsResponse
+	37, // 51: wendy.agent.services.v1.WendyContainerService.GetResourceStats:output_type -> wendy.agent.services.v1.GetResourceStatsResponse
+	42, // 52: wendy.agent.services.v1.WendyContainerService.GetContainerPorts:output_type -> wendy.agent.services.v1.GetContainerPortsResponse
+	44, // 53: wendy.agent.services.v1.WendyContainerService.StreamMCP:output_type -> wendy.agent.services.v1.MCPChunk
+	8,  // 54: wendy.agent.services.v1.WendyContainerService.QueryChunks:output_type -> wendy.agent.services.v1.QueryChunksResponse
+	10, // 55: wendy.agent.services.v1.WendyContainerService.WriteChunks:output_type -> wendy.agent.services.v1.WriteChunksResponse
+	12, // 56: wendy.agent.services.v1.WendyContainerService.QueryLayers:output_type -> wendy.agent.services.v1.QueryLayersResponse
+	38, // [38:57] is the sub-list for method output_type
+	19, // [19:38] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_init() }
@@ -2776,30 +2938,30 @@ func file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_init() 
 		return
 	}
 	file_wendy_agent_services_v1_shared_proto_init()
-	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[10].OneofWrappers = []any{}
-	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[11].OneofWrappers = []any{}
-	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[14].OneofWrappers = []any{
+	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[13].OneofWrappers = []any{}
+	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[14].OneofWrappers = []any{}
+	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[17].OneofWrappers = []any{
 		(*CreateContainerProgressResponse_Progress)(nil),
 		(*CreateContainerProgressResponse_Completed)(nil),
 	}
-	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[15].OneofWrappers = []any{}
-	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[16].OneofWrappers = []any{
+	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[18].OneofWrappers = []any{}
+	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[19].OneofWrappers = []any{
 		(*AttachContainerRequest_AppName)(nil),
 		(*AttachContainerRequest_StdinData)(nil),
 	}
-	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[18].OneofWrappers = []any{
+	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[21].OneofWrappers = []any{
 		(*RunContainerLayersResponse_Started_)(nil),
 		(*RunContainerLayersResponse_StdoutOutput)(nil),
 		(*RunContainerLayersResponse_StderrOutput)(nil),
 	}
-	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[34].OneofWrappers = []any{}
+	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[37].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDesc), len(file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   42,
+			NumMessages:   45,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/agentpb/wendy_agent_v1_container_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_container_service_grpc.pb.go
@@ -37,6 +37,7 @@ const (
 	WendyContainerService_StreamMCP_FullMethodName                   = "/wendy.agent.services.v1.WendyContainerService/StreamMCP"
 	WendyContainerService_QueryChunks_FullMethodName                 = "/wendy.agent.services.v1.WendyContainerService/QueryChunks"
 	WendyContainerService_WriteChunks_FullMethodName                 = "/wendy.agent.services.v1.WendyContainerService/WriteChunks"
+	WendyContainerService_QueryLayers_FullMethodName                 = "/wendy.agent.services.v1.WendyContainerService/QueryLayers"
 )
 
 // WendyContainerServiceClient is the client API for WendyContainerService service.
@@ -61,6 +62,11 @@ type WendyContainerServiceClient interface {
 	StreamMCP(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[MCPChunk, MCPChunk], error)
 	QueryChunks(ctx context.Context, in *QueryChunksRequest, opts ...grpc.CallOption) (*QueryChunksResponse, error)
 	WriteChunks(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[WriteChunksRequest, WriteChunksResponse], error)
+	// QueryLayers reports which uncompressed layers (by diff ID) the device
+	// already has in its content store, with their sizes. The CLI uses this to
+	// skip decompressing and content-chunking layers the device can reuse as-is
+	// — for those layers no dedup is possible, so chunking would be pure waste.
+	QueryLayers(ctx context.Context, in *QueryLayersRequest, opts ...grpc.CallOption) (*QueryLayersResponse, error)
 }
 
 type wendyContainerServiceClient struct {
@@ -308,6 +314,16 @@ func (c *wendyContainerServiceClient) WriteChunks(ctx context.Context, opts ...g
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type WendyContainerService_WriteChunksClient = grpc.ClientStreamingClient[WriteChunksRequest, WriteChunksResponse]
 
+func (c *wendyContainerServiceClient) QueryLayers(ctx context.Context, in *QueryLayersRequest, opts ...grpc.CallOption) (*QueryLayersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(QueryLayersResponse)
+	err := c.cc.Invoke(ctx, WendyContainerService_QueryLayers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // WendyContainerServiceServer is the server API for WendyContainerService service.
 // All implementations must embed UnimplementedWendyContainerServiceServer
 // for forward compatibility.
@@ -330,6 +346,11 @@ type WendyContainerServiceServer interface {
 	StreamMCP(grpc.BidiStreamingServer[MCPChunk, MCPChunk]) error
 	QueryChunks(context.Context, *QueryChunksRequest) (*QueryChunksResponse, error)
 	WriteChunks(grpc.ClientStreamingServer[WriteChunksRequest, WriteChunksResponse]) error
+	// QueryLayers reports which uncompressed layers (by diff ID) the device
+	// already has in its content store, with their sizes. The CLI uses this to
+	// skip decompressing and content-chunking layers the device can reuse as-is
+	// — for those layers no dedup is possible, so chunking would be pure waste.
+	QueryLayers(context.Context, *QueryLayersRequest) (*QueryLayersResponse, error)
 	mustEmbedUnimplementedWendyContainerServiceServer()
 }
 
@@ -393,6 +414,9 @@ func (UnimplementedWendyContainerServiceServer) QueryChunks(context.Context, *Qu
 }
 func (UnimplementedWendyContainerServiceServer) WriteChunks(grpc.ClientStreamingServer[WriteChunksRequest, WriteChunksResponse]) error {
 	return status.Error(codes.Unimplemented, "method WriteChunks not implemented")
+}
+func (UnimplementedWendyContainerServiceServer) QueryLayers(context.Context, *QueryLayersRequest) (*QueryLayersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method QueryLayers not implemented")
 }
 func (UnimplementedWendyContainerServiceServer) mustEmbedUnimplementedWendyContainerServiceServer() {}
 func (UnimplementedWendyContainerServiceServer) testEmbeddedByValue()                               {}
@@ -660,6 +684,24 @@ func _WendyContainerService_WriteChunks_Handler(srv interface{}, stream grpc.Ser
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type WendyContainerService_WriteChunksServer = grpc.ClientStreamingServer[WriteChunksRequest, WriteChunksResponse]
 
+func _WendyContainerService_QueryLayers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryLayersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendyContainerServiceServer).QueryLayers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendyContainerService_QueryLayers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendyContainerServiceServer).QueryLayers(ctx, req.(*QueryLayersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // WendyContainerService_ServiceDesc is the grpc.ServiceDesc for WendyContainerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -702,6 +744,10 @@ var WendyContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "QueryChunks",
 			Handler:    _WendyContainerService_QueryChunks_Handler,
+		},
+		{
+			MethodName: "QueryLayers",
+			Handler:    _WendyContainerService_QueryLayers_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{


### PR DESCRIPTION
## What

During `wendy run`, the chunk-diff push path (`deployByChunkDiff` → `pushLayersByChunks`) decompresses and FastCDC-chunks **every** fresh image layer before asking the device which chunks it lacks. For a layer the device already has in full, that work yields zero dedup — it's pure CPU waste, and shipping uncompressed chunk bytes is actually *worse* than a registry push.

This adds two cheap pre-checks that run **before** any decompress/chunk work, to detect when CBC can't help:

1. **Capability probe** — a single empty `QueryChunks` up front. An old agent returns `Unimplemented`, so `deployByChunkDiff` falls back to a registry push *before* wasting the first layer (previously this was only discovered after chunking layer 1).

2. **Layer pre-check (new `QueryLayers` RPC)** — the CLI reads each layer's uncompressed digest from the OCI image config's `rootfs.diff_ids` (**no decompression**), asks the device which layers it already holds, and for present layers emits a reassembly header directly — skipping decompress, chunk, and transfer entirely. The device reports each present layer's uncompressed size from its content store, so the header is correct without the CLI decompressing to learn it.

## How it stays correct & compatible

- A present-layer header (`Digest=DiffId=diffID`, device-reported `Size`, `COMPRESSION_NONE`, no `chunk_hashes`) is byte-for-byte consistent with what the existing chunk path emits, so `AssembleImage` references the already-present blob correctly and `RunContainer` skips reassembly.
- `rootfs.diff_ids` is only trusted when its count matches the manifest layers (OCI spec alignment); otherwise the layer falls back to the chunk path.
- **Backward compatible both directions:** new CLI + old agent (`QueryLayers` Unimplemented → chunk all); old CLI + new agent (unchanged). Any pre-check error degrades to chunking every layer.

## Tests

`go test ./internal/cli/commands ./internal/agent/services ./internal/agent/containerd` and the chunk-diff redeploy integration test all pass. New tests cover: present-layer skip (proves no decompression), probe-Unimplemented fallback, `QueryLayers` Unimplemented default, agent-side `QueryLayers` mapping, and `diff_ids` parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)