### PR TITLE
fix(cli): add horizontal scroll to device dashboard logs

### DIFF
--- a/go/internal/cli/commands/dashboard.go
+++ b/go/internal/cli/commands/dashboard.go
@@ -10,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
@@ -79,6 +80,7 @@ type dashboardModel struct {
 
 	logs       []string
 	logOffset  int
+	logHOffset int
 	autoScroll bool
 	metrics    []dashboardMetricEntry
 	metricMap  map[string]int
@@ -198,11 +200,22 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "g":
 			m.logOffset = 0
 			m.autoScroll = false
+		case "right", "l":
+			if maxOff := m.maxLogHOffset(); m.logHOffset < maxOff {
+				m.logHOffset = min(m.logHOffset+dashHScrollStep, maxOff)
+			}
+		case "left", "h":
+			m.logHOffset = max(m.logHOffset-dashHScrollStep, 0)
 		}
+		// A vertical scroll can change which lines are visible (and thus the
+		// widest one), so keep the horizontal offset within range to avoid
+		// leaving the pane stuck on blank columns.
+		m.clampLogHOffset()
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.clampLogHOffset()
 
 	case dashboardLogMsg:
 		m.logs = append(m.logs, formatLogLines(msg.service, msg.record)...)
@@ -213,6 +226,8 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.logOffset = maxOff
 		}
+		// Tailing onto shorter lines can shrink the widest visible line.
+		m.clampLogHOffset()
 		return m, waitForLog(m.logCh)
 
 	case dashboardAppsMsg:
@@ -251,6 +266,70 @@ func (m dashboardModel) logViewHeight() int {
 		available = 1
 	}
 	return available
+}
+
+// dashHScrollStep is how many columns each ←/→ press pans the logs pane. It
+// mirrors the bubble-table step so horizontal scrolling feels the same across
+// the CLI's TUIs.
+const dashHScrollStep = 8
+
+// logWindow returns the slice of log rows currently visible vertically, after
+// accounting for the two header rows (title + separator) that sit above the log
+// body in the right pane.
+func (m dashboardModel) logWindow() []string {
+	if len(m.logs) == 0 {
+		return nil
+	}
+	start := m.logOffset
+	end := start + m.logViewHeight() - 2 // subtract header rows
+	if end > len(m.logs) {
+		end = len(m.logs)
+	}
+	if start > end {
+		start = end
+	}
+	if start < 0 {
+		start = 0
+	}
+	return m.logs[start:end]
+}
+
+// visibleLogRows returns the currently visible log rows cropped to the logs
+// pane width starting at the horizontal scroll offset. ansi.Cut preserves SGR
+// styling across the cut so colored severity prefixes survive panning.
+func (m dashboardModel) visibleLogRows() []string {
+	lw := m.logsWidth()
+	window := m.logWindow()
+	rows := make([]string, 0, len(window))
+	for _, line := range window {
+		rows = append(rows, ansi.Cut(line, m.logHOffset, m.logHOffset+lw))
+	}
+	return rows
+}
+
+// maxLogHOffset is the furthest right the logs pane can pan: the widest visible
+// line minus the pane width. Beyond this there is nothing more to reveal.
+func (m dashboardModel) maxLogHOffset() int {
+	lw := m.logsWidth()
+	widest := 0
+	for _, line := range m.logWindow() {
+		if w := visibleWidth(line); w > widest {
+			widest = w
+		}
+	}
+	return max(widest-lw, 0)
+}
+
+// clampLogHOffset keeps the horizontal offset within [0, maxLogHOffset] so the
+// pane never gets stuck showing only blank columns after the visible content
+// narrows (e.g. after a vertical scroll or window resize).
+func (m *dashboardModel) clampLogHOffset() {
+	if maxOff := m.maxLogHOffset(); m.logHOffset > maxOff {
+		m.logHOffset = maxOff
+	}
+	if m.logHOffset < 0 {
+		m.logHOffset = 0
+	}
 }
 
 func (m dashboardModel) metricsWidth() int {
@@ -414,17 +493,7 @@ func (m dashboardModel) View() string {
 	if len(m.logs) == 0 {
 		rightLines = append(rightLines, dashDimStyle.Render("  Waiting for logs..."))
 	} else {
-		start := m.logOffset
-		end := start + viewH - 2 // subtract header lines
-		if end > len(m.logs) {
-			end = len(m.logs)
-		}
-		if start > end {
-			start = end
-		}
-		for i := start; i < end; i++ {
-			rightLines = append(rightLines, m.logs[i])
-		}
+		rightLines = append(rightLines, m.visibleLogRows()...)
 	}
 
 	sep := dashDimStyle.Render("│")
@@ -459,7 +528,7 @@ func (m dashboardModel) View() string {
 	}
 
 	// Footer
-	b.WriteString(dashFooterStyle.Render("q/Ctrl+C exit | ↑/↓ scroll logs | G/g end/start"))
+	b.WriteString(dashFooterStyle.Render("q/Ctrl+C exit | ↑/↓ scroll | ←/→ pan logs | G/g end/start"))
 
 	return b.String()
 }

--- a/go/internal/cli/commands/dashboard_test.go
+++ b/go/internal/cli/commands/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
 )
 
