### PR TITLE
fix(cli): make install device-type picker section headers clear

### DIFF
--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -545,7 +545,7 @@ func (m PickerModel) View() string {
 		return sb.String()
 	}
 
-	sb.WriteString(ColorizeProbeGlyphs(m.tableView()) + "\n")
+	sb.WriteString(colorizeSectionHeaders(ColorizeProbeGlyphs(m.tableView()), m.sectionLabels()) + "\n")
 
 	if m.flashMessage != "" {
 		style := lipgloss.NewStyle().Foreground(ColorPrimary)
@@ -935,22 +935,73 @@ func withSectionHeaders(visible []PickerItem, itemRows []bubbleTable.Row, ncols,
 	return rows, rowItem
 }
 
+// sectionHeaderPrefix marks a section-header cell so it reads as a group title
+// rather than a selectable row. It is a plain-text rule (see sectionHeaderRow
+// for why styling can't live in the cell); colorizeSectionHeaders keys on it to
+// apply color after layout.
+const sectionHeaderPrefix = "── "
+
 // sectionHeaderRow builds a non-selectable header row whose first column shows
-// the section label and whose remaining columns are blank.
+// the section label prefixed with a rule (── WendyOS) and whose remaining
+// columns are blank.
 //
 // The label is intentionally plain text, not a lipgloss-styled string: the
 // underlying bubbles table truncates every cell with runewidth.Truncate, which
 // is not ANSI-aware. A styled value's escape bytes count toward the column
 // width, so truncation cuts inside the escape sequence and the terminal renders
-// garbage.
+// garbage. The rule prefix keeps the header distinguishable even on terminals
+// with no color; colorizeSectionHeaders adds color after layout for the rest.
 func sectionHeaderRow(label string, ncols, labelOffset int) bubbleTable.Row {
 	row := make(bubbleTable.Row, max(ncols, 1))
+	cell := sectionHeaderPrefix + label
 	if labelOffset < len(row) {
-		row[labelOffset] = label
+		row[labelOffset] = cell
 	} else {
-		row[0] = label
+		row[0] = cell
 	}
 	return row
+}
+
+// pickerSectionHeader styles section-header lines: a bold accent so a group
+// title (── WendyOS) stands apart from the selectable device rows below it.
+var pickerSectionHeader = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary)
+
+// sectionLabels returns the distinct section names present in the picker, in the
+// order they first appear in the item list. Empty when no item sets a Section,
+// so a headerless picker skips colorizeSectionHeaders entirely.
+func (m PickerModel) sectionLabels() []string {
+	var labels []string
+	seen := make(map[string]bool)
+	for _, item := range m.items {
+		if item.Section != "" && !seen[item.Section] {
+			seen[item.Section] = true
+			labels = append(labels, item.Section)
+		}
+	}
+	return labels
+}
+
+// colorizeSectionHeaders applies pickerSectionHeader to the header lines of an
+// already-rendered table view, matching lines by the plain-text rule prefix and
+// a known section label. The section cell is kept plain inside the table (see
+// sectionHeaderRow); color is applied here, after layout, so it never counts
+// toward column widths or trips the table's non-ANSI-aware truncation.
+func colorizeSectionHeaders(view string, labels []string) string {
+	if len(labels) == 0 {
+		return view
+	}
+	lines := strings.Split(view, "\n")
+	for i, line := range lines {
+		content := strings.TrimLeft(line, " ")
+		indent := line[:len(line)-len(content)]
+		for _, label := range labels {
+			if strings.HasPrefix(content, sectionHeaderPrefix+label) {
+				lines[i] = indent + pickerSectionHeader.Render(strings.TrimRight(content, " "))
+				break
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func pickerActiveColumnsForDefs(items []PickerItem, defs []pickerColumnDef, fixed bool) []pickerColumnDef {

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -719,9 +719,10 @@ func TestPickerModel_RendersSectionHeaders(t *testing.T) {
 }
 
 // TestPickerModel_RendersSectionHeadersInColor verifies that section headers
-// render correctly in truecolor mode. Headers are plain text (no lipgloss
-// styling) to avoid ANSI truncation issues in the bubble table, but this test
-// ensures they still display correctly when the terminal supports truecolor.
+// render correctly in truecolor mode. The header cell text stays plain (no
+// lipgloss styling) to avoid ANSI truncation issues in the bubble table, but
+// this test ensures the label survives intact when the terminal supports
+// truecolor.
 func TestPickerModel_RendersSectionHeadersInColor(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.TrueColor)
 	defer lipgloss.SetColorProfile(termenv.Ascii)
@@ -733,6 +734,45 @@ func TestPickerModel_RendersSectionHeadersInColor(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected colorized sectioned picker to render header %q intact, got %q", want, view)
 		}
+	}
+}
+
+// TestPickerModel_SectionHeadersAreVisuallyDistinct guards the two cues that set
+// a header apart from a selectable device row: the plain-text rule prefix (so it
+// reads as a header even with no color) and the accent color applied after
+// layout (so it pops on capable terminals). Without both, a header like
+// "WendyOS" is indistinguishable from a device name.
+func TestPickerModel_SectionHeadersAreVisuallyDistinct(t *testing.T) {
+	// Rule prefix survives ANSI stripping, so it's present regardless of color.
+	pm := sectionedPicker(t)
+	plain := ansi.Strip(pm.View())
+	for _, label := range []string{"WendyOS", "Wendy Lite"} {
+		if !strings.Contains(plain, sectionHeaderPrefix+label) {
+			t.Fatalf("expected header %q to carry the %q rule prefix, got %q", label, sectionHeaderPrefix, plain)
+		}
+	}
+	// A device row must NOT carry the header prefix.
+	if strings.Contains(plain, sectionHeaderPrefix+"Raspberry Pi 5") {
+		t.Fatalf("device row unexpectedly rendered as a section header: %q", plain)
+	}
+
+	// In truecolor the header line carries escape codes (accent color) that a
+	// plain device row does not.
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(termenv.Ascii)
+	colored := sectionedPicker(t).View()
+	var headerLine string
+	for _, line := range strings.Split(colored, "\n") {
+		if strings.Contains(ansi.Strip(line), sectionHeaderPrefix+"WendyOS") {
+			headerLine = line
+			break
+		}
+	}
+	if headerLine == "" {
+		t.Fatal("could not locate the WendyOS header line in the colored view")
+	}
+	if headerLine == ansi.Strip(headerLine) {
+		t.Fatalf("expected the header line to be colorized, got plain %q", headerLine)
 	}
 }
 


### PR DESCRIPTION
## Problem

The `wendy install` device-type picker groups targets under **WendyOS** and **Wendy Lite** section headers. But the header cells rendered as plain, undecorated text in the Name column — visually identical to a selectable device row. There was no cue that "WendyOS" / "Wendy Lite" were group headers rather than devices.

The cells are intentionally plain text (not lipgloss-styled) because the underlying bubbles table truncates every cell with a non-ANSI-aware `runewidth.Truncate`; styling baked into a cell would count escape bytes toward the column width and get sliced mid-sequence into garbage. That constraint is exactly why the headers had no visual distinction.

## Fix

Give section headers two cues that respect the truncation constraint:

1. **Plain-text rule prefix** — `── WendyOS` baked into the cell, so the header reads as a divider even on terminals with no color.
2. **Accent color after layout** — a new `colorizeSectionHeaders` styles the header lines *post-render* (matching by the rule prefix + known section label), the same technique `ColorizeProbeGlyphs` already uses. Color is applied after layout, so it never affects column widths or trips truncation.

### Before
```
Name              Description
WendyOS
Jetson Orin Nano    (0.10.5)
Raspberry Pi 5      (0.10.5)
Wendy Lite
ESP32-C5            (latest)
```

### After
```
Name              Description
── WendyOS                          ← bold accent
Jetson Orin Nano    (0.10.5)
Raspberry Pi 5      (0.10.5)
── Wendy Lite                       ← bold accent
ESP32-C5            (latest)
```

## Tests

- Existing section-header tests (render, ordering, cursor-skips-header, color-intact) still pass.
- New `TestPickerModel_SectionHeadersAreVisuallyDistinct` guards both cues: the rule prefix survives ANSI stripping (present without color) and does not leak onto device rows, and the header line carries color escapes in truecolor mode.
- `go test ./internal/cli/tui/` and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)