### PR TITLE
feat(cli): auto sync-time and retry on clock-skew rejection

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -52,6 +52,33 @@ const provisionedAgentUnauthorizedMessage = "Unauthorized. Run 'wendy auth login
 
 var errProvisionedAgentUnauthorized = errors.New(provisionedAgentUnauthorizedMessage)
 
+// errTLSHandshakeRejected is the sentinel for "the device rejected our client
+// certificate during the TLS handshake" — the signature of clock skew (the
+// device clock lags the cert's validity window) or a genuine cert mismatch.
+// connectWithAutoTLSDiagnostics returns a tlsHandshakeRejectedError, so callers
+// can detect this case with errors.Is rather than string matching.
+var errTLSHandshakeRejected = errors.New("TLS handshake rejected by device")
+
+type tlsHandshakeRejectedError struct {
+	cause error
+}
+
+func newTLSHandshakeRejectedError(cause error) error {
+	return tlsHandshakeRejectedError{cause: cause}
+}
+
+func (e tlsHandshakeRejectedError) Is(target error) bool {
+	return target == errTLSHandshakeRejected
+}
+
+func (e tlsHandshakeRejectedError) Unwrap() error {
+	return e.cause
+}
+
+func (e tlsHandshakeRejectedError) Error() string {
+	return "TLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1"
+}
+
 type provisionedAgentUnauthorizedError struct {
 	cause error
 }
@@ -174,6 +201,76 @@ func offerCertRefreshAndRetry(ctx context.Context, cause error, retry func() (*g
 	conn, err := retry()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Still unable to connect after refreshing certificates: %v\n", err)
+		return nil, false
+	}
+	return conn, true
+}
+
+// clockSkewSyncTimeout bounds the Roughtime query + multicast.
+const clockSkewSyncTimeout = 5 * time.Second
+
+// clockSkewRetryDelay gives the device a moment to receive the multicast time
+// proof and advance its clock before we retry the TLS handshake.
+const clockSkewRetryDelay = 1500 * time.Millisecond
+
+// broadcastTimeFn fetches a signed time proof and multicasts it to devices on
+// the LAN. Indirected for tests.
+var broadcastTimeFn = func(ctx context.Context) error {
+	_, err := clitimesync.BroadcastTime(ctx)
+	return err
+}
+
+// clockSkewSyncSleep is the post-broadcast wait. Indirected for tests.
+var clockSkewSyncSleep = func(d time.Duration) { time.Sleep(d) }
+
+// clockSkewSyncAttempted guards against syncing more than once per CLI run, so
+// repeated connect attempts don't trigger a sync-and-sleep storm.
+var clockSkewSyncAttempted bool
+
+// isClockSkewSuspectError reports whether a connection failure looks like the
+// device rejected our client cert during the TLS handshake — the signature of
+// clock skew (which a time sync can fix). It matches the typed handshake
+// rejection as well as cert-refreshable TLS alerts.
+func isClockSkewSuspectError(err error) bool {
+	return errors.Is(err, errTLSHandshakeRejected) || isCertRefreshableError(err)
+}
+
+// autoSyncTimeAndRetry handles a likely clock-skew rejection automatically: it
+// broadcasts a signed time proof to the device (the same work as
+// `wendy sync-time`), waits briefly for the device to adopt it, then retries
+// the connection once. Returns (conn, true) only when the sync ran and the
+// retry connected; in every other case the caller falls through to its
+// existing error handling (e.g. the interactive cert-refresh offer).
+//
+// The sync runs at most once per CLI invocation. Unlike offerCertRefreshAndRetry
+// it is non-interactive — clock skew has an unambiguous, side-effect-free remedy
+// — so it does not gate on an interactive terminal.
+func autoSyncTimeAndRetry(ctx context.Context, cause error, retry func() (*grpcclient.AgentConnection, error)) (*grpcclient.AgentConnection, bool) {
+	if !isClockSkewSuspectError(cause) || clockSkewSyncAttempted {
+		return nil, false
+	}
+	clockSkewSyncAttempted = true
+
+	if !jsonOutput {
+		fmt.Fprintln(os.Stderr, "⏱  Possible clock skew — syncing device time and retrying...")
+	}
+
+	syncCtx, cancel := context.WithTimeout(ctx, clockSkewSyncTimeout)
+	syncErr := broadcastTimeFn(syncCtx)
+	cancel()
+	if syncErr != nil {
+		// Without a fresh time proof the device clock won't move, so retrying
+		// would just fail again. Surface the cause under the TLS debug flag.
+		if os.Getenv("WENDY_TLS_DEBUG") != "" {
+			fmt.Fprintf(os.Stderr, "[tls-debug] time sync failed: %v\n", syncErr)
+		}
+		return nil, false
+	}
+
+	clockSkewSyncSleep(clockSkewRetryDelay)
+
+	conn, err := retry()
+	if err != nil {
 		return nil, false
 	}
 	return conn, true
@@ -644,7 +741,11 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 			if errors.Is(connErr, ErrUserCancelled) {
 				return nil, connErr
 			}
-			if errors.Is(connErr, errProvisionedAgentUnauthorized) {
+			if syncedConn, ok := autoSyncTimeAndRetry(ctx, connErr, func() (*grpcclient.AgentConnection, error) {
+				return connectResolvedAgentWithProvisionedHint(ctx, hostname, addr, isDefault, provisionedMTLS)
+			}); ok {
+				conn = syncedConn
+			} else if errors.Is(connErr, errProvisionedAgentUnauthorized) {
 				refreshedConn, ok := offerCertRefreshAndRetry(ctx, connErr, func() (*grpcclient.AgentConnection, error) {
 					return connectResolvedAgentWithProvisionedHint(ctx, hostname, addr, isDefault, provisionedMTLS)
 				})
@@ -946,7 +1047,7 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 				}
 			}
 			if plaintextAddrCertReject || (mtlsPortCertFails > 0 && mtlsPortNonCertFails == 0) {
-				return nil, lastMTLSErr, fmt.Errorf("TLS handshake rejected by device (possible clock skew or cert mismatch).\n  Check the device clock: ssh wendy@<host> 'timedatectl status'\n  For full TLS details rerun with WENDY_TLS_DEBUG=1")
+				return nil, lastMTLSErr, newTLSHandshakeRejectedError(lastMTLSErr)
 			}
 		}
 	}
