### PR TITLE
Track docs install-copy events in GA4

### DIFF
--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -126,6 +126,7 @@ jobs:
       pr_number:   ${{ steps.resolve.outputs.pr_number }}
       head_sha:    ${{ steps.guard.outputs.head_sha }}
       head_branch: ${{ steps.guard.outputs.head_branch }}
+      proceed:     ${{ steps.guard.outputs.proceed }}
     steps:
       - name: Early actor verification
         # Live API re-check before any write operations or secrets are used.
@@ -352,23 +353,23 @@ jobs:
           if [ "$MATCHING_RULESETS" = "0" ]; then
             echo "::error::No active ruleset covers ai/** branches — server-side push restrictions not configured"
             echo "proceed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            exit 1
           fi
           echo "Matching active rulesets for ai/**: $MATCHING_RULESETS found"
 
           echo "proceed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Fail if not authorized
+      - name: Skip when automation is not authorized
         if: steps.resolve.outputs.pr_number == '' || steps.guard.outputs.proceed != 'true'
         run: |
-          echo "::error::Authorization not granted — gate failing to prevent write-token provisioning"
-          exit 1
+          echo "Authorization not granted or not applicable — skipping AI feedback loop without provisioning write tokens."
 
   # Execute job: write-capable tokens (GITHUB_TOKEN pull-requests:write, issues:write)
   # are provisioned ONLY after the gate job has confirmed authorization via live API checks.
   respond:
     name: Address PR feedback via Claude Code
     needs: gate
+    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -299,8 +299,10 @@ jobs:
           HEAD_BRANCH=$(printf '%s' "$PR_DATA" | jq -r '.head.ref // ""')
           HEAD_SHA=$(printf '%s' "$PR_DATA" | jq -r '.head.sha // ""')
           if ! printf '%s' "$HEAD_BRANCH" | grep -qE '^ai/[a-z0-9]'; then
+            # Non-ai branches are outside this automation's scope. This is a
+            # benign skip, distinct from proceed=false authorization failures.
             echo "PR head branch '$HEAD_BRANCH' does not match ai/ pattern — skipping"
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "proceed=skip" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "head_sha=$HEAD_SHA"       >> "$GITHUB_OUTPUT"
@@ -325,7 +327,7 @@ jobs:
           fi
 
           if [ "$ALLOWED" = "false" ]; then
-            echo "Actor '$ACTOR' (assoc: $ACTOR_ASSOC) is not authorized — skipping"
+            echo "::error::Actor '$ACTOR' (assoc: $ACTOR_ASSOC) is not authorized"
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -359,17 +361,23 @@ jobs:
 
           echo "proceed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Skip when automation is not authorized
-        if: steps.resolve.outputs.pr_number == '' || steps.guard.outputs.proceed != 'true'
+      - name: Skip when automation is not applicable
+        if: steps.resolve.outputs.pr_number == '' || steps.guard.outputs.proceed == 'skip'
         run: |
-          echo "::error::Authorization not granted or not applicable — skipping AI feedback loop without provisioning write tokens."
+          echo "::notice::AI feedback loop is not applicable for this event or branch; no write-token job will run."
+
+      - name: Fail when automation is not authorized
+        if: steps.guard.outputs.proceed == 'false'
+        run: |
+          echo "::error::Authorization not granted — gate failing to prevent write-token provisioning."
+          exit 1
 
   # Execute job: write-capable tokens (GITHUB_TOKEN pull-requests:write, issues:write)
   # are provisioned ONLY after the gate job has confirmed authorization via live API checks.
   respond:
     name: Address PR feedback via Claude Code
     needs: gate
-    if: needs.gate.outputs.proceed == 'true'
+    if: needs.gate.result == 'success' && needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/ai-pr-feedback.yml
+++ b/.github/workflows/ai-pr-feedback.yml
@@ -362,7 +362,7 @@ jobs:
       - name: Skip when automation is not authorized
         if: steps.resolve.outputs.pr_number == '' || steps.guard.outputs.proceed != 'true'
         run: |
-          echo "Authorization not granted or not applicable — skipping AI feedback loop without provisioning write tokens."
+          echo "::error::Authorization not granted or not applicable — skipping AI feedback loop without provisioning write tokens."
 
   # Execute job: write-capable tokens (GITHUB_TOKEN pull-requests:write, issues:write)
   # are provisioned ONLY after the gate job has confirmed authorization via live API checks.

--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -348,9 +348,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          set +e
+          timeout 180s bash <<'CLEANUP'
+          set -euo pipefail
+
           cutoff_epoch="$(date -u -d "${RETENTION_DAYS} days ago" +%s)"
           listing_file="$(mktemp)"
           delete_file="$(mktemp)"
