### PR TITLE
cli: support Jetson AGX Thor flashing on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,16 +87,6 @@ jobs:
             goarch: arm64
             product: wendy-agent
             cmd: wendy-agent
-          - artifact-name: wendy-cli-linux-amd64
-            goos: linux
-            goarch: amd64
-            product: wendy
-            cmd: wendy
-          - artifact-name: wendy-cli-linux-arm64
-            goos: linux
-            goarch: arm64
-            product: wendy
-            cmd: wendy
           - artifact-name: wendy-cli-windows-amd64
             goos: windows
             goarch: amd64
@@ -150,6 +140,104 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
+  # The Linux CLI links libusb via cgo (Thor USB recovery flashing, gousb), so it
+  # is built natively per arch instead of cross-compiled in the CGO_ENABLED=0
+  # matrix above. libusb is compiled from a pinned source tarball against musl
+  # (--disable-udev: enumeration falls back to sysfs/usbfs, all wendy needs) and
+  # linked statically, so the binary stays fully static and runs on any distro,
+  # like the previous CGO_ENABLED=0 build.
+  build-cli-linux:
+    name: ${{ matrix.artifact-name }}
+    runs-on: ${{ matrix.runner }}
+    needs: [determine-version]
+    strategy:
+      matrix:
+        include:
+          - artifact-name: wendy-cli-linux-amd64
+            goarch: amd64
+            runner: ubuntu-24.04
+          - artifact-name: wendy-cli-linux-arm64
+            goarch: arm64
+            runner: ubuntu-24.04-arm
+    env:
+      LIBUSB_VERSION: "1.0.29"
+      LIBUSB_SHA256: "5977fc950f8d1395ccea9bd48c06b3f808fd3c2c961b44b0c2e6e29fc3a70a85"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Install musl toolchain
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Build static libusb (musl, no udev)
+        run: |
+          set -euo pipefail
+          curl -fsSL -o libusb.tar.bz2 \
+            "https://github.com/libusb/libusb/releases/download/v${LIBUSB_VERSION}/libusb-${LIBUSB_VERSION}.tar.bz2"
+          echo "${LIBUSB_SHA256}  libusb.tar.bz2" | sha256sum -c -
+          tar -xjf libusb.tar.bz2
+          cd "libusb-${LIBUSB_VERSION}"
+          # libusb without udev needs kernel UAPI headers (linux/netlink.h), which
+          # musl-gcc's include path lacks. Stage just linux/, asm/ and asm-generic/
+          # (libc-agnostic) rather than exposing all of glibc's /usr/include.
+          KINC="${GITHUB_WORKSPACE}/kernel-headers"
+          mkdir -p "$KINC"
+          cp -r /usr/include/linux "$KINC/linux"
+          cp -r "/usr/include/$(gcc -print-multiarch)/asm" "$KINC/asm"
+          cp -r /usr/include/asm-generic "$KINC/asm-generic"
+          CC=musl-gcc CFLAGS="-I$KINC" ./configure --disable-udev --disable-shared \
+            --enable-static --prefix="${GITHUB_WORKSPACE}/libusb-prefix"
+          make -j"$(nproc)"
+          make install
+
+      - name: Build
+        working-directory: go
+        env:
+          CGO_ENABLED: "1"
+          CC: musl-gcc
+          GOARCH: ${{ matrix.goarch }}
+          # gousb resolves libusb via pkg-config; point it at the static build.
+          PKG_CONFIG_PATH: ${{ github.workspace }}/libusb-prefix/lib/pkgconfig
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          LDFLAGS="-s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=${VERSION}"
+          mkdir -p ../${{ matrix.artifact-name }}
+          go build -tags netgo,osusergo \
+            -ldflags "${LDFLAGS} -linkmode external -extldflags -static" \
+            -o ../${{ matrix.artifact-name }}/wendy ./cmd/wendy
+          # libusb is statically linked (LGPL-2.1): ship its attribution/license.
+          cp ../NOTICE ../${{ matrix.artifact-name }}/NOTICE
+
+      - name: Verify static binary and smoke test
+        run: |
+          set -euo pipefail
+          if ldd "${{ matrix.artifact-name }}/wendy" >/dev/null 2>&1; then
+            echo "ERROR: wendy is dynamically linked:"
+            ldd "${{ matrix.artifact-name }}/wendy"
+            exit 1
+          fi
+          ./${{ matrix.artifact-name }}/wendy --version
+
+      - name: Create archive
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          ARCHIVE="${{ matrix.artifact-name }}-${VERSION}.tar.gz"
+          tar -czvf "$ARCHIVE" ${{ matrix.artifact-name }}/
+          echo "archive=$ARCHIVE" >> $GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ env.archive }}
+          path: ${{ env.archive }}
+          retention-days: 14
+          if-no-files-found: error
+
   build-go-macos:
     name: ${{ matrix.artifact-name }}
     runs-on: macos-15
@@ -171,17 +259,21 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
+      - name: Install libusb
+        run: brew list libusb >/dev/null 2>&1 || brew install libusb
+
+      # build-wendy.sh links libusb statically and fails the build if a dynamic
+      # libusb dependency sneaks in — a plain `go build` would produce a binary
+      # that only runs on Macs with Homebrew libusb installed.
       - name: Build
-        working-directory: go
         env:
