### PR TITLE
feat(agent): disk-pressure-triggered device image GC (WDY-1679)

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -158,7 +158,21 @@ func main() {
 	if containerdAddr == "" {
 		containerdAddr = agentcontainerd.DefaultAddress
 	}
-	ctrdClient, ctrdErr := agentcontainerd.NewClient(logger, containerdAddr, proxyMgr)
+	// Image garbage collection (WDY-1679) is enabled by default; set
+	// WENDY_IMAGE_GC_ENABLED=false to disable it. When enabled, the post-deploy
+	// and boot sweeps only run while the containerd filesystem is under disk
+	// pressure (free space below diskspace.WarnFreePct), so roomy devices never
+	// reclaim — and so never force layers to be re-uploaded on the next deploy.
+	imageGCEnabled := true
+	if v := os.Getenv("WENDY_IMAGE_GC_ENABLED"); v != "" {
+		if parsed, perr := strconv.ParseBool(v); perr != nil {
+			logger.Warn("WENDY_IMAGE_GC_ENABLED has unrecognised value; image GC stays enabled",
+				zap.String("value", v))
+		} else {
+			imageGCEnabled = parsed
+		}
+	}
+	ctrdClient, ctrdErr := agentcontainerd.NewClient(logger, containerdAddr, proxyMgr, imageGCEnabled)
 	if ctrdErr != nil {
 		logger.Warn("Failed to connect to containerd (container features will be unavailable)", zap.Error(ctrdErr))
 	} else {
@@ -285,6 +299,12 @@ func main() {
 	if ctrdClient != nil {
 		if err := ctrdClient.ReapOrphanedROS2Sidecars(ctx); err != nil {
 			logger.Warn("ROS 2 sidecar reap on boot failed", zap.Error(err))
+		}
+		// Reclaim stale image layers/blobs left by deploys that completed while
+		// the agent was down or crashed mid-flow (WDY-1679). Runs only under disk
+		// pressure and is a no-op when GC is disabled.
+		if _, err := ctrdClient.GarbageCollectImages(ctx); err != nil {
+			logger.Warn("image GC on boot failed", zap.Error(err))
 		}
 	}
 

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -40,6 +41,7 @@ import (
 	localoci "github.com/wendylabsinc/wendy/go/internal/agent/oci"
 	"github.com/wendylabsinc/wendy/go/internal/agent/services"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/diskspace"
 	sharedenv "github.com/wendylabsinc/wendy/go/internal/shared/env"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -93,11 +95,48 @@ type Client struct {
 	// Defaults to "overlayfs" when supported; falls back to "native" on kernels
 	// that do not support overlay mounts (e.g. nested container environments).
 	snapshotter string
+
+	// imageGCEnabled gates the post-deploy / boot image garbage collector
+	// (WENDY_IMAGE_GC_ENABLED). When false, both triggerImageGCAsync and
+	// GarbageCollectImages are no-ops.
+	imageGCEnabled bool
+
+	// containerdRoot is the filesystem path whose free space governs whether the
+	// image GC engages (default /var/lib/containerd, overridable via
+	// WENDY_CONTAINERD_ROOT). It is the volume containerd's snapshots and content
+	// blobs live on.
+	containerdRoot string
+
+	// diskFreePct reports the free-% of the filesystem containing a path (and
+	// false if it cannot be measured). Defaults to diskspace.FreePercent; a seam
+	// so tests can simulate disk pressure without a real full disk.
+	diskFreePct func(path string) (float64, bool)
+
+	// gcRunning is the single-flight guard for image GC: at most one
+	// mark-and-sweep pass runs at a time across the deploy hook and boot sweep.
+	gcRunning atomic.Bool
+
+	// gcPass runs one mark-and-sweep pass (snapshots, plus content blobs when the
+	// argument is true). Defaults to garbageCollectImages; a seam so the
+	// disk-pressure gate and single-flight orchestration are testable without a
+	// live containerd.
+	gcPass func(ctx context.Context, includeContent bool) (GCStats, error)
 }
 
-func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) (*Client, error) {
+// defaultContainerdRoot is the filesystem the image GC measures for free space.
+// The agent connects to containerd over a socket and does not configure its data
+// root, so this mirrors containerd's own default; override with
+// WENDY_CONTAINERD_ROOT if the daemon is configured elsewhere.
+const defaultContainerdRoot = "/var/lib/containerd"
+
+func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager, imageGCEnabled bool) (*Client, error) {
 	if address == "" {
 		address = DefaultAddress
+	}
+
+	containerdRoot := defaultContainerdRoot
+	if v := os.Getenv("WENDY_CONTAINERD_ROOT"); v != "" {
+		containerdRoot = v
 	}
 
 	c, err := containerd.New(address)
@@ -113,21 +152,26 @@ func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) 
 
 	snapshotter := probeSnapshotter(logger)
 
-	return &Client{
-		client:       c,
-		logger:       logger,
-		namespace:    "default",
-		proxyManager: proxyMgr,
-		appServices:  make(map[string]map[string]*appconfig.ServiceConfig),
-		primaryPIDs:  make(map[string]uint32),
-		appIsolation: make(map[string]string),
-		serviceIPs:   make(map[string]map[string]string),
-		appStopping:  make(map[string]bool),
-		ros2ExecRefs: make(map[string]int),
-		chunkIndex:   idx,
-		staging:      newStaging(defaultChunkStagingDir),
-		snapshotter:  snapshotter,
-	}, nil
+	cl := &Client{
+		client:         c,
+		logger:         logger,
+		namespace:      "default",
+		proxyManager:   proxyMgr,
+		appServices:    make(map[string]map[string]*appconfig.ServiceConfig),
+		primaryPIDs:    make(map[string]uint32),
+		appIsolation:   make(map[string]string),
+		serviceIPs:     make(map[string]map[string]string),
+		appStopping:    make(map[string]bool),
+		ros2ExecRefs:   make(map[string]int),
+		chunkIndex:     idx,
+		staging:        newStaging(defaultChunkStagingDir),
+		snapshotter:    snapshotter,
+		imageGCEnabled: imageGCEnabled,
+		containerdRoot: containerdRoot,
+		diskFreePct:    diskspace.FreePercent,
+	}
+	cl.gcPass = cl.garbageCollectImages
+	return cl, nil
 }
 
 // probeSnapshotter returns "overlayfs" if the kernel supports overlay mounts,
@@ -942,6 +986,13 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}
 		c.appIsolation[appID] = appCfg.Isolation
 	}
+
+	// A newer image version is now active for this app. If the device is low on
+	// disk, kick off a background sweep to reclaim the prior version's gc.root
+	// snapshots. Async + single-flight so it never blocks or fails the deploy,
+	// and gated on disk pressure so roomy devices never reclaim (which would
+	// force layers to be re-uploaded on the next deploy).
+	c.triggerImageGCAsync()
 
 	return nil
 }

--- a/go/internal/agent/containerd/helpers.go
+++ b/go/internal/agent/containerd/helpers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
+	digest "github.com/opencontainers/go-digest"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -168,6 +169,20 @@ func computeChainID(parent, diffID string) string {
 	h := sha256.New()
 	h.Write([]byte(parent + " " + diffID))
 	return fmt.Sprintf("sha256:%x", h.Sum(nil))
+}
+
+// chainIDsForDiffIDs folds computeChainID over an ordered list of layer diff IDs
+// to produce the chain ID of each layer prefix. chainIDs[i] is the chain ID of
+// the snapshot built from layers 0..i — the same key UnpackImage commits and the
+// key GarbageCollectImages must keep alive while the image exists.
+func chainIDsForDiffIDs(diffIDs []digest.Digest) []string {
+	chainIDs := make([]string, len(diffIDs))
+	parent := ""
+	for i, diffID := range diffIDs {
+		chainIDs[i] = computeChainID(parent, diffID.String())
+		parent = chainIDs[i]
+	}
+	return chainIDs
 }
 
 // parseRestartPolicyLabel parses a restart policy label value such as

