### PR TITLE
feat(cli): accept custom blobs in wendy install (.tegraflash, .img, URLs)

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -21,9 +21,27 @@ wendy install --device-type raspberry-pi-5 --version 0.10.4 --drive /dev/disk4 -
 
 # Direct install from a local image (Linux only)
 wendy install path/to/image.img /dev/disk4 --force
+
+# Custom blob: local or remote disk image / Thor flashpack
+wendy install ./custom.img.zst --drive /dev/disk4 --force
+wendy install ./jetson-agx-thor-dev.flashpack.tar.zst
+wendy install https://ci.example.com/artifacts/custom.img.zst
 ```
 
 > **Note:** `--device-type` is not supported for ESP32 targets. Use the interactive picker to flash an ESP32.
+
+---
+
+## Custom blobs
+
+`wendy install <blob>` with a single positional argument installs a custom artifact — a locally built or otherwise unpublished image — instead of a manifest version. The blob may be a local path or an `http(s)` URL (downloaded to a temp file first, with a progress bar).
+
+The blob's type decides the flow:
+
+- **Disk images** (`.img`, `.raw`, `.wic`, `.sdimg`, `.zip`, `.img.gz`, `.img.zst`) are written to a drive — `--drive` or the interactive picker — exactly like the Linux path below, including config-partition provisioning (`--wifi*`, `--device-name`, `--pre-enroll`). zstd images are decompressed sequentially (no block map is used for custom blobs).
+- **Thor flashpacks** (`.tegraflash`, `.flashpack`, `.flashpack.tar.zst`, or any zstd-compressed tarball) flash a Jetson AGX Thor over USB recovery, exactly like the manifest Thor flow (macOS only). The tarball is extracted to a temp dir and never cached, and its contents are not verified against a published manifest — a note calls this out. `--drive` and provisioning flags are rejected: a Thor flashes over USB recovery, not to a drive.
+
+Type detection uses the file extension first and falls back to content sniffing (gzip/zip/zstd magic bytes; for zstd, the first decompressed block is checked for a tar header to tell a flashpack from an `.img.zst`). Because a blob carries its own device type and version, `--device-type`, `--version`, `--nightly`, and `--storage` are rejected with a blob argument.
 
 ---
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -34,7 +34,7 @@ wendy install https://ci.example.com/artifacts/custom.img.zst
 
 ## Custom blobs
 
-`wendy install <blob>` with a single positional argument installs a custom artifact — a locally built or otherwise unpublished image — instead of a manifest version. The blob may be a local path or an `http(s)` URL (downloaded to a temp file first, with a progress bar).
+`wendy install <blob>` with a single positional argument installs a custom artifact — a locally built or otherwise unpublished image — instead of a manifest version. The blob may be a local path or an `http(s)` URL (downloaded to a temp file first, with a progress bar). Pass `--sha256 <hex>` to verify the blob against a known digest before anything is installed; plain `http://` URLs print a warning since the transfer is unencrypted and unauthenticated.
 
 The blob's type decides the flow:
 
