### PR TITLE
docs: note macOS CLI requires Apple Silicon

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,8 @@ For most users, the recommended installation method is the install script docume
 
 ### macOS (Homebrew)
 
+> **Note:** The Wendy CLI for macOS requires **Apple Silicon (arm64)**. Intel (x86_64) Macs are not supported.
+
 On Homebrew versions that support formula trust:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Yocto image build system, it lives in
 
 ## Install the Wendy CLI
 
-Install or update the `wendy` CLI on macOS or Linux (x86_64 and ARM64):
+Install or update the `wendy` CLI on macOS (Apple Silicon) or Linux (x86_64 and ARM64):
 
 ```sh
 curl -fsSL https://install.wendy.dev/cli.sh | bash


### PR DESCRIPTION
Follow-up to #1276, addressing the user-facing documentation gap flagged by the AI docs-review bot on that PR.

Since the CLI no longer ships a `darwin-amd64` build (#1276 — cgo/libusb can't cross-link for x86_64 on GitHub's arm64 macOS runners), the docs should tell Intel-Mac users the macOS CLI requires Apple Silicon.

## Changes

- **`README.md`** — the install line claimed the CLI runs on "macOS or Linux (x86_64 and ARM64)"; the arch note now correctly applies only to Linux, with macOS scoped to Apple Silicon.
- **`INSTALL.md`** — added an Apple-Silicon requirement note to the macOS (Homebrew) section, since the Homebrew path can't serve Intel either.

## Bot items not actioned (and why)

- **Duplicate `cli.sh` / second `RELEASES.md`** — false positives: repo-root `docs/` is a symlink into `go/internal/cli/assets/docs`, and `.../content/` is a gitignored *generated* fumadocs mirror. The source files were already updated in #1276; the generated copies regenerate from them.
- **Note in `clients/wendy-cli/commands/install.md`** — that page documents `wendy install` (flashing WendyOS onto a device), not CLI installation, so it's the wrong place for a CLI-arch note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)