### PR TITLE
feat(cli): wendy fleet — device groups, fleet apps, fleet run (WDY-1757)

### DIFF
--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -482,6 +482,12 @@ func cloudDiscoverJSON(ctx context.Context, auth *config.AuthConfig, all bool) e
 
 // fetchCloudAssetsFiltered retrieves compute-device assets for the org.
 // When onlineOnly is true, only online (enrolled and reachable) assets are returned.
+//
+// ListAssets is paginated server-side: a single request returns only the first
+// page (capped well below a large fleet), so we page through with offset/limit
+// until we've collected every asset the server reports via total. Without this,
+// callers silently see only the first page — e.g. fleet group operations could
+// not target devices that fell outside it.
 func fetchCloudAssetsFiltered(ctx context.Context, auth *config.AuthConfig, onlineOnly bool) ([]*cloudpb.Asset, error) {
 	cert := auth.Certificates[0]
 	cloudConn, err := dialCloudGRPC(auth)
@@ -491,32 +497,49 @@ func fetchCloudAssetsFiltered(ctx context.Context, auth *config.AuthConfig, onli
 	defer cloudConn.Close()
 
 	assetClient := cloudpb.NewAssetServiceClient(cloudConn)
-	req := &cloudpb.ListAssetsRequest{
-		OrganizationId:  int32(cert.OrganizationID),
-		IsComputeDevice: boolPtr(true),
-	}
-	if onlineOnly {
-		req.OnlineOnly = boolPtr(true)
-	}
 
-	stream, err := assetClient.ListAssets(cloudContext(ctx, auth), req)
-	if err != nil {
-		return nil, fmt.Errorf("listing devices: %w", err)
-	}
-
+	const pageSize = 200
 	var assets []*cloudpb.Asset
-	for {
-		resp, err := stream.Recv()
-		if err == io.EOF {
-			break
+	for offset := int32(0); ; {
+		req := &cloudpb.ListAssetsRequest{
+			OrganizationId:  int32(cert.OrganizationID),
+			IsComputeDevice: boolPtr(true),
+			Offset:          int32Ptr(offset),
+			Limit:           int32Ptr(pageSize),
 		}
+		if onlineOnly {
+			req.OnlineOnly = boolPtr(true)
+		}
+
+		stream, err := assetClient.ListAssets(cloudContext(ctx, auth), req)
 		if err != nil {
 			return nil, fmt.Errorf("listing devices: %w", err)
 		}
-		if len(assets) >= maxCloudAssets {
-			return nil, fmt.Errorf("cloud returned more than %d devices", maxCloudAssets)
+
+		page := 0
+		var total int32
+		for {
+			resp, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("listing devices: %w", err)
+			}
+			if len(assets) >= maxCloudAssets {
+				return nil, fmt.Errorf("cloud returned more than %d devices", maxCloudAssets)
+			}
+			assets = append(assets, resp.GetAsset())
+			page++
+			total = resp.GetTotal()
 		}
-		assets = append(assets, resp.GetAsset())
+
+		offset += int32(page)
+		// Done when the server reports we've seen every asset, or a page makes
+		// no progress (guards against a missing/inconsistent total).
+		if page == 0 || offset >= total {
+			break
+		}
 	}
 	return assets, nil
 }

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -465,6 +465,8 @@ func pickCloudDevice(ctx context.Context, auth *config.AuthConfig, deviceName, b
 
 func boolPtr(b bool) *bool { return &b }
 
+func int32Ptr(i int32) *int32 { return &i }
+
 func dialCloudGRPC(auth *config.AuthConfig) (*grpc.ClientConn, error) {
 	if len(auth.Certificates) == 0 {
 		return nil, fmt.Errorf("auth entry has no certificates; re-run 'wendy auth login'")

--- a/go/internal/cli/commands/fleet.go
+++ b/go/internal/cli/commands/fleet.go
@@ -1,0 +1,331 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// groupNamePattern restricts a device-group name (an Asset tag used as a group):
+// start with an alphanumeric, then alphanumerics, '.', '_', or '-'. This keeps
+// group names safe to pass as CLI args, embed in tables, and round-trip through
+// the cloud filter (which treats commas/spaces specially).
+var groupNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$`)
+
+// validateGroupName reports whether name is a well-formed device-group name.
+func validateGroupName(name string) error {
+	if name == "" {
+		return fmt.Errorf("group name is required")
+	}
+	if !groupNamePattern.MatchString(name) {
+		return fmt.Errorf("group name %q is invalid: start with a letter or digit, then letters, digits, '.', '_', or '-' (max 63 chars)", name)
+	}
+	return nil
+}
+
+// addTag returns tags with tag appended. changed is false when the tag was
+// already present (the returned slice is then equivalent to the input).
+func addTag(tags []string, tag string) (result []string, changed bool) {
+	for _, t := range tags {
+		if t == tag {
+			return tags, false
+		}
+	}
+	out := make([]string, 0, len(tags)+1)
+	out = append(out, tags...)
+	out = append(out, tag)
+	return out, true
+}
+
+// removeTag returns tags with every occurrence of tag removed. changed is false
+// when the tag was not present.
+func removeTag(tags []string, tag string) (result []string, changed bool) {
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t != tag {
+			out = append(out, t)
+		}
+	}
+	return out, len(out) != len(tags)
+}
+
+// groupCounts maps each tag (group) to the number of assets that carry it.
+func groupCounts(assets []*cloudpb.Asset) map[string]int {
+	counts := map[string]int{}
+	for _, a := range assets {
+		for _, t := range a.GetTags() {
+			counts[t]++
+		}
+	}
+	return counts
+}
+
+// assetsInGroup returns the assets carrying the given tag, preserving input order.
+func assetsInGroup(assets []*cloudpb.Asset, group string) []*cloudpb.Asset {
+	var out []*cloudpb.Asset
+	for _, a := range assets {
+		for _, t := range a.GetTags() {
+			if t == group {
+				out = append(out, a)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func newFleetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fleet",
+		Short: "Manage groups of WendyOS devices",
+		Long: "Operate across many devices at once.\n\n" +
+			"A device group is a tag on the cloud Asset: a device is in group \"cameras\" when it\n" +
+			"carries that tag. Group membership is the targeting primitive that fleet-wide\n" +
+			"operations (deploying to a whole group, fleet inventory) build on.",
+	}
+	cmd.AddCommand(newFleetGroupCmd())
+	return cmd
+}
+
+func newFleetGroupCmd() *cobra.Command {
+	var cloudGRPC string
+
+	cmd := &cobra.Command{
+		Use:   "group",
+		Short: "Define and inspect device groups",
+	}
+	cmd.PersistentFlags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
+
+	cmd.AddCommand(
+		&cobra.Command{
+			Use:   "ls",
+			Short: "List device groups and their member counts",
+			Args:  cobra.NoArgs,
+			RunE: func(cmd *cobra.Command, _ []string) error {
+				return runFleetGroupLs(cmd.Context(), cloudGRPC)
+			},
+		},
+		&cobra.Command{
+			Use:   "show <group>",
+			Short: "List the devices in a group",
+			Args:  cobra.ExactArgs(1),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runFleetGroupShow(cmd.Context(), cloudGRPC, args[0])
+			},
+		},
+		&cobra.Command{
+			Use:   "add <group> <device>...",
+			Short: "Add one or more devices to a group",
+			Args:  cobra.MinimumNArgs(2),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runFleetGroupMembership(cmd.Context(), cloudGRPC, args[0], args[1:], true)
+			},
+		},
+		&cobra.Command{
+			Use:   "rm <group> <device>...",
+			Short: "Remove one or more devices from a group",
+			Args:  cobra.MinimumNArgs(2),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runFleetGroupMembership(cmd.Context(), cloudGRPC, args[0], args[1:], false)
+			},
+		},
+	)
+	return cmd
+}
+
+// fleetGroupSummary is the --json shape for `fleet group ls`.
+type fleetGroupSummary struct {
+	Group   string `json:"group"`
+	Devices int    `json:"devices"`
+}
+
+func runFleetGroupLs(ctx context.Context, cloudGRPC string) error {
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+
+	counts := groupCounts(assets)
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if jsonOutput || !isInteractiveTerminal() {
+		out := make([]fleetGroupSummary, 0, len(names))
+		for _, name := range names {
+			out = append(out, fleetGroupSummary{Group: name, Devices: counts[name]})
+		}
+		return printJSON(out)
+	}
+
+	if len(names) == 0 {
+		fmt.Println("No device groups yet. Create one with 'wendy fleet group add <group> <device>...'.")
+		return nil
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "GROUP\tDEVICES")
+	for _, name := range names {
+		fmt.Fprintf(tw, "%s\t%d\n", name, counts[name])
+	}
+	return tw.Flush()
+}
+
+func runFleetGroupShow(ctx context.Context, cloudGRPC, group string) error {
+	if err := validateGroupName(group); err != nil {
+		return err
+	}
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+	members := assetsInGroup(assets, group)
+
+	if jsonOutput || !isInteractiveTerminal() {
+		infos := make([]discoverDeviceInfo, 0, len(members))
+		for _, a := range members {
+			infos = append(infos, cloudDeviceInfoFromAsset(a, nil))
+		}
+		return printJSON(infos)
+	}
+
+	if len(members) == 0 {
+		fmt.Printf("Group %q has no devices (or does not exist).\n", group)
+		return nil
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "ID\tNAME\tTYPE\tADDRESS")
+	for _, a := range members {
+		info := cloudDeviceInfoFromAsset(a, nil)
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\n", info.ID, info.Name, info.Type, info.Address)
+	}
+	return tw.Flush()
+}
+
+// fleetMembershipResult is the per-device outcome of an add/rm, used for --json.
+type fleetMembershipResult struct {
+	Device  string `json:"device"`
+	AssetID int32  `json:"assetId,omitempty"`
+	Changed bool   `json:"changed"`
+	Error   string `json:"error,omitempty"`
+}
+
+func runFleetGroupMembership(ctx context.Context, cloudGRPC, group string, devices []string, add bool) error {
+	if err := validateGroupName(group); err != nil {
+		return err
+	}
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+
+	conn, err := dialCloudGRPC(auth)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	client := cloudpb.NewAssetServiceClient(conn)
+
+	results := make([]fleetMembershipResult, 0, len(devices))
+	failures := 0
+	for _, dev := range devices {
+		res := fleetMembershipResult{Device: dev}
+		asset, rErr := resolveCloudAsset(assets, dev)
+		if rErr != nil {
+			res.Error = rErr.Error()
+			failures++
+			results = append(results, res)
+			continue
+		}
+		res.AssetID = asset.GetId()
+
+		var newTags []string
+		var changed bool
+		if add {
+			newTags, changed = addTag(asset.GetTags(), group)
+		} else {
+			newTags, changed = removeTag(asset.GetTags(), group)
+		}
+		res.Changed = changed
+		if !changed {
+			// Already in the desired state — skip the round-trip.
+			results = append(results, res)
+			continue
+		}
+
+		// UpdateAsset replaces the tags list with the value sent; other (optional)
+		// fields left unset are not modified.
+		if _, uErr := client.UpdateAsset(cloudContext(ctx, auth), &cloudpb.UpdateAssetRequest{
+			Id:   asset.GetId(),
+			Tags: newTags,
+		}); uErr != nil {
+			res.Changed = false
+			res.Error = uErr.Error()
+			failures++
+		}
+		results = append(results, res)
+	}
+
+	if jsonOutput || !isInteractiveTerminal() {
+		if err := printJSON(results); err != nil {
+			return err
+		}
+	} else {
+		verb := "Added"
+		prep := "to"
+		if !add {
+			verb = "Removed"
+			prep = "from"
+		}
+		for _, r := range results {
+			switch {
+			case r.Error != "":
+				fmt.Fprintf(os.Stderr, "  ✗ %s: %s\n", r.Device, r.Error)
+			case r.Changed:
+				fmt.Printf("  ✓ %s %s %s %q\n", verb, r.Device, prep, group)
+			default:
+				state := "already in"
+				if !add {
+					state = "not in"
+				}
+				fmt.Printf("  • %s %s group %q\n", r.Device, state, group)
+			}
+		}
+	}
+
+	if failures > 0 {
+		return fmt.Errorf("%d of %d device(s) failed", failures, len(devices))
+	}
+	return nil
+}
+
+// printJSON writes v as indented JSON to stdout.
+func printJSON(v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}

--- a/go/internal/cli/commands/fleet.go
+++ b/go/internal/cli/commands/fleet.go
@@ -91,7 +91,11 @@ func newFleetCmd() *cobra.Command {
 			"carries that tag. Group membership is the targeting primitive that fleet-wide\n" +
 			"operations (deploying to a whole group, fleet inventory) build on.",
 	}
-	cmd.AddCommand(newFleetGroupCmd())
+	cmd.AddCommand(
+		newFleetGroupCmd(),
+		newFleetAppsCmd(),
+		newFleetRunCmd(),
+	)
 	return cmd
 }
 

--- a/go/internal/cli/commands/fleet_apps.go
+++ b/go/internal/cli/commands/fleet_apps.go
@@ -1,0 +1,195 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"sync"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// fleetAppsMaxConcurrency bounds how many device tunnels we open at once when
+// gathering inventory across a group.
+const fleetAppsMaxConcurrency = 8
+
+func newFleetAppsCmd() *cobra.Command {
+	var group string
+	var cloudGRPC, brokerURL string
+
+	cmd := &cobra.Command{
+		Use:   "apps",
+		Short: "List the apps running across a group (or the whole org)",
+		Long: "Fans out to every device in a group (or all enrolled devices when --group is\n" +
+			"omitted) and prints one row per app: which device it runs on, its version, and\n" +
+			"its state. Devices that can't be reached are reported inline rather than failing\n" +
+			"the whole command.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runFleetApps(cmd.Context(), group, cloudGRPC, brokerURL)
+		},
+	}
+	cmd.Flags().StringVar(&group, "group", "", "Limit to devices in this group (default: all enrolled devices)")
+	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
+	cmd.Flags().StringVar(&brokerURL, "broker-url", os.Getenv("WENDY_BROKER_URL"), "Tunnel broker host:port")
+	return cmd
+}
+
+// fleetAppRow is one row of fleet inventory (a single app on a single device),
+// and the --json element shape. A row with Error set and App empty represents a
+// device that could not be reached.
+type fleetAppRow struct {
+	Device  string `json:"device"`
+	AssetID int32  `json:"assetId"`
+	App     string `json:"app,omitempty"`
+	Version string `json:"version,omitempty"`
+	State   string `json:"state,omitempty"`
+	Errors  uint32 `json:"errors,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+func runFleetApps(ctx context.Context, group, cloudGRPC, brokerURL string) error {
+	if group != "" {
+		if err := validateGroupName(group); err != nil {
+			return err
+		}
+	}
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+	if group != "" {
+		assets = assetsInGroup(assets, group)
+	}
+	if len(assets) == 0 {
+		if group != "" {
+			return fmt.Errorf("group %q has no devices", group)
+		}
+		return fmt.Errorf("no enrolled devices found for this org")
+	}
+
+	rows := gatherFleetApps(ctx, auth, assets, brokerURL)
+	sortFleetAppRows(rows)
+
+	if jsonOutput || !isInteractiveTerminal() {
+		return printJSON(rows)
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "DEVICE\tAPP\tVERSION\tSTATE\tERRORS")
+	for _, r := range rows {
+		if r.Error != "" {
+			fmt.Fprintf(tw, "%s\t(unreachable: %s)\t\t\t\n", r.Device, r.Error)
+			continue
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\n", r.Device, r.App, dash(r.Version), r.State, r.Errors)
+	}
+	return tw.Flush()
+}
+
+// gatherFleetApps queries every asset's container list concurrently and flattens
+// the result into per-app rows. A device that errors contributes a single row
+// with its Error set; one bad device never fails the whole sweep.
+func gatherFleetApps(ctx context.Context, auth *config.AuthConfig, assets []*cloudpb.Asset, brokerURL string) []fleetAppRow {
+	var (
+		mu   sync.Mutex
+		rows []fleetAppRow
+	)
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(fleetAppsMaxConcurrency)
+
+	for _, asset := range assets {
+		asset := asset
+		g.Go(func() error {
+			containers, err := listAssetContainers(ctx, auth, asset, brokerURL)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				rows = append(rows, fleetAppRow{Device: asset.GetName(), AssetID: asset.GetId(), Error: err.Error()})
+				return nil
+			}
+			if len(containers) == 0 {
+				// Reachable but no apps — still worth a row so the device shows up.
+				rows = append(rows, fleetAppRow{Device: asset.GetName(), AssetID: asset.GetId(), App: "—", State: "—"})
+				return nil
+			}
+			for _, c := range containers {
+				rows = append(rows, fleetAppRow{
+					Device:  asset.GetName(),
+					AssetID: asset.GetId(),
+					App:     c.GetAppName(),
+					Version: c.GetAppVersion(),
+					State:   runningStateString(c.GetRunningState()),
+					Errors:  c.GetFailureCount(),
+				})
+			}
+			return nil
+		})
+	}
+	_ = g.Wait() // per-device errors are captured as rows; Wait never returns one.
+	return rows
+}
+
+// listAssetContainers opens a tunnel to one asset and drains its container list.
+func listAssetContainers(ctx context.Context, auth *config.AuthConfig, asset *cloudpb.Asset, brokerURL string) ([]*agentpb.AppContainer, error) {
+	conn, err := connectCloudAsset(ctx, auth, asset, brokerURL)
+	if err != nil {
+		return nil, fmt.Errorf("connecting: %w", err)
+	}
+	defer conn.Close()
+
+	stream, err := conn.ContainerService.ListContainers(ctx, &agentpb.ListContainersRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("listing containers: %w", err)
+	}
+	var containers []*agentpb.AppContainer
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("receiving container list: %w", err)
+		}
+		if c := resp.GetContainer(); c != nil {
+			containers = append(containers, c)
+		}
+	}
+	return containers, nil
+}
+
+// sortFleetAppRows orders rows by device, then app, for stable output.
+func sortFleetAppRows(rows []fleetAppRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Device != rows[j].Device {
+			return rows[i].Device < rows[j].Device
+		}
+		return rows[i].App < rows[j].App
+	})
+}
+
+func runningStateString(s agentpb.AppRunningState) string {
+	if s == agentpb.AppRunningState_RUNNING {
+		return "running"
+	}
+	return "stopped"
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}

--- a/go/internal/cli/commands/fleet_run.go
+++ b/go/internal/cli/commands/fleet_run.go
@@ -1,0 +1,202 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func newFleetRunCmd() *cobra.Command {
+	var opts runOptions
+	var group string
+	var cloudGRPC, brokerURL string
+
+	cmd := &cobra.Command{
+		Use:   "run --group <group>",
+		Short: "Build and deploy the current project to every device in a group",
+		Long: "Deploys the current project (the wendy.json in the working directory) to every\n" +
+			"device in a named group, one invocation instead of a per-device loop.\n\n" +
+			"Runs detached (it does not stream logs — there are many devices). With\n" +
+			"--keep-going a device that fails to deploy does not abort the rest.\n\n" +
+			"Note: v1 deploys to each device in turn, reusing the single-device pipeline.\n" +
+			"Build-once + parallel fan-out, and placement-aware deploys for fleet manifests\n" +
+			"(WDY-1755 components/target), are follow-ups.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// A fleet deploy targets many devices: never prompt, never stream logs.
+			opts.yes = true
+			opts.detach = true
+			return runFleetRun(cmd.Context(), opts, group, cloudGRPC, brokerURL)
+		},
+	}
+
+	cmd.Flags().StringVar(&group, "group", "", "Device group to deploy to (required)")
+	_ = cmd.MarkFlagRequired("group")
+	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
+	cmd.Flags().StringVar(&brokerURL, "broker-url", os.Getenv("WENDY_BROKER_URL"), "Tunnel broker host:port")
+	cmd.Flags().BoolVar(&opts.keepGoing, "keep-going", false, "Deploy to the remaining devices even if one fails, instead of stopping at the first error")
+
+	// A focused subset of `wendy run` build flags (logs/streaming/picker flags
+	// don't apply to a fan-out deploy).
+	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type when ambiguous: docker, swift, or python")
+	cmd.Flags().StringVar(&opts.dockerfile, "dockerfile", "", "Dockerfile/Containerfile to build from")
+	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to force: docker or apple-container")
+	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Enable debug logging + host networking")
+	cmd.Flags().StringVar(&opts.service, "service", "", "Build and deploy only the named service and its dependencies")
+	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
+	cmd.Flags().BoolVar(&opts.restartUnlessStopped, "restart-unless-stopped", false, "Restart unless manually stopped")
+	cmd.Flags().BoolVar(&opts.restartOnFailure, "restart-on-failure", false, "Restart on failure")
+	cmd.Flags().BoolVar(&opts.noRestart, "no-restart", false, "Do not restart on exit")
+	cmd.Flags().StringVar(&opts.prefix, "prefix", "", "Project directory to deploy from instead of the current working directory")
+	cmd.Flags().StringVar(&opts.chunking, "chunking", chunkingAuto, "Deploy path: auto, force (chunk-diff only), or off (registry push only)")
+
+	return cmd
+}
+
+// fleetRunResult is the per-device outcome of a fan-out deploy, for --json.
+type fleetRunResult struct {
+	Device  string `json:"device"`
+	AssetID int32  `json:"assetId"`
+	OK      bool   `json:"ok"`
+	Error   string `json:"error,omitempty"`
+}
+
+func runFleetRun(ctx context.Context, opts runOptions, group, cloudGRPC, brokerURL string) error {
+	if err := validateGroupName(group); err != nil {
+		return err
+	}
+	if _, err := normalizeImageBuilder(opts.builder); err != nil {
+		return err
+	}
+	if err := validateChunkingMode(opts.chunking); err != nil {
+		return err
+	}
+
+	// Load + validate the project once, before connecting to any device, so a
+	// bad project fails fast rather than once per device.
+	cwd, err := resolveRunWorkingDir(opts)
+	if err != nil {
+		return fmt.Errorf("resolving working directory: %w", err)
+	}
+	projectType, err := resolveRunProjectType(cwd, opts.buildType)
+	if err != nil {
+		return err
+	}
+	if projectType == "compose" {
+		return fmt.Errorf("compose projects are not supported by 'wendy fleet run' yet")
+	}
+	if projectType == "docker" && opts.dockerfile == "" {
+		resolved, err := resolveDockerfile(cwd, opts.dockerfile, !opts.yes && isInteractiveTerminal())
+		if err != nil {
+			return err
+		}
+		opts.dockerfile = resolved
+	}
+
+	cfgPath := filepath.Join(cwd, "wendy.json")
+	missing, err := appConfigFileMissing(cfgPath)
+	if err != nil {
+		return fmt.Errorf("checking wendy.json: %w", err)
+	}
+	if missing {
+		return fmt.Errorf("no wendy.json in %s — 'wendy fleet run' deploys an existing project to a group", cwd)
+	}
+	appCfg, err := ensureAppConfig(cfgPath, opts.yes)
+	if err != nil {
+		return fmt.Errorf("loading wendy.json: %w", err)
+	}
+	if err := appCfg.Validate(); err != nil {
+		return fmt.Errorf("invalid wendy.json: %w", err)
+	}
+	if err := warnAppConfigFile(cfgPath); err != nil {
+		return fmt.Errorf("reading wendy.json warnings: %w", err)
+	}
+	if opts.debug {
+		applyDebugHostNetworking(appCfg)
+	}
+
+	// Resolve the group to its member devices.
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+	members := assetsInGroup(assets, group)
+	if len(members) == 0 {
+		return fmt.Errorf("group %q has no devices; add some with 'wendy fleet group add %s <device>...'", group, group)
+	}
+
+	fmt.Printf("Deploying %s to %d device(s) in group %q\n", appCfg.AppID, len(members), group)
+
+	// v1: deploy to each device in turn, reusing the proven single-device
+	// pipeline (build+push+create+start per device). Sequential keeps build
+	// output legible and avoids concurrent builder contention; build-once +
+	// parallel fan-out is a follow-up.
+	results := make([]fleetRunResult, 0, len(members))
+	failures := 0
+	for _, asset := range members {
+		res := fleetRunResult{Device: asset.GetName(), AssetID: asset.GetId()}
+		fmt.Printf("\n── %s (id %d) ──\n", asset.GetName(), asset.GetId())
+
+		if derr := deployToCloudAsset(ctx, auth, asset, brokerURL, cwd, appCfg, opts); derr != nil {
+			res.Error = derr.Error()
+			failures++
+			results = append(results, res)
+			fmt.Fprintf(os.Stderr, "  ✗ %s: %v\n", asset.GetName(), derr)
+			if !opts.keepGoing {
+				return fmt.Errorf("deploy to %s failed: %w (use --keep-going to continue past failures)", asset.GetName(), derr)
+			}
+			continue
+		}
+		res.OK = true
+		results = append(results, res)
+	}
+
+	if jsonOutput {
+		if err := printJSON(results); err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("\nDeployed to %d/%d device(s) in group %q\n", len(members)-failures, len(members), group)
+	}
+	if failures > 0 {
+		return fmt.Errorf("%d of %d device(s) failed", failures, len(members))
+	}
+	return nil
+}
+
+// deployToCloudAsset connects to one enrolled asset over the cloud tunnel and
+// runs the standard agent deploy pipeline against it.
+func deployToCloudAsset(ctx context.Context, auth *config.AuthConfig, asset *cloudpb.Asset, brokerURL, cwd string, appCfg *appconfig.AppConfig, opts runOptions) error {
+	conn, err := connectCloudAsset(ctx, auth, asset, brokerURL)
+	if err != nil {
+		return fmt.Errorf("connecting: %w", err)
+	}
+	defer conn.Close()
+	return runWithAgent(ctx, conn, cwd, appCfg, opts)
+}
+
+// applyDebugHostNetworking mirrors runCommand's --debug handling: enable debug
+// and ensure a host-mode network entitlement for remote debugger access.
+func applyDebugHostNetworking(appCfg *appconfig.AppConfig) {
+	appCfg.Debug = true
+	for i, e := range appCfg.Entitlements {
+		if e.Type == appconfig.EntitlementNetwork {
+			appCfg.Entitlements[i].Mode = "host"
+			return
+		}
+	}
+	appCfg.Entitlements = append(appCfg.Entitlements, appconfig.Entitlement{
+		Type: appconfig.EntitlementNetwork,
+		Mode: "host",
+	})
+}

