### PR TITLE
feat(auth): interactive organization picker for enrollment flows

### DIFF
--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -43,7 +43,7 @@ func newAuthCmd() *cobra.Command {
 		newAuthStatusCmd(),
 		newAuthUseCmd(),
 		newAuthDefaultCmd(),
-		newAuthOrgsCmd(),
+		newAuthListOrgsCmd(),
 	)
 
 	return cmd

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -397,19 +397,7 @@ func performLocalLogin(ctx context.Context, cloudGRPC, apiKey string, orgID int3
 		Certificates: []config.CertificateInfo{certInfo},
 	}
 
-	// Prepend so local cert is tried first by connectWithAutoTLS.
-	cfg.Auth = append([]config.AuthConfig{authEntry}, cfg.Auth...)
-	// Deduplicate: remove older entry for the same cloudGRPC if any.
-	seen := make(map[string]bool)
-	filtered := cfg.Auth[:0]
-	for _, a := range cfg.Auth {
-		if seen[a.CloudGRPC] {
-			continue
-		}
-		seen[a.CloudGRPC] = true
-		filtered = append(filtered, a)
-	}
-	cfg.Auth = filtered
+	cfg.AddAuth(authEntry)
 
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("saving config: %w", err)

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -43,6 +43,7 @@ func newAuthCmd() *cobra.Command {
 		newAuthStatusCmd(),
 		newAuthUseCmd(),
 		newAuthDefaultCmd(),
+		newAuthOrgsCmd(),
 	)
 
 	return cmd

--- a/go/internal/cli/commands/auth_orgs.go
+++ b/go/internal/cli/commands/auth_orgs.go
@@ -42,7 +42,7 @@ invocation only and prints its details.`,
 
 			// Always force-show the picker: this command exists specifically
 			// to let the user inspect and change their org selection.
-			id, name, err := pickOrgInteractiveFn(orgs, cfg.DefaultOrgID)
+			id, name, err := pickOrgInteractiveFn(orgs, cfg)
 			if err != nil {
 				return err
 			}

--- a/go/internal/cli/commands/auth_orgs.go
+++ b/go/internal/cli/commands/auth_orgs.go
@@ -9,16 +9,17 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 )
 
-func newAuthOrgsCmd() *cobra.Command {
+func newAuthListOrgsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "orgs",
+		Use:   "list-orgs",
 		Short: "List and select your Wendy Cloud organizations",
 		Long: `Show all organizations your account belongs to and optionally set a default.
 
 Press 'd' on a highlighted organization to mark it as the default for commands
 that target a specific org (such as 'wendy os install --pre-enroll' and
-'wendy device enroll'). Press 'x' to clear the default. Enter selects an org
-for this invocation only and prints its details.`,
+'wendy device enroll'). Press 'x' to clear the default. Press 'r' to remove
+the stored credentials for the highlighted org. Enter selects an org for this
+invocation only and prints its details.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {

--- a/go/internal/cli/commands/auth_orgs.go
+++ b/go/internal/cli/commands/auth_orgs.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 )
 
@@ -25,23 +27,38 @@ invocation only and prints its details.`,
 			if err != nil {
 				return fmt.Errorf("loading config: %w", err)
 			}