--- a/go/internal/agent/containerd/imagegc.go
+++ b/go/internal/agent/containerd/imagegc.go
@@ -1,0 +1,469 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	digest "github.com/opencontainers/go-digest"
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/diskspace"
+)
+
+// imageGCTimeout bounds a single asynchronous (post-deploy) GC pass so a wedged
+// containerd call can't pin the single-flight guard forever.
+const imageGCTimeout = 5 * time.Minute
+
+// gcRootGrace is the concurrency-safety window applied to the EXISTING
+// containerd.io/gc.root commit timestamp: a gc.root snapshot or blob younger
+// than this is spared, because it may belong to a deploy still in flight (its
+// image record not yet written). It is NOT a retention policy — retention is
+// governed entirely by disk pressure (GC only runs when free space is low) — so
+// it only needs to cover the longest gap between an artifact being written and
+// the image record that references it existing. That bound is the unpack lease
+// window, so gcRootGrace mirrors unpackLeaseExpiration.
+const gcRootGrace = unpackLeaseExpiration
+
+// imageLister is the subset of images.Store the GC mark phase needs.
+type imageLister interface {
+	List(ctx context.Context, filters ...string) ([]images.Image, error)
+}
+
+// snapshotGC is the subset of snapshots.Snapshotter the GC needs. The GC never
+// mutates labels, so no Update method is required.
+type snapshotGC interface {
+	Walk(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error
+	Stat(ctx context.Context, key string) (snapshots.Info, error)
+	Usage(ctx context.Context, key string) (snapshots.Usage, error)
+	Remove(ctx context.Context, key string) error
+}
+
+// contentGC is the subset of content.Store the GC needs.
+type contentGC interface {
+	Walk(ctx context.Context, fn content.WalkFunc, filters ...string) error
+	Delete(ctx context.Context, dgst digest.Digest) error
+}
+
+// gcEnv collects the dependencies of one mark-and-sweep pass behind narrow
+// seams so the orchestration is unit-testable without a live containerd. The
+// concrete *Client wires these to the real containerd services.
+type gcEnv struct {
+	images                imageLister
+	snapshots             snapshotGC
+	content               contentGC
+	resolveImage          func(ctx context.Context, img images.Image) (chainIDs []string, blobs []string, err error)
+	containerSnapshotKeys func(ctx context.Context) ([]string, error)
+	now                   func() time.Time
+	grace                 time.Duration
+	logger                *zap.Logger
+}
+
+// gcRootFilter is the containerd label filter that selects only gc.root-pinned
+// entries — the only snapshots/blobs this GC ever considers for removal.
+const gcRootFilter = `labels."` + labelKeyGCRoot + `"`
+
+// runImageGC performs one mark-and-sweep pass over gc.root snapshots — and, when
+// includeContent is set, gc.root content blobs. It computes the reachable set
+// from current images and containers (fail-closed), then reaps every gc.root
+// artifact that is unreferenced and whose gc.root commit timestamp is older than
+// the grace window.
+//
+// includeContent gates the ENTIRE content section and must be true ONLY when no
+// deploy can be in flight (the boot sweep). A deploy that re-uses an existing
+// layer hits the CLI's push dedup and never re-writes that blob, so the blob's
+// gc.root timestamp stays old even though a new image record is about to
+// reference it; only quiescence makes blob reclamation provably safe. Chain-ID
+// snapshots have the favorable ordering — the image record exists before the
+// snapshot is committed — so the snapshot section always runs, protected against
+// a racing fresh commit by the gc.root grace window.
+func runImageGC(ctx context.Context, env gcEnv, includeContent bool) (GCStats, error) {
+	rSnap, rBlob, err := buildReachableSet(ctx, env)
+	if err != nil {
+		return GCStats{}, err
+	}
+	return sweep(ctx, env, rSnap, rBlob, includeContent)
+}
+
+// buildReachableSet (MARK) returns the chain-ID snapshot keys and content
+// digests that must be kept: everything referenced by a current image record or
+// an existing container. Any error aborts the whole pass with empty sets so the
+// caller never sweeps on a partial reachable set (which could delete live data).
+func buildReachableSet(ctx context.Context, env gcEnv) (rSnap, rBlob map[string]struct{}, err error) {
+	rSnap = make(map[string]struct{})
+	rBlob = make(map[string]struct{})
+
+	imgs, err := env.images.List(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing images: %w", err)
+	}
+	for _, img := range imgs {
+		chainIDs, blobs, err := env.resolveImage(ctx, img)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving image %q: %w", img.Name, err)
+		}
+		for _, id := range chainIDs {
+			rSnap[id] = struct{}{}
+		}
+		for _, b := range blobs {
+			rBlob[b] = struct{}{}
+		}
+	}
+
+	keys, err := env.containerSnapshotKeys(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing container snapshots: %w", err)
+	}
+	for _, key := range keys {
+		for key != "" {
+			rSnap[key] = struct{}{}
+			info, statErr := env.snapshots.Stat(ctx, key)
+			if statErr != nil {
+				if errdefs.IsNotFound(statErr) {
+					break // active snapshot raced a teardown; its parents are still covered by images
+				}
+				return nil, nil, fmt.Errorf("stat snapshot %q: %w", key, statErr)
+			}
+			key = info.Parent
+		}
+	}
+	return rSnap, rBlob, nil
+}
+
+// sweep removes the gc.root snapshots — and, when includeContent is set, gc.root
+// content blobs — that classifySnapshots/classifyBlobs mark reapable. Removal
+// failures are logged and counted in stats.Errors but never abort the pass; a
+// "has children" precondition error on snapshot removal is a benign skip (the
+// snapshot is still referenced — the structural safety backstop).
+func sweep(ctx context.Context, env gcEnv, rSnap, rBlob map[string]struct{}, includeContent bool) (GCStats, error) {
+	var stats GCStats
+	now := env.now()
+
+	var gcRootSnaps []snapshots.Info
+	err := env.snapshots.Walk(ctx, func(_ context.Context, info snapshots.Info) error {
+		gcRootSnaps = append(gcRootSnaps, info)
+		return nil
+	}, gcRootFilter)
+	if err != nil {
+		return stats, fmt.Errorf("walking snapshots: %w", err)
+	}
+
+	for _, key := range orderLeafFirst(classifySnapshots(gcRootSnaps, rSnap, now, env.grace)) {
+		var size int64
+		if u, uerr := env.snapshots.Usage(ctx, key); uerr == nil {
+			size = u.Size
+		}
+		if rerr := env.snapshots.Remove(ctx, key); rerr != nil {
+			if errdefs.IsFailedPrecondition(rerr) {
+				env.logger.Debug("skipping snapshot with children", zap.String("snapshot", key))
+				continue
+			}
+			env.logger.Warn("failed to remove orphan snapshot", zap.String("snapshot", key), zap.Error(rerr))
+			stats.Errors++
+			continue
+		}
+		stats.SnapshotsRemoved++
+		stats.SnapshotBytes += size
+	}
+
+	if !includeContent {
+		return stats, nil
+	}
+
+	var gcRootBlobs []content.Info
+	err = env.content.Walk(ctx, func(info content.Info) error {
+		gcRootBlobs = append(gcRootBlobs, info)
+		return nil
+	}, gcRootFilter)
+	if err != nil {
+		return stats, fmt.Errorf("walking content: %w", err)
+	}
+
+	for _, info := range classifyBlobs(gcRootBlobs, rBlob, now, env.grace) {
+		if derr := env.content.Delete(ctx, info.Digest); derr != nil {
+			if errdefs.IsNotFound(derr) {
+				continue
+			}
+			env.logger.Warn("failed to delete orphan blob", zap.String("digest", info.Digest.String()), zap.Error(derr))
+			stats.Errors++
+			continue
+		}
+		stats.BlobsReclaimed++
+		stats.BlobBytes += info.Size
+	}
+	return stats, nil
+}
+
+// GCStats summarises what one garbage-collection pass did. It exists purely for
+// observability — callers log it; no control flow branches on it.
+type GCStats struct {
+	SnapshotsRemoved int
+	SnapshotBytes    int64
+	BlobsReclaimed   int
+	BlobBytes        int64
+	Errors           int
+}
+
+// tryStartGC acquires the single-flight guard. It returns false when a pass is
+// already running, in which case the caller must not start another.
+func (c *Client) tryStartGC() bool {
+	return c.gcRunning.CompareAndSwap(false, true)
+}
+
+// finishGC releases the single-flight guard.
+func (c *Client) finishGC() {
+	c.gcRunning.Store(false)
+}
+
+// underDiskPressure reports whether the filesystem backing containerd's data
+// root is low enough on free space to justify reclaiming stale image data. It
+// uses the same free-% threshold `wendy device doctor` warns at, so both agree
+// on when a device is "too full". A failed measurement (statfs error, or any
+// non-Linux build) reports false, keeping the GC a no-op.
+func (c *Client) underDiskPressure() bool {
+	pct, ok := c.diskFreePct(c.containerdRoot)
+	if !ok {
+		return false
+	}
+	return pct < diskspace.WarnFreePct
+}
+
+// GarbageCollectImages runs one synchronous full mark-and-sweep pass (snapshots
+// AND content blobs) when the containerd filesystem is under disk pressure. It
+// is a no-op when GC is disabled, when free space is above the threshold, or
+// when a pass is already running (none of which is an error). Used for the boot
+// sweep, which is safe to reclaim content because it runs before the agent
+// serves any deploy RPC — no deploy can be in flight. The per-deploy hook
+// (triggerImageGCAsync) reclaims snapshots only, since a deploy that re-uses a
+// dedup-hit layer never refreshes that blob's gc.root timestamp, so only boot
+// quiescence makes blob reclamation provably safe.
+func (c *Client) GarbageCollectImages(ctx context.Context) (GCStats, error) {
+	if !c.imageGCEnabled {
+		return GCStats{}, nil
+	}
+	if !c.underDiskPressure() {
+		return GCStats{}, nil
+	}
+	if !c.tryStartGC() {
+		return GCStats{}, nil
+	}
+	defer c.finishGC()
+
+	stats, err := c.gcPass(ctx, true)
+	if err == nil {
+		logGCStats(c.logger, stats)
+	}
+	return stats, err
+}
+
+// triggerImageGCAsync kicks off a snapshot-only mark-and-sweep pass in the
+// background after a successful deploy, but only when the containerd filesystem
+// is under disk pressure — so normal, roomy deploys never reclaim (and so never
+// force a layer to be re-uploaded on the next deploy). It returns immediately so
+// it never blocks (or fails) the deploy. The pass runs on a detached,
+// time-bounded context because the deploy's request context is gone once the RPC
+// returns. Single-flight via the gcRunning guard means concurrent/back-to-back
+// deploys never overlap passes. Content blobs are intentionally left to the boot
+// sweep (see GarbageCollectImages / runImageGC).
+func (c *Client) triggerImageGCAsync() {
+	if !c.imageGCEnabled {
+		return
+	}
+	if !c.underDiskPressure() {
+		return
+	}
+	if !c.tryStartGC() {
+		return // a pass is already running; it (or the next deploy/boot) covers this
+	}
+	go func() {
+		defer c.finishGC()
+		ctx, cancel := context.WithTimeout(context.Background(), imageGCTimeout)
+		defer cancel()
+		stats, err := c.gcPass(ctx, false)
+		if err != nil {
+			c.logger.Warn("image GC pass failed", zap.Error(err))
+			return
+		}
+		logGCStats(c.logger, stats)
+	}()
+}
+
+// garbageCollectImages wires the concrete containerd services into a gcEnv and
+// runs one pass. It assumes the single-flight guard is already held.
+func (c *Client) garbageCollectImages(ctx context.Context, includeContent bool) (GCStats, error) {
+	ctx = c.withNamespace(ctx)
+	env := gcEnv{
+		images:                c.client.ImageService(),
+		snapshots:             c.client.SnapshotService(c.snapshotter),
+		content:               c.client.ContentStore(),
+		resolveImage:          c.resolveImageChain,
+		containerSnapshotKeys: c.containerSnapshotKeys,
+		now:                   time.Now,
+		grace:                 gcRootGrace,
+		logger:                c.logger,
+	}
+	return runImageGC(ctx, env, includeContent)
+}
+
+// resolveImageChain resolves an image record to the chain-ID snapshots and the
+// content digests (manifest, config, layers) it references. ctx must already
+// carry the containerd namespace.
+func (c *Client) resolveImageChain(ctx context.Context, img images.Image) (chainIDs []string, blobs []string, err error) {
+	cs := c.client.ContentStore()
+	manifest, err := images.Manifest(ctx, cs, img.Target, platforms.Default())
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading manifest: %w", err)
+	}
+	diffIDs, err := images.RootFS(ctx, cs, manifest.Config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading rootfs: %w", err)
+	}
+	chainIDs = chainIDsForDiffIDs(diffIDs)
+	blobs = make([]string, 0, len(manifest.Layers)+2)
+	blobs = append(blobs, img.Target.Digest.String(), manifest.Config.Digest.String())
+	for _, l := range manifest.Layers {
+		blobs = append(blobs, l.Digest.String())
+	}
+	return chainIDs, blobs, nil
+}
+
+// containerSnapshotKeys returns the active snapshot key of EVERY container
+// (running or stopped), not just app containers: ROS2 sidecars and any other
+// container carry their own snapshot chains and must be kept too. The mark phase
+// walks each key's parent chain to keep the read-only layers a container could
+// still need. Enumerating all containers makes the reachable set the primary
+// safety mechanism rather than leaning on the has-children removal backstop. ctx
+// must already carry the containerd namespace.
+func (c *Client) containerSnapshotKeys(ctx context.Context) ([]string, error) {
+	ctrs, err := c.client.Containers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(ctrs))
+	for _, ctr := range ctrs {
+		info, infoErr := ctr.Info(ctx)
+		if infoErr != nil {
+			return nil, fmt.Errorf("reading container %q info: %w", ctr.ID(), infoErr)
+		}
+		if info.SnapshotKey != "" {
+			keys = append(keys, info.SnapshotKey)
+		}
+	}
+	return keys, nil
+}
+
+// logGCStats emits a summary of a pass that actually reclaimed data or hit
+// errors. A fully quiet pass (nothing reclaimed, no errors) stays silent.
+func logGCStats(logger *zap.Logger, stats GCStats) {
+	if stats.SnapshotsRemoved+stats.BlobsReclaimed == 0 && stats.Errors == 0 {
+		return
+	}
+	logger.Info("image GC reclaimed stale image data",
+		zap.Int("snapshots_removed", stats.SnapshotsRemoved),
+		zap.Int64("snapshot_bytes", stats.SnapshotBytes),
+		zap.Int("blobs_reclaimed", stats.BlobsReclaimed),
+		zap.Int64("blob_bytes", stats.BlobBytes),
+		zap.Int("errors", stats.Errors),
+	)
+}
+
+// withinGrace reports whether a containerd.io/gc.root timestamp label is recent
+// enough that its artifact must be spared as potentially belonging to an
+// in-flight deploy. An empty or unparseable stamp is treated as NOT within grace
+// (i.e. aged): only a live deploy writes a fresh, parseable RFC3339 stamp via
+// gcTimestamp, so a bad value cannot belong to one, and reachability has already
+// established the artifact is otherwise unreferenced.
+func withinGrace(stamp string, now time.Time, grace time.Duration) bool {
+	ts, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		return false
+	}
+	return now.Sub(ts) <= grace
+}
+
+// classifySnapshots returns the gc.root snapshots that are safe to reap: those
+// not in the reachable set whose EXISTING containerd.io/gc.root commit timestamp
+// is older than grace. Reading the gc.root value means no extra bookkeeping
+// label is needed. The grace window spares an artifact a racing deploy just
+// wrote (its gc.root stamp is fresh) — the only concurrency hazard once the GC
+// runs solely under disk pressure. Everything else that is unreferenced is an
+// old superseded layer and, under disk pressure, is exactly what we want to
+// reclaim.
+func classifySnapshots(gcRoots []snapshots.Info, reachable map[string]struct{}, now time.Time, grace time.Duration) []snapshots.Info {
+	var reap []snapshots.Info
+	for _, info := range gcRoots {
+		if _, ok := reachable[info.Name]; ok {
+			continue // referenced by a current image or container
+		}
+		if withinGrace(info.Labels[labelKeyGCRoot], now, grace) {
+			continue // recently written -> spare a potentially in-flight deploy's artifact
+		}
+		reap = append(reap, info)
+	}
+	return reap
+}
+
+// classifyBlobs is the content-blob analogue of classifySnapshots, keyed on the
+// blob digest. Reaping is gated to the boot sweep by the caller (per-deploy
+// passes never touch content) — see runImageGC.
+func classifyBlobs(infos []content.Info, reachable map[string]struct{}, now time.Time, grace time.Duration) []content.Info {
+	var reap []content.Info
+	for _, info := range infos {
+		if _, ok := reachable[info.Digest.String()]; ok {
+			continue // referenced by a current image
+		}
+		if withinGrace(info.Labels[labelKeyGCRoot], now, grace) {
+			continue // recently written -> spare a potentially in-flight deploy's blob
+		}
+		reap = append(reap, info)
+	}
+	return reap
+}
+
+// orderLeafFirst returns the orphan snapshot keys ordered so that every child is
+// listed before its parent. Removing in this order means a parent layer is never
+// deleted while one of its still-orphaned children references it. Ordering is by
+// the number of ancestors within the orphan set, descending; ties break by name
+// for determinism.
+func orderLeafFirst(orphans []snapshots.Info) []string {
+	parentOf := make(map[string]string, len(orphans)) // name -> parent (within set)
+	for _, o := range orphans {
+		parentOf[o.Name] = o.Parent
+	}
+	ancestorsInSet := func(name string) int {
+		count := 0
+		// Chain-ID parents form a strict tree, so this terminates well before the
+		// bound; the len(parentOf) cap is defensive against a malformed cycle
+		// hanging the background GC goroutine.
+		for count <= len(parentOf) {
+			parent, ok := parentOf[name]
+			if !ok || parent == "" {
+				return count
+			}
+			if _, ok := parentOf[parent]; !ok {
+				return count
+			}
+			count++
+			name = parent
+		}
+		return count
+	}
+	keys := make([]string, 0, len(orphans))
+	for _, o := range orphans {
+		keys = append(keys, o.Name)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		di, dj := ancestorsInSet(keys[i]), ancestorsInSet(keys[j])
+		if di != dj {
+			return di > dj
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}

--- a/go/internal/agent/containerd/imagegc_test.go
+++ b/go/internal/agent/containerd/imagegc_test.go
@@ -1,0 +1,598 @@
+package containerd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/errdefs"
+	digest "github.com/opencontainers/go-digest"
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/diskspace"
+)
+
+// testGrace is the concurrency-safety grace used throughout these tests. A
+// gc.root artifact whose commit timestamp is older than this is reap-eligible;
+// a fresher one is spared as potentially belonging to an in-flight deploy.
+const testGrace = 24 * time.Hour
+
+// --- fakes for the mark-and-sweep orchestration (modeled on mockStatter) ---
+
+type fakeImageStore struct {
+	imgs []images.Image
+	err  error
+}
+
+func (f *fakeImageStore) List(_ context.Context, _ ...string) ([]images.Image, error) {
+	return f.imgs, f.err
+}
+
+type fakeSnapshotter struct {
+	infos   map[string]snapshots.Info
+	usage   map[string]int64
+	removed []string
+}
+
+func (f *fakeSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, _ ...string) error {
+	// Emulate the `labels."containerd.io/gc.root"` filter: yield only gc.root entries.
+	for _, info := range f.infos {
+		if _, ok := info.Labels[labelKeyGCRoot]; ok {
+			if err := fn(ctx, info); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *fakeSnapshotter) Stat(_ context.Context, key string) (snapshots.Info, error) {
+	info, ok := f.infos[key]
+	if !ok {
+		return snapshots.Info{}, errdefs.ErrNotFound
+	}
+	return info, nil
+}
+
+func (f *fakeSnapshotter) Usage(_ context.Context, key string) (snapshots.Usage, error) {
+	return snapshots.Usage{Size: f.usage[key]}, nil
+}
+
+func (f *fakeSnapshotter) Remove(_ context.Context, key string) error {
+	for _, info := range f.infos {
+		if info.Parent == key {
+			return errdefs.ErrFailedPrecondition // has-children backstop
+		}
+	}
+	if _, ok := f.infos[key]; !ok {
+		return errdefs.ErrNotFound
+	}
+	delete(f.infos, key)
+	f.removed = append(f.removed, key)
+	return nil
+}
+
+type fakeContent struct {
+	infos   map[digest.Digest]content.Info
+	deleted []digest.Digest
+}
+
+func (f *fakeContent) Walk(_ context.Context, fn content.WalkFunc, _ ...string) error {
+	for _, info := range f.infos {
+		if _, ok := info.Labels[labelKeyGCRoot]; ok {
+			if err := fn(info); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *fakeContent) Delete(_ context.Context, dgst digest.Digest) error {
+	if _, ok := f.infos[dgst]; !ok {
+		return errdefs.ErrNotFound
+	}
+	delete(f.infos, dgst)
+	f.deleted = append(f.deleted, dgst)
+	return nil
+}
+
+// gcRootAt marks an artifact gc.root with a commit timestamp of ts — the value
+// the GC reads to decide whether an orphan is fresh (spared) or aged (reapable).
+func gcRootAt(ts time.Time) map[string]string {
+	return map[string]string{labelKeyGCRoot: ts.UTC().Format(time.RFC3339)}
+}
+
+func TestRunImageGC_ReclaimsAgedOrphans(t *testing.T) {
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	aged := now.Add(-48 * time.Hour) // gc.root committed well past grace
+
+	const (
+		c0     = "sha256:c0" // base layer of current image
+		c1     = "sha256:c1" // top layer of current image
+		oldA   = "sha256:oldA"
+		oldB   = "sha256:oldB"
+		active = "wendy-app" // running container's writable snapshot (no gc.root)
+	)
+	mD := digest.Digest("sha256:manifest")
+	cfgD := digest.Digest("sha256:config")
+	l0 := digest.Digest("sha256:layer0")
+	l1 := digest.Digest("sha256:layer1")
+	oldL := digest.Digest("sha256:oldlayer")
+
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			c0:     {Name: c0, Labels: gcRootAt(now)},
+			c1:     {Name: c1, Parent: c0, Labels: gcRootAt(now)},
+			oldA:   {Name: oldA, Parent: c0, Labels: gcRootAt(aged)},
+			oldB:   {Name: oldB, Parent: oldA, Labels: gcRootAt(aged)},
+			active: {Name: active, Parent: c1}, // no gc.root label
+		},
+		usage: map[string]int64{oldA: 100, oldB: 200},
+	}
+	cs := &fakeContent{
+		infos: map[digest.Digest]content.Info{
+			l0:   {Digest: l0, Size: 10, Labels: gcRootAt(now)},
+			l1:   {Digest: l1, Size: 20, Labels: gcRootAt(now)},
+			oldL: {Digest: oldL, Size: 33, Labels: gcRootAt(aged)},
+		},
+	}
+
+	env := gcEnv{
+		images:    &fakeImageStore{imgs: []images.Image{{Name: "localhost:5000/app:latest"}}},
+		snapshots: sn,
+		content:   cs,
+		resolveImage: func(_ context.Context, _ images.Image) ([]string, []string, error) {
+			return []string{c0, c1}, []string{mD.String(), cfgD.String(), l0.String(), l1.String()}, nil
+		},
+		containerSnapshotKeys: func(_ context.Context) ([]string, error) {
+			return []string{active}, nil
+		},
+		now:    func() time.Time { return now },
+		grace:  testGrace,
+		logger: zap.NewNop(),
+	}
+
+	stats, err := runImageGC(context.Background(), env, true) // boot-style: full sweep
+	if err != nil {
+		t.Fatalf("runImageGC: %v", err)
+	}
+	if stats.SnapshotsRemoved != 2 || stats.SnapshotBytes != 300 {
+		t.Errorf("snapshots removed=%d bytes=%d; want 2/300", stats.SnapshotsRemoved, stats.SnapshotBytes)
+	}
+	if stats.BlobsReclaimed != 1 || stats.BlobBytes != 33 {
+		t.Errorf("blobs reclaimed=%d bytes=%d; want 1/33", stats.BlobsReclaimed, stats.BlobBytes)
+	}
+	if stats.Errors != 0 {
+		t.Errorf("errors=%d; want 0", stats.Errors)
+	}
+	// Old version's data gone; current image + container layers kept.
+	for _, k := range []string{oldA, oldB} {
+		if _, ok := sn.infos[k]; ok {
+			t.Errorf("snapshot %q should have been removed", k)
+		}
+	}
+	for _, k := range []string{c0, c1, active} {
+		if _, ok := sn.infos[k]; !ok {
+			t.Errorf("snapshot %q must be kept", k)
+		}
+	}
+	if _, ok := cs.infos[oldL]; ok {
+		t.Error("blob oldL should have been deleted")
+	}
+	for _, d := range []digest.Digest{l0, l1} {
+		if _, ok := cs.infos[d]; !ok {
+			t.Errorf("blob %q must be kept", d)
+		}
+	}
+}
+
+func TestRunImageGC_SnapshotsOnlySkipsContent(t *testing.T) {
+	// The per-deploy async path (includeContent=false) reaps aged orphan snapshots
+	// but must never touch content blobs — because a deploy that re-uses a
+	// dedup-hit layer never refreshes that blob's gc.root timestamp, so only the
+	// quiescent boot sweep may reclaim content.
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	aged := now.Add(-48 * time.Hour)
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			"orphanSnap": {Name: "orphanSnap", Labels: gcRootAt(aged)},
+		},
+		usage: map[string]int64{"orphanSnap": 50},
+	}
+	orphanBlob := digest.Digest("sha256:orphanblob")
+	cs := &fakeContent{
+		infos: map[digest.Digest]content.Info{
+			orphanBlob: {Digest: orphanBlob, Size: 99, Labels: gcRootAt(aged)},
+		},
+	}
+	env := gcEnv{
+		images:                &fakeImageStore{},
+		snapshots:             sn,
+		content:               cs,
+		resolveImage:          func(_ context.Context, _ images.Image) ([]string, []string, error) { return nil, nil, nil },
+		containerSnapshotKeys: func(_ context.Context) ([]string, error) { return nil, nil },
+		now:                   func() time.Time { return now },
+		grace:                 testGrace,
+		logger:                zap.NewNop(),
+	}
+
+	stats, err := runImageGC(context.Background(), env, false) // deploy-style: snapshots only
+	if err != nil {
+		t.Fatalf("runImageGC: %v", err)
+	}
+	if stats.SnapshotsRemoved != 1 {
+		t.Errorf("snapshots removed=%d; want 1", stats.SnapshotsRemoved)
+	}
+	if stats.BlobsReclaimed != 0 {
+		t.Errorf("blobs reclaimed=%d; want 0 (content fully gated on the deploy path)", stats.BlobsReclaimed)
+	}
+	if len(cs.deleted) != 0 {
+		t.Errorf("content store was deleted from %d times; want 0 on the snapshots-only path", len(cs.deleted))
+	}
+	if _, ok := cs.infos[orphanBlob]; !ok {
+		t.Error("the snapshots-only path must not delete content")
+	}
+}
+
+func TestRunImageGC_FailClosedOnResolveError(t *testing.T) {
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			"orphan": {Name: "orphan", Labels: gcRootAt(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))},
+		},
+	}
+	env := gcEnv{
+		images:    &fakeImageStore{imgs: []images.Image{{Name: "app:latest"}}},
+		snapshots: sn,
+		content:   &fakeContent{infos: map[digest.Digest]content.Info{}},
+		resolveImage: func(_ context.Context, _ images.Image) ([]string, []string, error) {
+			return nil, nil, errors.New("boom")
+		},
+		containerSnapshotKeys: func(_ context.Context) ([]string, error) { return nil, nil },
+		now:                   func() time.Time { return time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC) },
+		grace:                 testGrace,
+		logger:                zap.NewNop(),
+	}
+	stats, err := runImageGC(context.Background(), env, true)
+	if err == nil {
+		t.Fatal("expected error from fail-closed MARK")
+	}
+	if stats.SnapshotsRemoved != 0 {
+		t.Errorf("removed=%d; want 0 deletions on fail-closed", stats.SnapshotsRemoved)
+	}
+	if len(sn.removed) != 0 {
+		t.Errorf("no snapshot may be removed when MARK fails; got %v", sn.removed)
+	}
+	if _, ok := sn.infos["orphan"]; !ok {
+		t.Error("no snapshot may be deleted when MARK fails")
+	}
+}
+
+func TestSweep_HasChildrenBackstop(t *testing.T) {
+	// p is reap-eligible (aged gc.root, unreachable) but still has a reachable
+	// child ch; Remove must fail-precondition and be skipped, not counted an error.
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	aged := now.Add(-48 * time.Hour)
+	sn := &fakeSnapshotter{
+		infos: map[string]snapshots.Info{
+			"p":  {Name: "p", Labels: gcRootAt(aged)},
+			"ch": {Name: "ch", Parent: "p", Labels: gcRootAt(now)},
+		},
+		usage: map[string]int64{},
+	}
+	env := gcEnv{
+		snapshots: sn,
+		content:   &fakeContent{infos: map[digest.Digest]content.Info{}},
+		now:       func() time.Time { return now },
+		grace:     testGrace,
+		logger:    zap.NewNop(),
+	}
+	// ch is reachable; p is not.
+	rSnap := keySet("ch")
+	stats, err := sweep(context.Background(), env, rSnap, keySet(), true)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if stats.SnapshotsRemoved != 0 || stats.Errors != 0 {
+		t.Errorf("removed=%d errors=%d; want 0/0 (benign skip)", stats.SnapshotsRemoved, stats.Errors)
+	}
+	if _, ok := sn.infos["p"]; !ok {
+		t.Error("p must be kept: a snapshot with children is never removed")
+	}
+}
+
+// --- disk-pressure gate + single-flight ---
+
+func TestUnderDiskPressure(t *testing.T) {
+	mk := func(pct float64, ok bool) *Client {
+		return &Client{
+			containerdRoot: "/x",
+			diskFreePct:    func(string) (float64, bool) { return pct, ok },
+		}
+	}
+	if !mk(diskspace.WarnFreePct-1, true).underDiskPressure() {
+		t.Error("free % below the warn threshold must report disk pressure")
+	}
+	if mk(diskspace.WarnFreePct+1, true).underDiskPressure() {
+		t.Error("free % above the warn threshold must not report disk pressure")
+	}
+	if mk(0, false).underDiskPressure() {
+		t.Error("an unavailable measurement must not report disk pressure")
+	}
+}
+
+func TestGarbageCollectImages_DisabledNoOp(t *testing.T) {
+	var called atomic.Bool
+	c := &Client{
+		logger:         zap.NewNop(),
+		imageGCEnabled: false,
+		containerdRoot: "/x",
+		diskFreePct:    func(string) (float64, bool) { return 1, true }, // under pressure, yet disabled
+		gcPass:         func(context.Context, bool) (GCStats, error) { called.Store(true); return GCStats{}, nil },
+	}
+	stats, err := c.GarbageCollectImages(context.Background())
+	if err != nil {
+		t.Fatalf("GarbageCollectImages disabled: %v", err)
+	}
+	if called.Load() {
+		t.Error("no GC pass may run when GC is disabled")
+	}
+	if stats != (GCStats{}) {
+		t.Errorf("stats = %+v; want zero when disabled", stats)
+	}
+}
+
+func TestGarbageCollectImages_SkipsWhenHealthy(t *testing.T) {
+	var called atomic.Bool
+	c := &Client{
+		logger:         zap.NewNop(),
+		imageGCEnabled: true,
+		containerdRoot: "/x",
+		diskFreePct:    func(string) (float64, bool) { return 50, true }, // roomy
+		gcPass: func(context.Context, bool) (GCStats, error) {
+			called.Store(true)
+			return GCStats{SnapshotsRemoved: 1}, nil
+		},
+	}
+	stats, err := c.GarbageCollectImages(context.Background())
+	if err != nil {
+		t.Fatalf("GarbageCollectImages: %v", err)
+	}
+	if called.Load() {
+		t.Error("GC must not run when the device has free space")
+	}
+	if stats != (GCStats{}) {
+		t.Errorf("stats = %+v; want zero when healthy", stats)
+	}
+}
+
+func TestGarbageCollectImages_RunsUnderPressure(t *testing.T) {
+	var gotContent bool
+	var called atomic.Bool
+	c := &Client{
+		logger:         zap.NewNop(),
+		imageGCEnabled: true,
+		containerdRoot: "/x",
+		diskFreePct:    func(string) (float64, bool) { return 1, true }, // under pressure
+		gcPass: func(_ context.Context, includeContent bool) (GCStats, error) {
+			called.Store(true)
+			gotContent = includeContent
+			return GCStats{SnapshotsRemoved: 2, BlobsReclaimed: 1}, nil
+		},
+	}
+	stats, err := c.GarbageCollectImages(context.Background())
+	if err != nil {
+		t.Fatalf("GarbageCollectImages: %v", err)
+	}
+	if !called.Load() {
+		t.Fatal("GC must run under disk pressure")
+	}
+	if !gotContent {
+		t.Error("the boot sweep must include content (includeContent=true)")
+	}
+	if stats.SnapshotsRemoved != 2 || stats.BlobsReclaimed != 1 {
+		t.Errorf("stats = %+v; want 2 snapshots / 1 blob", stats)
+	}
+}
+
+func TestTriggerImageGCAsync_HealthySkips(t *testing.T) {
+	var called atomic.Bool
+	c := &Client{
+		logger:         zap.NewNop(),
+		imageGCEnabled: true,
+		containerdRoot: "/x",
+		diskFreePct:    func(string) (float64, bool) { return 50, true }, // roomy
+		gcPass:         func(context.Context, bool) (GCStats, error) { called.Store(true); return GCStats{}, nil },
+	}
+	c.triggerImageGCAsync()
+	if called.Load() {
+		t.Error("no GC pass may run on a roomy device")
+	}
+	// A healthy device returns before spawning any goroutine, so the single-flight
+	// guard must be free.
+	if !c.tryStartGC() {
+		t.Error("single-flight guard should be free when healthy (no pass was started)")
+	}
+	c.finishGC()
+}
+
+func TestTriggerImageGCAsync_RunsUnderPressureSnapshotsOnly(t *testing.T) {
+	got := make(chan bool, 1)
+	c := &Client{
+		logger:         zap.NewNop(),
+		imageGCEnabled: true,
+		containerdRoot: "/x",
+		diskFreePct:    func(string) (float64, bool) { return 5, true }, // under pressure
+		gcPass: func(_ context.Context, includeContent bool) (GCStats, error) {
+			got <- includeContent
+			return GCStats{}, nil
+		},
+	}
+	c.triggerImageGCAsync()
+	select {
+	case includeContent := <-got:
+		if includeContent {
+			t.Error("the deploy pass must be snapshots-only (includeContent=false)")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GC pass did not run under disk pressure")
+	}
+}
+
+func TestGCSingleFlight(t *testing.T) {
+	c := &Client{logger: zap.NewNop(), imageGCEnabled: true}
+	if !c.tryStartGC() {
+		t.Fatal("first acquire should win")
+	}
+	if c.tryStartGC() {
+		t.Fatal("second acquire must fail while a pass is running")
+	}
+	c.finishGC()
+	if !c.tryStartGC() {
+		t.Fatal("acquire should win again after finish")
+	}
+	c.finishGC()
+}
+
+// --- pure classifiers ---
+
+// keySet builds a reachable-set (set of snapshot keys or digest strings) for tests.
+func keySet(keys ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		m[k] = struct{}{}
+	}
+	return m
+}
+
+func names(infos []snapshots.Info) map[string]bool {
+	out := make(map[string]bool, len(infos))
+	for _, i := range infos {
+		out[i.Name] = true
+	}
+	return out
+}
+
+// snapNow is the fixed "now" used by the classify tests.
+var snapNow = time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
+
+func TestClassifySnapshots_ReachableKept(t *testing.T) {
+	// A reachable snapshot is never reaped, even with an ancient gc.root stamp.
+	gcRoots := []snapshots.Info{
+		{Name: "live", Labels: gcRootAt(snapNow.Add(-72 * time.Hour))},
+	}
+	if reap := classifySnapshots(gcRoots, keySet("live"), snapNow, testGrace); len(reap) != 0 {
+		t.Errorf("reachable snapshot must never be reaped; got %v", names(reap))
+	}
+}
+
+func TestClassifySnapshots_AgedOrphanReaped(t *testing.T) {
+	// base is still referenced; oldtop's gc.root is past grace -> reap.
+	gcRoots := []snapshots.Info{
+		{Name: "base", Labels: gcRootAt(snapNow)},
+		{Name: "oldtop", Parent: "base", Labels: gcRootAt(snapNow.Add(-48 * time.Hour))},
+	}
+	reap := names(classifySnapshots(gcRoots, keySet("base"), snapNow, testGrace))
+	if len(reap) != 1 || !reap["oldtop"] {
+		t.Errorf("reap = %v; want {oldtop}", reap)
+	}
+}
+
+func TestClassifySnapshots_FreshGcRootKept(t *testing.T) {
+	// An orphan whose gc.root stamp is within grace is spared (it may belong to an
+	// in-flight deploy); an aged sibling is reaped.
+	gcRoots := []snapshots.Info{
+		{Name: "fresh", Labels: gcRootAt(snapNow.Add(-time.Minute))},
+		{Name: "old", Labels: gcRootAt(snapNow.Add(-48 * time.Hour))},
+	}
+	reap := names(classifySnapshots(gcRoots, keySet(), snapNow, testGrace))
+	if reap["fresh"] {
+		t.Error("an orphan whose gc.root stamp is within grace must be kept")
+	}
+	if !reap["old"] {
+		t.Error("an orphan whose gc.root stamp is past grace must be reaped")
+	}
+}
+
+func TestClassifySnapshots_UnparseableGcRootReaped(t *testing.T) {
+	// A missing/unparseable gc.root value is treated as aged (an in-flight deploy
+	// always writes a fresh, parseable stamp), so an unreferenced one is reaped.
+	gcRoots := []snapshots.Info{
+		{Name: "bad", Labels: map[string]string{labelKeyGCRoot: "not-a-time"}},
+	}
+	reap := names(classifySnapshots(gcRoots, keySet(), snapNow, testGrace))
+	if len(reap) != 1 || !reap["bad"] {
+		t.Errorf("reap = %v; want {bad}", reap)
+	}
+}
+
+func TestOrderLeafFirst_Chain(t *testing.T) {
+	// root <- mid <- leaf: removal must proceed leaf, mid, root so a parent is
+	// never removed while a child still references it.
+	orphans := []snapshots.Info{
+		{Name: "root"},
+		{Name: "mid", Parent: "root"},
+		{Name: "leaf", Parent: "mid"},
+	}
+	got := orderLeafFirst(orphans)
+	want := []string{"leaf", "mid", "root"}
+	if len(got) != len(want) {
+		t.Fatalf("order = %v; want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v; want %v", got, want)
+		}
+	}
+}
+
+func TestOrderLeafFirst_Branching(t *testing.T) {
+	// root has two orphan children; root must be ordered after both.
+	orphans := []snapshots.Info{
+		{Name: "root"},
+		{Name: "c1", Parent: "root"},
+		{Name: "c2", Parent: "root"},
+	}
+	pos := map[string]int{}
+	for i, k := range orderLeafFirst(orphans) {
+		pos[k] = i
+	}
+	if pos["root"] < pos["c1"] || pos["root"] < pos["c2"] {
+		t.Fatalf("root must come after its children: %v", pos)
+	}
+}
+
+func TestClassifyBlobs(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	d := func(c string) digest.Digest { return digest.Digest("sha256:" + strings.Repeat(c, 64)) }
+	dReach, dOld, dFresh, dBad := d("1"), d("2"), d("3"), d("4")
+
+	infos := []content.Info{
+		{Digest: dReach, Labels: gcRootAt(now.Add(-72 * time.Hour))},   // reachable -> keep
+		{Digest: dOld, Labels: gcRootAt(now.Add(-48 * time.Hour))},     // orphan aged -> reap
+		{Digest: dFresh, Labels: gcRootAt(now.Add(-time.Minute))},      // orphan within grace -> keep
+		{Digest: dBad, Labels: map[string]string{labelKeyGCRoot: "x"}}, // orphan unparseable -> reap
+	}
+
+	reap := classifyBlobs(infos, keySet(dReach.String()), now, testGrace)
+	got := map[digest.Digest]bool{}
+	for _, i := range reap {
+		got[i.Digest] = true
+	}
+	if !got[dOld] || !got[dBad] {
+		t.Errorf("reap must include the aged and unparseable orphans; got %v", got)
+	}
+	if got[dReach] || got[dFresh] {
+		t.Errorf("reap must exclude the reachable and fresh blobs; got %v", got)
+	}
+	if len(reap) != 2 {
+		t.Errorf("reap size = %d; want 2", len(reap))
+	}
+}

