### PR TITLE
cli: auto-install Apple container and start its services on macOS

### DIFF
--- a/go/internal/cli/providers/apple_container.go
+++ b/go/internal/cli/providers/apple_container.go
@@ -69,19 +69,16 @@ func (p *AppleContainerProvider) CheckRequirements(ctx context.Context) error {
 	if !appleContainerSupportedHost(appleContainerHostGOOS(), appleContainerHostGOARCH()) {
 		return fmt.Errorf("Apple Container requires an Apple silicon Mac")
 	}
-	if _, err := appleContainerLookPath("container"); err != nil {
-		return fmt.Errorf("container CLI is not installed or not in PATH")
+	if err := ensureAppleContainerInstalled(ctx); err != nil {
+		return err
 	}
 	if err := appleContainerCommandContext(ctx, "container", "--version").Run(); err != nil {
 		return fmt.Errorf("container CLI is not usable: %w", err)
 	}
-	cmd := appleContainerCommandContext(ctx, "container", "system", "status")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		msg := strings.TrimSpace(string(out))
-		if msg != "" {
-			msg = ": " + msg
+	for _, service := range appleContainerServices {
+		if err := ensureAppleContainerServiceRunning(ctx, service); err != nil {
+			return err
 		}
-		return fmt.Errorf("Apple Container system is not running%s. Run 'container system start' and try again: %w", msg, err)
 	}
 	return nil
 }

--- a/go/internal/cli/providers/apple_container_setup.go
+++ b/go/internal/cli/providers/apple_container_setup.go
@@ -1,0 +1,152 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+// appleContainerFormula is the homebrew-core formula that provides Apple's
+// `container` CLI.
+const appleContainerFormula = "container"
+
+// appleContainerDocsURL points at Apple's container installation docs, shown
+// when Homebrew is unavailable to install it automatically.
+const appleContainerDocsURL = "https://apple.github.io/container/"
+
+// appleContainerServices are the container services that must be running before
+// local build/run, in start order: the system/API service, then the image
+// builder.
+var appleContainerServices = []string{"system", "builder"}
+
+// appleContainerBrewPaths lists the canonical Homebrew locations, checked in
+// order (Apple Silicon first, then Intel). Bypassing $PATH avoids executing an
+// unexpected binary in a compromised environment. These paths are root-owned on
+// a standard install; world-writable matches are skipped as untrustworthy.
+var appleContainerBrewPaths = []string{
+	"/opt/homebrew/bin/brew", // Apple Silicon (M-series)
+	"/usr/local/bin/brew",    // Intel
+}
+
+var (
+	appleContainerStat                  = os.Stat
+	appleContainerStdout      io.Writer = os.Stdout
+	appleContainerStderr      io.Writer = os.Stderr
+	appleContainerFindBrew              = defaultAppleContainerFindBrew
+	appleContainerInteractive           = func() bool {
+		return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+	}
+	appleContainerConfirm = func(question string) (bool, error) {
+		return tui.ConfirmDefaultYes(question)
+	}
+)
+
+// defaultAppleContainerFindBrew returns the first trustworthy brew binary path,
+// or "" if none is found.
+func defaultAppleContainerFindBrew() string {
+	for _, p := range appleContainerBrewPaths {
+		info, err := appleContainerStat(p)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&0o002 != 0 {
+			continue // skip world-writable paths — likely not the legitimate brew binary
+		}
+		return p
+	}
+	return ""
+}
+
+// ensureAppleContainerInstalled makes sure the `container` CLI is on PATH,
+// offering to install it via Homebrew when interactive.
+func ensureAppleContainerInstalled(ctx context.Context) error {
+	if _, err := appleContainerLookPath("container"); err == nil {
+		return nil
+	}
+
+	brewPath := appleContainerFindBrew()
+	if brewPath == "" {
+		return fmt.Errorf("Apple container is not installed; install it via Homebrew (brew install %s) or see %s", appleContainerFormula, appleContainerDocsURL)
+	}
+	if !appleContainerInteractive() {
+		return fmt.Errorf("Apple container is not installed; run: brew install %s", appleContainerFormula)
+	}
+
+	confirmed, err := appleContainerConfirm("Apple container is required for local containers. Install it now via Homebrew? (brew install " + appleContainerFormula + ")")
+	if err != nil {
+		if errors.Is(err, tui.ErrCancelled) {
+			return fmt.Errorf("Apple container install cancelled")
+		}
+		return fmt.Errorf("Apple container is not installed (prompt failed: %w); run: brew install %s", err, appleContainerFormula)
+	}
+	if !confirmed {
+		return fmt.Errorf("Apple container is required but not installed; run: brew install %s", appleContainerFormula)
+	}
+
+	fmt.Fprintf(appleContainerStdout, "Installing Apple container via Homebrew (brew install %s)...\n", appleContainerFormula)
+	cmd := appleContainerCommandContext(ctx, brewPath, "install", appleContainerFormula)
+	cmd.Stdout = appleContainerStdout
+	cmd.Stderr = appleContainerStderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("brew install %s: %w", appleContainerFormula, err)
+	}
+
+	if _, err := appleContainerLookPath("container"); err != nil {
+		return fmt.Errorf("Apple container was installed via Homebrew but is not yet on PATH; open a new terminal or run: eval \"$(brew shellenv)\"")
+	}
+	return nil
+}
+
+// ensureAppleContainerServiceRunning checks `container <service> status` and,
+// when the service is down, offers to start it (interactive) or returns an
+// actionable error (non-interactive).
+func ensureAppleContainerServiceRunning(ctx context.Context, service string) error {
+	out, err := appleContainerCommandContext(ctx, "container", service, "status").CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	startCmd := fmt.Sprintf("container %s start", service)
+	detail := suffixDetail(out)
+
+	if !appleContainerInteractive() {
+		return fmt.Errorf("Apple container's %s service is not running%s. Run '%s' and try again", service, detail, startCmd)
+	}
+
+	confirmed, cerr := appleContainerConfirm(fmt.Sprintf("Apple container's %s service is not running. Start it now? (%s)", service, startCmd))
+	if cerr != nil {
+		if errors.Is(cerr, tui.ErrCancelled) {
+			return fmt.Errorf("Apple container %s start cancelled", service)
+		}
+		return fmt.Errorf("Apple container's %s service is not running (prompt failed: %w). Run '%s' and try again", service, cerr, startCmd)
+	}
+	if !confirmed {
+		return fmt.Errorf("Apple container's %s service is required. Run '%s' and try again", service, startCmd)
+	}
+
+	fmt.Fprintf(appleContainerStdout, "Starting Apple container %s service (%s)...\n", service, startCmd)
+	run := appleContainerCommandContext(ctx, "container", service, "start")
+	run.Stdout = appleContainerStdout
+	run.Stderr = appleContainerStderr
+	if rerr := run.Run(); rerr != nil {
+		return fmt.Errorf("%s: %w", startCmd, rerr)
+	}
+	return nil
+}
+
+// suffixDetail formats trimmed command output as a parenthetical suffix, or ""
+// when there is nothing to show.
+func suffixDetail(out []byte) string {
+	msg := strings.TrimSpace(string(out))
+	if msg == "" {
+		return ""
+	}
+	return " (" + msg + ")"
+}

--- a/go/internal/cli/providers/apple_container_setup_test.go
+++ b/go/internal/cli/providers/apple_container_setup_test.go
@@ -1,0 +1,203 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// appleContainerSetupStubs configures all seams used by CheckRequirements so a
+// test runs fully offline. The returned command log path captures every
+// emulated `container`/`brew` invocation.
+func appleContainerSetupStubs(t *testing.T) string {
+	t.Helper()
+	restoreHost := stubAppleContainerHost(t)
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+
+	oldCommand := appleContainerCommandContext
+	oldLookPath := appleContainerLookPath
+	oldFindBrew := appleContainerFindBrew
+	oldInteractive := appleContainerInteractive
+	oldConfirm := appleContainerConfirm
+	oldStdout := appleContainerStdout
+	oldStderr := appleContainerStderr
+	t.Cleanup(func() {
+		restoreHost()
+		appleContainerCommandContext = oldCommand
+		appleContainerLookPath = oldLookPath
+		appleContainerFindBrew = oldFindBrew
+		appleContainerInteractive = oldInteractive
+		appleContainerConfirm = oldConfirm
+		appleContainerStdout = oldStdout
+		appleContainerStderr = oldStderr
+	})
+
+	appleContainerCommandContext = fakeAppleContainerCommandContext(logFile)
+	appleContainerLookPath = func(string) (string, error) { return "/usr/local/bin/container", nil }
+	appleContainerFindBrew = func() string { return "/opt/homebrew/bin/brew" }
+	appleContainerInteractive = func() bool { return true }
+	appleContainerConfirm = func(string) (bool, error) { return true, nil }
+	appleContainerStdout = io.Discard
+	appleContainerStderr = io.Discard
+	return logFile
+}
+
+func readAppleContainerLog(t *testing.T, logFile string) string {
+	t.Helper()
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return ""
+		}
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestAppleContainerCheckRequirementsStartsStoppedServices(t *testing.T) {
+	logFile := appleContainerSetupStubs(t)
+	t.Setenv("APPLE_CONTAINER_HELPER_SYSTEM_DOWN", "1")
+	t.Setenv("APPLE_CONTAINER_HELPER_BUILDER_DOWN", "1")
+
+	if err := (&AppleContainerProvider{}).CheckRequirements(context.Background()); err != nil {
+		t.Fatalf("CheckRequirements: %v", err)
+	}
+
+	log := readAppleContainerLog(t, logFile)
+	for _, want := range []string{
+		"container\x00system\x00start\n",
+		"container\x00builder\x00start\n",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("command log missing %q in:\n%s", want, log)
+		}
+	}
+}
+
+func TestAppleContainerCheckRequirementsServicesRunningDoesNotStart(t *testing.T) {
+	logFile := appleContainerSetupStubs(t)
+
+	if err := (&AppleContainerProvider{}).CheckRequirements(context.Background()); err != nil {
+		t.Fatalf("CheckRequirements: %v", err)
+	}
+
+	log := readAppleContainerLog(t, logFile)
+	if strings.Contains(log, "start") {
+		t.Fatalf("did not expect any start command in:\n%s", log)
+	}
+}
+
+func TestAppleContainerCheckRequirementsNonInteractiveStoppedServiceErrors(t *testing.T) {
+	appleContainerSetupStubs(t)
+	appleContainerInteractive = func() bool { return false }
+	t.Setenv("APPLE_CONTAINER_HELPER_SYSTEM_DOWN", "1")
+
+	err := (&AppleContainerProvider{}).CheckRequirements(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "container system start") {
+		t.Fatalf("CheckRequirements error = %v, want 'container system start' guidance", err)
+	}
+}
+
+func TestAppleContainerCheckRequirementsDeclinedServiceErrors(t *testing.T) {
+	appleContainerSetupStubs(t)
+	appleContainerConfirm = func(string) (bool, error) { return false, nil }
+	t.Setenv("APPLE_CONTAINER_HELPER_BUILDER_DOWN", "1")
+
+	err := (&AppleContainerProvider{}).CheckRequirements(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "container builder start") {
+		t.Fatalf("CheckRequirements error = %v, want 'container builder start' guidance", err)
+	}
+}
+
+func TestAppleContainerCheckRequirementsMissingCLIPromptsBrewInstall(t *testing.T) {
+	logFile := appleContainerSetupStubs(t)
+	calls := 0
+	appleContainerLookPath = func(string) (string, error) {
+		calls++
+		if calls == 1 {
+			return "", exec.ErrNotFound
+		}
+		return "/opt/homebrew/bin/container", nil
+	}
+
+	if err := (&AppleContainerProvider{}).CheckRequirements(context.Background()); err != nil {
+		t.Fatalf("CheckRequirements: %v", err)
+	}
+
+	log := readAppleContainerLog(t, logFile)
+	if !strings.Contains(log, "install\x00"+appleContainerFormula+"\n") {
+		t.Fatalf("command log missing brew install in:\n%s", log)
+	}
+}
+
+func TestAppleContainerCheckRequirementsNonInteractiveMissingCLIErrors(t *testing.T) {
+	appleContainerSetupStubs(t)
+	appleContainerLookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+	appleContainerInteractive = func() bool { return false }
+
+	err := (&AppleContainerProvider{}).CheckRequirements(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "brew install "+appleContainerFormula) {
+		t.Fatalf("CheckRequirements error = %v, want brew install guidance", err)
+	}
+}
+
+func TestAppleContainerCheckRequirementsMissingCLINoBrewErrors(t *testing.T) {
+	appleContainerSetupStubs(t)
+	appleContainerLookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+	appleContainerFindBrew = func() string { return "" }
+
+	err := (&AppleContainerProvider{}).CheckRequirements(context.Background())
+	if err == nil || !strings.Contains(err.Error(), appleContainerDocsURL) {
+		t.Fatalf("CheckRequirements error = %v, want docs URL fallback", err)
+	}
+}
+
+func TestAppleContainerCheckRequirementsBrewInstallFailureSurfaces(t *testing.T) {
+	appleContainerSetupStubs(t)
+	appleContainerLookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+	t.Setenv("APPLE_CONTAINER_HELPER_BREW_ERROR", "1")
+
+	err := (&AppleContainerProvider{}).CheckRequirements(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "brew install "+appleContainerFormula) {
+		t.Fatalf("CheckRequirements error = %v, want brew install failure", err)
+	}
+}
+
+type fakeFileInfo struct{ mode fs.FileMode }
+
+func (f fakeFileInfo) Name() string       { return "brew" }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() fs.FileMode  { return f.mode }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+func TestDefaultAppleContainerFindBrewSkipsWorldWritable(t *testing.T) {
+	oldStat := appleContainerStat
+	oldPaths := appleContainerBrewPaths
+	t.Cleanup(func() {
+		appleContainerStat = oldStat
+		appleContainerBrewPaths = oldPaths
+	})
+	appleContainerBrewPaths = []string{"/world/writable/brew", "/safe/brew"}
+	appleContainerStat = func(p string) (os.FileInfo, error) {
+		switch p {
+		case "/world/writable/brew":
+			return fakeFileInfo{mode: 0o777}, nil
+		case "/safe/brew":
+			return fakeFileInfo{mode: 0o755}, nil
+		}
+		return nil, fs.ErrNotExist
+	}
+
+	if got := defaultAppleContainerFindBrew(); got != "/safe/brew" {
+		t.Fatalf("defaultAppleContainerFindBrew() = %q, want /safe/brew", got)
+	}
+}

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -476,7 +476,29 @@ func TestAppleContainerHelperProcess(t *testing.T) {
 		_, _ = os.Stdout.WriteString("container 1.0.0\n")
 		os.Exit(0)
 	}
