### PR TITLE
feat(ros2): actions, lifecycle nodes, and components support (WDY-1722)

### DIFF
--- a/Examples/ROS2/README.md
+++ b/Examples/ROS2/README.md
@@ -27,7 +27,6 @@ ROS2/
 ```jsonc
 {
   "appId": "sh.wendy.examples.ros2",
-  "platform": "linux",
   "version": "1.0.0",
   "isolation": "shared-ipc",
   "frameworks": {
@@ -81,6 +80,28 @@ wendy device ros2 services       # list services
 wendy device ros2 graph          # full node/topic/service graph
 wendy device ros2 echo /chatter  # stream messages published by talker
 wendy device ros2 hz /chatter    # measure publish rate (~10 Hz)
+```
+
+Action, lifecycle, and component workflows have first-class subcommands too
+(all honor `--json` for scripting):
+
+```sh
+# Actions (nav2, manipulation, any long-running goal)
+wendy device ros2 action list
+wendy device ros2 action info /fibonacci
+wendy device ros2 action send_goal /fibonacci action_tutorials_interfaces/action/Fibonacci "{order: 5}" --feedback
+wendy device ros2 action cancel /fibonacci   # wendy-specific: cancels all in-flight goals
+
+# Lifecycle / managed nodes (start unconfigured; must be activated)
+wendy device ros2 lifecycle nodes
+wendy device ros2 lifecycle get /lc_talker
+wendy device ros2 lifecycle list /lc_talker  # available transitions
+wendy device ros2 lifecycle set /lc_talker configure
+
+# Composable-node component containers
+wendy device ros2 component list
+wendy device ros2 component load /ComponentManager composition composition::Talker
+wendy device ros2 component unload /ComponentManager 1
 ```
 
 ## See also

--- a/Proto/wendy/agent/services/v2/ros2_service.proto
+++ b/Proto/wendy/agent/services/v2/ros2_service.proto
@@ -34,6 +34,24 @@ service ROS2Service {
 
     // Escape hatch — raw `ros2` CLI passthrough.
     rpc Exec(ROS2ExecRequest) returns (stream ROS2ExecOutput);
+
+    // Actions — list/inspect action graphs and dispatch goals (WDY-1722).
+    rpc ListActions(ListROS2ActionsRequest) returns (ListROS2ActionsResponse);
+    rpc GetActionInfo(GetROS2ActionInfoRequest) returns (GetROS2ActionInfoResponse);
+    // SendActionGoal streams feedback/result until the goal finishes or the
+    // client cancels; output frames reuse ROS2ExecOutput.
+    rpc SendActionGoal(SendROS2ActionGoalRequest) returns (stream ROS2ExecOutput);
+
+    // Lifecycle — managed-node state inspection and transitions (WDY-1722).
+    rpc ListLifecycleNodes(ListROS2LifecycleNodesRequest) returns (ListROS2LifecycleNodesResponse);
+    rpc GetLifecycleState(GetROS2LifecycleStateRequest) returns (GetROS2LifecycleStateResponse);
+    rpc ListLifecycleTransitions(ListROS2LifecycleTransitionsRequest) returns (ListROS2LifecycleTransitionsResponse);
+    rpc SetLifecycleState(SetROS2LifecycleStateRequest) returns (SetROS2LifecycleStateResponse);
+
+    // Components — composable-node container management (WDY-1722).
+    rpc ListComponents(ListROS2ComponentsRequest) returns (ListROS2ComponentsResponse);
+    rpc LoadComponent(LoadROS2ComponentRequest) returns (LoadROS2ComponentResponse);
+    rpc UnloadComponent(UnloadROS2ComponentRequest) returns (UnloadROS2ComponentResponse);
 }
 
 message ROS2Node {
@@ -246,4 +264,135 @@ message ROS2ExecOutput {
     bytes stdout = 1;
     bytes stderr = 2;
     optional int32 exit_code = 3; // set on the final message
+}
+
+// --- Actions (WDY-1722) ---
+
+message ROS2Action {
+    string name = 1;
+    repeated string types = 2; // an action can advertise multiple types
+    // rmw identifies which RMW graph this action came from (WDY-1594). Empty on
+    // single-RMW devices.
+    string rmw = 3;
+}
+
+message ListROS2ActionsRequest {
+    optional int32 domain_id = 1;
+}
+
+message ListROS2ActionsResponse {
+    repeated ROS2Action actions = 1;
+}
+
+message GetROS2ActionInfoRequest {
+    optional int32 domain_id = 1;
+    string action = 2;
+}
+
+message GetROS2ActionInfoResponse {
+    string name = 1;
+    repeated string action_clients = 2; // fully-qualified client node names
+    repeated string action_servers = 3; // fully-qualified server node names
+    // Verbose raw `ros2 action info` output.
+    string verbose = 4;
+}
+
+message SendROS2ActionGoalRequest {
+    optional int32 domain_id = 1;
+    string action = 2;
+    string action_type = 3; // e.g. action_tutorials_interfaces/action/Fibonacci
+    string goal = 4;        // YAML goal payload
+    bool feedback = 5;      // forward --feedback to stream feedback messages
+}
+
+// --- Lifecycle / managed nodes (WDY-1722) ---
+
+message ROS2LifecycleTransition {
+    string label = 1; // e.g. "configure"
+    uint32 id = 2;
+    string start_state = 3;
+    string goal_state = 4;
+}
+
+message ListROS2LifecycleNodesRequest {
+    optional int32 domain_id = 1;
+}
+
+message ListROS2LifecycleNodesResponse {
+    repeated ROS2Node nodes = 1;
+}
+
+message GetROS2LifecycleStateRequest {
+    optional int32 domain_id = 1;
+    string node = 2;
+}
+
+message GetROS2LifecycleStateResponse {
+    string state = 1;     // e.g. "unconfigured", "inactive", "active"
+    uint32 state_id = 2;  // numeric state id (e.g. 1)
+}
+
+message ListROS2LifecycleTransitionsRequest {
+    optional int32 domain_id = 1;
+    string node = 2;
+}
+
+message ListROS2LifecycleTransitionsResponse {
+    repeated ROS2LifecycleTransition transitions = 1;
+}
+
+message SetROS2LifecycleStateRequest {
+    optional int32 domain_id = 1;
+    string node = 2;
+    string transition = 3; // e.g. "configure", "activate"
+}
+
+message SetROS2LifecycleStateResponse {
+    bool success = 1;
+    string message = 2;
+}
+
+// --- Components / composable nodes (WDY-1722) ---
+
+message ROS2LoadedComponent {
+    uint32 uid = 1;  // unique id within the container
+    string name = 2; // fully-qualified node name
+}
+
+message ROS2ComponentContainer {
+    string name = 1; // container node name, e.g. /ComponentManager
+    repeated ROS2LoadedComponent components = 2;
+    // rmw identifies which RMW graph this container came from (WDY-1594).
+    string rmw = 3;
+}
+
+message ListROS2ComponentsRequest {
+    optional int32 domain_id = 1;
+}
+
+message ListROS2ComponentsResponse {
+    repeated ROS2ComponentContainer containers = 1;
+}
+
+message LoadROS2ComponentRequest {
+    optional int32 domain_id = 1;
+    string container = 2; // container node name
+    string package = 3;
+    string plugin = 4;    // plugin class, e.g. composition::Talker
+}
+
+message LoadROS2ComponentResponse {
+    uint32 uid = 1;
+    string node_name = 2;
+    string message = 3;
+}
+
+message UnloadROS2ComponentRequest {
+    optional int32 domain_id = 1;
+    string container = 2;
+    uint32 uid = 3;
+}
+
+message UnloadROS2ComponentResponse {
+    string message = 1;
 }

--- a/go/internal/agent/services/ros2_parse.go
+++ b/go/internal/agent/services/ros2_parse.go
@@ -212,6 +212,196 @@ func parseROS2NodeInfo(out string) (publishes, subscribes []string) {
 	return publishes, subscribes
 }
 
+// parseROS2ActionList parses `ros2 action list -t` output: lines of the form
+// "/name [pkg/action/Type]" (same shape as `ros2 topic list -t`).
+func parseROS2ActionList(out string) []*agentpbv2.ROS2Action {
+	var actions []*agentpbv2.ROS2Action
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "/") {
+			continue
+		}
+		name := line
+		var types []string
+		if open := strings.Index(line, " ["); open >= 0 && strings.HasSuffix(line, "]") {
+			name = line[:open]
+			for _, t := range strings.Split(line[open+2:len(line)-1], ",") {
+				if t = strings.TrimSpace(t); t != "" {
+					types = append(types, t)
+				}
+			}
+		}
+		actions = append(actions, &agentpbv2.ROS2Action{Name: name, Types: types})
+	}
+	return actions
+}
+
+// parseROS2ActionInfo extracts the action name plus its client and server node
+// names from `ros2 action info <action>` output:
+//
+//	Action: /fibonacci
+//	Action clients: 1
+//	    /fibonacci_action_client
+//	Action servers: 1
+//	    /fibonacci_action_server
+//
+// Entry lines may carry a trailing " [type]" which is stripped from the name.
+func parseROS2ActionInfo(out string) (name string, clients, servers []string) {
+	section := ""
+	for _, raw := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "Action:"):
+			name = strings.TrimSpace(strings.TrimPrefix(trimmed, "Action:"))
+			section = ""
+			continue
+		case strings.HasPrefix(trimmed, "Action clients:"):
+			section = "clients"
+			continue
+		case strings.HasPrefix(trimmed, "Action servers:"):
+			section = "servers"
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "/") {
+			continue
+		}
+		node := trimmed
+		if open := strings.Index(node, " ["); open >= 0 {
+			node = node[:open]
+		}
+		switch section {
+		case "clients":
+			clients = append(clients, node)
+		case "servers":
+			servers = append(servers, node)
+		}
+	}
+	return name, clients, servers
+}
+
+// parseROS2LifecycleState parses `ros2 lifecycle get <node>` output, e.g.
+// "active [3]" → ("active", 3). A bare state with no id is also accepted.
+func parseROS2LifecycleState(out string) (state string, id uint32, ok bool) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if open := strings.Index(line, " ["); open >= 0 && strings.HasSuffix(line, "]") {
+			if n, err := strconv.Atoi(strings.TrimSpace(line[open+2 : len(line)-1])); err == nil {
+				return line[:open], uint32(n), true
+			}
+			return line[:open], 0, true
+		}
+		return line, 0, true
+	}
+	return "", 0, false
+}
+
+// parseROS2LifecycleTransitions parses `ros2 lifecycle list <node>` output:
+//
+//   - configure [1]
+//     Start: unconfigured
+//     Goal: configuring
+//   - shutdown [5]
+//     Start: unconfigured
+//     Goal: shuttingdown
+func parseROS2LifecycleTransitions(out string) []*agentpbv2.ROS2LifecycleTransition {
+	var transitions []*agentpbv2.ROS2LifecycleTransition
+	var current *agentpbv2.ROS2LifecycleTransition
+	for _, raw := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		if label, found := strings.CutPrefix(trimmed, "- "); found {
+			t := &agentpbv2.ROS2LifecycleTransition{}
+			if open := strings.Index(label, " ["); open >= 0 && strings.HasSuffix(label, "]") {
+				if n, err := strconv.Atoi(strings.TrimSpace(label[open+2 : len(label)-1])); err == nil {
+					t.Id = uint32(n)
+				}
+				label = label[:open]
+			}
+			t.Label = strings.TrimSpace(label)
+			transitions = append(transitions, t)
+			current = t
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		if v, found := strings.CutPrefix(trimmed, "Start:"); found {
+			current.StartState = strings.TrimSpace(v)
+		} else if v, found := strings.CutPrefix(trimmed, "Goal:"); found {
+			current.GoalState = strings.TrimSpace(v)
+		}
+	}
+	return transitions
+}
+
+// parseROS2ComponentList parses `ros2 component list` output. Container node
+// names are unindented "/name" lines; loaded components follow indented as
+// "  <uid>  /node":
+//
+//	/ComponentManager
+//	  1  /talker
+//	  2  /listener
+func parseROS2ComponentList(out string) []*agentpbv2.ROS2ComponentContainer {
+	var containers []*agentpbv2.ROS2ComponentContainer
+	var current *agentpbv2.ROS2ComponentContainer
+	for _, raw := range strings.Split(out, "\n") {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		// Container lines are unindented and start with "/".
+		if !strings.HasPrefix(raw, " ") && !strings.HasPrefix(raw, "\t") && strings.HasPrefix(strings.TrimSpace(raw), "/") {
+			current = &agentpbv2.ROS2ComponentContainer{Name: strings.TrimSpace(raw)}
+			containers = append(containers, current)
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		// Component entry lines: "<uid>  /node".
+		fields := strings.Fields(raw)
+		if len(fields) >= 2 {
+			if n, err := strconv.Atoi(fields[0]); err == nil {
+				current.Components = append(current.Components, &agentpbv2.ROS2LoadedComponent{
+					Uid:  uint32(n),
+					Name: fields[1],
+				})
+			}
+		}
+	}
+	return containers
+}
+
+// parseROS2ComponentLoad parses `ros2 component load …` output, e.g.
+// "Loaded node '/talker' as 1" → (1, "/talker").
+func parseROS2ComponentLoad(out string) (uid uint32, nodeName string, ok bool) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Loaded node") {
+			continue
+		}
+		if q1 := strings.Index(line, "'"); q1 >= 0 {
+			if q2 := strings.Index(line[q1+1:], "'"); q2 >= 0 {
+				nodeName = line[q1+1 : q1+1+q2]
+			}
+		}
+		if idx := strings.LastIndex(line, " as "); idx >= 0 {
+			if n, err := strconv.Atoi(strings.TrimSpace(line[idx+4:])); err == nil {
+				uid = uint32(n)
+			}
+		}
+		return uid, nodeName, true
+	}
+	return 0, "", false
+}
+
 // parseROS2BagDurationNanos extracts the recording duration from a rosbag2
 // metadata.yaml. It looks for the "nanoseconds:" entry following the
 // "duration:" key.

--- a/go/internal/agent/services/ros2_parse_test.go
+++ b/go/internal/agent/services/ros2_parse_test.go
@@ -58,6 +58,103 @@ func TestParseROS2TopicInfo(t *testing.T) {
 	}
 }
 
