### PR TITLE
Thor flash: fix inaccurate doc/message text (PR #1233 review)

### DIFF
--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -114,7 +114,7 @@ func CacheDir() (string, error) {
 func LogDir() (string, error) {
 	dir, err := os.UserCacheDir()
 	if err != nil {
-		return "", fmt.Errorf("determining cache directory: %w", err)
+		return "", fmt.Errorf("determining log directory: %w", err)
 	}
 	logDir := filepath.Join(dir, "wendy", "logs")
 	if err := os.MkdirAll(logDir, 0o755); err != nil {

--- a/go/scripts/build-wendy.sh
+++ b/go/scripts/build-wendy.sh
@@ -4,9 +4,9 @@
 # recovery flashing (gousb) is macOS-only for now; on other platforms wendy needs
 # no libusb and a plain `go build` suffices.
 #
-# Usage:
-#   scripts/build-wendy.sh [output-path]     # build to output-path (default ./bin/wendy)
-#   scripts/build-wendy.sh --install         # go install into GOBIN
+# Usage (run from the repo root):
+#   go/scripts/build-wendy.sh [output-path]  # build to output-path (default ./bin/wendy)
+#   go/scripts/build-wendy.sh --install      # go install into GOBIN
 set -euo pipefail
 cd "$(dirname "$0")/.."   # the go module root
 


### PR DESCRIPTION
Follow-up to the merged #1233, addressing two documentation/message-accuracy review comments.

- **`config.LogDir`** — the error on `os.UserCacheDir()` failure said *"determining cache directory"* even though the function resolves the **logs** directory. Now says *"determining log directory"* so flash-log failures are easier to diagnose. (`CacheDir`'s identical message is left as-is — it really is the cache dir.)
- **`go/scripts/build-wendy.sh`** — the usage examples referenced `scripts/build-wendy.sh`, but the script lives at `go/scripts/` and is invoked from the repo root. Corrected the paths and noted the working directory.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)