### PR TITLE
fix(agent): strengthen baseline seccomp profile (WDY-1012)

### DIFF
--- a/go/internal/agent/oci/spec.go
+++ b/go/internal/agent/oci/spec.go
@@ -292,6 +292,25 @@ func defaultSeccomp() *LinuxSeccomp {
 				ErrnoRet: &eperm,
 			},
 			{
+				// SECURITY (WDY-1012): deny kernel-attack-surface syscalls that
+				// a normal application container never needs — kernel module
+				// loading and kexec. These are pure host-escape primitives;
+				// blocking them here is defense-in-depth on top of the capability
+				// gating that already withholds CAP_SYS_MODULE / CAP_SYS_BOOT.
+				// (create_module is long-removed from Linux but is listed so the
+				// filter denies it on any kernel that still exposes it.)
+				Names: []string{
+					"init_module",
+					"finit_module",
+					"delete_module",
+					"create_module",
+					"kexec_load",
+					"kexec_file_load",
+				},
+				Action:   ActErrno,
+				ErrnoRet: &eperm,
+			},
+			{
 				Names:  []string{"clone"},
 				Action: ActErrno,
 				Args: []LinuxSeccompArg{

--- a/go/internal/agent/oci/spec_test.go
+++ b/go/internal/agent/oci/spec_test.go
@@ -5,6 +5,42 @@ import (
 	"testing"
 )
 
+// TestDefaultSeccompBlocksKernelAttackSurface is the regression test for
+// WDY-1012: the baseline seccomp profile must deny the kernel-attack-surface
+// syscalls a normal application container never needs (module loading, kexec),
+// in addition to the existing ptrace/unshare/clone-newuser blocks. These are
+// pure host-escape primitives; blocking them at seccomp is defense-in-depth on
+// top of the capability gating that already withholds CAP_SYS_MODULE/BOOT.
+func TestDefaultSeccompBlocksKernelAttackSurface(t *testing.T) {
+	sc := defaultSeccomp()
+	if sc == nil {
+		t.Fatal("defaultSeccomp() returned nil; containers would have no seccomp filter")
+	}
+	blocked := map[string]bool{}
+	for _, s := range sc.Syscalls {
+		if s.Action == ActErrno && len(s.Args) == 0 {
+			for _, n := range s.Names {
+				blocked[n] = true
+			}
+		}
+	}
+	// Existing protections must remain.
+	for _, name := range []string{"ptrace", "unshare"} {
+		if !blocked[name] {
+			t.Errorf("seccomp should still unconditionally block %q", name)
+		}
+	}
+	// WDY-1012: dangerous, never-needed kernel-surface syscalls.
+	for _, name := range []string{
+		"kexec_load", "kexec_file_load",
+		"init_module", "finit_module", "delete_module", "create_module",
+	} {
+		if !blocked[name] {
+			t.Errorf("seccomp must block dangerous syscall %q (WDY-1012)", name)
+		}
+	}
+}
+
 func TestDefaultSpec(t *testing.T) {
 	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 


### PR DESCRIPTION
## Summary

Isolation hardening from the security backlog. This PR delivers **WDY-1012**; the other three "isolation" tickets I reviewed turned out to need different handling (see below) and are intentionally **not** bundled here.

### WDY-1012 — seccomp baseline ✅
`oci.defaultSeccomp` already existed (so the ticket's "Seccomp is nil" premise was stale), but it only blocked `ptrace`/`unshare`/`clone(CLONE_NEWUSER)`. This adds the kernel-attack-surface syscalls a normal app container never needs:

- kernel module loading: `init_module`, `finit_module`, `delete_module`, `create_module`
- kexec: `kexec_load`, `kexec_file_load`

as `SCMP_ACT_ERRNO`. They're already cap-gated (containers carry neither `CAP_SYS_MODULE` nor `CAP_SYS_BOOT`), so this is **zero-regression defense-in-depth** — no normal workload issues these calls. Regression test added.

## Why the other three isolation tickets are not here

Investigation showed each is more nuanced than its ticket text, and two carry real breakage risk that can't be validated without a device:

- **WDY-1008 (camera `/dev`)** — the whole-`/dev` bind is deliberate (USB-webcam hotplug recreates `/dev/videoN` under new minors; WDY-1342), and a **deny-all device cgroup baseline** (`spec.go`: `{Allow:false, Access:"rwm"}`) already blocks opening `/dev/mem`/raw disks — only the allowed video/media majors are openable. The ticket's "trivial escape via `/dev/mem`" is already mitigated; its proposed enumerate-only fix would break hotplug for marginal gain. **Recommend re-triage**, not the literal fix.
- **WDY-1011 (user namespace)** — real (default `User{0,0}`, no userns), but a correct fix needs UID-mapped rootfs ownership, `/etc/subuid` setup, and runc/containerd userns support, and changes file-ownership semantics for every deployed app. **Needs a device soak → own PR.**
- **WDY-1014 (bridge default)** — CNI bridge networking does exist (`containerd/cni.go`), so it's buildable, but flipping the default off `host` breaks every host-networked app today. **Needs a device soak → own PR.**

## Validation
`go test ./internal/agent/oci/`, `go vet`, and `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)