+func TestParseROS2ActionList(t *testing.T) {
+	out := "/fibonacci [action_tutorials_interfaces/action/Fibonacci]\n/bare_action\n"
+	actions := parseROS2ActionList(out)
+	if len(actions) != 2 {
+		t.Fatalf("got %d actions, want 2: %+v", len(actions), actions)
+	}
+	if actions[0].GetName() != "/fibonacci" ||
+		!reflect.DeepEqual(actions[0].GetTypes(), []string{"action_tutorials_interfaces/action/Fibonacci"}) {
+		t.Errorf("actions[0] = %+v", actions[0])
+	}
+	if actions[1].GetName() != "/bare_action" || len(actions[1].GetTypes()) != 0 {
+		t.Errorf("actions[1] = %+v", actions[1])
+	}
+}
+
+func TestParseROS2ActionInfo(t *testing.T) {
+	out := "Action: /fibonacci\n" +
+		"Action clients: 1\n" +
+		"    /fibonacci_action_client\n" +
+		"Action servers: 1\n" +
+		"    /fibonacci_action_server\n"
+	name, clients, servers := parseROS2ActionInfo(out)
+	if name != "/fibonacci" {
+		t.Errorf("name = %q, want /fibonacci", name)
+	}
+	if !reflect.DeepEqual(clients, []string{"/fibonacci_action_client"}) {
+		t.Errorf("clients = %v", clients)
+	}
+	if !reflect.DeepEqual(servers, []string{"/fibonacci_action_server"}) {
+		t.Errorf("servers = %v", servers)
+	}
+}
+
+func TestParseROS2LifecycleState(t *testing.T) {
+	cases := []struct {
+		out       string
+		wantState string
+		wantID    uint32
+		wantOK    bool
+	}{
+		{"unconfigured [1]\n", "unconfigured", 1, true},
+		{"active [3]", "active", 3, true},
+		{"finalized", "finalized", 0, true},
+		{"\n", "", 0, false},
+	}
+	for _, c := range cases {
+		state, id, ok := parseROS2LifecycleState(c.out)
+		if state != c.wantState || id != c.wantID || ok != c.wantOK {
+			t.Errorf("parseROS2LifecycleState(%q) = (%q,%d,%v), want (%q,%d,%v)",
+				c.out, state, id, ok, c.wantState, c.wantID, c.wantOK)
+		}
+	}
+}
+
+func TestParseROS2LifecycleTransitions(t *testing.T) {
+	out := "- configure [1]\n\tStart: unconfigured\n\tGoal: configuring\n" +
+		"- shutdown [5]\n\tStart: unconfigured\n\tGoal: shuttingdown\n"
+	ts := parseROS2LifecycleTransitions(out)
+	if len(ts) != 2 {
+		t.Fatalf("got %d transitions, want 2: %+v", len(ts), ts)
+	}
+	if ts[0].GetLabel() != "configure" || ts[0].GetId() != 1 ||
+		ts[0].GetStartState() != "unconfigured" || ts[0].GetGoalState() != "configuring" {
+		t.Errorf("ts[0] = %+v", ts[0])
+	}
+	if ts[1].GetLabel() != "shutdown" || ts[1].GetId() != 5 {
+		t.Errorf("ts[1] = %+v", ts[1])
+	}
+}
+
+func TestParseROS2ComponentList(t *testing.T) {
+	out := "/ComponentManager\n  1  /talker\n  2  /listener\n/OtherContainer\n  1  /widget\n"
+	containers := parseROS2ComponentList(out)
+	if len(containers) != 2 {
+		t.Fatalf("got %d containers, want 2: %+v", len(containers), containers)
+	}
+	if containers[0].GetName() != "/ComponentManager" || len(containers[0].GetComponents()) != 2 {
+		t.Fatalf("containers[0] = %+v", containers[0])
+	}
+	if containers[0].GetComponents()[0].GetUid() != 1 || containers[0].GetComponents()[0].GetName() != "/talker" {
+		t.Errorf("components[0] = %+v", containers[0].GetComponents()[0])
+	}
+	if containers[1].GetName() != "/OtherContainer" || len(containers[1].GetComponents()) != 1 {
+		t.Errorf("containers[1] = %+v", containers[1])
+	}
+}
+
+func TestParseROS2ComponentLoad(t *testing.T) {
+	uid, node, ok := parseROS2ComponentLoad("Loaded node '/talker' as 1\n")
+	if !ok || uid != 1 || node != "/talker" {
+		t.Errorf("got (uid=%d, node=%q, ok=%v), want (1, /talker, true)", uid, node, ok)
+	}
+	if _, _, ok := parseROS2ComponentLoad("some other output\n"); ok {
+		t.Errorf("expected ok=false for non-matching output")
+	}
+}
+
 func TestParseROS2ParamList_AllNodes(t *testing.T) {
 	out := "/camera/driver:\n  exposure\n  gain\n/talker:\n  use_sim_time\n"
 	nodes := parseROS2ParamList(out, "")

--- a/go/internal/agent/services/ros2_service.go
+++ b/go/internal/agent/services/ros2_service.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -160,6 +161,14 @@ func (s *ROS2Service) pickSidecarForNode(ctx context.Context, scs []ros2SC, node
 
 func (s *ROS2Service) pickSidecarForService(ctx context.Context, scs []ros2SC, service string) ros2SC {
 	return s.pickSidecarOwning(ctx, scs, "service", service)
+}
+
+func (s *ROS2Service) pickSidecarForAction(ctx context.Context, scs []ros2SC, action string) ros2SC {
+	return s.pickSidecarOwning(ctx, scs, "action", action)
+}
+
+func (s *ROS2Service) pickSidecarForComponent(ctx context.Context, scs []ros2SC, container string) ros2SC {
+	return s.pickSidecarOwning(ctx, scs, "component", container)
 }
 
 func (s *ROS2Service) ListNodes(ctx context.Context, req *agentpbv2.ListROS2NodesRequest) (*agentpbv2.ListROS2NodesResponse, error) {
@@ -929,6 +938,244 @@ func (w *ros2ExecStreamWriter) Write(p []byte) (int, error) {
 		return 0, err
 	}
 	return len(p), nil
+}
+
+// --- Actions (WDY-1722) ---
+
+func (s *ROS2Service) ListActions(ctx context.Context, req *agentpbv2.ListROS2ActionsRequest) (*agentpbv2.ListROS2ActionsResponse, error) {
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return nil, err
+	}
+	outs, err := s.runMerged(ctx, scs, "action", "list", "-t")
+	if err != nil {
+		return nil, err
+	}
+	resp := &agentpbv2.ListROS2ActionsResponse{}
+	seen := map[string]bool{}
+	for _, o := range outs {
+		for _, a := range parseROS2ActionList(o.out) {
+			a.Rmw = o.rmw
+			key := a.GetName() + "\x00" + o.rmw
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			resp.Actions = append(resp.Actions, a)
+		}
+	}
+	return resp, nil
+}
+
+func (s *ROS2Service) GetActionInfo(ctx context.Context, req *agentpbv2.GetROS2ActionInfoRequest) (*agentpbv2.GetROS2ActionInfoResponse, error) {
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateROS2GraphName(req.GetAction()); err != nil {
+		return nil, err
+	}
+	sc := s.pickSidecarForAction(ctx, scs, req.GetAction())
+	out, err := s.runIn(ctx, sc, "action", "info", req.GetAction())
+	if err != nil {
+		return nil, err
+	}
+	name, clients, servers := parseROS2ActionInfo(out)
+	if name == "" {
+		name = req.GetAction()
+	}
+	return &agentpbv2.GetROS2ActionInfoResponse{
+		Name:          name,
+		ActionClients: clients,
+		ActionServers: servers,
+		Verbose:       out,
+	}, nil
+}
+
+func (s *ROS2Service) SendActionGoal(req *agentpbv2.SendROS2ActionGoalRequest, stream grpc.ServerStreamingServer[agentpbv2.ROS2ExecOutput]) error {
+	ctx := stream.Context()
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return err
+	}
+	if err := validateROS2GraphName(req.GetAction()); err != nil {
+		return err
+	}
+	if req.GetActionType() == "" {
+		return status.Error(codes.InvalidArgument, "action type must not be empty")
+	}
+	args := []string{"action", "send_goal", req.GetAction(), req.GetActionType(), req.GetGoal()}
+	if req.GetFeedback() {
+		args = append(args, "--feedback")
+	}
+	sc := s.pickSidecarForAction(ctx, scs, req.GetAction())
+	stdout := &ros2ExecStreamWriter{stream: stream, stderr: false}
+	stderr := &ros2ExecStreamWriter{stream: stream, stderr: true}
+	code, execErr := s.runtime.ExecROS2(ctx, ROS2ExecOptions{DomainID: sc.domainID, SidecarName: sc.name, Args: args}, stdout, stderr)
+	if ctx.Err() != nil {
+		return nil
+	}
+	if execErr != nil {
+		return status.Errorf(codes.Internal, "ros2 %s: %v", strings.Join(args, " "), execErr)
+	}
+	exitCode := int32(code)
+	return stream.Send(&agentpbv2.ROS2ExecOutput{ExitCode: &exitCode})
+}
+
+// --- Lifecycle / managed nodes (WDY-1722) ---
+
+func (s *ROS2Service) ListLifecycleNodes(ctx context.Context, req *agentpbv2.ListROS2LifecycleNodesRequest) (*agentpbv2.ListROS2LifecycleNodesResponse, error) {
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return nil, err
+	}
+	outs, err := s.runMerged(ctx, scs, "lifecycle", "nodes")
+	if err != nil {
+		return nil, err
+	}
+	resp := &agentpbv2.ListROS2LifecycleNodesResponse{}
+	seen := map[string]bool{}
+	for _, o := range outs {
+		for _, n := range parseROS2NodeList(o.out) {
+			n.Rmw = o.rmw
+			key := ros2NodeFQN(n) + "\x00" + o.rmw
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			resp.Nodes = append(resp.Nodes, n)
+		}
+	}
+	return resp, nil
+}
+
+func (s *ROS2Service) GetLifecycleState(ctx context.Context, req *agentpbv2.GetROS2LifecycleStateRequest) (*agentpbv2.GetROS2LifecycleStateResponse, error) {
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateROS2GraphName(req.GetNode()); err != nil {
+		return nil, err
+	}
+	sc := s.pickSidecarForNode(ctx, scs, req.GetNode())
+	out, err := s.runIn(ctx, sc, "lifecycle", "get", req.GetNode())
+	if err != nil {
+		return nil, err
+	}
+	state, id, ok := parseROS2LifecycleState(out)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "could not parse lifecycle state: %q", strings.TrimSpace(out))
+	}
+	return &agentpbv2.GetROS2LifecycleStateResponse{State: state, StateId: id}, nil
+}
+
+func (s *ROS2Service) ListLifecycleTransitions(ctx context.Context, req *agentpbv2.ListROS2LifecycleTransitionsRequest) (*agentpbv2.ListROS2LifecycleTransitionsResponse, error) {
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateROS2GraphName(req.GetNode()); err != nil {
+		return nil, err
+	}
+	sc := s.pickSidecarForNode(ctx, scs, req.GetNode())
+	out, err := s.runIn(ctx, sc, "lifecycle", "list", req.GetNode())
+	if err != nil {
+		return nil, err
+	}
+	return &agentpbv2.ListROS2LifecycleTransitionsResponse{
+		Transitions: parseROS2LifecycleTransitions(out),
+	}, nil
+}
+
+func (s *ROS2Service) SetLifecycleState(ctx context.Context, req *agentpbv2.SetROS2LifecycleStateRequest) (*agentpbv2.SetROS2LifecycleStateResponse, error) {
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateROS2GraphName(req.GetNode()); err != nil {
+		return nil, err
+	}
+	if req.GetTransition() == "" {
+		return nil, status.Error(codes.InvalidArgument, "transition must not be empty")
+	}
+	sc := s.pickSidecarForNode(ctx, scs, req.GetNode())
+	out, err := s.runIn(ctx, sc, "lifecycle", "set", req.GetNode(), req.GetTransition())
+	if err != nil {
+		// `ros2 lifecycle set` reports failures both via exit code and text.
+		return &agentpbv2.SetROS2LifecycleStateResponse{Success: false, Message: err.Error()}, nil
+	}
+	msg := strings.TrimSpace(out)
+	return &agentpbv2.SetROS2LifecycleStateResponse{
+		Success: strings.Contains(msg, "Transitioning successful"),
+		Message: msg,
+	}, nil
+}
+
+// --- Components / composable nodes (WDY-1722) ---
+
+func (s *ROS2Service) ListComponents(ctx context.Context, req *agentpbv2.ListROS2ComponentsRequest) (*agentpbv2.ListROS2ComponentsResponse, error) {
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return nil, err
+	}
+	outs, err := s.runMerged(ctx, scs, "component", "list")
+	if err != nil {
+		return nil, err
+	}
+	resp := &agentpbv2.ListROS2ComponentsResponse{}
+	seen := map[string]bool{}
+	for _, o := range outs {
+		for _, c := range parseROS2ComponentList(o.out) {
+			c.Rmw = o.rmw
+			key := c.GetName() + "\x00" + o.rmw
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			resp.Containers = append(resp.Containers, c)
+		}
+	}
+	return resp, nil
+}
+
+func (s *ROS2Service) LoadComponent(ctx context.Context, req *agentpbv2.LoadROS2ComponentRequest) (*agentpbv2.LoadROS2ComponentResponse, error) {
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateROS2GraphName(req.GetContainer()); err != nil {
+		return nil, err
+	}
+	if req.GetPackage() == "" || req.GetPlugin() == "" {
+		return nil, status.Error(codes.InvalidArgument, "package and plugin must not be empty")
+	}
+	sc := s.pickSidecarForComponent(ctx, scs, req.GetContainer())
+	out, err := s.runIn(ctx, sc, "component", "load", req.GetContainer(), req.GetPackage(), req.GetPlugin())
+	if err != nil {
+		return nil, err
+	}
+	uid, nodeName, _ := parseROS2ComponentLoad(out)
+	return &agentpbv2.LoadROS2ComponentResponse{
+		Uid:      uid,
+		NodeName: nodeName,
+		Message:  strings.TrimSpace(out),
+	}, nil
+}
+
+func (s *ROS2Service) UnloadComponent(ctx context.Context, req *agentpbv2.UnloadROS2ComponentRequest) (*agentpbv2.UnloadROS2ComponentResponse, error) {
+	scs, err := s.resolveSidecars(ctx, req.DomainId)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateROS2GraphName(req.GetContainer()); err != nil {
+		return nil, err
+	}
+	sc := s.pickSidecarForComponent(ctx, scs, req.GetContainer())
+	out, err := s.runIn(ctx, sc, "component", "unload", req.GetContainer(), strconv.Itoa(int(req.GetUid())))
+	if err != nil {
+		return nil, err
+	}
+	return &agentpbv2.UnloadROS2ComponentResponse{Message: strings.TrimSpace(out)}, nil
 }
 
 // validateROS2GraphName accepts ROS 2 graph names (topics, nodes, services):

--- a/go/internal/agent/services/ros2_service_test.go
+++ b/go/internal/agent/services/ros2_service_test.go
@@ -505,6 +505,191 @@ func TestROS2Service_DownloadBag(t *testing.T) {
 	}
 }
 
