### PR TITLE
fix(os install): auto-detect NVMe SSD in USB enclosure for image variant

### DIFF
--- a/go/internal/cli/commands/disklister_darwin.go
+++ b/go/internal/cli/commands/disklister_darwin.go
@@ -22,6 +22,10 @@ type drive struct {
 	SizeBytes   int64  // size in bytes
 	IsRemovable bool
 	StorageType StorageType // underlying storage protocol
+	// MediaFixed is positive evidence that the media is fixed, solid-state
+	// (an SSD) rather than removable (an SD card / thumb drive). Used to
+	// disambiguate a USB-attached SSD enclosure from an SD-card reader.
+	MediaFixed bool
 }
 
 // listAllDrives lists external physical drives (NVMe, USB, SD cards) on macOS.
@@ -117,18 +121,22 @@ func parseDiskutilOutput(out []byte, seen map[string]bool, isExternal bool) []dr
 			SizeBytes:   sizeBytes,
 			IsRemovable: removable,
 			StorageType: storageType,
+			// "Removable Media: Fixed" + "Solid State: Yes" is an SSD, not an
+			// SD card (which reports removable media).
+			MediaFixed: infoErr == nil && !info.removable && info.solidState,
 		})
 	}
 	return drives
 }
 
 type diskInfo struct {
-	name      string
-	size      string
-	sizeBytes int64
-	removable bool   // "Removable Media: Removable"
-	ejectable bool   // "Ejectable: Yes"
-	protocol  string // "Protocol:" field, e.g. "NVMe", "USB"
+	name       string
+	size       string
+	sizeBytes  int64
+	removable  bool   // "Removable Media: Removable"
+	ejectable  bool   // "Ejectable: Yes"
+	protocol   string // "Protocol:" field, e.g. "NVMe", "USB"
+	solidState bool   // "Solid State: Yes"
 }
 
 func getDiskInfo(devPath string) (*diskInfo, error) {
@@ -166,6 +174,10 @@ func getDiskInfo(devPath string) (*diskInfo, error) {
 		}
 		if strings.HasPrefix(line, "Protocol:") {
 			info.protocol = strings.TrimSpace(strings.TrimPrefix(line, "Protocol:"))
+		}
+		if strings.HasPrefix(line, "Solid State:") {
+			val := strings.TrimSpace(strings.TrimPrefix(line, "Solid State:"))
+			info.solidState = strings.EqualFold(val, "yes")
 		}
 	}
 	return info, nil

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -47,6 +47,10 @@ type drive struct {
 	SizeBytes   int64  // size in bytes
 	IsRemovable bool
 	StorageType StorageType // underlying storage protocol
+	// MediaFixed is positive evidence that the media is fixed, solid-state
+	// (an SSD) rather than removable (an SD card / thumb drive). Used to
+	// disambiguate a USB-attached SSD enclosure from an SD-card reader.
+	MediaFixed bool
 }
 
 // lsblkOutput is the JSON output from lsblk.
@@ -61,6 +65,7 @@ type lsblkDevice struct {
 	Removable  flexBool      `json:"rm"`
 	Hotplug    flexBool      `json:"hotplug"`
 	Transport  string        `json:"tran"`
+	Rotational flexBool      `json:"rota"`
 	Mountpoint string        `json:"mountpoint"`
 	Children   []lsblkDevice `json:"children"`
 }
@@ -79,7 +84,7 @@ func listExternalDrives() ([]drive, error) {
 }
 
 func listDrivesLinux() ([]drive, error) {
-	out, err := exec.Command("lsblk", "--json", "--bytes", "-o", "NAME,SIZE,TYPE,RM,HOTPLUG,TRAN,MOUNTPOINT").Output()
+	out, err := exec.Command("lsblk", "--json", "--bytes", "-o", "NAME,SIZE,TYPE,RM,HOTPLUG,TRAN,ROTA,MOUNTPOINT").Output()
 	if err != nil {
 		return nil, fmt.Errorf("running lsblk: %w", err)
 	}
@@ -123,6 +128,9 @@ func listDrivesLinux() ([]drive, error) {
 			// sees the same classification used to include this device.
 			IsRemovable: isExternal,
 			StorageType: storageType,
+			// Non-removable, non-rotational media is an SSD, not an SD card or
+			// thumb drive (both report RM=1).
+			MediaFixed: !bool(dev.Removable) && !bool(dev.Rotational),
 		})
 	}
 

