### PR TITLE
fix(cli): correct inaccurate progress tips

### DIFF
--- a/go/internal/cli/tui/hints.go
+++ b/go/internal/cli/tui/hints.go
@@ -19,14 +19,14 @@ var ProgressHints = []string{
 	"Tip: 'wendy run --watch' rebuilds and redeploys automatically as you edit files",
 	"Tip: Inspect a device's hardware and capabilities with 'wendy device info'",
 	"Tip: Update the device agent with 'wendy device update'",
-	"Tip: Discover devices on your network with 'wendy device discover'",
-	"Tip: List and manage running apps with 'wendy device ps'",
+	"Tip: Discover devices on your network with 'wendy discover'",
+	"Tip: List and manage running apps with 'wendy device apps'",
+	"Tip: Watch live CPU, memory, and GPU usage with 'wendy device top'",
 	"Tip: Scaffold a new project in seconds with 'wendy init'",
 	"Tip: Grant hardware access (GPU, camera, GPIO) via entitlements in wendy.json",
-	"Tip: Validate your wendy.json against the schema with 'wendy json'",
-	"Tip: Reach a device behind NAT with 'wendy cloud run'",
-	"Tip: Let Claude/Codex drive your devices - set up the MCP server with 'wendy mcp setup'",
-	"Tip: Let Claude/Codex help you debug - set up the MCP server with 'wendy mcp setup'",
+	"Tip: Validate your wendy.json against the schema with 'wendy json validate'",
+	"Tip: Reach a device behind NAT by forwarding a port with 'wendy cloud tunnel'",
+	"Tip: Let Claude/Codex drive and debug your devices - set up the MCP server with 'wendy mcp setup'",
 }
 
 // hintTickMsg is emitted on each hint rotation tick.


### PR DESCRIPTION
## Summary

Audited the rotating 💡 "did you know" progress hints (`go/internal/cli/tui/hints.go`, shown while a spinner runs) against the actual cobra command tree. Four tips pointed at commands that don't exist as written, are hidden, or are deprecated; one was a duplicate.

## Fixes

| Before | After | Why |
|---|---|---|
| `wendy device discover` | `wendy discover` | `discover` is a top-level command; there is no `discover` under `device` |
| `wendy device ps` | `wendy device apps` | `ps` is a *hidden* alias for `apps list` (list only); "manage" needs `apps` (start/stop/remove) |
| `wendy json` | `wendy json validate` | bare `wendy json` is a hidden parent with no action; validation lives in `validate` |
| `wendy cloud run` | `wendy cloud tunnel` | `cloud run` is deprecated + hidden ("use 'wendy run' instead"); `cloud tunnel` is the supported NAT-reach path |
| duplicate `wendy mcp setup` ×2 | merged into one + new `wendy device top` tip | removed redundancy; added a verified live CPU/memory/GPU tip |

Tips left unchanged (verified accurate): `wendy device logs`, `wendy run --watch`, `wendy device info`, `wendy device update`, `wendy init`, entitlements in wendy.json, `wendy mcp setup`.

## Verification

- `go build ./internal/cli/tui/` → exit 0
- `go test ./internal/cli/tui/` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)