### PR TITLE
Thor flash: security hardening (PR #1233 review)

### DIFF
--- a/go/internal/cli/tegraflash/adb/adb.go
+++ b/go/internal/cli/tegraflash/adb/adb.go
@@ -355,6 +355,13 @@ func (d *Device) readMsgTimeout(timeout time.Duration) (cmd, arg0, arg1 uint32, 
 	arg0 = binary.LittleEndian.Uint32(hdr[4:])
 	arg1 = binary.LittleEndian.Uint32(hdr[8:])
 	dlen := binary.LittleEndian.Uint32(hdr[12:])
+	// The length comes from the device; bound it so a malformed/oversized header
+	// can't drive an unbounded allocation in the reassembly loop below. ADB payloads
+	// never exceed the negotiated max.
+	if dlen > maxPayload {
+		err = fmt.Errorf("ADB payload too large: %d bytes (max %d)", dlen, maxPayload)
+		return
+	}
 
 	got := append([]byte{}, hdr[24:n]...) // any payload that rode with the header
 	for uint32(len(got)) < dlen {

--- a/go/internal/cli/tegraflash/flashpack/extract.go
+++ b/go/internal/cli/tegraflash/flashpack/extract.go
@@ -52,6 +52,12 @@ func extractZstTar(tarball, dest string) error {
 			return fmt.Errorf("unsafe path in archive: %q", hdr.Name)
 		}
 		target := filepath.Join(tmp, clean)
+		// Defense-in-depth against path traversal: even after Clean() and the
+		// checks above, require the joined target to stay inside tmp (guards any
+		// edge case the prefix check misses).
+		if target != tmp && !strings.HasPrefix(target, tmp+string(os.PathSeparator)) {
+			return fmt.Errorf("unsafe path in archive: %q", hdr.Name)
+		}
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, 0o755); err != nil {
@@ -69,7 +75,11 @@ func extractZstTar(tarball, dest string) error {
 				out.Close()
 				return err
 			}
-			out.Close()
+			// Check Close on the success path: a deferred flush can fail here and
+			// would otherwise silently truncate the extracted file.
+			if err := out.Close(); err != nil {
+				return fmt.Errorf("writing %s: %w", clean, err)
+			}
 		case tar.TypeSymlink, tar.TypeLink:
 			// The flashpack contains no links; skip rather than risk an escape.
 			continue

--- a/go/internal/cli/tegraflash/flashpack/extract_test.go
+++ b/go/internal/cli/tegraflash/flashpack/extract_test.go
@@ -1,0 +1,103 @@
+package flashpack
+
+import (
+	"archive/tar"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// writeZstTar writes entries (name→contents) as a .tar.zst at path.
+func writeZstTar(t *testing.T, path string, entries []tar.Header, bodies []string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	zw, err := zstd.NewWriter(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(zw)
+	for i, h := range entries {
+		hdr := h
+		hdr.Size = int64(len(bodies[i]))
+		if err := tw.WriteHeader(&hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(bodies[i])); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExtractZstTar_Normal(t *testing.T) {
+	dir := t.TempDir()
+	tarball := filepath.Join(dir, "pack.tar.zst")
+	writeZstTar(t,
+		tarball,
+		[]tar.Header{
+			{Name: "manifest.json", Mode: 0o644, Typeflag: tar.TypeReg},
+			{Name: "stage1/br.bct", Mode: 0o644, Typeflag: tar.TypeReg},
+		},
+		[]string{`{"schema":1}`, "bct-bytes"},
+	)
+
+	dest := filepath.Join(dir, "extracted")
+	if err := extractZstTar(tarball, dest); err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "stage1", "br.bct"))
+	if err != nil {
+		t.Fatalf("expected extracted file: %v", err)
+	}
+	if string(got) != "bct-bytes" {
+		t.Fatalf("content = %q, want %q", got, "bct-bytes")
+	}
+}
+
+func TestExtractZstTar_RejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	tarball := filepath.Join(dir, "evil.tar.zst")
+	writeZstTar(t,
+		tarball,
+		[]tar.Header{{Name: "../escape.txt", Mode: 0o644, Typeflag: tar.TypeReg}},
+		[]string{"pwned"},
+	)
+
+	dest := filepath.Join(dir, "extracted")
+	if err := extractZstTar(tarball, dest); err == nil {
+		t.Fatal("expected traversal entry to be rejected")
+	}
+	// The escape target must not have been written outside dest.
+	if _, err := os.Stat(filepath.Join(dir, "escape.txt")); !os.IsNotExist(err) {
+		t.Fatalf("path traversal wrote outside dest: %v", err)
+	}
+}
+
+func TestExtractZstTar_SkipsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	tarball := filepath.Join(dir, "link.tar.zst")
+	writeZstTar(t,
+		tarball,
+		[]tar.Header{{Name: "evil-link", Mode: 0o777, Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd"}},
+		[]string{""},
+	)
+
+	dest := filepath.Join(dir, "extracted")
+	if err := extractZstTar(tarball, dest); err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "evil-link")); !os.IsNotExist(err) {
+		t.Fatal("symlink entry should have been skipped, not created")
+	}
+}

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -117,7 +117,9 @@ func LogDir() (string, error) {
 		return "", fmt.Errorf("determining log directory: %w", err)
 	}
 	logDir := filepath.Join(dir, "wendy", "logs")
-	if err := os.MkdirAll(logDir, 0o755); err != nil {
+	// 0o700: flash logs can contain hardware identifiers (e.g. the device ECID),
+	// so keep them readable only by the owner.
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
 		return "", fmt.Errorf("creating log directory: %w", err)
 	}
 	return logDir, nil


### PR DESCRIPTION
Follow-up to the merged #1233, addressing security-review findings. Focused on the sound, low-risk hardening; each change has test or build coverage.

## Fixed
- **Tar path traversal (HIGH) + unchecked Close (CodeQL)** — `flashpack/extract.go`
  - Added a containment check that the joined target stays within the extraction dir, on top of the existing `Clean()`/`..`/absolute checks (defense-in-depth / ZipSlip).
  - The extracted file's `Close()` is now checked on the success path so a failed flush can't silently truncate a file.
  - New regression tests: traversal rejection, symlink skipping, normal extraction.
- **Unbounded ADB reassembly (MEDIUM)** — `adb/adb.go`
  - The payload length comes from the device header; reject anything larger than the negotiated max so a malformed/oversized header can't drive an unbounded allocation.
- **Log dir permissions (LOW)** — `config/config.go`
  - Create the logs dir `0o700` (was `0o755`). Flash logs can contain hardware identifiers such as the device ECID.

## Considered, deferred (with rationale)
- **Stage-2 image integrity (MEDIUM)** — already mitigated: the whole flashpack `.tar.zst` is SHA-256-verified against the manifest at download before extraction. `verifyStage1` additionally re-checks stage-1 files post-extraction; extending that to stage-2 files needs per-file checksums in the manifest (builder-side change).
- **Shim dir world-executable (HIGH)** — not reproduced: `os.MkdirTemp` already creates the shim dir `0o700`, so it isn't world-accessible.
- **`stage2_flash.py` sys.path / bootburn `os.Environ()` inheritance** — inherent to running NVIDIA's own bootburn Python from the (checksum-verified) flashpack; not changed here.
- **`gousb` marked `// indirect` in go.mod (MEDIUM)** — left out deliberately: `go mod tidy` also prunes an `x/crypto` version this (stale) branch doesn't need but concurrently-advancing `main` does, which would be noisy/risky in a security PR. Trivial standalone follow-up.

Build, vet, gofmt, and package tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)