### PR TITLE
feat(cli): hide local run targets in the device picker by default

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
@@ -45,15 +45,15 @@ or macOS permissions.
 
 By default `wendy discover` hides **local run targets** — this machine,
 Docker/OrbStack, and Apple Container — so the table shows only separate WendyOS
-devices. Pass `--all` to include them:
+devices. Set `WENDY_SHOW_LOCAL_DEVICES=1` to include them:
 
 ```sh
-wendy discover --all
+WENDY_SHOW_LOCAL_DEVICES=1 wendy discover
 ```
 
 > **Note:** JSON output (`wendy discover --json`) always includes local run
-> targets regardless of `--all`, so scripts and MCP callers continue to receive
-> the full set.
+> targets regardless of `WENDY_SHOW_LOCAL_DEVICES`, so scripts and MCP callers
+> continue to receive the full set.
 
 ## Flags
 
@@ -61,7 +61,12 @@ wendy discover --all
 |------|---------|-------------|
 | `--timeout` | `5s` | How long to wait for mDNS responses |
 | `--json` | `false` | Output results as a JSON array instead of a table |
-| `--all` | `false` | Include local run targets (this machine, Docker/OrbStack, Apple Container) in the table. JSON output always includes them regardless of this flag. |
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `WENDY_SHOW_LOCAL_DEVICES` | When truthy (`1`/`true`/`yes`/`on`), include local run targets (this machine, Docker/OrbStack, Apple Container) in the table. JSON output always includes them regardless. |
 
 ## Interactive table
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -46,6 +46,11 @@ apple-container` instead. Compose projects still require the Docker provider for
 local runs, but compose service builds targeting a WendyOS device can use
 `--builder apple-container`.
 
+The interactive device picker hides local run targets (this machine,
+Docker/OrbStack, Apple Container) by default so it lists separate WendyOS
+devices first. Select one explicitly with `--device` (as above), or set
+`WENDY_SHOW_LOCAL_DEVICES=1` to list them in the picker.
+
 | Build-arg | Values | Notes |
 |---|---|---|
 | `WENDY_PLATFORM` | `nvidia-jetson` \| `generic` | Platform tier derived from the device type |
@@ -130,7 +135,6 @@ On a **Windows host**, `wendy run` returns an actionable error for Swift project
 | `--max-concurrency <n>` | Max service images to build+push at once in multi-service projects. 0 = auto-throttle large groups (default). |
 | `--user-args <args>` | Extra arguments to pass to the container at runtime. |
 | `--chunking <mode>` | Controls the content-based chunking (CBC) chunk-diff deploy path: `auto` (default), `force`, or `off`. See [Deploy path: `--chunking`](#deploy-path---chunking). |
-| `--all` | Include local run targets (this machine, Docker/OrbStack, Apple Container) in the device picker. Hidden by default so the picker lists WendyOS devices first. |
 | `--watch` | Watch the project directory and redeploy on every change. Runs detached and non-interactive. See [Watch mode](#watch-mode). |
 | `--debounce <ms>` | Watch mode only: quiet period in milliseconds after the last change before redeploying (default `400`). |
 | `--verbose` | Watch mode only: always show build output. By default build output is hidden unless a build fails. |

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -126,31 +125,17 @@ func TestRunCmdWatchFlagAlias(t *testing.T) {
 	}
 }
 
-// TestRunResolveOptions_ExcludesLocalByDefault verifies that, without --all,
-// `wendy run`'s interactive picker hides the on-machine run targets.
-func TestRunResolveOptions_ExcludesLocalByDefault(t *testing.T) {
+// TestRunResolveOptions_NoProviderExclusionByDefault verifies `wendy run`
+// itself no longer excludes local run targets: the interactive picker hides
+// them centrally (unless WENDY_SHOW_LOCAL_DEVICES), so runResolveOptions leaves
+// provider filtering to the picker.
+func TestRunResolveOptions_NoProviderExclusionByDefault(t *testing.T) {
 	cfg := resolveConfig{excludeProviderKeys: map[string]bool{}}
 	for _, o := range runResolveOptions(runOptions{}) {
 		o(&cfg)
 	}
-	for _, k := range providers.LocalProviderKeys() {
-		if !cfg.excludeProviderKeys[k] {
-			t.Errorf("provider %q should be excluded from the picker by default", k)
-		}
-	}
-}
-
-// TestRunResolveOptions_AllShowsLocal verifies that --all surfaces the local
-// run targets in the picker again.
-func TestRunResolveOptions_AllShowsLocal(t *testing.T) {
-	cfg := resolveConfig{excludeProviderKeys: map[string]bool{}}
-	for _, o := range runResolveOptions(runOptions{allTargets: true}) {
-		o(&cfg)
-	}
-	for _, k := range providers.LocalProviderKeys() {
-		if cfg.excludeProviderKeys[k] {
-			t.Errorf("--all should not exclude provider %q", k)
-		}
+	if len(cfg.excludeProviderKeys) != 0 {
+		t.Errorf("runResolveOptions should not exclude any providers; got %v", cfg.excludeProviderKeys)
 	}
 }
 

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -31,7 +31,6 @@ import (
 func newDiscoverCmd() *cobra.Command {
 	var discoverType string
 	var timeout time.Duration
-	var all bool
 
 	cmd := &cobra.Command{
 		Use:   "discover",
@@ -68,30 +67,30 @@ func newDiscoverCmd() *cobra.Command {
 				}
 				opts.Timeout = timeout
 				// JSON output always lists every target so scripts/MCP keep the
-				// full set regardless of --all.
+				// full set regardless of WENDY_SHOW_LOCAL_DEVICES.
 				return discoverJSON(cmd.Context(), opts)
 			}
 
 			if timeoutSet {
 				opts.Timeout = timeout
-				return discoverOnce(cmd.Context(), opts, all)
+				return discoverOnce(cmd.Context(), opts, providers.ShowLocalDevices())
 			}
-			return discoverContinuous(cmd.Context(), opts, all)
+			return discoverContinuous(cmd.Context(), opts, providers.ShowLocalDevices())
 		},
 	}
 
 	cmd.Flags().StringVar(&discoverType, "type", "all", "Discovery type: usb, lan, bluetooth, external, all")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "Scan once for this duration then exit")
-	cmd.Flags().BoolVar(&all, "all", false, "Include local run targets (this machine, Docker/OrbStack, Apple Container) in the results; hidden by default")
 
 	return cmd
 }
 
 // discoverExternalDevices queries registered providers for their devices. This
 // uses AllProviders (not just available ones) so devices are discoverable even
-// when the build toolchain isn't installed. Unless includeLocal is set, local
-// run targets (this machine, Docker/OrbStack, Apple Container) are skipped so
-// the table lists separate WendyOS devices by default.
+// when the build toolchain isn't installed. Unless includeLocal is set (see
+// providers.ShowLocalDevices), local run targets (this machine, Docker/OrbStack,
+// Apple Container) are skipped so the table lists separate WendyOS devices by
+// default.
 func discoverExternalDevices(ctx context.Context, includeLocal bool) []models.ExternalDevice {
 	var all []models.ExternalDevice
 	for _, p := range providers.AllProviders() {

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -878,15 +878,12 @@ func TestCopyToClipboard_NoToolsFound(t *testing.T) {
 	}
 }
 
-// TestDiscoverCmdHasAllFlag verifies `wendy discover --all` exists and defaults
-// to off, so local run targets are hidden unless explicitly requested.
-func TestDiscoverCmdHasAllFlag(t *testing.T) {
+// TestDiscoverCmdHasNoAllFlag verifies `wendy discover` no longer carries an
+// --all flag: local run targets are hidden by default and revealed only via the
+// WENDY_SHOW_LOCAL_DEVICES environment variable.
+func TestDiscoverCmdHasNoAllFlag(t *testing.T) {
 	cmd := newDiscoverCmd()
-	flag := cmd.Flags().Lookup("all")
-	if flag == nil {
-		t.Fatal("discover is missing the --all flag")
-	}
-	if flag.DefValue != "false" {
-		t.Fatalf("--all default = %q; want false", flag.DefValue)
+	if flag := cmd.Flags().Lookup("all"); flag != nil {
+		t.Fatal("discover should no longer define an --all flag")
 	}
 }

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1885,12 +1885,33 @@ func usbFirstSortKey(name, usb string) string {
 	return "0_" + strings.ToLower(name)
 }
 
+// hideLocalProviders returns a copy of excludes that additionally hides the
+// local run targets (this machine, Docker/OrbStack, Apple Container) unless the
+// user opts them back in via providers.ShowLocalDevices. The input map is left
+// untouched (and may be nil); the picker lists separate WendyOS devices by
+// default so local runtimes don't crowd out real hardware.
+func hideLocalProviders(excludes map[string]bool) map[string]bool {
+	merged := make(map[string]bool, len(excludes)+len(providers.LocalProviderKeys()))
+	for k, v := range excludes {
+		merged[k] = v
+	}
+	if !providers.ShowLocalDevices() {
+		for _, k := range providers.LocalProviderKeys() {
+			merged[k] = true
+		}
+	}
+	return merged
+}
+
 // pickDevice runs an interactive TUI that discovers devices across all
 // transports and providers, then lets the user select one.
 // LAN discovery runs continuously so devices that come online after the
 // initial scan still appear in the picker.
-// excludeProviders hides the named provider keys from the picker.
+// excludeProviders hides the named provider keys from the picker. Local run
+// targets are hidden on top of these unless providers.ShowLocalDevices is set.
 func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBluetooth bool, suppressUpdateCheck bool) (*SelectedDevice, error) {
+	excludeProviders = hideLocalProviders(excludeProviders)
+
 	picker := tui.NewPicker()
 	picker.MergeItem = mergePickerItem
 

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -903,3 +903,40 @@ func TestUpdateCheckTTLCache(t *testing.T) {
 		t.Fatal("stale: expected marker older than TTL to fail the check")
 	}
 }
+
+// TestHideLocalProviders verifies the device picker hides local run targets by
+// default, preserves any caller-supplied excludes, leaves the input map
+// untouched, and reveals local targets when WENDY_SHOW_LOCAL_DEVICES is set.
+func TestHideLocalProviders(t *testing.T) {
+	t.Run("hidden by default", func(t *testing.T) {
+		t.Setenv(providers.ShowLocalDevicesEnv, "")
+		got := hideLocalProviders(nil)
+		for _, k := range providers.LocalProviderKeys() {
+			if !got[k] {
+				t.Errorf("hideLocalProviders(nil)[%q] = false; want true", k)
+			}
+		}
+	})
+
+	t.Run("preserves caller excludes and does not mutate input", func(t *testing.T) {
+		t.Setenv(providers.ShowLocalDevicesEnv, "")
+		in := map[string]bool{"wendy-lite": true}
+		got := hideLocalProviders(in)
+		if !got["wendy-lite"] {
+			t.Error("hideLocalProviders dropped caller-supplied exclude wendy-lite")
+		}
+		if len(in) != 1 {
+			t.Errorf("hideLocalProviders mutated input map: len = %d, want 1", len(in))
+		}
+	})
+
+	t.Run("reveals local targets when opted in", func(t *testing.T) {
+		t.Setenv(providers.ShowLocalDevicesEnv, "1")
+		got := hideLocalProviders(nil)
+		for _, k := range providers.LocalProviderKeys() {
+			if got[k] {
+				t.Errorf("hideLocalProviders(nil)[%q] = true with opt-in set; want false", k)
+			}
+		}
+	})
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -486,23 +486,16 @@ type runOptions struct {
 	// push on failure, chunkingForce uses chunk-diff with no fallback, and
 	// chunkingOff skips chunk-diff entirely (registry push only).
 	chunking string
-	// allTargets shows local run targets (the local machine, Docker/OrbStack,
-	// Apple Container) in the interactive device picker. They are hidden by
-	// default so the picker lists WendyOS devices first.
-	allTargets bool
 }
 
 // runResolveOptions builds the resolveTarget options shared by every `wendy run`
-// device-selection path. By default the interactive picker hides local run
-// targets (LocalProviderKeys); --all (opts.allTargets) surfaces them again.
-// --yes suppresses the picker entirely.
+// device-selection path. The interactive picker hides local run targets (the
+// local machine, Docker/OrbStack, Apple Container) unless
+// WENDY_SHOW_LOCAL_DEVICES is set; --yes suppresses the picker entirely.
 func runResolveOptions(opts runOptions) []resolveOption {
 	var resolveOpts []resolveOption
 	if opts.yes {
 		resolveOpts = append(resolveOpts, NonInteractive())
-	}
-	if !opts.allTargets {
-		resolveOpts = append(resolveOpts, ExcludeProviders(providers.LocalProviderKeys()...))
 	}
 	return resolveOpts
 }
@@ -566,7 +559,6 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().IntVar(&opts.maxConcurrency, "max-concurrency", 0, "Multi-service: max service images to build+push at once (0 = auto-throttle large groups)")
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
 	cmd.Flags().StringVar(&opts.chunking, "chunking", chunkingAuto, "Content-defined chunking (CBC) deploy path: auto (try chunk-diff, fall back to registry push), force (chunk-diff only, no fallback), or off (registry push only)")
-	cmd.Flags().BoolVar(&opts.allTargets, "all", false, "Include local run targets (this machine, Docker/OrbStack, Apple Container) in the device picker; hidden by default")
 	cmd.Flags().BoolVar(&watch, "watch", false, "Watch the project directory and redeploy on every change (runs detached; same as 'wendy watch')")
 	cmd.Flags().IntVar(&debounceMS, "debounce", 400, "Watch mode (--watch): quiet period in milliseconds after the last change before redeploying")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Watch mode (--watch): always show build output (default: hidden unless the build fails)")

--- a/go/internal/cli/providers/local_provider_keys_test.go
+++ b/go/internal/cli/providers/local_provider_keys_test.go
@@ -2,10 +2,29 @@ package providers
 
 import "testing"
 
-// TestLocalProviderKeys verifies the local-target classification used by
-// `wendy run`/`wendy discover` to hide on-machine run targets unless --all.
-// The local container runtimes and the local machine are in; real external
-// hardware (android phone, wendy-lite MCU) is out.
+// TestShowLocalDevices verifies the WENDY_SHOW_LOCAL_DEVICES opt-in parsing:
+// local run targets stay hidden unless the var is set to a truthy value.
+func TestShowLocalDevices(t *testing.T) {
+	truthy := []string{"1", "true", "TRUE", "yes", "Yes", "on", "ON", " true "}
+	for _, v := range truthy {
+		t.Setenv(ShowLocalDevicesEnv, v)
+		if !ShowLocalDevices() {
+			t.Errorf("ShowLocalDevices() = false for %q; want true", v)
+		}
+	}
+	falsy := []string{"", "0", "false", "no", "off", "maybe", "2"}
+	for _, v := range falsy {
+		t.Setenv(ShowLocalDevicesEnv, v)
+		if ShowLocalDevices() {
+			t.Errorf("ShowLocalDevices() = true for %q; want false", v)
+		}
+	}
+}
+
+// TestLocalProviderKeys verifies the local-target classification used by the
+// device picker and `wendy discover` to hide on-machine run targets unless
+// ShowLocalDevices. The local container runtimes and the local machine are in;
+// real external hardware (android phone, wendy-lite MCU) is out.
 func TestLocalProviderKeys(t *testing.T) {
 	want := map[string]bool{
 		ProviderKeyLocal:          true,

--- a/go/internal/cli/providers/provider.go
+++ b/go/internal/cli/providers/provider.go
@@ -80,8 +80,9 @@ func IsLocalProviderKey(key string) bool {
 const ShowLocalDevicesEnv = "WENDY_SHOW_LOCAL_DEVICES"
 
 // ShowLocalDevices reports whether local run targets should be shown in the
-// device picker and discovery output. It is false unless ShowLocalDevicesEnv is
-// set to a truthy value ("1", "true", "yes", "on"; case-insensitive).
+// interactive device picker and non-JSON `wendy discover` output. It is false
+// unless ShowLocalDevicesEnv is set to a truthy value ("1", "true", "yes", "on";
+// case-insensitive).
 func ShowLocalDevices() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(ShowLocalDevicesEnv))) {
 	case "yes", "on":

--- a/go/internal/cli/providers/provider.go
+++ b/go/internal/cli/providers/provider.go
@@ -4,7 +4,10 @@ package providers
 
 import (
 	"context"
+	"os"
 	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
@@ -57,10 +60,10 @@ const (
 
 // LocalProviderKeys are the providers whose "devices" are really this computer
 // or a local container runtime (the local machine, Docker/OrbStack, Apple
-// Container) rather than a separate WendyOS device. `wendy run` and
-// `wendy discover` hide these from the default device list unless --all is
-// given. Real external hardware providers (e.g. android, wendy-lite) are not
-// local and are always shown.
+// Container) rather than a separate WendyOS device. The interactive device
+// picker and `wendy discover` hide these from the default device list unless
+// ShowLocalDevices reports true. Real external hardware providers (e.g.
+// android, wendy-lite) are not local and are always shown.
 func LocalProviderKeys() []string {
 	return []string{ProviderKeyLocal, ProviderKeyDocker, ProviderKeyAppleContainer}
 }
@@ -69,6 +72,23 @@ func LocalProviderKeys() []string {
 // LocalProviderKeys).
 func IsLocalProviderKey(key string) bool {
 	return slices.Contains(LocalProviderKeys(), key)
+}
+
+// ShowLocalDevicesEnv is the environment variable that opts local run targets
+// (see LocalProviderKeys) back into the device picker and `wendy discover`.
+// They are hidden by default so those surfaces list separate WendyOS devices.
+const ShowLocalDevicesEnv = "WENDY_SHOW_LOCAL_DEVICES"
+
+// ShowLocalDevices reports whether local run targets should be shown in the
+// device picker and discovery output. It is false unless ShowLocalDevicesEnv is
+// set to a truthy value ("1", "true", "yes", "on"; case-insensitive).
+func ShowLocalDevices() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(ShowLocalDevicesEnv))) {
+	case "yes", "on":
+		return true
+	}
+	b, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(ShowLocalDevicesEnv)))
+	return err == nil && b
 }
 
 const (


### PR DESCRIPTION
## Summary

The interactive device picker showed **local run targets** — this machine, Docker/OrbStack, and Apple Container — in every command that didn't explicitly exclude them, so `apple-container`/`docker`/`local` crowded out real WendyOS devices in most utilities (`device info`, `os update`, `audio`, `camera`, `hardware`, `volumes`, `set-default`, …).

This hides them by default everywhere and replaces the two per-command `--all` opt-ins with a single environment variable.

## What changed

**One choke point covers every picker path.** A new `hideLocalProviders` helper runs each caller's exclude set through `providers.ShowLocalDevices()` inside `pickDevice`, adding `local`/`docker`/`apple-container` unless opted in. This covers `resolveTargetInner`, `connectToAgent`, default-device recovery, and `set-default` at once. As a bonus it fixes commands (wifi/ros2/device) that previously hid `local`/`docker` but still leaked `apple-container`.

**Opt-in via env var, `--all` flags removed:**
- New `WENDY_SHOW_LOCAL_DEVICES` (truthy = `1`/`true`/`yes`/`on`, case-insensitive; default off) reveals local targets in the picker and `wendy discover`.
- `wendy run` — dropped `--all`/`allTargets`; the picker now handles exclusion centrally.
- `wendy discover` — dropped `--all`; `includeLocal` driven by `ShowLocalDevices()`. JSON output still always includes everything for scripts/MCP.

**Unaffected:** explicit `--device docker`/`apple-container`/`local` still resolve directly. Unrelated `--all` flags (`wendy cloud discover`, `wendy audio`) are untouched.

## Tests & docs
- Added `TestShowLocalDevices` (env-var truthiness parsing) and `TestHideLocalProviders` (default-hide, preserves caller excludes, no input mutation, env-var reveal).
- Rewrote the obsolete run/discover flag tests.
- Updated `run.md` and `discover.md`.
- `gofmt`, `go vet`, `go build`, and the `commands` + `providers` test packages all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)