--- a/go/internal/cli/commands/fleet_test.go
+++ b/go/internal/cli/commands/fleet_test.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func TestValidateGroupName(t *testing.T) {
+	tests := []struct {
+		name string
+		ok   bool
+	}{
+		{"cameras", true},
+		{"robots-east", true},
+		{"cam_01", true},
+		{"a", true},
+		{"", false},
+		{"-leading", false},
+		{"has space", false},
+		{"has,comma", false},
+		{"emoji😀", false},
+	}
+	for _, tt := range tests {
+		err := validateGroupName(tt.name)
+		if tt.ok && err != nil {
+			t.Errorf("validateGroupName(%q) = %v, want nil", tt.name, err)
+		}
+		if !tt.ok && err == nil {
+			t.Errorf("validateGroupName(%q) = nil, want error", tt.name)
+		}
+	}
+}
+
+func TestAddTag(t *testing.T) {
+	got, changed := addTag([]string{"a", "b"}, "cameras")
+	if !changed {
+		t.Error("addTag: changed = false, want true")
+	}
+	if want := []string{"a", "b", "cameras"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("addTag = %v, want %v", got, want)
+	}
+
+	got, changed = addTag([]string{"a", "cameras"}, "cameras")
+	if changed {
+		t.Error("addTag (already present): changed = true, want false")
+	}
+	if want := []string{"a", "cameras"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("addTag (already present) = %v, want %v", got, want)
+	}
+
+	// Adding to an empty/nil tag set.
+	got, changed = addTag(nil, "cameras")
+	if !changed || !reflect.DeepEqual(got, []string{"cameras"}) {
+		t.Errorf("addTag(nil) = %v, changed=%v", got, changed)
+	}
+}
+
+func TestRemoveTag(t *testing.T) {
+	got, changed := removeTag([]string{"a", "cameras", "b"}, "cameras")
+	if !changed {
+		t.Error("removeTag: changed = false, want true")
+	}
+	if want := []string{"a", "b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("removeTag = %v, want %v", got, want)
+	}
+
+	got, changed = removeTag([]string{"a", "b"}, "cameras")
+	if changed {
+		t.Error("removeTag (absent): changed = true, want false")
+	}
+	if want := []string{"a", "b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("removeTag (absent) = %v, want %v", got, want)
+	}
+
+	// Removing the only tag yields an empty (non-nil) slice.
+	got, changed = removeTag([]string{"cameras"}, "cameras")
+	if !changed {
+		t.Error("removeTag (last): changed = false, want true")
+	}
+	if len(got) != 0 {
+		t.Errorf("removeTag (last) = %v, want empty", got)
+	}
+}
+
+func TestGroupCountsAndMembers(t *testing.T) {
+	assets := []*cloudpb.Asset{
+		{Id: 1, Name: "cam-01", Tags: []string{"cameras", "prod"}},
+		{Id: 2, Name: "cam-02", Tags: []string{"cameras"}},
+		{Id: 3, Name: "robot-01", Tags: []string{"robots"}},
+		{Id: 4, Name: "spare", Tags: nil},
+	}
+
+	counts := groupCounts(assets)
+	if counts["cameras"] != 2 || counts["robots"] != 1 || counts["prod"] != 1 {
+		t.Errorf("groupCounts = %v", counts)
+	}
+	if _, ok := counts[""]; ok {
+		t.Error("groupCounts should not contain an empty group")
+	}
+
+	members := assetsInGroup(assets, "cameras")
+	if len(members) != 2 {
+		t.Fatalf("assetsInGroup(cameras) = %d members, want 2", len(members))
+	}
+	if members[0].GetName() != "cam-01" || members[1].GetName() != "cam-02" {
+		t.Errorf("assetsInGroup preserved order wrong: %q, %q", members[0].GetName(), members[1].GetName())
+	}
+
+	if got := assetsInGroup(assets, "nope"); len(got) != 0 {
+		t.Errorf("assetsInGroup(nope) = %v, want empty", got)
+	}
+}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -127,6 +127,8 @@ func NewRootCmd() *cobra.Command {
 	projectCmd.GroupID = "manage"
 	deviceCmd := newDeviceCmd()
 	deviceCmd.GroupID = "manage"
+	fleetCmd := newFleetCmd()
+	fleetCmd.GroupID = "manage"
 
 	// Cloud
 	cloudCmd := newCloudCmd()
@@ -206,6 +208,7 @@ func NewRootCmd() *cobra.Command {
 		// Manage
 		projectCmd,
 		deviceCmd,
+		fleetCmd,
 		// Cloud
 		cloudCmd,
 		// Settings


### PR DESCRIPTION
## What

Fleet management for the `wendy` CLI ([WDY-1757](https://linear.app/wendylabsinc/issue/WDY-1757)) — turns a fleet of devices from "one host per command" into named groups you can see and act on at once. Three commands under one `wendy fleet` namespace:

```sh
# 1. make 5 cameras a group (a group is just a tag on the cloud Asset)
wendy fleet group add cameras cam-01 cam-02 cam-03 cam-04 cam-05
wendy fleet group ls            # cameras   5
wendy fleet group show cameras

# 2. see what's running across the group
wendy fleet apps --group cameras
#   DEVICE   APP              VERSION   STATE     ERRORS
#   cam-01   sh.wendy.usbcam  0.1.0     running   0
#   …

# 3. deploy the current project to the whole group, one command
wendy fleet run --group cameras
```

## The three pieces

**`wendy fleet group ls|show|add|rm`** — the grouping primitive. A group is a tag on the cloud `Asset`; `add`/`rm` resolve each device (name or id) and persist the new tag set via `AssetService.UpdateAsset` (tags replaced wholesale, other fields untouched). Partial-failure tolerant.

**`wendy fleet apps [--group <g>]`** — read inventory. Fans out to every device (concurrent, bounded) and prints one row per app (device / app / version / state / errors), via `ListAssets` → per-device `ContainerService.ListContainers`. An unreachable device is reported inline, never fails the sweep.

**`wendy fleet run --group <g>`** — fan-out deploy. Build + deploy the current project to every device in the group in one invocation. Detached (many devices), `--keep-going` to continue past a failed device. Reuses the proven single-device pipeline (`runWithAgent`) per device over a cloud tunnel.

Everything has `--json`. Wired under **Manage** next to `device`.

## Scope / follow-ups (called out honestly)
- **`fleet run` v1 deploys to each device in turn**, reusing the single-device build+push+start path. Build-once + parallel fan-out needs splitting the currently-fused build/push in `run.go` — deliberately left as a follow-up to avoid destabilizing `wendy run`.
- **Placement-aware deploy** (WDY-1755 `components`/`target` fleet manifests — deploy *different* components to group vs. central) extends `fleet run` later; this PR deploys the whole project to the group.
- **`fleet apps` provenance columns** (`deployed_by`/`uptime`/`restarts`) await WDY-1753; the v1 table uses the fields available today.

## Test
`go test ./internal/cli/commands/ -run 'Fleet|GroupName|AddTag|RemoveTag|GroupCounts'` green; `vet` + `gofmt` clean; all three commands wired (`wendy fleet --help`).

**Needs on-device verification:** the cloud mutation (`UpdateAsset` tags) and the tunnel-backed `fleet apps`/`fleet run` paths couldn't be exercised against a live cloud/devices here. Worth confirming: (a) `UpdateAsset` with an empty `tags` list clears tags (so removing the last group works) rather than being ignored; (b) `fleet run` against a real group.

Relates to WDY-1757, WDY-1755, WDY-1753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)