@@ -1464,7 +1565,11 @@ func resolveTarget(ctx context.Context, opts ...resolveOption) (*SelectedDevice,
 			if errors.Is(err, ErrUserCancelled) {
 				return nil, err
 			}
-			if errors.Is(err, errProvisionedAgentUnauthorized) {
+			if syncedConn, ok := autoSyncTimeAndRetry(ctx, err, func() (*grpcclient.AgentConnection, error) {
+				return connectResolvedAgentWithProvisionedHint(ctx, device, addr, isDefault, provisionedMTLS)
+			}); ok {
+				conn = syncedConn
+			} else if errors.Is(err, errProvisionedAgentUnauthorized) {
 				refreshedConn, ok := offerCertRefreshAndRetry(ctx, err, func() (*grpcclient.AgentConnection, error) {
 					return connectResolvedAgentWithProvisionedHint(ctx, device, addr, isDefault, provisionedMTLS)
 				})

--- a/go/internal/cli/commands/helpers_synctime_test.go
+++ b/go/internal/cli/commands/helpers_synctime_test.go
@@ -1,0 +1,149 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+)
+
+func TestAutoSyncTimeAndRetry(t *testing.T) {
+	skewErr := newTLSHandshakeRejectedError(errors.New("remote error: tls: bad certificate"))
+
+	setup := func(broadcastErr error) (restore func(), broadcastCalls, retryCalls *int) {
+		origBroadcast := broadcastTimeFn
+		origSleep := clockSkewSyncSleep
+		origJSON := jsonOutput
+		origAttempted := clockSkewSyncAttempted
+		broadcastCalls = new(int)
+		retryCalls = new(int)
+		broadcastTimeFn = func(context.Context) error {
+			*broadcastCalls++
+			return broadcastErr
+		}
+		clockSkewSyncSleep = func(time.Duration) {} // no real sleep in tests
+		jsonOutput = false
+		clockSkewSyncAttempted = false
+		return func() {
+			broadcastTimeFn = origBroadcast
+			clockSkewSyncSleep = origSleep
+			jsonOutput = origJSON
+			clockSkewSyncAttempted = origAttempted
+		}, broadcastCalls, retryCalls
+	}
+
+	t.Run("clock skew error syncs time and retries to success", func(t *testing.T) {
+		restore, broadcastCalls, retryCalls := setup(nil)
+		defer restore()
+
+		wantConn := &grpcclient.AgentConnection{Host: "device.local"}
+		conn, ok := autoSyncTimeAndRetry(context.Background(), skewErr, func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return wantConn, nil
+		})
+		if !ok || conn != wantConn {
+			t.Fatalf("autoSyncTimeAndRetry() = (%v, %v), want (%v, true)", conn, ok, wantConn)
+		}
+		if *broadcastCalls != 1 || *retryCalls != 1 {
+			t.Fatalf("broadcastCalls=%d retryCalls=%d, want 1 and 1", *broadcastCalls, *retryCalls)
+		}
+	})
+
+	t.Run("cert refreshable error also triggers sync and retry", func(t *testing.T) {
+		restore, broadcastCalls, retryCalls := setup(nil)
+		defer restore()
+
+		certErr := errors.New("remote error: tls: bad certificate")
+		wantConn := &grpcclient.AgentConnection{Host: "device.local"}
+		conn, ok := autoSyncTimeAndRetry(context.Background(), certErr, func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return wantConn, nil
+		})
+		if !ok || conn != wantConn {
+			t.Fatalf("autoSyncTimeAndRetry() = (%v, %v), want (%v, true)", conn, ok, wantConn)
+		}
+		if *broadcastCalls != 1 || *retryCalls != 1 {
+			t.Fatalf("broadcastCalls=%d retryCalls=%d, want 1 and 1", *broadcastCalls, *retryCalls)
+		}
+	})
+
+	t.Run("syncs at most once per run", func(t *testing.T) {
+		restore, broadcastCalls, retryCalls := setup(nil)
+		defer restore()
+
+		// First call attempts the sync (retry fails so the connection is not fixed).
+		_, _ = autoSyncTimeAndRetry(context.Background(), skewErr, func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return nil, errors.New("still rejected")
+		})
+		// Second call must not sync or retry again.
+		_, ok := autoSyncTimeAndRetry(context.Background(), skewErr, func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return nil, nil
+		})
+		if ok {
+			t.Fatal("expected ok=false on second attempt")
+		}
+		if *broadcastCalls != 1 {
+			t.Fatalf("broadcastCalls=%d, want 1 (synced only once)", *broadcastCalls)
+		}
+		if *retryCalls != 1 {
+			t.Fatalf("retryCalls=%d, want 1 (retried only on first attempt)", *retryCalls)
+		}
+	})
+
+	t.Run("broadcast failure does not retry", func(t *testing.T) {
+		restore, broadcastCalls, retryCalls := setup(errors.New("roughtime servers unreachable"))
+		defer restore()
+
+		_, ok := autoSyncTimeAndRetry(context.Background(), skewErr, func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return nil, nil
+		})
+		if ok || *broadcastCalls != 1 || *retryCalls != 0 {
+			t.Fatalf("ok=%v broadcastCalls=%d retryCalls=%d, want false, 1, 0", ok, *broadcastCalls, *retryCalls)
+		}
+	})
+
+	t.Run("non-skew error never syncs", func(t *testing.T) {
+		restore, broadcastCalls, retryCalls := setup(nil)
+		defer restore()
+
+		_, ok := autoSyncTimeAndRetry(context.Background(), errors.New("connection refused"), func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return nil, nil
+		})
+		if ok || *broadcastCalls != 0 || *retryCalls != 0 {
+			t.Fatalf("ok=%v broadcastCalls=%d retryCalls=%d, want false, 0, 0", ok, *broadcastCalls, *retryCalls)
+		}
+	})
+
+	t.Run("failed retry returns not ok", func(t *testing.T) {
+		restore, _, _ := setup(nil)
+		defer restore()
+
+		_, ok := autoSyncTimeAndRetry(context.Background(), skewErr, func() (*grpcclient.AgentConnection, error) {
+			return nil, errors.New("still rejected")
+		})
+		if ok {
+			t.Fatal("expected ok=false when retry fails")
+		}
+	})
+
+	t.Run("json mode still syncs and retries", func(t *testing.T) {
+		restore, broadcastCalls, retryCalls := setup(nil)
+		defer restore()
+		jsonOutput = true
+
+		wantConn := &grpcclient.AgentConnection{Host: "device.local"}
+		conn, ok := autoSyncTimeAndRetry(context.Background(), skewErr, func() (*grpcclient.AgentConnection, error) {
+			*retryCalls++
+			return wantConn, nil
+		})
+		if !ok || conn != wantConn || *broadcastCalls != 1 || *retryCalls != 1 {
+			t.Fatalf("ok=%v conn=%v broadcastCalls=%d retryCalls=%d, want true, conn, 1, 1", ok, conn, *broadcastCalls, *retryCalls)
+		}
+	})
+}


