### PR TITLE
agent: delegate OS-update healthchecks to wendyos-update commit

### DIFF
--- a/go/internal/agent/oshealth/gate.go
+++ b/go/internal/agent/oshealth/gate.go
@@ -2,6 +2,7 @@ package oshealth
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.uber.org/zap"
@@ -28,18 +29,29 @@ type MenderResult struct {
 	Err    error
 }
 
-// Gate decides, at agent startup, whether a pending Mender A/B update is
-// committed or rolled back, based on healthchecks of critical services. All
+// Gate decides, at agent startup, whether a pending A/B update is committed or
+// rolled back. For mender it bases that on agent-run healthchecks of critical
+// services; for a backend that runs its own health gate inside commit
+// (wendyos-update, DelegatedHealth) it acts on the commit verdict instead. All
 // side effects are injected so the decision logic is testable.
 type Gate struct {
 	Logger   *zap.Logger
 	StateDir string
 	Services []CriticalService
 	Checker  *Checker
-	// Commit runs `mender-update commit`.
+	// Commit runs `<backend> commit`.
 	Commit func() MenderResult
-	// Rollback runs `mender-update rollback`.
+	// Rollback runs `<backend> rollback`.
 	Rollback func() MenderResult
+	// DelegatedHealth is true when the update backend runs its own post-commit
+	// health gate (wendyos-update runs /etc/wendyos-update/health.d inside
+	// commit). The gate then skips its own CheckAll and lets the commit decide:
+	// a commit failure is the backend's health verdict, which drives the
+	// rollback. mender (false) keeps the agent-run CheckAll.
+	DelegatedHealth bool
+	// UpdaterLabel names the backend binary in user-facing notes
+	// ("wendyos-update", "mender-update"). Empty defaults to "mender-update".
+	UpdaterLabel string
 	// Reboot restarts the device.
 	Reboot func() error
 	// OSVersion reports the OS version of the currently running slot.
@@ -91,16 +103,26 @@ func (g *Gate) Run(ctx context.Context) {
 		return
 	}
 
-	g.Logger.Info("Pending OS update detected, healthchecking critical services before commit",
-		zap.String("old_os_version", marker.OldOSVersion))
-	results := g.Checker.CheckAll(ctx, g.Services)
-
 	record := UpdateResult{
 		OldOSVersion: marker.OldOSVersion,
 		NewOSVersion: g.OSVersion(),
 		CreatedAt:    g.now(),
-		Services:     results,
 	}
+
+	if g.DelegatedHealth {
+		// The backend (wendyos-update) runs /etc/wendyos-update/health.d inside
+		// `commit`, so the commit itself is the health verdict. Skip the agent's
+		// CheckAll and act on the commit result; a rejection rolls back.
+		g.Logger.Info("Pending OS update detected; delegating healthchecks to the updater's commit",
+			zap.String("old_os_version", marker.OldOSVersion))
+		g.commitDelegated(record)
+		return
+	}
+
+	g.Logger.Info("Pending OS update detected, healthchecking critical services before commit",
+		zap.String("old_os_version", marker.OldOSVersion))
+	results := g.Checker.CheckAll(ctx, g.Services)
+	record.Services = results
 
 	if failed := failedUnits(results); len(failed) > 0 {
 		// Log the full results too: if persisting the record fails, this
@@ -129,7 +151,7 @@ func (g *Gate) commit(record UpdateResult) {
 		// clearing the marker). Treat as success.
 		record.Outcome = OutcomeCommitted
 		record.FinalizedAt = g.now()
-		record.Note = "mender-update reported nothing to commit (update was already committed)"
+		record.Note = g.updaterLabel() + " reported nothing to commit (update was already committed)"
 		g.writeResult(record)
 		g.clearMarker()
 	default:
@@ -138,9 +160,68 @@ func (g *Gate) commit(record UpdateResult) {
 		// uncommitted update means the bootloader reverts on the next reboot,
 		// and rebooting here would throw away a healthy slot.
 		record.Outcome = OutcomeCommitFailed
-		record.Note = menderFailureReason("commit", res)
+		record.Note = menderFailureReason(g.updaterLabel(), "commit", res)
 		g.writeResult(record)
 		g.Logger.Error("Failed to commit OS update", zap.String("reason", record.Note))
+	}
+}
+
+// commitDelegated handles the commit/rollback decision for a backend that runs
+// its own health gate inside `commit` (wendyos-update runs
+// /etc/wendyos-update/health.d). It diverges from commit() only in the failure
+// branch: a commit the updater *rejected* is the health verdict, so it rolls
+// back rather than retrying. The two "no verdict was rendered" cases — a missing
+// binary and the agent's own commit timeout — keep the marker and retry instead,
+// so a transient early-boot hiccup never reverts a possibly-healthy slot.
+func (g *Gate) commitDelegated(record UpdateResult) {
+	res := g.Commit()
+	switch res.Status {
+	case MenderOK:
+		record.Outcome = OutcomeCommitted
+		record.FinalizedAt = g.now()
+		g.writeResult(record)
+		g.clearMarker()
+		g.Logger.Info("Committed OS update (updater-gated healthchecks passed)",
+			zap.String("output", res.Output))
+	case MenderNothingPending:
+		// Already committed (e.g. a previous agent start committed but died
+		// before clearing the marker). Treat as success.
+		record.Outcome = OutcomeCommitted
+		record.FinalizedAt = g.now()
+		record.Note = g.updaterLabel() + " reported nothing to commit (update was already committed)"
+		g.writeResult(record)
+		g.clearMarker()
+	case MenderUnavailable:
+		// The backend recorded in the marker is gone (binary removed between
+		// install and this boot). No health verdict was rendered, so do NOT roll
+		// back a slot over a missing tool. Keep the marker for a retry on the
+		// next start, mirroring the mender commit-failure path.
+		record.Outcome = OutcomeCommitFailed
+		record.Note = g.updaterLabel() + " binary not found at commit"
+		g.writeResult(record)
+		g.Logger.Warn("OS update backend unavailable at commit; leaving the update pending for retry",
+			zap.String("backend", g.updaterLabel()))
+	default:
+		if errors.Is(res.Err, context.DeadlineExceeded) {
+			// The agent's own commit timeout fired — likely storage/D-Bus was
+			// briefly busy early in boot, exactly the unhealthy-boot conditions
+			// this gate runs in. That is not a health verdict, so keep the
+			// marker and retry next start rather than reverting a healthy slot.
+			record.Outcome = OutcomeCommitFailed
+			record.Note = menderFailureReason(g.updaterLabel(), "commit", res)
+			g.writeResult(record)
+			g.Logger.Error("OS update commit timed out; leaving the update pending for retry",
+				zap.String("reason", record.Note))
+			return
+		}
+		// The updater ran and rejected the commit: its health.d failed (or the
+		// deployment is otherwise marked failed). Roll back and reboot — retrying
+		// a marked-failed deployment is futile and a degraded slot must not stay
+		// up. The commit output is the user-facing reason.
+		record.Note = menderFailureReason(g.updaterLabel(), "commit", res)
+		g.Logger.Error("Updater rejected the OS update commit, rolling back",
+			zap.String("reason", record.Note))
+		g.rollBack(record)
 	}
 }
 
@@ -164,16 +245,16 @@ func (g *Gate) rollBack(record UpdateResult) {
 		// stay up and reachable instead of reboot-looping.
 		record.Outcome = OutcomeRollbackFailed
 		if res.Status == MenderNothingPending {
-			record.RollbackError = "mender-update reported nothing to roll back"
+			record.RollbackError = g.updaterLabel() + " reported nothing to roll back"
 		} else {
-			record.RollbackError = "mender-update binary not found"
+			record.RollbackError = g.updaterLabel() + " binary not found"
 		}
 		g.writeResult(record)
 		g.Logger.Error("Cannot roll back OS update", zap.String("reason", record.RollbackError))
 	default:
 		// The rollback command failed, but the update is uncommitted, so the
 		// bootloader falls back to the old slot on reboot anyway.
-		record.RollbackError = menderFailureReason("rollback", res)
+		record.RollbackError = menderFailureReason(g.updaterLabel(), "rollback", res)
 		g.writeResult(record)
 		g.Logger.Error("mender-update rollback failed, rebooting to let the bootloader revert",
 			zap.String("reason", record.RollbackError))
@@ -246,6 +327,16 @@ func (g *Gate) bootID() string {
 	return CurrentBootID()
 }
 
+// updaterLabel is the backend binary name used in user-facing notes. It defaults
+// to "mender-update" so a Gate constructed without UpdaterLabel (e.g. the
+// degraded no-backend path, or older callers) keeps the historical wording.
+func (g *Gate) updaterLabel() string {
+	if g.UpdaterLabel != "" {
+		return g.UpdaterLabel
+	}
+	return "mender-update"
+}
+
 func failedUnits(results []ServiceResult) []string {
 	var failed []string
 	for _, r := range results {
@@ -256,12 +347,12 @@ func failedUnits(results []ServiceResult) []string {
 	return failed
 }
 
-func menderFailureReason(subcommand string, res MenderResult) string {
+func menderFailureReason(label, subcommand string, res MenderResult) string {
 	switch res.Status {
 	case MenderUnavailable:
-		return "mender-update binary not found"
+		return label + " binary not found"
 	default:
-		reason := "mender-update " + subcommand + " failed"
+		reason := label + " " + subcommand + " failed"
 		if res.Err != nil {
 			reason += ": " + res.Err.Error()
 		}

--- a/go/internal/agent/oshealth/gate_test.go
+++ b/go/internal/agent/oshealth/gate_test.go
@@ -446,6 +446,145 @@ func TestGateUnhealthyMenderUnavailable(t *testing.T) {
 	}
 }
 
+// delegateHealth flips a fixture's gate to the wendyos-update path: the backend
+// runs its own health gate inside commit, so the agent gate skips CheckAll.
+func (fx *gateFixture) delegateHealth() {
+	fx.gate.DelegatedHealth = true
+	fx.gate.UpdaterLabel = "wendyos-update"
+}
+
+func TestGateDelegatedHealthyCommitOK(t *testing.T) {
+	fx := newGateFixture(t, MenderResult{Status: MenderOK}, MenderResult{})
+	fx.delegateHealth()
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.commits != 1 || fx.rollback != 0 || fx.reboots != 0 {
+		t.Errorf("commits=%d rollback=%d reboots=%d, want 1/0/0", fx.commits, fx.rollback, fx.reboots)
+	}
+	if n := fx.systemd.callCount("a.service"); n != 0 {
+		t.Errorf("agent healthchecks must not run for a delegated backend (%d calls)", n)
+	}
+	if fx.markerExists(t) {
+		t.Error("marker should be cleared after commit")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeCommitted {
+		t.Fatalf("expected committed record, got found=%v %+v", found, rec)
+	}
+	if len(rec.Services) != 0 {
+		t.Errorf("delegated commit must not record agent service results: %+v", rec.Services)
+	}
+	if rec.FinalizedAt.IsZero() {
+		t.Error("committed record should be finalized")
+	}
+}
+
+func TestGateDelegatedCommitNothingPending(t *testing.T) {
+	fx := newGateFixture(t, MenderResult{Status: MenderNothingPending}, MenderResult{})
+	fx.delegateHealth()
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.rollback != 0 || fx.reboots != 0 {
+		t.Errorf("rollback=%d reboots=%d, want 0/0", fx.rollback, fx.reboots)
+	}
+	if n := fx.systemd.callCount("a.service"); n != 0 {
+		t.Errorf("agent healthchecks must not run for a delegated backend (%d calls)", n)
+	}
+	if fx.markerExists(t) {
+		t.Error("marker should be cleared")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeCommitted {
+		t.Fatalf("expected committed record, got found=%v %+v", found, rec)
+	}
+	if rec.Note == "" {
+		t.Error("expected a note explaining there was nothing to commit")
+	}
+}
+
+func TestGateDelegatedCommitRejectedRollsBack(t *testing.T) {
+	// wendyos-update commit ran its health.d, the deployment is marked failed,
+	// and commit returned a non-zero exit. The agent rolls back and reboots.
+	fx := newGateFixture(t,
+		MenderResult{Status: MenderError, Err: errors.New("exit status 1"),
+			Output: "pending update wendyos-image-... is marked failed; run rollback"},
+		MenderResult{Status: MenderOK})
+	fx.delegateHealth()
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.commits != 1 || fx.rollback != 1 || fx.reboots != 1 {
+		t.Errorf("commits=%d rollback=%d reboots=%d, want 1/1/1", fx.commits, fx.rollback, fx.reboots)
+	}
+	if n := fx.systemd.callCount("a.service"); n != 0 {
+		t.Errorf("agent healthchecks must not run for a delegated backend (%d calls)", n)
+	}
+	if fx.markerExists(t) {
+		t.Error("marker should be cleared before rebooting into the old slot")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeRolledBack {
+		t.Fatalf("expected rolled_back record, got found=%v %+v", found, rec)
+	}
+	if !strings.Contains(rec.Note, "is marked failed") {
+		t.Errorf("note should carry the commit output reason, got %q", rec.Note)
+	}
+	if !rec.FinalizedAt.IsZero() {
+		t.Error("rolled_back record must not be finalized until the old slot boots")
+	}
+}
+
+func TestGateDelegatedCommitUnavailableNoRollback(t *testing.T) {
+	// The recorded backend's binary is gone at commit time. No health verdict
+	// was rendered, so the gate must not roll back a real slot — keep the marker
+	// for a retry on the next start.
+	fx := newGateFixture(t, MenderResult{Status: MenderUnavailable}, MenderResult{Status: MenderOK})
+	fx.delegateHealth()
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.rollback != 0 || fx.reboots != 0 {
+		t.Errorf("rollback=%d reboots=%d, want 0/0 when the backend is unavailable", fx.rollback, fx.reboots)
+	}
+	if !fx.markerExists(t) {
+		t.Error("marker should be kept so the commit is retried next start")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeCommitFailed {
+		t.Fatalf("expected commit_failed record, got found=%v %+v", found, rec)
+	}
+}
+
+func TestGateDelegatedCommitTimeoutRetries(t *testing.T) {
+	// The agent's own commit timeout fired (storage/D-Bus briefly busy early in
+	// boot). That is not a health verdict, so keep the marker and retry rather
+	// than reverting a possibly-healthy slot.
+	fx := newGateFixture(t,
+		MenderResult{Status: MenderError, Err: context.DeadlineExceeded, Output: "timed out"},
+		MenderResult{Status: MenderOK})
+	fx.delegateHealth()
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.rollback != 0 || fx.reboots != 0 {
+		t.Errorf("rollback=%d reboots=%d, want 0/0 on a commit timeout", fx.rollback, fx.reboots)
+	}
+	if !fx.markerExists(t) {
+		t.Error("marker should be kept so the commit is retried next start")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeCommitFailed {
+		t.Fatalf("expected commit_failed record, got found=%v %+v", found, rec)
+	}
+}
+
 func TestGateAllSkippedCountsAsHealthy(t *testing.T) {
 	fx := newGateFixture(t, MenderResult{Status: MenderOK}, MenderResult{})
 	fx.systemd.sequences["a.service"] = []map[string]string{{"LoadState": "not-found", "ActiveState": "inactive"}}

--- a/go/internal/agent/services/mender_backend.go
+++ b/go/internal/agent/services/mender_backend.go
@@ -30,6 +30,12 @@ func newMenderUpdater(logger *zap.Logger) menderUpdater {
 
 func (m menderUpdater) name() string { return updaterNameMender }
 
+// delegatesHealthcheck is false: mender has no /etc/wendyos-update/health.d, so
+// the agent's boot-time gate keeps owning the post-reboot healthchecks for it.
+func (m menderUpdater) delegatesHealthcheck() bool { return false }
+
+func (m menderUpdater) commitCommand() string { return "mender-update" }
+
 func (m menderUpdater) available() bool {
 	_, found := resolveMenderBinary()
 	return found

--- a/go/internal/agent/services/os_update_gate.go
+++ b/go/internal/agent/services/os_update_gate.go
@@ -13,13 +13,16 @@ import (
 
 // RunOSUpdateGate confirms or rolls back a pending A/B update at agent startup.
 // When an OS update is pending verification (marker written by UpdateOS before
-// the reboot), it healthchecks the critical services first and rolls back to
-// the previous OS if any of them failed to come up. Without a pending update it
+// the reboot), it decides commit-or-rollback; without a pending update it
 // reduces to the plain "commit" the agent has always run on startup.
 //
 // The commit/rollback are driven by the backend that installed the update
 // (recorded in the marker): the in-house wendyos-update engine, or mender as a
-// fallback. The healthcheck logic itself is backend-agnostic.
+// fallback. Where the health verdict comes from depends on the backend:
+// wendyos-update runs its own health gate (/etc/wendyos-update/health.d) inside
+// commit, so the gate just triggers commit and rolls back if it is rejected;
+// mender has no such gate, so the agent healthchecks the critical services
+// itself and rolls back if any fail to come up.
 //
 // This must run before the gRPC server starts: the device must not appear back
 // online to a waiting `wendy os update` until the commit-or-rollback decision
@@ -32,16 +35,18 @@ func RunOSUpdateGate(logger *zap.Logger) {
 		logger.Warn("Pending OS update marker is unreadable; auto-selecting the update backend", zap.Error(err))
 	}
 	requested := requestedBackendFromMarker(marker, found && err == nil)
-	commit, rollback := commitClosures(logger, requested)
+	commit, rollback, delegatedHealth, label := commitClosures(logger, requested)
 
 	gate := &oshealth.Gate{
-		Logger:   logger,
-		StateDir: oshealth.DefaultStateDir,
-		Services: oshealth.DefaultCriticalServices,
-		Checker:  oshealth.NewChecker(logger),
-		Commit:   commit,
-		Rollback: rollback,
-		Reboot:   rebootSystem,
+		Logger:          logger,
+		StateDir:        oshealth.DefaultStateDir,
+		Services:        oshealth.DefaultCriticalServices,
+		Checker:         oshealth.NewChecker(logger),
+		Commit:          commit,
+		Rollback:        rollback,
+		DelegatedHealth: delegatedHealth,
+		UpdaterLabel:    label,
+		Reboot:          rebootSystem,
 		OSVersion: func() string {
 			v, _ := wendyOSVersion()
 			return v
@@ -61,20 +66,33 @@ func requestedBackendFromMarker(marker oshealth.PendingMarker, found bool) strin
 }
 
 // commitClosures resolves the backend for the gate and returns its
-// commit/rollback. It selects by binary presence (chooseUpdaterForCommit), not
-// the install-time connector probe: the update has already been installed, so a
-// transient probe failure must not block committing a healthy slot. If no
-// backend binary is present (e.g. a non-WendyOS host), it returns no-ops
-// reporting "unavailable" so the gate degrades to the pre-multi-backend no-op.
-func commitClosures(logger *zap.Logger, requested string) (commit, rollback func() oshealth.MenderResult) {
+// commit/rollback plus the two policy bits the gate needs: whether the backend
+// delegates healthchecking to its own commit (wendyos-update) and the binary
+// label for user-facing failure notes. It selects by binary presence
+// (chooseUpdaterForCommit), not the install-time connector probe: the update has
+// already been installed, so a transient probe failure must not block committing
+// a healthy slot. If no backend binary is present (e.g. a non-WendyOS host), it
+// returns no-ops reporting "unavailable" so the gate degrades to the
+// pre-multi-backend no-op (and the agent-driven, mender-style path).
+func commitClosures(logger *zap.Logger, requested string) (commit, rollback func() oshealth.MenderResult, delegatedHealth bool, label string) {
 	updater := chooseUpdaterForCommit(requested, productionUpdaters(logger))
 	if updater == nil {
 		logger.Debug("No OS update backend available for the gate; commit/rollback are no-ops",
 			zap.String("requested", requested))
-		noop := func() oshealth.MenderResult { return oshealth.MenderResult{Status: oshealth.MenderUnavailable} }
-		return noop, noop
 	}
-	return updater.commit, updater.rollback
+	return closuresForUpdater(updater)
+}
+
+// closuresForUpdater maps a resolved backend (or nil) to the four values the
+// gate needs. A nil updater (no backend binary present) degrades to no-op
+// commit/rollback that report "unavailable", the non-delegated (agent-run)
+// healthcheck path, and the legacy "mender-update" label.
+func closuresForUpdater(updater osUpdater) (commit, rollback func() oshealth.MenderResult, delegatedHealth bool, label string) {
+	if updater == nil {
+		noop := func() oshealth.MenderResult { return oshealth.MenderResult{Status: oshealth.MenderUnavailable} }
+		return noop, noop, false, "mender-update"
+	}
+	return updater.commit, updater.rollback, updater.delegatesHealthcheck(), updater.commitCommand()
 }
 
 // recordPendingOSUpdate persists the pending-update marker that the healthcheck

--- a/go/internal/agent/services/osupdater.go
+++ b/go/internal/agent/services/osupdater.go
@@ -48,6 +48,15 @@ type osUpdater interface {
 	commit() oshealth.MenderResult
 	// rollback reverts an uncommitted A/B update.
 	rollback() oshealth.MenderResult
+	// delegatesHealthcheck reports whether the backend runs its own post-commit
+	// health gate (wendyos-update runs /etc/wendyos-update/health.d inside
+	// commit), so the agent's boot-time gate must NOT run its own CheckAll for
+	// it. mender has no health.d, so the agent gate keeps owning the healthchecks.
+	delegatesHealthcheck() bool
+	// commitCommand is the binary name surfaced in user-facing commit/rollback
+	// failure notes ("wendyos-update", "mender-update"). It is distinct from
+	// name(): mender's backend id is "mender" but its binary is "mender-update".
+	commitCommand() string
 }
 
 // productionUpdaters returns the available backends in preference order

--- a/go/internal/agent/services/osupdater_test.go
+++ b/go/internal/agent/services/osupdater_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/wendylabsinc/wendy/go/internal/agent/oshealth"
 )
 
@@ -12,6 +14,8 @@ type fakeUpdater struct {
 	nameVal      string
 	detectVal    bool
 	availableVal bool
+	delegatesVal bool
+	commandVal   string
 }
 
 func (f fakeUpdater) name() string    { return f.nameVal }
@@ -22,6 +26,8 @@ func (f fakeUpdater) install(context.Context, string, func(string, int32)) error
 }
 func (f fakeUpdater) commit() oshealth.MenderResult   { return oshealth.MenderResult{} }
 func (f fakeUpdater) rollback() oshealth.MenderResult { return oshealth.MenderResult{} }
+func (f fakeUpdater) delegatesHealthcheck() bool      { return f.delegatesVal }
+func (f fakeUpdater) commitCommand() string           { return f.commandVal }
 
 func TestChooseUpdaterForCommit(t *testing.T) {
 	// The gate must select the commit backend by binary presence (available),
@@ -92,6 +98,74 @@ func TestChooseUpdaterForCommit(t *testing.T) {
 			}
 			if got.name() != tt.wantName {
 				t.Fatalf("chooseUpdaterForCommit(%q) = %q, want %q", tt.requested, got.name(), tt.wantName)
+			}
+		})
+	}
+}
+
+func TestBackendHealthcheckDelegationPolicy(t *testing.T) {
+	logger := zap.NewNop()
+	wendyos := newWendyOSUpdater(logger)
+	mender := newMenderUpdater(logger)
+
+	if !wendyos.delegatesHealthcheck() {
+		t.Error("wendyos-update must delegate healthchecking to its own commit (health.d)")
+	}
+	if wendyos.commitCommand() != "wendyos-update" {
+		t.Errorf("wendyos commitCommand = %q, want wendyos-update", wendyos.commitCommand())
+	}
+	if mender.delegatesHealthcheck() {
+		t.Error("mender has no health.d; the agent gate must run its own healthchecks")
+	}
+	if mender.commitCommand() != "mender-update" {
+		t.Errorf("mender commitCommand = %q, want mender-update", mender.commitCommand())
+	}
+}
+
+func TestClosuresForUpdater(t *testing.T) {
+	tests := []struct {
+		name          string
+		updater       osUpdater
+		wantDelegated bool
+		wantLabel     string
+	}{
+		{
+			name:          "wendyos delegates health and labels with its binary",
+			updater:       fakeUpdater{nameVal: updaterNameWendyOS, delegatesVal: true, commandVal: "wendyos-update"},
+			wantDelegated: true,
+			wantLabel:     "wendyos-update",
+		},
+		{
+			name:          "mender keeps the agent healthcheck path",
+			updater:       fakeUpdater{nameVal: updaterNameMender, delegatesVal: false, commandVal: "mender-update"},
+			wantDelegated: false,
+			wantLabel:     "mender-update",
+		},
+		{
+			name:          "no backend degrades to the non-delegated mender-labelled path",
+			updater:       nil,
+			wantDelegated: false,
+			wantLabel:     "mender-update",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commit, rollback, delegated, label := closuresForUpdater(tt.updater)
+			if commit == nil || rollback == nil {
+				t.Fatal("commit/rollback closures must never be nil")
+			}
+			if delegated != tt.wantDelegated {
+				t.Errorf("delegated = %v, want %v", delegated, tt.wantDelegated)
+			}
+			if label != tt.wantLabel {
+				t.Errorf("label = %q, want %q", label, tt.wantLabel)
+			}
+			if tt.updater == nil {
+				// The degraded no-op must report "unavailable" so the gate keeps
+				// the marker rather than committing/rolling back a real slot.
+				if got := commit().Status; got != oshealth.MenderUnavailable {
+					t.Errorf("degraded commit status = %v, want MenderUnavailable", got)
+				}
 			}
 		})
 	}

--- a/go/internal/agent/services/wendyos_backend.go
+++ b/go/internal/agent/services/wendyos_backend.go
@@ -34,6 +34,13 @@ func newWendyOSUpdater(logger *zap.Logger) wendyOSUpdater {
 
 func (w wendyOSUpdater) name() string { return updaterNameWendyOS }
 
+// delegatesHealthcheck is true: wendyos-update runs /etc/wendyos-update/health.d
+// inside `commit`, so the agent gate skips its own CheckAll and acts on the
+// commit verdict instead.
+func (w wendyOSUpdater) delegatesHealthcheck() bool { return true }
+
+func (w wendyOSUpdater) commitCommand() string { return "wendyos-update" }
+
 func (w wendyOSUpdater) available() bool {
 	_, found := resolveWendyOSBinary()
 	return found

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -657,6 +657,11 @@ func evaluateOSUpdateOutcome(
 		}
 		fmt.Fprintf(&b, "Update failed post-reboot healthchecks and was rolled back to %s.\n", rolledBackTo)
 		writeFailedServices(&b, resp.GetServices())
+		// When the updater ran its own health gate (wendyos-update health.d),
+		// there are no per-service results — the reason is carried in the note.
+		if note := resp.GetNote(); note != "" {
+			fmt.Fprintf(&b, "Reason: %s\n", note)
+		}
 		if re := resp.GetRollbackError(); re != "" {
 			fmt.Fprintf(&b, "Rollback error: %s\n", re)
 		}

--- a/go/internal/cli/commands/os_cmd_test.go
+++ b/go/internal/cli/commands/os_cmd_test.go
@@ -341,6 +341,15 @@ func TestEvaluateOSUpdateOutcome(t *testing.T) {
 		CreatedAtUnix: fresh,
 		Note:          "wendyos-update commit failed: exit status 1 (tegra: ESRT capsule not staged)",
 	}
+	// A delegated (wendyos-update health.d) rollback has no per-service results;
+	// the reason is carried in Note and must still reach the user.
+	delegatedRolledBack := &agentpb.GetOSUpdateStatusResponse{
+		HasResult:     true,
+		Outcome:       agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLED_BACK,
+		OldOsVersion:  "WendyOS-0.10.4",
+		CreatedAtUnix: fresh,
+		Note:          "wendyos-update commit failed: exit status 1 (pending update is marked failed; run rollback)",
+	}
 
 	tests := []struct {
 		name         string
@@ -389,6 +398,18 @@ func TestEvaluateOSUpdateOutcome(t *testing.T) {
 				"avahi-daemon.service",
 				"timed out after 30s",
 				"WendyOS-0.10.4",
+			},
+		},
+		{
+			name:    "delegated rollback surfaces the note when there are no service results",
+			resp:    delegatedRolledBack,
+			preVer:  "WendyOS-0.10.4",
+			postVer: "WendyOS-0.10.4",
+			wantErr: true,
+			wantContains: []string{
+				"rolled back",
+				"WendyOS-0.10.4",
+				"is marked failed",
 			},
 		},
 		{


### PR DESCRIPTION
## Context

Follow-up to #1142 (in-house `wendyos-update` backend) and the **WDY-1742** fixes. The team decided that **health checking lives in the updater, not the agent**, and the **OTA safety gate lives in the image**:

- WendyOS-Builder #139 masks `wendyos-update-commit.service` fleet-wide → a **manual-commit model**: a pending update is finalized only by an explicit `wendyos-update commit`, never auto-committed on boot. `wendyos-update-verify.service` runs at boot as the image safety gate (it only *marks* a slot failed; it does not switch slots or run health logic).
- `wendyos-update commit` runs `/etc/wendyos-update/health.d/` as the real health gate. `health.d` is **empty fleet-wide today**, so commit passes trivially until products add scripts.

Today the agent's post-reboot gate runs the **same** agent-owned `CheckAll()` (avahi-daemon, containerd, NetworkManager) for *both* backends, duplicating what `wendyos-update commit` now does.

## What this PR does

Makes `oshealth.Gate` **backend-aware**:

- **wendyos-update**: skip the agent `CheckAll()`. Trigger `wendyos-update commit` (which runs health.d) and act on its verdict. On a genuine commit **rejection** the agent auto-calls `wendyos-update rollback` + reboots, so `commit → healthcheck → rollback-if-failure → apply-if-success` stays functional (the image has no on-boot auto-rollback).
- **mender**: unchanged — the agent still runs `CheckAll()` and gates on it (mender has no health.d).

### Changes
- `osUpdater`: add `delegatesHealthcheck()` (wendyos→true, mender→false) and `commitCommand()` for accurate failure labels.
- `Gate`: add `DelegatedHealth`/`UpdaterLabel`; new `commitDelegated()`. A **missing binary** or the agent's own **60s commit timeout** keep the marker and retry instead of rolling back, so a transient early-boot hiccup never reverts a possibly-healthy slot.
- Relabel hardcoded `mender-update` failure notes (they previously mislabeled wendyos failures, e.g. the WDY-1742 repro).
- CLI: render `note` in the `ROLLED_BACK` outcome — delegated rollbacks carry the reason in `note` with no per-service results.

## Decisions
1. **Agent auto-rolls-back** on commit failure (no on-boot auto-rollback exists in the image).
2. **Interim** exit-code policy: roll back on any nonzero commit exit except timeout/missing-binary.

## Follow-up
File an issue to pin `wendyos-update`'s authoritative commit exit-code contract (docs say exit 4 = "verify failed"; the WDY-1742 repro shows exit 1 = "marked failed; run rollback") and add a dedicated verdict status so a transient nonzero commit exit retries instead of rebooting once health.d is populated.

## Testing
- `gofmt -l` clean, `go build ./...`, `go vet` clean.
- `go test ./internal/agent/...` and `./internal/cli/commands/...` pass, incl. new gate tests (healthy commit, nothing-pending, rejected→rollback, unavailable→no-rollback, timeout→retry), `closuresForUpdater` mapping, backend policy, and the CLI rolled-back-note case.
- **On-device verify pending** (Jetson Orin Nano / Pi with the #139 image): confirm wendyos commit finalizes without agent `CheckAll`, a failing `health.d` script triggers agent rollback, and `--updater=mender` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)