### PR TITLE
fix: apps list hides rows until arrow key when data arrives after resize

### DIFF
--- a/go/internal/cli/commands/apps_dashboard_test.go
+++ b/go/internal/cli/commands/apps_dashboard_test.go
@@ -153,6 +153,28 @@ func TestAppsDashboardModel_EnterSetsActionLogs(t *testing.T) {
 	}
 }
 
+// Regression: a single app must be visible on first render even when the
+// window-size message arrives before the container data (the common ordering).
+// Previously the empty SetRows from the resize drove the table cursor to -1 and
+// the row stayed hidden until the user pressed the down arrow.
+func TestAppsDashboardModel_SingleAppVisibleWhenSizeArrivesFirst(t *testing.T) {
+	m := newAppsDashboardModel(nil, context.Background())
+
+	// Window size lands before any container data (refreshTable runs with 0 rows).
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(appsDashboardModel)
+
+	// Then the first (and only) container arrives.
+	updated, _ = m.Update(appsDashContainersMsg{containers: []*agentpb.AppContainer{
+		{AppName: "solo-app", AppVersion: "1.0", RunningState: agentpb.AppRunningState_RUNNING},
+	}})
+	m = updated.(appsDashboardModel)
+
+	if !strings.Contains(m.View(), "solo-app") {
+		t.Fatalf("expected 'solo-app' visible without pressing a key, got:\n%s", m.View())
+	}
+}
+
 func TestFormatBytes(t *testing.T) {
 	tests := []struct {
 		n    int64

--- a/go/internal/cli/tui/table.go
+++ b/go/internal/cli/tui/table.go
@@ -185,6 +185,15 @@ func (t BubbleTable) Rows() []bubbleTable.Row {
 
 func (t *BubbleTable) SetRows(rows []bubbleTable.Row) {
 	t.model.SetRows(rows)
+	// bubbles' table.SetRows drives the cursor to -1 whenever it is called with
+	// an empty slice, and never restores it once rows reappear. A negative
+	// cursor makes UpdateViewport render zero rows, so a table that gets its
+	// data after an initial empty SetRows (a window-resize or empty poll landing
+	// before the first payload) looks empty until the user presses an arrow key.
+	// Clamp the cursor back into range so the first row is visible immediately.
+	if len(rows) > 0 && t.model.Cursor() < 0 {
+		t.model.SetCursor(0)
+	}
 }
 
 func (t BubbleTable) Cursor() int {

--- a/go/internal/cli/tui/table_test.go
+++ b/go/internal/cli/tui/table_test.go
@@ -1,0 +1,47 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	bubbleTable "github.com/charmbracelet/bubbles/table"
+)
+
+// The underlying bubbles table.SetRows() drives its cursor to -1 whenever it is
+// called with an empty slice, and never restores it once rows reappear. A
+// negative cursor makes the table render zero rows, so an interactive table
+// that receives its data after an initial empty SetRows (e.g. a window-resize
+// or empty poll landing before the first payload) looks empty until the user
+// presses an arrow key. BubbleTable.SetRows must guard against this.
+func TestBubbleTableSetRowsRecoversCursorAfterEmpty(t *testing.T) {
+	cols := []bubbleTable.Column{{Title: "Name", Width: 20}}
+	tbl := NewBubbleTable(true, cols)
+	tbl.SetHeight(5)
+
+	// Empty first (the trigger).
+	tbl.SetRows(nil)
+
+	// Then real data arrives.
+	tbl.SetRows([]bubbleTable.Row{{"my-app"}})
+
+	if cur := tbl.Cursor(); cur < 0 {
+		t.Fatalf("cursor = %d after non-empty SetRows, want >= 0", cur)
+	}
+	if view := tbl.FullView(); !strings.Contains(view, "my-app") {
+		t.Fatalf("expected row visible in view without arrow-key input, got:\n%s", view)
+	}
+}
+
+// A non-empty SetRows should not disturb an already-valid cursor position.
+func TestBubbleTableSetRowsPreservesValidCursor(t *testing.T) {
+	cols := []bubbleTable.Column{{Title: "Name", Width: 20}}
+	tbl := NewBubbleTable(true, cols)
+	tbl.SetHeight(10)
+	tbl.SetRows([]bubbleTable.Row{{"a"}, {"b"}, {"c"}})
+	tbl.SetCursor(2)
+
+	tbl.SetRows([]bubbleTable.Row{{"a"}, {"b"}, {"c"}, {"d"}})
+	if cur := tbl.Cursor(); cur != 2 {
+		t.Fatalf("cursor = %d after SetRows, want it preserved at 2", cur)
+	}
+}


### PR DESCRIPTION
## Problem

`wendy device apps list` (the interactive dashboard) could render **zero rows on first paint** — most visibly when there is a **single app** — and the app(s) only appeared after the user pressed the **down arrow**.

## Root cause

bubbles' `table.SetRows()` drives its cursor to `-1` whenever it is called with an **empty** slice, and never restores it once rows reappear:

```go
func (m *Model) SetRows(r []Row) {
    m.rows = r
    if m.cursor > len(m.rows)-1 { // 0 rows → 0 > -1 → true
        m.cursor = len(m.rows) - 1 // cursor becomes -1
    }
    m.UpdateViewport()
}
```

The apps dashboard rebuilds the table on **every** window-resize and poll. Whenever a `WindowSizeMsg` or an empty poll lands **before** the first container payload (the common ordering), `SetRows(nil)` sets `cursor = -1`. When data later arrives, `-1 > len-1` is `false`, so the cursor **stays negative** and `UpdateViewport` computes `end = 0`, rendering nothing. `MoveDown` clamps the cursor back to `0`, which is exactly why an arrow key "fixed" it.

## Fix

Guard the cursor in the shared `tui.BubbleTable.SetRows` wrapper: after setting non-empty rows, restore a negative cursor to `0`. This is the true root-cause layer and also closes the same latent bug in `bttable` and `wifitable` (which only guarded the *upper* bound); the picker already worked around it manually.

## Tests

- `tui`: `TestBubbleTableSetRowsRecoversCursorAfterEmpty` — empty then non-empty `SetRows` leaves the row visible without any key input; `TestBubbleTableSetRowsPreservesValidCursor` — a valid cursor is untouched.
- `commands`: `TestAppsDashboardModel_SingleAppVisibleWhenSizeArrivesFirst` — a `WindowSizeMsg` before the container data still shows the single app in `View()`.

Both new tests fail before the fix and pass after; full `tui/...` and `commands/...` suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)