### PR TITLE
device update: run the OS update on wendyos-update devices, keep --binary sticky; agent self-heals a stuck deployment

### DIFF
--- a/go/internal/agent/services/wendyos_backend.go
+++ b/go/internal/agent/services/wendyos_backend.go
@@ -76,6 +76,33 @@ func (w wendyOSUpdater) install(ctx context.Context, artifactURL string, onProgr
 		return errors.New("wendyos-update binary not found")
 	}
 
+	stale, err := w.runInstall(ctx, binary, artifactURL, onProgress)
+	if err == nil || !stale {
+		return err
+	}
+
+	// wendyos-update refused because a previous deployment is still recorded as
+	// in flight ("run rollback or mark-good first"). The post-reboot gate reverts
+	// the A/B slot on a failed update but can leave this terminal record behind,
+	// and the agent exposes no remote verb to clear it — so a single failed
+	// update would otherwise wedge the device out of every future OTA update.
+	// Clear it with the rollback the tool itself prescribes (mark-good would
+	// commit the failed slot, which we must not do), then retry the install once.
+	w.logger.Warn("wendyos-update rejected the install: a previous deployment is stuck in flight; clearing it with rollback and retrying")
+	if res := runUpdaterCommit(w.logger, binary, "rollback"); res.Status == oshealth.MenderError {
+		w.logger.Error("failed to clear the stuck wendyos-update deployment; surfacing the original install error",
+			zap.String("output", res.Output), zap.Error(res.Err))
+		return err
+	}
+	_, retryErr := w.runInstall(ctx, binary, artifactURL, onProgress)
+	return retryErr
+}
+
+// runInstall performs one `wendyos-update install` attempt, streaming progress
+// and returning a user-facing error on failure. stale is true only when the
+// failure was wendyos-update refusing because a prior deployment is stuck in
+// flight — the one case install() clears with a rollback and retries.
+func (w wendyOSUpdater) runInstall(ctx context.Context, binary, artifactURL string, onProgress func(string, int32)) (stale bool, err error) {
 	onProgress("downloading", 0)
 	cmd := exec.CommandContext(ctx, binary, "install", artifactURL)
 	cmd.Env = envWithPath("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
@@ -84,15 +111,15 @@ func (w wendyOSUpdater) install(ctx context.Context, artifactURL string, onProgr
 	// human logs, whose tail we keep so a non-zero exit reports the real cause.
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stdout pipe: %v", err)
+		return false, fmt.Errorf("failed to create stdout pipe: %v", err)
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stderr pipe: %v", err)
+		return false, fmt.Errorf("failed to create stderr pipe: %v", err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start wendyos-update: %v", err)
+		return false, fmt.Errorf("failed to start wendyos-update: %v", err)
 	}
 
 	outputTail := newLineRing(menderErrorTailLines)
@@ -128,12 +155,28 @@ func (w wendyOSUpdater) install(ctx context.Context, artifactURL string, onProgr
 
 	if err := cmd.Wait(); err != nil {
 		code := exitCodeOf(err)
-		msg := wendyOSInstallErrorMessage(code, outputTail.tail())
+		tail := outputTail.tail()
+		msg := wendyOSInstallErrorMessage(code, tail)
 		w.logger.Error("wendyos-update install failed",
-			zap.Int("exit_code", code), zap.Error(err), zap.Strings("output_tail", outputTail.tail()))
-		return errors.New(msg)
+			zap.Int("exit_code", code), zap.Error(err), zap.Strings("output_tail", tail))
+		return isStaleDeploymentError(tail), errors.New(msg)
 	}
-	return nil
+	return false, nil
+}
+
+// isStaleDeploymentError reports whether a failed `wendyos-update install` was
+// refused because a previous deployment is still recorded as in flight — e.g.
+// `an update is already in flight (phase "failed", …); run rollback or mark-good
+// first`. Matching the tool's stable "already in flight" wording keeps this a
+// pure recovery heuristic: if the wording ever changes we simply fall back to
+// today's behavior of surfacing the failure unchanged.
+func isStaleDeploymentError(tail []string) bool {
+	for _, line := range tail {
+		if strings.Contains(strings.ToLower(line), "already in flight") {
+			return true
+		}
+	}
+	return false
 }
 
 func (w wendyOSUpdater) commit() oshealth.MenderResult {

--- a/go/internal/agent/services/wendyos_backend_test.go
+++ b/go/internal/agent/services/wendyos_backend_test.go
@@ -106,6 +106,45 @@ func TestWendyOSInstallErrorMessage(t *testing.T) {
 	}
 }
 
+func TestIsStaleDeploymentError(t *testing.T) {
+	tests := []struct {
+		name string
+		tail []string
+		want bool
+	}{
+		{
+			name: "the in-flight rejection wendyos-update actually prints",
+			tail: []string{
+				"wendyos-update: install: downloading url=https://example/img.wendy status=200 OK",
+				`wendyos-update: an update is already in flight (phase "failed", artifact wendyos-image-jetson-orin-nano-devkit-nvme-wendyos-0.16.1); run rollback or mark-good first`,
+			},
+			want: true,
+		},
+		{
+			name: "match is case-insensitive",
+			tail: []string{`An update is Already In Flight (phase "failed")`},
+			want: true,
+		},
+		{
+			name: "an artifact rejection is not a stale-deployment error",
+			tail: []string{"wendyos-update: checksum mismatch", "wendyos-update: artifact rejected"},
+			want: false,
+		},
+		{
+			name: "empty tail",
+			tail: nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStaleDeploymentError(tt.tail); got != tt.want {
+				t.Fatalf("isStaleDeploymentError(%q) = %v, want %v", tt.tail, got, tt.want)
+			}
+		})
+	}
+}
+
 // exit 4 (verify failed) is a commit-time code in the wendyos-update contract;
 // install never emits it. The install error mapper must therefore not mislabel
 // a stray exit 4 as a verification failure — it falls through to the generic

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
@@ -1,6 +1,13 @@
-Updates the wendy-agent installation on the remote device. By default downloads the latest release binary from GitHub matching the device's CPU architecture. Pass `--binary <path>` to upload a locally built binary instead (e.g. a cross-compiled development build). The command waits for the restarted agent to become reachable before reporting success.
+Updates the wendy-agent installation on the remote device, then checks for a newer WendyOS image. By default downloads the latest release binary from GitHub matching the device's CPU architecture. Pass `--binary <path>` to upload a locally built binary instead (e.g. a cross-compiled development build). The command waits for the restarted agent to become reachable before reporting success.
 
 GitHub release lookups use the `GITHUB_TOKEN` environment variable for authentication when it is present, and fall back to unauthenticated requests otherwise.
 
+## OS update step
+
+After the agent is updated, the command checks for an OS update on WendyOS devices that advertise an OTA backend — the in-house **wendyos-update** engine or **mender** (auto-selection prefers wendyos-update). When a newer image is available it prompts before applying (default no); use `--yes` to apply without prompting, and `--nightly` to track the nightly channel for both the agent and the OS. Non-interactive runs report the available update without applying it. Devices without an OTA backend, and non-WendyOS hosts, skip this step silently — `device update` still succeeds as an agent-only update.
+
+## `--binary` survives the OS update
+
+An OS update reboots into a new image that ships its own bundled agent, which would otherwise replace a `--binary` build. When `--binary` was provided and an OS update is applied, the command re-uploads the same binary after the device comes back online, so the development agent you asked for is what ends up running. (The auto-download path is not re-applied, to avoid downgrading the new image's bundled agent.) On cloud-tunneled devices the command does not wait for the reboot, so it prints instructions to re-run `device update --binary` once the device is back online.
+
 > **TODO**: On ubuntu machines, this should use `apt upgrade wendy-agent`
-> **IDEA**: It could also prompt the question to run `wendy os update` if needed, as to avoid confusion.

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1801,24 +1801,41 @@ func reconnectAgentAfterRestart(ctx context.Context, conn *grpcclient.AgentConne
 	return waitForAgentRestart(ctx, hostPort(conn.Host, defaultAgentPort))
 }
 
+// osUpdateOutcome reports what `device update`'s OS-update step did, so the
+// caller can decide whether a --binary dev agent must be re-applied afterward
+// (see shouldReapplyBinary).
+type osUpdateOutcome struct {
+	// applied is true when an OTA was streamed to the device (it is rebooting
+	// into, or has rebooted into, the new image).
+	applied bool
+	// online is true when the device was confirmed back online within this run.
+	// It is only ever set on the LAN path; the cloud path returns without
+	// waiting for the reboot, so the caller cannot re-apply inline there.
+	online bool
+}
+
 // maybeCheckOSUpdate runs the OS-update step for `device update` after the
 // agent has been updated. preUpdateVersion is the version queried before the
 // agent restart; it is used only for a cheap up-front gate, since whether a
-// device runs WendyOS and supports mender does not change across an agent
-// update. When artifactURLOverride is set, that exact Mender artifact is
-// applied (prompting unless assumeYes) instead of the manifest's latest;
-// otherwise the device_type/storage_medium/os_version used for the decision
-// are re-read from the agent we just installed — a newer agent can report a
-// corrected device_type, so the pre-update snapshot may be stale.
-// Non-WendyOS / no-mender targets are skipped silently (no reconnect), and any
-// failure to re-read or look up the OS is reported but non-fatal — `device
-// update` still succeeds as an agent-only update.
-func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentVersionResponse, priorConn *grpcclient.AgentConnection, nightly, assumeYes bool, artifactURLOverride string) error {
+// device runs WendyOS and has an OTA backend does not change across an agent
+// update. priorConn must be a live connection to the just-restarted agent — it
+// is used both to talk to the device and (via its Host/Reconnect) to re-dial
+// the SAME device after the reboot, so this must not be nil once the gate
+// passes. When artifactURLOverride is set, that exact artifact is applied
+// (prompting unless assumeYes) instead of the manifest's latest; otherwise the
+// device_type/storage_medium/os_version used for the decision are re-read from
+// the agent we just installed — a newer agent can report a corrected
+// device_type, so the pre-update snapshot may be stale. Non-WendyOS targets and
+// devices without an OTA backend are skipped silently, and any failure to
+// re-read or look up the OS is reported but non-fatal — `device update` still
+// succeeds as an agent-only update. The returned outcome reports whether an OTA
+// was actually applied and whether the device came back online in this run.
+func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentVersionResponse, priorConn *grpcclient.AgentConnection, nightly, assumeYes bool, artifactURLOverride string) (osUpdateOutcome, error) {
 	if preUpdateVersion == nil {
-		return nil
+		return osUpdateOutcome{}, nil
 	}
-	if !isWendyOSUpdateTarget(preUpdateVersion) || !agentVersionHasFeature(preUpdateVersion, "mender") {
-		return nil
+	if !isWendyOSUpdateTarget(preUpdateVersion) || !hasOTABackend(preUpdateVersion) {
+		return osUpdateOutcome{}, nil
 	}
 
 	// Any OS work needs a live connection to the just-restarted agent. Reconnect
@@ -1829,7 +1846,7 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 	conn, err := reconnectAgentAfterRestart(ctx, priorConn)
 	if err != nil {
 		fmt.Printf("Could not check for OS updates: %v\n", err)
-		return nil
+		return osUpdateOutcome{}, nil
 	}
 	defer conn.Close()
 
@@ -1840,11 +1857,11 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 		if !assumeYes {
 			if !isInteractiveTerminal() {
 				fmt.Printf("OS artifact specified (%s). Re-run with --yes to apply.\n", artifactURLOverride)
-				return nil
+				return osUpdateOutcome{}, nil
 			}
 			if !promptYesNoDefaultNoFn(fmt.Sprintf("Apply OS update from %s? [y/N] ", artifactURLOverride)) {
 				fmt.Println("Skipping OS update.")
-				return nil
+				return osUpdateOutcome{}, nil
 			}
 		}
 		otaURL = artifactURLOverride
@@ -1855,19 +1872,19 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 		versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
 		if err != nil {
 			fmt.Printf("Could not check for OS updates: %v\n", err)
-			return nil
+			return osUpdateOutcome{}, nil
 		}
 
 		deviceType := versionResp.GetDeviceType()
 		if deviceType == "" {
 			// No device type → cannot auto-select the GCS artifact; skip quietly.
-			return nil
+			return osUpdateOutcome{}, nil
 		}
 
 		u, latestVer, err := getLatestOTAInfoForDeviceType(deviceType, versionResp.GetStorageMedium(), nightly)
 		if err != nil {
 			fmt.Printf("Could not check for OS updates: %v\n", err)
-			return nil
+			return osUpdateOutcome{}, nil
 		}
 
 		currentOS := versionResp.GetOsVersion()
@@ -1879,35 +1896,47 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 		switch decideOSUpdate(currentOS, latestVer, nightly, assumeYes, isInteractiveTerminal()) {
 		case osActionAlreadyCurrent:
 			fmt.Printf("OS is already at the latest version (%s).\n", currentOS)
-			return nil
+			return osUpdateOutcome{}, nil
 		case osActionReportOnly:
 			fmt.Printf("OS update available (%s). Re-run with --yes or run 'wendy os update' to apply.\n", latestVer)
-			return nil
+			return osUpdateOutcome{}, nil
 		case osActionApply:
 			// fall through to apply
 		case osActionPrompt:
 			if !promptYesNoDefaultNoFn(fmt.Sprintf("OS update available (%s → %s). Apply now? [y/N] ", fromVer, latestVer)) {
 				fmt.Println("Skipping OS update. Run 'wendy os update' to apply later.")
-				return nil
+				return osUpdateOutcome{}, nil
 			}
 		}
 		otaURL = u
 	}
 
 	if err := streamOSUpdate(ctx, conn, otaURL, ""); err != nil {
-		return err
+		return osUpdateOutcome{}, err
 	}
 
 	if _, isCloud := cloudDeviceConfigFromContext(ctx); isCloud {
 		fmt.Println("OS update applied; the device is rebooting. Reconnect once it is back online.")
-		return nil
+		return osUpdateOutcome{applied: true}, nil
 	}
 	fmt.Println("WendyOS update applied. Device is rebooting...")
 	if err := waitForDeviceOnline(ctx, priorConn.Host); err != nil {
-		return err
+		return osUpdateOutcome{applied: true}, err
 	}
 	fmt.Println("Device is back online.")
-	return nil
+	return osUpdateOutcome{applied: true, online: true}, nil
+}
+
+// shouldReapplyBinary reports whether `device update` should re-upload the
+// user-provided --binary agent after the OS update. It re-applies only when the
+// user explicitly passed --binary (a deliberate dev-agent override) AND an OS
+// update was actually applied AND the device came back online in this run. The
+// auto-download path is intentionally excluded: re-pushing a downloaded release
+// over the new image's bundled agent could silently downgrade it. The cloud
+// path (applied but not online here) is excluded too — there is no reboot to
+// wait on inline — and the caller prints guidance to re-run instead.
+func shouldReapplyBinary(binaryProvided bool, outcome osUpdateOutcome) bool {
+	return binaryProvided && outcome.applied && outcome.online
 }
 
 func newDeviceUpdateCmd() *cobra.Command {
@@ -2021,62 +2050,22 @@ func newDeviceUpdateCmd() *cobra.Command {
 			h := sha256.Sum256(binaryData)
 			sha256Hash := hex.EncodeToString(h[:])
 
-			if isInteractiveTerminal() && !jsonOutput {
-				s := tui.NewSpinner("Uploading agent binary...")
-				p := tui.NewProgressProgram(s)
-
-				go func() {
-					uploadErr := deviceUpdateUpload(ctx, conn.AgentService, binaryData, sha256Hash)
-					p.Send(tui.SpinnerDoneMsg{Err: uploadErr})
-				}()
-
-				finalModel, runErr := p.Run()
-				if runErr != nil {
-					return fmt.Errorf("TUI error: %w", runErr)
-				}
-
-				model := finalModel.(tui.SpinnerModel)
-				_, updateErr := model.Result()
-				if updateErr != nil {
-					return updateErr
-				}
-			} else if !jsonOutput {
-				fmt.Println(tui.InfoMessage("Uploading agent binary..."))
-				if err := deviceUpdateUpload(ctx, conn.AgentService, binaryData, sha256Hash); err != nil {
-					return err
-				}
-			} else {
-				if err := deviceUpdateUpload(ctx, conn.AgentService, binaryData, sha256Hash); err != nil {
-					return err
-				}
+			if err := uploadAgentBinary(ctx, conn.AgentService, binaryData, sha256Hash, jsonOutput); err != nil {
+				return err
 			}
 
+			// Keep the connection to the just-restarted agent. maybeCheckOSUpdate
+			// needs a live conn (and its Host/Reconnect) both to drive the OS
+			// update and to re-dial the SAME device after the reboot; passing nil
+			// here would nil-deref once the OS-update gate lets a device through.
 			reconnect := updatedAgentReconnectFunc(ctx, conn)
 			if conn != nil {
 				_ = conn.Close()
 				conn = nil
 			}
-			if isInteractiveTerminal() && !jsonOutput {
-				readyConn, err := runAgentConnectionSpinner(ctx, "Waiting for agent to restart...", func(spinCtx context.Context) (*grpcclient.AgentConnection, error) {
-					return waitForUpdatedAgentReady(spinCtx, reconnect, agentRestartWaitOptions{})
-				})
-				if err != nil {
-					return err
-				}
-				if readyConn != nil {
-					_ = readyConn.Close()
-				}
-			} else {
-				if !jsonOutput {
-					fmt.Println(tui.InfoMessage("Waiting for agent to restart..."))
-				}
-				readyConn, err := waitForUpdatedAgentReady(ctx, reconnect, agentRestartWaitOptions{})
-				if err != nil {
-					return err
-				}
-				if readyConn != nil {
-					_ = readyConn.Close()
-				}
+			conn, err = awaitAgentRestart(ctx, reconnect, jsonOutput)
+			if err != nil {
+				return err
 			}
 
 			if jsonOutput {
@@ -2093,14 +2082,38 @@ func newDeviceUpdateCmd() *cobra.Command {
 				return nil
 			}
 			fmt.Println(tui.SuccessMessage("Agent updated successfully."))
-			if err := maybeCheckOSUpdate(ctx, preUpdateVersion, conn, nightly, assumeYes, artifactURL); err != nil {
-				return err
+
+			var outcome osUpdateOutcome
+			if conn != nil {
+				outcome, err = maybeCheckOSUpdate(ctx, preUpdateVersion, conn, nightly, assumeYes, artifactURL)
+				if err != nil {
+					return err
+				}
+			}
+
+			// A --binary dev agent does not survive an OS update on its own: the
+			// updated image ships its own bundled agent. Re-upload the same binary
+			// so the agent the user explicitly asked for is what ends up running.
+			if binaryPath != "" && outcome.applied && !outcome.online {
+				// Cloud path: the reboot is in flight and we did not wait for it,
+				// so we cannot re-apply inline. Tell the user how to restore it.
+				fmt.Println(tui.InfoMessage(fmt.Sprintf(
+					"The OS update is rebooting the device; its new image ships a bundled agent. "+
+						"Re-run 'wendy device update --binary %s' once it is back online to restore your dev agent.",
+					binaryPath)))
+			}
+			if shouldReapplyBinary(binaryPath != "", outcome) {
+				fmt.Println(tui.InfoMessage("Re-applying your --binary agent onto the updated OS..."))
+				if err := reapplyBinaryAfterOSUpdate(ctx, conn, binaryData, sha256Hash, jsonOutput); err != nil {
+					return fmt.Errorf("re-applying --binary after OS update: %w", err)
+				}
+				fmt.Println(tui.SuccessMessage("Dev agent re-applied; it survived the OS update."))
 			}
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&binaryPath, "binary", "", "Path to a local agent binary to upload (skips download)")
+	cmd.Flags().StringVar(&binaryPath, "binary", "", "Path to a local agent binary to upload (skips download); re-applied after an OS update so it survives the reboot")
 	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use the latest nightly (prerelease) build for both the agent and the OS")
 	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Apply an available OS update without prompting")
 	cmd.Flags().StringVar(&artifactURL, "artifact-url", "", "Apply this OS (Mender) artifact URL instead of the manifest's latest")
@@ -2171,6 +2184,82 @@ const (
 	defaultAgentRestartTimeout      = 20 * time.Second
 	defaultAgentRestartPollInterval = time.Second
 )
+
+// uploadAgentBinary uploads binaryData to the device, showing a spinner when
+// interactive and a plain status line otherwise (nothing extra in JSON mode).
+// It is the shared upload used by both `device update`'s initial agent update
+// and the post-OS-update --binary re-apply, so the two stay in lockstep.
+func uploadAgentBinary(ctx context.Context, agentService agentpb.WendyAgentServiceClient, binaryData []byte, sha256Hash string, jsonOutput bool) error {
+	if isInteractiveTerminal() && !jsonOutput {
+		s := tui.NewSpinner("Uploading agent binary...")
+		p := tui.NewProgressProgram(s)
+
+		go func() {
+			uploadErr := deviceUpdateUpload(ctx, agentService, binaryData, sha256Hash)
+			p.Send(tui.SpinnerDoneMsg{Err: uploadErr})
+		}()
+
+		finalModel, runErr := p.Run()
+		if runErr != nil {
+			return fmt.Errorf("TUI error: %w", runErr)
+		}
+		model := finalModel.(tui.SpinnerModel)
+		if _, updateErr := model.Result(); updateErr != nil {
+			return updateErr
+		}
+		return nil
+	}
+	if !jsonOutput {
+		fmt.Println(tui.InfoMessage("Uploading agent binary..."))
+	}
+	return deviceUpdateUpload(ctx, agentService, binaryData, sha256Hash)
+}
+
+// awaitAgentRestart waits for the agent to come back after an upload and returns
+// a live connection to it (showing a spinner when interactive).
+func awaitAgentRestart(ctx context.Context, reconnect func(context.Context) (*grpcclient.AgentConnection, error), jsonOutput bool) (*grpcclient.AgentConnection, error) {
+	if isInteractiveTerminal() && !jsonOutput {
+		return runAgentConnectionSpinner(ctx, "Waiting for agent to restart...", func(spinCtx context.Context) (*grpcclient.AgentConnection, error) {
+			return waitForUpdatedAgentReady(spinCtx, reconnect, agentRestartWaitOptions{})
+		})
+	}
+	if !jsonOutput {
+		fmt.Println(tui.InfoMessage("Waiting for agent to restart..."))
+	}
+	return waitForUpdatedAgentReady(ctx, reconnect, agentRestartWaitOptions{})
+}
+
+// reapplyBinaryAfterOSUpdate re-uploads the --binary dev agent after an OS
+// update so it replaces the updated image's bundled agent. priorConn is the
+// (now-stale) connection whose Host/Reconnect identifies the device; the device
+// is expected to already be back online (maybeCheckOSUpdate waited for it), so
+// the first reconnect resolves promptly. The upload restarts the agent, so it
+// then waits once more for the re-applied dev agent to return.
+func reapplyBinaryAfterOSUpdate(ctx context.Context, priorConn *grpcclient.AgentConnection, binaryData []byte, sha256Hash string, jsonOutput bool) error {
+	conn, err := awaitAgentRestart(ctx, updatedAgentReconnectFunc(ctx, priorConn), jsonOutput)
+	if err != nil {
+		return err
+	}
+	if conn == nil {
+		return errors.New("reconnected to a nil agent connection after the OS update")
+	}
+
+	if err := uploadAgentBinary(ctx, conn.AgentService, binaryData, sha256Hash, jsonOutput); err != nil {
+		_ = conn.Close()
+		return err
+	}
+
+	reconnectAfter := updatedAgentReconnectFunc(ctx, conn)
+	_ = conn.Close()
+	readyConn, err := awaitAgentRestart(ctx, reconnectAfter, jsonOutput)
+	if err != nil {
+		return err
+	}
+	if readyConn != nil {
+		_ = readyConn.Close()
+	}
+	return nil
+}
 
 func deviceUpdateUpload(ctx context.Context, agentService agentpb.WendyAgentServiceClient, binaryData []byte, sha256Hash string) error {
 	stream, err := agentService.UpdateAgent(ctx)

--- a/go/internal/cli/commands/device_test.go
+++ b/go/internal/cli/commands/device_test.go
@@ -100,17 +100,22 @@ func TestMaybeCheckOSUpdateSkips(t *testing.T) {
 	}{
 		{"nil version", nil},
 		{"non-wendyos darwin", &agentpb.GetAgentVersionResponse{Os: "darwin", OsVersion: strp("14.4")}},
-		{"wendyos without mender",
+		{"wendyos without an OTA backend",
 			&agentpb.GetAgentVersionResponse{Os: "linux", OsVersion: strp("WendyOS-0.10.4"), DeviceType: strp("raspberry-pi-5")}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// These inputs must return from the cheap pre-reconnect gate, before
-			// any reconnect/manifest/network call. (WendyOS+mender devices do
-			// reconnect to re-read the version, so they're not covered here.)
-			// A nil connection is safe because the gate returns before it is used.
-			if err := maybeCheckOSUpdate(context.Background(), tc.version, nil, false, false, ""); err != nil {
+			// any reconnect/manifest/network call. (WendyOS devices with an OTA
+			// backend — wendyos-update or mender — do reconnect to re-read the
+			// version, so they're not covered here.) A nil connection is safe
+			// because the gate returns before it is used.
+			outcome, err := maybeCheckOSUpdate(context.Background(), tc.version, nil, false, false, "")
+			if err != nil {
 				t.Fatalf("maybeCheckOSUpdate() error = %v, want nil", err)
+			}
+			if outcome.applied || outcome.online {
+				t.Fatalf("maybeCheckOSUpdate() outcome = %+v, want zero (skipped)", outcome)
 			}
 		})
 	}

--- a/go/internal/cli/commands/device_update_test.go
+++ b/go/internal/cli/commands/device_update_test.go
@@ -10,6 +10,47 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 )
 
+func TestShouldReapplyBinary(t *testing.T) {
+	tests := []struct {
+		name           string
+		binaryProvided bool
+		outcome        osUpdateOutcome
+		want           bool
+	}{
+		{
+			name:           "--binary + OS applied + back online → re-apply",
+			binaryProvided: true,
+			outcome:        osUpdateOutcome{applied: true, online: true},
+			want:           true,
+		},
+		{
+			name:           "auto-download path is never re-applied",
+			binaryProvided: false,
+			outcome:        osUpdateOutcome{applied: true, online: true},
+			want:           false,
+		},
+		{
+			name:           "no OS update applied → nothing to survive",
+			binaryProvided: true,
+			outcome:        osUpdateOutcome{applied: false},
+			want:           false,
+		},
+		{
+			name:           "applied but device not confirmed online (cloud) → skip inline re-apply",
+			binaryProvided: true,
+			outcome:        osUpdateOutcome{applied: true, online: false},
+			want:           false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldReapplyBinary(tc.binaryProvided, tc.outcome); got != tc.want {
+				t.Fatalf("shouldReapplyBinary(%v, %+v) = %v, want %v", tc.binaryProvided, tc.outcome, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWaitForUpdatedAgentReadyRetriesUntilReachable(t *testing.T) {
 	started := time.Now()
 	attempts := 0

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -75,12 +75,21 @@ func validateOSUpdateTarget(versionResp *agentpb.GetAgentVersionResponse) error 
 	if err := validateOSUpdateIdentity(versionResp); err != nil {
 		return err
 	}
-	// Either OS update backend qualifies: the in-house wendyos-update engine or
-	// mender. The agent picks one per the request's --updater value.
-	if !agentVersionHasFeature(versionResp, "wendyos-update") && !agentVersionHasFeature(versionResp, "mender") {
+	if !hasOTABackend(versionResp) {
 		return errors.New(wendyOSMissingUpdaterMessage)
 	}
 	return nil
+}
+
+// hasOTABackend reports whether the device advertises an OS update backend the
+// agent can drive: the in-house wendyos-update engine or mender. Both
+// `wendy os update` and `wendy device update` gate their OS-update step on this,
+// so a device with either backend is offered an update and the two paths cannot
+// drift on which backends count. (The agent picks one per the request's
+// --updater value; auto-selection prefers wendyos-update.)
+func hasOTABackend(versionResp *agentpb.GetAgentVersionResponse) bool {
+	return agentVersionHasFeature(versionResp, "wendyos-update") ||
+		agentVersionHasFeature(versionResp, "mender")
 }
 
 // isWendyOSUpdateTarget reports whether the device is a WendyOS OTA target. The

--- a/go/internal/cli/commands/os_cmd_test.go
+++ b/go/internal/cli/commands/os_cmd_test.go
@@ -174,6 +174,47 @@ func TestValidateOSUpdateTarget(t *testing.T) {
 	}
 }
 
+func TestHasOTABackend(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *agentpb.GetAgentVersionResponse
+		want bool
+	}{
+		{
+			name: "wendyos-update only (e.g. Jetson Orin Nano)",
+			resp: &agentpb.GetAgentVersionResponse{Featureset: []string{"gpu", "wendyos-update", "os-healthcheck"}},
+			want: true,
+		},
+		{
+			name: "mender only",
+			resp: &agentpb.GetAgentVersionResponse{Featureset: []string{"mender"}},
+			want: true,
+		},
+		{
+			name: "both backends",
+			resp: &agentpb.GetAgentVersionResponse{Featureset: []string{"wendyos-update", "mender"}},
+			want: true,
+		},
+		{
+			name: "no update backend",
+			resp: &agentpb.GetAgentVersionResponse{Featureset: []string{"gpu", "audio"}},
+			want: false,
+		},
+		{
+			name: "empty featureset",
+			resp: &agentpb.GetAgentVersionResponse{},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasOTABackend(tc.resp); got != tc.want {
+				t.Fatalf("hasOTABackend() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProgressLabel(t *testing.T) {
 	tests := []struct {
 		phase   string


### PR DESCRIPTION
## Problem

Two related gaps in the WendyOS OTA path, surfaced on a Jetson Orin Nano (featureset `[gpu, audio, bluetooth, wendyos-update, os-healthcheck]` — `wendyos-update`, **no `mender`**):

1. **A failed OS update permanently wedges the device out of all future OTA updates.** `wendyos-update` leaves a failed deployment in a terminal `failed` state; the post-reboot health gate reverts the A/B slot but that record survives, so every later `install` refuses with `an update is already in flight (phase "failed", …); run rollback or mark-good first`. The agent exposes no remote verb to clear it (`os_update_service.proto` = `UpdateOS` + `GetOSUpdateStatus` only) and WendyOS has no SSH — so there is no remote recovery.

2. **`wendy device update` never offered an OS update on these devices.** It updates the agent then calls `maybeCheckOSUpdate`, but that step gated on the `mender` feature only. wendyos-update-only devices fell through the gate, so `device update` silently behaved as an agent-only update.

## Changes

**`fix(agent)` — self-heal a stuck deployment before install.** When `wendyos-update install` is refused because a prior deployment is stuck in flight, run the `rollback` the tool itself prescribes (never `mark-good`, which would commit the failed slot) and retry the install once. Single-attempt logic moves to `runInstall()`; `install()` becomes a thin retry orchestrator. Detection is a pure heuristic on the tool's stable `"already in flight"` wording — if that ever changes, behavior falls back to today's (surface the failure), so there is no regression risk.

**`feat(cli)` — `device update` does the OS on any OTA backend + sticky `--binary`.**
- Gate the OS-update step on **any** OTA backend, not just mender: extract `hasOTABackend()` (`wendyos-update` OR `mender`) and share it with `validateOSUpdateTarget` so `os update` and `device update` can't drift.
- Fix a **latent nil-deref** this exposed: the call site closed the connection and passed `nil` to `maybeCheckOSUpdate` — harmless only because the old mender gate returned early. With the gate broadened, wendyos-update devices now reach `reconnectAgentAfterRestart(nil)`. Keep the restarted-agent connection and hand it in.
- Keep a `--binary` dev agent **sticky across the OS update**: the updated image ships its own bundled agent, so when `--binary` was provided and an OS update is applied, re-upload the same binary once the device is back online. The auto-download path is intentionally not re-applied (would risk downgrading the new image's bundled agent); cloud devices print guidance to re-run.
- Factor the upload / await-restart blocks into `uploadAgentBinary` and `awaitAgentRestart` helpers; `maybeCheckOSUpdate` now returns `osUpdateOutcome{applied, online}`.

## Testing

- New unit tests: `isStaleDeploymentError`, `hasOTABackend`, `shouldReapplyBinary`, and the broadened `maybeCheckOSUpdate` skip-gate.
- `go build ./go/...`, `go vet`, `gofmt -l`, and the full `internal/cli/commands` + `internal/agent/services` packages all pass.
- Not yet exercised end-to-end on hardware; the agent self-heal path in particular is verified by unit tests + code reading, since the on-device `wendyos-update` binary lives in another repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)