### PR DESCRIPTION
## What

When `wendy-agent` rejects the client TLS certificate because the **device clock lags the cert's validity window** (clock skew), the CLI now runs a background time sync — the same work as `wendy sync-time` (`clitimesync.BroadcastTime`) — and **retries the connection once**, instead of immediately surfacing a `tls: bad certificate` failure and asking the user to check the device clock by hand.

## Why

Today the LAN connect path only *diagnoses* possible clock skew (`"TLS handshake rejected by device (possible clock skew or cert mismatch)... check the device clock"`) and otherwise offers an interactive **cert refresh** — which doesn't fix a skewed clock. Meanwhile the BLE path already best-effort syncs time before its handshake. This closes that gap for LAN/mTLS connections.

## How

- The clock-skew conclusion in `connectWithAutoTLSDiagnostics` now returns a typed `errTLSHandshakeRejected` (user-facing message **unchanged**) so callers can detect it via `errors.Is` instead of string matching.
- New `autoSyncTimeAndRetry` helper, called at the orchestration level in `connectToAgent` and `resolveTarget`, **before** the existing interactive cert-refresh offer:
  1. detect a clock-skew-suspect error (`errTLSHandshakeRejected` or a cert-refreshable TLS alert),
  2. print a brief notice (`⏱  Possible clock skew — syncing device time and retrying...`), suppressed in `--json`,
  3. `BroadcastTime` (5s budget); if it fails, fall through (no point retrying without a fresh proof),
  4. wait ~1.5s for the device to adopt the time, then retry the connection once.
- On any failure it **falls through to the existing behavior unchanged** (interactive cert-refresh offer, default-device recovery, etc.).
- Non-interactive by design (clock skew has a safe, unambiguous remedy) and guarded to run **at most once per CLI invocation** (no sync-and-sleep storm across repeated attempts).
- Injectable `broadcastTimeFn` / `clockSkewSyncSleep` vars mirror the existing `refreshAllCertsFn` / `promptYesNoFn` test seams.

## Scope note

This hooks the user-facing connect orchestration (`connectToAgent` / device resolution), which all commands route through. Lower-level discovery probes that call `connectWithAutoTLS` directly are intentionally **not** auto-synced, to avoid sync storms while probing many devices.

## Testing

New `TestAutoSyncTimeAndRetry` covers: clock-skew error → sync + retry → success; cert-refreshable error also triggers; sync at most once per run; broadcast failure → no retry; non-skew error → no sync; failed retry → not ok; `--json` still syncs (notice suppressed). Full `internal/cli/commands` suite, `go build ./...`, `go vet`, and `gofmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)