### PR TITLE
refactor(cli): rename `device logs --os` to hidden `device os-logs`

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/logs.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/logs.md
@@ -4,10 +4,4 @@ With `--app`, you can filter on a per-app basis. You an also set a minimum log l
 
 If you provide `--json`, the output will be JSONL, one line per log statement.
 
-## Kernel log (`--os`)
-
-`wendy device logs --os` streams the device's kernel ring buffer (`dmesg`) for inspecting kernel/boot/hardware messages. By default it replays the buffered records and then keeps following new ones until you interrupt with ctrl-c (like `dmesg -w`). Pass `--follow=false` (`-f=false`) for a one-shot snapshot that prints the current buffer and exits (like `dmesg`).
-
-The output is raw and unredacted, so `--os` cannot be combined with the container-log filters (`--app`, `--service`, `--level`, `--min-severity`, `--tail`). The `--follow` flag applies only to `--os`; container logs always stream live.
-
-Each record is printed in classic dmesg style, `[ seconds.microseconds] message`. With `--json`, each record is emitted as one JSON object (`timestamp_us`, `level`, `message`). Available on Linux devices only.
+To inspect the device's kernel ring buffer (`dmesg`) instead of container/agent logs, use [`wendy device os-logs`](./os-logs).

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/meta.json
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/meta.json
@@ -2,6 +2,7 @@
   "pages": [
     "apps",
     "logs",
+    "os-logs",
     "dashboard",
     "top",
     "info",

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/os-logs.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/os-logs.md
@@ -1,0 +1,5 @@
+`wendy device os-logs` streams the device's kernel ring buffer (`dmesg`) for inspecting kernel/boot/hardware messages. By default it replays the buffered records and then keeps following new ones until you interrupt with ctrl-c (like `dmesg -w`). Pass `--follow=false` (`-f=false`) for a one-shot snapshot that prints the current buffer and exits (like `dmesg`).
+
+The output is raw and unredacted. This is the kernel log, distinct from the container/agent logs shown by [`wendy device logs`](./logs) and not filterable by app or service.
+
+Each record is printed in classic dmesg style, `[ seconds.microseconds] message`. With `--json`, each record is emitted as one JSON object (`timestamp_us`, `level`, `message`). Available on Linux devices only.

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -62,6 +62,7 @@ func newDeviceCmd() *cobra.Command {
 	addToGroup("common",
 		newAppsCmd(),
 		newDeviceLogsCmd(),
+		newDeviceOSLogsCmd(),
 		newROS2Cmd(),
 		newDeviceDashboardCmd(),
 		newTopCmd(),
@@ -929,23 +930,6 @@ func parseSeverityLevel(name string) int32 {
 	}
 }
 
-// kernelLogConflictFlags are the container-log filters that cannot be combined
-// with --os, which dumps the kernel ring buffer instead of container logs.
-var kernelLogConflictFlags = []string{"app", "service", "min-severity", "level", "tail"}
-
-// conflictingOSFlags returns, in declaration order, the kernelLogConflictFlags
-// that the caller reports as set. changed reports whether a flag was set on the
-// command line (typically cmd.Flags().Changed).
-func conflictingOSFlags(changed func(name string) bool) []string {
-	var out []string
-	for _, f := range kernelLogConflictFlags {
-		if changed(f) {
-			out = append(out, f)
-		}
-	}
-	return out
-}
-
 // formatKernelLogRecord renders a kernel record in classic dmesg style:
 // "[ seconds.microseconds] message", with seconds right-aligned to 5 columns
 // and microseconds zero-padded to 6 digits.
@@ -962,8 +946,6 @@ func newDeviceLogsCmd() *cobra.Command {
 	var minSeverity int32
 	var level string
 	var tail int32
-	var osDump bool
-	var follow bool
 
 	cmd := &cobra.Command{
 		Use:   "logs [app]",
@@ -971,23 +953,11 @@ func newDeviceLogsCmd() *cobra.Command {
 		Long: "Stream logs from containers on the device.\n\n" +
 			"Pass an app name (positionally or with --app) to see only that app's\n" +
 			"logs. Without a filter, logs from every container and the agent itself\n" +
-			"are streamed, which can include agent lifecycle messages.",
+			"are streamed, which can include agent lifecycle messages.\n\n" +
+			"To inspect the device kernel ring buffer (dmesg), use `wendy device os-logs`.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-
-			if osDump {
-				if conflicts := conflictingOSFlags(cmd.Flags().Changed); len(conflicts) > 0 {
-					return fmt.Errorf("--os cannot be combined with container log filters: --%s", strings.Join(conflicts, ", --"))
-				}
-				return runKernelLogDump(ctx, follow)
-			}
-			// --follow only governs the kernel ring buffer dump; container logs
-			// always stream live. Reject an explicit --follow without --os so the
-			// flag never silently does nothing.
-			if cmd.Flags().Changed("follow") {
-				return errors.New("--follow only applies to --os (the kernel ring buffer dump)")
-			}
 
 			// Accept the app name positionally (e.g. `wendy device logs IronPaws`)
 			// as well as via --app. Without this the positional argument was
@@ -1111,8 +1081,40 @@ func newDeviceLogsCmd() *cobra.Command {
 	cmd.Flags().Int32Var(&minSeverity, "min-severity", 0, "Minimum log severity number")
 	cmd.Flags().StringVar(&level, "level", "", "Minimum log level (trace, debug, info, warn, error, fatal)")
 	cmd.Flags().Int32Var(&tail, "tail", 0, "Replay the last N log batches before streaming live (0 = live only)")
-	cmd.Flags().BoolVar(&osDump, "os", false, "Dump the device kernel ring buffer (dmesg) instead of container logs")
-	cmd.Flags().BoolVarP(&follow, "follow", "f", true, "With --os, keep following new kernel records after the buffer; use --follow=false for a one-shot dump")
+
+	return cmd
+}
+
+// newDeviceOSLogsCmd dumps the device kernel ring buffer (dmesg). It is a sibling
+// of `device logs` (container/agent logs): the kernel buffer is a different data
+// flow — raw, unredacted, and not filterable by app/service — so it lives in its
+// own command rather than as a flag on `logs`.
+func newDeviceOSLogsCmd() *cobra.Command {
+	var follow bool
+
+	cmd := &cobra.Command{
+		Use: "os-logs",
+		// Hidden: a low-level kernel diagnostic for operators who know to reach
+		// for it, kept out of the main `device` listing to avoid cluttering the
+		// everyday command surface. It still works and is documented.
+		Hidden: true,
+		Short:  "Dump the device kernel ring buffer (dmesg)",
+		Long: "Dump the device's kernel ring buffer (dmesg) for inspecting kernel,\n" +
+			"boot, and hardware messages.\n\n" +
+			"By default it replays the buffered records and then keeps following new\n" +
+			"ones until you interrupt with ctrl-c (like `dmesg -w`). Pass --follow=false\n" +
+			"(-f=false) for a one-shot snapshot that prints the current buffer and exits\n" +
+			"(like `dmesg`).\n\n" +
+			"Output is raw and unredacted. Each record is printed in classic dmesg style,\n" +
+			"`[ seconds.microseconds] message`; with --json each record is emitted as one\n" +
+			"JSON object (timestamp_us, level, message). Available on Linux devices only.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runKernelLogDump(cmd.Context(), follow)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&follow, "follow", "f", true, "Keep following new kernel records after replaying the buffer; use --follow=false for a one-shot dump")
 
 	return cmd
 }

--- a/go/internal/cli/commands/device_test.go
+++ b/go/internal/cli/commands/device_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -39,29 +38,10 @@ func TestFormatKernelLogRecord(t *testing.T) {
 	}
 }
 
-func TestConflictingOSFlags(t *testing.T) {
-	changed := map[string]bool{"app": true, "tail": true, "service": false}
-	got := conflictingOSFlags(func(name string) bool { return changed[name] })
-	// Order follows kernelLogConflictFlags declaration order.
-	want := []string{"app", "tail"}
-	if len(got) != len(want) {
-		t.Fatalf("conflictingOSFlags() = %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("conflictingOSFlags() = %v, want %v", got, want)
-		}
-	}
-
-	if none := conflictingOSFlags(func(string) bool { return false }); len(none) != 0 {
-		t.Errorf("expected no conflicts when nothing changed, got %v", none)
-	}
-}
-
-func TestDeviceLogsFollowFlag(t *testing.T) {
-	f := newDeviceLogsCmd().Flags().Lookup("follow")
+func TestDeviceOSLogsFollowFlag(t *testing.T) {
+	f := newDeviceOSLogsCmd().Flags().Lookup("follow")
 	if f == nil {
-		t.Fatal("expected --follow flag on device logs command")
+		t.Fatal("expected --follow flag on device os-logs command")
 	}
 	// Follow defaults to true: the kernel dump tails unless explicitly disabled.
 	if f.DefValue != "true" {
@@ -70,16 +50,16 @@ func TestDeviceLogsFollowFlag(t *testing.T) {
 	if f.Shorthand != "f" {
 		t.Errorf("--follow shorthand = %q, want \"f\"", f.Shorthand)
 	}
+}
 
-	// --follow only governs --os; using it for container logs must error rather
-	// than silently do nothing.
-	cmd := newDeviceLogsCmd()
-	cmd.SetArgs([]string{"--follow=false"})
-	cmd.SilenceUsage = true
-	cmd.SilenceErrors = true
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "--follow only applies to --os") {
-		t.Fatalf("expected --follow-without-os error, got %v", err)
+// The kernel ring buffer is now its own `os-logs` command, not a flag on `logs`.
+// Guard against the flags drifting back onto `logs`.
+func TestDeviceLogsHasNoKernelFlags(t *testing.T) {
+	flags := newDeviceLogsCmd().Flags()
+	for _, name := range []string{"os", "follow"} {
+		if flags.Lookup(name) != nil {
+			t.Errorf("device logs should not have --%s flag; use `device os-logs`", name)
+		}
 	}
 }
 

--- a/specs/superpowers/2026-06-24-device-logs-os-dmesg-design.md
+++ b/specs/superpowers/2026-06-24-device-logs-os-dmesg-design.md
@@ -3,6 +3,12 @@
 **Date:** 2026-06-24
 **Status:** Approved design
 
+> **Update (2026-06-30, rename):** the `--os` flag on `device logs` was
+> promoted to its own sibling command, `wendy device os-logs` (same behaviour,
+> same `--follow`/`--json` semantics). References to `wendy device logs --os`
+> below describe the original design; the kernel-dump path now lives in
+> `newDeviceOSLogsCmd`.
+
 > **Update (2026-06-30):** `--os` now follows by default. The
 > `DumpKernelLogRequest` carries an `optional bool follow` (true when unset):
 > with follow the agent opens `/dev/kmsg` blocking, replays the buffer, then


### PR DESCRIPTION
## What

Promotes the kernel ring buffer dump from a `--os` flag on `wendy device logs` to its own subcommand, `wendy device os-logs`, and marks it **hidden** so it stays off the everyday `device` command listing.

```
# before
wendy device logs --os [--follow=false]

# after
wendy device os-logs [--follow=false]   # hidden from `device --help`, still runs
```

## Why

The kernel buffer is a different data flow from container/agent logs: raw, unredacted, and not filterable by app/service. Sharing a flag set with `logs` forced mutual-exclusion plumbing (`--os` rejects the container-log filters; `--follow` only applied with `--os`). Splitting it into its own command removes that coupling. It's hidden because it's a low-level operator diagnostic, not an everyday command — it still works and is documented.

## Changes

- **`device.go`**: add `newDeviceOSLogsCmd` (`Hidden`, `NoArgs`) carrying `--follow`/`-f`; reuse `runKernelLogDump`/`formatKernelLogRecord` unchanged. Drop the `--os`/`--follow` flags and the now-moot `kernelLogConflictFlags`/`conflictingOSFlags` helpers from `newDeviceLogsCmd`.
- **Tests**: replace the `--os` flag + conflict tests with os-logs follow-flag coverage and a guard that `logs` no longer carries the kernel flags.
- **Docs**: new `device/os-logs.md`; trim the kernel section out of `logs.md` (now cross-links); add `os-logs` to the device nav; note the rename in the design spec.

## Compatibility

`wendy device logs --os` now errors with unknown-flag rather than being aliased. The feature only landed in #1164 (same day), so no released surface depended on the old form.

## Verification

`go build ./...`, `go vet`, and the `internal/cli/commands` test suite all pass. Confirmed via `--help` that `os-logs` is absent from the `device` listing but still invokable, and that `logs` no longer exposes `--os`/`--follow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)