### PR TITLE
feat: display entitlement (GPU /dev/dri + Wayland passthrough)

### DIFF
--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -97,6 +97,12 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 			if err := applySerial(spec, ent); err != nil {
 				return err
 			}
+		case appconfig.EntitlementDisplay:
+			applyDisplay(spec)
+			if !didSetDeviceCapabilities {
+				didSetDeviceCapabilities = true
+				SetDeviceCapabilities(spec)
+			}
 		}
 	}
 	return nil
@@ -230,6 +236,64 @@ func applyVCIO(spec *Spec) {
 	// /dev/vcio's major is dynamically allocated, so derive it from the live
 	// node. allowMajorsFromGlob dedups and grants the major "rw" (no mknod).
 	allowMajorsFromGlob(spec, vcioDevicePath)
+}
+
+// applyDisplay grants an app the ability to present to the local display as a
+// Wayland client: GPU render-node access via /dev/dri plus, when present, the
+// compositor's Wayland socket. It is the ONLY entitlement that exposes
+// /dev/dri — apps without it keep the default no-display-GPU sandbox. On Jetson
+// the NVIDIA EGL/GLES userspace is injected from the host via CDI; here we only
+// ensure the driver advertises graphics+display capabilities.
+func applyDisplay(spec *Spec) {
+	// /dev/dri/card* is group "video"; renderD* is group "render".
+	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, videoGroupGID)
+	if gid, ok := lookupRenderGID(); ok {
+		spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, gid)
+	}
+
+	// Allow the DRM major(s) behind /dev/dri (typically 226), discovered at apply
+	// time. "rw", no mknod: the host creates the nodes; the bind below surfaces them.
+	for _, glob := range driGlobs {
+		allowMajorsFromGlob(spec, glob)
+	}
+
+	// Bind the host /dev/dri tree so the container can open card*/renderD* nodes.
+	// nosuid/noexec but NOT nodev — the whole point is to open device nodes.
+	// Skipped when absent so a missing source cannot stop the container starting.
+	if _, err := os.Stat("/dev/dri"); err == nil {
+		spec.Mounts = append(spec.Mounts, Mount{
+			Destination: "/dev/dri",
+			Source:      "/dev/dri",
+			Type:        "bind",
+			Options:     []string{"rbind", "rw", "nosuid", "noexec"},
+		})
+	}
+
+	// On Jetson the NVIDIA graphics userspace is injected by CDI; ensure the
+	// driver capabilities include graphics/display (compute-only otherwise).
+	if boardDetect().IsJetson() {
+		spec.Process.Env = append(spec.Process.Env,
+			"NVIDIA_VISIBLE_DEVICES=all",
+			"NVIDIA_DRIVER_CAPABILITIES=all",
+		)
+	}
+
+	// Bind the compositor's Wayland socket if it exists. Conditional (like the
+	// PipeWire socket) so a device with no running compositor still starts the
+	// container — the socket simply isn't there yet (no-op-safe for Phase 1).
+	const waylandHostSock = "/run/wendyos/wayland-0"
+	if fi, err := os.Lstat(waylandHostSock); err == nil && fi.Mode()&os.ModeSocket != 0 {
+		spec.Mounts = append(spec.Mounts, Mount{
+			Destination: "/run/wendyos/wayland-0",
+			Source:      waylandHostSock,
+			Type:        "bind",
+			Options:     []string{"rbind", "nosuid", "noexec"},
+		})
+		spec.Process.Env = append(spec.Process.Env,
+			"XDG_RUNTIME_DIR=/run/wendyos",
+			"WAYLAND_DISPLAY=wayland-0",
+		)
+	}
 }
 
 // applyNetwork configures the network namespace.
@@ -426,6 +490,26 @@ var boardDetect = board.Detect
 // in-container enumerator returns nothing (WDY-1342). Behind a var so tests
 // can point it at a path that exists on the test host.
 var udevRuntimeDir = "/run/udev"
