### PR TITLE
Support flashing Thor on Mac using flashpack artefact

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/google/gousb v1.1.3 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/gousb v1.1.3 h1:xt6M5TDsGSZ+rlomz5Si5Hmd/Fvbmo2YCJHN+yGaK4o=
+github.com/google/gousb v1.1.3/go.mod h1:GGWUkK0gAXDzxhwrzetW592aOmkkqSGcj5KLEgmCVUg=
 github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/analytics"
 	"github.com/wendylabsinc/wendy/go/internal/cli/commands"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/shim"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 	"google.golang.org/grpc/codes"
@@ -19,6 +21,14 @@ import (
 )
 
 func main() {
+	// When invoked as adb/lsusb/timeout (via the symlinks wendy plants on PATH for
+	// NVIDIA's bootburn during a Thor flash), act as that tool and exit. macOS only;
+	// IsShimName is always false elsewhere.
+	if shim.IsShimName(filepath.Base(os.Args[0])) {
+		shim.Dispatch()
+		return
+	}
+
 	start := time.Now()
 	cmd := commands.NewRootCmd()
 	executed, err := cmd.ExecuteC()

--- a/go/internal/cli/commands/cache.go
+++ b/go/internal/cli/commands/cache.go
@@ -97,19 +97,29 @@ func newCacheListCmd() *cobra.Command {
 						return fmt.Errorf("reading os-images cache directory: %w", err)
 					}
 					for _, img := range imgs {
-						if img.IsDir() {
-							continue
-						}
 						imgPath := filepath.Join(path, img.Name())
-						imgInfo, err := img.Info()
-						if err != nil {
-							return fmt.Errorf("reading os-images cache entry info for %q: %w", img.Name(), err)
+						// Files report their own size; directories (e.g. an extracted
+						// Thor flashpack tree) are sized recursively so they show up and
+						// can be selected for deletion like any other cache entry.
+						var sz int64
+						if img.IsDir() {
+							s, err := entrySize(imgPath)
+							if err != nil {
+								return fmt.Errorf("sizing os-images cache entry %q: %w", img.Name(), err)
+							}
+							sz = s
+						} else {
+							imgInfo, err := img.Info()
+							if err != nil {
+								return fmt.Errorf("reading os-images cache entry info for %q: %w", img.Name(), err)
+							}
+							sz = imgInfo.Size()
 						}
 						items = append(items, cacheEntry{
 							Name:      "os-images/" + img.Name(),
 							Path:      imgPath,
-							SizeBytes: imgInfo.Size(),
-							Size:      formatSize(imgInfo.Size()),
+							SizeBytes: sz,
+							Size:      formatSize(sz),
 						})
 					}
 					continue

--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -67,6 +67,12 @@ type deviceVersion struct {
 	SDZstPath      string `json:"sd_zst_path"`
 	SDZstChecksum  string `json:"sd_zst_checksum"`
 	SDZstSizeBytes int64  `json:"sd_zst_size_bytes"`
+
+	// Thor flashpack: the USB-recovery flash artifact (a .tar.zst) wendy downloads,
+	// extracts and flashes. Only present for jetson-agx-thor.
+	FlashpackPath      string `json:"flashpack_path"`
+	FlashpackChecksum  string `json:"flashpack_checksum"`
+	FlashpackSizeBytes int64  `json:"flashpack_size_bytes"`
 }
 
 // deviceInfo is the aggregated info shown in the picker for one device.
@@ -273,6 +279,56 @@ func getLatestOTAInfoForDeviceType(deviceType string, storageMedium string, nigh
 		return "", "", err
 	}
 	return u, latest, nil
+}
+
+// thorDeviceType is the manifest key / --device-type for the AGX Thor.
+const thorDeviceType = "jetson-agx-thor"
+
+// thorFlashpackInfo is the resolved flashpack download for a Thor version.
+type thorFlashpackInfo struct {
+	URL       string
+	Checksum  string
+	SizeBytes int64
+	Version   string
+}
+
+// getThorFlashpackInfo fetches the jetson-agx-thor manifest and returns the flashpack
+// artifact for version (or the latest stable / nightly when version is "").
+func getThorFlashpackInfo(version string, nightly bool) (*thorFlashpackInfo, error) {
+	main, err := fetchMainManifest()
+	if err != nil {
+		return nil, fmt.Errorf("fetching manifest: %w", err)
+	}
+	dev, ok := main.Devices[thorDeviceType]
+	if !ok || dev.ManifestPath == "" {
+		return nil, fmt.Errorf("%s not found in manifest", thorDeviceType)
+	}
+	dm, err := fetchDeviceManifest(dev.ManifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching device manifest: %w", err)
+	}
+	if version == "" {
+		version = dev.Latest
+		if nightly && dev.LatestNightly != "" {
+			version = dev.LatestNightly
+		}
+	}
+	if version == "" {
+		return nil, fmt.Errorf("no version available for %s", thorDeviceType)
+	}
+	v, ok := dm.Versions[version]
+	if !ok {
+		return nil, fmt.Errorf("version %s not found for %s", version, thorDeviceType)
+	}
+	if v.FlashpackPath == "" {
+		return nil, fmt.Errorf("version %s has no flashpack artifact in the manifest", version)
+	}
+	return &thorFlashpackInfo{
+		URL:       gcsBaseURL + "/" + v.FlashpackPath,
+		Checksum:  v.FlashpackChecksum,
+		SizeBytes: v.FlashpackSizeBytes,
+		Version:   version,
+	}, nil
 }
 
 // firmwareManifest contains version info for a specific chip.

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -352,6 +352,14 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 		}
 	}
 
