### PR TITLE
feat(cli): always prefer Apple Container over Docker when available

### DIFF
--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -564,7 +564,11 @@ func buildDockerProjectWithBuilder(ctx context.Context, builder, dir, imageName,
 		return err
 	}
 	if !imageBuilderWasExplicit(builder) && shouldAutoAttemptAppleContainerBuilder() {
-		if err := checkAppleContainerBuilder(ctx); err == nil {
+		// Prefer Apple Container whenever its CLI is available: start the system
+		// if it isn't running yet rather than silently falling back to Docker.
+		// We only fall back when the CLI is unavailable, the user declines to
+		// start it, or the build itself fails.
+		if err := ensureAppleContainerSystem(ctx, false); err == nil {
 			if err := runAppleContainerBuildWithProgress(ctx, dir, imageName, platform, dockerfile); err == nil {
 				return nil
 			} else {

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1583,9 +1583,13 @@ func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnec
 		return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, builder, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput)
 	}
 	if shouldAutoAttemptAppleContainerBuilder() {
+		// Prefer Apple Container whenever its CLI is available: start the system
+		// if it isn't running yet rather than silently falling back to Docker.
 		// Apple Container builds don't use buildx, so the local-cache key never
 		// applies; only the Docker fallback below consumes it.
-		if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, "", streamOutput, logOutput); err == nil {
+		if err := ensureAppleContainerSystem(ctx, false); err != nil {
+			logAppleContainerFallback(logOutput, err)
+		} else if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, "", streamOutput, logOutput); err == nil {
 			return nil
 		} else {
 			logAppleContainerFallback(logOutput, err)
@@ -1719,9 +1723,12 @@ var (
 )
 
 // ensureAppleContainerSystem verifies the Apple Container system is running and
-// offers to start it when it is not. It is called only on explicit
-// `--builder apple-container` paths; the silent auto-attempt paths keep using
-// checkAppleContainerBuilder so they fall back to Docker without side effects.
+// offers to start it when it is not. It is called both on explicit
+// `--builder apple-container` paths and on the no-builder auto-attempt paths
+// (Apple silicon), which now prefer Apple Container whenever its CLI is
+// available and start the system on demand rather than silently falling back to
+// Docker. Callers fall back to Docker when this returns an error (CLI
+// unavailable, user declined, or the system failed to start).
 //
 // When the system is not running and we are attached to an interactive terminal,
 // the user is prompted before starting. assumeYes (from --yes, and implicitly
@@ -1772,11 +1779,10 @@ func ensureAppleContainerSystem(ctx context.Context, assumeYes bool) error {
 }
 
 // ensureAppleContainerSystemForBuilder runs ensureAppleContainerSystem only when
-// the builder was explicitly set to apple-container. The silent auto-attempt
-// selection (no --builder, on Apple silicon) is intentionally left to
-// checkAppleContainerBuilder so it can fall back to Docker without prompting or
-// starting the system. Safe to call from any build path: it no-ops unless the
-// builder is explicit apple-container.
+// the builder was explicitly set to apple-container. The no-builder auto-attempt
+// selection (no --builder, on Apple silicon) calls ensureAppleContainerSystem
+// directly at its decision point, so this helper is a no-op for it. Safe to call
+// from any build path: it no-ops unless the builder is explicit apple-container.
 func ensureAppleContainerSystemForBuilder(ctx context.Context, builder string, assumeYes bool) error {
 	if !imageBuilderWasExplicit(builder) {
 		return nil

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -320,6 +320,44 @@ func TestBuildDockerProjectWithBuilderFallsBackToDockerWhenAutoAppleContainerFai
 	}
 }
 
+// When Apple Container's CLI is installed but its system is not running, the
+// no-builder auto path now starts the system and uses Apple Container instead
+// of silently falling back to Docker.
+func TestBuildDockerProjectWithBuilderStartsAppleContainerWhenStoppedOnAppleSilicon(t *testing.T) {
+	logFile := setupAppleContainerEnsureSeams(t)
+	isInteractiveTerminalFn = func() bool { return false }
+	promptYesNoFn = func(string) bool { t.Fatal("must not prompt in non-interactive auto path"); return false }
+	// System is down until "container system start" creates the readiness file.
+	t.Setenv("IMAGE_BUILDER_STATUS_READY_FILE", filepath.Join(t.TempDir(), "ready"))
+
+	oldDockerBuild := buildDockerProjectWithDocker
+	t.Cleanup(func() { buildDockerProjectWithDocker = oldDockerBuild })
+	buildDockerProjectWithDocker = func(dir, imageName, platform, dockerfile string) error {
+		t.Fatal("Docker fallback should not run when Apple Container can be started")
+		return nil
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Containerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := buildDockerProjectWithBuilder(context.Background(), "", dir, "test-app:latest", "linux/arm64", "Containerfile"); err != nil {
+		t.Fatalf("buildDockerProjectWithBuilder: %v", err)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "container\x00system\x00start\x00--timeout\x0060") {
+		t.Fatalf("expected Apple Container system to be started:\n%s", data)
+	}
+	if !strings.Contains(string(data), "container\x00build\x00") {
+		t.Fatalf("expected Apple Container build to run:\n%s", data)
+	}
+}
+
 func fakeImageBuilderCommandContext(logFile string) func(context.Context, string, ...string) *exec.Cmd {
 	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		cmdArgs := []string{"-test.run=TestImageBuilderHelperProcess", "--", name}


### PR DESCRIPTION
## Summary

On Apple silicon, the no-`--builder` auto-selection already preferred Apple Container — but **only when its system was already running**. If the `container` CLI was installed but the system was stopped, the CLI would silently fall back to Docker (`logAppleContainerFallback`).

This change makes the CLI **always prefer Apple Container whenever its CLI is available** (it's lighter-weight than Docker/OrbStack). The auto-selection paths now call `ensureAppleContainerSystem` to start the system on demand instead of dropping to Docker.

Docker is used only when:
- the `container` CLI is not available (not installed / not Apple silicon),
- the user declines the start prompt, or
- the Apple Container build itself fails.

## Behavior

- **Interactive TTY:** prompts `Apple Container system is not running. Start it now? [Y/n]` (defaults to yes) — declining falls back to Docker.
- **Non-interactive / CI:** auto-starts the system (no prompt), waits up to 60s for readiness.

This matches the existing explicit `--builder apple-container` policy, so the auto and explicit paths are now consistent.

## Scope

Both auto-selection paths are updated:
- `buildDockerProjectWithBuilder` — local `wendy build` of a Dockerfile/Containerfile project
- `buildAndPushImageForAgent` — `wendy run` build-and-push to a device

Explicit `--builder docker` / `--builder apple-container` behavior is unchanged.

## Tests

- Added `TestBuildDockerProjectWithBuilderStartsAppleContainerWhenStoppedOnAppleSilicon` covering the new start-on-demand behavior.
- Existing fallback test (build failure → Docker) still passes.
- `go build ./...` and the full `internal/cli/commands` package tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)