+          trap 'rm -f "${listing_file}" "${delete_file}"' EXIT
 
           gcloud storage ls -l --recursive "gs://${DOCS_BUCKET}/branch-*/**" \
             --project="${GCP_PROJECT_ID}" > "${listing_file}" 2>/dev/null || true
@@ -368,6 +373,19 @@ jobs:
           if [[ -s "${delete_file}" ]]; then
             xargs -r -n 100 gcloud storage rm --quiet --project="${GCP_PROJECT_ID}" < "${delete_file}"
           fi
+          CLEANUP
+          cleanup_status=$?
+          set -e
+
+          case "${cleanup_status}" in
+            0) ;;
+            124)
+              echo "::warning::Expired branch preview cleanup timed out; docs deployment already completed."
+              ;;
+            *)
+              echo "::warning::Expired branch preview cleanup failed with status ${cleanup_status}; docs deployment already completed."
+              ;;
+          esac
 
   comment-preview:
     name: Comment with docs preview URL

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -98,6 +98,24 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      - name: Prepare macOS build dependencies
+        if: inputs.hostname == '' || inputs.jobs == 'all' || inputs.jobs == 'discover'
+        run: |
+          set -euo pipefail
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          missing=()
+          if ! command -v pkg-config >/dev/null 2>&1; then
+            missing+=(pkg-config)
+          fi
+          if ! pkg-config --exists libusb-1.0 >/dev/null 2>&1; then
+            missing+=(libusb)
+          fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            brew install "${missing[@]}"
+          fi
+
       - name: Build CLI
         if: inputs.hostname == '' || inputs.jobs == 'all' || inputs.jobs == 'discover'
         working-directory: go
@@ -233,6 +251,23 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+
+      - name: Prepare macOS build dependencies
+        run: |
+          set -euo pipefail
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          missing=()
+          if ! command -v pkg-config >/dev/null 2>&1; then
+            missing+=(pkg-config)
+          fi
+          if ! pkg-config --exists libusb-1.0 >/dev/null 2>&1; then
+            missing+=(libusb)
+          fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            brew install "${missing[@]}"
+          fi
 
       - name: Build CLI
         working-directory: go

--- a/go/internal/cli/assets/docs/components/analytics.tsx
+++ b/go/internal/cli/assets/docs/components/analytics.tsx
@@ -1,29 +1,6 @@
 import { GoogleAnalytics } from '@next/third-parties/google';
 import Script from 'next/script';
-
-const GOOGLE_CONSENT_DEFAULT = `
-(function() {
-  var analyticsConsent = 'denied';
-  try {
-    var stored = window.localStorage.getItem('wendy_docs_analytics_consent');
-    var cookieMatch = document.cookie.match(/(?:^|; )wendy_docs_analytics_consent=(granted|denied)(?:;|$)/);
-    if (stored === 'granted' || stored === 'denied') {
-      analyticsConsent = stored;
-    } else if (cookieMatch) {
-      analyticsConsent = cookieMatch[1];
-    }
-  } catch (error) {}
-
-  window.dataLayer = window.dataLayer || [];
-  window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
-  window.gtag('consent', 'default', {
-    analytics_storage: analyticsConsent,
-    ad_storage: 'denied',
-    ad_user_data: 'denied',
-    ad_personalization: 'denied'
-  });
-})();
-`;
+import { withBasePath } from '@/lib/shared';
 
 // Google Analytics 4 / Firebase Analytics — shares the same measurement ID as
 // the marketing site (wendy.dev): the "marketing-website-wendy" Firebase web
@@ -41,9 +18,10 @@ export function Analytics() {
 
   return (
     <>
-      <Script id="docs-google-analytics-consent-default" strategy="beforeInteractive">
-        {GOOGLE_CONSENT_DEFAULT}
-      </Script>
+      <Script
+        src={withBasePath('/static/docs-google-analytics-consent-default.js')}
+        strategy="beforeInteractive"
+      />
       <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />
     </>
   );

--- a/go/internal/cli/assets/docs/components/analytics.tsx
+++ b/go/internal/cli/assets/docs/components/analytics.tsx
@@ -1,4 +1,29 @@
 import { GoogleAnalytics } from '@next/third-parties/google';
+import Script from 'next/script';
+
+const GOOGLE_CONSENT_DEFAULT = `
+(function() {
+  var analyticsConsent = 'denied';
+  try {
+    var stored = window.localStorage.getItem('wendy_docs_analytics_consent');
+    var cookieMatch = document.cookie.match(/(?:^|; )wendy_docs_analytics_consent=(granted|denied)(?:;|$)/);
+    if (stored === 'granted' || stored === 'denied') {
+      analyticsConsent = stored;
+    } else if (cookieMatch) {
+      analyticsConsent = cookieMatch[1];
+    }
+  } catch (error) {}
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
+  window.gtag('consent', 'default', {
+    analytics_storage: analyticsConsent,
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied'
+  });
+})();
+`;
 
 // Google Analytics 4 / Firebase Analytics — shares the same measurement ID as
 // the marketing site (wendy.dev): the "marketing-website-wendy" Firebase web
@@ -14,5 +39,12 @@ export function Analytics() {
     return null;
   }
 
-  return <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />;
+  return (
+    <>
+      <Script id="docs-google-analytics-consent-default" strategy="beforeInteractive">
+        {GOOGLE_CONSENT_DEFAULT}
+      </Script>
+      <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />
+    </>
+  );
 }

