### PR TITLE
fix(cli): let discover probe complete a provisioned device's mTLS handshake

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -39,7 +39,6 @@ import (
 const defaultAgentPort = 50051
 const agentMTLSPortOffset = 1
 
-const lanAddressProbeTimeout = 1500 * time.Millisecond
 const agentPlaintextProbeTimeout = 3 * time.Second
 
 // mtlsProbeTimeout bounds a single mTLS connect+probe. The dial target is
@@ -47,6 +46,17 @@ const agentPlaintextProbeTimeout = 3 * time.Second
 // handshake; keeping it tight stops an unreachable/plaintext-only mTLS port
 // from stalling the connect before the plaintext fallback.
 const mtlsProbeTimeout = 3 * time.Second
+
+// lanAddressProbeTimeout bounds a single candidate address in the discover/
+// picker version probe (resolveLANAgentVersion). It wraps connectWithAutoTLS,
+// whose successful path for a provisioned device costs a TCP+TLS handshake plus
+// one mtlsProbeTimeout GetAgentVersion probe (~2.2s observed). A budget shorter
+// than mtlsProbeTimeout therefore cancelled the mTLS probe before it could
+// answer, leaving provisioned rows — especially USB devices, probed via .local
+// first — stuck on the failure glyph even though `wendy device info` (which
+// connects with the un-capped root context) succeeded. Derive it from
+// mtlsProbeTimeout with headroom so the two budgets can't silently invert again.
+const lanAddressProbeTimeout = mtlsProbeTimeout + 2*time.Second
 const provisionedAgentMetadataDiscoveryTimeout = 500 * time.Millisecond
 
 const provisionedAgentUnauthorizedMessage = "Unauthorized. Run 'wendy auth login' with an account that can access this provisioned wendy-agent."

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -373,6 +373,41 @@ func TestResolveLANAgentVersionFallsBackAcrossAddresses(t *testing.T) {
 	}
 }
 
+// TestResolveLANAgentVersionAllowsMTLSHandshakeTime guards against the
+// nested-timeout inversion that left provisioned devices stuck on the failure
+// glyph in the discover picker: the per-address probe budget
+// (lanAddressProbeTimeout) must comfortably contain a single autoTLS
+// connect+probe, whose own budget is mtlsProbeTimeout. A provisioned device's
+// handshake takes ~2.2s, so a per-address budget shorter than mtlsProbeTimeout
+// cancelled the mTLS probe before it could answer — even though `wendy device
+// info` (which connects with the un-capped root context) succeeded.
+func TestResolveLANAgentVersionAllowsMTLSHandshakeTime(t *testing.T) {
+	orig := getAgentVersionAtAddress
+	defer func() { getAgentVersionAtAddress = orig }()
+
+	// Simulate a provisioned device whose autoTLS handshake takes longer than
+	// the old 1500ms budget but well within a single mtlsProbeTimeout.
+	const handshake = 2200 * time.Millisecond
+	getAgentVersionAtAddress = func(ctx context.Context, _ string) (bool, *agentpb.GetAgentVersionResponse, error) {
+		select {
+		case <-time.After(handshake):
+			return true, &agentpb.GetAgentVersionResponse{Version: "9.9.9"}, nil
+		case <-ctx.Done():
+			return false, nil, ctx.Err()
+		}
+	}
+
+	dev := models.LANDevice{IPAddress: "192.168.1.50", Port: defaultAgentPort}
+
+	_, _, resp, err := resolveLANAgentVersion(context.Background(), dev)
+	if err != nil {
+		t.Fatalf("resolveLANAgentVersion() error = %v; per-address probe budget too short to complete an mTLS handshake", err)
+	}
+	if resp.GetVersion() != "9.9.9" {
+		t.Fatalf("resolveLANAgentVersion() version = %q, want %q", resp.GetVersion(), "9.9.9")
+	}
+}
+
 // setTempConfig points HOME at a temp dir and writes cfg via config.Save so
 // the test uses the same serialisation path as production code. t.Setenv
 // automatically restores the original HOME when the test finishes.


### PR DESCRIPTION
## Problem

In the `discover`/device-picker menu, provisioned devices show the probe-failed glyph (`▲`) in the **Agent** and **OS** columns — yet `wendy device info` against the very same device works. This was reported for a **USB, LAN** device ("Clever Poppy") that resolved fine via `wendy device info`.

## Root cause

A **nested-timeout inversion**:

- `resolveLANAgentVersion` wraps each candidate address in a `lanAddressProbeTimeout` (**1500ms**) context.
- Inside it, `connectWithAutoTLS` runs the mTLS path, whose own single connect+probe budget is `mtlsProbeTimeout` (**3s**).
- A provisioned device's autoTLS handshake takes **~2.2s**, so the 1.5s outer cap cancelled the mTLS probe before it could ever answer → `▲`.
- `wendy device info` connects through `resolveTarget(ctx)` with the **un-capped root context**, so mTLS completed and it worked — exactly the observed discrepancy.

USB+LAN devices trip this most reliably because `lanAgentAddresses` probes the `.local` hostname **first** for USB devices, stacking mDNS-resolution latency on top of the handshake.

## Fix

Derive the per-address budget from the inner mTLS budget so it always contains a full mTLS connect+probe, and the two budgets can't silently invert again:

```go
const lanAddressProbeTimeout = mtlsProbeTimeout + 2*time.Second   // was 1500ms
```

## Verification

Added `TestResolveLANAgentVersionAllowsMTLSHandshakeTime` (simulates a ~2.2s provisioned handshake):

- **Before fix:** fails at exactly 1.50s — `context deadline exceeded`.
- **After fix:** passes.

Existing discover/probe/version tests still pass; package builds clean.

## Trade-off

In the *synchronous* paths (`discover --timeout`, `discover --json`), a genuinely unreachable device can now block up to `lanAddressProbeTimeout` (5s) per candidate address instead of 1.5s. These probes run concurrently across devices, so it's per-device latency, not cumulative. The interactive picker probe is async (background `tea.Cmd`), so there it just means the spinner shows slightly longer, never a blocked UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AesqiPFz9hhLmCEfhtupdJ