### PR TITLE
fix: run postStart hook on wendy run fast path

### DIFF
--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -305,11 +305,18 @@ func tryDeployFastPath(ctx context.Context, conn *grpcclient.AgentConnection, ap
 
 	if state == agentpb.AppRunningState_RUNNING {
 		cliLogln("No changes detected; %s is already up to date and running.", appCfg.AppID)
+		// The container is untouched, so the agent-side (in-container) hook can't
+		// be re-run, but fire the host-side postStart hook so `wendy run` behaves
+		// the same whether or not it took the fast path (e.g. re-opening the URL).
+		runPostStartHostHook(ctx, appCfg, conn.Host)
 		return true, nil
 	}
 
-	// Present but stopped — start it without rebuilding.
-	if _, err := conn.ContainerService.StartContainer(ctx, &agentpb.StartContainerRequest{
+	// Present but stopped — start it without rebuilding. Mirror the normal
+	// detached deploy path so the fast path stays a transparent optimization:
+	// attach the agent-side postStart hook to the start RPC (via context
+	// metadata), then fire the host-side postStart hook below.
+	if _, err := conn.ContainerService.StartContainer(contextWithPostStartAgentHook(ctx, appCfg), &agentpb.StartContainerRequest{
 		AppName:       appCfg.AppID,
 		RestartPolicy: resolveRestartPolicy(opts),
 	}); err != nil {
@@ -317,7 +324,21 @@ func tryDeployFastPath(ctx context.Context, conn *grpcclient.AgentConnection, ap
 		return false, nil
 	}
 	cliLogln("No changes detected; started existing %s.", appCfg.AppID)
+	runPostStartHostHook(ctx, appCfg, conn.Host)
 	return true, nil
+}
+
+// runPostStartHostHook mirrors the normal detached deploy path's host-side
+// postStart handling: wait for readiness, then fire the host hook
+// fire-and-forget on a background context so it outlives the CLI process. The
+// agent-side (in-container) hook is attached separately to the StartContainer
+// RPC's context, so it only runs when the fast path actually (re)starts the
+// container.
+func runPostStartHostHook(ctx context.Context, appCfg *appconfig.AppConfig, host string) {
+	if err := waitForReadiness(ctx, appCfg.Readiness, host); err != nil {
+		cliLogln("Warning: %v", err)
+	}
+	startPostStartHook(context.Background(), appCfg, host)
 }
 
 // lookupAppState queries the device for the running state of a single app.

--- a/go/internal/cli/commands/deployfastpath_hooks_test.go
+++ b/go/internal/cli/commands/deployfastpath_hooks_test.go
@@ -1,0 +1,177 @@
+package commands
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// fastPathContainerClient is a minimal WendyContainerServiceClient for driving
+// tryDeployFastPath: ListContainers reports a single app in a configurable
+// state, and StartContainer records the context it was invoked with so tests can
+// assert the agent-side postStart hook metadata is attached.
+type fastPathContainerClient struct {
+	agentpb.WendyContainerServiceClient // embedded nil — satisfies interface
+
+	appName    string
+	state      agentpb.AppRunningState
+	startCtx   context.Context
+	startCalls int
+}
+
+func (f *fastPathContainerClient) ListContainers(_ context.Context, _ *agentpb.ListContainersRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[agentpb.ListContainersResponse], error) {
+	return &fakeListContainersStream{resp: &agentpb.ListContainersResponse{
+		Container: &agentpb.AppContainer{AppName: f.appName, RunningState: f.state},
+	}}, nil
+}
+
+func (f *fastPathContainerClient) StartContainer(ctx context.Context, _ *agentpb.StartContainerRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[agentpb.RunContainerLayersResponse], error) {
+	f.startCalls++
+	f.startCtx = ctx
+	return &fakeRunContainerStream{}, nil
+}
+
+type fakeListContainersStream struct {
+	grpc.ServerStreamingClient[agentpb.ListContainersResponse] // embedded nil
+	resp                                                       *agentpb.ListContainersResponse
+	sent                                                       bool
+}
+
+func (s *fakeListContainersStream) Recv() (*agentpb.ListContainersResponse, error) {
+	if s.sent {
+		return nil, io.EOF
+	}
+	s.sent = true
+	return s.resp, nil
+}
+
+type fakeRunContainerStream struct {
+	grpc.ServerStreamingClient[agentpb.RunContainerLayersResponse] // embedded nil
+}
+
+// isolateFingerprintCache points os.UserCacheDir() at a temp dir so the deploy
+// fingerprint the test writes is found by tryDeployFastPath, without touching the
+// real user cache.
+func isolateFingerprintCache(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)           // darwin: $HOME/Library/Caches
+	t.Setenv("XDG_CACHE_HOME", dir) // linux: $XDG_CACHE_HOME
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("host-side postStart hook did not run: %s was never created", path)
+}
+
+// TestTryDeployFastPath_StoppedRunsPostStartHooks verifies the fast path fires
+// BOTH postStart hooks when it starts a stopped-but-unchanged app: the agent-side
+// (in-container) hook via StartContainer metadata, and the host-side hook.
+func TestTryDeployFastPath_StoppedRunsPostStartHooks(t *testing.T) {
+	isolateFingerprintCache(t)
+
+	const (
+		appID     = "fastpath-app"
+		deviceKey = "testdevice"
+		inputHash = "sha256:deadbeef"
+	)
+	saveDeployFingerprint(appID, deviceKey, deployFingerprint{InputHash: inputHash})
+
+	sentinel := filepath.Join(t.TempDir(), "poststart-cli-ran")
+	const agentHook = "wendy-agent utils open-browser http://localhost:3000"
+	appCfg := &appconfig.AppConfig{
+		AppID: appID,
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{
+				Agent: agentHook,
+				CLI:   "touch " + sentinel,
+			},
+		},
+	}
+
+	fake := &fastPathContainerClient{appName: appID, state: agentpb.AppRunningState_STOPPED}
+	conn := &grpcclient.AgentConnection{Host: "localhost", ContainerService: fake}
+
+	done, err := tryDeployFastPath(context.Background(), conn, appCfg, deviceKey, inputHash, runOptions{detach: true})
+	if err != nil {
+		t.Fatalf("tryDeployFastPath returned error: %v", err)
+	}
+	if !done {
+		t.Fatal("expected fast path to handle the stopped app (done=true)")
+	}
+	if fake.startCalls != 1 {
+		t.Fatalf("StartContainer calls = %d, want 1", fake.startCalls)
+	}
+
+	// Agent-side postStart hook must be attached to the start RPC's context.
+	md, ok := metadata.FromOutgoingContext(fake.startCtx)
+	if !ok {
+		t.Fatal("StartContainer context carried no outgoing metadata (agent postStart hook skipped)")
+	}
+	if got := md.Get(appconfig.PostStartAgentHookMetadataKey); len(got) != 1 || got[0] != agentHook {
+		t.Fatalf("agent postStart hook metadata = %#v, want [%q]", got, agentHook)
+	}
+
+	// Host-side CLI postStart hook must fire (fire-and-forget → poll briefly).
+	if runtime.GOOS != "windows" {
+		waitForFile(t, sentinel, 3*time.Second)
+	}
+}
+
+// TestTryDeployFastPath_RunningFiresHostPostStartHook verifies that when the app
+// is already running and unchanged, the fast path still fires the host-side
+// postStart hook (so `wendy run` behaves the same regardless of the fast path)
+// without restarting the container.
+func TestTryDeployFastPath_RunningFiresHostPostStartHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("host-side hook uses `touch`, unavailable on Windows")
+	}
+	isolateFingerprintCache(t)
+
+	const (
+		appID     = "fastpath-app"
+		deviceKey = "testdevice"
+		inputHash = "sha256:deadbeef"
+	)
+	saveDeployFingerprint(appID, deviceKey, deployFingerprint{InputHash: inputHash})
+
+	sentinel := filepath.Join(t.TempDir(), "poststart-cli-ran")
+	appCfg := &appconfig.AppConfig{
+		AppID: appID,
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{CLI: "touch " + sentinel},
+		},
+	}
+
+	fake := &fastPathContainerClient{appName: appID, state: agentpb.AppRunningState_RUNNING}
+	conn := &grpcclient.AgentConnection{Host: "localhost", ContainerService: fake}
+
+	done, err := tryDeployFastPath(context.Background(), conn, appCfg, deviceKey, inputHash, runOptions{detach: true})
+	if err != nil {
+		t.Fatalf("tryDeployFastPath returned error: %v", err)
+	}
+	if !done {
+		t.Fatal("expected fast path to handle the running app (done=true)")
+	}
+	if fake.startCalls != 0 {
+		t.Fatalf("StartContainer should not be called for an already-running app, got %d calls", fake.startCalls)
+	}
+	waitForFile(t, sentinel, 3*time.Second)
+}