+// --- Actions / lifecycle / components (WDY-1722) ---
+
+func TestROS2Service_ListActions_MergesPerRMW(t *testing.T) {
+	rt := twoSidecarRuntime(func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+		if strings.Join(opts.Args, " ") != "action list -t" {
+			return 1, nil
+		}
+		switch opts.SidecarName {
+		case "sc-cyc":
+			io.WriteString(stdout, "/fibonacci [action_tutorials_interfaces/action/Fibonacci]\n")
+		case "sc-fast":
+			io.WriteString(stdout, "/navigate [nav2_msgs/action/NavigateToPose]\n")
+		}
+		return 0, nil
+	})
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	resp, err := svc.ListActions(context.Background(), &agentpbv2.ListROS2ActionsRequest{})
+	if err != nil {
+		t.Fatalf("ListActions: %v", err)
+	}
+	if len(resp.GetActions()) != 2 {
+		t.Fatalf("got %d actions, want 2 (merged across RMWs)", len(resp.GetActions()))
+	}
+	byRMW := map[string]string{}
+	for _, a := range resp.GetActions() {
+		byRMW[a.GetRmw()] = a.GetName()
+	}
+	if byRMW["rmw_cyclonedds_cpp"] != "/fibonacci" || byRMW["rmw_fastrtps_cpp"] != "/navigate" {
+		t.Errorf("actions not tagged by RMW: %+v", byRMW)
+	}
+}
+
+func TestROS2Service_GetActionInfo(t *testing.T) {
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Distro: "humble"},
+		outputs: map[string]string{
+			"action list":            "/fibonacci\n",
+			"action info /fibonacci": "Action: /fibonacci\nAction clients: 1\n    /fibonacci_action_client\nAction servers: 1\n    /fibonacci_action_server\n",
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	resp, err := svc.GetActionInfo(context.Background(), &agentpbv2.GetROS2ActionInfoRequest{Action: "/fibonacci"})
+	if err != nil {
+		t.Fatalf("GetActionInfo: %v", err)
+	}
+	if resp.GetName() != "/fibonacci" ||
+		len(resp.GetActionClients()) != 1 || resp.GetActionClients()[0] != "/fibonacci_action_client" ||
+		len(resp.GetActionServers()) != 1 || resp.GetActionServers()[0] != "/fibonacci_action_server" {
+		t.Errorf("GetActionInfo resp = %+v", resp)
+	}
+}
+
+func TestROS2Service_GetActionInfo_RejectsBadName(t *testing.T) {
+	rt := &fakeROS2Runtime{sidecar: ROS2Sidecar{Distro: "humble"}}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	_, err := svc.GetActionInfo(context.Background(), &agentpbv2.GetROS2ActionInfoRequest{Action: "/fib;rm -rf /"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument", err)
+	}
+}
+
+func TestROS2Service_SendActionGoal(t *testing.T) {
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Distro: "humble"},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			key := strings.Join(opts.Args, " ")
+			if key == "action list" {
+				io.WriteString(stdout, "/fibonacci\n")
+				return 0, nil
+			}
+			io.WriteString(stdout, "Result:\n  sequence: [0, 1, 1, 2, 3]\n")
+			return 0, nil
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2ExecOutput]{ctx: context.Background()}
+	req := &agentpbv2.SendROS2ActionGoalRequest{
+		Action:     "/fibonacci",
+		ActionType: "action_tutorials_interfaces/action/Fibonacci",
+		Goal:       "{order: 5}",
+		Feedback:   true,
+	}
+	if err := svc.SendActionGoal(req, stream); err != nil {
+		t.Fatalf("SendActionGoal: %v", err)
+	}
+	var out string
+	var exit *int32
+	for _, m := range stream.sent {
+		out += string(m.GetStdout())
+		if m.ExitCode != nil {
+			exit = m.ExitCode
+		}
+	}
+	if !strings.Contains(out, "sequence") {
+		t.Errorf("stream stdout = %q", out)
+	}
+	if exit == nil || *exit != 0 {
+		t.Errorf("exit code = %v, want 0", exit)
+	}
+	// --feedback must be forwarded to ros2.
+	var sawSendGoal bool
+	for _, c := range rt.calls {
+		if len(c.Args) >= 2 && c.Args[0] == "action" && c.Args[1] == "send_goal" {
+			sawSendGoal = true
+			if c.Args[len(c.Args)-1] != "--feedback" {
+				t.Errorf("send_goal args = %v, want trailing --feedback", c.Args)
+			}
+		}
+	}
+	if !sawSendGoal {
+		t.Errorf("send_goal was never invoked; calls=%+v", rt.calls)
+	}
+}
+
+func TestROS2Service_Lifecycle_GetAndSet(t *testing.T) {
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Distro: "humble"},
+		outputs: map[string]string{
+			"node list":                          "/lc_talker\n",
+			"lifecycle nodes":                    "/lc_talker\n",
+			"lifecycle get /lc_talker":           "unconfigured [1]\n",
+			"lifecycle list /lc_talker":          "- configure [1]\n\tStart: unconfigured\n\tGoal: configuring\n",
+			"lifecycle set /lc_talker configure": "Transitioning successful\n",
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+
+	nodes, err := svc.ListLifecycleNodes(context.Background(), &agentpbv2.ListROS2LifecycleNodesRequest{})
+	if err != nil || len(nodes.GetNodes()) != 1 || nodes.GetNodes()[0].GetName() != "lc_talker" {
+		t.Fatalf("ListLifecycleNodes = %+v, err=%v", nodes, err)
+	}
+
+	st, err := svc.GetLifecycleState(context.Background(), &agentpbv2.GetROS2LifecycleStateRequest{Node: "/lc_talker"})
+	if err != nil || st.GetState() != "unconfigured" || st.GetStateId() != 1 {
+		t.Fatalf("GetLifecycleState = %+v, err=%v", st, err)
+	}
+
+	tr, err := svc.ListLifecycleTransitions(context.Background(), &agentpbv2.ListROS2LifecycleTransitionsRequest{Node: "/lc_talker"})
+	if err != nil || len(tr.GetTransitions()) != 1 || tr.GetTransitions()[0].GetLabel() != "configure" {
+		t.Fatalf("ListLifecycleTransitions = %+v, err=%v", tr, err)
+	}
+
+	set, err := svc.SetLifecycleState(context.Background(), &agentpbv2.SetROS2LifecycleStateRequest{Node: "/lc_talker", Transition: "configure"})
+	if err != nil {
+		t.Fatalf("SetLifecycleState: %v", err)
+	}
+	if !set.GetSuccess() {
+		t.Errorf("SetLifecycleState success = false, message=%q", set.GetMessage())
+	}
+}
+
+func TestROS2Service_Components(t *testing.T) {
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Distro: "humble"},
+		outputs: map[string]string{
+			"component list": "/ComponentManager\n  1  /talker\n",
+			"component load /ComponentManager composition composition::Listener": "Loaded node '/listener' as 2\n",
+			"component unload /ComponentManager 1":                               "Unloaded component 1 from '/ComponentManager' container\n",
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+
+	list, err := svc.ListComponents(context.Background(), &agentpbv2.ListROS2ComponentsRequest{})
+	if err != nil || len(list.GetContainers()) != 1 || list.GetContainers()[0].GetName() != "/ComponentManager" {
+		t.Fatalf("ListComponents = %+v, err=%v", list, err)
+	}
+	if len(list.GetContainers()[0].GetComponents()) != 1 || list.GetContainers()[0].GetComponents()[0].GetUid() != 1 {
+		t.Errorf("loaded components = %+v", list.GetContainers()[0].GetComponents())
+	}
+
+	loaded, err := svc.LoadComponent(context.Background(), &agentpbv2.LoadROS2ComponentRequest{
+		Container: "/ComponentManager", Package: "composition", Plugin: "composition::Listener",
+	})
+	if err != nil || loaded.GetUid() != 2 || loaded.GetNodeName() != "/listener" {
+		t.Fatalf("LoadComponent = %+v, err=%v", loaded, err)
+	}
+
+	unloaded, err := svc.UnloadComponent(context.Background(), &agentpbv2.UnloadROS2ComponentRequest{
+		Container: "/ComponentManager", Uid: 1,
+	})
+	if err != nil || !strings.Contains(unloaded.GetMessage(), "Unloaded component 1") {
+		t.Fatalf("UnloadComponent = %+v, err=%v", unloaded, err)
+	}
+}
+
 func TestROS2Service_Exec(t *testing.T) {
 	rt := &fakeROS2Runtime{
 		sidecar: ROS2Sidecar{Distro: "humble"},

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -49,6 +50,9 @@ ros2 commands there — no SSH and no setup.bash sourcing required.`,
 		newROS2GraphCmd(),
 		newROS2BagCmd(),
 		newROS2DoctorCmd(),
+		newROS2ActionCmd(),
+		newROS2LifecycleCmd(),
+		newROS2ComponentCmd(),
 		newROS2ExecCmd(),
 	)
 	return cmd
@@ -540,6 +544,476 @@ func newROS2DoctorCmd() *cobra.Command {
 		},
 	}
 	ros2DomainFlag(cmd, &domain)
+	return cmd
+}
+
+// ── actions / lifecycle / components (WDY-1722) ─────────────────────
+
+func newROS2ActionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "action",
+		Short: "Inspect ROS 2 actions and dispatch goals",
+	}
+
+	var listDomain int32
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List ROS 2 actions",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := newROS2Client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			resp, err := client.client.ListActions(cmd.Context(), &agentpbv2.ListROS2ActionsRequest{DomainId: ros2DomainPtr(listDomain)})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			if jsonOutput {
+				type action struct {
+					Name  string   `json:"name"`
+					Types []string `json:"types"`
+					RMW   string   `json:"rmw,omitempty"`
+				}
+				actions := make([]action, 0, len(resp.GetActions()))
+				for _, a := range resp.GetActions() {
+					actions = append(actions, action{Name: a.GetName(), Types: a.GetTypes(), RMW: a.GetRmw()})
+				}
+				return printROS2JSON(actions)
+			}
+			if len(resp.GetActions()) == 0 {
+				cliNotice("No ROS 2 actions found.")
+				return nil
+			}
+			rmws := make([]string, 0, len(resp.GetActions()))
+			for _, a := range resp.GetActions() {
+				rmws = append(rmws, a.GetRmw())
+			}
+			rmwCol := ros2ShowRMWTags(rmws...)
+			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			if rmwCol {
+				fmt.Fprintln(w, "ACTION\tTYPE\tRMW")
+				for _, a := range resp.GetActions() {
+					fmt.Fprintf(w, "%s\t%s\t%s\n", a.GetName(), strings.Join(a.GetTypes(), ", "), ros2RMWShort(a.GetRmw()))
+				}
+			} else {
+				fmt.Fprintln(w, "ACTION\tTYPE")
+				for _, a := range resp.GetActions() {
+					fmt.Fprintf(w, "%s\t%s\n", a.GetName(), strings.Join(a.GetTypes(), ", "))
+				}
+			}
+			return w.Flush()
+		},
+	}
+	ros2DomainFlag(list, &listDomain)
+
+	var infoDomain int32
+	info := &cobra.Command{
+		Use:   "info <action>",
+		Short: "Show clients and servers for an action",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newROS2Client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			resp, err := client.client.GetActionInfo(cmd.Context(), &agentpbv2.GetROS2ActionInfoRequest{
+				DomainId: ros2DomainPtr(infoDomain),
+				Action:   args[0],
+			})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			if jsonOutput {
+				return printROS2JSON(map[string]any{
+					"name":    resp.GetName(),
+					"clients": resp.GetActionClients(),
+					"servers": resp.GetActionServers(),
+					"verbose": resp.GetVerbose(),
+				})
+			}
+			fmt.Print(resp.GetVerbose())
+			return nil
+		},
+	}
+	ros2DomainFlag(info, &infoDomain)
+
+	var sendDomain int32
+	var feedback bool
+	sendGoal := &cobra.Command{
+		Use:   "send_goal <action> <type> <goal>",
+		Short: "Send a goal to an action and stream feedback/result (ctrl-c to cancel)",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			client, err := newROS2Client(ctx)
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			stream, err := client.client.SendActionGoal(ctx, &agentpbv2.SendROS2ActionGoalRequest{
+				DomainId:   ros2DomainPtr(sendDomain),
+				Action:     args[0],
+				ActionType: args[1],
+				Goal:       args[2],
+				Feedback:   feedback,
+			})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			return drainExecStream(ctx, stream, []string{"action", "send_goal", args[0]}, os.Stdout, os.Stderr)
+		},
+	}
+	ros2DomainFlag(sendGoal, &sendDomain)
+	sendGoal.Flags().BoolVar(&feedback, "feedback", false, "Stream feedback messages as the goal executes")
+
+	var cancelDomain int32
+	cancel := &cobra.Command{
+		Use:   "cancel <action>",
+		Short: "Cancel all in-flight goals on an action (wendy-specific, best-effort)",
+		Long: `Cancel all in-flight goals on an action.
+
+Upstream ros2 has no "action cancel" verb; this is a wendy convenience that
+calls the action's _action/cancel_goal service with an all-zero goal id, which
+the action server interprets as "cancel all active goals". To cancel a single
+goal interactively, ctrl-c its "send_goal" instead.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			client, err := newROS2Client(ctx)
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			// Route through the generic Exec passthrough: cancel-all via the
+			// action's cancel_goal service (zero goal id + zero stamp).
+			fwdArgs := []string{
+				"service", "call",
+				strings.TrimRight(args[0], "/") + "/_action/cancel_goal",
+				"action_msgs/srv/CancelGoal",
+				"{goal_info: {goal_id: {uuid: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}, stamp: {sec: 0, nanosec: 0}}}",
+			}
+			stream, err := client.client.Exec(ctx, &agentpbv2.ROS2ExecRequest{
+				DomainId: ros2DomainPtr(cancelDomain),
+				Args:     fwdArgs,
+			})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			return drainExecStream(ctx, stream, fwdArgs, os.Stdout, os.Stderr)
+		},
+	}
+	ros2DomainFlag(cancel, &cancelDomain)
+
+	cmd.AddCommand(list, info, sendGoal, cancel)
+	return cmd
+}
+
+func newROS2LifecycleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lifecycle",
+		Short: "Inspect and transition managed (lifecycle) nodes",
+	}
+
+	var nodesDomain int32
+	nodes := &cobra.Command{
+		Use:   "nodes",
+		Short: "List managed (lifecycle) nodes",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := newROS2Client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			resp, err := client.client.ListLifecycleNodes(cmd.Context(), &agentpbv2.ListROS2LifecycleNodesRequest{DomainId: ros2DomainPtr(nodesDomain)})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			if jsonOutput {
+				type node struct {
+					Name      string `json:"name"`
+					Namespace string `json:"namespace"`
+					RMW       string `json:"rmw,omitempty"`
+				}
+				ns := make([]node, 0, len(resp.GetNodes()))
+				for _, n := range resp.GetNodes() {
+					ns = append(ns, node{Name: n.GetName(), Namespace: n.GetNamespace(), RMW: n.GetRmw()})
+				}
+				return printROS2JSON(ns)
+			}
+			if len(resp.GetNodes()) == 0 {
+				cliNotice("No managed (lifecycle) nodes found.")
+				return nil
+			}
+			rmws := make([]string, 0, len(resp.GetNodes()))
+			for _, n := range resp.GetNodes() {
+				rmws = append(rmws, n.GetRmw())
+			}
+			showTags := ros2ShowRMWTags(rmws...)
+			for _, n := range resp.GetNodes() {
+				line := ros2GraphNodeFQN(n)
+				if showTags && n.GetRmw() != "" {
+					line += "  [" + ros2RMWShort(n.GetRmw()) + "]"
+				}
+				fmt.Println(line)
+			}
+			return nil
+		},
+	}
+	ros2DomainFlag(nodes, &nodesDomain)
+
+	var getDomain int32
+	get := &cobra.Command{
+		Use:   "get <node>",
+		Short: "Get the current lifecycle state of a node",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newROS2Client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			resp, err := client.client.GetLifecycleState(cmd.Context(), &agentpbv2.GetROS2LifecycleStateRequest{
+				DomainId: ros2DomainPtr(getDomain),
+				Node:     args[0],
+			})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			if jsonOutput {
+				return printROS2JSON(map[string]any{"node": args[0], "state": resp.GetState(), "stateId": resp.GetStateId()})
+			}
+			fmt.Printf("%s [%d]\n", resp.GetState(), resp.GetStateId())
+			return nil
+		},
+	}
+	ros2DomainFlag(get, &getDomain)
+
+	var listDomain int32
+	list := &cobra.Command{
+		Use:   "list <node>",
+		Short: "List the available lifecycle transitions for a node",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newROS2Client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			resp, err := client.client.ListLifecycleTransitions(cmd.Context(), &agentpbv2.ListROS2LifecycleTransitionsRequest{
+				DomainId: ros2DomainPtr(listDomain),
+				Node:     args[0],
+			})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			if jsonOutput {
+				type transition struct {
+					Label string `json:"label"`
+					ID    uint32 `json:"id"`
+					Start string `json:"start"`
+					Goal  string `json:"goal"`
+				}
+				ts := make([]transition, 0, len(resp.GetTransitions()))
+				for _, t := range resp.GetTransitions() {
+					ts = append(ts, transition{Label: t.GetLabel(), ID: t.GetId(), Start: t.GetStartState(), Goal: t.GetGoalState()})
+				}
+				return printROS2JSON(ts)
+			}
+			if len(resp.GetTransitions()) == 0 {
+				cliNotice("No lifecycle transitions available.")
+				return nil
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "TRANSITION\tID\tSTART\tGOAL")
+			for _, t := range resp.GetTransitions() {
+				fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", t.GetLabel(), t.GetId(), t.GetStartState(), t.GetGoalState())
+			}
+			return w.Flush()
+		},
+	}
+	ros2DomainFlag(list, &listDomain)
+
+	var setDomain int32
+	set := &cobra.Command{
+		Use:   "set <node> <transition>",
+		Short: "Trigger a lifecycle transition (e.g. configure, activate)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newROS2Client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			resp, err := client.client.SetLifecycleState(cmd.Context(), &agentpbv2.SetROS2LifecycleStateRequest{
+				DomainId:   ros2DomainPtr(setDomain),
+				Node:       args[0],
+				Transition: args[1],
+			})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			if jsonOutput {
+				return printROS2JSON(map[string]any{"success": resp.GetSuccess(), "message": resp.GetMessage()})
+			}
+			if !resp.GetSuccess() {
+				return fmt.Errorf("transition failed: %s", resp.GetMessage())
+			}
+			cliSuccess("%s", resp.GetMessage())
+			return nil
+		},
+	}
+	ros2DomainFlag(set, &setDomain)
+
+	cmd.AddCommand(nodes, get, list, set)
+	return cmd
+}
+
+func newROS2ComponentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "component",
+		Short: "Manage composable-node component containers",
+	}
+
+	var listDomain int32
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List component containers and their loaded components",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := newROS2Client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			resp, err := client.client.ListComponents(cmd.Context(), &agentpbv2.ListROS2ComponentsRequest{DomainId: ros2DomainPtr(listDomain)})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			if jsonOutput {
+				type component struct {
+					UID  uint32 `json:"uid"`
+					Name string `json:"name"`
+				}
+				type container struct {
+					Name       string      `json:"name"`
+					RMW        string      `json:"rmw,omitempty"`
+					Components []component `json:"components"`
+				}
+				containers := make([]container, 0, len(resp.GetContainers()))
+				for _, c := range resp.GetContainers() {
+					comps := make([]component, 0, len(c.GetComponents()))
+					for _, comp := range c.GetComponents() {
+						comps = append(comps, component{UID: comp.GetUid(), Name: comp.GetName()})
+					}
+					containers = append(containers, container{Name: c.GetName(), RMW: c.GetRmw(), Components: comps})
+				}
+				return printROS2JSON(containers)
+			}
+			if len(resp.GetContainers()) == 0 {
+				cliNotice("No component containers found.")
+				return nil
+			}
+			rmws := make([]string, 0, len(resp.GetContainers()))
+			for _, c := range resp.GetContainers() {
+				rmws = append(rmws, c.GetRmw())
+			}
+			showTags := ros2ShowRMWTags(rmws...)
+			for _, c := range resp.GetContainers() {
+				header := c.GetName()
+				if showTags && c.GetRmw() != "" {
+					header += "  [" + ros2RMWShort(c.GetRmw()) + "]"
+				}
+				fmt.Println(header)
+				for _, comp := range c.GetComponents() {
+					fmt.Printf("  %d  %s\n", comp.GetUid(), comp.GetName())
+				}
+			}
+			return nil
+		},
+	}
+	ros2DomainFlag(list, &listDomain)
+
+	var loadDomain int32
+	load := &cobra.Command{
+		Use:   "load <container> <package> <plugin>",
+		Short: "Load a component into a running container",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newROS2Client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			resp, err := client.client.LoadComponent(cmd.Context(), &agentpbv2.LoadROS2ComponentRequest{
+				DomainId:  ros2DomainPtr(loadDomain),
+				Container: args[0],
+				Package:   args[1],
+				Plugin:    args[2],
+			})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			if jsonOutput {
+				return printROS2JSON(map[string]any{"uid": resp.GetUid(), "nodeName": resp.GetNodeName(), "message": resp.GetMessage()})
+			}
+			cliSuccess("%s", resp.GetMessage())
+			return nil
+		},
+	}
+	ros2DomainFlag(load, &loadDomain)
+
+	var unloadDomain int32
+	unload := &cobra.Command{
+		Use:   "unload <container> <uid>",
+		Short: "Unload a component from a running container",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			uid, err := strconv.ParseUint(args[1], 10, 32)
+			if err != nil {
+				return fmt.Errorf("invalid component uid %q: must be a number", args[1])
+			}
+			client, err := newROS2Client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			resp, err := client.client.UnloadComponent(cmd.Context(), &agentpbv2.UnloadROS2ComponentRequest{
+				DomainId:  ros2DomainPtr(unloadDomain),
+				Container: args[0],
+				Uid:       uint32(uid),
+			})
+			if err != nil {
+				return ros2RPCError(err)
+			}
+			if jsonOutput {
+				return printROS2JSON(map[string]any{"message": resp.GetMessage()})
+			}
+			cliSuccess("%s", resp.GetMessage())
+			return nil
+		},
+	}
+	ros2DomainFlag(unload, &unloadDomain)
+
+	cmd.AddCommand(list, load, unload)
 	return cmd
 }
 

