### PR TITLE
fix(cli): surface real build error instead of registry-push fallback (#1166)

### DIFF
--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -445,6 +446,25 @@ func digestToHex(digest string) (string, error) {
 	return strings.TrimPrefix(digest, prefix), nil
 }
 
+// imageBuildFailedError marks a failure of the actual image build (the buildx
+// or Apple Container *solve* of the Dockerfile) in the chunk-diff deploy path,
+// as opposed to a builder-setup or OCI-export failure. The registry-push
+// fallback rebuilds the same image from the same Dockerfile, so a solve failure
+// there recurs identically — falling back only buries the actionable build
+// error behind a confusing secondary failure (e.g. buildx /etc/hosts setup).
+// Callers surface this error directly instead of falling back. See issue #1166.
+type imageBuildFailedError struct{ err error }
+
+func (e *imageBuildFailedError) Error() string { return e.err.Error() }
+func (e *imageBuildFailedError) Unwrap() error { return e.err }
+
+// isImageBuildFailure reports whether err (or anything it wraps) is an
+// imageBuildFailedError, i.e. the Dockerfile build itself failed.
+func isImageBuildFailure(err error) bool {
+	var bErr *imageBuildFailedError
+	return errors.As(err, &bErr)
+}
+
 // buildImageToOCILayout builds an OCI-layout tar to dest for the chunk-diff
 // deploy path. When builder is apple-container, it uses the Apple Container CLI;
 // otherwise it runs `docker buildx build` with `--output type=oci,dest=<dest>`.
@@ -574,7 +594,7 @@ func buildImageToOCILayout(ctx context.Context, cwd, dockerfile, platform string
 	}
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker buildx build (OCI export) failed: %w", err)
+		return &imageBuildFailedError{fmt.Errorf("docker buildx build (OCI export) failed: %w", err)}
 	}
 	return nil
 }
@@ -635,7 +655,7 @@ func buildImageToOCILayoutWithAppleContainer(ctx context.Context, cwd, dockerfil
 	buildCmd.Stdout = stdout
 	buildCmd.Stderr = stderr
 	if err := buildCmd.Run(); err != nil {
-		return fmt.Errorf("container build (OCI layout) failed: %w", err)
+		return &imageBuildFailedError{fmt.Errorf("container build (OCI layout) failed: %w", err)}
 	}
 	// The image is in the store now — remove the temporary tag once we are done,
 	// even if the export below is cancelled.

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -7,11 +7,49 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// TestIsImageBuildFailure verifies the classification used by the chunk-diff
+// deploy path to decide whether the registry-push fallback would help. Only an
+// imageBuildFailedError (the Dockerfile build itself failing) suppresses the
+// fallback; builder-setup and transport failures stay eligible for it. (#1166)
+func TestIsImageBuildFailure(t *testing.T) {
+	buildErr := &imageBuildFailedError{errors.New("colcon: error: unrecognized arguments: --log-base log")}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain transport error", errors.New("QueryChunks unimplemented"), false},
+		{"setup error", errors.New("adding hosts entry to builder: sed: can't move"), false},
+		{"build failure", buildErr, true},
+		{"wrapped build failure", fmt.Errorf("deploy failed: %w", buildErr), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isImageBuildFailure(tc.err); got != tc.want {
+				t.Fatalf("isImageBuildFailure(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+
+	// The error message must surface the underlying build error verbatim so the
+	// user sees the actionable failure, not a fallback-specific wrapper.
+	if got := buildErr.Error(); got != "colcon: error: unrecognized arguments: --log-base log" {
+		t.Fatalf("imageBuildFailedError.Error() = %q, want underlying message", got)
+	}
+	if !errors.Is(buildErr, buildErr.err) {
+		t.Fatal("imageBuildFailedError should unwrap to its underlying error")
+	}
+}
 
 // sha256Hex returns the lowercase hex-encoded SHA-256 digest of b.
 func sha256Hex(b []byte) string {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1486,6 +1486,13 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 			// --chunking=force opts out of the registry-push fallback so the
 			// failure is surfaced instead of silently masked by a slower path.
 			return fmt.Errorf("chunk-diff deploy failed and --chunking=force disables the registry-push fallback: %w", err)
+		} else if isImageBuildFailure(err) {
+			// The image build itself failed (e.g. a Dockerfile/build-command
+			// error). The registry-push fallback rebuilds the same image from the
+			// same Dockerfile, so it would fail identically — and can even mask the
+			// real error behind an unrelated builder-setup failure. Surface the
+			// actionable build error directly instead of falling back. (#1166)
+			return err
 		} else {
 			cliLogln("Fast deploy unavailable; using registry push.")
 		}


### PR DESCRIPTION
## Problem

Fixes #1166.

When `wendy run` fails during the initial OCI/buildx image build, it falls back to the registry-push path. If the original failure was the **build itself** (a Dockerfile/build-command error), the fallback rebuilds the same image from the same Dockerfile and fails too — often at an *unrelated* builder-setup step. The user then only sees the confusing secondary error and never the actionable one.

Reported example: the real error was

```
colcon: error: unrecognized arguments: --log-base log
```

but Wendy fell back and ended with

```
✗ building and pushing image: adding hosts entry to builder: sed: can't move '/etc/hostsfdEoFG' to '/etc/hosts': Resource busy
```

making it look like a Docker/buildx host-injection problem rather than the Dockerfile build command.

## Fix

- Mark the actual buildx / Apple Container **solve** failures (the Dockerfile build) in `buildImageToOCILayout` with a sentinel `imageBuildFailedError`. Builder-setup, OCI-export, and transport failures are deliberately *not* marked.
- In `runWithAgent`, when the chunk-diff deploy fails with that sentinel, surface the build error directly and skip the registry-push fallback — the fallback rebuilds the identical image and would fail the same way (or mask the real error).
- Legitimate fallback cases (e.g. `QueryChunks` unimplemented on older agents, or any non-build failure) are unchanged and still fall back as before.

## Why skipping the fallback is safe here

Both the chunk-diff OCI-layout build and the registry-push build run `docker buildx build` (or `container build`) against the same Dockerfile, build args, and platform. A Dockerfile command error is deterministic across both, so the fallback can only ever fail again — never recover.

## Testing

- New `TestIsImageBuildFailure` covers the classification (nil / transport / setup → fall back; build failure & wrapped build failure → suppress fallback) and verifies the error surfaces the underlying message verbatim.
- `go build`, `go vet`, and the full `internal/cli/commands` test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)