### PR DESCRIPTION
## Problem

`wendy run --detach` has a fast path (`tryDeployFastPath`) that skips the whole build → OCI export → chunk-diff pipeline when the project fingerprint is unchanged, and instead just ensures the already-deployed container is running. That made it behaviorally identical to `wendy device apps start` — and, crucially, it **skipped the `postStart` hook**, which a normal `wendy run` always fires.

Both halves of the hook were dropped:

- **Agent-side (in-container) hook** — normally attached to the `StartContainer` RPC via context metadata (`contextWithPostStartAgentHook`). The fast path started the container with a bare context, so the metadata was never sent.
- **Host-side hook** (`openURL` / `CLI`) — normally fired by `startPostStartHook` after readiness. The fast path returned before ever calling it.

## Fix

Make the fast path a transparent optimization of the normal detached deploy path:

- **Stopped → started branch**: attach the agent-side hook to `StartContainer` and fire the host-side hook (after readiness) via a new `runPostStartHostHook` helper.
- **Already-running branch**: also fire the host-side hook, so `wendy run` behaves the same whether or not it took the fast path (e.g. re-opening the app URL). The container isn't restarted here, so the agent-side hook can't re-run — noted in a comment.

## Tests

Added `deployfastpath_hooks_test.go` with a fake `WendyContainerServiceClient`:

- `TestTryDeployFastPath_StoppedRunsPostStartHooks` — asserts `StartContainer` carries the agent-hook metadata **and** the host-side CLI hook fires.
- `TestTryDeployFastPath_RunningFiresHostPostStartHook` — asserts the host-side hook fires without restarting the container.

Both fail before the change and pass after. `go test ./internal/cli/commands/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxQ7oD7oa3cgbjhRkmwxTn