### PR TITLE
ci: drop darwin-amd64 CLI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,10 +157,11 @@ jobs:
     strategy:
       matrix:
         include:
+          # Intel (amd64) macOS is not built: the CLI links libusb via cgo
+          # (github.com/google/gousb), and cross-compiling x86_64 on the arm64
+          # macos-15 runner fails to link the arm64-only Homebrew libusb.
           - artifact-name: wendy-cli-darwin-arm64
             goarch: arm64
-          - artifact-name: wendy-cli-darwin-amd64
-            goarch: amd64
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/go/internal/cli/assets/docs/RELEASES.md
+++ b/go/internal/cli/assets/docs/RELEASES.md
@@ -95,7 +95,6 @@ All platform builds are included:
 - `wendy-cli-linux-arm64-${VERSION}.tar.gz`
 - `wendy-cli-linux-amd64-${VERSION}.tar.gz`
 - `wendy-cli-darwin-arm64-${VERSION}.tar.gz`
-- `wendy-cli-darwin-amd64-${VERSION}.tar.gz`
 - `wendy-cli-windows-amd64-${VERSION}.zip`
 - `wendy-cli-windows-arm64-${VERSION}.zip`
 

--- a/go/internal/cli/assets/docs/cli.sh
+++ b/go/internal/cli/assets/docs/cli.sh
@@ -173,6 +173,11 @@ echo ""
 
 # ===== macOS =====
 if [[ "$OS" == "darwin" ]]; then
+  if [[ "$ARCH" != "arm64" ]]; then
+    echo "Error: the Wendy CLI for macOS requires Apple Silicon (arm64)." >&2
+    echo "Intel (x86_64) Macs are no longer supported." >&2
+    exit 1
+  fi
   if command -v brew &>/dev/null; then
     if homebrew_supports_trust; then
       echo "Homebrew detected. Will trust and install via:"

--- a/go/internal/cli/assets/docs/cli.sh
+++ b/go/internal/cli/assets/docs/cli.sh
@@ -174,9 +174,14 @@ echo ""
 # ===== macOS =====
 if [[ "$OS" == "darwin" ]]; then
   if [[ "$ARCH" != "arm64" ]]; then
-    echo "Error: the Wendy CLI for macOS requires Apple Silicon (arm64)." >&2
-    echo "Intel (x86_64) Macs are no longer supported." >&2
-    exit 1
+    # On Apple Silicon running under Rosetta, uname -m reports x86_64; still install arm64.
+    if [[ "$(sysctl -in hw.optional.arm64 2>/dev/null || echo 0)" == "1" ]]; then
+      ARCH="arm64"
+    else
+      echo "Error: the Wendy CLI for macOS requires Apple Silicon (arm64)." >&2
+      echo "Intel (x86_64) Macs are no longer supported." >&2
+      exit 1
+    fi
   fi
   if command -v brew &>/dev/null; then
     if homebrew_supports_trust; then


### PR DESCRIPTION
## Problem

The `wendy-cli-darwin-amd64` job in `build.yml` fails to link, breaking the release build ([failing run](https://github.com/wendylabsinc/WendyOS/actions/runs/28539270575/job/84608655555)):

```
ld: warning: ignoring file '/opt/homebrew/.../libusb-1.0.dylib': found architecture 'arm64', required architecture 'x86_64'
Undefined symbols for architecture x86_64: _libusb_init, _libusb_open, ...
ld: symbol(s) not found for architecture x86_64
```

**Root cause:** the CLI now links **libusb** via cgo (`github.com/google/gousb`, introduced in #1233 for Thor flashpack flashing). GitHub's `macos-15` runners are Apple Silicon, so the `darwin-amd64` matrix entry cross-compiles to x86_64 and can't link the arm64-only Homebrew libusb. The `darwin-arm64` build (native) and the pure-Go Linux/Windows amd64 builds are unaffected.

## Change

- **`.github/workflows/build.yml`** — remove the `wendy-cli-darwin-amd64` matrix entry from `build-go-macos` (comment explains why).
- **`RELEASES.md`** — drop `wendy-cli-darwin-amd64` from the published-artifacts list.
- **`cli.sh`** — Intel Macs can't run the arm64 binary (Rosetta only translates x86_64 → arm64), so the installer now errors clearly on Intel instead of 404ing on the missing artifact.

## Follow-up (not in this PR)

The nightly Homebrew tap formula lives in a separate repo. If its bottle logic references a darwin-amd64 build or an x86_64 bottle, Intel `brew install` will also break and should be updated there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)