### PR TITLE
fix(os install): mount macOS config partition as caller to fix EACCES on SSD targets

### DIFF
--- a/go/internal/cli/commands/mount_msdos_args.go
+++ b/go/internal/cli/commands/mount_msdos_args.go
@@ -1,0 +1,47 @@
+package commands
+
+// This file is intentionally untagged (no _darwin suffix) so the pure
+// argument-construction + validation below is unit-testable on any host,
+// mirroring disklister_dd_args.go. The darwin-only orchestration that consumes
+// it lives in os_provision_darwin.go.
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+)
+
+var validDarwinPartitionPath = regexp.MustCompile(`^/dev/disk[0-9]+s[0-9]+$`)
+
+// darwinMountMsdosArgs builds the argv for `mount_msdos`, mounting the FAT
+// config partition so the calling (non-root) user owns the mounted view.
+//
+// macOS mounts FAT volumes on fixed/SSD-backed media (an NVMe SSD, or an SSD in
+// a USB enclosure — the Jetson Nano nvme target) respecting ownership, which
+// leaves the auto-mount root-owned and makes the non-root writes in
+// writeConfigFiles fail with EACCES. -u/-g remap the synthesized owner to the
+// caller. vfat carries no on-disk ownership, so the device applies its own uid
+// when it boots — this only affects the host-side view. Mirrors the Linux
+// uid=/gid= mount fix in os_provision_linux.go.
+//
+// The result is passed to a privileged `sudo mount_msdos`, so partDev and
+// mountPoint are validated defensively, matching darwinDDArgs.
+func darwinMountMsdosArgs(uid, gid int, partDev, mountPoint string) ([]string, error) {
+	if !validDarwinPartitionPath.MatchString(partDev) {
+		return nil, fmt.Errorf("invalid Darwin partition path %q", partDev)
+	}
+	if uid < 0 || gid < 0 {
+		return nil, fmt.Errorf("invalid uid/gid %d/%d", uid, gid)
+	}
+	if !filepath.IsAbs(mountPoint) {
+		return nil, fmt.Errorf("mount point must be an absolute path, got %q", mountPoint)
+	}
+	return []string{
+		"mount_msdos",
+		"-u", strconv.Itoa(uid),
+		"-g", strconv.Itoa(gid),
+		partDev,
+		mountPoint,
+	}, nil
+}

--- a/go/internal/cli/commands/mount_msdos_args_test.go
+++ b/go/internal/cli/commands/mount_msdos_args_test.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"slices"
+	"strconv"
+	"testing"
+)
+
+// Without -u/-g, mount_msdos synthesizes uid=0 for every file on the FAT
+// config partition, so the subsequent non-root WriteFile calls in
+// writeConfigFiles fail with EACCES (the reported "open /Volumes/config/
+// wendy-agent: permission denied"). This is the macOS analog of the Linux
+// uid=/gid= fix. Lock in that the caller's ownership is always mapped.
+func TestDarwinMountMsdosArgsMapsOwnershipToCaller(t *testing.T) {
+	const uid, gid = 501, 20
+	args, err := darwinMountMsdosArgs(uid, gid, "/dev/disk4s2", "/tmp/wendyos-config-xyz")
+	if err != nil {
+		t.Fatalf("darwinMountMsdosArgs() error = %v", err)
+	}
+
+	if len(args) == 0 || args[0] != "mount_msdos" {
+		t.Fatalf("darwinMountMsdosArgs() = %v; want mount_msdos as argv[0]", args)
+	}
+
+	if i := slices.Index(args, "-u"); i < 0 || i+1 >= len(args) || args[i+1] != strconv.Itoa(uid) {
+		t.Fatalf("darwinMountMsdosArgs() = %v; -u must be followed by uid %d", args, uid)
+	}
+	if i := slices.Index(args, "-g"); i < 0 || i+1 >= len(args) || args[i+1] != strconv.Itoa(gid) {
+		t.Fatalf("darwinMountMsdosArgs() = %v; -g must be followed by gid %d", args, gid)
+	}
+
+	if !slices.Contains(args, "/dev/disk4s2") {
+		t.Fatalf("darwinMountMsdosArgs() = %v; missing partition device", args)
+	}
+	if !slices.Contains(args, "/tmp/wendyos-config-xyz") {
+		t.Fatalf("darwinMountMsdosArgs() = %v; missing mount point", args)
+	}
+}
+
+// The args are handed to a privileged `sudo mount_msdos`. Reject anything that
+// is not a real partition node or absolute mount point, matching the defensive
+// validation darwinDDArgs applies to the raw disk path.
+func TestDarwinMountMsdosArgsRejectsInvalidInput(t *testing.T) {
+	for _, partDev := range []string{
+		"",
+		"/dev/disk4",    // whole disk, not a partition slice
+		"/dev/rdisk4s2", // raw char device is not used for mounting
+		"/dev/disk4s2 seek=0",
+		"/dev/disk4s2;rm -rf /",
+		"../../etc/passwd",
+		"/tmp/wendyos.img",
+	} {
+		t.Run("partDev "+partDev, func(t *testing.T) {
+			if _, err := darwinMountMsdosArgs(501, 20, partDev, "/tmp/m"); err == nil {
+				t.Fatalf("darwinMountMsdosArgs(%q) error = nil; want validation error", partDev)
+			}
+		})
+	}
+
+	if _, err := darwinMountMsdosArgs(501, 20, "/dev/disk4s2", "relative/path"); err == nil {
+		t.Fatalf("darwinMountMsdosArgs(relative mountPoint) error = nil; want validation error")
+	}
+	if _, err := darwinMountMsdosArgs(-1, 20, "/dev/disk4s2", "/tmp/m"); err == nil {
+		t.Fatalf("darwinMountMsdosArgs(negative uid) error = nil; want validation error")
+	}
+}

