### PR TITLE
feat(appconfig): fleet manifest schema — components/target/expose/discovers (WDY-1755 Phase 1)

### DIFF
--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -143,6 +143,59 @@ type ServiceConfig struct {
 	Resources *ResourceLimits `json:"resources,omitempty"`
 }
 
+// ComponentConfig describes one placed component of a fleet app (WDY-1755). A
+// wendy.json with a non-empty Components map is a "fleet manifest": each
+// component is built from its own context and placed independently — fanned out
+// to a device group (the edge tier) or run once centrally (the central tier).
+// Per-component Entitlements/Readiness/Hooks/Frameworks/Resources mirror the
+// single-app fields; in fleet mode they live here rather than at the top level.
+type ComponentConfig struct {
+	// Context is the build context directory, relative to wendy.json. Required.
+	Context      string            `json:"context"`
+	Target       *ComponentTarget  `json:"target,omitempty"`
+	Expose       *ComponentExpose  `json:"expose,omitempty"`
+	Discovers    []DiscoverRef     `json:"discovers,omitempty"`
+	Entitlements []Entitlement     `json:"entitlements,omitempty"`
+	Readiness    *ReadinessConfig  `json:"readiness,omitempty"`
+	Hooks        *HooksConfig      `json:"hooks,omitempty"`
+	Frameworks   *FrameworksConfig `json:"frameworks,omitempty"`
+	Resources    *ResourceLimits   `json:"resources,omitempty"`
+}
+
+// ComponentTarget places a component. Exactly one of Group or Central must be
+// set: Group fans the component out to every device in a named device group;
+// Central runs it once (on an edge device, a separate host, or the cloud).
+type ComponentTarget struct {
+	Group   string `json:"group,omitempty"`
+	Central bool   `json:"central,omitempty"`
+}
+
+// ComponentExpose declares the network endpoint a component serves so the
+// platform can advertise it for cross-device discovery. Named "expose" rather
+// than "service" to avoid collision with the multi-container Services map.
+type ComponentExpose struct {
+	Name string `json:"name,omitempty"`
+	Port int    `json:"port"`
+	Path string `json:"path,omitempty"`
+}
+
+// DiscoverRef wires one component's live endpoints into another. The resolved
+// peer list is injected into the consuming container as a JSON snapshot under
+// the env var named by As, plus a live discovery API under WENDY_DISCOVERY_URL.
+type DiscoverRef struct {
+	Component string `json:"component"`
+	As        string `json:"as"`
+}
+
+// DiscoveryURLEnvVar is the env var the platform auto-injects into any component
+// that declares a "discovers" entry, pointing at a local discovery API the app
+// can poll/subscribe to for live membership. It is reserved: a discovers[].as
+// may not reuse it.
+const DiscoveryURLEnvVar = "WENDY_DISCOVERY_URL"
+
+// envVarNamePattern matches a POSIX-portable environment variable name.
+var envVarNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // AppConfig represents the wendy.json application configuration.
 type AppConfig struct {
 	AppID string `json:"appId"`
@@ -175,6 +228,16 @@ type AppConfig struct {
 	// Resources optionally caps the app's CPU/memory/PID usage. For
 	// multi-service apps it is the default; a service may override it.
 	Resources *ResourceLimits `json:"resources,omitempty"`
+	// Components, when non-empty, makes this a fleet manifest (WDY-1755): a map
+	// of placed components fanned out to device groups and/or run centrally.
+	// Mutually exclusive with the single-app top-level fields.
+	Components map[string]*ComponentConfig `json:"components,omitempty"`
+}
+
+// IsFleet reports whether this is a fleet manifest, i.e. it declares a
+// components map rather than a single deployable app.
+func (c *AppConfig) IsFleet() bool {
+	return len(c.Components) > 0
 }
 
 // ContainerName returns the container identifier for this app config.
@@ -491,6 +554,176 @@ func (c *AppConfig) Validate() error {
 		}
 	}
 