--- a/go/internal/cli/assets/docs/components/docs/get-started-section.tsx
+++ b/go/internal/cli/assets/docs/components/docs/get-started-section.tsx
@@ -13,16 +13,25 @@ import { withBasePath } from '@/lib/shared';
 type CliPlatform = 'unix' | 'windows';
 
 const cliPlatforms: Array<{
+  analyticsLabel: string;
+  analyticsTarget: string;
+  analyticsVariant: string;
   id: CliPlatform;
   label: string;
   command: string;
 }> = [
   {
+    analyticsLabel: 'macOS/Linux CLI',
+    analyticsTarget: 'unix',
+    analyticsVariant: 'cli for macOS/linux',
     id: 'unix',
     label: 'macOS/Linux',
     command: cliCurlCommand,
   },
   {
+    analyticsLabel: 'windows CLI',
+    analyticsTarget: 'windows',
+    analyticsVariant: 'cli for windows',
     id: 'windows',
     label: 'Windows',
     command: cliWingetCommand,
@@ -103,7 +112,16 @@ export function GetStartedSection() {
               </div>
             </div>
 
-            <InstallCommand command={activePlatform.command} />
+            <InstallCommand
+              analyticsEventName="cli_install_copy"
+              analyticsEventParams={{
+                install_target: activePlatform.analyticsTarget,
+                install_variant: activePlatform.analyticsVariant,
+                install_label: activePlatform.analyticsLabel,
+                location: 'docs_get_started_cli_install_command',
+              }}
+              command={activePlatform.command}
+            />
           </section>
 
           <section className="border-t pt-6">
@@ -118,7 +136,16 @@ export function GetStartedSection() {
             <p className="mt-1 text-sm text-fd-muted-foreground">
               Install this on an existing Linux target. WendyOS images already include it.
             </p>
-            <InstallCommand command={agentCurlCommand} />
+            <InstallCommand
+              analyticsEventName="cli_install_copy"
+              analyticsEventParams={{
+                install_target: 'agent-linux',
+                install_variant: 'wendy-agent for Linux',
+                install_label: 'wendy-agent for Linux',
+                location: 'docs_get_started_agent_install_command',
+              }}
+              command={agentCurlCommand}
+            />
           </section>
 
           <section className="border-t pt-6">

--- a/go/internal/cli/assets/docs/components/docs/get-started-section.tsx
+++ b/go/internal/cli/assets/docs/components/docs/get-started-section.tsx
@@ -8,14 +8,25 @@ import {
   cliWingetCommand,
   InstallCommand,
 } from '@/components/docs/install-command';
+import type {
+  DocsAnalyticsLocation,
+  DocsInstallCopyLabel,
+  DocsInstallCopyTarget,
+  DocsInstallCopyVariant,
+} from '@/lib/analytics-events';
 import { withBasePath } from '@/lib/shared';
 
 type CliPlatform = 'unix' | 'windows';
+type CliAnalyticsTarget = Extract<DocsInstallCopyTarget, 'unix' | 'windows'>;
+type CliAnalyticsVariant = Extract<
+  DocsInstallCopyVariant,
+  'cli for macOS/linux' | 'cli for windows'
+>;
 
 const cliPlatforms: Array<{
-  analyticsLabel: string;
-  analyticsTarget: string;
-  analyticsVariant: string;
+  analyticsLabel: Extract<DocsInstallCopyLabel, 'macOS/Linux CLI' | 'windows CLI'>;
+  analyticsTarget: CliAnalyticsTarget;
+  analyticsVariant: CliAnalyticsVariant;
   id: CliPlatform;
   label: string;
   command: string;
@@ -37,6 +48,10 @@ const cliPlatforms: Array<{
     command: cliWingetCommand,
   },
 ];
+
+const docsGetStartedCliLocation = 'docs_get_started_cli_install_command' satisfies DocsAnalyticsLocation;
+const docsGetStartedAgentLocation =
+  'docs_get_started_agent_install_command' satisfies DocsAnalyticsLocation;
 
 function detectCliPlatform(): CliPlatform {
   if (typeof navigator === 'undefined') return 'unix';
@@ -118,7 +133,7 @@ export function GetStartedSection() {
                 install_target: activePlatform.analyticsTarget,
                 install_variant: activePlatform.analyticsVariant,
                 install_label: activePlatform.analyticsLabel,
-                location: 'docs_get_started_cli_install_command',
+                location: docsGetStartedCliLocation,
               }}
               command={activePlatform.command}
             />
@@ -142,7 +157,7 @@ export function GetStartedSection() {
                 install_target: 'agent-linux',
                 install_variant: 'wendy-agent for Linux',
                 install_label: 'wendy-agent for Linux',
-                location: 'docs_get_started_agent_install_command',
+                location: docsGetStartedAgentLocation,
               }}
               command={agentCurlCommand}
             />

--- a/go/internal/cli/assets/docs/components/docs/install-command.tsx
+++ b/go/internal/cli/assets/docs/components/docs/install-command.tsx
@@ -2,19 +2,13 @@
 
 import { Check, Copy } from 'lucide-react';
 import { useState } from 'react';
-import {
-  trackDocsAnalyticsEvent,
-  type DocsAnalyticsEventName,
-  type DocsAnalyticsEventParams,
-} from '@/lib/analytics-events';
+import { trackDocsAnalyticsEvent, type DocsAnalyticsTrackingProps } from '@/lib/analytics-events';
 
 export const cliCurlCommand = 'curl -fsSL https://install.wendy.dev/cli.sh | bash';
 export const cliWingetCommand = 'winget install WendyLabs.Wendy --source winget';
 export const agentCurlCommand = 'curl -fsSL https://install.wendy.dev/agent.sh | bash';
 
-type CopyButtonProps = {
-  analyticsEventName?: DocsAnalyticsEventName;
-  analyticsEventParams?: DocsAnalyticsEventParams;
+type CopyButtonProps = DocsAnalyticsTrackingProps & {
   text: string;
 };
 
@@ -44,19 +38,21 @@ function CopyButton({ analyticsEventName, analyticsEventParams, text }: CopyButt
   );
 }
 
-type InstallCommandProps = {
-  analyticsEventName?: DocsAnalyticsEventName;
-  analyticsEventParams?: DocsAnalyticsEventParams;
+type InstallCommandProps = DocsAnalyticsTrackingProps & {
   command: string;
   label?: string;
 };
 
-export function InstallCommand({
-  analyticsEventName,
-  analyticsEventParams,
-  label,
-  command,
-}: InstallCommandProps) {
+export function InstallCommand(props: InstallCommandProps) {
+  const { label, command } = props;
+  const copyButtonProps: CopyButtonProps = props.analyticsEventName
+    ? {
+        analyticsEventName: props.analyticsEventName,
+        analyticsEventParams: props.analyticsEventParams,
+        text: command,
+      }
+    : { text: command };
+
   return (
     <div className="mt-2">
       {label ? (
@@ -66,11 +62,7 @@ export function InstallCommand({
         <code className="min-w-0 flex-1 whitespace-pre-wrap break-all px-3 py-2.5 font-mono text-sm text-fd-foreground">
           {command}
         </code>
-        <CopyButton
-          analyticsEventName={analyticsEventName}
-          analyticsEventParams={analyticsEventParams}
-          text={command}
-        />
+        <CopyButton {...copyButtonProps} />
       </div>
     </div>
   );

--- a/go/internal/cli/assets/docs/components/docs/install-command.tsx
+++ b/go/internal/cli/assets/docs/components/docs/install-command.tsx
@@ -2,12 +2,23 @@
 
 import { Check, Copy } from 'lucide-react';
 import { useState } from 'react';
+import {
+  trackDocsAnalyticsEvent,
+  type DocsAnalyticsEventName,
+  type DocsAnalyticsEventParams,
+} from '@/lib/analytics-events';
 
 export const cliCurlCommand = 'curl -fsSL https://install.wendy.dev/cli.sh | bash';
 export const cliWingetCommand = 'winget install WendyLabs.Wendy --source winget';
 export const agentCurlCommand = 'curl -fsSL https://install.wendy.dev/agent.sh | bash';
 
-function CopyButton({ text }: { text: string }) {
+type CopyButtonProps = {
+  analyticsEventName?: DocsAnalyticsEventName;
+  analyticsEventParams?: DocsAnalyticsEventParams;
+  text: string;
+};
+
+function CopyButton({ analyticsEventName, analyticsEventParams, text }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
   return (
@@ -17,6 +28,9 @@ function CopyButton({ text }: { text: string }) {
       onClick={async () => {
         try {
           await navigator.clipboard.writeText(text);
+          if (analyticsEventName) {
+            trackDocsAnalyticsEvent(analyticsEventName, analyticsEventParams);
+          }
           setCopied(true);
           setTimeout(() => setCopied(false), 1500);
         } catch {
@@ -30,7 +44,19 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-export function InstallCommand({ label, command }: { label?: string; command: string }) {
+type InstallCommandProps = {
+  analyticsEventName?: DocsAnalyticsEventName;
+  analyticsEventParams?: DocsAnalyticsEventParams;
+  command: string;
+  label?: string;
+};
+
+export function InstallCommand({
+  analyticsEventName,
+  analyticsEventParams,
+  label,
+  command,
+}: InstallCommandProps) {
   return (
     <div className="mt-2">
       {label ? (
@@ -40,7 +66,11 @@ export function InstallCommand({ label, command }: { label?: string; command: st
         <code className="min-w-0 flex-1 whitespace-pre-wrap break-all px-3 py-2.5 font-mono text-sm text-fd-foreground">
           {command}
         </code>
-        <CopyButton text={command} />
+        <CopyButton
+          analyticsEventName={analyticsEventName}
+          analyticsEventParams={analyticsEventParams}
+          text={command}
+        />
       </div>
     </div>
   );

--- a/go/internal/cli/assets/docs/components/docs/install-scripts.tsx
+++ b/go/internal/cli/assets/docs/components/docs/install-scripts.tsx
@@ -53,10 +53,24 @@ export function InstallScripts() {
                 Install this on your developer machine or continuous integration machine.
               </p>
               <InstallCommand
+                analyticsEventName="cli_install_copy"
+                analyticsEventParams={{
+                  install_target: 'unix',
+                  install_variant: 'cli for macOS/linux',
+                  install_label: 'macOS/Linux CLI',
+                  location: 'docs_install_scripts_dialog',
+                }}
                 label="macOS / Linux"
                 command={cliCurlCommand}
               />
               <InstallCommand
+                analyticsEventName="cli_install_copy"
+                analyticsEventParams={{
+                  install_target: 'windows',
+                  install_variant: 'cli for windows',
+                  install_label: 'windows CLI',
+                  location: 'docs_install_scripts_dialog',
+                }}
                 label="Windows"
                 command={cliWingetCommand}
               />
@@ -71,6 +85,13 @@ export function InstallScripts() {
                 WendyOS — it&apos;s already there!
               </p>
               <InstallCommand
+                analyticsEventName="cli_install_copy"
+                analyticsEventParams={{
+                  install_target: 'agent-linux',
+                  install_variant: 'wendy-agent for Linux',
+                  install_label: 'wendy-agent for Linux',
+                  location: 'docs_install_scripts_dialog',
+                }}
                 label="Linux"
                 command={agentCurlCommand}
               />

--- a/go/internal/cli/assets/docs/lib/analytics-events.ts
+++ b/go/internal/cli/assets/docs/lib/analytics-events.ts
@@ -15,7 +15,7 @@ export function trackDocsAnalyticsEvent(
   if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
 
   window.gtag('event', eventName, {
-    event_category: 'marketing',
     ...params,
+    event_category: 'marketing',
   });
 }

--- a/go/internal/cli/assets/docs/lib/analytics-events.ts
+++ b/go/internal/cli/assets/docs/lib/analytics-events.ts
@@ -1,6 +1,39 @@
-export type DocsAnalyticsEventName = 'cli_install_copy';
+export const DOCS_ANALYTICS_CONSENT_KEY = 'wendy_docs_analytics_consent';
 
-export type DocsAnalyticsEventParams = Record<string, string | number | boolean | null | undefined>;
+export type DocsAnalyticsConsentState = 'granted' | 'denied';
+export type DocsInstallCopyTarget = 'unix' | 'windows' | 'agent-linux';
+export type DocsInstallCopyVariant =
+  | 'cli for macOS/linux'
+  | 'cli for windows'
+  | 'wendy-agent for Linux';
+export type DocsInstallCopyLabel = 'macOS/Linux CLI' | 'windows CLI' | 'wendy-agent for Linux';
+export type DocsAnalyticsLocation =
+  | 'docs_get_started_cli_install_command'
+  | 'docs_get_started_agent_install_command'
+  | 'docs_install_scripts_dialog';
+
+export type DocsAnalyticsEvents = {
+  cli_install_copy: {
+    install_target: DocsInstallCopyTarget;
+    install_variant: DocsInstallCopyVariant;
+    install_label: DocsInstallCopyLabel;
+    location: DocsAnalyticsLocation;
+  };
+};
+
+export type DocsAnalyticsEventName = keyof DocsAnalyticsEvents;
+export type DocsAnalyticsEventParams<T extends DocsAnalyticsEventName = DocsAnalyticsEventName> =
+  DocsAnalyticsEvents[T];
+
+export type DocsAnalyticsTrackingProps<T extends DocsAnalyticsEventName = DocsAnalyticsEventName> =
+  | {
+      analyticsEventName: T;
+      analyticsEventParams: DocsAnalyticsEventParams<T>;
+    }
+  | {
+      analyticsEventName?: undefined;
+      analyticsEventParams?: undefined;
+    };
 
 declare global {
   interface Window {
@@ -8,14 +41,75 @@ declare global {
   }
 }
 
-export function trackDocsAnalyticsEvent(
-  eventName: DocsAnalyticsEventName,
-  params: DocsAnalyticsEventParams = {},
+function isDocsAnalyticsConsentState(value: string | null): value is DocsAnalyticsConsentState {
+  return value === 'granted' || value === 'denied';
+}
+
+function getStoredDocsAnalyticsConsent(): DocsAnalyticsConsentState | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const stored = window.localStorage.getItem(DOCS_ANALYTICS_CONSENT_KEY);
+    if (isDocsAnalyticsConsentState(stored)) return stored;
+  } catch {
+    // Storage can be unavailable in private browsing or restricted embeds.
+  }
+
+  if (typeof document === 'undefined') return null;
+
+  const cookieValue =
+    document.cookie
+      .split('; ')
+      .find((cookie) => cookie.startsWith(`${DOCS_ANALYTICS_CONSENT_KEY}=`))
+      ?.split('=')
+      .at(1) ?? null;
+
+  return isDocsAnalyticsConsentState(cookieValue) ? cookieValue : null;
+}
+
+function updateGoogleAnalyticsConsent(state: DocsAnalyticsConsentState) {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+
+  window.gtag('consent', 'update', {
+    analytics_storage: state,
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+  });
+}
+
+export function hasDocsAnalyticsConsent() {
+  return getStoredDocsAnalyticsConsent() === 'granted';
+}
+
+export function setDocsAnalyticsConsent(state: DocsAnalyticsConsentState) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(DOCS_ANALYTICS_CONSENT_KEY, state);
+  } catch {
+    // Storage can be unavailable in private browsing or restricted embeds.
+  }
+
+  if (typeof document !== 'undefined') {
+    document.cookie = `${DOCS_ANALYTICS_CONSENT_KEY}=${state}; Path=/; Max-Age=31536000; SameSite=Lax; Secure`;
+  }
+
+  updateGoogleAnalyticsConsent(state);
+}
+
+export function trackDocsAnalyticsEvent<T extends DocsAnalyticsEventName>(
+  eventName: T,
+  params: DocsAnalyticsEventParams<T>,
 ) {
   if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+  if (getStoredDocsAnalyticsConsent() !== 'granted') return;
+
+  updateGoogleAnalyticsConsent('granted');
 
   window.gtag('event', eventName, {
     ...params,
+    // Docs install-copy events intentionally share the marketing-site GA4 schema.
     event_category: 'marketing',
   });
 }

--- a/go/internal/cli/assets/docs/lib/analytics-events.ts
+++ b/go/internal/cli/assets/docs/lib/analytics-events.ts
@@ -1,0 +1,21 @@
+export type DocsAnalyticsEventName = 'cli_install_copy';
+
+export type DocsAnalyticsEventParams = Record<string, string | number | boolean | null | undefined>;
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function trackDocsAnalyticsEvent(
+  eventName: DocsAnalyticsEventName,
+  params: DocsAnalyticsEventParams = {},
+) {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+
+  window.gtag('event', eventName, {
+    event_category: 'marketing',
+    ...params,
+  });
+}

--- a/go/internal/cli/assets/docs/lib/analytics-events.ts
+++ b/go/internal/cli/assets/docs/lib/analytics-events.ts
@@ -1,7 +1,3 @@
-export const DOCS_ANALYTICS_CONSENT_KEY = 'wendy_docs_analytics_consent';
-const DOCS_ANALYTICS_CONSENT_MAX_AGE_SECONDS = 60 * 60 * 24 * 180;
-
-export type DocsAnalyticsConsentState = 'granted' | 'denied';
 export type DocsInstallCopyTarget = 'unix' | 'windows' | 'agent-linux';
 export type DocsInstallCopyVariant =
   | 'cli for macOS/linux'
@@ -42,83 +38,15 @@ declare global {
   }
 }
 
-function isDocsAnalyticsConsentState(value: string | null): value is DocsAnalyticsConsentState {
-  return value === 'granted' || value === 'denied';
-}
-
-function getStoredDocsAnalyticsConsent(): DocsAnalyticsConsentState | null {
-  if (typeof window === 'undefined') return null;
-
-  try {
-    const stored = window.localStorage.getItem(DOCS_ANALYTICS_CONSENT_KEY);
-    if (isDocsAnalyticsConsentState(stored)) return stored;
-  } catch {
-    // Storage can be unavailable in private browsing or restricted embeds.
-  }
-
-  if (typeof document === 'undefined') return null;
-
-  const cookiePrefix = `${DOCS_ANALYTICS_CONSENT_KEY}=`;
-  const encodedCookieValue =
-    document.cookie
-      .split('; ')
-      .find((cookie) => cookie.startsWith(cookiePrefix))
-      ?.slice(cookiePrefix.length) ?? null;
-
-  let cookieValue: string | null = null;
-  if (encodedCookieValue) {
-    try {
-      cookieValue = decodeURIComponent(encodedCookieValue);
-    } catch {
-      cookieValue = encodedCookieValue;
-    }
-  }
-
-  return isDocsAnalyticsConsentState(cookieValue) ? cookieValue : null;
-}
-
-function updateGoogleAnalyticsConsent(state: DocsAnalyticsConsentState) {
-  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
-
-  window.gtag('consent', 'update', {
-    analytics_storage: state,
-    ad_storage: 'denied',
-    ad_user_data: 'denied',
-    ad_personalization: 'denied',
-  });
-}
-
-export function hasDocsAnalyticsConsent() {
-  return getStoredDocsAnalyticsConsent() === 'granted';
-}
-
-export function setDocsAnalyticsConsent(state: DocsAnalyticsConsentState) {
-  if (typeof window === 'undefined') return;
-
-  try {
-    window.localStorage.setItem(DOCS_ANALYTICS_CONSENT_KEY, state);
-  } catch {
-    // Storage can be unavailable in private browsing or restricted embeds.
-  }
-
-  if (typeof document !== 'undefined') {
-    // HttpOnly is intentionally omitted so the pre-bundle consent bootstrap can
-    // read this non-sensitive consent state before GA initializes.
-    document.cookie = `${DOCS_ANALYTICS_CONSENT_KEY}=${encodeURIComponent(
-      state,
-    )}; Path=/; Max-Age=${DOCS_ANALYTICS_CONSENT_MAX_AGE_SECONDS}; SameSite=Lax; Secure`;
-  }
-
-  updateGoogleAnalyticsConsent(state);
-}
-
 export function trackDocsAnalyticsEvent<T extends DocsAnalyticsEventName>(
   eventName: T,
   params: DocsAnalyticsEventParams<T>,
 ) {
   if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
-  if (getStoredDocsAnalyticsConsent() !== 'granted') return;
 
+  // Consent state is handled centrally through Google Consent Mode. The docs
+  // bootstrap defaults analytics storage to denied and this helper does not keep
+  // a separate JS-writable consent store.
   window.gtag('event', eventName, {
     ...params,
     // Docs install-copy events intentionally share the marketing-site GA4 schema.

--- a/go/internal/cli/assets/docs/lib/analytics-events.ts
+++ b/go/internal/cli/assets/docs/lib/analytics-events.ts
@@ -1,4 +1,5 @@
 export const DOCS_ANALYTICS_CONSENT_KEY = 'wendy_docs_analytics_consent';
+const DOCS_ANALYTICS_CONSENT_MAX_AGE_SECONDS = 60 * 60 * 24 * 180;
 
 export type DocsAnalyticsConsentState = 'granted' | 'denied';
 export type DocsInstallCopyTarget = 'unix' | 'windows' | 'agent-linux';
@@ -57,12 +58,21 @@ function getStoredDocsAnalyticsConsent(): DocsAnalyticsConsentState | null {
 
   if (typeof document === 'undefined') return null;
 
-  const cookieValue =
+  const cookiePrefix = `${DOCS_ANALYTICS_CONSENT_KEY}=`;
+  const encodedCookieValue =
     document.cookie
       .split('; ')
-      .find((cookie) => cookie.startsWith(`${DOCS_ANALYTICS_CONSENT_KEY}=`))
-      ?.split('=')
-      .at(1) ?? null;
+      .find((cookie) => cookie.startsWith(cookiePrefix))
+      ?.slice(cookiePrefix.length) ?? null;
+
+  let cookieValue: string | null = null;
+  if (encodedCookieValue) {
+    try {
+      cookieValue = decodeURIComponent(encodedCookieValue);
+    } catch {
+      cookieValue = encodedCookieValue;
+    }
+  }
 
   return isDocsAnalyticsConsentState(cookieValue) ? cookieValue : null;
 }
@@ -92,7 +102,11 @@ export function setDocsAnalyticsConsent(state: DocsAnalyticsConsentState) {
   }
 
   if (typeof document !== 'undefined') {
-    document.cookie = `${DOCS_ANALYTICS_CONSENT_KEY}=${state}; Path=/; Max-Age=31536000; SameSite=Lax; Secure`;
+    // HttpOnly is intentionally omitted so the pre-bundle consent bootstrap can
+    // read this non-sensitive consent state before GA initializes.
+    document.cookie = `${DOCS_ANALYTICS_CONSENT_KEY}=${encodeURIComponent(
+      state,
+    )}; Path=/; Max-Age=${DOCS_ANALYTICS_CONSENT_MAX_AGE_SECONDS}; SameSite=Lax; Secure`;
   }
 
   updateGoogleAnalyticsConsent(state);
@@ -104,8 +118,6 @@ export function trackDocsAnalyticsEvent<T extends DocsAnalyticsEventName>(
 ) {
   if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
   if (getStoredDocsAnalyticsConsent() !== 'granted') return;
-
-  updateGoogleAnalyticsConsent('granted');
 
   window.gtag('event', eventName, {
     ...params,

--- a/go/internal/cli/assets/docs/scripts/prepare-content.mjs
+++ b/go/internal/cli/assets/docs/scripts/prepare-content.mjs
@@ -24,6 +24,7 @@ const skipDirs = new Set([
 const publicAssetExtensions = new Set([
   '.gif',
   '.ico',
+  '.js',
   '.jpeg',
   '.jpg',
   '.json',

--- a/go/internal/cli/assets/docs/static/docs-google-analytics-consent-default.js
+++ b/go/internal/cli/assets/docs/static/docs-google-analytics-consent-default.js
@@ -1,0 +1,50 @@
+(function () {
+  var key = 'wendy_docs_analytics_consent';
+  var analyticsConsent = 'denied';
+
+  function isConsentState(value) {
+    return value === 'granted' || value === 'denied';
+  }
+
+  function readConsentCookie() {
+    var prefix = key + '=';
+    var cookies = document.cookie ? document.cookie.split('; ') : [];
+
+    for (var index = 0; index < cookies.length; index += 1) {
+      var cookie = cookies[index];
+      if (cookie.indexOf(prefix) !== 0) continue;
+
+      try {
+        return decodeURIComponent(cookie.slice(prefix.length));
+      } catch (error) {
+        return cookie.slice(prefix.length);
+      }
+    }
+
+    return null;
+  }
+
+  try {
+    var stored = window.localStorage.getItem(key);
+    var cookieValue = readConsentCookie();
+
+    if (isConsentState(stored)) {
+      analyticsConsent = stored;
+    } else if (isConsentState(cookieValue)) {
+      analyticsConsent = cookieValue;
+    }
+  } catch (error) {}
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag =
+    window.gtag ||
+    function () {
+      window.dataLayer.push(arguments);
+    };
+  window.gtag('consent', 'default', {
+    analytics_storage: analyticsConsent,
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+  });
+})();

--- a/go/internal/cli/assets/docs/static/docs-google-analytics-consent-default.js
+++ b/go/internal/cli/assets/docs/static/docs-google-analytics-consent-default.js
@@ -1,40 +1,4 @@
 (function () {
-  var key = 'wendy_docs_analytics_consent';
-  var analyticsConsent = 'denied';
-
-  function isConsentState(value) {
-    return value === 'granted' || value === 'denied';
-  }
-
-  function readConsentCookie() {
-    var prefix = key + '=';
-    var cookies = document.cookie ? document.cookie.split('; ') : [];
-
-    for (var index = 0; index < cookies.length; index += 1) {
-      var cookie = cookies[index];
-      if (cookie.indexOf(prefix) !== 0) continue;
-
-      try {
-        return decodeURIComponent(cookie.slice(prefix.length));
-      } catch (error) {
-        return cookie.slice(prefix.length);
-      }
-    }
-
-    return null;
-  }
-
-  try {
-    var stored = window.localStorage.getItem(key);
-    var cookieValue = readConsentCookie();
-
-    if (isConsentState(stored)) {
-      analyticsConsent = stored;
-    } else if (isConsentState(cookieValue)) {
-      analyticsConsent = cookieValue;
-    }
-  } catch (error) {}
-
   window.dataLayer = window.dataLayer || [];
   window.gtag =
     window.gtag ||
@@ -42,7 +6,7 @@
       window.dataLayer.push(arguments);
     };
   window.gtag('consent', 'default', {
-    analytics_storage: analyticsConsent,
+    analytics_storage: 'denied',
     ad_storage: 'denied',
     ad_user_data: 'denied',
     ad_personalization: 'denied',


### PR DESCRIPTION
## Summary
- Add a docs-side GA4 event helper for `cli_install_copy`
- Track install command copy events from the docs get-started section and Install Scripts dialog
- Preserve the same install variant strings used by the marketing site: `cli for macOS/linux`, `cli for windows`, and `wendy-agent for Linux`

Linear: WDY-1791

## Validation
- `npm run types:check`
- `NEXT_PUBLIC_BASE_PATH=/latest NEXT_PUBLIC_GA_MEASUREMENT_ID=<set> npm run build`
- `npm audit --audit-level=high`
- `git diff --check`