### PR TITLE
WDY-1754: investigate Swift E2E timeout handling

### DIFF
--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -125,7 +125,7 @@ runs:
         require_match AGENT_OS "$AGENT_OS" '^[A-Za-z0-9._-]{1,40}$'
         require_match TRANSPORT "$TRANSPORT" '^[A-Za-z0-9._-]{1,40}$'
         require_match MANAGED_AGENT "$MANAGED_AGENT" '^(true|false)$'
-        require_match TEST_TIMEOUT_MINUTES "$TEST_TIMEOUT_MINUTES" '^[0-9]{1,4}$'
+        require_match TEST_TIMEOUT_MINUTES "$TEST_TIMEOUT_MINUTES" '^(0|[1-9][0-9]{0,3})$'
         if (( 10#$TEST_TIMEOUT_MINUTES > 1440 )); then
           echo "ERROR: invalid TEST_TIMEOUT_MINUTES" >&2
           exit 64
@@ -212,7 +212,7 @@ runs:
         Require-Match AGENT_OS $env:AGENT_OS '^[A-Za-z0-9._-]{1,40}$'
         Require-Match TRANSPORT $env:TRANSPORT '^[A-Za-z0-9._-]{1,40}$'
         Require-Match MANAGED_AGENT $env:MANAGED_AGENT '^(true|false)$'
-        Require-Match TEST_TIMEOUT_MINUTES $env:TEST_TIMEOUT_MINUTES '^[0-9]{1,4}$'
+        Require-Match TEST_TIMEOUT_MINUTES $env:TEST_TIMEOUT_MINUTES '^(0|[1-9][0-9]{0,3})$'
         if ([int]$env:TEST_TIMEOUT_MINUTES -gt 1440) { throw 'invalid TEST_TIMEOUT_MINUTES' }
         Reject-Newline DEVICE_ADDRESS $env:DEVICE_ADDRESS
         Reject-Newline TESTS $env:TESTS
@@ -312,7 +312,6 @@ runs:
                 "runID": os.environ.get("GITHUB_RUN_ID"),
                 "runAttempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
                 "job": os.environ.get("GITHUB_JOB"),
-                "actor": os.environ.get("GITHUB_ACTOR"),
                 "sha": os.environ.get("GITHUB_SHA"),
             },
             "target": {

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -37,6 +37,12 @@ inputs:
     description: Build and launch a local wendy-agent process for this run.
     required: false
     default: 'false'
+  test_timeout_minutes:
+    description: >-
+      Maximum minutes allowed for the SwiftPM test process before preserving
+      artifacts and failing the attempt.
+    required: false
+    default: '90'
 
 runs:
   using: composite
@@ -53,6 +59,7 @@ runs:
         AGENT_OS: ${{ inputs.agent_os }}
         TRANSPORT: ${{ inputs.transport }}
         MANAGED_AGENT: ${{ inputs.managed_agent }}
+        TEST_TIMEOUT_MINUTES: ${{ inputs.test_timeout_minutes }}
         DEVICE_ADDRESS: ${{ inputs.device_address }}
         TESTS: ${{ inputs.tests }}
       run: |
@@ -118,6 +125,11 @@ runs:
         require_match AGENT_OS "$AGENT_OS" '^[A-Za-z0-9._-]{1,40}$'
         require_match TRANSPORT "$TRANSPORT" '^[A-Za-z0-9._-]{1,40}$'
         require_match MANAGED_AGENT "$MANAGED_AGENT" '^(true|false)$'
+        require_match TEST_TIMEOUT_MINUTES "$TEST_TIMEOUT_MINUTES" '^[0-9]{1,4}$'
+        if (( 10#$TEST_TIMEOUT_MINUTES > 1440 )); then
+          echo "ERROR: invalid TEST_TIMEOUT_MINUTES" >&2
+          exit 64
+        fi
         reject_newline DEVICE_ADDRESS "$DEVICE_ADDRESS"
         reject_newline TESTS "$TESTS"
         if ! valid_device_address "$DEVICE_ADDRESS"; then
@@ -135,6 +147,7 @@ runs:
         write_output cli_os "$CLI_OS"
         write_output agent_os "$AGENT_OS"
         write_output transport "$TRANSPORT"
+        write_output test_timeout_seconds "$((10#$TEST_TIMEOUT_MINUTES * 60))"
 
     - name: Validate Swift E2E inputs (Windows)
       id: validate-windows
@@ -148,6 +161,7 @@ runs:
         AGENT_OS: ${{ inputs.agent_os }}
         TRANSPORT: ${{ inputs.transport }}
         MANAGED_AGENT: ${{ inputs.managed_agent }}
+        TEST_TIMEOUT_MINUTES: ${{ inputs.test_timeout_minutes }}
         DEVICE_ADDRESS: ${{ inputs.device_address }}
         TESTS: ${{ inputs.tests }}
       run: |
@@ -198,6 +212,8 @@ runs:
         Require-Match AGENT_OS $env:AGENT_OS '^[A-Za-z0-9._-]{1,40}$'
         Require-Match TRANSPORT $env:TRANSPORT '^[A-Za-z0-9._-]{1,40}$'
         Require-Match MANAGED_AGENT $env:MANAGED_AGENT '^(true|false)$'
+        Require-Match TEST_TIMEOUT_MINUTES $env:TEST_TIMEOUT_MINUTES '^[0-9]{1,4}$'
+        if ([int]$env:TEST_TIMEOUT_MINUTES -gt 1440) { throw 'invalid TEST_TIMEOUT_MINUTES' }
         Reject-Newline DEVICE_ADDRESS $env:DEVICE_ADDRESS
         Reject-Newline TESTS $env:TESTS
         if (-not (Test-DeviceAddress $env:DEVICE_ADDRESS)) {
@@ -213,6 +229,7 @@ runs:
         Write-OutputValue cli_os $env:CLI_OS
         Write-OutputValue agent_os $env:AGENT_OS
         Write-OutputValue transport $env:TRANSPORT
+        Write-OutputValue test_timeout_seconds ([string]([int]$env:TEST_TIMEOUT_MINUTES * 60))
 
     - name: Compute Swift E2E run ID (Unix)
       if: runner.os != 'Windows'
@@ -295,6 +312,7 @@ runs:
                 "runID": os.environ.get("GITHUB_RUN_ID"),
                 "runAttempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
                 "job": os.environ.get("GITHUB_JOB"),
+                "actor": os.environ.get("GITHUB_ACTOR"),
                 "sha": os.environ.get("GITHUB_SHA"),
             },
             "target": {
@@ -392,6 +410,7 @@ runs:
         WENDY_E2E_CLI_OS: ${{ steps.validate-unix.outputs.cli_os }}
         WENDY_E2E_AGENT_OS: ${{ steps.validate-unix.outputs.agent_os }}
         WENDY_E2E_TRANSPORT: ${{ steps.validate-unix.outputs.transport }}
+        WENDY_E2E_TEST_TIMEOUT_SECONDS: ${{ steps.validate-unix.outputs.test_timeout_seconds }}
         MANAGED_AGENT: ${{ steps.validate-unix.outputs.managed_agent }}
         DEVICE_ADDRESS: ${{ steps.validate-unix.outputs.device_address }}
       run: |
@@ -416,6 +435,7 @@ runs:
         WENDY_E2E_CLI_OS: ${{ steps.validate-windows.outputs.cli_os }}
         WENDY_E2E_AGENT_OS: ${{ steps.validate-windows.outputs.agent_os }}
         WENDY_E2E_TRANSPORT: ${{ steps.validate-windows.outputs.transport }}
+        WENDY_E2E_TEST_TIMEOUT_SECONDS: ${{ steps.validate-windows.outputs.test_timeout_seconds }}
         MANAGED_AGENT: ${{ steps.validate-windows.outputs.managed_agent }}
         DEVICE_ADDRESS: ${{ steps.validate-windows.outputs.device_address }}
       run: |

--- a/.github/actions/swift-e2e-run/action.yml
+++ b/.github/actions/swift-e2e-run/action.yml
@@ -213,7 +213,7 @@ runs:
         Require-Match TRANSPORT $env:TRANSPORT '^[A-Za-z0-9._-]{1,40}$'
         Require-Match MANAGED_AGENT $env:MANAGED_AGENT '^(true|false)$'
         Require-Match TEST_TIMEOUT_MINUTES $env:TEST_TIMEOUT_MINUTES '^(0|[1-9][0-9]{0,3})$'
-        if ([int]$env:TEST_TIMEOUT_MINUTES -gt 1440) { throw 'invalid TEST_TIMEOUT_MINUTES' }
+        if ([long]$env:TEST_TIMEOUT_MINUTES -gt 1440) { throw 'invalid TEST_TIMEOUT_MINUTES' }
         Reject-Newline DEVICE_ADDRESS $env:DEVICE_ADDRESS
         Reject-Newline TESTS $env:TESTS
         if (-not (Test-DeviceAddress $env:DEVICE_ADDRESS)) {
@@ -229,7 +229,7 @@ runs:
         Write-OutputValue cli_os $env:CLI_OS
         Write-OutputValue agent_os $env:AGENT_OS
         Write-OutputValue transport $env:TRANSPORT
-        Write-OutputValue test_timeout_seconds ([string]([int]$env:TEST_TIMEOUT_MINUTES * 60))
+        Write-OutputValue test_timeout_seconds ([string]([long]$env:TEST_TIMEOUT_MINUTES * 60))
 
     - name: Compute Swift E2E run ID (Unix)
       if: runner.os != 'Windows'
@@ -312,6 +312,7 @@ runs:
                 "runID": os.environ.get("GITHUB_RUN_ID"),
                 "runAttempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
                 "job": os.environ.get("GITHUB_JOB"),
+                "actor": os.environ.get("GITHUB_ACTOR"),
                 "sha": os.environ.get("GITHUB_SHA"),
             },
             "target": {

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -66,6 +66,7 @@ AGENT_INFO_JSON=""
 ISOLATION="${WENDY_E2E_ISOLATION:-per-test}"
 VERBOSE="${WENDY_E2E_VERBOSE:-false}"
 PARALLEL="${WENDY_E2E_PARALLEL:-false}"
+TEST_TIMEOUT_SECONDS="${WENDY_E2E_TEST_TIMEOUT_SECONDS:-5400}"
 TEST_FILTERS=()
 
 normalize_bool() {
@@ -100,6 +101,20 @@ normalize_isolation() {
       exit 64
       ;;
   esac
+}
+
+normalize_timeout_seconds() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: $name must be a non-negative integer number of seconds." >&2
+    exit 64
+  fi
+  if (( 10#$value > 86400 )); then
+    echo "ERROR: $name must be 86400 seconds or less." >&2
+    exit 64
+  fi
+  printf "%s" "$((10#$value))"
 }
 
 normalized_agent_os() {
@@ -181,6 +196,9 @@ Options:
   --parallel            Allow SwiftPM to run tests in parallel. Only valid when
                         both CLI and agent machines use local transport.
   --no-parallel         Do not run SwiftPM tests in parallel.
+  --test-timeout SECONDS
+                        Kill the SwiftPM test process after this many seconds;
+                        defaults to WENDY_E2E_TEST_TIMEOUT_SECONDS or 5400.
   --verbose             Print each E2E machine command before it runs.
   --no-verbose          Do not print each E2E machine command before it runs.
   --help                Show this help message.
@@ -208,6 +226,7 @@ Environment:
   WENDY_E2E_TRANSPORT                 Optional transport label for report metadata.
   WENDY_E2E_ISOLATION                 none, per-run, or per-test; defaults to per-test.
   WENDY_E2E_PARALLEL                  Boolean; enables SwiftPM parallel tests.
+  WENDY_E2E_TEST_TIMEOUT_SECONDS      SwiftPM test process timeout in seconds; 0 disables.
   WENDY_E2E_VERBOSE                   Boolean; prints machine commands.
 
 Boolean values accept true/false, 1/0, yes/no, on/off, enabled/disabled.
@@ -304,6 +323,10 @@ while [[ $# -gt 0 ]]; do
       PARALLEL="false"
       shift
       ;;
+    --test-timeout)
+      TEST_TIMEOUT_SECONDS="$2"
+      shift 2
+      ;;
     --verbose)
       VERBOSE="true"
       shift
@@ -360,6 +383,7 @@ fi
 
 ISOLATION="$(normalize_isolation "$ISOLATION")"
 PARALLEL="$(normalize_bool "WENDY_E2E_PARALLEL" "$PARALLEL")"
+TEST_TIMEOUT_SECONDS="$(normalize_timeout_seconds "WENDY_E2E_TEST_TIMEOUT_SECONDS" "$TEST_TIMEOUT_SECONDS")"
 VERBOSE="$(normalize_bool "WENDY_E2E_VERBOSE" "$VERBOSE")"
 MANAGED_AGENT="$(normalize_bool "WENDY_E2E_MANAGED_AGENT" "$MANAGED_AGENT")"
 
@@ -946,6 +970,78 @@ normalize_xunit_output() {
   fi
 }
 
+run_swift_test_with_timeout() {
+  local timeout_seconds="$1"
+  local timeout_path="$2"
+  shift 2
+
+  python3 - "$timeout_seconds" "$timeout_path" "$@" <<'PY'
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+
+def utc_now():
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+timeout_seconds = int(sys.argv[1])
+timeout_path = sys.argv[2]
+command = sys.argv[3:]
+started_at = time.time()
+process = subprocess.Popen(command, start_new_session=True)
+try:
+    exit_status = process.wait(timeout=None if timeout_seconds == 0 else timeout_seconds)
+except subprocess.TimeoutExpired:
+    elapsed = time.time() - started_at
+    message = (
+        f"Swift E2E test process exceeded {timeout_seconds} seconds and was "
+        "terminated before the GitHub Actions job timeout."
+    )
+    print(f"::error::{message}", flush=True)
+    print(f"==> {message}", flush=True)
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    killed_with = "SIGTERM"
+    try:
+        process.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        print("==> Swift E2E test process did not exit after SIGTERM; sending SIGKILL", flush=True)
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        killed_with = "SIGKILL"
+        process.wait()
+
+    os.makedirs(os.path.dirname(timeout_path), exist_ok=True)
+    with open(timeout_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "kind": "wendy-e2e-timeout",
+                "phase": "swift test",
+                "timeoutSeconds": timeout_seconds,
+                "elapsedSeconds": round(elapsed, 3),
+                "terminatedAt": utc_now(),
+                "signal": killed_with,
+                "exitStatus": 124,
+                "message": message,
+            },
+            handle,
+            indent=2,
+            sort_keys=True,
+        )
+        handle.write("\n")
+    exit_status = 124
+sys.exit(exit_status)
+PY
+}
+
 write_attempt_info() {
   local status="$1"
   local info_path="$RUN_DIR/attempt.json"
@@ -987,6 +1083,7 @@ write_attempt_info() {
     printf '    "runID": '; json_string_or_null "${GITHUB_RUN_ID:-}"; echo ","
     printf '    "runAttempt": '; json_string_or_null "${GITHUB_RUN_ATTEMPT:-}"; echo ","
     printf '    "job": '; json_string_or_null "${GITHUB_JOB:-}"; echo ","
+    printf '    "actor": '; json_string_or_null "${GITHUB_ACTOR:-}"; echo ","
     printf '    "sha": '; json_string_or_null "$github_sha"; echo
     echo '  },'
     echo '  "target": {'
@@ -1018,7 +1115,18 @@ write_attempt_info() {
     printf '    "go": '; json_string_or_null "$go_version"; echo ","
     printf '    "wendy": '; json_string_or_null "${WENDY_CLI_VERSION:-}"; echo ","
     printf '    "wendyPath": '; json_string "$CLI_BIN_DIR/wendy"; echo
-    echo '  }'
+    if [[ -f "$RUN_DIR/timeout.json" ]]; then
+      echo '  },'
+      echo '  "failure": {'
+      printf '    "kind": '; json_string "timeout"; echo ","
+      printf '    "phase": '; json_string "swift test"; echo ","
+      printf '    "timeoutSeconds": %s,\n' "$TEST_TIMEOUT_SECONDS"
+      printf '    "message": '; json_string "Swift E2E test process exceeded ${TEST_TIMEOUT_SECONDS} seconds and was terminated before the GitHub Actions job timeout."; echo ","
+      printf '    "evidence": '; json_string "timeout.json"; echo
+      echo '  }'
+    else
+      echo '  }'
+    fi
     echo "}"
   } > "$info_path"
   ATTEMPT_INFO_WRITTEN="true"
@@ -1102,6 +1210,7 @@ echo "    Filters:  ${TEST_FILTERS[*]}"
 echo "    Isolation: $ISOLATION"
 echo "    Verbose:  $VERBOSE"
 echo "    Parallel: $PARALLEL"
+echo "    Timeout:  ${TEST_TIMEOUT_SECONDS}s"
 echo "    HTML:     <deferred to Scripts/E2EReport.sh>"
 echo "    CLI target: ${CLI_USER:+$CLI_USER@}${CLI_ADDRESS:-<local>}:${CLI_REPO_DIR:-<no-repo>}"
 echo "    CLI OS:   ${CLI_OS:-<current>}"
@@ -1120,7 +1229,10 @@ echo "    Managed agent: $MANAGED_AGENT"
 set +e
 (
   cd "$PACKAGE_DIR"
-  env "${SWIFT_TEST_ENV[@]}" \
+  export "${SWIFT_TEST_ENV[@]}"
+  run_swift_test_with_timeout \
+    "$TEST_TIMEOUT_SECONDS" \
+    "$RUN_DIR/timeout.json" \
     swift "${SWIFT_TEST_ARGS[@]}" \
     --xunit-output "$TEST_RESULTS_OUTPUT_PATH"
 )

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -910,6 +910,9 @@ prepare_managed_agent_auth_fixture() {
   local auth_dir="$RUN_DIR/managed-agent/cli-auth"
   mkdir -p "$auth_dir"
   CLI_AUTH_CONFIG_PATH="$auth_dir/config.json"
+  # Managed E2Es run with throwaway HOME directories. Pre-dismiss only the
+  # ambient shell-completion install prompt so PTY-backed command tests do not
+  # block after printing their real command output.
   printf '{"completionPromptDismissed":true}\n' > "$CLI_AUTH_CONFIG_PATH"
   chmod 600 "$CLI_AUTH_CONFIG_PATH" 2>/dev/null || true
 }
@@ -992,6 +995,10 @@ def utc_now():
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
+def github_annotation_escape(value):
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
 timeout_seconds = int(sys.argv[1])
 timeout_path = sys.argv[2]
 command = sys.argv[3:]
@@ -1005,7 +1012,7 @@ except subprocess.TimeoutExpired:
         f"Swift E2E test process exceeded {timeout_seconds} seconds and was "
         "terminated before the GitHub Actions job timeout."
     )
-    print(f"::error::{message}", flush=True)
+    print(f"::error::{github_annotation_escape(message)}", flush=True)
     print(f"==> {message}", flush=True)
     try:
         # start_new_session=True calls setsid(), so the child PID is also its process group ID.
@@ -1091,6 +1098,7 @@ write_attempt_info() {
     printf '    "runID": '; json_string_or_null "${GITHUB_RUN_ID:-}"; echo ","
     printf '    "runAttempt": '; json_string_or_null "${GITHUB_RUN_ATTEMPT:-}"; echo ","
     printf '    "job": '; json_string_or_null "${GITHUB_JOB:-}"; echo ","
+    printf '    "actor": '; json_string_or_null "${GITHUB_ACTOR:-}"; echo ","
     printf '    "sha": '; json_string_or_null "$github_sha"; echo
     echo '  },'
     echo '  "target": {'
@@ -1236,6 +1244,8 @@ echo "    Managed agent: $MANAGED_AGENT"
 set +e
 (
   cd "$PACKAGE_DIR"
+  # Export is intentional: run_swift_test_with_timeout launches python3, which
+  # inherits this environment before spawning swift test.
   export "${SWIFT_TEST_ENV[@]}"
   run_swift_test_with_timeout \
     "$TEST_TIMEOUT_SECONDS" \

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -910,7 +910,7 @@ prepare_managed_agent_auth_fixture() {
   local auth_dir="$RUN_DIR/managed-agent/cli-auth"
   mkdir -p "$auth_dir"
   CLI_AUTH_CONFIG_PATH="$auth_dir/config.json"
-  printf '{}\n' > "$CLI_AUTH_CONFIG_PATH"
+  printf '{"completionPromptDismissed":true}\n' > "$CLI_AUTH_CONFIG_PATH"
   chmod 600 "$CLI_AUTH_CONFIG_PATH" 2>/dev/null || true
 }
 

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -106,7 +106,7 @@ normalize_isolation() {
 normalize_timeout_seconds() {
   local name="$1"
   local value="$2"
-  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+  if [[ ! "$value" =~ ^(0|[1-9][0-9]*)$ ]]; then
     echo "ERROR: $name must be a non-negative integer number of seconds." >&2
     exit 64
   fi
@@ -324,6 +324,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --test-timeout)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "ERROR: --test-timeout requires a numeric argument." >&2
+        exit 64
+      fi
       TEST_TIMEOUT_SECONDS="$2"
       shift 2
       ;;
@@ -1004,6 +1008,7 @@ except subprocess.TimeoutExpired:
     print(f"::error::{message}", flush=True)
     print(f"==> {message}", flush=True)
     try:
+        # start_new_session=True calls setsid(), so the child PID is also its process group ID.
         os.killpg(process.pid, signal.SIGTERM)
     except ProcessLookupError:
         pass
@@ -1017,7 +1022,10 @@ except subprocess.TimeoutExpired:
         except ProcessLookupError:
             pass
         killed_with = "SIGKILL"
-        process.wait()
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            print("==> WARNING: Swift E2E test process did not exit after SIGKILL", flush=True)
 
     os.makedirs(os.path.dirname(timeout_path), exist_ok=True)
     with open(timeout_path, "w", encoding="utf-8") as handle:
@@ -1083,7 +1091,6 @@ write_attempt_info() {
     printf '    "runID": '; json_string_or_null "${GITHUB_RUN_ID:-}"; echo ","
     printf '    "runAttempt": '; json_string_or_null "${GITHUB_RUN_ATTEMPT:-}"; echo ","
     printf '    "job": '; json_string_or_null "${GITHUB_JOB:-}"; echo ","
-    printf '    "actor": '; json_string_or_null "${GITHUB_ACTOR:-}"; echo ","
     printf '    "sha": '; json_string_or_null "$github_sha"; echo
     echo '  },'
     echo '  "target": {'

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
@@ -11,6 +11,7 @@ let e2eSourceIndexFileName = "source-index.md"
 
 private let e2eAttemptJSONMaxBytes = 1_048_576
 private let e2eAttemptXUnitMaxBytes = 50 * 1_048_576
+private let e2eAttemptMessageMaxCharacters = 2_048
 
 func e2eAttemptArtifactsRootURL(in runURL: URL) -> URL {
     runURL.appendingPathComponent(e2eAttemptArtifactsDirectoryName, isDirectory: true)
@@ -89,9 +90,17 @@ private func e2eAttemptTimeoutDetail(at attemptURL: URL) -> String? {
         let message = object["message"] as? String,
         !message.isEmpty
     {
-        return message
+        return e2eBoundedMessage(message)
     }
     return "Swift E2E attempt timed out"
+}
+
+private func e2eBoundedMessage(_ message: String) -> String {
+    let normalized = message
+        .replacingOccurrences(of: "\r", with: " ")
+        .replacingOccurrences(of: "\n", with: " ")
+    guard normalized.count > e2eAttemptMessageMaxCharacters else { return normalized }
+    return String(normalized.prefix(e2eAttemptMessageMaxCharacters)) + "…"
 }
 
 private func e2eAttemptXUnitProblem(at attemptURL: URL) -> String? {

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
@@ -9,6 +9,9 @@ let e2eObservationsDirectoryName = "observations"
 let e2eSourceArtifactFileName = "source.md"
 let e2eSourceIndexFileName = "source-index.md"
 
+private let e2eAttemptJSONMaxBytes = 1_048_576
+private let e2eAttemptXUnitMaxBytes = 50 * 1_048_576
+
 func e2eAttemptArtifactsRootURL(in runURL: URL) -> URL {
     runURL.appendingPathComponent(e2eAttemptArtifactsDirectoryName, isDirectory: true)
 }
@@ -67,7 +70,7 @@ func e2eAttemptInfrastructureFailureDetail(at attemptURL: URL) -> String? {
 private func e2eAttemptJSON(at attemptURL: URL) -> [String: Any]? {
     let url = attemptURL.appendingPathComponent("attempt.json")
     guard FileManager.default.fileExists(atPath: url.path),
-        let data = try? Data(contentsOf: url),
+        let data = e2eReadDataIfSmall(at: url, maxBytes: e2eAttemptJSONMaxBytes),
         let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
     else {
         return nil
@@ -78,7 +81,10 @@ private func e2eAttemptJSON(at attemptURL: URL) -> [String: Any]? {
 private func e2eAttemptTimeoutDetail(at attemptURL: URL) -> String? {
     let url = attemptURL.appendingPathComponent("timeout.json")
     guard FileManager.default.fileExists(atPath: url.path) else { return nil }
-    if let data = try? Data(contentsOf: url),
+    if let size = e2eFileSize(url), size > e2eAttemptJSONMaxBytes {
+        return "timeout.json is too large to inspect (\(size) bytes)"
+    }
+    if let data = e2eReadDataIfSmall(at: url, maxBytes: e2eAttemptJSONMaxBytes),
         let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
         let message = object["message"] as? String,
         !message.isEmpty
@@ -90,7 +96,10 @@ private func e2eAttemptTimeoutDetail(at attemptURL: URL) -> String? {
 
 private func e2eAttemptXUnitProblem(at attemptURL: URL) -> String? {
     guard let url = e2eAttemptXUnitURL(at: attemptURL) else { return nil }
-    guard let data = try? Data(contentsOf: url) else {
+    if let size = e2eFileSize(url), size > e2eAttemptXUnitMaxBytes {
+        return "\(url.lastPathComponent) is too large to validate (\(size) bytes)"
+    }
+    guard let data = e2eReadDataIfSmall(at: url, maxBytes: e2eAttemptXUnitMaxBytes) else {
         return "could not read \(url.lastPathComponent)"
     }
     guard !data.isEmpty else {
@@ -103,4 +112,13 @@ private func e2eAttemptXUnitProblem(at attemptURL: URL) -> String? {
     }
 
     return "\(url.lastPathComponent) is truncated or not parseable"
+}
+
+private func e2eReadDataIfSmall(at url: URL, maxBytes: Int) -> Data? {
+    guard let size = e2eFileSize(url), size <= maxBytes else { return nil }
+    return try? Data(contentsOf: url)
+}
+
+private func e2eFileSize(_ url: URL) -> Int? {
+    (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? nil
 }

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/E2ERunLayout.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+#if canImport(FoundationXML)
+    import FoundationXML
+#endif
+
 let e2eAttemptArtifactsDirectoryName = "attempts"
 let e2eObservationsDirectoryName = "observations"
 let e2eSourceArtifactFileName = "source.md"
@@ -20,6 +24,47 @@ func e2eAttemptArtifactsURL(in runURL: URL, targetName: String, attempt: String)
 }
 
 func e2eAttemptExitStatus(at attemptURL: URL) -> Int? {
+    guard let object = e2eAttemptJSON(at: attemptURL) else { return nil }
+    return object["exitStatus"] as? Int
+}
+
+func e2eAttemptXUnitURL(at attemptURL: URL) -> URL? {
+    let normalizedURL = attemptURL.appendingPathComponent("test-results.xml")
+    if FileManager.default.fileExists(atPath: normalizedURL.path) {
+        return normalizedURL
+    }
+
+    let swiftTestingURL = attemptURL.appendingPathComponent("test-results-swift-testing.xml")
+    if FileManager.default.fileExists(atPath: swiftTestingURL.path) {
+        return swiftTestingURL
+    }
+
+    return nil
+}
+
+func e2eAttemptInfrastructureFailureDetail(at attemptURL: URL) -> String? {
+    if let timeout = e2eAttemptTimeoutDetail(at: attemptURL) {
+        return timeout
+    }
+
+    let xunitProblem = e2eAttemptXUnitProblem(at: attemptURL)
+    if let exitStatus = e2eAttemptExitStatus(at: attemptURL), exitStatus != 0 {
+        if let xunitProblem {
+            return "attempt exited with status \(exitStatus) and produced unusable xUnit output: \(xunitProblem)"
+        }
+        if e2eAttemptXUnitURL(at: attemptURL) == nil {
+            return "attempt exited with status \(exitStatus) before producing test-results.xml"
+        }
+    }
+
+    if let xunitProblem {
+        return "attempt produced unusable xUnit output: \(xunitProblem)"
+    }
+
+    return nil
+}
+
+private func e2eAttemptJSON(at attemptURL: URL) -> [String: Any]? {
     let url = attemptURL.appendingPathComponent("attempt.json")
     guard FileManager.default.fileExists(atPath: url.path),
         let data = try? Data(contentsOf: url),
@@ -27,5 +72,35 @@ func e2eAttemptExitStatus(at attemptURL: URL) -> Int? {
     else {
         return nil
     }
-    return object["exitStatus"] as? Int
+    return object
+}
+
+private func e2eAttemptTimeoutDetail(at attemptURL: URL) -> String? {
+    let url = attemptURL.appendingPathComponent("timeout.json")
+    guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+    if let data = try? Data(contentsOf: url),
+        let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let message = object["message"] as? String,
+        !message.isEmpty
+    {
+        return message
+    }
+    return "Swift E2E attempt timed out"
+}
+
+private func e2eAttemptXUnitProblem(at attemptURL: URL) -> String? {
+    guard let url = e2eAttemptXUnitURL(at: attemptURL) else { return nil }
+    guard let data = try? Data(contentsOf: url) else {
+        return "could not read \(url.lastPathComponent)"
+    }
+    guard !data.isEmpty else {
+        return "\(url.lastPathComponent) is empty"
+    }
+
+    let parser = XMLParser(data: data)
+    if parser.parse() {
+        return nil
+    }
+
+    return "\(url.lastPathComponent) is truncated or not parseable"
 }

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReportCommand.swift
@@ -534,6 +534,9 @@ private func loadRunTestResults(
                         targetName: targetName,
                         attempt: attemptName
                     )
+                    if e2eAttemptInfrastructureFailureDetail(at: attemptArtifactsURL) != nil {
+                        continue
+                    }
                     let metadata = try loadE2ETestMetadata(in: attemptURL)
                     let identityKey = metadata.identityKey
                     let status = try runObservationStatus(
@@ -601,8 +604,7 @@ private func runObservationStatus(
     metadata: E2ETestMetadata,
     attemptURL: URL
 ) throws -> ReportTestStatus {
-    let resultURL = attemptURL.appendingPathComponent("test-results.xml")
-    guard FileManager.default.fileExists(atPath: resultURL.path) else {
+    guard let resultURL = e2eAttemptXUnitURL(at: attemptURL) else {
         return .unknown
     }
 
@@ -1098,7 +1100,9 @@ private func buildTargetOverview(
         let observedAttempts = observedAttemptsByTarget[target, default: []]
         for attemptURL in attemptURLs
         where !observedAttempts.contains(attemptURL.lastPathComponent) {
-            guard let exitStatus = e2eAttemptExitStatus(at: attemptURL), exitStatus != 0 else {
+            let infrastructureFailure = e2eAttemptInfrastructureFailureDetail(at: attemptURL)
+            let exitStatus = e2eAttemptExitStatus(at: attemptURL)
+            guard infrastructureFailure != nil || (exitStatus != nil && exitStatus != 0) else {
                 continue
             }
             var row = rowsByTarget[target] ?? ReportTargetOverviewAccumulator()

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/RunOverview.swift
@@ -192,6 +192,9 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
                         targetName: targetName,
                         attempt: attemptName
                     )
+                    if e2eAttemptInfrastructureFailureDetail(at: attemptArtifactsURL) != nil {
+                        continue
+                    }
                     let result = try overviewObservationResult(
                         observationURL: attemptURL,
                         attemptArtifactsURL: attemptArtifactsURL
@@ -215,6 +218,7 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
                 }
 
                 attempts.sort { $0.attempt < $1.attempt }
+                guard !attempts.isEmpty else { continue }
                 let outcome = overviewOutcome(for: attempts.map(\.status))
                 hasTargetOutcome = true
 
@@ -268,9 +272,12 @@ private func makeRunOverview(in runURL: URL) throws -> E2ERunOverview {
         let observedAttempts = observedAttemptsByTarget[targetName, default: []]
         for attemptURL in try overviewDirectoryChildren(of: targetURL) {
             let attemptName = attemptURL.lastPathComponent
-            guard !observedAttempts.contains(attemptName),
-                let exitStatus = e2eAttemptExitStatus(at: attemptURL), exitStatus != 0
-            else {
+            guard !observedAttempts.contains(attemptName) else {
+                continue
+            }
+            let infrastructureFailure = e2eAttemptInfrastructureFailureDetail(at: attemptURL)
+            let exitStatus = e2eAttemptExitStatus(at: attemptURL)
+            guard infrastructureFailure != nil || (exitStatus != nil && exitStatus != 0) else {
                 continue
             }
 
@@ -327,8 +334,7 @@ private func overviewObservationResult(
     observationURL: URL,
     attemptArtifactsURL: URL
 ) throws -> OverviewObservationResult {
-    let resultURL = attemptArtifactsURL.appendingPathComponent("test-results.xml")
-    guard FileManager.default.fileExists(atPath: resultURL.path) else {
+    guard let resultURL = e2eAttemptXUnitURL(at: attemptArtifactsURL) else {
         return OverviewObservationResult(
             status: .unknown,
             durationSeconds: nil,
@@ -400,7 +406,8 @@ private func overviewArtifacts(
             runURL: runURL
         ),
         testResults: overviewRelativeFilePath(
-            fileName: "test-results.xml",
+            fileName: e2eAttemptXUnitURL(at: attemptArtifactsURL)?.lastPathComponent
+                ?? "test-results.xml",
             attemptURL: attemptArtifactsURL,
             runURL: runURL
         )

--- a/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2ESession.swift
+++ b/swift/WendyE2ETests/Sources/WendyE2ETesting/WendyE2ESession.swift
@@ -430,15 +430,28 @@ public actor WendyE2ESession {
             workingDirectory: nil
         )
         let duration = start.duration(to: .now)
+        let standardOutput = self.machine.os == .macOS
+            ? Self.trimmingLeadingPTYEOFControlEcho(output.standardOutput)
+            : output.standardOutput
         return WendyE2EShellResult(
             machine: self.machine,
             command: command,
             processID: output.processIdentifier,
             status: WendyE2EShellStatus(output.terminationStatus),
             duration: duration,
-            stdout: output.standardOutput,
+            stdout: standardOutput,
             stderr: output.standardError
         )
+    }
+
+    private static func trimmingLeadingPTYEOFControlEcho(_ output: String) -> String {
+        if output.hasPrefix("^D\u{8}\u{8}") {
+            return String(output.dropFirst(4))
+        }
+        if output.hasPrefix("\u{4}") {
+            return String(output.dropFirst())
+        }
+        return output
     }
 
     private func powerPTY(

--- a/swift/WendyE2ETests/Support/Schemas/wendy-e2e-attempt.schema.json
+++ b/swift/WendyE2ETests/Support/Schemas/wendy-e2e-attempt.schema.json
@@ -38,14 +38,13 @@
     "github": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repository", "workflow", "runID", "runAttempt", "job", "actor", "sha"],
+      "required": ["repository", "workflow", "runID", "runAttempt", "job", "sha"],
       "properties": {
         "repository": { "type": ["string", "null"] },
         "workflow": { "type": ["string", "null"] },
         "runID": { "type": ["string", "null"] },
         "runAttempt": { "type": ["string", "null"] },
         "job": { "type": ["string", "null"] },
-        "actor": { "type": ["string", "null"] },
         "sha": { "type": ["string", "null"] }
       }
     },
@@ -61,7 +60,9 @@
         "agentAddress": { "type": ["string", "null"] },
         "agentUser": { "type": ["string", "null"] },
         "transport": { "type": ["string", "null"] },
-        "agentInfo": true
+        "agentInfo": {
+          "description": "Optional agent response captured for preflight debugging; shape may evolve with the agent API."
+        }
       }
     },
     "paths": {

--- a/swift/WendyE2ETests/Support/Schemas/wendy-e2e-attempt.schema.json
+++ b/swift/WendyE2ETests/Support/Schemas/wendy-e2e-attempt.schema.json
@@ -38,13 +38,14 @@
     "github": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repository", "workflow", "runID", "runAttempt", "job", "sha"],
+      "required": ["repository", "workflow", "runID", "runAttempt", "job", "actor", "sha"],
       "properties": {
         "repository": { "type": ["string", "null"] },
         "workflow": { "type": ["string", "null"] },
         "runID": { "type": ["string", "null"] },
         "runAttempt": { "type": ["string", "null"] },
         "job": { "type": ["string", "null"] },
+        "actor": { "type": ["string", "null"] },
         "sha": { "type": ["string", "null"] }
       }
     },

--- a/swift/WendyE2ETests/Support/Schemas/wendy-e2e-attempt.schema.json
+++ b/swift/WendyE2ETests/Support/Schemas/wendy-e2e-attempt.schema.json
@@ -60,7 +60,8 @@
         "agentOS": { "type": ["string", "null"] },
         "agentAddress": { "type": ["string", "null"] },
         "agentUser": { "type": ["string", "null"] },
-        "transport": { "type": ["string", "null"] }
+        "transport": { "type": ["string", "null"] },
+        "agentInfo": true
       }
     },
     "paths": {
@@ -96,7 +97,8 @@
           "type": "string",
           "enum": ["per-test", "per-run", "none"]
         },
-        "parallel": { "type": "boolean" }
+        "parallel": { "type": "boolean" },
+        "managedAgent": { "type": "boolean" }
       }
     },
     "tools": {
@@ -108,6 +110,18 @@
         "go": { "type": ["string", "null"] },
         "wendy": { "type": ["string", "null"] },
         "wendyPath": { "type": ["string", "null"] }
+      }
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "phase", "message"],
+      "properties": {
+        "kind": { "type": "string" },
+        "phase": { "type": "string" },
+        "timeoutSeconds": { "type": "integer", "minimum": 0 },
+        "message": { "type": "string" },
+        "evidence": { "type": "string" }
       }
     }
   }

--- a/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
+++ b/swift/WendyE2ETests/Tests/SwiftE2ETestingCLITests/RunOverviewTests.swift
@@ -130,6 +130,76 @@ struct `run overview` {
     }
 
     @Test
+    func `collapses truncated xunit attempts into one infrastructure failure`() throws {
+        let rootURL = e2eTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let runURL = rootURL.appendingPathComponent("Run", isDirectory: true)
+        let target = "local-ubuntu-24"
+        let attempt = "0001"
+        let firstObservationURL =
+            runURL
+            .appendingPathComponent("observations", isDirectory: true)
+            .appendingPathComponent("wendy-device-info", isDirectory: true)
+            .appendingPathComponent("prints-human-readable-device-information", isDirectory: true)
+            .appendingPathComponent(target, isDirectory: true)
+            .appendingPathComponent(attempt, isDirectory: true)
+        let secondObservationURL =
+            runURL
+            .appendingPathComponent("observations", isDirectory: true)
+            .appendingPathComponent("wendy-device-camera-view", isDirectory: true)
+            .appendingPathComponent("prints-command-help", isDirectory: true)
+            .appendingPathComponent(target, isDirectory: true)
+            .appendingPathComponent(attempt, isDirectory: true)
+        let attemptURL =
+            runURL
+            .appendingPathComponent("attempts", isDirectory: true)
+            .appendingPathComponent(target, isDirectory: true)
+            .appendingPathComponent(attempt, isDirectory: true)
+
+        try FileManager.default.createDirectory(
+            at: firstObservationURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: secondObservationURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(at: attemptURL, withIntermediateDirectories: true)
+        try writeTestMetadata(to: firstObservationURL)
+        try writeTestMetadata(
+            to: secondObservationURL,
+            sourceFilePath: "Tests/WendyE2ETests/WendyDeviceCameraViewTests.swift",
+            sourceFileName: "WendyDeviceCameraViewTests",
+            suiteName: "wendy device camera view",
+            testName: "prints command help"
+        )
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+        """.write(
+            to: attemptURL.appendingPathComponent("test-results-swift-testing.xml"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let overview = try writeRunOverview(in: runURL)
+
+        #expect(overview.summary.tests == 0)
+        #expect(overview.summary.testTargets == 0)
+        #expect(overview.summary.attemptResults == 1)
+        #expect(overview.summary.failed == 1)
+        #expect(overview.summary.unknown == 0)
+        #expect(overview.noteworthy.unknowns.isEmpty)
+
+        let targetOverview = try #require(overview.targets.first)
+        #expect(targetOverview.name == target)
+        #expect(targetOverview.outcome == .failed)
+        #expect(targetOverview.failed == 1)
+        #expect(targetOverview.unknown == 0)
+    }
+
+    @Test
     func `uses test metadata to distinguish duplicate test names`() throws {
         let rootURL = e2eTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: rootURL) }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceInfoTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceInfoTests.swift
@@ -126,7 +126,7 @@ struct `'wendy device info'` {
     /**
      The summary includes the agent version, OS, OS version, CPU architecture, and CLI version. Optional hardware fields appear when the agent reports them.
      */
-    @Test
+    @Test(.timeLimit(.minutes(1)))
     func `prints human-readable device information`() async throws {
         // AI: Review the human-readable output for usefulness, not exact text.
         // It should be clean terminal output with coherent labels, no JSON leak,
@@ -305,7 +305,7 @@ struct `'wendy device info'` {
     /**
      With `--check-updates`, the command compares the connected agent to the selected release channel and reports whether an update is available.
      */
-    @Test
+    @Test(.timeLimit(.minutes(1)))
     func `'--check-updates' reports update status`() async throws {
         // AI: Review the update-check wording for ambiguity. The output should
         // clearly distinguish current device information from update status and


### PR DESCRIPTION
## Summary

- Add a 90-minute SwiftPM test-process timeout for Swift E2E attempts so hosted jobs fail with uploadable artifacts before GitHub cancels the 120-minute job.
- Record timeout metadata (`timeout.json` plus `attempt.json` failure details) and terminate the whole Swift test process group before normal xUnit normalization/sanitization runs.
- Treat timeout/truncated xUnit output as an attempt-level infrastructure failure in aggregation/reporting instead of expanding one killed attempt into every observed test as `UNKNOWN`.
- Bound the PTY-backed `wendy device info` specs and suppress the throwaway managed-E2E shell-completion prompt that was causing those hosted PTY commands to hang after printing valid output.

## Failing run inspection

- Inspected run `28336275319` (`Swift E2E Tests` #627): both hosted local jobs were cancelled at the 120-minute job timeout.
- Downloaded artifacts to `/tmp/wdy-1754-run-28336275319`.
- Ubuntu stopped making progress in/around `wendy device camera view`; macOS stopped in/around `wendy device bluetooth disconnect`.
- Both raw attempt artifacts contained only a 52-byte `test-results-swift-testing.xml` with the XML header/opening `<testsuites>` and no `attempt.json`, so the old aggregation rendered the run as broadly unknown.

## Follow-up CI diagnosis

- A hosted rerun with the new 90-minute process timeout produced explicit timeout artifacts on both local targets instead of being cancelled by GitHub.
- Adding Swift Testing time limits to the two PTY `wendy device info` tests narrowed the deterministic hang to the ambient shell-completion installer prompt appearing after the command output in a throwaway managed-agent HOME.
- The managed-agent auth fixture now pre-dismisses only that completion prompt (`completionPromptDismissed`) so PTY tests remain non-interactive in CI.
- macOS PTY recordings also now strip the harness-only leading EOT echo from `script(1)` output, keeping review artifacts clean.

## Design

- Keep the GitHub job timeout at 120 minutes, but bound the Swift test process to 90 minutes by default (`test_timeout_minutes`, passed through as `WENDY_E2E_TEST_TIMEOUT_SECONDS`).
- On timeout, kill the SwiftPM process group, preserve partial xUnit/logs, write explicit timeout evidence, then let the existing artifact upload path run.
- During aggregation/report rendering, collapse attempts with timeout evidence or unusable/truncated xUnit into a single failed target attempt.
- Harden timeout metadata/reporting by preserving `actor` attribution, escaping GitHub annotation messages, bounding rendered timeout messages, and validating timeout inputs.

## Validation

- `bash -n swift/Scripts/E2ETest.sh swift/Scripts/E2EAnalyze.sh swift/Scripts/E2EReport.sh swift/Scripts/E2EReview.sh swift/Scripts/E2ESanitizeXUnit.sh`
- `python3 -m json.tool swift/WendyE2ETests/Support/Schemas/wendy-e2e-attempt.schema.json >/dev/null`
- `git diff --check`
- `cd swift/WendyE2ETests && swift test --filter SwiftE2ETestingCLITests`
- Re-aggregated the downloaded failing artifacts with the new code; the overview reports two failed target attempts and zero unknowns.
- PR CI on head `a1fe44c4`: Swift E2E `28506661712` passed on `Local: Ubuntu 24`, `Local: macOS 26`, and `Analyze E2E Results`; final overview reports `117` passed attempt-results, `0` failed, `0` unknown, and no generated Swift E2E review issues.

## Limitations / follow-ups

- I did not reproduce the original 120-minute hang locally; the initial timeout work is harness hardening based on CI artifacts, followed by hosted CI diagnosis/fixes for the deterministic PTY prompt hang.
- The 90-minute timeout is attempt-level around `swift test`, not a replacement for targeted Swift Testing per-test limits. The `wendy device info` PTY specs now also have per-test time limits so future prompt regressions fail with focused evidence.

Closes WDY-1754