+	// Thor flashes over USB recovery via its flashpack, never to a drive. The
+	// interactive picker reaches here too (the flag is empty), so route it to
+	// installThor here as well — otherwise it falls through to the disk-image
+	// flow and dd's the wrong artifact onto an external drive.
+	if selected == thorDeviceType {
+		return installThor(ctx, flagVersion, nightly, force)
+	}
+
 	device := deviceMap[selected]
 
 	if device.IsESP32 {

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -250,6 +250,13 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	if storageOverride != "" && storageOverride != "nvme" && storageOverride != "sd" {
 		return fmt.Errorf("invalid --storage %q: must be \"nvme\" or \"sd\"", storageOverride)
 	}
+
+	// AGX Thor flashes over USB recovery (not a drive), via its own flashpack
+	// artifact and device selection — a separate path from the disk-image flow below.
+	if flagDeviceType == thorDeviceType {
+		return installThor(ctx, flagVersion, nightly, force)
+	}
+
 	fmt.Println("Fetching available devices...")
 
 	// Fetch Linux devices from GCS manifest.

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -874,11 +874,45 @@ func probeRangeSupport(client *http.Client, img *imageInfo) (contentLength int64
 	return cl, true
 }
 
-// downloadImage downloads an OS image to a temp file with a progress bar.
-// If the server supports HTTP range requests, it downloads in parallel using
-// parallelDownloadWorkers concurrent connections. Falls back to a single
-// sequential stream otherwise.
+// downloadImage downloads an OS image to a temp file behind a standalone
+// progress-bar TUI. Prefer downloadImageInto when embedding the download inside
+// another progress UI (it takes a plain byte callback and owns no TUI).
 func downloadImage(img *imageInfo) (string, error) {
+	prog := tui.NewProgress(fmt.Sprintf("Downloading %s...", img.Version))
+	p := tui.NewProgressProgram(prog)
+	sendProgress := throttledProgress(p, 33*time.Millisecond)
+
+	type result struct {
+		path string
+		err  error
+	}
+	resC := make(chan result, 1)
+	go func() {
+		path, err := downloadImageInto(img, sendProgress)
+		resC <- result{path, err}
+		p.Send(tui.ProgressDoneMsg{Err: err})
+	}()
+
+	if _, err := p.Run(); err != nil {
+		if r := <-resC; r.path != "" {
+			os.Remove(r.path)
+		}
+		return "", fmt.Errorf("progress TUI: %w", err)
+	}
+	r := <-resC
+	return r.path, r.err
+}
+
+// downloadImageInto downloads img to a temp file in the OS cache directory,
+// reporting progress via onProgress(downloaded, total). It runs synchronously
+// and owns no TUI, so callers can drive their own progress display (or pass a
+// nil-effect callback). On any error it removes the partial file. If the server
+// supports HTTP range requests it downloads in parallel across
+// parallelDownloadWorkers connections; otherwise it streams sequentially.
+func downloadImageInto(img *imageInfo, onProgress func(downloaded, total int64)) (string, error) {
+	if onProgress == nil {
+		onProgress = func(int64, int64) {}
+	}
 	client := &http.Client{Timeout: 30 * time.Minute}
 
 	// Write directly into the OS cache directory so we never land in /tmp
@@ -892,77 +926,63 @@ func downloadImage(img *imageInfo) (string, error) {
 		return "", fmt.Errorf("creating temp file: %w", err)
 	}
 
-	prog := tui.NewProgress(fmt.Sprintf("Downloading %s...", img.Version))
-	p := tui.NewProgressProgram(prog)
-	sendProgress := throttledProgress(p, 33*time.Millisecond)
-
 	contentLength, supportsRanges := probeRangeSupport(client, img)
-
+	var dlErr error
 	if supportsRanges {
 		if err := tmpFile.Truncate(contentLength); err != nil {
 			tmpFile.Close()
 			os.Remove(tmpFile.Name())
 			return "", fmt.Errorf("pre-allocating: %w", err)
 		}
-		go func() {
-			p.Send(tui.ProgressDoneMsg{Err: downloadParallel(client, img.DownloadURL, contentLength, tmpFile, sendProgress)})
-		}()
+		dlErr = downloadParallel(client, img.DownloadURL, contentLength, tmpFile, onProgress)
 	} else {
-		go func() {
-			resp, err := client.Get(img.DownloadURL)
-			if err != nil {
-				p.Send(tui.ProgressDoneMsg{Err: fmt.Errorf("downloading: %w", err)})
-				return
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusOK {
-				p.Send(tui.ProgressDoneMsg{Err: fmt.Errorf("download returned status %d", resp.StatusCode)})
-				return
-			}
-			total := resp.ContentLength
-			if img.ImageSize > 0 {
-				total = img.ImageSize
-			}
-			buf := make([]byte, 1*1024*1024)
-			var downloaded int64
-			for {
-				n, readErr := resp.Body.Read(buf)
-				if n > 0 {
-					if _, writeErr := tmpFile.Write(buf[:n]); writeErr != nil {
-						p.Send(tui.ProgressDoneMsg{Err: writeErr})
-						return
-					}
-					downloaded += int64(n)
-					sendProgress(downloaded, total)
-				}
-				if readErr == io.EOF {
-					p.Send(tui.ProgressDoneMsg{})
-					return
-				}
-				if readErr != nil {
-					p.Send(tui.ProgressDoneMsg{Err: readErr})
-					return
-				}
-			}
-		}()
+		dlErr = downloadSequential(client, img, tmpFile, onProgress)
 	}
-
-	finalModel, err := p.Run()
-	if err != nil {
+	if dlErr != nil {
 		tmpFile.Close()
 		os.Remove(tmpFile.Name())
-		return "", fmt.Errorf("progress TUI: %w", err)
+		return "", dlErr
 	}
-
-	model := finalModel.(tui.ProgressModel)
-	if model.Err() != nil {
-		tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
 		os.Remove(tmpFile.Name())
-		return "", model.Err()
+		return "", err
 	}
-
-	tmpFile.Close()
 	return tmpFile.Name(), nil
+}
+
+// downloadSequential streams img into dst over a single connection, reporting
+// progress via onProgress. Used when the server does not support range requests.
+func downloadSequential(client *http.Client, img *imageInfo, dst *os.File, onProgress func(downloaded, total int64)) error {
+	resp, err := client.Get(img.DownloadURL)
+	if err != nil {
+		return fmt.Errorf("downloading: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+	total := resp.ContentLength
+	if img.ImageSize > 0 {
+		total = img.ImageSize
+	}
+	buf := make([]byte, 1*1024*1024)
+	var downloaded int64
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
+				return writeErr
+			}
+			downloaded += int64(n)
+			onProgress(downloaded, total)
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
 }
 
 func osCacheDir() (string, error) {

--- a/go/internal/cli/commands/os_install_thor_darwin.go
+++ b/go/internal/cli/commands/os_install_thor_darwin.go
@@ -10,11 +10,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/bringup"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flasher"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashpack"
@@ -24,23 +27,33 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 )
 
-// installThor flashes a Jetson AGX Thor (T264) over USB recovery: resolve the
-// flashpack (cache-first, else download from the manifest), pick the device, then
-// stage-1 RCM boot → stage-2 ADB partition flash. macOS only.
+// Step IDs for the flashing progress list.
+const (
+	stepDownload = iota
+	stepStage1
+	stepStage2
+)
+
+// installThor flashes a Jetson AGX Thor (T264) over USB recovery. It plans the
+// flashpack (version + cache state) from the manifest, briefs and confirms with
+// the user, then runs download → stage-1 RCM boot → stage-2 ADB partition flash
+// as a live BuildKit-style step list whose verbose output surfaces only on
+// failure. macOS only.
 func installThor(ctx context.Context, version string, nightly, force bool) error {
 	cacheDir, err := osCacheDir()
 	if err != nil {
 		return fmt.Errorf("resolving cache dir: %w", err)
 	}
 
-	fp, err := resolveThorFlashpack(cacheDir, version, nightly)
+	// Resolve which flashpack to use and whether it's cached, but don't download
+	// or extract yet — we do that inside the progress UI, after the user commits.
+	plan, err := planThorFlashpack(cacheDir, version, nightly)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Flashpack: %s (WendyOS %s)\n", fp.Root, fp.Manifest.WendyOSVersion)
 
 	// Brief the user on cabling / recovery mode, then confirm before scanning.
-	if err := confirmThorReady(); err != nil {
+	if err := confirmThorReady(plan.version); err != nil {
 		return err
 	}
 
@@ -49,110 +62,299 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Target: %s\n", dev.Describe())
+	fmt.Printf("\n%s %s\n", tui.Dim("Target:"), tui.Device(dev.Describe()))
 
 	if !force {
-		fmt.Printf("\nThis ERASES and reflashes the Thor (QSPI + internal NVMe). This cannot be undone.\nFlash %s? [y/N] ", dev.Describe())
-		if !readYes() {
+		fmt.Println()
+		fmt.Println(tui.WarningMessage("This erases QSPI + internal NVMe on the Thor. This cannot be undone."))
+		ok, err := tui.ConfirmNoDefaultDanger(fmt.Sprintf("Flash %s?", dev.Describe()))
+		if errors.Is(err, tui.ErrCancelled) || (err == nil && !ok) {
 			return ErrUserCancelled
 		}
-	}
-
-	// Materialize wendy's own adb/lsusb/timeout shim for bootburn, and pin the
-	// flashing gadget to the selected device's USB location for stage 2.
-	shimDir, err := shim.MaterializeADBDir()
-	if err != nil {
-		return fmt.Errorf("preparing adb shim: %w", err)
-	}
-	defer os.RemoveAll(shimDir)
-	// bootburn also calls adb by absolute path inside the bundle and workspace.
-	for _, p := range []string{
-		filepath.Join(fp.BundleDir(), "unified_flash", "tools", "flashtools", "flash", "adb"),
-		filepath.Join(fp.WorkspaceOutDir(), "tools", "flashtools", "flash", "adb"),
-	} {
-		if err := shim.LinkSelfAt(p); err != nil {
-			return fmt.Errorf("installing adb shim at %s: %w", p, err)
+		if err != nil {
+			return err
 		}
 	}
-	fmt.Println("\n== Stage 1: RCM boot ==")
-	if err := bringup.Run(bringup.Options{
-		Dir:        fp.Stage1Dir(),
-		MemBCT:     fp.MemBCT(),
-		DevicePath: dev.PathKey,
-		SendOrder:  fp.Manifest.Stage1SendOrder,
-		Out:        os.Stdout,
-	}); err != nil {
-		return fmt.Errorf("stage 1 (RCM boot): %w", err)
-	}
 
-	// Log bootburn's verbose output to a conventional logs dir, not the terminal.
+	// bootburn's full output goes to a conventional logs dir, not the terminal.
 	logPath := ""
 	if dir, derr := config.LogDir(); derr == nil {
 		logPath = filepath.Join(dir, "thor-flash-"+time.Now().Format("20060102-150405")+".log")
 	}
 
-	fmt.Println("\n== Stage 2: flash partitions over ADB ==")
-	if err := flasher.Run(flasher.Options{
-		BundleDir:    fp.BundleDir(),
-		WorkspaceDir: fp.WorkspaceOutDir(),
-		ADBDir:       shimDir,
-		ADBPort:      dev.PathKey, // pin the flashing gadget to the selected device
-		LogPath:      logPath,
-		PyYAMLDir:    fp.PyYAMLDir(),
-		Out:          os.Stdout,
-	}); err != nil {
-		return fmt.Errorf("stage 2 (flash): %w", err)
+	// fp/shimDir are populated by the download and stage-1 steps and read by
+	// later steps; the steps run sequentially in one goroutine, so no locking.
+	var (
+		fp      *flashpack.Flashpack
+		shimDir string
+	)
+	steps := []flashStep{
+		{id: stepDownload, label: "Download flashpack", run: func(out io.Writer, detail func(string)) (bool, error) {
+			resolved, cached, err := downloadAndExtractFlashpack(cacheDir, plan, detail)
+			fp = resolved
+			return cached, err
+		}},
+		{id: stepStage1, label: "Stage 1  RCM boot", run: func(out io.Writer, detail func(string)) (bool, error) {
+			// The adb/lsusb/timeout shim is set up here (device untouched until
+			// bringup) so a shim failure aborts before we boot the payload.
+			var serr error
+			if shimDir, serr = setupADBShim(fp); serr != nil {
+				return false, serr
+			}
+			return false, bringup.Run(bringup.Options{
+				Dir:        fp.Stage1Dir(),
+				MemBCT:     fp.MemBCT(),
+				DevicePath: dev.PathKey,
+				SendOrder:  fp.Manifest.Stage1SendOrder,
+				Out:        out,
+			})
+		}},
+		{id: stepStage2, label: "Stage 2  flash partitions", run: func(out io.Writer, _ func(string)) (bool, error) {
+			return false, flasher.Run(flasher.Options{
+				BundleDir:    fp.BundleDir(),
+				WorkspaceDir: fp.WorkspaceOutDir(),
+				ADBDir:       shimDir,
+				ADBPort:      dev.PathKey, // pin the flashing gadget to the selected device
+				LogPath:      logPath,
+				PyYAMLDir:    fp.PyYAMLDir(),
+				Out:          out,
+			})
+		}},
 	}
 
-	fmt.Println("\nFlash complete. Power-cycle the Thor out of recovery to boot WendyOS.")
+	// A running Google adb server (Android platform-tools) claims every ADB device
+	// it sees — including the Thor flashing gadget — exclusively, which makes our
+	// own serverless adb fail to claim the interface ("bad access"). Stop it first.
+	if stopConflictingADBServer() {
+		fmt.Println(tui.InfoMessage("Stopped a running adb server (it would hold the Thor's flashing gadget)."))
+	}
+
+	failedID, err := runFlashSteps(fmt.Sprintf("Flashing WendyOS %s", plan.version), steps)
+	if shimDir != "" {
+		os.RemoveAll(shimDir)
+	}
+	if err != nil {
+		switch {
+		case errors.Is(err, tui.ErrCancelled):
+			return ErrUserCancelled
+		case errors.Is(err, flasher.ErrGadgetUnreachable):
+			// Died at ADB setup before any write — the Thor is untouched, so
+			// advise a plain retry rather than a scary bad-state recovery.
+			printThorGadgetUnreachableHint(os.Stdout)
+		case failedID == stepStage2:
+			// Partitions were being written when it failed; the Thor can be left
+			// unbootable (UEFI-only). Guide the user through recovering it.
+			printThorBadStateHint(os.Stdout)
+		case failedID == stepStage1:
+			// RCM boot failed before any write — device untouched.
+			fmt.Println()
+			fmt.Println(tui.WarningMessage("RCM boot failed — the Thor wasn't modified. Re-enter recovery mode and try again."))
+		}
+		return err
+	}
+
+	fmt.Println(tui.SuccessMessage(fmt.Sprintf("Flashed WendyOS %s — power-cycle the Thor out of recovery to boot it.", plan.version)))
 	return nil
 }
 
-// resolveThorFlashpack returns the flashpack for version, cache-first, downloading
-// from the manifest on a cache miss. An empty version means the manifest's latest.
-func resolveThorFlashpack(cacheDir, version string, nightly bool) (*flashpack.Flashpack, error) {
-	if version != "" {
-		if fp, err := flashpack.Resolve(cacheDir, version); err == nil {
-			return fp, nil
-		} else if !errors.Is(err, flashpack.ErrNotInCache) {
-			return nil, err
-		}
+// thorFlashPlan is the resolved flashpack to install and whether it is already
+// cached. info is set (download source + checksum) only when a download is needed.
+type thorFlashPlan struct {
+	version string
+	cached  bool
+	info    *thorFlashpackInfo
+}
+
+// planThorFlashpack resolves the target version and cache state without touching
+// the network when a specific, already-cached version is requested. On a cache
+// miss it consults the manifest for the version and download source. An empty
+// version means the manifest's latest (or latest nightly).
+func planThorFlashpack(cacheDir, version string, nightly bool) (thorFlashPlan, error) {
+	if version != "" && flashpackCached(cacheDir, version) {
+		return thorFlashPlan{version: version, cached: true}, nil
 	}
 
-	// Cache miss (or no version given): consult the manifest.
-	info, mErr := getThorFlashpackInfo(version, nightly)
-	if mErr != nil {
-		if version != "" {
-			return nil, fmt.Errorf("flashpack %s not in cache and manifest lookup failed: %w", version, mErr)
-		}
-		return nil, mErr
-	}
-	version = info.Version
-
-	if fp, err := flashpack.Resolve(cacheDir, version); err == nil {
-		return fp, nil
-	} else if !errors.Is(err, flashpack.ErrNotInCache) {
-		return nil, err
-	}
-
-	fmt.Printf("Downloading Thor flashpack %s...\n", version)
-	tmp, err := downloadImage(&imageInfo{DownloadURL: info.URL, ImageSize: info.SizeBytes, Version: version})
+	info, err := getThorFlashpackInfo(version, nightly)
 	if err != nil {
-		return nil, fmt.Errorf("downloading flashpack: %w", err)
+		if version != "" {
+			return thorFlashPlan{}, fmt.Errorf("flashpack %s not in cache and manifest lookup failed: %w", version, err)
+		}
+		return thorFlashPlan{}, err
 	}
-	// Verify the download against the manifest checksum before trusting it.
-	if info.Checksum != "" {
-		if err := verifySHA256(tmp, info.Checksum); err != nil {
+	if flashpackCached(cacheDir, info.Version) {
+		return thorFlashPlan{version: info.Version, cached: true}, nil
+	}
+	return thorFlashPlan{version: info.Version, info: info}, nil
+}
+
+// flashpackCached reports whether an extracted tree or a downloaded .tar.zst for
+// version is present, i.e. Resolve can proceed without a download.
+func flashpackCached(cacheDir, version string) bool {
+	if _, err := os.Stat(filepath.Join(cacheDir, flashpack.FlashpackName(version))); err == nil {
+		return true
+	}
+	if _, err := os.Stat(flashpack.TarballCachePath(cacheDir, version)); err == nil {
+		return true
+	}
+	return false
+}
+
+// downloadAndExtractFlashpack downloads the flashpack (when not cached),
+// verifies it against the manifest checksum, and extracts it via Resolve,
+// reporting live progress through detail. It returns the ready flashpack and
+// whether the download was skipped (cache hit).
+func downloadAndExtractFlashpack(cacheDir string, plan thorFlashPlan, detail func(string)) (*flashpack.Flashpack, bool, error) {
+	if !plan.cached {
+		img := &imageInfo{DownloadURL: plan.info.URL, ImageSize: plan.info.SizeBytes, Version: plan.version}
+		tmp, err := downloadImageInto(img, throttledDetail(detail, byteProgress))
+		if err != nil {
+			return nil, false, fmt.Errorf("downloading flashpack: %w", err)
+		}
+		if plan.info.Checksum != "" {
+			detail("verifying")
+			if err := verifySHA256(tmp, plan.info.Checksum); err != nil {
+				os.Remove(tmp)
+				return nil, false, err
+			}
+		}
+		if err := os.Rename(tmp, flashpack.TarballCachePath(cacheDir, plan.version)); err != nil {
 			os.Remove(tmp)
-			return nil, err
+			return nil, false, fmt.Errorf("caching flashpack: %w", err)
 		}
 	}
-	dest := flashpack.TarballCachePath(cacheDir, version)
-	if err := os.Rename(tmp, dest); err != nil {
-		os.Remove(tmp)
-		return nil, fmt.Errorf("caching flashpack: %w", err)
+	detail("extracting")
+	fp, err := flashpack.Resolve(cacheDir, plan.version)
+	return fp, plan.cached, err
+}
+
+// setupADBShim materializes wendy's adb/lsusb/timeout shim on a temp PATH dir and
+// replaces the flashpack's bundled adb binaries with it (bootburn calls adb by
+// absolute path too). Returns the shim dir for the caller to clean up.
+func setupADBShim(fp *flashpack.Flashpack) (string, error) {
+	shimDir, err := shim.MaterializeADBDir()
+	if err != nil {
+		return "", fmt.Errorf("preparing adb shim: %w", err)
 	}
-	return flashpack.Resolve(cacheDir, version)
+	for _, p := range []string{
+		filepath.Join(fp.BundleDir(), "unified_flash", "tools", "flashtools", "flash", "adb"),
+		filepath.Join(fp.WorkspaceOutDir(), "tools", "flashtools", "flash", "adb"),
+	} {
+		if err := shim.LinkSelfAt(p); err != nil {
+			os.RemoveAll(shimDir)
+			return "", fmt.Errorf("installing adb shim at %s: %w", p, err)
+		}
+	}
+	return shimDir, nil
+}
+
+// flashStep is one entry in the flashing progress list.
+type flashStep struct {
+	id    int
+	label string
+	// run performs the step. It writes verbose output to out (captured and shown
+	// only on failure in interactive mode) and may call detail to update the live
+	// trailing text (e.g. a byte count). It returns cached=true when the work was
+	// skipped because a cache was warm.
+	run func(out io.Writer, detail func(string)) (cached bool, err error)
+}
+
+// runFlashSteps runs steps in order, rendering them as a live BuildKit-style step
+// list on an interactive terminal (verbose per-step output buffered and printed
+// only if a step fails) or as concise streamed lines otherwise. It returns the id
+// of the failing step (or -1 on success/cancel) and the error.
+func runFlashSteps(title string, steps []flashStep) (int, error) {
+	if !isInteractiveTerminal() {
+		return runFlashStepsPlain(title, steps)
+	}
+
+	m := tui.NewStepsModel(title)
+	prog := tui.NewProgressProgram(m)
+
+	type outcome struct {
+		failedID int
+		err      error
+		verbose  []byte
+	}
+	resC := make(chan outcome, 1)
+	go func() {
+		failedID, runErr := -1, error(nil)
+		var failVerbose []byte
+		for _, s := range steps {
+			// Per-step buffer so a later failure surfaces only that step's output,
+			// not the successful earlier steps.
+			buf := &boundedBuffer{max: maxRawBuildCapture}
+			prog.Send(tui.StepStartMsg{ID: s.id, Label: s.label})
+			cached, err := s.run(buf, func(d string) { prog.Send(tui.StepDetailMsg{ID: s.id, Detail: d}) })
+			if err != nil {
+				prog.Send(tui.StepFailMsg{ID: s.id})
+				failedID, runErr, failVerbose = s.id, err, buf.Bytes()
+				break
+			}
+			prog.Send(tui.StepDoneMsg{ID: s.id, Cached: cached})
+		}
+		resC <- outcome{failedID, runErr, failVerbose}
+		prog.Send(tui.StepsDoneMsg{Err: runErr})
+	}()
+
+	final, uiErr := prog.Run()
+	if uiErr != nil {
+		return -1, fmt.Errorf("flash progress UI: %w", uiErr)
+	}
+	if cancelErr := final.(tui.StepsModel).Err(); errors.Is(cancelErr, tui.ErrCancelled) {
+		return -1, cancelErr
+	}
+	res := <-resC
+	if res.err != nil {
+		// The live UI suppressed the failing step's output; surface it now.
+		os.Stdout.Write(res.verbose)
+	}
+	return res.failedID, res.err
+}
+
+// runFlashStepsPlain is the non-interactive fallback: a header per step with the
+// step's verbose output streamed live (useful in CI, and safe against idle
+// timeouts during the multi-minute flash).
+func runFlashStepsPlain(title string, steps []flashStep) (int, error) {
+	fmt.Println(title)
+	for _, s := range steps {
+		fmt.Printf("==> %s\n", s.label)
+		cached, err := s.run(os.Stdout, func(string) {})
+		if err != nil {
+			return s.id, err
+		}
+		if cached {
+			fmt.Println("    (cached)")
+		}
+	}
+	return -1, nil
+}
+
+// throttledDetail wraps a byte-progress callback so it emits a formatted detail
+// string at most every ~66ms, coalescing the flood from parallel download
+// workers. Safe for concurrent callers.
+func throttledDetail(detail func(string), format func(downloaded, total int64) string) func(downloaded, total int64) {
+	var lastNanos atomic.Int64
+	const minInterval = int64(66 * time.Millisecond)
+	return func(downloaded, total int64) {
+		now := time.Now().UnixNano()
+		prev := lastNanos.Load()
+		if now-prev < minInterval {
+			return
+		}
+		if !lastNanos.CompareAndSwap(prev, now) {
+			return
+		}
+		detail(format(downloaded, total))
+	}
+}
+
+// byteProgress formats a download's progress like "1.2/3.0 GiB".
+func byteProgress(downloaded, total int64) string {
+	const gib = 1 << 30
+	if total <= 0 {
+		return fmt.Sprintf("%.1f GiB", float64(downloaded)/gib)
+	}
+	return fmt.Sprintf("%.1f/%.1f GiB", float64(downloaded)/gib, float64(total)/gib)
 }
 
 // verifySHA256 checks that path's SHA-256 matches the expected lowercase-hex digest.
@@ -233,51 +435,143 @@ func readQuit() bool {
 	}
 }
 
-// thorRecoveryBriefing explains the cabling and recovery-mode steps the user
-// must complete before a Thor will appear in the USB recovery scan.
-const thorRecoveryBriefing = `
-Before flashing, please read the following:
+// Styles for the pre-flash briefing. Color carries the hierarchy: emerald
+// section headers, amber for things the user physically presses/disconnects,
+// sky for cabling/ports, so the box scans rather than reading as a wall of text.
+var (
+	briefBorder = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(tui.ColorBorder).
+			Padding(1, 3)
+	briefMarker = lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	briefTitle  = lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	briefKey    = lipgloss.NewStyle().Foreground(tui.ColorNotice).Bold(true) // buttons / "disconnect"
+	briefPort   = lipgloss.NewStyle().Foreground(tui.Sky500).Bold(true)      // cabling / ports
+	briefNum    = lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	briefDim    = lipgloss.NewStyle().Foreground(tui.ColorDim)
+)
 
-  Storage
-    WendyOS is installed to the Thor's internal flash and NVMe drive. It does
-    not use an external USB drive — if one is connected, disconnect it now and
-    leave it out for the rest of this process.
-
-  USB-C cabling
-    Connect this computer to the Thor's USB-C port directly next to the HDMI
-    port. The other USB-C port may be used for power only.
-
-  Entering recovery mode
-    The three front buttons, left to right, are Power, Force Recovery, and Reset.
-    1. Start with the Thor unplugged and powered off.
-    2. Plug in power.
-    3. Press and hold the Force Recovery button (middle). While holding it,
-       briefly press the Reset button (right), then release Force Recovery.
-    4. Connect it to this computer using the USB-C port next to the HDMI port.
-`
-
-// confirmThorReady prints the recovery-mode briefing and asks the user to
-// confirm the target Thor is connected and in recovery mode before scanning.
-// Returns ErrUserCancelled if the user declines.
-func confirmThorReady() error {
-	fmt.Print(thorRecoveryBriefing)
-	fmt.Print("\nIs the target Thor connected and in recovery mode? [y/n] ")
-	if !readYes() {
-		return ErrUserCancelled
+// thorRecoveryBriefingBox renders the cabling and recovery-mode steps the user
+// must complete before a Thor will appear in the USB recovery scan, as a colored,
+// scannable box.
+func thorRecoveryBriefingBox() string {
+	section := func(title string) string {
+		return briefMarker.Render("●") + " " + briefTitle.Render(title)
 	}
-	return nil
+	step := func(n int, text string) string {
+		return "    " + briefNum.Render(fmt.Sprintf("%d.", n)) + " " + text
+	}
+	lines := []string{
+		section("Storage"),
+		"  WendyOS installs to the Thor's internal flash + NVMe — it uses no",
+		"  external USB drive. " + briefKey.Render("Disconnect any USB drive now") + " and leave it out.",
+		"",
+		section("USB-C cabling"),
+		"  Connect this computer to the " + briefPort.Render("USB-C port next to the HDMI port") + ".",
+		"  The other USB-C port is " + briefDim.Render("power-only") + ".",
+		"",
+		section("Entering recovery mode"),
+		"  Front buttons, left → right:  " +
+			briefKey.Render("Power") + briefDim.Render(" · ") +
+			briefKey.Render("Force Recovery") + briefDim.Render(" · ") +
+			briefKey.Render("Reset"),
+		"",
+		step(1, "Start with the Thor "+briefDim.Render("unplugged and powered off")+"."),
+		step(2, "Plug in power."),
+		step(3, "Hold "+briefKey.Render("Force Recovery")+" (middle); briefly tap "+briefKey.Render("Reset")+" (right),"),
+		"       then release " + briefKey.Render("Force Recovery") + ".",
+		step(4, "Connect the "+briefPort.Render("USB-C port next to HDMI")+" to this computer."),
+	}
+	return briefBorder.Render(strings.Join(lines, "\n"))
 }
 
-// readYes reads a single line and reports whether it is an affirmative (y/yes).
-func readYes() bool {
-	s := bufio.NewScanner(os.Stdin)
-	if !s.Scan() {
+// Styles for the interrupted-flash recovery notice. A red border + bold red
+// title make it impossible to miss when a flash dies partway through.
+var (
+	thorHintBorder = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(tui.ColorError).
+			Padding(1, 3)
+	thorHintTitle = lipgloss.NewStyle().Foreground(tui.ColorError).Bold(true)
+	thorHintEmph  = lipgloss.NewStyle().Foreground(tui.ColorNotice).Bold(true)
+	thorHintCmd   = lipgloss.NewStyle().Foreground(tui.Sky500).Bold(true)
+)
+
+// printThorBadStateHint prints a prominent recovery notice for a Thor whose
+// flash was interrupted partway through. Such a Thor can be left booting only
+// into the UEFI shell; zeroing both rootfs slot-status variables clears the
+// "bad" marks so it will attempt a normal boot (or re-enter recovery) again.
+func printThorBadStateHint(w io.Writer) {
+	const guid = "781E084C-A330-417C-B678-38E696380CB9"
+	cmdA := fmt.Sprintf("setvar RootfsStatusSlotA -guid %s -bs -rt -nv =0x00000000", guid)
+	cmdB := fmt.Sprintf("setvar RootfsStatusSlotB -guid %s -bs -rt -nv =0x00000000", guid)
+
+	body := strings.Join([]string{
+		thorHintTitle.Render("⚠  Flashing was interrupted — the Thor may be in a bad state"),
+		"",
+		"Plug the Thor into a monitor and power-cycle it.",
+		"If the screen shows " + thorHintEmph.Render("UEFI") + ", the Thor is in a bad state.",
+		"",
+		"Attach a USB keyboard and type these two commands exactly:",
+		"",
+		thorHintCmd.Render("  " + cmdA),
+		thorHintCmd.Render("  " + cmdB),
+		"",
+		"Then power-cycle again, re-enter recovery mode, and re-run the flash.",
+	}, "\n")
+
+	fmt.Fprintln(w, "\n"+thorHintBorder.Render(body))
+}
+
+// stopConflictingADBServer stops a running Google adb server (Android
+// platform-tools) at its default port. Such a server claims every ADB device it
+// sees — including the Thor flashing gadget — exclusively, so wendy's own
+// serverless adb then fails to claim the interface ("bad access [code -3]").
+// Returns true if a server was contacted.
+func stopConflictingADBServer() bool {
+	return stopADBServer("127.0.0.1:5037")
+}
+
+// stopADBServer sends the adb host "kill" command to an adb server at addr,
+// stopping it without depending on which adb binary (or version) is installed.
+// It is a no-op (returns false) when nothing is listening.
+func stopADBServer(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 300*time.Millisecond)
+	if err != nil {
+		return false // no server listening
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	// adb host protocol: a 4-hex-digit length prefix followed by the request.
+	if _, err := conn.Write([]byte("0009host:kill")); err != nil {
 		return false
 	}
-	switch strings.ToLower(strings.TrimSpace(s.Text())) {
-	case "y", "yes":
-		return true
-	default:
-		return false
+	_, _ = io.ReadFull(conn, make([]byte, 4)) // drain OKAY/FAIL; the server exits either way
+	return true
+}
+
+// printThorGadgetUnreachableHint prints a calm, non-alarming note for a flash
+// that died at ADB setup before writing anything: the Thor is untouched, so the
+// fix is a plain retry (the gadget can re-enumerate on a different USB port).
+func printThorGadgetUnreachableHint(w io.Writer) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, tui.WarningMessage("Couldn't reach the Thor's flashing gadget over USB — nothing was written, so the Thor is safe."))
+	fmt.Fprintln(w, tui.Dim("  A running adb server can hold the gadget; if you have Android platform-tools,"))
+	fmt.Fprintln(w, tui.Dim("  run `adb kill-server`. Otherwise unplug/replug the USB-C cable (the port next to"))
+	fmt.Fprintln(w, tui.Dim("  HDMI), re-enter recovery mode, and flash again."))
+}
+
+// confirmThorReady prints a titled recovery-mode briefing and asks the user to
+// confirm the target Thor is connected and in recovery mode before scanning.
+// Returns ErrUserCancelled if the user declines or cancels.
+func confirmThorReady(version string) error {
+	fmt.Println()
+	fmt.Println(tui.Header("Flashing WendyOS " + version))
+	fmt.Println(thorRecoveryBriefingBox())
+	fmt.Println()
+	ok, err := tui.Confirm("Is the target Thor connected and in recovery mode?")
+	if errors.Is(err, tui.ErrCancelled) || (err == nil && !ok) {
+		return ErrUserCancelled
 	}
+	return err
 }

--- a/go/internal/cli/commands/os_install_thor_darwin.go
+++ b/go/internal/cli/commands/os_install_thor_darwin.go
@@ -1,0 +1,215 @@
+//go:build darwin
+
+package commands
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/bringup"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flasher"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashpack"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/shim"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// installThor flashes a Jetson AGX Thor (T264) over USB recovery: resolve the
+// flashpack (cache-first, else download from the manifest), pick the device, then
+// stage-1 RCM boot → stage-2 ADB partition flash. macOS only.
+func installThor(ctx context.Context, version string, nightly, force bool) error {
+	cacheDir, err := osCacheDir()
+	if err != nil {
+		return fmt.Errorf("resolving cache dir: %w", err)
+	}
+
+	fp, err := resolveThorFlashpack(cacheDir, version, nightly)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Flashpack: %s (WendyOS %s)\n", fp.Root, fp.Manifest.WendyOSVersion)
+
+	// Pick the device to flash.
+	dev, err := pickRecoveryDevice()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Target: %s\n", dev.Describe())
+
+	if !force {
+		fmt.Printf("\nThis ERASES and reflashes the Thor (QSPI + internal NVMe). This cannot be undone.\nFlash %s? [y/N] ", dev.Describe())
+		if !readYes() {
+			return ErrUserCancelled
+		}
+	}
+
+	// Materialize wendy's own adb/lsusb/timeout shim for bootburn, and pin the
+	// flashing gadget to the selected device's USB location for stage 2.
+	shimDir, err := shim.MaterializeADBDir()
+	if err != nil {
+		return fmt.Errorf("preparing adb shim: %w", err)
+	}
+	defer os.RemoveAll(shimDir)
+	// bootburn also calls adb by absolute path inside the bundle and workspace.
+	for _, p := range []string{
+		filepath.Join(fp.BundleDir(), "unified_flash", "tools", "flashtools", "flash", "adb"),
+		filepath.Join(fp.WorkspaceOutDir(), "tools", "flashtools", "flash", "adb"),
+	} {
+		if err := shim.LinkSelfAt(p); err != nil {
+			return fmt.Errorf("installing adb shim at %s: %w", p, err)
+		}
+	}
+	fmt.Println("\n== Stage 1: RCM boot ==")
+	if err := bringup.Run(bringup.Options{
+		Dir:        fp.Stage1Dir(),
+		MemBCT:     fp.MemBCT(),
+		DevicePath: dev.PathKey,
+		SendOrder:  fp.Manifest.Stage1SendOrder,
+		Out:        os.Stdout,
+	}); err != nil {
+		return fmt.Errorf("stage 1 (RCM boot): %w", err)
+	}
+
+	// Log bootburn's verbose output to a conventional logs dir, not the terminal.
+	logPath := ""
+	if dir, derr := config.LogDir(); derr == nil {
+		logPath = filepath.Join(dir, "thor-flash-"+time.Now().Format("20060102-150405")+".log")
+	}
+
+	fmt.Println("\n== Stage 2: flash partitions over ADB ==")
+	if err := flasher.Run(flasher.Options{
+		BundleDir:    fp.BundleDir(),
+		WorkspaceDir: fp.WorkspaceOutDir(),
+		ADBDir:       shimDir,
+		ADBPort:      dev.PathKey, // pin the flashing gadget to the selected device
+		LogPath:      logPath,
+		PyYAMLDir:    fp.PyYAMLDir(),
+		Out:          os.Stdout,
+	}); err != nil {
+		return fmt.Errorf("stage 2 (flash): %w", err)
+	}
+
+	fmt.Println("\nFlash complete. Power-cycle the Thor out of recovery to boot WendyOS.")
+	return nil
+}
+
+// resolveThorFlashpack returns the flashpack for version, cache-first, downloading
+// from the manifest on a cache miss. An empty version means the manifest's latest.
+func resolveThorFlashpack(cacheDir, version string, nightly bool) (*flashpack.Flashpack, error) {
+	if version != "" {
+		if fp, err := flashpack.Resolve(cacheDir, version); err == nil {
+			return fp, nil
+		} else if !errors.Is(err, flashpack.ErrNotInCache) {
+			return nil, err
+		}
+	}
+
+	// Cache miss (or no version given): consult the manifest.
+	info, mErr := getThorFlashpackInfo(version, nightly)
+	if mErr != nil {
+		if version != "" {
+			return nil, fmt.Errorf("flashpack %s not in cache and manifest lookup failed: %w", version, mErr)
+		}
+		return nil, mErr
+	}
+	version = info.Version
+
+	if fp, err := flashpack.Resolve(cacheDir, version); err == nil {
+		return fp, nil
+	} else if !errors.Is(err, flashpack.ErrNotInCache) {
+		return nil, err
+	}
+
+	fmt.Printf("Downloading Thor flashpack %s...\n", version)
+	tmp, err := downloadImage(&imageInfo{DownloadURL: info.URL, ImageSize: info.SizeBytes, Version: version})
+	if err != nil {
+		return nil, fmt.Errorf("downloading flashpack: %w", err)
+	}
+	// Verify the download against the manifest checksum before trusting it.
+	if info.Checksum != "" {
+		if err := verifySHA256(tmp, info.Checksum); err != nil {
+			os.Remove(tmp)
+			return nil, err
+		}
+	}
+	dest := flashpack.TarballCachePath(cacheDir, version)
+	if err := os.Rename(tmp, dest); err != nil {
+		os.Remove(tmp)
+		return nil, fmt.Errorf("caching flashpack: %w", err)
+	}
+	return flashpack.Resolve(cacheDir, version)
+}
+
+// verifySHA256 checks that path's SHA-256 matches the expected lowercase-hex digest.
+func verifySHA256(path, want string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hashing %s: %w", filepath.Base(path), err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("flashpack checksum mismatch: got %s, manifest says %s", got, want)
+	}
+	return nil
+}
+
+// pickRecoveryDevice lists Jetsons in recovery mode and selects one (auto when there
+// is exactly one, interactive picker when there are several).
+func pickRecoveryDevice() (rcm.RecoveryDevice, error) {
+	devs, err := rcm.ListRecoveryDevices()
+	if err != nil {
+		return rcm.RecoveryDevice{}, err
+	}
+	if len(devs) == 0 {
+		return rcm.RecoveryDevice{}, fmt.Errorf("no Jetson found in USB recovery mode\n  Put the Thor in recovery (hold force-recovery, tap reset), connect USB, and allow the accessory if macOS prompts.")
+	}
+	if len(devs) == 1 {
+		return devs[0], nil
+	}
+	var items []tui.PickerItem
+	byKey := make(map[string]rcm.RecoveryDevice, len(devs))
+	for _, d := range devs {
+		byKey[d.PathKey] = d
+		items = append(items, tui.PickerItem{
+			Name:        d.Describe(),
+			Description: "",
+			Section:     "Recovery devices",
+			SortKey:     d.PathKey,
+			Value:       d.PathKey,
+		})
+	}
+	sel, err := pickFromItems("Select the Thor to flash", items)
+	if err != nil {
+		return rcm.RecoveryDevice{}, err
+	}
+	return byKey[sel], nil
+}
+
+// readYes reads a single line and reports whether it is an affirmative (y/yes).
+func readYes() bool {
+	s := bufio.NewScanner(os.Stdin)
+	if !s.Scan() {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(s.Text())) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}

--- a/go/internal/cli/commands/os_install_thor_darwin.go
+++ b/go/internal/cli/commands/os_install_thor_darwin.go
@@ -39,6 +39,11 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 	}
 	fmt.Printf("Flashpack: %s (WendyOS %s)\n", fp.Root, fp.Manifest.WendyOSVersion)
 
+	// Brief the user on cabling / recovery mode, then confirm before scanning.
+	if err := confirmThorReady(); err != nil {
+		return err
+	}
+
 	// Pick the device to flash.
 	dev, err := pickRecoveryDevice()
 	if err != nil {
@@ -171,33 +176,96 @@ func verifySHA256(path, want string) error {
 // pickRecoveryDevice lists Jetsons in recovery mode and selects one (auto when there
 // is exactly one, interactive picker when there are several).
 func pickRecoveryDevice() (rcm.RecoveryDevice, error) {
-	devs, err := rcm.ListRecoveryDevices()
-	if err != nil {
-		return rcm.RecoveryDevice{}, err
+	for {
+		devs, err := rcm.ListRecoveryDevices()
+		if err != nil {
+			return rcm.RecoveryDevice{}, err
+		}
+		switch len(devs) {
+		case 0:
+			// The user already confirmed the Thor is in recovery mode, so a zero
+			// scan usually means cabling or the button sequence needs another try.
+			// Offer a rescan instead of aborting.
+			fmt.Print("\nNo Jetson found in USB recovery mode.\n" +
+				"  Check the USB-C cable is in the port next to the HDMI port and re-do the\n" +
+				"  recovery-mode button sequence, then rescan.\n" +
+				"Press Enter to rescan, or 'q' to quit: ")
+			if readQuit() {
+				return rcm.RecoveryDevice{}, ErrUserCancelled
+			}
+			continue
+		case 1:
+			return devs[0], nil
+		default:
+			var items []tui.PickerItem
+			byKey := make(map[string]rcm.RecoveryDevice, len(devs))
+			for _, d := range devs {
+				byKey[d.PathKey] = d
+				items = append(items, tui.PickerItem{
+					Name:        d.Describe(),
+					Description: "",
+					Section:     "Recovery devices",
+					SortKey:     d.PathKey,
+					Value:       d.PathKey,
+				})
+			}
+			sel, err := pickFromItems("Select the Thor to flash", items)
+			if err != nil {
+				return rcm.RecoveryDevice{}, err
+			}
+			return byKey[sel], nil
+		}
 	}
-	if len(devs) == 0 {
-		return rcm.RecoveryDevice{}, fmt.Errorf("no Jetson found in USB recovery mode\n  Put the Thor in recovery (hold force-recovery, tap reset), connect USB, and allow the accessory if macOS prompts.")
+}
+
+// readQuit reads a single line and reports whether the user asked to quit
+// (q/quit). Any other input — including a bare Enter — means "continue".
+func readQuit() bool {
+	s := bufio.NewScanner(os.Stdin)
+	if !s.Scan() {
+		return true // EOF (e.g. closed stdin) — don't loop forever
 	}
-	if len(devs) == 1 {
-		return devs[0], nil
+	switch strings.ToLower(strings.TrimSpace(s.Text())) {
+	case "q", "quit":
+		return true
+	default:
+		return false
 	}
-	var items []tui.PickerItem
-	byKey := make(map[string]rcm.RecoveryDevice, len(devs))
-	for _, d := range devs {
-		byKey[d.PathKey] = d
-		items = append(items, tui.PickerItem{
-			Name:        d.Describe(),
-			Description: "",
-			Section:     "Recovery devices",
-			SortKey:     d.PathKey,
-			Value:       d.PathKey,
-		})
+}
+
+// thorRecoveryBriefing explains the cabling and recovery-mode steps the user
+// must complete before a Thor will appear in the USB recovery scan.
+const thorRecoveryBriefing = `
+Before flashing, please read the following:
+
+  Storage
+    WendyOS is installed to the Thor's internal flash and NVMe drive. It does
+    not use an external USB drive — if one is connected, disconnect it now and
+    leave it out for the rest of this process.
+
+  USB-C cabling
+    Connect this computer to the Thor's USB-C port directly next to the HDMI
+    port. The other USB-C port may be used for power only.
+
+  Entering recovery mode
+    The three front buttons, left to right, are Power, Force Recovery, and Reset.
+    1. Start with the Thor unplugged and powered off.
+    2. Plug in power.
+    3. Press and hold the Force Recovery button (middle). While holding it,
+       briefly press the Reset button (right), then release Force Recovery.
+    4. Connect it to this computer using the USB-C port next to the HDMI port.
+`
+
+// confirmThorReady prints the recovery-mode briefing and asks the user to
+// confirm the target Thor is connected and in recovery mode before scanning.
+// Returns ErrUserCancelled if the user declines.
+func confirmThorReady() error {
+	fmt.Print(thorRecoveryBriefing)
+	fmt.Print("\nIs the target Thor connected and in recovery mode? [y/n] ")
+	if !readYes() {
+		return ErrUserCancelled
 	}
-	sel, err := pickFromItems("Select the Thor to flash", items)
-	if err != nil {
-		return rcm.RecoveryDevice{}, err
-	}
-	return byKey[sel], nil
+	return nil
 }
 
 // readYes reads a single line and reports whether it is an affirmative (y/yes).

--- a/go/internal/cli/commands/os_install_thor_darwin_test.go
+++ b/go/internal/cli/commands/os_install_thor_darwin_test.go
@@ -1,0 +1,145 @@
+//go:build darwin
+
+package commands
+
+import (
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashpack"
+)
+
+func TestStopADBServer(t *testing.T) {
+	// No server listening → no-op, false.
+	if stopADBServer("127.0.0.1:1") {
+		t.Fatal("stopADBServer should return false when nothing is listening")
+	}
+
+	// A fake adb server: accept one connection, record the request, reply OKAY.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	got := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			got <- ""
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, len("0009host:kill"))
+		io.ReadFull(conn, buf)
+		conn.Write([]byte("OKAY"))
+		got <- string(buf)
+	}()
+
+	if !stopADBServer(ln.Addr().String()) {
+		t.Fatal("stopADBServer should return true when a server is contacted")
+	}
+	if req := <-got; req != "0009host:kill" {
+		t.Fatalf("server received %q, want %q", req, "0009host:kill")
+	}
+}
+
+func TestByteProgress(t *testing.T) {
+	const gib = 1 << 30
+	if got := byteProgress(gib*3/2, gib*3); got != "1.5/3.0 GiB" {
+		t.Errorf("byteProgress = %q, want %q", got, "1.5/3.0 GiB")
+	}
+	// Unknown total: report only what's downloaded.
+	if got := byteProgress(gib/2, 0); got != "0.5 GiB" {
+		t.Errorf("byteProgress unknown total = %q, want %q", got, "0.5 GiB")
+	}
+}
+
+func TestFlashpackCached(t *testing.T) {
+	dir := t.TempDir()
+	const version = "nightly-20260701T135030"
+
+	if flashpackCached(dir, version) {
+		t.Fatal("empty cache should not report cached")
+	}
+
+	// A downloaded tarball counts as cached.
+	tarball := flashpack.TarballCachePath(dir, version)
+	if err := os.WriteFile(tarball, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !flashpackCached(dir, version) {
+		t.Fatal("tarball present should report cached")
+	}
+
+	// An already-extracted tree also counts.
+	os.Remove(tarball)
+	if err := os.MkdirAll(filepath.Join(dir, flashpack.FlashpackName(version)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !flashpackCached(dir, version) {
+		t.Fatal("extracted tree should report cached")
+	}
+}
+
+func TestRunFlashStepsPlain_Sequencing(t *testing.T) {
+	// runFlashSteps falls back to the plain runner in a non-TTY test env.
+	var ran []int
+	steps := []flashStep{
+		{id: stepDownload, label: "Download flashpack", run: func(out io.Writer, detail func(string)) (bool, error) {
+			ran = append(ran, stepDownload)
+			return true, nil // cached
+		}},
+		{id: stepStage1, label: "Stage 1", run: func(out io.Writer, detail func(string)) (bool, error) {
+			ran = append(ran, stepStage1)
+			return false, nil
+		}},
+		{id: stepStage2, label: "Stage 2", run: func(out io.Writer, detail func(string)) (bool, error) {
+			ran = append(ran, stepStage2)
+			return false, nil
+		}},
+	}
+
+	failedID, err := runFlashSteps("Flashing", steps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if failedID != -1 {
+		t.Fatalf("failedID = %d, want -1", failedID)
+	}
+	if len(ran) != 3 || ran[0] != stepDownload || ran[2] != stepStage2 {
+		t.Fatalf("steps ran out of order: %v", ran)
+	}
+}
+
+func TestRunFlashStepsPlain_StopsOnFailure(t *testing.T) {
+	sentinel := errors.New("stage 1 boom")
+	var reachedStage2 bool
+	steps := []flashStep{
+		{id: stepDownload, label: "Download flashpack", run: func(out io.Writer, detail func(string)) (bool, error) {
+			return false, nil
+		}},
+		{id: stepStage1, label: "Stage 1", run: func(out io.Writer, detail func(string)) (bool, error) {
+			return false, sentinel
+		}},
+		{id: stepStage2, label: "Stage 2", run: func(out io.Writer, detail func(string)) (bool, error) {
+			reachedStage2 = true
+			return false, nil
+		}},
+	}
+
+	failedID, err := runFlashSteps("Flashing", steps)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel", err)
+	}
+	if failedID != stepStage1 {
+		t.Fatalf("failedID = %d, want %d (stepStage1)", failedID, stepStage1)
+	}
+	if reachedStage2 {
+		t.Fatal("stage 2 should not run after stage 1 fails")
+	}
+}

--- a/go/internal/cli/commands/os_install_thor_other.go
+++ b/go/internal/cli/commands/os_install_thor_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package commands
+
+import (
+	"context"
+	"fmt"
+)
+
+// installThor is macOS-only for now (USB recovery flashing uses gousb/libusb).
+func installThor(_ context.Context, _ string, _ bool, _ bool) error {
+	return fmt.Errorf("Thor (jetson-agx-thor) flashing is currently only supported on macOS")
+}

--- a/go/internal/cli/tegraflash/adb/adb.go
+++ b/go/internal/cli/tegraflash/adb/adb.go
@@ -59,6 +59,14 @@ const (
 	// long time with no output, and a timed-out bulk-IN read is destructive on macOS
 	// (it aborts the endpoint), so we must not time out during a legitimate op.
 	ioTimeout = 30 * time.Minute
+
+	// handshakeReadTimeout bounds the CNXN reply read specifically. Unlike a data
+	// transfer, the handshake reply is immediate on a healthy adbd, so a short
+	// timeout here lets Open() fail fast and retry (across bootburn's own
+	// `timeout N adb wait-for-device` windows) while the gadget's adbd is still
+	// coming up — instead of blocking on the 30-minute ioTimeout until bootburn
+	// SIGKILLs the probe (rc 124), which also risks poisoning the USB endpoint.
+	handshakeReadTimeout = 3 * time.Second
 )
 
 // Device is a connected ADB transport over USB.
@@ -171,12 +179,16 @@ func openOnce() (*Device, error) {
 
 	cfg, err := dev.Config(cfgNum)
 	if err != nil {
+		// Logged (not just returned) because Open()'s retry loop and bootburn's
+		// outer `timeout` otherwise swallow why the claim keeps failing.
+		fmt.Fprintf(os.Stderr, "wendy adb: usb %s: claiming config %d failed: %v\n", adbPortKey(dev.Desc), cfgNum, err)
 		dev.Close()
 		ctx.Close()
 		return nil, fmt.Errorf("claiming config %d: %w", cfgNum, err)
 	}
 	iface, err := cfg.Interface(ifNum, altNum)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "wendy adb: usb %s: claiming interface %d.%d failed: %v\n", adbPortKey(dev.Desc), ifNum, altNum, err)
 		cfg.Close()
 		dev.Close()
 		ctx.Close()
@@ -205,6 +217,12 @@ func openOnce() (*Device, error) {
 
 	d := &Device{ctx: ctx, dev: dev, cfg: cfg, iface: iface, in: inEP, out: outEP, nextID: 1}
 	if err := d.connect(); err != nil {
+		// The ADB interface was found and claimed but the CNXN handshake failed.
+		// Surface why here: Open() retries internally and bootburn's outer `timeout`
+		// often kills the process mid-retry before Open() returns, so this is the
+		// only place the underlying reason (adbd not up, USB read error, auth) is
+		// visible in the flash log.
+		fmt.Fprintf(os.Stderr, "wendy adb: claimed ADB interface at usb %s but CNXN handshake failed: %v\n", adbPortKey(dev.Desc), err)
 		d.Close()
 		return nil, err
 	}
@@ -264,8 +282,11 @@ func (d *Device) connect() error {
 	if err := d.writeMsg(cmdCNXN, adbVersion, maxPayload, []byte("host::\x00")); err != nil {
 		return fmt.Errorf("sending CNXN: %w", err)
 	}
+	// Bound the reply read: a healthy adbd answers immediately, so a slow/absent
+	// reply means the gadget isn't ready — fail fast so Open() can retry rather
+	// than block on the 30-minute data timeout.
 	for {
-		cmd, _, _, data, err := d.readMsg()
+		cmd, _, _, data, err := d.readMsgTimeout(handshakeReadTimeout)
 		if err != nil {
 			return fmt.Errorf("reading CNXN reply: %w", err)
 		}
@@ -309,7 +330,13 @@ func (d *Device) writeMsg(cmd, arg0, arg1 uint32, data []byte) error {
 
 // readMsg reads one ADB message: a 24-byte header then data_length bytes of payload.
 func (d *Device) readMsg() (cmd, arg0, arg1 uint32, data []byte, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), ioTimeout)
+	return d.readMsgTimeout(ioTimeout)
+}
+
+// readMsgTimeout is readMsg with an explicit per-transfer timeout, so the CNXN
+// handshake can use a short bound while data transfers keep the long ioTimeout.
+func (d *Device) readMsgTimeout(timeout time.Duration) (cmd, arg0, arg1 uint32, data []byte, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	// Read into a full max-packet buffer (a sub-packet read length can error on

--- a/go/internal/cli/tegraflash/adb/adb.go
+++ b/go/internal/cli/tegraflash/adb/adb.go
@@ -1,0 +1,559 @@
+//go:build darwin
+
+// Package adb speaks the Android Debug Bridge wire protocol directly over USB —
+// no adb binary and no adb server. It implements the host side of the transport
+// (the CNXN handshake plus OPEN/OKAY/WRTE/CLSE stream multiplexing) and the
+// "shell:" and "sync:" (file push) services, so the wendy CLI can drive a
+// device's adbd self-contained. This is used to drive the T264 initrd-flash
+// gadget that comes up after the RCM boot.
+//
+// The ADB interface is identified by USB vendor class 0xFF / subclass 0x42 /
+// protocol 0x01. Auth (the on-device "allow this computer" RSA prompt) is not
+// implemented: a headless flashing initrd runs adbd insecure, so the device
+// replies to CNXN with CNXN rather than AUTH.
+package adb
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/gousb"
+)
+
+// adbPortKey is the stable physical-location key (bus + parent-port chain), matching
+// rcm.portKey, so a device can be tracked across the RCM→ADB re-enumeration.
+func adbPortKey(desc *gousb.DeviceDesc) string {
+	parts := make([]string, len(desc.Path))
+	for i, p := range desc.Path {
+		parts[i] = strconv.Itoa(p)
+	}
+	return fmt.Sprintf("%d-%s", desc.Bus, strings.Join(parts, "."))
+}
+
+// ADB message commands (little-endian 4-byte tags).
+const (
+	cmdCNXN = 0x4e584e43 // "CNXN"
+	cmdAUTH = 0x48545541 // "AUTH"
+	cmdOPEN = 0x4e45504f // "OPEN"
+	cmdOKAY = 0x59414b4f // "OKAY"
+	cmdCLSE = 0x45534c43 // "CLSE"
+	cmdWRTE = 0x45545257 // "WRTE"
+
+	adbVersion = 0x01000001
+	maxPayload = 256 * 1024
+
+	classVendor = 0xff
+	subclassADB = 0x42
+	protocolADB = 0x01
+
+	syncDataMax = 64 * 1024
+
+	// ioTimeout bounds each USB transfer. It is large because device-side flash
+	// steps (QSPI erase, dd of multi-GB partitions) hold the shell stream open for a
+	// long time with no output, and a timed-out bulk-IN read is destructive on macOS
+	// (it aborts the endpoint), so we must not time out during a legitimate op.
+	ioTimeout = 30 * time.Minute
+)
+
+// Device is a connected ADB transport over USB.
+type Device struct {
+	ctx    *gousb.Context
+	dev    *gousb.Device
+	cfg    *gousb.Config
+	iface  *gousb.Interface
+	in     *gousb.InEndpoint
+	out    *gousb.OutEndpoint
+	nextID uint32
+	// Banner is the device identity string from the CNXN reply.
+	Banner string
+	// shellV2 is set when the device advertises the shell_v2 feature; its legacy
+	// shell:/exec: services are non-functional on the T264 flashing adbd, so we must
+	// use the shell-protocol-v2 service instead.
+	shellV2 bool
+}
+
+// shell-protocol-v2 stream message ids (1-byte id + 4-byte LE length + payload).
+const (
+	shellStdout = 1
+	shellStderr = 2
+	shellExit   = 3
+)
+
+// ExitError reports a non-zero shell exit status.
+type ExitError struct{ Code int }
+
+func (e *ExitError) Error() string { return fmt.Sprintf("shell exited with status %d", e.Code) }
+
+// Open finds a USB device exposing an ADB interface, claims it, and performs the
+// CNXN handshake. It retries on transient failures: bootburn drives many short-lived
+// adb invocations back-to-back, and macOS/libusb does not release the interface
+// synchronously when the previous process exits, so a claim can briefly fail with
+// "bad access" until the kernel frees it.
+func Open() (*Device, error) {
+	var lastErr error
+	for attempt := 0; attempt < 12; attempt++ {
+		d, err := openOnce()
+		if err == nil {
+			return d, nil
+		}
+		lastErr = err
+		time.Sleep(time.Duration(150+attempt*150) * time.Millisecond)
+	}
+	return nil, lastErr
+}
+
+func openOnce() (*Device, error) {
+	ctx := gousb.NewContext()
+	ctx.Debug(0)
+
+	// WENDY_ADB_PATH, when set, pins which physical device we drive — the flashing
+	// gadget re-enumerates at the same USB location (bus + parent-port chain) the
+	// RCM device was selected at, so multi-device hosts flash the chosen board.
+	wantPath := os.Getenv("WENDY_ADB_PATH")
+	devs, err := ctx.OpenDevices(func(desc *gousb.DeviceDesc) bool {
+		_, _, _, ok := findADBInterface(desc)
+		return ok && (wantPath == "" || adbPortKey(desc) == wantPath)
+	})
+	if err != nil {
+		// OpenDevices returns opened handles plus an aggregate error; keep going if
+		// we got at least one device.
+		for i := 1; i < len(devs); i++ {
+			devs[i].Close()
+		}
+	}
+	if len(devs) == 0 {
+		ctx.Close()
+		return nil, fmt.Errorf("no USB device with an ADB interface (ff/42/01) found: %v", err)
+	}
+	dev := devs[0]
+	for i := 1; i < len(devs); i++ {
+		devs[i].Close()
+	}
+
+	cfgNum, ifNum, altNum, ok := findADBInterface(dev.Desc)
+	if !ok {
+		dev.Close()
+		ctx.Close()
+		return nil, fmt.Errorf("ADB interface disappeared")
+	}
+
+	cfg, err := dev.Config(cfgNum)
+	if err != nil {
+		dev.Close()
+		ctx.Close()
+		return nil, fmt.Errorf("claiming config %d: %w", cfgNum, err)
+	}
+	iface, err := cfg.Interface(ifNum, altNum)
+	if err != nil {
+		cfg.Close()
+		dev.Close()
+		ctx.Close()
+		return nil, fmt.Errorf("claiming interface %d.%d: %w", ifNum, altNum, err)
+	}
+
+	var inEP *gousb.InEndpoint
+	var outEP *gousb.OutEndpoint
+	for _, ep := range iface.Setting.Endpoints {
+		if ep.TransferType != gousb.TransferTypeBulk {
+			continue
+		}
+		if ep.Direction == gousb.EndpointDirectionIn && inEP == nil {
+			inEP, _ = iface.InEndpoint(ep.Number)
+		} else if ep.Direction == gousb.EndpointDirectionOut && outEP == nil {
+			outEP, _ = iface.OutEndpoint(ep.Number)
+		}
+	}
+	if inEP == nil || outEP == nil {
+		iface.Close()
+		cfg.Close()
+		dev.Close()
+		ctx.Close()
+		return nil, fmt.Errorf("ADB interface is missing bulk endpoints")
+	}
+
+	d := &Device{ctx: ctx, dev: dev, cfg: cfg, iface: iface, in: inEP, out: outEP, nextID: 1}
+	if err := d.connect(); err != nil {
+		d.Close()
+		return nil, err
+	}
+	return d, nil
+}
+
+// VendorPresent reports whether any USB device with the given vendor id is present.
+// It only inspects descriptors (the filter returns false), so no device is claimed.
+func VendorPresent(vid uint16) bool {
+	ctx := gousb.NewContext()
+	defer ctx.Close()
+	found := false
+	devs, _ := ctx.OpenDevices(func(desc *gousb.DeviceDesc) bool {
+		if uint16(desc.Vendor) == vid {
+			found = true
+		}
+		return false
+	})
+	for _, d := range devs {
+		d.Close()
+	}
+	return found
+}
+
+// findADBInterface returns the config/interface/alt numbers of the first ADB
+// interface (vendor class 0xFF, subclass 0x42, protocol 0x01) in desc.
+func findADBInterface(desc *gousb.DeviceDesc) (cfgNum, ifNum, altNum int, ok bool) {
+	for _, c := range desc.Configs {
+		for _, i := range c.Interfaces {
+			for _, a := range i.AltSettings {
+				if uint8(a.Class) == classVendor && uint8(a.SubClass) == subclassADB && uint8(a.Protocol) == protocolADB {
+					return c.Number, a.Number, a.Alternate, true
+				}
+			}
+		}
+	}
+	return 0, 0, 0, false
+}
+
+// Close releases the USB resources.
+func (d *Device) Close() {
+	if d.iface != nil {
+		d.iface.Close()
+	}
+	if d.cfg != nil {
+		d.cfg.Close()
+	}
+	if d.dev != nil {
+		d.dev.Close()
+	}
+	if d.ctx != nil {
+		d.ctx.Close()
+	}
+}
+
+func (d *Device) connect() error {
+	if err := d.writeMsg(cmdCNXN, adbVersion, maxPayload, []byte("host::\x00")); err != nil {
+		return fmt.Errorf("sending CNXN: %w", err)
+	}
+	for {
+		cmd, _, _, data, err := d.readMsg()
+		if err != nil {
+			return fmt.Errorf("reading CNXN reply: %w", err)
+		}
+		switch cmd {
+		case cmdCNXN:
+			d.Banner = string(data)
+			d.shellV2 = strings.Contains(d.Banner, "shell_v2")
+			return nil
+		case cmdAUTH:
+			return fmt.Errorf("device requires ADB authentication (secure adbd); not supported")
+		}
+	}
+}
+
+// writeMsg sends one ADB message: a 24-byte header then the payload.
+func (d *Device) writeMsg(cmd, arg0, arg1 uint32, data []byte) error {
+	var check uint32
+	for _, b := range data {
+		check += uint32(b)
+	}
+	hdr := make([]byte, 24)
+	binary.LittleEndian.PutUint32(hdr[0:], cmd)
+	binary.LittleEndian.PutUint32(hdr[4:], arg0)
+	binary.LittleEndian.PutUint32(hdr[8:], arg1)
+	binary.LittleEndian.PutUint32(hdr[12:], uint32(len(data)))
+	binary.LittleEndian.PutUint32(hdr[16:], check)
+	binary.LittleEndian.PutUint32(hdr[20:], cmd^0xffffffff)
+
+	ctx, cancel := context.WithTimeout(context.Background(), ioTimeout)
+	defer cancel()
+	if _, err := d.out.WriteContext(ctx, hdr); err != nil {
+		return err
+	}
+	if len(data) > 0 {
+		if _, err := d.out.WriteContext(ctx, data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readMsg reads one ADB message: a 24-byte header then data_length bytes of payload.
+func (d *Device) readMsg() (cmd, arg0, arg1 uint32, data []byte, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ioTimeout)
+	defer cancel()
+
+	// Read into a full max-packet buffer (a sub-packet read length can error on
+	// macOS IOKit). adbd writes the header as its own transfer, so this returns 24.
+	hdr := make([]byte, 512)
+	n, e := d.in.ReadContext(ctx, hdr)
+	if e != nil {
+		err = e
+		return
+	}
+	if n < 24 {
+		err = fmt.Errorf("short ADB header (%d bytes)", n)
+		return
+	}
+	cmd = binary.LittleEndian.Uint32(hdr[0:])
+	arg0 = binary.LittleEndian.Uint32(hdr[4:])
+	arg1 = binary.LittleEndian.Uint32(hdr[8:])
+	dlen := binary.LittleEndian.Uint32(hdr[12:])
+
+	got := append([]byte{}, hdr[24:n]...) // any payload that rode with the header
+	for uint32(len(got)) < dlen {
+		buf := make([]byte, syncDataMax)
+		m, re := d.in.ReadContext(ctx, buf)
+		if re != nil {
+			err = re
+			return
+		}
+		got = append(got, buf[:m]...)
+	}
+	data = got[:dlen]
+	return
+}
+
+// Shell runs command on the device and returns its combined stdout+stderr. If the
+// command exits non-zero the returned error is an *ExitError carrying the code.
+//
+// The T264 flashing adbd advertises shell_v2 and does not service the legacy
+// "shell:"/"exec:" requests (they return "fork failed"), so when shell_v2 is
+// available we use the shell-protocol-v2 service ("shell,v2,raw:") and decode its
+// framed stream. Otherwise we fall back to the legacy raw service.
+func (d *Device) Shell(command string) (string, error) {
+	if d.shellV2 {
+		return d.shellV2Run("shell,v2,raw:" + command)
+	}
+	local := d.nextID
+	d.nextID++
+	if err := d.writeMsg(cmdOPEN, local, 0, []byte("shell:"+command+"\x00")); err != nil {
+		return "", err
+	}
+	var out []byte
+	for {
+		cmd, a0, _, data, err := d.readMsg()
+		if err != nil {
+			return string(out), err
+		}
+		switch cmd {
+		case cmdOKAY:
+			// stream is open / our write was accepted
+		case cmdWRTE:
+			out = append(out, data...)
+			if err := d.writeMsg(cmdOKAY, local, a0, nil); err != nil {
+				return string(out), err
+			}
+		case cmdCLSE:
+			_ = d.writeMsg(cmdCLSE, local, a0, nil)
+			return string(out), nil
+		}
+	}
+}
+
+// shellV2Run opens a shell-protocol-v2 service and decodes its framed stream into
+// combined stdout+stderr, returning an *ExitError if the device reports non-zero.
+func (d *Device) shellV2Run(service string) (string, error) {
+	local := d.nextID
+	d.nextID++
+	if err := d.writeMsg(cmdOPEN, local, 0, []byte(service+"\x00")); err != nil {
+		return "", err
+	}
+
+	var out []byte
+	var buf []byte // accumulated, undecoded stream bytes
+	exit := -1
+	for {
+		// Decode whole packets out of buf.
+		for len(buf) >= 5 {
+			length := int(binary.LittleEndian.Uint32(buf[1:5]))
+			if len(buf) < 5+length {
+				break
+			}
+			id, payload := buf[0], buf[5:5+length]
+			switch id {
+			case shellStdout, shellStderr:
+				out = append(out, payload...)
+			case shellExit:
+				if length >= 1 {
+					exit = int(payload[0])
+				}
+			}
+			buf = buf[5+length:]
+		}
+		cmd, a0, _, data, err := d.readMsg()
+		if err != nil {
+			return string(out), err
+		}
+		switch cmd {
+		case cmdWRTE:
+			buf = append(buf, data...)
+			if err := d.writeMsg(cmdOKAY, local, a0, nil); err != nil {
+				return string(out), err
+			}
+		case cmdCLSE:
+			_ = d.writeMsg(cmdCLSE, local, a0, nil)
+			if exit > 0 {
+				return string(out), &ExitError{Code: exit}
+			}
+			return string(out), nil
+		}
+	}
+}
+
+// Push streams r to remotePath via the sync SEND service with the given unix mode
+// (e.g. 0644). It reads in syncDataMax chunks so a multi-GB image (e.g. the rootfs)
+// is never buffered whole in memory.
+func (d *Device) Push(r io.Reader, remotePath string, mode int) error {
+	local := d.nextID
+	d.nextID++
+	if err := d.writeMsg(cmdOPEN, local, 0, []byte("sync:\x00")); err != nil {
+		return err
+	}
+	remote, err := d.expectOkay(local)
+	if err != nil {
+		return fmt.Errorf("opening sync stream: %w", err)
+	}
+
+	// sendWrite sends one WRTE and waits for the device's OKAY (flow control),
+	// acking any WRTE the device sends back in the meantime.
+	sendWrite := func(p []byte) error {
+		if err := d.writeMsg(cmdWRTE, local, remote, p); err != nil {
+			return err
+		}
+		for {
+			cmd, a0, _, _, err := d.readMsg()
+			if err != nil {
+				return err
+			}
+			switch cmd {
+			case cmdOKAY:
+				return nil
+			case cmdWRTE:
+				_ = d.writeMsg(cmdOKAY, local, a0, nil)
+			case cmdCLSE:
+				return fmt.Errorf("sync stream closed unexpectedly")
+			}
+		}
+	}
+
+	// SEND "<path>,<mode>"
+	pathmode := fmt.Sprintf("%s,%d", remotePath, mode)
+	if err := sendWrite(syncReq("SEND", []byte(pathmode))); err != nil {
+		return fmt.Errorf("SEND: %w", err)
+	}
+	// DATA chunks, streamed from r.
+	buf := make([]byte, syncDataMax)
+	for {
+		n, rerr := r.Read(buf)
+		if n > 0 {
+			if err := sendWrite(syncReq("DATA", buf[:n])); err != nil {
+				return fmt.Errorf("DATA: %w", err)
+			}
+		}
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return fmt.Errorf("reading push source: %w", rerr)
+		}
+	}
+	// DONE <mtime>
+	done := make([]byte, 8)
+	copy(done, "DONE")
+	binary.LittleEndian.PutUint32(done[4:], 0)
+	if err := sendWrite(done); err != nil {
+		return fmt.Errorf("DONE: %w", err)
+	}
+
+	// The device reports the result as a WRTE: "OKAY" or "FAIL"+len+msg.
+	cmd, a0, _, pd, err := d.readMsg()
+	if err != nil {
+		return fmt.Errorf("reading sync result: %w", err)
+	}
+	if cmd == cmdWRTE {
+		_ = d.writeMsg(cmdOKAY, local, a0, nil)
+		if len(pd) >= 4 && string(pd[0:4]) == "FAIL" {
+			msg := ""
+			if len(pd) > 8 {
+				msg = string(pd[8:])
+			}
+			return fmt.Errorf("push rejected: %s", msg)
+		}
+	}
+	_ = d.writeMsg(cmdCLSE, local, remote, nil)
+	return nil
+}
+
+// Stat returns the unix mode of remotePath via the sync STAT service (0 if the
+// path does not exist).
+func (d *Device) Stat(remotePath string) (mode uint32, err error) {
+	local := d.nextID
+	d.nextID++
+	if err := d.writeMsg(cmdOPEN, local, 0, []byte("sync:\x00")); err != nil {
+		return 0, err
+	}
+	remote, err := d.expectOkay(local)
+	if err != nil {
+		return 0, fmt.Errorf("opening sync stream: %w", err)
+	}
+	if err := d.writeMsg(cmdWRTE, local, remote, syncReq("STAT", []byte(remotePath))); err != nil {
+		return 0, err
+	}
+	for {
+		cmd, a0, _, data, err := d.readMsg()
+		if err != nil {
+			return 0, err
+		}
+		switch cmd {
+		case cmdWRTE:
+			_ = d.writeMsg(cmdOKAY, local, a0, nil)
+			if len(data) >= 8 && string(data[0:4]) == "STAT" {
+				mode = binary.LittleEndian.Uint32(data[4:])
+				_ = d.writeMsg(cmdCLSE, local, remote, nil)
+				return mode, nil
+			}
+		case cmdCLSE:
+			return mode, nil
+		}
+	}
+}
+
+// IsDir reports whether remotePath is a directory on the device.
+func (d *Device) IsDir(remotePath string) bool {
+	mode, err := d.Stat(remotePath)
+	return err == nil && mode&0o170000 == 0o040000
+}
+
+// expectOkay reads until an OKAY for our stream and returns the device's stream id.
+// Messages addressed to a different local stream (arg1) are stale (e.g. the CLSE
+// ack of a previous stream on this connection) and skipped.
+func (d *Device) expectOkay(local uint32) (uint32, error) {
+	for {
+		cmd, a0, a1, _, err := d.readMsg()
+		if err != nil {
+			return 0, err
+		}
+		if a1 != local {
+			continue
+		}
+		switch cmd {
+		case cmdOKAY:
+			return a0, nil
+		case cmdCLSE:
+			return 0, fmt.Errorf("stream rejected by device")
+		}
+	}
+}
+
+// syncReq builds a sync request: 4-byte id + 4-byte length + payload.
+func syncReq(id string, payload []byte) []byte {
+	b := make([]byte, 8+len(payload))
+	copy(b[0:], id)
+	binary.LittleEndian.PutUint32(b[4:], uint32(len(payload)))
+	copy(b[8:], payload)
+	return b
+}

--- a/go/internal/cli/tegraflash/adb/adb.go
+++ b/go/internal/cli/tegraflash/adb/adb.go
@@ -112,28 +112,54 @@ func openOnce() (*Device, error) {
 	ctx := gousb.NewContext()
 	ctx.Debug(0)
 
-	// WENDY_ADB_PATH, when set, pins which physical device we drive — the flashing
-	// gadget re-enumerates at the same USB location (bus + parent-port chain) the
-	// RCM device was selected at, so multi-device hosts flash the chosen board.
+	// Open every device exposing an ADB interface; we select among them below. We do
+	// NOT pre-filter by WENDY_ADB_PATH here because the flashing gadget can
+	// re-enumerate at a different USB location than the RCM device was selected at.
 	wantPath := os.Getenv("WENDY_ADB_PATH")
 	devs, err := ctx.OpenDevices(func(desc *gousb.DeviceDesc) bool {
 		_, _, _, ok := findADBInterface(desc)
-		return ok && (wantPath == "" || adbPortKey(desc) == wantPath)
+		return ok
 	})
-	if err != nil {
-		// OpenDevices returns opened handles plus an aggregate error; keep going if
-		// we got at least one device.
-		for i := 1; i < len(devs); i++ {
-			devs[i].Close()
-		}
-	}
+	// OpenDevices returns opened handles plus an aggregate error; proceed as long as
+	// we got at least one usable handle.
 	if len(devs) == 0 {
 		ctx.Close()
 		return nil, fmt.Errorf("no USB device with an ADB interface (ff/42/01) found: %v", err)
 	}
-	dev := devs[0]
-	for i := 1; i < len(devs); i++ {
-		devs[i].Close()
+
+	// Pick which device to drive. WENDY_ADB_PATH pins a physical USB location (bus +
+	// parent-port chain) so a multi-device host flashes the chosen board. But the
+	// flashing gadget often re-enumerates at a *different* port than the RCM device:
+	// on macOS the RCM device is USB-2 Hi-Speed while the ADB gadget is USB-3
+	// SuperSpeed, which lands on the companion port (e.g. 1-1 -> 1-2). So when the pin
+	// matches nothing but exactly one ADB device is present, fall back to it.
+	sel := 0
+	if wantPath != "" {
+		sel = -1
+		for i, d := range devs {
+			if adbPortKey(d.Desc) == wantPath {
+				sel = i
+				break
+			}
+		}
+		if sel == -1 {
+			if len(devs) == 1 {
+				sel = 0
+				fmt.Fprintf(os.Stderr, "wendy adb: no ADB device at usb %s; using the only ADB device present (usb %s)\n", wantPath, adbPortKey(devs[0].Desc))
+			} else {
+				for _, d := range devs {
+					d.Close()
+				}
+				ctx.Close()
+				return nil, fmt.Errorf("no ADB device at usb %s among %d ADB devices present", wantPath, len(devs))
+			}
+		}
+	}
+	dev := devs[sel]
+	for i, d := range devs {
+		if i != sel {
+			d.Close()
+		}
 	}
 
 	cfgNum, ifNum, altNum, ok := findADBInterface(dev.Desc)

--- a/go/internal/cli/tegraflash/adb/adb_unsupported.go
+++ b/go/internal/cli/tegraflash/adb/adb_unsupported.go
@@ -1,0 +1,25 @@
+//go:build !darwin
+
+package adb
+
+import (
+	"fmt"
+	"io"
+)
+
+// Device is a stub on platforms where direct USB access is not implemented.
+type Device struct{ Banner string }
+
+func Open() (*Device, error) {
+	return nil, fmt.Errorf("ADB over USB is only supported on macOS")
+}
+
+func (d *Device) Close() {}
+
+func (d *Device) Shell(string) (string, error) {
+	return "", fmt.Errorf("ADB over USB is only supported on macOS")
+}
+
+func (d *Device) Push(io.Reader, string, int) error {
+	return fmt.Errorf("ADB over USB is only supported on macOS")
+}

--- a/go/internal/cli/tegraflash/bringup/bringup.go
+++ b/go/internal/cli/tegraflash/bringup/bringup.go
@@ -1,0 +1,155 @@
+// Package bringup performs the T264 (Thor) stage-1 RCM boot from a host: it sends
+// the bootROM image chain over USB Recovery Mode and then bct_mem + the blob, so
+// mb1 boots the payload and the device comes up as the initrd-flash ADB gadget.
+// All images are sent verbatim; reading the bct_mb1 response on the same handle is
+// what keeps mb1 alive between downloads.
+//
+// The input files live in the flashpack's stage1/ dir, signed and generated offline
+// by the builder (WendyOS-Builder/scripts/make-thor-flashpack.sh) — they are
+// class-level for ODM-open devices, so one set per BSP serves every board:
+//
+//	br_bct_BR.bct                                    -> bct_br
+//	mb1_t264_prod_aligned_sigheader.bin.encrypt      -> mb1
+//	psc_bl1_t264_prod_aligned_sigheader.bin.encrypt  -> psc_bl1
+//	mb1_bct_MB1_sigheader.bct.encrypt                -> bct_mb1
+//	membct_<RAMCODE/2>_sigheader.bct.encrypt         -> bct_mem (membct_6 for RAMCODE 12)
+//	blob.bin                                         -> the ~171 MB mb2/UEFI/initrd payload
+package bringup
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
+)
+
+// Artifact file names within the rcm-boot directory.
+const (
+	FileBctBR     = "br_bct_BR.bct"
+	FileMB1       = "mb1_t264_prod_aligned_sigheader.bin.encrypt"
+	FilePSCBL1    = "psc_bl1_t264_prod_aligned_sigheader.bin.encrypt"
+	FileBctMB1    = "mb1_bct_MB1_sigheader.bct.encrypt"
+	FileBlob      = "blob.bin"
+	DefaultMemBCT = "membct_6_sigheader.bct.encrypt"
+)
+
+// Options controls a stage-1 RCM boot.
+type Options struct {
+	// Dir holds the rcm-boot artifacts (the rcmboot_blob directory, or any dir
+	// containing the files named above).
+	Dir string
+	// MemBCT is the membct filename to use; empty means DefaultMemBCT. The correct
+	// one is selected by the on-board RAMCODE (RAMCODE/2); membct_6 fits RAMCODE 12.
+	MemBCT string
+	// DevicePath, when set, pins which Jetson in recovery mode to flash (a PathKey
+	// from rcm.ListRecoveryDevices). Empty flashes the first device found.
+	DevicePath string
+	// SendOrder is the bootROM image filenames to send, in order. Empty uses the
+	// built-in default (bct_br → mb1 → psc_bl1 → bct_mb1). Driving this from the
+	// flashpack manifest lets a future BSP reorder the chain without a code change.
+	SendOrder []string
+	Out       io.Writer
+}
+
+// DefaultSendOrder is the bootROM download order when the manifest omits one.
+var DefaultSendOrder = []string{FileBctBR, FileMB1, FilePSCBL1, FileBctMB1}
+
+// Run executes the stage-1 RCM boot. On success the device has booted the blob and
+// is re-enumerating as the initrd-flash ADB gadget.
+func Run(opts Options) error {
+	out := opts.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	memBCT := opts.MemBCT
+	if memBCT == "" {
+		memBCT = DefaultMemBCT
+	}
+
+	order := opts.SendOrder
+	if len(order) == 0 {
+		order = DefaultSendOrder
+	}
+	images := make([][]byte, 0, len(order))
+	for _, name := range order {
+		data, err := read(opts.Dir, name)
+		if err != nil {
+			return err
+		}
+		images = append(images, data)
+	}
+	bctMem, err := read(opts.Dir, memBCT)
+	if err != nil {
+		return err
+	}
+	blob, err := read(opts.Dir, FileBlob)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, "Waiting for Jetson in USB recovery mode...")
+	dev, err := rcm.WaitForDeviceAt(opts.DevicePath)
+	if err != nil {
+		return fmt.Errorf("waiting for device: %w", err)
+	}
+	defer dev.Close()
+	fmt.Fprintf(out, "  device: %s\n", dev.String())
+
+	fmt.Fprintf(out, "Sending %d bootROM images (%s)...\n", len(order), strings.Join(order, ", "))
+	if err := rcm.DownloadBootROMImages(dev, images); err != nil {
+		return fmt.Errorf("bootROM image sequence: %w", err)
+	}
+	// Read the bct_mb1 response (the mb1 version) on the same handle. This
+	// completes the bootROM handshake and is what keeps mb1 alive for bct_mem/blob.
+	if v := readResponse(dev); v != "" {
+		fmt.Fprintf(out, "  mb1 up: %s\n", v)
+	}
+
+	fmt.Fprintf(out, "Sending bct_mem (%s, %d bytes)...\n", memBCT, len(bctMem))
+	if err := dev.Write(bctMem); err != nil {
+		return fmt.Errorf("sending bct_mem: %w", err)
+	}
+	readResponse(dev)
+
+	fmt.Fprintf(out, "Sending blob (%d bytes; mb2/UEFI/initrd)...\n", len(blob))
+	t0 := time.Now()
+	if err := dev.Write(blob); err != nil {
+		return fmt.Errorf("sending blob: %w", err)
+	}
+	fmt.Fprintf(out, "  blob sent in %v; mb1 is booting the payload.\n", time.Since(t0).Round(time.Millisecond))
+	readResponse(dev)
+	return nil
+}
+
+// readResponse does a tolerant bulk-IN read of any status the device returns and
+// returns it as a printable string (empty if none / not printable).
+func readResponse(dev *rcm.Device) string {
+	buf := make([]byte, 512)
+	n, err := dev.ReadWithTimeout(buf, 2*time.Second)
+	if err != nil || n == 0 {
+		return ""
+	}
+	out := make([]byte, 0, n)
+	for _, c := range buf[:n] {
+		if c == 0 {
+			break
+		}
+		if c >= 0x20 && c < 0x7f {
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}
+
+func read(dir, name string) ([]byte, error) {
+	p := filepath.Join(dir, name)
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, fmt.Errorf("reading rcm-boot artifact %s: %w", name, err)
+	}
+	return data, nil
+}

--- a/go/internal/cli/tegraflash/flasher/failure_test.go
+++ b/go/internal/cli/tegraflash/flasher/failure_test.go
@@ -1,0 +1,52 @@
+package flasher
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClassifyFlashFailure(t *testing.T) {
+	dir := t.TempDir()
+	write := func(body string) string {
+		p := filepath.Join(dir, "log.txt")
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	if got := classifyFlashFailure(write("...\n${s_ERROR_ADB_TIMEOUT}\n...")); got != "the flashing gadget never came up over USB (ADB timeout)" {
+		t.Errorf("adb timeout classify = %q", got)
+	}
+	if got := classifyFlashFailure(write("boom: No such file or directory")); got != "a required flash file was missing (see log)" {
+		t.Errorf("missing file classify = %q", got)
+	}
+	if got := classifyFlashFailure(write("some other unexpected explosion")); got != "see the log for details" {
+		t.Errorf("default classify = %q", got)
+	}
+}
+
+func TestFlashFailure_ClassifiesUnreachable(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "log.txt")
+	os.WriteFile(logPath, []byte("${s_ERROR_ADB_TIMEOUT}"), 0o644)
+	boom := errors.New("exit status 5")
+
+	// Zero bytes written → the device is untouched → ErrGadgetUnreachable.
+	err := flashFailure(io.Discard, logPath, "3m56s", 0, boom)
+	if !errors.Is(err, ErrGadgetUnreachable) {
+		t.Fatalf("maxBytes=0 should wrap ErrGadgetUnreachable, got %v", err)
+	}
+
+	// Bytes were written → a real mid-flash failure, not "unreachable".
+	err = flashFailure(io.Discard, logPath, "5m0s", 1<<30, boom)
+	if errors.Is(err, ErrGadgetUnreachable) {
+		t.Fatalf("maxBytes>0 must not be ErrGadgetUnreachable, got %v", err)
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("underlying error should be wrapped, got %v", err)
+	}
+}

--- a/go/internal/cli/tegraflash/flasher/flasher.go
+++ b/go/internal/cli/tegraflash/flasher/flasher.go
@@ -20,11 +20,13 @@ package flasher
 import (
 	"bufio"
 	_ "embed"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -32,6 +34,17 @@ import (
 // estFlashDuration is a rough estimate shown to the user. Measured ~15.4 min on a
 // jetson-agx-thor devkit (NVMe) over USB; the rootfs A/B writes dominate.
 const estFlashDuration = "around 15 minutes"
+
+// ErrGadgetUnreachable is returned when the flash fails before a single byte is
+// written — i.e. bootburn never established ADB with the initrd-flash gadget. The
+// device was not modified, so the caller can advise a plain retry rather than
+// warning about a half-flashed (UEFI-only) device.
+var ErrGadgetUnreachable = errors.New("flashing gadget never came up over USB (ADB)")
+
+// EnvADBProgress names the file the adb shim writes its running push byte-count to
+// (cumulative for the current push, reset per push). Run points the shim at a temp
+// file via this env var and polls it to display transfer throughput.
+const EnvADBProgress = "WENDY_ADB_PROGRESS"
 
 //go:embed stage2_flash.py
 var stage2Driver []byte
@@ -135,11 +148,20 @@ func Run(opts Options) error {
 	defer logFile.Close()
 	fmt.Fprintf(logFile, "$ %s %s\n(cwd %s)\n\n", python, strings.Join(args, " "), bootburnDir)
 
+	// The adb shim writes its running push byte-count here so we can show live
+	// throughput; best-effort, so a temp-file failure just disables the readout.
+	progressPath := ""
+	if pf, perr := os.CreateTemp("", "thor-flash-progress-*"); perr == nil {
+		progressPath = pf.Name()
+		pf.Close()
+		defer os.Remove(progressPath)
+	}
+
 	cmd := exec.Command(python, args...)
 	cmd.Dir = bootburnDir
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
-	cmd.Env = envWithADB(opts.ADBDir, pyDir, opts.ADBPort)
+	cmd.Env = envWithADB(opts.ADBDir, pyDir, opts.ADBPort, progressPath)
 
 	// Up-front plan from FileToFlash.txt, so the (long, mostly silent) write reads
 	// as deliberate progress rather than a hang.
@@ -155,26 +177,77 @@ func Run(opts Options) error {
 		return fmt.Errorf("starting bootburn flash: %w", err)
 	}
 
-	// Heartbeat so a multi-minute silent rootfs write doesn't look hung.
+	// Sample bytes-pushed every second (to tell a genuine failure from a gadget
+	// that never came up) and log a heartbeat every minute so a multi-minute silent
+	// rootfs write doesn't look hung in the verbose/CI log.
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 	start := time.Now()
-	ticker := time.NewTicker(60 * time.Second)
-	defer ticker.Stop()
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
+	var maxBytes int64 // most bytes seen pushed; 0 means nothing was ever written
+	lastHeartbeat := start
 	for {
 		select {
 		case werr := <-done:
+			if n, ok := readProgressFile(progressPath); ok && n > maxBytes {
+				maxBytes = n
+			}
 			if werr != nil {
-				fmt.Fprintf(out, "Flash failed after %s. Last lines of the log:\n", elapsed(start))
-				fmt.Fprint(out, tailFile(logPath, 30))
-				return fmt.Errorf("bootburn flash failed (full log: %s): %w", logPath, werr)
+				return flashFailure(out, logPath, elapsed(start).String(), maxBytes, werr)
 			}
 			fmt.Fprintf(out, "Partitions written in %s.\n", elapsed(start))
 			return nil
-		case <-ticker.C:
-			fmt.Fprintf(out, "  … still flashing (%s elapsed)\n", elapsed(start))
+		case now := <-tick.C:
+			if n, ok := readProgressFile(progressPath); ok && n > maxBytes {
+				maxBytes = n
+			}
+			if now.Sub(lastHeartbeat) >= 60*time.Second {
+				lastHeartbeat = now
+				fmt.Fprintf(out, "  … still flashing (%s elapsed)\n", elapsed(start))
+			}
 		}
 	}
+}
+
+// flashFailure writes a concise failure summary (the full bootburn output is in
+// the log) and returns a classified error. When nothing was written it wraps
+// ErrGadgetUnreachable so the caller can advise a plain retry.
+func flashFailure(out io.Writer, logPath, took string, maxBytes int64, werr error) error {
+	reason := classifyFlashFailure(logPath)
+	fmt.Fprintf(out, "Flash failed after %s: %s\n", took, reason)
+	fmt.Fprintf(out, "Full log: %s\n", logPath)
+	if maxBytes == 0 {
+		return fmt.Errorf("%w (full log: %s): %v", ErrGadgetUnreachable, logPath, werr)
+	}
+	return fmt.Errorf("bootburn flash failed after writing data (full log: %s): %w", logPath, werr)
+}
+
+// classifyFlashFailure turns the tail of the bootburn log into a one-line human
+// reason. Best-effort: an unrecognized failure points the user at the log.
+func classifyFlashFailure(logPath string) string {
+	tail := tailFile(logPath, 60)
+	switch {
+	case strings.Contains(tail, "ADB_TIMEOUT"), strings.Contains(tail, "adb wait-for-device"):
+		return "the flashing gadget never came up over USB (ADB timeout)"
+	case strings.Contains(tail, "No such file"), strings.Contains(tail, "not found"):
+		return "a required flash file was missing (see log)"
+	default:
+		return "see the log for details"
+	}
+}
+
+// readProgressFile reads the single integer byte-count the adb shim writes.
+func readProgressFile(path string) (int64, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // flashPlan is a human summary of FileToFlash.txt.
@@ -241,9 +314,10 @@ func tailFile(path string, n int) string {
 }
 
 // envWithADB returns the environment with adbDir prepended to PATH, pyDir prepended
-// to PYTHONPATH, and WENDY_ADB_PATH set to adbPort (each only when non-empty). The
-// adb shim inherits WENDY_ADB_PATH and uses it to target the selected device.
-func envWithADB(adbDir, pyDir, adbPort string) []string {
+// to PYTHONPATH, WENDY_ADB_PATH set to adbPort, and EnvADBProgress set to
+// progressPath (each only when non-empty). The adb shim inherits WENDY_ADB_PATH to
+// target the selected device and EnvADBProgress to report transfer progress.
+func envWithADB(adbDir, pyDir, adbPort, progressPath string) []string {
 	env := os.Environ()
 	if adbDir != "" {
 		if abs, err := filepath.Abs(adbDir); err == nil {
@@ -256,6 +330,9 @@ func envWithADB(adbDir, pyDir, adbPort string) []string {
 	}
 	if adbPort != "" {
 		env = append(env, "WENDY_ADB_PATH="+adbPort)
+	}
+	if progressPath != "" {
+		env = append(env, EnvADBProgress+"="+progressPath)
 	}
 	return env
 }

--- a/go/internal/cli/tegraflash/flasher/flasher.go
+++ b/go/internal/cli/tegraflash/flasher/flasher.go
@@ -1,0 +1,278 @@
+// Package flasher performs T264 (Thor) stage-2 flashing once stage-1 RCM boot has
+// brought the device up as the initrd-flash ADB gadget.
+//
+// Rather than reimplementing NVIDIA's device-side flasher, it drives NVIDIA's own
+// bootburn FlashImages() over ADB, unmodified, via a small monkeypatch driver
+// (stage2_flash.py) that skips bootburn's i386-only boot/probe steps (the Go stage-1
+// already did the equivalent). bootburn shells out to adb/lsusb/timeout; wendy
+// supplies those itself — it re-execs as those names (see package shim), with no
+// Google adb binary and no adb server. The caller (commands.installThor) materializes
+// a shim directory on PATH and replaces the bundle's flash/adb with the same shim;
+// this package just sets up the environment and runs bootburn.
+//
+// Inputs come from a flashpack (see package flashpack), produced offline on an
+// x86_64 builder by scripts/make-thor-flashpack.sh; the relevant dirs are the
+// Options fields below. Run-time requirements: python3 on PATH (PyYAML ships in the
+// flashpack and is put on PYTHONPATH here), and a device already up as the
+// initrd-flash ADB gadget (its adbd advertises shell_v2, which the adb package uses).
+package flasher
+
+import (
+	"bufio"
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// estFlashDuration is a rough estimate shown to the user. Measured ~15.4 min on a
+// jetson-agx-thor devkit (NVMe) over USB; the rootfs A/B writes dominate.
+const estFlashDuration = "around 15 minutes"
+
+//go:embed stage2_flash.py
+var stage2Driver []byte
+
+// Options controls stage-2 flashing.
+type Options struct {
+	// BundleDir is a local copy of the extracted tegraflash bundle; it provides
+	// NVIDIA's bootburn scripts (unified_flash/tools/flashtools/bootburn).
+	BundleDir string
+	// WorkspaceDir is the builder's generated "out" dir. It holds flash_workspace/
+	// (with flash-images/FileToFlash.txt + the signed partition images) and a sibling
+	// tools/ that bootburn reads as <flash_workspace>/../tools; bootburn runs with
+	// -P <WorkspaceDir>/flash_workspace.
+	WorkspaceDir string
+	// ADBDir, if set, is prepended to PATH so bootburn's bare-name lsusb/timeout calls
+	// resolve to wendy's shim. (bootburn also calls adb by absolute path, so the
+	// caller replaces the bundle's flash/adb with the shim too.)
+	ADBDir string
+	// ADBPort, if set, pins the flashing gadget to a specific USB location (a
+	// PathKey) via WENDY_ADB_PATH, which the adb shim honors. Lets a multi-device
+	// host flash the chosen board across the RCM→ADB re-enumeration.
+	ADBPort string
+	// LogPath is where bootburn's full output is written. If empty, a flash.log is
+	// written alongside the workspace.
+	LogPath string
+	// PyYAMLDir is the flashpack's pure-python PyYAML dir (contains a yaml/ package);
+	// it is prepended to PYTHONPATH so bootburn's `import yaml` resolves without pip
+	// or a system PyYAML (macOS system python has none).
+	PyYAMLDir string
+	// Board is the bootburn board name (default "jetson-t264").
+	Board string
+	Out   io.Writer
+}
+
+// Run drives bootburn's FlashImages over ADB via the monkeypatch driver.
+func Run(opts Options) error {
+	out := opts.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	board := opts.Board
+	if board == "" {
+		board = "jetson-t264"
+	}
+
+	bootburnDir := filepath.Join(opts.BundleDir, "unified_flash", "tools", "flashtools", "bootburn")
+	flashWorkspace := filepath.Join(opts.WorkspaceDir, "flash_workspace")
+	if _, err := os.Stat(bootburnDir); err != nil {
+		return fmt.Errorf("bootburn scripts not found at %s (need a local copy of the extracted bundle): %w", bootburnDir, err)
+	}
+	if _, err := os.Stat(filepath.Join(flashWorkspace, "flash-images", "FileToFlash.txt")); err != nil {
+		return fmt.Errorf("flash workspace at %s is missing flash-images/FileToFlash.txt (need the linux-stage2 'out' artifact): %w", flashWorkspace, err)
+	}
+
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		return fmt.Errorf("python3 not found on PATH: %w", err)
+	}
+
+	// Write the monkeypatch driver to a temp file. The name must contain
+	// "flash_bsp_images": bootburn special-cases that argv[0] to take the normal
+	// flashing path (e.g. it then tolerates a chip version not read from the device,
+	// which our skipped ECID step would have set). It adds the bootburn dirs to
+	// sys.path itself (it runs with cwd = bootburnDir).
+	driver, err := os.CreateTemp("", "flash_bsp_images-wendy-*.py")
+	if err != nil {
+		return fmt.Errorf("creating driver temp file: %w", err)
+	}
+	defer os.Remove(driver.Name())
+	if _, err := driver.Write(stage2Driver); err != nil {
+		driver.Close()
+		return fmt.Errorf("writing driver: %w", err)
+	}
+	driver.Close()
+
+	// PyYAML ships in the flashpack; it goes on PYTHONPATH (in envWithADB) so
+	// bootburn's `import yaml` resolves without pip or a system PyYAML.
+	pyDir := opts.PyYAMLDir
+	if pyDir != "" {
+		if _, err := os.Stat(filepath.Join(pyDir, "yaml", "__init__.py")); err != nil {
+			return fmt.Errorf("PyYAML not found in flashpack at %s (need stage2/pyyaml/yaml): %w", pyDir, err)
+		}
+	}
+
+	// Flash args mirror out/doflash.sh minus the RCM --usb-instance. -y disables
+	// pipelining so partitions flash serially: our adb shim claims the USB interface
+	// exclusively, so the parallel path's concurrent adb processes would collide.
+	args := []string{driver.Name(), "-b", board, "--l4t", "-y", "-P", flashWorkspace}
+
+	// bootburn is extremely verbose and emits nothing useful per-partition at the
+	// normal level (it captures the adb/nvdd I/O internally), so stream its full
+	// output to a log file and show a curated summary here instead.
+	logPath := opts.LogPath
+	if logPath == "" {
+		logPath = filepath.Join(opts.WorkspaceDir, "flash.log")
+	}
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return fmt.Errorf("creating flash log: %w", err)
+	}
+	defer logFile.Close()
+	fmt.Fprintf(logFile, "$ %s %s\n(cwd %s)\n\n", python, strings.Join(args, " "), bootburnDir)
+
+	cmd := exec.Command(python, args...)
+	cmd.Dir = bootburnDir
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.Env = envWithADB(opts.ADBDir, pyDir, opts.ADBPort)
+
+	// Up-front plan from FileToFlash.txt, so the (long, mostly silent) write reads
+	// as deliberate progress rather than a hang.
+	plan := summarizeFlashPlan(filepath.Join(flashWorkspace, "flash-images", "FileToFlash.txt"))
+	fmt.Fprintf(out, "Writing %d partitions to QSPI + internal NVMe over USB.\n", plan.count)
+	if plan.summary != "" {
+		fmt.Fprintf(out, "  Includes: %s\n", plan.summary)
+	}
+	fmt.Fprintf(out, "  Expect %s; the rootfs (A/B slots) is the bulk and writes silently for several minutes — that is normal.\n", estFlashDuration)
+	fmt.Fprintf(out, "  Full log: %s\n", logPath)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting bootburn flash: %w", err)
+	}
+
+	// Heartbeat so a multi-minute silent rootfs write doesn't look hung.
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	start := time.Now()
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case werr := <-done:
+			if werr != nil {
+				fmt.Fprintf(out, "Flash failed after %s. Last lines of the log:\n", elapsed(start))
+				fmt.Fprint(out, tailFile(logPath, 30))
+				return fmt.Errorf("bootburn flash failed (full log: %s): %w", logPath, werr)
+			}
+			fmt.Fprintf(out, "Partitions written in %s.\n", elapsed(start))
+			return nil
+		case <-ticker.C:
+			fmt.Fprintf(out, "  … still flashing (%s elapsed)\n", elapsed(start))
+		}
+	}
+}
+
+// flashPlan is a human summary of FileToFlash.txt.
+type flashPlan struct {
+	count   int    // number of partition entries
+	summary string // notable partitions, e.g. "ESP, rootfs (A/B), config"
+}
+
+// summarizeFlashPlan parses FileToFlash.txt for a count and the notable large
+// NVMe partitions. It is best-effort: a parse miss just yields a thinner summary.
+func summarizeFlashPlan(fileToFlash string) flashPlan {
+	var p flashPlan
+	f, err := os.Open(fileToFlash)
+	if err != nil {
+		return p
+	}
+	defer f.Close()
+	var hasESP, hasRootfs, hasConfig bool
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		p.count++
+		low := strings.ToLower(line)
+		switch {
+		case strings.Contains(low, "esp.img"):
+			hasESP = true
+		case strings.Contains(low, ".simg"):
+			hasRootfs = true
+		case strings.Contains(low, "config-partition"):
+			hasConfig = true
+		}
+	}
+	var parts []string
+	if hasESP {
+		parts = append(parts, "ESP")
+	}
+	if hasRootfs {
+		parts = append(parts, "rootfs (A/B)")
+	}
+	if hasConfig {
+		parts = append(parts, "config")
+	}
+	p.summary = strings.Join(parts, ", ")
+	return p
+}
+
+// elapsed formats time since start to whole seconds.
+func elapsed(start time.Time) time.Duration { return time.Since(start).Round(time.Second) }
+
+// tailFile returns the last n lines of a file (best-effort, for error context).
+func tailFile(path string, n int) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// envWithADB returns the environment with adbDir prepended to PATH, pyDir prepended
+// to PYTHONPATH, and WENDY_ADB_PATH set to adbPort (each only when non-empty). The
+// adb shim inherits WENDY_ADB_PATH and uses it to target the selected device.
+func envWithADB(adbDir, pyDir, adbPort string) []string {
+	env := os.Environ()
+	if adbDir != "" {
+		if abs, err := filepath.Abs(adbDir); err == nil {
+			adbDir = abs
+		}
+		env = prependEnv(env, "PATH", adbDir)
+	}
+	if pyDir != "" {
+		env = prependEnv(env, "PYTHONPATH", pyDir)
+	}
+	if adbPort != "" {
+		env = append(env, "WENDY_ADB_PATH="+adbPort)
+	}
+	return env
+}
+
+// prependEnv prepends val to a path-list env var (key), preserving any existing value.
+func prependEnv(env []string, key, val string) []string {
+	prefix := key + "="
+	for i, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			old := kv[len(prefix):]
+			if old == "" {
+				env[i] = prefix + val
+			} else {
+				env[i] = prefix + val + string(os.PathListSeparator) + old
+			}
+			return env
+		}
+	}
+	return append(env, prefix+val)
+}

--- a/go/internal/cli/tegraflash/flasher/stage2_flash.py
+++ b/go/internal/cli/tegraflash/flasher/stage2_flash.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# wendy stage-2 flasher driver.
+#
+# Runs NVIDIA bootburn's FlashImages() over our ADB transport, WITHOUT editing any
+# bundled NVIDIA script. We import bootburn's modules and monkeypatch the
+# device-touching pre-flash steps to no-ops, because our Go stage-1 already RCM-
+# booted the device to the initrd-flash ADB gadget — and those steps shell out to
+# the i386 flash tools (tegrarcm_v2 etc.) that do not run on macOS arm64.
+# bootburn's actual partition flashing (FlashImages) runs unmodified; on the host
+# it only invokes `adb`, which thor-flash points at our wendy-shim via PATH/the bundle adb swap.
+#
+# Run from the bundle's .../unified_flash/tools/flashtools/bootburn directory, the
+# same way flash_bsp_images.py is normally run; pass the usual bootburn flash args
+# (e.g. -b jetson-t264 --l4t -P <flash_workspace>).
+#
+# Note: class/method names below match the T264 BSP inspected (bootburn_t264_py).
+# If a different BSP changes them, adjust the monkeypatch targets accordingly.
+
+import sys
+import os
+
+here = os.getcwd()                          # .../flashtools/bootburn
+flashtools = os.path.dirname(here)
+sys.path.insert(0, here)                    # bootburn/  -> select_socgrp
+
+from select_socgrp import select_socgrp
+
+soc = select_socgrp()
+if not soc.isSocGrpFound():
+    print("wendy stage2: SOC group not found (run from flashtools/bootburn)", file=sys.stderr)
+    sys.exit(1)
+
+# Put the SOC scripts dir first on sys.path and import its modules by their TOP-LEVEL
+# names. This matters: flash_bsp_images.py uses `import bootburn_lib` /
+# `from bootburn_thor import ...` (top-level), so we must patch the same module
+# objects it resolves — not the package-qualified bootburn_<soc>_py.bootburn_lib,
+# which is a distinct entry in sys.modules and would leave the real methods in place.
+sys.path.insert(0, os.path.join(flashtools, soc.soc_scripts_dir))
+
+import bootburn_lib
+import bootburn_thor
+import flash_utilities
+
+
+def _noop(self, *args, **kwargs):
+    return 0
+
+
+# CheckUSBServiceInit greps /etc/udev/rules.d for a 0955 udev rule (informational on
+# a Linux host). That folder doesn't exist on macOS, and grepInFolder aborts on a
+# missing path. Treat a missing folder as "no matches" so it doesn't abort; the
+# result is unused by the caller.
+_orig_grep_in_folder = flash_utilities.shell_utilities.grepInFolder
+
+
+def _grep_in_folder_safe(self, path, searchString, printOut=False):
+    if not os.path.isdir(path):
+        return []
+    return _orig_grep_in_folder(self, path, searchString, printOut)
+
+
+flash_utilities.shell_utilities.grepInFolder = _grep_in_folder_safe
+
+
+# Our Go stage-1 already booted the device; skip bootburn's own boot/probe (it uses
+# i386 host tools and expects a recovery-mode device on the bus). FlashImages() —
+# the real adb-driven flashing — is left intact.
+bootburn_lib.bootburn_lib.CheckRecoveryTargets = _noop  # looks for a 0955: recovery device via lsusb
+bootburn_lib.bootburn_lib.SetUsbAutoSuspend = _noop      # host USB power management, not applicable
+bootburn_lib.bootburn_lib.StartNewSession_t264 = _noop
+bootburn_lib.bootburn_lib.GetTargetECID = _noop
+bootburn_lib.bootburn_lib.CheckFuseForAuthentication = _noop
+bootburn_lib.bootburn_lib.CheckFuseForEncryption = _noop
+# These classify the board (INT/PROD) and validate options against device-read state
+# (chip id / fuses) that only the skipped session/ECID steps would populate. They
+# affect image *generation* (already done on the Linux builder), not the adb push of
+# the pre-built FileToFlash.txt, so they are not needed here.
+bootburn_lib.bootburn_lib.CheckForDeviceType = _noop
+bootburn_lib.bootburn_lib.ValidateUserOptionAndDeviceType = _noop
+bootburn_lib.bootburn_lib.ValidateFindBoardForFused = _noop
+bootburn_thor.bootburn_thor.BootRCM = _noop
+bootburn_thor.bootburn_thor.runPlatformDetection = _noop
+
+
+# Pin the adb serial wendy-shim reports, so `adb -s <serial>` / `adb devices` match.
+def _gen_serial(self, *args, **kwargs):
+    self.targetConfig.s_AdbSerialNum = "wendythor"
+
+
+bootburn_lib.bootburn_lib.GenAdbSerialNum = _gen_serial
+
+import flash_bsp_images
+sys.exit(flash_bsp_images.flash_bsp(sys.argv))

--- a/go/internal/cli/tegraflash/flashpack/extract.go
+++ b/go/internal/cli/tegraflash/flashpack/extract.go
@@ -1,0 +1,84 @@
+package flashpack
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// extractZstTar extracts a .tar.zst into dest (created fresh). It is defensive
+// against path traversal: every entry must stay within dest.
+func extractZstTar(tarball, dest string) error {
+	f, err := os.Open(tarball)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	zr, err := zstd.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer zr.Close()
+
+	// Extract into a temp sibling, then rename into place, so an interrupted
+	// extraction never leaves a half-populated dir that open() would accept.
+	tmp := dest + ".tmp"
+	_ = os.RemoveAll(tmp)
+	if err := os.MkdirAll(tmp, 0o755); err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+
+	tr := tar.NewReader(zr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		clean := filepath.Clean(hdr.Name)
+		if clean == "." {
+			continue
+		}
+		if strings.HasPrefix(clean, ".."+string(os.PathSeparator)) || clean == ".." || filepath.IsAbs(clean) {
+			return fmt.Errorf("unsafe path in archive: %q", hdr.Name)
+		}
+		target := filepath.Join(tmp, clean)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&0o777)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			out.Close()
+		case tar.TypeSymlink, tar.TypeLink:
+			// The flashpack contains no links; skip rather than risk an escape.
+			continue
+		}
+	}
+
+	_ = os.RemoveAll(dest)
+	if err := os.Rename(tmp, dest); err != nil {
+		return err
+	}
+	return nil
+}

--- a/go/internal/cli/tegraflash/flashpack/flashpack.go
+++ b/go/internal/cli/tegraflash/flashpack/flashpack.go
@@ -1,0 +1,216 @@
+// Package flashpack locates and opens a Jetson AGX Thor (T264) flashpack — the
+// single self-describing artifact produced by the builder (scripts/make-thor-
+// flashpack.sh) that wendy downloads, extracts and flashes. It resolves cache-first
+// so a locally-planted artifact is used even before it is published online.
+//
+// Layout (see the builder script):
+//
+//	flashpack/
+//	  manifest.json
+//	  stage1/                         RCM-boot images (sent verbatim)
+//	  stage2/out/flash_workspace/     FileToFlash.txt + signed partition images
+//	  stage2/out/tools/               bootburn's sibling tools/ (ToolsVersion.txt …)
+//	  stage2/bundle/unified_flash/…/bootburn   NVIDIA bootburn scripts
+//	  stage2/pyyaml/                  pure-python PyYAML (+ LICENSE) bootburn imports
+//
+// Manifest is the authoritative definition of manifest.json: the builder script must
+// emit exactly these fields. Fields are marked [consumed] (the flash logic depends
+// on them) or [provenance] (recorded for humans inspecting the artifact; not read by
+// code — keep them lean).
+package flashpack
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SupportedSchema is the manifest schema version this wendy understands. A flashpack
+// declaring a newer schema is refused (forward-incompatible).
+const SupportedSchema = 1
+
+// ErrNotInCache is returned by Resolve when no extracted tree or .tar.zst for the
+// requested version is present in the cache. The caller may download the artifact
+// to TarballCachePath and retry.
+var ErrNotInCache = errors.New("flashpack not in cache")
+
+// clearCacheHint is appended to integrity errors; the cached copy is untrusted and
+// the user should discard it and re-fetch.
+const clearCacheHint = "the cached flashpack is corrupt — clear it with `wendy cache clear` and re-run"
+
+// FileMeta is one entry in the manifest's integrity map.
+type FileMeta struct {
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+// Manifest is the parsed manifest.json (the authoritative schema — see package doc).
+type Manifest struct {
+	Schema         int    `json:"schema"`          // [consumed] format version; checked against SupportedSchema
+	WendyOSVersion string `json:"wendyos_version"` // [consumed] shown to the user
+	DefaultMemBCT  string `json:"default_membct"`  // [consumed] stage-1 membct filename (RAMCODE/2)
+
+	// [consumed] stage-1 bootROM image filenames, in the exact order the bootROM
+	// expects them. Driving this from data lets a future BSP reorder the chain
+	// without a wendy code change. Empty falls back to the built-in default order.
+	Stage1SendOrder []string `json:"stage1_send_order"`
+
+	// [consumed] where the major trees live, relative to the flashpack root.
+	Layout struct {
+		Stage1         string `json:"stage1"`
+		FlashWorkspace string `json:"flash_workspace"`
+	} `json:"layout"`
+
+	// [consumed] integrity map for stage-1 files (path relative to root → sha256/size).
+	// Stage-2 images are NOT listed: bootburn verifies each one device-side after
+	// writing (its own MD5 column), and the download itself is checksummed, so the
+	// only un-covered surface is the verbatim-sent stage-1 set.
+	Files map[string]FileMeta `json:"files"`
+
+	// [provenance] recorded for humans; not read by code.
+	Board         string `json:"board"`
+	Machine       string `json:"machine"`
+	Chip          string `json:"chip"`
+	Ramcode       string `json:"ramcode"`
+	ChipSKU       string `json:"chip_sku"`
+	PyYAMLVersion string `json:"pyyaml_version"`
+}
+
+// Flashpack is an opened, extracted flashpack on disk.
+type Flashpack struct {
+	Root     string
+	Manifest Manifest
+}
+
+// Stage1Dir holds the RCM-boot images the bringup stage sends verbatim.
+func (f *Flashpack) Stage1Dir() string {
+	return filepath.Join(f.Root, f.Manifest.Layout.Stage1)
+}
+
+// FlashWorkspaceDir is the bootburn -P workspace (contains flash-images/).
+func (f *Flashpack) FlashWorkspaceDir() string {
+	return filepath.Join(f.Root, f.Manifest.Layout.FlashWorkspace)
+}
+
+// WorkspaceOutDir is the generated "out" dir (flash_workspace/ + sibling tools/);
+// bootburn reads flash_workspace/../tools, so the sibling layout must be preserved.
+func (f *Flashpack) WorkspaceOutDir() string {
+	return filepath.Dir(f.FlashWorkspaceDir())
+}
+
+// BundleDir holds NVIDIA's bootburn scripts. The path is fixed by the flashpack
+// layout the builder produces (stage2/bundle), so it is not a manifest field.
+func (f *Flashpack) BundleDir() string {
+	return filepath.Join(f.Root, "stage2", "bundle")
+}
+
+// PyYAMLDir holds the pure-python PyYAML package (a yaml/ dir + LICENSE) that
+// bootburn imports; the host adds it to PYTHONPATH at flash time. Fixed by the
+// flashpack layout (stage2/pyyaml), so it is not a manifest field.
+func (f *Flashpack) PyYAMLDir() string {
+	return filepath.Join(f.Root, "stage2", "pyyaml")
+}
+
+// MemBCT is the membct filename to send in stage 1 (selected by on-board RAMCODE/2
+// on the builder; all variants are shipped under stage1/).
+func (f *Flashpack) MemBCT() string { return f.Manifest.DefaultMemBCT }
+
+// FlashpackName is the cache basename for a given version (without extension).
+func FlashpackName(version string) string {
+	return "jetson-agx-thor-" + version + ".flashpack"
+}
+
+// TarballCachePath is where a downloaded/planted flashpack tarball for version lives.
+func TarballCachePath(cacheDir, version string) string {
+	return filepath.Join(cacheDir, FlashpackName(version)+".tar.zst")
+}
+
+// Resolve returns the flashpack for version, cache-first: an already-extracted tree,
+// else a planted/downloaded .tar.zst extracted on demand (atomically). The stage-1
+// files are integrity-checked against the manifest before the flashpack is returned,
+// so a corrupt cache aborts the flash rather than producing an opaque bootROM
+// failure. Returns ErrNotInCache when nothing is present for the caller to download.
+func Resolve(cacheDir, version string) (*Flashpack, error) {
+	if version == "" {
+		return nil, fmt.Errorf("a version is required to resolve a Thor flashpack")
+	}
+	extracted := filepath.Join(cacheDir, FlashpackName(version))
+	if fp, err := open(extracted); err == nil {
+		return fp, fp.verifyStage1()
+	}
+	tarball := TarballCachePath(cacheDir, version)
+	if _, err := os.Stat(tarball); err == nil {
+		if err := extractZstTar(tarball, extracted); err != nil {
+			return nil, fmt.Errorf("extracting %s: %w", filepath.Base(tarball), err)
+		}
+		fp, err := open(extracted)
+		if err != nil {
+			return nil, err
+		}
+		return fp, fp.verifyStage1()
+	}
+	return nil, fmt.Errorf("%w: version %s in %s", ErrNotInCache, version, cacheDir)
+}
+
+func open(root string) (*Flashpack, error) {
+	data, err := os.ReadFile(filepath.Join(root, "manifest.json"))
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing manifest.json: %w", err)
+	}
+	if m.Schema > SupportedSchema {
+		return nil, fmt.Errorf("flashpack schema %d is newer than this wendy supports (%d); update wendy", m.Schema, SupportedSchema)
+	}
+	if m.Layout.Stage1 == "" || m.Layout.FlashWorkspace == "" {
+		return nil, fmt.Errorf("flashpack manifest missing layout")
+	}
+	return &Flashpack{Root: root, Manifest: m}, nil
+}
+
+// verifyStage1 checks every stage-1 file in the manifest against its recorded size
+// and SHA-256. A missing or mismatched file aborts (the cached copy is untrusted).
+func (f *Flashpack) verifyStage1() error {
+	for rel, meta := range f.Manifest.Files {
+		if !strings.HasPrefix(rel, "stage1/") {
+			continue
+		}
+		p := filepath.Join(f.Root, rel)
+		info, err := os.Stat(p)
+		if err != nil {
+			return fmt.Errorf("flashpack missing %s: %w; %s", rel, err, clearCacheHint)
+		}
+		if info.Size() != meta.Size {
+			return fmt.Errorf("flashpack %s wrong size (got %d, want %d); %s", rel, info.Size(), meta.Size, clearCacheHint)
+		}
+		sum, err := sha256File(p)
+		if err != nil {
+			return fmt.Errorf("hashing %s: %w", rel, err)
+		}
+		if !strings.EqualFold(sum, meta.SHA256) {
+			return fmt.Errorf("flashpack %s checksum mismatch (got %s, want %s); %s", rel, sum, meta.SHA256, clearCacheHint)
+		}
+	}
+	return nil
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/go/internal/cli/tegraflash/rcm/bootrom.go
+++ b/go/internal/cli/tegraflash/rcm/bootrom.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package rcm
+
+import "fmt"
+
+// DownloadBootROMImages sends each pre-signed RCM blob verbatim over bulk OUT, in
+// the order given (the T264 sequence is bct_br → mb1 → psc_bl1 → bct_mb1). No status
+// word is read between images: the bootROM ACKs none of them except bct_mb1, so a
+// per-image read would just time out — and a timed-out bulk-IN read is destructive
+// on macOS (libusb aborts the endpoint, libusb #1110). The blobs are sent raw, with
+// no RCM40/DL_MINILOADER envelope; wrapping them makes the bootROM reset the device.
+func DownloadBootROMImages(dev *Device, images [][]byte) error {
+	for i, img := range images {
+		if err := dev.Write(img); err != nil {
+			return fmt.Errorf("sending bootROM image %d (%d bytes): %w", i, len(img), err)
+		}
+	}
+	return nil
+}

--- a/go/internal/cli/tegraflash/rcm/constants.go
+++ b/go/internal/cli/tegraflash/rcm/constants.go
@@ -1,0 +1,8 @@
+package rcm
+
+// USB identifiers for Jetsons in recovery mode (vendor 0x0955, PID 0x70<chip-id>).
+const (
+	VendorNVIDIA = 0x0955
+	ProductOrin  = 0x7023 // T234 chip id 0x23; not yet verified on real hardware
+	ProductThor  = 0x7026 // T264 (AGX Thor); confirmed on live hardware
+)

--- a/go/internal/cli/tegraflash/rcm/device.go
+++ b/go/internal/cli/tegraflash/rcm/device.go
@@ -1,0 +1,171 @@
+//go:build darwin
+
+// USB device handling for the RCM stage (bootROM level).
+// USB transfer mechanics translated from NVIDIA tegrarcm usb.c
+// (BSD 3-Clause License, Copyright (c) 2011-2016 NVIDIA CORPORATION)
+package rcm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/gousb"
+)
+
+// Device represents a Jetson in RCM mode.
+type Device struct {
+	ctx    *gousb.Context
+	dev    *gousb.Device
+	iface  *gousb.Interface
+	in     *gousb.InEndpoint
+	out    *gousb.OutEndpoint
+	doneFn func()
+}
+
+func openDevice(ctx *gousb.Context, dev *gousb.Device) (*Device, error) {
+	cfg, err := dev.Config(1)
+	if err != nil {
+		return nil, fmt.Errorf("claiming config: %w", err)
+	}
+
+	iface, done, err := dev.DefaultInterface()
+	if err != nil {
+		cfg.Close()
+		return nil, fmt.Errorf("claiming interface: %w", err)
+	}
+
+	// Find bulk IN and OUT endpoints
+	var inEP *gousb.InEndpoint
+	var outEP *gousb.OutEndpoint
+
+	ifaceDesc := iface.Setting
+	for _, ep := range ifaceDesc.Endpoints {
+		if ep.TransferType != gousb.TransferTypeBulk {
+			continue
+		}
+		if ep.Direction == gousb.EndpointDirectionIn && inEP == nil {
+			inEP, err = iface.InEndpoint(int(ep.Number))
+			if err != nil {
+				done()
+				return nil, fmt.Errorf("opening IN endpoint: %w", err)
+			}
+		} else if ep.Direction == gousb.EndpointDirectionOut && outEP == nil {
+			outEP, err = iface.OutEndpoint(int(ep.Number))
+			if err != nil {
+				done()
+				return nil, fmt.Errorf("opening OUT endpoint: %w", err)
+			}
+		}
+	}
+
+	if inEP == nil || outEP == nil {
+		done()
+		return nil, fmt.Errorf("device missing bulk IN or OUT endpoints")
+	}
+
+	// Do NOT pre-submit a speculative bulk-IN read here. T264's bootROM sends no
+	// UID at connect, so the read only times out — and on macOS a timed-out bulk-IN
+	// read is destructive: libusb_cancel_transfer aborts the whole endpoint and
+	// issues a CLEAR_FEATURE/ENDPOINT_HALT, desyncing the data toggle (libusb #1110).
+	// Read the chip ID via the EP0 control transfer instead (ReadChipID).
+	return &Device{
+		ctx:    ctx,
+		dev:    dev,
+		iface:  iface,
+		in:     inEP,
+		out:    outEP,
+		doneFn: done,
+	}, nil
+}
+
+func (d *Device) String() string {
+	desc := d.dev.Desc
+	return fmt.Sprintf("NVIDIA 0x%04x:0x%04x", uint16(desc.Vendor), uint16(desc.Product))
+}
+
+func (d *Device) Close() {
+	if d.doneFn != nil {
+		d.doneFn()
+	}
+	d.dev.Close()
+	d.ctx.Close()
+}
+
+// ReadWithTimeout reads from the bulk IN endpoint, returning when buf is filled,
+// the device sends a short packet, or the timeout elapses. Pass a max-packet-sized
+// buf (>= 512 for high-speed bulk): a sub-packet read length can error on macOS IOKit.
+func (d *Device) ReadWithTimeout(buf []byte, timeout time.Duration) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return d.in.ReadContext(ctx, buf)
+}
+
+// Write sends buf to the bulk OUT endpoint the way the bootROM expects:
+//
+//   - split into chunks of at most 16 KiB (0x4000) — a single large bulk OUT fails
+//     on macOS IOKit with kIOReturnNotResponding;
+//   - if the total length is an exact multiple of the endpoint max packet size,
+//     follow with a zero-length packet to mark end-of-transfer.
+func (d *Device) Write(buf []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const maxChunk = 0x4000 // 16 KiB
+	for off := 0; off < len(buf); {
+		end := off + maxChunk
+		if end > len(buf) {
+			end = len(buf)
+		}
+		n, err := d.out.WriteContext(ctx, buf[off:end])
+		if err != nil {
+			return err
+		}
+		off += n
+	}
+
+	if mps := d.out.Desc.MaxPacketSize; mps > 0 && len(buf) > 0 && len(buf)%mps == 0 {
+		if _, err := d.out.WriteContext(ctx, []byte{}); err != nil {
+			return fmt.Errorf("sending zero-length packet: %w", err)
+		}
+	}
+	return nil
+}
+
+// parseChipIDDescriptor extracts the BR_CID from a GET_STRING_DESCRIPTOR (index 3)
+// response (buf[0]=bLength, buf[1]=0x03, buf[2:]=UTF-16LE payload). The bootROM
+// stores the hex string reversed, so we take each code unit's low byte and reverse.
+func parseChipIDDescriptor(buf []byte, n int) (string, error) {
+	if n < 4 {
+		return "", fmt.Errorf("chip-id descriptor too short: got %d bytes, need at least 4", n)
+	}
+	length := int(buf[0])
+	if length > n {
+		length = n
+	}
+	var sb strings.Builder
+	for i := 2; i+1 < length; i += 2 {
+		c := buf[i]
+		if !isHexDigit(c) {
+			return "", fmt.Errorf("chip-id descriptor byte 0x%02x is not a hex digit", c)
+		}
+		sb.WriteByte(c)
+	}
+	if sb.Len() == 0 {
+		return "", fmt.Errorf("chip-id descriptor empty")
+	}
+	return reverseASCII(sb.String()), nil
+}
+
+func isHexDigit(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')
+}
+
+func reverseASCII(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}

--- a/go/internal/cli/tegraflash/rcm/device_test.go
+++ b/go/internal/cli/tegraflash/rcm/device_test.go
@@ -1,0 +1,73 @@
+//go:build darwin
+
+package rcm
+
+import "testing"
+
+// utf16Desc builds a USB string descriptor (bLength, 0x03, then UTF-16LE of s).
+func utf16Desc(s string) []byte {
+	b := []byte{0, 0x03}
+	for i := 0; i < len(s); i++ {
+		b = append(b, s[i], 0x00)
+	}
+	b[0] = byte(len(b))
+	return b
+}
+
+func TestParseChipIDDescriptor(t *testing.T) {
+	// Read from a live T264 (Thor) over macOS IOKit. The descriptor payload is the
+	// BR_CID hex string reversed; un-reversed it equals the chip's BR_CID
+	// (0x80012641783DE2442400000016FF80C0).
+	liveT264 := utf16Desc("0C08FF6100000042442ED38714621008")
+
+	tests := []struct {
+		name    string
+		buf     []byte
+		n       int
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "live T264 BR_CID",
+			buf:  liveT264,
+			n:    len(liveT264),
+			want: "80012641783DE2442400000016FF80C0",
+		},
+		{
+			// reversal is the whole point: "12" stored → "21" returned
+			name: "reversal",
+			buf:  utf16Desc("12"),
+			n:    6,
+			want: "21",
+		},
+		{
+			name:    "non-hex byte returns error",
+			buf:     []byte{0x06, 0x03, 0x05, 0x00, 0x00, 0x00},
+			n:       6,
+			wantErr: true,
+		},
+		{
+			name:    "n=2 too short",
+			buf:     []byte{0x04, 0x03},
+			n:       2,
+			wantErr: true,
+		},
+		{
+			name:    "n=0 empty read",
+			buf:     make([]byte, 96),
+			n:       0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseChipIDDescriptor(tt.buf, tt.n)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseChipIDDescriptor() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseChipIDDescriptor() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/cli/tegraflash/rcm/device_unsupported.go
+++ b/go/internal/cli/tegraflash/rcm/device_unsupported.go
@@ -1,0 +1,24 @@
+//go:build !darwin
+
+package rcm
+
+import (
+	"fmt"
+	"time"
+)
+
+// Device is a stub on platforms where direct Jetson recovery USB access is not
+// implemented (Thor flashing is macOS-only for now).
+type Device struct{}
+
+func (d *Device) String() string { return "" }
+func (d *Device) Close()         {}
+
+func (d *Device) ReadWithTimeout([]byte, time.Duration) (int, error) {
+	return 0, errUnsupported
+}
+func (d *Device) Write([]byte) error { return errUnsupported }
+
+func DownloadBootROMImages(dev *Device, images [][]byte) error { return errUnsupported }
+
+var errUnsupported = fmt.Errorf("Jetson USB recovery flashing is only supported on macOS")

--- a/go/internal/cli/tegraflash/rcm/recovery.go
+++ b/go/internal/cli/tegraflash/rcm/recovery.go
@@ -1,0 +1,31 @@
+package rcm
+
+import "fmt"
+
+// RecoveryDevice identifies a Jetson sitting in USB recovery mode. PathKey is the
+// physical USB location (bus + parent-port chain); it is stable across the
+// re-enumeration the device undergoes between RCM boot and the ADB flashing gadget,
+// so it is the right handle for "flash this specific board".
+type RecoveryDevice struct {
+	PathKey string // e.g. "20-1.2" (bus 20, hub port 1 → port 2)
+	Product uint16 // USB PID: 0x7023 Orin, 0x7026 Thor
+	ECID    string // chip BR_CID read over EP0 (may be empty if unreadable)
+}
+
+// IsThor reports whether the device is a T264 (AGX Thor).
+func (r RecoveryDevice) IsThor() bool { return r.Product == uint16(ProductThor) }
+
+// Describe returns a one-line human label for pickers/logs.
+func (r RecoveryDevice) Describe() string {
+	chip := "Jetson"
+	if r.IsThor() {
+		chip = "AGX Thor (T264)"
+	} else if r.Product == uint16(ProductOrin) {
+		chip = "Orin (T234)"
+	}
+	ecid := r.ECID
+	if ecid == "" {
+		ecid = "unknown"
+	}
+	return fmt.Sprintf("%s  [usb %s, ECID %s]", chip, r.PathKey, ecid)
+}

--- a/go/internal/cli/tegraflash/rcm/select_darwin.go
+++ b/go/internal/cli/tegraflash/rcm/select_darwin.go
@@ -1,0 +1,85 @@
+//go:build darwin
+
+package rcm
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/gousb"
+)
+
+func isRecoveryPID(p gousb.ID) bool {
+	return p == gousb.ID(ProductOrin) || p == gousb.ID(ProductThor)
+}
+
+// portKey is the stable physical-location key (bus + parent-port chain).
+func portKey(desc *gousb.DeviceDesc) string {
+	parts := make([]string, len(desc.Path))
+	for i, p := range desc.Path {
+		parts[i] = strconv.Itoa(p)
+	}
+	return fmt.Sprintf("%d-%s", desc.Bus, strings.Join(parts, "."))
+}
+
+// ListRecoveryDevices enumerates every Jetson currently in USB recovery mode,
+// reading each one's chip ECID over EP0 (no interface is claimed).
+func ListRecoveryDevices() ([]RecoveryDevice, error) {
+	ctx := gousb.NewContext()
+	ctx.Debug(0)
+	defer ctx.Close()
+
+	devs, _ := ctx.OpenDevices(func(d *gousb.DeviceDesc) bool {
+		return d.Vendor == gousb.ID(VendorNVIDIA) && isRecoveryPID(d.Product)
+	})
+	var out []RecoveryDevice
+	for _, dev := range devs {
+		rd := RecoveryDevice{PathKey: portKey(dev.Desc), Product: uint16(dev.Desc.Product)}
+		buf := make([]byte, 96)
+		if n, err := dev.Control(0x80, 0x06, 0x0303, 0x0000, buf); err == nil {
+			if id, err := parseChipIDDescriptor(buf, n); err == nil {
+				rd.ECID = id
+			}
+		}
+		out = append(out, rd)
+		dev.Close()
+	}
+	return out, nil
+}
+
+// WaitForDeviceAt blocks until the Jetson at pathKey (from ListRecoveryDevices)
+// appears in recovery mode, then claims it. An empty pathKey matches any device.
+func WaitForDeviceAt(pathKey string) (*Device, error) {
+	ctx := gousb.NewContext()
+	ctx.Debug(0)
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		devs, _ := ctx.OpenDevices(func(d *gousb.DeviceDesc) bool {
+			return d.Vendor == gousb.ID(VendorNVIDIA) && isRecoveryPID(d.Product) &&
+				(pathKey == "" || portKey(d) == pathKey)
+		})
+		var chosen *gousb.Device
+		for i, dev := range devs {
+			if i == 0 {
+				chosen = dev
+			} else {
+				dev.Close()
+			}
+		}
+		if chosen != nil {
+			d, err := openDevice(ctx, chosen)
+			if err != nil {
+				chosen.Close()
+				ctx.Close()
+				return nil, err
+			}
+			return d, nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	ctx.Close()
+	return nil, fmt.Errorf("timed out waiting for Jetson at usb %s in recovery mode", pathKey)
+}

--- a/go/internal/cli/tegraflash/rcm/select_other.go
+++ b/go/internal/cli/tegraflash/rcm/select_other.go
@@ -1,0 +1,15 @@
+//go:build !darwin
+
+package rcm
+
+import "fmt"
+
+// ListRecoveryDevices is unsupported off macOS.
+func ListRecoveryDevices() ([]RecoveryDevice, error) {
+	return nil, fmt.Errorf("Jetson USB recovery flashing is only supported on macOS")
+}
+
+// WaitForDeviceAt is unsupported off macOS.
+func WaitForDeviceAt(string) (*Device, error) {
+	return nil, fmt.Errorf("Jetson USB recovery flashing is only supported on macOS")
+}

--- a/go/internal/cli/tegraflash/shim/adbdir.go
+++ b/go/internal/cli/tegraflash/shim/adbdir.go
@@ -1,0 +1,51 @@
+package shim
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MaterializeADBDir creates a temp directory containing symlinks named adb, lsusb
+// and timeout that all point at the running wendy binary, and returns the directory.
+// Prepending it to PATH makes bootburn's bare-name tool calls resolve to wendy's
+// own shim (see IsShimName/Dispatch). The caller removes the directory when done.
+func MaterializeADBDir() (string, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("locating wendy binary: %w", err)
+	}
+	self, err = filepath.EvalSymlinks(self)
+	if err != nil {
+		return "", fmt.Errorf("resolving wendy binary: %w", err)
+	}
+	dir, err := os.MkdirTemp("", "wendy-adbshim-")
+	if err != nil {
+		return "", err
+	}
+	for _, name := range []string{"adb", "lsusb", "timeout"} {
+		if err := os.Symlink(self, filepath.Join(dir, name)); err != nil {
+			os.RemoveAll(dir)
+			return "", fmt.Errorf("linking %s: %w", name, err)
+		}
+	}
+	return dir, nil
+}
+
+// LinkSelfAt points path at the running wendy binary (replacing any existing file).
+// bootburn calls adb by an absolute path inside the bundle/workspace as well as by
+// PATH, so that path must also resolve to wendy's shim.
+func LinkSelfAt(path string) error {
+	self, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	if self, err = filepath.EvalSymlinks(self); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	_ = os.Remove(path)
+	return os.Symlink(self, path)
+}

--- a/go/internal/cli/tegraflash/shim/shim.go
+++ b/go/internal/cli/tegraflash/shim/shim.go
@@ -10,6 +10,7 @@ package shim
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/adb"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flasher"
 )
 
 // adbSerial is the serial we report for the single USB device. bootburn's flasher
@@ -99,14 +101,20 @@ func openADB() *adb.Device {
 
 func waitForDevice() {
 	deadline := time.Now().Add(60 * time.Second)
+	var lastErr error
 	for time.Now().Before(deadline) {
-		if d, err := adb.Open(); err == nil {
+		d, err := adb.Open()
+		if err == nil {
 			d.Close()
 			return
 		}
+		// Surface why each attempt failed; bootburn's `timeout` may SIGKILL us
+		// before the loop ends, so log as we go rather than only at the end.
+		lastErr = err
+		fmt.Fprintf(os.Stderr, "wendy adb: wait-for-device: %v\n", err)
 		time.Sleep(time.Second)
 	}
-	fmt.Fprintln(os.Stderr, "wendy adb: wait-for-device timed out")
+	fmt.Fprintf(os.Stderr, "wendy adb: wait-for-device timed out: %v\n", lastErr)
 	os.Exit(1)
 }
 
@@ -136,11 +144,48 @@ func doPush(rest []string) {
 	if strings.HasSuffix(remote, "/") || d.IsDir(remote) {
 		remote = strings.TrimSuffix(remote, "/") + "/" + filepath.Base(rest[0])
 	}
-	if err := d.Push(file, remote, int(info.Mode().Perm())); err != nil {
+	// Report transfer progress to the parent flasher, when it asked us to.
+	var reader io.Reader = file
+	if pp := os.Getenv(flasher.EnvADBProgress); pp != "" {
+		reader = &progressReader{r: file, path: pp}
+	}
+	if err := d.Push(reader, remote, int(info.Mode().Perm())); err != nil {
 		fmt.Fprintf(os.Stderr, "wendy adb: push failed: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Printf("%s: 1 file pushed\n", rest[0])
+}
+
+// progressReader tallies bytes read and periodically writes the running total to
+// path (as a single integer), so the parent flasher process can display transfer
+// throughput. Writes are best-effort and atomic via a temp file + rename.
+type progressReader struct {
+	r         io.Reader
+	path      string
+	n         int64
+	lastFlush time.Time
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	if n > 0 {
+		p.n += int64(n)
+		if now := time.Now(); now.Sub(p.lastFlush) >= 200*time.Millisecond {
+			p.lastFlush = now
+			p.flush()
+		}
+	}
+	if err != nil {
+		p.flush() // final total for this push
+	}
+	return n, err
+}
+
+func (p *progressReader) flush() {
+	tmp := p.path + ".tmp"
+	if os.WriteFile(tmp, []byte(strconv.FormatInt(p.n, 10)), 0o644) == nil {
+		_ = os.Rename(tmp, p.path)
+	}
 }
 
 func doShell(rest []string) {

--- a/go/internal/cli/tegraflash/shim/shim.go
+++ b/go/internal/cli/tegraflash/shim/shim.go
@@ -1,0 +1,222 @@
+//go:build darwin
+
+// Package shim is the multi-call host shim for driving the T264 initrd-flash gadget,
+// folded into the wendy binary. NVIDIA's bootburn flasher shells out to `adb`,
+// `lsusb` and `timeout`; on macOS those are missing or x86-only. Rather than ship a
+// separate binary, wendy re-execs itself: a directory of symlinks (adb/lsusb/timeout
+// -> the wendy binary) is put on PATH, and main() dispatches to Dispatch() when it is
+// invoked under one of those names (see IsShimName).
+package shim
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/adb"
+)
+
+// adbSerial is the serial we report for the single USB device. bootburn's flasher
+// must use this serial (the monkeypatch driver sets s_AdbSerialNum to it).
+const adbSerial = "wendythor"
+
+// shimNames are the tool names wendy impersonates for bootburn.
+var shimNames = map[string]bool{"adb": true, "lsusb": true, "timeout": true}
+
+// IsShimName reports whether argv[0]'s basename is one of the tools wendy stands in
+// for. main() calls Dispatch() when this is true, before cobra runs.
+func IsShimName(name string) bool { return shimNames[name] }
+
+// Dispatch runs the shim for the current invocation name and exits the process.
+func Dispatch() {
+	switch filepath.Base(os.Args[0]) {
+	case "lsusb":
+		runLsusb(os.Args[1:])
+	case "timeout":
+		runTimeout(os.Args[1:])
+	default: // "adb"
+		runAdb(os.Args[1:])
+	}
+	os.Exit(0)
+}
+
+// ---- adb ----
+
+func runAdb(args []string) {
+	// Skip leading global options (only -s/-H/-P/-L/-t take an argument).
+	i := 0
+	for i < len(args) {
+		switch a := args[i]; {
+		case a == "-s" || a == "-H" || a == "-P" || a == "-L" || a == "-t":
+			i += 2
+		case strings.HasPrefix(a, "-"):
+			i++
+		default:
+			goto found
+		}
+	}
+found:
+	if i >= len(args) {
+		fmt.Fprintln(os.Stderr, "wendy adb: no command")
+		os.Exit(1)
+	}
+	cmd, rest := args[i], args[i+1:]
+
+	switch cmd {
+	case "version":
+		fmt.Println("Android Debug Bridge version 1.0.41")
+		fmt.Println("wendy: ADB over USB, serverless")
+	case "start-server", "kill-server":
+		// no-op: there is no server
+	case "devices":
+		fmt.Println("List of devices attached")
+		fmt.Printf("%s\tdevice\n", adbSerial)
+		fmt.Println()
+	case "wait-for-device":
+		waitForDevice()
+	case "push":
+		doPush(rest)
+	case "shell":
+		doShell(rest)
+	default:
+		fmt.Fprintf(os.Stderr, "wendy adb: unsupported command %q\n", cmd)
+		os.Exit(1)
+	}
+}
+
+func openADB() *adb.Device {
+	d, err := adb.Open()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wendy adb: %v\n", err)
+		os.Exit(1)
+	}
+	return d
+}
+
+func waitForDevice() {
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if d, err := adb.Open(); err == nil {
+			d.Close()
+			return
+		}
+		time.Sleep(time.Second)
+	}
+	fmt.Fprintln(os.Stderr, "wendy adb: wait-for-device timed out")
+	os.Exit(1)
+}
+
+func doPush(rest []string) {
+	if len(rest) < 2 {
+		fmt.Fprintln(os.Stderr, "wendy adb: push needs <local> <remote>")
+		os.Exit(1)
+	}
+	info, err := os.Stat(rest[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wendy adb: %v\n", err)
+		os.Exit(1)
+	}
+	file, err := os.Open(rest[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wendy adb: %v\n", err)
+		os.Exit(1)
+	}
+	defer file.Close()
+	d := openADB()
+	defer d.Close()
+	// Match adb: pushing a file to a directory writes <dir>/<basename>, and the
+	// pushed file keeps the local file's permission bits (e.g. wr_sh.sh/nvdd are
+	// 0755 and must stay executable on the device). The file is streamed, not read
+	// whole, so a multi-GB rootfs push stays bounded in memory.
+	remote := rest[1]
+	if strings.HasSuffix(remote, "/") || d.IsDir(remote) {
+		remote = strings.TrimSuffix(remote, "/") + "/" + filepath.Base(rest[0])
+	}
+	if err := d.Push(file, remote, int(info.Mode().Perm())); err != nil {
+		fmt.Fprintf(os.Stderr, "wendy adb: push failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("%s: 1 file pushed\n", rest[0])
+}
+
+func doShell(rest []string) {
+	d := openADB()
+	defer d.Close()
+	out, err := d.Shell(strings.Join(rest, " "))
+	fmt.Print(out)
+	if ee, ok := err.(*adb.ExitError); ok {
+		os.Exit(ee.Code)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wendy adb: shell error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// ---- lsusb ----
+
+// runLsusb supports `lsusb -d <vid>:` (the only form bootburn uses, in
+// CheckUSBServiceInit) and exits 0 iff a USB device with that vendor id is present.
+func runLsusb(args []string) {
+	vid := ""
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-d" && i+1 < len(args) {
+			vid = strings.SplitN(args[i+1], ":", 2)[0]
+			i++
+		}
+	}
+	if vid == "" {
+		os.Exit(0)
+	}
+	n, err := strconv.ParseUint(vid, 16, 16)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wendy lsusb: bad vendor id %q\n", vid)
+		os.Exit(2)
+	}
+	if adb.VendorPresent(uint16(n)) {
+		os.Exit(0)
+	}
+	os.Exit(1)
+}
+
+// ---- timeout ----
+
+// runTimeout implements `timeout <seconds> <cmd...>`: run cmd, killing it (exit 124)
+// if it does not finish within the given whole seconds. The child's exit code is
+// propagated otherwise.
+func runTimeout(args []string) {
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, "wendy timeout: usage: timeout <seconds> <cmd> [args...]")
+		os.Exit(125)
+	}
+	secs, err := strconv.Atoi(strings.TrimSuffix(args[0], "s"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wendy timeout: bad duration %q\n", args[0])
+		os.Exit(125)
+	}
+	cmd := exec.Command(args[1], args[2:]...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "wendy timeout: %v\n", err)
+		os.Exit(126)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if ee, ok := err.(*exec.ExitError); ok {
+			os.Exit(ee.ExitCode())
+		}
+		if err != nil {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	case <-time.After(time.Duration(secs) * time.Second):
+		_ = cmd.Process.Kill()
+		os.Exit(124)
+	}
+}

--- a/go/internal/cli/tegraflash/shim/shim_other.go
+++ b/go/internal/cli/tegraflash/shim/shim_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package shim
+
+// On non-darwin platforms wendy is never invoked as adb/lsusb/timeout (Thor
+// flashing is macOS-only for now), so the shim is inert.
+
+// IsShimName always reports false off macOS.
+func IsShimName(string) bool { return false }
+
+// Dispatch is a no-op off macOS.
+func Dispatch() {}

--- a/go/internal/cli/tui/steps.go
+++ b/go/internal/cli/tui/steps.go
@@ -1,0 +1,188 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// StepStatus is the lifecycle state of a step in a StepsModel.
+type StepStatus int
+
+const (
+	StepRunning StepStatus = iota
+	StepCached
+	StepDone
+	StepFailed
+)
+
+// Step lifecycle messages, sent to a running StepsModel via (*tea.Program).Send.
+type (
+	// StepStartMsg adds a step (or moves an existing one back to running).
+	StepStartMsg struct {
+		ID    int
+		Label string
+	}
+	// StepDetailMsg sets the trailing detail of a running step (e.g. a byte
+	// count like "1.2/3.0 GiB"). An empty Detail restores the auto elapsed timer.
+	StepDetailMsg struct {
+		ID     int
+		Detail string
+	}
+	// StepDoneMsg marks a step finished. Cached renders "⚡ cached" instead of a
+	// duration (for work that was skipped because a cache was warm).
+	StepDoneMsg struct {
+		ID     int
+		Cached bool
+	}
+	// StepFailMsg marks a step failed (✗).
+	StepFailMsg struct{ ID int }
+	// StepsDoneMsg ends the program; Err is nil on success.
+	StepsDoneMsg struct{ Err error }
+)
+
+type stepRow struct {
+	id     int
+	label  string
+	status StepStatus
+	start  time.Time
+	dur    time.Duration
+	detail string
+}
+
+// StepsModel renders a live, Docker BuildKit-style list of named steps: a spinner
+// while running, a per-step elapsed timer (or a caller-supplied detail such as a
+// byte count), and ✓/⚡/✗ terminal states with durations. Unlike BuildStepsModel
+// it is driven by explicit Step* messages rather than a buildx log parser, for
+// flows (e.g. Thor flashing) that have no buildkit vertices to parse.
+type StepsModel struct {
+	title   string
+	rows    []stepRow
+	byID    map[int]int
+	spinner spinner.Model
+	done    bool
+	err     error
+}
+
+// NewStepsModel returns a model with the given title (the spinner line shown
+// above the steps, e.g. "Flashing WendyOS nightly-…").
+func NewStepsModel(title string) StepsModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(ColorPrimary)
+	return StepsModel{
+		title:   title,
+		byID:    map[int]int{},
+		spinner: s,
+	}
+}
+
+// Init implements tea.Model.
+func (m StepsModel) Init() tea.Cmd { return m.spinner.Tick }
+
+// Update implements tea.Model.
+func (m StepsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			m.done = true
+			m.err = ErrCancelled
+			return m, tea.Quit
+		}
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	case StepStartMsg:
+		if i, ok := m.byID[msg.ID]; ok {
+			m.rows[i].status = StepRunning
+			m.rows[i].start = time.Now()
+			m.rows[i].detail = ""
+			return m, nil
+		}
+		m.rows = append(m.rows, stepRow{id: msg.ID, label: msg.Label, status: StepRunning, start: time.Now()})
+		m.byID[msg.ID] = len(m.rows) - 1
+	case StepDetailMsg:
+		if i, ok := m.byID[msg.ID]; ok {
+			m.rows[i].detail = msg.Detail
+		}
+	case StepDoneMsg:
+		if i, ok := m.byID[msg.ID]; ok {
+			m.rows[i].dur = time.Since(m.rows[i].start)
+			m.rows[i].detail = ""
+			if msg.Cached {
+				m.rows[i].status = StepCached
+			} else {
+				m.rows[i].status = StepDone
+			}
+		}
+	case StepFailMsg:
+		if i, ok := m.byID[msg.ID]; ok {
+			m.rows[i].dur = time.Since(m.rows[i].start)
+			m.rows[i].status = StepFailed
+		}
+	case StepsDoneMsg:
+		m.done = true
+		m.err = msg.Err
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+var (
+	stepCheck = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true)
+	stepCache = lipgloss.NewStyle().Foreground(ColorPrimary)
+	stepCross = lipgloss.NewStyle().Foreground(ColorError).Bold(true)
+	stepDim   = lipgloss.NewStyle().Foreground(ColorDim)
+	stepTitle = lipgloss.NewStyle().Foreground(ColorPrimary)
+)
+
+const stepsLabelWidth = 26
+
+// View implements tea.Model.
+func (m StepsModel) View() string {
+	if m.done {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s %s\n", m.spinner.View(), stepTitle.Render(m.title)))
+	for _, r := range m.rows {
+		label := padLabel(r.label, stepsLabelWidth)
+		switch r.status {
+		case StepRunning:
+			trail := time.Since(r.start).Round(time.Second).String()
+			if r.detail != "" {
+				trail += " · " + r.detail
+			}
+			sb.WriteString(fmt.Sprintf("  %s %s %s\n", m.spinner.View(), label, stepDim.Render(trail)))
+		case StepCached:
+			sb.WriteString(fmt.Sprintf("  %s %s %s\n", stepCache.Render("⚡"), label, stepDim.Render("cached")))
+		case StepDone:
+			sb.WriteString(fmt.Sprintf("  %s %s %s\n", stepCheck.Render("✓"), label, stepDim.Render(r.dur.Round(time.Second).String())))
+		case StepFailed:
+			sb.WriteString(fmt.Sprintf("  %s %s\n", stepCross.Render("✗"), label))
+		}
+	}
+	return sb.String()
+}
+
+// Err returns the terminal error (ErrCancelled on ctrl+c, the error from
+// StepsDoneMsg, or nil).
+func (m StepsModel) Err() error { return m.err }
+
+// padLabel left-aligns s in a field of width runes, truncating with an ellipsis
+// when too long so trailing detail columns line up.
+func padLabel(s string, width int) string {
+	r := []rune(s)
+	if len(r) > width {
+		if width <= 1 {
+			return string(r[:width])
+		}
+		return string(r[:width-1]) + "…"
+	}
+	return s + strings.Repeat(" ", width-len(r))
+}

--- a/go/internal/cli/tui/steps_test.go
+++ b/go/internal/cli/tui/steps_test.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// drive applies a sequence of messages to a StepsModel and returns the result.
+func drive(m StepsModel, msgs ...any) StepsModel {
+	for _, msg := range msgs {
+		mm, _ := m.Update(msg)
+		m = mm.(StepsModel)
+	}
+	return m
+}
+
+func TestStepsModel_RunningShowsDetailThenElapsed(t *testing.T) {
+	m := drive(NewStepsModel("Flashing"),
+		StepStartMsg{ID: 0, Label: "Download flashpack"},
+		StepDetailMsg{ID: 0, Detail: "1.2/3.0 GiB"},
+	)
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Download flashpack") || !strings.Contains(view, "1.2/3.0 GiB") {
+		t.Fatalf("running step should show label + detail, got:\n%s", view)
+	}
+
+	// Clearing the detail falls back to the elapsed timer, not a stale byte count.
+	m = drive(m, StepDetailMsg{ID: 0, Detail: ""})
+	if v := ansi.Strip(m.View()); strings.Contains(v, "GiB") {
+		t.Fatalf("cleared detail should drop byte count, got:\n%s", v)
+	}
+}
+
+func TestStepsModel_TerminalStates(t *testing.T) {
+	m := drive(NewStepsModel("Flashing"),
+		StepStartMsg{ID: 0, Label: "Download flashpack"},
+		StepDoneMsg{ID: 0, Cached: true},
+		StepStartMsg{ID: 1, Label: "Stage 1"},
+		StepDoneMsg{ID: 1},
+		StepStartMsg{ID: 2, Label: "Stage 2"},
+		StepFailMsg{ID: 2},
+	)
+	view := ansi.Strip(m.View())
+	for _, want := range []string{"⚡", "cached", "✓", "Stage 1", "✗", "Stage 2"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected %q in view:\n%s", want, view)
+		}
+	}
+}
+
+func TestStepsModel_DoneRendersEmpty(t *testing.T) {
+	m := drive(NewStepsModel("Flashing"),
+		StepStartMsg{ID: 0, Label: "Download flashpack"},
+		StepsDoneMsg{Err: nil},
+	)
+	if v := m.View(); v != "" {
+		t.Fatalf("finished model should render empty, got: %q", v)
+	}
+}
+
+func TestStepsModel_ErrPropagates(t *testing.T) {
+	m := drive(NewStepsModel("Flashing"), StepsDoneMsg{Err: ErrCancelled})
+	if m.Err() != ErrCancelled {
+		t.Fatalf("Err() = %v, want ErrCancelled", m.Err())
+	}
+}
+
+func TestPadLabel(t *testing.T) {
+	if got := padLabel("abc", 6); got != "abc   " {
+		t.Errorf("padLabel pad = %q, want %q", got, "abc   ")
+	}
+	if got := padLabel("abcdef", 6); got != "abcdef" {
+		t.Errorf("padLabel exact = %q, want %q", got, "abcdef")
+	}
+	if got := padLabel("abcdefgh", 6); got != "abcde…" {
+		t.Errorf("padLabel truncate = %q, want %q", got, "abcde…")
+	}
+}

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -105,6 +105,20 @@ func CacheDir() (string, error) {
 	return cacheDir, nil
 }
 
+// LogDir returns the directory for CLI-written log files (e.g. the Thor flash log),
+// creating it if needed.
+func LogDir() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("determining cache directory: %w", err)
+	}
+	logDir := filepath.Join(dir, "wendy", "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating log directory: %w", err)
+	}
+	return logDir, nil
+}
+
 // configPath returns the full path to config.json.
 func configPath() (string, error) {
 	dir, err := ConfigDir()

--- a/go/scripts/build-wendy.sh
+++ b/go/scripts/build-wendy.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Build (or install) the wendy CLI with libusb linked statically, so the shipped
+# binary carries no /opt/homebrew (or other) libusb dylib dependency. Thor USB
+# recovery flashing (gousb) is macOS-only for now; on other platforms wendy needs
+# no libusb and a plain `go build` suffices.
+#
+# Usage:
+#   scripts/build-wendy.sh [output-path]     # build to output-path (default ./bin/wendy)
+#   scripts/build-wendy.sh --install         # go install into GOBIN
+set -euo pipefail
+cd "$(dirname "$0")/.."   # the go module root
+
+LDFLAGS="-s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=${VERSION:-dev}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    # No libusb needed off macOS (Thor path compiles to the unsupported stub).
+    if [[ "${1:-}" == "--install" ]]; then exec go install -ldflags "$LDFLAGS" ./cmd/wendy; fi
+    exec go build -ldflags "$LDFLAGS" -o "${1:-bin/wendy}" ./cmd/wendy
+fi
+
+# --- macOS: static libusb -------------------------------------------------------
+LIBUSB_PREFIX="$(brew --prefix libusb 2>/dev/null || echo /opt/homebrew/opt/libusb)"
+ARCHIVE="$LIBUSB_PREFIX/lib/libusb-1.0.a"
+HEADERS="$LIBUSB_PREFIX/include/libusb-1.0"
+[[ -f "$ARCHIVE" ]] || { echo "error: $ARCHIVE not found (brew install libusb)"; exit 1; }
+
+# gousb links libusb via `#cgo pkg-config: libusb-1.0`. To force the STATIC archive
+# we (a) neutralize pkg-config so it can't re-introduce the .dylib search path, and
+# (b) point the linker at a dir containing ONLY the .a, so the macOS linker has no
+# .dylib to prefer.
+STATICDIR="$(mktemp -d)"
+trap 'rm -rf "$STATICDIR"' EXIT
+ln -s "$ARCHIVE" "$STATICDIR/libusb-1.0.a"
+
+export CGO_ENABLED=1
+export PKG_CONFIG=/usr/bin/true
+export CGO_CFLAGS="-I$HEADERS"
+export CGO_LDFLAGS="-L$STATICDIR -lusb-1.0 -lobjc -Wl,-framework,IOKit -Wl,-framework,CoreFoundation -Wl,-framework,Security"
+
+if [[ "${1:-}" == "--install" ]]; then
+    go install -ldflags "$LDFLAGS" ./cmd/wendy
+    echo "installed wendy (static libusb) into ${GOBIN:-$(go env GOPATH)/bin}"
+    exit 0
+fi
+OUT="${1:-bin/wendy}"
+mkdir -p "$(dirname "$OUT")"
+go build -ldflags "$LDFLAGS" -o "$OUT" ./cmd/wendy
+echo "built $OUT (static libusb)"
+# Fail loudly if a libusb dylib snuck back in.
+if otool -L "$OUT" | grep -qi 'libusb'; then
+    echo "ERROR: $OUT still has a dynamic libusb dependency:"; otool -L "$OUT" | grep -i usb
+    exit 1
+fi
+echo "verified: no dynamic libusb dependency"


### PR DESCRIPTION
I'll leave this in draft until it's tested end-to-end against https://github.com/wendylabsinc/WendyOS-Builder/pull/142

I have tested it successfully by dropping the .tar.zst into the local cache. Example flash output: https://gist.github.com/thombles/abc9395bd4506b5dd50f595264d63593

* Bring in the RCM functionality explored on `jo/emmc` and `thombles/emmc-thor-flash`, plus the flashing logic previously tested in the `thor-flash` binary
* When targeting AGX Thor, download and extract the flashpack
* Link against libusb statically.
* Linux is currently unsupported to simplify building the `wendy` CLI - we need to decide if we want to link dynamically against libusb (possibly an extra package for users to install) or similarly attempt static linkage. The latter will require more complicated cross-compilation steps in CI/CD. Today, CGO is not enabled.
* Merge the `wendy-shim` functionality into `wendy` itself so it can act as a "fake `adb`" etc. when required without needing to drop additional binaries.