### PR TITLE
feat(agent): garbage-collect stale device image data with orphan-age tombstones (WDY-1679)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/containerd/containerd/api v1.11.1
 	github.com/containerd/containerd/v2 v2.3.2
 	github.com/containerd/errdefs v1.0.0
+	github.com/containerd/platforms v1.0.0-rc.4
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/distribution/reference v0.6.0
 	github.com/dustin/go-humanize v1.0.1
@@ -56,7 +57,6 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
-	github.com/containerd/platforms v1.0.0-rc.4 // indirect
 	github.com/containerd/plugin v1.1.0 // indirect
 	github.com/containerd/ttrpc v1.2.8 // indirect
 	github.com/creack/goselect v0.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,6 @@ golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliY
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
-golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
-golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f h1:XdNn9LlyWAhLVp6P/i8QYBW+hlyhrhei9uErw2B5GJo=
 golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f/go.mod h1:D5SMRVC3C2/4+F/DB1wZsLRnSNimn2Sp/NPsCrsv8ak=

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/agent/timesync"
 	"github.com/wendylabsinc/wendy/go/internal/shared/browseropen"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+	sharedenv "github.com/wendylabsinc/wendy/go/internal/shared/env"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
@@ -161,6 +162,9 @@ func main() {
 	}
 	// Image garbage collection (WDY-1679) is enabled by default; set
 	// WENDY_IMAGE_GC_ENABLED=false to disable the post-deploy + boot sweeps.
+	// WENDY_IMAGE_GC_GRACE_PERIOD (default 24h, clamped to a 30m floor) is the
+	// orphan-age window a superseded layer must stay unused before it is
+	// reclaimed — longer keeps layers cached for redeploys instead of re-uploaded.
 	imageGCEnabled := true
 	if v := os.Getenv("WENDY_IMAGE_GC_ENABLED"); v != "" {
 		if parsed, perr := strconv.ParseBool(v); perr != nil {
@@ -170,7 +174,8 @@ func main() {
 			imageGCEnabled = parsed
 		}
 	}
-	ctrdClient, ctrdErr := agentcontainerd.NewClient(logger, containerdAddr, proxyMgr, imageGCEnabled)
+	imageGCGrace := sharedenv.ImageGCGracePeriod()
+	ctrdClient, ctrdErr := agentcontainerd.NewClient(logger, containerdAddr, proxyMgr, imageGCEnabled, imageGCGrace)
 	if ctrdErr != nil {
 		logger.Warn("Failed to connect to containerd (container features will be unavailable)", zap.Error(ctrdErr))
 	} else {

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -159,7 +159,18 @@ func main() {
 	if containerdAddr == "" {
 		containerdAddr = agentcontainerd.DefaultAddress
 	}
-	ctrdClient, ctrdErr := agentcontainerd.NewClient(logger, containerdAddr, proxyMgr)
+	// Image garbage collection (WDY-1679) is enabled by default; set
+	// WENDY_IMAGE_GC_ENABLED=false to disable the post-deploy + boot sweeps.
+	imageGCEnabled := true
+	if v := os.Getenv("WENDY_IMAGE_GC_ENABLED"); v != "" {
+		if parsed, perr := strconv.ParseBool(v); perr != nil {
+			logger.Warn("WENDY_IMAGE_GC_ENABLED has unrecognised value; image GC stays enabled",
+				zap.String("value", v))
+		} else {
+			imageGCEnabled = parsed
+		}
+	}
+	ctrdClient, ctrdErr := agentcontainerd.NewClient(logger, containerdAddr, proxyMgr, imageGCEnabled)
 	if ctrdErr != nil {
 		logger.Warn("Failed to connect to containerd (container features will be unavailable)", zap.Error(ctrdErr))
 	} else {
@@ -286,6 +297,11 @@ func main() {
 	if ctrdClient != nil {
 		if err := ctrdClient.ReapOrphanedROS2Sidecars(ctx); err != nil {
 			logger.Warn("ROS 2 sidecar reap on boot failed", zap.Error(err))
+		}
+		// Reclaim stale image layers/blobs left by deploys that completed while
+		// the agent was down or crashed mid-flow (WDY-1679). No-op when disabled.
+		if _, err := ctrdClient.GarbageCollectImages(ctx); err != nil {
+			logger.Warn("image GC on boot failed", zap.Error(err))
 		}
 	}
 

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -100,14 +100,36 @@ type Client struct {
 	// GarbageCollectImages are no-ops.
 	imageGCEnabled bool
 
+	// imageGCGrace is the orphan-age grace window for the image GC: a
+	// gc.root-pinned snapshot or content blob must stay continuously
+	// unreferenced for at least this long (measured from its labelKeyOrphanedAt
+	// tombstone) before a sweep may reclaim it. Configured via
+	// WENDY_IMAGE_GC_GRACE_PERIOD and clamped to a floor in NewClient.
+	imageGCGrace time.Duration
+
 	// gcRunning is the single-flight guard for image GC: at most one
 	// mark-and-sweep pass runs at a time across the deploy hook and boot sweep.
 	gcRunning atomic.Bool
 }
 
-func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager, imageGCEnabled bool) (*Client, error) {
+func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager, imageGCEnabled bool, imageGCGrace time.Duration) (*Client, error) {
 	if address == "" {
 		address = DefaultAddress
+	}
+
+	// Clamp the configured grace to a safety floor. Under the tombstone GC the
+	// floor is defense-in-depth against a pathologically small value, not the
+	// primary safety mechanism (see imagegc.go): it keeps the stamp→reap spacing
+	// comfortably above a single pass's imageGCTimeout so an in-flight deploy's
+	// freshly created artifacts are always re-marked reachable before they could
+	// age out.
+	if imageGCGrace < unpackLeaseExpiration {
+		if imageGCGrace > 0 {
+			logger.Warn("WENDY_IMAGE_GC_GRACE_PERIOD below floor; clamping",
+				zap.Duration("requested", imageGCGrace),
+				zap.Duration("floor", unpackLeaseExpiration))
+		}
+		imageGCGrace = unpackLeaseExpiration
 	}
 
 	c, err := containerd.New(address)
@@ -138,6 +160,7 @@ func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager, 
 		staging:        newStaging(defaultChunkStagingDir),
 		snapshotter:    snapshotter,
 		imageGCEnabled: imageGCEnabled,
+		imageGCGrace:   imageGCGrace,
 	}, nil
 }
 

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -93,9 +94,18 @@ type Client struct {
 	// Defaults to "overlayfs" when supported; falls back to "native" on kernels
 	// that do not support overlay mounts (e.g. nested container environments).
 	snapshotter string
+
+	// imageGCEnabled gates the post-deploy / boot image garbage collector
+	// (WENDY_IMAGE_GC_ENABLED). When false, both triggerImageGCAsync and
+	// GarbageCollectImages are no-ops.
+	imageGCEnabled bool
+
+	// gcRunning is the single-flight guard for image GC: at most one
+	// mark-and-sweep pass runs at a time across the deploy hook and boot sweep.
+	gcRunning atomic.Bool
 }
 
-func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) (*Client, error) {
+func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager, imageGCEnabled bool) (*Client, error) {
 	if address == "" {
 		address = DefaultAddress
 	}
@@ -114,19 +124,20 @@ func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) 
 	snapshotter := probeSnapshotter(logger)
 
 	return &Client{
-		client:       c,
-		logger:       logger,
-		namespace:    "default",
-		proxyManager: proxyMgr,
-		appServices:  make(map[string]map[string]*appconfig.ServiceConfig),
-		primaryPIDs:  make(map[string]uint32),
-		appIsolation: make(map[string]string),
-		serviceIPs:   make(map[string]map[string]string),
-		appStopping:  make(map[string]bool),
-		ros2ExecRefs: make(map[string]int),
-		chunkIndex:   idx,
-		staging:      newStaging(defaultChunkStagingDir),
-		snapshotter:  snapshotter,
+		client:         c,
+		logger:         logger,
+		namespace:      "default",
+		proxyManager:   proxyMgr,
+		appServices:    make(map[string]map[string]*appconfig.ServiceConfig),
+		primaryPIDs:    make(map[string]uint32),
+		appIsolation:   make(map[string]string),
+		serviceIPs:     make(map[string]map[string]string),
+		appStopping:    make(map[string]bool),
+		ros2ExecRefs:   make(map[string]int),
+		chunkIndex:     idx,
+		staging:        newStaging(defaultChunkStagingDir),
+		snapshotter:    snapshotter,
+		imageGCEnabled: imageGCEnabled,
 	}, nil
 }
 
@@ -942,6 +953,12 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}
 		c.appIsolation[appID] = appCfg.Isolation
 	}
+
+	// A newer image version is now active for this app: kick off a background
+	// sweep to reclaim the prior version's gc.root snapshots and layer blobs.
+	// Async + single-flight so it never blocks or fails the deploy; the
+	// just-created container and re-pointed image keep the new version safe.
+	c.triggerImageGCAsync()
 
 	return nil
 }

--- a/go/internal/agent/containerd/helpers.go
+++ b/go/internal/agent/containerd/helpers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
+	digest "github.com/opencontainers/go-digest"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -168,6 +169,20 @@ func computeChainID(parent, diffID string) string {
 	h := sha256.New()
 	h.Write([]byte(parent + " " + diffID))
 	return fmt.Sprintf("sha256:%x", h.Sum(nil))
+}
+
+// chainIDsForDiffIDs folds computeChainID over an ordered list of layer diff IDs
+// to produce the chain ID of each layer prefix. chainIDs[i] is the chain ID of
+// the snapshot built from layers 0..i — the same key UnpackImage commits and the
+// key GarbageCollectImages must keep alive while the image exists.
+func chainIDsForDiffIDs(diffIDs []digest.Digest) []string {
+	chainIDs := make([]string, len(diffIDs))
+	parent := ""
+	for i, diffID := range diffIDs {
+		chainIDs[i] = computeChainID(parent, diffID.String())
+		parent = chainIDs[i]
+	}
+	return chainIDs
 }
 
 // parseRestartPolicyLabel parses a restart policy label value such as

--- a/go/internal/agent/containerd/helpers.go
+++ b/go/internal/agent/containerd/helpers.go
@@ -69,6 +69,14 @@ const labelKeyMCPPort = "sh.wendy/mcp.port"
 // labelKeyGCRoot prevents garbage collection of content blobs.
 const labelKeyGCRoot = "containerd.io/gc.root"
 
+// labelKeyOrphanedAt records, as an RFC3339 UTC timestamp, when the image GC
+// first observed a gc.root-pinned snapshot or content blob to be unreferenced.
+// The GC's orphan-age grace is measured from this value (not the gc.root commit
+// time), so a layer that is re-adopted by a later deploy — which clears this
+// label — keeps its retention window reset. See imagegc.go for the full
+// tombstone semantics.
+const labelKeyOrphanedAt = "sh.wendy/gc.orphaned-at"
+
 // labelKeyWendyLayer marks a content blob as a Wendy-pushed layer.
 const labelKeyWendyLayer = "sh.wendy.layer"
 