--- a/go/internal/cli/commands/disklister_windows.go
+++ b/go/internal/cli/commands/disklister_windows.go
@@ -63,6 +63,10 @@ type drive struct {
 	SizeBytes   int64  // size in bytes
 	IsRemovable bool
 	StorageType StorageType // underlying storage protocol
+	// MediaFixed is positive evidence that the media is fixed, solid-state
+	// (an SSD) rather than removable (an SD card / thumb drive). Used to
+	// disambiguate a USB-attached SSD enclosure from an SD-card reader.
+	MediaFixed bool
 }
 
 // psDisk is the JSON structure returned by the joined Get-Disk / Get-PhysicalDisk query.
@@ -151,6 +155,11 @@ func listDrivesWindows(externalOnly bool) ([]drive, error) {
 			SizeBytes:   d.Size,
 			IsRemovable: external || looksLikeCardReader(d),
 			StorageType: storageType,
+			// An SSD reports MediaType "SSD"; SD cards / thumb drives report
+			// "Unspecified" or removable. (USB enclosures often report
+			// "Unspecified" too, in which case this stays false and the
+			// ambiguous-USB prompt resolves it.)
+			MediaFixed: strings.EqualFold(d.MediaType, "SSD"),
 		})
 	}
 

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -464,7 +464,30 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	if !ok {
 		return fmt.Errorf("version %s not found in device manifest", selectedVersion)
 	}
-	storage := manifestStorage(ver, targetDrive.StorageType, storageOverride)
+	storage := manifestStorage(ver, targetDrive.StorageType, targetDrive.MediaFixed, storageOverride)
+
+	// A USB-attached SD reader and an SSD enclosure are indistinguishable by bus
+	// type, and not every platform reports fixed-media signals. When the variant
+	// is a guess on a dual-variant device, ask the user which slot the drive is
+	// for rather than silently picking the wrong image (a wrong guess can produce
+	// a non-booting device). Non-interactive runs keep the manifest default.
+	if storageOverride == "" && storageChoiceAmbiguous(ver, targetDrive.StorageType, targetDrive.MediaFixed) && isInteractiveTerminal() {
+		bootNVMe, err := tui.ConfirmNoDefault(fmt.Sprintf(
+			"Can't tell if %s is an SD card or an SSD. Will it boot from the NVMe/SSD slot?",
+			targetDrive.DevicePath))
+		if err != nil {
+			return err
+		}
+		if bootNVMe {
+			storage = "nvme"
+		} else {
+			storage = "sd"
+		}
+	} else if storageOverride == "" && targetDrive.MediaFixed && storage == "nvme" {
+		// Auto-detected an SSD enclosure. Surface the inference and the override
+		// so a surprising choice is at least visible and reversible.
+		fmt.Printf("Detected a fixed SSD on %s — using the NVMe image (pass --storage sd to override).\n", targetDrive.DevicePath)
+	}
 
 	fmt.Printf("\nPreparing %s %s image...\n", device.Name, selectedVersion)
 	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, storage)
