### PR TITLE
Update docs homepage install flow

### DIFF
--- a/go/internal/cli/assets/docs/app/(docs)/layout.tsx
+++ b/go/internal/cli/assets/docs/app/(docs)/layout.tsx
@@ -20,7 +20,7 @@ function DiscordIcon() {
 }
 
 const sidebarFooter = (
-  <div className="flex items-center gap-1 px-2 py-1">
+  <div key="sidebar-footer" className="flex items-center gap-1 px-2 py-1">
     <a
       href="https://github.com/wendylabsinc"
       target="_blank"

--- a/go/internal/cli/assets/docs/app/global.css
+++ b/go/internal/cli/assets/docs/app/global.css
@@ -2,6 +2,11 @@
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
 
+@theme {
+  --color-wendy-seafoam: #9fe2bf;
+  --color-wendy-seafoam-hover: #86d3a8;
+}
+
 html {
   scrollbar-gutter: stable;
 }
@@ -25,6 +30,13 @@ html > body[data-scroll-locked] {
 :root {
   --radius: 0px;
   --fd-radius: 0px;
+  --color-fd-primary: var(--color-wendy-seafoam);
+  --color-fd-primary-foreground: hsl(0, 0%, 9%);
+}
+
+.dark {
+  --color-fd-primary: var(--color-wendy-seafoam);
+  --color-fd-primary-foreground: hsl(0, 0%, 9%);
 }
 
 *,

--- a/go/internal/cli/assets/docs/components/docs/get-started-section.tsx
+++ b/go/internal/cli/assets/docs/components/docs/get-started-section.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import {
+  agentCurlCommand,
+  cliCurlCommand,
+  cliWingetCommand,
+  InstallCommand,
+} from '@/components/docs/install-command';
+
+type CliPlatform = 'unix' | 'windows';
+
+const cliPlatforms: Array<{
+  id: CliPlatform;
+  label: string;
+  command: string;
+}> = [
+  {
+    id: 'unix',
+    label: 'macOS/Linux',
+    command: cliCurlCommand,
+  },
+  {
+    id: 'windows',
+    label: 'Windows',
+    command: cliWingetCommand,
+  },
+];
+
+function detectCliPlatform(): CliPlatform {
+  if (typeof navigator === 'undefined') return 'unix';
+
+  const agent = `${navigator.userAgent} ${navigator.platform}`;
+  return /\bWin/i.test(agent) ? 'windows' : 'unix';
+}
+
+export function GetStartedSection() {
+  const [selectedPlatform, setSelectedPlatform] = useState<CliPlatform>('unix');
+  const activePlatform =
+    cliPlatforms.find((platform) => platform.id === selectedPlatform) ?? cliPlatforms[0];
+
+  useEffect(() => {
+    setSelectedPlatform(detectCliPlatform());
+  }, []);
+
+  return (
+    <section className="not-prose my-10 border-y py-8">
+      <div className="grid gap-8 lg:grid-cols-[minmax(260px,0.8fr)_minmax(440px,1.2fr)] lg:items-start">
+        <div>
+          <p className="font-mono text-[11px] font-medium tracking-widest text-wendy-seafoam uppercase">
+            Get Started
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-fd-foreground">Install Wendy</h2>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-fd-muted-foreground">
+            Plug in an NVIDIA Jetson or Raspberry Pi over USB and start deploying in seconds.{' '}
+            <a
+              href="/installation/wendy-agent-macos"
+              className="font-medium text-wendy-seafoam no-underline transition-colors hover:text-wendy-seafoam-hover"
+            >
+              Wendy for macOS
+            </a>{' '}
+            is available in beta for Apple Silicon targets.
+          </p>
+        </div>
+
+        <div className="space-y-7">
+          <section>
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <h3 className="text-base font-semibold text-fd-foreground">Wendy CLI</h3>
+                <p className="mt-1 text-sm text-fd-muted-foreground">
+                  Install this on your developer machine.
+                </p>
+              </div>
+
+              <div
+                role="tablist"
+                aria-label="Wendy CLI install platform"
+                className="grid grid-cols-2 border bg-fd-secondary/40 p-1"
+              >
+                {cliPlatforms.map((platform) => {
+                  const active = platform.id === selectedPlatform;
+
+                  return (
+                    <button
+                      key={platform.id}
+                      type="button"
+                      role="tab"
+                      aria-selected={active}
+                      onClick={() => setSelectedPlatform(platform.id)}
+                      className={
+                        active
+                          ? 'bg-fd-primary px-3 py-1.5 text-xs font-medium text-fd-primary-foreground'
+                          : 'px-3 py-1.5 text-xs font-medium text-fd-muted-foreground transition-colors hover:text-fd-foreground'
+                      }
+                    >
+                      {platform.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <InstallCommand command={activePlatform.command} />
+          </section>
+
+          <section className="border-t pt-6">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-base font-semibold text-fd-foreground">
+                <code className="font-mono text-[0.95em]">wendy-agent</code> for Linux
+              </h3>
+              <span className="border border-wendy-seafoam/40 px-2 py-0.5 text-[11px] font-medium text-wendy-seafoam">
+                Optional
+              </span>
+            </div>
+            <p className="mt-1 text-sm text-fd-muted-foreground">
+              Install this on an existing Linux target. WendyOS images already include it.
+            </p>
+            <InstallCommand command={agentCurlCommand} />
+          </section>
+
+          <section className="border-t pt-6">
+            <h3 className="text-base font-semibold text-fd-foreground">
+              Developer machine setup
+            </h3>
+            <p className="mt-1 text-sm text-fd-muted-foreground">
+              Configure your local tools, editor, and first device connection.
+            </p>
+            <a
+              href="/installation/developer-machine-setup"
+              className="mt-3 inline-flex items-center gap-2 bg-fd-primary px-4 py-2 text-sm font-medium text-fd-primary-foreground no-underline transition-transform hover:translate-x-0.5"
+            >
+              Open setup guide
+              <ArrowRight className="size-4" />
+            </a>
+          </section>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/go/internal/cli/assets/docs/components/docs/install-command.tsx
+++ b/go/internal/cli/assets/docs/components/docs/install-command.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Check, Copy } from 'lucide-react';
+import { useState } from 'react';
+
+export const cliCurlCommand = 'curl -fsSL https://install.wendy.dev/cli.sh | bash';
+export const cliWingetCommand = 'winget install WendyLabs.Wendy --source winget';
+export const agentCurlCommand = 'curl -fsSL https://install.wendy.dev/agent.sh | bash';
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <button
+      type="button"
+      aria-label="Copy to clipboard"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          /* clipboard unavailable */
+        }
+      }}
+      className="shrink-0 border-l p-2.5 text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+    >
+      {copied ? <Check className="size-4 text-green-500" /> : <Copy className="size-4" />}
+    </button>
+  );
+}
+
+export function InstallCommand({ label, command }: { label?: string; command: string }) {
+  return (
+    <div className="mt-2">
+      {label ? (
+        <p className="mb-1 text-xs font-medium text-fd-muted-foreground">{label}</p>
+      ) : null}
+      <div className="flex items-stretch border bg-fd-secondary/40">
+        <code className="min-w-0 flex-1 whitespace-pre-wrap break-all px-3 py-2.5 font-mono text-sm text-fd-foreground">
+          {command}
+        </code>
+        <CopyButton text={command} />
+      </div>
+    </div>
+  );
+}

--- a/go/internal/cli/assets/docs/components/docs/install-scripts.tsx
+++ b/go/internal/cli/assets/docs/components/docs/install-scripts.tsx
@@ -1,46 +1,13 @@
 'use client';
 
-import { Check, Copy, Terminal, X } from 'lucide-react';
-import { useRef, useState } from 'react';
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  return (
-    <button
-      type="button"
-      aria-label="Copy to clipboard"
-      onClick={async () => {
-        try {
-          await navigator.clipboard.writeText(text);
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        } catch {
-          /* clipboard unavailable */
-        }
-      }}
-      className="shrink-0 border-l p-2.5 text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-    >
-      {copied ? <Check className="size-4 text-green-500" /> : <Copy className="size-4" />}
-    </button>
-  );
-}
-
-function Command({ label, command }: { label?: string; command: string }) {
-  return (
-    <div className="mt-2">
-      {label ? (
-        <p className="mb-1 text-xs font-medium text-fd-muted-foreground">{label}</p>
-      ) : null}
-      <div className="flex items-stretch border bg-fd-secondary/40">
-        <code className="flex-1 overflow-x-auto whitespace-nowrap px-3 py-2.5 font-mono text-sm text-fd-foreground">
-          {command}
-        </code>
-        <CopyButton text={command} />
-      </div>
-    </div>
-  );
-}
+import { Terminal, X } from 'lucide-react';
+import { useRef } from 'react';
+import {
+  agentCurlCommand,
+  cliCurlCommand,
+  cliWingetCommand,
+  InstallCommand,
+} from '@/components/docs/install-command';
 
 export function InstallScripts() {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -85,13 +52,13 @@ export function InstallScripts() {
               <p className="mt-1 text-sm text-fd-muted-foreground">
                 Install this on your developer machine or continuous integration machine.
               </p>
-              <Command
+              <InstallCommand
                 label="macOS / Linux"
-                command="curl -fsSL https://install.wendy.dev/cli.sh | bash"
+                command={cliCurlCommand}
               />
-              <Command
+              <InstallCommand
                 label="Windows"
-                command="winget install WendyLabs.Wendy --source winget"
+                command={cliWingetCommand}
               />
             </section>
 
@@ -103,9 +70,9 @@ export function InstallScripts() {
                 Install this on your Linux machine. You do <strong>not</strong> need to do this for
                 WendyOS — it&apos;s already there!
               </p>
-              <Command
+              <InstallCommand
                 label="Linux"
-                command="curl -fsSL https://install.wendy.dev/agent.sh | bash"
+                command={agentCurlCommand}
               />
             </section>
           </div>

--- a/go/internal/cli/assets/docs/components/docs/overview-intro.tsx
+++ b/go/internal/cli/assets/docs/components/docs/overview-intro.tsx
@@ -1,21 +1,14 @@
 export function OverviewIntro() {
   return (
     <div className="not-prose mb-8 bg-zinc-950 p-8 sm:p-10">
-      <p className="mb-4 font-mono text-[11px] font-medium tracking-widest text-orange-500 uppercase">
+      <p className="mb-4 font-mono text-[11px] font-medium tracking-widest text-wendy-seafoam uppercase">
         Physical AI Platform
       </p>
       <p className="text-xl font-semibold leading-snug text-white sm:text-2xl">
         The open source OS and toolchain for robots, drones, and edge AI.
       </p>
       <p className="mt-3 max-w-2xl text-sm leading-relaxed text-zinc-400">
-        Plug in an NVIDIA Jetson or Raspberry Pi over USB and start deploying in seconds.{' '}
-        <a
-          href="/installation/wendy-agent-macos"
-          className="text-orange-400 transition-colors hover:text-orange-300"
-        >
-          Wendy for macOS
-        </a>{' '}
-        is available in beta for Apple Silicon targets.
+        Develop, deploy, debug, and observe physical AI apps from a local CLI and editor workflow.
       </p>
       <div className="mt-5 flex flex-wrap gap-x-6 gap-y-1 font-mono text-xs text-zinc-600">
         <span>Jetson Orin · AGX Thor</span>

--- a/go/internal/cli/assets/docs/components/docs/usp-grid.tsx
+++ b/go/internal/cli/assets/docs/components/docs/usp-grid.tsx
@@ -9,49 +9,49 @@ type USP = {
 
 const usps: USP[] = [
   {
-    icon: <Plug className="size-5 text-orange-500" />,
+    icon: <Plug className="size-5 text-wendy-seafoam" />,
     title: 'USB-C Deployment',
     description:
       'Plug in your Jetson or Pi and deploy in seconds. No SSH, no network config, no ceremony.',
   },
   {
-    icon: <BugPlay className="size-5 text-orange-500" />,
+    icon: <BugPlay className="size-5 text-wendy-seafoam" />,
     title: 'Remote Debugging',
     description:
       'Full VSCode debugger with breakpoints over USB or the internet — on any device, anywhere.',
   },
   {
-    icon: <Activity className="size-5 text-orange-500" />,
+    icon: <Activity className="size-5 text-wendy-seafoam" />,
     title: 'Observability',
     description:
       'Real-time logs, metrics, and distributed traces from every device in your fleet.',
   },
   {
-    icon: <Bot className="size-5 text-orange-500" />,
+    icon: <Bot className="size-5 text-wendy-seafoam" />,
     title: 'ROS2 Support',
     description:
       'Run ROS2 nodes natively alongside WendyOS apps on the same hardware.',
   },
   {
-    icon: <RefreshCw className="size-5 text-orange-500" />,
+    icon: <RefreshCw className="size-5 text-wendy-seafoam" />,
     title: 'Atomic OTA Updates',
     description:
       'Push firmware to one device or ten thousand. Automatic rollback on failure.',
   },
   {
-    icon: <Code2 className="size-5 text-orange-500" />,
+    icon: <Code2 className="size-5 text-wendy-seafoam" />,
     title: 'VSCode & Cursor',
     description:
       'Deploy and debug without leaving your editor. Extensions for VSCode, Cursor, and Windsurf.',
   },
   {
-    icon: <LockOpen className="size-5 text-orange-500" />,
+    icon: <LockOpen className="size-5 text-wendy-seafoam" />,
     title: 'Apache 2.0',
     description:
       'No black boxes, no lock-in. The full OS and toolchain are open source and auditable.',
   },
   {
-    icon: <CircuitBoard className="size-5 text-orange-500" />,
+    icon: <CircuitBoard className="size-5 text-wendy-seafoam" />,
     title: 'NVIDIA & Raspberry Pi',
     description:
       'First-class support for Jetson Orin, AGX Thor, and Raspberry Pi 3, 4, and 5.',

--- a/go/internal/cli/assets/docs/faq.mdx
+++ b/go/internal/cli/assets/docs/faq.mdx
@@ -227,7 +227,7 @@ Find answers to common questions about WendyOS.
     | | Raspberry Pi 5 | <span className="text-emerald-600 dark:text-emerald-400">✓ Supported</span> |
     | | Raspberry Pi 4 | <span className="text-emerald-600 dark:text-emerald-400">✓ Supported</span> |
     | | Raspberry Pi 3 | <span className="text-emerald-600 dark:text-emerald-400">✓ Supported</span> |
-    | | Headless Apple Silicon Mac | <span className="text-orange-500 dark:text-orange-400">Beta</span> |
+    | | Headless Apple Silicon Mac | <span className="text-wendy-seafoam">Beta</span> |
     | | Ubuntu (any ARM64/x86_64) | <span className="text-emerald-600 dark:text-emerald-400">✓ Supported</span> |
     | | ESP32-C6 / ESP32-C5 (Wendy Lite) | <span className="text-emerald-600 dark:text-emerald-400">✓ Supported</span> |
   </Accordion>

--- a/go/internal/cli/assets/docs/index.mdx
+++ b/go/internal/cli/assets/docs/index.mdx
@@ -4,27 +4,17 @@ description: The open source operating system and toolchain for Physical AI — 
 full: true
 ---
 
-import { Database, Monitor, Box, Terminal, ArrowRight, Microchip } from 'lucide-react';
+import { Database, Monitor, Box, Terminal, Microchip } from 'lucide-react';
 import { HardwareShowcase } from '@/components/docs/hardware-showcase';
 import { OverviewIntro } from '@/components/docs/overview-intro';
 import { USPGrid } from '@/components/docs/usp-grid';
+import { GetStartedSection } from '@/components/docs/get-started-section';
 
 <OverviewIntro />
 
 <USPGrid />
 
-<a
-  href="/docs/installation/developer-machine-setup"
-  className="not-prose group my-8 flex flex-col items-center gap-2 border bg-fd-card px-6 py-10 text-center transition-colors hover:border-fd-primary/50 hover:bg-fd-accent no-underline"
->
-  <span className="text-2xl font-semibold text-fd-card-foreground">Get Started!</span>
-  <span className="text-fd-muted-foreground">Set up your developer machine and deploy your first app.</span>
-  <span className="text-sm text-fd-muted-foreground">Develop from macOS, Windows, or Linux.</span>
-  <span className="mt-4 inline-flex items-center gap-2 bg-fd-primary px-5 py-2.5 font-medium text-fd-primary-foreground transition-transform group-hover:translate-x-0.5">
-    Developer Machine Setup
-    <ArrowRight className="size-4" />
-  </span>
-</a>
+<GetStartedSection />
 
 ## Supported Hardware
 
@@ -42,14 +32,14 @@ Wendy consists of several core components:
   </Card>
 
   <div className="relative flex flex-col">
-    <span className="absolute -top-px right-0 z-10 bg-orange-500 text-white text-xs px-2 py-1 font-medium">Beta</span>
-    <Card icon={<Terminal />} title="Headless Mac" className="h-full">
-      Deploy native macOS apps to Apple Silicon Mac targets with [Headless Mac](/docs/installation/wendy-agent-macos) beta. Supports SwiftPM and Xcode projects with the same CLI workflow.
+    <span className="absolute -top-px right-0 z-10 bg-wendy-seafoam text-zinc-950 text-xs px-2 py-1 font-medium">Beta</span>
+    <Card icon={<Terminal />} title="Wendy for macOS" className="h-full">
+      Deploy native macOS apps to Apple Silicon Mac targets with [Wendy for macOS](/installation/wendy-agent-macos) beta. Supports SwiftPM and Xcode projects with the same CLI workflow.
     </Card>
   </div>
 
   <div className="relative flex flex-col">
-    <span className="absolute -top-px right-0 z-10 bg-orange-500 text-white text-xs px-2 py-1 font-medium">Beta</span>
+    <span className="absolute -top-px right-0 z-10 bg-wendy-seafoam text-zinc-950 text-xs px-2 py-1 font-medium">Beta</span>
     <Card icon={<Monitor />} title="Wendy Cloud" className="h-full">
       A fleet management solution for OTA updates, crash reporting, and remote telemetry. Built for teams scaling from prototypes to thousands of devices.
     </Card>


### PR DESCRIPTION
@Joannis

- Replaced the homepage Get Started card with a dedicated install section that defaults the Wendy CLI tab from the visitor's OS.
- Added shared copyable install commands for macOS/Linux, Windows, and optional Linux `wendy-agent` setup.
- Swapped the docs homepage and related highlights to the Wendy seafoam accent while fixing the sidebar footer key warning.

Validation: `npm run types:check`; `git diff --check origin/main...HEAD`.