@@ -142,6 +143,67 @@ func TestFormatLogLinesPreservesInteriorBlankLines(t *testing.T) {
 	}
 	if !strings.HasSuffix(stripANSI(rows[2]), "b") {
 		t.Errorf("row 2 should carry body line b, got %q", stripANSI(rows[2]))
+	}
+}
+
+func TestDashboardLogsHorizontalScrollCropsAtOffset(t *testing.T) {
+	m := dashboardModel{
+		width:  60,
+		height: 12,
+		logs:   []string{"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"},
+	}
+
+	// At offset 0 the visible row begins at the start of the line.
+	rows := m.visibleLogRows()
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 visible row, got %d: %#v", len(rows), rows)
+	}
+	if got := stripANSI(rows[0]); !strings.HasPrefix(got, "0123") {
+		t.Fatalf("offset 0 should start at the line start, got %q", got)
+	}
+
+	// Panning right shifts the visible window further into the line, exposing
+	// content that was previously off-screen to the right.
+	m.logHOffset = 10
+	rows = m.visibleLogRows()
+	if got := stripANSI(rows[0]); !strings.HasPrefix(got, "ABC") {
+		t.Fatalf("offset 10 should start at 'A', got %q", got)
+	}
+}
+
+func TestDashboardLogsHorizontalScrollRightClampsToWidestLine(t *testing.T) {
+	m := dashboardModel{
+		width:  60,
+		height: 12,
+		logs:   []string{"short", strings.Repeat("x", 100)},
+	}
+
+	var model tea.Model = m
+	for range 50 { // far more presses than needed to reach the clamp
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRight})
+	}
+	dm := model.(dashboardModel)
+
+	if dm.logHOffset == 0 {
+		t.Fatalf("expected a non-zero horizontal offset after panning right")
+	}
+	if maxOff := dm.maxLogHOffset(); dm.logHOffset != maxOff {
+		t.Fatalf("expected horizontal offset clamped to %d, got %d", maxOff, dm.logHOffset)
+	}
+}
+
+func TestDashboardLogsHorizontalScrollLeftClampsAtZero(t *testing.T) {
+	m := dashboardModel{
+		width:      60,
+		height:     12,
+		logs:       []string{strings.Repeat("x", 100)},
+		logHOffset: 5,
+	}
+
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	dm := model.(dashboardModel)
+	if dm.logHOffset != 0 {
+		t.Fatalf("expected horizontal offset clamped to 0, got %d", dm.logHOffset)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1182 — the macOS TUI device dashboard (`wendy device dashboard`) could not scroll logs horizontally, so long log lines were truncated at the pane width with no way to read the rest.

This adds **←/→ (and `h`/`l`) horizontal panning** to the logs pane, matching the bubble-table horizontal-scroll step (8 columns) and key convention already used elsewhere in the CLI (e.g. the apps dashboard).

## Details

- New `logHOffset` on the dashboard model tracks the horizontal scroll position.
- Visible log rows are cropped with `ansi.Cut` (same helper backing `CropANSIView`), so SGR styling — colored severity prefixes and `[service]` tags — survives the cut.
- The offset is clamped to the widest currently-visible line and **re-clamped on vertical scroll, new log arrival, and window resize**, so the pane never sticks on blank columns when the visible content narrows.
- Footer hint updated: `q/Ctrl+C exit | ↑/↓ scroll | ←/→ pan logs | G/g end/start`.

The log-rendering window logic was extracted into small helpers (`logWindow`, `visibleLogRows`, `maxLogHOffset`, `clampLogHOffset`) to keep `View()` readable and make the behavior unit-testable.

## Tests

Added unit tests in `dashboard_test.go`:
- `TestDashboardLogsHorizontalScrollCropsAtOffset` — visible content shifts with the offset.
- `TestDashboardLogsHorizontalScrollRightClampsToWidestLine` — panning right clamps to the widest visible line.
- `TestDashboardLogsHorizontalScrollLeftClampsAtZero` — panning left clamps at 0.

Ran locally in `go/`:
- `go test ./internal/cli/commands/` — pass
- `go build ./...` — pass
- `gofmt` / `go vet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)