--- a/go/internal/cli/commands/os_provision_darwin.go
+++ b/go/internal/cli/commands/os_provision_darwin.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -24,11 +25,11 @@ func writeConfigPartition(d drive, agentBinary []byte, creds []wendyconf.WifiCre
 		return fmt.Errorf("locating config partition on %s: %w", d.DevicePath, err)
 	}
 
-	mountPoint, err := mountConfigPartition(partDev)
+	mountPoint, unmount, err := mountConfigPartition(partDev)
 	if err != nil {
 		return fmt.Errorf("mounting config partition %s: %w", partDev, err)
 	}
-	defer exec.Command("diskutil", "unmount", partDev).Run() //nolint:errcheck
+	defer unmount()
 
 	return writeConfigFiles(mountPoint, agentBinary, creds, deviceName, provisioningJSON)
 }
@@ -60,31 +61,42 @@ func findConfigPartition(diskDev string) (string, error) {
 	return "", fmt.Errorf("config partition not found on %s (is the image fully written?)", diskDev)
 }
 
-// mountConfigPartition ensures partDev is mounted and returns its mount point.
-// It calls `diskutil mount` (a no-op if already mounted) then queries
-// `diskutil info` for the authoritative mount point, avoiding brittle output
-// parsing of the mount command itself.
-func mountConfigPartition(partDev string) (string, error) {
-	// Attempt to mount; ignore errors — the partition may already be auto-mounted
-	// by macOS (FAT32 volumes are mounted automatically when they appear).
-	exec.Command("diskutil", "mount", partDev).Run() //nolint:errcheck
+// mountConfigPartition mounts the FAT32 config partition at a private temp
+// directory owned by the calling user and returns the mount point plus an
+// unmount/cleanup func to defer.
+//
+// macOS auto-mounts FAT volumes when the partition table is rescanned (by the
+// `diskutil list` in findConfigPartition). On removable SD cards that auto-mount
+// ignores ownership and is writable, but on fixed/SSD-backed media (an NVMe SSD,
+// or an SSD in a USB enclosure — the Jetson Nano nvme target) macOS respects
+// ownership and mounts the volume root-owned, so the non-root WriteFile calls in
+// writeConfigFiles fail with EACCES. We drop any such auto-mount, then re-mount
+// via `sudo mount_msdos -u/-g` so the caller owns the files. vfat has no on-disk
+// ownership; the device applies its own uid at boot, so this only affects the
+// host-side view. Mirrors the Linux uid=/gid= fix in os_provision_linux.go.
+func mountConfigPartition(partDev string) (string, func(), error) {
+	// Drop any auto-mount (possibly root-owned) so mount_msdos can take the device.
+	exec.Command("diskutil", "unmount", partDev).Run() //nolint:errcheck
 
-	out, err := exec.Command("diskutil", "info", partDev).Output()
+	tmpDir, err := os.MkdirTemp("", "wendyos-config-*")
 	if err != nil {
-		return "", fmt.Errorf("diskutil info %s: %w", partDev, err)
+		return "", nil, fmt.Errorf("creating temp mount dir: %w", err)
 	}
 
-	// Parse "   Mount Point:               /Volumes/config"
-	for _, line := range strings.Split(string(out), "\n") {
-		if !strings.Contains(line, "Mount Point:") {
-			continue
-		}
-		parts := strings.SplitN(line, ":", 2)
-		if len(parts) == 2 {
-			if mp := strings.TrimSpace(parts[1]); mp != "" {
-				return mp, nil
-			}
-		}
+	args, err := darwinMountMsdosArgs(os.Getuid(), os.Getgid(), partDev, tmpDir)
+	if err != nil {
+		os.RemoveAll(tmpDir) //nolint:errcheck
+		return "", nil, err
 	}
-	return "", fmt.Errorf("config partition %s is not mounted (diskutil mount may have failed)", partDev)
+
+	if out, err := exec.Command("sudo", args...).CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir) //nolint:errcheck
+		return "", nil, fmt.Errorf("mount_msdos %s: %s: %w", partDev, strings.TrimSpace(string(out)), err)
+	}
+
+	unmount := func() {
+		exec.Command("sudo", "umount", tmpDir).Run() //nolint:errcheck
+		os.RemoveAll(tmpDir)                         //nolint:errcheck
+	}
+	return tmpDir, unmount, nil
 }


