### PR TITLE
feat(cli): show wendyos-update status in wendy device info

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
@@ -509,7 +509,61 @@ message KernelLogRecord {
     string message = 3;
 }
 
-message GetOSUpdateStatusRequest {}
+message GetOSUpdateStatusRequest {
+    // When true, the agent additionally probes the OS updater's live status
+    // (`wendyos-update status --json`) and returns it in engine_status. Off by
+    // default because the probe execs a binary on the device.
+    bool include_engine_status = 1;
+}
+
+// Live A/B-slot snapshot from `wendyos-update status --json` (frozen v1 CLI
+// contract of github.com/wendylabsinc/wendyos-update). Mirrors that contract's
+// field names; all fields are best-effort and may be empty.
+message OSUpdateEngineStatus {
+    // Platform connector driving the A/B scheme, e.g. "tegrauefi" or "ubootenv".
+    string connector = 1;
+    // Slot the device is currently booted from ("a" or "b").
+    string current_slot = 2;
+
+    message Slot {
+        // Slot name ("a" or "b").
+        string slot = 1;
+        // True for the slot the device is booted from.
+        bool booted = 2;
+        // Rootfs partition device, e.g. "/dev/nvme0n1p1".
+        string partition = 3;
+        // Distro version installed in the slot; "" when unreadable.
+        string distro = 4;
+        // Kernel version installed in the slot; "" when unreadable.
+        string kernel = 5;
+        // Slot health as reported by the bootloader, e.g. "normal".
+        string rootfs_health = 6;
+        // Remaining boot-trial retries, when the platform tracks them.
+        string retries = 7;
+        // Free-form platform note about the slot.
+        string note = 8;
+    }
+    repeated Slot slots = 3;
+
+    // Ordered system-wide key/value pairs (bootloader version, capsule
+    // status, ...) exactly as the engine reports them.
+    message SystemEntry {
+        string key = 1;
+        string value = 2;
+    }
+    repeated SystemEntry system = 4;
+
+    // In-flight (uncommitted) update, absent when none is pending.
+    message PendingUpdate {
+        string artifact_name = 1;
+        string artifact_version = 2;
+        // Engine phase, e.g. "installed" (awaiting reboot + commit).
+        string phase = 3;
+        // Slot the update was written to ("a" or "b").
+        string target_slot = 4;
+    }
+    PendingUpdate pending = 5;
+}
 
 // Outcome of the most recent OS update attempt, produced by the agent's
 // post-reboot healthcheck gate and persisted on the device's data partition
