### PR TITLE
fix(agent): Phase 0 security hardening (WDY-1009, WDY-1010, WDY-1093, WDY-1102)

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -146,7 +146,10 @@ func main() {
 	if dbusproxy.IsAvailable() {
 		proxyMgr = dbusproxy.NewManager(logger)
 	} else {
-		logger.Warn("xdg-dbus-proxy not found, Bluetooth containers will have unfiltered D-Bus access")
+		// WDY-1093: without xdg-dbus-proxy there is no way to scope D-Bus to
+		// org.bluez, so containers declaring the bluetooth entitlement are
+		// refused rather than started with unfiltered access.
+		logger.Warn("xdg-dbus-proxy not found; containers with the bluetooth entitlement will be refused")
 	}
 
 	// Initialize containerd client (best-effort; may fail on non-Linux or without containerd).

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -445,9 +445,15 @@ func (c *Client) AssembleImage(ctx context.Context, imageName string, layers []*
 }
 
 // wrapWithDebugpy modifies the command args to run through debugpy for remote debugging.
-// It injects "-m debugpy --listen 0.0.0.0:5678" after the Python binary.
+// It injects "-m debugpy --listen 127.0.0.1:5678" after the Python binary.
+//
+// SECURITY (WDY-1010): the listener binds loopback only, never 0.0.0.0. debugpy
+// exposes an unauthenticated DAP endpoint with full Python RCE; binding all
+// interfaces made that reachable by anyone on the device's network during a
+// debug session. Remote attach reaches the listener through a device-side
+// tunnel (e.g. SSH/`wendy` port-forward) terminating on the device's loopback.
 func wrapWithDebugpy(args []string) []string {
-	debugpyArgs := []string{"-m", "debugpy", "--listen", "0.0.0.0:5678"}
+	debugpyArgs := []string{"-m", "debugpy", "--listen", "127.0.0.1:5678"}
 
 	if len(args) > 0 {
 		base := args[0]
@@ -455,7 +461,7 @@ func wrapWithDebugpy(args []string) []string {
 			base = base[i+1:]
 		}
 		if base == "python" || base == "python3" || strings.HasPrefix(base, "python3.") {
-			// python3 app.py -> python3 -m debugpy --listen 0.0.0.0:5678 app.py
+			// python3 app.py -> python3 -m debugpy --listen 127.0.0.1:5678 app.py
 			result := make([]string, 0, len(args)+len(debugpyArgs))
 			result = append(result, args[0])
 			result = append(result, debugpyArgs...)
@@ -631,6 +637,12 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	// bluetooth entitlement verbatim — reconstructing it from appID alone would
 	// drop the service suffix and runc would fail with a missing bind-mount
 	// source.
+	// SECURITY (WDY-1093): refuse to start a bluetooth container when the D-Bus
+	// proxy is unavailable, rather than silently starting it without the filter.
+	if err := c.requireDBusProxy(appCfg, containerName); err != nil {
+		return err
+	}
+
 	var dbusProxyStarted bool
 	var dbusProxySocketDir string
 	if c.proxyManager != nil && hasBluetooth(appCfg) {
@@ -861,6 +873,14 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	// same node, and runc mknod()s each entry, so a duplicate path would fail
 	// container creation with EEXIST.
 	localoci.DedupeDevices(spec)
+
+	// SECURITY (WDY-1102): backstop against any mount whose source resolves into
+	// containerd's runtime directory (the control socket is a host-escape vector).
+	// Runs on the fully assembled spec — entitlement, shared-SHM, and default
+	// mounts — immediately before it is handed to the runtime.
+	if err := localoci.ValidateMounts(spec); err != nil {
+		return err
+	}
 
 	// Serialize our custom OCI spec to JSON for WithSpecFromBytes.
 	specJSON, err := json.Marshal(spec)
@@ -1247,13 +1267,6 @@ func (c *Client) StartContainerWithStdin(ctx context.Context, appName string, st
 	return outputCh, nil
 }
 
-func shellCommand() (string, string) {
-	if runtime.GOOS == "windows" {
-		return "cmd.exe", "/C"
-	}
-	return "sh", "-c"
-}
-
 var deviceHostnameWithSuffix = func() string {
 	h, err := os.Hostname()
 	if err != nil || h == "" {
@@ -1513,8 +1526,17 @@ func expandAgentHook(command, appName string) string {
 	})
 }
 
-var startPostStartHookCommand = func(shell, flag, command string) (func() error, error) {
-	cmd := exec.Command(shell, flag, command)
+var startPostStartHookCommand = func(argv []string) (func() error, error) {
+	// SECURITY (WDY-1009): exec the hook directly via argv. The command must
+	// never be passed to a shell — doing so would let any app's wendy.json
+	// inject arbitrary commands that run as the agent (root) on the host,
+	// bypassing the container sandbox and entitlement boundary.
+	if len(argv) == 0 {
+		// Keep the argv[0] invariant local to the runner so a future caller
+		// gets an error rather than a panic.
+		return nil, errors.New("postStart hook argv is empty")
+	}
+	cmd := exec.Command(argv[0], argv[1:]...)
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
@@ -1526,9 +1548,32 @@ func (c *Client) startPostStartAgentHook(command, appName string) bool {
 		return false
 	}
 
-	expanded := expandAgentHook(command, appName)
-	shell, flag := shellCommand()
-	wait, err := startPostStartHookCommand(shell, flag, expanded)
+	// Expand ${WENDY_*}/env references, then split into argv on whitespace.
+	// Because the result is exec'd directly (no shell), shell metacharacters in
+	// the command or in any expanded value are inert — they become literal
+	// arguments rather than new commands.
+	argv := strings.Fields(expandAgentHook(command, appName))
+	if len(argv) == 0 {
+		// Log the raw (pre-expansion) command, not the expanded value: it is the
+		// developer-authored wendy.json string (variable references, not their
+		// expanded values), so it is safe to log and tells the operator which
+		// hook misfired.
+		c.logger.Warn("postStart agent hook expanded to an empty command; skipping",
+			zap.String("app_name", appName),
+			zap.String("configured_command", command),
+		)
+		return false
+	}
+	// strings.Fields does not honor shell quoting, so a quoted argument is split
+	// on whitespace. Warn rather than mis-execute silently; quoting users should
+	// move the logic into a script file.
+	if strings.ContainsAny(command, `"'`) {
+		c.logger.Warn("postStart agent hook contains quote characters; quoting is not honored and arguments are split on whitespace — move shell logic into a script file",
+			zap.String("app_name", appName),
+			zap.String("configured_command", command),
+		)
+	}
+	wait, err := startPostStartHookCommand(argv)
 	if err != nil {
 		c.logger.Warn("Failed to start postStart agent hook",
 			zap.String("app_name", appName),
@@ -2609,4 +2654,17 @@ func hasBluetooth(cfg *appconfig.AppConfig) bool {
 		}
 	}
 	return false
+}
+
+// requireDBusProxy enforces the D-Bus sandboxing invariant for WDY-1093: a
+// container that declares the bluetooth (D-Bus) entitlement may only start when
+// xdg-dbus-proxy is available to scope D-Bus to org.bluez. When the proxy
+// manager is absent, starting the container would silently break bluetooth (or,
+// in older builds, grant unfiltered system-bus access), so refuse loudly
+// instead of degrading silently. Returns nil when it is safe to proceed.
+func (c *Client) requireDBusProxy(cfg *appconfig.AppConfig, containerName string) error {
+	if hasBluetooth(cfg) && c.proxyManager == nil {
+		return fmt.Errorf("cannot start container %q: the bluetooth entitlement requires xdg-dbus-proxy to filter D-Bus access, which is not available on this device", containerName)
+	}
+	return nil
 }

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -2,15 +2,47 @@ package containerd
 
 import (
 	"errors"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/wendylabsinc/wendy/go/internal/agent/dbusproxy"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+// TestRequireDBusProxyRefusesBluetoothWithoutProxy is the regression test for
+// WDY-1093: a container that declares the bluetooth (D-Bus) entitlement must be
+// refused when xdg-dbus-proxy is unavailable. Without the proxy there is no way
+// to scope D-Bus to org.bluez, so starting the container would silently break
+// bluetooth (or, in older builds, expose the unfiltered system bus). The agent
+// must fail loudly instead of degrading silently.
+func TestRequireDBusProxyRefusesBluetoothWithoutProxy(t *testing.T) {
+	client := &Client{logger: zap.NewNop(), proxyManager: nil}
+	cfg := &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementBluetooth}}}
+	if err := client.requireDBusProxy(cfg, "demo-app"); err == nil {
+		t.Fatal("expected error when bluetooth entitlement is declared but xdg-dbus-proxy is unavailable")
+	}
+}
+
+func TestRequireDBusProxyAllowsBluetoothWithProxy(t *testing.T) {
+	client := &Client{logger: zap.NewNop(), proxyManager: dbusproxy.NewManager(zap.NewNop())}
+	cfg := &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementBluetooth}}}
+	if err := client.requireDBusProxy(cfg, "demo-app"); err != nil {
+		t.Fatalf("expected no error when xdg-dbus-proxy is available; got %v", err)
+	}
+}
+
+func TestRequireDBusProxyAllowsNonBluetoothWithoutProxy(t *testing.T) {
+	client := &Client{logger: zap.NewNop(), proxyManager: nil}
+	cfg := &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork}}}
+	if err := client.requireDBusProxy(cfg, "demo-app"); err != nil {
+		t.Fatalf("expected no error for a non-bluetooth app without the proxy; got %v", err)
+	}
+}
 
 // TestROS2SidecarName maps each RMW to a distinct, prefix-scoped sidecar name
 // and collapses empty RMW to the CycloneDDS (config-default) sidecar — the
