### PR TITLE
feat(cli): pin device organisation + cloud host on set-default (WDY-1149)

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/set-default.md
@@ -9,3 +9,9 @@ wendy run
 ```
 
 Use `wendy device get-default` to see the current default, or `wendy device unset-default` to clear it.
+
+## Certificate pinning
+
+When you set a default device (and again on the first successful connection if the device was offline at set-default time), the CLI **pins** the device's identity — the organisation and cloud host its TLS certificate belongs to. On every later connection to the default device, the CLI checks that the device still presents that same organisation and cloud host.
+
+A routine certificate **renewal or re-enrollment** keeps the same organisation and cloud, so it is accepted silently. Only a change of organisation or cloud host — which can indicate a man-in-the-middle or a swapped device — triggers a red warning and an interactive prompt asking whether to trust the new identity. In non-interactive mode (`--json` or no TTY) the connection is refused; re-run `wendy device set-default` to deliberately re-pin.

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -325,6 +325,15 @@ func newDeviceSetDefaultCmd() *cobra.Command {
 			}
 
 			fmt.Printf("Default device set to: %s\n", tui.Device(device))
+
+			// WDY-1149: pin the device's (organisation, cloud host) identity now
+			// if it is reachable, so later connections detect a swapped device or
+			// MITM. Best-effort and non-interactive: an offline device is pinned
+			// instead on its first successful connection. The pin itself is
+			// established inside connectToAgent's default-device path.
+			if conn, connErr := connectToAgent(cmd.Context(), SuppressProvisioningHint(), SuppressUpdateCheck(), NonInteractive()); connErr == nil {
+				_ = conn.Close()
+			}
 			return nil
 		},
 	}

--- a/go/internal/cli/commands/device_pin.go
+++ b/go/internal/cli/commands/device_pin.go
@@ -1,0 +1,81 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// cloudGRPCForOrg returns the cloud gRPC endpoint of the auth session that owns
+// a certificate for orgID, or "" if none is found. It maps the org carried by
+// the verifying mTLS cert back to the cloud host that issued it.
+func cloudGRPCForOrg(cfg *config.Config, orgID int) string {
+	for _, auth := range cfg.Auth {
+		for _, c := range auth.Certificates {
+			if c.OrganizationID == orgID {
+				return auth.CloudGRPC
+			}
+		}
+	}
+	return ""
+}
+
+func displayCloud(c string) string {
+	if c == "" {
+		return "an unknown cloud"
+	}
+	return c
+}
+
+// enforceDevicePin checks the (organisation, cloud host) pin for a freshly
+// connected device (WDY-1149) and records or challenges it:
+//
+//   - first use → record the pin, proceed
+//   - match     → proceed; a renewed or re-enrolled cert within the same
+//     organisation + cloud is expected and never challenged
+//   - mismatch  → warn in red and interactively ask whether to trust the new
+//     identity; declining, or running non-interactively, aborts the connection
+//
+// Plaintext / unprovisioned connections carry no verifiable identity and are
+// skipped. It is best-effort about local state: a config read/write failure
+// never blocks an already-verified mTLS connection.
+func enforceDevicePin(hostname string, conn *grpcclient.AgentConnection) error {
+	if conn == nil || !conn.IsMTLS || conn.CertInfo == nil {
+		return nil
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return nil
+	}
+	org := conn.CertInfo.OrganizationID
+	cloud := cloudGRPCForOrg(cfg, org)
+
+	switch cfg.EvaluateDevicePin(hostname, org, cloud) {
+	case config.PinMatch:
+		return nil
+	case config.PinFirstUse:
+		cfg.SetDevicePin(hostname, org, cloud)
+		_ = config.Save(cfg)
+		return nil
+	default: // config.PinMismatch
+		prev, _ := cfg.DevicePinFor(hostname)
+		fmt.Fprintln(os.Stderr, tui.ErrorMessage(fmt.Sprintf("Device %q now presents a different identity than the one you pinned.", hostname)))
+		fmt.Fprintln(os.Stderr, tui.ErrorMessage(fmt.Sprintf("  pinned: organization %d via %s", prev.OrgID, displayCloud(prev.CloudGRPC))))
+		fmt.Fprintln(os.Stderr, tui.ErrorMessage(fmt.Sprintf("  now:    organization %d via %s", org, displayCloud(cloud))))
+		fmt.Fprintln(os.Stderr, tui.ErrorMessage("A renewed or re-enrolled certificate keeps the same organization and cloud, so this change is unexpected — it may be a man-in-the-middle or a swapped device."))
+
+		if jsonOutput || !isInteractiveTerminal() {
+			return fmt.Errorf("device %q identity changed (organization/cloud); refusing to connect — re-run 'wendy device set-default %s' to re-pin if this is expected", hostname, hostname)
+		}
+		trusted, cErr := tui.ConfirmNoDefaultDanger(fmt.Sprintf("Trust the new identity for %q and re-pin it?", hostname))
+		if cErr != nil || !trusted {
+			return fmt.Errorf("device %q identity change was not trusted; connection aborted", hostname)
+		}
+		cfg.SetDevicePin(hostname, org, cloud)
+		_ = config.Save(cfg)
+		return nil
+	}
+}

--- a/go/internal/cli/commands/device_pin_test.go
+++ b/go/internal/cli/commands/device_pin_test.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// TestCloudGRPCForOrg maps the org carried by a verifying mTLS cert back to the
+// cloud host of the auth session that issued it — the cloud half of the
+// WDY-1149 (org, cloud) pin.
+func TestCloudGRPCForOrg(t *testing.T) {
+	cfg := &config.Config{Auth: []config.AuthConfig{
+		{CloudGRPC: "grpc.a.sh:443", Certificates: []config.CertificateInfo{{OrganizationID: 7}}},
+		{CloudGRPC: "grpc.b.sh:443", Certificates: []config.CertificateInfo{{OrganizationID: 9}}},
+	}}
+
+	if got := cloudGRPCForOrg(cfg, 9); got != "grpc.b.sh:443" {
+		t.Errorf("org 9: got %q, want grpc.b.sh:443", got)
+	}
+	if got := cloudGRPCForOrg(cfg, 7); got != "grpc.a.sh:443" {
+		t.Errorf("org 7: got %q, want grpc.a.sh:443", got)
+	}
+	if got := cloudGRPCForOrg(cfg, 42); got != "" {
+		t.Errorf("unknown org: got %q, want empty", got)
+	}
+}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -652,7 +652,7 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 					return nil, connErr
 				}
 				conn = refreshedConn
-			} else if isDefault && !jsonOutput && isInteractiveTerminal() {
+			} else if isDefault && !jsonOutput && !cfg.nonInteractive && isInteractiveTerminal() {
 				// Default device is unreachable — offer interactive recovery.
 				hostname, _, _ := net.SplitHostPort(addr)
 				target, recErr := handleDefaultDeviceRecovery(ctx, hostname, time.Since(startedAt), connErr, cfg.excludeProviderKeys, cfg.excludeBluetooth, cfg.suppressUpdateCheck)
@@ -674,6 +674,14 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 			conn, updateErr = checkAndOfferUpdate(ctx, conn)
 			if updateErr != nil {
 				return nil, updateErr
+			}
+		}
+		// WDY-1149: verify the resolved default device still belongs to the
+		// organisation + cloud it was pinned to (and pin it on first use).
+		if isDefault {
+			if pinErr := enforceDevicePin(hostname, conn); pinErr != nil {
+				conn.Close()
+				return nil, pinErr
 			}
 		}
 		return conn, nil

--- a/go/internal/cli/tui/confirm.go
+++ b/go/internal/cli/tui/confirm.go
@@ -18,6 +18,9 @@ type ConfirmModel struct {
 	// y/n keypress. Enter, arrows, and tab are ignored, and no option is
 	// pre-highlighted. Ctrl+C / q still cancels.
 	requireExplicit bool
+	// danger renders the question in the error (red) style to flag a
+	// security-sensitive decision the user must look at carefully.
+	danger bool
 }
 
 func NewConfirm(question string) ConfirmModel {
@@ -26,6 +29,12 @@ func NewConfirm(question string) ConfirmModel {
 
 func NewConfirmDefaultYes(question string) ConfirmModel {
 	return ConfirmModel{Question: question, choice: true}
+}
+
+// NewConfirmNoDefaultDanger builds a no-default prompt whose question is
+// rendered in red, for security-sensitive decisions that must catch attention.
+func NewConfirmNoDefaultDanger(question string) ConfirmModel {
+	return ConfirmModel{Question: question, requireExplicit: true, danger: true}
 }
 
 // NewConfirmNoDefault builds a prompt with no default answer. The user must
@@ -82,6 +91,7 @@ func (m ConfirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 var (
 	confirmQuestion = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary)
+	confirmDanger   = lipgloss.NewStyle().Bold(true).Foreground(ColorError)
 	confirmActive   = lipgloss.NewStyle().Bold(true).Foreground(ColorSelectedFg).Background(ColorSelectedBg).Padding(0, 1)
 	confirmInactive = lipgloss.NewStyle().Foreground(ColorDim).Padding(0, 1)
 	confirmHint     = lipgloss.NewStyle().Foreground(ColorDim)
@@ -94,10 +104,14 @@ func (m ConfirmModel) View() string {
 
 	if m.requireExplicit {
 		// No default: render the question with a neutral hint and no
-		// pre-highlighted option.
+		// pre-highlighted option. Danger prompts render the question in red.
+		qStyle := confirmQuestion
+		if m.danger {
+			qStyle = confirmDanger
+		}
 		return fmt.Sprintf(
 			"%s  %s\n",
-			confirmQuestion.Render(m.Question),
+			qStyle.Render(m.Question),
 			confirmHint.Render("[y/n]"),
 		)
 	}
@@ -160,6 +174,12 @@ func ConfirmDefaultYes(question string, programOpts ...tea.ProgramOption) (bool,
 // must press y or n. Returns ErrCancelled on Ctrl+C / q.
 func ConfirmNoDefault(question string, programOpts ...tea.ProgramOption) (bool, error) {
 	return runConfirm(NewConfirmNoDefault(question), programOpts)
+}
+
+// ConfirmNoDefaultDanger is ConfirmNoDefault with the question rendered in red,
+// for security-sensitive decisions that must catch the user's attention.
+func ConfirmNoDefaultDanger(question string, programOpts ...tea.ProgramOption) (bool, error) {
+	return runConfirm(NewConfirmNoDefaultDanger(question), programOpts)
 }
 
 // ConfirmWithIO runs a styled yes/no prompt reading from r and discarding

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -41,6 +41,11 @@ type Config struct {
 	// (YYYY-MM-DD) of the last time the tip (or a build-time optimize scan) was
 	// surfaced for that project.
 	OptimizeTipShownAt map[string]string `json:"optimizeTipShownAt,omitempty"`
+	// DevicePins binds a device hostname to the organisation + cloud host its
+	// TLS identity must belong to (WDY-1149), so a different trust domain
+	// answering at that hostname is caught. Renewal/re-enrollment within the
+	// same org+cloud does not trip it. Keyed by normalized hostname.
+	DevicePins map[string]DevicePin `json:"devicePins,omitempty"`
 }
 
 // AuthConfig holds authentication details for a cloud environment.

--- a/go/internal/shared/config/devicepin.go
+++ b/go/internal/shared/config/devicepin.go
@@ -1,0 +1,61 @@
+package config
+
+import "strings"
+
+// DevicePin binds a device hostname to the organisation and cloud host its TLS
+// identity must belong to (WDY-1149). It is deliberately NOT a certificate
+// fingerprint: a device legitimately rotates or re-enrolls its cert, which we
+// must not treat as an attack. What we anchor is the device's org + cloud — so
+// only a change of organisation or cloud host (a different trust domain
+// answering at this hostname) trips the pin.
+type DevicePin struct {
+	OrgID     int    `json:"orgId"`
+	CloudGRPC string `json:"cloudGRPC"`
+}
+
+// PinVerdict is the result of comparing an observed device identity against the
+// stored pin for its hostname.
+type PinVerdict int
+
+const (
+	// PinFirstUse means no pin is recorded for the hostname yet.
+	PinFirstUse PinVerdict = iota
+	// PinMatch means the observed org + cloud host match the stored pin.
+	PinMatch
+	// PinMismatch means the observed org or cloud host differs from the pin.
+	PinMismatch
+)
+
+// normalizePinHost lowercases, trims whitespace, and strips a trailing dot and
+// ".local" suffix so cosmetic variants of the same hostname key the same pin.
+func normalizePinHost(host string) string {
+	h := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	return strings.TrimSuffix(h, ".local")
+}
+
+// DevicePinFor returns the stored pin for a hostname, if any.
+func (c *Config) DevicePinFor(hostname string) (DevicePin, bool) {
+	p, ok := c.DevicePins[normalizePinHost(hostname)]
+	return p, ok
+}
+
+// EvaluateDevicePin compares an observed (orgID, cloudGRPC) for a hostname
+// against the stored pin without mutating the config.
+func (c *Config) EvaluateDevicePin(hostname string, orgID int, cloudGRPC string) PinVerdict {
+	pin, ok := c.DevicePinFor(hostname)
+	if !ok {
+		return PinFirstUse
+	}
+	if pin.OrgID == orgID && pin.CloudGRPC == cloudGRPC {
+		return PinMatch
+	}
+	return PinMismatch
+}
+
+// SetDevicePin records (or replaces) the pin for a hostname.
+func (c *Config) SetDevicePin(hostname string, orgID int, cloudGRPC string) {
+	if c.DevicePins == nil {
+		c.DevicePins = make(map[string]DevicePin)
+	}
+	c.DevicePins[normalizePinHost(hostname)] = DevicePin{OrgID: orgID, CloudGRPC: cloudGRPC}
+}

--- a/go/internal/shared/config/devicepin_test.go
+++ b/go/internal/shared/config/devicepin_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestEvaluateDevicePin covers the WDY-1149 trust anchor: a device hostname is
+// pinned to its (organisation, cloud host). The pin is renewal/re-enrollment
+// tolerant — only an org or cloud-host change trips it, never a routine cert
+// rotation (which keeps the same org+cloud).
+func TestEvaluateDevicePin(t *testing.T) {
+	c := &Config{}
+
+	if v := c.EvaluateDevicePin("wendy-thor.local", 7, "grpc.wendy.sh:443"); v != PinFirstUse {
+		t.Fatalf("unpinned host: want PinFirstUse, got %v", v)
+	}
+
+	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.sh:443")
+
+	// Same org + cloud (e.g. a renewed or re-enrolled cert) must match.
+	if v := c.EvaluateDevicePin("wendy-thor.local", 7, "grpc.wendy.sh:443"); v != PinMatch {
+		t.Fatalf("same org+cloud: want PinMatch, got %v", v)
+	}
+	// Different org → mismatch.
+	if v := c.EvaluateDevicePin("wendy-thor.local", 9, "grpc.wendy.sh:443"); v != PinMismatch {
+		t.Fatalf("org change: want PinMismatch, got %v", v)
+	}
+	// Different cloud host → mismatch.
+	if v := c.EvaluateDevicePin("wendy-thor.local", 7, "evil.example.com:443"); v != PinMismatch {
+		t.Fatalf("cloud change: want PinMismatch, got %v", v)
+	}
+}
+
+// TestEvaluateDevicePinNormalizesHostname ensures cosmetic hostname differences
+// (case, trailing dot, .local) don't spuriously read as a different device.
+func TestEvaluateDevicePinNormalizesHostname(t *testing.T) {
+	c := &Config{}
+	c.SetDevicePin("Wendy-Thor.local.", 7, "grpc.wendy.sh:443")
+	if v := c.EvaluateDevicePin("wendy-thor", 7, "grpc.wendy.sh:443"); v != PinMatch {
+		t.Fatalf("normalized host should match pin, got %v", v)
+	}
+}
+
+func TestDevicePinRoundTripsThroughConfig(t *testing.T) {
+	c := &Config{}
+	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.sh:443")
+
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Config
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if v := got.EvaluateDevicePin("wendy-thor.local", 7, "grpc.wendy.sh:443"); v != PinMatch {
+		t.Fatalf("pin did not round-trip through JSON, got %v", v)
+	}
+}


### PR DESCRIPTION
## Summary

`wendy device set-default` now pins the selected device's **identity** — the organisation and cloud host its mTLS cert belongs to — and every later connection to the default device verifies it still presents that same org + cloud. The pin is also established on the **first successful connection** if the device was offline at set-default time.

### Why org+cloud, not a cert fingerprint
A device legitimately **renews or re-enrolls** its certificate. That keeps the same organisation and cloud host, so it is accepted **silently** — no spurious warnings. The pin only trips when the organisation or cloud host changes, i.e. a *different trust domain* is answering at that hostname (possible MITM or swapped device). This matches the intent: don't punish rotation, do catch identity substitution.

### On a mismatch
- **Interactive:** a red warning (pinned vs. now: org/cloud) plus a prompt — "trust the new identity and re-pin?" Declining aborts the connection.
- **Non-interactive (`--json` / no TTY):** the connection is refused with a clear message; re-run `wendy device set-default` to deliberately re-pin.

## Implementation
- **`config`** — `DevicePins map[hostname]{orgId, cloudGRPC}` with `EvaluateDevicePin` / `SetDevicePin` (hostname-normalised, renewal-tolerant). Pure logic, unit-tested.
- **`commands`** — `enforceDevicePin` runs in `connectToAgent`'s default-device path, mapping the verifying cert's org back to its cloud host (`cloudGRPCForOrg`); `set-default` triggers a best-effort non-interactive connect to establish the pin.
- **`tui`** — red-styled no-default confirm (`ConfirmNoDefaultDanger`).
- A `NonInteractive()` connect no longer triggers the default-device recovery picker, so `set-default`'s pin probe can't hijack the UX.

## Context
Builds on the existing `devicepin` SPKI trust-on-first-use store (kept as-is, informational). This adds the deliberate, renewal-tolerant org+cloud anchor the ticket asks for.

## Tests
Pin verdict matrix (first-use / match / org-change / cloud-change), JSON round-trip, hostname normalisation, and org→cloud mapping. `gofmt` / `go vet` / `go build ./...` clean; config, commands, and tui packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)