--- a/go/internal/cli/commands/doctor.go
+++ b/go/internal/cli/commands/doctor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
+	"github.com/wendylabsinc/wendy/go/internal/shared/diskspace"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -59,12 +60,12 @@ type doctorReport struct {
 	Summary doctorSummary `json:"summary"`
 }
 
-// Thresholds for the resource and app-health checks.
+// Thresholds for the resource and app-health checks. The disk free-% thresholds
+// live in shared/diskspace so the agent's image GC engages at the same level
+// this check warns at.
 const (
-	diskWarnFreePct    = 10.0 // warn when a filesystem has less than this % free
-	diskFailFreePct    = 2.0  // fail when a filesystem has less than this % free
-	mtlsExpiryWarnDays = 14   // warn when the client cert expires within this many days
-	crashLoopFailCount = 5    // fail an app whose restart count reaches this
+	mtlsExpiryWarnDays = 14 // warn when the client cert expires within this many days
+	crashLoopFailCount = 5  // fail an app whose restart count reaches this
 )
 
 // agentPorts are the ports the agent serves on: 50051 (plaintext, shut down
@@ -508,9 +509,9 @@ func evaluateDiskUsage(mount string, used, total int64) checkResult {
 	freePct := float64(free) / float64(total) * 100
 	detail := fmt.Sprintf("%s free of %s (%.0f%% free)", formatBytes(free), formatBytes(total), freePct)
 	switch {
-	case freePct < diskFailFreePct:
+	case freePct < diskspace.FailFreePct:
 		return checkResult{Name: name, Status: statusFail, Detail: detail, Hint: "Disk almost full — free space or new deploys will fail."}
-	case freePct < diskWarnFreePct:
+	case freePct < diskspace.WarnFreePct:
 		return checkResult{Name: name, Status: statusWarn, Detail: detail, Hint: "Disk running low — consider clearing old images and volumes."}
 	default:
 		return checkResult{Name: name, Status: statusPass, Detail: detail}

--- a/go/internal/shared/diskspace/diskspace.go
+++ b/go/internal/shared/diskspace/diskspace.go
@@ -1,0 +1,21 @@
+// Package diskspace defines the WendyOS device disk-space policy: the free-%
+// thresholds shared by the agent's image garbage collector and the CLI's
+// `wendy device doctor` diagnostics, plus a helper to measure a filesystem's
+// free percentage. Keeping the thresholds in one neutral leaf package lets both
+// the agent and the CLI agree on when a device is "too full" without either
+// importing the other's internals.
+package diskspace
+
+// Free-space thresholds, expressed as a percentage of total filesystem
+// capacity. They are the single source of truth for "how full is too full" on a
+// WendyOS device, consumed by both `wendy device doctor` (which warns/fails its
+// disk check) and the agent image GC (which reclaims stale image data once free
+// space drops below WarnFreePct).
+const (
+	// WarnFreePct is the free-% at or below which a filesystem is considered
+	// under disk pressure: doctor warns, and the image GC engages.
+	WarnFreePct = 10.0
+	// FailFreePct is the free-% at or below which a filesystem is critically
+	// full: doctor fails (new deploys are at risk of running out of space).
+	FailFreePct = 2.0
+)

--- a/go/internal/shared/diskspace/diskspace_test.go
+++ b/go/internal/shared/diskspace/diskspace_test.go
@@ -1,0 +1,12 @@
+package diskspace
+
+import "testing"
+
+func TestThresholdsOrdered(t *testing.T) {
+	if !(WarnFreePct > FailFreePct) {
+		t.Fatalf("WarnFreePct (%v) must be greater than FailFreePct (%v)", WarnFreePct, FailFreePct)
+	}
+	if FailFreePct <= 0 || WarnFreePct >= 100 {
+		t.Fatalf("thresholds out of range: warn=%v fail=%v", WarnFreePct, FailFreePct)
+	}
+}

--- a/go/internal/shared/diskspace/freepercent_linux.go
+++ b/go/internal/shared/diskspace/freepercent_linux.go
@@ -1,0 +1,22 @@
+//go:build linux
+
+package diskspace
+
+import "golang.org/x/sys/unix"
+
+// FreePercent returns the percentage of the filesystem containing path that is
+// free, and true on success. It returns (0, false) on any statfs error so the
+// caller can treat the measurement as unavailable and skip any disk-pressure
+// action. Free space is computed from Bfree/Blocks (all blocks, matching the
+// agent's own disk-usage reporting in agent/services) rather than Bavail, so the
+// percentage lines up with what `wendy device doctor` shows.
+func FreePercent(path string) (float64, bool) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return 0, false
+	}
+	if st.Blocks == 0 {
+		return 0, false
+	}
+	return float64(st.Bfree) / float64(st.Blocks) * 100, true
+}