### PR DESCRIPTION
## Problem

`wendy os install` warned on macOS when flashing the 0.16.0 Jetson Nano image to an NVMe/SSD target:

```
Warning: could not apply provisioning data — --wifi / --device-name / --pre-enroll
were requested but not written: writing wendy-agent to config partition:
open /Volumes/config/wendy-agent: permission denied
```

The image install still "succeeds" but the agent binary, `wendy.conf`, and `provisioning.json` are silently dropped.

## Root cause

The main install process runs **non-root** (only `dd`/`bmap-write`/`unmountDisk` shell out to `sudo`), and `writeConfigFiles` writes the FAT32 config partition with plain `os.WriteFile`. macOS *ignores* ownership on removable SD cards (so the existing code worked there) but *respects* it on fixed/SSD-backed media — an NVMe SSD, or an SSD in a USB enclosure, i.e. the Jetson Nano `nvme` target — where `diskarbitrationd` auto-mounts the FAT volume **root-owned**, so the non-root write gets EACCES.

0.16.0's NVMe-in-USB-enclosure detection (#1254) surfaced this by routing macOS users to SSD targets for the first time. The **identical bug was already fixed on Linux** in `3829852a` with a `uid=/gid=` vfat mount — darwin never got the equivalent.

## Fix

`mountConfigPartition` (darwin) now drops any root-owned auto-mount (`diskutil unmount`) and re-mounts via `sudo mount_msdos -u/-g` to a caller-owned temp dir, returning an unmount/cleanup closure. `vfat` has no on-disk ownership, so the device applies its own uid at boot — this only affects the host-side view. This mirrors the Linux precedent.

The pure, validated arg builder `darwinMountMsdosArgs` lives in an **untagged** file (`mount_msdos_args.go`, not `*_darwin.go` which would auto-constrain the build) so it's unit-testable on any host, mirroring `darwinDDArgs`/`disklister_dd_args.go`.

## Testing

- New unit tests (`mount_msdos_args_test.go`): assert ownership is always remapped to the caller (the exact regression), plus injection/validation rejection of bad device paths.
- `go build ./...`, `go vet`, full `go test ./internal/cli/commands/`, and `gofmt` all green.
- **Verified on-device** on macOS against an SSD/NVMe target: config partition is populated, no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)