### PR TITLE
docs+ci: backfill overlooked review suggestions from PRs merged this week

### DIFF
--- a/.github/ci-tests/python-device-top/Dockerfile
+++ b/.github/ci-tests/python-device-top/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py .
+ENV PYTHONUNBUFFERED=1
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-device-top/main.py
+++ b/.github/ci-tests/python-device-top/main.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Long-running app for the `wendy device top` integration test.
+
+`wendy device top` is a live monitor, so it needs a container that stays running
+and is observable. This app binds a TCP and a UDP port (so it also shows up in
+top's per-app ports panel) and then idles, doing only trivial periodic work so
+its CPU usage stays low. The test harness deploys it detached, runs
+`wendy device top --json`, asserts the host and container fields are present,
+then removes it.
+"""
+
+import socket
+import sys
+import time
+
+TCP_PORT = 18080
+UDP_PORT = 18081
+
+try:
+    tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    tcp.bind(("0.0.0.0", TCP_PORT))
+    tcp.listen(8)
+
+    udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    udp.bind(("0.0.0.0", UDP_PORT))
+except OSError as e:
+    print(f"FAIL: could not bind ports: {e}", flush=True)
+    sys.exit(1)
+
+print(f"listening on tcp/{TCP_PORT} and udp/{UDP_PORT}; idling for `wendy device top`", flush=True)
+
+while True:
+    time.sleep(5)

--- a/.github/ci-tests/python-device-top/wendy.json
+++ b/.github/ci-tests/python-device-top/wendy.json
@@ -1,0 +1,11 @@
+{
+    "appId": "sh.wendy.ci.python-device-top",
+    "version": "1.0.0",
+    "language": "python",
+    "entitlements": [
+        {
+            "type": "network",
+            "mode": "host"
+        }
+    ]
+}

--- a/.github/ci-tests/python-multiservice-resources/api/Dockerfile
+++ b/.github/ci-tests/python-multiservice-resources/api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py .
+ENV PYTHONUNBUFFERED=1
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-multiservice-resources/api/main.py
+++ b/.github/ci-tests/python-multiservice-resources/api/main.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Multi-service resource-limit test (WDY-1729): the `api` service.
+
+`api` overrides memory to 128Mi while leaving `pids` unset, so it must inherit
+the app-level pids (256) and use its own memory limit. This verifies
+ResolveResourcesForService overlays a service's declared fields on top of the
+app-level limits (field-level merge, not all-or-nothing).
+"""
+
+import os
+import sys
+
+EXPECTED_MEM_BYTES = 128 * 1024 * 1024  # per-service override
+EXPECTED_PIDS = 256                     # inherited app-level limit
+CGROUP_ROOT = "/sys/fs/cgroup"
+
+failures = []
+
+
+def read_int(v2_path, v1_path):
+    if os.path.exists(os.path.join(CGROUP_ROOT, "cgroup.controllers")):
+        with open(f"{CGROUP_ROOT}/{v2_path}") as f:
+            return int(f.read().strip())
+    with open(f"{CGROUP_ROOT}/{v1_path}") as f:
+        return int(f.read().strip())
+
+
+try:
+    mem = read_int("memory.max", "memory/memory.limit_in_bytes")
+    pids = read_int("pids.max", "pids/pids.max")
+except (OSError, ValueError) as e:
+    print(f"api: FAIL could not read cgroup limits: {e}", flush=True)
+    sys.exit(1)
+
+if mem != EXPECTED_MEM_BYTES:
+    failures.append(f"memory.max={mem}, want {EXPECTED_MEM_BYTES} (per-service override 128Mi)")
+if pids != EXPECTED_PIDS:
+    failures.append(f"pids.max={pids}, want {EXPECTED_PIDS} (inherited app-level 256)")
+
+if failures:
+    print("api: FAIL " + "; ".join(failures), flush=True)
+    sys.exit(1)
+
+print(f"api: PASS memory.max={mem} (override 128Mi), pids.max={pids} (inherited 256)", flush=True)
+sys.exit(0)

--- a/.github/ci-tests/python-multiservice-resources/db/Dockerfile
+++ b/.github/ci-tests/python-multiservice-resources/db/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py .
+ENV PYTHONUNBUFFERED=1
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-multiservice-resources/db/main.py
+++ b/.github/ci-tests/python-multiservice-resources/db/main.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Multi-service resource-limit test (WDY-1729): the `db` service.
+
+`db` declares no per-service `resources`, so it inherits the app-level limit
+(memory 256Mi). This verifies ResolveResourcesForService falls back to the
+app-level limits when a service doesn't override them.
+"""
+
+import os
+import sys
+
+EXPECTED_MEM_BYTES = 256 * 1024 * 1024  # inherited app-level limit
+CGROUP_ROOT = "/sys/fs/cgroup"
+
+
+def memory_max_bytes():
+    if os.path.exists(os.path.join(CGROUP_ROOT, "cgroup.controllers")):
+        with open(f"{CGROUP_ROOT}/memory.max") as f:
+            return int(f.read().strip())
+    with open(f"{CGROUP_ROOT}/memory/memory.limit_in_bytes") as f:
+        return int(f.read().strip())
+
+
+try:
+    got = memory_max_bytes()
+except (OSError, ValueError) as e:
+    print(f"db: FAIL could not read memory limit: {e}", flush=True)
+    sys.exit(1)
+
+if got == EXPECTED_MEM_BYTES:
+    print(f"db: PASS memory.max={got} (inherited app-level 256Mi)", flush=True)
+    sys.exit(0)
+
+print(f"db: FAIL memory.max={got}, want {EXPECTED_MEM_BYTES} (inherited 256Mi)", flush=True)
+sys.exit(1)

--- a/.github/ci-tests/python-multiservice-resources/wendy.json
+++ b/.github/ci-tests/python-multiservice-resources/wendy.json
@@ -1,0 +1,20 @@
+{
+    "appId": "sh.wendy.ci.python-multiservice-resources",
+    "version": "1.0.0",
+    "resources": {
+        "memory": "256Mi",
+        "pids": 256
+    },
+    "services": {
+        "db": {
+            "context": "db"
+        },
+        "api": {
+            "context": "api",
+            "dependsOn": ["db"],
+            "resources": {
+                "memory": "128Mi"
+            }
+        }
+    }
+}

--- a/.github/ci-tests/python-network-host-admin/Dockerfile
+++ b/.github/ci-tests/python-network-host-admin/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py .
+ENV PYTHONUNBUFFERED=1
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-network-host-admin/main.py
+++ b/.github/ci-tests/python-network-host-admin/main.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Positive test: the `host-admin` network mode grants CAP_NET_ADMIN (WDY-1094).
+
+`{"type": "network", "mode": "host-admin"}` is the explicit opt-in that lets a
+container reconfigure host network interfaces/routes/netfilter. The agent must
+add CAP_NET_ADMIN (capability 12) to the effective set. We read CapEff from
+/proc/self/status and require bit 12 to be set."""
+
+import sys
+
+CAP_NET_ADMIN = 12
+CAP_NET_ADMIN_BIT = 1 << CAP_NET_ADMIN
+
+
+def read_cap_eff():
+    with open("/proc/self/status", "r") as f:
+        for line in f:
+            if line.startswith("CapEff:"):
+                return int(line.split()[1], 16)
+    raise RuntimeError("CapEff not found in /proc/self/status")
+
+
+try:
+    cap_eff = read_cap_eff()
+except Exception as e:
+    print(f"FAIL: could not read effective capabilities: {e}")
+    sys.exit(1)
+
+if cap_eff & CAP_NET_ADMIN_BIT:
+    print(f"PASS: CAP_NET_ADMIN present with host-admin networking (CapEff={cap_eff:016x})")
+    sys.exit(0)
+
+print(f"FAIL: CAP_NET_ADMIN missing under host-admin networking (CapEff={cap_eff:016x})")
+sys.exit(1)

--- a/.github/ci-tests/python-network-host-admin/wendy.json
+++ b/.github/ci-tests/python-network-host-admin/wendy.json
@@ -1,0 +1,11 @@
+{
+    "appId": "sh.wendy.ci.python-network-host-admin",
+    "version": "1.0.0",
+    "language": "python",
+    "entitlements": [
+        {
+            "type": "network",
+            "mode": "host-admin"
+        }
+    ]
+}

--- a/.github/ci-tests/python-no-kexec-module/Dockerfile
+++ b/.github/ci-tests/python-no-kexec-module/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py .
+ENV PYTHONUNBUFFERED=1
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-no-kexec-module/main.py
+++ b/.github/ci-tests/python-no-kexec-module/main.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Negative test: verify the kernel-module and kexec syscalls are blocked by the
+default seccomp profile (WDY-1012).
+
+The baseline seccomp profile denies init_module, finit_module, delete_module,
+create_module, kexec_load, and kexec_file_load with EPERM — these are pure
+host-escape primitives a normal application container never needs. A successful
+call (return 0) means the filter was not applied and is a hard failure.
+
+create_module is deliberately omitted: it was removed from Linux long ago and
+has no syscall number on arm64, so it can't be exercised portably."""
+
+import ctypes
+import ctypes.util
+import platform
+import sys
+
+# Syscall numbers per architecture. WendyOS devices are arm64; x86_64 is
+# included so the test is meaningful on dev machines / amd64 runners too.
+SYSCALLS = {
+    "aarch64": {
+        "init_module": 105,
+        "finit_module": 273,
+        "delete_module": 106,
+        "kexec_load": 104,
+        "kexec_file_load": 294,
+    },
+    "x86_64": {
+        "init_module": 175,
+        "finit_module": 313,
+        "delete_module": 176,
+        "kexec_load": 246,
+        "kexec_file_load": 320,
+    },
+}
+
+arch = platform.machine()
+table = SYSCALLS.get(arch)
+if table is None:
+    print(f"FAIL: unsupported architecture {arch!r}; cannot resolve syscall numbers")
+    sys.exit(1)
+
+libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+
+failures = []
+for name, nr in table.items():
+    ctypes.set_errno(0)
+    # Benign/invalid args: if the syscall were permitted it would still fail
+    # (EBADF/EFAULT/EPERM from the capability check), so a -1 return is expected.
+    # The only unacceptable outcome is a successful (0) call.
+    ret = libc.syscall(nr, 0, 0, 0, 0, 0)
+    err = ctypes.get_errno()
+    if ret == 0:
+        failures.append(f"{name} (nr {nr}) SUCCEEDED — seccomp profile not applied")
+    else:
+        print(f"  {name} (nr {nr}) blocked: ret={ret} errno={err}")
+
+if failures:
+    for f in failures:
+        print(f"FAIL: {f}")
+    sys.exit(1)
+
+print(f"PASS: all kernel-module / kexec syscalls blocked on {arch}")
+sys.exit(0)

--- a/.github/ci-tests/python-no-kexec-module/wendy.json
+++ b/.github/ci-tests/python-no-kexec-module/wendy.json
@@ -1,0 +1,5 @@
+{
+    "appId": "sh.wendy.ci.python-no-kexec-module",
+    "version": "1.0.0",
+    "language": "python"
+}

--- a/.github/ci-tests/python-no-net-admin/Dockerfile
+++ b/.github/ci-tests/python-no-net-admin/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py .
+ENV PYTHONUNBUFFERED=1
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-no-net-admin/main.py
+++ b/.github/ci-tests/python-no-net-admin/main.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Negative/regression test: plain `host` networking must NOT grant CAP_NET_ADMIN
+(WDY-1094).
+
+`{"type": "network", "mode": "host"}` gives network *visibility* (bind ports,
+see interfaces) but must not let the container reconfigure host networking. The
+agent must withhold CAP_NET_ADMIN (capability 12). We read CapEff from
+/proc/self/status and require bit 12 to be clear. This guards against a
+regression that re-couples CAP_NET_ADMIN to plain host networking."""
+
+import sys
+
+CAP_NET_ADMIN = 12
+CAP_NET_ADMIN_BIT = 1 << CAP_NET_ADMIN
+
+
+def read_cap_eff():
+    with open("/proc/self/status", "r") as f:
+        for line in f:
+            if line.startswith("CapEff:"):
+                return int(line.split()[1], 16)
+    raise RuntimeError("CapEff not found in /proc/self/status")
+
+
+try:
+    cap_eff = read_cap_eff()
+except Exception as e:
+    print(f"FAIL: could not read effective capabilities: {e}")
+    sys.exit(1)
+
+if cap_eff & CAP_NET_ADMIN_BIT:
+    print(f"FAIL: CAP_NET_ADMIN granted under plain host networking (CapEff={cap_eff:016x})")
+    sys.exit(1)
+
+print(f"PASS: CAP_NET_ADMIN correctly withheld under plain host networking (CapEff={cap_eff:016x})")
+sys.exit(0)

--- a/.github/ci-tests/python-no-net-admin/wendy.json
+++ b/.github/ci-tests/python-no-net-admin/wendy.json
@@ -1,0 +1,11 @@
+{
+    "appId": "sh.wendy.ci.python-no-net-admin",
+    "version": "1.0.0",
+    "language": "python",
+    "entitlements": [
+        {
+            "type": "network",
+            "mode": "host"
+        }
+    ]
+}

--- a/.github/ci-tests/python-resources/Dockerfile
+++ b/.github/ci-tests/python-resources/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py .
+ENV PYTHONUNBUFFERED=1
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-resources/main.py
+++ b/.github/ci-tests/python-resources/main.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Integration test for WDY-1729: app-level resource limits in wendy.json.
+
+wendy.json declares:
+    "resources": { "memory": "128Mi", "cpus": "0.5", "pids": 64 }
+
+The agent must translate these into cgroup limits on the container. We read the
+container's own cgroup (cgroup v2 preferred, with a cgroup v1 fallback) and
+verify each ceiling was applied end-to-end:
+    memory -> 128 MiB  = 134217728 bytes
+    cpus   -> 0.5 core = quota 50000 / period 100000 us
+    pids   -> 64
+"""
+
+import os
+import sys
+
+EXPECTED_MEM_BYTES = 128 * 1024 * 1024  # 128Mi
+EXPECTED_CPU_QUOTA = 50000              # 0.5 * 100000us period
+EXPECTED_CPU_PERIOD = 100000
+EXPECTED_PIDS = 64
+
+CGROUP_ROOT = "/sys/fs/cgroup"
+
+failures = []
+
+
+def read(path):
+    with open(path, "r") as f:
+        return f.read().strip()
+
+
+def check(label, got, want):
+    if got == want:
+        print(f"OK  {label}: {got}")
+    else:
+        failures.append(f"{label}: got {got!r}, want {want!r}")
+
+
+cgroup_v2 = os.path.exists(os.path.join(CGROUP_ROOT, "cgroup.controllers"))
+print(f"cgroup version: {'v2' if cgroup_v2 else 'v1'}")
+
+try:
+    if cgroup_v2:
+        check("memory.max", int(read(f"{CGROUP_ROOT}/memory.max")), EXPECTED_MEM_BYTES)
+        check("pids.max", int(read(f"{CGROUP_ROOT}/pids.max")), EXPECTED_PIDS)
+        # cpu.max is "<quota> <period>" (quota may be "max" when unset).
+        quota_s, period_s = read(f"{CGROUP_ROOT}/cpu.max").split()
+        check("cpu.max quota", int(quota_s), EXPECTED_CPU_QUOTA)
+        check("cpu.max period", int(period_s), EXPECTED_CPU_PERIOD)
+    else:
+        check("memory.limit_in_bytes",
+              int(read(f"{CGROUP_ROOT}/memory/memory.limit_in_bytes")), EXPECTED_MEM_BYTES)
+        check("pids.max", int(read(f"{CGROUP_ROOT}/pids/pids.max")), EXPECTED_PIDS)
+        check("cpu.cfs_quota_us",
+              int(read(f"{CGROUP_ROOT}/cpu/cpu.cfs_quota_us")), EXPECTED_CPU_QUOTA)
+        check("cpu.cfs_period_us",
+              int(read(f"{CGROUP_ROOT}/cpu/cpu.cfs_period_us")), EXPECTED_CPU_PERIOD)
+except (OSError, ValueError) as e:
+    print(f"FAIL: could not read cgroup limits: {e}")
+    sys.exit(1)
+
+if failures:
+    print("\nFAIL: resource limits not applied correctly:")
+    for f in failures:
+        print(f"  - {f}")
+    sys.exit(1)
+
+print("\nPASS: app-level resource limits enforced via cgroups")
+sys.exit(0)

--- a/.github/ci-tests/python-resources/wendy.json
+++ b/.github/ci-tests/python-resources/wendy.json
@@ -1,0 +1,10 @@
+{
+    "appId": "sh.wendy.ci.python-resources",
+    "version": "1.0.0",
+    "language": "python",
+    "resources": {
+        "memory": "128Mi",
+        "cpus": "0.5",
+        "pids": 64
+    }
+}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -295,7 +295,7 @@ jobs:
               exit 0
             fi
           else
-            for t in swift-hello swift-network swift-bluetooth swift-resources python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-multiservice python-servicename otel-localhost-only; do
+            for t in swift-hello swift-network swift-bluetooth swift-resources python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-no-kexec-module python-network-host-admin python-no-net-admin python-resources python-multiservice python-multiservice-resources python-servicename python-device-top otel-localhost-only; do
               TEST_ARGS+=(-t "$t")
             done
           fi
@@ -405,7 +405,7 @@ jobs:
               exit 0
             fi
           else
-            for t in python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-multiservice python-servicename otel-localhost-only; do
+            for t in python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-no-kexec-module python-network-host-admin python-no-net-admin python-resources python-multiservice python-multiservice-resources python-servicename python-device-top otel-localhost-only; do
               TEST_ARGS+=(-t "$t")
             done
           fi

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -47,7 +47,7 @@ Docker for local provider runs.
 | Build-arg | Values | Notes |
 |---|---|---|
 | `WENDY_PLATFORM` | `nvidia-jetson` \| `generic` | Platform tier derived from the device type |
-| `WENDY_DEBUG` | `true` \| `false` | Set when `--debug` is passed |
+| `WENDY_DEBUG` | `true` \| `false` | Set when `--debug` is passed. [`wendy project optimize`](project/optimize.md) flags it when it's declared (`ARG`/`ENV`) but no `RUN` step branches on it — gate your optimization level on it so debug builds aren't shipped to release. |
 | `WENDY_DEVICE_TYPE` | e.g. `jetson-agx-orin` | Raw device type; absent when unknown |
 | `WENDY_HAS_GPU` | `true` \| `false` | Absent on older agents |
 | `WENDY_GPU_VENDOR` | e.g. `nvidia`, `qualcomm` | Absent when no GPU is reported |
@@ -75,6 +75,18 @@ Builds with `xcodebuild`. Xcode project support exists for native Mac packages t
 Wendy passes `-skipMacroValidation` and `-skipPackagePluginValidation` so `xcodebuild` can run from a headless CLI/agent session. Xcode's macro/plugin prompts are an interactive consent layer on top of SwiftPM's build-time code and package-plugin sandbox model; headless Wendy builds treat invoking the build as consent, similar to CLI build tools. Only use Xcode projects with trusted, pinned package dependencies.
 
 For native Mac runs, if a `Brewfile.wendy` is present in the project root, Wendy applies it on the target Mac before starting the app. A plain project-root `Brewfile` is left for developer-machine setup unless explicitly referenced by `wendy.json`.
+
+## Post-build optimization hint
+
+After a **slow incremental build** — one that reused cached layers but still took longer than ~50 seconds — `wendy build` runs a quick static [`wendy project optimize`](project/optimize.md) scan and, if it finds fixable build-config issues, prints them and offers to apply the safe fixes:
+
+```
+This incremental build took 1m4s. A quick scan found 2 build-config issue(s):
+…
+Apply 2 safe fix(es) now? (takes effect on your next build) [Y/n]
+```
+
+The fixes take effect on your **next** build; the build that just completed is unchanged. This nudge is purely interactive and is a **no-op in CI / non-interactive shells**. A separate one-line tip pointing at `wendy project optimize` is throttled to at most once per day per project.
 
 ## Platform support for Swift projects
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/completion.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/completion.md
@@ -40,6 +40,8 @@ Detects the running shell from `$SHELL` (Unix) or defaults to `powershell` (Wind
 
 Running `install` more than once is safe — the rc file is only modified on the first run. Subsequent runs detect the `# wendy-completion` sentinel and make no changes.
 
+A successful `install` also records `completionInstalled: true` in `~/.wendy/config.json`, which permanently suppresses the [ambient install prompt](#automatic-prompt-to-install-completions). The dry-run flags `--print-path` and `--stdout` do **not** set this flag, since they don't actually install anything.
+
 ### Shell detection and install paths
 
 | Shell | Script path | rc file modified |
@@ -92,3 +94,37 @@ wendy completion install --shell bash --stdout
 The `--stdout` flag is intended for package managers such as Homebrew that call the binary directly and expect the completion script on stdout (e.g. via `generate_completions_from_executable`). It prints the script for the selected shell and exits without touching the filesystem or shell rc files.
 
 After installation, restart your shell (or source the relevant rc file) for completions to take effect. Fish and bash-completion v2 load the script automatically on the next shell start without any rc change.
+
+## Automatic prompt to install completions
+
+When shell completions aren't installed yet, the CLI may offer to install them with an ambient prompt after a command finishes:
+
+```
+Shell completions for `wendy` aren't installed yet.
+Install them now? [y/n]
+```
+
+The prompt has no default — you must answer `y` or `n`.
+
+- **`y`** installs completions for the detected shell (same as `wendy completion install`).
+- **`n`** permanently dismisses the prompt (sets `completionPromptDismissed`); it won't be shown again.
+- **Ctrl+C / EOF** leaves the prompt unanswered. It is throttled and won't reappear until the throttle window (24 hours) elapses.
+
+The prompt is intentionally unobtrusive and is **never** shown when:
+
+- the session is non-interactive (no TTY) or output is machine-readable (`--json`),
+- completions are already installed (`completionInstalled`) or the prompt was dismissed (`completionPromptDismissed`),
+- the first-run analytics notice or a CLI-update prompt is shown in the same invocation (the prompt never stacks on top of those),
+- the command runs its own completion flow — `wendy completion …` and [`wendy tour`](tour.md) — or is an internal helper.
+
+> **See also:** [`wendy tour`](tour.md) includes a completions step that installs shell completions as part of first-time setup. Completing the tour, or installing completions there, suppresses this ambient prompt.
+
+### Config fields
+
+The prompt's state is persisted in `~/.wendy/config.json`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `completionInstalled` | bool | Set once `wendy completion install` (or the prompt/tour install path) succeeds. Permanently suppresses the prompt. |
+| `completionPromptDismissed` | bool | Set when you answer `n` to the prompt. Permanently suppresses the prompt. |
+| `lastCompletionPromptCheck` | RFC3339 timestamp | When the prompt was last shown. Used to throttle it to at most once per 24-hour window. |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/info.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/info.md
@@ -25,6 +25,8 @@ On GPU-capable devices, the following GPU fields are included. Each is omitted f
 | `cudaVersion` | `CUDA:` | CUDA toolkit version (e.g. `12.6`). |
 | `gpuArch` | `GPU Arch:` | GPU architecture identifier. Format is vendor-specific (e.g. `sm_87` for NVIDIA). |
 
+`wendy device info` reports static GPU *metadata* (vendor, architecture, toolkit versions). For **live** GPU utilization, memory, temperature, and power draw, use [`wendy device top`](top.md).
+
 ## Flags
 
 | Flag | Default | Description |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/meta.json
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/meta.json
@@ -3,6 +3,7 @@
     "apps",
     "logs",
     "dashboard",
+    "top",
     "info",
     "set-default",
     "unset-default",

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/top.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/top.md
@@ -1,0 +1,79 @@
+# `wendy device top`
+
+Live CPU, memory, and GPU usage for the device and its containers — an `htop`-style monitor for a WendyOS device.
+
+## Usage
+
+```sh
+wendy device top [flags]
+```
+
+## Description
+
+`wendy device top` opens a full-screen, auto-refreshing dashboard showing whole-machine CPU and memory utilization, per-GPU utilization/memory (and temperature/power where reported), and a per-app/per-container table of CPU% and memory. CPU percentages are computed from deltas between refreshes, so the first frame may read low until a second sample is taken.
+
+Apps are grouped the same way as [`wendy device dashboard`](dashboard.md): multi-service apps show a group header with one subrow per service. A side panel shows the listening ports of the currently selected app.
+
+> **Note:** This command requires a recent device agent. Against an agent that's too old to report resource stats, the command reports that the agent doesn't support resource stats and suggests updating it with [`wendy device update`](update.md).
+
+### Keyboard shortcuts
+
+| Key | Action |
+|---|---|
+| `↑` / `k`, `↓` / `j` | Move the selection up / down |
+| `c` | Sort apps by CPU usage (descending) |
+| `m` | Sort apps by memory usage (descending) |
+| `q` / `Ctrl+C` | Quit |
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--interval` | `2s` | Refresh interval for the live view |
+
+The [global `--json` flag](../../global-flags.md) is also honored — see below.
+
+## JSON snapshot mode
+
+`wendy device top` is a live TUI, so it cannot stream into a pipe. When `--json` is passed (or stdout is not a TTY), the command switches to a **one-shot snapshot**: it samples the device, prints a single JSON object, and exits instead of rendering the dashboard.
+
+```sh
+wendy device top --json
+```
+
+The snapshot has this shape:
+
+```json
+{
+  "host": {
+    "cpuPercent": 12.5,
+    "cpuCount": 8,
+    "memUsedBytes": 2147483648,
+    "memTotalBytes": 8589934592,
+    "gpus": [
+      {
+        "index": 0,
+        "name": "Orin",
+        "utilPercent": 30.0,
+        "memUsedBytes": 1073741824,
+        "memTotalBytes": 8589934592,
+        "tempC": 45.0,
+        "powerW": 7.5
+      }
+    ]
+  },
+  "containers": [
+    { "name": "my-app", "state": "running", "cpuPercent": 4.2, "memBytes": 134217728 }
+  ]
+}
+```
+
+- `host.gpus` is omitted on devices that report no GPU.
+- Each GPU's `tempC` and `powerW` are omitted when the agent doesn't report them.
+- `containers[].cpuPercent` is each container's share of the whole machine (0–100 across all cores).
+
+## Related
+
+- [`wendy device dashboard`](dashboard.md) — full-screen app/service status dashboard
+- [`wendy device info`](info.md) — one-shot device hardware and GPU metadata
+- [`wendy device apps`](apps/) — list and manage deployed apps

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/install.md
@@ -1,0 +1,31 @@
+# `wendy install`
+
+Installs WendyOS onto an NVMe or SD card, or flashes Wendy Lite firmware onto an ESP32 over USB.
+
+`wendy install` is the surfaced, top-level alias for [`wendy os install`](os/install.md). It is the recommended entry point: the underlying `wendy os` group is hidden from the main help, but the install flow is the most common first step when bringing up a device, so it is promoted to a first-class command.
+
+The two commands are the **same command** — they accept identical flags and arguments and behave identically. `wendy os install` remains available for backward compatibility and for discoverability under the `wendy os` group.
+
+```sh
+# Interactive (recommended)
+wendy install
+
+# Install nightly firmware
+wendy install --nightly
+
+# Linux: non-interactive with all flags
+wendy install --device-type raspberry-pi-5 --version 0.10.4 --drive /dev/disk4 --force
+
+# Direct install from a local image (Linux only)
+wendy install path/to/image.img /dev/disk4 --force
+```
+
+## Reference
+
+See [`wendy os install`](os/install.md) for the complete reference: the ESP32 (Wendy Lite) flash path, the Linux (WendyOS) write path, WiFi pre-configuration, pre-enrollment, exit-code semantics, and the full flags table.
+
+## Related
+
+- [`wendy os install`](os/install.md) — full installation reference (same command)
+- [`wendy os download`](os/download.md) — pre-download a WendyOS image into the cache
+- [`wendy device setup`](device/setup.md) — provision a device after first boot

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/meta.json
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/meta.json
@@ -2,6 +2,7 @@
   "pages": [
     "init",
     "run",
+    "install",
     "project",
     "device",
     "cloud",

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/cache/list.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/cache/list.md
@@ -62,5 +62,5 @@ If reading the metadata for a cache entry fails, the command exits with an error
 ## Related
 
 - [`wendy cache list`](../../cache/list.md) — lists all cached items, including OS images
-- [`wendy os install`](../install.md) — installs WendyOS and populates the cache
+- [`wendy install`](../../install.md) / [`wendy os install`](../install.md) — installs WendyOS and populates the cache
 - [`wendy os download`](../download.md) — downloads WendyOS images into the cache

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -2,6 +2,8 @@
 
 Installs WendyOS onto an NVMe or SD card, or flashes Wendy Lite firmware onto an ESP32 over USB.
 
+> **Tip:** [`wendy install`](../install.md) is the recommended, surfaced entry point for this command. `wendy os install` remains available and behaves identically — it is kept for backward compatibility and for discoverability under the `wendy os` group.
+
 The command presents a unified device picker that lists both Linux targets (Raspberry Pi, Jetson, …) and ESP32 targets (C6, C5). Select the device type to take the appropriate path:
 
 - **Linux targets** → download OS image → write to SD/NVMe → write config partition
@@ -130,6 +132,8 @@ wendy os install --no-wifi
 ```
 
 `--wifi-ssid` without `--wifi-password` checks the system keychain (macOS) first, then prompts. In interactive mode without any `--wifi` flags, the CLI asks whether to configure WiFi and offers to scan nearby networks. If the scan fails or finds no networks, you can choose to enter credentials manually or skip WiFi setup entirely (configure later with `wendy device wifi connect`).
+
+> **Note:** When a password is entered at an interactive prompt, the input is masked — characters appear as `•` so the password is never displayed in plaintext on screen.
 
 The `--wifi` flag accepts `key=value` pairs separated by commas. Keys: `ssid` (required), `password`/`pass`/`psk`, `priority` (integer), `hidden` (true/false), `security` (e.g. `wpa2`). Commas inside values can be escaped with `\,`.
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/project/optimize.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/project/optimize.md
@@ -36,6 +36,18 @@ wendy project optimize --agentic  # emit a context bundle for an AI agent
 
 After a slow incremental build (one that reused cached layers and still took more than ~50s), `wendy run` / `wendy build` will run this scan automatically in an interactive terminal, show the findings, and offer to apply the safe fixes for your next build. This never runs in CI or non-interactive shells.
 
+## Sample projects
+
+The repository ships small, deliberately un-optimized sample projects under [`Examples/project-optimize-samples/`](https://github.com/wendylabsinc/wendyos/tree/main/Examples/project-optimize-samples) that each trigger a specific finding, so you can see the analyzer and `--fix` in action:
+
+| Sample | Demonstrates |
+|---|---|
+| `rust-debug-no-cache` | Missing build-cache mount + a debug (non-release) build |
+| `swift-debug-wendy-debug` | A declared-but-unused `WENDY_DEBUG` arg and a debug Swift build |
+| `python-cuda-mismatch` | A CUDA wheel that doesn't match the target's CUDA version |
+
+Run `wendy project optimize` (or `--fix`) inside any sample directory to reproduce the corresponding finding. See the [samples README](https://github.com/wendylabsinc/wendyos/tree/main/Examples/project-optimize-samples) for details.
+
 ## A note on `--agentic` and secrets
 
 The `--agentic` bundle includes the **verbatim contents** of your Dockerfile(s), `requirements.txt`, and `wendy.json` so the agent has full context. These files can contain secrets (`ARG`/`ENV` tokens, private registry URLs). The command prints a reminder to stderr; review the bundle before sending it to an external agent.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/global-flags.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/global-flags.md
@@ -20,6 +20,8 @@ wendy device list | cat
 wendy device list --json=false | cat
 ```
 
+> **Note:** For live, full-screen TUI commands such as [`wendy device top`](./commands/device/top.md), `--json` does not stream the interface — it switches the command to a one-shot **snapshot** mode that prints a single JSON object and exits, instead of rendering the interactive dashboard.
+
 ## `--device`
 
 Specifies a target device by IP address, hostname, provider key, or explicit `host:port`, bypassing [device selection](./device-selection.md).
@@ -40,6 +42,18 @@ The Wendy CLI checks GitHub for a newer release in the background once every 24 
 - **Linux:** `curl -fsSL https://install.wendy.sh/cli.sh | bash`.
 
 > **Note:** The 24-hour cooldown between update checks depends on `~/.wendy/config.json` being writable. If the file cannot be saved, the background check runs on every CLI invocation.
+
+## Automatic shell-completion prompt
+
+When shell completions aren't installed, the CLI offers — at most once per 24-hour window — to install them with an ambient `Install them now? [y/n]` prompt after a command finishes. It is never shown in non-interactive or `--json` contexts, on commands that handle completions themselves (`wendy completion …`, [`wendy tour`](./commands/tour.md)), or once completions are installed or the prompt is dismissed. See [`wendy completion`](./commands/completion.md#automatic-prompt-to-install-completions) for the full behavior.
+
+Its state is persisted in `~/.wendy/config.json`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `completionInstalled` | bool | Completions were installed through the CLI; permanently suppresses the prompt. |
+| `completionPromptDismissed` | bool | The user answered `n` to the prompt; permanently suppresses it. |
+| `lastCompletionPromptCheck` | RFC3339 timestamp | When the prompt was last shown; throttles it to once per 24-hour window. |
 
 ## Environment variables
 

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -27,8 +27,14 @@ Tests:
   python-no-bluetooth       Verify bluetooth is blocked WITHOUT entitlement
   python-no-ptrace          Verify ptrace is blocked by default seccomp profile (WDY-1099)
   python-no-unshare         Verify unshare is blocked by default seccomp profile (WDY-1099)
+  python-no-kexec-module    Verify kernel-module/kexec syscalls are blocked by seccomp (WDY-1012)
+  python-network-host-admin Verify host-admin networking grants CAP_NET_ADMIN (WDY-1094)
+  python-no-net-admin       Verify plain host networking does NOT grant CAP_NET_ADMIN (WDY-1094)
+  python-resources          Verify app-level CPU/memory/PID limits are enforced via cgroups (WDY-1729)
+  python-multiservice-resources  Verify per-service resource override + app-level inheritance (WDY-1729)
   python-multiservice       Multi-service wendy.json: parallel build + dep-order creation
   python-servicename        Single service with serviceName: verifies WENDY_HOSTNAME/WENDY_APP_GROUP env injection (WDY-878)
+  python-device-top         Deploy a long-running app and verify 'wendy device top --json' reports it (device top)
   compose-hello             docker-compose multi-service deployment with build: Dockerfiles
   compose-images            docker-compose multi-service deployment using public images
   otel-localhost-only       Verify OTEL receivers (4317/4318) are not reachable from the network
@@ -195,12 +201,18 @@ ALL_TESTS=(
     python-no-bluetooth
     python-no-ptrace
     python-no-unshare
+    python-no-kexec-module
+    python-network-host-admin
+    python-no-net-admin
+    python-resources
     python-multiservice
+    python-multiservice-resources
     python-servicename
     compose-hello
     compose-images
     compose-companion
     otel-localhost-only
+    python-device-top
 )
 
 # If specific tests were requested via -t, filter the list.
@@ -273,6 +285,84 @@ for test_name in "${TESTS[@]}"; do
         }
         run_test "python-multiservice (--service ghost -> error)" unknown_service_fails
 
+        continue
+    fi
+
+    # ── Multi-service resource limits (WDY-1729) ─────────────────────────
+    # Deploys two services: 'db' inherits the app-level memory limit (256Mi),
+    # 'api' overrides it to 128Mi while inheriting pids. Each service asserts
+    # its own cgroup limits and prints "<svc>: PASS" / "<svc>: FAIL". We read
+    # back the logs (bounded by a background reader) and require both PASS lines
+    # with no FAIL.
+    if [[ "$test_name" == "python-multiservice-resources" ]]; then
+        echo -e "${BOLD}── $test_name${RESET}"
+        app_id="sh.wendy.ci.python-multiservice-resources"
+
+        run_test "python-multiservice-resources (deploy)" \
+            "$WENDY" run --device "$HOSTNAME" --prefix "$test_dir" --deploy
+
+        per_service_limits_enforced() {
+            local logs logfile
+            logfile=$(mktemp -t wendy-mres-logs.XXXXXX)
+            # device logs streams; read it in the background and stop after a
+            # few seconds (portable: no `timeout` dependency).
+            "$WENDY" device logs --device "$HOSTNAME" --app "$app_id" --tail 50 \
+                >"$logfile" 2>&1 &
+            local logs_pid=$!
+            sleep 8
+            kill "$logs_pid" 2>/dev/null
+            wait "$logs_pid" 2>/dev/null
+            logs=$(cat "$logfile")
+            rm -f "$logfile"
+
+            if echo "$logs" | grep -qi "FAIL"; then
+                echo "Service reported FAIL:"; echo "$logs" | grep -i "fail"
+                return 1
+            fi
+            if echo "$logs" | grep -q "db: PASS" && echo "$logs" | grep -q "api: PASS"; then
+                return 0
+            fi
+            echo "Did not observe both 'db: PASS' and 'api: PASS' in logs:"; echo "$logs"
+            return 1
+        }
+        run_test "python-multiservice-resources (per-service limits)" per_service_limits_enforced
+
+        "$WENDY" device apps remove "$app_id" --device "$HOSTNAME" --force --cleanup >/dev/null 2>&1 || true
+        continue
+    fi
+
+    # ── device top (live monitor) ────────────────────────────────────────
+    # Deploy a long-running app, then verify `wendy device top --json` reports
+    # the host snapshot and lists the deployed container.
+    if [[ "$test_name" == "python-device-top" ]]; then
+        echo -e "${BOLD}── $test_name${RESET}"
+        app_id="sh.wendy.ci.python-device-top"
+
+        run_test "python-device-top (deploy)" \
+            "$WENDY" run --device "$HOSTNAME" --prefix "$test_dir" --detach
+
+        device_top_snapshot() {
+            local out rc
+            out=$("$WENDY" device top --device "$HOSTNAME" --json 2>&1)
+            rc=$?
+            if [[ $rc -ne 0 ]]; then
+                echo "wendy device top --json failed (rc=$rc): $out"
+                return 1
+            fi
+            if ! echo "$out" | jq -e '.host.cpuCount > 0 and .host.memTotalBytes > 0' >/dev/null 2>&1; then
+                echo "host.cpuCount / host.memTotalBytes missing or zero: $out"
+                return 1
+            fi
+            if ! echo "$out" | jq -e --arg a "$app_id" \
+                '(.containers // []) | map(.name) | index($a) != null' >/dev/null 2>&1; then
+                echo "deployed app '$app_id' not found in containers[]: $out"
+                return 1
+            fi
+            return 0
+        }
+        run_test "python-device-top (snapshot reports host + container)" device_top_snapshot
+
+        "$WENDY" device apps remove "$app_id" --device "$HOSTNAME" --force --cleanup >/dev/null 2>&1 || true
         continue
     fi
 


### PR DESCRIPTION
## Summary

Backfills documentation and CI integration-test suggestions that automated reviewers (**AI Docs Review** / **Integration test review**) left on PRs merged in the past week but that were merged without being applied. Built off the latest `main`.

### Docs
- **#1200** — surfaced `wendy install` page + meta registration, tip on `os/install`, fixed Related link in `os/cache/list`.
- **#1201** — documented the ambient shell-completion prompt and its config fields (`completionInstalled` / `completionPromptDismissed` / `lastCompletionPromptCheck`) in `completion.md` and `global-flags.md`.
- **#1202** — documented the post-build optimize hint + `WENDY_DEBUG` analyzer in `build.md`, and the optimize sample projects in `project/optimize.md`.
- **#1203** — added a `device/top` page, cross-referenced it from `device/info`, and documented `--json` snapshot mode for live TUIs in `global-flags.md`.
- **#1186** — noted that interactive WiFi-password input is masked in `os/install`.

### CI integration tests
Registered in both `go/scripts/test-ci.sh` and `.github/workflows/integration-tests.yml`:
- **#1211** `python-no-kexec-module` — seccomp denies module/kexec syscalls (WDY-1012).
- **#1212** `python-network-host-admin` / `python-no-net-admin` — `host-admin` grants `CAP_NET_ADMIN`, plain `host` does not (WDY-1094).
- **#1173** `python-resources` / `python-multiservice-resources` — app-level cgroup limits + per-service override/inheritance (WDY-1729).
- **#1203** `python-device-top` — `wendy device top --json` reports the host snapshot and a deployed container.

## Testing
- `python3 -m py_compile` on all new `main.py`; all `wendy.json` / `meta.json` parse.
- `bash -n` + `shellcheck -S warning` clean on `test-ci.sh`; workflow YAML parses.
- Embedded-docs assets package builds (`go build ./internal/cli/assets/`).
- ⚠️ The new integration tests are wired into the harness but **have not been run against hardware** — they follow the existing self-asserting (exit-code) and log-assertion conventions, with cgroup v1/v2 tolerance and portable log-bounding (no `timeout` dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)