--- a/go/internal/shared/diskspace/freepercent_linux_test.go
+++ b/go/internal/shared/diskspace/freepercent_linux_test.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package diskspace
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFreePercent_RealPath(t *testing.T) {
+	pct, ok := FreePercent(os.TempDir())
+	if !ok {
+		t.Fatal("FreePercent on TempDir returned ok=false")
+	}
+	if pct < 0 || pct > 100 {
+		t.Fatalf("FreePercent = %v, want within [0,100]", pct)
+	}
+}
+
+func TestFreePercent_BogusPath(t *testing.T) {
+	if _, ok := FreePercent("/nonexistent/path/that/should/not/resolve"); ok {
+		t.Fatal("FreePercent on a bogus path returned ok=true")
+	}
+}

--- a/go/internal/shared/diskspace/freepercent_other.go
+++ b/go/internal/shared/diskspace/freepercent_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package diskspace
+
+// FreePercent is unavailable off-device: the image garbage collector that uses
+// it only runs on WendyOS Linux targets, and the CLI reads disk data over the
+// wire rather than statfs-ing locally. It always reports (0, false) so callers
+// no-op. See the Linux build for the real implementation.
+func FreePercent(_ string) (float64, bool) {
+	return 0, false
+}

--- a/go/internal/shared/diskspace/freepercent_other_test.go
+++ b/go/internal/shared/diskspace/freepercent_other_test.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package diskspace
+
+import "testing"
+
+func TestFreePercent_UnsupportedIsNoOp(t *testing.T) {
+	pct, ok := FreePercent("/")
+	if ok {
+		t.Fatal("FreePercent should report ok=false off-device")
+	}
+	if pct != 0 {
+		t.Fatalf("FreePercent = %v, want 0 off-device", pct)
+	}
+}


