### PR TITLE
fix(agent): separate CAP_NET_ADMIN from host networking (WDY-1094)

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1493,7 +1493,7 @@ func injectOTELEnvIfNeeded(env []string, appCfg *appconfig.AppConfig, appID stri
 
 func hasHostNetworkEntitlement(appCfg *appconfig.AppConfig) bool {
 	for _, e := range appCfg.Entitlements {
-		if e.Type == appconfig.EntitlementNetwork && (e.Mode == "host" || e.Mode == "") {
+		if e.Type == appconfig.EntitlementNetwork && (e.Mode == "host" || e.Mode == "host-admin" || e.Mode == "") {
 			return true
 		}
 	}

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -550,6 +550,21 @@ func TestHasHostNetworkEntitlementEmptyModeIsHost(t *testing.T) {
 	}
 }
 
+// TestHasHostNetworkEntitlementHostAdmin verifies the WDY-1094 opt-in mode is
+// still recognised as host networking (it shares the host network stack; it
+// just additionally carries CAP_NET_ADMIN), so host-network-dependent wiring
+// like OTEL endpoint injection continues to apply.
+func TestHasHostNetworkEntitlementHostAdmin(t *testing.T) {
+	cfg := &appconfig.AppConfig{
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementNetwork, Mode: "host-admin"},
+		},
+	}
+	if !hasHostNetworkEntitlement(cfg) {
+		t.Error("host-admin mode should imply host networking")
+	}
+}
+
 func TestExpandAgentHook(t *testing.T) {
 	t.Setenv("EXTRA_VALUE", "ok")
 

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -239,7 +239,7 @@ func applyNetwork(spec *Spec, ent appconfig.Entitlement) {
 		mode = "host"
 	}
 
-	if mode == "host" {
+	if mode == "host" || mode == "host-admin" {
 		// Remove the network namespace to use host networking.
 		var namespaces []LinuxNamespace
 		for _, ns := range spec.Linux.Namespaces {
@@ -264,10 +264,18 @@ func applyNetwork(spec *Spec, ent appconfig.Entitlement) {
 			}
 		}
 
-		// Add CAP_NET_ADMIN and CAP_NET_RAW for host networking.
-		spec.Process.Capabilities.Bounding = appendUnique(spec.Process.Capabilities.Bounding, "CAP_NET_ADMIN")
-		spec.Process.Capabilities.Effective = appendUnique(spec.Process.Capabilities.Effective, "CAP_NET_ADMIN")
-		spec.Process.Capabilities.Permitted = appendUnique(spec.Process.Capabilities.Permitted, "CAP_NET_ADMIN")
+		// SECURITY (WDY-1094): CAP_NET_ADMIN lets a container reconfigure host
+		// network interfaces, routes, and netfilter — a privilege that plain
+		// host networking (visibility: bind ports, see interfaces) does not
+		// require. Grant it only for the explicit "host-admin" opt-in, so the
+		// reconfiguration capability is separate from, and auditable apart from,
+		// the visibility entitlement. (CAP_NET_RAW for ping etc. comes from the
+		// baseline capability set, not from here, so it is unaffected.)
+		if mode == "host-admin" {
+			spec.Process.Capabilities.Bounding = appendUnique(spec.Process.Capabilities.Bounding, "CAP_NET_ADMIN")
+			spec.Process.Capabilities.Effective = appendUnique(spec.Process.Capabilities.Effective, "CAP_NET_ADMIN")
+			spec.Process.Capabilities.Permitted = appendUnique(spec.Process.Capabilities.Permitted, "CAP_NET_ADMIN")
+		}
 
 		// Mount a resolv.conf from the host so DNS works inside the container.
 		// The container has its own mount namespace, so its rootfs resolv.conf

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -269,9 +269,43 @@ func TestApplyEntitlements_Network_Host(t *testing.T) {
 		t.Error("host network entitlement did not remove network namespace")
 	}
 
-	// CAP_NET_ADMIN should be added.
-	if !slices.Contains(spec.Process.Capabilities.Bounding, "CAP_NET_ADMIN") {
-		t.Error("host network entitlement did not add CAP_NET_ADMIN")
+	// WDY-1094: plain "host" grants network *visibility* only. It must NOT grant
+	// CAP_NET_ADMIN — that lets a container reconfigure host interfaces, routes,
+	// and netfilter. Reconfiguration requires the explicit "host-admin" opt-in.
+	if slices.Contains(spec.Process.Capabilities.Bounding, "CAP_NET_ADMIN") {
+		t.Error("plain host network entitlement must not grant CAP_NET_ADMIN (WDY-1094)")
+	}
+}
+
+// TestApplyEntitlements_Network_HostAdmin verifies the explicit opt-in: mode
+// "host-admin" is host networking AND grants CAP_NET_ADMIN for apps that
+// genuinely need to reconfigure the network (WDY-1094).
+func TestApplyEntitlements_Network_HostAdmin(t *testing.T) {
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "test-app",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementNetwork, Mode: "host-admin"},
+		},
+	}
+
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+
+	// host-admin is host networking: the network namespace is removed.
+	if hasNamespace(spec, "network") {
+		t.Error("host-admin entitlement did not remove network namespace")
+	}
+	// host-admin is the opt-in that grants CAP_NET_ADMIN.
+	for _, set := range [][]string{
+		spec.Process.Capabilities.Bounding,
+		spec.Process.Capabilities.Effective,
+		spec.Process.Capabilities.Permitted,
+	} {
+		if !slices.Contains(set, "CAP_NET_ADMIN") {
+			t.Error("host-admin entitlement must grant CAP_NET_ADMIN in all capability sets")
+		}
 	}
 }
 

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -158,8 +158,11 @@ IP networking access.
 | `mode` | Description |
 |--------|-------------|
 | *(omitted)* | Default isolated network |