-          CGO_ENABLED: "1"
-          GOOS: darwin
+          VERSION: ${{ needs.determine-version.outputs.version }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          VERSION="${{ needs.determine-version.outputs.version }}"
-          LDFLAGS="-s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=${VERSION}"
-          mkdir -p ../${{ matrix.artifact-name }}
-          go build -ldflags "${LDFLAGS}" -o ../${{ matrix.artifact-name }}/wendy ./cmd/wendy
+          mkdir -p ${{ matrix.artifact-name }}
+          go/scripts/build-wendy.sh ../${{ matrix.artifact-name }}/wendy
+          # libusb is statically linked (LGPL-2.1): ship its attribution/license.
+          cp NOTICE ${{ matrix.artifact-name }}/NOTICE
 
       - name: Create archive
         working-directory: .
@@ -268,7 +360,7 @@ jobs:
   package-linux:
     name: Package Linux (${{ matrix.arch }})
     runs-on: ubuntu-latest
-    needs: [determine-version, build]
+    needs: [determine-version, build, build-cli-linux]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
     strategy:
       matrix:
@@ -310,6 +402,8 @@ jobs:
           set -euo pipefail
 
           mkdir -p pkgroot/wendy/usr/bin
+          mkdir -p pkgroot/wendy/usr/lib/udev/rules.d
+          mkdir -p pkgroot/wendy/usr/share/doc/wendy
           mkdir -p pkgroot/wendy-agent/usr/bin
           mkdir -p pkgroot/wendy-agent/usr/lib/systemd/system
           mkdir -p pkgroot/wendy-agent/usr/lib/wendy-agent
@@ -320,6 +414,11 @@ jobs:
 
           install -m755 ./wendy-cli-linux-${{ matrix.goarch }}/wendy \
             pkgroot/wendy/usr/bin/wendy
+          # USB access for Jetson recovery flashing (`wendy os install`).
+          install -m644 packaging/linux/udev/70-wendy-jetson.rules \
+            pkgroot/wendy/usr/lib/udev/rules.d/70-wendy-jetson.rules
+          # libusb is statically linked into wendy (LGPL-2.1): ship its notice.
+          install -m644 NOTICE pkgroot/wendy/usr/share/doc/wendy/NOTICE
           install -m755 ./wendy-agent-linux-${{ matrix.goarch }}/wendy-agent \
             pkgroot/wendy-agent/usr/bin/wendy-agent
 
@@ -354,6 +453,7 @@ jobs:
             --category "devel" \
             --depends "usbutils" \
             --depends "ca-certificates" \
+            --after-install packaging/linux/fpm/wendy-postinstall.sh \
             -C pkgroot/wendy \
             .
 
@@ -407,6 +507,7 @@ jobs:
             --category "Development/Tools" \
             --depends "usbutils" \
             --depends "ca-certificates" \
+            --after-install packaging/linux/fpm/wendy-postinstall.sh \
             -C pkgroot/wendy \
             .
 
@@ -448,6 +549,9 @@ jobs:
 
           dpkg-deb -I "$WENDY_DEB" | grep -E "Depends:.*usbutils"
           dpkg-deb -I "$WENDY_DEB" | grep -E "Depends:.*ca-certificates"
+          dpkg-deb -c "$WENDY_DEB" | grep "usr/lib/udev/rules.d/70-wendy-jetson.rules" > /dev/null
+          dpkg-deb -c "$WENDY_DEB" | grep "usr/share/doc/wendy/NOTICE" > /dev/null
+          rpm -qpl "$WENDY_RPM" | grep "/usr/lib/udev/rules.d/70-wendy-jetson.rules" > /dev/null
           dpkg-deb -I "$WENDY_AGENT_DEB" | grep -E "Depends:.*containerd"
           dpkg-deb -I "$WENDY_AGENT_DEB" | grep -E "Depends:.*dbus"
           dpkg-deb -I "$WENDY_AGENT_DEB" | grep -E "Depends:.*systemd"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -558,7 +558,6 @@ jobs:
           dpkg-deb -I "$WENDY_DEB" | grep -E "Depends:.*ca-certificates"
           dpkg-deb -c "$WENDY_DEB" | grep "usr/lib/udev/rules.d/70-wendy-jetson.rules" > /dev/null
           dpkg-deb -c "$WENDY_DEB" | grep "usr/share/doc/wendy/NOTICE" > /dev/null
-          rpm -qpl "$WENDY_RPM" | grep "/usr/lib/udev/rules.d/70-wendy-jetson.rules" > /dev/null
           dpkg-deb -I "$WENDY_AGENT_DEB" | grep -E "Depends:.*containerd"
           dpkg-deb -I "$WENDY_AGENT_DEB" | grep -E "Depends:.*dbus"
           dpkg-deb -I "$WENDY_AGENT_DEB" | grep -E "Depends:.*systemd"
@@ -575,6 +574,8 @@ jobs:
           rpm -qp --requires "$WENDY_AGENT_RPM" | grep "^systemd" > /dev/null
           rpm -qp --requires "$WENDY_AGENT_RPM" | grep "^ca-certificates" > /dev/null
           rpm -qp --requires "$WENDY_AGENT_RPM" | grep "^avahi" > /dev/null
+          rpm -qpl "$WENDY_RPM" | grep "/usr/lib/udev/rules.d/70-wendy-jetson.rules" > /dev/null
+          rpm -qpl "$WENDY_RPM" | grep "/usr/share/doc/wendy/NOTICE" > /dev/null
           rpm -qpl "$WENDY_AGENT_RPM" | grep "/usr/lib/systemd/system/wendy-agent.service" > /dev/null
           rpm -qpl "$WENDY_AGENT_RPM" | grep "/etc/default/wendy-agent" > /dev/null
           rpm -qpl "$WENDY_AGENT_RPM" | grep "/etc/avahi/services/wendy-agent.service" > /dev/null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,8 @@ jobs:
             runner: ubuntu-24.04-arm
     env:
       LIBUSB_VERSION: "1.0.29"
+      # sha256 of libusb-1.0.29.tar.bz2 from the upstream GitHub release
+      # (github.com/libusb/libusb/releases/tag/v1.0.29), computed at pin time.
       LIBUSB_SHA256: "5977fc950f8d1395ccea9bd48c06b3f808fd3c2c961b44b0c2e6e29fc3a70a85"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -204,31 +206,34 @@ jobs:
           # gousb resolves libusb via pkg-config; point it at the static build.
           PKG_CONFIG_PATH: ${{ github.workspace }}/libusb-prefix/lib/pkgconfig
         run: |
+          ARTIFACT="${{ matrix.artifact-name }}"
           VERSION="${{ needs.determine-version.outputs.version }}"
           LDFLAGS="-s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=${VERSION}"
-          mkdir -p ../${{ matrix.artifact-name }}
+          mkdir -p "../${ARTIFACT}"
           go build -tags netgo,osusergo \
             -ldflags "${LDFLAGS} -linkmode external -extldflags -static" \
-            -o ../${{ matrix.artifact-name }}/wendy ./cmd/wendy
+            -o "../${ARTIFACT}/wendy" ./cmd/wendy
           # libusb is statically linked (LGPL-2.1): ship its attribution/license.
-          cp ../NOTICE ../${{ matrix.artifact-name }}/NOTICE
+          cp ../NOTICE "../${ARTIFACT}/NOTICE"
 
       - name: Verify static binary and smoke test
         run: |
           set -euo pipefail
-          if ldd "${{ matrix.artifact-name }}/wendy" >/dev/null 2>&1; then
+          ARTIFACT="${{ matrix.artifact-name }}"
+          if ldd "${ARTIFACT}/wendy" >/dev/null 2>&1; then
             echo "ERROR: wendy is dynamically linked:"
-            ldd "${{ matrix.artifact-name }}/wendy"
+            ldd "${ARTIFACT}/wendy"
             exit 1
           fi
-          ./${{ matrix.artifact-name }}/wendy --version
+          "./${ARTIFACT}/wendy" --version
 
       - name: Create archive
         run: |
+          ARTIFACT="${{ matrix.artifact-name }}"
           VERSION="${{ needs.determine-version.outputs.version }}"
-          ARCHIVE="${{ matrix.artifact-name }}-${VERSION}.tar.gz"
-          tar -czvf "$ARCHIVE" ${{ matrix.artifact-name }}/
-          echo "archive=$ARCHIVE" >> $GITHUB_ENV
+          ARCHIVE="${ARTIFACT}-${VERSION}.tar.gz"
+          tar -czvf "$ARCHIVE" "${ARTIFACT}/"
+          echo "archive=$ARCHIVE" >> "$GITHUB_ENV"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -270,10 +275,12 @@ jobs:
           VERSION: ${{ needs.determine-version.outputs.version }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          mkdir -p ${{ matrix.artifact-name }}
-          go/scripts/build-wendy.sh ../${{ matrix.artifact-name }}/wendy
+          ARTIFACT="${{ matrix.artifact-name }}"
+          mkdir -p "${ARTIFACT}"
+          # build-wendy.sh cds into go/, so the output path is relative to go/.
+          go/scripts/build-wendy.sh "../${ARTIFACT}/wendy"
           # libusb is statically linked (LGPL-2.1): ship its attribution/license.
-          cp NOTICE ${{ matrix.artifact-name }}/NOTICE
+          cp NOTICE "${ARTIFACT}/NOTICE"
 
       - name: Create archive
         working-directory: .

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -30,7 +30,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libusb-1.0-0-dev
 
       - name: Run tests
         working-directory: go
@@ -67,7 +67,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libusb-1.0-0-dev
 
       - name: Run go vet
         working-directory: go

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -391,6 +391,20 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      # The Linux CLI links libusb via cgo (Thor flashing), so the self-hosted
+      # runner needs the dev headers before `make build-cli`.
+      - name: Prepare Linux build dependencies
+        run: |
+          set -euo pipefail
+          if pkg-config --exists libusb-1.0 2>/dev/null; then exit 0; fi
+          if sudo -n true 2>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y pkg-config libusb-1.0-0-dev
+          else
+            echo "error: libusb-1.0 dev headers missing on this runner and passwordless sudo is unavailable." >&2
+            echo "Install them once with: sudo apt-get install -y pkg-config libusb-1.0-0-dev" >&2
+            exit 1
+          fi
+
       - name: Build CLI
         working-directory: go
         run: make build-cli

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -396,13 +396,8 @@ jobs:
       - name: Prepare Linux build dependencies
         run: |
           set -euo pipefail
-          if pkg-config --exists libusb-1.0 2>/dev/null; then exit 0; fi
-          if sudo -n true 2>/dev/null; then
+          if ! pkg-config --exists libusb-1.0 2>/dev/null; then
             sudo apt-get update && sudo apt-get install -y pkg-config libusb-1.0-0-dev
-          else
-            echo "error: libusb-1.0 dev headers missing on this runner and passwordless sudo is unavailable." >&2
-            echo "Install them once with: sudo apt-get install -y pkg-config libusb-1.0-0-dev" >&2
-            exit 1
           fi
 
       - name: Build CLI

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,7 +33,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libusb-1.0-0-dev
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.2.0

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -67,7 +67,7 @@ jobs:
       queue: max
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/swift-e2e-run
         with:
           tests: ${{ inputs.tests || '' }}
@@ -90,7 +90,7 @@ jobs:
       queue: max
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # The Linux wendy CLI links libusb via cgo (Thor flashing); the harness
       # builds the CLI on this runner.
       - name: Install libusb
@@ -179,7 +179,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -204,7 +204,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -229,7 +229,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -254,7 +254,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -279,7 +279,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -304,7 +304,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -329,7 +329,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -354,7 +354,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -379,7 +379,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -404,7 +404,7 @@ jobs:
   #     queue: max
   #   timeout-minutes: 120
   #   steps:
-  #     - uses: actions/checkout@v7.0.0
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #     - uses: ./.github/actions/swift-e2e-run
   #       with:
   #         tests: ${{ inputs.tests || '' }}
@@ -426,7 +426,7 @@ jobs:
     runs-on: [self-hosted, AI]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -91,6 +91,10 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7.0.0
+      # The Linux wendy CLI links libusb via cgo (Thor flashing); the harness
+      # builds the CLI on this runner.
+      - name: Install libusb
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libusb-1.0-0-dev
       - uses: ./.github/actions/swift-e2e-run
         with:
           tests: ${{ inputs.tests || '' }}

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -257,13 +257,8 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           set -euo pipefail
-          if pkg-config --exists libusb-1.0 2>/dev/null; then exit 0; fi
-          if sudo -n true 2>/dev/null; then
+          if ! pkg-config --exists libusb-1.0 2>/dev/null; then
             sudo apt-get update && sudo apt-get install -y pkg-config libusb-1.0-0-dev
-          else
-            echo "error: libusb-1.0 dev headers missing on this runner and passwordless sudo is unavailable." >&2
-            echo "Install them once with: sudo apt-get install -y pkg-config libusb-1.0-0-dev" >&2
-            exit 1
           fi
 
       - name: Build CLI

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -70,6 +70,9 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev
+
       - name: Build CLI
         working-directory: go
         run: make build-cli
@@ -247,6 +250,21 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+
+      # The Linux CLI links libusb via cgo (Thor flashing), so the self-hosted
+      # runner needs the dev headers before `make build-cli`.
+      - name: Prepare Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          if pkg-config --exists libusb-1.0 2>/dev/null; then exit 0; fi
+          if sudo -n true 2>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y pkg-config libusb-1.0-0-dev
+          else
+            echo "error: libusb-1.0 dev headers missing on this runner and passwordless sudo is unavailable." >&2
+            echo "Install them once with: sudo apt-get install -y pkg-config libusb-1.0-0-dev" >&2
+            exit 1
+          fi
 
       - name: Build CLI
         working-directory: go

--- a/NOTICE
+++ b/NOTICE
@@ -84,3 +84,515 @@ This product includes software from the SwiftContainerPlugin project
 developed by Apple Inc. and the SwiftContainerPlugin project authors
 (https://github.com/apple/swift-container-plugin).
 Licensed under Apache License v2.0.
+
+-------------------------------------------------------------------------------
+
+The wendy CLI binaries for macOS and Linux statically link libusb
+(https://github.com/libusb/libusb), Copyright (c) the libusb authors,
+licensed under the GNU Lesser General Public License version 2.1 or later
+(LGPL-2.1-or-later). The complete license text follows. The wendy CLI's own
+source code is available under the Apache License 2.0 at
+https://github.com/wendylabsinc/WendyOS, which permits rebuilding and
+relinking against a modified libusb as provided for by the LGPL.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/go/Makefile
+++ b/go/Makefile
@@ -56,11 +56,26 @@ build-agent-linux-amd64:
 build-agent-linux-arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-agent-linux-arm64 ./cmd/wendy-agent
 
+# The Linux CLI links libusb via cgo (Thor USB recovery flashing), so it can only
+# be built natively: Linux host, matching arch, libusb dev headers installed (see
+# scripts/build-wendy.sh). Release binaries come from CI (build.yml
+# build-cli-linux), which links libusb statically against musl. Elsewhere the
+# target skips — and removes any stale binary so build-all can't hand out an
+# outdated one.
+define build-cli-linux-native
+	@if [ "$(UNAME_S)" = "Linux" ] && [ "$$(go env GOHOSTARCH)" = "$(1)" ]; then \
+		CGO_ENABLED=1 go build -ldflags "$(LDFLAGS)" -o bin/wendy-linux-$(1) ./cmd/wendy; \
+	else \
+		rm -f bin/wendy-linux-$(1); \
+		echo "skipping bin/wendy-linux-$(1): the Linux CLI needs native cgo/libusb — build it on a Linux $(1) host or in CI"; \
+	fi
+endef
+
 build-cli-linux-amd64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-linux-amd64 ./cmd/wendy
+	$(call build-cli-linux-native,amd64)
 
 build-cli-linux-arm64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-linux-arm64 ./cmd/wendy
+	$(call build-cli-linux-native,arm64)
 
 build-cli-darwin-amd64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/wendy-darwin-amd64 ./cmd/wendy

--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -22,8 +22,8 @@ import (
 
 func main() {
 	// When invoked as adb/lsusb/timeout (via the symlinks wendy plants on PATH for
-	// NVIDIA's bootburn during a Thor flash), act as that tool and exit. macOS only;
-	// IsShimName is always false elsewhere.
+	// NVIDIA's bootburn during a Thor flash), act as that tool and exit. macOS and
+	// Linux only; IsShimName is always false elsewhere.
 	if shim.IsShimName(filepath.Base(os.Args[0])) {
 		shim.Dispatch()
 		return

--- a/go/internal/cli/commands/os_install_thor.go
+++ b/go/internal/cli/commands/os_install_thor.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin || linux
 
 package commands
 
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -38,7 +39,7 @@ const (
 // flashpack (version + cache state) from the manifest, briefs and confirms with
 // the user, then runs download → stage-1 RCM boot → stage-2 ADB partition flash
 // as a live BuildKit-style step list whose verbose output surfaces only on
-// failure. macOS only.
+// failure. macOS and Linux.
 func installThor(ctx context.Context, version string, nightly, force bool) error {
 	cacheDir, err := osCacheDir()
 	if err != nil {
@@ -137,6 +138,10 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 		switch {
 		case errors.Is(err, tui.ErrCancelled):
 			return ErrUserCancelled
+		case errors.Is(err, rcm.ErrUSBAccess):
+			// Stage 1 re-opens the device (it can re-enumerate between the scan
+			// and the flash); a denied re-open gets the same guidance as the scan.
+			fmt.Println("\n" + usbAccessHintBox())
 		case errors.Is(err, flasher.ErrGadgetUnreachable):
 			// Died at ADB setup before any write — the Thor is untouched, so
 			// advise a plain retry rather than a scary bad-state recovery.
@@ -380,7 +385,23 @@ func verifySHA256(path, want string) error {
 func pickRecoveryDevice() (rcm.RecoveryDevice, error) {
 	for {
 		devs, err := rcm.ListRecoveryDevices()
-		if err != nil {
+		switch {
+		case errors.Is(err, rcm.ErrUSBAccess) && len(devs) == 0:
+			// Nothing usable: explain the fix, then offer a rescan — the user can
+			// install the udev rule (or replug; the ACL grant can race a fresh
+			// plug-in) without restarting the flash.
+			fmt.Println("\n" + usbAccessHintBox())
+			fmt.Print("Press Enter to rescan, or 'q' to quit: ")
+			if readQuit() {
+				return rcm.RecoveryDevice{}, fmt.Errorf("cannot open the Jetson's USB device: permission denied")
+			}
+			continue
+		case errors.Is(err, rcm.ErrUSBAccess):
+			// Some boards opened, another was denied. Warn rather than proceed
+			// silently: auto-select below could otherwise flash the wrong Thor.
+			fmt.Println()
+			fmt.Println(tui.WarningMessage("Another Jetson in recovery mode was detected but couldn't be opened (USB access denied) — it is NOT listed below."))
+		case err != nil:
 			return rcm.RecoveryDevice{}, err
 		}
 		switch len(devs) {
@@ -559,6 +580,47 @@ func printThorGadgetUnreachableHint(w io.Writer) {
 	fmt.Fprintln(w, tui.Dim("  A running adb server can hold the gadget; if you have Android platform-tools,"))
 	fmt.Fprintln(w, tui.Dim("  run `adb kill-server`. Otherwise unplug/replug the USB-C cable (the port next to"))
 	fmt.Fprintln(w, tui.Dim("  HDMI), re-enter recovery mode, and flash again."))
+}
+
+// The udev rule that grants users access to NVIDIA Jetson USB devices (recovery
+// mode 0955:7023/7026 and the initrd-flash ADB gadget 0955:7100). The deb/rpm
+// packages install the same rule from packaging/linux/udev/70-wendy-jetson.rules;
+// a test asserts the two copies stay identical (a stale copy here would have
+// users write an /etc rule that overrides the packaged /usr/lib one).
+const (
+	usbUdevRulePath = "/etc/udev/rules.d/70-wendy-jetson.rules"
+	usbUdevRule     = `SUBSYSTEM=="usb", ATTRS{idVendor}=="0955", MODE="0660", GROUP="plugdev", TAG+="uaccess"`
+)
+
+// usbAccessHintBox explains how to regain USB access to the Jetson when the OS
+// refuses to open it: on Linux, udev permissions; on macOS, almost always
+// another process holding the device.
+func usbAccessHintBox() string {
+	lines := []string{
+		thorHintTitle.Render("⚠  USB access denied"),
+		"",
+		"A Jetson is in recovery mode, but the OS refused wendy access to its USB device.",
+	}
+	if runtime.GOOS == "linux" {
+		lines = append(lines,
+			"Grant access with a udev rule (one-time; the wendy deb/rpm packages install it):",
+			"",
+			thorHintCmd.Render("  echo '"+usbUdevRule+"' \\"),
+			thorHintCmd.Render("    | sudo tee "+usbUdevRulePath),
+			thorHintCmd.Render("  sudo udevadm control --reload-rules && sudo udevadm trigger"),
+			"",
+			"Add your user to the "+thorHintEmph.Render("plugdev")+" group — if your distro has none, create it",
+			"("+thorHintCmd.Render("sudo groupadd plugdev && sudo usermod -aG plugdev $USER")+", then log in",
+			"again) — replug the USB-C cable and rescan. Or re-run the flash with sudo.",
+		)
+	} else {
+		lines = append(lines,
+			"Another process is likely holding it (another flashing tool, a VM with USB",
+			"passthrough, or another wendy). Quit it, unplug/replug the USB-C cable, and",
+			"rescan.",
+		)
+	}
+	return thorHintBorder.Render(strings.Join(lines, "\n"))
 }
 
 // confirmThorReady prints a titled recovery-mode briefing and asks the user to

--- a/go/internal/cli/commands/os_install_thor_other.go
+++ b/go/internal/cli/commands/os_install_thor_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package commands
 
@@ -7,7 +7,7 @@ import (
 	"fmt"
 )
 
-// installThor is macOS-only for now (USB recovery flashing uses gousb/libusb).
+// installThor is macOS/Linux-only (USB recovery flashing uses gousb/libusb).
 func installThor(_ context.Context, _ string, _ bool, _ bool) error {
-	return fmt.Errorf("Thor (jetson-agx-thor) flashing is currently only supported on macOS")
+	return fmt.Errorf("Thor (jetson-agx-thor) flashing is currently only supported on macOS and Linux")
 }

--- a/go/internal/cli/commands/os_install_thor_test.go
+++ b/go/internal/cli/commands/os_install_thor_test.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin || linux
 
 package commands
 
@@ -8,10 +8,33 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashpack"
 )
+
+// The usbAccessHintBox tells tarball users to install usbUdevRule verbatim, and
+// the deb/rpm install packaging/linux/udev/70-wendy-jetson.rules. The two must
+// stay identical: /etc/udev/rules.d overrides /usr/lib/udev/rules.d for the same
+// filename, so a stale hint-box copy would permanently mask the packaged rule.
+func TestUsbUdevRuleMatchesPackagedRule(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "..", "packaging", "linux", "udev", "70-wendy-jetson.rules")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading packaged udev rule: %v", err)
+	}
+	var rules []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "#") {
+			rules = append(rules, line)
+		}
+	}
+	if len(rules) != 1 || rules[0] != usbUdevRule {
+		t.Fatalf("packaged udev rule diverged from usbUdevRule:\npackaged: %q\nconst:    %q", rules, usbUdevRule)
+	}
+}
 
 func TestStopADBServer(t *testing.T) {
 	// No server listening → no-op, false.

--- a/go/internal/cli/tegraflash/adb/adb.go
+++ b/go/internal/cli/tegraflash/adb/adb.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin || linux
 
 // Package adb speaks the Android Debug Bridge wire protocol directly over USB —
 // no adb binary and no adb server. It implements the host side of the transport
@@ -16,6 +16,7 @@ package adb
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -132,6 +133,13 @@ func openOnce() (*Device, error) {
 	// we got at least one usable handle.
 	if len(devs) == 0 {
 		ctx.Close()
+		// Distinguish permissions from absence: the gadget re-enumerates with its
+		// own PID (0955:7100), so a host whose udev rules cover only the recovery
+		// PIDs hits this even after a clean stage 1. The message lands in the
+		// flash log, where classifyFlashFailure picks it up.
+		if errors.Is(err, gousb.ErrorAccess) {
+			return nil, fmt.Errorf("USB access denied opening the flashing gadget: %v (install a udev rule covering USB vendor 0955, or run with sudo)", err)
+		}
 		return nil, fmt.Errorf("no USB device with an ADB interface (ff/42/01) found: %v", err)
 	}
 
@@ -169,6 +177,10 @@ func openOnce() (*Device, error) {
 			d.Close()
 		}
 	}
+
+	// On Linux a kernel driver bound to the interface makes the claim fail with
+	// "busy"; auto-detach clears it. No-op on macOS (gousb swallows NOT_SUPPORTED).
+	_ = dev.SetAutoDetach(true)
 
 	cfgNum, ifNum, altNum, ok := findADBInterface(dev.Desc)
 	if !ok {

--- a/go/internal/cli/tegraflash/adb/adb_unsupported.go
+++ b/go/internal/cli/tegraflash/adb/adb_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package adb
 
@@ -11,15 +11,15 @@ import (
 type Device struct{ Banner string }
 
 func Open() (*Device, error) {
-	return nil, fmt.Errorf("ADB over USB is only supported on macOS")
+	return nil, fmt.Errorf("ADB over USB is only supported on macOS and Linux")
 }
 
 func (d *Device) Close() {}
 
 func (d *Device) Shell(string) (string, error) {
-	return "", fmt.Errorf("ADB over USB is only supported on macOS")
+	return "", fmt.Errorf("ADB over USB is only supported on macOS and Linux")
 }
 
 func (d *Device) Push(io.Reader, string, int) error {
-	return fmt.Errorf("ADB over USB is only supported on macOS")
+	return fmt.Errorf("ADB over USB is only supported on macOS and Linux")
 }

--- a/go/internal/cli/tegraflash/flasher/flasher.go
+++ b/go/internal/cli/tegraflash/flasher/flasher.go
@@ -228,6 +228,10 @@ func flashFailure(out io.Writer, logPath, took string, maxBytes int64, werr erro
 func classifyFlashFailure(logPath string) string {
 	tail := tailFile(logPath, 60)
 	switch {
+	// Check access errors before the generic timeout: a denied gadget also times
+	// out, and the wait-for-device retries log the access-denied reason.
+	case strings.Contains(tail, "access denied"), strings.Contains(tail, "bad access"):
+		return "USB access denied opening the flashing gadget — on Linux install the wendy udev rule (USB vendor 0955) or run with sudo; on macOS quit whatever holds the gadget (e.g. `adb kill-server`)"
 	case strings.Contains(tail, "ADB_TIMEOUT"), strings.Contains(tail, "adb wait-for-device"):
 		return "the flashing gadget never came up over USB (ADB timeout)"
 	case strings.Contains(tail, "No such file"), strings.Contains(tail, "not found"):

--- a/go/internal/cli/tegraflash/flasher/flasher.go
+++ b/go/internal/cli/tegraflash/flasher/flasher.go
@@ -229,8 +229,12 @@ func classifyFlashFailure(logPath string) string {
 	tail := tailFile(logPath, 60)
 	switch {
 	// Check access errors before the generic timeout: a denied gadget also times
-	// out, and the wait-for-device retries log the access-denied reason.
-	case strings.Contains(tail, "access denied"), strings.Contains(tail, "bad access"):
+	// out, and the wait-for-device retries log the access-denied reason. Match
+	// only the exact markers our own code emits (adb.openOnce's message and
+	// libusb's "bad access [code -3]" as relayed by the adb shim) so an image
+	// filename or device string can't trip this branch.
+	case strings.Contains(tail, "USB access denied opening the flashing gadget"),
+		strings.Contains(tail, "bad access [code"):
 		return "USB access denied opening the flashing gadget — on Linux install the wendy udev rule (USB vendor 0955) or run with sudo; on macOS quit whatever holds the gadget (e.g. `adb kill-server`)"
 	case strings.Contains(tail, "ADB_TIMEOUT"), strings.Contains(tail, "adb wait-for-device"):
 		return "the flashing gadget never came up over USB (ADB timeout)"

--- a/go/internal/cli/tegraflash/rcm/bootrom.go
+++ b/go/internal/cli/tegraflash/rcm/bootrom.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin || linux
 
 package rcm
 

--- a/go/internal/cli/tegraflash/rcm/device.go
+++ b/go/internal/cli/tegraflash/rcm/device.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin || linux
 
 // USB device handling for the RCM stage (bootROM level).
 // USB transfer mechanics translated from NVIDIA tegrarcm usb.c
@@ -25,6 +25,10 @@ type Device struct {
 }
 
 func openDevice(ctx *gousb.Context, dev *gousb.Device) (*Device, error) {
+	// On Linux a kernel driver bound to the interface makes the claim fail with
+	// "busy"; auto-detach clears it. No-op on macOS (gousb swallows NOT_SUPPORTED).
+	_ = dev.SetAutoDetach(true)
+
 	cfg, err := dev.Config(1)
 	if err != nil {
 		return nil, fmt.Errorf("claiming config: %w", err)

--- a/go/internal/cli/tegraflash/rcm/device_test.go
+++ b/go/internal/cli/tegraflash/rcm/device_test.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin || linux
 
 package rcm
 

--- a/go/internal/cli/tegraflash/rcm/device_unsupported.go
+++ b/go/internal/cli/tegraflash/rcm/device_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package rcm
 
@@ -8,7 +8,7 @@ import (
 )
 
 // Device is a stub on platforms where direct Jetson recovery USB access is not
-// implemented (Thor flashing is macOS-only for now).
+// implemented (Thor flashing is supported on macOS and Linux).
 type Device struct{}
 
 func (d *Device) String() string { return "" }
@@ -21,4 +21,4 @@ func (d *Device) Write([]byte) error { return errUnsupported }
 
 func DownloadBootROMImages(dev *Device, images [][]byte) error { return errUnsupported }
 
-var errUnsupported = fmt.Errorf("Jetson USB recovery flashing is only supported on macOS")
+var errUnsupported = fmt.Errorf("Jetson USB recovery flashing is only supported on macOS and Linux")

--- a/go/internal/cli/tegraflash/rcm/select_other.go
+++ b/go/internal/cli/tegraflash/rcm/select_other.go
@@ -1,15 +1,15 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package rcm
 
 import "fmt"
 
-// ListRecoveryDevices is unsupported off macOS.
+// ListRecoveryDevices is unsupported off macOS/Linux.
 func ListRecoveryDevices() ([]RecoveryDevice, error) {
-	return nil, fmt.Errorf("Jetson USB recovery flashing is only supported on macOS")
+	return nil, fmt.Errorf("Jetson USB recovery flashing is only supported on macOS and Linux")
 }
 
-// WaitForDeviceAt is unsupported off macOS.
+// WaitForDeviceAt is unsupported off macOS/Linux.
 func WaitForDeviceAt(string) (*Device, error) {
-	return nil, fmt.Errorf("Jetson USB recovery flashing is only supported on macOS")
+	return nil, fmt.Errorf("Jetson USB recovery flashing is only supported on macOS and Linux")
 }

--- a/go/internal/cli/tegraflash/rcm/select_usb.go
+++ b/go/internal/cli/tegraflash/rcm/select_usb.go
@@ -1,8 +1,9 @@
-//go:build darwin
+//go:build darwin || linux
 
 package rcm
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -10,6 +11,12 @@ import (
 
 	"github.com/google/gousb"
 )
+
+// ErrUSBAccess reports that a Jetson in recovery mode is present but the OS
+// refused to open it (LIBUSB_ERROR_ACCESS). On Linux this means the current user
+// lacks permission on the /dev/bus/usb node — fixed by a udev rule or sudo; the
+// caller turns this into actionable guidance.
+var ErrUSBAccess = errors.New("USB device access denied")
 
 func isRecoveryPID(p gousb.ID) bool {
 	return p == gousb.ID(ProductOrin) || p == gousb.ID(ProductThor)
@@ -31,9 +38,18 @@ func ListRecoveryDevices() ([]RecoveryDevice, error) {
 	ctx.Debug(0)
 	defer ctx.Close()
 
-	devs, _ := ctx.OpenDevices(func(d *gousb.DeviceDesc) bool {
+	devs, err := ctx.OpenDevices(func(d *gousb.DeviceDesc) bool {
 		return d.Vendor == gousb.ID(VendorNVIDIA) && isRecoveryPID(d.Product)
 	})
+	// The filter only opens Jetson recovery devices, so an access error means one
+	// is attached but unopenable. Return it alongside whatever did open — a
+	// multi-device host must not silently flash the wrong board because the
+	// intended one was dropped. Other enumeration errors keep the lenient
+	// "rescan" behavior.
+	var accessErr error
+	if errors.Is(err, gousb.ErrorAccess) {
+		accessErr = fmt.Errorf("%w: a Jetson in recovery mode is connected but could not be opened: %v", ErrUSBAccess, err)
+	}
 	var out []RecoveryDevice
 	for _, dev := range devs {
 		rd := RecoveryDevice{PathKey: portKey(dev.Desc), Product: uint16(dev.Desc.Product)}
@@ -46,7 +62,7 @@ func ListRecoveryDevices() ([]RecoveryDevice, error) {
 		out = append(out, rd)
 		dev.Close()
 	}
-	return out, nil
+	return out, accessErr
 }
 
 // WaitForDeviceAt blocks until the Jetson at pathKey (from ListRecoveryDevices)
@@ -57,10 +73,16 @@ func WaitForDeviceAt(pathKey string) (*Device, error) {
 
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
-		devs, _ := ctx.OpenDevices(func(d *gousb.DeviceDesc) bool {
+		devs, err := ctx.OpenDevices(func(d *gousb.DeviceDesc) bool {
 			return d.Vendor == gousb.ID(VendorNVIDIA) && isRecoveryPID(d.Product) &&
 				(pathKey == "" || portKey(d) == pathKey)
 		})
+		// Access denied won't heal within the wait window; fail now with the
+		// classified error instead of spinning to a misleading timeout.
+		if len(devs) == 0 && errors.Is(err, gousb.ErrorAccess) {
+			ctx.Close()
+			return nil, fmt.Errorf("%w: %v", ErrUSBAccess, err)
+		}
 		var chosen *gousb.Device
 		for i, dev := range devs {
 			if i == 0 {

--- a/go/internal/cli/tegraflash/shim/shim.go
+++ b/go/internal/cli/tegraflash/shim/shim.go
@@ -1,11 +1,13 @@
-//go:build darwin
+//go:build darwin || linux
 
 // Package shim is the multi-call host shim for driving the T264 initrd-flash gadget,
 // folded into the wendy binary. NVIDIA's bootburn flasher shells out to `adb`,
-// `lsusb` and `timeout`; on macOS those are missing or x86-only. Rather than ship a
-// separate binary, wendy re-execs itself: a directory of symlinks (adb/lsusb/timeout
-// -> the wendy binary) is put on PATH, and main() dispatches to Dispatch() when it is
-// invoked under one of those names (see IsShimName).
+// `lsusb` and `timeout`; on macOS those are missing or x86-only, and on Linux a
+// stock adb would spawn a server that claims the flashing gadget away from wendy's
+// serverless transport. Rather than ship a separate binary, wendy re-execs itself:
+// a directory of symlinks (adb/lsusb/timeout -> the wendy binary) is put on PATH,
+// and main() dispatches to Dispatch() when it is invoked under one of those names
+// (see IsShimName).
 package shim
 
 import (

--- a/go/internal/cli/tegraflash/shim/shim_other.go
+++ b/go/internal/cli/tegraflash/shim/shim_other.go
@@ -1,12 +1,12 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package shim
 
-// On non-darwin platforms wendy is never invoked as adb/lsusb/timeout (Thor
-// flashing is macOS-only for now), so the shim is inert.
+// Thor flashing exists only on macOS and Linux, so on other platforms wendy is
+// never invoked as adb/lsusb/timeout and the shim is inert.
 
-// IsShimName always reports false off macOS.
+// IsShimName always reports false here.
 func IsShimName(string) bool { return false }
 
-// Dispatch is a no-op off macOS.
+// Dispatch is a no-op here.
 func Dispatch() {}

--- a/go/scripts/build-wendy.sh
+++ b/go/scripts/build-wendy.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Build (or install) the wendy CLI with libusb linked statically, so the shipped
-# binary carries no /opt/homebrew (or other) libusb dylib dependency. Thor USB
-# recovery flashing (gousb) is macOS-only for now; on other platforms wendy needs
-# no libusb and a plain `go build` suffices.
+# Build (or install) the wendy CLI. Thor USB recovery flashing (gousb) needs
+# libusb on macOS and Linux; on macOS it is linked statically so the shipped
+# binary carries no /opt/homebrew (or other) libusb dylib dependency. Linux dev
+# builds link the system libusb dynamically (release builds are fully static —
+# see .github/workflows/build.yml). Windows needs no libusb (unsupported stub).
 #
 # Usage (run from the repo root):
 #   go/scripts/build-wendy.sh [output-path]  # build to output-path (default ./bin/wendy)
@@ -13,7 +14,12 @@ cd "$(dirname "$0")/.."   # the go module root
 LDFLAGS="-s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=${VERSION:-dev}"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
-    # No libusb needed off macOS (Thor path compiles to the unsupported stub).
+    # Linux links the system libusb dynamically (dev builds; releases are static
+    # via CI); other platforms need no libusb (Thor path compiles to a stub).
+    if [[ "$(uname -s)" == "Linux" ]] && ! pkg-config --exists libusb-1.0 2>/dev/null; then
+        echo "error: libusb-1.0 dev headers not found (apt install libusb-1.0-0-dev / dnf install libusb1-devel)"
+        exit 1
+    fi
     if [[ "${1:-}" == "--install" ]]; then exec go install -ldflags "$LDFLAGS" ./cmd/wendy; fi
     exec go build -ldflags "$LDFLAGS" -o "${1:-bin/wendy}" ./cmd/wendy
 fi

--- a/packaging/linux/fpm/wendy-postinstall.sh
+++ b/packaging/linux/fpm/wendy-postinstall.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Reload udev so the Jetson rules (70-wendy-jetson.rules) apply without a reboot.
+# Best-effort: containers and minimal systems may not run udev.
+if command -v udevadm >/dev/null 2>&1; then
+    udevadm control --reload-rules 2>/dev/null || true
+    udevadm trigger --subsystem-match=usb 2>/dev/null || true
+fi
+exit 0

--- a/packaging/linux/fpm/wendy-postinstall.sh
+++ b/packaging/linux/fpm/wendy-postinstall.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 # Reload udev so the Jetson rules (70-wendy-jetson.rules) apply without a reboot.
-# Best-effort: containers and minimal systems may not run udev.
+# Best-effort (|| true): containers, chroots and minimal systems have no running
+# udev, and package installation must not fail there. The trigger is scoped to
+# NVIDIA (0955) devices so unrelated USB devices are not re-processed.
 if command -v udevadm >/dev/null 2>&1; then
     udevadm control --reload-rules 2>/dev/null || true
-    udevadm trigger --subsystem-match=usb 2>/dev/null || true
+    udevadm trigger --subsystem-match=usb --attr-match=idVendor=0955 2>/dev/null || true
+fi
+# An /etc rule with the same filename overrides the packaged /usr/lib one (e.g.
+# from following the wendy CLI's hint before installing the package); warn if it
+# has diverged so a stale copy doesn't mask future packaged updates.
+etc_rule=/etc/udev/rules.d/70-wendy-jetson.rules
+usr_rule=/usr/lib/udev/rules.d/70-wendy-jetson.rules
+if [ -f "$etc_rule" ] && ! cmp -s "$etc_rule" "$usr_rule"; then
+    echo "wendy: $etc_rule differs from the packaged $usr_rule and overrides it;" >&2
+    echo "wendy: consider removing the /etc copy (sudo rm $etc_rule) to use the packaged rule." >&2
 fi
 exit 0

--- a/packaging/linux/udev/70-wendy-jetson.rules
+++ b/packaging/linux/udev/70-wendy-jetson.rules
@@ -1,7 +1,13 @@
 # NVIDIA Jetson devices used by `wendy os install` Thor flashing:
 # recovery mode (0955:7023 Orin, 0955:7026 Thor) and the initrd-flash
 # ADB gadget (0955:7100). Grants access to plugdev members and, via
-# uaccess, the physically logged-in user. On distros without a plugdev
+# uaccess, the physically logged-in user.
+#
+# The match is deliberately vendor-wide rather than per-PID: NVIDIA assigns a
+# distinct recovery/gadget PID per Jetson module (oe4t lists 14+), wendy will
+# grow support for more of them, and a stale narrow rule left on user machines
+# would mask later additions. Vendor 0955 devices only expose these interfaces
+# transiently in recovery/flashing mode, so the extra grant is bounded. On distros without a plugdev
 # group (e.g. Fedora/RHEL) create it and add yourself, or run with sudo:
 #   sudo groupadd plugdev && sudo usermod -aG plugdev $USER
 # Must stay identical to usbUdevRule in

--- a/packaging/linux/udev/70-wendy-jetson.rules
+++ b/packaging/linux/udev/70-wendy-jetson.rules
@@ -1,0 +1,9 @@
+# NVIDIA Jetson devices used by `wendy os install` Thor flashing:
+# recovery mode (0955:7023 Orin, 0955:7026 Thor) and the initrd-flash
+# ADB gadget (0955:7100). Grants access to plugdev members and, via
+# uaccess, the physically logged-in user. On distros without a plugdev
+# group (e.g. Fedora/RHEL) create it and add yourself, or run with sudo:
+#   sudo groupadd plugdev && sudo usermod -aG plugdev $USER
+# Must stay identical to usbUdevRule in
+# go/internal/cli/commands/os_install_thor.go (a test asserts it).
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0955", MODE="0660", GROUP="plugdev", TAG+="uaccess"

--- a/swift/Scripts/E2ETest.sh
+++ b/swift/Scripts/E2ETest.sh
@@ -644,6 +644,13 @@ wendy_path="\$cli_bin_dir/wendy"
 
 mkdir -p "\$cli_bin_dir"
 cd "\$cli_repo_dir/go"
+# The Linux CLI links libusb via cgo (Thor flashing); fail with a clear message
+# instead of an opaque cgo error when the CLI machine lacks the dev headers.
+if [[ "\$(uname -s)" == "Linux" ]] && ! pkg-config --exists libusb-1.0 2>/dev/null; then
+  echo "ERROR: building the wendy CLI on Linux needs libusb dev headers" >&2
+  echo "  (apt install libusb-1.0-0-dev / dnf install libusb1-devel)" >&2
+  exit 1
+fi
 go build -o "\$wendy_path" ./cmd/wendy
 
 resolved="\$(PATH="\$cli_bin_dir:\$PATH" command -v wendy || true)"


### PR DESCRIPTION
Makes `wendy os install` for Thor flashpack installation work on Linux hosts, alongside macOS. The changes are mostly around updating conditional compilation, CI, and USB permission management on Linux.

A full flash of WendyOS 0.16.1 to an AGX Thor devkit from Ubuntu 26.04 amd64 was successfully tested in 20m57s.

## CLI changes

- `tegraflash` packages (`rcm`, `adb`, `shim`) and the Thor install path now build on Linux
- `SetAutoDetach` before interface claims (kernel-driver insurance on Linux; no-op on macOS).
- USB access-denied (`LIBUSB_ERROR_ACCESS`) is now classified at every open site instead of surfacing as "no device found"

## CI / packaging

- New `build-cli-linux` job: native runners per arch (`ubuntu-24.04`, `ubuntu-24.04-arm`), libusb 1.0.29 built from a sha256-pinned tarball with musl (`--disable-udev`), statically linked → fully static binary. Replaces the `CGO_ENABLED=0` cross-compile matrix entries.
- macOS job now uses `build-wendy.sh` (static libusb)
- deb/rpm install `70-wendy-jetson.rules` (all of USB vendor 0955) with a udev-reload postinstall, so package users never hit the permission error
- NOTICE gains the libusb LGPL-2.1 attribution + license text and ships in the tarballs and `/usr/share/doc/wendy/`.
- `make build-cli-linux-<arch>` builds natively only (host OS + arch guard), skipping and removing stale binaries elsewhere; `build-wendy.sh` handles Linux dev builds with a clear missing-headers error.

## Static-linking rationale

libusb's Linux backend is a thin wrapper over usbfs ioctls + sysfs — stable kernel ABI, safe to pin at build time (Android platform-tools does the same). Building with `--disable-udev` drops the libudev dependency (enumeration falls back to netlink/sysfs, which is all gousb needs, and works in containers). musl keeps the binary fully static so the runs-anywhere property of the old `CGO_ENABLED=0` artifact is preserved.

## Testing

- Real-hardware flash from Linux (above); permission-denied and udev-rule paths validated against the live devkit.
- `go build`/`go vet`/`go test` green on macOS and Linux (including `-race` for tegraflash packages).
- Shim smoke tests on Linux (`adb version/devices`, `lsusb -d`, `timeout` exit-code semantics).
- Validation `build.yml` dispatch (no publish) on this branch: https://github.com/wendylabsinc/WendyOS/actions/runs/28560273517 — exercises arm64, which has not run before this.