### PR DESCRIPTION
## Context

Old app-image versions accumulate on WendyOS devices and are never reclaimed. `wendy run` always re-tags `localhost:5000/<appid>:latest` and re-points that one image record every deploy, so old versions leak as two kinds of `containerd.io/gc.root`-pinned artifacts that containerd's native GC never reclaims: chain-ID layer **snapshots** (`unpack.go`) and compressed layer **content blobs** (`client.go` `WriteLayer`). OS/OTA images are out of scope (A/B slots bound them to two).

This **replaces the scrapped #1249**. That PR's tombstone GC was rejected for being (1) *over-eager* — it ran on every deploy + boot, so superseded layers were reaped then re-uploaded on the next deploy/branch-switch (the device-local registry shares containerd's content store, so deleting a blob defeats the CLI's push dedup) — and (2) for *adding a bookkeeping label to layers* (`sh.wendy/gc.orphaned-at`). Per @Joannis's note on #1237 (`doctor.go`), the GC should "sync … on the % free for both triggers."

> ⚠️ **Stacked on #1237** (`wdy-1756-…-device-doctor`), which owns the disk-%-free thresholds. Review/merge that first. This PR moves those thresholds into a shared package and points `doctor.go` at it.

## Approach — trigger only under disk pressure

Run GC **only when the containerd filesystem is genuinely low on space**, reusing the same free-% threshold `wendy device doctor` warns at (`diskspace.WarnFreePct`, 10%). Roomy devices reclaim nothing → nothing gets re-uploaded during normal operation. This fixes objection (1).