@@ -564,6 +618,11 @@ message GetOSUpdateStatusResponse {
     // the commit command's failure reason, including the OS updater's output,
     // so the failure is diagnosable without shell access to the device.
     string note = 9;
+
+    // Live updater snapshot; set only when the request asked for it via
+    // include_engine_status AND the device uses the wendyos-update engine AND
+    // the probe succeeded. Independent of has_result.
+    OSUpdateEngineStatus engine_status = 10;
 }
 
 message SetHostnameRequest {

--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
@@ -522,11 +522,11 @@ message GetOSUpdateStatusRequest {
 message OSUpdateEngineStatus {
     // Platform connector driving the A/B scheme, e.g. "tegrauefi" or "ubootenv".
     string connector = 1;
-    // Slot the device is currently booted from ("a" or "b").
+    // Slot the device is currently booted from ("A" or "B").
     string current_slot = 2;
 
     message Slot {
-        // Slot name ("a" or "b").
+        // Slot name ("A" or "B").
         string slot = 1;
         // True for the slot the device is booted from.
         bool booted = 2;
@@ -559,7 +559,7 @@ message OSUpdateEngineStatus {
         string artifact_version = 2;
         // Engine phase, e.g. "installed" (awaiting reboot + commit).
         string phase = 3;
-        // Slot the update was written to ("a" or "b").
+        // Slot the update was written to ("A" or "B").
         string target_slot = 4;
     }
     PendingUpdate pending = 5;

--- a/Proto/wendy/agent/services/v2/os_update_service.proto
+++ b/Proto/wendy/agent/services/v2/os_update_service.proto
@@ -52,11 +52,11 @@ message GetOSUpdateStatusRequest {
 message OSUpdateEngineStatus {
     // Platform connector driving the A/B scheme, e.g. "tegrauefi" or "ubootenv".
     string connector = 1;
-    // Slot the device is currently booted from ("a" or "b").
+    // Slot the device is currently booted from ("A" or "B").
     string current_slot = 2;
 
     message Slot {
-        // Slot name ("a" or "b").
+        // Slot name ("A" or "B").
         string slot = 1;
         // True for the slot the device is booted from.
         bool booted = 2;
@@ -89,7 +89,7 @@ message OSUpdateEngineStatus {
         string artifact_version = 2;
         // Engine phase, e.g. "installed" (awaiting reboot + commit).
         string phase = 3;
-        // Slot the update was written to ("a" or "b").
+        // Slot the update was written to ("A" or "B").
         string target_slot = 4;
     }
     PendingUpdate pending = 5;

--- a/Proto/wendy/agent/services/v2/os_update_service.proto
+++ b/Proto/wendy/agent/services/v2/os_update_service.proto
@@ -39,7 +39,61 @@ message UpdateOSResponse {
     }
 }
 
-message GetOSUpdateStatusRequest {}
+message GetOSUpdateStatusRequest {
+    // When true, the agent additionally probes the OS updater's live status
+    // (`wendyos-update status --json`) and returns it in engine_status. Off by
+    // default because the probe execs a binary on the device.
+    bool include_engine_status = 1;
+}
+
+// Live A/B-slot snapshot from `wendyos-update status --json` (frozen v1 CLI
+// contract of github.com/wendylabsinc/wendyos-update). Mirrors that contract's
+// field names; all fields are best-effort and may be empty.
+message OSUpdateEngineStatus {
+    // Platform connector driving the A/B scheme, e.g. "tegrauefi" or "ubootenv".
+    string connector = 1;
+    // Slot the device is currently booted from ("a" or "b").
+    string current_slot = 2;
+
+    message Slot {
+        // Slot name ("a" or "b").
+        string slot = 1;
+        // True for the slot the device is booted from.
+        bool booted = 2;
+        // Rootfs partition device, e.g. "/dev/nvme0n1p1".
+        string partition = 3;
+        // Distro version installed in the slot; "" when unreadable.
+        string distro = 4;
+        // Kernel version installed in the slot; "" when unreadable.
+        string kernel = 5;
+        // Slot health as reported by the bootloader, e.g. "normal".
+        string rootfs_health = 6;
+        // Remaining boot-trial retries, when the platform tracks them.
+        string retries = 7;
+        // Free-form platform note about the slot.
+        string note = 8;
+    }
+    repeated Slot slots = 3;
+
+    // Ordered system-wide key/value pairs (bootloader version, capsule
+    // status, ...) exactly as the engine reports them.
+    message SystemEntry {
+        string key = 1;
+        string value = 2;
+    }
+    repeated SystemEntry system = 4;
+
+    // In-flight (uncommitted) update, absent when none is pending.
+    message PendingUpdate {
+        string artifact_name = 1;
+        string artifact_version = 2;
+        // Engine phase, e.g. "installed" (awaiting reboot + commit).
+        string phase = 3;
+        // Slot the update was written to ("a" or "b").
+        string target_slot = 4;
+    }
+    PendingUpdate pending = 5;
+}
 
 // Outcome of the most recent OS update attempt, produced by the agent's
 // post-reboot healthcheck gate and persisted on the device's data partition
@@ -94,4 +148,9 @@ message GetOSUpdateStatusResponse {
     // the commit command's failure reason, including the OS updater's output,
     // so the failure is diagnosable without shell access to the device.
     string note = 9;
+
+    // Live updater snapshot; set only when the request asked for it via
+    // include_engine_status AND the device uses the wendyos-update engine AND
+    // the probe succeeded. Independent of has_result.
+    OSUpdateEngineStatus engine_status = 10;
 }

--- a/go/internal/agent/services/os_update_status.go
+++ b/go/internal/agent/services/os_update_status.go
@@ -12,16 +12,22 @@ import (
 
 // GetOSUpdateStatus reports the persisted outcome of the most recent OS
 // update attempt (see oshealth.Gate). The record survives an A/B rollback
-// because it lives on the data partition.
-func (s *AgentService) GetOSUpdateStatus(_ context.Context, _ *agentpb.GetOSUpdateStatusRequest) (*agentpb.GetOSUpdateStatusResponse, error) {
+// because it lives on the data partition. When the request asks for it, the
+// response also carries a live `wendyos-update status --json` snapshot,
+// independent of whether an update record exists.
+func (s *AgentService) GetOSUpdateStatus(ctx context.Context, req *agentpb.GetOSUpdateStatusRequest) (*agentpb.GetOSUpdateStatusResponse, error) {
 	record, found, err := oshealth.ReadUpdateResult(s.osUpdateStateDir)
 	if err != nil {
 		s.logger.Warn("Failed to read OS update result record", zap.Error(err))
 	}
-	if !found || err != nil {
-		return &agentpb.GetOSUpdateStatusResponse{HasResult: false}, nil
+	resp := &agentpb.GetOSUpdateStatusResponse{HasResult: false}
+	if found && err == nil {
+		resp = osUpdateStatusToProtoV1(record)
 	}
-	return osUpdateStatusToProtoV1(record), nil
+	if req.GetIncludeEngineStatus() {
+		resp.EngineStatus = probeWendyOSEngineStatus(ctx, s.logger)
+	}
+	return resp, nil
 }
 
 func osUpdateStatusToProtoV1(r oshealth.UpdateResult) *agentpb.GetOSUpdateStatusResponse {
@@ -76,15 +82,19 @@ func serviceStatusToProtoV1(s oshealth.ServiceStatus) agentpb.GetOSUpdateStatusR
 }
 
 // GetOSUpdateStatus is the v2 mirror of AgentService.GetOSUpdateStatus.
-func (s *OSUpdateService) GetOSUpdateStatus(_ context.Context, _ *agentpbv2.GetOSUpdateStatusRequest) (*agentpbv2.GetOSUpdateStatusResponse, error) {
+func (s *OSUpdateService) GetOSUpdateStatus(ctx context.Context, req *agentpbv2.GetOSUpdateStatusRequest) (*agentpbv2.GetOSUpdateStatusResponse, error) {
 	record, found, err := oshealth.ReadUpdateResult(s.stateDir)
 	if err != nil {
 		s.logger.Warn("Failed to read OS update result record", zap.Error(err))
 	}
-	if !found || err != nil {
-		return &agentpbv2.GetOSUpdateStatusResponse{HasResult: false}, nil
+	resp := &agentpbv2.GetOSUpdateStatusResponse{HasResult: false}
+	if found && err == nil {
+		resp = osUpdateStatusToProtoV2(record)
 	}
-	return osUpdateStatusToProtoV2(record), nil
+	if req.GetIncludeEngineStatus() {
+		resp.EngineStatus = engineStatusToProtoV2(probeWendyOSEngineStatus(ctx, s.logger))
+	}
+	return resp, nil
 }
 
 func osUpdateStatusToProtoV2(r oshealth.UpdateResult) *agentpbv2.GetOSUpdateStatusResponse {

--- a/go/internal/agent/services/wendyos_engine_status.go
+++ b/go/internal/agent/services/wendyos_engine_status.go
@@ -1,0 +1,165 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"time"
+
+	"go.uber.org/zap"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+// wendyOSStatusProbeTimeout bounds the `wendyos-update status --json` probe
+// used to enrich GetOSUpdateStatus. Matches the detect() probe budget.
+const wendyOSStatusProbeTimeout = 10 * time.Second
+
+// Wire shape of `wendyos-update status --json`, per the frozen v1 CLI
+// contract (wendyos-update docs/cli-contract.md). Additive-only, so unknown
+// fields are safely ignored.
+type wendyOSEngineStatus struct {
+	Connector   string                `json:"connector"`
+	CurrentSlot string                `json:"current_slot"`
+	Slots       []wendyOSEngineSlot   `json:"slots"`
+	System      []wendyOSEngineKV     `json:"system"`
+	Pending     *wendyOSEnginePending `json:"pending"`
+}
+
+type wendyOSEngineSlot struct {
+	Slot         string `json:"slot"`
+	Booted       bool   `json:"booted"`
+	Partition    string `json:"partition"`
+	Distro       string `json:"distro"`
+	Kernel       string `json:"kernel"`
+	RootfsHealth string `json:"rootfs_health"`
+	Retries      string `json:"retries"`
+	Note         string `json:"note"`
+}
+
+type wendyOSEngineKV struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type wendyOSEnginePending struct {
+	ArtifactName    string `json:"artifact_name"`
+	ArtifactVersion string `json:"artifact_version"`
+	Phase           string `json:"phase"`
+	TargetSlot      int    `json:"target_slot"`
+}
+
+// parseWendyOSEngineStatus decodes `wendyos-update status --json` output into
+// the v1 proto message. Pure function, unit-tested.
+func parseWendyOSEngineStatus(out []byte) (*agentpb.OSUpdateEngineStatus, error) {
+	var st wendyOSEngineStatus
+	if err := json.Unmarshal(out, &st); err != nil {
+		return nil, err
+	}
+	resp := &agentpb.OSUpdateEngineStatus{
+		Connector:   st.Connector,
+		CurrentSlot: st.CurrentSlot,
+	}
+	for _, s := range st.Slots {
+		resp.Slots = append(resp.Slots, &agentpb.OSUpdateEngineStatus_Slot{
+			Slot:         s.Slot,
+			Booted:       s.Booted,
+			Partition:    s.Partition,
+			Distro:       s.Distro,
+			Kernel:       s.Kernel,
+			RootfsHealth: s.RootfsHealth,
+			Retries:      s.Retries,
+			Note:         s.Note,
+		})
+	}
+	for _, kv := range st.System {
+		resp.System = append(resp.System, &agentpb.OSUpdateEngineStatus_SystemEntry{
+			Key:   kv.Key,
+			Value: kv.Value,
+		})
+	}
+	if st.Pending != nil {
+		resp.Pending = &agentpb.OSUpdateEngineStatus_PendingUpdate{
+			ArtifactName:    st.Pending.ArtifactName,
+			ArtifactVersion: st.Pending.ArtifactVersion,
+			Phase:           st.Pending.Phase,
+			TargetSlot:      slotName(st.Pending.TargetSlot),
+		}
+	}
+	return resp, nil
+}
+
+// slotName renders the engine's numeric slot (state-schema target_slot) the
+// way the engine itself does: 0 → "A", anything else → "B".
+func slotName(slot int) string {
+	if slot == 0 {
+		return "A"
+	}
+	return "B"
+}
+
+// probeWendyOSEngineStatus runs `wendyos-update status --json` and returns the
+// parsed snapshot, or nil when the device does not use wendyos-update or the
+// probe fails. Callers treat the result as best-effort enrichment: a nil
+// return never fails the surrounding RPC.
+func probeWendyOSEngineStatus(ctx context.Context, logger *zap.Logger) *agentpb.OSUpdateEngineStatus {
+	binary, found := resolveWendyOSBinary()
+	if !found {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, wendyOSStatusProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, "status", "--json")
+	cmd.Env = envWithPath("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+	out, err := cmd.Output()
+	if err != nil {
+		logger.Debug("wendyos-update status probe failed; omitting engine status", zap.Error(err))
+		return nil
+	}
+	status, err := parseWendyOSEngineStatus(out)
+	if err != nil {
+		logger.Warn("wendyos-update status --json output could not be parsed", zap.Error(err))
+		return nil
+	}
+	return status
+}
+
+// engineStatusToProtoV2 mirrors the v1 engine-status message into its
+// identical v2 counterpart.
+func engineStatusToProtoV2(v1 *agentpb.OSUpdateEngineStatus) *agentpbv2.OSUpdateEngineStatus {
+	if v1 == nil {
+		return nil
+	}
+	resp := &agentpbv2.OSUpdateEngineStatus{
+		Connector:   v1.GetConnector(),
+		CurrentSlot: v1.GetCurrentSlot(),
+	}
+	for _, s := range v1.GetSlots() {
+		resp.Slots = append(resp.Slots, &agentpbv2.OSUpdateEngineStatus_Slot{
+			Slot:         s.GetSlot(),
+			Booted:       s.GetBooted(),
+			Partition:    s.GetPartition(),
+			Distro:       s.GetDistro(),
+			Kernel:       s.GetKernel(),
+			RootfsHealth: s.GetRootfsHealth(),
+			Retries:      s.GetRetries(),
+			Note:         s.GetNote(),
+		})
+	}
+	for _, kv := range v1.GetSystem() {
+		resp.System = append(resp.System, &agentpbv2.OSUpdateEngineStatus_SystemEntry{
+			Key:   kv.GetKey(),
+			Value: kv.GetValue(),
+		})
+	}
+	if p := v1.GetPending(); p != nil {
+		resp.Pending = &agentpbv2.OSUpdateEngineStatus_PendingUpdate{
+			ArtifactName:    p.GetArtifactName(),
+			ArtifactVersion: p.GetArtifactVersion(),
+			Phase:           p.GetPhase(),
+			TargetSlot:      p.GetTargetSlot(),
+		}
+	}
+	return resp
+}

--- a/go/internal/agent/services/wendyos_engine_status_test.go
+++ b/go/internal/agent/services/wendyos_engine_status_test.go
@@ -1,0 +1,121 @@
+package services
+
+import (
+	"testing"
+)
+
+// Sample matching the frozen v1 `status --json` contract
+// (wendyos-update docs/cli-contract.md), including a pending update.
+const sampleEngineStatusJSON = `{
+  "connector": "tegrauefi",
+  "current_slot": "A",
+  "slots": [
+    {
+      "slot": "A",
+      "booted": true,
+      "partition": "/dev/nvme0n1p1",
+      "distro": "WendyOS 0.17.0",
+      "kernel": "5.15.148-tegra",
+      "rootfs_health": "normal"
+    },
+    {
+      "slot": "B",
+      "booted": false,
+      "partition": "/dev/nvme0n1p2",
+      "retries": "2",
+      "note": "trial boot pending"
+    }
+  ],
+  "system": [
+    {"key": "bootloader", "value": "36.3.0"},
+    {"key": "capsule status", "value": "none"}
+  ],
+  "pending": {
+    "schema": 1,
+    "phase": "installed",
+    "target_slot": 1,
+    "artifact_name": "wendyos-jetson",
+    "artifact_version": "0.18.0",
+    "bootloader_update": false
+  },
+  "diagnostics": {"RootfsStatusSlotA": "0x0"}
+}`
+
+func TestParseWendyOSEngineStatus(t *testing.T) {
+	st, err := parseWendyOSEngineStatus([]byte(sampleEngineStatusJSON))
+	if err != nil {
+		t.Fatalf("parseWendyOSEngineStatus: %v", err)
+	}
+
+	if st.GetConnector() != "tegrauefi" {
+		t.Errorf("connector = %q, want tegrauefi", st.GetConnector())
+	}
+	if st.GetCurrentSlot() != "A" {
+		t.Errorf("current_slot = %q, want A", st.GetCurrentSlot())
+	}
+
+	if len(st.GetSlots()) != 2 {
+		t.Fatalf("slots = %d, want 2", len(st.GetSlots()))
+	}
+	a := st.GetSlots()[0]
+	if !a.GetBooted() || a.GetPartition() != "/dev/nvme0n1p1" || a.GetRootfsHealth() != "normal" ||
+		a.GetDistro() != "WendyOS 0.17.0" || a.GetKernel() != "5.15.148-tegra" {
+		t.Errorf("slot A mapped wrong: %+v", a)
+	}
+	b := st.GetSlots()[1]
+	if b.GetBooted() || b.GetRetries() != "2" || b.GetNote() != "trial boot pending" {
+		t.Errorf("slot B mapped wrong: %+v", b)
+	}
+
+	if len(st.GetSystem()) != 2 || st.GetSystem()[0].GetKey() != "bootloader" || st.GetSystem()[0].GetValue() != "36.3.0" {
+		t.Errorf("system entries mapped wrong: %+v", st.GetSystem())
+	}
+
+	p := st.GetPending()
+	if p == nil {
+		t.Fatal("pending = nil, want populated")
+	}
+	if p.GetArtifactName() != "wendyos-jetson" || p.GetArtifactVersion() != "0.18.0" ||
+		p.GetPhase() != "installed" || p.GetTargetSlot() != "B" {
+		t.Errorf("pending mapped wrong: %+v", p)
+	}
+}
+
+func TestParseWendyOSEngineStatusNoPending(t *testing.T) {
+	st, err := parseWendyOSEngineStatus([]byte(`{"connector":"ubootenv","current_slot":"B","pending":null,"diagnostics":{}}`))
+	if err != nil {
+		t.Fatalf("parseWendyOSEngineStatus: %v", err)
+	}
+	if st.GetPending() != nil {
+		t.Errorf("pending = %+v, want nil", st.GetPending())
+	}
+	if st.GetCurrentSlot() != "B" {
+		t.Errorf("current_slot = %q, want B", st.GetCurrentSlot())
+	}
+}
+
+func TestParseWendyOSEngineStatusRejectsMalformedJSON(t *testing.T) {
+	if _, err := parseWendyOSEngineStatus([]byte("not json")); err == nil {
+		t.Fatal("expected an error for malformed JSON")
+	}
+}
+
+func TestEngineStatusToProtoV2RoundTrip(t *testing.T) {
+	v1, err := parseWendyOSEngineStatus([]byte(sampleEngineStatusJSON))
+	if err != nil {
+		t.Fatalf("parseWendyOSEngineStatus: %v", err)
+	}
+	v2 := engineStatusToProtoV2(v1)
+	if v2.GetConnector() != v1.GetConnector() || v2.GetCurrentSlot() != v1.GetCurrentSlot() {
+		t.Errorf("v2 header mismatch: %+v", v2)
+	}
+	if len(v2.GetSlots()) != len(v1.GetSlots()) || len(v2.GetSystem()) != len(v1.GetSystem()) {
+		t.Errorf("v2 collection sizes mismatch: %+v", v2)
+	}
+	if v2.GetPending().GetTargetSlot() != "B" {
+		t.Errorf("v2 pending target slot = %q, want B", v2.GetPending().GetTargetSlot())
+	}
+	if engineStatusToProtoV2(nil) != nil {
+		t.Error("engineStatusToProtoV2(nil) should be nil")
+	}
+}

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -173,6 +173,17 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				return fmt.Errorf("selected device does not support this command")
 			}
 
+			// Best-effort OS-update status (wendyos-update slots + last update
+			// outcome). Older agents answer Unimplemented and OTA-less devices
+			// have nothing to report — device info must keep working either way.
+			var osUpdateStatus *agentpb.GetOSUpdateStatusResponse
+			if target.Agent != nil {
+				if resp, err := target.Agent.AgentService.GetOSUpdateStatus(ctx,
+					&agentpb.GetOSUpdateStatusRequest{IncludeEngineStatus: true}); err == nil {
+					osUpdateStatus = resp
+				}
+			}
+
 			var latestVersion string
 			if checkUpdates {
 				release, err := fetchAgentRelease(prerelease)
@@ -224,6 +235,9 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				if gpuArch != "" {
 					out["gpuArch"] = gpuArch
 				}
+				if osUpdate := osUpdateJSON(osUpdateStatus); osUpdate != nil {
+					out["osUpdate"] = osUpdate
+				}
 				if checkUpdates {
 					out["latestVersion"] = latestVersion
 					out["updateAvailable"] = version.CompareVersions(latestVersion, agentVersion) > 0
@@ -265,6 +279,9 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				if gpuArch != "" {
 					fmt.Printf("%s %s\n", tui.Dim("GPU Arch:"), tui.Value(gpuArch))
 				}
+			}
+			if block := formatOSUpdateInfo(osUpdateStatus); block != "" {
+				fmt.Print(block)
 			}
 			fmt.Printf("%s %s\n", tui.Dim("CLI Version:"), tui.Value(version.Version))
 

--- a/go/internal/cli/commands/device_osupdate.go
+++ b/go/internal/cli/commands/device_osupdate.go
@@ -4,7 +4,19 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// Outcome/health words carry their severity as color: green for a healthy or
+// committed state, amber for a rollback that saved the device, red for
+// anything that needs the user's attention.
+var (
+	osUpdateGoodStyle = lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	osUpdateWarnStyle = lipgloss.NewStyle().Foreground(tui.ColorNotice).Bold(true)
+	osUpdateBadStyle  = lipgloss.NewStyle().Foreground(tui.ColorError).Bold(true)
 )
 
 // formatOSUpdateInfo renders the OS-update block for `wendy device info`: the
@@ -21,24 +33,32 @@ func formatOSUpdateInfo(resp *agentpb.GetOSUpdateStatusResponse) string {
 	}
 
 	var b strings.Builder
-	b.WriteString("OS Update:\n")
+	b.WriteString(tui.Dim("OS Update:") + "\n")
 
 	for _, s := range engine.GetSlots() {
 		b.WriteString("  " + formatOSUpdateSlot(s) + "\n")
 	}
 	if p := engine.GetPending(); p != nil {
-		fmt.Fprintf(&b, "  Pending: %s %s (%s, target slot %s)\n",
-			p.GetArtifactName(), p.GetArtifactVersion(), p.GetPhase(), p.GetTargetSlot())
+		// "failed" means the deployment was marked failed and needs a
+		// rollback — the one pending phase that is bad news.
+		phase := tui.Dim(p.GetPhase())
+		if p.GetPhase() == "failed" {
+			phase = osUpdateBadStyle.Render(p.GetPhase())
+		}
+		fmt.Fprintf(&b, "  %s %s %s%s%s\n",
+			tui.Dim("Pending:"),
+			tui.Value(p.GetArtifactName()+" "+p.GetArtifactVersion()),
+			tui.Dim("("), phase, tui.Dim(", target slot "+p.GetTargetSlot()+")"))
 	}
 
 	if resp.GetHasResult() {
-		line := "  Last update: " + osUpdateOutcomeLabel(resp.GetOutcome())
+		line := "  " + tui.Dim("Last update:") + " " + styledOSUpdateOutcome(resp.GetOutcome())
 		if resp.GetOldOsVersion() != "" && resp.GetNewOsVersion() != "" {
-			line += fmt.Sprintf(" (%s → %s)", resp.GetOldOsVersion(), resp.GetNewOsVersion())
+			line += " " + tui.Dim(fmt.Sprintf("(%s → %s)", resp.GetOldOsVersion(), resp.GetNewOsVersion()))
 		}
 		b.WriteString(line + "\n")
 		if resp.GetOutcome() != agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMITTED {
-			b.WriteString("  Details: wendy device os update-status\n")
+			b.WriteString("  " + tui.Dim("Details:") + " " + tui.Command("wendy device os update-status") + "\n")
 		}
 	}
 
@@ -52,21 +72,42 @@ func formatOSUpdateSlot(s *agentpb.OSUpdateEngineStatus_Slot) string {
 	if s.GetBooted() {
 		state = "booted"
 	}
-	parts := []string{state}
+	parts := []string{tui.Value(state)}
 	if h := s.GetRootfsHealth(); h != "" {
-		parts = append(parts, "rootfs "+h)
+		style := osUpdateBadStyle
+		if h == "normal" {
+			style = osUpdateGoodStyle
+		}
+		parts = append(parts, tui.Value("rootfs ")+style.Render(h))
 	}
 	if d := s.GetDistro(); d != "" {
-		parts = append(parts, d)
+		parts = append(parts, tui.Value(d))
 	}
 	if r := s.GetRetries(); r != "" {
-		parts = append(parts, "retries "+r)
+		parts = append(parts, tui.Value("retries "+r))
 	}
-	line := fmt.Sprintf("Slot %s: %s", s.GetSlot(), strings.Join(parts, ", "))
+	line := tui.Dim(fmt.Sprintf("Slot %s:", s.GetSlot())) + " " + strings.Join(parts, ", ")
 	if n := s.GetNote(); n != "" {
-		line += " (" + n + ")"
+		line += " " + tui.Dim("("+n+")")
 	}
 	return line
+}
+
+// styledOSUpdateOutcome colors the outcome word by severity: committed green,
+// rolled back amber (the safety net worked), both failure modes red.
+func styledOSUpdateOutcome(o agentpb.GetOSUpdateStatusResponse_Outcome) string {
+	label := osUpdateOutcomeLabel(o)
+	switch o {
+	case agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMITTED:
+		return osUpdateGoodStyle.Render(label)
+	case agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLED_BACK:
+		return osUpdateWarnStyle.Render(label)
+	case agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLBACK_FAILED,
+		agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMIT_FAILED:
+		return osUpdateBadStyle.Render(label)
+	default:
+		return tui.Value(label)
+	}
 }
 
 // osUpdateOutcomeLabel is the compact outcome wording used in `device info`;

--- a/go/internal/cli/commands/device_osupdate.go
+++ b/go/internal/cli/commands/device_osupdate.go
@@ -1,0 +1,159 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// formatOSUpdateInfo renders the OS-update block for `wendy device info`: the
+// live wendyos-update A/B slot snapshot (when the agent returned one) plus a
+// one-line summary of the last recorded update outcome. Returns "" when there
+// is nothing to show, so devices without OTA support keep their old output.
+func formatOSUpdateInfo(resp *agentpb.GetOSUpdateStatusResponse) string {
+	if resp == nil {
+		return ""
+	}
+	engine := resp.GetEngineStatus()
+	if engine == nil && !resp.GetHasResult() {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("OS Update:\n")
+
+	for _, s := range engine.GetSlots() {
+		b.WriteString("  " + formatOSUpdateSlot(s) + "\n")
+	}
+	if p := engine.GetPending(); p != nil {
+		fmt.Fprintf(&b, "  Pending: %s %s (%s, target slot %s)\n",
+			p.GetArtifactName(), p.GetArtifactVersion(), p.GetPhase(), p.GetTargetSlot())
+	}
+
+	if resp.GetHasResult() {
+		line := "  Last update: " + osUpdateOutcomeLabel(resp.GetOutcome())
+		if resp.GetOldOsVersion() != "" && resp.GetNewOsVersion() != "" {
+			line += fmt.Sprintf(" (%s → %s)", resp.GetOldOsVersion(), resp.GetNewOsVersion())
+		}
+		b.WriteString(line + "\n")
+		if resp.GetOutcome() != agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMITTED {
+			b.WriteString("  Details: wendy device os update-status\n")
+		}
+	}
+
+	return b.String()
+}
+
+// formatOSUpdateSlot renders one A/B slot as a single compact line, e.g.
+// "Slot A: booted, rootfs normal, WendyOS 0.17.0".
+func formatOSUpdateSlot(s *agentpb.OSUpdateEngineStatus_Slot) string {
+	state := "inactive"
+	if s.GetBooted() {
+		state = "booted"
+	}
+	parts := []string{state}
+	if h := s.GetRootfsHealth(); h != "" {
+		parts = append(parts, "rootfs "+h)
+	}
+	if d := s.GetDistro(); d != "" {
+		parts = append(parts, d)
+	}
+	if r := s.GetRetries(); r != "" {
+		parts = append(parts, "retries "+r)
+	}
+	line := fmt.Sprintf("Slot %s: %s", s.GetSlot(), strings.Join(parts, ", "))
+	if n := s.GetNote(); n != "" {
+		line += " (" + n + ")"
+	}
+	return line
+}
+
+// osUpdateOutcomeLabel is the compact outcome wording used in `device info`;
+// the full record stays with `wendy device os update-status`.
+func osUpdateOutcomeLabel(o agentpb.GetOSUpdateStatusResponse_Outcome) string {
+	switch o {
+	case agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMITTED:
+		return "committed"
+	case agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLED_BACK:
+		return "rolled back"
+	case agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLBACK_FAILED:
+		return "rollback failed"
+	case agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMIT_FAILED:
+		return "commit failed"
+	default:
+		return "unknown"
+	}
+}
+
+// osUpdateJSON is the `--json` counterpart of formatOSUpdateInfo. Returns nil
+// when there is nothing to report so the key is omitted entirely.
+func osUpdateJSON(resp *agentpb.GetOSUpdateStatusResponse) map[string]any {
+	if resp == nil {
+		return nil
+	}
+	engine := resp.GetEngineStatus()
+	if engine == nil && !resp.GetHasResult() {
+		return nil
+	}
+
+	out := map[string]any{}
+
+	if resp.GetHasResult() {
+		last := map[string]any{
+			"outcome":       osUpdateOutcomeLabel(resp.GetOutcome()),
+			"createdAtUnix": resp.GetCreatedAtUnix(),
+		}
+		if v := resp.GetOldOsVersion(); v != "" {
+			last["oldOsVersion"] = v
+		}
+		if v := resp.GetNewOsVersion(); v != "" {
+			last["newOsVersion"] = v
+		}
+		if n := resp.GetNote(); n != "" {
+			last["note"] = n
+		}
+		out["lastUpdate"] = last
+	}
+
+	if engine != nil {
+		e := map[string]any{
+			"connector":   engine.GetConnector(),
+			"currentSlot": engine.GetCurrentSlot(),
+		}
+		if len(engine.GetSlots()) > 0 {
+			slots := make([]map[string]any, len(engine.GetSlots()))
+			for i, s := range engine.GetSlots() {
+				slots[i] = map[string]any{
+					"slot":         s.GetSlot(),
+					"booted":       s.GetBooted(),
+					"partition":    s.GetPartition(),
+					"distro":       s.GetDistro(),
+					"kernel":       s.GetKernel(),
+					"rootfsHealth": s.GetRootfsHealth(),
+					"retries":      s.GetRetries(),
+					"note":         s.GetNote(),
+				}
+			}
+			e["slots"] = slots
+		}
+		if len(engine.GetSystem()) > 0 {
+			system := make([]map[string]any, len(engine.GetSystem()))
+			for i, kv := range engine.GetSystem() {
+				system[i] = map[string]any{"key": kv.GetKey(), "value": kv.GetValue()}
+			}
+			e["system"] = system
+		}
+		if p := engine.GetPending(); p != nil {
+			e["pending"] = map[string]any{
+				"artifactName":    p.GetArtifactName(),
+				"artifactVersion": p.GetArtifactVersion(),
+				"phase":           p.GetPhase(),
+				"targetSlot":      p.GetTargetSlot(),
+			}
+		}
+		out["engine"] = e
+	}
+
+	return out
+}

--- a/go/internal/cli/commands/device_osupdate_test.go
+++ b/go/internal/cli/commands/device_osupdate_test.go
@@ -1,0 +1,140 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func fullOSUpdateStatus() *agentpb.GetOSUpdateStatusResponse {
+	return &agentpb.GetOSUpdateStatusResponse{
+		HasResult:     true,
+		Outcome:       agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMITTED,
+		OldOsVersion:  "0.16.0",
+		NewOsVersion:  "0.17.0",
+		CreatedAtUnix: 1_750_000_000,
+		EngineStatus: &agentpb.OSUpdateEngineStatus{
+			Connector:   "tegrauefi",
+			CurrentSlot: "A",
+			Slots: []*agentpb.OSUpdateEngineStatus_Slot{
+				{Slot: "A", Booted: true, Partition: "/dev/nvme0n1p1", Distro: "WendyOS 0.17.0", RootfsHealth: "normal"},
+				{Slot: "B", Booted: false, Partition: "/dev/nvme0n1p2", Retries: "2", Note: "trial boot pending"},
+			},
+			System: []*agentpb.OSUpdateEngineStatus_SystemEntry{
+				{Key: "bootloader", Value: "36.3.0"},
+			},
+			Pending: &agentpb.OSUpdateEngineStatus_PendingUpdate{
+				ArtifactName:    "wendyos-jetson",
+				ArtifactVersion: "0.18.0",
+				Phase:           "installed",
+				TargetSlot:      "B",
+			},
+		},
+	}
+}
+
+func TestFormatOSUpdateInfo(t *testing.T) {
+	got := formatOSUpdateInfo(fullOSUpdateStatus())
+
+	for _, want := range []string{
+		"OS Update:\n",
+		"Slot A: booted, rootfs normal, WendyOS 0.17.0",
+		"Slot B: inactive, retries 2 (trial boot pending)",
+		"Pending: wendyos-jetson 0.18.0 (installed, target slot B)",
+		"Last update: committed (0.16.0 → 0.17.0)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatOSUpdateInfo() missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Details:") {
+		t.Errorf("committed outcome should not print the details hint:\n%s", got)
+	}
+}
+
+func TestFormatOSUpdateInfoFailureShowsHint(t *testing.T) {
+	resp := &agentpb.GetOSUpdateStatusResponse{
+		HasResult: true,
+		Outcome:   agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLED_BACK,
+	}
+	got := formatOSUpdateInfo(resp)
+	if !strings.Contains(got, "Last update: rolled back") {
+		t.Errorf("missing rolled-back line:\n%s", got)
+	}
+	if !strings.Contains(got, "wendy device os update-status") {
+		t.Errorf("failure outcome should point at the detailed command:\n%s", got)
+	}
+}
+
+func TestFormatOSUpdateInfoEmpty(t *testing.T) {
+	if got := formatOSUpdateInfo(nil); got != "" {
+		t.Errorf("formatOSUpdateInfo(nil) = %q, want empty", got)
+	}
+	// No record and no engine snapshot (e.g. a mender device with no update
+	// history) — the section must disappear entirely.
+	if got := formatOSUpdateInfo(&agentpb.GetOSUpdateStatusResponse{}); got != "" {
+		t.Errorf("formatOSUpdateInfo(empty) = %q, want empty", got)
+	}
+}
+
+func TestFormatOSUpdateInfoRecordOnly(t *testing.T) {
+	// Old agents (or mender devices) report only the persisted record.
+	resp := &agentpb.GetOSUpdateStatusResponse{
+		HasResult:    true,
+		Outcome:      agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMITTED,
+		OldOsVersion: "0.15.0",
+		NewOsVersion: "0.16.0",
+	}
+	got := formatOSUpdateInfo(resp)
+	if !strings.Contains(got, "Last update: committed (0.15.0 → 0.16.0)") {
+		t.Errorf("missing last-update line:\n%s", got)
+	}
+	if strings.Contains(got, "Slot") || strings.Contains(got, "Pending") {
+		t.Errorf("record-only response should not render slot lines:\n%s", got)
+	}
+}
+
+func TestOSUpdateJSON(t *testing.T) {
+	out := osUpdateJSON(fullOSUpdateStatus())
+	if out == nil {
+		t.Fatal("osUpdateJSON returned nil for a populated response")
+	}
+
+	last, ok := out["lastUpdate"].(map[string]any)
+	if !ok {
+		t.Fatalf("lastUpdate missing: %+v", out)
+	}
+	if last["outcome"] != "committed" || last["oldOsVersion"] != "0.16.0" || last["newOsVersion"] != "0.17.0" {
+		t.Errorf("lastUpdate mapped wrong: %+v", last)
+	}
+
+	engine, ok := out["engine"].(map[string]any)
+	if !ok {
+		t.Fatalf("engine missing: %+v", out)
+	}
+	if engine["connector"] != "tegrauefi" || engine["currentSlot"] != "A" {
+		t.Errorf("engine header mapped wrong: %+v", engine)
+	}
+	slots, ok := engine["slots"].([]map[string]any)
+	if !ok || len(slots) != 2 {
+		t.Fatalf("slots mapped wrong: %+v", engine["slots"])
+	}
+	if slots[0]["slot"] != "A" || slots[0]["booted"] != true || slots[0]["rootfsHealth"] != "normal" {
+		t.Errorf("slot A mapped wrong: %+v", slots[0])
+	}
+	pending, ok := engine["pending"].(map[string]any)
+	if !ok {
+		t.Fatalf("pending missing: %+v", engine)
+	}
+	if pending["artifactVersion"] != "0.18.0" || pending["targetSlot"] != "B" {
+		t.Errorf("pending mapped wrong: %+v", pending)
+	}
+
+	if osUpdateJSON(nil) != nil {
+		t.Error("osUpdateJSON(nil) should be nil")
+	}
+	if osUpdateJSON(&agentpb.GetOSUpdateStatusResponse{}) != nil {
+		t.Error("osUpdateJSON(empty) should be nil")
+	}
+}

--- a/go/proto/gen/agentpb/v2/os_update_service.pb.go
+++ b/go/proto/gen/agentpb/v2/os_update_service.pb.go
@@ -77,7 +77,7 @@ func (x GetOSUpdateStatusResponse_Outcome) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use GetOSUpdateStatusResponse_Outcome.Descriptor instead.
 func (GetOSUpdateStatusResponse_Outcome) EnumDescriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{3, 0}
+	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{4, 0}
 }
 
 type GetOSUpdateStatusResponse_ServiceResult_Status int32
@@ -130,7 +130,7 @@ func (x GetOSUpdateStatusResponse_ServiceResult_Status) Number() protoreflect.En
 
 // Deprecated: Use GetOSUpdateStatusResponse_ServiceResult_Status.Descriptor instead.
 func (GetOSUpdateStatusResponse_ServiceResult_Status) EnumDescriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{3, 0, 0}
+	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{4, 0, 0}
 }
 
 type UpdateOSRequest struct {
@@ -286,9 +286,13 @@ func (*UpdateOSResponse_Completed_) isUpdateOSResponse_ResponseType() {}
 func (*UpdateOSResponse_Failed_) isUpdateOSResponse_ResponseType() {}
 
 type GetOSUpdateStatusRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// When true, the agent additionally probes the OS updater's live status
+	// (`wendyos-update status --json`) and returns it in engine_status. Off by
+	// default because the probe execs a binary on the device.
+	IncludeEngineStatus bool `protobuf:"varint,1,opt,name=include_engine_status,json=includeEngineStatus,proto3" json:"include_engine_status,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *GetOSUpdateStatusRequest) Reset() {
@@ -321,6 +325,94 @@ func (*GetOSUpdateStatusRequest) Descriptor() ([]byte, []int) {
 	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{2}
 }
 
+func (x *GetOSUpdateStatusRequest) GetIncludeEngineStatus() bool {
+	if x != nil {
+		return x.IncludeEngineStatus
+	}
+	return false
+}
+
+// Live A/B-slot snapshot from `wendyos-update status --json` (frozen v1 CLI
+// contract of github.com/wendylabsinc/wendyos-update). Mirrors that contract's
+// field names; all fields are best-effort and may be empty.
+type OSUpdateEngineStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Platform connector driving the A/B scheme, e.g. "tegrauefi" or "ubootenv".
+	Connector string `protobuf:"bytes,1,opt,name=connector,proto3" json:"connector,omitempty"`
+	// Slot the device is currently booted from ("a" or "b").
+	CurrentSlot   string                              `protobuf:"bytes,2,opt,name=current_slot,json=currentSlot,proto3" json:"current_slot,omitempty"`
+	Slots         []*OSUpdateEngineStatus_Slot        `protobuf:"bytes,3,rep,name=slots,proto3" json:"slots,omitempty"`
+	System        []*OSUpdateEngineStatus_SystemEntry `protobuf:"bytes,4,rep,name=system,proto3" json:"system,omitempty"`
+	Pending       *OSUpdateEngineStatus_PendingUpdate `protobuf:"bytes,5,opt,name=pending,proto3" json:"pending,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OSUpdateEngineStatus) Reset() {
+	*x = OSUpdateEngineStatus{}
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OSUpdateEngineStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OSUpdateEngineStatus) ProtoMessage() {}
+
+func (x *OSUpdateEngineStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OSUpdateEngineStatus.ProtoReflect.Descriptor instead.
+func (*OSUpdateEngineStatus) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *OSUpdateEngineStatus) GetConnector() string {
+	if x != nil {
+		return x.Connector
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus) GetCurrentSlot() string {
+	if x != nil {
+		return x.CurrentSlot
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus) GetSlots() []*OSUpdateEngineStatus_Slot {
+	if x != nil {
+		return x.Slots
+	}
+	return nil
+}
+
+func (x *OSUpdateEngineStatus) GetSystem() []*OSUpdateEngineStatus_SystemEntry {
+	if x != nil {
+		return x.System
+	}
+	return nil
+}
+
+func (x *OSUpdateEngineStatus) GetPending() *OSUpdateEngineStatus_PendingUpdate {
+	if x != nil {
+		return x.Pending
+	}
+	return nil
+}
+
 // Outcome of the most recent OS update attempt, produced by the agent's
 // post-reboot healthcheck gate and persisted on the device's data partition
 // (so it survives an A/B slot rollback).
@@ -344,14 +436,18 @@ type GetOSUpdateStatusResponse struct {
 	// Human-readable detail for the outcome. For OUTCOME_COMMIT_FAILED this is
 	// the commit command's failure reason, including the OS updater's output,
 	// so the failure is diagnosable without shell access to the device.
-	Note          string `protobuf:"bytes,9,opt,name=note,proto3" json:"note,omitempty"`
+	Note string `protobuf:"bytes,9,opt,name=note,proto3" json:"note,omitempty"`
+	// Live updater snapshot; set only when the request asked for it via
+	// include_engine_status AND the device uses the wendyos-update engine AND
+	// the probe succeeded. Independent of has_result.
+	EngineStatus  *OSUpdateEngineStatus `protobuf:"bytes,10,opt,name=engine_status,json=engineStatus,proto3" json:"engine_status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetOSUpdateStatusResponse) Reset() {
 	*x = GetOSUpdateStatusResponse{}
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[3]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -363,7 +459,7 @@ func (x *GetOSUpdateStatusResponse) String() string {
 func (*GetOSUpdateStatusResponse) ProtoMessage() {}
 
 func (x *GetOSUpdateStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[3]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -376,7 +472,7 @@ func (x *GetOSUpdateStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOSUpdateStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetOSUpdateStatusResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{3}
+	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *GetOSUpdateStatusResponse) GetHasResult() bool {
@@ -442,6 +538,13 @@ func (x *GetOSUpdateStatusResponse) GetNote() string {
 	return ""
 }
 
+func (x *GetOSUpdateStatusResponse) GetEngineStatus() *OSUpdateEngineStatus {
+	if x != nil {
+		return x.EngineStatus
+	}
+	return nil
+}
+
 type UpdateOSResponse_Progress struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Phase         string                 `protobuf:"bytes,1,opt,name=phase,proto3" json:"phase,omitempty"`
@@ -452,7 +555,7 @@ type UpdateOSResponse_Progress struct {
 
 func (x *UpdateOSResponse_Progress) Reset() {
 	*x = UpdateOSResponse_Progress{}
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[4]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -464,7 +567,7 @@ func (x *UpdateOSResponse_Progress) String() string {
 func (*UpdateOSResponse_Progress) ProtoMessage() {}
 
 func (x *UpdateOSResponse_Progress) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[4]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -503,7 +606,7 @@ type UpdateOSResponse_Completed struct {
 
 func (x *UpdateOSResponse_Completed) Reset() {
 	*x = UpdateOSResponse_Completed{}
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[5]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -515,7 +618,7 @@ func (x *UpdateOSResponse_Completed) String() string {
 func (*UpdateOSResponse_Completed) ProtoMessage() {}
 
 func (x *UpdateOSResponse_Completed) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[5]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -547,7 +650,7 @@ type UpdateOSResponse_Failed struct {
 
 func (x *UpdateOSResponse_Failed) Reset() {
 	*x = UpdateOSResponse_Failed{}
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[6]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -559,7 +662,7 @@ func (x *UpdateOSResponse_Failed) String() string {
 func (*UpdateOSResponse_Failed) ProtoMessage() {}
 
 func (x *UpdateOSResponse_Failed) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[6]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -582,6 +685,239 @@ func (x *UpdateOSResponse_Failed) GetErrorMessage() string {
 	return ""
 }
 
+type OSUpdateEngineStatus_Slot struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Slot name ("a" or "b").
+	Slot string `protobuf:"bytes,1,opt,name=slot,proto3" json:"slot,omitempty"`
+	// True for the slot the device is booted from.
+	Booted bool `protobuf:"varint,2,opt,name=booted,proto3" json:"booted,omitempty"`
+	// Rootfs partition device, e.g. "/dev/nvme0n1p1".
+	Partition string `protobuf:"bytes,3,opt,name=partition,proto3" json:"partition,omitempty"`
+	// Distro version installed in the slot; "" when unreadable.
+	Distro string `protobuf:"bytes,4,opt,name=distro,proto3" json:"distro,omitempty"`
+	// Kernel version installed in the slot; "" when unreadable.
+	Kernel string `protobuf:"bytes,5,opt,name=kernel,proto3" json:"kernel,omitempty"`
+	// Slot health as reported by the bootloader, e.g. "normal".
+	RootfsHealth string `protobuf:"bytes,6,opt,name=rootfs_health,json=rootfsHealth,proto3" json:"rootfs_health,omitempty"`
+	// Remaining boot-trial retries, when the platform tracks them.
+	Retries string `protobuf:"bytes,7,opt,name=retries,proto3" json:"retries,omitempty"`
+	// Free-form platform note about the slot.
+	Note          string `protobuf:"bytes,8,opt,name=note,proto3" json:"note,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OSUpdateEngineStatus_Slot) Reset() {
+	*x = OSUpdateEngineStatus_Slot{}
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OSUpdateEngineStatus_Slot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OSUpdateEngineStatus_Slot) ProtoMessage() {}
+
+func (x *OSUpdateEngineStatus_Slot) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OSUpdateEngineStatus_Slot.ProtoReflect.Descriptor instead.
+func (*OSUpdateEngineStatus_Slot) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{3, 0}
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetSlot() string {
+	if x != nil {
+		return x.Slot
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetBooted() bool {
+	if x != nil {
+		return x.Booted
+	}
+	return false
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetPartition() string {
+	if x != nil {
+		return x.Partition
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetDistro() string {
+	if x != nil {
+		return x.Distro
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetKernel() string {
+	if x != nil {
+		return x.Kernel
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetRootfsHealth() string {
+	if x != nil {
+		return x.RootfsHealth
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetRetries() string {
+	if x != nil {
+		return x.Retries
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetNote() string {
+	if x != nil {
+		return x.Note
+	}
+	return ""
+}
+
+// Ordered system-wide key/value pairs (bootloader version, capsule
+// status, ...) exactly as the engine reports them.
+type OSUpdateEngineStatus_SystemEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value         string                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OSUpdateEngineStatus_SystemEntry) Reset() {
+	*x = OSUpdateEngineStatus_SystemEntry{}
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OSUpdateEngineStatus_SystemEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OSUpdateEngineStatus_SystemEntry) ProtoMessage() {}
+
+func (x *OSUpdateEngineStatus_SystemEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OSUpdateEngineStatus_SystemEntry.ProtoReflect.Descriptor instead.
+func (*OSUpdateEngineStatus_SystemEntry) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{3, 1}
+}
+
+func (x *OSUpdateEngineStatus_SystemEntry) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_SystemEntry) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+// In-flight (uncommitted) update, absent when none is pending.
+type OSUpdateEngineStatus_PendingUpdate struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ArtifactName    string                 `protobuf:"bytes,1,opt,name=artifact_name,json=artifactName,proto3" json:"artifact_name,omitempty"`
+	ArtifactVersion string                 `protobuf:"bytes,2,opt,name=artifact_version,json=artifactVersion,proto3" json:"artifact_version,omitempty"`
+	// Engine phase, e.g. "installed" (awaiting reboot + commit).
+	Phase string `protobuf:"bytes,3,opt,name=phase,proto3" json:"phase,omitempty"`
+	// Slot the update was written to ("a" or "b").
+	TargetSlot    string `protobuf:"bytes,4,opt,name=target_slot,json=targetSlot,proto3" json:"target_slot,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) Reset() {
+	*x = OSUpdateEngineStatus_PendingUpdate{}
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OSUpdateEngineStatus_PendingUpdate) ProtoMessage() {}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OSUpdateEngineStatus_PendingUpdate.ProtoReflect.Descriptor instead.
+func (*OSUpdateEngineStatus_PendingUpdate) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{3, 2}
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) GetArtifactName() string {
+	if x != nil {
+		return x.ArtifactName
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) GetArtifactVersion() string {
+	if x != nil {
+		return x.ArtifactVersion
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) GetPhase() string {
+	if x != nil {
+		return x.Phase
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) GetTargetSlot() string {
+	if x != nil {
+		return x.TargetSlot
+	}
+	return ""
+}
+
 type GetOSUpdateStatusResponse_ServiceResult struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// systemd unit name, e.g. "avahi-daemon.service"
@@ -595,7 +931,7 @@ type GetOSUpdateStatusResponse_ServiceResult struct {
 
 func (x *GetOSUpdateStatusResponse_ServiceResult) Reset() {
 	*x = GetOSUpdateStatusResponse_ServiceResult{}
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[7]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -607,7 +943,7 @@ func (x *GetOSUpdateStatusResponse_ServiceResult) String() string {
 func (*GetOSUpdateStatusResponse_ServiceResult) ProtoMessage() {}
 
 func (x *GetOSUpdateStatusResponse_ServiceResult) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[7]
+	mi := &file_wendy_agent_services_v2_os_update_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -620,7 +956,7 @@ func (x *GetOSUpdateStatusResponse_ServiceResult) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use GetOSUpdateStatusResponse_ServiceResult.ProtoReflect.Descriptor instead.
 func (*GetOSUpdateStatusResponse_ServiceResult) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{3, 0}
+	return file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP(), []int{4, 0}
 }
 
 func (x *GetOSUpdateStatusResponse_ServiceResult) GetUnit() string {
@@ -663,8 +999,33 @@ const file_wendy_agent_services_v2_os_update_service_proto_rawDesc = "" +
 	"\x0freboot_required\x18\x01 \x01(\bR\x0erebootRequired\x1a-\n" +
 	"\x06Failed\x12#\n" +
 	"\rerror_message\x18\x01 \x01(\tR\ferrorMessageB\x0f\n" +
-	"\rresponse_type\"\x1a\n" +
-	"\x18GetOSUpdateStatusRequest\"\xd2\x06\n" +
+	"\rresponse_type\"N\n" +
+	"\x18GetOSUpdateStatusRequest\x122\n" +
+	"\x15include_engine_status\x18\x01 \x01(\bR\x13includeEngineStatus\"\xf1\x05\n" +
+	"\x14OSUpdateEngineStatus\x12\x1c\n" +
+	"\tconnector\x18\x01 \x01(\tR\tconnector\x12!\n" +
+	"\fcurrent_slot\x18\x02 \x01(\tR\vcurrentSlot\x12H\n" +
+	"\x05slots\x18\x03 \x03(\v22.wendy.agent.services.v2.OSUpdateEngineStatus.SlotR\x05slots\x12Q\n" +
+	"\x06system\x18\x04 \x03(\v29.wendy.agent.services.v2.OSUpdateEngineStatus.SystemEntryR\x06system\x12U\n" +
+	"\apending\x18\x05 \x01(\v2;.wendy.agent.services.v2.OSUpdateEngineStatus.PendingUpdateR\apending\x1a\xd3\x01\n" +
+	"\x04Slot\x12\x12\n" +
+	"\x04slot\x18\x01 \x01(\tR\x04slot\x12\x16\n" +
+	"\x06booted\x18\x02 \x01(\bR\x06booted\x12\x1c\n" +
+	"\tpartition\x18\x03 \x01(\tR\tpartition\x12\x16\n" +
+	"\x06distro\x18\x04 \x01(\tR\x06distro\x12\x16\n" +
+	"\x06kernel\x18\x05 \x01(\tR\x06kernel\x12#\n" +
+	"\rrootfs_health\x18\x06 \x01(\tR\frootfsHealth\x12\x18\n" +
+	"\aretries\x18\a \x01(\tR\aretries\x12\x12\n" +
+	"\x04note\x18\b \x01(\tR\x04note\x1a5\n" +
+	"\vSystemEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\x1a\x96\x01\n" +
+	"\rPendingUpdate\x12#\n" +
+	"\rartifact_name\x18\x01 \x01(\tR\fartifactName\x12)\n" +
+	"\x10artifact_version\x18\x02 \x01(\tR\x0fartifactVersion\x12\x14\n" +
+	"\x05phase\x18\x03 \x01(\tR\x05phase\x12\x1f\n" +
+	"\vtarget_slot\x18\x04 \x01(\tR\n" +
+	"targetSlot\"\xa6\a\n" +
 	"\x19GetOSUpdateStatusResponse\x12\x1d\n" +
 	"\n" +
 	"has_result\x18\x01 \x01(\bR\thasResult\x12T\n" +
@@ -675,7 +1036,9 @@ const file_wendy_agent_services_v2_os_update_service_proto_rawDesc = "" +
 	"\x0fcreated_at_unix\x18\x06 \x01(\x03R\rcreatedAtUnix\x12*\n" +
 	"\x11finalized_at_unix\x18\a \x01(\x03R\x0ffinalizedAtUnix\x12%\n" +
 	"\x0erollback_error\x18\b \x01(\tR\rrollbackError\x12\x12\n" +
-	"\x04note\x18\t \x01(\tR\x04note\x1a\xf9\x01\n" +
+	"\x04note\x18\t \x01(\tR\x04note\x12R\n" +
+	"\rengine_status\x18\n" +
+	" \x01(\v2-.wendy.agent.services.v2.OSUpdateEngineStatusR\fengineStatus\x1a\xf9\x01\n" +
 	"\rServiceResult\x12\x12\n" +
 	"\x04unit\x18\x01 \x01(\tR\x04unit\x12_\n" +
 	"\x06status\x18\x02 \x01(\x0e2G.wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult.StatusR\x06status\x12\x16\n" +
@@ -708,35 +1071,43 @@ func file_wendy_agent_services_v2_os_update_service_proto_rawDescGZIP() []byte {
 }
 
 var file_wendy_agent_services_v2_os_update_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_wendy_agent_services_v2_os_update_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_wendy_agent_services_v2_os_update_service_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_wendy_agent_services_v2_os_update_service_proto_goTypes = []any{
 	(GetOSUpdateStatusResponse_Outcome)(0),              // 0: wendy.agent.services.v2.GetOSUpdateStatusResponse.Outcome
 	(GetOSUpdateStatusResponse_ServiceResult_Status)(0), // 1: wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult.Status
 	(*UpdateOSRequest)(nil),                             // 2: wendy.agent.services.v2.UpdateOSRequest
 	(*UpdateOSResponse)(nil),                            // 3: wendy.agent.services.v2.UpdateOSResponse
 	(*GetOSUpdateStatusRequest)(nil),                    // 4: wendy.agent.services.v2.GetOSUpdateStatusRequest
-	(*GetOSUpdateStatusResponse)(nil),                   // 5: wendy.agent.services.v2.GetOSUpdateStatusResponse
-	(*UpdateOSResponse_Progress)(nil),                   // 6: wendy.agent.services.v2.UpdateOSResponse.Progress
-	(*UpdateOSResponse_Completed)(nil),                  // 7: wendy.agent.services.v2.UpdateOSResponse.Completed
-	(*UpdateOSResponse_Failed)(nil),                     // 8: wendy.agent.services.v2.UpdateOSResponse.Failed
-	(*GetOSUpdateStatusResponse_ServiceResult)(nil),     // 9: wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult
+	(*OSUpdateEngineStatus)(nil),                        // 5: wendy.agent.services.v2.OSUpdateEngineStatus
+	(*GetOSUpdateStatusResponse)(nil),                   // 6: wendy.agent.services.v2.GetOSUpdateStatusResponse
+	(*UpdateOSResponse_Progress)(nil),                   // 7: wendy.agent.services.v2.UpdateOSResponse.Progress
+	(*UpdateOSResponse_Completed)(nil),                  // 8: wendy.agent.services.v2.UpdateOSResponse.Completed
+	(*UpdateOSResponse_Failed)(nil),                     // 9: wendy.agent.services.v2.UpdateOSResponse.Failed
+	(*OSUpdateEngineStatus_Slot)(nil),                   // 10: wendy.agent.services.v2.OSUpdateEngineStatus.Slot
+	(*OSUpdateEngineStatus_SystemEntry)(nil),            // 11: wendy.agent.services.v2.OSUpdateEngineStatus.SystemEntry
+	(*OSUpdateEngineStatus_PendingUpdate)(nil),          // 12: wendy.agent.services.v2.OSUpdateEngineStatus.PendingUpdate
+	(*GetOSUpdateStatusResponse_ServiceResult)(nil),     // 13: wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult
 }
 var file_wendy_agent_services_v2_os_update_service_proto_depIdxs = []int32{
-	6, // 0: wendy.agent.services.v2.UpdateOSResponse.progress:type_name -> wendy.agent.services.v2.UpdateOSResponse.Progress
-	7, // 1: wendy.agent.services.v2.UpdateOSResponse.completed:type_name -> wendy.agent.services.v2.UpdateOSResponse.Completed
-	8, // 2: wendy.agent.services.v2.UpdateOSResponse.failed:type_name -> wendy.agent.services.v2.UpdateOSResponse.Failed
-	0, // 3: wendy.agent.services.v2.GetOSUpdateStatusResponse.outcome:type_name -> wendy.agent.services.v2.GetOSUpdateStatusResponse.Outcome
-	9, // 4: wendy.agent.services.v2.GetOSUpdateStatusResponse.services:type_name -> wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult
-	1, // 5: wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult.status:type_name -> wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult.Status
-	2, // 6: wendy.agent.services.v2.WendyOSUpdateService.UpdateOS:input_type -> wendy.agent.services.v2.UpdateOSRequest
-	4, // 7: wendy.agent.services.v2.WendyOSUpdateService.GetOSUpdateStatus:input_type -> wendy.agent.services.v2.GetOSUpdateStatusRequest
-	3, // 8: wendy.agent.services.v2.WendyOSUpdateService.UpdateOS:output_type -> wendy.agent.services.v2.UpdateOSResponse
-	5, // 9: wendy.agent.services.v2.WendyOSUpdateService.GetOSUpdateStatus:output_type -> wendy.agent.services.v2.GetOSUpdateStatusResponse
-	8, // [8:10] is the sub-list for method output_type
-	6, // [6:8] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	7,  // 0: wendy.agent.services.v2.UpdateOSResponse.progress:type_name -> wendy.agent.services.v2.UpdateOSResponse.Progress
+	8,  // 1: wendy.agent.services.v2.UpdateOSResponse.completed:type_name -> wendy.agent.services.v2.UpdateOSResponse.Completed
+	9,  // 2: wendy.agent.services.v2.UpdateOSResponse.failed:type_name -> wendy.agent.services.v2.UpdateOSResponse.Failed
+	10, // 3: wendy.agent.services.v2.OSUpdateEngineStatus.slots:type_name -> wendy.agent.services.v2.OSUpdateEngineStatus.Slot
+	11, // 4: wendy.agent.services.v2.OSUpdateEngineStatus.system:type_name -> wendy.agent.services.v2.OSUpdateEngineStatus.SystemEntry
+	12, // 5: wendy.agent.services.v2.OSUpdateEngineStatus.pending:type_name -> wendy.agent.services.v2.OSUpdateEngineStatus.PendingUpdate
+	0,  // 6: wendy.agent.services.v2.GetOSUpdateStatusResponse.outcome:type_name -> wendy.agent.services.v2.GetOSUpdateStatusResponse.Outcome
+	13, // 7: wendy.agent.services.v2.GetOSUpdateStatusResponse.services:type_name -> wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult
+	5,  // 8: wendy.agent.services.v2.GetOSUpdateStatusResponse.engine_status:type_name -> wendy.agent.services.v2.OSUpdateEngineStatus
+	1,  // 9: wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult.status:type_name -> wendy.agent.services.v2.GetOSUpdateStatusResponse.ServiceResult.Status
+	2,  // 10: wendy.agent.services.v2.WendyOSUpdateService.UpdateOS:input_type -> wendy.agent.services.v2.UpdateOSRequest
+	4,  // 11: wendy.agent.services.v2.WendyOSUpdateService.GetOSUpdateStatus:input_type -> wendy.agent.services.v2.GetOSUpdateStatusRequest
+	3,  // 12: wendy.agent.services.v2.WendyOSUpdateService.UpdateOS:output_type -> wendy.agent.services.v2.UpdateOSResponse
+	6,  // 13: wendy.agent.services.v2.WendyOSUpdateService.GetOSUpdateStatus:output_type -> wendy.agent.services.v2.GetOSUpdateStatusResponse
+	12, // [12:14] is the sub-list for method output_type
+	10, // [10:12] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_wendy_agent_services_v2_os_update_service_proto_init() }
@@ -755,7 +1126,7 @@ func file_wendy_agent_services_v2_os_update_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v2_os_update_service_proto_rawDesc), len(file_wendy_agent_services_v2_os_update_service_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   8,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/agentpb/v2/os_update_service.pb.go
+++ b/go/proto/gen/agentpb/v2/os_update_service.pb.go
@@ -339,7 +339,7 @@ type OSUpdateEngineStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Platform connector driving the A/B scheme, e.g. "tegrauefi" or "ubootenv".
 	Connector string `protobuf:"bytes,1,opt,name=connector,proto3" json:"connector,omitempty"`
-	// Slot the device is currently booted from ("a" or "b").
+	// Slot the device is currently booted from ("A" or "B").
 	CurrentSlot   string                              `protobuf:"bytes,2,opt,name=current_slot,json=currentSlot,proto3" json:"current_slot,omitempty"`
 	Slots         []*OSUpdateEngineStatus_Slot        `protobuf:"bytes,3,rep,name=slots,proto3" json:"slots,omitempty"`
 	System        []*OSUpdateEngineStatus_SystemEntry `protobuf:"bytes,4,rep,name=system,proto3" json:"system,omitempty"`
@@ -687,7 +687,7 @@ func (x *UpdateOSResponse_Failed) GetErrorMessage() string {
 
 type OSUpdateEngineStatus_Slot struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Slot name ("a" or "b").
+	// Slot name ("A" or "B").
 	Slot string `protobuf:"bytes,1,opt,name=slot,proto3" json:"slot,omitempty"`
 	// True for the slot the device is booted from.
 	Booted bool `protobuf:"varint,2,opt,name=booted,proto3" json:"booted,omitempty"`
@@ -854,7 +854,7 @@ type OSUpdateEngineStatus_PendingUpdate struct {
 	ArtifactVersion string                 `protobuf:"bytes,2,opt,name=artifact_version,json=artifactVersion,proto3" json:"artifact_version,omitempty"`
 	// Engine phase, e.g. "installed" (awaiting reboot + commit).
 	Phase string `protobuf:"bytes,3,opt,name=phase,proto3" json:"phase,omitempty"`
-	// Slot the update was written to ("a" or "b").
+	// Slot the update was written to ("A" or "B").
 	TargetSlot    string `protobuf:"bytes,4,opt,name=target_slot,json=targetSlot,proto3" json:"target_slot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/go/proto/gen/agentpb/wendy_agent_v1_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_service.pb.go
@@ -139,7 +139,7 @@ func (x GetOSUpdateStatusResponse_Outcome) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use GetOSUpdateStatusResponse_Outcome.Descriptor instead.
 func (GetOSUpdateStatusResponse_Outcome) EnumDescriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{41, 0}
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{42, 0}
 }
 
 type GetOSUpdateStatusResponse_ServiceResult_Status int32
@@ -192,7 +192,7 @@ func (x GetOSUpdateStatusResponse_ServiceResult_Status) Number() protoreflect.En
 
 // Deprecated: Use GetOSUpdateStatusResponse_ServiceResult_Status.Descriptor instead.
 func (GetOSUpdateStatusResponse_ServiceResult_Status) EnumDescriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{41, 0, 0}
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{42, 0, 0}
 }
 
 type RunContainerRequest struct {
@@ -2564,9 +2564,13 @@ func (x *KernelLogRecord) GetMessage() string {
 }
 
 type GetOSUpdateStatusRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// When true, the agent additionally probes the OS updater's live status
+	// (`wendyos-update status --json`) and returns it in engine_status. Off by
+	// default because the probe execs a binary on the device.
+	IncludeEngineStatus bool `protobuf:"varint,1,opt,name=include_engine_status,json=includeEngineStatus,proto3" json:"include_engine_status,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *GetOSUpdateStatusRequest) Reset() {
@@ -2599,6 +2603,94 @@ func (*GetOSUpdateStatusRequest) Descriptor() ([]byte, []int) {
 	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{40}
 }
 
+func (x *GetOSUpdateStatusRequest) GetIncludeEngineStatus() bool {
+	if x != nil {
+		return x.IncludeEngineStatus
+	}
+	return false
+}
+
+// Live A/B-slot snapshot from `wendyos-update status --json` (frozen v1 CLI
+// contract of github.com/wendylabsinc/wendyos-update). Mirrors that contract's
+// field names; all fields are best-effort and may be empty.
+type OSUpdateEngineStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Platform connector driving the A/B scheme, e.g. "tegrauefi" or "ubootenv".
+	Connector string `protobuf:"bytes,1,opt,name=connector,proto3" json:"connector,omitempty"`
+	// Slot the device is currently booted from ("a" or "b").
+	CurrentSlot   string                              `protobuf:"bytes,2,opt,name=current_slot,json=currentSlot,proto3" json:"current_slot,omitempty"`
+	Slots         []*OSUpdateEngineStatus_Slot        `protobuf:"bytes,3,rep,name=slots,proto3" json:"slots,omitempty"`
+	System        []*OSUpdateEngineStatus_SystemEntry `protobuf:"bytes,4,rep,name=system,proto3" json:"system,omitempty"`
+	Pending       *OSUpdateEngineStatus_PendingUpdate `protobuf:"bytes,5,opt,name=pending,proto3" json:"pending,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OSUpdateEngineStatus) Reset() {
+	*x = OSUpdateEngineStatus{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OSUpdateEngineStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OSUpdateEngineStatus) ProtoMessage() {}
+
+func (x *OSUpdateEngineStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OSUpdateEngineStatus.ProtoReflect.Descriptor instead.
+func (*OSUpdateEngineStatus) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *OSUpdateEngineStatus) GetConnector() string {
+	if x != nil {
+		return x.Connector
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus) GetCurrentSlot() string {
+	if x != nil {
+		return x.CurrentSlot
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus) GetSlots() []*OSUpdateEngineStatus_Slot {
+	if x != nil {
+		return x.Slots
+	}
+	return nil
+}
+
+func (x *OSUpdateEngineStatus) GetSystem() []*OSUpdateEngineStatus_SystemEntry {
+	if x != nil {
+		return x.System
+	}
+	return nil
+}
+
+func (x *OSUpdateEngineStatus) GetPending() *OSUpdateEngineStatus_PendingUpdate {
+	if x != nil {
+		return x.Pending
+	}
+	return nil
+}
+
 // Outcome of the most recent OS update attempt, produced by the agent's
 // post-reboot healthcheck gate and persisted on the device's data partition
 // (so it survives an A/B slot rollback).
@@ -2622,14 +2714,18 @@ type GetOSUpdateStatusResponse struct {
 	// Human-readable detail for the outcome. For OUTCOME_COMMIT_FAILED this is
 	// the commit command's failure reason, including the OS updater's output,
 	// so the failure is diagnosable without shell access to the device.
-	Note          string `protobuf:"bytes,9,opt,name=note,proto3" json:"note,omitempty"`
+	Note string `protobuf:"bytes,9,opt,name=note,proto3" json:"note,omitempty"`
+	// Live updater snapshot; set only when the request asked for it via
+	// include_engine_status AND the device uses the wendyos-update engine AND
+	// the probe succeeded. Independent of has_result.
+	EngineStatus  *OSUpdateEngineStatus `protobuf:"bytes,10,opt,name=engine_status,json=engineStatus,proto3" json:"engine_status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetOSUpdateStatusResponse) Reset() {
 	*x = GetOSUpdateStatusResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[41]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2641,7 +2737,7 @@ func (x *GetOSUpdateStatusResponse) String() string {
 func (*GetOSUpdateStatusResponse) ProtoMessage() {}
 
 func (x *GetOSUpdateStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[41]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2654,7 +2750,7 @@ func (x *GetOSUpdateStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOSUpdateStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetOSUpdateStatusResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{41}
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *GetOSUpdateStatusResponse) GetHasResult() bool {
@@ -2720,6 +2816,13 @@ func (x *GetOSUpdateStatusResponse) GetNote() string {
 	return ""
 }
 
+func (x *GetOSUpdateStatusResponse) GetEngineStatus() *OSUpdateEngineStatus {
+	if x != nil {
+		return x.EngineStatus
+	}
+	return nil
+}
+
 type SetHostnameRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The literal hostname to apply. Must be a valid DNS label: starts with a
@@ -2732,7 +2835,7 @@ type SetHostnameRequest struct {
 
 func (x *SetHostnameRequest) Reset() {
 	*x = SetHostnameRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[42]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2744,7 +2847,7 @@ func (x *SetHostnameRequest) String() string {
 func (*SetHostnameRequest) ProtoMessage() {}
 
 func (x *SetHostnameRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[42]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2757,7 +2860,7 @@ func (x *SetHostnameRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetHostnameRequest.ProtoReflect.Descriptor instead.
 func (*SetHostnameRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{42}
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *SetHostnameRequest) GetHostname() string {
@@ -2777,7 +2880,7 @@ type SetHostnameResponse struct {
 
 func (x *SetHostnameResponse) Reset() {
 	*x = SetHostnameResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[43]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2789,7 +2892,7 @@ func (x *SetHostnameResponse) String() string {
 func (*SetHostnameResponse) ProtoMessage() {}
 
 func (x *SetHostnameResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[43]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2802,7 +2905,7 @@ func (x *SetHostnameResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetHostnameResponse.ProtoReflect.Descriptor instead.
 func (*SetHostnameResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{43}
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *SetHostnameResponse) GetHostname() string {
@@ -2826,7 +2929,7 @@ type RunContainerRequest_Header struct {
 
 func (x *RunContainerRequest_Header) Reset() {
 	*x = RunContainerRequest_Header{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[44]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2838,7 +2941,7 @@ func (x *RunContainerRequest_Header) String() string {
 func (*RunContainerRequest_Header) ProtoMessage() {}
 
 func (x *RunContainerRequest_Header) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[44]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2885,7 +2988,7 @@ type RunContainerRequest_Chunk struct {
 
 func (x *RunContainerRequest_Chunk) Reset() {
 	*x = RunContainerRequest_Chunk{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[45]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2897,7 +3000,7 @@ func (x *RunContainerRequest_Chunk) String() string {
 func (*RunContainerRequest_Chunk) ProtoMessage() {}
 
 func (x *RunContainerRequest_Chunk) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[45]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2932,7 +3035,7 @@ type ControlCommand_Run struct {
 
 func (x *ControlCommand_Run) Reset() {
 	*x = ControlCommand_Run{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[46]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2944,7 +3047,7 @@ func (x *ControlCommand_Run) String() string {
 func (*ControlCommand_Run) ProtoMessage() {}
 
 func (x *ControlCommand_Run) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[46]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2982,7 +3085,7 @@ type ControlCommand_Stop struct {
 
 func (x *ControlCommand_Stop) Reset() {
 	*x = ControlCommand_Stop{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[47]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2994,7 +3097,7 @@ func (x *ControlCommand_Stop) String() string {
 func (*ControlCommand_Stop) ProtoMessage() {}
 
 func (x *ControlCommand_Stop) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[47]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3021,7 +3124,7 @@ type RunContainerResponse_Started struct {
 
 func (x *RunContainerResponse_Started) Reset() {
 	*x = RunContainerResponse_Started{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[48]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3033,7 +3136,7 @@ func (x *RunContainerResponse_Started) String() string {
 func (*RunContainerResponse_Started) ProtoMessage() {}
 
 func (x *RunContainerResponse_Started) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[48]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3064,7 +3167,7 @@ type RunContainerResponse_Stopped struct {
 
 func (x *RunContainerResponse_Stopped) Reset() {
 	*x = RunContainerResponse_Stopped{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[49]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3076,7 +3179,7 @@ func (x *RunContainerResponse_Stopped) String() string {
 func (*RunContainerResponse_Stopped) ProtoMessage() {}
 
 func (x *RunContainerResponse_Stopped) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[49]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3102,7 +3205,7 @@ type RunContainerResponse_ConsoleOutput struct {
 
 func (x *RunContainerResponse_ConsoleOutput) Reset() {
 	*x = RunContainerResponse_ConsoleOutput{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[50]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3114,7 +3217,7 @@ func (x *RunContainerResponse_ConsoleOutput) String() string {
 func (*RunContainerResponse_ConsoleOutput) ProtoMessage() {}
 
 func (x *RunContainerResponse_ConsoleOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[50]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3146,7 +3249,7 @@ type UpdateAgentRequest_Chunk struct {
 
 func (x *UpdateAgentRequest_Chunk) Reset() {
 	*x = UpdateAgentRequest_Chunk{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[51]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3158,7 +3261,7 @@ func (x *UpdateAgentRequest_Chunk) String() string {
 func (*UpdateAgentRequest_Chunk) ProtoMessage() {}
 
 func (x *UpdateAgentRequest_Chunk) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[51]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3193,7 +3296,7 @@ type UpdateAgentRequest_ControlCommand struct {
 
 func (x *UpdateAgentRequest_ControlCommand) Reset() {
 	*x = UpdateAgentRequest_ControlCommand{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[52]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3205,7 +3308,7 @@ func (x *UpdateAgentRequest_ControlCommand) String() string {
 func (*UpdateAgentRequest_ControlCommand) ProtoMessage() {}
 
 func (x *UpdateAgentRequest_ControlCommand) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[52]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3257,7 +3360,7 @@ type UpdateAgentRequest_ControlCommand_Update struct {
 
 func (x *UpdateAgentRequest_ControlCommand_Update) Reset() {
 	*x = UpdateAgentRequest_ControlCommand_Update{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[53]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3269,7 +3372,7 @@ func (x *UpdateAgentRequest_ControlCommand_Update) String() string {
 func (*UpdateAgentRequest_ControlCommand_Update) ProtoMessage() {}
 
 func (x *UpdateAgentRequest_ControlCommand_Update) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[53]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3300,7 +3403,7 @@ type UpdateAgentResponse_Updated struct {
 
 func (x *UpdateAgentResponse_Updated) Reset() {
 	*x = UpdateAgentResponse_Updated{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[54]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3312,7 +3415,7 @@ func (x *UpdateAgentResponse_Updated) String() string {
 func (*UpdateAgentResponse_Updated) ProtoMessage() {}
 
 func (x *UpdateAgentResponse_Updated) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[54]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3353,7 +3456,7 @@ type ListWiFiNetworksResponse_WiFiNetwork struct {
 
 func (x *ListWiFiNetworksResponse_WiFiNetwork) Reset() {
 	*x = ListWiFiNetworksResponse_WiFiNetwork{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[55]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3365,7 +3468,7 @@ func (x *ListWiFiNetworksResponse_WiFiNetwork) String() string {
 func (*ListWiFiNetworksResponse_WiFiNetwork) ProtoMessage() {}
 
 func (x *ListWiFiNetworksResponse_WiFiNetwork) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[55]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3446,7 +3549,7 @@ type ListKnownWiFiNetworksResponse_KnownWiFiNetwork struct {
 
 func (x *ListKnownWiFiNetworksResponse_KnownWiFiNetwork) Reset() {
 	*x = ListKnownWiFiNetworksResponse_KnownWiFiNetwork{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[56]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3458,7 +3561,7 @@ func (x *ListKnownWiFiNetworksResponse_KnownWiFiNetwork) String() string {
 func (*ListKnownWiFiNetworksResponse_KnownWiFiNetwork) ProtoMessage() {}
 
 func (x *ListKnownWiFiNetworksResponse_KnownWiFiNetwork) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[56]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3519,7 +3622,7 @@ type ListHardwareCapabilitiesResponse_HardwareCapability struct {
 
 func (x *ListHardwareCapabilitiesResponse_HardwareCapability) Reset() {
 	*x = ListHardwareCapabilitiesResponse_HardwareCapability{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[57]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3531,7 +3634,7 @@ func (x *ListHardwareCapabilitiesResponse_HardwareCapability) String() string {
 func (*ListHardwareCapabilitiesResponse_HardwareCapability) ProtoMessage() {}
 
 func (x *ListHardwareCapabilitiesResponse_HardwareCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[57]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3587,7 +3690,7 @@ type UpdateOSResponse_Progress struct {
 
 func (x *UpdateOSResponse_Progress) Reset() {
 	*x = UpdateOSResponse_Progress{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[59]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3599,7 +3702,7 @@ func (x *UpdateOSResponse_Progress) String() string {
 func (*UpdateOSResponse_Progress) ProtoMessage() {}
 
 func (x *UpdateOSResponse_Progress) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[59]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3639,7 +3742,7 @@ type UpdateOSResponse_Completed struct {
 
 func (x *UpdateOSResponse_Completed) Reset() {
 	*x = UpdateOSResponse_Completed{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[60]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3651,7 +3754,7 @@ func (x *UpdateOSResponse_Completed) String() string {
 func (*UpdateOSResponse_Completed) ProtoMessage() {}
 
 func (x *UpdateOSResponse_Completed) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[60]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3684,7 +3787,7 @@ type UpdateOSResponse_Failed struct {
 
 func (x *UpdateOSResponse_Failed) Reset() {
 	*x = UpdateOSResponse_Failed{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[61]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3696,7 +3799,7 @@ func (x *UpdateOSResponse_Failed) String() string {
 func (*UpdateOSResponse_Failed) ProtoMessage() {}
 
 func (x *UpdateOSResponse_Failed) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[61]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3719,6 +3822,239 @@ func (x *UpdateOSResponse_Failed) GetErrorMessage() string {
 	return ""
 }
 
+type OSUpdateEngineStatus_Slot struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Slot name ("a" or "b").
+	Slot string `protobuf:"bytes,1,opt,name=slot,proto3" json:"slot,omitempty"`
+	// True for the slot the device is booted from.
+	Booted bool `protobuf:"varint,2,opt,name=booted,proto3" json:"booted,omitempty"`
+	// Rootfs partition device, e.g. "/dev/nvme0n1p1".
+	Partition string `protobuf:"bytes,3,opt,name=partition,proto3" json:"partition,omitempty"`
+	// Distro version installed in the slot; "" when unreadable.
+	Distro string `protobuf:"bytes,4,opt,name=distro,proto3" json:"distro,omitempty"`
+	// Kernel version installed in the slot; "" when unreadable.
+	Kernel string `protobuf:"bytes,5,opt,name=kernel,proto3" json:"kernel,omitempty"`
+	// Slot health as reported by the bootloader, e.g. "normal".
+	RootfsHealth string `protobuf:"bytes,6,opt,name=rootfs_health,json=rootfsHealth,proto3" json:"rootfs_health,omitempty"`
+	// Remaining boot-trial retries, when the platform tracks them.
+	Retries string `protobuf:"bytes,7,opt,name=retries,proto3" json:"retries,omitempty"`
+	// Free-form platform note about the slot.
+	Note          string `protobuf:"bytes,8,opt,name=note,proto3" json:"note,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OSUpdateEngineStatus_Slot) Reset() {
+	*x = OSUpdateEngineStatus_Slot{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[63]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OSUpdateEngineStatus_Slot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OSUpdateEngineStatus_Slot) ProtoMessage() {}
+
+func (x *OSUpdateEngineStatus_Slot) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[63]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OSUpdateEngineStatus_Slot.ProtoReflect.Descriptor instead.
+func (*OSUpdateEngineStatus_Slot) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{41, 0}
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetSlot() string {
+	if x != nil {
+		return x.Slot
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetBooted() bool {
+	if x != nil {
+		return x.Booted
+	}
+	return false
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetPartition() string {
+	if x != nil {
+		return x.Partition
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetDistro() string {
+	if x != nil {
+		return x.Distro
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetKernel() string {
+	if x != nil {
+		return x.Kernel
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetRootfsHealth() string {
+	if x != nil {
+		return x.RootfsHealth
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetRetries() string {
+	if x != nil {
+		return x.Retries
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_Slot) GetNote() string {
+	if x != nil {
+		return x.Note
+	}
+	return ""
+}
+
+// Ordered system-wide key/value pairs (bootloader version, capsule
+// status, ...) exactly as the engine reports them.
+type OSUpdateEngineStatus_SystemEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value         string                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OSUpdateEngineStatus_SystemEntry) Reset() {
+	*x = OSUpdateEngineStatus_SystemEntry{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OSUpdateEngineStatus_SystemEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OSUpdateEngineStatus_SystemEntry) ProtoMessage() {}
+
+func (x *OSUpdateEngineStatus_SystemEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OSUpdateEngineStatus_SystemEntry.ProtoReflect.Descriptor instead.
+func (*OSUpdateEngineStatus_SystemEntry) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{41, 1}
+}
+
+func (x *OSUpdateEngineStatus_SystemEntry) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_SystemEntry) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+// In-flight (uncommitted) update, absent when none is pending.
+type OSUpdateEngineStatus_PendingUpdate struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ArtifactName    string                 `protobuf:"bytes,1,opt,name=artifact_name,json=artifactName,proto3" json:"artifact_name,omitempty"`
+	ArtifactVersion string                 `protobuf:"bytes,2,opt,name=artifact_version,json=artifactVersion,proto3" json:"artifact_version,omitempty"`
+	// Engine phase, e.g. "installed" (awaiting reboot + commit).
+	Phase string `protobuf:"bytes,3,opt,name=phase,proto3" json:"phase,omitempty"`
+	// Slot the update was written to ("a" or "b").
+	TargetSlot    string `protobuf:"bytes,4,opt,name=target_slot,json=targetSlot,proto3" json:"target_slot,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) Reset() {
+	*x = OSUpdateEngineStatus_PendingUpdate{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OSUpdateEngineStatus_PendingUpdate) ProtoMessage() {}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OSUpdateEngineStatus_PendingUpdate.ProtoReflect.Descriptor instead.
+func (*OSUpdateEngineStatus_PendingUpdate) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{41, 2}
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) GetArtifactName() string {
+	if x != nil {
+		return x.ArtifactName
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) GetArtifactVersion() string {
+	if x != nil {
+		return x.ArtifactVersion
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) GetPhase() string {
+	if x != nil {
+		return x.Phase
+	}
+	return ""
+}
+
+func (x *OSUpdateEngineStatus_PendingUpdate) GetTargetSlot() string {
+	if x != nil {
+		return x.TargetSlot
+	}
+	return ""
+}
+
 type GetOSUpdateStatusResponse_ServiceResult struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// systemd unit name, e.g. "avahi-daemon.service"
@@ -3732,7 +4068,7 @@ type GetOSUpdateStatusResponse_ServiceResult struct {
 
 func (x *GetOSUpdateStatusResponse_ServiceResult) Reset() {
 	*x = GetOSUpdateStatusResponse_ServiceResult{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[62]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3744,7 +4080,7 @@ func (x *GetOSUpdateStatusResponse_ServiceResult) String() string {
 func (*GetOSUpdateStatusResponse_ServiceResult) ProtoMessage() {}
 
 func (x *GetOSUpdateStatusResponse_ServiceResult) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[62]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3757,7 +4093,7 @@ func (x *GetOSUpdateStatusResponse_ServiceResult) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use GetOSUpdateStatusResponse_ServiceResult.ProtoReflect.Descriptor instead.
 func (*GetOSUpdateStatusResponse_ServiceResult) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{41, 0}
+	return file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP(), []int{42, 0}
 }
 
 func (x *GetOSUpdateStatusResponse_ServiceResult) GetUnit() string {
@@ -4015,8 +4351,33 @@ const file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc = "" +
 	"\x0fKernelLogRecord\x12!\n" +
 	"\ftimestamp_us\x18\x01 \x01(\x03R\vtimestampUs\x12\x14\n" +
 	"\x05level\x18\x02 \x01(\x05R\x05level\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"\x1a\n" +
-	"\x18GetOSUpdateStatusRequest\"\xd2\x06\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"N\n" +
+	"\x18GetOSUpdateStatusRequest\x122\n" +
+	"\x15include_engine_status\x18\x01 \x01(\bR\x13includeEngineStatus\"\xf1\x05\n" +
+	"\x14OSUpdateEngineStatus\x12\x1c\n" +
+	"\tconnector\x18\x01 \x01(\tR\tconnector\x12!\n" +
+	"\fcurrent_slot\x18\x02 \x01(\tR\vcurrentSlot\x12H\n" +
+	"\x05slots\x18\x03 \x03(\v22.wendy.agent.services.v1.OSUpdateEngineStatus.SlotR\x05slots\x12Q\n" +
+	"\x06system\x18\x04 \x03(\v29.wendy.agent.services.v1.OSUpdateEngineStatus.SystemEntryR\x06system\x12U\n" +
+	"\apending\x18\x05 \x01(\v2;.wendy.agent.services.v1.OSUpdateEngineStatus.PendingUpdateR\apending\x1a\xd3\x01\n" +
+	"\x04Slot\x12\x12\n" +
+	"\x04slot\x18\x01 \x01(\tR\x04slot\x12\x16\n" +
+	"\x06booted\x18\x02 \x01(\bR\x06booted\x12\x1c\n" +
+	"\tpartition\x18\x03 \x01(\tR\tpartition\x12\x16\n" +
+	"\x06distro\x18\x04 \x01(\tR\x06distro\x12\x16\n" +
+	"\x06kernel\x18\x05 \x01(\tR\x06kernel\x12#\n" +
+	"\rrootfs_health\x18\x06 \x01(\tR\frootfsHealth\x12\x18\n" +
+	"\aretries\x18\a \x01(\tR\aretries\x12\x12\n" +
+	"\x04note\x18\b \x01(\tR\x04note\x1a5\n" +
+	"\vSystemEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\x1a\x96\x01\n" +
+	"\rPendingUpdate\x12#\n" +
+	"\rartifact_name\x18\x01 \x01(\tR\fartifactName\x12)\n" +
+	"\x10artifact_version\x18\x02 \x01(\tR\x0fartifactVersion\x12\x14\n" +
+	"\x05phase\x18\x03 \x01(\tR\x05phase\x12\x1f\n" +
+	"\vtarget_slot\x18\x04 \x01(\tR\n" +
+	"targetSlot\"\xa6\a\n" +
 	"\x19GetOSUpdateStatusResponse\x12\x1d\n" +
 	"\n" +
 	"has_result\x18\x01 \x01(\bR\thasResult\x12T\n" +
@@ -4027,7 +4388,9 @@ const file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc = "" +
 	"\x0fcreated_at_unix\x18\x06 \x01(\x03R\rcreatedAtUnix\x12*\n" +
 	"\x11finalized_at_unix\x18\a \x01(\x03R\x0ffinalizedAtUnix\x12%\n" +
 	"\x0erollback_error\x18\b \x01(\tR\rrollbackError\x12\x12\n" +
-	"\x04note\x18\t \x01(\tR\x04note\x1a\xf9\x01\n" +
+	"\x04note\x18\t \x01(\tR\x04note\x12R\n" +
+	"\rengine_status\x18\n" +
+	" \x01(\v2-.wendy.agent.services.v1.OSUpdateEngineStatusR\fengineStatus\x1a\xf9\x01\n" +
 	"\rServiceResult\x12\x12\n" +
 	"\x04unit\x18\x01 \x01(\tR\x04unit\x12_\n" +
 	"\x06status\x18\x02 \x01(\x0e2G.wendy.agent.services.v1.GetOSUpdateStatusResponse.ServiceResult.StatusR\x06status\x12\x16\n" +
@@ -4090,7 +4453,7 @@ func file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDescGZIP() []b
 }
 
 var file_wendy_agent_services_v1_wendy_agent_v1_service_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 63)
+var file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_wendy_agent_services_v1_wendy_agent_v1_service_proto_goTypes = []any{
 	(WiFiSecurityType)(0),                                       // 0: wendy.agent.services.v1.WiFiSecurityType
 	(GetOSUpdateStatusResponse_Outcome)(0),                      // 1: wendy.agent.services.v1.GetOSUpdateStatusResponse.Outcome
@@ -4136,106 +4499,114 @@ var file_wendy_agent_services_v1_wendy_agent_v1_service_proto_goTypes = []any{
 	(*DumpKernelLogResponse)(nil),                               // 41: wendy.agent.services.v1.DumpKernelLogResponse
 	(*KernelLogRecord)(nil),                                     // 42: wendy.agent.services.v1.KernelLogRecord
 	(*GetOSUpdateStatusRequest)(nil),                            // 43: wendy.agent.services.v1.GetOSUpdateStatusRequest
-	(*GetOSUpdateStatusResponse)(nil),                           // 44: wendy.agent.services.v1.GetOSUpdateStatusResponse
-	(*SetHostnameRequest)(nil),                                  // 45: wendy.agent.services.v1.SetHostnameRequest
-	(*SetHostnameResponse)(nil),                                 // 46: wendy.agent.services.v1.SetHostnameResponse
-	(*RunContainerRequest_Header)(nil),                          // 47: wendy.agent.services.v1.RunContainerRequest.Header
-	(*RunContainerRequest_Chunk)(nil),                           // 48: wendy.agent.services.v1.RunContainerRequest.Chunk
-	(*ControlCommand_Run)(nil),                                  // 49: wendy.agent.services.v1.ControlCommand.Run
-	(*ControlCommand_Stop)(nil),                                 // 50: wendy.agent.services.v1.ControlCommand.Stop
-	(*RunContainerResponse_Started)(nil),                        // 51: wendy.agent.services.v1.RunContainerResponse.Started
-	(*RunContainerResponse_Stopped)(nil),                        // 52: wendy.agent.services.v1.RunContainerResponse.Stopped
-	(*RunContainerResponse_ConsoleOutput)(nil),                  // 53: wendy.agent.services.v1.RunContainerResponse.ConsoleOutput
-	(*UpdateAgentRequest_Chunk)(nil),                            // 54: wendy.agent.services.v1.UpdateAgentRequest.Chunk
-	(*UpdateAgentRequest_ControlCommand)(nil),                   // 55: wendy.agent.services.v1.UpdateAgentRequest.ControlCommand
-	(*UpdateAgentRequest_ControlCommand_Update)(nil),            // 56: wendy.agent.services.v1.UpdateAgentRequest.ControlCommand.Update
-	(*UpdateAgentResponse_Updated)(nil),                         // 57: wendy.agent.services.v1.UpdateAgentResponse.Updated
-	(*ListWiFiNetworksResponse_WiFiNetwork)(nil),                // 58: wendy.agent.services.v1.ListWiFiNetworksResponse.WiFiNetwork
-	(*ListKnownWiFiNetworksResponse_KnownWiFiNetwork)(nil),      // 59: wendy.agent.services.v1.ListKnownWiFiNetworksResponse.KnownWiFiNetwork
-	(*ListHardwareCapabilitiesResponse_HardwareCapability)(nil), // 60: wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability
-	nil,                                // 61: wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability.PropertiesEntry
-	(*UpdateOSResponse_Progress)(nil),  // 62: wendy.agent.services.v1.UpdateOSResponse.Progress
-	(*UpdateOSResponse_Completed)(nil), // 63: wendy.agent.services.v1.UpdateOSResponse.Completed
-	(*UpdateOSResponse_Failed)(nil),    // 64: wendy.agent.services.v1.UpdateOSResponse.Failed
-	(*GetOSUpdateStatusResponse_ServiceResult)(nil), // 65: wendy.agent.services.v1.GetOSUpdateStatusResponse.ServiceResult
-	(*RestartPolicy)(nil),                           // 66: RestartPolicy
+	(*OSUpdateEngineStatus)(nil),                                // 44: wendy.agent.services.v1.OSUpdateEngineStatus
+	(*GetOSUpdateStatusResponse)(nil),                           // 45: wendy.agent.services.v1.GetOSUpdateStatusResponse
+	(*SetHostnameRequest)(nil),                                  // 46: wendy.agent.services.v1.SetHostnameRequest
+	(*SetHostnameResponse)(nil),                                 // 47: wendy.agent.services.v1.SetHostnameResponse
+	(*RunContainerRequest_Header)(nil),                          // 48: wendy.agent.services.v1.RunContainerRequest.Header
+	(*RunContainerRequest_Chunk)(nil),                           // 49: wendy.agent.services.v1.RunContainerRequest.Chunk
+	(*ControlCommand_Run)(nil),                                  // 50: wendy.agent.services.v1.ControlCommand.Run
+	(*ControlCommand_Stop)(nil),                                 // 51: wendy.agent.services.v1.ControlCommand.Stop
+	(*RunContainerResponse_Started)(nil),                        // 52: wendy.agent.services.v1.RunContainerResponse.Started
+	(*RunContainerResponse_Stopped)(nil),                        // 53: wendy.agent.services.v1.RunContainerResponse.Stopped
+	(*RunContainerResponse_ConsoleOutput)(nil),                  // 54: wendy.agent.services.v1.RunContainerResponse.ConsoleOutput
+	(*UpdateAgentRequest_Chunk)(nil),                            // 55: wendy.agent.services.v1.UpdateAgentRequest.Chunk
+	(*UpdateAgentRequest_ControlCommand)(nil),                   // 56: wendy.agent.services.v1.UpdateAgentRequest.ControlCommand
+	(*UpdateAgentRequest_ControlCommand_Update)(nil),            // 57: wendy.agent.services.v1.UpdateAgentRequest.ControlCommand.Update
+	(*UpdateAgentResponse_Updated)(nil),                         // 58: wendy.agent.services.v1.UpdateAgentResponse.Updated
+	(*ListWiFiNetworksResponse_WiFiNetwork)(nil),                // 59: wendy.agent.services.v1.ListWiFiNetworksResponse.WiFiNetwork
+	(*ListKnownWiFiNetworksResponse_KnownWiFiNetwork)(nil),      // 60: wendy.agent.services.v1.ListKnownWiFiNetworksResponse.KnownWiFiNetwork
+	(*ListHardwareCapabilitiesResponse_HardwareCapability)(nil), // 61: wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability
+	nil,                                             // 62: wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability.PropertiesEntry
+	(*UpdateOSResponse_Progress)(nil),               // 63: wendy.agent.services.v1.UpdateOSResponse.Progress
+	(*UpdateOSResponse_Completed)(nil),              // 64: wendy.agent.services.v1.UpdateOSResponse.Completed
+	(*UpdateOSResponse_Failed)(nil),                 // 65: wendy.agent.services.v1.UpdateOSResponse.Failed
+	(*OSUpdateEngineStatus_Slot)(nil),               // 66: wendy.agent.services.v1.OSUpdateEngineStatus.Slot
+	(*OSUpdateEngineStatus_SystemEntry)(nil),        // 67: wendy.agent.services.v1.OSUpdateEngineStatus.SystemEntry
+	(*OSUpdateEngineStatus_PendingUpdate)(nil),      // 68: wendy.agent.services.v1.OSUpdateEngineStatus.PendingUpdate
+	(*GetOSUpdateStatusResponse_ServiceResult)(nil), // 69: wendy.agent.services.v1.GetOSUpdateStatusResponse.ServiceResult
+	(*RestartPolicy)(nil),                           // 70: RestartPolicy
 }
 var file_wendy_agent_services_v1_wendy_agent_v1_service_proto_depIdxs = []int32{
-	47, // 0: wendy.agent.services.v1.RunContainerRequest.header:type_name -> wendy.agent.services.v1.RunContainerRequest.Header
-	48, // 1: wendy.agent.services.v1.RunContainerRequest.chunk:type_name -> wendy.agent.services.v1.RunContainerRequest.Chunk
+	48, // 0: wendy.agent.services.v1.RunContainerRequest.header:type_name -> wendy.agent.services.v1.RunContainerRequest.Header
+	49, // 1: wendy.agent.services.v1.RunContainerRequest.chunk:type_name -> wendy.agent.services.v1.RunContainerRequest.Chunk
 	4,  // 2: wendy.agent.services.v1.RunContainerRequest.control:type_name -> wendy.agent.services.v1.ControlCommand
-	49, // 3: wendy.agent.services.v1.ControlCommand.run:type_name -> wendy.agent.services.v1.ControlCommand.Run
-	50, // 4: wendy.agent.services.v1.ControlCommand.stop:type_name -> wendy.agent.services.v1.ControlCommand.Stop
-	51, // 5: wendy.agent.services.v1.RunContainerResponse.started:type_name -> wendy.agent.services.v1.RunContainerResponse.Started
-	52, // 6: wendy.agent.services.v1.RunContainerResponse.stopped:type_name -> wendy.agent.services.v1.RunContainerResponse.Stopped
-	53, // 7: wendy.agent.services.v1.RunContainerResponse.stdout_output:type_name -> wendy.agent.services.v1.RunContainerResponse.ConsoleOutput
-	53, // 8: wendy.agent.services.v1.RunContainerResponse.stderr_output:type_name -> wendy.agent.services.v1.RunContainerResponse.ConsoleOutput
-	54, // 9: wendy.agent.services.v1.UpdateAgentRequest.chunk:type_name -> wendy.agent.services.v1.UpdateAgentRequest.Chunk
-	55, // 10: wendy.agent.services.v1.UpdateAgentRequest.control:type_name -> wendy.agent.services.v1.UpdateAgentRequest.ControlCommand
-	57, // 11: wendy.agent.services.v1.UpdateAgentResponse.updated:type_name -> wendy.agent.services.v1.UpdateAgentResponse.Updated
+	50, // 3: wendy.agent.services.v1.ControlCommand.run:type_name -> wendy.agent.services.v1.ControlCommand.Run
+	51, // 4: wendy.agent.services.v1.ControlCommand.stop:type_name -> wendy.agent.services.v1.ControlCommand.Stop
+	52, // 5: wendy.agent.services.v1.RunContainerResponse.started:type_name -> wendy.agent.services.v1.RunContainerResponse.Started
+	53, // 6: wendy.agent.services.v1.RunContainerResponse.stopped:type_name -> wendy.agent.services.v1.RunContainerResponse.Stopped
+	54, // 7: wendy.agent.services.v1.RunContainerResponse.stdout_output:type_name -> wendy.agent.services.v1.RunContainerResponse.ConsoleOutput
+	54, // 8: wendy.agent.services.v1.RunContainerResponse.stderr_output:type_name -> wendy.agent.services.v1.RunContainerResponse.ConsoleOutput
+	55, // 9: wendy.agent.services.v1.UpdateAgentRequest.chunk:type_name -> wendy.agent.services.v1.UpdateAgentRequest.Chunk
+	56, // 10: wendy.agent.services.v1.UpdateAgentRequest.control:type_name -> wendy.agent.services.v1.UpdateAgentRequest.ControlCommand
+	58, // 11: wendy.agent.services.v1.UpdateAgentResponse.updated:type_name -> wendy.agent.services.v1.UpdateAgentResponse.Updated
 	10, // 12: wendy.agent.services.v1.GetAgentVersionResponse.partitions:type_name -> wendy.agent.services.v1.DiskPartition
-	58, // 13: wendy.agent.services.v1.ListWiFiNetworksResponse.networks:type_name -> wendy.agent.services.v1.ListWiFiNetworksResponse.WiFiNetwork
+	59, // 13: wendy.agent.services.v1.ListWiFiNetworksResponse.networks:type_name -> wendy.agent.services.v1.ListWiFiNetworksResponse.WiFiNetwork
 	0,  // 14: wendy.agent.services.v1.ConnectToWiFiRequest.security:type_name -> wendy.agent.services.v1.WiFiSecurityType
-	59, // 15: wendy.agent.services.v1.ListKnownWiFiNetworksResponse.networks:type_name -> wendy.agent.services.v1.ListKnownWiFiNetworksResponse.KnownWiFiNetwork
-	60, // 16: wendy.agent.services.v1.ListHardwareCapabilitiesResponse.capabilities:type_name -> wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability
+	60, // 15: wendy.agent.services.v1.ListKnownWiFiNetworksResponse.networks:type_name -> wendy.agent.services.v1.ListKnownWiFiNetworksResponse.KnownWiFiNetwork
+	61, // 16: wendy.agent.services.v1.ListHardwareCapabilitiesResponse.capabilities:type_name -> wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability
 	30, // 17: wendy.agent.services.v1.ScanBluetoothPeripheralsResponse.discovered_devices:type_name -> wendy.agent.services.v1.DiscoveredBluetoothPeripheral
-	62, // 18: wendy.agent.services.v1.UpdateOSResponse.progress:type_name -> wendy.agent.services.v1.UpdateOSResponse.Progress
-	63, // 19: wendy.agent.services.v1.UpdateOSResponse.completed:type_name -> wendy.agent.services.v1.UpdateOSResponse.Completed
-	64, // 20: wendy.agent.services.v1.UpdateOSResponse.failed:type_name -> wendy.agent.services.v1.UpdateOSResponse.Failed
+	63, // 18: wendy.agent.services.v1.UpdateOSResponse.progress:type_name -> wendy.agent.services.v1.UpdateOSResponse.Progress
+	64, // 19: wendy.agent.services.v1.UpdateOSResponse.completed:type_name -> wendy.agent.services.v1.UpdateOSResponse.Completed
+	65, // 20: wendy.agent.services.v1.UpdateOSResponse.failed:type_name -> wendy.agent.services.v1.UpdateOSResponse.Failed
 	42, // 21: wendy.agent.services.v1.DumpKernelLogResponse.records:type_name -> wendy.agent.services.v1.KernelLogRecord
-	1,  // 22: wendy.agent.services.v1.GetOSUpdateStatusResponse.outcome:type_name -> wendy.agent.services.v1.GetOSUpdateStatusResponse.Outcome
-	65, // 23: wendy.agent.services.v1.GetOSUpdateStatusResponse.services:type_name -> wendy.agent.services.v1.GetOSUpdateStatusResponse.ServiceResult
-	66, // 24: wendy.agent.services.v1.ControlCommand.Run.restart_policy:type_name -> RestartPolicy
-	56, // 25: wendy.agent.services.v1.UpdateAgentRequest.ControlCommand.update:type_name -> wendy.agent.services.v1.UpdateAgentRequest.ControlCommand.Update
-	0,  // 26: wendy.agent.services.v1.ListWiFiNetworksResponse.WiFiNetwork.security:type_name -> wendy.agent.services.v1.WiFiSecurityType
-	0,  // 27: wendy.agent.services.v1.ListKnownWiFiNetworksResponse.KnownWiFiNetwork.security:type_name -> wendy.agent.services.v1.WiFiSecurityType
-	61, // 28: wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability.properties:type_name -> wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability.PropertiesEntry
-	2,  // 29: wendy.agent.services.v1.GetOSUpdateStatusResponse.ServiceResult.status:type_name -> wendy.agent.services.v1.GetOSUpdateStatusResponse.ServiceResult.Status
-	3,  // 30: wendy.agent.services.v1.WendyAgentService.RunContainer:input_type -> wendy.agent.services.v1.RunContainerRequest
-	6,  // 31: wendy.agent.services.v1.WendyAgentService.UpdateAgent:input_type -> wendy.agent.services.v1.UpdateAgentRequest
-	8,  // 32: wendy.agent.services.v1.WendyAgentService.GetAgentVersion:input_type -> wendy.agent.services.v1.GetAgentVersionRequest
-	11, // 33: wendy.agent.services.v1.WendyAgentService.ListWiFiNetworks:input_type -> wendy.agent.services.v1.ListWiFiNetworksRequest
-	13, // 34: wendy.agent.services.v1.WendyAgentService.ConnectToWiFi:input_type -> wendy.agent.services.v1.ConnectToWiFiRequest
-	15, // 35: wendy.agent.services.v1.WendyAgentService.GetWiFiStatus:input_type -> wendy.agent.services.v1.GetWiFiStatusRequest
-	17, // 36: wendy.agent.services.v1.WendyAgentService.DisconnectWiFi:input_type -> wendy.agent.services.v1.DisconnectWiFiRequest
-	19, // 37: wendy.agent.services.v1.WendyAgentService.ListKnownWiFiNetworks:input_type -> wendy.agent.services.v1.ListKnownWiFiNetworksRequest
-	21, // 38: wendy.agent.services.v1.WendyAgentService.SetWiFiNetworkPriority:input_type -> wendy.agent.services.v1.SetWiFiNetworkPriorityRequest
-	23, // 39: wendy.agent.services.v1.WendyAgentService.ReorderKnownWiFiNetworks:input_type -> wendy.agent.services.v1.ReorderKnownWiFiNetworksRequest
-	25, // 40: wendy.agent.services.v1.WendyAgentService.ForgetWiFiNetwork:input_type -> wendy.agent.services.v1.ForgetWiFiNetworkRequest
-	27, // 41: wendy.agent.services.v1.WendyAgentService.ListHardwareCapabilities:input_type -> wendy.agent.services.v1.ListHardwareCapabilitiesRequest
-	29, // 42: wendy.agent.services.v1.WendyAgentService.ScanBluetoothPeripherals:input_type -> wendy.agent.services.v1.ScanBluetoothPeripheralsRequest
-	32, // 43: wendy.agent.services.v1.WendyAgentService.ConnectBluetoothPeripheral:input_type -> wendy.agent.services.v1.ConnectBluetoothPeripheralRequest
-	34, // 44: wendy.agent.services.v1.WendyAgentService.DisconnectBluetoothPeripheral:input_type -> wendy.agent.services.v1.DisconnectBluetoothPeripheralRequest
-	36, // 45: wendy.agent.services.v1.WendyAgentService.ForgetBluetoothPeripheral:input_type -> wendy.agent.services.v1.ForgetBluetoothPeripheralRequest
-	38, // 46: wendy.agent.services.v1.WendyAgentService.UpdateOS:input_type -> wendy.agent.services.v1.UpdateOSRequest
-	40, // 47: wendy.agent.services.v1.WendyAgentService.DumpKernelLog:input_type -> wendy.agent.services.v1.DumpKernelLogRequest
-	43, // 48: wendy.agent.services.v1.WendyAgentService.GetOSUpdateStatus:input_type -> wendy.agent.services.v1.GetOSUpdateStatusRequest
-	45, // 49: wendy.agent.services.v1.WendyAgentService.SetHostname:input_type -> wendy.agent.services.v1.SetHostnameRequest
-	5,  // 50: wendy.agent.services.v1.WendyAgentService.RunContainer:output_type -> wendy.agent.services.v1.RunContainerResponse
-	7,  // 51: wendy.agent.services.v1.WendyAgentService.UpdateAgent:output_type -> wendy.agent.services.v1.UpdateAgentResponse
-	9,  // 52: wendy.agent.services.v1.WendyAgentService.GetAgentVersion:output_type -> wendy.agent.services.v1.GetAgentVersionResponse
-	12, // 53: wendy.agent.services.v1.WendyAgentService.ListWiFiNetworks:output_type -> wendy.agent.services.v1.ListWiFiNetworksResponse
-	14, // 54: wendy.agent.services.v1.WendyAgentService.ConnectToWiFi:output_type -> wendy.agent.services.v1.ConnectToWiFiResponse
-	16, // 55: wendy.agent.services.v1.WendyAgentService.GetWiFiStatus:output_type -> wendy.agent.services.v1.GetWiFiStatusResponse
-	18, // 56: wendy.agent.services.v1.WendyAgentService.DisconnectWiFi:output_type -> wendy.agent.services.v1.DisconnectWiFiResponse
-	20, // 57: wendy.agent.services.v1.WendyAgentService.ListKnownWiFiNetworks:output_type -> wendy.agent.services.v1.ListKnownWiFiNetworksResponse
-	22, // 58: wendy.agent.services.v1.WendyAgentService.SetWiFiNetworkPriority:output_type -> wendy.agent.services.v1.SetWiFiNetworkPriorityResponse
-	24, // 59: wendy.agent.services.v1.WendyAgentService.ReorderKnownWiFiNetworks:output_type -> wendy.agent.services.v1.ReorderKnownWiFiNetworksResponse
-	26, // 60: wendy.agent.services.v1.WendyAgentService.ForgetWiFiNetwork:output_type -> wendy.agent.services.v1.ForgetWiFiNetworkResponse
-	28, // 61: wendy.agent.services.v1.WendyAgentService.ListHardwareCapabilities:output_type -> wendy.agent.services.v1.ListHardwareCapabilitiesResponse
-	31, // 62: wendy.agent.services.v1.WendyAgentService.ScanBluetoothPeripherals:output_type -> wendy.agent.services.v1.ScanBluetoothPeripheralsResponse
-	33, // 63: wendy.agent.services.v1.WendyAgentService.ConnectBluetoothPeripheral:output_type -> wendy.agent.services.v1.ConnectBluetoothPeripheralResponse
-	35, // 64: wendy.agent.services.v1.WendyAgentService.DisconnectBluetoothPeripheral:output_type -> wendy.agent.services.v1.DisconnectBluetoothPeripheralResponse
-	37, // 65: wendy.agent.services.v1.WendyAgentService.ForgetBluetoothPeripheral:output_type -> wendy.agent.services.v1.ForgetBluetoothPeripheralResponse
-	39, // 66: wendy.agent.services.v1.WendyAgentService.UpdateOS:output_type -> wendy.agent.services.v1.UpdateOSResponse
-	41, // 67: wendy.agent.services.v1.WendyAgentService.DumpKernelLog:output_type -> wendy.agent.services.v1.DumpKernelLogResponse
-	44, // 68: wendy.agent.services.v1.WendyAgentService.GetOSUpdateStatus:output_type -> wendy.agent.services.v1.GetOSUpdateStatusResponse
-	46, // 69: wendy.agent.services.v1.WendyAgentService.SetHostname:output_type -> wendy.agent.services.v1.SetHostnameResponse
-	50, // [50:70] is the sub-list for method output_type
-	30, // [30:50] is the sub-list for method input_type
-	30, // [30:30] is the sub-list for extension type_name
-	30, // [30:30] is the sub-list for extension extendee
-	0,  // [0:30] is the sub-list for field type_name
+	66, // 22: wendy.agent.services.v1.OSUpdateEngineStatus.slots:type_name -> wendy.agent.services.v1.OSUpdateEngineStatus.Slot
+	67, // 23: wendy.agent.services.v1.OSUpdateEngineStatus.system:type_name -> wendy.agent.services.v1.OSUpdateEngineStatus.SystemEntry
+	68, // 24: wendy.agent.services.v1.OSUpdateEngineStatus.pending:type_name -> wendy.agent.services.v1.OSUpdateEngineStatus.PendingUpdate
+	1,  // 25: wendy.agent.services.v1.GetOSUpdateStatusResponse.outcome:type_name -> wendy.agent.services.v1.GetOSUpdateStatusResponse.Outcome
+	69, // 26: wendy.agent.services.v1.GetOSUpdateStatusResponse.services:type_name -> wendy.agent.services.v1.GetOSUpdateStatusResponse.ServiceResult
+	44, // 27: wendy.agent.services.v1.GetOSUpdateStatusResponse.engine_status:type_name -> wendy.agent.services.v1.OSUpdateEngineStatus
+	70, // 28: wendy.agent.services.v1.ControlCommand.Run.restart_policy:type_name -> RestartPolicy
+	57, // 29: wendy.agent.services.v1.UpdateAgentRequest.ControlCommand.update:type_name -> wendy.agent.services.v1.UpdateAgentRequest.ControlCommand.Update
+	0,  // 30: wendy.agent.services.v1.ListWiFiNetworksResponse.WiFiNetwork.security:type_name -> wendy.agent.services.v1.WiFiSecurityType
+	0,  // 31: wendy.agent.services.v1.ListKnownWiFiNetworksResponse.KnownWiFiNetwork.security:type_name -> wendy.agent.services.v1.WiFiSecurityType
+	62, // 32: wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability.properties:type_name -> wendy.agent.services.v1.ListHardwareCapabilitiesResponse.HardwareCapability.PropertiesEntry
+	2,  // 33: wendy.agent.services.v1.GetOSUpdateStatusResponse.ServiceResult.status:type_name -> wendy.agent.services.v1.GetOSUpdateStatusResponse.ServiceResult.Status
+	3,  // 34: wendy.agent.services.v1.WendyAgentService.RunContainer:input_type -> wendy.agent.services.v1.RunContainerRequest
+	6,  // 35: wendy.agent.services.v1.WendyAgentService.UpdateAgent:input_type -> wendy.agent.services.v1.UpdateAgentRequest
+	8,  // 36: wendy.agent.services.v1.WendyAgentService.GetAgentVersion:input_type -> wendy.agent.services.v1.GetAgentVersionRequest
+	11, // 37: wendy.agent.services.v1.WendyAgentService.ListWiFiNetworks:input_type -> wendy.agent.services.v1.ListWiFiNetworksRequest
+	13, // 38: wendy.agent.services.v1.WendyAgentService.ConnectToWiFi:input_type -> wendy.agent.services.v1.ConnectToWiFiRequest
+	15, // 39: wendy.agent.services.v1.WendyAgentService.GetWiFiStatus:input_type -> wendy.agent.services.v1.GetWiFiStatusRequest
+	17, // 40: wendy.agent.services.v1.WendyAgentService.DisconnectWiFi:input_type -> wendy.agent.services.v1.DisconnectWiFiRequest
+	19, // 41: wendy.agent.services.v1.WendyAgentService.ListKnownWiFiNetworks:input_type -> wendy.agent.services.v1.ListKnownWiFiNetworksRequest
+	21, // 42: wendy.agent.services.v1.WendyAgentService.SetWiFiNetworkPriority:input_type -> wendy.agent.services.v1.SetWiFiNetworkPriorityRequest
+	23, // 43: wendy.agent.services.v1.WendyAgentService.ReorderKnownWiFiNetworks:input_type -> wendy.agent.services.v1.ReorderKnownWiFiNetworksRequest
+	25, // 44: wendy.agent.services.v1.WendyAgentService.ForgetWiFiNetwork:input_type -> wendy.agent.services.v1.ForgetWiFiNetworkRequest
+	27, // 45: wendy.agent.services.v1.WendyAgentService.ListHardwareCapabilities:input_type -> wendy.agent.services.v1.ListHardwareCapabilitiesRequest
+	29, // 46: wendy.agent.services.v1.WendyAgentService.ScanBluetoothPeripherals:input_type -> wendy.agent.services.v1.ScanBluetoothPeripheralsRequest
+	32, // 47: wendy.agent.services.v1.WendyAgentService.ConnectBluetoothPeripheral:input_type -> wendy.agent.services.v1.ConnectBluetoothPeripheralRequest
+	34, // 48: wendy.agent.services.v1.WendyAgentService.DisconnectBluetoothPeripheral:input_type -> wendy.agent.services.v1.DisconnectBluetoothPeripheralRequest
+	36, // 49: wendy.agent.services.v1.WendyAgentService.ForgetBluetoothPeripheral:input_type -> wendy.agent.services.v1.ForgetBluetoothPeripheralRequest
+	38, // 50: wendy.agent.services.v1.WendyAgentService.UpdateOS:input_type -> wendy.agent.services.v1.UpdateOSRequest
+	40, // 51: wendy.agent.services.v1.WendyAgentService.DumpKernelLog:input_type -> wendy.agent.services.v1.DumpKernelLogRequest
+	43, // 52: wendy.agent.services.v1.WendyAgentService.GetOSUpdateStatus:input_type -> wendy.agent.services.v1.GetOSUpdateStatusRequest
+	46, // 53: wendy.agent.services.v1.WendyAgentService.SetHostname:input_type -> wendy.agent.services.v1.SetHostnameRequest
+	5,  // 54: wendy.agent.services.v1.WendyAgentService.RunContainer:output_type -> wendy.agent.services.v1.RunContainerResponse
+	7,  // 55: wendy.agent.services.v1.WendyAgentService.UpdateAgent:output_type -> wendy.agent.services.v1.UpdateAgentResponse
+	9,  // 56: wendy.agent.services.v1.WendyAgentService.GetAgentVersion:output_type -> wendy.agent.services.v1.GetAgentVersionResponse
+	12, // 57: wendy.agent.services.v1.WendyAgentService.ListWiFiNetworks:output_type -> wendy.agent.services.v1.ListWiFiNetworksResponse
+	14, // 58: wendy.agent.services.v1.WendyAgentService.ConnectToWiFi:output_type -> wendy.agent.services.v1.ConnectToWiFiResponse
+	16, // 59: wendy.agent.services.v1.WendyAgentService.GetWiFiStatus:output_type -> wendy.agent.services.v1.GetWiFiStatusResponse
+	18, // 60: wendy.agent.services.v1.WendyAgentService.DisconnectWiFi:output_type -> wendy.agent.services.v1.DisconnectWiFiResponse
+	20, // 61: wendy.agent.services.v1.WendyAgentService.ListKnownWiFiNetworks:output_type -> wendy.agent.services.v1.ListKnownWiFiNetworksResponse
+	22, // 62: wendy.agent.services.v1.WendyAgentService.SetWiFiNetworkPriority:output_type -> wendy.agent.services.v1.SetWiFiNetworkPriorityResponse
+	24, // 63: wendy.agent.services.v1.WendyAgentService.ReorderKnownWiFiNetworks:output_type -> wendy.agent.services.v1.ReorderKnownWiFiNetworksResponse
+	26, // 64: wendy.agent.services.v1.WendyAgentService.ForgetWiFiNetwork:output_type -> wendy.agent.services.v1.ForgetWiFiNetworkResponse
+	28, // 65: wendy.agent.services.v1.WendyAgentService.ListHardwareCapabilities:output_type -> wendy.agent.services.v1.ListHardwareCapabilitiesResponse
+	31, // 66: wendy.agent.services.v1.WendyAgentService.ScanBluetoothPeripherals:output_type -> wendy.agent.services.v1.ScanBluetoothPeripheralsResponse
+	33, // 67: wendy.agent.services.v1.WendyAgentService.ConnectBluetoothPeripheral:output_type -> wendy.agent.services.v1.ConnectBluetoothPeripheralResponse
+	35, // 68: wendy.agent.services.v1.WendyAgentService.DisconnectBluetoothPeripheral:output_type -> wendy.agent.services.v1.DisconnectBluetoothPeripheralResponse
+	37, // 69: wendy.agent.services.v1.WendyAgentService.ForgetBluetoothPeripheral:output_type -> wendy.agent.services.v1.ForgetBluetoothPeripheralResponse
+	39, // 70: wendy.agent.services.v1.WendyAgentService.UpdateOS:output_type -> wendy.agent.services.v1.UpdateOSResponse
+	41, // 71: wendy.agent.services.v1.WendyAgentService.DumpKernelLog:output_type -> wendy.agent.services.v1.DumpKernelLogResponse
+	45, // 72: wendy.agent.services.v1.WendyAgentService.GetOSUpdateStatus:output_type -> wendy.agent.services.v1.GetOSUpdateStatusResponse
+	47, // 73: wendy.agent.services.v1.WendyAgentService.SetHostname:output_type -> wendy.agent.services.v1.SetHostnameResponse
+	54, // [54:74] is the sub-list for method output_type
+	34, // [34:54] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_wendy_agent_services_v1_wendy_agent_v1_service_proto_init() }
@@ -4281,18 +4652,18 @@ func file_wendy_agent_services_v1_wendy_agent_v1_service_proto_init() {
 		(*UpdateOSResponse_Failed_)(nil),
 	}
 	file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[37].OneofWrappers = []any{}
-	file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[46].OneofWrappers = []any{}
-	file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[52].OneofWrappers = []any{
+	file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[47].OneofWrappers = []any{}
+	file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[53].OneofWrappers = []any{
 		(*UpdateAgentRequest_ControlCommand_Update_)(nil),
 	}
-	file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[55].OneofWrappers = []any{}
+	file_wendy_agent_services_v1_wendy_agent_v1_service_proto_msgTypes[56].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc), len(file_wendy_agent_services_v1_wendy_agent_v1_service_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   63,
+			NumMessages:   67,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/agentpb/wendy_agent_v1_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_service.pb.go
@@ -2617,7 +2617,7 @@ type OSUpdateEngineStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Platform connector driving the A/B scheme, e.g. "tegrauefi" or "ubootenv".
 	Connector string `protobuf:"bytes,1,opt,name=connector,proto3" json:"connector,omitempty"`
-	// Slot the device is currently booted from ("a" or "b").
+	// Slot the device is currently booted from ("A" or "B").
 	CurrentSlot   string                              `protobuf:"bytes,2,opt,name=current_slot,json=currentSlot,proto3" json:"current_slot,omitempty"`
 	Slots         []*OSUpdateEngineStatus_Slot        `protobuf:"bytes,3,rep,name=slots,proto3" json:"slots,omitempty"`
 	System        []*OSUpdateEngineStatus_SystemEntry `protobuf:"bytes,4,rep,name=system,proto3" json:"system,omitempty"`
@@ -3824,7 +3824,7 @@ func (x *UpdateOSResponse_Failed) GetErrorMessage() string {
 
 type OSUpdateEngineStatus_Slot struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Slot name ("a" or "b").
+	// Slot name ("A" or "B").
 	Slot string `protobuf:"bytes,1,opt,name=slot,proto3" json:"slot,omitempty"`
 	// True for the slot the device is booted from.
 	Booted bool `protobuf:"varint,2,opt,name=booted,proto3" json:"booted,omitempty"`
@@ -3991,7 +3991,7 @@ type OSUpdateEngineStatus_PendingUpdate struct {
 	ArtifactVersion string                 `protobuf:"bytes,2,opt,name=artifact_version,json=artifactVersion,proto3" json:"artifact_version,omitempty"`
 	// Engine phase, e.g. "installed" (awaiting reboot + commit).
 	Phase string `protobuf:"bytes,3,opt,name=phase,proto3" json:"phase,omitempty"`
-	// Slot the update was written to ("a" or "b").
+	// Slot the update was written to ("A" or "B").
 	TargetSlot    string `protobuf:"bytes,4,opt,name=target_slot,json=targetSlot,proto3" json:"target_slot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache


### PR DESCRIPTION
## Summary

`wendy device info` now surfaces the device's OS-update state — the live `wendyos-update status` snapshot plus the last recorded update outcome:

```
OS Update:
  Slot A: booted, rootfs normal, WendyOS 0.17.0
  Slot B: inactive, retries 2 (trial boot pending)
  Pending: wendyos-jetson 0.18.0 (installed, target slot B)
  Last update: committed (0.16.0 → 0.17.0)
```

`--json` gains a matching `osUpdate` object (`lastUpdate` + `engine` with connector, slots, system entries, pending update).

## How

- **Proto (v1 + v2, additive):** `GetOSUpdateStatusRequest.include_engine_status` opts into the probe; `GetOSUpdateStatusResponse.engine_status` carries the parsed `wendyos-update status --json` snapshot, mirroring the engine's frozen v1 CLI contract field-for-field.
- **Agent:** when requested, `GetOSUpdateStatus` best-effort runs `wendyos-update status --json` (10s budget, same binary resolution + PATH as the updater backend). Probe failure, mender-only devices, or no binary → the field is simply omitted; the RPC never fails because of it.
- **CLI:** `device info` requests the snapshot and renders the block between the hardware info and CLI version. Any RPC error (e.g. `Unimplemented` from older agents) or an empty report keeps the previous output byte-identical. On a non-committed last outcome it points at `wendy device os update-status` for the full record.

## Testing

- `go test ./internal/agent/services ./internal/cli/commands` — includes new unit tests for the status-JSON parser (full/empty/malformed, pending slot-number mapping), the v1→v2 mirror, the text formatter (all outcome shapes, record-only, empty), and the JSON mapping.
- Verified live against a Jetson Orin Nano running the 2026.07.01 nightly agent: the back-compat record-only path renders the device's real rolled-back 0.16.1 update, and text/JSON output is otherwise unchanged.
- The live engine-snapshot path (new agent + wendyos-update on device) is unit-tested but not yet exercised on hardware; it needs an agent built from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ynXmbCy2tfVxue3kYEiyj