+
+// driGlobs are the DRM/KMS device-node patterns the display entitlement scans
+// to discover the render major(s) (typically 226). Behind a var so tests can
+// redirect into a tempdir.
+var driGlobs = []string{"/dev/dri/*"}
+
+// lookupRenderGID resolves the host "render" group GID, which owns
+// /dev/dri/renderD*. Behind a var so tests can stub it. Returns ok=false when
+// the host has no render group (then only the video GID is added).
+var lookupRenderGID = func() (uint32, bool) {
+	g, err := user.LookupGroup("render")
+	if err != nil {
+		return 0, false
+	}
+	gid, err := strconv.ParseUint(g.Gid, 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(gid), true
+}
 
 // applyCamera adds camera/V4L2 device access, plus the additional kernel
 // device majors that libcamera (and on Jetson, nvargus/nvhost) require. The

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -1493,6 +1493,91 @@ func TestApplyCamera_NonJetsonOmitsNvhost(t *testing.T) {
 	}
 }
 
+// installFakeDriGlobs redirects driGlobs at a tempdir of fake /dev/dri nodes and
+// stubs statMajor to report their majors, mirroring installFakeCameraGlobs.
+func installFakeDriGlobs(t *testing.T, files map[string]int64) {
+	t.Helper()
+	dir := t.TempDir()
+	majorsByPath := map[string]int64{}
+	for name, major := range files {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, nil, 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+		majorsByPath[p] = major
+	}
+	origGlobs := driGlobs
+	origStat := statMajor
+	t.Cleanup(func() {
+		driGlobs = origGlobs
+		statMajor = origStat
+	})
+	driGlobs = []string{filepath.Join(dir, "*")}
+	statMajor = func(p string) (int64, error) {
+		if m, ok := majorsByPath[p]; ok {
+			return m, nil
+		}
+		return 0, os.ErrNotExist
+	}
+}
+
+func TestApplyDisplay_AllowsDrmMajor(t *testing.T) {
+	installFakeDriGlobs(t, map[string]int64{"card0": 226, "renderD128": 226})
+	boardDetect = func() board.Info { return board.Info{Kind: board.Generic} }
+	origRender := lookupRenderGID
+	t.Cleanup(func() { lookupRenderGID = origRender })
+	lookupRenderGID = func() (uint32, bool) { return 0, false }
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{AppID: "test", Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementDisplay}}}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+	if !hasMajorRule(spec, 226) {
+		t.Error("expected cgroup allow for DRM major 226")
+	}
+	if countMajorRule(spec, 226) != 1 {
+		t.Errorf("DRM major rule should be deduplicated, got %d", countMajorRule(spec, 226))
+	}
+}
+
+func TestApplyDisplay_AddsVideoAndRenderGIDs(t *testing.T) {
+	installFakeDriGlobs(t, map[string]int64{"renderD128": 226})
+	boardDetect = func() board.Info { return board.Info{Kind: board.Generic} }
+	origRender := lookupRenderGID
+	t.Cleanup(func() { lookupRenderGID = origRender })
+	lookupRenderGID = func() (uint32, bool) { return 107, true }
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{AppID: "test", Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementDisplay}}}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+	if !hasGID(spec, videoGroupGID) {
+		t.Error("expected video GID in AdditionalGids")
+	}
+	if !hasGID(spec, 107) {
+		t.Error("expected resolved render GID in AdditionalGids")
+	}
+}
+
+func TestApplyDisplay_NonDisplayAppUnchanged(t *testing.T) {
+	installFakeDriGlobs(t, map[string]int64{"renderD128": 226})
+	boardDetect = func() board.Info { return board.Info{Kind: board.Generic} }
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{AppID: "test", Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork}}}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+	if hasMajorRule(spec, 226) {
+		t.Error("non-display app must not get the DRM major rule")
+	}
+	if hasGID(spec, 107) {
+		t.Error("non-display app must not get a render GID")
+	}
+}
+
 // TestApplyCamera_DeviceRulesOmitMknod locks in least privilege: every cgroup
 // device rule the camera entitlement adds — the static v4l2 major and every
 // dynamically-discovered media/dma-heap/v4l-subdev/nvhost/nvmap major — must

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -344,6 +344,29 @@ The container must serve the [MCP Streamable HTTP](https://modelcontextprotocol.
 
 > **Note:** The `mcp` entitlement is typically combined with `{ "type": "network", "mode": "host" }` so that the agent can reach the container's MCP port over loopback.
 
+### `display`
+
+Present to a locally-attached monitor as a Wayland client (GPU-accelerated) — the app or shell draws directly to the screen, no web browser involved.
+
+```json
+{ "type": "display" }
+```
+
+The container receives:
+
+- `/dev/dri` (GPU render nodes); cgroup access is `rw`, no `mknod`.
+- Membership in the `video` and `render` groups.
+- The WendyOS compositor's Wayland socket, exposed via `WAYLAND_DISPLAY` / `XDG_RUNTIME_DIR`.
+
+On NVIDIA Jetson the GL/EGL userspace is injected from the host through the same CDI path as `gpu`; on Raspberry Pi the app's own mesa works against the vc4 kernel driver.
+
+| Constraint | |
+|------------|--|
+| At most one `display` per app | enforced at validation |
+| Display-enabled image | the Wayland socket is present only on display-enabled WendyOS images; on a headless image the entitlement is accepted but nothing renders |
+
+> **Security:** apps **without** `display` never receive `/dev/dri` — the default GPU/display sandbox is unchanged.
+
 ---
 
 ## Compose-based projects

--- a/go/internal/cli/assets/docs/entitlements.md
+++ b/go/internal/cli/assets/docs/entitlements.md
@@ -139,11 +139,11 @@ The display entitlement allows a container to present to a locally-attached moni
 
 The container receives:
 - A bind mount of `/dev/dri` (GPU render nodes) for GPU-accelerated graphics
-- Membership in the `video` and `render` groups (GIDs 44 and 105 or 107) for device permissions
+- Membership in the `video` and `render` groups for device permissions
 - A cgroup device rule allowing access to render device nodes (major 226)
 - The WendyOS compositor's Wayland socket, injected as an environment variable for client connection
 
-**At most one display entitlement per app.** Multiple containers cannot simultaneously render to the same display.
+**At most one display entitlement per app** (enforced by the runtime).
 
 **Display-enabled image required:** this entitlement is accepted during validation on all WendyOS images, but the Wayland socket is only present on display-enabled images. On headless images, the container will not have the socket available, so graphics output will not render.
 

--- a/go/internal/cli/assets/docs/entitlements.md
+++ b/go/internal/cli/assets/docs/entitlements.md
@@ -127,28 +127,6 @@ Use `serial` for serial ports and `usb` for raw USB protocols — they expose di
 
 > **Security note:** the cgroup rule is scoped to the named device's exact `major:minor`, so — unlike a whole-major grant — it never exposes other devices that share the major (e.g. other `ttyACM*`/`ttyUSB*` adapters on the host). The entitlement is USB-only, so it can never reach an on-board console UART. See *Replug behavior* above for why a reconnect needs a redeploy.
 
-## Display
-
-The display entitlement allows a container to present to a locally-attached monitor as a Wayland client.
-
-```json
-{
-    "type": "display"
-}
-```
-
-The container receives:
-- A bind mount of `/dev/dri` (GPU render nodes) for GPU-accelerated graphics
-- Membership in the `video` and `render` groups for device permissions
-- A cgroup device rule allowing access to render device nodes (major 226)
-- The WendyOS compositor's Wayland socket, injected as an environment variable for client connection
-
-**At most one display entitlement per app** (enforced by the runtime).
-
-**Display-enabled image required:** this entitlement is accepted during validation on all WendyOS images, but the Wayland socket is only present on display-enabled images. On headless images, the container will not have the socket available, so graphics output will not render.
-
-On Jetson devices, GPU graphics userspace (libraries, drivers) is injected from the host via Container Device Interface (CDI) integration.
-
 ## Persist
 
 The persist entitlement allows the container to persist data across restarts. Data is stored on the host filesystem and mounted into the container at the specified path.

--- a/go/internal/cli/assets/docs/entitlements.md
+++ b/go/internal/cli/assets/docs/entitlements.md
@@ -127,6 +127,28 @@ Use `serial` for serial ports and `usb` for raw USB protocols — they expose di
 
 > **Security note:** the cgroup rule is scoped to the named device's exact `major:minor`, so — unlike a whole-major grant — it never exposes other devices that share the major (e.g. other `ttyACM*`/`ttyUSB*` adapters on the host). The entitlement is USB-only, so it can never reach an on-board console UART. See *Replug behavior* above for why a reconnect needs a redeploy.
 
+## Display
+
+The display entitlement allows a container to present to a locally-attached monitor as a Wayland client.
+
+```json
+{
+    "type": "display"
+}
+```
+
+The container receives:
+- A bind mount of `/dev/dri` (GPU render nodes) for GPU-accelerated graphics
+- Membership in the `video` and `render` groups (GIDs 44 and 105 or 107) for device permissions
+- A cgroup device rule allowing access to render device nodes (major 226)
+- The WendyOS compositor's Wayland socket, injected as an environment variable for client connection
+
+**At most one display entitlement per app.** Multiple containers cannot simultaneously render to the same display.
+
+**Display-enabled image required:** this entitlement is accepted during validation on all WendyOS images, but the Wayland socket is only present on display-enabled images. On headless images, the container will not have the socket available, so graphics output will not render.
+
+On Jetson devices, GPU graphics userspace (libraries, drivers) is injected from the host via Container Device Interface (CDI) integration.
+
 ## Persist
 
 The persist entitlement allows the container to persist data across restarts. Data is stored on the host filesystem and mounted into the container at the specified path.

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -44,6 +44,7 @@ const (
 	EntitlementInput     = "input"
 	EntitlementSerial    = "serial"
 	EntitlementMCP       = "mcp"
+	EntitlementDisplay   = "display"
 )
 
 // ValidEntitlementTypes is the set of all recognized entitlement type strings.
@@ -62,6 +63,7 @@ var ValidEntitlementTypes = []string{
 	EntitlementInput,
 	EntitlementSerial,
 	EntitlementMCP,
+	EntitlementDisplay,
 }
 
 var deprecatedEntitlementReplacements = map[string]string{
@@ -84,6 +86,7 @@ var allowedKeys = map[string][]string{
 	EntitlementInput:     {"type"},
 	EntitlementSerial:    {"type", "device"},
 	EntitlementMCP:       {"type", "port"},
+	EntitlementDisplay:   {"type"},
 }
 
 // Platform constants identify the target hardware family.
@@ -348,6 +351,16 @@ func validateEntitlements(entitlements []Entitlement, prefix string) error {
 	}
 	if mcpCount > 1 {
 		return fmt.Errorf("at most one mcp entitlement is allowed in %s, found %d", prefix, mcpCount)
+	}
+
+	displayCount := 0
+	for _, e := range entitlements {
+		if e.Type == EntitlementDisplay {
+			displayCount++
+		}
+	}
+	if displayCount > 1 {
+		return fmt.Errorf("at most one display entitlement is allowed in %s, found %d", prefix, displayCount)
 	}
 
 	return nil

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -1163,6 +1163,49 @@ func TestMCPEntitlementPortOutOfRange(t *testing.T) {
 	}
 }
 
+func TestDisplayEntitlementValid(t *testing.T) {
+	cfg := &AppConfig{
+		AppID:        "test",
+		Entitlements: []Entitlement{{Type: EntitlementDisplay}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestDisplayEntitlementDuplicateRejected(t *testing.T) {
+	cfg := &AppConfig{
+		AppID: "test",
+		Entitlements: []Entitlement{
+			{Type: EntitlementDisplay},
+			{Type: EntitlementDisplay},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for duplicate display entitlement")
+	}
+}
+
+func TestDisplayEntitlementJSONNoWarnings(t *testing.T) {
+	warnings := ValidateJSON([]byte(`{
+		"appId": "test",
+		"entitlements": [ {"type": "display"} ]
+	}`))
+	if len(warnings) != 0 {
+		t.Fatalf("got %d warnings for valid display entitlement, want 0: %v", len(warnings), warnings)
+	}
+}
+
+func TestDisplayEntitlementJSONUnknownKeyWarns(t *testing.T) {
+	warnings := ValidateJSON([]byte(`{
+		"appId": "test",
+		"entitlements": [ {"type": "display", "bogus": 1} ]
+	}`))
+	if len(warnings) == 0 {
+		t.Fatal("expected warning for unknown key on display entitlement, got none")
+	}
+}
+
 func TestServiceConfigValidation(t *testing.T) {
 	t.Run("valid services", func(t *testing.T) {
 		cfg := &AppConfig{

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -248,6 +248,14 @@
           "required": ["type", "device"],
           "additionalProperties": false,
           "description": "Serial tty device access (USB-attached servo buses, sensors, microcontrollers)."
+        },
+        {
+          "properties": {
+            "type": { "const": "display" }
+          },
+          "required": ["type"],
+          "additionalProperties": false,
+          "description": "Present to a locally-attached monitor as a Wayland client: GPU render nodes (/dev/dri) plus the WendyOS compositor's Wayland socket. At most one per app; requires a display-enabled WendyOS image."
         }
       ]
     },

--- a/plugins/wendy-agentic-coding/skills/wendy-entitlements/SKILL.md
+++ b/plugins/wendy-agentic-coding/skills/wendy-entitlements/SKILL.md
@@ -17,6 +17,7 @@ Ask what the app actually touches, then choose the smallest entitlement set:
 
 - Server, WebRTC, callbacks, debugger, or LAN-visible API: `network`.
 - NVIDIA/Jetson inference or CUDA: `gpu`.
+- Present to a locally-attached monitor as a Wayland client: `display`.
 - Microphone, speaker, ALSA, PipeWire, PulseAudio compatibility: `audio`.
 - V4L2 cameras or USB webcams: `camera`.
 - Model cache, database, user uploads, generated files, or persistent app state: `persist`.
@@ -39,6 +40,7 @@ Use this table as the starting point, then verify against the local repo when ch
 | --- | --- | --- | --- |
 | `network` | none | `mode` as `host` or `none` | Defaults to host networking when `mode` is empty; `host` removes the network namespace and mounts host DNS config. |
 | `gpu` | none | none | Jetson: adds NVIDIA device nodes, env vars, CDI wiring. Raspberry Pi: exposes `/dev/vcio` for board telemetry. |
+| `display` | none | none | Grants `/dev/dri` (GPU render nodes) and the WendyOS compositor's Wayland socket; allows the container to present to a locally-attached monitor as a Wayland client. Requires a display-enabled WendyOS image; on headless images the socket is absent so nothing renders. On Jetson, GPU graphics userspace is injected from the host via CDI. At most one per app. |
 | `audio` | none | none | Adds audio group, mounts `/dev/snd`, allows sound devices, and mounts PipeWire/Pulse sockets when present. |
 | `camera` | none | `mode`, `allowlist` | Canonical V4L2/camera entitlement; allows major 81, bind-mounts host `/dev` for live camera hotplug, and bind-mounts `/run/udev` read-only for libcamera CSI enumeration. |
 | `video` | none | `mode`, `allowlist` | Deprecated compatibility alias for `camera`; prefer `camera` in new configs. |


### PR DESCRIPTION
## What

A new **`display`** entitlement that grants a container GPU render-node + Wayland access so it can present to a locally-attached monitor — the agent-side foundation for native on-device UI (a Wayland-client app or the WendyOS shell rendering directly to the screen).

## How it works

- **`display` entitlement** (`appconfig`): a capability flag `{ "type": "display" }`, at most one per app (mirrors the `mcp` rule).
- **`applyDisplay`** (`oci/entitlements.go`), following the `applyGPU`/`applyCamera` pattern:
  - exposes `/dev/dri` render nodes (cgroup allow for the DRM major, `rw` not `rwm`) + the `video`/`render` GIDs,
  - bind-mounts the compositor's Wayland socket + sets `WAYLAND_DISPLAY`/`XDG_RUNTIME_DIR`, **conditional on the socket existing** (no-op-safe on headless images),
  - on **Jetson**, sets the NVIDIA graphics/display driver capabilities so the GL/EGL userspace is injected via the existing CDI path; on **Pi**, the app's own mesa works against the stable vc4 kernel ABI.
- **Invariant:** an app *without* `display` gets a byte-for-byte unchanged OCI spec — `/dev/dri` stays withheld exactly as today, so the default sandbox is unchanged (enforced by `TestApplyDisplay_NonDisplayAppUnchanged`).

## Security

`display` is an opt-in privilege escalation (GPU render node + Wayland). Apps without it are unaffected. Granted deliberately, documented in `entitlements.md`.

## Tests

appconfig (valid / duplicate-rejected / JSON warnings); oci (`/dev/dri` cgroup rule + GIDs, the non-`display`-unchanged invariant).

## Context

This is the agent-side piece. The native renderer (a wlroots/Mir compositor + Slint shell) and the display-enabled OS image are separate downstream work; design is in #1226. Verified end-to-end on a Jetson Orin Nano (the shell renders live device data on the monitor) as part of that effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
