### PR TITLE
fix(cli): keep Apple Container startup prompt responsive

### DIFF
--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -564,11 +564,11 @@ func buildDockerProjectWithBuilder(ctx context.Context, builder, dir, imageName,
 		return err
 	}
 	if !imageBuilderWasExplicit(builder) && shouldAutoAttemptAppleContainerBuilder() {
-		// Prefer Apple Container whenever its CLI is available: start the system
-		// if it isn't running yet rather than silently falling back to Docker.
-		// We only fall back when the CLI is unavailable, the user declines to
-		// start it, or the build itself fails.
-		if err := ensureAppleContainerSystem(ctx, false); err == nil {
+		// The auto-attempt path must not prompt or start services as a side effect:
+		// if Apple Container is not already ready, fall back to Docker. Use
+		// --builder apple-container to require Apple Container and get the startup
+		// prompt.
+		if err := checkAppleContainerBuilder(ctx); err == nil {
 			if err := runAppleContainerBuildWithProgress(ctx, dir, imageName, platform, dockerfile); err == nil {
 				return nil
 			} else {

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1583,11 +1583,12 @@ func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnec
 		return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, builder, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput)
 	}
 	if shouldAutoAttemptAppleContainerBuilder() {
-		// Prefer Apple Container whenever its CLI is available: start the system
-		// if it isn't running yet rather than silently falling back to Docker.
 		// Apple Container builds don't use buildx, so the local-cache key never
-		// applies; only the Docker fallback below consumes it.
-		if err := ensureAppleContainerSystem(ctx, false); err != nil {
+		// applies; only the Docker fallback below consumes it. The auto-attempt path
+		// must not prompt or start services as a side effect: if Apple Container is
+		// not already ready, fall back to Docker. Use --builder apple-container to
+		// require Apple Container and get the startup prompt.
+		if err := checkAppleContainerBuilder(ctx); err != nil {
 			logAppleContainerFallback(logOutput, err)
 		} else if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, "", streamOutput, logOutput); err == nil {
 			return nil

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -85,7 +85,7 @@ func TestBuildAndPushImageWithAppleContainerUsesContainerCLI(t *testing.T) {
 		t.Fatalf("buildAndPushImageWithBuilder: %v", err)
 	}
 
-	resolvedDockerfile, err := confinedDockerfilePath(dir, "Dockerfile")
+	resolvedDockerfile, err := appleContainerBuildFilePath(dir, "Dockerfile")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +254,7 @@ func TestBuildDockerProjectWithBuilderDefaultsToAppleContainerOnAppleSilicon(t *
 		t.Fatalf("buildDockerProjectWithBuilder: %v", err)
 	}
 
-	resolvedBuildFile, err := confinedDockerfilePath(dir, "Containerfile")
+	resolvedBuildFile, err := appleContainerBuildFilePath(dir, "Containerfile")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,6 +269,57 @@ func TestBuildDockerProjectWithBuilderDefaultsToAppleContainerOnAppleSilicon(t *
 	want := "container\x00build\x00--progress\x00plain\x00--platform\x00linux/arm64\x00-t\x00test-app:latest\x00-f\x00" + resolvedBuildFile + "\x00" + buildContext + "\n"
 	if !strings.Contains(string(data), want) {
 		t.Fatalf("command log missing %q in:\n%s", want, string(data))
+	}
+}
+
+func TestBuildDockerProjectWithBuilderFallsBackToDockerWhenAutoAppleContainerSystemStoppedDoesNotPrompt(t *testing.T) {
+	oldCommand := imageBuilderCommandContext
+	oldLookPath := imageBuilderLookPath
+	oldGOOS := imageBuilderHostGOOS
+	oldGOARCH := imageBuilderHostGOARCH
+	oldDockerBuild := buildDockerProjectWithDocker
+	oldPrompt := promptYesNoFn
+	t.Cleanup(func() {
+		imageBuilderCommandContext = oldCommand
+		imageBuilderLookPath = oldLookPath
+		imageBuilderHostGOOS = oldGOOS
+		imageBuilderHostGOARCH = oldGOARCH
+		buildDockerProjectWithDocker = oldDockerBuild
+		promptYesNoFn = oldPrompt
+	})
+
+	logFile := filepath.Join(t.TempDir(), "commands.log")
+	t.Setenv("IMAGE_BUILDER_FAIL_STATUS", "1")
+	imageBuilderCommandContext = fakeImageBuilderCommandContext(logFile)
+	imageBuilderLookPath = func(file string) (string, error) {
+		if file == "container" {
+			return "/usr/local/bin/container", nil
+		}
+		return "", errors.New("not found")
+	}
+	imageBuilderHostGOOS = func() string { return "darwin" }
+	imageBuilderHostGOARCH = func() string { return "arm64" }
+	promptYesNoFn = func(string) bool {
+		t.Fatal("auto Apple Container fallback must not prompt")
+		return false
+	}
+
+	var dockerFallbackCalled bool
+	buildDockerProjectWithDocker = func(dir, imageName, platform, dockerfile string) error {
+		dockerFallbackCalled = true
+		return nil
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := buildDockerProjectWithBuilder(context.Background(), "", dir, "test-app:latest", "linux/arm64", "Dockerfile"); err != nil {
+		t.Fatalf("buildDockerProjectWithBuilder: %v", err)
+	}
+	if !dockerFallbackCalled {
+		t.Fatal("Docker fallback was not called")
 	}
 }
 
@@ -321,19 +372,20 @@ func TestBuildDockerProjectWithBuilderFallsBackToDockerWhenAutoAppleContainerFai
 }
 
 // When Apple Container's CLI is installed but its system is not running, the
-// no-builder auto path now starts the system and uses Apple Container instead
-// of silently falling back to Docker.
-func TestBuildDockerProjectWithBuilderStartsAppleContainerWhenStoppedOnAppleSilicon(t *testing.T) {
+// no-builder auto path falls back to Docker without prompting or starting Apple
+// Container. Use --builder apple-container to require Apple Container.
+func TestBuildDockerProjectWithBuilderFallsBackWhenAutoAppleContainerStoppedOnAppleSilicon(t *testing.T) {
 	logFile := setupAppleContainerEnsureSeams(t)
 	isInteractiveTerminalFn = func() bool { return false }
-	promptYesNoFn = func(string) bool { t.Fatal("must not prompt in non-interactive auto path"); return false }
-	// System is down until "container system start" creates the readiness file.
+	promptYesNoFn = func(string) bool { t.Fatal("must not prompt in auto path"); return false }
+	// System stays down because the auto path must not run "container system start".
 	t.Setenv("IMAGE_BUILDER_STATUS_READY_FILE", filepath.Join(t.TempDir(), "ready"))
 
 	oldDockerBuild := buildDockerProjectWithDocker
 	t.Cleanup(func() { buildDockerProjectWithDocker = oldDockerBuild })
+	var dockerFallbackCalled bool
 	buildDockerProjectWithDocker = func(dir, imageName, platform, dockerfile string) error {
-		t.Fatal("Docker fallback should not run when Apple Container can be started")
+		dockerFallbackCalled = true
 		return nil
 	}
 
@@ -345,16 +397,19 @@ func TestBuildDockerProjectWithBuilderStartsAppleContainerWhenStoppedOnAppleSili
 	if err := buildDockerProjectWithBuilder(context.Background(), "", dir, "test-app:latest", "linux/arm64", "Containerfile"); err != nil {
 		t.Fatalf("buildDockerProjectWithBuilder: %v", err)
 	}
+	if !dockerFallbackCalled {
+		t.Fatal("Docker fallback was not called")
+	}
 
 	data, err := os.ReadFile(logFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), "container\x00system\x00start\x00--timeout\x0060") {
-		t.Fatalf("expected Apple Container system to be started:\n%s", data)
+	if strings.Contains(string(data), "container\x00system\x00start") {
+		t.Fatalf("did not expect Apple Container system to be started:\n%s", data)
 	}
-	if !strings.Contains(string(data), "container\x00build\x00") {
-		t.Fatalf("expected Apple Container build to run:\n%s", data)
+	if strings.Contains(string(data), "container\x00build\x00") {
+		t.Fatalf("did not expect Apple Container build to run:\n%s", data)
 	}
 }
 

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/netip"
 	"os"
@@ -143,26 +144,49 @@ func isCertRefreshableError(err error) bool {
 	return false
 }
 
-// promptYesNoFn reads a Y/n answer from stdin; empty input counts as yes.
-// Stubbed in tests.
+// promptYesNoFn reads a Y/n answer from the controlling terminal; empty input
+// counts as yes. Stubbed in tests.
 var promptYesNoFn = func(prompt string) bool {
-	fmt.Fprint(os.Stderr, prompt)
-	reader := bufio.NewReader(os.Stdin)
-	answer, _ := reader.ReadString('\n')
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	return answer == "" || answer == "y" || answer == "yes"
+	return promptYesNoLine(prompt, true)
 }
 
-// promptYesNoDefaultNoFn reads a y/N answer from stdin; empty input counts as
-// no. Used for more speculative offers (e.g. a timeout against an enrolled
-// device, where refreshing certs is a guess rather than a clear diagnosis).
-// Stubbed in tests.
+// promptYesNoDefaultNoFn reads a y/N answer from the controlling terminal;
+// empty input counts as no. Used for more speculative offers (e.g. a timeout
+// against an enrolled device, where refreshing certs is a guess rather than a
+// clear diagnosis). Stubbed in tests.
 var promptYesNoDefaultNoFn = func(prompt string) bool {
-	fmt.Fprint(os.Stderr, prompt)
-	reader := bufio.NewReader(os.Stdin)
-	answer, _ := reader.ReadString('\n')
+	return promptYesNoLine(prompt, false)
+}
+
+func promptYesNoLine(prompt string, defaultYes bool) bool {
+	in, out, cleanup := promptTTYIO()
+	defer cleanup()
+
+	// Clear any stale spinner/hint line before printing the prompt. This keeps a
+	// simple line prompt from visually colliding with a previously-rendered TUI.
+	fmt.Fprint(out, "\r\x1b[2K")
+	fmt.Fprint(out, prompt)
+
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && strings.TrimSpace(answer) == "" {
+		return false
+	}
+	return parseYesNoAnswer(answer, defaultYes)
+}
+
+func parseYesNoAnswer(answer string, defaultYes bool) bool {
 	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer == "" {
+		return defaultYes
+	}
 	return answer == "y" || answer == "yes"
+}
+
+func promptTTYIO() (io.Reader, io.Writer, func()) {
+	if tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err == nil {
+		return tty, tty, func() { _ = tty.Close() }
+	}
+	return os.Stdin, os.Stderr, func() {}
 }
 
 var refreshAllCertsFn = refreshAllCerts

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -20,6 +20,27 @@ import (
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
+func TestParseYesNoAnswer(t *testing.T) {
+	tests := []struct {
+		answer     string
+		defaultYes bool
+		want       bool
+	}{
+		{"", true, true},
+		{"\n", true, true},
+		{"", false, false},
+		{"y", false, true},
+		{" YES \n", false, true},
+		{"n", true, false},
+		{"no", true, false},
+	}
+	for _, tt := range tests {
+		if got := parseYesNoAnswer(tt.answer, tt.defaultYes); got != tt.want {
+			t.Fatalf("parseYesNoAnswer(%q, %t) = %t, want %t", tt.answer, tt.defaultYes, got, tt.want)
+		}
+	}
+}
+
 // ── hostPort ────────────────────────────────────────────────────────
 
 func TestHostPort(t *testing.T) {

--- a/go/internal/cli/providers/apple_container_test.go
+++ b/go/internal/cli/providers/apple_container_test.go
@@ -161,7 +161,7 @@ func TestAppleContainerBuildWithDockerfileUsesContainerBuild(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolvedDockerfile, err := filepath.EvalSymlinks(dockerfile)
+	resolvedDockerfile, err := confinedProviderDockerfilePath(dir, "Dockerfile.prod")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestAppleContainerBuildWithContainerfileUsesContainerBuild(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolvedContainerfile, err := filepath.EvalSymlinks(containerfile)
+	resolvedContainerfile, err := confinedProviderDockerfilePath(dir, "Containerfile")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Keep the default Apple Container auto-attempt non-blocking: if the system is stopped, fall back to Docker instead of prompting under the build progress UI.
- Preserve the explicit Apple Container path: `--builder apple-container` still asks to start the system, but the prompt runs before the build UI starts and reads from the controlling terminal.
- Clear stale prompt lines and cover the auto-fallback behavior in tests.

Fixes WDY-1787

## Tests
- `go test ./go/internal/cli/commands`
- `go test ./go/internal/cli/...`
