### PR TITLE
docs: show Raspberry Pi 3, 4 & 5 support in hardware overview

### DIFF
--- a/go/internal/cli/assets/docs/components/docs/hardware-showcase.tsx
+++ b/go/internal/cli/assets/docs/components/docs/hardware-showcase.tsx
@@ -22,8 +22,8 @@ const boards: Board[] = [
     ],
   },
   {
-    name: 'Raspberry Pi 5',
-    tagline: 'Pi 5 (8GB recommended)',
+    name: 'Raspberry Pi',
+    tagline: 'Pi 3, 4 & 5 (8GB Pi 5 recommended)',
     logo: '/icons/icons8-raspberry-pi.svg',
     animation: '/images/boards/raspberry-pi-5.webp',
     features: [


### PR DESCRIPTION
## Summary

The hardware showcase overview card was labeled **Raspberry Pi 5** only, which understated supported hardware. This updates the card to make clear that Pi 3, 4 & 5 are all supported.

- Title: `Raspberry Pi 5` → `Raspberry Pi`
- Tagline: `Pi 5 (8GB recommended)` → `Pi 3, 4 & 5 (8GB Pi 5 recommended)`

Feature bullets (low power, GPIO, PWM/SPI/I2C, affordable) hold across all three generations and were left unchanged.

## Testing

Content-only change to a TSX data array; no behavior change. Not separately tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)