--- a/go/internal/agent/containerd/helpers_test.go
+++ b/go/internal/agent/containerd/helpers_test.go
@@ -8,9 +8,43 @@ import (
 	"testing"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
+
+func TestChainIDsForDiffIDs(t *testing.T) {
+	d0 := digest.Digest("sha256:" + strings.Repeat("a", 64))
+	d1 := digest.Digest("sha256:" + strings.Repeat("b", 64))
+	d2 := digest.Digest("sha256:" + strings.Repeat("c", 64))
+
+	// Independently compute the expected chain IDs from the OCI definition:
+	//   chainID(L0)       = diffID(L0)
+	//   chainID(L0..Ln)   = SHA256(chainID(L0..Ln-1) + " " + diffID(Ln))
+	expect0 := d0.String()
+	h1 := sha256.Sum256([]byte(expect0 + " " + d1.String()))
+	expect1 := fmt.Sprintf("sha256:%x", h1)
+	h2 := sha256.Sum256([]byte(expect1 + " " + d2.String()))
+	expect2 := fmt.Sprintf("sha256:%x", h2)
+
+	got := chainIDsForDiffIDs([]digest.Digest{d0, d1, d2})
+	want := []string{expect0, expect1, expect2}
+	if len(got) != len(want) {
+		t.Fatalf("len(got) = %d; want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("chainID[%d] = %q; want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestChainIDsForDiffIDs_Empty(t *testing.T) {
+	if got := chainIDsForDiffIDs(nil); len(got) != 0 {
+		t.Errorf("len(got) = %d; want 0", len(got))
+	}
+}
 
 func TestContainerName_SingleContainer(t *testing.T) {
 	// Single-container apps: name must equal the appID unchanged.

--- a/go/internal/agent/containerd/imagegc.go
+++ b/go/internal/agent/containerd/imagegc.go
@@ -24,17 +24,22 @@ type imageLister interface {
 	List(ctx context.Context, filters ...string) ([]images.Image, error)
 }
 
-// snapshotGC is the subset of snapshots.Snapshotter the GC needs.
+// snapshotGC is the subset of snapshots.Snapshotter the GC needs. Update is used
+// to write/clear the labelKeyOrphanedAt tombstone; the fieldpaths argument scopes
+// the mutation to that one label so the gc.root pin is preserved.
 type snapshotGC interface {
 	Walk(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error
 	Stat(ctx context.Context, key string) (snapshots.Info, error)
 	Usage(ctx context.Context, key string) (snapshots.Usage, error)
+	Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error)
 	Remove(ctx context.Context, key string) error
 }
 
-// contentGC is the subset of content.Store the GC needs.
+// contentGC is the subset of content.Store the GC needs. Update writes/clears the
+// labelKeyOrphanedAt tombstone (fieldpath-scoped, preserving gc.root).
 type contentGC interface {
 	Walk(ctx context.Context, fn content.WalkFunc, filters ...string) error
+	Update(ctx context.Context, info content.Info, fieldpaths ...string) (content.Info, error)
 	Delete(ctx context.Context, dgst digest.Digest) error
 }
 
@@ -56,18 +61,20 @@ type gcEnv struct {
 // entries — the only snapshots/blobs this GC ever considers for removal.
 const gcRootFilter = `labels."` + labelKeyGCRoot + `"`
 
-// runImageGC performs one mark-and-sweep pass: it computes the reachable set
-// from current images and containers (fail-closed), then reclaims gc.root
-// snapshots — and, when includeContent is set, gc.root content blobs — outside
-// that set.
+// runImageGC performs one mark-and-sweep pass over gc.root snapshots — and, when
+// includeContent is set, gc.root content blobs. It computes the reachable set
+// from current images and containers (fail-closed), then applies the two-phase
+// tombstone in sweep: stamp newly-orphaned artifacts, clear re-adopted ones, and
+// reap only those that have been continuously orphaned past the grace window.
 //
-// includeContent must be true ONLY when no deploy can be in flight (the boot
-// sweep). A gc.root layer blob is written by WriteLayer *before* AssembleImage
-// creates the image record that references it, so during a concurrent deploy a
-// just-pushed blob is legitimately unreferenced; only quiescence (not the
-// wall-clock grace alone) makes blob reclamation provably safe. Chain-ID
-// snapshots have no such hazard — UnpackImage commits them *after* the image
-// record exists — so the snapshot sweep always runs.
+// includeContent gates the ENTIRE content section (stamp, clear, and reap) and
+// must be true ONLY when no deploy can be in flight (the boot sweep). A gc.root
+// layer blob is written by WriteLayer *before* AssembleImage creates the image
+// record that references it, so during a concurrent deploy a just-pushed blob is
+// legitimately unreferenced; only quiescence makes blob reclamation provably
+// safe, and per-deploy passes must not so much as tombstone content. Chain-ID
+// snapshots have the favorable ordering — UnpackImage commits them *after* the
+// image record exists — so the snapshot section always runs.
 func runImageGC(ctx context.Context, env gcEnv, includeContent bool) (GCStats, error) {
 	rSnap, rBlob, err := buildReachableSet(ctx, env)
 	if err != nil {
@@ -121,13 +128,19 @@ func buildReachableSet(ctx context.Context, env gcEnv) (rSnap, rBlob map[string]
 	return rSnap, rBlob, nil
 }
 
-// sweep (SWEEP) removes gc.root snapshots not in the reachable set, and (only
-// when includeContent is set) gc.root content blobs not in the reachable set.
-// Individual removal failures are logged and counted but never abort the pass; a
-// "has children" precondition error is a benign skip (the snapshot is still
-// referenced — the structural safety backstop).
+// sweep applies the two-phase tombstone against gc.root snapshots — and, when
+// includeContent is set, gc.root content blobs. Per artifact it either stamps a
+// fresh orphanedAt tombstone, clears the tombstone of a re-adopted artifact, or
+// reaps one that has been continuously orphaned past the grace window. Label
+// (stamp/clear) and removal failures are logged and counted in stats.Errors but
+// never abort the pass; a "has children" precondition error on removal is a
+// benign skip (the snapshot is still referenced — the structural safety
+// backstop). The stamp timestamp comes from env.now so passes are deterministic
+// under test.
 func sweep(ctx context.Context, env gcEnv, rSnap, rBlob map[string]struct{}, includeContent bool) (GCStats, error) {
 	var stats GCStats
+	now := env.now()
+	stamp := now.UTC().Format(time.RFC3339)
 
 	var gcRootSnaps []snapshots.Info
 	err := env.snapshots.Walk(ctx, func(_ context.Context, info snapshots.Info) error {
@@ -138,8 +151,24 @@ func sweep(ctx context.Context, env gcEnv, rSnap, rBlob map[string]struct{}, inc
 		return stats, fmt.Errorf("walking snapshots: %w", err)
 	}
 
-	orphans := selectOrphanSnapshots(gcRootSnaps, rSnap, env.now(), env.grace)
-	for _, key := range orderLeafFirst(orphans) {
+	sc := classifySnapshots(gcRootSnaps, rSnap, now, env.grace)
+	for _, info := range sc.stamp {
+		if uerr := stampSnapshot(ctx, env.snapshots, info.Name, stamp); uerr != nil {
+			env.logger.Warn("failed to tombstone snapshot", zap.String("snapshot", info.Name), zap.Error(uerr))
+			stats.Errors++
+			continue
+		}
+		stats.SnapshotsTombstoned++
+	}
+	for _, info := range sc.clear {
+		if uerr := stampSnapshot(ctx, env.snapshots, info.Name, ""); uerr != nil {
+			env.logger.Warn("failed to clear snapshot tombstone", zap.String("snapshot", info.Name), zap.Error(uerr))
+			stats.Errors++
+			continue
+		}
+		stats.StampsCleared++
+	}
+	for _, key := range orderLeafFirst(sc.reap) {
 		var size int64
 		if u, uerr := env.snapshots.Usage(ctx, key); uerr == nil {
 			size = u.Size
@@ -170,50 +199,93 @@ func sweep(ctx context.Context, env gcEnv, rSnap, rBlob map[string]struct{}, inc
 		return stats, fmt.Errorf("walking content: %w", err)
 	}
 
-	sizeByDigest := make(map[digest.Digest]int64, len(gcRootBlobs))
-	for _, info := range gcRootBlobs {
-		sizeByDigest[info.Digest] = info.Size
+	bc := classifyBlobs(gcRootBlobs, rBlob, now, env.grace)
+	for _, info := range bc.stamp {
+		if uerr := stampBlob(ctx, env.content, info.Digest, stamp); uerr != nil {
+			env.logger.Warn("failed to tombstone blob", zap.String("digest", info.Digest.String()), zap.Error(uerr))
+			stats.Errors++
+			continue
+		}
+		stats.BlobsTombstoned++
 	}
-	for _, d := range selectOrphanBlobs(gcRootBlobs, rBlob, env.now(), env.grace) {
-		if derr := env.content.Delete(ctx, d); derr != nil {
+	for _, info := range bc.clear {
+		if uerr := stampBlob(ctx, env.content, info.Digest, ""); uerr != nil {
+			env.logger.Warn("failed to clear blob tombstone", zap.String("digest", info.Digest.String()), zap.Error(uerr))
+			stats.Errors++
+			continue
+		}
+		stats.StampsCleared++
+	}
+	for _, info := range bc.reap {
+		if derr := env.content.Delete(ctx, info.Digest); derr != nil {
 			if errdefs.IsNotFound(derr) {
 				continue
 			}
-			env.logger.Warn("failed to delete orphan blob", zap.String("digest", d.String()), zap.Error(derr))
+			env.logger.Warn("failed to delete orphan blob", zap.String("digest", info.Digest.String()), zap.Error(derr))
 			stats.Errors++
 			continue
 		}
 		stats.BlobsReclaimed++
-		stats.BlobBytes += sizeByDigest[d]
+		stats.BlobBytes += info.Size
 	}
 	return stats, nil
 }
 
-// imageGCGracePeriod is the minimum age a gc.root-labelled snapshot or content
-// blob must reach (by its gc.root RFC3339 timestamp) before the sweep may reclaim
-// it. It protects artifacts a concurrent in-flight deploy created that this pass's
-// reachable set may not cover:
-//   - content blobs: WriteLayer labels a layer blob gc.root *before* AssembleImage
-//     creates the referencing image record, so a just-pushed blob is briefly
-//     unreferenced;
-//   - snapshots: the async pass marks reachability once and sweeps later, so a
-//     back-to-back deploy can commit new gc.root chain-ID snapshots after the mark
-//     that are absent from the (older) reachable set.
-//
-// It is pinned to the unpack lease expiration (30m), which far exceeds a single
-// pass's imageGCTimeout (5m); any artifact created during a pass is therefore
-// comfortably within grace and kept, while genuine orphans age past it and are
-// reclaimed by a later pass or the boot sweep.
-const imageGCGracePeriod = unpackLeaseExpiration
+// stampSnapshot writes (or, with an empty ts, clears) the labelKeyOrphanedAt
+// tombstone on a snapshot. The "labels.<key>" fieldpath scopes the update to that
+// one label so the gc.root pin — and any other labels — survive; an empty value
+// deletes the label.
+func stampSnapshot(ctx context.Context, sn snapshotGC, name, ts string) error {
+	_, err := sn.Update(ctx, snapshots.Info{
+		Name:   name,
+		Labels: map[string]string{labelKeyOrphanedAt: ts},
+	}, "labels."+labelKeyOrphanedAt)
+	return err
+}
 
-// GCStats summarises what one garbage-collection pass reclaimed. It exists purely
-// for observability — callers log it; no control flow branches on it.
+// stampBlob writes (or, with an empty ts, clears) the labelKeyOrphanedAt
+// tombstone on a content blob, fieldpath-scoped exactly like stampSnapshot.
+func stampBlob(ctx context.Context, cs contentGC, dgst digest.Digest, ts string) error {
+	_, err := cs.Update(ctx, content.Info{
+		Digest: dgst,
+		Labels: map[string]string{labelKeyOrphanedAt: ts},
+	}, "labels."+labelKeyOrphanedAt)
+	return err
+}
+
+// The image GC's grace window is an ORPHAN-AGE window: a gc.root snapshot or
+// content blob must stay continuously unreferenced for at least env.grace —
+// measured from its labelKeyOrphanedAt tombstone (when the GC first observed it
+// unreferenced), not its gc.root commit time — before a sweep may reap it. A
+// layer re-adopted by a later deploy has its tombstone cleared, resetting the
+// clock, so a long-lived base layer reused after a brief gap is never reaped and
+// re-uploaded. The grace duration is configured per Client (imageGCGrace,
+// WENDY_IMAGE_GC_GRACE_PERIOD) and clamped to a floor in NewClient.
+//
+// Safety under concurrent deploys does NOT depend on the grace length: the first
+// sweep that sees an orphan only stamps it (classifySnapshots/classifyBlobs route
+// an un-tombstoned orphan to the stamp bucket, never reap), so reaping always
+// requires a later sweep to still find it orphaned with an aged tombstone. A
+// snapshot's image record exists before the snapshot is committed (UnpackImage
+// runs after is.Create), and content is reaped only at boot/quiescence, so an
+// in-flight deploy's artifacts are re-marked reachable and cleared before they can
+// age out. The floor is therefore pure defense-in-depth against a pathologically
+// small configured value.
+
+// GCStats summarises what one garbage-collection pass did. It exists purely for
+// observability — callers log it; no control flow branches on it. The Tombstoned
+// and StampsCleared counters surface the two-phase activity (an orphan is stamped
+// on one pass and only reaped on a later pass past grace), so a pass that reclaims
+// nothing yet is still observable.
 type GCStats struct {
-	SnapshotsRemoved int
-	SnapshotBytes    int64
-	BlobsReclaimed   int
-	BlobBytes        int64
-	Errors           int
+	SnapshotsRemoved    int
+	SnapshotBytes       int64
+	BlobsReclaimed      int
+	BlobBytes           int64
+	SnapshotsTombstoned int
+	BlobsTombstoned     int
+	StampsCleared       int
+	Errors              int
 }
 
 // tryStartGC acquires the single-flight guard. It returns false when a pass is
@@ -288,7 +360,7 @@ func (c *Client) garbageCollectImages(ctx context.Context, includeContent bool) 
 		resolveImage:          c.resolveImageChain,
 		containerSnapshotKeys: c.containerSnapshotKeys,
 		now:                   time.Now,
-		grace:                 imageGCGracePeriod,
+		grace:                 c.imageGCGrace,
 		logger:                c.logger,
 	}
 	return runImageGC(ctx, env, includeContent)
@@ -341,47 +413,76 @@ func (c *Client) containerSnapshotKeys(ctx context.Context) ([]string, error) {
 	return keys, nil
 }
 
-// logGCStats emits a single summary line when a pass reclaimed something (or hit
-// errors); quiet passes stay silent to avoid log noise on every deploy.
+// logGCStats emits a summary of one pass. A pass that actually reclaimed data (or
+// hit errors) logs at Info; a pass that only tombstoned or cleared stamps — the
+// routine two-phase bookkeeping on most deploys — logs at Debug to avoid Info
+// noise. A fully quiet pass stays silent.
 func logGCStats(logger *zap.Logger, stats GCStats) {
-	if stats.SnapshotsRemoved+stats.BlobsReclaimed == 0 && stats.Errors == 0 {
+	reaped := stats.SnapshotsRemoved + stats.BlobsReclaimed
+	tombstoneActivity := stats.SnapshotsTombstoned + stats.BlobsTombstoned + stats.StampsCleared
+	if reaped == 0 && stats.Errors == 0 && tombstoneActivity == 0 {
 		return
 	}
-	logger.Info("image GC reclaimed stale image data",
+	fields := []zap.Field{
 		zap.Int("snapshots_removed", stats.SnapshotsRemoved),
 		zap.Int64("snapshot_bytes", stats.SnapshotBytes),
 		zap.Int("blobs_reclaimed", stats.BlobsReclaimed),
 		zap.Int64("blob_bytes", stats.BlobBytes),
+		zap.Int("snapshots_tombstoned", stats.SnapshotsTombstoned),
+		zap.Int("blobs_tombstoned", stats.BlobsTombstoned),
+		zap.Int("stamps_cleared", stats.StampsCleared),
 		zap.Int("errors", stats.Errors),
-	)
+	}
+	if reaped == 0 && stats.Errors == 0 {
+		logger.Debug("image GC tombstoned stale image data", fields...)
+		return
+	}
+	logger.Info("image GC reclaimed stale image data", fields...)
 }
 
-// selectOrphanSnapshots returns the gc.root snapshots eligible for removal:
-// those whose key is not in the reachable set AND whose gc.root timestamp is
-// older than grace. The age guard is essential because the async per-deploy pass
-// builds its reachable set once and sweeps later: a back-to-back deploy can
-// commit new gc.root chain-ID snapshots after the mark, and those would be absent
-// from the (older) reachable set. Keeping anything younger than grace — which far
-// exceeds a single pass's imageGCTimeout — prevents reaping a concurrent deploy's
-// freshly committed layers. A snapshot is kept (conservatively) when its gc.root
-// value is missing/unparseable or still within the grace window; genuine orphans
-// age past grace and are reclaimed by a later pass or the boot sweep.
-func selectOrphanSnapshots(gcRoots []snapshots.Info, reachable map[string]struct{}, now time.Time, grace time.Duration) []snapshots.Info {
-	var orphans []snapshots.Info
+// snapClass is the per-pass partition of gc.root snapshots produced by
+// classifySnapshots: which to tombstone, which to clear, and which to reap.
+type snapClass struct {
+	stamp []snapshots.Info // orphaned, not yet tombstoned -> write orphanedAt
+	clear []snapshots.Info // reachable but still tombstoned -> remove orphanedAt
+	reap  []snapshots.Info // orphaned with a tombstone older than grace -> remove
+}
+
+// classifySnapshots partitions gc.root snapshots against the reachable set using
+// the orphan-age tombstone (labelKeyOrphanedAt), NOT the gc.root commit time:
+//   - reachable + tombstoned         -> clear (re-adopted; reset its clock)
+//   - orphaned, no/empty/bad stamp   -> stamp (first sighting; never reaped this pass)
+//   - orphaned, stamp older than grace -> reap
+//   - orphaned, stamp within grace     -> keep (no-op)
+//
+// Routing every un-tombstoned orphan to stamp (never reap) is what makes the GC
+// safe without a commit-age guard: reaping always requires a *later* pass to find
+// the artifact still orphaned with an aged tombstone. A missing, empty, or
+// unparseable tombstone is treated as "not yet stamped", so a corrupt value can
+// only delay — never hasten — reclamation. The clear branch is the load-bearing
+// part of the re-upload fix: a base layer reused after a gap gets its tombstone
+// wiped here, so its grace clock restarts from the next time it falls out of use.
+func classifySnapshots(gcRoots []snapshots.Info, reachable map[string]struct{}, now time.Time, grace time.Duration) snapClass {
+	var c snapClass
 	for _, info := range gcRoots {
+		stamp := info.Labels[labelKeyOrphanedAt]
 		if _, ok := reachable[info.Name]; ok {
+			if stamp != "" {
+				c.clear = append(c.clear, info)
+			}
 			continue // referenced by a current image or container
 		}
-		ts, err := time.Parse(time.RFC3339, info.Labels[labelKeyGCRoot])
-		if err != nil {
-			continue // unparseable gc.root timestamp -> keep
+		ts, err := time.Parse(time.RFC3339, stamp)
+		if stamp == "" || err != nil {
+			c.stamp = append(c.stamp, info)
+			continue // first sighting (or corrupt stamp) -> tombstone, never reap
 		}
 		if now.Sub(ts) <= grace {
-			continue // committed too recently -> may belong to an in-flight deploy
+			continue // orphaned recently -> still within grace, keep
 		}
-		orphans = append(orphans, info)
+		c.reap = append(c.reap, info)
 	}
-	return orphans
+	return c
 }
 
 // orderLeafFirst returns the orphan snapshot keys ordered so that every child is
@@ -426,24 +527,38 @@ func orderLeafFirst(orphans []snapshots.Info) []string {
 	return keys
 }
 
-// selectOrphanBlobs returns the gc.root content blobs eligible for reclamation:
-// those whose digest is not in the reachable set AND whose gc.root timestamp is
-// older than grace. A blob is kept (conservatively) when its gc.root label value
-// is missing/unparseable or still within the grace window.
-func selectOrphanBlobs(infos []content.Info, reachable map[string]struct{}, now time.Time, grace time.Duration) []digest.Digest {
-	var orphans []digest.Digest
+// blobClass is the per-pass partition of gc.root content blobs produced by
+// classifyBlobs. Each bucket holds the full content.Info so the sweep can read
+// the digest (and Size, for reaped blobs) without a second lookup.
+type blobClass struct {
+	stamp []content.Info
+	clear []content.Info
+	reap  []content.Info
+}
+
+// classifyBlobs is the content-blob analogue of classifySnapshots, keyed on the
+// blob digest. See classifySnapshots for the tombstone rules; the same orphan-age
+// semantics apply. Reaping the reap bucket is gated to the boot sweep by the
+// caller (per-deploy passes never touch content) — see runImageGC.
+func classifyBlobs(infos []content.Info, reachable map[string]struct{}, now time.Time, grace time.Duration) blobClass {
+	var c blobClass
 	for _, info := range infos {
+		stamp := info.Labels[labelKeyOrphanedAt]
 		if _, ok := reachable[info.Digest.String()]; ok {
+			if stamp != "" {
+				c.clear = append(c.clear, info)
+			}
 			continue // referenced by a current image
 		}
-		ts, err := time.Parse(time.RFC3339, info.Labels[labelKeyGCRoot])
-		if err != nil {
-			continue // unparseable gc.root timestamp -> keep
+		ts, err := time.Parse(time.RFC3339, stamp)
+		if stamp == "" || err != nil {
+			c.stamp = append(c.stamp, info)
+			continue // first sighting (or corrupt stamp) -> tombstone, never reap
 		}
 		if now.Sub(ts) <= grace {
-			continue // within grace -> may belong to an in-flight deploy
+			continue // orphaned recently -> still within grace, keep
 		}
-		orphans = append(orphans, info.Digest)
+		c.reap = append(c.reap, info)
 	}
-	return orphans
+	return c
 }

--- a/go/internal/agent/containerd/imagegc.go
+++ b/go/internal/agent/containerd/imagegc.go
@@ -1,0 +1,425 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	digest "github.com/opencontainers/go-digest"
+	"go.uber.org/zap"
+)
+
+// imageGCTimeout bounds a single asynchronous (post-deploy) GC pass so a wedged
+// containerd call can't pin the single-flight guard forever.
+const imageGCTimeout = 5 * time.Minute
+
+// imageLister is the subset of images.Store the GC mark phase needs.
+type imageLister interface {
+	List(ctx context.Context, filters ...string) ([]images.Image, error)
+}
+
+// snapshotGC is the subset of snapshots.Snapshotter the GC needs.
+type snapshotGC interface {
+	Walk(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error
+	Stat(ctx context.Context, key string) (snapshots.Info, error)
+	Usage(ctx context.Context, key string) (snapshots.Usage, error)
+	Remove(ctx context.Context, key string) error
+}
+
+// contentGC is the subset of content.Store the GC needs.
+type contentGC interface {
+	Walk(ctx context.Context, fn content.WalkFunc, filters ...string) error
+	Delete(ctx context.Context, dgst digest.Digest) error
+}
+
+// gcEnv collects the dependencies of one mark-and-sweep pass behind narrow
+// seams so the orchestration is unit-testable without a live containerd. The
+// concrete *Client wires these to the real containerd services.
+type gcEnv struct {
+	images                imageLister
+	snapshots             snapshotGC
+	content               contentGC
+	resolveImage          func(ctx context.Context, img images.Image) (chainIDs []string, blobs []string, err error)
+	containerSnapshotKeys func(ctx context.Context) ([]string, error)
+	now                   func() time.Time
+	grace                 time.Duration
+	logger                *zap.Logger
+}
+
+// gcRootFilter is the containerd label filter that selects only gc.root-pinned
+// entries — the only snapshots/blobs this GC ever considers for removal.
+const gcRootFilter = `labels."` + labelKeyGCRoot + `"`
+
+// runImageGC performs one mark-and-sweep pass: it computes the reachable set
+// from current images and containers (fail-closed), then reclaims gc.root
+// snapshots — and, when includeContent is set, gc.root content blobs — outside
+// that set.
+//
+// includeContent must be true ONLY when no deploy can be in flight (the boot
+// sweep). A gc.root layer blob is written by WriteLayer *before* AssembleImage
+// creates the image record that references it, so during a concurrent deploy a
+// just-pushed blob is legitimately unreferenced; only quiescence (not the
+// wall-clock grace alone) makes blob reclamation provably safe. Chain-ID
+// snapshots have no such hazard — UnpackImage commits them *after* the image
+// record exists — so the snapshot sweep always runs.
+func runImageGC(ctx context.Context, env gcEnv, includeContent bool) (GCStats, error) {
+	rSnap, rBlob, err := buildReachableSet(ctx, env)
+	if err != nil {
+		return GCStats{}, err
+	}
+	return sweep(ctx, env, rSnap, rBlob, includeContent)
+}
+
+// buildReachableSet (MARK) returns the chain-ID snapshot keys and content
+// digests that must be kept: everything referenced by a current image record or
+// an existing container. Any error aborts the whole pass with empty sets so the
+// caller never sweeps on a partial reachable set (which could delete live data).
+func buildReachableSet(ctx context.Context, env gcEnv) (rSnap, rBlob map[string]struct{}, err error) {
+	rSnap = make(map[string]struct{})
+	rBlob = make(map[string]struct{})
+
+	imgs, err := env.images.List(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing images: %w", err)
+	}
+	for _, img := range imgs {
+		chainIDs, blobs, err := env.resolveImage(ctx, img)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving image %q: %w", img.Name, err)
+		}
+		for _, id := range chainIDs {
+			rSnap[id] = struct{}{}
+		}
+		for _, b := range blobs {
+			rBlob[b] = struct{}{}
+		}
+	}
+
+	keys, err := env.containerSnapshotKeys(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing container snapshots: %w", err)
+	}
+	for _, key := range keys {
+		for key != "" {
+			rSnap[key] = struct{}{}
+			info, statErr := env.snapshots.Stat(ctx, key)
+			if statErr != nil {
+				if errdefs.IsNotFound(statErr) {
+					break // active snapshot raced a teardown; its parents are still covered by images
+				}
+				return nil, nil, fmt.Errorf("stat snapshot %q: %w", key, statErr)
+			}
+			key = info.Parent
+		}
+	}
+	return rSnap, rBlob, nil
+}
+
+// sweep (SWEEP) removes gc.root snapshots not in the reachable set, and (only
+// when includeContent is set) gc.root content blobs not in the reachable set.
+// Individual removal failures are logged and counted but never abort the pass; a
+// "has children" precondition error is a benign skip (the snapshot is still
+// referenced — the structural safety backstop).
+func sweep(ctx context.Context, env gcEnv, rSnap, rBlob map[string]struct{}, includeContent bool) (GCStats, error) {
+	var stats GCStats
+
+	var gcRootSnaps []snapshots.Info
+	err := env.snapshots.Walk(ctx, func(_ context.Context, info snapshots.Info) error {
+		gcRootSnaps = append(gcRootSnaps, info)
+		return nil
+	}, gcRootFilter)
+	if err != nil {
+		return stats, fmt.Errorf("walking snapshots: %w", err)
+	}
+
+	orphans := selectOrphanSnapshots(gcRootSnaps, rSnap)
+	for _, key := range orderLeafFirst(orphans) {
+		var size int64
+		if u, uerr := env.snapshots.Usage(ctx, key); uerr == nil {
+			size = u.Size
+		}
+		if rerr := env.snapshots.Remove(ctx, key); rerr != nil {
+			if errdefs.IsFailedPrecondition(rerr) {
+				env.logger.Debug("skipping snapshot with children", zap.String("snapshot", key))
+				continue
+			}
+			env.logger.Warn("failed to remove orphan snapshot", zap.String("snapshot", key), zap.Error(rerr))
+			stats.Errors++
+			continue
+		}
+		stats.SnapshotsRemoved++
+		stats.SnapshotBytes += size
+	}
+
+	if !includeContent {
+		return stats, nil
+	}
+
+	var gcRootBlobs []content.Info
+	err = env.content.Walk(ctx, func(info content.Info) error {
+		gcRootBlobs = append(gcRootBlobs, info)
+		return nil
+	}, gcRootFilter)
+	if err != nil {
+		return stats, fmt.Errorf("walking content: %w", err)
+	}
+
+	sizeByDigest := make(map[digest.Digest]int64, len(gcRootBlobs))
+	for _, info := range gcRootBlobs {
+		sizeByDigest[info.Digest] = info.Size
+	}
+	for _, d := range selectOrphanBlobs(gcRootBlobs, rBlob, env.now(), env.grace) {
+		if derr := env.content.Delete(ctx, d); derr != nil {
+			if errdefs.IsNotFound(derr) {
+				continue
+			}
+			env.logger.Warn("failed to delete orphan blob", zap.String("digest", d.String()), zap.Error(derr))
+			stats.Errors++
+			continue
+		}
+		stats.BlobsReclaimed++
+		stats.BlobBytes += sizeByDigest[d]
+	}
+	return stats, nil
+}
+
+// imageGCGracePeriod is the minimum age a gc.root-labelled content blob must
+// reach before the sweep may reclaim it. It is pinned to the unpack lease
+// expiration: WriteLayer labels a layer blob with gc.root *before* AssembleImage
+// creates the image record that references it, so a blob written by an in-flight
+// deploy is briefly orphaned-looking. The grace window guarantees such a blob is
+// never reclaimed while a concurrent deploy (or its lease) could still need it.
+const imageGCGracePeriod = unpackLeaseExpiration
+
+// GCStats summarises what one garbage-collection pass reclaimed. It exists purely
+// for observability — callers log it; no control flow branches on it.
+type GCStats struct {
+	SnapshotsRemoved int
+	SnapshotBytes    int64
+	BlobsReclaimed   int
+	BlobBytes        int64
+	Errors           int
+}
+
+// tryStartGC acquires the single-flight guard. It returns false when a pass is
+// already running, in which case the caller must not start another.
+func (c *Client) tryStartGC() bool {
+	return c.gcRunning.CompareAndSwap(false, true)
+}
+
+// finishGC releases the single-flight guard.
+func (c *Client) finishGC() {
+	c.gcRunning.Store(false)
+}
+
+// GarbageCollectImages runs one synchronous full mark-and-sweep pass (snapshots
+// AND content blobs). It is a no-op when GC is disabled or a pass is already
+// running (a skip is not an error). Used for the boot sweep, which is safe to
+// reclaim content because it runs before the agent serves any deploy RPC — no
+// deploy can be in flight. The per-deploy hook (triggerImageGCAsync) reclaims
+// snapshots only, since a concurrent deploy's just-pushed blobs are not yet
+// referenced by an image record.
+func (c *Client) GarbageCollectImages(ctx context.Context) (GCStats, error) {
+	if !c.imageGCEnabled {
+		return GCStats{}, nil
+	}
+	if !c.tryStartGC() {
+		return GCStats{}, nil
+	}
+	defer c.finishGC()
+
+	stats, err := c.garbageCollectImages(ctx, true)
+	if err == nil {
+		logGCStats(c.logger, stats)
+	}
+	return stats, err
+}
+
+// triggerImageGCAsync kicks off a snapshot-only mark-and-sweep pass in the
+// background after a successful deploy. It returns immediately so it never blocks
+// (or fails) the deploy. The pass runs on a detached, time-bounded context
+// because the deploy's request context is gone once the RPC returns. Single-flight
+// via the gcRunning guard means concurrent/back-to-back deploys never overlap
+// passes. Content blobs are intentionally left to the boot sweep (see
+// GarbageCollectImages / runImageGC).
+func (c *Client) triggerImageGCAsync() {
+	if !c.imageGCEnabled {
+		return
+	}
+	if !c.tryStartGC() {
+		return // a pass is already running; it (or the next deploy/boot) covers this
+	}
+	go func() {
+		defer c.finishGC()
+		ctx, cancel := context.WithTimeout(context.Background(), imageGCTimeout)
+		defer cancel()
+		stats, err := c.garbageCollectImages(ctx, false)
+		if err != nil {
+			c.logger.Warn("image GC pass failed", zap.Error(err))
+			return
+		}
+		logGCStats(c.logger, stats)
+	}()
+}
+
+// garbageCollectImages wires the concrete containerd services into a gcEnv and
+// runs one pass. It assumes the single-flight guard is already held.
+func (c *Client) garbageCollectImages(ctx context.Context, includeContent bool) (GCStats, error) {
+	ctx = c.withNamespace(ctx)
+	env := gcEnv{
+		images:                c.client.ImageService(),
+		snapshots:             c.client.SnapshotService(c.snapshotter),
+		content:               c.client.ContentStore(),
+		resolveImage:          c.resolveImageChain,
+		containerSnapshotKeys: c.containerSnapshotKeys,
+		now:                   time.Now,
+		grace:                 imageGCGracePeriod,
+		logger:                c.logger,
+	}
+	return runImageGC(ctx, env, includeContent)
+}
+
+// resolveImageChain resolves an image record to the chain-ID snapshots and the
+// content digests (manifest, config, layers) it references. ctx must already
+// carry the containerd namespace.
+func (c *Client) resolveImageChain(ctx context.Context, img images.Image) (chainIDs []string, blobs []string, err error) {
+	cs := c.client.ContentStore()
+	manifest, err := images.Manifest(ctx, cs, img.Target, platforms.Default())
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading manifest: %w", err)
+	}
+	diffIDs, err := images.RootFS(ctx, cs, manifest.Config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading rootfs: %w", err)
+	}
+	chainIDs = chainIDsForDiffIDs(diffIDs)
+	blobs = make([]string, 0, len(manifest.Layers)+2)
+	blobs = append(blobs, img.Target.Digest.String(), manifest.Config.Digest.String())
+	for _, l := range manifest.Layers {
+		blobs = append(blobs, l.Digest.String())
+	}
+	return chainIDs, blobs, nil
+}
+
+// containerSnapshotKeys returns the active snapshot key of EVERY container
+// (running or stopped), not just app containers: ROS2 sidecars and any other
+// container carry their own snapshot chains and must be kept too. The mark phase
+// walks each key's parent chain to keep the read-only layers a container could
+// still need. Enumerating all containers makes the reachable set the primary
+// safety mechanism rather than leaning on the has-children removal backstop. ctx
+// must already carry the containerd namespace.
+func (c *Client) containerSnapshotKeys(ctx context.Context) ([]string, error) {
+	ctrs, err := c.client.Containers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(ctrs))
+	for _, ctr := range ctrs {
+		info, infoErr := ctr.Info(ctx)
+		if infoErr != nil {
+			return nil, fmt.Errorf("reading container %q info: %w", ctr.ID(), infoErr)
+		}
+		if info.SnapshotKey != "" {
+			keys = append(keys, info.SnapshotKey)
+		}
+	}
+	return keys, nil
+}
+
+// logGCStats emits a single summary line when a pass reclaimed something (or hit
+// errors); quiet passes stay silent to avoid log noise on every deploy.
+func logGCStats(logger *zap.Logger, stats GCStats) {
+	if stats.SnapshotsRemoved+stats.BlobsReclaimed == 0 && stats.Errors == 0 {
+		return
+	}
+	logger.Info("image GC reclaimed stale image data",
+		zap.Int("snapshots_removed", stats.SnapshotsRemoved),
+		zap.Int64("snapshot_bytes", stats.SnapshotBytes),
+		zap.Int("blobs_reclaimed", stats.BlobsReclaimed),
+		zap.Int64("blob_bytes", stats.BlobBytes),
+		zap.Int("errors", stats.Errors),
+	)
+}
+
+// selectOrphanSnapshots returns the gc.root snapshots whose key is not in the
+// reachable set: layers left behind by an image version that no current image
+// record or running container references any more.
+func selectOrphanSnapshots(gcRoots []snapshots.Info, reachable map[string]struct{}) []snapshots.Info {
+	var orphans []snapshots.Info
+	for _, info := range gcRoots {
+		if _, ok := reachable[info.Name]; !ok {
+			orphans = append(orphans, info)
+		}
+	}
+	return orphans
+}
+
+// orderLeafFirst returns the orphan snapshot keys ordered so that every child is
+// listed before its parent. Removing in this order means a parent layer is never
+// deleted while one of its still-orphaned children references it. Ordering is by
+// the number of ancestors within the orphan set, descending; ties break by name
+// for determinism.
+func orderLeafFirst(orphans []snapshots.Info) []string {
+	parentOf := make(map[string]string, len(orphans)) // name -> parent (within set)
+	for _, o := range orphans {
+		parentOf[o.Name] = o.Parent
+	}
+	ancestorsInSet := func(name string) int {
+		count := 0
+		// Chain-ID parents form a strict tree, so this terminates well before the
+		// bound; the len(parentOf) cap is defensive against a malformed cycle
+		// hanging the background GC goroutine.
+		for count <= len(parentOf) {
+			parent, ok := parentOf[name]
+			if !ok || parent == "" {
+				return count
+			}
+			if _, ok := parentOf[parent]; !ok {
+				return count
+			}
+			count++
+			name = parent
+		}
+		return count
+	}
+	keys := make([]string, 0, len(orphans))
+	for _, o := range orphans {
+		keys = append(keys, o.Name)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		di, dj := ancestorsInSet(keys[i]), ancestorsInSet(keys[j])
+		if di != dj {
+			return di > dj
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+// selectOrphanBlobs returns the gc.root content blobs eligible for reclamation:
+// those whose digest is not in the reachable set AND whose gc.root timestamp is
+// older than grace. A blob is kept (conservatively) when its gc.root label value
+// is missing/unparseable or still within the grace window.
+func selectOrphanBlobs(infos []content.Info, reachable map[string]struct{}, now time.Time, grace time.Duration) []digest.Digest {
+	var orphans []digest.Digest
+	for _, info := range infos {
+		if _, ok := reachable[info.Digest.String()]; ok {
+			continue // referenced by a current image
+		}
+		ts, err := time.Parse(time.RFC3339, info.Labels[labelKeyGCRoot])
+		if err != nil {
+			continue // unparseable gc.root timestamp -> keep
+		}
+		if now.Sub(ts) <= grace {
+			continue // within grace -> may belong to an in-flight deploy
+		}
+		orphans = append(orphans, info.Digest)
+	}
+	return orphans
+}

--- a/go/internal/agent/containerd/imagegc.go
+++ b/go/internal/agent/containerd/imagegc.go
@@ -138,7 +138,7 @@ func sweep(ctx context.Context, env gcEnv, rSnap, rBlob map[string]struct{}, inc
 		return stats, fmt.Errorf("walking snapshots: %w", err)
 	}
 
-	orphans := selectOrphanSnapshots(gcRootSnaps, rSnap)
+	orphans := selectOrphanSnapshots(gcRootSnaps, rSnap, env.now(), env.grace)
 	for _, key := range orderLeafFirst(orphans) {
 		var size int64
 		if u, uerr := env.snapshots.Usage(ctx, key); uerr == nil {
@@ -189,12 +189,21 @@ func sweep(ctx context.Context, env gcEnv, rSnap, rBlob map[string]struct{}, inc
 	return stats, nil
 }
 
-// imageGCGracePeriod is the minimum age a gc.root-labelled content blob must
-// reach before the sweep may reclaim it. It is pinned to the unpack lease
-// expiration: WriteLayer labels a layer blob with gc.root *before* AssembleImage
-// creates the image record that references it, so a blob written by an in-flight
-// deploy is briefly orphaned-looking. The grace window guarantees such a blob is
-// never reclaimed while a concurrent deploy (or its lease) could still need it.
+// imageGCGracePeriod is the minimum age a gc.root-labelled snapshot or content
+// blob must reach (by its gc.root RFC3339 timestamp) before the sweep may reclaim
+// it. It protects artifacts a concurrent in-flight deploy created that this pass's
+// reachable set may not cover:
+//   - content blobs: WriteLayer labels a layer blob gc.root *before* AssembleImage
+//     creates the referencing image record, so a just-pushed blob is briefly
+//     unreferenced;
+//   - snapshots: the async pass marks reachability once and sweeps later, so a
+//     back-to-back deploy can commit new gc.root chain-ID snapshots after the mark
+//     that are absent from the (older) reachable set.
+//
+// It is pinned to the unpack lease expiration (30m), which far exceeds a single
+// pass's imageGCTimeout (5m); any artifact created during a pass is therefore
+// comfortably within grace and kept, while genuine orphans age past it and are
+// reclaimed by a later pass or the boot sweep.
 const imageGCGracePeriod = unpackLeaseExpiration
 
 // GCStats summarises what one garbage-collection pass reclaimed. It exists purely
@@ -347,15 +356,30 @@ func logGCStats(logger *zap.Logger, stats GCStats) {
 	)
 }
 
-// selectOrphanSnapshots returns the gc.root snapshots whose key is not in the
-// reachable set: layers left behind by an image version that no current image
-// record or running container references any more.
-func selectOrphanSnapshots(gcRoots []snapshots.Info, reachable map[string]struct{}) []snapshots.Info {
+// selectOrphanSnapshots returns the gc.root snapshots eligible for removal:
+// those whose key is not in the reachable set AND whose gc.root timestamp is
+// older than grace. The age guard is essential because the async per-deploy pass
+// builds its reachable set once and sweeps later: a back-to-back deploy can
+// commit new gc.root chain-ID snapshots after the mark, and those would be absent
+// from the (older) reachable set. Keeping anything younger than grace — which far
+// exceeds a single pass's imageGCTimeout — prevents reaping a concurrent deploy's
+// freshly committed layers. A snapshot is kept (conservatively) when its gc.root
+// value is missing/unparseable or still within the grace window; genuine orphans
+// age past grace and are reclaimed by a later pass or the boot sweep.
+func selectOrphanSnapshots(gcRoots []snapshots.Info, reachable map[string]struct{}, now time.Time, grace time.Duration) []snapshots.Info {
 	var orphans []snapshots.Info
 	for _, info := range gcRoots {
-		if _, ok := reachable[info.Name]; !ok {
-			orphans = append(orphans, info)
+		if _, ok := reachable[info.Name]; ok {
+			continue // referenced by a current image or container
 		}
+		ts, err := time.Parse(time.RFC3339, info.Labels[labelKeyGCRoot])
+		if err != nil {
+			continue // unparseable gc.root timestamp -> keep
+		}
+		if now.Sub(ts) <= grace {
+			continue // committed too recently -> may belong to an in-flight deploy
+		}
+		orphans = append(orphans, info)
 	}
 	return orphans
 }

--- a/go/internal/agent/containerd/imagegc_test.go
+++ b/go/internal/agent/containerd/imagegc_test.go
@@ -1,0 +1,415 @@
+package containerd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/errdefs"
+	digest "github.com/opencontainers/go-digest"
+	"go.uber.org/zap"
+)
+
+// --- fakes for the mark-and-sweep orchestration (modeled on mockStatter) ---
+
+type fakeImageStore struct {
+	imgs []images.Image
+	err  error
+}
+
+func (f *fakeImageStore) List(_ context.Context, _ ...string) ([]images.Image, error) {
+	return f.imgs, f.err
+}
+
+type fakeSnapshotter struct {
+	infos   map[string]snapshots.Info
+	usage   map[string]int64
+	removed []string
+}
+
+func (f *fakeSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, _ ...string) error {
+	// Emulate the `labels."containerd.io/gc.root"` filter: yield only gc.root entries.
+	for _, info := range f.infos {
+		if _, ok := info.Labels[labelKeyGCRoot]; ok {
+			if err := fn(ctx, info); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *fakeSnapshotter) Stat(_ context.Context, key string) (snapshots.Info, error) {
+	info, ok := f.infos[key]
+	if !ok {
+		return snapshots.Info{}, errdefs.ErrNotFound
+	}
+	return info, nil
+}
+
+func (f *fakeSnapshotter) Usage(_ context.Context, key string) (snapshots.Usage, error) {
+	return snapshots.Usage{Size: f.usage[key]}, nil
+}
+
+func (f *fakeSnapshotter) Remove(_ context.Context, key string) error {
+	for _, info := range f.infos {
+		if info.Parent == key {
+			return errdefs.ErrFailedPrecondition // has-children backstop
+		}
+	}
+	if _, ok := f.infos[key]; !ok {
+		return errdefs.ErrNotFound
+	}
+	delete(f.infos, key)
+	f.removed = append(f.removed, key)
+	return nil
+}
+
+type fakeContent struct {
+	infos   map[digest.Digest]content.Info
+	deleted []digest.Digest
+}
+
+func (f *fakeContent) Walk(_ context.Context, fn content.WalkFunc, _ ...string) error {
+	for _, info := range f.infos {
+		if _, ok := info.Labels[labelKeyGCRoot]; ok {
+			if err := fn(info); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *fakeContent) Delete(_ context.Context, dgst digest.Digest) error {
+	if _, ok := f.infos[dgst]; !ok {
+		return errdefs.ErrNotFound
+	}
+	delete(f.infos, dgst)
+	f.deleted = append(f.deleted, dgst)
+	return nil
+}
+
+func gcLabel(ts string) map[string]string {
+	return map[string]string{labelKeyGCRoot: ts}
+}
+
+func TestRunImageGC_ReclaimsOldVersionData(t *testing.T) {
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	oldTS := now.Add(-time.Hour).UTC().Format(time.RFC3339) // older than grace
+
+	const (
+		c0     = "sha256:c0" // base layer of current image
+		c1     = "sha256:c1" // top layer of current image
+		oldA   = "sha256:oldA"
+		oldB   = "sha256:oldB"
+		active = "wendy-app" // running container's writable snapshot (no gc.root)
+	)
+	mD := digest.Digest("sha256:manifest")
+	cfgD := digest.Digest("sha256:config")
+	l0 := digest.Digest("sha256:layer0")
+	l1 := digest.Digest("sha256:layer1")
+	oldL := digest.Digest("sha256:oldlayer")
+
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			c0:     {Name: c0, Labels: gcLabel(oldTS)},
+			c1:     {Name: c1, Parent: c0, Labels: gcLabel(oldTS)},
+			oldA:   {Name: oldA, Parent: c0, Labels: gcLabel(oldTS)},
+			oldB:   {Name: oldB, Parent: oldA, Labels: gcLabel(oldTS)},
+			active: {Name: active, Parent: c1}, // no gc.root label
+		},
+		usage: map[string]int64{oldA: 100, oldB: 200},
+	}
+	cs := &fakeContent{
+		infos: map[digest.Digest]content.Info{
+			l0:   {Digest: l0, Size: 10, Labels: gcLabel(oldTS)},
+			l1:   {Digest: l1, Size: 20, Labels: gcLabel(oldTS)},
+			oldL: {Digest: oldL, Size: 33, Labels: gcLabel(oldTS)},
+		},
+	}
+
+	env := gcEnv{
+		images:    &fakeImageStore{imgs: []images.Image{{Name: "localhost:5000/app:latest"}}},
+		snapshots: sn,
+		content:   cs,
+		resolveImage: func(_ context.Context, _ images.Image) ([]string, []string, error) {
+			return []string{c0, c1}, []string{mD.String(), cfgD.String(), l0.String(), l1.String()}, nil
+		},
+		containerSnapshotKeys: func(_ context.Context) ([]string, error) {
+			return []string{active}, nil
+		},
+		now:    func() time.Time { return now },
+		grace:  imageGCGracePeriod,
+		logger: zap.NewNop(),
+	}
+
+	stats, err := runImageGC(context.Background(), env, true) // boot-style: full sweep
+	if err != nil {
+		t.Fatalf("runImageGC: %v", err)
+	}
+	if stats.SnapshotsRemoved != 2 || stats.SnapshotBytes != 300 {
+		t.Errorf("snapshots removed=%d bytes=%d; want 2/300", stats.SnapshotsRemoved, stats.SnapshotBytes)
+	}
+	if stats.BlobsReclaimed != 1 || stats.BlobBytes != 33 {
+		t.Errorf("blobs reclaimed=%d bytes=%d; want 1/33", stats.BlobsReclaimed, stats.BlobBytes)
+	}
+	if stats.Errors != 0 {
+		t.Errorf("errors=%d; want 0", stats.Errors)
+	}
+	// Old version's data gone; current image + container layers kept.
+	for _, k := range []string{oldA, oldB} {
+		if _, ok := sn.infos[k]; ok {
+			t.Errorf("snapshot %q should have been removed", k)
+		}
+	}
+	for _, k := range []string{c0, c1, active} {
+		if _, ok := sn.infos[k]; !ok {
+			t.Errorf("snapshot %q must be kept", k)
+		}
+	}
+	if _, ok := cs.infos[oldL]; ok {
+		t.Error("blob oldL should have been deleted")
+	}
+	for _, d := range []digest.Digest{l0, l1} {
+		if _, ok := cs.infos[d]; !ok {
+			t.Errorf("blob %q must be kept", d)
+		}
+	}
+}
+
+func TestRunImageGC_SnapshotsOnlySkipsContent(t *testing.T) {
+	// The per-deploy async path (includeContent=false) reclaims orphan snapshots
+	// but must never touch content blobs — a concurrent deploy's just-pushed blob
+	// is legitimately unreferenced until its image record is created.
+	oldTS := "2020-01-01T00:00:00Z"
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			"orphanSnap": {Name: "orphanSnap", Labels: gcLabel(oldTS)},
+		},
+		usage: map[string]int64{"orphanSnap": 50},
+	}
+	orphanBlob := digest.Digest("sha256:orphanblob")
+	cs := &fakeContent{
+		infos: map[digest.Digest]content.Info{
+			orphanBlob: {Digest: orphanBlob, Size: 99, Labels: gcLabel(oldTS)},
+		},
+	}
+	env := gcEnv{
+		images:                &fakeImageStore{},
+		snapshots:             sn,
+		content:               cs,
+		resolveImage:          func(_ context.Context, _ images.Image) ([]string, []string, error) { return nil, nil, nil },
+		containerSnapshotKeys: func(_ context.Context) ([]string, error) { return nil, nil },
+		now:                   func() time.Time { return time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC) },
+		grace:                 imageGCGracePeriod,
+		logger:                zap.NewNop(),
+	}
+
+	stats, err := runImageGC(context.Background(), env, false) // deploy-style: snapshots only
+	if err != nil {
+		t.Fatalf("runImageGC: %v", err)
+	}
+	if stats.SnapshotsRemoved != 1 {
+		t.Errorf("snapshots removed=%d; want 1", stats.SnapshotsRemoved)
+	}
+	if stats.BlobsReclaimed != 0 {
+		t.Errorf("blobs reclaimed=%d; want 0 (content sweep deferred to boot)", stats.BlobsReclaimed)
+	}
+	if _, ok := cs.infos[orphanBlob]; !ok {
+		t.Error("content blob must be kept by the snapshots-only path")
+	}
+}
+
+func TestRunImageGC_FailClosedOnResolveError(t *testing.T) {
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			"orphan": {Name: "orphan", Labels: gcLabel("2020-01-01T00:00:00Z")},
+		},
+	}
+	env := gcEnv{
+		images:    &fakeImageStore{imgs: []images.Image{{Name: "app:latest"}}},
+		snapshots: sn,
+		content:   &fakeContent{infos: map[digest.Digest]content.Info{}},
+		resolveImage: func(_ context.Context, _ images.Image) ([]string, []string, error) {
+			return nil, nil, errors.New("boom")
+		},
+		containerSnapshotKeys: func(_ context.Context) ([]string, error) { return nil, nil },
+		now:                   func() time.Time { return time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC) },
+		grace:                 imageGCGracePeriod,
+		logger:                zap.NewNop(),
+	}
+	stats, err := runImageGC(context.Background(), env, true)
+	if err == nil {
+		t.Fatal("expected error from fail-closed MARK")
+	}
+	if stats.SnapshotsRemoved != 0 {
+		t.Errorf("removed=%d; want 0 deletions on fail-closed", stats.SnapshotsRemoved)
+	}
+	if _, ok := sn.infos["orphan"]; !ok {
+		t.Error("no snapshot may be deleted when MARK fails")
+	}
+}
+
+func TestSweep_HasChildrenBackstop(t *testing.T) {
+	// p is selected as an orphan but still has a reachable child ch; Remove must
+	// fail-precondition and be skipped, not counted as an error.
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			"p":  {Name: "p", Labels: gcLabel("2020-01-01T00:00:00Z")},
+			"ch": {Name: "ch", Parent: "p", Labels: gcLabel("2020-01-01T00:00:00Z")},
+		},
+		usage: map[string]int64{},
+	}
+	env := gcEnv{
+		snapshots: sn,
+		content:   &fakeContent{infos: map[digest.Digest]content.Info{}},
+		now:       func() time.Time { return time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC) },
+		grace:     imageGCGracePeriod,
+		logger:    zap.NewNop(),
+	}
+	// ch is reachable; p is not.
+	rSnap := keySet("ch")
+	stats, err := sweep(context.Background(), env, rSnap, keySet(), true)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if stats.SnapshotsRemoved != 0 || stats.Errors != 0 {
+		t.Errorf("removed=%d errors=%d; want 0/0 (benign skip)", stats.SnapshotsRemoved, stats.Errors)
+	}
+	if _, ok := sn.infos["p"]; !ok {
+		t.Error("p must be kept: a snapshot with children is never removed")
+	}
+}
+
+func TestGCSingleFlight(t *testing.T) {
+	c := &Client{logger: zap.NewNop(), imageGCEnabled: true}
+	if !c.tryStartGC() {
+		t.Fatal("first acquire should win")
+	}
+	if c.tryStartGC() {
+		t.Fatal("second acquire must fail while a pass is running")
+	}
+	c.finishGC()
+	if !c.tryStartGC() {
+		t.Fatal("acquire should win again after finish")
+	}
+	c.finishGC()
+}
+
+func TestGarbageCollectImages_DisabledNoOp(t *testing.T) {
+	c := &Client{logger: zap.NewNop(), imageGCEnabled: false}
+	stats, err := c.GarbageCollectImages(context.Background())
+	if err != nil {
+		t.Fatalf("GarbageCollectImages disabled: %v", err)
+	}
+	if stats != (GCStats{}) {
+		t.Errorf("stats = %+v; want zero when disabled", stats)
+	}
+	// Disabled path must not have touched the (nil) containerd client.
+}
+
+// keySet builds a reachable-set (set of snapshot keys or digest strings) for tests.
+func keySet(keys ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		m[k] = struct{}{}
+	}
+	return m
+}
+
+func names(infos []snapshots.Info) map[string]bool {
+	out := make(map[string]bool, len(infos))
+	for _, i := range infos {
+		out[i.Name] = true
+	}
+	return out
+}
+
+func TestSelectOrphanSnapshots_AllReachable(t *testing.T) {
+	gcRoots := []snapshots.Info{{Name: "a"}, {Name: "b"}}
+	if got := selectOrphanSnapshots(gcRoots, keySet("a", "b")); len(got) != 0 {
+		t.Fatalf("got %d orphans; want 0", len(got))
+	}
+}
+
+func TestSelectOrphanSnapshots_OldVersionOrphaned(t *testing.T) {
+	// a,b are the current image chain (reachable); c,d are an old version's
+	// top layers that nothing references any more.
+	gcRoots := []snapshots.Info{{Name: "a"}, {Name: "b"}, {Name: "c"}, {Name: "d"}}
+	got := names(selectOrphanSnapshots(gcRoots, keySet("a", "b")))
+	if len(got) != 2 || !got["c"] || !got["d"] {
+		t.Fatalf("orphans = %v; want {c,d}", got)
+	}
+}
+
+func TestSelectOrphanSnapshots_SharedBaseKept(t *testing.T) {
+	// base is still referenced by a current image; only the old top layer is orphaned.
+	gcRoots := []snapshots.Info{{Name: "base"}, {Name: "oldtop", Parent: "base"}}
+	got := selectOrphanSnapshots(gcRoots, keySet("base"))
+	if len(got) != 1 || got[0].Name != "oldtop" {
+		t.Fatalf("orphans = %v; want {oldtop}", names(got))
+	}
+}
+
+func TestOrderLeafFirst_Chain(t *testing.T) {
+	// root <- mid <- leaf: removal must proceed leaf, mid, root so a parent is
+	// never removed while a child still references it.
+	orphans := []snapshots.Info{
+		{Name: "root"},
+		{Name: "mid", Parent: "root"},
+		{Name: "leaf", Parent: "mid"},
+	}
+	got := orderLeafFirst(orphans)
+	want := []string{"leaf", "mid", "root"}
+	if len(got) != len(want) {
+		t.Fatalf("order = %v; want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v; want %v", got, want)
+		}
+	}
+}
+
+func TestOrderLeafFirst_Branching(t *testing.T) {
+	// root has two orphan children; root must be ordered after both.
+	orphans := []snapshots.Info{
+		{Name: "root"},
+		{Name: "c1", Parent: "root"},
+		{Name: "c2", Parent: "root"},
+	}
+	pos := map[string]int{}
+	for i, k := range orderLeafFirst(orphans) {
+		pos[k] = i
+	}
+	if pos["root"] < pos["c1"] || pos["root"] < pos["c2"] {
+		t.Fatalf("root must come after its children: %v", pos)
+	}
+}
+
+func TestSelectOrphanBlobs(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-time.Hour).UTC().Format(time.RFC3339)         // older than grace
+	fresh := now.Add(-1 * time.Minute).UTC().Format(time.RFC3339) // within grace
+
+	d := func(c string) digest.Digest { return digest.Digest("sha256:" + strings.Repeat(c, 64)) }
+	dReach, dOld, dFresh, dBad := d("1"), d("2"), d("3"), d("4")
+
+	infos := []content.Info{
+		{Digest: dReach, Labels: map[string]string{labelKeyGCRoot: old}},   // reachable -> kept
+		{Digest: dOld, Labels: map[string]string{labelKeyGCRoot: old}},     // orphan + old -> selected
+		{Digest: dFresh, Labels: map[string]string{labelKeyGCRoot: fresh}}, // orphan + in-grace -> kept
+		{Digest: dBad, Labels: map[string]string{labelKeyGCRoot: "nope"}},  // orphan + unparseable -> kept
+	}
+
+	got := selectOrphanBlobs(infos, keySet(dReach.String()), now, imageGCGracePeriod)
+	if len(got) != 1 || got[0] != dOld {
+		t.Fatalf("orphan blobs = %v; want {%s}", got, dOld)
+	}
+}

--- a/go/internal/agent/containerd/imagegc_test.go
+++ b/go/internal/agent/containerd/imagegc_test.go
@@ -331,9 +331,17 @@ func names(infos []snapshots.Info) map[string]bool {
 	return out
 }
 
+// snapNow and snapOld are a fixed "now" and an over-grace-old gc.root timestamp
+// used by the snapshot selection tests.
+var snapNow = time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
+
+func snapOldLabel() map[string]string {
+	return gcLabel(snapNow.Add(-time.Hour).UTC().Format(time.RFC3339)) // older than grace
+}
+
 func TestSelectOrphanSnapshots_AllReachable(t *testing.T) {
-	gcRoots := []snapshots.Info{{Name: "a"}, {Name: "b"}}
-	if got := selectOrphanSnapshots(gcRoots, keySet("a", "b")); len(got) != 0 {
+	gcRoots := []snapshots.Info{{Name: "a", Labels: snapOldLabel()}, {Name: "b", Labels: snapOldLabel()}}
+	if got := selectOrphanSnapshots(gcRoots, keySet("a", "b"), snapNow, imageGCGracePeriod); len(got) != 0 {
 		t.Fatalf("got %d orphans; want 0", len(got))
 	}
 }
@@ -341,8 +349,11 @@ func TestSelectOrphanSnapshots_AllReachable(t *testing.T) {
 func TestSelectOrphanSnapshots_OldVersionOrphaned(t *testing.T) {
 	// a,b are the current image chain (reachable); c,d are an old version's
 	// top layers that nothing references any more.
-	gcRoots := []snapshots.Info{{Name: "a"}, {Name: "b"}, {Name: "c"}, {Name: "d"}}
-	got := names(selectOrphanSnapshots(gcRoots, keySet("a", "b")))
+	gcRoots := []snapshots.Info{
+		{Name: "a", Labels: snapOldLabel()}, {Name: "b", Labels: snapOldLabel()},
+		{Name: "c", Labels: snapOldLabel()}, {Name: "d", Labels: snapOldLabel()},
+	}
+	got := names(selectOrphanSnapshots(gcRoots, keySet("a", "b"), snapNow, imageGCGracePeriod))
 	if len(got) != 2 || !got["c"] || !got["d"] {
 		t.Fatalf("orphans = %v; want {c,d}", got)
 	}
@@ -350,10 +361,31 @@ func TestSelectOrphanSnapshots_OldVersionOrphaned(t *testing.T) {
 
 func TestSelectOrphanSnapshots_SharedBaseKept(t *testing.T) {
 	// base is still referenced by a current image; only the old top layer is orphaned.
-	gcRoots := []snapshots.Info{{Name: "base"}, {Name: "oldtop", Parent: "base"}}
-	got := selectOrphanSnapshots(gcRoots, keySet("base"))
+	gcRoots := []snapshots.Info{
+		{Name: "base", Labels: snapOldLabel()},
+		{Name: "oldtop", Parent: "base", Labels: snapOldLabel()},
+	}
+	got := selectOrphanSnapshots(gcRoots, keySet("base"), snapNow, imageGCGracePeriod)
 	if len(got) != 1 || got[0].Name != "oldtop" {
 		t.Fatalf("orphans = %v; want {oldtop}", names(got))
+	}
+}
+
+func TestSelectOrphanSnapshots_FreshSnapshotKept(t *testing.T) {
+	// A back-to-back deploy commits a new gc.root chain-ID snapshot after this
+	// pass built its reachable set; it is unreachable in the stale set but must
+	// NOT be removed because it is within the grace window (WDY-1679 P1 race).
+	fresh := snapNow.Add(-time.Minute).UTC().Format(time.RFC3339)
+	gcRoots := []snapshots.Info{
+		{Name: "fresh", Labels: gcLabel(fresh)},
+		{Name: "old", Labels: snapOldLabel()},
+	}
+	got := names(selectOrphanSnapshots(gcRoots, keySet(), snapNow, imageGCGracePeriod))
+	if got["fresh"] {
+		t.Error("a snapshot committed within grace must be kept (may belong to an in-flight deploy)")
+	}
+	if !got["old"] {
+		t.Error("an old unreachable snapshot must be selected")
 	}
 }
 

--- a/go/internal/agent/containerd/imagegc_test.go
+++ b/go/internal/agent/containerd/imagegc_test.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// testGrace is the orphan-age grace used throughout these tests (the production
+// default). Tombstones older than this are reapable; younger ones are kept.
+const testGrace = 24 * time.Hour
+
 // --- fakes for the mark-and-sweep orchestration (modeled on mockStatter) ---
 
 type fakeImageStore struct {
@@ -27,9 +31,11 @@ func (f *fakeImageStore) List(_ context.Context, _ ...string) ([]images.Image, e
 }
 
 type fakeSnapshotter struct {
-	infos   map[string]snapshots.Info
-	usage   map[string]int64
-	removed []string
+	infos     map[string]snapshots.Info
+	usage     map[string]int64
+	removed   []string
+	updated   []string
+	updateErr error
 }
 
 func (f *fakeSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, _ ...string) error {
@@ -56,6 +62,27 @@ func (f *fakeSnapshotter) Usage(_ context.Context, key string) (snapshots.Usage,
 	return snapshots.Usage{Size: f.usage[key]}, nil
 }
 
+// Update applies each "labels.<key>" fieldpath to the stored Info, reproducing
+// containerd's metadata semantics: an empty value deletes the label, a non-empty
+// value sets it, and labels outside the named fieldpaths are left untouched (so
+// gc.root survives an orphanedAt write).
+func (f *fakeSnapshotter) Update(_ context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	if f.updateErr != nil {
+		return snapshots.Info{}, f.updateErr
+	}
+	cur, ok := f.infos[info.Name]
+	if !ok {
+		return snapshots.Info{}, errdefs.ErrNotFound
+	}
+	if cur.Labels == nil {
+		cur.Labels = map[string]string{}
+	}
+	applyLabelFieldpaths(cur.Labels, info.Labels, fieldpaths)
+	f.infos[info.Name] = cur
+	f.updated = append(f.updated, info.Name)
+	return cur, nil
+}
+
 func (f *fakeSnapshotter) Remove(_ context.Context, key string) error {
 	for _, info := range f.infos {
 		if info.Parent == key {
@@ -71,8 +98,10 @@ func (f *fakeSnapshotter) Remove(_ context.Context, key string) error {
 }
 
 type fakeContent struct {
-	infos   map[digest.Digest]content.Info
-	deleted []digest.Digest
+	infos     map[digest.Digest]content.Info
+	deleted   []digest.Digest
+	updated   []digest.Digest
+	updateErr error
 }
 
 func (f *fakeContent) Walk(_ context.Context, fn content.WalkFunc, _ ...string) error {
@@ -86,6 +115,23 @@ func (f *fakeContent) Walk(_ context.Context, fn content.WalkFunc, _ ...string) 
 	return nil
 }
 
+func (f *fakeContent) Update(_ context.Context, info content.Info, fieldpaths ...string) (content.Info, error) {
+	if f.updateErr != nil {
+		return content.Info{}, f.updateErr
+	}
+	cur, ok := f.infos[info.Digest]
+	if !ok {
+		return content.Info{}, errdefs.ErrNotFound
+	}
+	if cur.Labels == nil {
+		cur.Labels = map[string]string{}
+	}
+	applyLabelFieldpaths(cur.Labels, info.Labels, fieldpaths)
+	f.infos[info.Digest] = cur
+	f.updated = append(f.updated, info.Digest)
+	return cur, nil
+}
+
 func (f *fakeContent) Delete(_ context.Context, dgst digest.Digest) error {
 	if _, ok := f.infos[dgst]; !ok {
 		return errdefs.ErrNotFound
@@ -95,13 +141,40 @@ func (f *fakeContent) Delete(_ context.Context, dgst digest.Digest) error {
 	return nil
 }
 
-func gcLabel(ts string) map[string]string {
-	return map[string]string{labelKeyGCRoot: ts}
+// applyLabelFieldpaths mutates dst per the "labels.<key>" fieldpaths, mirroring
+// containerd's boltutil.writeMap (empty value -> delete).
+func applyLabelFieldpaths(dst, src map[string]string, fieldpaths []string) {
+	for _, p := range fieldpaths {
+		key, found := strings.CutPrefix(p, "labels.")
+		if !found {
+			continue
+		}
+		if v := src[key]; v == "" {
+			delete(dst, key)
+		} else {
+			dst[key] = v
+		}
+	}
 }
 
-func TestRunImageGC_ReclaimsOldVersionData(t *testing.T) {
+// gcRootLabels marks an artifact gc.root so the fake Walk yields it. The value is
+// irrelevant to the tombstone GC (only presence matters) and never the age basis.
+func gcRootLabels() map[string]string {
+	return map[string]string{labelKeyGCRoot: "x"}
+}
+
+// tombstone marks an artifact gc.root AND stamps its orphanedAt at ts — i.e. an
+// artifact the GC has already observed orphaned.
+func tombstone(ts time.Time) map[string]string {
+	return map[string]string{
+		labelKeyGCRoot:     "x",
+		labelKeyOrphanedAt: ts.UTC().Format(time.RFC3339),
+	}
+}
+
+func TestRunImageGC_ReclaimsAgedOrphans(t *testing.T) {
 	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
-	oldTS := now.Add(-time.Hour).UTC().Format(time.RFC3339) // older than grace
+	aged := now.Add(-48 * time.Hour) // orphaned well past grace
 
 	const (
 		c0     = "sha256:c0" // base layer of current image
@@ -118,19 +191,19 @@ func TestRunImageGC_ReclaimsOldVersionData(t *testing.T) {
 
 	sn := &fakeSnapshotter{
 		infos: map[string]snapshots.Info{
-			c0:     {Name: c0, Labels: gcLabel(oldTS)},
-			c1:     {Name: c1, Parent: c0, Labels: gcLabel(oldTS)},
-			oldA:   {Name: oldA, Parent: c0, Labels: gcLabel(oldTS)},
-			oldB:   {Name: oldB, Parent: oldA, Labels: gcLabel(oldTS)},
+			c0:     {Name: c0, Labels: gcRootLabels()},
+			c1:     {Name: c1, Parent: c0, Labels: gcRootLabels()},
+			oldA:   {Name: oldA, Parent: c0, Labels: tombstone(aged)},
+			oldB:   {Name: oldB, Parent: oldA, Labels: tombstone(aged)},
 			active: {Name: active, Parent: c1}, // no gc.root label
 		},
 		usage: map[string]int64{oldA: 100, oldB: 200},
 	}
 	cs := &fakeContent{
 		infos: map[digest.Digest]content.Info{
-			l0:   {Digest: l0, Size: 10, Labels: gcLabel(oldTS)},
-			l1:   {Digest: l1, Size: 20, Labels: gcLabel(oldTS)},
-			oldL: {Digest: oldL, Size: 33, Labels: gcLabel(oldTS)},
+			l0:   {Digest: l0, Size: 10, Labels: gcRootLabels()},
+			l1:   {Digest: l1, Size: 20, Labels: gcRootLabels()},
+			oldL: {Digest: oldL, Size: 33, Labels: tombstone(aged)},
 		},
 	}
 
@@ -145,7 +218,7 @@ func TestRunImageGC_ReclaimsOldVersionData(t *testing.T) {
 			return []string{active}, nil
 		},
 		now:    func() time.Time { return now },
-		grace:  imageGCGracePeriod,
+		grace:  testGrace,
 		logger: zap.NewNop(),
 	}
 
@@ -158,6 +231,9 @@ func TestRunImageGC_ReclaimsOldVersionData(t *testing.T) {
 	}
 	if stats.BlobsReclaimed != 1 || stats.BlobBytes != 33 {
 		t.Errorf("blobs reclaimed=%d bytes=%d; want 1/33", stats.BlobsReclaimed, stats.BlobBytes)
+	}
+	if stats.SnapshotsTombstoned != 0 || stats.BlobsTombstoned != 0 || stats.StampsCleared != 0 {
+		t.Errorf("unexpected tombstone activity: %+v", stats)
 	}
 	if stats.Errors != 0 {
 		t.Errorf("errors=%d; want 0", stats.Errors)
@@ -183,21 +259,147 @@ func TestRunImageGC_ReclaimsOldVersionData(t *testing.T) {
 	}
 }
 
-func TestRunImageGC_SnapshotsOnlySkipsContent(t *testing.T) {
-	// The per-deploy async path (includeContent=false) reclaims orphan snapshots
-	// but must never touch content blobs — a concurrent deploy's just-pushed blob
-	// is legitimately unreferenced until its image record is created.
-	oldTS := "2020-01-01T00:00:00Z"
+func TestRunImageGC_FirstSightingStampsNotReaps(t *testing.T) {
+	// An orphan with an ANCIENT gc.root commit time but no orphanedAt tombstone
+	// must be stamped (not reaped) on first sighting — this is the core fix: the
+	// grace clock starts when a layer becomes orphaned, never from its commit time.
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
 	sn := &fakeSnapshotter{
 		infos: map[string]snapshots.Info{
-			"orphanSnap": {Name: "orphanSnap", Labels: gcLabel(oldTS)},
+			// gc.root value is years old, but there is no orphanedAt label.
+			"orphan": {Name: "orphan", Labels: map[string]string{labelKeyGCRoot: "2020-01-01T00:00:00Z"}},
+		},
+		usage: map[string]int64{"orphan": 500},
+	}
+	env := gcEnv{
+		images:                &fakeImageStore{},
+		snapshots:             sn,
+		content:               &fakeContent{infos: map[digest.Digest]content.Info{}},
+		resolveImage:          func(_ context.Context, _ images.Image) ([]string, []string, error) { return nil, nil, nil },
+		containerSnapshotKeys: func(_ context.Context) ([]string, error) { return nil, nil },
+		now:                   func() time.Time { return now },
+		grace:                 testGrace,
+		logger:                zap.NewNop(),
+	}
+
+	stats, err := runImageGC(context.Background(), env, false)
+	if err != nil {
+		t.Fatalf("runImageGC: %v", err)
+	}
+	if stats.SnapshotsTombstoned != 1 || stats.SnapshotsRemoved != 0 {
+		t.Errorf("tombstoned=%d removed=%d; want 1/0 (stamp, never reap on first sighting)",
+			stats.SnapshotsTombstoned, stats.SnapshotsRemoved)
+	}
+	got := sn.infos["orphan"].Labels[labelKeyOrphanedAt]
+	if want := now.UTC().Format(time.RFC3339); got != want {
+		t.Errorf("orphanedAt=%q; want %q", got, want)
+	}
+}
+
+func TestRunImageGC_ClearOnReachable(t *testing.T) {
+	// A snapshot that is reachable again (re-adopted by a deploy) but still carries
+	// a stale orphanedAt must have that tombstone cleared and must not be reaped —
+	// this resets the retention clock so the layer is never re-uploaded.
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	stale := now.Add(-72 * time.Hour) // well past grace, yet reachable -> must clear
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			"base": {Name: "base", Labels: tombstone(stale)},
+		},
+	}
+	env := gcEnv{
+		images:    &fakeImageStore{imgs: []images.Image{{Name: "app:latest"}}},
+		snapshots: sn,
+		content:   &fakeContent{infos: map[digest.Digest]content.Info{}},
+		resolveImage: func(_ context.Context, _ images.Image) ([]string, []string, error) {
+			return []string{"base"}, nil, nil
+		},
+		containerSnapshotKeys: func(_ context.Context) ([]string, error) { return nil, nil },
+		now:                   func() time.Time { return now },
+		grace:                 testGrace,
+		logger:                zap.NewNop(),
+	}
+
+	stats, err := runImageGC(context.Background(), env, false)
+	if err != nil {
+		t.Fatalf("runImageGC: %v", err)
+	}
+	if stats.StampsCleared != 1 || stats.SnapshotsRemoved != 0 {
+		t.Errorf("cleared=%d removed=%d; want 1/0", stats.StampsCleared, stats.SnapshotsRemoved)
+	}
+	if _, ok := sn.infos["base"].Labels[labelKeyOrphanedAt]; ok {
+		t.Error("orphanedAt must be cleared on a reachable snapshot")
+	}
+	if _, ok := sn.infos["base"].Labels[labelKeyGCRoot]; !ok {
+		t.Error("clearing orphanedAt must preserve the gc.root pin")
+	}
+}
+
+func TestRunImageGC_TwoBootsContent(t *testing.T) {
+	// Content reclamation takes two boots: the first stamps the orphan blob, a
+	// later boot past grace reaps it. The fake carries the label between passes.
+	t0 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	orphan := digest.Digest("sha256:orphanblob")
+	cs := &fakeContent{
+		infos: map[digest.Digest]content.Info{
+			orphan: {Digest: orphan, Size: 77, Labels: gcRootLabels()},
+		},
+	}
+	newEnv := func(now time.Time) gcEnv {
+		return gcEnv{
+			images:                &fakeImageStore{},
+			snapshots:             &fakeSnapshotter{infos: map[string]snapshots.Info{}},
+			content:               cs,
+			resolveImage:          func(_ context.Context, _ images.Image) ([]string, []string, error) { return nil, nil, nil },
+			containerSnapshotKeys: func(_ context.Context) ([]string, error) { return nil, nil },
+			now:                   func() time.Time { return now },
+			grace:                 testGrace,
+			logger:                zap.NewNop(),
+		}
+	}
+
+	// Boot 1: stamp only.
+	stats, err := runImageGC(context.Background(), newEnv(t0), true)
+	if err != nil {
+		t.Fatalf("boot 1: %v", err)
+	}
+	if stats.BlobsTombstoned != 1 || stats.BlobsReclaimed != 0 {
+		t.Fatalf("boot 1 tombstoned=%d reclaimed=%d; want 1/0", stats.BlobsTombstoned, stats.BlobsReclaimed)
+	}
+	if _, ok := cs.infos[orphan]; !ok {
+		t.Fatal("boot 1 must not reclaim content")
+	}
+
+	// Boot 2, past grace: reap.
+	stats, err = runImageGC(context.Background(), newEnv(t0.Add(48*time.Hour)), true)
+	if err != nil {
+		t.Fatalf("boot 2: %v", err)
+	}
+	if stats.BlobsReclaimed != 1 || stats.BlobBytes != 77 {
+		t.Errorf("boot 2 reclaimed=%d bytes=%d; want 1/77", stats.BlobsReclaimed, stats.BlobBytes)
+	}
+	if _, ok := cs.infos[orphan]; ok {
+		t.Error("boot 2 must reclaim the aged orphan blob")
+	}
+}
+
+func TestRunImageGC_SnapshotsOnlySkipsContent(t *testing.T) {
+	// The per-deploy async path (includeContent=false) reaps aged orphan snapshots
+	// but must never touch content blobs — not even to tombstone them — because a
+	// concurrent deploy's just-pushed blob is legitimately unreferenced until its
+	// image record is created.
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	aged := now.Add(-48 * time.Hour)
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			"orphanSnap": {Name: "orphanSnap", Labels: tombstone(aged)},
 		},
 		usage: map[string]int64{"orphanSnap": 50},
 	}
 	orphanBlob := digest.Digest("sha256:orphanblob")
 	cs := &fakeContent{
 		infos: map[digest.Digest]content.Info{
-			orphanBlob: {Digest: orphanBlob, Size: 99, Labels: gcLabel(oldTS)},
+			orphanBlob: {Digest: orphanBlob, Size: 99, Labels: gcRootLabels()},
 		},
 	}
 	env := gcEnv{
@@ -206,8 +408,8 @@ func TestRunImageGC_SnapshotsOnlySkipsContent(t *testing.T) {
 		content:               cs,
 		resolveImage:          func(_ context.Context, _ images.Image) ([]string, []string, error) { return nil, nil, nil },
 		containerSnapshotKeys: func(_ context.Context) ([]string, error) { return nil, nil },
-		now:                   func() time.Time { return time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC) },
-		grace:                 imageGCGracePeriod,
+		now:                   func() time.Time { return now },
+		grace:                 testGrace,
 		logger:                zap.NewNop(),
 	}
 
@@ -218,18 +420,49 @@ func TestRunImageGC_SnapshotsOnlySkipsContent(t *testing.T) {
 	if stats.SnapshotsRemoved != 1 {
 		t.Errorf("snapshots removed=%d; want 1", stats.SnapshotsRemoved)
 	}
-	if stats.BlobsReclaimed != 0 {
-		t.Errorf("blobs reclaimed=%d; want 0 (content sweep deferred to boot)", stats.BlobsReclaimed)
+	if stats.BlobsReclaimed != 0 || stats.BlobsTombstoned != 0 {
+		t.Errorf("blobs reclaimed=%d tombstoned=%d; want 0/0 (content fully gated)",
+			stats.BlobsReclaimed, stats.BlobsTombstoned)
 	}
-	if _, ok := cs.infos[orphanBlob]; !ok {
-		t.Error("content blob must be kept by the snapshots-only path")
+	if len(cs.updated) != 0 {
+		t.Errorf("content store was updated %d times; want 0 on the snapshots-only path", len(cs.updated))
+	}
+	if _, ok := cs.infos[orphanBlob].Labels[labelKeyOrphanedAt]; ok {
+		t.Error("the snapshots-only path must not tombstone content")
+	}
+}
+
+func TestSweep_StampFailureDoesNotReap(t *testing.T) {
+	// A failed tombstone Update is counted as an error but never removes the
+	// artifact (it is in the stamp bucket, structurally excluded from reaping).
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	sn := &fakeSnapshotter{
+		infos:     map[string]snapshots.Info{"orphan": {Name: "orphan", Labels: gcRootLabels()}},
+		updateErr: errors.New("update boom"),
+	}
+	env := gcEnv{
+		snapshots: sn,
+		content:   &fakeContent{infos: map[digest.Digest]content.Info{}},
+		now:       func() time.Time { return now },
+		grace:     testGrace,
+		logger:    zap.NewNop(),
+	}
+	stats, err := sweep(context.Background(), env, keySet(), keySet(), false)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if stats.Errors != 1 || stats.SnapshotsTombstoned != 0 || stats.SnapshotsRemoved != 0 {
+		t.Errorf("errors=%d tombstoned=%d removed=%d; want 1/0/0", stats.Errors, stats.SnapshotsTombstoned, stats.SnapshotsRemoved)
+	}
+	if _, ok := sn.infos["orphan"]; !ok {
+		t.Error("artifact must be retained when its tombstone write fails")
 	}
 }
 
 func TestRunImageGC_FailClosedOnResolveError(t *testing.T) {
 	sn := &fakeSnapshotter{
 		infos: map[string]snapshots.Info{
-			"orphan": {Name: "orphan", Labels: gcLabel("2020-01-01T00:00:00Z")},
+			"orphan": {Name: "orphan", Labels: tombstone(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))},
 		},
 	}
 	env := gcEnv{
@@ -241,7 +474,7 @@ func TestRunImageGC_FailClosedOnResolveError(t *testing.T) {
 		},
 		containerSnapshotKeys: func(_ context.Context) ([]string, error) { return nil, nil },
 		now:                   func() time.Time { return time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC) },
-		grace:                 imageGCGracePeriod,
+		grace:                 testGrace,
 		logger:                zap.NewNop(),
 	}
 	stats, err := runImageGC(context.Background(), env, true)
@@ -251,26 +484,31 @@ func TestRunImageGC_FailClosedOnResolveError(t *testing.T) {
 	if stats.SnapshotsRemoved != 0 {
 		t.Errorf("removed=%d; want 0 deletions on fail-closed", stats.SnapshotsRemoved)
 	}
+	if len(sn.updated) != 0 {
+		t.Errorf("no label may be written when MARK fails; got %d updates", len(sn.updated))
+	}
 	if _, ok := sn.infos["orphan"]; !ok {
 		t.Error("no snapshot may be deleted when MARK fails")
 	}
 }
 
 func TestSweep_HasChildrenBackstop(t *testing.T) {
-	// p is selected as an orphan but still has a reachable child ch; Remove must
-	// fail-precondition and be skipped, not counted as an error.
+	// p is reap-eligible (aged tombstone, unreachable) but still has a reachable
+	// child ch; Remove must fail-precondition and be skipped, not counted an error.
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	aged := now.Add(-48 * time.Hour)
 	sn := &fakeSnapshotter{
 		infos: map[string]snapshots.Info{
-			"p":  {Name: "p", Labels: gcLabel("2020-01-01T00:00:00Z")},
-			"ch": {Name: "ch", Parent: "p", Labels: gcLabel("2020-01-01T00:00:00Z")},
+			"p":  {Name: "p", Labels: tombstone(aged)},
+			"ch": {Name: "ch", Parent: "p", Labels: gcRootLabels()},
 		},
 		usage: map[string]int64{},
 	}
 	env := gcEnv{
 		snapshots: sn,
 		content:   &fakeContent{infos: map[digest.Digest]content.Info{}},
-		now:       func() time.Time { return time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC) },
-		grace:     imageGCGracePeriod,
+		now:       func() time.Time { return now },
+		grace:     testGrace,
 		logger:    zap.NewNop(),
 	}
 	// ch is reachable; p is not.
@@ -331,61 +569,82 @@ func names(infos []snapshots.Info) map[string]bool {
 	return out
 }
 
-// snapNow and snapOld are a fixed "now" and an over-grace-old gc.root timestamp
-// used by the snapshot selection tests.
+// snapNow is the fixed "now" used by the classify tests.
 var snapNow = time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
 
-func snapOldLabel() map[string]string {
-	return gcLabel(snapNow.Add(-time.Hour).UTC().Format(time.RFC3339)) // older than grace
-}
-
-func TestSelectOrphanSnapshots_AllReachable(t *testing.T) {
-	gcRoots := []snapshots.Info{{Name: "a", Labels: snapOldLabel()}, {Name: "b", Labels: snapOldLabel()}}
-	if got := selectOrphanSnapshots(gcRoots, keySet("a", "b"), snapNow, imageGCGracePeriod); len(got) != 0 {
-		t.Fatalf("got %d orphans; want 0", len(got))
-	}
-}
-
-func TestSelectOrphanSnapshots_OldVersionOrphaned(t *testing.T) {
-	// a,b are the current image chain (reachable); c,d are an old version's
-	// top layers that nothing references any more.
+func TestClassifySnapshots_ReachableClearsTombstone(t *testing.T) {
 	gcRoots := []snapshots.Info{
-		{Name: "a", Labels: snapOldLabel()}, {Name: "b", Labels: snapOldLabel()},
-		{Name: "c", Labels: snapOldLabel()}, {Name: "d", Labels: snapOldLabel()},
+		{Name: "a", Labels: tombstone(snapNow.Add(-time.Hour))}, // reachable + stamped -> clear
+		{Name: "b", Labels: gcRootLabels()},                     // reachable, no stamp -> no-op
 	}
-	got := names(selectOrphanSnapshots(gcRoots, keySet("a", "b"), snapNow, imageGCGracePeriod))
-	if len(got) != 2 || !got["c"] || !got["d"] {
-		t.Fatalf("orphans = %v; want {c,d}", got)
+	c := classifySnapshots(gcRoots, keySet("a", "b"), snapNow, testGrace)
+	if got := names(c.clear); len(got) != 1 || !got["a"] {
+		t.Errorf("clear = %v; want {a}", got)
 	}
-}
-
-func TestSelectOrphanSnapshots_SharedBaseKept(t *testing.T) {
-	// base is still referenced by a current image; only the old top layer is orphaned.
-	gcRoots := []snapshots.Info{
-		{Name: "base", Labels: snapOldLabel()},
-		{Name: "oldtop", Parent: "base", Labels: snapOldLabel()},
-	}
-	got := selectOrphanSnapshots(gcRoots, keySet("base"), snapNow, imageGCGracePeriod)
-	if len(got) != 1 || got[0].Name != "oldtop" {
-		t.Fatalf("orphans = %v; want {oldtop}", names(got))
+	if len(c.stamp) != 0 || len(c.reap) != 0 {
+		t.Errorf("stamp=%v reap=%v; want both empty", names(c.stamp), names(c.reap))
 	}
 }
 
-func TestSelectOrphanSnapshots_FreshSnapshotKept(t *testing.T) {
-	// A back-to-back deploy commits a new gc.root chain-ID snapshot after this
-	// pass built its reachable set; it is unreachable in the stale set but must
-	// NOT be removed because it is within the grace window (WDY-1679 P1 race).
-	fresh := snapNow.Add(-time.Minute).UTC().Format(time.RFC3339)
+func TestClassifySnapshots_FirstSightingStamps(t *testing.T) {
+	// Ancient gc.root, no orphanedAt: must be stamped, never reaped (commit age is
+	// no longer a reap trigger).
 	gcRoots := []snapshots.Info{
-		{Name: "fresh", Labels: gcLabel(fresh)},
-		{Name: "old", Labels: snapOldLabel()},
+		{Name: "a", Labels: gcRootLabels()}, {Name: "b", Labels: gcRootLabels()}, // reachable
+		{Name: "c", Labels: gcRootLabels()}, {Name: "d", Labels: gcRootLabels()}, // orphaned, unstamped
 	}
-	got := names(selectOrphanSnapshots(gcRoots, keySet(), snapNow, imageGCGracePeriod))
-	if got["fresh"] {
-		t.Error("a snapshot committed within grace must be kept (may belong to an in-flight deploy)")
+	c := classifySnapshots(gcRoots, keySet("a", "b"), snapNow, testGrace)
+	if got := names(c.stamp); len(got) != 2 || !got["c"] || !got["d"] {
+		t.Errorf("stamp = %v; want {c,d}", got)
 	}
-	if !got["old"] {
-		t.Error("an old unreachable snapshot must be selected")
+	if len(c.reap) != 0 {
+		t.Errorf("reap = %v; want empty", names(c.reap))
+	}
+}
+
+func TestClassifySnapshots_AgedOrphanReaped(t *testing.T) {
+	// base is still referenced; oldtop has an aged tombstone -> reap.
+	gcRoots := []snapshots.Info{
+		{Name: "base", Labels: gcRootLabels()},
+		{Name: "oldtop", Parent: "base", Labels: tombstone(snapNow.Add(-48 * time.Hour))},
+	}
+	c := classifySnapshots(gcRoots, keySet("base"), snapNow, testGrace)
+	if got := names(c.reap); len(got) != 1 || !got["oldtop"] {
+		t.Errorf("reap = %v; want {oldtop}", got)
+	}
+}
+
+func TestClassifySnapshots_WithinGraceKept(t *testing.T) {
+	// An orphan tombstoned within grace is neither re-stamped nor reaped; an aged
+	// sibling is reaped.
+	gcRoots := []snapshots.Info{
+		{Name: "fresh", Labels: tombstone(snapNow.Add(-time.Minute))},
+		{Name: "old", Labels: tombstone(snapNow.Add(-48 * time.Hour))},
+	}
+	c := classifySnapshots(gcRoots, keySet(), snapNow, testGrace)
+	if names(c.reap)["fresh"] {
+		t.Error("an orphan tombstoned within grace must be kept")
+	}
+	if names(c.stamp)["fresh"] {
+		t.Error("an already-tombstoned orphan must not be re-stamped")
+	}
+	if !names(c.reap)["old"] {
+		t.Error("an orphan tombstoned past grace must be reaped")
+	}
+}
+
+func TestClassifySnapshots_UnparseableStampReStamped(t *testing.T) {
+	// A corrupt orphanedAt is treated as "not yet stamped" -> re-stamped (kept),
+	// so a bad value can only ever delay reclamation.
+	gcRoots := []snapshots.Info{
+		{Name: "bad", Labels: map[string]string{labelKeyGCRoot: "x", labelKeyOrphanedAt: "not-a-time"}},
+	}
+	c := classifySnapshots(gcRoots, keySet(), snapNow, testGrace)
+	if got := names(c.stamp); len(got) != 1 || !got["bad"] {
+		t.Errorf("stamp = %v; want {bad}", got)
+	}
+	if len(c.reap) != 0 {
+		t.Errorf("reap = %v; want empty", names(c.reap))
 	}
 }
 
@@ -425,23 +684,29 @@ func TestOrderLeafFirst_Branching(t *testing.T) {
 	}
 }
 
-func TestSelectOrphanBlobs(t *testing.T) {
+func TestClassifyBlobs(t *testing.T) {
 	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
-	old := now.Add(-time.Hour).UTC().Format(time.RFC3339)         // older than grace
-	fresh := now.Add(-1 * time.Minute).UTC().Format(time.RFC3339) // within grace
+	aged := tombstone(now.Add(-48 * time.Hour)) // orphaned past grace
+	fresh := tombstone(now.Add(-time.Minute))   // orphaned within grace
 
 	d := func(c string) digest.Digest { return digest.Digest("sha256:" + strings.Repeat(c, 64)) }
-	dReach, dOld, dFresh, dBad := d("1"), d("2"), d("3"), d("4")
+	dReach, dOld, dFresh, dNew := d("1"), d("2"), d("3"), d("4")
 
 	infos := []content.Info{
-		{Digest: dReach, Labels: map[string]string{labelKeyGCRoot: old}},   // reachable -> kept
-		{Digest: dOld, Labels: map[string]string{labelKeyGCRoot: old}},     // orphan + old -> selected
-		{Digest: dFresh, Labels: map[string]string{labelKeyGCRoot: fresh}}, // orphan + in-grace -> kept
-		{Digest: dBad, Labels: map[string]string{labelKeyGCRoot: "nope"}},  // orphan + unparseable -> kept
+		{Digest: dReach, Labels: tombstone(now.Add(-48 * time.Hour))}, // reachable + stamped -> clear
+		{Digest: dOld, Labels: aged},                                  // orphan + aged -> reap
+		{Digest: dFresh, Labels: fresh},                               // orphan + in-grace -> keep
+		{Digest: dNew, Labels: gcRootLabels()},                        // orphan + unstamped -> stamp
 	}
 
-	got := selectOrphanBlobs(infos, keySet(dReach.String()), now, imageGCGracePeriod)
-	if len(got) != 1 || got[0] != dOld {
-		t.Fatalf("orphan blobs = %v; want {%s}", got, dOld)
+	c := classifyBlobs(infos, keySet(dReach.String()), now, testGrace)
+	if len(c.reap) != 1 || c.reap[0].Digest != dOld {
+		t.Errorf("reap = %v; want {%s}", c.reap, dOld)
+	}
+	if len(c.clear) != 1 || c.clear[0].Digest != dReach {
+		t.Errorf("clear = %v; want {%s}", c.clear, dReach)
+	}
+	if len(c.stamp) != 1 || c.stamp[0].Digest != dNew {
+		t.Errorf("stamp = %v; want {%s}", c.stamp, dNew)
 	}
 }

--- a/go/internal/agent/containerd/unpack.go
+++ b/go/internal/agent/containerd/unpack.go
@@ -137,12 +137,7 @@ func (c *Client) UnpackImage(ctx context.Context, img containerd.Image, progress
 	}
 
 	// Pre-compute all chain IDs in a single pass, then check existence in parallel.
-	chainIDs := make([]string, len(diffIDs))
-	parent := ""
-	for i, diffID := range diffIDs {
-		chainIDs[i] = computeChainID(parent, diffID.String())
-		parent = chainIDs[i]
-	}
+	chainIDs := chainIDsForDiffIDs(diffIDs)
 
 	exists, err := statLayers(ctx, sn, chainIDs)
 	if err != nil {

--- a/go/internal/shared/env/env.go
+++ b/go/internal/shared/env/env.go
@@ -19,6 +19,15 @@ func DiscoverExternalInterval() time.Duration {
 	return parseDuration("WENDY_DISCOVER_EXTERNAL_INTERVAL", 5*time.Second)
 }
 
+// ImageGCGracePeriod is how long a superseded image layer must remain
+// continuously unreferenced (orphaned) before the agent's image GC may reclaim
+// it. A longer window keeps layers cached for redeploys/branch-switches so they
+// are not re-uploaded. The caller clamps this to a safety floor; see
+// containerd.NewClient.
+func ImageGCGracePeriod() time.Duration {
+	return parseDuration("WENDY_IMAGE_GC_GRACE_PERIOD", 24*time.Hour)
+}
+
 func Analytics() bool {
 	v := strings.TrimSpace(os.Getenv("WENDY_ANALYTICS"))
 	switch strings.ToLower(v) {


### PR DESCRIPTION
## Context

Old app-image versions accumulate on devices and are never reclaimed (the ticket was prompted by Docker's VM disk image ballooning to 378 GB locally from the same unbounded accumulation; on storage-constrained devices this is worse).

Investigation reframed the problem: `wendy run` **always tags `localhost:5000/<appid>:latest`** and re-points that one image record on every deploy (`AssembleImage` → `is.Update`). So there are **no separately-named "old versions"** to delete. Prior versions linger as two kinds of `containerd.io/gc.root`-pinned data that containerd's **native GC never reclaims**:
1. chain-ID layer **snapshots** — pinned in `UnpackImage` (`unpack.go`)
2. compressed layer **content blobs** — pinned in `WriteLayer` (`client.go`)

OS/OTA images are **out of scope**: A/B partition slots already bound them to two copies.

## Approach — explicit mark-and-sweep on the agent

New file `go/internal/agent/containerd/imagegc.go`.

- **MARK** (`buildReachableSet`): chain IDs of every current image (`images.Manifest` → `RootFS` → `chainIDsForDiffIDs`) + every container's active-snapshot parent chain. Enumerates **all** containers (incl. ROS2 sidecars). **Fail-closed** on any error — never sweeps on a partial reachable set.
- **SWEEP**: applies the orphan-age tombstone (below), removing snapshots leaf-first with the snapshotter's has-children (`FailedPrecondition`) error as a structural safety backstop.
- **Triggers**:
  - per-deploy: async + single-flight (`atomic.Bool`), non-blocking, at the success tail of `CreateContainerWithProgress` — **snapshots only**.
  - boot: synchronous full sweep including **content blobs**, which is quiescent (runs before the gRPC server serves, so no deploy is in flight).
- Gated by `WENDY_IMAGE_GC_ENABLED` (default on), threaded through `NewClient`.

## Orphan-age tombstone (addresses review feedback)

Review feedback: an earlier revision reclaimed superseded layers **too eagerly**, forcing them to be **re-uploaded** on the next deploy — especially painful for large base layers. Because the **device-local registry shares containerd's content store**, deleting a content blob also defeats the CLI's chunk-diff / registry-push dedup, so the next deploy re-pushes it over the wire.

Root cause: the grace window was measured from a layer's **gc.root commit time**. A long-lived base layer already carries an old timestamp the moment it becomes orphaned, so it was reaped on the *first* sweep — and switching back to it (branch switch, A/B test) re-uploaded it.

Fix: measure grace from when a layer **became orphaned**, not when it was committed — a two-phase deletion using a new `sh.wendy/gc.orphaned-at` tombstone label. Each sweep classifies every `gc.root` artifact against the reachable set:

| Artifact state | Action |
| --- | --- |
| reachable + tombstoned | **clear** the tombstone (re-adopted → retention clock resets) |
| orphaned + un-tombstoned | **stamp** `orphanedAt = now` (never deletes on first sighting) |
| orphaned + tombstone older than grace | **reap** |
| orphaned + tombstone within grace | keep |

A layer reused within the grace window is therefore never reaped and never re-uploaded. The **clear** branch is the load-bearing part of the fix.

- **Configurable**: `WENDY_IMAGE_GC_GRACE_PERIOD` (default **24h**), clamped to a **30m floor** in `NewClient`.
- Labels are written with a `"labels.<key>"` fieldpath so the `gc.root` pin (and any other labels) survive; an empty value clears the tombstone (verified against containerd v2.3.2 `boltutil.writeMap` semantics).
- `GCStats` gains `*Tombstoned` / `StampsCleared` counters; tombstone-only passes log at **Debug** to avoid per-deploy Info noise.

### Safety

Nothing referenced by a running/stopped container, the just-deployed image, or a base layer shared with another app can be reaped — proven by the reachable-set computation plus the has-children backstop.

The tombstone makes reclamation safe under concurrent deploys **without** a commit-age guard: the first sweep that sees an orphan only *stamps* it, and reaping always requires a *later* sweep to still find it orphaned with an aged tombstone, while reachability is recomputed every pass (re-marking and clearing an in-flight deploy's artifacts). Because a snapshot's image record exists *before* the snapshot is committed (`is.Create` precedes `UnpackImage`), and content is reaped only at boot/quiescence (a `WriteLayer`-pinned blob is written *before* its image record, so per-deploy passes must not touch content at all), an in-flight deploy's artifacts are always cleared before they can age out. The 30m floor is now pure defense-in-depth against a pathologically small configured value.

**Consequence — content takes two boots to reclaim**: a blob is tombstoned at one boot and reaped at a later boot past grace. This is intentional (keeps layers cached longer; aligned with avoiding re-uploads).

## Tests

`imagegc_test.go` — fakes gained `Update` (faithful `labels.<key>` fieldpath + empty-value-deletes semantics); tests migrated to the two-phase model with new coverage for: first-sighting stamping (and that an ancient commit time no longer triggers a reap), clear-on-reachable, two-boot content reclamation, stamp-failure handling (counted, never reaps), the snapshots-only-vs-full split, leaf-first ordering, fail-closed MARK, and the has-children backstop. `go test ./...`, `go vet ./...`, `gofmt -l .` all clean.

## Verification

- [x] Unit tests + vet + gofmt green locally
- [ ] **On-device E2E pending**:
  - Deploy v1 → change a layer → deploy v2 → confirm the per-deploy pass logs `tombstoned` (not `reclaimed`); v1's old snapshot is stamped, **not** removed.
  - Within the grace window, redeploy/switch back to v1's layers → confirm **no re-upload** of the large base layer (chunk-diff/registry dedup hits the still-present blob).
  - `WENDY_IMAGE_GC_GRACE_PERIOD=1m`, reboot twice → confirm stamped orphans reap on the second boot; snapshots reap on a per-deploy pass once aged.
  - `WENDY_IMAGE_GC_ENABLED=false` → both paths remain no-ops.
  - Confirm `df` on the containerd data dir drops after genuine abandonment ages past grace.

> Note: the **first boot after this change** only stamps existing orphans (they have no `orphaned-at` label yet), so the first reclamation is delayed by one grace window — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