--- a/go/internal/cli/commands/ros2_test.go
+++ b/go/internal/cli/commands/ros2_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -705,4 +706,39 @@ type errOnFirstEchoRecv struct{ err error }
 
 func (e *errOnFirstEchoRecv) Recv() (*agentpbv2.ROS2Message, error) {
 	return nil, e.err
+}
+
+// TestROS2CommandTree locks the WDY-1722 command surface: the action,
+// lifecycle, and component groups and their subcommands must be registered,
+// so a missing AddCommand is caught without a live device.
+func TestROS2CommandTree(t *testing.T) {
+	root := newROS2Cmd()
+	find := func(parent *cobra.Command, name string) *cobra.Command {
+		t.Helper()
+		for _, c := range parent.Commands() {
+			if c.Name() == name {
+				return c
+			}
+		}
+		t.Fatalf("%q has no %q subcommand", parent.Name(), name)
+		return nil
+	}
+	want := map[string][]string{
+		"action":    {"list", "info", "send_goal", "cancel"},
+		"lifecycle": {"nodes", "get", "list", "set"},
+		"component": {"list", "load", "unload"},
+	}
+	for group, subs := range want {
+		g := find(root, group)
+		for _, sub := range subs {
+			child := find(g, sub)
+			if child.Flag("domain") == nil {
+				t.Errorf("%s %s: missing --domain flag", group, sub)
+			}
+		}
+	}
+	// send_goal must expose --feedback.
+	if find(find(root, "action"), "send_goal").Flag("feedback") == nil {
+		t.Errorf("action send_goal: missing --feedback flag")
+	}
 }

--- a/go/proto/gen/agentpb/v2/ros2_service.pb.go
+++ b/go/proto/gen/agentpb/v2/ros2_service.pb.go
@@ -1886,6 +1886,1254 @@ func (x *ROS2ExecOutput) GetExitCode() int32 {
 	return 0
 }
 