-| `"host"` | Shares the host network stack |
+| `"host"` | Shares the host network stack (visibility: bind host ports, see interfaces). Does **not** grant the ability to reconfigure host networking. |
+| `"host-admin"` | Host networking **plus** `CAP_NET_ADMIN` — allows reconfiguring interfaces, routes, and netfilter. Only request this if your app genuinely manages the network; it is a high-privilege capability. |
 | `"none"` | Networking fully disabled |
+
+> **Security note:** `CAP_NET_ADMIN` (host network reconfiguration) is granted only by `"host-admin"`, never by plain `"host"`. Apps that previously relied on `CAP_NET_ADMIN` under `"host"` must switch to `"host-admin"`.
 
 ### `gpu`
 

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -293,8 +293,8 @@ func validateEntitlements(entitlements []Entitlement, prefix string) error {
 
 		switch e.Type {
 		case EntitlementNetwork:
-			if e.Mode != "" && e.Mode != "host" && e.Mode != "none" {
-				return fmt.Errorf("%s[%d]: network mode must be \"host\" or \"none\", got %q", prefix, i, e.Mode)
+			if e.Mode != "" && e.Mode != "host" && e.Mode != "host-admin" && e.Mode != "none" {
+				return fmt.Errorf("%s[%d]: network mode must be \"host\", \"host-admin\", or \"none\", got %q", prefix, i, e.Mode)
 			}
 		case EntitlementPersist:
 			if e.Name == "" {

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -103,6 +103,27 @@ func TestValidate_ValidConfig(t *testing.T) {
 	}
 }
 
+// TestValidate_NetworkHostAdminMode covers the WDY-1094 opt-in: "host-admin"
+// is a valid network mode (host networking + CAP_NET_ADMIN), while an unknown
+// mode is still rejected.
+func TestValidate_NetworkHostAdminMode(t *testing.T) {
+	valid := &AppConfig{
+		AppID:        "com.example.app",
+		Entitlements: []Entitlement{{Type: EntitlementNetwork, Mode: "host-admin"}},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Errorf("Validate() rejected host-admin mode: %v", err)
+	}
+
+	invalid := &AppConfig{
+		AppID:        "com.example.app",
+		Entitlements: []Entitlement{{Type: EntitlementNetwork, Mode: "bogus"}},
+	}
+	if err := invalid.Validate(); err == nil {
+		t.Error("Validate() accepted an unknown network mode; want error")
+	}
+}
+
 func TestValidate_MissingAppID(t *testing.T) {
 	cfg := &AppConfig{}
 	err := cfg.Validate()

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -90,8 +90,8 @@
             "type": { "const": "network" },
             "mode": {
               "type": "string",
-              "enum": ["host", "none"],
-              "description": "Network mode. \"host\" shares the host network stack; \"none\" disables networking."
+              "enum": ["host", "host-admin", "none"],
+              "description": "Network mode. \"host\" shares the host network stack (visibility only); \"host-admin\" additionally grants CAP_NET_ADMIN to reconfigure host networking; \"none\" disables networking."
             }
           },
           "required": ["type"],


### PR DESCRIPTION
## Summary

`network: host` containers were granted **CAP_NET_ADMIN** unconditionally. That capability lets a container reconfigure host network interfaces, routing tables, and netfilter — far beyond what plain host networking (binding ports, seeing interfaces) requires. This separates the reconfiguration capability from the visibility entitlement.

- **`mode: "host"`** — host networking **without** CAP_NET_ADMIN. `CAP_NET_RAW` (ping, etc.) comes from the baseline capability set and is unaffected.
- **`mode: "host-admin"`** (new) — explicit opt-in that adds CAP_NET_ADMIN, for apps that genuinely manage the network. Identical to host networking otherwise, and still treated as host networking everywhere (e.g. OTEL endpoint injection, `hasHostNetworkEntitlement`).

Updated `appconfig` validation, the `wendy.schema.json` enum, and the `wendy.json` docs (including the migration note for apps that relied on CAP_NET_ADMIN under `host`).

## ⚠️ Behavior change
Apps using `network: host` that **reconfigure** the network (set routes, manage interfaces, program netfilter, etc.) must switch to `network: host-admin`. The common case — binding/listening on host ports — is unaffected.

## Tests
- plain `host` no longer carries CAP_NET_ADMIN; `host-admin` does (all capability sets)
- validation accepts `host-admin`, rejects unknown modes
- `hasHostNetworkEntitlement` treats `host-admin` as host networking

`go test` (oci, appconfig, containerd), `go vet`, `go build ./...`, and `gofmt` all clean.

## Context
Came out of the isolation review; pairs with the bridge-default work documented on WDY-1014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)