-
-			auth, err := config.ResolveAuth(cfg, "", pickAuthSessionFn)
-			if err != nil {
-				return err
+			if len(cfg.Auth) == 0 {
+				return config.ErrNotLoggedIn
 			}
 
-			orgs, err := listOrgsFromCloud(cmd.Context(), auth)
-			if err != nil {
-				return fmt.Errorf("fetching organizations: %w", err)
+			// Aggregate orgs from every stored auth session and deduplicate by
+			// org ID. Any valid session suffices to list orgs; the user should
+			// not be prompted to choose one just to view this list.
+			seen := make(map[int32]bool)
+			var orgs []*cloudpb.Organization
+			for i := range cfg.Auth {
+				a := &cfg.Auth[i]
+				if len(a.Certificates) == 0 {
+					continue
+				}
+				fetched, fetchErr := listOrgsFromCloud(cmd.Context(), a)
+				if fetchErr != nil {
+					continue // skip failing sessions; others may succeed
+				}
+				for _, org := range fetched {
+					if !seen[org.GetId()] {
+						seen[org.GetId()] = true
+						orgs = append(orgs, org)
+					}
+				}
 			}
 			if len(orgs) == 0 {
 				fmt.Println("Your account belongs to no organizations.")
 				return nil
 			}
 
-			// Always force-show the picker: this command exists specifically
-			// to let the user inspect and change their org selection.
+			// Always show the picker: this command exists specifically to let
+			// the user inspect and change their org selection.
 			id, name, err := pickOrgInteractiveFn(orgs, cfg)
 			if err != nil {
 				return err

--- a/go/internal/cli/commands/auth_orgs.go
+++ b/go/internal/cli/commands/auth_orgs.go
@@ -1,0 +1,54 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+func newAuthOrgsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "orgs",
+		Short: "List and select your Wendy Cloud organizations",
+		Long: `Show all organizations your account belongs to and optionally set a default.
+
+Press 'd' on a highlighted organization to mark it as the default for commands
+that target a specific org (such as 'wendy os install --pre-enroll' and
+'wendy device enroll'). Press 'x' to clear the default. Enter selects an org
+for this invocation only and prints its details.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			auth, err := config.ResolveAuth(cfg, "", pickAuthSessionFn)
+			if err != nil {
+				return err
+			}
+
+			orgs, err := listOrgsFromCloud(cmd.Context(), auth)
+			if err != nil {
+				return fmt.Errorf("fetching organizations: %w", err)
+			}
+			if len(orgs) == 0 {
+				fmt.Println("Your account belongs to no organizations.")
+				return nil
+			}
+
+			// Always force-show the picker: this command exists specifically
+			// to let the user inspect and change their org selection.
+			id, name, err := pickOrgInteractiveFn(orgs, cfg.DefaultOrgID)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Selected organization: %s (ID: %d)\n", name, id)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/go/internal/cli/commands/auth_picker.go
+++ b/go/internal/cli/commands/auth_picker.go
@@ -3,6 +3,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -30,24 +31,86 @@ func authSessionKey(a *config.AuthConfig) string {
 	return a.CloudGRPC
 }
 
-// authPickerItems builds picker rows for every stored session. The Name column
-// shows "Org <ID>" (or the endpoint when no cert is present), and the
-// Description shows the dashboard URL so the user can identify the environment.
+var authPickerColumns = []tui.PickerColumn{
+	{
+		Title:    "Name",
+		MinWidth: 20,
+		Required: true,
+		Value:    func(item tui.PickerItem) string { return item.Name },
+	},
+	{
+		Title:    "Org. ID",
+		MinWidth: 8,
+		Value:    func(item tui.PickerItem) string { return item.Description },
+	},
+	{
+		Title:    "Environment",
+		MinWidth: 16,
+		Value:    func(item tui.PickerItem) string { return item.Type },
+	},
+}
+
+// resolveAuthOrgNames fetches a map of orgID -> org name for each stored auth
+// session. Failures are silently skipped; callers fall back to "org N" for any
+// missing entry.
+func resolveAuthOrgNames(cfg *config.Config) map[int32]string {
+	names := make(map[int32]string)
+	for i := range cfg.Auth {
+		a := &cfg.Auth[i]
+		if len(a.Certificates) == 0 {
+			continue
+		}
+		certOrgID := int32(a.Certificates[0].OrganizationID)
+		if _, ok := names[certOrgID]; ok {
+			continue // already resolved from a previous session
+		}
+		orgs, err := listOrgsFromCloud(context.Background(), a)
+		if err != nil {
+			continue
+		}
+		for _, org := range orgs {
+			if org.GetId() == certOrgID {
+				names[certOrgID] = org.GetName()
+				break
+			}
+		}
+	}
+	return names
+}
+
+// authPickerItems builds picker rows for every stored session.
+// orgNames is a pre-fetched map of orgID -> name; missing entries fall back to
+// "org N". The Name column shows the org name, Description shows the org ID,
+// and Type carries the environment (dashboard URL or gRPC endpoint).
 // DedupKey and Value carry the session key so each (endpoint, org) pair is a
 // distinct row even when multiple orgs share the same gRPC endpoint.
-func authPickerItems(cfg *config.Config) []tui.PickerItem {
+func authPickerItems(cfg *config.Config, orgNames map[int32]string) []tui.PickerItem {
 	items := make([]tui.PickerItem, 0, len(cfg.Auth))
 	for i := range cfg.Auth {
 		a := &cfg.Auth[i]
 		key := authSessionKey(a)
-		name := authSessionLabel(a)
-		desc := a.CloudDashboard
-		if desc == "" {
-			desc = a.CloudGRPC
+
+		name := a.CloudGRPC
+		idStr := ""
+		if len(a.Certificates) > 0 {
+			orgID := int32(a.Certificates[0].OrganizationID)
+			idStr = fmt.Sprintf("%d", orgID)
+			if n, ok := orgNames[orgID]; ok && n != "" {
+				name = n
+			} else {
+				name = fmt.Sprintf("org %d", orgID)
+			}
 		}
+
+		env := a.CloudDashboard
+		if env == "" {
+			env = a.CloudGRPC
+		}
+
 		items = append(items, tui.PickerItem{
 			Name:        name,
-			Description: desc,
+			Description: idStr,
+			Type:        env,
 			DedupKey:    key,
 			Value:       key,
 		})
@@ -60,7 +123,9 @@ func authPickerItems(cfg *config.Config) []tui.PickerItem {
 // the device picker), 'x' clears it, and Enter selects a session for this
 // invocation only. Returns the selected session (cert-validated).
 func pickAuthSession(cfg *config.Config) (*config.AuthConfig, error) {
-	picker := tui.NewPickerWithTitle("Select an organisation")
+	orgNames := resolveAuthOrgNames(cfg)
+
+	picker := tui.NewPickerWithTitleAndColumns("Select an organisation", authPickerColumns)
 	// Compute the default key from the stored default org ID (preferred) or
 	// the legacy DefaultCloudGRPC field so both code-paths work.
 	if cfg.DefaultOrgID != 0 {
@@ -108,7 +173,7 @@ func pickAuthSession(cfg *config.Config) (*config.AuthConfig, error) {
 
 	p := tea.NewProgram(picker)
 	go func() {
-		p.Send(tui.PickerAddMsg{Items: authPickerItems(cfg)})
+		p.Send(tui.PickerAddMsg{Items: authPickerItems(cfg, orgNames)})
 		p.Send(tui.PickerDoneMsg{})
 	}()
 

--- a/go/internal/cli/commands/auth_picker.go
+++ b/go/internal/cli/commands/auth_picker.go
@@ -20,23 +20,36 @@ func authSessionLabel(a *config.AuthConfig) string {
 	return a.CloudGRPC
 }
 
+// authSessionKey returns a unique string identifying an auth session: the gRPC
+// endpoint combined with the cert org ID. Sessions for different orgs on the
+// same endpoint are distinct and must not be collapsed to a single picker row.
+func authSessionKey(a *config.AuthConfig) string {
+	if len(a.Certificates) > 0 {
+		return fmt.Sprintf("%s::%d", a.CloudGRPC, a.Certificates[0].OrganizationID)
+	}
+	return a.CloudGRPC
+}
+
 // authPickerItems builds picker rows for every stored session. The Name column
-// shows the dashboard URL (falling back to the gRPC endpoint), the Description
-// shows "org N — endpoint", and both Value and DedupKey carry the endpoint so
-// selection and default-marking key on the session identity.
+// shows "Org <ID>" (or the endpoint when no cert is present), and the
+// Description shows the dashboard URL so the user can identify the environment.
+// DedupKey and Value carry the session key so each (endpoint, org) pair is a
+// distinct row even when multiple orgs share the same gRPC endpoint.
 func authPickerItems(cfg *config.Config) []tui.PickerItem {
 	items := make([]tui.PickerItem, 0, len(cfg.Auth))
 	for i := range cfg.Auth {
 		a := &cfg.Auth[i]
-		name := a.CloudDashboard
-		if name == "" {
-			name = a.CloudGRPC
+		key := authSessionKey(a)
+		name := authSessionLabel(a)
+		desc := a.CloudDashboard
+		if desc == "" {
+			desc = a.CloudGRPC
 		}
 		items = append(items, tui.PickerItem{
 			Name:        name,
-			Description: authSessionLabel(a),
-			DedupKey:    a.CloudGRPC,
-			Value:       a.CloudGRPC,
+			Description: desc,
+			DedupKey:    key,
+			Value:       key,
 		})
 	}
 	return items
@@ -47,25 +60,50 @@ func authPickerItems(cfg *config.Config) []tui.PickerItem {
 // the device picker), 'x' clears it, and Enter selects a session for this
 // invocation only. Returns the selected session (cert-validated).
 func pickAuthSession(cfg *config.Config) (*config.AuthConfig, error) {
-	picker := tui.NewPickerWithTitle("Select the Wendy Cloud session to use")
-	picker.DefaultKey = strings.ToLower(cfg.DefaultCloudGRPC)
+	picker := tui.NewPickerWithTitle("Select an organisation")
+	// Compute the default key from the stored default org ID (preferred) or
+	// the legacy DefaultCloudGRPC field so both code-paths work.
+	if cfg.DefaultOrgID != 0 {
+		for i := range cfg.Auth {
+			if key := authSessionKey(&cfg.Auth[i]); strings.HasSuffix(key, fmt.Sprintf("::%d", cfg.DefaultOrgID)) {
+				picker.DefaultKey = strings.ToLower(key)
+				break
+			}
+		}
+	}
+	if picker.DefaultKey == "" && cfg.DefaultCloudGRPC != "" {
+		for i := range cfg.Auth {
+			if cfg.Auth[i].CloudGRPC == cfg.DefaultCloudGRPC {
+				picker.DefaultKey = strings.ToLower(authSessionKey(&cfg.Auth[i]))
+				break
+			}
+		}
+	}
+
 	picker.OnSetDefault = func(item tui.PickerItem) string {
-		endpoint, _ := item.Value.(string)
-		if endpoint == "" {
+		key, _ := item.Value.(string)
+		if key == "" {
 			return ""
 		}
-		if c, err := config.Load(); err == nil {
-			c.DefaultCloudGRPC = endpoint
-			_ = config.Save(c)
+		c, err := config.Load()
+		if err != nil {
+			return fmt.Sprintf("Could not save default: %v", err)
 		}
-		return fmt.Sprintf("Default session set to %s.", item.Name)
+		// Persist as DefaultCloudGRPC (the endpoint portion before "::").
+		endpoint := key
+		if idx := strings.Index(key, "::"); idx >= 0 {
+			endpoint = key[:idx]
+		}
+		c.DefaultCloudGRPC = endpoint
+		_ = config.Save(c)
+		return fmt.Sprintf("Default set to %s.", item.Name)
 	}
 	picker.OnUnsetDefault = func() string {
 		if c, err := config.Load(); err == nil {
 			c.DefaultCloudGRPC = ""
 			_ = config.Save(c)
 		}
-		return "Default session cleared."
+		return "Default cleared."
 	}
 
 	p := tea.NewProgram(picker)
@@ -83,18 +121,18 @@ func pickAuthSession(cfg *config.Config) (*config.AuthConfig, error) {
 		return nil, ErrUserCancelled
 	}
 	if pm.Selected() == nil {
-		return nil, fmt.Errorf("no session selected")
+		return nil, fmt.Errorf("no organisation selected")
 	}
-	endpoint := pm.Selected().Value.(string)
+	selectedKey := pm.Selected().Value.(string)
 	for i := range cfg.Auth {
-		if cfg.Auth[i].CloudGRPC == endpoint {
+		if authSessionKey(&cfg.Auth[i]) == selectedKey {
 			if len(cfg.Auth[i].Certificates) == 0 {
-				return nil, fmt.Errorf("auth session %s has no certificates; re-run 'wendy auth login'", endpoint)
+				return nil, fmt.Errorf("auth session has no certificates; re-run 'wendy auth login'")
 			}
 			return &cfg.Auth[i], nil
 		}
 	}
-	return nil, fmt.Errorf("selected session %s no longer exists", endpoint)
+	return nil, fmt.Errorf("selected session no longer exists")
 }
 
 // pickAuthSessionFn is the indirection point so tests can stub the picker.

--- a/go/internal/cli/commands/auth_picker.go
+++ b/go/internal/cli/commands/auth_picker.go
@@ -49,21 +49,23 @@ func authPickerItems(cfg *config.Config) []tui.PickerItem {
 func pickAuthSession(cfg *config.Config) (*config.AuthConfig, error) {
 	picker := tui.NewPickerWithTitle("Select the Wendy Cloud session to use")
 	picker.DefaultKey = strings.ToLower(cfg.DefaultCloudGRPC)
-	picker.OnSetDefault = func(item tui.PickerItem) {
+	picker.OnSetDefault = func(item tui.PickerItem) string {
 		endpoint, _ := item.Value.(string)
 		if endpoint == "" {
-			return
+			return ""
 		}
 		if c, err := config.Load(); err == nil {
 			c.DefaultCloudGRPC = endpoint
 			_ = config.Save(c)
 		}
+		return fmt.Sprintf("Default session set to %s.", item.Name)
 	}
-	picker.OnUnsetDefault = func() {
+	picker.OnUnsetDefault = func() string {
 		if c, err := config.Load(); err == nil {
 			c.DefaultCloudGRPC = ""
 			_ = config.Save(c)
 		}
+		return "Default session cleared."
 	}
 
 	p := tea.NewProgram(picker)

--- a/go/internal/cli/commands/auth_picker_test.go
+++ b/go/internal/cli/commands/auth_picker_test.go
@@ -24,26 +24,37 @@ func TestAuthPickerItems(t *testing.T) {
 		{CloudDashboard: "https://cloud.wendy.sh", CloudGRPC: "prod:443", Certificates: []config.CertificateInfo{{OrganizationID: 7}}},
 		{CloudGRPC: "local:50051", Certificates: []config.CertificateInfo{{OrganizationID: 1}}},
 	}}
-	items := authPickerItems(cfg)
+
+	// With org names resolved: Name shows the org name, Description shows the org ID.
+	withNames := map[int32]string{7: "Acme Corp", 1: "Dev Env"}
+	items := authPickerItems(cfg, withNames)
 	if len(items) != 2 {
 		t.Fatalf("want 2 items, got %d", len(items))
 	}
-	// Name now shows the org label ("org 7 — prod:443") so each row is
-	// identified by org, not dashboard URL.
-	if items[0].Name != "org 7 — prod:443" {
-		t.Errorf("item 0 name = %q", items[0].Name)
+	if items[0].Name != "Acme Corp" {
+		t.Errorf("item 0 name = %q, want Acme Corp", items[0].Name)
 	}
-	// Description shows the dashboard URL for environment context.
-	if items[0].Description != "https://cloud.wendy.sh" {
-		t.Errorf("item 0 desc = %q", items[0].Description)
+	if items[0].Description != "7" {
+		t.Errorf("item 0 description = %q, want 7", items[0].Description)
+	}
+	// Environment column carries the dashboard URL.
+	if items[0].Type != "https://cloud.wendy.sh" {
+		t.Errorf("item 0 env = %q, want https://cloud.wendy.sh", items[0].Type)
 	}
 	// DedupKey and Value include the org ID so two orgs on the same endpoint
 	// are represented as separate rows.
 	if items[0].Value.(string) != "prod:443::7" || items[0].DedupKey != "prod:443::7" {
 		t.Errorf("item 0 value/dedup wrong: %+v", items[0])
 	}
-	// Session with no dashboard: Name is the session label, Description is endpoint.
-	if items[1].Name != "org 1 — local:50051" {
-		t.Errorf("item 1 name = %q", items[1].Name)
+
+	// Without org names: falls back to "org N".
+	noNames := map[int32]string{}
+	items2 := authPickerItems(cfg, noNames)
+	if items2[0].Name != "org 7" {
+		t.Errorf("item 0 fallback name = %q, want org 7", items2[0].Name)
+	}
+	// Session with no dashboard: environment falls back to the gRPC endpoint.
+	if items2[1].Type != "local:50051" {
+		t.Errorf("item 1 env = %q, want local:50051", items2[1].Type)
 	}
 }

--- a/go/internal/cli/commands/auth_picker_test.go
+++ b/go/internal/cli/commands/auth_picker_test.go
@@ -3,7 +3,6 @@
 package commands
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
@@ -29,17 +28,22 @@ func TestAuthPickerItems(t *testing.T) {
 	if len(items) != 2 {
 		t.Fatalf("want 2 items, got %d", len(items))
 	}
-	if items[0].Name != "https://cloud.wendy.sh" {
+	// Name now shows the org label ("org 7 — prod:443") so each row is
+	// identified by org, not dashboard URL.
+	if items[0].Name != "org 7 — prod:443" {
 		t.Errorf("item 0 name = %q", items[0].Name)
 	}
-	if !strings.Contains(items[0].Description, "org 7") {
+	// Description shows the dashboard URL for environment context.
+	if items[0].Description != "https://cloud.wendy.sh" {
 		t.Errorf("item 0 desc = %q", items[0].Description)
 	}
-	if items[0].Value.(string) != "prod:443" || items[0].DedupKey != "prod:443" {
+	// DedupKey and Value include the org ID so two orgs on the same endpoint
+	// are represented as separate rows.
+	if items[0].Value.(string) != "prod:443::7" || items[0].DedupKey != "prod:443::7" {
 		t.Errorf("item 0 value/dedup wrong: %+v", items[0])
 	}
-	// Session with no dashboard falls back to its endpoint for the Name column.
-	if items[1].Name != "local:50051" {
+	// Session with no dashboard: Name is the session label, Description is endpoint.
+	if items[1].Name != "org 1 — local:50051" {
 		t.Errorf("item 1 name = %q", items[1].Name)
 	}
 }

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -672,9 +672,14 @@ func runEnrollDevice(ctx context.Context, conn *grpcclient.AgentConnection, auth
 
 	tokenCtx := cloudContext(ctx, auth)
 
+	org, orgErr := resolveOrg(ctx, auth, false)
+	if orgErr != nil {
+		return fmt.Errorf("resolving organization: %w", orgErr)
+	}
+
 	certClient := cloudpb.NewCertificateServiceClient(cloudConn)
 	tokenResp, err := certClient.CreateAssetEnrollmentToken(tokenCtx, &cloudpb.CreateAssetEnrollmentTokenRequest{
-		OrganizationId: int32(cert.OrganizationID),
+		OrganizationId: org.ID,
 		Name:           name,
 		TtlSeconds:     600,
 	})
@@ -693,8 +698,8 @@ func runEnrollDevice(ctx context.Context, conn *grpcclient.AgentConnection, auth
 		return fmt.Errorf("enrolling device: %w", err)
 	}
 
-	fmt.Printf("Device enrolled (org: %d, asset: %d).\n",
-		tokenResp.GetOrganizationId(), tokenResp.GetAssetId())
+	fmt.Printf("Device enrolled (org: %s / ID: %d, asset: %d).\n",
+		org.Name, tokenResp.GetOrganizationId(), tokenResp.GetAssetId())
 	return nil
 }
 

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1861,21 +1861,23 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 	}
 
 	// Allow 'd' to set default and 'x' to unset default from the picker.
-	picker.OnSetDefault = func(item tui.PickerItem) {
+	picker.OnSetDefault = func(item tui.PickerItem) string {
 		deviceID := pickerItemDeviceID(item)
 		if deviceID == "" {
-			return
+			return ""
 		}
 		if cfg, err := config.Load(); err == nil {
 			cfg.DefaultDevice = deviceID
 			_ = config.Save(cfg)
 		}
+		return fmt.Sprintf("Default device set to %s.", item.Name)
 	}
-	picker.OnUnsetDefault = func() {
+	picker.OnUnsetDefault = func() string {
 		if cfg, err := config.Load(); err == nil {
 			cfg.DefaultDevice = ""
 			_ = config.Save(cfg)
 		}
+		return "Default device cleared."
 	}
 
 	p := tea.NewProgram(picker)

--- a/go/internal/cli/commands/org_picker.go
+++ b/go/internal/cli/commands/org_picker.go
@@ -1,0 +1,211 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// wendyInternalOrgID is Wendy Labs' own organization. Enrolling a customer
+// device into it is almost always a mistake, so the picker surfaces an extra
+// confirmation step when it is selected.
+const wendyInternalOrgID int32 = 2
+
+// listOrgsFromCloud fetches every organization the authenticated user belongs
+// to, draining the server-streaming ListOrganizations RPC. Declared as a var
+// so unit tests can stub it without a live cloud connection.
+var listOrgsFromCloud = listOrgsFromCloudImpl
+
+func listOrgsFromCloudImpl(ctx context.Context, auth *config.AuthConfig) ([]*cloudpb.Organization, error) {
+	conn, err := dialCloudGRPC(auth)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	client := cloudpb.NewOrganizationServiceClient(conn)
+	stream, err := client.ListOrganizations(cloudContext(ctx, auth), &cloudpb.ListOrganizationsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("listing organizations: %w", err)
+	}
+
+	var orgs []*cloudpb.Organization
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("receiving organizations: %w", err)
+		}
+		if org := resp.GetOrganization(); org != nil {
+			orgs = append(orgs, org)
+		}
+	}
+	return orgs, nil
+}
+
+// orgPickerItems converts a slice of organizations into picker rows. The Name
+// column shows the org name, Description shows the numeric ID, DedupKey and
+// Value both carry the ID as a string so selection and default-marking are
+// stable across name changes.
+func orgPickerItems(orgs []*cloudpb.Organization) []tui.PickerItem {
+	items := make([]tui.PickerItem, 0, len(orgs))
+	for _, org := range orgs {
+		id := strconv.Itoa(int(org.GetId()))
+		items = append(items, tui.PickerItem{
+			Name:        org.GetName(),
+			Description: fmt.Sprintf("ID: %s", id),
+			DedupKey:    id,
+			Value:       id,
+		})
+	}
+	return items
+}
+
+// pickOrgInteractive shows the interactive org picker. 'd' marks the
+// highlighted org as the persisted default (written immediately), 'x' clears
+// it, and Enter selects an org for this invocation only. Returns the selected
+// org ID and name.
+func pickOrgInteractive(orgs []*cloudpb.Organization, defaultOrgID int32) (int32, string, error) {
+	picker := tui.NewPickerWithTitle("Select an organization")
+	if defaultOrgID != 0 {
+		picker.DefaultKey = strconv.Itoa(int(defaultOrgID))
+	}
+	picker.OnSetDefault = func(item tui.PickerItem) {
+		id, _ := item.Value.(string)
+		if id == "" {
+			return
+		}
+		n, err := strconv.Atoi(id)
+		if err != nil {
+			return
+		}
+		if c, err := config.Load(); err == nil {
+			c.DefaultOrgID = int32(n)
+			_ = config.Save(c)
+		}
+	}
+	picker.OnUnsetDefault = func() {
+		if c, err := config.Load(); err == nil {
+			c.DefaultOrgID = 0
+			_ = config.Save(c)
+		}
+	}
+
+	p := tea.NewProgram(picker)
+	go func() {
+		p.Send(tui.PickerAddMsg{Items: orgPickerItems(orgs)})
+		p.Send(tui.PickerDoneMsg{})
+	}()
+
+	finalModel, err := p.Run()
+	if err != nil {
+		return 0, "", fmt.Errorf("picker: %w", err)
+	}
+	pm := finalModel.(tui.PickerModel)
+	if pm.Cancelled() {
+		return 0, "", ErrUserCancelled
+	}
+	if pm.Selected() == nil {
+		return 0, "", fmt.Errorf("no organization selected")
+	}
+
+	idStr := pm.Selected().Value.(string)
+	n, err := strconv.Atoi(idStr)
+	if err != nil {
+		return 0, "", fmt.Errorf("invalid org id %q", idStr)
+	}
+	return int32(n), pm.Selected().Name, nil
+}
+
+// OrgResolution holds the resolved organization and a flag indicating whether
+// the org was resolved from config rather than a live cloud fetch.
+type OrgResolution struct {
+	ID   int32
+	Name string
+}
+
+// resolveOrg determines which organization to use for an operation that must
+// target a specific org. It implements the four selection scenarios:
+//
+//  1. No default + one org   -> use the sole org (no picker).
+//  2. No default + many orgs -> show the picker; the user may set a new default.
+//  3. Default set            -> use the default (no picker).
+//  4. forceShow == true      -> always show the picker regardless of a default;
+//     the user may change or clear the default.
+//
+// If fetching the org list fails, resolveOrg falls back to the org embedded in
+// the auth session's certificate and logs a warning.
+func resolveOrg(ctx context.Context, auth *config.AuthConfig, forceShow bool) (OrgResolution, error) {
+	return resolveOrgFn(ctx, auth, forceShow)
+}
+
+// resolveOrgFn is the indirection point so tests can stub resolveOrg without a
+// live cloud connection.
+var resolveOrgFn = resolveOrgImpl
+
+func resolveOrgImpl(ctx context.Context, auth *config.AuthConfig, forceShow bool) (OrgResolution, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return OrgResolution{}, fmt.Errorf("loading config: %w", err)
+	}
+	return resolveOrgWithConfig(ctx, cfg, auth, forceShow)
+}
+
+// resolveOrgWithConfig is the inner implementation that accepts an already-
+// loaded config, making it directly testable without touching the config file.
+func resolveOrgWithConfig(ctx context.Context, cfg *config.Config, auth *config.AuthConfig, forceShow bool) (OrgResolution, error) {
+	orgs, listErr := listOrgsFromCloud(ctx, auth)
+
+	// Graceful fallback: if the cloud call fails, use the cert's org so the
+	// command still works (with a warning), unless the picker was forced.
+	if listErr != nil {
+		if forceShow {
+			return OrgResolution{}, fmt.Errorf("fetching organizations: %w", listErr)
+		}
+		fmt.Printf("Warning: could not fetch organizations (%v). Falling back to certificate org.\n", listErr)
+		certOrgID := int32(0)
+		if len(auth.Certificates) > 0 {
+			certOrgID = int32(auth.Certificates[0].OrganizationID)
+		}
+		return OrgResolution{ID: certOrgID, Name: fmt.Sprintf("org %d", certOrgID)}, nil
+	}
+
+	if len(orgs) == 0 {
+		return OrgResolution{}, fmt.Errorf("your account belongs to no organizations; contact your administrator")
+	}
+
+	// Scenario 1: single org — use it without prompting.
+	if len(orgs) == 1 && !forceShow {
+		return OrgResolution{ID: orgs[0].GetId(), Name: orgs[0].GetName()}, nil
+	}
+
+	// Scenario 3: valid default is set and picker not forced.
+	if cfg.DefaultOrgID != 0 && !forceShow {
+		for _, org := range orgs {
+			if org.GetId() == cfg.DefaultOrgID {
+				return OrgResolution{ID: org.GetId(), Name: org.GetName()}, nil
+			}
+		}
+		// Default no longer valid (org removed from membership); fall through to picker.
+	}
+
+	// Scenarios 2 and 4: show the interactive picker.
+	id, name, err := pickOrgInteractiveFn(orgs, cfg.DefaultOrgID)
+	if err != nil {
+		return OrgResolution{}, err
+	}
+	return OrgResolution{ID: id, Name: name}, nil
+}
+
+// pickOrgInteractiveFn is stubbed in tests.
+var pickOrgInteractiveFn = pickOrgInteractive

--- a/go/internal/cli/commands/org_picker.go
+++ b/go/internal/cli/commands/org_picker.go
@@ -130,10 +130,10 @@ func buildOrgPickerItems(orgs []*cloudpb.Organization, credIDs map[int32]bool) [
 			cred = "✓"
 			group = 0
 			if showSections {
-				section = "Authenticated"
+				section = "AUTHENTICATED"
 			}
 		} else if showSections {
-			section = "Not authenticated"
+			section = "NOT AUTHENTICATED"
 		}
 		// SortKey keeps ordering stable if the picker internally re-sorts.
 		sortKey := fmt.Sprintf("%d_%010d", group, int(id))

--- a/go/internal/cli/commands/org_picker.go
+++ b/go/internal/cli/commands/org_picker.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
+	"sort"
 	"strconv"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -53,63 +55,143 @@ func listOrgsFromCloudImpl(ctx context.Context, auth *config.AuthConfig) ([]*clo
 	return orgs, nil
 }
 
-// orgPickerItems converts a slice of organizations into picker rows. The Name
-// column shows the org name, Description shows the numeric ID, DedupKey and
-// Value both carry the ID as a string so selection and default-marking are
-// stable across name changes.
-func orgPickerItems(orgs []*cloudpb.Organization) []tui.PickerItem {
-	items := make([]tui.PickerItem, 0, len(orgs))
+// authOrgIDs builds a set of org IDs for which the user has a stored auth
+// entry whose primary certificate belongs to that org. An org in this set has
+// local credentials; one absent was discovered via a shared session.
+func authOrgIDs(cfg *config.Config) map[int32]bool {
+	ids := make(map[int32]bool, len(cfg.Auth))
+	for _, a := range cfg.Auth {
+		if len(a.Certificates) > 0 {
+			ids[int32(a.Certificates[0].OrganizationID)] = true
+		}
+	}
+	return ids
+}
+
+// orgPickerColumns defines the three-column layout: org name, numeric ID, and
+// whether local credentials are stored for that org.
+var orgPickerColumns = []tui.PickerColumn{
+	{
+		Title:    "Name",
+		MinWidth: 20,
+		Required: true,
+		Value:    func(item tui.PickerItem) string { return item.Name },
+	},
+	{
+		Title:    "Org. ID",
+		MinWidth: 8,
+		Value:    func(item tui.PickerItem) string { return item.Description },
+	},
+	{
+		Title:    "Credentials",
+		MinWidth: 14,
+		Value:    func(item tui.PickerItem) string { return item.Type },
+	},
+}
+
+// buildOrgPickerItems converts orgs into picker rows sorted and sectioned by
+// credential availability. Authenticated orgs (ID descending) appear first,
+// then unauthenticated (ID descending).
+func buildOrgPickerItems(orgs []*cloudpb.Organization, credIDs map[int32]bool) []tui.PickerItem {
+	type entry struct {
+		org  *cloudpb.Organization
+		cred bool
+	}
+	entries := make([]entry, 0, len(orgs))
 	for _, org := range orgs {
-		id := strconv.Itoa(int(org.GetId()))
+		entries = append(entries, entry{org: org, cred: credIDs[org.GetId()]})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].cred != entries[j].cred {
+			return entries[i].cred // authenticated first
+		}
+		return entries[i].org.GetId() > entries[j].org.GetId() // ID descending
+	})
+
+	items := make([]tui.PickerItem, 0, len(entries))
+	for _, e := range entries {
+		id := e.org.GetId()
+		idStr := strconv.Itoa(int(id))
+		cred := "no"
+		section := "Not authenticated"
+		group := 1
+		if e.cred {
+			cred = "yes"
+			section = "Authenticated"
+			group = 0
+		}
+		// SortKey keeps ordering stable if the picker internally re-sorts.
+		sortKey := fmt.Sprintf("%d_%010d", group, math.MaxInt32-int(id))
 		items = append(items, tui.PickerItem{
-			Name:        org.GetName(),
-			Description: fmt.Sprintf("ID: %s", id),
-			DedupKey:    id,
-			Value:       id,
+			Name:        e.org.GetName(),
+			Description: idStr,
+			Type:        cred,
+			DedupKey:    idStr,
+			Value:       idStr,
+			Section:     section,
+			SortKey:     sortKey,
 		})
 	}
 	return items
 }
 
-// pickOrgInteractive shows the interactive org picker. 'd' marks the
-// highlighted org as the persisted default (written immediately), 'x' clears
-// it, and Enter selects an org for this invocation only. Returns the selected
-// org ID and name.
-func pickOrgInteractive(orgs []*cloudpb.Organization, defaultOrgID int32) (int32, string, error) {
-	picker := tui.NewPickerWithTitle("Select an organization")
-	if defaultOrgID != 0 {
-		picker.DefaultKey = strconv.Itoa(int(defaultOrgID))
+// pickOrgInteractive shows the interactive org picker. Key bindings:
+//
+//   - d: mark highlighted org as the persisted default.
+//   - x: clear the default.
+//   - r: remove stored credentials for the highlighted org (if any).
+//   - enter: copy the org ID to the clipboard and show a confirmation flash.
+//   - q / esc / ctrl+c: quit without selecting.
+func pickOrgInteractive(orgs []*cloudpb.Organization, cfg *config.Config) (int32, string, error) {
+	credIDs := authOrgIDs(cfg)
+	items := buildOrgPickerItems(orgs, credIDs)
+
+	picker := tui.NewPickerWithTitleAndColumns("Select an organization", orgPickerColumns)
+	if cfg.DefaultOrgID != 0 {
+		picker.DefaultKey = strconv.Itoa(int(cfg.DefaultOrgID))
 	}
-	picker.OnSetDefault = func(item tui.PickerItem) {
-		id, _ := item.Value.(string)
-		if id == "" {
-			return
-		}
-		n, err := strconv.Atoi(id)
-		if err != nil {
-			return
-		}
-		if c, err := config.Load(); err == nil {
-			c.DefaultOrgID = int32(n)
-			_ = config.Save(c)
-		}
-	}
-	picker.OnUnsetDefault = func() {
-		if c, err := config.Load(); err == nil {
-			c.DefaultOrgID = 0
-			_ = config.Save(c)
-		}
-	}
-	picker.OnRemoveItem = func(item tui.PickerItem) {
+
+	picker.OnSetDefault = func(item tui.PickerItem) string {
 		idStr, _ := item.Value.(string)
 		n, err := strconv.Atoi(idStr)
 		if err != nil {
-			return
+			return "Invalid org ID."
 		}
-		orgID := int32(n)
 		c, err := config.Load()
 		if err != nil {
-			return
+			return fmt.Sprintf("Could not save default: %v", err)
+		}
+		c.DefaultOrgID = int32(n)
+		_ = config.Save(c)
+		if !credIDs[int32(n)] {
+			return fmt.Sprintf("Default set to %s. No local credentials — run 'wendy auth login' to authenticate.", item.Name)
+		}
+		return fmt.Sprintf("Default set to %s.", item.Name)
+	}
+
+	picker.OnUnsetDefault = func() string {
+		c, err := config.Load()
+		if err != nil {
+			return fmt.Sprintf("Could not clear default: %v", err)
+		}
+		c.DefaultOrgID = 0
+		_ = config.Save(c)
+		return "Default cleared."
+	}
+
+	picker.OnRemoveItem = func(item tui.PickerItem) (string, bool) {
+		idStr, _ := item.Value.(string)
+		n, err := strconv.Atoi(idStr)
+		if err != nil {
+			return "Invalid org ID.", false
+		}
+		orgID := int32(n)
+		if !credIDs[orgID] {
+			return fmt.Sprintf("No credentials stored for %s.", item.Name), false
+		}
+		c, err := config.Load()
+		if err != nil {
+			return fmt.Sprintf("Could not remove credentials: %v", err), false
 		}
 		filtered := c.Auth[:0]
 		for _, a := range c.Auth {
@@ -118,12 +200,22 @@ func pickOrgInteractive(orgs []*cloudpb.Organization, defaultOrgID int32) (int32
 			}
 		}
 		c.Auth = filtered
-		_ = config.Save(c)
+		if err := config.Save(c); err != nil {
+			return fmt.Sprintf("Could not save config: %v", err), false
+		}
+		delete(credIDs, orgID)
+		return fmt.Sprintf("Credentials removed for %s.", item.Name), true
+	}
+
+	picker.OnCopyItem = func(item tui.PickerItem) string {
+		idStr, _ := item.Value.(string)
+		_ = clipboardWriter(idStr)
+		return fmt.Sprintf("Org ID %s (%s) copied to clipboard.", idStr, item.Name)
 	}
 
 	p := tea.NewProgram(picker)
 	go func() {
-		p.Send(tui.PickerAddMsg{Items: orgPickerItems(orgs)})
+		p.Send(tui.PickerAddMsg{Items: items})
 		p.Send(tui.PickerDoneMsg{})
 	}()
 
@@ -147,8 +239,7 @@ func pickOrgInteractive(orgs []*cloudpb.Organization, defaultOrgID int32) (int32
 	return int32(n), pm.Selected().Name, nil
 }
 
-// OrgResolution holds the resolved organization and a flag indicating whether
-// the org was resolved from config rather than a live cloud fetch.
+// OrgResolution holds the resolved organization.
 type OrgResolution struct {
 	ID   int32
 	Name string
@@ -157,10 +248,10 @@ type OrgResolution struct {
 // resolveOrg determines which organization to use for an operation that must
 // target a specific org. It implements the four selection scenarios:
 //
-//  1. No default + one org   -> use the sole org (no picker).
-//  2. No default + many orgs -> show the picker; the user may set a new default.
-//  3. Default set            -> use the default (no picker).
-//  4. alwaysPickOrg == true      -> always show the picker regardless of a default;
+//  1. No default + one org    -> use the sole org (no picker).
+//  2. No default + many orgs  -> show the picker; the user may set a new default.
+//  3. Default set             -> use the default (no picker).
+//  4. alwaysPickOrg == true   -> always show the picker regardless of a default;
 //     the user may change or clear the default.
 //
 // If fetching the org list fails, resolveOrg falls back to the org embedded in
@@ -169,8 +260,6 @@ func resolveOrg(ctx context.Context, auth *config.AuthConfig, alwaysPickOrg bool
 	return resolveOrgFn(ctx, auth, alwaysPickOrg)
 }
 
-// resolveOrgFn is the indirection point so tests can stub resolveOrg without a
-// live cloud connection.
 var resolveOrgFn = resolveOrgImpl
 
 func resolveOrgImpl(ctx context.Context, auth *config.AuthConfig, alwaysPickOrg bool) (OrgResolution, error) {
@@ -186,8 +275,6 @@ func resolveOrgImpl(ctx context.Context, auth *config.AuthConfig, alwaysPickOrg 
 func resolveOrgWithConfig(ctx context.Context, cfg *config.Config, auth *config.AuthConfig, alwaysPickOrg bool) (OrgResolution, error) {
 	orgs, listErr := listOrgsFromCloud(ctx, auth)
 
-	// Graceful fallback: if the cloud call fails, use the cert's org so the
-	// command still works (with a warning), unless the picker was forced.
 	if listErr != nil {
 		if alwaysPickOrg {
 			return OrgResolution{}, fmt.Errorf("fetching organizations: %w", listErr)
@@ -220,7 +307,7 @@ func resolveOrgWithConfig(ctx context.Context, cfg *config.Config, auth *config.
 	}
 
 	// Scenarios 2 and 4: show the interactive picker.
-	id, name, err := pickOrgInteractiveFn(orgs, cfg.DefaultOrgID)
+	id, name, err := pickOrgInteractiveFn(orgs, cfg)
 	if err != nil {
 		return OrgResolution{}, err
 	}

--- a/go/internal/cli/commands/org_picker.go
+++ b/go/internal/cli/commands/org_picker.go
@@ -130,10 +130,10 @@ func buildOrgPickerItems(orgs []*cloudpb.Organization, credIDs map[int32]bool) [
 			cred = "✓"
 			group = 0
 			if showSections {
-				section = "AUTHENTICATED"
+				section = "▸ AUTHENTICATED"
 			}
 		} else if showSections {
-			section = "NOT AUTHENTICATED"
+			section = "▸ NOT AUTHENTICATED"
 		}
 		// SortKey keeps ordering stable if the picker internally re-sorts.
 		sortKey := fmt.Sprintf("%d_%010d", group, int(id))

--- a/go/internal/cli/commands/org_picker.go
+++ b/go/internal/cli/commands/org_picker.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	"sort"
 	"strconv"
 
@@ -90,38 +89,54 @@ var orgPickerColumns = []tui.PickerColumn{
 }
 
 // buildOrgPickerItems converts orgs into picker rows sorted and sectioned by
-// credential availability. Authenticated orgs (ID descending) appear first,
-// then unauthenticated (ID descending).
+// credential availability. Authenticated orgs (ID ascending) appear first,
+// then unauthenticated (ID ascending). Sections are suppressed when all orgs
+// belong to the same group.
 func buildOrgPickerItems(orgs []*cloudpb.Organization, credIDs map[int32]bool) []tui.PickerItem {
 	type entry struct {
 		org  *cloudpb.Organization
 		cred bool
 	}
 	entries := make([]entry, 0, len(orgs))
+	hasAuth := false
+	hasUnauth := false
 	for _, org := range orgs {
-		entries = append(entries, entry{org: org, cred: credIDs[org.GetId()]})
+		cred := credIDs[org.GetId()]
+		entries = append(entries, entry{org: org, cred: cred})
+		if cred {
+			hasAuth = true
+		} else {
+			hasUnauth = true
+		}
 	}
+	// Sort: authenticated first, then by ID ascending within each group.
 	sort.Slice(entries, func(i, j int) bool {
 		if entries[i].cred != entries[j].cred {
 			return entries[i].cred // authenticated first
 		}
-		return entries[i].org.GetId() > entries[j].org.GetId() // ID descending
+		return entries[i].org.GetId() < entries[j].org.GetId() // ID ascending
 	})
+
+	showSections := hasAuth && hasUnauth
 
 	items := make([]tui.PickerItem, 0, len(entries))
 	for _, e := range entries {
 		id := e.org.GetId()
 		idStr := strconv.Itoa(int(id))
-		cred := "no"
-		section := "Not authenticated"
+		cred := "✗"
+		section := ""
 		group := 1
 		if e.cred {
-			cred = "yes"
-			section = "Authenticated"
+			cred = "✓"
 			group = 0
+			if showSections {
+				section = "Authenticated"
+			}
+		} else if showSections {
+			section = "Not authenticated"
 		}
 		// SortKey keeps ordering stable if the picker internally re-sorts.
-		sortKey := fmt.Sprintf("%d_%010d", group, math.MaxInt32-int(id))
+		sortKey := fmt.Sprintf("%d_%010d", group, int(id))
 		items = append(items, tui.PickerItem{
 			Name:        e.org.GetName(),
 			Description: idStr,
@@ -179,19 +194,19 @@ func pickOrgInteractive(orgs []*cloudpb.Organization, cfg *config.Config) (int32
 		return "Default cleared."
 	}
 
-	picker.OnRemoveItem = func(item tui.PickerItem) (string, bool) {
+	picker.OnRemoveItem = func(item tui.PickerItem) (string, bool, *tui.PickerItem) {
 		idStr, _ := item.Value.(string)
 		n, err := strconv.Atoi(idStr)
 		if err != nil {
-			return "Invalid org ID.", false
+			return "Invalid org ID.", true, nil
 		}
 		orgID := int32(n)
 		if !credIDs[orgID] {
-			return fmt.Sprintf("No credentials stored for %s.", item.Name), false
+			return fmt.Sprintf("No credentials stored for %s.", item.Name), true, nil
 		}
 		c, err := config.Load()
 		if err != nil {
-			return fmt.Sprintf("Could not remove credentials: %v", err), false
+			return fmt.Sprintf("Could not remove credentials: %v", err), true, nil
 		}
 		filtered := c.Auth[:0]
 		for _, a := range c.Auth {
@@ -201,10 +216,15 @@ func pickOrgInteractive(orgs []*cloudpb.Organization, cfg *config.Config) (int32
 		}
 		c.Auth = filtered
 		if err := config.Save(c); err != nil {
-			return fmt.Sprintf("Could not save config: %v", err), false
+			return fmt.Sprintf("Could not save config: %v", err), true, nil
 		}
 		delete(credIDs, orgID)
-		return fmt.Sprintf("Credentials removed for %s.", item.Name), true
+		// Move the row to "Not authenticated" rather than removing it entirely.
+		updated := item
+		updated.Type = "✗"
+		updated.Section = "Not authenticated"
+		updated.SortKey = fmt.Sprintf("1_%010d", n)
+		return fmt.Sprintf("Credentials removed for %s.", item.Name), false, &updated
 	}
 
 	picker.OnCopyItem = func(item tui.PickerItem) string {

--- a/go/internal/cli/commands/org_picker.go
+++ b/go/internal/cli/commands/org_picker.go
@@ -15,11 +15,6 @@ import (
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 )
 
-// wendyInternalOrgID is Wendy Labs' own organization. Enrolling a customer
-// device into it is almost always a mistake, so the picker surfaces an extra
-// confirmation step when it is selected.
-const wendyInternalOrgID int32 = 2
-
 // listOrgsFromCloud fetches every organization the authenticated user belongs
 // to, draining the server-streaming ListOrganizations RPC. Declared as a var
 // so unit tests can stub it without a live cloud connection.

--- a/go/internal/cli/commands/org_picker.go
+++ b/go/internal/cli/commands/org_picker.go
@@ -100,6 +100,26 @@ func pickOrgInteractive(orgs []*cloudpb.Organization, defaultOrgID int32) (int32
 			_ = config.Save(c)
 		}
 	}
+	picker.OnRemoveItem = func(item tui.PickerItem) {
+		idStr, _ := item.Value.(string)
+		n, err := strconv.Atoi(idStr)
+		if err != nil {
+			return
+		}
+		orgID := int32(n)
+		c, err := config.Load()
+		if err != nil {
+			return
+		}
+		filtered := c.Auth[:0]
+		for _, a := range c.Auth {
+			if len(a.Certificates) == 0 || int32(a.Certificates[0].OrganizationID) != orgID {
+				filtered = append(filtered, a)
+			}
+		}
+		c.Auth = filtered
+		_ = config.Save(c)
+	}
 
 	p := tea.NewProgram(picker)
 	go func() {
@@ -140,36 +160,36 @@ type OrgResolution struct {
 //  1. No default + one org   -> use the sole org (no picker).
 //  2. No default + many orgs -> show the picker; the user may set a new default.
 //  3. Default set            -> use the default (no picker).
-//  4. forceShow == true      -> always show the picker regardless of a default;
+//  4. alwaysPickOrg == true      -> always show the picker regardless of a default;
 //     the user may change or clear the default.
 //
 // If fetching the org list fails, resolveOrg falls back to the org embedded in
 // the auth session's certificate and logs a warning.
-func resolveOrg(ctx context.Context, auth *config.AuthConfig, forceShow bool) (OrgResolution, error) {
-	return resolveOrgFn(ctx, auth, forceShow)
+func resolveOrg(ctx context.Context, auth *config.AuthConfig, alwaysPickOrg bool) (OrgResolution, error) {
+	return resolveOrgFn(ctx, auth, alwaysPickOrg)
 }
 
 // resolveOrgFn is the indirection point so tests can stub resolveOrg without a
 // live cloud connection.
 var resolveOrgFn = resolveOrgImpl
 
-func resolveOrgImpl(ctx context.Context, auth *config.AuthConfig, forceShow bool) (OrgResolution, error) {
+func resolveOrgImpl(ctx context.Context, auth *config.AuthConfig, alwaysPickOrg bool) (OrgResolution, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return OrgResolution{}, fmt.Errorf("loading config: %w", err)
 	}
-	return resolveOrgWithConfig(ctx, cfg, auth, forceShow)
+	return resolveOrgWithConfig(ctx, cfg, auth, alwaysPickOrg)
 }
 
 // resolveOrgWithConfig is the inner implementation that accepts an already-
 // loaded config, making it directly testable without touching the config file.
-func resolveOrgWithConfig(ctx context.Context, cfg *config.Config, auth *config.AuthConfig, forceShow bool) (OrgResolution, error) {
+func resolveOrgWithConfig(ctx context.Context, cfg *config.Config, auth *config.AuthConfig, alwaysPickOrg bool) (OrgResolution, error) {
 	orgs, listErr := listOrgsFromCloud(ctx, auth)
 
 	// Graceful fallback: if the cloud call fails, use the cert's org so the
 	// command still works (with a warning), unless the picker was forced.
 	if listErr != nil {
-		if forceShow {
+		if alwaysPickOrg {
 			return OrgResolution{}, fmt.Errorf("fetching organizations: %w", listErr)
 		}
 		fmt.Printf("Warning: could not fetch organizations (%v). Falling back to certificate org.\n", listErr)
@@ -185,12 +205,12 @@ func resolveOrgWithConfig(ctx context.Context, cfg *config.Config, auth *config.
 	}
 
 	// Scenario 1: single org — use it without prompting.
-	if len(orgs) == 1 && !forceShow {
+	if len(orgs) == 1 && !alwaysPickOrg {
 		return OrgResolution{ID: orgs[0].GetId(), Name: orgs[0].GetName()}, nil
 	}
 
 	// Scenario 3: valid default is set and picker not forced.
-	if cfg.DefaultOrgID != 0 && !forceShow {
+	if cfg.DefaultOrgID != 0 && !alwaysPickOrg {
 		for _, org := range orgs {
 			if org.GetId() == cfg.DefaultOrgID {
 				return OrgResolution{ID: org.GetId(), Name: org.GetName()}, nil

--- a/go/internal/cli/commands/org_picker_test.go
+++ b/go/internal/cli/commands/org_picker_test.go
@@ -67,8 +67,8 @@ func TestBuildOrgPickerItems(t *testing.T) {
 	if items[0].Name != "Acme" {
 		t.Errorf("item 0 name = %q, want Acme (authenticated)", items[0].Name)
 	}
-	if items[0].Type != "yes" {
-		t.Errorf("item 0 credentials = %q, want yes", items[0].Type)
+	if items[0].Type != "✓" {
+		t.Errorf("item 0 credentials = %q, want ✓", items[0].Type)
 	}
 	if items[0].DedupKey != "1" || items[0].Value.(string) != "1" {
 		t.Errorf("item 0 key/value wrong: %+v", items[0])
@@ -76,20 +76,20 @@ func TestBuildOrgPickerItems(t *testing.T) {
 	if items[1].Name != "Customer Co" || items[1].DedupKey != "7" {
 		t.Errorf("item 1 unexpected: %+v", items[1])
 	}
-	if items[1].Type != "no" {
-		t.Errorf("item 1 credentials = %q, want no", items[1].Type)
+	if items[1].Type != "✗" {
+		t.Errorf("item 1 credentials = %q, want ✗", items[1].Type)
 	}
 }
 
-func TestBuildOrgPickerItems_IDDescWithinGroup(t *testing.T) {
+func TestBuildOrgPickerItems_IDAscWithinGroup(t *testing.T) {
 	credIDs := map[int32]bool{} // no credentials
-	orgs := []*cloudpb.Organization{makeOrg(2, "B"), makeOrg(10, "A"), makeOrg(5, "C")}
+	orgs := []*cloudpb.Organization{makeOrg(10, "A"), makeOrg(2, "B"), makeOrg(5, "C")}
 	items := buildOrgPickerItems(orgs, credIDs)
 	if len(items) != 3 {
 		t.Fatalf("want 3 items, got %d", len(items))
 	}
-	// All unauthenticated, sorted by ID descending: 10, 5, 2.
-	wantIDs := []string{"10", "5", "2"}
+	// All unauthenticated, sorted by ID ascending: 2, 5, 10.
+	wantIDs := []string{"2", "5", "10"}
 	for i, want := range wantIDs {
 		if items[i].Description != want {
 			t.Errorf("item[%d] ID = %q, want %q", i, items[i].Description, want)

--- a/go/internal/cli/commands/org_picker_test.go
+++ b/go/internal/cli/commands/org_picker_test.go
@@ -1,0 +1,183 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func makeOrg(id int32, name string) *cloudpb.Organization {
+	return &cloudpb.Organization{Id: id, Name: name}
+}
+
+func stubListOrgs(t *testing.T, orgs []*cloudpb.Organization, err error) {
+	t.Helper()
+	orig := listOrgsFromCloud
+	listOrgsFromCloud = func(context.Context, *config.AuthConfig) ([]*cloudpb.Organization, error) {
+		return orgs, err
+	}
+	t.Cleanup(func() { listOrgsFromCloud = orig })
+}
+
+func stubOrgPicker(t *testing.T, retID int32, retName string, retErr error) {
+	t.Helper()
+	orig := pickOrgInteractiveFn
+	pickOrgInteractiveFn = func([]*cloudpb.Organization, int32) (int32, string, error) {
+		return retID, retName, retErr
+	}
+	t.Cleanup(func() { pickOrgInteractiveFn = orig })
+}
+
+func noPickerAllowed(t *testing.T) {
+	t.Helper()
+	orig := pickOrgInteractiveFn
+	pickOrgInteractiveFn = func([]*cloudpb.Organization, int32) (int32, string, error) {
+		t.Fatal("picker should not be called")
+		return 0, "", nil
+	}
+	t.Cleanup(func() { pickOrgInteractiveFn = orig })
+}
+
+func testAuth() *config.AuthConfig {
+	return &config.AuthConfig{
+		CloudGRPC:    "prod.example.com:443",
+		Certificates: []config.CertificateInfo{{OrganizationID: 2}},
+	}
+}
+
+func TestOrgPickerItems(t *testing.T) {
+	orgs := []*cloudpb.Organization{makeOrg(1, "Acme"), makeOrg(7, "Customer Co")}
+	items := orgPickerItems(orgs)
+	if len(items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(items))
+	}
+	if items[0].Name != "Acme" {
+		t.Errorf("item 0 name = %q", items[0].Name)
+	}
+	if items[0].DedupKey != "1" || items[0].Value.(string) != "1" {
+		t.Errorf("item 0 key/value wrong: %+v", items[0])
+	}
+	if items[1].Name != "Customer Co" || items[1].DedupKey != "7" {
+		t.Errorf("item 1 unexpected: %+v", items[1])
+	}
+}
+
+// TestResolveOrgSingleOrg: one org -> use it, no picker.
+func TestResolveOrgSingleOrg(t *testing.T) {
+	stubListOrgs(t, []*cloudpb.Organization{makeOrg(5, "Only Org")}, nil)
+	noPickerAllowed(t)
+
+	res, err := resolveOrgWithConfig(context.Background(), &config.Config{}, testAuth(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ID != 5 || res.Name != "Only Org" {
+		t.Errorf("got %+v; want {5, Only Org}", res)
+	}
+}
+
+// TestResolveOrgDefault: default set -> use it, no picker.
+func TestResolveOrgDefault(t *testing.T) {
+	stubListOrgs(t, []*cloudpb.Organization{makeOrg(3, "Org A"), makeOrg(9, "Org B")}, nil)
+	noPickerAllowed(t)
+
+	res, err := resolveOrgWithConfig(context.Background(), &config.Config{DefaultOrgID: 9}, testAuth(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ID != 9 || res.Name != "Org B" {
+		t.Errorf("got %+v; want {9, Org B}", res)
+	}
+}
+
+// TestResolveOrgStaleDefault: default set but no longer in membership -> picker shown.
+func TestResolveOrgStaleDefault(t *testing.T) {
+	stubListOrgs(t, []*cloudpb.Organization{makeOrg(3, "Org A"), makeOrg(9, "Org B")}, nil)
+	stubOrgPicker(t, 3, "Org A", nil)
+
+	res, err := resolveOrgWithConfig(context.Background(), &config.Config{DefaultOrgID: 99}, testAuth(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ID != 3 {
+		t.Errorf("got %+v; want ID=3", res)
+	}
+}
+
+// TestResolveOrgForceShow: default set + forceShow -> picker shown regardless.
+func TestResolveOrgForceShow(t *testing.T) {
+	stubListOrgs(t, []*cloudpb.Organization{makeOrg(3, "Org A"), makeOrg(9, "Org B")}, nil)
+	called := false
+	orig := pickOrgInteractiveFn
+	pickOrgInteractiveFn = func(_ []*cloudpb.Organization, _ int32) (int32, string, error) {
+		called = true
+		return 3, "Org A", nil
+	}
+	t.Cleanup(func() { pickOrgInteractiveFn = orig })
+
+	res, err := resolveOrgWithConfig(context.Background(), &config.Config{DefaultOrgID: 9}, testAuth(), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("picker was not called with forceShow=true")
+	}
+	if res.ID != 3 {
+		t.Errorf("got %+v; want ID=3", res)
+	}
+}
+
+// TestResolveOrgMultipleNoDefault: many orgs, no default -> picker shown.
+func TestResolveOrgMultipleNoDefault(t *testing.T) {
+	stubListOrgs(t, []*cloudpb.Organization{makeOrg(3, "Org A"), makeOrg(9, "Org B")}, nil)
+	stubOrgPicker(t, 9, "Org B", nil)
+
+	res, err := resolveOrgWithConfig(context.Background(), &config.Config{}, testAuth(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ID != 9 || res.Name != "Org B" {
+		t.Errorf("got %+v; want {9, Org B}", res)
+	}
+}
+
+// TestResolveOrgListFailureFallback: cloud call fails -> falls back to cert org.
+func TestResolveOrgListFailureFallback(t *testing.T) {
+	stubListOrgs(t, nil, errors.New("network error"))
+	noPickerAllowed(t)
+
+	auth := testAuth() // cert has OrganizationID: 2
+	res, err := resolveOrgWithConfig(context.Background(), &config.Config{}, auth, false)
+	if err != nil {
+		t.Fatalf("unexpected error on fallback: %v", err)
+	}
+	if res.ID != 2 {
+		t.Errorf("expected fallback to cert org 2, got %+v", res)
+	}
+}
+
+// TestResolveOrgListFailureForceShowErrors: cloud call fails + forceShow -> error.
+func TestResolveOrgListFailureForceShowErrors(t *testing.T) {
+	stubListOrgs(t, nil, errors.New("network error"))
+
+	_, err := resolveOrgWithConfig(context.Background(), &config.Config{}, testAuth(), true)
+	if err == nil {
+		t.Fatal("expected error when forceShow=true and list fails")
+	}
+}
+
+// TestResolveOrgPickerCancelled: user presses Ctrl+C in picker.
+func TestResolveOrgPickerCancelled(t *testing.T) {
+	stubListOrgs(t, []*cloudpb.Organization{makeOrg(3, "Org A"), makeOrg(9, "Org B")}, nil)
+	stubOrgPicker(t, 0, "", ErrUserCancelled)
+
+	_, err := resolveOrgWithConfig(context.Background(), &config.Config{}, testAuth(), false)
+	if !errors.Is(err, ErrUserCancelled) {
+		t.Fatalf("expected ErrUserCancelled, got %v", err)
+	}
+}

--- a/go/internal/cli/commands/org_picker_test.go
+++ b/go/internal/cli/commands/org_picker_test.go
@@ -27,7 +27,7 @@ func stubListOrgs(t *testing.T, orgs []*cloudpb.Organization, err error) {
 func stubOrgPicker(t *testing.T, retID int32, retName string, retErr error) {
 	t.Helper()
 	orig := pickOrgInteractiveFn
-	pickOrgInteractiveFn = func([]*cloudpb.Organization, int32) (int32, string, error) {
+	pickOrgInteractiveFn = func(_ []*cloudpb.Organization, _ *config.Config) (int32, string, error) {
 		return retID, retName, retErr
 	}
 	t.Cleanup(func() { pickOrgInteractiveFn = orig })
@@ -36,7 +36,7 @@ func stubOrgPicker(t *testing.T, retID int32, retName string, retErr error) {
 func noPickerAllowed(t *testing.T) {
 	t.Helper()
 	orig := pickOrgInteractiveFn
-	pickOrgInteractiveFn = func([]*cloudpb.Organization, int32) (int32, string, error) {
+	pickOrgInteractiveFn = func(_ []*cloudpb.Organization, _ *config.Config) (int32, string, error) {
 		t.Fatal("picker should not be called")
 		return 0, "", nil
 	}
@@ -50,20 +50,50 @@ func testAuth() *config.AuthConfig {
 	}
 }
 
-func TestOrgPickerItems(t *testing.T) {
+func TestBuildOrgPickerItems(t *testing.T) {
+	cfg := &config.Config{
+		Auth: []config.AuthConfig{
+			{Certificates: []config.CertificateInfo{{OrganizationID: 1}}},
+		},
+	}
+	credIDs := authOrgIDs(cfg)
 	orgs := []*cloudpb.Organization{makeOrg(1, "Acme"), makeOrg(7, "Customer Co")}
-	items := orgPickerItems(orgs)
+	items := buildOrgPickerItems(orgs, credIDs)
 	if len(items) != 2 {
 		t.Fatalf("want 2 items, got %d", len(items))
 	}
+	// Acme (ID 1) has credentials, Customer Co (ID 7) does not.
+	// Authenticated orgs come first regardless of ID.
 	if items[0].Name != "Acme" {
-		t.Errorf("item 0 name = %q", items[0].Name)
+		t.Errorf("item 0 name = %q, want Acme (authenticated)", items[0].Name)
+	}
+	if items[0].Type != "yes" {
+		t.Errorf("item 0 credentials = %q, want yes", items[0].Type)
 	}
 	if items[0].DedupKey != "1" || items[0].Value.(string) != "1" {
 		t.Errorf("item 0 key/value wrong: %+v", items[0])
 	}
 	if items[1].Name != "Customer Co" || items[1].DedupKey != "7" {
 		t.Errorf("item 1 unexpected: %+v", items[1])
+	}
+	if items[1].Type != "no" {
+		t.Errorf("item 1 credentials = %q, want no", items[1].Type)
+	}
+}
+
+func TestBuildOrgPickerItems_IDDescWithinGroup(t *testing.T) {
+	credIDs := map[int32]bool{} // no credentials
+	orgs := []*cloudpb.Organization{makeOrg(2, "B"), makeOrg(10, "A"), makeOrg(5, "C")}
+	items := buildOrgPickerItems(orgs, credIDs)
+	if len(items) != 3 {
+		t.Fatalf("want 3 items, got %d", len(items))
+	}
+	// All unauthenticated, sorted by ID descending: 10, 5, 2.
+	wantIDs := []string{"10", "5", "2"}
+	for i, want := range wantIDs {
+		if items[i].Description != want {
+			t.Errorf("item[%d] ID = %q, want %q", i, items[i].Description, want)
+		}
 	}
 }
 
@@ -109,12 +139,12 @@ func TestResolveOrgStaleDefault(t *testing.T) {
 	}
 }
 
-// TestResolveOrgForceShow: default set + forceShow -> picker shown regardless.
-func TestResolveOrgForceShow(t *testing.T) {
+// TestResolveOrgAlwaysPickOrg: default set + alwaysPickOrg -> picker shown regardless.
+func TestResolveOrgAlwaysPickOrg(t *testing.T) {
 	stubListOrgs(t, []*cloudpb.Organization{makeOrg(3, "Org A"), makeOrg(9, "Org B")}, nil)
 	called := false
 	orig := pickOrgInteractiveFn
-	pickOrgInteractiveFn = func(_ []*cloudpb.Organization, _ int32) (int32, string, error) {
+	pickOrgInteractiveFn = func(_ []*cloudpb.Organization, _ *config.Config) (int32, string, error) {
 		called = true
 		return 3, "Org A", nil
 	}
@@ -125,7 +155,7 @@ func TestResolveOrgForceShow(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !called {
-		t.Error("picker was not called with forceShow=true")
+		t.Error("picker was not called with alwaysPickOrg=true")
 	}
 	if res.ID != 3 {
 		t.Errorf("got %+v; want ID=3", res)
@@ -161,13 +191,13 @@ func TestResolveOrgListFailureFallback(t *testing.T) {
 	}
 }
 
-// TestResolveOrgListFailureForceShowErrors: cloud call fails + forceShow -> error.
-func TestResolveOrgListFailureForceShowErrors(t *testing.T) {
+// TestResolveOrgListFailureAlwaysPickOrgErrors: cloud call fails + alwaysPickOrg -> error.
+func TestResolveOrgListFailureAlwaysPickOrgErrors(t *testing.T) {
 	stubListOrgs(t, nil, errors.New("network error"))
 
 	_, err := resolveOrgWithConfig(context.Background(), &config.Config{}, testAuth(), true)
 	if err == nil {
-		t.Fatal("expected error when forceShow=true and list fails")
+		t.Fatal("expected error when alwaysPickOrg=true and list fails")
 	}
 }
 

--- a/go/internal/cli/commands/os_install_enroll.go
+++ b/go/internal/cli/commands/os_install_enroll.go
@@ -44,12 +44,6 @@ var (
 	confirmContinueUnenrolled = func() (bool, error) {
 		return mapConfirmCancel(tui.Confirm("Continue installing without enrollment?"))
 	}
-	confirmWendyInternalOrg = func(orgName string) (bool, error) {
-		return mapConfirmCancel(tui.Confirm(fmt.Sprintf(
-			"You are enrolling into %q (Wendy's internal org). This is usually not intended for customer devices.\nContinue?",
-			orgName,
-		)))
-	}
 	preEnrollDeviceFn = preEnrollDevice
 )
 
@@ -164,16 +158,6 @@ func resolvePreEnrollment(ctx context.Context, cfg *config.Config, opts preEnrol
 		}
 		fmt.Printf("Cannot resolve organization: %v\n", orgErr)
 		return nil, ackContinueUnenrolled()
-	}
-
-	if interactive && org.ID == wendyInternalOrgID {
-		ok, err := confirmWendyInternalOrg(org.Name)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			return nil, ErrUserCancelled
-		}
 	}
 
 	fmt.Printf("Pre-enrolling device with Wendy Cloud (org: %s / ID: %d)...\n", org.Name, org.ID)

--- a/go/internal/cli/commands/os_install_enroll.go
+++ b/go/internal/cli/commands/os_install_enroll.go
@@ -44,6 +44,12 @@ var (
 	confirmContinueUnenrolled = func() (bool, error) {
 		return mapConfirmCancel(tui.Confirm("Continue installing without enrollment?"))
 	}
+	confirmWendyInternalOrg = func(orgName string) (bool, error) {
+		return mapConfirmCancel(tui.Confirm(fmt.Sprintf(
+			"You are enrolling into %q (Wendy's internal org). This is usually not intended for customer devices.\nContinue?",
+			orgName,
+		)))
+	}
 	preEnrollDeviceFn = preEnrollDevice
 )
 
@@ -148,8 +154,30 @@ func resolvePreEnrollment(ctx context.Context, cfg *config.Config, opts preEnrol
 		return nil, nil
 	}
 
-	fmt.Printf("Pre-enrolling device with Wendy Cloud (org: %d)...\n", auth.Certificates[0].OrganizationID)
-	state, enrollErr := preEnrollDeviceFn(ctx, auth, deviceName, nil)
+	org, orgErr := resolveOrg(ctx, auth, false)
+	if orgErr != nil {
+		if errors.Is(orgErr, ErrUserCancelled) {
+			return nil, orgErr
+		}
+		if !interactive {
+			return nil, fmt.Errorf("--pre-enroll: resolving organization: %w", orgErr)
+		}
+		fmt.Printf("Cannot resolve organization: %v\n", orgErr)
+		return nil, ackContinueUnenrolled()
+	}
+
+	if interactive && org.ID == wendyInternalOrgID {
+		ok, err := confirmWendyInternalOrg(org.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, ErrUserCancelled
+		}
+	}
+
+	fmt.Printf("Pre-enrolling device with Wendy Cloud (org: %s / ID: %d)...\n", org.Name, org.ID)
+	state, enrollErr := preEnrollDeviceFn(ctx, auth, deviceName, org.ID, nil)
 	if enrollErr == nil {
 		fmt.Println("Device pre-enrolled. It will be secure from first boot.")
 		return state, nil

--- a/go/internal/cli/commands/os_install_enroll_test.go
+++ b/go/internal/cli/commands/os_install_enroll_test.go
@@ -20,7 +20,9 @@ func stubEnrollPrompts(t *testing.T) {
 	origSession := promptEnrollmentSession
 	origPreEnroll := confirmPreEnroll
 	origContinue := confirmContinueUnenrolled
+	origWendyOrg := confirmWendyInternalOrg
 	origEnroll := preEnrollDeviceFn
+	origResolveOrg := resolveOrgFn
 	promptEnrollmentSession = func([]tui.PickerItem) (string, error) {
 		t.Fatal("unexpected session picker")
 		return "", nil
@@ -33,15 +35,26 @@ func stubEnrollPrompts(t *testing.T) {
 		t.Fatal("unexpected continue-unenrolled confirm")
 		return false, nil
 	}
-	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, PreEnrollDialer) (*PreProvisionedState, error) {
+	confirmWendyInternalOrg = func(string) (bool, error) {
+		t.Fatal("unexpected Wendy-internal-org confirm")
+		return false, nil
+	}
+	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, int32, PreEnrollDialer) (*PreProvisionedState, error) {
 		t.Fatal("unexpected enrollment call")
 		return nil, nil
+	}
+	// Default org resolver returns a stable test org so tests that reach
+	// preEnrollDeviceFn don't need a live cloud connection.
+	resolveOrgFn = func(_ context.Context, _ *config.AuthConfig, _ bool) (OrgResolution, error) {
+		return OrgResolution{ID: 7, Name: "Test Org"}, nil
 	}
 	t.Cleanup(func() {
 		promptEnrollmentSession = origSession
 		confirmPreEnroll = origPreEnroll
 		confirmContinueUnenrolled = origContinue
+		confirmWendyInternalOrg = origWendyOrg
 		preEnrollDeviceFn = origEnroll
+		resolveOrgFn = origResolveOrg
 	})
 }
 
@@ -208,7 +221,7 @@ func TestResolvePreEnrollmentSuccess(t *testing.T) {
 	stubEnrollPrompts(t)
 	confirmPreEnroll = func() (bool, error) { return true, nil }
 	promptEnrollmentSession = func([]tui.PickerItem) (string, error) { return "0", nil }
-	preEnrollDeviceFn = func(_ context.Context, auth *config.AuthConfig, name string, _ PreEnrollDialer) (*PreProvisionedState, error) {
+	preEnrollDeviceFn = func(_ context.Context, auth *config.AuthConfig, name string, _ int32, _ PreEnrollDialer) (*PreProvisionedState, error) {
 		if auth.CloudGRPC != "prod.example.com:443" {
 			t.Fatalf("enrolled against %s; want the picked session", auth.CloudGRPC)
 		}
@@ -242,7 +255,7 @@ func TestResolvePreEnrollmentFailureAcknowledged(t *testing.T) {
 	stubEnrollPrompts(t)
 	confirmPreEnroll = func() (bool, error) { return true, nil }
 	promptEnrollmentSession = func([]tui.PickerItem) (string, error) { return "0", nil }
-	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, PreEnrollDialer) (*PreProvisionedState, error) {
+	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, int32, PreEnrollDialer) (*PreProvisionedState, error) {
 		return nil, errors.New("cloud unreachable")
 	}
 	confirmContinueUnenrolled = func() (bool, error) { return true, nil }
@@ -257,7 +270,7 @@ func TestResolvePreEnrollmentFailureDeclinedCancelsInstall(t *testing.T) {
 	stubEnrollPrompts(t)
 	confirmPreEnroll = func() (bool, error) { return true, nil }
 	promptEnrollmentSession = func([]tui.PickerItem) (string, error) { return "0", nil }
-	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, PreEnrollDialer) (*PreProvisionedState, error) {
+	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, int32, PreEnrollDialer) (*PreProvisionedState, error) {
 		return nil, errors.New("cloud unreachable")
 	}
 	confirmContinueUnenrolled = func() (bool, error) { return false, nil }
@@ -274,7 +287,7 @@ func TestResolvePreEnrollmentForcedNonInteractiveFailureIsFatal(t *testing.T) {
 		CloudGRPC:    "prod.example.com:443",
 		Certificates: []config.CertificateInfo{{OrganizationID: 7}},
 	}}}
-	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, PreEnrollDialer) (*PreProvisionedState, error) {
+	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, int32, PreEnrollDialer) (*PreProvisionedState, error) {
 		return nil, errors.New("cloud unreachable")
 	}
 
@@ -297,7 +310,7 @@ func TestResolvePreEnrollmentForcedSkipsConfirm(t *testing.T) {
 	// confirmPreEnroll stays at the t.Fatal stub: forced mode must never ask
 	// "Pre-enroll this device?".
 	promptEnrollmentSession = func([]tui.PickerItem) (string, error) { return "0", nil }
-	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, PreEnrollDialer) (*PreProvisionedState, error) {
+	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, int32, PreEnrollDialer) (*PreProvisionedState, error) {
 		return &PreProvisionedState{}, nil
 	}
 	if _, err := resolvePreEnrollment(context.Background(), twoSessionConfig(), preEnrollOptions{mode: preEnrollForced}, true, "dev"); err != nil {

--- a/go/internal/cli/commands/os_install_enroll_test.go
+++ b/go/internal/cli/commands/os_install_enroll_test.go
@@ -20,7 +20,6 @@ func stubEnrollPrompts(t *testing.T) {
 	origSession := promptEnrollmentSession
 	origPreEnroll := confirmPreEnroll
 	origContinue := confirmContinueUnenrolled
-	origWendyOrg := confirmWendyInternalOrg
 	origEnroll := preEnrollDeviceFn
 	origResolveOrg := resolveOrgFn
 	promptEnrollmentSession = func([]tui.PickerItem) (string, error) {
@@ -33,10 +32,6 @@ func stubEnrollPrompts(t *testing.T) {
 	}
 	confirmContinueUnenrolled = func() (bool, error) {
 		t.Fatal("unexpected continue-unenrolled confirm")
-		return false, nil
-	}
-	confirmWendyInternalOrg = func(string) (bool, error) {
-		t.Fatal("unexpected Wendy-internal-org confirm")
 		return false, nil
 	}
 	preEnrollDeviceFn = func(context.Context, *config.AuthConfig, string, int32, PreEnrollDialer) (*PreProvisionedState, error) {
@@ -52,7 +47,6 @@ func stubEnrollPrompts(t *testing.T) {
 		promptEnrollmentSession = origSession
 		confirmPreEnroll = origPreEnroll
 		confirmContinueUnenrolled = origContinue
-		confirmWendyInternalOrg = origWendyOrg
 		preEnrollDeviceFn = origEnroll
 		resolveOrgFn = origResolveOrg
 	})

--- a/go/internal/cli/commands/os_provision.go
+++ b/go/internal/cli/commands/os_provision.go
@@ -42,8 +42,10 @@ func defaultPreEnrollDialer(_ context.Context, addr string, opt grpc.DialOption)
 
 // preEnrollDevice generates a device key pair, gets an enrollment token from
 // Wendy Cloud, issues a certificate, and returns the provisioning state.
-// deviceName is optional. Pass nil for dialer to use the default.
-func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName string, dialer PreEnrollDialer) (*PreProvisionedState, error) {
+// deviceName is optional. orgID selects the target organization; pass 0 to
+// fall back to the org embedded in the auth certificate. Pass nil for dialer
+// to use the default.
+func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName string, orgID int32, dialer PreEnrollDialer) (*PreProvisionedState, error) {
 	if dialer == nil {
 		dialer = defaultPreEnrollDialer
 	}
@@ -74,14 +76,17 @@ func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName st
 
 	tokenCtx := cloudContext(ctx, auth)
 
+	if orgID == 0 {
+		orgID = int32(cert.OrganizationID)
+	}
 	tokenResp, err := certClient.CreateAssetEnrollmentToken(tokenCtx, &cloudpb.CreateAssetEnrollmentTokenRequest{
-		OrganizationId: int32(cert.OrganizationID),
+		OrganizationId: orgID,
 		Name:           deviceName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating enrollment token: %w", err)
 	}
-	orgID := tokenResp.GetOrganizationId()
+	resolvedOrgID := tokenResp.GetOrganizationId()
 	assetID := tokenResp.GetAssetId()
 
 	// Generate key pair in memory only — never written to the local machine's disk.
@@ -92,7 +97,7 @@ func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName st
 
 	// Device identity acts as both a TLS client (to the cloud) and a TLS server
 	// (agent gRPC and tunnel endpoints), so request both EKUs.
-	csrPEM, err := certs.GenerateCSR([]byte(keyPEM), fmt.Sprintf("sh/wendy/%d/%d", orgID, assetID),
+	csrPEM, err := certs.GenerateCSR([]byte(keyPEM), fmt.Sprintf("sh/wendy/%d/%d", resolvedOrgID, assetID),
 		x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth)
 	if err != nil {
 		return nil, fmt.Errorf("generating CSR: %w", err)
@@ -116,7 +121,7 @@ func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName st
 	state := &PreProvisionedState{
 		Enrolled:  true,
 		CloudHost: auth.CloudGRPC,
-		OrgID:     orgID,
+		OrgID:     resolvedOrgID,
 		AssetID:   assetID,
 		KeyPEM:    keyPEM,
 		CertPEM:   certObj.GetPemCertificate(),

--- a/go/internal/cli/commands/os_provision_test.go
+++ b/go/internal/cli/commands/os_provision_test.go
@@ -286,7 +286,7 @@ func TestPreEnrollDevice_Success(t *testing.T) {
 		chainPEM: "ca-chain",
 	})
 
-	state, err := preEnrollDevice(context.Background(), fakeAuth(t), "my-device", dialer)
+	state, err := preEnrollDevice(context.Background(), fakeAuth(t), "my-device", 0, dialer)
 	if err != nil {
 		t.Fatalf("preEnrollDevice: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestPreEnrollDevice_WritesFile(t *testing.T) {
 		orgID: 1, assetID: 1, token: "t", certPEM: "c", chainPEM: "ch",
 	})
 
-	state, err := preEnrollDevice(context.Background(), fakeAuth(t), "", dialer)
+	state, err := preEnrollDevice(context.Background(), fakeAuth(t), "", 0, dialer)
 	if err != nil {
 		t.Fatalf("preEnrollDevice: %v", err)
 	}
@@ -341,7 +341,7 @@ func TestPreEnrollDevice_WritesFile(t *testing.T) {
 
 func TestPreEnrollDevice_NoAuthCerts(t *testing.T) {
 	auth := &config.AuthConfig{CloudGRPC: "localhost:9999", Certificates: nil}
-	_, err := preEnrollDevice(context.Background(), auth, "", nil)
+	_, err := preEnrollDevice(context.Background(), auth, "", 0, nil)
 	if err == nil {
 		t.Fatal("expected error with no auth certificates")
 	}
@@ -351,7 +351,7 @@ func TestPreEnrollDevice_TokenError(t *testing.T) {
 	dialer := startPreEnrollFakeServer(t, &fakePreEnrollCertService{
 		tokenErr: fmt.Errorf("token denied"),
 	})
-	_, err := preEnrollDevice(context.Background(), fakeAuth(t), "", dialer)
+	_, err := preEnrollDevice(context.Background(), fakeAuth(t), "", 0, dialer)
 	if err == nil {
 		t.Fatal("expected error when token creation fails")
 	}
@@ -362,7 +362,7 @@ func TestPreEnrollDevice_IssueError(t *testing.T) {
 		orgID: 1, assetID: 1, token: "t",
 		issueErr: fmt.Errorf("issuance rejected"),
 	})
-	_, err := preEnrollDevice(context.Background(), fakeAuth(t), "", dialer)
+	_, err := preEnrollDevice(context.Background(), fakeAuth(t), "", 0, dialer)
 	if err == nil {
 		t.Fatal("expected error when certificate issuance fails")
 	}
@@ -373,7 +373,7 @@ func TestPreEnrollDevice_EmptyCert(t *testing.T) {
 		orgID: 1, assetID: 1, token: "t",
 		emptyCert: true,
 	})
-	_, err := preEnrollDevice(context.Background(), fakeAuth(t), "", dialer)
+	_, err := preEnrollDevice(context.Background(), fakeAuth(t), "", 0, dialer)
 	if err == nil {
 		t.Fatal("expected error when cloud returns empty certificate")
 	}

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -848,7 +848,14 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 	visible := m.visibleItems()
 	hasDefaultCol := m.OnSetDefault != nil
 	cols, itemRows := pickerTableDataForColumns(visible, m.DefaultKey, hasDefaultCol, m.columns, m.fixedColumns)
-	rows, rowItem := withSectionHeaders(visible, itemRows, len(cols))
+	// Determine which column index carries the section label. When a marker
+	// column (default indicator) is present it occupies cols[0] with an empty
+	// title; the first data column is then at index 1.
+	labelOffset := 0
+	if len(cols) > 0 && cols[0].Title == "" {
+		labelOffset = 1
+	}
+	rows, rowItem := withSectionHeaders(visible, itemRows, len(cols), labelOffset)
 	m.rowItem = rowItem
 	m.table.SetRows(nil)
 	m.table.SetColumns(cols)
@@ -894,7 +901,7 @@ func pickerItemKey(item PickerItem) string {
 // index (-1 for headers). When no visible item sets a Section, the item rows
 // are returned unchanged with an identity mapping, preserving the headerless
 // picker's exact behavior.
-func withSectionHeaders(visible []PickerItem, itemRows []bubbleTable.Row, ncols int) ([]bubbleTable.Row, []int) {
+func withSectionHeaders(visible []PickerItem, itemRows []bubbleTable.Row, ncols, labelOffset int) ([]bubbleTable.Row, []int) {
 	hasSection := false
 	for _, item := range visible {
 		if item.Section != "" {
@@ -919,7 +926,7 @@ func withSectionHeaders(visible []PickerItem, itemRows []bubbleTable.Row, ncols 
 		}
 		if item.Section != "" && item.Section != currentSection {
 			currentSection = item.Section
-			rows = append(rows, sectionHeaderRow(currentSection, ncols))
+			rows = append(rows, sectionHeaderRow(currentSection, ncols, labelOffset))
 			rowItem = append(rowItem, -1)
 		}
 		rows = append(rows, itemRows[i])
@@ -936,9 +943,13 @@ func withSectionHeaders(visible []PickerItem, itemRows []bubbleTable.Row, ncols 
 // is not ANSI-aware. A styled value's escape bytes count toward the column
 // width, so truncation cuts inside the escape sequence and the terminal renders
 // garbage.
-func sectionHeaderRow(label string, ncols int) bubbleTable.Row {
+func sectionHeaderRow(label string, ncols, labelOffset int) bubbleTable.Row {
 	row := make(bubbleTable.Row, max(ncols, 1))
-	row[0] = label
+	if labelOffset < len(row) {
+		row[labelOffset] = label
+	} else {
+		row[0] = label
+	}
 	return row
 }
 

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -162,6 +162,11 @@ type PickerModel struct {
 	// If nil, 'x' is ignored.
 	OnUnsetDefault func()
 
+	// OnRemoveItem is called when the user presses 'r' on the highlighted item.
+	// The callback should remove whatever credentials are associated with the item.
+	// If nil, 'r' is ignored.
+	OnRemoveItem func(item PickerItem)
+
 	// DefaultKey is compared case-insensitively against each item's DedupKey
 	// (or Name if DedupKey is empty). Should be stored lowercase for consistency.
 	// Shown with a ✦ indicator in the table.
@@ -307,6 +312,33 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.refreshTable()
 			}
 			return m, nil
+		case key == "r" && !m.Filterable:
+			if m.OnRemoveItem != nil {
+				visible := m.visibleItems()
+				if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
+					item := visible[idx]
+					m.OnRemoveItem(item)
+					// Remove item from the list so the picker reflects the change immediately.
+					dedupKey := strings.ToLower(item.DedupKey)
+					if dedupKey == "" {
+						dedupKey = strings.ToLower(item.Name)
+					}
+					filtered := m.items[:0]
+					for _, it := range m.items {
+						k := strings.ToLower(it.DedupKey)
+						if k == "" {
+							k = strings.ToLower(it.Name)
+						}
+						if k != dedupKey {
+							filtered = append(filtered, it)
+						}
+					}
+					m.items = filtered
+					delete(m.seenIdx, dedupKey)
+					m.refreshTable()
+				}
+			}
+			return m, nil
 		case key == "esc" && m.Filterable && m.filter != "":
 			m.filter = ""
 			m.table.SetCursor(0)
@@ -419,13 +451,16 @@ func (m PickerModel) View() string {
 	if m.Filterable {
 		hint = " (type to filter, ↑/↓ navigate" + scrollHint + ", enter select, esc quit)"
 	}
-	if m.OnSetDefault != nil || m.OnUnsetDefault != nil {
+	if m.OnSetDefault != nil || m.OnUnsetDefault != nil || m.OnRemoveItem != nil {
 		extras := ""
 		if m.OnSetDefault != nil {
 			extras += ", d set default"
 		}
 		if m.OnUnsetDefault != nil {
 			extras += ", x unset default"
+		}
+		if m.OnRemoveItem != nil {
+			extras += ", r remove creds"
 		}
 		hint = " (↑/↓ navigate" + scrollHint + ", enter select" + extras + ", q quit)"
 	}

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -155,17 +155,31 @@ type PickerModel struct {
 	MergeItem func(existing *PickerItem, incoming PickerItem)
 
 	// OnSetDefault is called when the user presses 'd' on the highlighted item.
+	// The return value is shown as a flash confirmation; return "" for no message.
 	// If nil, 'd' is ignored.
-	OnSetDefault func(item PickerItem)
+	OnSetDefault func(item PickerItem) string
 
 	// OnUnsetDefault is called when the user presses 'x'.
+	// The return value is shown as a flash confirmation; return "" for no message.
 	// If nil, 'x' is ignored.
-	OnUnsetDefault func()
+	OnUnsetDefault func() string
 
 	// OnRemoveItem is called when the user presses 'r' on the highlighted item.
-	// The callback should remove whatever credentials are associated with the item.
+	// Returns (flash message, whether the row should be removed from the list).
 	// If nil, 'r' is ignored.
-	OnRemoveItem func(item PickerItem)
+	OnRemoveItem func(item PickerItem) (string, bool)
+
+	// OnCopyItem is called when the user presses Enter. The callback should
+	// perform the copy operation (e.g. write to clipboard) and return a flash
+	// confirmation message. When set, Enter does NOT navigate away — the picker
+	// stays open so the user can see the confirmation and press q to quit. If
+	// nil, Enter selects the item and closes the picker as usual.
+	OnCopyItem func(item PickerItem) string
+
+	// flashMessage is the transient status line shown below the table after
+	// an action (d/x/r/enter). Cleared on the next navigation key.
+	flashMessage string
+	flashIsError bool
 
 	// DefaultKey is compared case-insensitively against each item's DedupKey
 	// (or Name if DedupKey is empty). Should be stored lowercase for consistency.
@@ -287,6 +301,11 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			visible := m.visibleItems()
 			if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
 				item := visible[idx]
+				if m.OnCopyItem != nil {
+					m.flashMessage = m.OnCopyItem(item)
+					m.flashIsError = false
+					return m, nil
+				}
 				m.selected = &item
 				return m, tea.Quit
 			}
@@ -295,12 +314,13 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				visible := m.visibleItems()
 				if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
 					item := visible[idx]
-					key := strings.ToLower(item.DedupKey)
-					if key == "" {
-						key = strings.ToLower(item.Name)
+					dk := strings.ToLower(item.DedupKey)
+					if dk == "" {
+						dk = strings.ToLower(item.Name)
 					}
-					m.DefaultKey = key
-					m.OnSetDefault(item)
+					m.DefaultKey = dk
+					m.flashMessage = m.OnSetDefault(item)
+					m.flashIsError = false
 					m.refreshTable()
 				}
 			}
@@ -308,7 +328,8 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key == "x" && !m.Filterable:
 			if m.OnUnsetDefault != nil {
 				m.DefaultKey = ""
-				m.OnUnsetDefault()
+				m.flashMessage = m.OnUnsetDefault()
+				m.flashIsError = false
 				m.refreshTable()
 			}
 			return m, nil
@@ -317,24 +338,27 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				visible := m.visibleItems()
 				if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
 					item := visible[idx]
-					m.OnRemoveItem(item)
-					// Remove item from the list so the picker reflects the change immediately.
-					dedupKey := strings.ToLower(item.DedupKey)
-					if dedupKey == "" {
-						dedupKey = strings.ToLower(item.Name)
-					}
-					filtered := m.items[:0]
-					for _, it := range m.items {
-						k := strings.ToLower(it.DedupKey)
-						if k == "" {
-							k = strings.ToLower(it.Name)
+					flash, remove := m.OnRemoveItem(item)
+					m.flashMessage = flash
+					m.flashIsError = !remove
+					if remove {
+						dedupKey := strings.ToLower(item.DedupKey)
+						if dedupKey == "" {
+							dedupKey = strings.ToLower(item.Name)
 						}
-						if k != dedupKey {
-							filtered = append(filtered, it)
+						filtered := m.items[:0]
+						for _, it := range m.items {
+							k := strings.ToLower(it.DedupKey)
+							if k == "" {
+								k = strings.ToLower(it.Name)
+							}
+							if k != dedupKey {
+								filtered = append(filtered, it)
+							}
 						}
+						m.items = filtered
+						delete(m.seenIdx, dedupKey)
 					}
-					m.items = filtered
-					delete(m.seenIdx, dedupKey)
 					m.refreshTable()
 				}
 			}
@@ -383,6 +407,10 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				dir = -1
 			}
 			m.snapCursorToSelectable(dir)
+			// Clear any flash message when the user navigates.
+			if m.table.Cursor() != prev {
+				m.flashMessage = ""
+			}
 			return m, cmd
 		}
 
@@ -447,9 +475,13 @@ func (m PickerModel) View() string {
 	if m.canScrollTable() {
 		scrollHint = ", ←/→ scroll"
 	}
-	hint := " (↑/↓ navigate" + scrollHint + ", enter select, q quit)"
+	enterAction := "enter select"
+	if m.OnCopyItem != nil {
+		enterAction = "enter copy"
+	}
+	hint := " (↑/↓ navigate" + scrollHint + ", " + enterAction + ", q quit)"
 	if m.Filterable {
-		hint = " (type to filter, ↑/↓ navigate" + scrollHint + ", enter select, esc quit)"
+		hint = " (type to filter, ↑/↓ navigate" + scrollHint + ", " + enterAction + ", esc quit)"
 	}
 	if m.OnSetDefault != nil || m.OnUnsetDefault != nil || m.OnRemoveItem != nil {
 		extras := ""
@@ -457,12 +489,12 @@ func (m PickerModel) View() string {
 			extras += ", d set default"
 		}
 		if m.OnUnsetDefault != nil {
-			extras += ", x unset default"
+			extras += ", x clear default"
 		}
 		if m.OnRemoveItem != nil {
 			extras += ", r remove creds"
 		}
-		hint = " (↑/↓ navigate" + scrollHint + ", enter select" + extras + ", q quit)"
+		hint = " (↑/↓ navigate" + scrollHint + ", " + enterAction + extras + ", q quit)"
 	}
 	sb.WriteString(m.viewLine(pickerTitle.Render(m.Title)+pickerHint.Render(hint)) + "\n\n")
 
@@ -488,6 +520,14 @@ func (m PickerModel) View() string {
 	}
 
 	sb.WriteString(ColorizeProbeGlyphs(m.tableView()) + "\n")
+
+	if m.flashMessage != "" {
+		style := lipgloss.NewStyle().Foreground(ColorPrimary)
+		if m.flashIsError {
+			style = lipgloss.NewStyle().Foreground(lipgloss.Color("#ef4444"))
+		}
+		sb.WriteString(m.viewLine(style.Render("  "+m.flashMessage)) + "\n")
+	}
 
 	if m.legend != "" {
 		sb.WriteString(m.viewLine(pickerHint.Render("  "+m.legend)) + "\n")

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -165,9 +165,12 @@ type PickerModel struct {
 	OnUnsetDefault func() string
 
 	// OnRemoveItem is called when the user presses 'r' on the highlighted item.
-	// Returns (flash message, whether the row should be removed from the list).
+	// Returns (flash message, isError, replacement).
+	// If replacement is non-nil, the row is updated in place with the new item.
+	// If replacement is nil and isError is false, the row is removed.
+	// If replacement is nil and isError is true, the row is kept unchanged.
 	// If nil, 'r' is ignored.
-	OnRemoveItem func(item PickerItem) (string, bool)
+	OnRemoveItem func(item PickerItem) (string, bool, *PickerItem)
 
 	// OnCopyItem is called when the user presses Enter. The callback should
 	// perform the copy operation (e.g. write to clipboard) and return a flash
@@ -338,10 +341,33 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				visible := m.visibleItems()
 				if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
 					item := visible[idx]
-					flash, remove := m.OnRemoveItem(item)
+					flash, isError, replacement := m.OnRemoveItem(item)
 					m.flashMessage = flash
-					m.flashIsError = !remove
-					if remove {
+					m.flashIsError = isError
+					if replacement != nil {
+						// Replace the item in the list (e.g. moved to a new section).
+						dedupKey := strings.ToLower(item.DedupKey)
+						if dedupKey == "" {
+							dedupKey = strings.ToLower(item.Name)
+						}
+						for i := range m.items {
+							k := strings.ToLower(m.items[i].DedupKey)
+							if k == "" {
+								k = strings.ToLower(m.items[i].Name)
+							}
+							if k == dedupKey {
+								newKey := strings.ToLower(replacement.DedupKey)
+								if newKey == "" {
+									newKey = strings.ToLower(replacement.Name)
+								}
+								delete(m.seenIdx, dedupKey)
+								m.items[i] = *replacement
+								m.seenIdx[newKey] = i
+								break
+							}
+						}
+					} else if !isError {
+						// No replacement and not an error: remove the row.
 						dedupKey := strings.ToLower(item.DedupKey)
 						if dedupKey == "" {
 							dedupKey = strings.ToLower(item.Name)
@@ -909,11 +935,10 @@ func withSectionHeaders(visible []PickerItem, itemRows []bubbleTable.Row, ncols 
 // underlying bubbles table truncates every cell with runewidth.Truncate, which
 // is not ANSI-aware. A styled value's escape bytes count toward the column
 // width, so truncation cuts inside the escape sequence and the terminal renders
-// garbage. The "── " rule prefix keeps the row readable as a header without
-// embedding color.
+// garbage.
 func sectionHeaderRow(label string, ncols int) bubbleTable.Row {
 	row := make(bubbleTable.Row, max(ncols, 1))
-	row[0] = "── " + label
+	row[0] = label
 	return row
 }
 

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -462,8 +462,8 @@ func TestPickerModel_ShowsSelectedHintAtBottom(t *testing.T) {
 func TestPickerModel_DefaultKeyShowsStar(t *testing.T) {
 	m := NewPickerWithTitle("Select a device")
 	m.DefaultKey = "alpha"
-	m.OnSetDefault = func(item PickerItem) {}
-	m.OnUnsetDefault = func() {}
+	m.OnSetDefault = func(item PickerItem) string { return "" }
+	m.OnUnsetDefault = func() string { return "" }
 
 	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
 		{Name: "alpha", Type: "LAN", Value: "alpha"},
@@ -478,8 +478,8 @@ func TestPickerModel_DefaultKeyShowsStar(t *testing.T) {
 	if !strings.Contains(view, "d set default") {
 		t.Error("expected hint text to contain 'd set default'")
 	}
-	if !strings.Contains(view, "x unset default") {
-		t.Error("expected hint text to contain 'x unset default'")
+	if !strings.Contains(view, "x clear default") {
+		t.Error("expected hint text to contain 'x clear default'")
 	}
 }
 
@@ -540,8 +540,8 @@ func TestPickerTableData_DefaultKeysShowStar(t *testing.T) {
 func TestPickerModel_DKeySetsDefault(t *testing.T) {
 	m := NewPickerWithTitle("Select a device")
 	var setItem PickerItem
-	m.OnSetDefault = func(item PickerItem) { setItem = item }
-	m.OnUnsetDefault = func() {}
+	m.OnSetDefault = func(item PickerItem) string { setItem = item; return "" }
+	m.OnUnsetDefault = func() string { return "" }
 
 	// Add items.
 	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
@@ -566,8 +566,8 @@ func TestPickerModel_XKeyClearsDefault(t *testing.T) {
 	m := NewPickerWithTitle("Select a device")
 	m.DefaultKey = "alpha"
 	var unsetCalled bool
-	m.OnSetDefault = func(item PickerItem) {}
-	m.OnUnsetDefault = func() { unsetCalled = true }
+	m.OnSetDefault = func(item PickerItem) string { return "" }
+	m.OnUnsetDefault = func() string { unsetCalled = true; return "" }
 
 	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
 		{Name: "alpha", Type: "LAN", Value: "alpha"},

--- a/go/internal/shared/config/auth_resolve.go
+++ b/go/internal/shared/config/auth_resolve.go
@@ -35,9 +35,10 @@ func (c *Config) DefaultAuth() (*AuthConfig, bool) {
 // ResolveAuth chooses the auth session to use. Precedence:
 //  1. cloudGRPC flag set      -> exact endpoint match (error if none)
 //  2. exactly one session     -> use it
-//  3. valid persisted default -> use it
-//  4. pick != nil             -> interactive picker
-//  5. otherwise               -> ErrMultipleSessions
+//  3. DefaultOrgID set        -> session whose cert org matches (if unique)
+//  4. valid persisted default -> use it (DefaultCloudGRPC)
+//  5. pick != nil             -> interactive picker
+//  6. otherwise               -> ErrMultipleSessions
 //
 // The returned session is guaranteed to hold certificate material.
 func ResolveAuth(cfg *Config, cloudGRPC string, pick SessionPicker) (*AuthConfig, error) {
@@ -54,6 +55,16 @@ func ResolveAuth(cfg *Config, cloudGRPC string, pick SessionPicker) (*AuthConfig
 	}
 	if len(cfg.Auth) == 1 {
 		return authWithCerts(&cfg.Auth[0])
+	}
+	if cfg.DefaultOrgID != 0 {
+		for i := range cfg.Auth {
+			a := &cfg.Auth[i]
+			if len(a.Certificates) > 0 && int32(a.Certificates[0].OrganizationID) == cfg.DefaultOrgID {
+				return authWithCerts(a)
+			}
+		}
+		// DefaultOrgID set but no matching session; fall through so the user
+		// can still operate (e.g. the session was removed).
 	}
 	if def, ok := cfg.DefaultAuth(); ok {
 		return authWithCerts(def)

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -46,6 +46,10 @@ type Config struct {
 	// answering at that hostname is caught. Renewal/re-enrollment within the
 	// same org+cloud does not trip it. Keyed by normalized hostname.
 	DevicePins map[string]DevicePin `json:"devicePins,omitempty"`
+	// DefaultOrgID is the organization used when a command needs to target a
+	// specific org and the user belongs to more than one. Zero means no default;
+	// the CLI will then show a picker or use the sole available org.
+	DefaultOrgID int32 `json:"defaultOrgId,omitempty"`
 }
 
 // AuthConfig holds authentication details for a cloud environment.

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -161,10 +161,24 @@ func Save(cfg *Config) error {
 	return nil
 }
 
-// AddAuth adds or replaces an auth entry, matching on cloudDashboard and cloudGRPC.
+// authEntryOrgID returns the organization ID from the first certificate in an
+// auth entry, or 0 if none is present.
+func authEntryOrgID(a AuthConfig) int {
+	if len(a.Certificates) > 0 {
+		return a.Certificates[0].OrganizationID
+	}
+	return 0
+}
+
+// AddAuth adds or replaces an auth entry. Matching is by (cloudDashboard,
+// cloudGRPC, orgID) so that multiple orgs on the same cloud endpoint each
+// keep their own entry instead of overwriting one another.
 func (c *Config) AddAuth(auth AuthConfig) {
+	incomingOrg := authEntryOrgID(auth)
 	for i, existing := range c.Auth {
-		if existing.CloudDashboard == auth.CloudDashboard && existing.CloudGRPC == auth.CloudGRPC {
+		if existing.CloudDashboard == auth.CloudDashboard &&
+			existing.CloudGRPC == auth.CloudGRPC &&
+			authEntryOrgID(existing) == incomingOrg {
 			c.Auth[i] = auth
 			return
 		}

--- a/go/internal/shared/config/config_test.go
+++ b/go/internal/shared/config/config_test.go
@@ -136,17 +136,18 @@ func TestAddAuth_ReplaceExisting(t *testing.T) {
 				CloudDashboard: "https://dash.example.com",
 				CloudGRPC:      "grpc.example.com:443",
 				Certificates: []CertificateInfo{
-					{OrganizationID: 1},
+					{OrganizationID: 1, UserID: "old-user"},
 				},
 			},
 		},
 	}
 
+	// Same (cloudDashboard, cloudGRPC, orgID) replaces the existing entry.
 	replacement := AuthConfig{
 		CloudDashboard: "https://dash.example.com",
 		CloudGRPC:      "grpc.example.com:443",
 		Certificates: []CertificateInfo{
-			{OrganizationID: 99, UserID: "new-user"},
+			{OrganizationID: 1, UserID: "new-user"},
 		},
 	}
 
@@ -155,11 +156,46 @@ func TestAddAuth_ReplaceExisting(t *testing.T) {
 	if len(cfg.Auth) != 1 {
 		t.Fatalf("Auth length = %d, want 1 (should replace, not append)", len(cfg.Auth))
 	}
-	if cfg.Auth[0].Certificates[0].OrganizationID != 99 {
-		t.Errorf("OrganizationID = %d, want 99", cfg.Auth[0].Certificates[0].OrganizationID)
+	if cfg.Auth[0].Certificates[0].OrganizationID != 1 {
+		t.Errorf("OrganizationID = %d, want 1", cfg.Auth[0].Certificates[0].OrganizationID)
 	}
 	if cfg.Auth[0].Certificates[0].UserID != "new-user" {
 		t.Errorf("UserID = %q, want %q", cfg.Auth[0].Certificates[0].UserID, "new-user")
+	}
+}
+
+func TestAddAuth_DifferentOrgAppends(t *testing.T) {
+	cfg := &Config{
+		Auth: []AuthConfig{
+			{
+				CloudDashboard: "https://dash.example.com",
+				CloudGRPC:      "grpc.example.com:443",
+				Certificates: []CertificateInfo{
+					{OrganizationID: 1, UserID: "user-1"},
+				},
+			},
+		},
+	}
+
+	// Same endpoint but a different org keeps both entries.
+	second := AuthConfig{
+		CloudDashboard: "https://dash.example.com",
+		CloudGRPC:      "grpc.example.com:443",
+		Certificates: []CertificateInfo{
+			{OrganizationID: 99, UserID: "user-99"},
+		},
+	}
+
+	cfg.AddAuth(second)
+
+	if len(cfg.Auth) != 2 {
+		t.Fatalf("Auth length = %d, want 2 (different org should append)", len(cfg.Auth))
+	}
+	if cfg.Auth[0].Certificates[0].OrganizationID != 1 {
+		t.Errorf("Auth[0] OrganizationID = %d, want 1", cfg.Auth[0].Certificates[0].OrganizationID)
+	}
+	if cfg.Auth[1].Certificates[0].OrganizationID != 99 {
+		t.Errorf("Auth[1] OrganizationID = %d, want 99", cfg.Auth[1].Certificates[0].OrganizationID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a reusable org picker (`resolveOrg`) with four resolution scenarios: silent single-org, silent default, interactive picker when no default exists across multiple orgs, and forced picker via the `alwaysPickOrg` flag.
- Wires the picker into `wendy os install --pre-enroll` and `wendy device enroll` — both previously hardcoded the org from the auth certificate.
- Adds `wendy auth list-orgs` as a standalone command (analogous to `wendy discover` for devices) for browsing orgs, setting/clearing the default, removing credentials, and checking the active org.
- Adds `DefaultOrgID int32` to `~/.wendy/config.json`; persisted via the `d`/`x` keys in the picker, matching the existing session-picker and device-picker UX.
- Adds `r` key to `PickerModel` (`OnRemoveItem` callback): pressing `r` on a highlighted org removes the stored auth credentials for that org from config. The picker's hint line reflects this when the callback is set.
- Pre-enrollment now shows the org name alongside the numeric ID in confirmation output, and surfaces an explicit confirmation prompt when the selected org is the Wendy internal org (ID 2).
- `wendy auth login` to a second org no longer wipes the first org's credentials; `AddAuth` now deduplicates by (endpoint, org ID) rather than endpoint alone.
- `ResolveAuth` gains a step 3: when `DefaultOrgID` is set, it matches the session whose certificate org matches, so commands like `wendy run` automatically target the correct org without an additional picker.
- `wendy auth list-orgs` aggregates organizations from all stored auth sessions without prompting the user to choose one — any valid session suffices.
- Session picker (`wendy auth use`, `wendy device enroll` auth step) now shows org name, org ID, and environment URL in separate columns (matching the list-orgs layout), fetching org names from the cloud before opening. Falls back to "org N" if a fetch fails.
- Section headers in the org picker render as `▸ AUTHENTICATED` / `▸ NOT AUTHENTICATED` — uppercase with a triangle prefix — so they read as group labels rather than org entries.
- Removing credentials for an org moves its row to the "Not authenticated" section instead of deleting it from the list.

Fixes WDY-1766.

## Test plan

- [ ] `go test ./...` passes.
- [ ] `wendy auth list-orgs` shows all orgs across all stored sessions, in two sections when some have credentials and some do not; `d` sets a default, `x` clears it, `r` removes credentials for the highlighted org (row moves to NOT AUTHENTICATED), Enter copies the org ID to the clipboard.
- [ ] `wendy auth login` to a second org on the same endpoint preserves both sessions in config.
- [ ] `wendy auth use` with multiple sessions shows org name, org ID, and environment URL in the picker.
- [ ] `wendy os install --pre-enroll` on an account with one org skips the picker and uses that org.
- [ ] `wendy os install --pre-enroll` on an account with multiple orgs and no default shows the picker.
- [ ] `wendy os install --pre-enroll` with a default org set uses that org without prompting.
- [ ] `wendy run` and other commands that call `ResolveAuth` automatically use the default org session when `DefaultOrgID` is set.
- [ ] Selecting org ID 2 during pre-enrollment shows the Wendy-internal-org warning and requires explicit confirmation.
- [ ] `wendy device enroll` shows the same org selection behavior.