@@ -181,5 +181,6 @@ Requires an active `wendy auth login` session. The CLI creates an enrollment tok
 | `--pre-enroll` | auto | Pre-enroll with Wendy Cloud during imaging |
 | `--storage` | auto | Force image storage variant: `nvme` or `sd` (default: auto-detect — real NVMe drives use `nvme`; a USB-attached drive uses the device's published image, `sd` for Raspberry Pi / `nvme` for Jetson SSD enclosures) |
 | `--no-bmap` | false | Disable bmap-accelerated flashing even when a block map is available |
+| `--sha256` | — | Expected SHA-256 (hex) of a blob argument; verified before installing |
 
 > **TODO**: Post-flashing Linux devices still need certificate provisioning and Wendy Cloud enrollment if `--pre-enroll` was not used. See [`wendy device setup`](../device/setup.md), [PKI](../../../../pki/), and [Wendy Cloud](../../../../cloud/).

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -59,6 +59,7 @@ func newOSInstallCmd() *cobra.Command {
 	var noWifi bool
 	var deviceName string
 	var enrollCloudGRPC string
+	var sha256Flag string
 
 	cmd := &cobra.Command{
 		Use:   "install [blob] [drive]",
@@ -88,13 +89,17 @@ Pre-seed multiple WiFi networks (repeatable, highest-priority first):
 Flags can be provided progressively — omitted values trigger interactive pickers.`,
 		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Two-positional direct-install mode is incompatible with manifest-backed flags.
-			if len(args) == 2 && (deviceType != "" || versionFlag != "" || driveFlag != "" || wifiSSID != "" || wifiPassword != "" || len(wifiEntries) > 0 || noWifi || deviceName != "" || enrollCloudGRPC != "") {
-				return fmt.Errorf("positional [image] [drive] arguments cannot be combined with --device-type, --version, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, or --cloud-grpc")
+			// Two-positional direct-install mode ignores manifest and provisioning
+			// steps entirely, so reject flags that would otherwise be silently dropped.
+			if len(args) == 2 && (deviceType != "" || versionFlag != "" || nightly || storageOverride != "" || driveFlag != "" || wifiSSID != "" || wifiPassword != "" || len(wifiEntries) > 0 || noWifi || deviceName != "" || cmd.Flags().Changed("pre-enroll") || enrollCloudGRPC != "" || sha256Flag != "") {
+				return fmt.Errorf("positional [image] [drive] arguments cannot be combined with --device-type, --version, --nightly, --storage, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, --pre-enroll, --cloud-grpc, or --sha256")
 			}
 			// A blob carries its own device type and version.
 			if len(args) == 1 && (deviceType != "" || versionFlag != "" || nightly || storageOverride != "") {
 				return fmt.Errorf("a blob install cannot be combined with --device-type, --version, --nightly, or --storage")
+			}
+			if len(args) == 0 && sha256Flag != "" {
+				return fmt.Errorf("--sha256 requires a blob argument (wendy os install <blob> --sha256 <hex>)")
 			}
 			if nightly && versionFlag != "" {
 				return fmt.Errorf("--nightly and --version are mutually exclusive")
@@ -125,6 +130,7 @@ Flags can be provided progressively — omitted values trigger interactive picke
 					drive:                driveFlag,
 					force:                force,
 					yesOverwriteInternal: yesOverwriteInternal,
+					sha256:               sha256Flag,
 					wifi:                 opts,
 					deviceName:           deviceName,
 					preOpts:              preOpts,
@@ -149,6 +155,7 @@ Flags can be provided progressively — omitted values trigger interactive picke
 	cmd.Flags().StringVar(&deviceName, "device-name", "", "Set device name on first boot (e.g. brave-dolphin)")
 	cmd.Flags().BoolVar(&preEnroll, "pre-enroll", false, "Pre-enroll this device with Wendy Cloud during imaging (requires 'wendy auth login')")
 	cmd.Flags().StringVar(&enrollCloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint of the auth session to use for pre-enrollment (optional when a default is set via 'wendy auth use')")
+	cmd.Flags().StringVar(&sha256Flag, "sha256", "", "Expected SHA-256 (hex) of a blob argument; verified before installing")
 
 	return cmd
 }

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -61,11 +61,19 @@ func newOSInstallCmd() *cobra.Command {
 	var enrollCloudGRPC string
 
 	cmd := &cobra.Command{
-		Use:   "install [image] [drive]",
+		Use:   "install [blob] [drive]",
 		Short: "Install WendyOS or Wendy Lite firmware on a device",
 		Long: `Interactively select a supported device, download the latest OS image or firmware, and write it to the target.
 
-When called with positional arguments, skips interactive prompts:
+When called with a single positional argument, installs a custom blob — a disk
+image (.img, .wic, .img.zst, .zip, .gz) written to a drive, or a Jetson AGX Thor
+flashpack (.tegraflash, .flashpack.tar.zst) flashed over USB recovery. The blob
+may be a local path or an http(s) URL:
+  wendy os install ./custom.img.zst --drive /dev/disk4 --force
+  wendy os install ./jetson-agx-thor-dev.flashpack.tar.zst
+  wendy os install https://ci.example.com/artifacts/custom.img.zst
+
+When called with two positional arguments, writes a local image without prompts:
   wendy os install <image-path> <drive-id> --force
 
 When called with manifest-backed flags, installs a specific version:
@@ -78,20 +86,15 @@ Pre-seed multiple WiFi networks (repeatable, highest-priority first):
     --wifi "ssid=Cafe,hidden=true"
 
 Flags can be provided progressively — omitted values trigger interactive pickers.`,
-		Args: func(cmd *cobra.Command, args []string) error {
-			switch len(args) {
-			case 0, 2:
-				return nil
-			case 1:
-				return fmt.Errorf("positional arguments must be provided as [image] [drive]; got 1 argument")
-			default:
-				return cobra.MaximumNArgs(2)(cmd, args)
-			}
-		},
+		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Positional direct-install mode is incompatible with manifest-backed flags.
-			if len(args) > 0 && (deviceType != "" || versionFlag != "" || driveFlag != "" || wifiSSID != "" || wifiPassword != "" || len(wifiEntries) > 0 || noWifi || deviceName != "" || enrollCloudGRPC != "") {
+			// Two-positional direct-install mode is incompatible with manifest-backed flags.
+			if len(args) == 2 && (deviceType != "" || versionFlag != "" || driveFlag != "" || wifiSSID != "" || wifiPassword != "" || len(wifiEntries) > 0 || noWifi || deviceName != "" || enrollCloudGRPC != "") {
 				return fmt.Errorf("positional [image] [drive] arguments cannot be combined with --device-type, --version, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, or --cloud-grpc")
+			}
+			// A blob carries its own device type and version.
+			if len(args) == 1 && (deviceType != "" || versionFlag != "" || nightly || storageOverride != "") {
+				return fmt.Errorf("a blob install cannot be combined with --device-type, --version, --nightly, or --storage")
 			}
 			if nightly && versionFlag != "" {
 				return fmt.Errorf("--nightly and --version are mutually exclusive")
@@ -115,7 +118,19 @@ Flags can be provided progressively — omitted values trigger interactive picke
 					mode = preEnrollSkip
 				}
 			}
-			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, noBmap, storageOverride, opts, deviceName, preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC})
+			preOpts := preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC}
+
+			if len(args) == 1 {
+				return runOSInstallBlob(cmd.Context(), args[0], blobInstallOptions{
+					drive:                driveFlag,
+					force:                force,
+					yesOverwriteInternal: yesOverwriteInternal,
+					wifi:                 opts,
+					deviceName:           deviceName,
+					preOpts:              preOpts,
+				})
+			}
+			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, noBmap, storageOverride, opts, deviceName, preOpts)
 		},
 	}
 
@@ -152,23 +167,12 @@ func runOSInstallDirect(imagePath string, driveID string, force bool, yesOverwri
 	}
 
 	// Find the target drive.
-	drives, err := listAllDrives()
+	targetDrive, err := findDriveByPath(driveID)
 	if err != nil {
-		return fmt.Errorf("listing drives: %w", err)
+		return err
 	}
 
-	var targetDrive *drive
-	for _, d := range drives {
-		if d.DevicePath == driveID {
-			targetDrive = &d
-			break
-		}
-	}
-	if targetDrive == nil {
-		return fmt.Errorf("drive %s not found", driveID)
-	}
-
-	if err := confirmOverwriteInternalDrive(*targetDrive, force, yesOverwriteInternal); err != nil {
+	if err := confirmOverwriteInternalDrive(targetDrive, force, yesOverwriteInternal); err != nil {
 		return err
 	}
 
@@ -191,7 +195,7 @@ func runOSInstallDirect(imagePath string, driveID string, force bool, yesOverwri
 
 	fmt.Printf("Writing image to %s...\n", targetDrive.DevicePath)
 	fmt.Println(elevationHint())
-	if err := writeImageToDisk(stream, stream.uncompressedSize, *targetDrive, nil); err != nil {
+	if err := writeImageToDisk(stream, stream.uncompressedSize, targetDrive, nil); err != nil {
 		return fmt.Errorf("writing image: %w", err)
 	}
 
@@ -398,21 +402,11 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	// Step 2: Resolve target drive — use flag or interactive picker.
 	var targetDrive drive
 	if flagDrive != "" {
-		drives, err := listAllDrives()
+		d, err := findDriveByPath(flagDrive)
 		if err != nil {
-			return fmt.Errorf("listing drives: %w", err)
+			return err
 		}
-		var found bool
-		for _, d := range drives {
-			if d.DevicePath == flagDrive {
-				targetDrive = d
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("drive %s not found", flagDrive)
-		}
+		targetDrive = d
 	} else {
 		fmt.Println()
 		selectedDrive, err := pickExternalDrive(ctx)
@@ -438,37 +432,9 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		}
 	}
 
-	provCreds, err := resolveWiFiCredentialsList(wifi)
+	provCreds, provDeviceName, provisioningJSON, err := resolveProvisioningInputs(ctx, wifi, deviceName, preOpts)
 	if err != nil {
 		return err
-	}
-
-	provDeviceName, err := resolveDeviceName(deviceName)
-	if err != nil {
-		return err
-	}
-
-	// Resolve pre-enrollment — must happen before provisionConfigPartition because
-	// the config partition is mounted and unmounted inside that call.
-	var provisioningJSON []byte
-	if preOpts.mode != preEnrollSkip {
-		cfg, cfgErr := config.Load()
-		if cfgErr != nil {
-			if preOpts.mode == preEnrollForced {
-				return fmt.Errorf("--pre-enroll: loading config: %w", cfgErr)
-			}
-			cfg = &config.Config{} // auto mode: treat an unreadable config as not logged in
-		}
-		provisioning, resolveErr := resolvePreEnrollment(ctx, cfg, preOpts, isInteractiveTerminal(), provDeviceName)
-		if resolveErr != nil {
-			return resolveErr
-		}
-		if provisioning != nil {
-			provisioningJSON, err = json.Marshal(provisioning)
-			if err != nil {
-				return fmt.Errorf("marshaling provisioning state: %w", err)
-			}
-		}
 	}
 
 	// Step 5: Resolve image metadata for the target storage. A USB-attached
@@ -669,6 +635,72 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		}
 	}
 
+	if err := applyProvisioningAndEject(targetDrive, provCreds, provDeviceName, provisioningJSON); err != nil {
+		return err
+	}
+
+	fmt.Printf("\nSuccessfully installed %s %s on %s.\n", device.Name, imgInfo.Version, targetDrive.Name)
+	fmt.Println("You can now insert the drive into your device and power it on.")
+	return nil
+}
+
+// findDriveByPath resolves a --drive / positional drive id to a listed drive.
+func findDriveByPath(devicePath string) (drive, error) {
+	drives, err := listAllDrives()
+	if err != nil {
+		return drive{}, fmt.Errorf("listing drives: %w", err)
+	}
+	for _, d := range drives {
+		if d.DevicePath == devicePath {
+			return d, nil
+		}
+	}
+	return drive{}, fmt.Errorf("drive %s not found", devicePath)
+}
+
+// resolveProvisioningInputs gathers everything provisioning needs — WiFi
+// credentials, the device name, and the pre-enrollment payload — before any
+// drive write, because the config partition is mounted and unmounted inside
+// provisionConfigPartition.
+func resolveProvisioningInputs(ctx context.Context, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) ([]wendyconf.WifiCredential, string, []byte, error) {
+	provCreds, err := resolveWiFiCredentialsList(wifi)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	provDeviceName, err := resolveDeviceName(deviceName)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	var provisioningJSON []byte
+	if preOpts.mode != preEnrollSkip {
+		cfg, cfgErr := config.Load()
+		if cfgErr != nil {
+			if preOpts.mode == preEnrollForced {
+				return nil, "", nil, fmt.Errorf("--pre-enroll: loading config: %w", cfgErr)
+			}
+			cfg = &config.Config{} // auto mode: treat an unreadable config as not logged in
+		}
+		provisioning, resolveErr := resolvePreEnrollment(ctx, cfg, preOpts, isInteractiveTerminal(), provDeviceName)
+		if resolveErr != nil {
+			return nil, "", nil, resolveErr
+		}
+		if provisioning != nil {
+			provisioningJSON, err = json.Marshal(provisioning)
+			if err != nil {
+				return nil, "", nil, fmt.Errorf("marshaling provisioning state: %w", err)
+			}
+		}
+	}
+	return provCreds, provDeviceName, provisioningJSON, nil
+}
+
+// applyProvisioningAndEject writes the provisioning data to the drive's config
+// partition (when the platform supports it) and ejects the drive. Called after
+// the OS image has landed, so a provisioning failure is surfaced without
+// implying the flash failed.
+func applyProvisioningAndEject(targetDrive drive, provCreds []wendyconf.WifiCredential, provDeviceName string, provisioningJSON []byte) error {
 	hasProvisioningData := provisioningRequired(provCreds, provDeviceName, provisioningJSON)
 
 	if !configPartitionSupported {
@@ -690,9 +722,6 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	}
 
 	ejectDisk(targetDrive)
-
-	fmt.Printf("\nSuccessfully installed %s %s on %s.\n", device.Name, imgInfo.Version, targetDrive.Name)
-	fmt.Println("You can now insert the drive into your device and power it on.")
 	return nil
 }
 
@@ -1524,13 +1553,17 @@ func openOSImageStream(deviceKey string, img *imageInfo) (*imageStream, error) {
 
 // openLocalImageStream opens an arbitrary local file for streaming.
 // If the path ends in .zip it finds the first image entry inside it.
-// Otherwise it opens the file directly as a reader.
+// Compressed images (gzip, zstd) are detected by magic bytes and decompressed
+// on the fly; anything else is opened directly as a raw image.
 func openLocalImageStream(imagePath string) (*imageStream, error) {
 	if strings.HasSuffix(strings.ToLower(imagePath), ".zip") {
 		return streamZipImageEntry(imagePath)
 	}
 	if isGzipFile(imagePath) {
 		return streamGzipImage(imagePath)
+	}
+	if isZstdFile(imagePath) {
+		return streamZstdImage(imagePath)
 	}
 	return openRawImageStream(imagePath)
 }

--- a/go/internal/cli/commands/os_install_blob.go
+++ b/go/internal/cli/commands/os_install_blob.go
@@ -1,0 +1,331 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+// blobKind classifies a user-supplied blob for `wendy os install <blob>`.
+type blobKind int
+
+const (
+	// blobDiskImage is a raw/compressed disk image written to a drive.
+	blobDiskImage blobKind = iota
+	// blobFlashpack is a Thor flashpack tarball flashed over USB recovery.
+	blobFlashpack
+)
+
+// blobInstallOptions carries the flags applicable to the one-positional blob
+// install mode.
+type blobInstallOptions struct {
+	drive                string
+	force                bool
+	yesOverwriteInternal bool
+	wifi                 wifiCLIOptions
+	deviceName           string
+	preOpts              preEnrollOptions
+}
+
+// flashpackIncompatibleFlags names the flags that make no sense for a
+// flashpack blob: a Thor flashes over USB recovery, not to a drive, and no
+// config partition is written during the flash.
+func (o blobInstallOptions) flashpackIncompatibleFlags() []string {
+	var set []string
+	if o.drive != "" {
+		set = append(set, "--drive")
+	}
+	if o.wifi.SSID != "" {
+		set = append(set, "--wifi-ssid")
+	}
+	if o.wifi.Password != "" {
+		set = append(set, "--wifi-password")
+	}
+	if len(o.wifi.Entries) > 0 {
+		set = append(set, "--wifi")
+	}
+	if o.wifi.NoWifi {
+		set = append(set, "--no-wifi")
+	}
+	if o.deviceName != "" {
+		set = append(set, "--device-name")
+	}
+	if o.preOpts.mode == preEnrollForced {
+		set = append(set, "--pre-enroll")
+	}
+	if o.preOpts.cloudGRPC != "" {
+		set = append(set, "--cloud-grpc")
+	}
+	return set
+}
+
+// isRemoteBlobURL reports whether arg names a blob by http(s) URL rather than
+// a local path.
+func isRemoteBlobURL(arg string) bool {
+	return strings.HasPrefix(arg, "http://") || strings.HasPrefix(arg, "https://")
+}
+
+// runOSInstallBlob installs a custom blob — a disk image or a Thor flashpack,
+// from a local path or an http(s) URL. The blob's type decides the flow: disk
+// images are written to a drive (interactive picker unless --drive), flashpacks
+// route to the Thor USB-recovery flash.
+func runOSInstallBlob(ctx context.Context, arg string, opts blobInstallOptions) error {
+	localPath, nameHint := arg, arg
+	if isRemoteBlobURL(arg) {
+		u, err := url.Parse(arg)
+		if err != nil {
+			return fmt.Errorf("invalid blob URL: %w", err)
+		}
+		nameHint = path.Base(u.Path)
+		fmt.Printf("Downloading %s...\n", arg)
+		tmp, err := downloadImage(&imageInfo{DownloadURL: arg, Version: nameHint})
+		if err != nil {
+			return fmt.Errorf("downloading blob: %w", err)
+		}
+		defer os.Remove(tmp)
+		localPath = tmp
+	} else if _, err := os.Stat(arg); err != nil {
+		return fmt.Errorf("image file: %w", err)
+	}
+
+	kind, err := detectBlobKind(localPath, nameHint)
+	if err != nil {
+		return err
+	}
+
+	switch kind {
+	case blobFlashpack:
+		if bad := opts.flashpackIncompatibleFlags(); len(bad) != 0 {
+			return fmt.Errorf("%s is a Thor flashpack, which flashes over USB recovery: %s cannot be used with it", nameHint, strings.Join(bad, ", "))
+		}
+		return installThorLocalFlashpack(ctx, localPath, nameHint, opts.force)
+	default:
+		return installLocalDiskImage(ctx, localPath, opts)
+	}
+}
+
+// installLocalDiskImage writes a local disk-image blob to a drive: elevation
+// pre-auth → drive resolve (--drive or interactive picker) → destructive-write
+// confirm → provisioning inputs → stream write → config-partition provisioning.
+// The mirror of installLinuxImage without the manifest/download/bmap steps.
+func installLocalDiskImage(ctx context.Context, imagePath string, opts blobInstallOptions) error {
+	if err := preAuthElevation(); err != nil {
+		return err
+	}
+	elevationCtx, cancelElevation := context.WithCancel(ctx)
+	defer cancelElevation()
+	keepElevationAlive(elevationCtx)
+
+	var targetDrive drive
+	if opts.drive != "" {
+		d, err := findDriveByPath(opts.drive)
+		if err != nil {
+			return err
+		}
+		targetDrive = d
+	} else {
+		fmt.Println()
+		d, err := pickExternalDrive(ctx)
+		if err != nil {
+			return err
+		}
+		targetDrive = d
+	}
+
+	if err := confirmOverwriteInternalDrive(targetDrive, opts.force, opts.yesOverwriteInternal); err != nil {
+		return err
+	}
+	if !opts.force {
+		fmt.Println()
+		confirmed, err := tui.Confirm(fmt.Sprintf("Writing will ERASE ALL DATA on %s (%s). Continue?", targetDrive.Name, targetDrive.DevicePath))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	provCreds, provDeviceName, provisioningJSON, err := resolveProvisioningInputs(ctx, opts.wifi, opts.deviceName, opts.preOpts)
+	if err != nil {
+		return err
+	}
+
+	stream, err := openLocalImageStream(imagePath)
+	if err != nil {
+		return fmt.Errorf("opening image: %w", err)
+	}
+	defer stream.Close()
+
+	if stream.uncompressedSize == 0 && stream.sourcePath != "" {
+		if err := measureImageWithProgress(stream); err != nil {
+			fmt.Printf("Could not determine image size: %v\n", err)
+		}
+	}
+
+	fmt.Printf("Writing image to %s...\n", targetDrive.DevicePath)
+	fmt.Println(elevationHint())
+	wp := tui.NewProgressProgram(tui.NewProgress(fmt.Sprintf("Writing to %s...", targetDrive.DevicePath)))
+	go func() {
+		wp.Send(tui.ProgressDoneMsg{Err: writeImageToDisk(stream, stream.uncompressedSize, targetDrive, func(written int64) {
+			if msg, ok := stream.writeProgressMsg(written); ok {
+				wp.Send(msg)
+			}
+		})})
+	}()
+	final, err := wp.Run()
+	if err != nil {
+		return fmt.Errorf("progress TUI: %w", err)
+	}
+	if m := final.(tui.ProgressModel); m.Err() != nil {
+		return fmt.Errorf("writing image: %w", m.Err())
+	}
+
+	if err := applyProvisioningAndEject(targetDrive, provCreds, provDeviceName, provisioningJSON); err != nil {
+		return err
+	}
+
+	fmt.Printf("\nSuccessfully installed image on %s.\n", targetDrive.Name)
+	fmt.Println("You can now insert the drive into your device and power it on.")
+	return nil
+}
+
+// detectBlobKind classifies a local blob file. nameHint is the name the user
+// supplied (a URL's path basename for downloads) and is consulted first; when
+// the extension is unknown or ambiguous the file's magic bytes decide.
+func detectBlobKind(filePath, nameHint string) (blobKind, error) {
+	name := strings.ToLower(path.Base(strings.ReplaceAll(nameHint, "\\", "/")))
+	switch {
+	case strings.HasSuffix(name, ".tegraflash"),
+		strings.HasSuffix(name, ".flashpack"),
+		strings.HasSuffix(name, ".tar.zst"):
+		return blobFlashpack, nil
+	case strings.HasSuffix(name, ".img"),
+		strings.HasSuffix(name, ".raw"),
+		strings.HasSuffix(name, ".wic"),
+		strings.HasSuffix(name, ".sdimg"),
+		strings.HasSuffix(name, ".zip"),
+		strings.HasSuffix(name, ".gz"),
+		strings.HasSuffix(name, ".img.zst"):
+		return blobDiskImage, nil
+	}
+	return sniffBlobKind(filePath)
+}
+
+// sniffBlobKind classifies a blob by content. gzip and zip are always disk
+// images; zstd is ambiguous (a flashpack .tar.zst vs an .img.zst), so the
+// first decompressed block is checked for the tar magic. Anything else is
+// treated as a raw disk image.
+func sniffBlobKind(filePath string) (blobKind, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return blobDiskImage, fmt.Errorf("image file: %w", err)
+	}
+	defer f.Close()
+
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return blobDiskImage, nil // too short to sniff; let the image path report it
+	}
+	switch {
+	case magic[0] == 0x1f && magic[1] == 0x8b: // gzip
+		return blobDiskImage, nil
+	case magic[0] == 'P' && magic[1] == 'K': // zip
+		return blobDiskImage, nil
+	case magic[0] == 0x28 && magic[1] == 0xb5 && magic[2] == 0x2f && magic[3] == 0xfd: // zstd
+		isTar, err := zstdContainsTar(f)
+		if err != nil {
+			return blobDiskImage, err
+		}
+		if isTar {
+			return blobFlashpack, nil
+		}
+		return blobDiskImage, nil
+	default:
+		return blobDiskImage, nil
+	}
+}
+
+// isZstdFile returns true when path begins with the zstd magic bytes.
+func isZstdFile(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var magic [4]byte
+	_, err = io.ReadFull(f, magic[:])
+	return err == nil && magic[0] == 0x28 && magic[1] == 0xb5 && magic[2] == 0x2f && magic[3] == 0xfd
+}
+
+// zstdReadCloser wraps a zstd.Decoder so that closing it also closes the
+// underlying file, matching the io.ReadCloser contract.
+type zstdReadCloser struct {
+	dec *zstd.Decoder
+	f   *os.File
+}
+
+func (z *zstdReadCloser) Read(p []byte) (int, error) { return z.dec.Read(p) }
+func (z *zstdReadCloser) Close() error {
+	z.dec.Close()
+	return z.f.Close()
+}
+
+// streamZstdImage opens a zstd-compressed image file for sequential writing.
+// A seekable-zstd file carries the exact decompressed size in its seek table,
+// so try that layout first; a plain zstd stream can't report its size and
+// falls back to compressed-consumption progress.
+func streamZstdImage(path string) (*imageStream, error) {
+	if si, err := openSeekableZstd(path); err == nil {
+		return &imageStream{ReadCloser: si, uncompressedSize: si.Size()}, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening zstd image: %w", err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("stat zstd image: %w", err)
+	}
+	cr := &countingReader{r: f}
+	dec, err := zstd.NewReader(cr)
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("creating zstd reader: %w", err)
+	}
+	return &imageStream{
+		ReadCloser:     &zstdReadCloser{dec: dec, f: f},
+		compressedRead: cr.n.Load,
+		compressedSize: info.Size(),
+	}, nil
+}
+
+// zstdContainsTar decompresses the first tar header block of a zstd file and
+// checks for the "ustar" magic at offset 257.
+func zstdContainsTar(f *os.File) (bool, error) {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return false, err
+	}
+	dec, err := zstd.NewReader(f)
+	if err != nil {
+		return false, fmt.Errorf("reading zstd blob: %w", err)
+	}
+	defer dec.Close()
+	buf := make([]byte, 262)
+	n, err := io.ReadFull(dec, buf)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return false, fmt.Errorf("decompressing zstd blob: %w", err)
+	}
+	return n >= 262 && string(buf[257:262]) == "ustar", nil
+}

--- a/go/internal/cli/commands/os_install_blob.go
+++ b/go/internal/cli/commands/os_install_blob.go
@@ -4,11 +4,14 @@ package commands
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/klauspost/compress/zstd"
@@ -31,6 +34,7 @@ type blobInstallOptions struct {
 	drive                string
 	force                bool
 	yesOverwriteInternal bool
+	sha256               string // expected blob digest (hex); empty skips verification
 	wifi                 wifiCLIOptions
 	deviceName           string
 	preOpts              preEnrollOptions
@@ -86,6 +90,17 @@ func runOSInstallBlob(ctx context.Context, arg string, opts blobInstallOptions) 
 			return fmt.Errorf("invalid blob URL: %w", err)
 		}
 		nameHint = path.Base(u.Path)
+		// Fail fast on flag conflicts detectable from the URL's name alone,
+		// before paying for the download. Ambiguous names are re-checked after
+		// the content sniff below.
+		if kind, known := blobKindFromName(nameHint); known && kind == blobFlashpack {
+			if err := rejectFlashpackFlags(nameHint, opts); err != nil {
+				return err
+			}
+		}
+		if strings.HasPrefix(arg, "http://") {
+			fmt.Println(tui.WarningMessage("Downloading over plain http:// — the transfer is unencrypted and unauthenticated. Prefer https://, or pass --sha256 to verify the blob."))
+		}
 		fmt.Printf("Downloading %s...\n", arg)
 		tmp, err := downloadImage(&imageInfo{DownloadURL: arg, Version: nameHint})
 		if err != nil {
@@ -97,6 +112,13 @@ func runOSInstallBlob(ctx context.Context, arg string, opts blobInstallOptions) 
 		return fmt.Errorf("image file: %w", err)
 	}
 
+	if opts.sha256 != "" {
+		fmt.Println("Verifying blob checksum...")
+		if err := verifySHA256(localPath, opts.sha256); err != nil {
+			return err
+		}
+	}
+
 	kind, err := detectBlobKind(localPath, nameHint)
 	if err != nil {
 		return err
@@ -104,13 +126,40 @@ func runOSInstallBlob(ctx context.Context, arg string, opts blobInstallOptions) 
 
 	switch kind {
 	case blobFlashpack:
-		if bad := opts.flashpackIncompatibleFlags(); len(bad) != 0 {
-			return fmt.Errorf("%s is a Thor flashpack, which flashes over USB recovery: %s cannot be used with it", nameHint, strings.Join(bad, ", "))
+		if err := rejectFlashpackFlags(nameHint, opts); err != nil {
+			return err
 		}
 		return installThorLocalFlashpack(ctx, localPath, nameHint, opts.force)
 	default:
 		return installLocalDiskImage(ctx, localPath, opts)
 	}
+}
+
+// rejectFlashpackFlags errors when flags that make no sense for a flashpack
+// blob were set.
+func rejectFlashpackFlags(nameHint string, opts blobInstallOptions) error {
+	if bad := opts.flashpackIncompatibleFlags(); len(bad) != 0 {
+		return fmt.Errorf("%s is a Thor flashpack, which flashes over USB recovery: %s cannot be used with it", nameHint, strings.Join(bad, ", "))
+	}
+	return nil
+}
+
+// verifySHA256 checks that path's SHA-256 matches the expected lowercase-hex digest.
+func verifySHA256(path, want string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hashing %s: %w", filepath.Base(path), err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("checksum mismatch: got %s, expected %s", got, want)
+	}
+	return nil
 }
 
 // installLocalDiskImage writes a local disk-image blob to a drive: elevation
@@ -204,12 +253,21 @@ func installLocalDiskImage(ctx context.Context, imagePath string, opts blobInsta
 // supplied (a URL's path basename for downloads) and is consulted first; when
 // the extension is unknown or ambiguous the file's magic bytes decide.
 func detectBlobKind(filePath, nameHint string) (blobKind, error) {
+	if kind, known := blobKindFromName(nameHint); known {
+		return kind, nil
+	}
+	return sniffBlobKind(filePath)
+}
+
+// blobKindFromName classifies a blob by its extension alone. known is false
+// when the extension doesn't identify the kind and the content must be sniffed.
+func blobKindFromName(nameHint string) (kind blobKind, known bool) {
 	name := strings.ToLower(path.Base(strings.ReplaceAll(nameHint, "\\", "/")))
 	switch {
 	case strings.HasSuffix(name, ".tegraflash"),
 		strings.HasSuffix(name, ".flashpack"),
 		strings.HasSuffix(name, ".tar.zst"):
-		return blobFlashpack, nil
+		return blobFlashpack, true
 	case strings.HasSuffix(name, ".img"),
 		strings.HasSuffix(name, ".raw"),
 		strings.HasSuffix(name, ".wic"),
@@ -217,9 +275,9 @@ func detectBlobKind(filePath, nameHint string) (blobKind, error) {
 		strings.HasSuffix(name, ".zip"),
 		strings.HasSuffix(name, ".gz"),
 		strings.HasSuffix(name, ".img.zst"):
-		return blobDiskImage, nil
+		return blobDiskImage, true
 	}
-	return sniffBlobKind(filePath)
+	return blobDiskImage, false
 }
 
 // sniffBlobKind classifies a blob by content. gzip and zip are always disk

--- a/go/internal/cli/commands/os_install_blob_test.go
+++ b/go/internal/cli/commands/os_install_blob_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
@@ -216,6 +217,30 @@ func TestFlashpackIncompatibleFlags(t *testing.T) {
 		if bad[i] != want[i] {
 			t.Errorf("flag %d = %q, want %q", i, bad[i], want[i])
 		}
+	}
+}
+
+func TestVerifySHA256(t *testing.T) {
+	path := writeBlob(t, "blob.img", []byte("wendy"))
+	// sha256("wendy")
+	const want = "962cd22346a772beb97a793d2680b0f518615d9de049ce34079d625fbe938f4d"
+	if err := verifySHA256(path, want); err != nil {
+		t.Errorf("matching digest rejected: %v", err)
+	}
+	if err := verifySHA256(path, strings.ToUpper(want)); err != nil {
+		t.Errorf("digest comparison should be case-insensitive: %v", err)
+	}
+	err := verifySHA256(path, "deadbeef")
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("want checksum mismatch, got %v", err)
+	}
+}
+
+func TestInstallBlobSHA256Mismatch(t *testing.T) {
+	path := writeBlob(t, "blob.img", []byte("payload"))
+	err := runOSInstallBlob(t.Context(), path, blobInstallOptions{sha256: "deadbeef", force: true})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("want checksum mismatch before any install work, got %v", err)
 	}
 }
 

--- a/go/internal/cli/commands/os_install_blob_test.go
+++ b/go/internal/cli/commands/os_install_blob_test.go
@@ -1,0 +1,239 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// writeBlob writes content to a file named name in a temp dir and returns its path.
+func writeBlob(t *testing.T, name string, content []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func zstdCompress(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func tarArchive(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func gzipCompress(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func zipArchive(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestDetectBlobKind(t *testing.T) {
+	rawImage := bytes.Repeat([]byte{0xde, 0xad, 0xbe, 0xef}, 256)
+	tarBytes := tarArchive(t, "manifest.json", []byte("{}"))
+
+	tests := []struct {
+		name     string
+		fileName string
+		content  []byte
+		want     blobKind
+	}{
+		// Extension-driven classification.
+		{"tegraflash ext", "custom.tegraflash", rawImage, blobFlashpack},
+		{"flashpack ext", "custom.flashpack", rawImage, blobFlashpack},
+		{"flashpack tarball ext", "jetson-agx-thor-dev.flashpack.tar.zst", rawImage, blobFlashpack},
+		{"generic tar.zst ext", "custom.tar.zst", rawImage, blobFlashpack},
+		{"img ext", "custom.img", tarBytes, blobDiskImage},
+		{"raw ext", "custom.raw", rawImage, blobDiskImage},
+		{"wic ext", "custom.wic", rawImage, blobDiskImage},
+		{"sdimg ext", "custom.sdimg", rawImage, blobDiskImage},
+		{"zip ext", "custom.zip", zipArchive(t, "a.img", rawImage), blobDiskImage},
+		{"img.gz ext", "custom.img.gz", gzipCompress(t, rawImage), blobDiskImage},
+		// .img.zst must win over the generic zstd→tar sniff.
+		{"img.zst ext", "custom.img.zst", zstdCompress(t, tarBytes), blobDiskImage},
+
+		// Content sniffing for unknown extensions.
+		{"sniff gzip", "custom.blob", gzipCompress(t, rawImage), blobDiskImage},
+		{"sniff zip", "custom.blob", zipArchive(t, "a.img", rawImage), blobDiskImage},
+		{"sniff zstd tar", "custom.blob", zstdCompress(t, tarBytes), blobFlashpack},
+		{"sniff zstd raw", "custom.blob", zstdCompress(t, rawImage), blobDiskImage},
+		{"sniff raw", "custom.blob", rawImage, blobDiskImage},
+		{"sniff short file", "custom.blob", []byte{0x00}, blobDiskImage},
+		// .zst without .tar/.img qualifier falls through to the sniff.
+		{"bare zst ext tar", "custom.zst", zstdCompress(t, tarBytes), blobFlashpack},
+		{"bare zst ext raw", "custom.zst", zstdCompress(t, rawImage), blobDiskImage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeBlob(t, tt.fileName, tt.content)
+			got, err := detectBlobKind(path, tt.fileName)
+			if err != nil {
+				t.Fatalf("detectBlobKind: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("detectBlobKind(%s) = %d, want %d", tt.fileName, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDetectBlobKindURLHint verifies the name hint (a URL basename) drives the
+// extension check even when the local temp file has no meaningful name.
+func TestDetectBlobKindURLHint(t *testing.T) {
+	path := writeBlob(t, "wendyos-123456.img", zstdCompress(t, tarArchive(t, "manifest.json", []byte("{}"))))
+	got, err := detectBlobKind(path, "thing.flashpack.tar.zst")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != blobFlashpack {
+		t.Errorf("want flashpack from URL hint, got %d", got)
+	}
+}
+
+func TestStreamZstdImage(t *testing.T) {
+	raw := bytes.Repeat([]byte("wendyos-image-data"), 1024)
+	path := writeBlob(t, "custom.img.zst", zstdCompress(t, raw))
+
+	stream, err := streamZstdImage(path)
+	if err != nil {
+		t.Fatalf("streamZstdImage: %v", err)
+	}
+	defer stream.Close()
+
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("reading stream: %v", err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Errorf("decompressed bytes differ: got %d bytes, want %d", len(got), len(raw))
+	}
+	// A plain (non-seekable) zstd stream can't know its decompressed size and
+	// must report compressed-consumption progress instead.
+	if stream.uncompressedSize != 0 {
+		t.Errorf("uncompressedSize = %d, want 0 for plain zstd", stream.uncompressedSize)
+	}
+	if stream.compressedRead == nil || stream.compressedSize == 0 {
+		t.Error("plain zstd stream should carry compressed-progress info")
+	}
+}
+
+func TestOpenLocalImageStreamZstd(t *testing.T) {
+	raw := bytes.Repeat([]byte{0x42}, 4096)
+	path := writeBlob(t, "custom.bin", zstdCompress(t, raw))
+
+	stream, err := openLocalImageStream(path)
+	if err != nil {
+		t.Fatalf("openLocalImageStream: %v", err)
+	}
+	defer stream.Close()
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Error("zstd image not transparently decompressed")
+	}
+}
+
+func TestFlashpackIncompatibleFlags(t *testing.T) {
+	none := blobInstallOptions{force: true, yesOverwriteInternal: true}
+	if bad := none.flashpackIncompatibleFlags(); len(bad) != 0 {
+		t.Errorf("force/yes-overwrite-internal should be allowed, got %v", bad)
+	}
+
+	all := blobInstallOptions{
+		drive:      "/dev/disk4",
+		wifi:       wifiCLIOptions{SSID: "net", Password: "pw", Entries: []string{"ssid=x"}, NoWifi: true},
+		deviceName: "brave-dolphin",
+		preOpts:    preEnrollOptions{mode: preEnrollForced, cloudGRPC: "cloud.example:443"},
+	}
+	bad := all.flashpackIncompatibleFlags()
+	want := []string{"--drive", "--wifi-ssid", "--wifi-password", "--wifi", "--no-wifi", "--device-name", "--pre-enroll", "--cloud-grpc"}
+	if len(bad) != len(want) {
+		t.Fatalf("got %v, want %v", bad, want)
+	}
+	for i := range want {
+		if bad[i] != want[i] {
+			t.Errorf("flag %d = %q, want %q", i, bad[i], want[i])
+		}
+	}
+}
+
+func TestInstallBlobFlagValidation(t *testing.T) {
+	// A blob install with manifest-backed flags must fail fast.
+	for _, flags := range [][]string{
+		{"--device-type", "raspberry-pi-5"},
+		{"--version", "1.0.0"},
+		{"--nightly"},
+		{"--storage", "sd"},
+	} {
+		args := append([]string{"install", "./custom.img"}, flags...)
+		cmd := newOSCmd()
+		cmd.SetArgs(args)
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		if err := cmd.Execute(); err == nil {
+			t.Errorf("wendy os %v should fail flag validation", args)
+		}
+	}
+}

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -23,8 +23,8 @@ import (
 
 func TestNewOSInstallCmd_Flags(t *testing.T) {
 	cmd := newOSInstallCmd()
-	if cmd.Use != "install [image] [drive]" {
-		t.Errorf("Use = %q; want %q", cmd.Use, "install [image] [drive]")
+	if cmd.Use != "install [blob] [drive]" {
+		t.Errorf("Use = %q; want %q", cmd.Use, "install [blob] [drive]")
 	}
 
 	expectedFlags := []string{"nightly", "force", "yes-overwrite-internal", "device-type", "version", "drive", "wifi-ssid", "wifi-password", "wifi", "no-wifi", "device-name", "storage", "no-bmap"}
@@ -73,16 +73,17 @@ func TestNewOSInstallCmd_PositionalArgsIncompatibleWithFlags(t *testing.T) {
 	}
 }
 
-func TestNewOSInstallCmd_SinglePositionalArgRejected(t *testing.T) {
+// A single positional arg is the blob-install mode: the file is resolved as a
+// custom blob, so a nonexistent path fails at the stat, not at arg validation.
+func TestNewOSInstallCmd_SinglePositionalArgIsBlobMode(t *testing.T) {
 	cmd := newOSInstallCmd()
 	cmd.SetArgs([]string{"image.img"})
 	err := cmd.Execute()
 	if err == nil {
-		t.Fatal("expected error when exactly 1 positional arg is provided")
+		t.Fatal("expected error for a nonexistent blob path")
 	}
-	expected := "positional arguments must be provided as [image] [drive]; got 1 argument"
-	if got := err.Error(); got != expected {
-		t.Errorf("unexpected error: %q; want %q", got, expected)
+	if got := err.Error(); !strings.Contains(got, "image file:") {
+		t.Errorf("unexpected error: %q; want a stat failure for the blob path", got)
 	}
 }
 

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -65,7 +65,7 @@ func TestNewOSInstallCmd_PositionalArgsIncompatibleWithFlags(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error when positional args are combined with manifest flags")
 			}
-			expected := "positional [image] [drive] arguments cannot be combined with --device-type, --version, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, or --cloud-grpc"
+			expected := "positional [image] [drive] arguments cannot be combined with --device-type, --version, --nightly, --storage, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, --pre-enroll, --cloud-grpc, or --sha256"
 			if got := err.Error(); got != expected {
 				t.Errorf("unexpected error: %q; want %q", got, expected)
 			}

--- a/go/internal/cli/commands/os_install_thor_darwin.go
+++ b/go/internal/cli/commands/os_install_thor_darwin.go
@@ -52,8 +52,46 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 		return err
 	}
 
+	return flashThor("WendyOS "+plan.version, "Download flashpack", force,
+		func(detail func(string)) (*flashpack.Flashpack, bool, error) {
+			return downloadAndExtractFlashpack(cacheDir, plan, detail)
+		})
+}
+
+// installThorLocalFlashpack flashes a custom local flashpack tarball (a
+// .tegraflash / .flashpack.tar.zst blob) over USB recovery. The tarball is
+// extracted into a temp dir removed after the flash — custom flashpacks are
+// never cached — and no manifest checksum exists to verify it against, so the
+// user is told the artifact is unverified. displayName is what the user typed
+// (a URL's basename for downloads); localPath is where the bytes live.
+func installThorLocalFlashpack(_ context.Context, localPath, displayName string, force bool) error {
+	label := filepath.Base(strings.ReplaceAll(displayName, "\\", "/"))
+	fmt.Println()
+	fmt.Println(tui.InfoMessage("Custom flashpack: its contents are not verified against a published manifest."))
+
+	tmpDir, err := os.MkdirTemp("", "wendy-flashpack-")
+	if err != nil {
+		return fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	return flashThor(label, "Extract flashpack", force,
+		func(detail func(string)) (*flashpack.Flashpack, bool, error) {
+			detail("extracting")
+			fp, err := flashpack.ResolveTarball(localPath, filepath.Join(tmpDir, "flashpack"))
+			return fp, false, err
+		})
+}
+
+// flashThor is the shared Thor USB-recovery flash flow: recovery-mode briefing
+// and confirm, device pick, destructive-write confirm, then prepare → stage-1
+// RCM boot → stage-2 ADB partition flash as a live step list. title names what
+// is being flashed (e.g. "WendyOS 0.12.0" or a custom tarball's basename);
+// prepare resolves the flashpack (download+extract for manifest installs,
+// extract-only for local tarballs) and reports whether its work was cached.
+func flashThor(title, prepareLabel string, force bool, prepare func(detail func(string)) (*flashpack.Flashpack, bool, error)) error {
 	// Brief the user on cabling / recovery mode, then confirm before scanning.
-	if err := confirmThorReady(plan.version); err != nil {
+	if err := confirmThorReady(title); err != nil {
 		return err
 	}
 
@@ -82,15 +120,15 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 		logPath = filepath.Join(dir, "thor-flash-"+time.Now().Format("20060102-150405")+".log")
 	}
 
-	// fp/shimDir are populated by the download and stage-1 steps and read by
+	// fp/shimDir are populated by the prepare and stage-1 steps and read by
 	// later steps; the steps run sequentially in one goroutine, so no locking.
 	var (
 		fp      *flashpack.Flashpack
 		shimDir string
 	)
 	steps := []flashStep{
-		{id: stepDownload, label: "Download flashpack", run: func(out io.Writer, detail func(string)) (bool, error) {
-			resolved, cached, err := downloadAndExtractFlashpack(cacheDir, plan, detail)
+		{id: stepDownload, label: prepareLabel, run: func(out io.Writer, detail func(string)) (bool, error) {
+			resolved, cached, err := prepare(detail)
 			fp = resolved
 			return cached, err
 		}},
@@ -129,7 +167,7 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 		fmt.Println(tui.InfoMessage("Stopped a running adb server (it would hold the Thor's flashing gadget)."))
 	}
 
-	failedID, err := runFlashSteps(fmt.Sprintf("Flashing WendyOS %s", plan.version), steps)
+	failedID, err := runFlashSteps("Flashing "+title, steps)
 	if shimDir != "" {
 		os.RemoveAll(shimDir)
 	}
@@ -153,7 +191,7 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 		return err
 	}
 
-	fmt.Println(tui.SuccessMessage(fmt.Sprintf("Flashed WendyOS %s — power-cycle the Thor out of recovery to boot it.", plan.version)))
+	fmt.Println(tui.SuccessMessage(fmt.Sprintf("Flashed %s — power-cycle the Thor out of recovery to boot it.", title)))
 	return nil
 }
 
@@ -564,9 +602,9 @@ func printThorGadgetUnreachableHint(w io.Writer) {
 // confirmThorReady prints a titled recovery-mode briefing and asks the user to
 // confirm the target Thor is connected and in recovery mode before scanning.
 // Returns ErrUserCancelled if the user declines or cancels.
-func confirmThorReady(version string) error {
+func confirmThorReady(title string) error {
 	fmt.Println()
-	fmt.Println(tui.Header("Flashing WendyOS " + version))
+	fmt.Println(tui.Header("Flashing " + title))
 	fmt.Println(thorRecoveryBriefingBox())
 	fmt.Println()
 	ok, err := tui.Confirm("Is the target Thor connected and in recovery mode?")

--- a/go/internal/cli/commands/os_install_thor_darwin.go
+++ b/go/internal/cli/commands/os_install_thor_darwin.go
@@ -5,8 +5,6 @@ package commands
 import (
 	"bufio"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -393,24 +391,6 @@ func byteProgress(downloaded, total int64) string {
 		return fmt.Sprintf("%.1f GiB", float64(downloaded)/gib)
 	}
 	return fmt.Sprintf("%.1f/%.1f GiB", float64(downloaded)/gib, float64(total)/gib)
-}
-
-// verifySHA256 checks that path's SHA-256 matches the expected lowercase-hex digest.
-func verifySHA256(path, want string) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return fmt.Errorf("hashing %s: %w", filepath.Base(path), err)
-	}
-	got := hex.EncodeToString(h.Sum(nil))
-	if !strings.EqualFold(got, want) {
-		return fmt.Errorf("flashpack checksum mismatch: got %s, manifest says %s", got, want)
-	}
-	return nil
 }
 
 // pickRecoveryDevice lists Jetsons in recovery mode and selects one (auto when there

--- a/go/internal/cli/commands/os_install_thor_other.go
+++ b/go/internal/cli/commands/os_install_thor_other.go
@@ -11,3 +11,8 @@ import (
 func installThor(_ context.Context, _ string, _ bool, _ bool) error {
 	return fmt.Errorf("Thor (jetson-agx-thor) flashing is currently only supported on macOS")
 }
+
+// installThorLocalFlashpack is macOS-only for the same reason as installThor.
+func installThorLocalFlashpack(_ context.Context, _ string, _ string, _ bool) error {
+	return fmt.Errorf("flashpack blobs flash a Jetson AGX Thor over USB recovery, which is currently only supported on macOS")
+}

--- a/go/internal/cli/tegraflash/flashpack/flashpack.go
+++ b/go/internal/cli/tegraflash/flashpack/flashpack.go
@@ -158,6 +158,22 @@ func Resolve(cacheDir, version string) (*Flashpack, error) {
 	return nil, fmt.Errorf("%w: version %s in %s", ErrNotInCache, version, cacheDir)
 }
 
+// ResolveTarball extracts an arbitrary local flashpack tarball (a custom /
+// unpublished build) into destDir and opens it. Unlike Resolve it is not
+// version-keyed and never consults the cache; the caller owns destDir's
+// lifetime. The stage-1 integrity check still runs against the embedded
+// manifest, so a corrupt tarball aborts before flashing.
+func ResolveTarball(tarball, destDir string) (*Flashpack, error) {
+	if err := extractZstTar(tarball, destDir); err != nil {
+		return nil, fmt.Errorf("extracting %s: %w", filepath.Base(tarball), err)
+	}
+	fp, err := open(destDir)
+	if err != nil {
+		return nil, fmt.Errorf("%s is not a valid flashpack: %w", filepath.Base(tarball), err)
+	}
+	return fp, fp.verifyStage1()
+}
+
 func open(root string) (*Flashpack, error) {
 	data, err := os.ReadFile(filepath.Join(root, "manifest.json"))
 	if err != nil {

--- a/go/internal/cli/tegraflash/flashpack/flashpack_test.go
+++ b/go/internal/cli/tegraflash/flashpack/flashpack_test.go
@@ -110,6 +110,63 @@ func TestResolveTarballNotAFlashpack(t *testing.T) {
 	}
 }
 
+// TestResolveTarballPathTraversal proves extractZstTar rejects tar entries
+// that escape the destination dir ("tar slip") — custom tarballs are untrusted.
+func TestResolveTarballPathTraversal(t *testing.T) {
+	files := validFlashpackFiles(t)
+	files["../evil.txt"] = []byte("escaped")
+	tarball := buildTarball(t, files)
+
+	parent := t.TempDir()
+	_, err := ResolveTarball(tarball, filepath.Join(parent, "extracted"))
+	if err == nil || !strings.Contains(err.Error(), "unsafe path") {
+		t.Fatalf("want unsafe-path error, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(parent, "evil.txt")); statErr == nil {
+		t.Fatal("traversal entry escaped the destination dir")
+	}
+}
+
+// TestResolveTarballSkipsSymlinks proves symlink entries are never
+// materialized, so a later entry can't write through one to escape.
+func TestResolveTarballSkipsSymlinks(t *testing.T) {
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(zw)
+	if err := tw.WriteHeader(&tar.Header{Name: "escape", Typeflag: tar.TypeSymlink, Linkname: "/tmp"}); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range validFlashpackFiles(t) {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	tarball := filepath.Join(t.TempDir(), "links.flashpack.tar.zst")
+	if err := os.WriteFile(tarball, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "extracted")
+	if _, err := ResolveTarball(tarball, dest); err != nil {
+		t.Fatalf("ResolveTarball: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "escape")); !os.IsNotExist(err) {
+		t.Fatal("symlink entry was materialized")
+	}
+}
+
 func TestResolveTarballNotZstd(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "plain.img")
 	if err := os.WriteFile(path, []byte("raw disk image bytes"), 0o644); err != nil {

--- a/go/internal/cli/tegraflash/flashpack/flashpack_test.go
+++ b/go/internal/cli/tegraflash/flashpack/flashpack_test.go
@@ -1,0 +1,123 @@
+package flashpack
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// buildTarball writes a .tar.zst containing the given files (path → content)
+// to a temp file and returns its path.
+func buildTarball(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(zw)
+	for name, content := range files {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "custom.flashpack.tar.zst")
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// validFlashpackFiles builds the minimal file set open() and verifyStage1 accept.
+func validFlashpackFiles(t *testing.T) map[string][]byte {
+	t.Helper()
+	stage1 := []byte("rcm-image-bytes")
+	sum := sha256.Sum256(stage1)
+	manifest, err := json.Marshal(map[string]any{
+		"schema":          SupportedSchema,
+		"wendyos_version": "dev",
+		"default_membct":  "membct.bct",
+		"layout": map[string]string{
+			"stage1":          "stage1",
+			"flash_workspace": "stage2/out/flash_workspace",
+		},
+		"files": map[string]FileMeta{
+			"stage1/rcm.img": {SHA256: hex.EncodeToString(sum[:]), Size: int64(len(stage1))},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return map[string][]byte{
+		"manifest.json":  manifest,
+		"stage1/rcm.img": stage1,
+	}
+}
+
+func TestResolveTarball(t *testing.T) {
+	tarball := buildTarball(t, validFlashpackFiles(t))
+	dest := filepath.Join(t.TempDir(), "extracted")
+
+	fp, err := ResolveTarball(tarball, dest)
+	if err != nil {
+		t.Fatalf("ResolveTarball: %v", err)
+	}
+	if fp.Manifest.WendyOSVersion != "dev" {
+		t.Errorf("WendyOSVersion = %q, want dev", fp.Manifest.WendyOSVersion)
+	}
+	if fp.Root != dest {
+		t.Errorf("Root = %q, want %q", fp.Root, dest)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "stage1", "rcm.img")); err != nil {
+		t.Errorf("stage1 file not extracted: %v", err)
+	}
+}
+
+func TestResolveTarballCorruptStage1(t *testing.T) {
+	files := validFlashpackFiles(t)
+	files["stage1/rcm.img"] = []byte("tampered-bytes!")
+	tarball := buildTarball(t, files)
+
+	_, err := ResolveTarball(tarball, filepath.Join(t.TempDir(), "extracted"))
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("want checksum mismatch error, got %v", err)
+	}
+}
+
+func TestResolveTarballNotAFlashpack(t *testing.T) {
+	tarball := buildTarball(t, map[string][]byte{"README.txt": []byte("not a flashpack")})
+
+	_, err := ResolveTarball(tarball, filepath.Join(t.TempDir(), "extracted"))
+	if err == nil {
+		t.Fatal("want error for tarball without manifest.json")
+	}
+}
+
+func TestResolveTarballNotZstd(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plain.img")
+	if err := os.WriteFile(path, []byte("raw disk image bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ResolveTarball(path, filepath.Join(t.TempDir(), "extracted"))
+	if err == nil {
+		t.Fatal("want error for non-zstd input")
+	}
+}

--- a/specs/2026-07-02-install-custom-blob-design.md
+++ b/specs/2026-07-02-install-custom-blob-design.md
@@ -1,0 +1,101 @@
+# `wendy install <blob>` — custom image / flashpack installs
+
+**Date:** 2026-07-02
+**Status:** Approved
+
+## Problem
+
+`wendy install` (alias of `wendy os install`) can only install artifacts published in
+the GCS manifest, plus a legacy two-positional `<image> <drive>` mode that dd's a local
+`.img`/`.zip`/gzip file to a drive. There is no way to install:
+
+- a locally built / unpublished **Thor flashpack** (`.tar.zst` / `.tegraflash`) over USB
+  recovery — the Thor path always resolves `jetson-agx-thor-<version>.flashpack.tar.zst`
+  from the manifest or the version-keyed cache;
+- a custom **zstd-compressed disk image** (`.img.zst`);
+- a blob referenced by **URL** rather than a local path.
+
+## CLI surface
+
+`wendy install` gains a **one-positional mode** (today `len(args)==1` errors). The
+argument is a local path or an `http(s)://` URL:
+
+```
+wendy install ./build/jetson-agx-thor-dev.flashpack.tar.zst
+wendy install ./wendyos-rpi5.img.zst --drive /dev/disk4 --force
+wendy install https://ci.example.com/artifacts/custom.img.zst
+wendy install ./custom.img                 # → interactive drive picker
+wendy install ./custom.img /dev/disk4      # legacy 2-arg form, unchanged
+```
+
+- The two-arg form and all manifest-flag flows are unchanged.
+- Blob mode flags: `--drive` (non-interactive target), `--force`,
+  `--yes-overwrite-internal`, and — for disk images — the provisioning flags
+  (`--wifi`, `--wifi-ssid`, `--wifi-password`, `--no-wifi`, `--device-name`,
+  `--pre-enroll`, `--cloud-grpc`).
+- Rejected with blob mode: `--device-type`, `--version`, `--nightly`, `--storage`
+  (the blob *is* the version/variant).
+- Rejected with a **flashpack** blob: `--drive` and all provisioning flags (Thor
+  flashes over USB recovery, not to a drive; no config partition is written).
+
+## Blob type detection
+
+Extension hint first, content sniff as fallback:
+
+| Kind | Extensions |
+|---|---|
+| Flashpack | `.tegraflash`, `.flashpack`, `.flashpack.tar.zst`, `.tar.zst` |
+| Disk image | `.img`, `.raw`, `.wic`, `.sdimg`, `.zip`, `.gz`, `.img.gz`, `.img.zst`, `.zst` (non-tar) |
+
+Content sniff (unknown/ambiguous extension):
+
+- gzip magic (`1f 8b`) → gzip disk image (existing stream path)
+- zip magic (`PK`) → zip archive, first `.img`/`.raw`/`.wic`/`.sdimg` entry (existing)
+- zstd magic (`28 b5 2f fd`) → decode the first ~1 KiB; tar `ustar` magic at offset 257
+  → **flashpack**, else **disk image**
+- anything else → raw disk image
+
+## Disk-image route
+
+Reuses the existing direct-install internals: elevation pre-auth → drive resolve
+(`--drive` or interactive picker) → destructive-write confirm → stream write with
+progress. Two extensions:
+
+1. **zstd decoding** in `openLocalImageStream` — sequential decode (seekable-zstd files
+   decode fine sequentially; no bmap fast path for custom blobs). Progress uses the
+   zstd frame content size when present, else the compressed-bytes progress mode.
+2. **Provisioning** — after the write, `--wifi*` / `--device-name` / `--pre-enroll`
+   are applied via the existing `provisionConfigWithRetry`, same as the manifest flow.
+
+## Flashpack route (Thor, macOS only)
+
+`installThor` is refactored to accept a flashpack *source*: manifest plan (unchanged)
+or local tarball. A new `flashpack.ResolveTarball(tarballPath, destDir)` extracts into
+an `os.MkdirTemp` directory, removed after the flash (success or failure) — **no
+caching** of custom flashpacks. No checksum verification; a note is printed that the
+flashpack is unverified. The brief/confirm/RCM/stage-2 flow and step UI are identical;
+the displayed "version" is the file's basename. On non-macOS platforms a flashpack blob
+fails with a clear "Thor flashing is currently macOS-only" error.
+
+## Remote URLs
+
+`http(s)://` arguments download first via the existing `downloadImageInto` (parallel
+range requests + progress) into a temp file in the OS cache dir, removed when the
+install finishes. Detection uses the URL path basename as the extension hint, then
+content-sniffs the downloaded file.
+
+## Errors & edge cases
+
+- Nonexistent path → existing `image file:` stat error.
+- zstd tar that isn't a valid flashpack layout → `ResolveTarball`'s manifest-validation
+  error.
+- Invalid flag combinations fail fast, before any download or elevation prompt.
+
+## Testing
+
+- Table-driven unit tests for blob detection (extensions + magic bytes, including the
+  `.tar.zst` vs `.img.zst` sniff).
+- Flag-combination validation tests.
+- `ResolveTarball` temp-extraction and cleanup tests.
+- Thor wiring covered by extending the existing darwin-gated tests; drive-write paths
+  reuse already-covered code.

--- a/specs/2026-07-02-install-custom-blob-design.md
+++ b/specs/2026-07-02-install-custom-blob-design.md
@@ -63,7 +63,8 @@ progress. Two extensions:
 
 1. **zstd decoding** in `openLocalImageStream` — sequential decode (seekable-zstd files
    decode fine sequentially; no bmap fast path for custom blobs). Progress uses the
-   zstd frame content size when present, else the compressed-bytes progress mode.
+   exact size from the seekable-zstd seek table when the file has one, else the
+   compressed-bytes progress mode (a plain zstd stream cannot report its size).
 2. **Provisioning** — after the write, `--wifi*` / `--device-name` / `--pre-enroll`
    are applied via the existing `provisionConfigWithRetry`, same as the manifest flow.
 
@@ -72,17 +73,27 @@ progress. Two extensions:
 `installThor` is refactored to accept a flashpack *source*: manifest plan (unchanged)
 or local tarball. A new `flashpack.ResolveTarball(tarballPath, destDir)` extracts into
 an `os.MkdirTemp` directory, removed after the flash (success or failure) — **no
-caching** of custom flashpacks. No checksum verification; a note is printed that the
-flashpack is unverified. The brief/confirm/RCM/stage-2 flow and step UI are identical;
+caching** of custom flashpacks. There is no published manifest to verify a custom
+flashpack against; a note is printed that the flashpack is unverified, and callers can
+pass `--sha256 <hex>` to pin the blob to a known digest (the tar extraction rejects
+path traversal and skips symlink/hardlink entries, and the embedded stage-1 integrity
+map is still enforced). The brief/confirm/RCM/stage-2 flow and step UI are identical;
 the displayed "version" is the file's basename. On non-macOS platforms a flashpack blob
 fails with a clear "Thor flashing is currently macOS-only" error.
+
+*Future work:* signature-based verification (e.g. a detached Sigstore signature, in
+line with the release SBOM/provenance work) so custom artifacts can be authenticated
+rather than merely pinned by hash.
 
 ## Remote URLs
 
 `http(s)://` arguments download first via the existing `downloadImageInto` (parallel
 range requests + progress) into a temp file in the OS cache dir, removed when the
 install finishes. Detection uses the URL path basename as the extension hint, then
-content-sniffs the downloaded file.
+content-sniffs the downloaded file. When the URL's basename already identifies a
+flashpack, incompatible flags fail before the download starts. Plain `http://` URLs
+print a warning (unencrypted, unauthenticated); `--sha256 <hex>` verifies the
+downloaded blob before any install work.
 
 ## Errors & edge cases
 


### PR DESCRIPTION
## Summary

`wendy install <blob>` now accepts a single positional argument naming a custom artifact — a locally built or otherwise unpublished image — instead of a manifest version:

```sh
wendy install ./jetson-agx-thor-dev.flashpack.tar.zst         # Thor USB-recovery flash
wendy install ./wendyos-rpi5.img.zst --drive /dev/disk4 --force
wendy install https://ci.example.com/artifacts/custom.img.zst  # downloads first
wendy install ./custom.img                                     # interactive drive picker
```

- **Type detection** is extension-first (`.tegraflash` / `.flashpack` / `.tar.zst` → flashpack; `.img` / `.wic` / `.img.zst` / `.zip` / `.gz` / … → disk image) with magic-byte sniffing as fallback; a zstd blob is disambiguated by checking the first decompressed block for a tar header (`.tar.zst` flashpack vs `.img.zst` image).
- **Disk-image blobs** reuse the direct-install write path and gain zstd decoding (seekable-zstd size from the seek table, sequential fallback with compressed-consumption progress) plus config-partition provisioning — `--wifi*`, `--device-name`, `--pre-enroll` now work with custom images.
- **Flashpack blobs** run the existing Thor USB-recovery flow via a new `flashpack.ResolveTarball`: extracted to a temp dir (never cached), stage-1 integrity still verified against the embedded manifest, with a printed note that the artifact is unverified against a published manifest. macOS only, same as the manifest Thor flow.
- **Flag rules:** manifest flags (`--device-type`, `--version`, `--nightly`, `--storage`) are rejected with a blob; `--drive` and provisioning flags are rejected with a flashpack. The legacy `<image> <drive>` two-arg form and all manifest flows are unchanged.
- Refactors: `installThor` and the local path share a `flashThor` helper; `installLinuxImage`'s provisioning blocks extracted into `resolveProvisioningInputs` / `applyProvisioningAndEject`, now shared with the blob path; `findDriveByPath` deduplicates drive lookup.

Design spec: `specs/2026-07-02-install-custom-blob-design.md`.

## Testing

- New unit tests: blob-kind detection table (extensions + magic bytes, incl. the `.tar.zst` vs `.img.zst` sniff), zstd stream round-trip, flashpack-incompatible-flag matrix, blob flag validation via cobra, `flashpack.ResolveTarball` (valid / corrupt stage-1 checksum / not-a-flashpack / not-zstd).
- Full `./internal/cli/commands` and `./internal/cli/tegraflash/flashpack` suites pass; `go vet` clean; linux/arm64 and windows/amd64 cross-compiles pass.
- Exercised the built binary on error paths: nonexistent blob, flashpack + `--drive`, blob + `--device-type`, and a fake flashpack reaching the recovery-mode briefing.
- **Not verified on hardware:** an actual Thor flash from a custom tarball (the flow past the extract step is unchanged code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nvKLtKrskQdo9cpdBMTkc