@@ -569,12 +601,36 @@ func TestExpandAgentHookMissingEnv(t *testing.T) {
 	}
 }
 
+// TestWrapWithDebugpyBindsLoopback is the regression test for WDY-1010: the
+// debugpy DAP listener must bind to loopback (127.0.0.1), never 0.0.0.0.
+// Binding all interfaces exposed unauthenticated Python RCE to anyone on the
+// device's network for the duration of a debug session. Remote attach now goes
+// through a device-side tunnel to loopback.
+func TestWrapWithDebugpyBindsLoopback(t *testing.T) {
+	cases := map[string][]string{
+		"python entrypoint":     {"python3", "app.py"},
+		"non-python entrypoint": {"/app/server"},
+	}
+	for name, args := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := wrapWithDebugpy(args)
+			joined := strings.Join(got, " ")
+			if strings.Contains(joined, "0.0.0.0:5678") {
+				t.Fatalf("debugpy must not bind 0.0.0.0; got %q", joined)
+			}
+			if !slices.Contains(got, "127.0.0.1:5678") {
+				t.Fatalf("debugpy must bind loopback 127.0.0.1:5678; got %q", joined)
+			}
+		})
+	}
+}
+
 func TestStartPostStartAgentHookSkippedWhenEmpty(t *testing.T) {
 	old := startPostStartHookCommand
 	t.Cleanup(func() { startPostStartHookCommand = old })
 
 	var calls int
-	startPostStartHookCommand = func(_, _, _ string) (func() error, error) {
+	startPostStartHookCommand = func(_ []string) (func() error, error) {
 		calls++
 		return func() error { return nil }, nil
 	}
@@ -594,11 +650,9 @@ func TestStartPostStartAgentHookRunsWhenPresent(t *testing.T) {
 	old := startPostStartHookCommand
 	t.Cleanup(func() { startPostStartHookCommand = old })
 
-	var gotShell, gotFlag, gotCommand string
-	startPostStartHookCommand = func(shell, flag, command string) (func() error, error) {
-		gotShell = shell
-		gotFlag = flag
-		gotCommand = command
+	var gotArgv []string
+	startPostStartHookCommand = func(argv []string) (func() error, error) {
+		gotArgv = argv
 		return func() error { return nil }, nil
 	}
 
@@ -607,12 +661,141 @@ func TestStartPostStartAgentHookRunsWhenPresent(t *testing.T) {
 	if !started {
 		t.Fatal("startPostStartAgentHook returned false with command")
 	}
-	if gotShell == "" || gotFlag == "" {
-		t.Fatalf("shell command not populated: shell=%q flag=%q", gotShell, gotFlag)
+	wantArgv := []string{"echo", "camera-app", "localhost", "ok"}
+	if !slices.Equal(gotArgv, wantArgv) {
+		t.Fatalf("hook argv = %q; want %q", gotArgv, wantArgv)
 	}
-	wantCommand := "echo camera-app localhost ok"
-	if gotCommand != wantCommand {
-		t.Fatalf("hook command = %q; want %q", gotCommand, wantCommand)
+}
+
+// TestStartPostStartAgentHookDoesNotInterpretShellMetacharacters is the
+// regression test for WDY-1009: the hook command must be executed directly via
+// argv, never handed to a shell. Shell metacharacters (;, &&, |, $(...)) must
+// survive as inert literal arguments to argv[0] rather than spawning new
+// commands.
+func TestStartPostStartAgentHookDoesNotInterpretShellMetacharacters(t *testing.T) {
+	old := startPostStartHookCommand
+	t.Cleanup(func() { startPostStartHookCommand = old })
+
+	var gotArgv []string
+	startPostStartHookCommand = func(argv []string) (func() error, error) {
+		gotArgv = argv
+		return func() error { return nil }, nil
+	}
+
+	client := &Client{logger: zap.NewNop()}
+	started := client.startPostStartAgentHook("/app/post-start.sh ; touch /tmp/pwned && rm -rf /", "camera-app")
+	if !started {
+		t.Fatal("startPostStartAgentHook returned false with command")
+	}
+	if len(gotArgv) == 0 {
+		t.Fatal("hook argv is empty")
+	}
+	// The program executed is the first token only; the injected command tokens
+	// must appear verbatim as arguments, proving no shell parsed them.
+	for _, tok := range gotArgv {
+		if tok == "sh" || tok == "-c" || tok == "cmd.exe" || tok == "/C" {
+			t.Fatalf("hook argv must not invoke a shell, got %q", gotArgv)
+		}
+	}
+	// The whole command must survive as argv[0] (the program) plus inert literal
+	// tokens — the metacharacters are arguments, never separators.
+	wantArgv := []string{"/app/post-start.sh", ";", "touch", "/tmp/pwned", "&&", "rm", "-rf", "/"}
+	if !slices.Equal(gotArgv, wantArgv) {
+		t.Fatalf("hook argv = %q; want %q", gotArgv, wantArgv)
+	}
+}
+
+// TestStartPostStartAgentHookEmptyExpansionLogsConfiguredCommand asserts the
+// "expanded to empty" warning is actionable: it carries the raw, pre-expansion
+// command from wendy.json so an operator can tell which hook misfired. The raw
+// command holds variable references (not their expanded values), so it is safe
+// to log — unlike the expanded string, which may contain secrets.
+func TestStartPostStartAgentHookEmptyExpansionLogsConfiguredCommand(t *testing.T) {
+	t.Setenv("MISSING_VALUE", "")
+	old := startPostStartHookCommand
+	t.Cleanup(func() { startPostStartHookCommand = old })
+	startPostStartHookCommand = func(_ []string) (func() error, error) {
+		return func() error { return nil }, nil
+	}
+
+	core, observed := observer.New(zap.WarnLevel)
+	client := &Client{logger: zap.New(core)}
+	client.startPostStartAgentHook("${MISSING_VALUE}", "camera-app")
+
+	logs := observed.FilterMessageSnippet("empty command")
+	if logs.Len() != 1 {
+		t.Fatalf("expected one empty-command warning; got %d", logs.Len())
+	}
+	var found bool
+	for _, f := range logs.All()[0].Context {
+		if f.Key == "configured_command" && f.String == "${MISSING_VALUE}" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("empty-command warning must include the raw configured_command field; got %+v", logs.All()[0].Context)
+	}
+}
+
+// TestStartPostStartAgentHookWarnsOnQuotedArguments guards the silent
+// behavioral regression from dropping `sh -c`: strings.Fields does not honor
+// quotes, so a quoted argument is split on whitespace. The hook still runs
+// (best-effort), but the operator must get a warning rather than silent
+// mis-execution.
+func TestStartPostStartAgentHookWarnsOnQuotedArguments(t *testing.T) {
+	old := startPostStartHookCommand
+	t.Cleanup(func() { startPostStartHookCommand = old })
+	var calls int
+	startPostStartHookCommand = func(_ []string) (func() error, error) {
+		calls++
+		return func() error { return nil }, nil
+	}
+
+	core, observed := observer.New(zap.WarnLevel)
+	client := &Client{logger: zap.New(core)}
+	started := client.startPostStartAgentHook(`/app/run --message "hello world"`, "camera-app")
+
+	if !started {
+		t.Fatal("hook with quoted args should still run (best-effort)")
+	}
+	if calls != 1 {
+		t.Fatalf("hook runner called %d times; want 1", calls)
+	}
+	if observed.FilterMessageSnippet("quot").Len() == 0 {
+		t.Fatal("expected a warning that quoting is not honored")
+	}
+}
+
+// TestStartPostStartHookCommandRejectsEmptyArgv keeps the argv[0] indexing
+// invariant local to the runner: an empty argv must return an error, never
+// panic, even if a future caller forgets the length guard.
+func TestStartPostStartHookCommandRejectsEmptyArgv(t *testing.T) {
+	if _, err := startPostStartHookCommand(nil); err == nil {
+		t.Fatal("expected error for empty argv, got nil")
+	}
+}
+
+// TestStartPostStartAgentHookSkippedWhenExpansionEmpty guards the case where a
+// command consists solely of an env reference that expands to nothing: there is
+// no program to run, so the runner must not be invoked.
+func TestStartPostStartAgentHookSkippedWhenExpansionEmpty(t *testing.T) {
+	t.Setenv("MISSING_VALUE", "")
+	old := startPostStartHookCommand
+	t.Cleanup(func() { startPostStartHookCommand = old })
+
+	var calls int
+	startPostStartHookCommand = func(_ []string) (func() error, error) {
+		calls++
+		return func() error { return nil }, nil
+	}
+
+	client := &Client{logger: zap.NewNop()}
+	started := client.startPostStartAgentHook("${MISSING_VALUE}", "camera-app")
+	if started {
+		t.Fatal("startPostStartAgentHook returned true for a command that expanded to nothing")
+	}
+	if calls != 0 {
+		t.Fatalf("hook runner called %d times; want 0", calls)
 	}
 }
 
@@ -620,7 +803,7 @@ func TestStartPostStartAgentHookStartErrorDoesNotLogCommand(t *testing.T) {
 	old := startPostStartHookCommand
 	t.Cleanup(func() { startPostStartHookCommand = old })
 
-	startPostStartHookCommand = func(_, _, _ string) (func() error, error) {
+	startPostStartHookCommand = func(_ []string) (func() error, error) {
 		return nil, errors.New("start failed")
 	}
 

--- a/go/internal/agent/oci/mounts.go
+++ b/go/internal/agent/oci/mounts.go
@@ -1,0 +1,34 @@
+package oci
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// containerdRuntimeDirs are containerd's host runtime directories — they hold
+// the control socket (containerd.sock) and runtime state. No container may
+// mount them. Both /run/containerd and its conventional /var/run alias are
+// listed because /var/run is typically a symlink to /run, and ValidateMounts
+// matches lexically (it does not resolve symlinks).
+var containerdRuntimeDirs = []string{"/run/containerd", "/var/run/containerd"}
+
+// ValidateMounts is a defense-in-depth backstop for WDY-1102: it rejects a spec
+// whose bind-mount sources resolve into containerd's runtime directory. A
+// container with write access to the containerd socket can spawn privileged
+// containers and modify host namespaces — a full host escape. The spec builder
+// does not intentionally mount these paths; this guard ensures no future code
+// path or crafted source can either. It must be called on the fully assembled
+// spec, immediately before the spec is handed to the runtime.
+func ValidateMounts(spec *Spec) error {
+	for _, m := range spec.Mounts {
+		// path.Clean resolves any ".." so a crafted source cannot slip past.
+		clean := path.Clean(m.Source)
+		for _, dir := range containerdRuntimeDirs {
+			if clean == dir || strings.HasPrefix(clean, dir+"/") {
+				return fmt.Errorf("security: refusing container mount with source %q: %s is off-limits to containers (WDY-1102)", m.Source, dir)
+			}
+		}
+	}
+	return nil
+}

--- a/go/internal/agent/oci/mounts_test.go
+++ b/go/internal/agent/oci/mounts_test.go
@@ -1,0 +1,64 @@
+package oci
+
+import "testing"
+
+// TestValidateMountsRejectsContainerdRuntimeDir is the regression test for
+// WDY-1102: no container bind mount may resolve into containerd's runtime
+// directory. Writable access to the containerd control socket lets a container
+// spawn privileged containers and escape to the host, so the spec builder must
+// reject such a mount as a defense-in-depth backstop.
+func TestValidateMountsRejectsContainerdRuntimeDir(t *testing.T) {
+	spec := &Spec{Mounts: []Mount{
+		{Destination: "/run/containerd", Source: "/run/containerd", Type: "bind", Options: []string{"rbind", "rw"}},
+	}}
+	if err := ValidateMounts(spec); err == nil {
+		t.Fatal("expected error for a bind mount of /run/containerd")
+	}
+}
+
+func TestValidateMountsRejectsContainerdSocketSubpath(t *testing.T) {
+	spec := &Spec{Mounts: []Mount{
+		{Destination: "/x", Source: "/run/containerd/containerd.sock", Type: "bind", Options: []string{"rbind", "rw"}},
+	}}
+	if err := ValidateMounts(spec); err == nil {
+		t.Fatal("expected error for a bind mount of the containerd socket")
+	}
+}
+
+// TestValidateMountsRejectsUncleanTraversal ensures the check resolves
+// ".."-bearing sources before matching, so a crafted source cannot slip past.
+// /var/lib/wendy/volumes + four ".." resolves to "/", then /run/containerd/...
+func TestValidateMountsRejectsUncleanTraversal(t *testing.T) {
+	spec := &Spec{Mounts: []Mount{
+		{Destination: "/x", Source: "/var/lib/wendy/volumes/../../../../run/containerd/containerd.sock", Type: "bind"},
+	}}
+	if err := ValidateMounts(spec); err == nil {
+		t.Fatal("expected error for a traversal that resolves into /run/containerd")
+	}
+}
+
+// TestValidateMountsRejectsVarRunAlias guards the conventional /var/run -> /run
+// symlink alias, which would otherwise reach the same socket lexically.
+func TestValidateMountsRejectsVarRunAlias(t *testing.T) {
+	spec := &Spec{Mounts: []Mount{
+		{Destination: "/x", Source: "/var/run/containerd/containerd.sock", Type: "bind"},
+	}}
+	if err := ValidateMounts(spec); err == nil {
+		t.Fatal("expected error for the /var/run/containerd alias")
+	}
+}
+
+// TestValidateMountsAllowsNormalMounts ensures the guard does not reject
+// legitimate mounts, including a sibling directory whose path merely shares the
+// /run/containerd prefix.
+func TestValidateMountsAllowsNormalMounts(t *testing.T) {
+	spec := &Spec{Mounts: []Mount{
+		{Destination: "/proc", Source: "proc", Type: "proc"},
+		{Destination: "/dev/shm", Source: "tmpfs", Type: "tmpfs"},
+		{Destination: "/data", Source: "/var/lib/wendy/volumes/data", Type: "bind", Options: []string{"rbind"}},
+		{Destination: "/c", Source: "/run/containerd-helper", Type: "bind", Options: []string{"rbind"}},
+	}}
+	if err := ValidateMounts(spec); err != nil {
+		t.Fatalf("expected no error for legitimate mounts; got %v", err)
+	}
+}

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -125,6 +125,8 @@ Lifecycle commands to run at specific points during the app lifecycle.
 | `hooks.postStart.cli` | Command run on the developer's machine after the app starts |
 | `hooks.postStart.agent` | Command run on the device after the app starts |
 
+> **Note:** `hooks.postStart.agent` is executed directly on the device, not through a shell. Shell features such as pipes (`|`), redirects (`>`), command chaining (`;`, `&&`), and command substitution (`$(...)`) are **not** interpreted — they are passed through as literal arguments. If you need them, put the logic in a script file (e.g. `/app/post-start.sh`) and invoke that. `${WENDY_APP_ID}`, `${WENDY_HOSTNAME}`, and environment variables are still expanded.
+
 ### `python`
 
 Python-specific settings.

--- a/go/internal/cli/assets/docs/guides/device/vscode-extension.mdx
+++ b/go/internal/cli/assets/docs/guides/device/vscode-extension.mdx
@@ -368,6 +368,14 @@ debugpy>=1.8.0
 - Debug multi-threaded applications
 - Exception breakpoints for catching errors
 
+<Callout type="warning">
+  **Security**: the debugpy listener binds to the device's loopback interface
+  (`127.0.0.1:5678`), not all interfaces. debugpy is an unauthenticated remote
+  code execution endpoint, so it is never exposed on the device's network.
+  Remote attach reaches it through a tunnel that forwards your local `5678` to
+  the device's loopback.
+</Callout>
+
 {/* SCREENSHOT PLACEHOLDER: Python debugging session with breakpoint and variable inspection */}
 
 <Callout type="info">


### PR DESCRIPTION
## Summary

Four self-contained agent hardening fixes from the security backlog (the start of Phase 0 of the [security remediation plan](../blob/main/specs/2026-06-27-security-issues-remediation-plan.md)). Each was implemented test-first.

| Ticket | Severity | Fix |
|--------|----------|-----|
| **WDY-1009** | HIGH | Command injection via `postStart` agent hook |
| **WDY-1010** | HIGH | Unauthenticated debugpy RCE |
| **WDY-1093** | HIGH | D-Bus proxy bypass (silent fallback) |
| **WDY-1102** | MED | containerd-socket mount host escape |

### WDY-1009 — command injection
The `hooks.postStart.agent` command was run via `sh -c` as the agent (root) on the host, outside the container sandbox — a crafted `wendy.json` could chain arbitrary commands (`;`, `&&`, `$(...)`). Now exec'd directly via `exec.Command(argv[0], argv[1:]...)` with no shell; `${WENDY_*}`/env expansion is preserved and metacharacters become inert literal args. Warns when the command contains quotes (no longer honored), and logs the raw pre-expansion command when it expands to nothing.

### WDY-1010 — debugpy RCE
`wrapWithDebugpy` bound the unauthenticated DAP listener to `0.0.0.0:5678`, exposing full Python RCE on the device LAN during a debug session. Now binds `127.0.0.1:5678`.

⚠️ **Cross-repo follow-up:** remote Python attach via the VSCode extension currently connects to `device-ip:5678` and will need a device-side tunnel / CLI port-forward. Tracked as a sub-task of WDY-1010 (extension + CLI repos).

### WDY-1093 — D-Bus proxy hard-fail
A container declaring the `bluetooth` entitlement still started when `xdg-dbus-proxy` was absent (silent degradation; the startup log even claimed "unfiltered access"). New `requireDBusProxy` gate refuses to start such a container, and the startup warning is corrected.

### WDY-1102 — containerd socket mount guard
Defense-in-depth `oci.ValidateMounts` rejects any container mount whose source resolves (after `path.Clean`) into `/run/containerd` or the `/var/run/containerd` alias. Wired in at final spec assembly, before the spec reaches the runtime.

## Tests
Added via TDD for each fix: shell-injection regression + quote/empty-expansion handling, debugpy loopback binding, D-Bus refuse/allow matrix, and mount-guard cases (exact dir, socket subpath, unclean traversal, `/var/run` alias, sibling-prefix negative).

`gofmt`, `go vet`, and `go build ./...` are clean; `agent/containerd`, `agent/oci`, and `cmd/wendy-agent` packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)