+	if c.IsFleet() {
+		if err := c.validateComponents(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// singleAppFieldsSet returns the names of any top-level single-app fields that
+// are set. These are not permitted alongside a fleet "components" map — in
+// fleet mode each component carries its own build/runtime config.
+func (c *AppConfig) singleAppFieldsSet() []string {
+	var set []string
+	if c.ServiceName != "" {
+		set = append(set, "serviceName")
+	}
+	if c.Run != nil {
+		set = append(set, "run")
+	}
+	if len(c.Entitlements) > 0 {
+		set = append(set, "entitlements")
+	}
+	if c.Readiness != nil {
+		set = append(set, "readiness")
+	}
+	if c.Hooks != nil {
+		set = append(set, "hooks")
+	}
+	if c.Python != nil {
+		set = append(set, "python")
+	}
+	if c.Xcode != nil {
+		set = append(set, "xcode")
+	}
+	if len(c.Files) > 0 {
+		set = append(set, "files")
+	}
+	if c.Brewfile != "" {
+		set = append(set, "brewfile")
+	}
+	if c.Isolation != "" {
+		set = append(set, "isolation")
+	}
+	if c.Frameworks != nil {
+		set = append(set, "frameworks")
+	}
+	if c.Resources != nil {
+		set = append(set, "resources")
+	}
+	if len(c.Services) > 0 {
+		set = append(set, "services")
+	}
+	sort.Strings(set)
+	return set
+}
+
+// validateComponents validates a fleet manifest's components map: top-level
+// mutual exclusivity, per-component placement/build config, and discovers
+// wiring. Called only when IsFleet() is true.
+func (c *AppConfig) validateComponents() error {
+	if conflicting := c.singleAppFieldsSet(); len(conflicting) > 0 {
+		return fmt.Errorf("a fleet manifest (with \"components\") must not also set single-app field(s): %s — move them into the relevant component", strings.Join(conflicting, ", "))
+	}
+
+	for name, comp := range c.Components {
+		if comp == nil {
+			return fmt.Errorf("components[%q]: must not be null", name)
+		}
+		if comp.Context == "" {
+			return fmt.Errorf("components[%q]: context is required", name)
+		}
+		if filepath.IsAbs(comp.Context) {
+			return fmt.Errorf("components[%q]: context must be a relative path", name)
+		}
+		if cleaned := filepath.Clean(comp.Context); strings.HasPrefix(cleaned, "..") {
+			return fmt.Errorf("components[%q]: context must not contain '..' components", name)
+		}
+
+		if err := validateComponentTarget(name, comp.Target); err != nil {
+			return err
+		}
+		if err := validateComponentExpose(name, comp.Expose); err != nil {
+			return err
+		}
+		if err := validateEntitlements(comp.Entitlements, fmt.Sprintf("components[%q].entitlement", name)); err != nil {
+			return err
+		}
+		if comp.Readiness != nil {
+			if comp.Readiness.TCPSocket != nil {
+				port := comp.Readiness.TCPSocket.Port
+				if port < 1 || port > 65535 {
+					return fmt.Errorf("components[%q].readiness.tcpSocket.port must be between 1 and 65535, got %d", name, port)
+				}
+			}
+			if comp.Readiness.TimeoutSeconds < 0 {
+				return fmt.Errorf("components[%q].readiness.timeoutSeconds must not be negative, got %d", name, comp.Readiness.TimeoutSeconds)
+			}
+		}
+		if comp.Frameworks != nil {
+			if err := validateROS2Config(fmt.Sprintf("components[%q].frameworks.ros2", name), comp.Frameworks.ROS2); err != nil {
+				return err
+			}
+		}
+		if err := comp.Resources.validate(fmt.Sprintf("components[%q].resources", name)); err != nil {
+			return err
+		}
+	}
+
+	// discovers wiring is validated in a second pass so it can reference any
+	// declared component regardless of map iteration order.
+	for name, comp := range c.Components {
+		for i, d := range comp.Discovers {
+			if d.Component == "" {
+				return fmt.Errorf("components[%q].discovers[%d]: component is required", name, i)
+			}
+			target, ok := c.Components[d.Component]
+			if !ok {
+				return fmt.Errorf("components[%q].discovers[%d]: references unknown component %q", name, i, d.Component)
+			}
+			if target.Target == nil || target.Target.Group == "" {
+				return fmt.Errorf("components[%q].discovers[%d]: %q is not a group target — only group (edge) components can be discovered", name, i, d.Component)
+			}
+			if d.As == "" {
+				return fmt.Errorf("components[%q].discovers[%d]: as (env var name) is required", name, i)
+			}
+			if d.As == DiscoveryURLEnvVar {
+				return fmt.Errorf("components[%q].discovers[%d]: as must not be %q (reserved, auto-injected)", name, i, DiscoveryURLEnvVar)
+			}
+			if !envVarNamePattern.MatchString(d.As) {
+				return fmt.Errorf("components[%q].discovers[%d]: as %q is not a valid environment variable name", name, i, d.As)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateComponentTarget checks that a component declares exactly one
+// placement: a non-empty group, or central:true.
+func validateComponentTarget(name string, t *ComponentTarget) error {
+	if t == nil {
+		return fmt.Errorf("components[%q]: target is required (\"group\" or \"central\")", name)
+	}
+	hasGroup := t.Group != ""
+	if hasGroup && t.Central {
+		return fmt.Errorf("components[%q].target: set exactly one of \"group\" or \"central\", not both", name)
+	}
+	if !hasGroup && !t.Central {
+		return fmt.Errorf("components[%q].target: must set \"group\" (edge) or \"central\"", name)
+	}
+	return nil
+}
+
+// validateComponentExpose checks an optional exposed endpoint declaration.
+func validateComponentExpose(name string, e *ComponentExpose) error {
+	if e == nil {
+		return nil
+	}
+	if e.Port < 1 || e.Port > 65535 {
+		return fmt.Errorf("components[%q].expose.port must be between 1 and 65535, got %d", name, e.Port)
+	}
+	if e.Name != "" {
+		if err := ValidateServiceName(e.Name); err != nil {
+			return fmt.Errorf("components[%q].expose.name: %w", name, err)
+		}
+	}
+	if e.Path != "" && !strings.HasPrefix(e.Path, "/") {
+		return fmt.Errorf("components[%q].expose.path must start with '/', got %q", name, e.Path)
+	}
 	return nil
 }
 
@@ -646,6 +879,22 @@ func ValidateJSON(data []byte) []string {
 				prefix := fmt.Sprintf("services[%q].entitlement", name)
 				warnings = append(warnings, validateEntitlementsJSON(svc["entitlements"], prefix)...)
 				warnings = append(warnings, validateFrameworksJSON(svc["frameworks"], fmt.Sprintf("services[%q].frameworks", name))...)
+			}
+		}
+	}
+
+	// Validate component-level entitlements and frameworks for fleet manifests.
+	if componentsRaw, ok := raw["components"]; ok && len(componentsRaw) > 0 {
+		var componentEntries map[string]json.RawMessage
+		if err := json.Unmarshal(componentsRaw, &componentEntries); err == nil {
+			for name, compRaw := range componentEntries {
+				var comp map[string]json.RawMessage
+				if err := json.Unmarshal(compRaw, &comp); err != nil {
+					continue
+				}
+				prefix := fmt.Sprintf("components[%q].entitlement", name)
+				warnings = append(warnings, validateEntitlementsJSON(comp["entitlements"], prefix)...)
+				warnings = append(warnings, validateFrameworksJSON(comp["frameworks"], fmt.Sprintf("components[%q].frameworks", name))...)
 			}
 		}
 	}

--- a/go/internal/shared/appconfig/fleet_test.go
+++ b/go/internal/shared/appconfig/fleet_test.go
@@ -1,0 +1,259 @@
+package appconfig
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// cameraFleetJSON mirrors the camera-fleet template's wendy.json (templates
+// PR #59) with template variables rendered to concrete values. It is the
+// canonical valid fleet manifest and acts as the acceptance fixture for the
+// Phase 1 schema work (WDY-1755).
+const cameraFleetJSON = `{
+  "appId": "sh.wendy.examples.camerafleet",
+  "version": "0.1.0",
+  "platform": "linux",
+  "components": {
+    "camera": {
+      "context": "camera",
+      "target": { "group": "cameras" },
+      "expose": { "name": "usbcam", "port": 8000, "path": "/stream" },
+      "entitlements": [
+        { "type": "network", "mode": "host" },
+        { "type": "camera" }
+      ],
+      "readiness": { "tcpSocket": { "port": 8000 }, "timeoutSeconds": 30 }
+    },
+    "dashboard": {
+      "context": "dashboard",
+      "target": { "central": true },
+      "discovers": [ { "component": "camera", "as": "WENDY_FLEET_PEERS" } ],
+      "entitlements": [ { "type": "network", "mode": "host" } ],
+      "readiness": { "tcpSocket": { "port": 9000 }, "timeoutSeconds": 30 },
+      "hooks": { "postStart": { "openURL": "http://${WENDY_HOSTNAME}:9000" } }
+    }
+  }
+}`
+
+func TestFleetManifest_Valid(t *testing.T) {
+	cfg, err := LoadFromBytes([]byte(cameraFleetJSON))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !cfg.IsFleet() {
+		t.Fatal("IsFleet() = false, want true")
+	}
+	if len(cfg.Components) != 2 {
+		t.Fatalf("got %d components, want 2", len(cfg.Components))
+	}
+	cam := cfg.Components["camera"]
+	if cam == nil || cam.Target == nil || cam.Target.Group != "cameras" {
+		t.Fatalf("camera component target group not parsed: %+v", cam)
+	}
+	if cam.Expose == nil || cam.Expose.Port != 8000 || cam.Expose.Path != "/stream" {
+		t.Fatalf("camera expose not parsed: %+v", cam.Expose)
+	}
+	dash := cfg.Components["dashboard"]
+	if dash == nil || dash.Target == nil || !dash.Target.Central {
+		t.Fatalf("dashboard component target central not parsed: %+v", dash)
+	}
+	if len(dash.Discovers) != 1 || dash.Discovers[0].Component != "camera" || dash.Discovers[0].As != "WENDY_FLEET_PEERS" {
+		t.Fatalf("dashboard discovers not parsed: %+v", dash.Discovers)
+	}
+}
+
+func TestIsFleet_SingleApp(t *testing.T) {
+	cfg, err := LoadFromBytes([]byte(`{"appId":"sh.wendy.app","entitlements":[{"type":"gpu"}]}`))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	if cfg.IsFleet() {
+		t.Fatal("IsFleet() = true for single-app config, want false")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("single-app Validate regressed: %v", err)
+	}
+}
+
+func TestFleetManifest_RejectsSingleAppFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		extra     string
+		wantField string
+	}{
+		{"services", `"services": { "a": { "context": "a" } },`, "services"},
+		{"entitlements", `"entitlements": [ { "type": "gpu" } ],`, "entitlements"},
+		{"run", `"run": { "args": ["x"] },`, "run"},
+		{"isolation", `"isolation": "shared-ipc",`, "isolation"},
+		{"resources", `"resources": { "cpus": "1" },`, "resources"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := `{"appId":"sh.wendy.app",` + tt.extra +
+				`"components":{"c":{"context":"c","target":{"central":true}}}}`
+			cfg, err := LoadFromBytes([]byte(raw))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			err = cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected mutual-exclusivity error for %q", tt.wantField)
+			}
+			if !strings.Contains(err.Error(), tt.wantField) {
+				t.Errorf("error %q does not mention conflicting field %q", err, tt.wantField)
+			}
+		})
+	}
+}
+
+func TestComponentTarget_Validation(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		ok     bool
+	}{
+		{"group only", `{ "group": "cameras" }`, true},
+		{"central only", `{ "central": true }`, true},
+		{"both set", `{ "group": "cameras", "central": true }`, false},
+		{"neither set", `{}`, false},
+		{"missing target", ``, false},
+		{"empty group", `{ "group": "" }`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp := `{"context":"c"`
+			if tt.target != "" {
+				comp += `,"target":` + tt.target
+			}
+			comp += `}`
+			raw := `{"appId":"sh.wendy.app","components":{"c":` + comp + `}}`
+			cfg, err := LoadFromBytes([]byte(raw))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			err = cfg.Validate()
+			if tt.ok && err != nil {
+				t.Errorf("Validate: unexpected error: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Error("Validate: expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestComponentExpose_Validation(t *testing.T) {
+	tests := []struct {
+		name   string
+		expose string
+		ok     bool
+	}{
+		{"valid", `{ "name": "usbcam", "port": 8000, "path": "/stream" }`, true},
+		{"port zero", `{ "port": 0 }`, false},
+		{"port too high", `{ "port": 70000 }`, false},
+		{"path no slash", `{ "port": 8000, "path": "stream" }`, false},
+		{"bad name", `{ "port": 8000, "name": "Bad_Name" }`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := `{"appId":"sh.wendy.app","components":{"c":{"context":"c","target":{"group":"g"},"expose":` + tt.expose + `}}}`
+			cfg, err := LoadFromBytes([]byte(raw))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			err = cfg.Validate()
+			if tt.ok && err != nil {
+				t.Errorf("Validate: unexpected error: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Error("Validate: expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestDiscovers_Validation(t *testing.T) {
+	// base has an edge "cam" (group) and a central "c" we attach discovers to.
+	build := func(discovers string) string {
+		return `{"appId":"sh.wendy.app","components":{` +
+			`"cam":{"context":"cam","target":{"group":"cams"}},` +
+			`"c":{"context":"c","target":{"central":true},"discovers":` + discovers + `}}}`
+	}
+	tests := []struct {
+		name      string
+		discovers string
+		ok        bool
+	}{
+		{"valid", `[{ "component": "cam", "as": "WENDY_FLEET_PEERS" }]`, true},
+		{"unknown component", `[{ "component": "nope", "as": "PEERS" }]`, false},
+		{"reserved env var", `[{ "component": "cam", "as": "WENDY_DISCOVERY_URL" }]`, false},
+		{"bad env var name", `[{ "component": "cam", "as": "1bad" }]`, false},
+		{"missing as", `[{ "component": "cam" }]`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := LoadFromBytes([]byte(build(tt.discovers)))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			err = cfg.Validate()
+			if tt.ok && err != nil {
+				t.Errorf("Validate: unexpected error: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Error("Validate: expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestDiscovers_RejectsDiscoveringCentral(t *testing.T) {
+	// Discovering a central (non-group) component is meaningless and rejected.
+	raw := `{"appId":"sh.wendy.app","components":{` +
+		`"a":{"context":"a","target":{"central":true}},` +
+		`"b":{"context":"b","target":{"central":true},"discovers":[{"component":"a","as":"PEERS"}]}}}`
+	cfg, err := LoadFromBytes([]byte(raw))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error discovering a non-group component, got nil")
+	}
+}
+
+func TestFleetManifest_ComponentEntitlementWarnings(t *testing.T) {
+	// An unknown key on a component-level entitlement should surface as a warning.
+	raw := `{"appId":"sh.wendy.app","components":{"cam":{"context":"cam","target":{"group":"g"},` +
+		`"entitlements":[{"type":"gpu","bogus":true}]}}}`
+	warnings := ValidateJSON([]byte(raw))
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, `components["cam"].entitlement`) && strings.Contains(w, "bogus") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a component entitlement warning about 'bogus', got %v", warnings)
+	}
+}
+
+func TestSchemaJSON_HasComponents(t *testing.T) {
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if _, ok := props["components"]; !ok {
+		t.Error("schema missing top-level 'components' property")
+	}
+	defs, _ := schema["$defs"].(map[string]any)
+	for _, def := range []string{"component", "componentTarget", "componentExpose", "discoverRef"} {
+		if _, ok := defs[def]; !ok {
+			t.Errorf("schema missing $defs.%s", def)
+		}
+	}
+}

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -78,9 +78,69 @@
       "type": "object",
       "description": "Per-service build and runtime configuration for a multi-service app.",
       "additionalProperties": { "$ref": "#/$defs/service" }
+    },
+    "components": {
+      "type": "object",
+      "description": "Fleet manifest: a map of placed components, each fanned out to a device group (edge tier) or run once centrally (central tier). When set, the single-app top-level fields (run, services, entitlements, readiness, hooks, files, python, xcode, brewfile, isolation, resources) must not also be set — they move into each component.",
+      "additionalProperties": { "$ref": "#/$defs/component" }
     }
   },
   "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["context", "target"],
+      "description": "A single placed component of a fleet app.",
+      "properties": {
+        "context": { "type": "string", "minLength": 1, "description": "Build context directory relative to wendy.json." },
+        "target": { "$ref": "#/$defs/componentTarget" },
+        "expose": { "$ref": "#/$defs/componentExpose" },
+        "discovers": {
+          "type": "array",
+          "description": "Other components whose live endpoints are injected into this component.",
+          "items": { "$ref": "#/$defs/discoverRef" }
+        },
+        "entitlements": { "type": "array", "items": { "$ref": "#/$defs/entitlement" } },
+        "readiness": { "$ref": "#/$defs/readiness" },
+        "hooks": { "$ref": "#/$defs/hooks" },
+        "frameworks": { "$ref": "#/$defs/frameworks" },
+        "resources": { "$ref": "#/$defs/resourceLimits" }
+      }
+    },
+    "componentTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Where a component runs. Set exactly one of \"group\" or \"central\".",
+      "properties": {
+        "group": { "type": "string", "minLength": 1, "description": "Fan the component out to every device in this named device group (edge tier)." },
+        "central": { "type": "boolean", "description": "Run the component once (central tier) — on an edge device, a separate host, or the cloud." }
+      },
+      "oneOf": [
+        { "required": ["group"], "not": { "required": ["central"] } },
+        { "required": ["central"], "not": { "required": ["group"] } }
+      ]
+    },
+    "componentExpose": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["port"],
+      "description": "The network endpoint this component serves, advertised for cross-device discovery.",
+      "properties": {
+        "name": { "type": "string", "description": "Optional endpoint name." },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "Port the component listens on." },
+        "path": { "type": "string", "pattern": "^/", "description": "Optional URL path the platform folds into the advertised endpoint URL (e.g. \"/stream\")." }
+      }
+    },
+    "discoverRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component", "as"],
+      "description": "Inject another (group/edge) component's live endpoints into this component.",
+      "properties": {
+        "component": { "type": "string", "minLength": 1, "description": "Name of the group component to discover." },
+        "as": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "description": "Environment variable to receive the JSON peer snapshot. WENDY_DISCOVERY_URL (live API) is auto-injected and reserved." }
+      }
+    },
     "entitlement": {
       "type": "object",
       "required": ["type"],


### PR DESCRIPTION
## What

**Phase 1 of fleet apps ([WDY-1755](https://linear.app/wendylabsinc/issue/WDY-1755))** — the placement/topology manifest **schema only**. No runtime behavior yet; this is the parsing + validation foundation everything else builds on.

A `wendy.json` with a top-level `components` map is now a **fleet manifest**: each component is built from its own context and placed independently — fanned out to a device **group** (edge tier) or run once **centrally**.

```jsonc
"components": {
  "camera":    { "context": "camera",    "target": { "group": "cameras" }, "expose": { "port": 8000, "path": "/stream" } },
  "dashboard": { "context": "dashboard", "target": { "central": true },    "discovers": [ { "component": "camera", "as": "WENDY_FLEET_PEERS" } ] }
}
```

### New schema surface (small — everything else reuses existing `AppConfig` fields)
- `components` — map of placed components (presence ⇒ fleet mode)
- `target` — `{ group }` | `{ central }`, exactly one
- `expose` — `{ name, port, path }`, the endpoint a component serves (named `expose`, **not** `service`, to avoid collision with the multi-container `services` map)
- `discovers` — `[{ component, as }]`, inject a group component's live endpoints into another component under env var `as`; `WENDY_DISCOVERY_URL` is reserved + auto-injected

### Changes
- `appconfig.go`: `ComponentConfig`/`ComponentTarget`/`ComponentExpose`/`DiscoverRef` + `AppConfig.Components` + `IsFleet()`. `Validate()` enforces mutual exclusivity with single-app fields, exactly-one target, expose ranges, and `discovers` wiring (must reference a declared **group** component). `ValidateJSON` warns on component-level entitlement/frameworks issues.
- `wendy.schema.json`: `component`/`componentTarget`/`componentExpose`/`discoverRef` defs.
- `fleet_test.go`: the [`camera-fleet` template](https://github.com/wendylabsinc/templates/pull/59) manifest as the canonical valid fixture + rejection cases.

**No proto change** — rides the existing `app_config` bytes, like `startOnBoot`.

## Test
`go test ./internal/shared/appconfig/` — green; `vet` + `gofmt` clean.

## Not in this PR (later phases)
Device groups, fan-out deploy (`wendy fleet run`), endpoint advertise/discovery, injection, transport/mTLS — see WDY-1755. The grouping + fan-out substrate is owned by the sibling issue **WDY-1757** (`wendy fleet apps`/`fleet run`).

Relates to WDY-1755, WDY-1757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)