- **Deploy** (`triggerImageGCAsync`, success tail of `CreateContainerWithProgress`): async + single-flight, **snapshots only**, fires only if free% < 10%.
- **Boot** (`GarbageCollectImages`, after `ReapOrphanedROS2Sidecars`, before serving): synchronous, **snapshots + content**, only if free% < 10%.
- Event-driven — no periodic ticker (image data only grows via deploys).

### No new label (fixes objection 2)
On `main`, `containerd.io/gc.root` is **already** an RFC3339 timestamp (`gcTimestamp()`, written at `unpack.go` and `client.go`). The concurrency-safety grace guard (`gcRootGrace = unpackLeaseExpiration`, 30m) reads that **existing** value to spare a racing deploy's just-written (still-fresh) artifact. The entire orphan-age tombstone — the `sh.wendy/gc.orphaned-at` label, two-phase stamp/clear/reap, and `WENDY_IMAGE_GC_GRACE_PERIOD` — is deleted. `classifySnapshots`/`classifyBlobs` collapse to: reachable → keep; orphan with fresh `gc.root` → keep; orphan with aged (or unparseable) `gc.root` → reap.

### Content stays boot-only (kept the deploy/boot split)
A deploy that re-references a dedup-hit layer hits the CLI push-dedup and **never re-writes that blob**, so its `gc.root` timestamp stays old; a concurrent deploy-time GC could reap it in the window before the new image record exists → dangling reference → re-upload. Only boot quiescence makes blob reclamation provably safe. Snapshots are safe at deploy time (the image record is created before the chain-ID snapshot is committed).

