### PR TITLE
fix(cli): treat dev builds as the latest version (WDY-1770)

### DIFF
--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -43,7 +43,8 @@ func main() {
 //     breakdowns that survive PostHog's 25-row table cap.
 //   - duration_ms: wall-clock time from process start.
 //   - success: bool serialized as "true"/"false".
-//   - is_dev_build: true when version.Version == "dev".
+//   - is_dev_build: true for development builds (version.IsDev) — the local
+//     "dev" default or a CI branch build with a "-dev" suffix.
 //   - error_class (only when err != nil): bounded enum derived from err —
 //     never the error message text, which can leak hostnames or paths.
 func trackCommand(executed *cobra.Command, err error, dur time.Duration) {
@@ -55,7 +56,7 @@ func trackCommand(executed *cobra.Command, err error, dur time.Duration) {
 		"command_root": commandRoot(executed),
 		"duration_ms":  strconv.FormatInt(dur.Milliseconds(), 10),
 		"success":      strconv.FormatBool(err == nil),
-		"is_dev_build": strconv.FormatBool(version.Version == "dev"),
+		"is_dev_build": strconv.FormatBool(version.IsDev(version.Version)),
 	}
 	if err != nil {
 		props["error_class"] = errorClass(err)

--- a/go/cmd/wendy/main_test.go
+++ b/go/cmd/wendy/main_test.go
@@ -267,6 +267,7 @@ func TestTrackCommand_IsDevBuildReflectsVersion(t *testing.T) {
 		want string
 	}{
 		{"dev", "true"},
+		{"2026.04.27-103045-dev", "true"},
 		{"2026.04.27-103045", "false"},
 		{"v0.10.0", "false"},
 	} {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -267,10 +267,10 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 			}
 			fmt.Printf("%s %s\n", tui.Dim("CLI Version:"), tui.Value(version.Version))
 
-			if cmp := version.CompareVersions(version.Version, agentVersion); cmp > 0 && agentVersion != "dev" {
+			if agentBehindCLI(version.Version, agentVersion) {
 				fmt.Println()
 				fmt.Println(tui.WarningMessage("Agent is behind the CLI — run 'wendy device update' to update."))
-			} else if cmp < 0 {
+			} else if cliBehindAgent(version.Version, agentVersion) {
 				fmt.Println()
 				fmt.Println(tui.WarningMessage("CLI is behind the agent — consider updating the CLI."))
 			}
@@ -506,7 +506,7 @@ func newDeviceSetupCmd() *cobra.Command {
 				fmt.Printf("Unable to check agent version: %v\n", err)
 			} else {
 				fmt.Printf("Agent version: %s\n", versionResp.GetVersion())
-				if cmp := version.CompareVersions(version.Version, versionResp.GetVersion()); cmp > 0 && versionResp.GetVersion() != "dev" {
+				if agentBehindCLI(version.Version, versionResp.GetVersion()) {
 					fmt.Println("Agent is behind the CLI — consider running 'wendy device update'.")
 				}
 			}

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -451,7 +451,7 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.flashIsError = true
 				return m, clearFlashAfter(3 * time.Second)
 			}
-			if item.info.Version == "" || version.CompareVersions(version.Version, item.info.Version) <= 0 {
+			if !agentBehindCLI(version.Version, item.info.Version) {
 				m.flashMessage = "Device is already up to date."
 				m.flashIsError = false
 				return m, clearFlashAfter(3 * time.Second)
@@ -924,10 +924,31 @@ func lanNoAccessHint(lan *models.LANDevice, agentVersion string) string {
 	return ""
 }
 
+// agentBehindCLI reports whether agentVer is an older release than cliVer and
+// should be flagged as outdated. A dev build on either side (see version.IsDev)
+// is treated as the latest version, so a dev CLI never flags real agents and a
+// dev agent is never flagged (WDY-1770). An empty agentVer is treated as
+// unknown (not behind).
+func agentBehindCLI(cliVer, agentVer string) bool {
+	if agentVer == "" || version.IsDev(cliVer) || version.IsDev(agentVer) {
+		return false
+	}
+	return version.CompareVersions(cliVer, agentVer) > 0
+}
+
+// cliBehindAgent reports whether cliVer is an older release than agentVer, with
+// the same dev-build handling as agentBehindCLI.
+func cliBehindAgent(cliVer, agentVer string) bool {
+	if agentVer == "" || version.IsDev(cliVer) || version.IsDev(agentVer) {
+		return false
+	}
+	return version.CompareVersions(cliVer, agentVer) < 0
+}
+
 // markOutdated prefixes the version string with "* " when the agent is behind
 // the CLI, serving as a visible indicator in discover-style tables.
 func markOutdated(agentVer string) string {
-	if agentVer != "" && version.CompareVersions(version.Version, agentVer) > 0 {
+	if agentBehindCLI(version.Version, agentVer) {
 		return "* " + agentVer
 	}
 	return agentVer
@@ -1165,7 +1186,7 @@ func discoverAgentVersionDisplay(agentVer string) string {
 	if displayVersion == "" {
 		return ""
 	}
-	if version.CompareVersions(version.Version, agentVer) > 0 {
+	if agentBehindCLI(version.Version, agentVer) {
 		displayVersion += " ⚠"
 	}
 	return displayVersion

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1198,13 +1198,13 @@ func checkAndOfferUpdate(ctx context.Context, conn *grpcclient.AgentConnection) 
 
 	agentVer := resp.GetVersion()
 	// Dev CLI builds skip the update check entirely.
-	if version.Version == "dev" {
+	if version.IsDev(version.Version) {
 		markUpdateCheckPassed(conn.Host)
 		return conn, nil
 	}
 	// A dev agent build is running intentionally — never offer to replace it
-	// with a stable release (CompareVersions treats "dev" as always-behind).
-	if agentVer == "dev" {
+	// with a stable release (dev is treated as the latest version).
+	if version.IsDev(agentVer) {
 		markUpdateCheckPassed(conn.Host)
 		return conn, nil
 	}

--- a/go/internal/cli/commands/mcp_cmd_test.go
+++ b/go/internal/cli/commands/mcp_cmd_test.go
@@ -102,6 +102,7 @@ func TestShouldRefreshMCPSetup(t *testing.T) {
 	}{
 		{name: "never set up", lastVersion: "", current: "0.11.0", want: false},
 		{name: "dev build never refreshes", lastVersion: "0.10.0", current: "dev", want: false},
+		{name: "dev branch build never refreshes", lastVersion: "0.10.0", current: "2026.06.30-1-dev", want: false},
 		{name: "same version", lastVersion: "0.11.0", current: "0.11.0", want: false},
 		{name: "upgraded", lastVersion: "0.10.0", current: "0.11.0", want: true},
 		{name: "downgraded", lastVersion: "0.11.0", current: "0.10.0", want: true},

--- a/go/internal/cli/commands/mcp_setup.go
+++ b/go/internal/cli/commands/mcp_setup.go
@@ -56,11 +56,11 @@ func recordMCPSetupVersion() {
 // shouldRefreshMCPSetup reports whether the root command should silently re-run
 // MCP setup. It refreshes only when the user has previously run `wendy mcp
 // setup` (non-empty lastSetupVersion) and the running CLI differs from the
-// version that last set it up. A "dev" build never auto-refreshes, and the
+// version that last set it up. A dev build never auto-refreshes, and the
 // comparison is an exact mismatch so downgrades re-install the matching skills
 // too. It never opts a user into the MCP server on its own.
 func shouldRefreshMCPSetup(lastSetupVersion, currentVersion string) bool {
-	if currentVersion == "dev" {
+	if version.IsDev(currentVersion) {
 		return false
 	}
 	if lastSetupVersion == "" {

--- a/go/internal/cli/commands/update.go
+++ b/go/internal/cli/commands/update.go
@@ -37,7 +37,7 @@ func scheduleCLIUpdateCheck(cfg *config.Config) {
 // dueCLIUpdateCheck returns true when the CLI is a released build and enough
 // time has passed since the last check.
 func dueCLIUpdateCheck(cfg *config.Config) bool {
-	if version.Version == "dev" {
+	if version.IsDev(version.Version) {
 		return false
 	}
 	if cfg.LastCLIUpdateCheck == "" {

--- a/go/internal/cli/commands/update_test.go
+++ b/go/internal/cli/commands/update_test.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/version"
+)
+
+// TestDueCLIUpdateCheckSkipsDevBuilds asserts that development builds — both the
+// literal "dev" default and CI branch builds carrying a "-dev" suffix — never
+// trigger the periodic CLI update check (WDY-1770).
+func TestDueCLIUpdateCheckSkipsDevBuilds(t *testing.T) {
+	original := version.Version
+	t.Cleanup(func() { version.Version = original })
+
+	for _, ver := range []string{"dev", "2026.06.30-133859-dev"} {
+		t.Run(ver, func(t *testing.T) {
+			version.Version = ver
+			// Empty LastCLIUpdateCheck would otherwise mark the check as due.
+			if dueCLIUpdateCheck(&config.Config{}) {
+				t.Errorf("dueCLIUpdateCheck for dev build %q = true, want false", ver)
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/version_guard_test.go
+++ b/go/internal/cli/commands/version_guard_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import "testing"
+
+// TestAgentBehindCLI / TestCLIBehindAgent pin the dev-aware "is one side behind
+// the other?" predicates used by discover/device version messaging. Dev builds
+// on either side (the literal "dev" or a "-dev" suffix) are treated as the
+// latest version, so neither side is ever reported as behind (WDY-1770).
+func TestAgentBehindCLI(t *testing.T) {
+	tests := []struct {
+		cli, agent string
+		want       bool
+	}{
+		{"0.11.0", "0.10.0", true},  // agent genuinely behind
+		{"0.10.0", "0.11.0", false}, // agent ahead
+		{"0.10.0", "0.10.0", false}, // equal
+		{"dev", "0.10.0", false},    // dev CLI never flags real agents
+		{"2026.06.30-1-dev", "0.10.0", false},
+		{"0.11.0", "dev", false}, // dev agent never flagged
+		{"0.11.0", "2026.06.30-1-dev", false},
+		{"0.11.0", "", false}, // unknown agent version
+	}
+	for _, tt := range tests {
+		if got := agentBehindCLI(tt.cli, tt.agent); got != tt.want {
+			t.Errorf("agentBehindCLI(%q, %q) = %v, want %v", tt.cli, tt.agent, got, tt.want)
+		}
+	}
+}
+
+func TestCLIBehindAgent(t *testing.T) {
+	tests := []struct {
+		cli, agent string
+		want       bool
+	}{
+		{"0.10.0", "0.11.0", true},  // CLI genuinely behind
+		{"0.11.0", "0.10.0", false}, // CLI ahead
+		{"0.10.0", "0.10.0", false}, // equal
+		{"dev", "0.11.0", false},    // dev CLI is never behind
+		{"2026.06.30-1-dev", "0.11.0", false},
+		{"0.10.0", "dev", false}, // dev agent never makes the CLI look behind
+		{"0.10.0", "", false},    // unknown agent version
+	}
+	for _, tt := range tests {
+		if got := cliBehindAgent(tt.cli, tt.agent); got != tt.want {
+			t.Errorf("cliBehindAgent(%q, %q) = %v, want %v", tt.cli, tt.agent, got, tt.want)
+		}
+	}
+}

--- a/go/internal/shared/version/version.go
+++ b/go/internal/shared/version/version.go
@@ -8,20 +8,32 @@ import (
 // Version is set at build time via -ldflags
 var Version = "dev"
 
+// IsDev reports whether v is a development build: the local default "dev" or a
+// CI branch build carrying the "-dev" suffix (e.g. "2026.06.30-133859-dev").
+// Dev builds are treated as the latest version and are never out of date, so
+// they don't trigger update prompts or auto-updates during debugging (WDY-1770).
+func IsDev(v string) bool {
+	return v == "dev" || strings.HasSuffix(v, "-dev")
+}
+
 // CompareVersions returns -1 if a < b, 0 if a == b, +1 if a > b.
 // Handles semver (e.g. "0.10.0"), date-based (e.g. "v2025.06.02-133859"),
 // and mixed formats by splitting on ".", "-" and comparing each component
 // numerically when possible, falling back to lexicographic comparison.
-// "dev" is treated as always less than any real version.
+// Dev builds (see IsDev) are treated as newer than any real version, and two
+// dev builds compare equal.
 func CompareVersions(a, b string) int {
 	if a == b {
 		return 0
 	}
-	if a == "dev" {
-		return -1
-	}
-	if b == "dev" {
+	aDev, bDev := IsDev(a), IsDev(b)
+	switch {
+	case aDev && bDev:
+		return 0
+	case aDev:
 		return 1
+	case bDev:
+		return -1
 	}
 
 	aParts := splitVersion(strings.TrimPrefix(a, "v"))

--- a/go/internal/shared/version/version_test.go
+++ b/go/internal/shared/version/version_test.go
@@ -11,9 +11,18 @@ func TestCompareVersions(t *testing.T) {
 		{"1.0.0", "1.0.0", 0},
 		{"dev", "dev", 0},
 
-		// Dev is always less.
-		{"dev", "0.1.0", -1},
-		{"0.1.0", "dev", 1},
+		// Dev is treated as the newest version (WDY-1770), so a real
+		// release is never considered ahead of a dev build.
+		{"dev", "0.1.0", 1},
+		{"0.1.0", "dev", -1},
+
+		// CI branch builds carry a "-dev" suffix and are dev builds too.
+		{"2026.06.30-1-dev", "2026.06.30-1", 1},
+		{"2026.06.30-1", "2026.06.30-1-dev", -1},
+		{"2026.06.30-1-dev", "99.99.99", 1},
+		// Two dev builds (any flavor) compare equal.
+		{"dev", "2026.06.30-1-dev", 0},
+		{"2026.06.30-1-dev", "2026.06.30-2-dev", 0},
 
 		// Basic semver.
 		{"0.9.3", "0.9.8", -1},
@@ -43,6 +52,29 @@ func TestCompareVersions(t *testing.T) {
 		got := CompareVersions(tt.a, tt.b)
 		if got != tt.want {
 			t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestIsDev(t *testing.T) {
+	tests := []struct {
+		v    string
+		want bool
+	}{
+		{"dev", true},                   // local default build
+		{"2026.06.30-133859-dev", true}, // CI branch build
+		{"0.10.0-dev", true},
+		{"0.10.0", false},
+		{"2026.06.30-133859", false}, // main-branch CI build
+		{"v1.0.0", false},
+		{"", false},
+		{"development", false}, // not the literal "dev" and no "-dev" suffix
+		{"dev-2", false},       // "dev" only counts as an exact match or suffix
+	}
+
+	for _, tt := range tests {
+		if got := IsDev(tt.v); got != tt.want {
+			t.Errorf("IsDev(%q) = %v, want %v", tt.v, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Context

WDY-1770. The CLI/Agent treated `dev` builds as **older** than any release because `CompareVersions` (`go/internal/shared/version/version.go`) hardcoded `"dev"` → `-1`. Symptoms: spurious "update available" prompts, `*` / `⚠` outdated markers in `discover`, and offers to overwrite a `dev` agent with a stable release (incl. the on-boot auto-updater).

Maintainers had patched this ad-hoc at a few callsites (`agentVersion != "dev"`), but only for the literal string, only in one direction, and not everywhere — and CI branch builds use a `-dev` **suffix** (`2026.06.30-133859-dev`) that none of those checks recognized.

## Change

- **`version.IsDev(v)`** — single source of truth; matches the literal `"dev"` default and any `-dev` suffix.
- **Flip `CompareVersions`** so dev sorts as the **newest** version (two dev builds compare equal). Kept a valid total order so OS-image version sorting (`os_install.go`) stays correct.
- **`agentBehindCLI` / `cliBehindAgent` predicates** treat a dev build on either side as current. `markOutdated`, `discoverAgentVersionDisplay`, the discover manual-update guard, and both `device.go` info/setup messages now route through them — without this, dev=newest would cause a dev **CLI** to newly mislabel every real agent as outdated.
- **Centralized remaining literal `== "dev"` checks** through `IsDev`: `checkAndOfferUpdate` guards, `dueCLIUpdateCheck`, `shouldRefreshMCPSetup`, and the `is_dev_build` analytics flag.

Callsites comparing a release tag against the agent version (`device.go` list, `os_cmd.go`, `cloud_discover.go`) are fixed automatically by the comparator flip — verified, no edit needed.

## Tests

TDD throughout (RED→GREEN): `IsDev`, the flipped comparator (+`-dev` cases), `agentBehindCLI`/`cliBehindAgent`, `shouldRefreshMCPSetup`, `is_dev_build`, and `dueCLIUpdateCheck`. `go build ./...`, `go vet`, `gofmt` clean; full suite (46 packages) green.

## Follow-ups

- [ ] On-device verification (dev-CLI × dev-agent matrix).
- [x] **Companion change in WendyOS-Builder:** the on-boot `wendyos-agent-updater.sh` must skip the binary replace when the installed agent is a dev build. That script lives outside this repo; this PR stops the CLI from prompting/pushing overwrites but does not touch the on-boot updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)