### PR TITLE
fix(os update): preserve .wendy artifact extension on local serve

### DIFF
--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -430,6 +430,28 @@ func resolveArtifactPath(path string) (string, error) {
 	return "", fmt.Errorf("no .wendy or .mender artifact found in directory: %s", absPath)
 }
 
+// artifactSuffix returns the OS-update artifact extension embedded in a URL or
+// path: ".mender.xz", ".wendy", or ".mender". A wendyos-update (.wendy)
+// artifact and a Mender (.mender) artifact share the manifest's
+// ota_update_path, and the install backends key off the artifact, so the
+// extension must survive a local download+serve round-trip — serving a .wendy
+// artifact under a .mender name makes wendyos-update reject it. Falls back to
+// ".mender" when no known suffix is present (backward-compatible default).
+func artifactSuffix(artifactURL string) string {
+	name := artifactURL
+	if u, err := url.Parse(artifactURL); err == nil && u.Path != "" {
+		name = u.Path
+	}
+	switch {
+	case strings.HasSuffix(name, ".mender.xz"):
+		return ".mender.xz"
+	case strings.HasSuffix(name, ".wendy"):
+		return ".wendy"
+	default:
+		return ".mender"
+	}
+}
+
 // artifactURLPath generates a short hash prefix for the URL path.
 func artifactURLPath(filePath string) string {
 	h := sha256.New()
@@ -1008,7 +1030,10 @@ func downloadArtifactToTemp(artifactURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolving cache dir: %w", err)
 	}
-	tmpFile, err := os.CreateTemp(cacheDir, "wendyos-*.mender")
+	// Preserve the artifact's real extension (.wendy / .mender / .mender.xz) so
+	// the locally served filename matches the artifact type; the device's
+	// install backend keys off it.
+	tmpFile, err := os.CreateTemp(cacheDir, "wendyos-*"+artifactSuffix(artifactURL))
 	if err != nil {
 		return "", fmt.Errorf("creating temp file: %w", err)
 	}

--- a/go/internal/cli/commands/os_cmd_test.go
+++ b/go/internal/cli/commands/os_cmd_test.go
@@ -287,6 +287,28 @@ func TestResolveArtifactPath(t *testing.T) {
 	})
 }
 
+func TestArtifactSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"wendy artifact", "https://storage.example.com/images/raspberry-pi-5/1.0/wendyos-image-x.rootfs.wendy", ".wendy"},
+		{"mender artifact", "https://storage.example.com/images/jetson/1.0/wendyos-image-x.mender", ".mender"},
+		{"mender.xz artifact", "https://storage.example.com/images/rpi/1.0/wendyos-image-x.mender.xz", ".mender.xz"},
+		{"wendy with query string", "https://storage.example.com/x.wendy?token=abc&exp=123", ".wendy"},
+		{"unknown extension falls back to mender", "https://storage.example.com/images/x.bin", ".mender"},
+		{"bare local path", "/tmp/update.wendy", ".wendy"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := artifactSuffix(tc.url); got != tc.want {
+				t.Fatalf("artifactSuffix(%q) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestValidateUpdaterBackend(t *testing.T) {
 	valid := []string{"", "auto", "wendyos", "wendyos-update", "mender"}
 	for _, v := range valid {


### PR DESCRIPTION
## What

Make `wendy os update` correctly install `.wendy` (wendyos-update) OTA artifacts that arrive via the manifest's `ota_update_path`.

## Why

The builder (wendylabsinc/WendyOS-Builder#144) now uploads `.wendy` artifacts into the **same** `ota_update_path` field as Mender `.mender` artifacts — a board runs one OTA stack or the other (gated by `WENDYOS_OTA`), never both.

- **WiFi path (already works):** the device fetches the GCS URL directly (ending `.wendy`); the agent's auto-select runs `wendyos-update detect()` → installs via the in-house engine. No change needed.
- **No-WiFi path (broken):** `wendy os update` downloads the artifact to a temp file **hardcoded** as `wendyos-*.mender` (`os_cmd.go`) and serves it over local HTTP under that name. A `.wendy` artifact then reached `wendyos-update install` as a `*.mender` URL and was rejected.

## How

Preserve the artifact's real extension across the download → local-serve round trip. New `artifactSuffix()` helper parses the source URL/path and returns `.mender.xz`, `.wendy`, or `.mender` (backward-compatible fallback); `downloadArtifactToTemp` uses it for the temp-file pattern so the served filename matches the artifact type.

No backend-selection change: wendy-stack boards only ship `wendyos-update` (preferred first in auto mode), and the post-reboot commit/rollback already routes by the recorded backend.

## Tests

- New `TestArtifactSuffix` (wendy, mender, mender.xz, query-string URL, unknown→mender fallback, bare local path).
- `go test ./internal/cli/commands/` — full package green; `gofmt`, `go vet`, `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)