-	if len(args) >= 3 && args[0] == "container" && args[1] == "system" && args[2] == "status" {
+	// `container <service> status`: report a service as down when the matching
+	// env var is set, otherwise report it running.
+	if len(args) >= 3 && args[0] == "container" && args[2] == "status" {
+		if os.Getenv("APPLE_CONTAINER_HELPER_"+strings.ToUpper(args[1])+"_DOWN") != "" {
+			_, _ = os.Stderr.WriteString(args[1] + " service is not running\n")
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	// `container <service> start`.
+	if len(args) >= 3 && args[0] == "container" && args[2] == "start" {
+		if os.Getenv("APPLE_CONTAINER_HELPER_START_ERROR") != "" {
+			_, _ = os.Stderr.WriteString("start failed\n")
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	// `brew install <formula>`: arg0 is the brew binary path, not "container".
+	if len(args) >= 2 && args[0] != "container" && args[1] == "install" {
+		if os.Getenv("APPLE_CONTAINER_HELPER_BREW_ERROR") != "" {
+			_, _ = os.Stderr.WriteString("brew install failed\n")
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 	if len(args) >= 2 && args[0] == "container" && args[1] == "build" {


### PR DESCRIPTION
## Summary
On Apple-silicon macOS, the Apple Container provider's `CheckRequirements` (called by both `wendy build` and `wendy run`) now sets up the local container runtime instead of just failing when it's missing or stopped:

1. **Missing `container` CLI** → offers `brew install container` (interactive, default-yes), runs it, and re-checks PATH. Non-interactive / no Homebrew → actionable error pointing at the command and https://apple.github.io/container/.
2. **`container system` not running** → prompts `container system start`.
3. **`container builder` not running** → prompts `container builder start`.

Non-interactive or declined at any step → actionable error containing the exact command.

This is **Part 2** of a two-part effort; Part 1 (the Homebrew formula recommending `container`) is in [homebrew-tap#262](https://github.com/wendylabsinc/homebrew-tap/pull/262).

## Implementation
- `go/internal/cli/providers/apple_container_setup.go` *(new)* — install + service-start helpers and stubbable seams. Brew discovery reuses the `swifttoolchain` hardening (canonical `/opt/homebrew` → `/usr/local` paths, world-writable skip, no `$PATH` reliance).
- `go/internal/cli/providers/apple_container.go` — `CheckRequirements` rewritten to call the helpers (install check → version → ensure `system` then `builder`).
- `go/internal/cli/providers/apple_container_setup_test.go` *(new)* — 9 unit tests: start/decline/non-interactive branches, brew install (incl. failure), no-brew fallback, and world-writable brew skip.
- `go/internal/cli/providers/apple_container_test.go` — helper-process emulator extended for `container <svc> status/start` and `brew install`.

## Verification
- `go build`, `go vet` — clean
- `go test ./internal/cli/providers/ -count=1` — pass (9 new tests + existing suite)
- `gofmt` — clean

## Note for reviewers
The **builder** service is checked in `CheckRequirements`, which also runs for `wendy run` — so running an already-built image will prompt to start the builder even though only builds strictly need it. This matches the "builder start too" requirement; happy to scope the builder check to `build` only if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)