@@ -1017,18 +1040,18 @@ func osCachedBmapPath(deviceKey, version, storage string) (string, error) {
 // manifestStorage picks the manifest storage key ("sd"/"nvme") for a target
 // drive, honoring an explicit override.
 //
-// A real NVMe controller is unambiguous → nvme. A USB-attached drive is NOT:
+// A real NVMe controller is unambiguous → nvme. A USB-attached drive is harder:
 // an SD card in a USB reader and an NVMe SSD in a USB enclosure both enumerate
 // as USB on every platform (the StorageType enum has no SD value), so bus type
-// alone can't tell them apart. We disambiguate from the variants this manifest
-// version actually publishes via defaultManifestStorage: prefer the SD image
-// when the device ships one (Raspberry Pi), else the NVMe image (a Jetson SSD
-// enclosure), else legacy/sd. Unknown buses (built-in card readers) → sd.
-//
-// Assumption: a device that publishes BOTH an sd and an nvme variant is
-// SD-natural for an ambiguous USB target (true for the only dual-variant device
-// today, Raspberry Pi 5). Pass --storage to override.
-func manifestStorage(v deviceVersion, st StorageType, override string) string {
+// alone can't tell them apart. We disambiguate with mediaFixed — positive
+// evidence from the platform lister that the media is fixed, solid-state (an
+// SSD), not removable (an SD card / thumb drive). An SSD in a USB enclosure is
+// bound for the device's NVMe slot, so when the device also publishes an NVMe
+// variant we pick it. Without that evidence we fall back to what the manifest
+// publishes via defaultManifestStorage: the SD image when the device ships one
+// (Raspberry Pi), else the NVMe image (a Jetson SSD enclosure), else legacy/sd.
+// Unknown buses (built-in card readers) → sd. Pass --storage to override.
+func manifestStorage(v deviceVersion, st StorageType, mediaFixed bool, override string) string {
 	switch override {
 	case "nvme", "sd":
 		return override
@@ -1037,10 +1060,26 @@ func manifestStorage(v deviceVersion, st StorageType, override string) string {
 	case StorageNVMe:
 		return "nvme"
 	case StorageUSB:
+		// Fixed, solid-state media behind a USB bridge is an SSD headed for the
+		// NVMe slot, not an SD card in a reader. Prefer nvme when the device
+		// actually publishes that variant.
+		if mediaFixed && v.NVMEPath != "" {
+			return "nvme"
+		}
 		return defaultManifestStorage(v)
 	default:
 		return "sd"
 	}
+}
+
+// storageChoiceAmbiguous reports whether the image variant for a USB target
+// can't be determined from bus and media signals alone, so the caller should
+// ask the user which slot the drive is for. It is only ambiguous when the bus
+// is USB (an SD reader and an SSD enclosure look identical), the platform found
+// no positive fixed-media evidence, and the device publishes BOTH variants —
+// otherwise there is nothing to choose between.
+func storageChoiceAmbiguous(v deviceVersion, st StorageType, mediaFixed bool) bool {
+	return st == StorageUSB && !mediaFixed && v.SDPath != "" && v.NVMEPath != ""
 }
 
 // defaultManifestStorage returns the device's natural removable image variant

--- a/go/internal/cli/commands/storage_select_test.go
+++ b/go/internal/cli/commands/storage_select_test.go
@@ -20,11 +20,12 @@ func TestManifestStorage(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		v        deviceVersion
-		st       StorageType
-		override string
-		want     string
+		name       string
+		v          deviceVersion
+		st         StorageType
+		mediaFixed bool
+		override   string
+		want       string
 	}{
 		{
 			name:     "override nvme wins regardless of storage type",
@@ -53,12 +54,31 @@ func TestManifestStorage(t *testing.T) {
 			want: "sd",
 		},
 		{
-			// The regression: an RPi 5 SD card in a USB reader enumerates as USB.
-			// It must resolve to the SD image, not the NVMe image.
-			name: "USB drive + device publishes an SD variant returns sd (RPi 5)",
+			// The regression: an RPi 5 SD card in a USB reader enumerates as USB
+			// and reports removable media. It must resolve to the SD image.
+			name: "USB drive + removable media + dual variant returns sd (RPi 5 SD reader)",
 			v:    rpi5,
 			st:   StorageUSB,
 			want: "sd",
+		},
+		{
+			// An RPi 5 NVMe SSD in a USB enclosure enumerates as USB but reports
+			// fixed, solid-state media — not an SD card. It is bound for the NVMe
+			// slot, so it must resolve to the NVMe image.
+			name:       "USB drive + fixed SSD media + dual variant returns nvme (RPi 5 NVMe enclosure)",
+			v:          rpi5,
+			st:         StorageUSB,
+			mediaFixed: true,
+			want:       "nvme",
+		},
+		{
+			// Fixed media but a legacy-only device (RPi 3/4) ships no NVMe variant,
+			// so there is nothing to upgrade to — stays sd.
+			name:       "USB drive + fixed media + legacy-only device returns sd",
+			v:          legacyOnly,
+			st:         StorageUSB,
+			mediaFixed: true,
+			want:       "sd",
 		},
 		{
 			// Preserves commit 95d63153: a Jetson NVMe SSD in a USB enclosure has
@@ -85,9 +105,9 @@ func TestManifestStorage(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := manifestStorage(tc.v, tc.st, tc.override)
+			got := manifestStorage(tc.v, tc.st, tc.mediaFixed, tc.override)
 			if got != tc.want {
-				t.Errorf("manifestStorage(%+v, %v, %q) = %q; want %q", tc.v, tc.st, tc.override, got, tc.want)
+				t.Errorf("manifestStorage(%+v, %v, fixed=%v, %q) = %q; want %q", tc.v, tc.st, tc.mediaFixed, tc.override, got, tc.want)
 			}
 		})
 	}
@@ -108,7 +128,7 @@ func TestManifestStorage_RPi5USBResolvesSDImage(t *testing.T) {
 	}
 	v := dm.Versions["nightly"]
 
-	storage := manifestStorage(v, StorageUSB, "")
+	storage := manifestStorage(v, StorageUSB, false, "")
 	if storage != "sd" {
 		t.Fatalf("manifestStorage for RPi5 USB = %q; want sd", storage)
 	}
@@ -122,6 +142,36 @@ func TestManifestStorage_RPi5USBResolvesSDImage(t *testing.T) {
 	}
 	if info.Storage != "sd" {
 		t.Errorf("imageInfo.Storage = %q; want sd", info.Storage)
+	}
+}
+
+// storageChoiceAmbiguous decides when to ask the user which slot a USB drive
+// is for, rather than silently guessing the image variant.
+func TestStorageChoiceAmbiguous(t *testing.T) {
+	rpi5 := deviceVersion{Path: "n", NVMEPath: "n", SDPath: "s"} // dual-variant
+	jetson := deviceVersion{Path: "n", NVMEPath: "n"}            // nvme-only
+	legacyOnly := deviceVersion{Path: "s"}                       // sd-only
+
+	cases := []struct {
+		name       string
+		v          deviceVersion
+		st         StorageType
+		mediaFixed bool
+		want       bool
+	}{
+		{"USB + unsure media + dual variant is ambiguous", rpi5, StorageUSB, false, true},
+		{"USB + detected fixed SSD is not ambiguous (auto nvme)", rpi5, StorageUSB, true, false},
+		{"USB + nvme-only device is not ambiguous (no sd alternative)", jetson, StorageUSB, false, false},
+		{"USB + legacy-only device is not ambiguous (no nvme alternative)", legacyOnly, StorageUSB, false, false},
+		{"real NVMe controller is not ambiguous", rpi5, StorageNVMe, false, false},
+		{"unknown bus is not ambiguous", rpi5, StorageUnknown, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := storageChoiceAmbiguous(tc.v, tc.st, tc.mediaFixed); got != tc.want {
+				t.Errorf("storageChoiceAmbiguous(%+v, %v, %v) = %v; want %v", tc.v, tc.st, tc.mediaFixed, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Flashing a Raspberry Pi 5 NVMe SSD that's connected via a USB-to-NVMe enclosure picked the **SD** image instead of the **NVMe** image. A USB SD-card reader and a USB SSD enclosure both enumerate as `USB` (the inner NVMe controller is hidden behind the bridge chip — e.g. a Realtek RTL9210C), so the ambiguous-USB tiebreaker on a dual-variant device (Pi 5 publishes both `sd` and `nvme`) silently defaulted to `sd`. The SD/NVMe images differ in boot configuration, so the wrong variant can produce a non-booting device.

## Fix

**Auto-diagnose fixed solid-state media per platform** (new `drive.MediaFixed`):
- **macOS**: `Removable Media: Fixed` + `Solid State: Yes`
- **Linux**: lsblk `RM=0` + `ROTA=0` (SD cards / thumb drives report `RM=1`)
- **Windows**: `MediaType == "SSD"`

`manifestStorage` now upgrades an ambiguous USB target to `nvme` when the media is a fixed SSD **and** the device publishes that variant, printing the inference and the `--storage sd` override.

**Prompt when genuinely unsure**: when a USB target on a dual-variant device has no fixed-media evidence (e.g. Windows enclosures reporting `Unspecified`, or a real SD-card reader), it asks which slot the drive is for instead of guessing. Gated on `isInteractiveTerminal()` so scripted/CI runs keep the manifest default. `--storage` still short-circuits all detection.

## Tests

- `TestManifestStorage`: added fixed-SSD→`nvme`, removable→`sd`, and legacy-only cases; existing SD-reader regression still passes.
- `TestStorageChoiceAmbiguous`: new — covers exactly when to prompt.
- `go test ./internal/cli/commands` passes; cross-compiles for `linux/arm64` and `windows/amd64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)