### PR TITLE
fix(agent,cli): clarify "wendy device logs" for detached runs (#1169)

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1960,10 +1960,20 @@ func (c *Client) streamOutput(
 	exitStatus := <-exitStatusCh
 	code, _, err := exitStatus.Result()
 	if err != nil {
-		c.logger.Error("Task exited with error",
-			zap.String("app_name", appName),
-			zap.Error(err),
-		)
+		if errors.Is(err, context.Canceled) {
+			// The wait was canceled because the RPC that started this monitor
+			// ended — e.g. `wendy run --detach` returned and tore down its
+			// deploy stream. The container keeps running; this is normal
+			// teardown, not a task failure, so don't log it as an error.
+			c.logger.Debug("Stopped monitoring task exit (stream canceled)",
+				zap.String("app_name", appName),
+			)
+		} else {
+			c.logger.Error("Task exited with error",
+				zap.String("app_name", appName),
+				zap.Error(err),
+			)
+		}
 	} else {
 		c.logger.Info("Task exited",
 			zap.String("app_name", appName),

--- a/go/internal/agent/interceptor/error.go
+++ b/go/internal/agent/interceptor/error.go
@@ -2,6 +2,7 @@ package interceptor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 
@@ -10,6 +11,16 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// isClientCanceled reports whether err is the normal cancellation that occurs
+// when a client closes a stream — for example when `wendy run --detach` returns
+// and tears down its deploy stream, or when `wendy device logs` is stopped with
+// Ctrl-C. These are expected teardown, not handler failures, so they should not
+// be logged at ERROR (they otherwise surface in `wendy device logs` and read as
+// if the app had crashed).
+func isClientCanceled(err error) bool {
+	return errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled
+}
 
 func UnaryErrorInterceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
@@ -70,10 +81,17 @@ func StreamErrorInterceptor(logger *zap.Logger) grpc.StreamServerInterceptor {
 
 		err = handler(srv, wrapped)
 		if err != nil {
-			logger.Error("gRPC stream handler error",
-				zap.String("method", info.FullMethod),
-				zap.Error(err),
-			)
+			if isClientCanceled(err) {
+				logger.Debug("gRPC stream closed by client",
+					zap.String("method", info.FullMethod),
+					zap.Error(err),
+				)
+			} else {
+				logger.Error("gRPC stream handler error",
+					zap.String("method", info.FullMethod),
+					zap.Error(err),
+				)
+			}
 		}
 		return
 	}

--- a/go/internal/agent/interceptor/error_test.go
+++ b/go/internal/agent/interceptor/error_test.go
@@ -1,0 +1,99 @@
+package interceptor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// stubServerStream is a no-op grpc.ServerStream for driving the interceptor.
+type stubServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *stubServerStream) Context() context.Context { return s.ctx }
+
+// runStreamInterceptor invokes StreamErrorInterceptor with a handler that
+// returns handlerErr, returning the captured log entries.
+func runStreamInterceptor(t *testing.T, handlerErr error) []observer.LoggedEntry {
+	t.Helper()
+
+	// Capture every level so we can assert on both Debug and Error.
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	interceptor := StreamErrorInterceptor(logger)
+	info := &grpc.StreamServerInfo{FullMethod: "/wendy.agent.services.v1.WendyContainerService/RunContainer"}
+	handler := func(srv any, stream grpc.ServerStream) error { return handlerErr }
+
+	err := interceptor(nil, &stubServerStream{ctx: context.Background()}, info, handler)
+	if !errors.Is(err, handlerErr) {
+		t.Fatalf("interceptor should pass the handler error through unchanged, got %v", err)
+	}
+
+	return logs.All()
+}
+
+// TestStreamErrorInterceptor_CancellationLoggedAtDebug verifies that the normal
+// cancellation produced when a client closes a stream (e.g. `wendy run
+// --detach` returning) is logged at Debug, not Error — otherwise it surfaces in
+// `wendy device logs` and reads like the app crashed (issue #1169).
+func TestStreamErrorInterceptor_CancellationLoggedAtDebug(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"context.Canceled", context.Canceled},
+		{"wrapped context.Canceled", errors.Join(errors.New("run container"), context.Canceled)},
+		{"grpc codes.Canceled", status.Error(codes.Canceled, "context canceled")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := runStreamInterceptor(t, tc.err)
+			if len(entries) != 1 {
+				t.Fatalf("expected exactly one log entry, got %d: %+v", len(entries), entries)
+			}
+			entry := entries[0]
+			if entry.Level != zapcore.DebugLevel {
+				t.Errorf("cancellation should be logged at Debug, got %v (%q)", entry.Level, entry.Message)
+			}
+			if entry.Message == "gRPC stream handler error" {
+				t.Errorf("cancellation must not use the error message that reads as a crash")
+			}
+		})
+	}
+}
+
+// TestStreamErrorInterceptor_RealErrorLoggedAtError verifies genuine handler
+// failures are still logged at Error level.
+func TestStreamErrorInterceptor_RealErrorLoggedAtError(t *testing.T) {
+	entries := runStreamInterceptor(t, errors.New("boom"))
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one log entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Level != zapcore.ErrorLevel {
+		t.Errorf("real errors should be logged at Error, got %v", entry.Level)
+	}
+	if entry.Message != "gRPC stream handler error" {
+		t.Errorf("unexpected message %q", entry.Message)
+	}
+}
+
+// TestStreamErrorInterceptor_NoErrorNoLog verifies a successful handler logs
+// nothing.
+func TestStreamErrorInterceptor_NoErrorNoLog(t *testing.T) {
+	entries := runStreamInterceptor(t, nil)
+	if len(entries) != 0 {
+		t.Fatalf("expected no log entries for a successful handler, got %d: %+v", len(entries), entries)
+	}
+}

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -930,10 +930,27 @@ func newDeviceLogsCmd() *cobra.Command {
 	var tail int32
 
 	cmd := &cobra.Command{
-		Use:   "logs",
+		Use:   "logs [app]",
 		Short: "Stream logs from containers on the device",
+		Long: "Stream logs from containers on the device.\n\n" +
+			"Pass an app name (positionally or with --app) to see only that app's\n" +
+			"logs. Without a filter, logs from every container and the agent itself\n" +
+			"are streamed, which can include agent lifecycle messages.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			// Accept the app name positionally (e.g. `wendy device logs IronPaws`)
+			// as well as via --app. Without this the positional argument was
+			// silently ignored, so the command streamed every container's logs
+			// instead of the requested app's (see issue #1169).
+			if len(args) == 1 {
+				if appName != "" && appName != args[0] {
+					return fmt.Errorf("conflicting app names: %q (positional) and %q (--app)", args[0], appName)
+				}
+				appName = args[0]
+			}
+
 			conn, err := connectToAgent(ctx)
 			if err != nil {
 				return err
@@ -970,6 +987,26 @@ func newDeviceLogsCmd() *cobra.Command {
 			stream, err := conn.TelemetryService.StreamLogs(ctx, req)
 			if err != nil {
 				return fmt.Errorf("starting log stream: %w", err)
+			}
+
+			// Tell the user the stream is live and that waiting is expected.
+			// Without this the command appears to hang after connecting, with
+			// no way to tell streaming from a stuck command (see issue #1169).
+			// Printed to stderr (via cliLogln) so it never mixes into piped or
+			// --json log output.
+			if !jsonOutput {
+				target := "the device"
+				switch {
+				case appName != "":
+					target = appName
+				case serviceName != "":
+					target = serviceName
+				}
+				if tail > 0 {
+					cliLogln("Streaming logs from %s — replaying up to %d recent, then live. Press Ctrl-C to stop.", target, tail)
+				} else {
+					cliLogln("Streaming logs from %s. Waiting for new logs — press Ctrl-C to stop.", target)
+				}
 			}
 
 			liveSeparatorPrinted := tail == 0


### PR DESCRIPTION
Fixes #1169

## Problem

After `wendy run --detach`, running `wendy device logs <app>` showed agent
`ERROR` lines and then appeared to hang with no explanation, making a healthy
app look like it had crashed and the command look stuck:

```text
ERROR [wendy-agent] Task exited with error app_name=IronPaws error=rpc error: code = Canceled desc = context canceled
ERROR [wendy-agent] gRPC stream handler error method=.../RunContainer error=context canceled
INFO  [wendy-agent] StreamLogs client connected sub_id=sub-6
# …then nothing
```

Those `ERROR` lines are the **agent's own logs**, surfaced through
`wendy device logs` (which streams journald/agent output). They come from the
detached deploy stream being torn down normally when `--detach` returns — not
from the app failing. `wendy device apps list` correctly showed the app as
running.

There were three things wrong:

1. **Normal cancellation logged as `ERROR`.** Both the task-exit monitor and the
   gRPC stream interceptor logged `context.Canceled` at `ERROR`.
2. **No streaming status.** The CLI gave no feedback after connecting, so there
   was no way to tell live streaming from a stuck command.
3. **Positional arg silently ignored.** `wendy device logs IronPaws` did not
   filter to the app (filtering was `--app`-only), so the user saw *every*
   container's logs **plus agent internals** — which is why the scary lines
   appeared at all.

## Changes

**Agent**
- `streamOutput` no longer logs `"Task exited with error"` when the exit wait was
  canceled because the deploy RPC ended (`context.Canceled`) — logs at `Debug`.
- `StreamErrorInterceptor` logs normal client cancellation (`context.Canceled` /
  `codes.Canceled`) at `Debug`. Genuine handler errors are still `ERROR`.

**CLI (`wendy device logs`)**
- Prints a status line on connect (stderr, suppressed under `--json`):
  `Streaming logs from IronPaws. Waiting for new logs — press Ctrl-C to stop.`
- Accepts the app name positionally, so `wendy device logs IronPaws` filters to
  that app instead of ignoring the argument.

**Tests**
- New `error_test.go` covers cancellation-at-`Debug` (context, wrapped, and gRPC
  codes) vs. real-error-at-`Error` and the no-error/no-log case.

## Verification
- `go build ./...`, `go vet`, and `go test ./internal/agent/interceptor/... ./internal/cli/commands/...` pass.
- `wendy device logs --help` shows the new `[app]` usage and Long description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ly6B21mAtJdhZzCtoeVX9i