+type ROS2Action struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Types []string               `protobuf:"bytes,2,rep,name=types,proto3" json:"types,omitempty"` // an action can advertise multiple types
+	// rmw identifies which RMW graph this action came from (WDY-1594). Empty on
+	// single-RMW devices.
+	Rmw           string `protobuf:"bytes,3,opt,name=rmw,proto3" json:"rmw,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ROS2Action) Reset() {
+	*x = ROS2Action{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ROS2Action) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ROS2Action) ProtoMessage() {}
+
+func (x *ROS2Action) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ROS2Action.ProtoReflect.Descriptor instead.
+func (*ROS2Action) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ROS2Action) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ROS2Action) GetTypes() []string {
+	if x != nil {
+		return x.Types
+	}
+	return nil
+}
+
+func (x *ROS2Action) GetRmw() string {
+	if x != nil {
+		return x.Rmw
+	}
+	return ""
+}
+
+type ListROS2ActionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListROS2ActionsRequest) Reset() {
+	*x = ListROS2ActionsRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListROS2ActionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListROS2ActionsRequest) ProtoMessage() {}
+
+func (x *ListROS2ActionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListROS2ActionsRequest.ProtoReflect.Descriptor instead.
+func (*ListROS2ActionsRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *ListROS2ActionsRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+type ListROS2ActionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Actions       []*ROS2Action          `protobuf:"bytes,1,rep,name=actions,proto3" json:"actions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListROS2ActionsResponse) Reset() {
+	*x = ListROS2ActionsResponse{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListROS2ActionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListROS2ActionsResponse) ProtoMessage() {}
+
+func (x *ListROS2ActionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListROS2ActionsResponse.ProtoReflect.Descriptor instead.
+func (*ListROS2ActionsResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *ListROS2ActionsResponse) GetActions() []*ROS2Action {
+	if x != nil {
+		return x.Actions
+	}
+	return nil
+}
+
+type GetROS2ActionInfoRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	Action        string                 `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetROS2ActionInfoRequest) Reset() {
+	*x = GetROS2ActionInfoRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetROS2ActionInfoRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetROS2ActionInfoRequest) ProtoMessage() {}
+
+func (x *GetROS2ActionInfoRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetROS2ActionInfoRequest.ProtoReflect.Descriptor instead.
+func (*GetROS2ActionInfoRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *GetROS2ActionInfoRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+func (x *GetROS2ActionInfoRequest) GetAction() string {
+	if x != nil {
+		return x.Action
+	}
+	return ""
+}
+
+type GetROS2ActionInfoResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	ActionClients []string               `protobuf:"bytes,2,rep,name=action_clients,json=actionClients,proto3" json:"action_clients,omitempty"` // fully-qualified client node names
+	ActionServers []string               `protobuf:"bytes,3,rep,name=action_servers,json=actionServers,proto3" json:"action_servers,omitempty"` // fully-qualified server node names
+	// Verbose raw `ros2 action info` output.
+	Verbose       string `protobuf:"bytes,4,opt,name=verbose,proto3" json:"verbose,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetROS2ActionInfoResponse) Reset() {
+	*x = GetROS2ActionInfoResponse{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetROS2ActionInfoResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetROS2ActionInfoResponse) ProtoMessage() {}
+
+func (x *GetROS2ActionInfoResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetROS2ActionInfoResponse.ProtoReflect.Descriptor instead.
+func (*GetROS2ActionInfoResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *GetROS2ActionInfoResponse) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *GetROS2ActionInfoResponse) GetActionClients() []string {
+	if x != nil {
+		return x.ActionClients
+	}
+	return nil
+}
+
+func (x *GetROS2ActionInfoResponse) GetActionServers() []string {
+	if x != nil {
+		return x.ActionServers
+	}
+	return nil
+}
+
+func (x *GetROS2ActionInfoResponse) GetVerbose() string {
+	if x != nil {
+		return x.Verbose
+	}
+	return ""
+}
+
+type SendROS2ActionGoalRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	Action        string                 `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
+	ActionType    string                 `protobuf:"bytes,3,opt,name=action_type,json=actionType,proto3" json:"action_type,omitempty"` // e.g. action_tutorials_interfaces/action/Fibonacci
+	Goal          string                 `protobuf:"bytes,4,opt,name=goal,proto3" json:"goal,omitempty"`                               // YAML goal payload
+	Feedback      bool                   `protobuf:"varint,5,opt,name=feedback,proto3" json:"feedback,omitempty"`                      // forward --feedback to stream feedback messages
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendROS2ActionGoalRequest) Reset() {
+	*x = SendROS2ActionGoalRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendROS2ActionGoalRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendROS2ActionGoalRequest) ProtoMessage() {}
+
+func (x *SendROS2ActionGoalRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendROS2ActionGoalRequest.ProtoReflect.Descriptor instead.
+func (*SendROS2ActionGoalRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *SendROS2ActionGoalRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+func (x *SendROS2ActionGoalRequest) GetAction() string {
+	if x != nil {
+		return x.Action
+	}
+	return ""
+}
+
+func (x *SendROS2ActionGoalRequest) GetActionType() string {
+	if x != nil {
+		return x.ActionType
+	}
+	return ""
+}
+
+func (x *SendROS2ActionGoalRequest) GetGoal() string {
+	if x != nil {
+		return x.Goal
+	}
+	return ""
+}
+
+func (x *SendROS2ActionGoalRequest) GetFeedback() bool {
+	if x != nil {
+		return x.Feedback
+	}
+	return false
+}
+
+type ROS2LifecycleTransition struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Label         string                 `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"` // e.g. "configure"
+	Id            uint32                 `protobuf:"varint,2,opt,name=id,proto3" json:"id,omitempty"`
+	StartState    string                 `protobuf:"bytes,3,opt,name=start_state,json=startState,proto3" json:"start_state,omitempty"`
+	GoalState     string                 `protobuf:"bytes,4,opt,name=goal_state,json=goalState,proto3" json:"goal_state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ROS2LifecycleTransition) Reset() {
+	*x = ROS2LifecycleTransition{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ROS2LifecycleTransition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ROS2LifecycleTransition) ProtoMessage() {}
+
+func (x *ROS2LifecycleTransition) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ROS2LifecycleTransition.ProtoReflect.Descriptor instead.
+func (*ROS2LifecycleTransition) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *ROS2LifecycleTransition) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+func (x *ROS2LifecycleTransition) GetId() uint32 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *ROS2LifecycleTransition) GetStartState() string {
+	if x != nil {
+		return x.StartState
+	}
+	return ""
+}
+
+func (x *ROS2LifecycleTransition) GetGoalState() string {
+	if x != nil {
+		return x.GoalState
+	}
+	return ""
+}
+
+type ListROS2LifecycleNodesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListROS2LifecycleNodesRequest) Reset() {
+	*x = ListROS2LifecycleNodesRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListROS2LifecycleNodesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListROS2LifecycleNodesRequest) ProtoMessage() {}
+
+func (x *ListROS2LifecycleNodesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListROS2LifecycleNodesRequest.ProtoReflect.Descriptor instead.
+func (*ListROS2LifecycleNodesRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *ListROS2LifecycleNodesRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+type ListROS2LifecycleNodesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Nodes         []*ROS2Node            `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListROS2LifecycleNodesResponse) Reset() {
+	*x = ListROS2LifecycleNodesResponse{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListROS2LifecycleNodesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListROS2LifecycleNodesResponse) ProtoMessage() {}
+
+func (x *ListROS2LifecycleNodesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListROS2LifecycleNodesResponse.ProtoReflect.Descriptor instead.
+func (*ListROS2LifecycleNodesResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *ListROS2LifecycleNodesResponse) GetNodes() []*ROS2Node {
+	if x != nil {
+		return x.Nodes
+	}
+	return nil
+}
+
+type GetROS2LifecycleStateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	Node          string                 `protobuf:"bytes,2,opt,name=node,proto3" json:"node,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetROS2LifecycleStateRequest) Reset() {
+	*x = GetROS2LifecycleStateRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetROS2LifecycleStateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetROS2LifecycleStateRequest) ProtoMessage() {}
+
+func (x *GetROS2LifecycleStateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetROS2LifecycleStateRequest.ProtoReflect.Descriptor instead.
+func (*GetROS2LifecycleStateRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *GetROS2LifecycleStateRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+func (x *GetROS2LifecycleStateRequest) GetNode() string {
+	if x != nil {
+		return x.Node
+	}
+	return ""
+}
+
+type GetROS2LifecycleStateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	State         string                 `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`                     // e.g. "unconfigured", "inactive", "active"
+	StateId       uint32                 `protobuf:"varint,2,opt,name=state_id,json=stateId,proto3" json:"state_id,omitempty"` // numeric state id (e.g. 1)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetROS2LifecycleStateResponse) Reset() {
+	*x = GetROS2LifecycleStateResponse{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetROS2LifecycleStateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetROS2LifecycleStateResponse) ProtoMessage() {}
+
+func (x *GetROS2LifecycleStateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetROS2LifecycleStateResponse.ProtoReflect.Descriptor instead.
+func (*GetROS2LifecycleStateResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *GetROS2LifecycleStateResponse) GetState() string {
+	if x != nil {
+		return x.State
+	}
+	return ""
+}
+
+func (x *GetROS2LifecycleStateResponse) GetStateId() uint32 {
+	if x != nil {
+		return x.StateId
+	}
+	return 0
+}
+
+type ListROS2LifecycleTransitionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	Node          string                 `protobuf:"bytes,2,opt,name=node,proto3" json:"node,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListROS2LifecycleTransitionsRequest) Reset() {
+	*x = ListROS2LifecycleTransitionsRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListROS2LifecycleTransitionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListROS2LifecycleTransitionsRequest) ProtoMessage() {}
+
+func (x *ListROS2LifecycleTransitionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListROS2LifecycleTransitionsRequest.ProtoReflect.Descriptor instead.
+func (*ListROS2LifecycleTransitionsRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *ListROS2LifecycleTransitionsRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+func (x *ListROS2LifecycleTransitionsRequest) GetNode() string {
+	if x != nil {
+		return x.Node
+	}
+	return ""
+}
+
+type ListROS2LifecycleTransitionsResponse struct {
+	state         protoimpl.MessageState     `protogen:"open.v1"`
+	Transitions   []*ROS2LifecycleTransition `protobuf:"bytes,1,rep,name=transitions,proto3" json:"transitions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListROS2LifecycleTransitionsResponse) Reset() {
+	*x = ListROS2LifecycleTransitionsResponse{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListROS2LifecycleTransitionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListROS2LifecycleTransitionsResponse) ProtoMessage() {}
+
+func (x *ListROS2LifecycleTransitionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListROS2LifecycleTransitionsResponse.ProtoReflect.Descriptor instead.
+func (*ListROS2LifecycleTransitionsResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *ListROS2LifecycleTransitionsResponse) GetTransitions() []*ROS2LifecycleTransition {
+	if x != nil {
+		return x.Transitions
+	}
+	return nil
+}
+
+type SetROS2LifecycleStateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	Node          string                 `protobuf:"bytes,2,opt,name=node,proto3" json:"node,omitempty"`
+	Transition    string                 `protobuf:"bytes,3,opt,name=transition,proto3" json:"transition,omitempty"` // e.g. "configure", "activate"
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetROS2LifecycleStateRequest) Reset() {
+	*x = SetROS2LifecycleStateRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetROS2LifecycleStateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetROS2LifecycleStateRequest) ProtoMessage() {}
+
+func (x *SetROS2LifecycleStateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetROS2LifecycleStateRequest.ProtoReflect.Descriptor instead.
+func (*SetROS2LifecycleStateRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *SetROS2LifecycleStateRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+func (x *SetROS2LifecycleStateRequest) GetNode() string {
+	if x != nil {
+		return x.Node
+	}
+	return ""
+}
+
+func (x *SetROS2LifecycleStateRequest) GetTransition() string {
+	if x != nil {
+		return x.Transition
+	}
+	return ""
+}
+
+type SetROS2LifecycleStateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetROS2LifecycleStateResponse) Reset() {
+	*x = SetROS2LifecycleStateResponse{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetROS2LifecycleStateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetROS2LifecycleStateResponse) ProtoMessage() {}
+
+func (x *SetROS2LifecycleStateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetROS2LifecycleStateResponse.ProtoReflect.Descriptor instead.
+func (*SetROS2LifecycleStateResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *SetROS2LifecycleStateResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *SetROS2LifecycleStateResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+type ROS2LoadedComponent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Uid           uint32                 `protobuf:"varint,1,opt,name=uid,proto3" json:"uid,omitempty"`  // unique id within the container
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"` // fully-qualified node name
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ROS2LoadedComponent) Reset() {
+	*x = ROS2LoadedComponent{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ROS2LoadedComponent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ROS2LoadedComponent) ProtoMessage() {}
+
+func (x *ROS2LoadedComponent) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ROS2LoadedComponent.ProtoReflect.Descriptor instead.
+func (*ROS2LoadedComponent) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *ROS2LoadedComponent) GetUid() uint32 {
+	if x != nil {
+		return x.Uid
+	}
+	return 0
+}
+
+func (x *ROS2LoadedComponent) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type ROS2ComponentContainer struct {
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Name       string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"` // container node name, e.g. /ComponentManager
+	Components []*ROS2LoadedComponent `protobuf:"bytes,2,rep,name=components,proto3" json:"components,omitempty"`
+	// rmw identifies which RMW graph this container came from (WDY-1594).
+	Rmw           string `protobuf:"bytes,3,opt,name=rmw,proto3" json:"rmw,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ROS2ComponentContainer) Reset() {
+	*x = ROS2ComponentContainer{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ROS2ComponentContainer) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ROS2ComponentContainer) ProtoMessage() {}
+
+func (x *ROS2ComponentContainer) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ROS2ComponentContainer.ProtoReflect.Descriptor instead.
+func (*ROS2ComponentContainer) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *ROS2ComponentContainer) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ROS2ComponentContainer) GetComponents() []*ROS2LoadedComponent {
+	if x != nil {
+		return x.Components
+	}
+	return nil
+}
+
+func (x *ROS2ComponentContainer) GetRmw() string {
+	if x != nil {
+		return x.Rmw
+	}
+	return ""
+}
+
+type ListROS2ComponentsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListROS2ComponentsRequest) Reset() {
+	*x = ListROS2ComponentsRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListROS2ComponentsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListROS2ComponentsRequest) ProtoMessage() {}
+
+func (x *ListROS2ComponentsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListROS2ComponentsRequest.ProtoReflect.Descriptor instead.
+func (*ListROS2ComponentsRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *ListROS2ComponentsRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+type ListROS2ComponentsResponse struct {
+	state         protoimpl.MessageState    `protogen:"open.v1"`
+	Containers    []*ROS2ComponentContainer `protobuf:"bytes,1,rep,name=containers,proto3" json:"containers,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListROS2ComponentsResponse) Reset() {
+	*x = ListROS2ComponentsResponse{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListROS2ComponentsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListROS2ComponentsResponse) ProtoMessage() {}
+
+func (x *ListROS2ComponentsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListROS2ComponentsResponse.ProtoReflect.Descriptor instead.
+func (*ListROS2ComponentsResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *ListROS2ComponentsResponse) GetContainers() []*ROS2ComponentContainer {
+	if x != nil {
+		return x.Containers
+	}
+	return nil
+}
+
+type LoadROS2ComponentRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	Container     string                 `protobuf:"bytes,2,opt,name=container,proto3" json:"container,omitempty"` // container node name
+	Package       string                 `protobuf:"bytes,3,opt,name=package,proto3" json:"package,omitempty"`
+	Plugin        string                 `protobuf:"bytes,4,opt,name=plugin,proto3" json:"plugin,omitempty"` // plugin class, e.g. composition::Talker
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoadROS2ComponentRequest) Reset() {
+	*x = LoadROS2ComponentRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoadROS2ComponentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoadROS2ComponentRequest) ProtoMessage() {}
+
+func (x *LoadROS2ComponentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoadROS2ComponentRequest.ProtoReflect.Descriptor instead.
+func (*LoadROS2ComponentRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *LoadROS2ComponentRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+func (x *LoadROS2ComponentRequest) GetContainer() string {
+	if x != nil {
+		return x.Container
+	}
+	return ""
+}
+
+func (x *LoadROS2ComponentRequest) GetPackage() string {
+	if x != nil {
+		return x.Package
+	}
+	return ""
+}
+
+func (x *LoadROS2ComponentRequest) GetPlugin() string {
+	if x != nil {
+		return x.Plugin
+	}
+	return ""
+}
+
+type LoadROS2ComponentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Uid           uint32                 `protobuf:"varint,1,opt,name=uid,proto3" json:"uid,omitempty"`
+	NodeName      string                 `protobuf:"bytes,2,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
+	Message       string                 `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoadROS2ComponentResponse) Reset() {
+	*x = LoadROS2ComponentResponse{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoadROS2ComponentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoadROS2ComponentResponse) ProtoMessage() {}
+
+func (x *LoadROS2ComponentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoadROS2ComponentResponse.ProtoReflect.Descriptor instead.
+func (*LoadROS2ComponentResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *LoadROS2ComponentResponse) GetUid() uint32 {
+	if x != nil {
+		return x.Uid
+	}
+	return 0
+}
+
+func (x *LoadROS2ComponentResponse) GetNodeName() string {
+	if x != nil {
+		return x.NodeName
+	}
+	return ""
+}
+
+func (x *LoadROS2ComponentResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+type UnloadROS2ComponentRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DomainId      *int32                 `protobuf:"varint,1,opt,name=domain_id,json=domainId,proto3,oneof" json:"domain_id,omitempty"`
+	Container     string                 `protobuf:"bytes,2,opt,name=container,proto3" json:"container,omitempty"`
+	Uid           uint32                 `protobuf:"varint,3,opt,name=uid,proto3" json:"uid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnloadROS2ComponentRequest) Reset() {
+	*x = UnloadROS2ComponentRequest{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnloadROS2ComponentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnloadROS2ComponentRequest) ProtoMessage() {}
+
+func (x *UnloadROS2ComponentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnloadROS2ComponentRequest.ProtoReflect.Descriptor instead.
+func (*UnloadROS2ComponentRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *UnloadROS2ComponentRequest) GetDomainId() int32 {
+	if x != nil && x.DomainId != nil {
+		return *x.DomainId
+	}
+	return 0
+}
+
+func (x *UnloadROS2ComponentRequest) GetContainer() string {
+	if x != nil {
+		return x.Container
+	}
+	return ""
+}
+
+func (x *UnloadROS2ComponentRequest) GetUid() uint32 {
+	if x != nil {
+		return x.Uid
+	}
+	return 0
+}
+
+type UnloadROS2ComponentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Message       string                 `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnloadROS2ComponentResponse) Reset() {
+	*x = UnloadROS2ComponentResponse{}
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnloadROS2ComponentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnloadROS2ComponentResponse) ProtoMessage() {}
+
+func (x *UnloadROS2ComponentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnloadROS2ComponentResponse.ProtoReflect.Descriptor instead.
+func (*UnloadROS2ComponentResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *UnloadROS2ComponentResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 type ListROS2ServicesResponse_Service struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -1898,7 +3146,7 @@ type ListROS2ServicesResponse_Service struct {
 
 func (x *ListROS2ServicesResponse_Service) Reset() {
 	*x = ListROS2ServicesResponse_Service{}
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[34]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1910,7 +3158,7 @@ func (x *ListROS2ServicesResponse_Service) String() string {
 func (*ListROS2ServicesResponse_Service) ProtoMessage() {}
 
 func (x *ListROS2ServicesResponse_Service) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[34]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1957,7 +3205,7 @@ type ListROS2ParamsResponse_NodeParams struct {
 
 func (x *ListROS2ParamsResponse_NodeParams) Reset() {
 	*x = ListROS2ParamsResponse_NodeParams{}
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[35]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1969,7 +3217,7 @@ func (x *ListROS2ParamsResponse_NodeParams) String() string {
 func (*ListROS2ParamsResponse_NodeParams) ProtoMessage() {}
 
 func (x *ListROS2ParamsResponse_NodeParams) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[35]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2010,7 +3258,7 @@ type GetROS2GraphResponse_Edge struct {
 
 func (x *GetROS2GraphResponse_Edge) Reset() {
 	*x = GetROS2GraphResponse_Edge{}
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[36]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2022,7 +3270,7 @@ func (x *GetROS2GraphResponse_Edge) String() string {
 func (*GetROS2GraphResponse_Edge) ProtoMessage() {}
 
 func (x *GetROS2GraphResponse_Edge) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[36]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2070,7 +3318,7 @@ type RecordROS2BagRequest_RecordStart struct {
 
 func (x *RecordROS2BagRequest_RecordStart) Reset() {
 	*x = RecordROS2BagRequest_RecordStart{}
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[37]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2082,7 +3330,7 @@ func (x *RecordROS2BagRequest_RecordStart) String() string {
 func (*RecordROS2BagRequest_RecordStart) ProtoMessage() {}
 
 func (x *RecordROS2BagRequest_RecordStart) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[37]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2127,7 +3375,7 @@ type RecordROS2BagRequest_RecordStop struct {
 
 func (x *RecordROS2BagRequest_RecordStop) Reset() {
 	*x = RecordROS2BagRequest_RecordStop{}
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[38]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2139,7 +3387,7 @@ func (x *RecordROS2BagRequest_RecordStop) String() string {
 func (*RecordROS2BagRequest_RecordStop) ProtoMessage() {}
 
 func (x *RecordROS2BagRequest_RecordStop) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[38]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2167,7 +3415,7 @@ type ListROS2BagsResponse_Bag struct {
 
 func (x *ListROS2BagsResponse_Bag) Reset() {
 	*x = ListROS2BagsResponse_Bag{}
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[39]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2179,7 +3427,7 @@ func (x *ListROS2BagsResponse_Bag) String() string {
 func (*ListROS2BagsResponse_Bag) ProtoMessage() {}
 
 func (x *ListROS2BagsResponse_Bag) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[39]
+	mi := &file_wendy_agent_services_v2_ros2_service_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2393,7 +3641,112 @@ const file_wendy_agent_services_v2_ros2_service_proto_rawDesc = "" +
 	"\x06stderr\x18\x02 \x01(\fR\x06stderr\x12 \n" +
 	"\texit_code\x18\x03 \x01(\x05H\x00R\bexitCode\x88\x01\x01B\f\n" +
 	"\n" +
-	"_exit_code2\xb9\r\n" +
+	"_exit_code\"H\n" +
+	"\n" +
+	"ROS2Action\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05types\x18\x02 \x03(\tR\x05types\x12\x10\n" +
+	"\x03rmw\x18\x03 \x01(\tR\x03rmw\"H\n" +
+	"\x16ListROS2ActionsRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01B\f\n" +
+	"\n" +
+	"_domain_id\"X\n" +
+	"\x17ListROS2ActionsResponse\x12=\n" +
+	"\aactions\x18\x01 \x03(\v2#.wendy.agent.services.v2.ROS2ActionR\aactions\"b\n" +
+	"\x18GetROS2ActionInfoRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01\x12\x16\n" +
+	"\x06action\x18\x02 \x01(\tR\x06actionB\f\n" +
+	"\n" +
+	"_domain_id\"\x97\x01\n" +
+	"\x19GetROS2ActionInfoResponse\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
+	"\x0eaction_clients\x18\x02 \x03(\tR\ractionClients\x12%\n" +
+	"\x0eaction_servers\x18\x03 \x03(\tR\ractionServers\x12\x18\n" +
+	"\averbose\x18\x04 \x01(\tR\averbose\"\xb4\x01\n" +
+	"\x19SendROS2ActionGoalRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01\x12\x16\n" +
+	"\x06action\x18\x02 \x01(\tR\x06action\x12\x1f\n" +
+	"\vaction_type\x18\x03 \x01(\tR\n" +
+	"actionType\x12\x12\n" +
+	"\x04goal\x18\x04 \x01(\tR\x04goal\x12\x1a\n" +
+	"\bfeedback\x18\x05 \x01(\bR\bfeedbackB\f\n" +
+	"\n" +
+	"_domain_id\"\x7f\n" +
+	"\x17ROS2LifecycleTransition\x12\x14\n" +
+	"\x05label\x18\x01 \x01(\tR\x05label\x12\x0e\n" +
+	"\x02id\x18\x02 \x01(\rR\x02id\x12\x1f\n" +
+	"\vstart_state\x18\x03 \x01(\tR\n" +
+	"startState\x12\x1d\n" +
+	"\n" +
+	"goal_state\x18\x04 \x01(\tR\tgoalState\"O\n" +
+	"\x1dListROS2LifecycleNodesRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01B\f\n" +
+	"\n" +
+	"_domain_id\"Y\n" +
+	"\x1eListROS2LifecycleNodesResponse\x127\n" +
+	"\x05nodes\x18\x01 \x03(\v2!.wendy.agent.services.v2.ROS2NodeR\x05nodes\"b\n" +
+	"\x1cGetROS2LifecycleStateRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01\x12\x12\n" +
+	"\x04node\x18\x02 \x01(\tR\x04nodeB\f\n" +
+	"\n" +
+	"_domain_id\"P\n" +
+	"\x1dGetROS2LifecycleStateResponse\x12\x14\n" +
+	"\x05state\x18\x01 \x01(\tR\x05state\x12\x19\n" +
+	"\bstate_id\x18\x02 \x01(\rR\astateId\"i\n" +
+	"#ListROS2LifecycleTransitionsRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01\x12\x12\n" +
+	"\x04node\x18\x02 \x01(\tR\x04nodeB\f\n" +
+	"\n" +
+	"_domain_id\"z\n" +
+	"$ListROS2LifecycleTransitionsResponse\x12R\n" +
+	"\vtransitions\x18\x01 \x03(\v20.wendy.agent.services.v2.ROS2LifecycleTransitionR\vtransitions\"\x82\x01\n" +
+	"\x1cSetROS2LifecycleStateRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01\x12\x12\n" +
+	"\x04node\x18\x02 \x01(\tR\x04node\x12\x1e\n" +
+	"\n" +
+	"transition\x18\x03 \x01(\tR\n" +
+	"transitionB\f\n" +
+	"\n" +
+	"_domain_id\"S\n" +
+	"\x1dSetROS2LifecycleStateResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\";\n" +
+	"\x13ROS2LoadedComponent\x12\x10\n" +
+	"\x03uid\x18\x01 \x01(\rR\x03uid\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"\x8c\x01\n" +
+	"\x16ROS2ComponentContainer\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12L\n" +
+	"\n" +
+	"components\x18\x02 \x03(\v2,.wendy.agent.services.v2.ROS2LoadedComponentR\n" +
+	"components\x12\x10\n" +
+	"\x03rmw\x18\x03 \x01(\tR\x03rmw\"K\n" +
+	"\x19ListROS2ComponentsRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01B\f\n" +
+	"\n" +
+	"_domain_id\"m\n" +
+	"\x1aListROS2ComponentsResponse\x12O\n" +
+	"\n" +
+	"containers\x18\x01 \x03(\v2/.wendy.agent.services.v2.ROS2ComponentContainerR\n" +
+	"containers\"\x9a\x01\n" +
+	"\x18LoadROS2ComponentRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01\x12\x1c\n" +
+	"\tcontainer\x18\x02 \x01(\tR\tcontainer\x12\x18\n" +
+	"\apackage\x18\x03 \x01(\tR\apackage\x12\x16\n" +
+	"\x06plugin\x18\x04 \x01(\tR\x06pluginB\f\n" +
+	"\n" +
+	"_domain_id\"d\n" +
+	"\x19LoadROS2ComponentResponse\x12\x10\n" +
+	"\x03uid\x18\x01 \x01(\rR\x03uid\x12\x1b\n" +
+	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"|\n" +
+	"\x1aUnloadROS2ComponentRequest\x12 \n" +
+	"\tdomain_id\x18\x01 \x01(\x05H\x00R\bdomainId\x88\x01\x01\x12\x1c\n" +
+	"\tcontainer\x18\x02 \x01(\tR\tcontainer\x12\x10\n" +
+	"\x03uid\x18\x03 \x01(\rR\x03uidB\f\n" +
+	"\n" +
+	"_domain_id\"7\n" +
+	"\x1bUnloadROS2ComponentResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage2\xb1\x17\n" +
 	"\vROS2Service\x12j\n" +
 	"\tListNodes\x12-.wendy.agent.services.v2.ListROS2NodesRequest\x1a..wendy.agent.services.v2.ListROS2NodesResponse\x12m\n" +
 	"\n" +
@@ -2412,7 +3765,17 @@ const file_wendy_agent_services_v2_ros2_service_proto_rawDesc = "" +
 	"\tRecordBag\x12-.wendy.agent.services.v2.RecordROS2BagRequest\x1a..wendy.agent.services.v2.RecordROS2BagResponse(\x010\x01\x12g\n" +
 	"\bListBags\x12,.wendy.agent.services.v2.ListROS2BagsRequest\x1a-.wendy.agent.services.v2.ListROS2BagsResponse\x12g\n" +
 	"\vDownloadBag\x12/.wendy.agent.services.v2.DownloadROS2BagRequest\x1a%.wendy.agent.services.v2.ROS2BagChunk0\x01\x12[\n" +
-	"\x04Exec\x12(.wendy.agent.services.v2.ROS2ExecRequest\x1a'.wendy.agent.services.v2.ROS2ExecOutput0\x01B>Z<github.com/wendylabsinc/wendy/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
+	"\x04Exec\x12(.wendy.agent.services.v2.ROS2ExecRequest\x1a'.wendy.agent.services.v2.ROS2ExecOutput0\x01\x12p\n" +
+	"\vListActions\x12/.wendy.agent.services.v2.ListROS2ActionsRequest\x1a0.wendy.agent.services.v2.ListROS2ActionsResponse\x12v\n" +
+	"\rGetActionInfo\x121.wendy.agent.services.v2.GetROS2ActionInfoRequest\x1a2.wendy.agent.services.v2.GetROS2ActionInfoResponse\x12o\n" +
+	"\x0eSendActionGoal\x122.wendy.agent.services.v2.SendROS2ActionGoalRequest\x1a'.wendy.agent.services.v2.ROS2ExecOutput0\x01\x12\x85\x01\n" +
+	"\x12ListLifecycleNodes\x126.wendy.agent.services.v2.ListROS2LifecycleNodesRequest\x1a7.wendy.agent.services.v2.ListROS2LifecycleNodesResponse\x12\x82\x01\n" +
+	"\x11GetLifecycleState\x125.wendy.agent.services.v2.GetROS2LifecycleStateRequest\x1a6.wendy.agent.services.v2.GetROS2LifecycleStateResponse\x12\x97\x01\n" +
+	"\x18ListLifecycleTransitions\x12<.wendy.agent.services.v2.ListROS2LifecycleTransitionsRequest\x1a=.wendy.agent.services.v2.ListROS2LifecycleTransitionsResponse\x12\x82\x01\n" +
+	"\x11SetLifecycleState\x125.wendy.agent.services.v2.SetROS2LifecycleStateRequest\x1a6.wendy.agent.services.v2.SetROS2LifecycleStateResponse\x12y\n" +
+	"\x0eListComponents\x122.wendy.agent.services.v2.ListROS2ComponentsRequest\x1a3.wendy.agent.services.v2.ListROS2ComponentsResponse\x12v\n" +
+	"\rLoadComponent\x121.wendy.agent.services.v2.LoadROS2ComponentRequest\x1a2.wendy.agent.services.v2.LoadROS2ComponentResponse\x12|\n" +
+	"\x0fUnloadComponent\x123.wendy.agent.services.v2.UnloadROS2ComponentRequest\x1a4.wendy.agent.services.v2.UnloadROS2ComponentResponseB>Z<github.com/wendylabsinc/wendy/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
 
 var (
 	file_wendy_agent_services_v2_ros2_service_proto_rawDescOnce sync.Once
@@ -2427,100 +3790,148 @@ func file_wendy_agent_services_v2_ros2_service_proto_rawDescGZIP() []byte {
 }
 
 var file_wendy_agent_services_v2_ros2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_wendy_agent_services_v2_ros2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_wendy_agent_services_v2_ros2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 63)
 var file_wendy_agent_services_v2_ros2_service_proto_goTypes = []any{
-	(RecordROS2BagResponse_State)(0),          // 0: wendy.agent.services.v2.RecordROS2BagResponse.State
-	(*ROS2Node)(nil),                          // 1: wendy.agent.services.v2.ROS2Node
-	(*ROS2Topic)(nil),                         // 2: wendy.agent.services.v2.ROS2Topic
-	(*ListROS2NodesRequest)(nil),              // 3: wendy.agent.services.v2.ListROS2NodesRequest
-	(*ListROS2NodesResponse)(nil),             // 4: wendy.agent.services.v2.ListROS2NodesResponse
-	(*ListROS2TopicsRequest)(nil),             // 5: wendy.agent.services.v2.ListROS2TopicsRequest
-	(*ListROS2TopicsResponse)(nil),            // 6: wendy.agent.services.v2.ListROS2TopicsResponse
-	(*GetROS2TopicInfoRequest)(nil),           // 7: wendy.agent.services.v2.GetROS2TopicInfoRequest
-	(*GetROS2TopicInfoResponse)(nil),          // 8: wendy.agent.services.v2.GetROS2TopicInfoResponse
-	(*ListROS2ServicesRequest)(nil),           // 9: wendy.agent.services.v2.ListROS2ServicesRequest
-	(*ListROS2ServicesResponse)(nil),          // 10: wendy.agent.services.v2.ListROS2ServicesResponse
-	(*ListROS2ParamsRequest)(nil),             // 11: wendy.agent.services.v2.ListROS2ParamsRequest
-	(*ListROS2ParamsResponse)(nil),            // 12: wendy.agent.services.v2.ListROS2ParamsResponse
-	(*GetROS2ParamRequest)(nil),               // 13: wendy.agent.services.v2.GetROS2ParamRequest
-	(*GetROS2ParamResponse)(nil),              // 14: wendy.agent.services.v2.GetROS2ParamResponse
-	(*SetROS2ParamRequest)(nil),               // 15: wendy.agent.services.v2.SetROS2ParamRequest
-	(*SetROS2ParamResponse)(nil),              // 16: wendy.agent.services.v2.SetROS2ParamResponse
-	(*CallROS2ServiceRequest)(nil),            // 17: wendy.agent.services.v2.CallROS2ServiceRequest
-	(*CallROS2ServiceResponse)(nil),           // 18: wendy.agent.services.v2.CallROS2ServiceResponse
-	(*GetROS2GraphRequest)(nil),               // 19: wendy.agent.services.v2.GetROS2GraphRequest
-	(*GetROS2GraphResponse)(nil),              // 20: wendy.agent.services.v2.GetROS2GraphResponse
-	(*ROS2DoctorRequest)(nil),                 // 21: wendy.agent.services.v2.ROS2DoctorRequest
-	(*ROS2DoctorResponse)(nil),                // 22: wendy.agent.services.v2.ROS2DoctorResponse
-	(*EchoROS2TopicRequest)(nil),              // 23: wendy.agent.services.v2.EchoROS2TopicRequest
-	(*ROS2Message)(nil),                       // 24: wendy.agent.services.v2.ROS2Message
-	(*MonitorROS2HzRequest)(nil),              // 25: wendy.agent.services.v2.MonitorROS2HzRequest
-	(*ROS2HzSample)(nil),                      // 26: wendy.agent.services.v2.ROS2HzSample
-	(*RecordROS2BagRequest)(nil),              // 27: wendy.agent.services.v2.RecordROS2BagRequest
-	(*RecordROS2BagResponse)(nil),             // 28: wendy.agent.services.v2.RecordROS2BagResponse
-	(*ListROS2BagsRequest)(nil),               // 29: wendy.agent.services.v2.ListROS2BagsRequest
-	(*ListROS2BagsResponse)(nil),              // 30: wendy.agent.services.v2.ListROS2BagsResponse
-	(*DownloadROS2BagRequest)(nil),            // 31: wendy.agent.services.v2.DownloadROS2BagRequest
-	(*ROS2BagChunk)(nil),                      // 32: wendy.agent.services.v2.ROS2BagChunk
-	(*ROS2ExecRequest)(nil),                   // 33: wendy.agent.services.v2.ROS2ExecRequest
-	(*ROS2ExecOutput)(nil),                    // 34: wendy.agent.services.v2.ROS2ExecOutput
-	(*ListROS2ServicesResponse_Service)(nil),  // 35: wendy.agent.services.v2.ListROS2ServicesResponse.Service
-	(*ListROS2ParamsResponse_NodeParams)(nil), // 36: wendy.agent.services.v2.ListROS2ParamsResponse.NodeParams
-	(*GetROS2GraphResponse_Edge)(nil),         // 37: wendy.agent.services.v2.GetROS2GraphResponse.Edge
-	(*RecordROS2BagRequest_RecordStart)(nil),  // 38: wendy.agent.services.v2.RecordROS2BagRequest.RecordStart
-	(*RecordROS2BagRequest_RecordStop)(nil),   // 39: wendy.agent.services.v2.RecordROS2BagRequest.RecordStop
-	(*ListROS2BagsResponse_Bag)(nil),          // 40: wendy.agent.services.v2.ListROS2BagsResponse.Bag
+	(RecordROS2BagResponse_State)(0),             // 0: wendy.agent.services.v2.RecordROS2BagResponse.State
+	(*ROS2Node)(nil),                             // 1: wendy.agent.services.v2.ROS2Node
+	(*ROS2Topic)(nil),                            // 2: wendy.agent.services.v2.ROS2Topic
+	(*ListROS2NodesRequest)(nil),                 // 3: wendy.agent.services.v2.ListROS2NodesRequest
+	(*ListROS2NodesResponse)(nil),                // 4: wendy.agent.services.v2.ListROS2NodesResponse
+	(*ListROS2TopicsRequest)(nil),                // 5: wendy.agent.services.v2.ListROS2TopicsRequest
+	(*ListROS2TopicsResponse)(nil),               // 6: wendy.agent.services.v2.ListROS2TopicsResponse
+	(*GetROS2TopicInfoRequest)(nil),              // 7: wendy.agent.services.v2.GetROS2TopicInfoRequest
+	(*GetROS2TopicInfoResponse)(nil),             // 8: wendy.agent.services.v2.GetROS2TopicInfoResponse
+	(*ListROS2ServicesRequest)(nil),              // 9: wendy.agent.services.v2.ListROS2ServicesRequest
+	(*ListROS2ServicesResponse)(nil),             // 10: wendy.agent.services.v2.ListROS2ServicesResponse
+	(*ListROS2ParamsRequest)(nil),                // 11: wendy.agent.services.v2.ListROS2ParamsRequest
+	(*ListROS2ParamsResponse)(nil),               // 12: wendy.agent.services.v2.ListROS2ParamsResponse
+	(*GetROS2ParamRequest)(nil),                  // 13: wendy.agent.services.v2.GetROS2ParamRequest
+	(*GetROS2ParamResponse)(nil),                 // 14: wendy.agent.services.v2.GetROS2ParamResponse
+	(*SetROS2ParamRequest)(nil),                  // 15: wendy.agent.services.v2.SetROS2ParamRequest
+	(*SetROS2ParamResponse)(nil),                 // 16: wendy.agent.services.v2.SetROS2ParamResponse
+	(*CallROS2ServiceRequest)(nil),               // 17: wendy.agent.services.v2.CallROS2ServiceRequest
+	(*CallROS2ServiceResponse)(nil),              // 18: wendy.agent.services.v2.CallROS2ServiceResponse
+	(*GetROS2GraphRequest)(nil),                  // 19: wendy.agent.services.v2.GetROS2GraphRequest
+	(*GetROS2GraphResponse)(nil),                 // 20: wendy.agent.services.v2.GetROS2GraphResponse
+	(*ROS2DoctorRequest)(nil),                    // 21: wendy.agent.services.v2.ROS2DoctorRequest
+	(*ROS2DoctorResponse)(nil),                   // 22: wendy.agent.services.v2.ROS2DoctorResponse
+	(*EchoROS2TopicRequest)(nil),                 // 23: wendy.agent.services.v2.EchoROS2TopicRequest
+	(*ROS2Message)(nil),                          // 24: wendy.agent.services.v2.ROS2Message
+	(*MonitorROS2HzRequest)(nil),                 // 25: wendy.agent.services.v2.MonitorROS2HzRequest
+	(*ROS2HzSample)(nil),                         // 26: wendy.agent.services.v2.ROS2HzSample
+	(*RecordROS2BagRequest)(nil),                 // 27: wendy.agent.services.v2.RecordROS2BagRequest
+	(*RecordROS2BagResponse)(nil),                // 28: wendy.agent.services.v2.RecordROS2BagResponse
+	(*ListROS2BagsRequest)(nil),                  // 29: wendy.agent.services.v2.ListROS2BagsRequest
+	(*ListROS2BagsResponse)(nil),                 // 30: wendy.agent.services.v2.ListROS2BagsResponse
+	(*DownloadROS2BagRequest)(nil),               // 31: wendy.agent.services.v2.DownloadROS2BagRequest
+	(*ROS2BagChunk)(nil),                         // 32: wendy.agent.services.v2.ROS2BagChunk
+	(*ROS2ExecRequest)(nil),                      // 33: wendy.agent.services.v2.ROS2ExecRequest
+	(*ROS2ExecOutput)(nil),                       // 34: wendy.agent.services.v2.ROS2ExecOutput
+	(*ROS2Action)(nil),                           // 35: wendy.agent.services.v2.ROS2Action
+	(*ListROS2ActionsRequest)(nil),               // 36: wendy.agent.services.v2.ListROS2ActionsRequest
+	(*ListROS2ActionsResponse)(nil),              // 37: wendy.agent.services.v2.ListROS2ActionsResponse
+	(*GetROS2ActionInfoRequest)(nil),             // 38: wendy.agent.services.v2.GetROS2ActionInfoRequest
+	(*GetROS2ActionInfoResponse)(nil),            // 39: wendy.agent.services.v2.GetROS2ActionInfoResponse
+	(*SendROS2ActionGoalRequest)(nil),            // 40: wendy.agent.services.v2.SendROS2ActionGoalRequest
+	(*ROS2LifecycleTransition)(nil),              // 41: wendy.agent.services.v2.ROS2LifecycleTransition
+	(*ListROS2LifecycleNodesRequest)(nil),        // 42: wendy.agent.services.v2.ListROS2LifecycleNodesRequest
+	(*ListROS2LifecycleNodesResponse)(nil),       // 43: wendy.agent.services.v2.ListROS2LifecycleNodesResponse
+	(*GetROS2LifecycleStateRequest)(nil),         // 44: wendy.agent.services.v2.GetROS2LifecycleStateRequest
+	(*GetROS2LifecycleStateResponse)(nil),        // 45: wendy.agent.services.v2.GetROS2LifecycleStateResponse
+	(*ListROS2LifecycleTransitionsRequest)(nil),  // 46: wendy.agent.services.v2.ListROS2LifecycleTransitionsRequest
+	(*ListROS2LifecycleTransitionsResponse)(nil), // 47: wendy.agent.services.v2.ListROS2LifecycleTransitionsResponse
+	(*SetROS2LifecycleStateRequest)(nil),         // 48: wendy.agent.services.v2.SetROS2LifecycleStateRequest
+	(*SetROS2LifecycleStateResponse)(nil),        // 49: wendy.agent.services.v2.SetROS2LifecycleStateResponse
+	(*ROS2LoadedComponent)(nil),                  // 50: wendy.agent.services.v2.ROS2LoadedComponent
+	(*ROS2ComponentContainer)(nil),               // 51: wendy.agent.services.v2.ROS2ComponentContainer
+	(*ListROS2ComponentsRequest)(nil),            // 52: wendy.agent.services.v2.ListROS2ComponentsRequest
+	(*ListROS2ComponentsResponse)(nil),           // 53: wendy.agent.services.v2.ListROS2ComponentsResponse
+	(*LoadROS2ComponentRequest)(nil),             // 54: wendy.agent.services.v2.LoadROS2ComponentRequest
+	(*LoadROS2ComponentResponse)(nil),            // 55: wendy.agent.services.v2.LoadROS2ComponentResponse
+	(*UnloadROS2ComponentRequest)(nil),           // 56: wendy.agent.services.v2.UnloadROS2ComponentRequest
+	(*UnloadROS2ComponentResponse)(nil),          // 57: wendy.agent.services.v2.UnloadROS2ComponentResponse
+	(*ListROS2ServicesResponse_Service)(nil),     // 58: wendy.agent.services.v2.ListROS2ServicesResponse.Service
+	(*ListROS2ParamsResponse_NodeParams)(nil),    // 59: wendy.agent.services.v2.ListROS2ParamsResponse.NodeParams
+	(*GetROS2GraphResponse_Edge)(nil),            // 60: wendy.agent.services.v2.GetROS2GraphResponse.Edge
+	(*RecordROS2BagRequest_RecordStart)(nil),     // 61: wendy.agent.services.v2.RecordROS2BagRequest.RecordStart
+	(*RecordROS2BagRequest_RecordStop)(nil),      // 62: wendy.agent.services.v2.RecordROS2BagRequest.RecordStop
+	(*ListROS2BagsResponse_Bag)(nil),             // 63: wendy.agent.services.v2.ListROS2BagsResponse.Bag
 }
 var file_wendy_agent_services_v2_ros2_service_proto_depIdxs = []int32{
 	1,  // 0: wendy.agent.services.v2.ListROS2NodesResponse.nodes:type_name -> wendy.agent.services.v2.ROS2Node
 	2,  // 1: wendy.agent.services.v2.ListROS2TopicsResponse.topics:type_name -> wendy.agent.services.v2.ROS2Topic
 	2,  // 2: wendy.agent.services.v2.GetROS2TopicInfoResponse.topic:type_name -> wendy.agent.services.v2.ROS2Topic
-	35, // 3: wendy.agent.services.v2.ListROS2ServicesResponse.services:type_name -> wendy.agent.services.v2.ListROS2ServicesResponse.Service
-	36, // 4: wendy.agent.services.v2.ListROS2ParamsResponse.nodes:type_name -> wendy.agent.services.v2.ListROS2ParamsResponse.NodeParams
+	58, // 3: wendy.agent.services.v2.ListROS2ServicesResponse.services:type_name -> wendy.agent.services.v2.ListROS2ServicesResponse.Service
+	59, // 4: wendy.agent.services.v2.ListROS2ParamsResponse.nodes:type_name -> wendy.agent.services.v2.ListROS2ParamsResponse.NodeParams
 	1,  // 5: wendy.agent.services.v2.GetROS2GraphResponse.nodes:type_name -> wendy.agent.services.v2.ROS2Node
-	37, // 6: wendy.agent.services.v2.GetROS2GraphResponse.publishes:type_name -> wendy.agent.services.v2.GetROS2GraphResponse.Edge
-	37, // 7: wendy.agent.services.v2.GetROS2GraphResponse.subscribes:type_name -> wendy.agent.services.v2.GetROS2GraphResponse.Edge
-	38, // 8: wendy.agent.services.v2.RecordROS2BagRequest.start:type_name -> wendy.agent.services.v2.RecordROS2BagRequest.RecordStart
-	39, // 9: wendy.agent.services.v2.RecordROS2BagRequest.stop:type_name -> wendy.agent.services.v2.RecordROS2BagRequest.RecordStop
+	60, // 6: wendy.agent.services.v2.GetROS2GraphResponse.publishes:type_name -> wendy.agent.services.v2.GetROS2GraphResponse.Edge
+	60, // 7: wendy.agent.services.v2.GetROS2GraphResponse.subscribes:type_name -> wendy.agent.services.v2.GetROS2GraphResponse.Edge
+	61, // 8: wendy.agent.services.v2.RecordROS2BagRequest.start:type_name -> wendy.agent.services.v2.RecordROS2BagRequest.RecordStart
+	62, // 9: wendy.agent.services.v2.RecordROS2BagRequest.stop:type_name -> wendy.agent.services.v2.RecordROS2BagRequest.RecordStop
 	0,  // 10: wendy.agent.services.v2.RecordROS2BagResponse.state:type_name -> wendy.agent.services.v2.RecordROS2BagResponse.State
-	40, // 11: wendy.agent.services.v2.ListROS2BagsResponse.bags:type_name -> wendy.agent.services.v2.ListROS2BagsResponse.Bag
-	3,  // 12: wendy.agent.services.v2.ROS2Service.ListNodes:input_type -> wendy.agent.services.v2.ListROS2NodesRequest
-	5,  // 13: wendy.agent.services.v2.ROS2Service.ListTopics:input_type -> wendy.agent.services.v2.ListROS2TopicsRequest
-	7,  // 14: wendy.agent.services.v2.ROS2Service.GetTopicInfo:input_type -> wendy.agent.services.v2.GetROS2TopicInfoRequest
-	9,  // 15: wendy.agent.services.v2.ROS2Service.ListServices:input_type -> wendy.agent.services.v2.ListROS2ServicesRequest
-	11, // 16: wendy.agent.services.v2.ROS2Service.ListParams:input_type -> wendy.agent.services.v2.ListROS2ParamsRequest
-	13, // 17: wendy.agent.services.v2.ROS2Service.GetParam:input_type -> wendy.agent.services.v2.GetROS2ParamRequest
-	15, // 18: wendy.agent.services.v2.ROS2Service.SetParam:input_type -> wendy.agent.services.v2.SetROS2ParamRequest
-	17, // 19: wendy.agent.services.v2.ROS2Service.CallService:input_type -> wendy.agent.services.v2.CallROS2ServiceRequest
-	19, // 20: wendy.agent.services.v2.ROS2Service.GetGraph:input_type -> wendy.agent.services.v2.GetROS2GraphRequest
-	21, // 21: wendy.agent.services.v2.ROS2Service.Doctor:input_type -> wendy.agent.services.v2.ROS2DoctorRequest
-	23, // 22: wendy.agent.services.v2.ROS2Service.EchoTopic:input_type -> wendy.agent.services.v2.EchoROS2TopicRequest
-	25, // 23: wendy.agent.services.v2.ROS2Service.MonitorHz:input_type -> wendy.agent.services.v2.MonitorROS2HzRequest
-	27, // 24: wendy.agent.services.v2.ROS2Service.RecordBag:input_type -> wendy.agent.services.v2.RecordROS2BagRequest
-	29, // 25: wendy.agent.services.v2.ROS2Service.ListBags:input_type -> wendy.agent.services.v2.ListROS2BagsRequest
-	31, // 26: wendy.agent.services.v2.ROS2Service.DownloadBag:input_type -> wendy.agent.services.v2.DownloadROS2BagRequest
-	33, // 27: wendy.agent.services.v2.ROS2Service.Exec:input_type -> wendy.agent.services.v2.ROS2ExecRequest
-	4,  // 28: wendy.agent.services.v2.ROS2Service.ListNodes:output_type -> wendy.agent.services.v2.ListROS2NodesResponse
-	6,  // 29: wendy.agent.services.v2.ROS2Service.ListTopics:output_type -> wendy.agent.services.v2.ListROS2TopicsResponse
-	8,  // 30: wendy.agent.services.v2.ROS2Service.GetTopicInfo:output_type -> wendy.agent.services.v2.GetROS2TopicInfoResponse
-	10, // 31: wendy.agent.services.v2.ROS2Service.ListServices:output_type -> wendy.agent.services.v2.ListROS2ServicesResponse
-	12, // 32: wendy.agent.services.v2.ROS2Service.ListParams:output_type -> wendy.agent.services.v2.ListROS2ParamsResponse
-	14, // 33: wendy.agent.services.v2.ROS2Service.GetParam:output_type -> wendy.agent.services.v2.GetROS2ParamResponse
-	16, // 34: wendy.agent.services.v2.ROS2Service.SetParam:output_type -> wendy.agent.services.v2.SetROS2ParamResponse
-	18, // 35: wendy.agent.services.v2.ROS2Service.CallService:output_type -> wendy.agent.services.v2.CallROS2ServiceResponse
-	20, // 36: wendy.agent.services.v2.ROS2Service.GetGraph:output_type -> wendy.agent.services.v2.GetROS2GraphResponse
-	22, // 37: wendy.agent.services.v2.ROS2Service.Doctor:output_type -> wendy.agent.services.v2.ROS2DoctorResponse
-	24, // 38: wendy.agent.services.v2.ROS2Service.EchoTopic:output_type -> wendy.agent.services.v2.ROS2Message
-	26, // 39: wendy.agent.services.v2.ROS2Service.MonitorHz:output_type -> wendy.agent.services.v2.ROS2HzSample
-	28, // 40: wendy.agent.services.v2.ROS2Service.RecordBag:output_type -> wendy.agent.services.v2.RecordROS2BagResponse
-	30, // 41: wendy.agent.services.v2.ROS2Service.ListBags:output_type -> wendy.agent.services.v2.ListROS2BagsResponse
-	32, // 42: wendy.agent.services.v2.ROS2Service.DownloadBag:output_type -> wendy.agent.services.v2.ROS2BagChunk
-	34, // 43: wendy.agent.services.v2.ROS2Service.Exec:output_type -> wendy.agent.services.v2.ROS2ExecOutput
-	28, // [28:44] is the sub-list for method output_type
-	12, // [12:28] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	63, // 11: wendy.agent.services.v2.ListROS2BagsResponse.bags:type_name -> wendy.agent.services.v2.ListROS2BagsResponse.Bag
+	35, // 12: wendy.agent.services.v2.ListROS2ActionsResponse.actions:type_name -> wendy.agent.services.v2.ROS2Action
+	1,  // 13: wendy.agent.services.v2.ListROS2LifecycleNodesResponse.nodes:type_name -> wendy.agent.services.v2.ROS2Node
+	41, // 14: wendy.agent.services.v2.ListROS2LifecycleTransitionsResponse.transitions:type_name -> wendy.agent.services.v2.ROS2LifecycleTransition
+	50, // 15: wendy.agent.services.v2.ROS2ComponentContainer.components:type_name -> wendy.agent.services.v2.ROS2LoadedComponent
+	51, // 16: wendy.agent.services.v2.ListROS2ComponentsResponse.containers:type_name -> wendy.agent.services.v2.ROS2ComponentContainer
+	3,  // 17: wendy.agent.services.v2.ROS2Service.ListNodes:input_type -> wendy.agent.services.v2.ListROS2NodesRequest
+	5,  // 18: wendy.agent.services.v2.ROS2Service.ListTopics:input_type -> wendy.agent.services.v2.ListROS2TopicsRequest
+	7,  // 19: wendy.agent.services.v2.ROS2Service.GetTopicInfo:input_type -> wendy.agent.services.v2.GetROS2TopicInfoRequest
+	9,  // 20: wendy.agent.services.v2.ROS2Service.ListServices:input_type -> wendy.agent.services.v2.ListROS2ServicesRequest
+	11, // 21: wendy.agent.services.v2.ROS2Service.ListParams:input_type -> wendy.agent.services.v2.ListROS2ParamsRequest
+	13, // 22: wendy.agent.services.v2.ROS2Service.GetParam:input_type -> wendy.agent.services.v2.GetROS2ParamRequest
+	15, // 23: wendy.agent.services.v2.ROS2Service.SetParam:input_type -> wendy.agent.services.v2.SetROS2ParamRequest
+	17, // 24: wendy.agent.services.v2.ROS2Service.CallService:input_type -> wendy.agent.services.v2.CallROS2ServiceRequest
+	19, // 25: wendy.agent.services.v2.ROS2Service.GetGraph:input_type -> wendy.agent.services.v2.GetROS2GraphRequest
+	21, // 26: wendy.agent.services.v2.ROS2Service.Doctor:input_type -> wendy.agent.services.v2.ROS2DoctorRequest
+	23, // 27: wendy.agent.services.v2.ROS2Service.EchoTopic:input_type -> wendy.agent.services.v2.EchoROS2TopicRequest
+	25, // 28: wendy.agent.services.v2.ROS2Service.MonitorHz:input_type -> wendy.agent.services.v2.MonitorROS2HzRequest
+	27, // 29: wendy.agent.services.v2.ROS2Service.RecordBag:input_type -> wendy.agent.services.v2.RecordROS2BagRequest
+	29, // 30: wendy.agent.services.v2.ROS2Service.ListBags:input_type -> wendy.agent.services.v2.ListROS2BagsRequest
+	31, // 31: wendy.agent.services.v2.ROS2Service.DownloadBag:input_type -> wendy.agent.services.v2.DownloadROS2BagRequest
+	33, // 32: wendy.agent.services.v2.ROS2Service.Exec:input_type -> wendy.agent.services.v2.ROS2ExecRequest
+	36, // 33: wendy.agent.services.v2.ROS2Service.ListActions:input_type -> wendy.agent.services.v2.ListROS2ActionsRequest
+	38, // 34: wendy.agent.services.v2.ROS2Service.GetActionInfo:input_type -> wendy.agent.services.v2.GetROS2ActionInfoRequest
+	40, // 35: wendy.agent.services.v2.ROS2Service.SendActionGoal:input_type -> wendy.agent.services.v2.SendROS2ActionGoalRequest
+	42, // 36: wendy.agent.services.v2.ROS2Service.ListLifecycleNodes:input_type -> wendy.agent.services.v2.ListROS2LifecycleNodesRequest
+	44, // 37: wendy.agent.services.v2.ROS2Service.GetLifecycleState:input_type -> wendy.agent.services.v2.GetROS2LifecycleStateRequest
+	46, // 38: wendy.agent.services.v2.ROS2Service.ListLifecycleTransitions:input_type -> wendy.agent.services.v2.ListROS2LifecycleTransitionsRequest
+	48, // 39: wendy.agent.services.v2.ROS2Service.SetLifecycleState:input_type -> wendy.agent.services.v2.SetROS2LifecycleStateRequest
+	52, // 40: wendy.agent.services.v2.ROS2Service.ListComponents:input_type -> wendy.agent.services.v2.ListROS2ComponentsRequest
+	54, // 41: wendy.agent.services.v2.ROS2Service.LoadComponent:input_type -> wendy.agent.services.v2.LoadROS2ComponentRequest
+	56, // 42: wendy.agent.services.v2.ROS2Service.UnloadComponent:input_type -> wendy.agent.services.v2.UnloadROS2ComponentRequest
+	4,  // 43: wendy.agent.services.v2.ROS2Service.ListNodes:output_type -> wendy.agent.services.v2.ListROS2NodesResponse
+	6,  // 44: wendy.agent.services.v2.ROS2Service.ListTopics:output_type -> wendy.agent.services.v2.ListROS2TopicsResponse
+	8,  // 45: wendy.agent.services.v2.ROS2Service.GetTopicInfo:output_type -> wendy.agent.services.v2.GetROS2TopicInfoResponse
+	10, // 46: wendy.agent.services.v2.ROS2Service.ListServices:output_type -> wendy.agent.services.v2.ListROS2ServicesResponse
+	12, // 47: wendy.agent.services.v2.ROS2Service.ListParams:output_type -> wendy.agent.services.v2.ListROS2ParamsResponse
+	14, // 48: wendy.agent.services.v2.ROS2Service.GetParam:output_type -> wendy.agent.services.v2.GetROS2ParamResponse
+	16, // 49: wendy.agent.services.v2.ROS2Service.SetParam:output_type -> wendy.agent.services.v2.SetROS2ParamResponse
+	18, // 50: wendy.agent.services.v2.ROS2Service.CallService:output_type -> wendy.agent.services.v2.CallROS2ServiceResponse
+	20, // 51: wendy.agent.services.v2.ROS2Service.GetGraph:output_type -> wendy.agent.services.v2.GetROS2GraphResponse
+	22, // 52: wendy.agent.services.v2.ROS2Service.Doctor:output_type -> wendy.agent.services.v2.ROS2DoctorResponse
+	24, // 53: wendy.agent.services.v2.ROS2Service.EchoTopic:output_type -> wendy.agent.services.v2.ROS2Message
+	26, // 54: wendy.agent.services.v2.ROS2Service.MonitorHz:output_type -> wendy.agent.services.v2.ROS2HzSample
+	28, // 55: wendy.agent.services.v2.ROS2Service.RecordBag:output_type -> wendy.agent.services.v2.RecordROS2BagResponse
+	30, // 56: wendy.agent.services.v2.ROS2Service.ListBags:output_type -> wendy.agent.services.v2.ListROS2BagsResponse
+	32, // 57: wendy.agent.services.v2.ROS2Service.DownloadBag:output_type -> wendy.agent.services.v2.ROS2BagChunk
+	34, // 58: wendy.agent.services.v2.ROS2Service.Exec:output_type -> wendy.agent.services.v2.ROS2ExecOutput
+	37, // 59: wendy.agent.services.v2.ROS2Service.ListActions:output_type -> wendy.agent.services.v2.ListROS2ActionsResponse
+	39, // 60: wendy.agent.services.v2.ROS2Service.GetActionInfo:output_type -> wendy.agent.services.v2.GetROS2ActionInfoResponse
+	34, // 61: wendy.agent.services.v2.ROS2Service.SendActionGoal:output_type -> wendy.agent.services.v2.ROS2ExecOutput
+	43, // 62: wendy.agent.services.v2.ROS2Service.ListLifecycleNodes:output_type -> wendy.agent.services.v2.ListROS2LifecycleNodesResponse
+	45, // 63: wendy.agent.services.v2.ROS2Service.GetLifecycleState:output_type -> wendy.agent.services.v2.GetROS2LifecycleStateResponse
+	47, // 64: wendy.agent.services.v2.ROS2Service.ListLifecycleTransitions:output_type -> wendy.agent.services.v2.ListROS2LifecycleTransitionsResponse
+	49, // 65: wendy.agent.services.v2.ROS2Service.SetLifecycleState:output_type -> wendy.agent.services.v2.SetROS2LifecycleStateResponse
+	53, // 66: wendy.agent.services.v2.ROS2Service.ListComponents:output_type -> wendy.agent.services.v2.ListROS2ComponentsResponse
+	55, // 67: wendy.agent.services.v2.ROS2Service.LoadComponent:output_type -> wendy.agent.services.v2.LoadROS2ComponentResponse
+	57, // 68: wendy.agent.services.v2.ROS2Service.UnloadComponent:output_type -> wendy.agent.services.v2.UnloadROS2ComponentResponse
+	43, // [43:69] is the sub-list for method output_type
+	17, // [17:43] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_wendy_agent_services_v2_ros2_service_proto_init() }
@@ -2546,14 +3957,24 @@ func file_wendy_agent_services_v2_ros2_service_proto_init() {
 	}
 	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[32].OneofWrappers = []any{}
 	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[33].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[35].OneofWrappers = []any{}
 	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[37].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[39].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[41].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[43].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[45].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[47].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[51].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[53].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[55].OneofWrappers = []any{}
+	file_wendy_agent_services_v2_ros2_service_proto_msgTypes[60].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v2_ros2_service_proto_rawDesc), len(file_wendy_agent_services_v2_ros2_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   40,
+			NumMessages:   63,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/agentpb/v2/ros2_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/v2/ros2_service_grpc.pb.go
@@ -19,22 +19,32 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ROS2Service_ListNodes_FullMethodName    = "/wendy.agent.services.v2.ROS2Service/ListNodes"
-	ROS2Service_ListTopics_FullMethodName   = "/wendy.agent.services.v2.ROS2Service/ListTopics"
-	ROS2Service_GetTopicInfo_FullMethodName = "/wendy.agent.services.v2.ROS2Service/GetTopicInfo"
-	ROS2Service_ListServices_FullMethodName = "/wendy.agent.services.v2.ROS2Service/ListServices"
-	ROS2Service_ListParams_FullMethodName   = "/wendy.agent.services.v2.ROS2Service/ListParams"
-	ROS2Service_GetParam_FullMethodName     = "/wendy.agent.services.v2.ROS2Service/GetParam"
-	ROS2Service_SetParam_FullMethodName     = "/wendy.agent.services.v2.ROS2Service/SetParam"
-	ROS2Service_CallService_FullMethodName  = "/wendy.agent.services.v2.ROS2Service/CallService"
-	ROS2Service_GetGraph_FullMethodName     = "/wendy.agent.services.v2.ROS2Service/GetGraph"
-	ROS2Service_Doctor_FullMethodName       = "/wendy.agent.services.v2.ROS2Service/Doctor"
-	ROS2Service_EchoTopic_FullMethodName    = "/wendy.agent.services.v2.ROS2Service/EchoTopic"
-	ROS2Service_MonitorHz_FullMethodName    = "/wendy.agent.services.v2.ROS2Service/MonitorHz"
-	ROS2Service_RecordBag_FullMethodName    = "/wendy.agent.services.v2.ROS2Service/RecordBag"
-	ROS2Service_ListBags_FullMethodName     = "/wendy.agent.services.v2.ROS2Service/ListBags"
-	ROS2Service_DownloadBag_FullMethodName  = "/wendy.agent.services.v2.ROS2Service/DownloadBag"
-	ROS2Service_Exec_FullMethodName         = "/wendy.agent.services.v2.ROS2Service/Exec"
+	ROS2Service_ListNodes_FullMethodName                = "/wendy.agent.services.v2.ROS2Service/ListNodes"
+	ROS2Service_ListTopics_FullMethodName               = "/wendy.agent.services.v2.ROS2Service/ListTopics"
+	ROS2Service_GetTopicInfo_FullMethodName             = "/wendy.agent.services.v2.ROS2Service/GetTopicInfo"
+	ROS2Service_ListServices_FullMethodName             = "/wendy.agent.services.v2.ROS2Service/ListServices"
+	ROS2Service_ListParams_FullMethodName               = "/wendy.agent.services.v2.ROS2Service/ListParams"
+	ROS2Service_GetParam_FullMethodName                 = "/wendy.agent.services.v2.ROS2Service/GetParam"
+	ROS2Service_SetParam_FullMethodName                 = "/wendy.agent.services.v2.ROS2Service/SetParam"
+	ROS2Service_CallService_FullMethodName              = "/wendy.agent.services.v2.ROS2Service/CallService"
+	ROS2Service_GetGraph_FullMethodName                 = "/wendy.agent.services.v2.ROS2Service/GetGraph"
+	ROS2Service_Doctor_FullMethodName                   = "/wendy.agent.services.v2.ROS2Service/Doctor"
+	ROS2Service_EchoTopic_FullMethodName                = "/wendy.agent.services.v2.ROS2Service/EchoTopic"
+	ROS2Service_MonitorHz_FullMethodName                = "/wendy.agent.services.v2.ROS2Service/MonitorHz"
+	ROS2Service_RecordBag_FullMethodName                = "/wendy.agent.services.v2.ROS2Service/RecordBag"
+	ROS2Service_ListBags_FullMethodName                 = "/wendy.agent.services.v2.ROS2Service/ListBags"
+	ROS2Service_DownloadBag_FullMethodName              = "/wendy.agent.services.v2.ROS2Service/DownloadBag"
+	ROS2Service_Exec_FullMethodName                     = "/wendy.agent.services.v2.ROS2Service/Exec"
+	ROS2Service_ListActions_FullMethodName              = "/wendy.agent.services.v2.ROS2Service/ListActions"
+	ROS2Service_GetActionInfo_FullMethodName            = "/wendy.agent.services.v2.ROS2Service/GetActionInfo"
+	ROS2Service_SendActionGoal_FullMethodName           = "/wendy.agent.services.v2.ROS2Service/SendActionGoal"
+	ROS2Service_ListLifecycleNodes_FullMethodName       = "/wendy.agent.services.v2.ROS2Service/ListLifecycleNodes"
+	ROS2Service_GetLifecycleState_FullMethodName        = "/wendy.agent.services.v2.ROS2Service/GetLifecycleState"
+	ROS2Service_ListLifecycleTransitions_FullMethodName = "/wendy.agent.services.v2.ROS2Service/ListLifecycleTransitions"
+	ROS2Service_SetLifecycleState_FullMethodName        = "/wendy.agent.services.v2.ROS2Service/SetLifecycleState"
+	ROS2Service_ListComponents_FullMethodName           = "/wendy.agent.services.v2.ROS2Service/ListComponents"
+	ROS2Service_LoadComponent_FullMethodName            = "/wendy.agent.services.v2.ROS2Service/LoadComponent"
+	ROS2Service_UnloadComponent_FullMethodName          = "/wendy.agent.services.v2.ROS2Service/UnloadComponent"
 )
 
 // ROS2ServiceClient is the client API for ROS2Service service.
@@ -69,6 +79,21 @@ type ROS2ServiceClient interface {
 	DownloadBag(ctx context.Context, in *DownloadROS2BagRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ROS2BagChunk], error)
 	// Escape hatch — raw `ros2` CLI passthrough.
 	Exec(ctx context.Context, in *ROS2ExecRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ROS2ExecOutput], error)
+	// Actions — list/inspect action graphs and dispatch goals (WDY-1722).
+	ListActions(ctx context.Context, in *ListROS2ActionsRequest, opts ...grpc.CallOption) (*ListROS2ActionsResponse, error)
+	GetActionInfo(ctx context.Context, in *GetROS2ActionInfoRequest, opts ...grpc.CallOption) (*GetROS2ActionInfoResponse, error)
+	// SendActionGoal streams feedback/result until the goal finishes or the
+	// client cancels; output frames reuse ROS2ExecOutput.
+	SendActionGoal(ctx context.Context, in *SendROS2ActionGoalRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ROS2ExecOutput], error)
+	// Lifecycle — managed-node state inspection and transitions (WDY-1722).
+	ListLifecycleNodes(ctx context.Context, in *ListROS2LifecycleNodesRequest, opts ...grpc.CallOption) (*ListROS2LifecycleNodesResponse, error)
+	GetLifecycleState(ctx context.Context, in *GetROS2LifecycleStateRequest, opts ...grpc.CallOption) (*GetROS2LifecycleStateResponse, error)
+	ListLifecycleTransitions(ctx context.Context, in *ListROS2LifecycleTransitionsRequest, opts ...grpc.CallOption) (*ListROS2LifecycleTransitionsResponse, error)
+	SetLifecycleState(ctx context.Context, in *SetROS2LifecycleStateRequest, opts ...grpc.CallOption) (*SetROS2LifecycleStateResponse, error)
+	// Components — composable-node container management (WDY-1722).
+	ListComponents(ctx context.Context, in *ListROS2ComponentsRequest, opts ...grpc.CallOption) (*ListROS2ComponentsResponse, error)
+	LoadComponent(ctx context.Context, in *LoadROS2ComponentRequest, opts ...grpc.CallOption) (*LoadROS2ComponentResponse, error)
+	UnloadComponent(ctx context.Context, in *UnloadROS2ComponentRequest, opts ...grpc.CallOption) (*UnloadROS2ComponentResponse, error)
 }
 
 type rOS2ServiceClient struct {
@@ -278,6 +303,115 @@ func (c *rOS2ServiceClient) Exec(ctx context.Context, in *ROS2ExecRequest, opts 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type ROS2Service_ExecClient = grpc.ServerStreamingClient[ROS2ExecOutput]
 
+func (c *rOS2ServiceClient) ListActions(ctx context.Context, in *ListROS2ActionsRequest, opts ...grpc.CallOption) (*ListROS2ActionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListROS2ActionsResponse)
+	err := c.cc.Invoke(ctx, ROS2Service_ListActions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rOS2ServiceClient) GetActionInfo(ctx context.Context, in *GetROS2ActionInfoRequest, opts ...grpc.CallOption) (*GetROS2ActionInfoResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetROS2ActionInfoResponse)
+	err := c.cc.Invoke(ctx, ROS2Service_GetActionInfo_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rOS2ServiceClient) SendActionGoal(ctx context.Context, in *SendROS2ActionGoalRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ROS2ExecOutput], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &ROS2Service_ServiceDesc.Streams[5], ROS2Service_SendActionGoal_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[SendROS2ActionGoalRequest, ROS2ExecOutput]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type ROS2Service_SendActionGoalClient = grpc.ServerStreamingClient[ROS2ExecOutput]
+
+func (c *rOS2ServiceClient) ListLifecycleNodes(ctx context.Context, in *ListROS2LifecycleNodesRequest, opts ...grpc.CallOption) (*ListROS2LifecycleNodesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListROS2LifecycleNodesResponse)
+	err := c.cc.Invoke(ctx, ROS2Service_ListLifecycleNodes_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rOS2ServiceClient) GetLifecycleState(ctx context.Context, in *GetROS2LifecycleStateRequest, opts ...grpc.CallOption) (*GetROS2LifecycleStateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetROS2LifecycleStateResponse)
+	err := c.cc.Invoke(ctx, ROS2Service_GetLifecycleState_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rOS2ServiceClient) ListLifecycleTransitions(ctx context.Context, in *ListROS2LifecycleTransitionsRequest, opts ...grpc.CallOption) (*ListROS2LifecycleTransitionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListROS2LifecycleTransitionsResponse)
+	err := c.cc.Invoke(ctx, ROS2Service_ListLifecycleTransitions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rOS2ServiceClient) SetLifecycleState(ctx context.Context, in *SetROS2LifecycleStateRequest, opts ...grpc.CallOption) (*SetROS2LifecycleStateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetROS2LifecycleStateResponse)
+	err := c.cc.Invoke(ctx, ROS2Service_SetLifecycleState_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rOS2ServiceClient) ListComponents(ctx context.Context, in *ListROS2ComponentsRequest, opts ...grpc.CallOption) (*ListROS2ComponentsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListROS2ComponentsResponse)
+	err := c.cc.Invoke(ctx, ROS2Service_ListComponents_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rOS2ServiceClient) LoadComponent(ctx context.Context, in *LoadROS2ComponentRequest, opts ...grpc.CallOption) (*LoadROS2ComponentResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(LoadROS2ComponentResponse)
+	err := c.cc.Invoke(ctx, ROS2Service_LoadComponent_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rOS2ServiceClient) UnloadComponent(ctx context.Context, in *UnloadROS2ComponentRequest, opts ...grpc.CallOption) (*UnloadROS2ComponentResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UnloadROS2ComponentResponse)
+	err := c.cc.Invoke(ctx, ROS2Service_UnloadComponent_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ROS2ServiceServer is the server API for ROS2Service service.
 // All implementations must embed UnimplementedROS2ServiceServer
 // for forward compatibility.
@@ -310,6 +444,21 @@ type ROS2ServiceServer interface {
 	DownloadBag(*DownloadROS2BagRequest, grpc.ServerStreamingServer[ROS2BagChunk]) error
 	// Escape hatch — raw `ros2` CLI passthrough.
 	Exec(*ROS2ExecRequest, grpc.ServerStreamingServer[ROS2ExecOutput]) error
+	// Actions — list/inspect action graphs and dispatch goals (WDY-1722).
+	ListActions(context.Context, *ListROS2ActionsRequest) (*ListROS2ActionsResponse, error)
+	GetActionInfo(context.Context, *GetROS2ActionInfoRequest) (*GetROS2ActionInfoResponse, error)
+	// SendActionGoal streams feedback/result until the goal finishes or the
+	// client cancels; output frames reuse ROS2ExecOutput.
+	SendActionGoal(*SendROS2ActionGoalRequest, grpc.ServerStreamingServer[ROS2ExecOutput]) error
+	// Lifecycle — managed-node state inspection and transitions (WDY-1722).
+	ListLifecycleNodes(context.Context, *ListROS2LifecycleNodesRequest) (*ListROS2LifecycleNodesResponse, error)
+	GetLifecycleState(context.Context, *GetROS2LifecycleStateRequest) (*GetROS2LifecycleStateResponse, error)
+	ListLifecycleTransitions(context.Context, *ListROS2LifecycleTransitionsRequest) (*ListROS2LifecycleTransitionsResponse, error)
+	SetLifecycleState(context.Context, *SetROS2LifecycleStateRequest) (*SetROS2LifecycleStateResponse, error)
+	// Components — composable-node container management (WDY-1722).
+	ListComponents(context.Context, *ListROS2ComponentsRequest) (*ListROS2ComponentsResponse, error)
+	LoadComponent(context.Context, *LoadROS2ComponentRequest) (*LoadROS2ComponentResponse, error)
+	UnloadComponent(context.Context, *UnloadROS2ComponentRequest) (*UnloadROS2ComponentResponse, error)
 	mustEmbedUnimplementedROS2ServiceServer()
 }
 
@@ -367,6 +516,36 @@ func (UnimplementedROS2ServiceServer) DownloadBag(*DownloadROS2BagRequest, grpc.
 }
 func (UnimplementedROS2ServiceServer) Exec(*ROS2ExecRequest, grpc.ServerStreamingServer[ROS2ExecOutput]) error {
 	return status.Error(codes.Unimplemented, "method Exec not implemented")
+}
+func (UnimplementedROS2ServiceServer) ListActions(context.Context, *ListROS2ActionsRequest) (*ListROS2ActionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListActions not implemented")
+}
+func (UnimplementedROS2ServiceServer) GetActionInfo(context.Context, *GetROS2ActionInfoRequest) (*GetROS2ActionInfoResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetActionInfo not implemented")
+}
+func (UnimplementedROS2ServiceServer) SendActionGoal(*SendROS2ActionGoalRequest, grpc.ServerStreamingServer[ROS2ExecOutput]) error {
+	return status.Error(codes.Unimplemented, "method SendActionGoal not implemented")
+}
+func (UnimplementedROS2ServiceServer) ListLifecycleNodes(context.Context, *ListROS2LifecycleNodesRequest) (*ListROS2LifecycleNodesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListLifecycleNodes not implemented")
+}
+func (UnimplementedROS2ServiceServer) GetLifecycleState(context.Context, *GetROS2LifecycleStateRequest) (*GetROS2LifecycleStateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetLifecycleState not implemented")
+}
+func (UnimplementedROS2ServiceServer) ListLifecycleTransitions(context.Context, *ListROS2LifecycleTransitionsRequest) (*ListROS2LifecycleTransitionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListLifecycleTransitions not implemented")
+}
+func (UnimplementedROS2ServiceServer) SetLifecycleState(context.Context, *SetROS2LifecycleStateRequest) (*SetROS2LifecycleStateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetLifecycleState not implemented")
+}
+func (UnimplementedROS2ServiceServer) ListComponents(context.Context, *ListROS2ComponentsRequest) (*ListROS2ComponentsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListComponents not implemented")
+}
+func (UnimplementedROS2ServiceServer) LoadComponent(context.Context, *LoadROS2ComponentRequest) (*LoadROS2ComponentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method LoadComponent not implemented")
+}
+func (UnimplementedROS2ServiceServer) UnloadComponent(context.Context, *UnloadROS2ComponentRequest) (*UnloadROS2ComponentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UnloadComponent not implemented")
 }
 func (UnimplementedROS2ServiceServer) mustEmbedUnimplementedROS2ServiceServer() {}
 func (UnimplementedROS2ServiceServer) testEmbeddedByValue()                     {}
@@ -638,6 +817,179 @@ func _ROS2Service_Exec_Handler(srv interface{}, stream grpc.ServerStream) error 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type ROS2Service_ExecServer = grpc.ServerStreamingServer[ROS2ExecOutput]
 
+func _ROS2Service_ListActions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListROS2ActionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ROS2ServiceServer).ListActions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ROS2Service_ListActions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ROS2ServiceServer).ListActions(ctx, req.(*ListROS2ActionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ROS2Service_GetActionInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetROS2ActionInfoRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ROS2ServiceServer).GetActionInfo(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ROS2Service_GetActionInfo_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ROS2ServiceServer).GetActionInfo(ctx, req.(*GetROS2ActionInfoRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ROS2Service_SendActionGoal_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(SendROS2ActionGoalRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(ROS2ServiceServer).SendActionGoal(m, &grpc.GenericServerStream[SendROS2ActionGoalRequest, ROS2ExecOutput]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type ROS2Service_SendActionGoalServer = grpc.ServerStreamingServer[ROS2ExecOutput]
+
+func _ROS2Service_ListLifecycleNodes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListROS2LifecycleNodesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ROS2ServiceServer).ListLifecycleNodes(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ROS2Service_ListLifecycleNodes_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ROS2ServiceServer).ListLifecycleNodes(ctx, req.(*ListROS2LifecycleNodesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ROS2Service_GetLifecycleState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetROS2LifecycleStateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ROS2ServiceServer).GetLifecycleState(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ROS2Service_GetLifecycleState_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ROS2ServiceServer).GetLifecycleState(ctx, req.(*GetROS2LifecycleStateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ROS2Service_ListLifecycleTransitions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListROS2LifecycleTransitionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ROS2ServiceServer).ListLifecycleTransitions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ROS2Service_ListLifecycleTransitions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ROS2ServiceServer).ListLifecycleTransitions(ctx, req.(*ListROS2LifecycleTransitionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ROS2Service_SetLifecycleState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetROS2LifecycleStateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ROS2ServiceServer).SetLifecycleState(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ROS2Service_SetLifecycleState_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ROS2ServiceServer).SetLifecycleState(ctx, req.(*SetROS2LifecycleStateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ROS2Service_ListComponents_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListROS2ComponentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ROS2ServiceServer).ListComponents(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ROS2Service_ListComponents_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ROS2ServiceServer).ListComponents(ctx, req.(*ListROS2ComponentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ROS2Service_LoadComponent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LoadROS2ComponentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ROS2ServiceServer).LoadComponent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ROS2Service_LoadComponent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ROS2ServiceServer).LoadComponent(ctx, req.(*LoadROS2ComponentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ROS2Service_UnloadComponent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UnloadROS2ComponentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ROS2ServiceServer).UnloadComponent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ROS2Service_UnloadComponent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ROS2ServiceServer).UnloadComponent(ctx, req.(*UnloadROS2ComponentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ROS2Service_ServiceDesc is the grpc.ServiceDesc for ROS2Service service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -689,6 +1041,42 @@ var ROS2Service_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "ListBags",
 			Handler:    _ROS2Service_ListBags_Handler,
 		},
+		{
+			MethodName: "ListActions",
+			Handler:    _ROS2Service_ListActions_Handler,
+		},
+		{
+			MethodName: "GetActionInfo",
+			Handler:    _ROS2Service_GetActionInfo_Handler,
+		},
+		{
+			MethodName: "ListLifecycleNodes",
+			Handler:    _ROS2Service_ListLifecycleNodes_Handler,
+		},
+		{
+			MethodName: "GetLifecycleState",
+			Handler:    _ROS2Service_GetLifecycleState_Handler,
+		},
+		{
+			MethodName: "ListLifecycleTransitions",
+			Handler:    _ROS2Service_ListLifecycleTransitions_Handler,
+		},
+		{
+			MethodName: "SetLifecycleState",
+			Handler:    _ROS2Service_SetLifecycleState_Handler,
+		},
+		{
+			MethodName: "ListComponents",
+			Handler:    _ROS2Service_ListComponents_Handler,
+		},
+		{
+			MethodName: "LoadComponent",
+			Handler:    _ROS2Service_LoadComponent_Handler,
+		},
+		{
+			MethodName: "UnloadComponent",
+			Handler:    _ROS2Service_UnloadComponent_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
@@ -715,6 +1103,11 @@ var ROS2Service_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "Exec",
 			Handler:       _ROS2Service_Exec_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "SendActionGoal",
+			Handler:       _ROS2Service_SendActionGoal_Handler,
 			ServerStreams: true,
 		},
 	},


### PR DESCRIPTION
## Summary
Adds first-class inspection/control for three ROS 2 graph concepts, building on the existing mixed-RMW-aware ROS2 service:

- **Actions** — `wendy ros2 action list|info|send_goal|cancel`
- **Lifecycle (managed nodes)** — `wendy ros2 lifecycle nodes|get|list|set`
- **Components (composable nodes)** — `wendy ros2 component list|load|unload`

## What's in it
- **Proto:** 11 new RPCs on the v2 ROS2 service (+ regenerated Go bindings).
- **Agent:** service implementations and `ros2 …` output parsers, RMW-aware (carries the per-RMW `rmw` field for single-device mixed-RMW graphs).
- **CLI:** three new command trees under `wendy ros2`.

## Provenance
Cherry-picked from the stale #1141 (`ros2-open-issue-fixes`), which bundled this **undescribed** feature alongside bug fixes that have since landed (WDY-1717 via f49e7830, WDY-1720 group start) or been superseded (WDY-1719 default-RMW flip, replaced by main's CycloneDDS sidecar). This PR isolates the still-valuable WDY-1722 work onto a clean branch off current `main`.

Supersedes #1141. Follow-up: WDY-1721 (service-set cache merge) still applies to `main` and is being ported separately.

## Testing
`go build ./...`, `go vet`, and the ROS2 package tests (`internal/agent/services`, `internal/cli/commands`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)