### Reused from #1249
The trigger-independent mark-and-sweep core is carried over: `buildReachableSet` (fail-closed MARK over all images + all container snapshot chains, incl. ROS2 sidecars), `orderLeafFirst` (leaf-first removal), the single-flight guard, and the has-children `FailedPrecondition` backstop.

## Changes
- **New `go/internal/shared/diskspace/`** — `WarnFreePct`/`FailFreePct` consts + build-tagged `FreePercent(path)` (linux `unix.Statfs`; non-linux stub → GC no-ops off-device). Neutral leaf package both the agent and the CLI can import.
- **`doctor.go`** — consumes `diskspace.WarnFreePct`/`FailFreePct` instead of local consts.
- **New `imagegc.go` / `imagegc_test.go`** — tombstone-free mark-and-sweep + disk-pressure gate.
- **`helpers.go`** — ports `chainIDsForDiffIDs` (no tombstone label).
- **`client.go`** — `NewClient(…, imageGCEnabled bool)`; fields `containerdRoot` (`/var/lib/containerd`, `WENDY_CONTAINERD_ROOT` override), `diskFreePct` + `gcPass` (seams so the gate/single-flight are unit-testable without a live containerd); deploy trigger.
- **`main.go`** — `WENDY_IMAGE_GC_ENABLED` (default on); boot hook.

## Config
- `WENDY_IMAGE_GC_ENABLED` (default `true`) — master switch.
- `WENDY_CONTAINERD_ROOT` (default `/var/lib/containerd`) — filesystem whose free% drives GC.

## Accepted tradeoff (please don't re-raise)
Under **genuine disk pressure**, a cacheable superseded layer *can* be reaped and re-uploaded on the next deploy. This is intentional — it's precisely what avoids reaping (and re-uploading) during normal, roomy operation, answering the "constant re-uploads" objection.

## Testing
- [x] `go build ./...` on **darwin** + cross-compiled **linux/arm64**
- [x] `go vet ./...` (host + `GOOS=linux`), `gofmt -l` clean
- [x] `go test` — `diskspace`, `agent/containerd` (incl. new pressure-gate/grace/single-flight tests, `-race`), `cli/commands`, full `agent/...` suite green
- [ ] **On-device E2E pending**: fill containerd FS < 10% → deploy → confirm snapshot reclaim; reboot → confirm content reclaim + `df` drops; healthy FS (>10%) → GC is a no-op (no reclaim, no re-upload on redeploy); `WENDY_IMAGE_GC_ENABLED=false` → both paths no-op; redeploy re-using a fresh layer → no re-upload (grace guard keeps it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)