### PR TITLE
agent: detect CUDA version on JetPack 7.2 for the WENDY_CUDA_VERSION hint

### DIFF
--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -12,8 +12,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -238,12 +236,9 @@ func runDetectCommand(name string, args ...string) ([]byte, error) {
 //     layouts; CUDA 11.1+ dropped version.txt, newer releases also dropped
 //     version.json).
 //  2. nvcc on PATH.
-//  3. nvcc inside versioned toolkit dirs (cuda-X.Y/bin/nvcc), newest first —
-//     the JetPack 7 layout ships no cuda symlink, no version files, and does
-//     not put nvcc on PATH.
-//  4. The nvidia-smi banner ("CUDA Version: X.Y"). This is the driver's CUDA
-//     version rather than the toolkit's, but on Jetson images they match and
-//     it beats returning nothing.
+//  3. nvcc inside versioned toolkit dirs (cuda-X.Y/bin/nvcc) — the JetPack 7
+//     layout ships no cuda symlink, no version files, and does not put nvcc
+//     on PATH.
 func detectCUDAVersionIn(usrLocal string, lookPath func(string) (string, error), runCmd func(string, ...string) ([]byte, error)) string {
 	for _, name := range []string{"version.txt", "version.json"} {
 		if data, err := os.ReadFile(filepath.Join(usrLocal, "cuda", name)); err == nil {
@@ -259,17 +254,10 @@ func detectCUDAVersionIn(usrLocal string, lookPath func(string) (string, error),
 		}
 	}
 
-	for _, nvcc := range versionedNvccCandidates(usrLocal) {
+	matches, _ := filepath.Glob(filepath.Join(usrLocal, "cuda-*", "bin", "nvcc"))
+	for _, nvcc := range matches {
 		if v := cudaVersionFromNvcc(nvcc, runCmd); v != "" {
 			return v
-		}
-	}
-
-	if smi, err := lookPath("nvidia-smi"); err == nil {
-		if out, err := runCmd(smi); err == nil {
-			if m := cudaVersionFileRe.FindSubmatch(out); len(m) > 1 {
-				return string(m[1])
-			}
 		}
 	}
 
@@ -285,34 +273,6 @@ func cudaVersionFromNvcc(nvcc string, runCmd func(string, ...string) ([]byte, er
 		return string(m[1])
 	}
 	return ""
-}
-
-var cudaDirVersionRe = regexp.MustCompile(`cuda-([0-9]+)(?:\.([0-9]+))?$`)
-
-// versionedNvccCandidates returns the nvcc binaries found inside versioned
-// CUDA toolkit dirs (<usrLocal>/cuda-*/bin/nvcc), highest version first so a
-// host with several toolkits reports the newest one.
-func versionedNvccCandidates(usrLocal string) []string {
-	matches, _ := filepath.Glob(filepath.Join(usrLocal, "cuda-*", "bin", "nvcc"))
-	version := func(nvcc string) (major, minor int) {
-		dir := filepath.Dir(filepath.Dir(nvcc))
-		m := cudaDirVersionRe.FindStringSubmatch(filepath.Base(dir))
-		if m == nil {
-			return 0, 0
-		}
-		major, _ = strconv.Atoi(m[1])
-		minor, _ = strconv.Atoi(m[2])
-		return major, minor
-	}
-	sort.SliceStable(matches, func(i, j int) bool {
-		iMaj, iMin := version(matches[i])
-		jMaj, jMin := version(matches[j])
-		if iMaj != jMaj {
-			return iMaj > jMaj
-		}
-		return iMin > jMin
-	})
-	return matches
 }
 
 var computeCapRe = regexp.MustCompile(`^\s*(\d+)\.(\d+)\s*$`)

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -217,24 +219,54 @@ func detectJetPackVersion() string {
 var cudaVersionFileRe = regexp.MustCompile(`(?i)CUDA[^0-9]*([0-9]+\.[0-9]+(?:\.[0-9]+)?)`)
 
 func detectCUDAVersion() string {
-	if data, err := os.ReadFile("/usr/local/cuda/version.txt"); err == nil {
-		if m := cudaVersionFileRe.FindSubmatch(data); len(m) > 1 {
-			return string(m[1])
+	return detectCUDAVersionIn("/usr/local", exec.LookPath, runDetectCommand)
+}
+
+// runDetectCommand runs a detection helper binary with a timeout so detection
+// cannot block an RPC handler.
+func runDetectCommand(name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+// detectCUDAVersionIn probes for the installed CUDA toolkit version under
+// usrLocal (normally /usr/local). lookPath and runCmd are injectable for tests.
+//
+// Probe order:
+//  1. version.txt / version.json under the well-known cuda symlink (legacy
+//     layouts; CUDA 11.1+ dropped version.txt, newer releases also dropped
+//     version.json).
+//  2. nvcc on PATH.
+//  3. nvcc inside versioned toolkit dirs (cuda-X.Y/bin/nvcc), newest first —
+//     the JetPack 7 layout ships no cuda symlink, no version files, and does
+//     not put nvcc on PATH.
+//  4. The nvidia-smi banner ("CUDA Version: X.Y"). This is the driver's CUDA
+//     version rather than the toolkit's, but on Jetson images they match and
+//     it beats returning nothing.
+func detectCUDAVersionIn(usrLocal string, lookPath func(string) (string, error), runCmd func(string, ...string) ([]byte, error)) string {
+	for _, name := range []string{"version.txt", "version.json"} {
+		if data, err := os.ReadFile(filepath.Join(usrLocal, "cuda", name)); err == nil {
+			if m := cudaVersionFileRe.FindSubmatch(data); len(m) > 1 {
+				return string(m[1])
+			}
 		}
 	}
 
-	if data, err := os.ReadFile("/usr/local/cuda/version.json"); err == nil {
-		if m := cudaVersionFileRe.FindSubmatch(data); len(m) > 1 {
-			return string(m[1])
+	if nvcc, err := lookPath("nvcc"); err == nil {
+		if v := cudaVersionFromNvcc(nvcc, runCmd); v != "" {
+			return v
 		}
 	}
 
-	// Fall back to nvcc --version with a timeout so detection cannot block an RPC handler.
-	if nvcc, err := exec.LookPath("nvcc"); err == nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		out, err := exec.CommandContext(ctx, nvcc, "--version").Output()
-		if err == nil {
+	for _, nvcc := range versionedNvccCandidates(usrLocal) {
+		if v := cudaVersionFromNvcc(nvcc, runCmd); v != "" {
+			return v
+		}
+	}
+
+	if smi, err := lookPath("nvidia-smi"); err == nil {
+		if out, err := runCmd(smi); err == nil {
 			if m := cudaVersionFileRe.FindSubmatch(out); len(m) > 1 {
 				return string(m[1])
 			}
@@ -242,6 +274,45 @@ func detectCUDAVersion() string {
 	}
 
 	return ""
+}
+
+func cudaVersionFromNvcc(nvcc string, runCmd func(string, ...string) ([]byte, error)) string {
+	out, err := runCmd(nvcc, "--version")
+	if err != nil {
+		return ""
+	}
+	if m := cudaVersionFileRe.FindSubmatch(out); len(m) > 1 {
+		return string(m[1])
+	}
+	return ""
+}
+
+var cudaDirVersionRe = regexp.MustCompile(`cuda-([0-9]+)(?:\.([0-9]+))?$`)
+
+// versionedNvccCandidates returns the nvcc binaries found inside versioned
+// CUDA toolkit dirs (<usrLocal>/cuda-*/bin/nvcc), highest version first so a
+// host with several toolkits reports the newest one.
+func versionedNvccCandidates(usrLocal string) []string {
+	matches, _ := filepath.Glob(filepath.Join(usrLocal, "cuda-*", "bin", "nvcc"))
+	version := func(nvcc string) (major, minor int) {
+		dir := filepath.Dir(filepath.Dir(nvcc))
+		m := cudaDirVersionRe.FindStringSubmatch(filepath.Base(dir))
+		if m == nil {
+			return 0, 0
+		}
+		major, _ = strconv.Atoi(m[1])
+		minor, _ = strconv.Atoi(m[2])
+		return major, minor
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		iMaj, iMin := version(matches[i])
+		jMaj, jMin := version(matches[j])
+		if iMaj != jMaj {
+			return iMaj > jMaj
+		}
+		return iMin > jMin
+	})
+	return matches
 }
 
 var computeCapRe = regexp.MustCompile(`^\s*(\d+)\.(\d+)\s*$`)

--- a/go/internal/agent/services/agent_service_test.go
+++ b/go/internal/agent/services/agent_service_test.go
@@ -662,3 +662,157 @@ func TestGetOSUpdateStatus_ZeroFinalizedAt(t *testing.T) {
 		t.Errorf("FinalizedAtUnix = %d, want 0 for unfinalized record", resp.GetFinalizedAtUnix())
 	}
 }
+
+// ---------- detectCUDAVersionIn ----------
+
+const nvccVersionOutput = `nvcc: NVIDIA (R) Cuda compiler driver
+Copyright (c) 2005-2025 NVIDIA Corporation
+Built on Tue_Oct_14_19:22:29_PDT_2025
+Cuda compilation tools, release 13.2, V13.2.78
+Build cuda_13.2.r13.2/compiler.36123456_0
+`
+
+const nvidiaSmiBanner = `Thu Jul  2 12:00:00 2026
++-----------------------------------------------------------------------------+
+| NVIDIA-SMI 580.00                 Driver Version: 580.00  CUDA Version: 13.2 |
++-----------------------------------------------------------------------------+
+`
+
+func noLookPath(string) (string, error) {
+	return "", fmt.Errorf("not found")
+}
+
+func noRunCmd(name string, _ ...string) ([]byte, error) {
+	return nil, fmt.Errorf("unexpected command %q", name)
+}
+
+func writeCUDAFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDetectCUDAVersion_LegacyVersionTxt(t *testing.T) {
+	usrLocal := t.TempDir()
+	writeCUDAFile(t, filepath.Join(usrLocal, "cuda", "version.txt"), "CUDA Version 10.2.89")
+
+	if got := detectCUDAVersionIn(usrLocal, noLookPath, noRunCmd); got != "10.2.89" {
+		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "10.2.89")
+	}
+}
+
+func TestDetectCUDAVersion_LegacyVersionJSON(t *testing.T) {
+	usrLocal := t.TempDir()
+	writeCUDAFile(t, filepath.Join(usrLocal, "cuda", "version.json"),
+		`{"cuda": {"name": "CUDA SDK", "version": "12.6.68"}}`)
+
+	if got := detectCUDAVersionIn(usrLocal, noLookPath, noRunCmd); got != "12.6.68" {
+		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "12.6.68")
+	}
+}
+
+func TestDetectCUDAVersion_NvccOnPath(t *testing.T) {
+	usrLocal := t.TempDir()
+	lookPath := func(name string) (string, error) {
+		if name == "nvcc" {
+			return "/opt/bin/nvcc", nil
+		}
+		return "", fmt.Errorf("not found")
+	}
+	runCmd := func(name string, args ...string) ([]byte, error) {
+		if name == "/opt/bin/nvcc" && len(args) == 1 && args[0] == "--version" {
+			return []byte(nvccVersionOutput), nil
+		}
+		return nil, fmt.Errorf("unexpected command %q %v", name, args)
+	}
+
+	if got := detectCUDAVersionIn(usrLocal, lookPath, runCmd); got != "13.2" {
+		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "13.2")
+	}
+}
+
+// JetPack 7 (Thor) layout: no /usr/local/cuda symlink, no version files, nvcc
+// not on PATH — only /usr/local/cuda-13.2/bin/nvcc exists.
+func TestDetectCUDAVersion_JetPack7VersionedDir(t *testing.T) {
+	usrLocal := t.TempDir()
+	nvcc := filepath.Join(usrLocal, "cuda-13.2", "bin", "nvcc")
+	writeCUDAFile(t, nvcc, "")
+
+	runCmd := func(name string, args ...string) ([]byte, error) {
+		if name == nvcc && len(args) == 1 && args[0] == "--version" {
+			return []byte(nvccVersionOutput), nil
+		}
+		return nil, fmt.Errorf("unexpected command %q %v", name, args)
+	}
+
+	if got := detectCUDAVersionIn(usrLocal, noLookPath, runCmd); got != "13.2" {
+		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "13.2")
+	}
+}
+
+// Several versioned toolkits: the highest version wins, compared numerically
+// (cuda-13.2 beats cuda-9.0 even though it sorts lower lexically).
+func TestDetectCUDAVersion_PrefersNewestVersionedDir(t *testing.T) {
+	usrLocal := t.TempDir()
+	oldNvcc := filepath.Join(usrLocal, "cuda-9.0", "bin", "nvcc")
+	newNvcc := filepath.Join(usrLocal, "cuda-13.2", "bin", "nvcc")
+	writeCUDAFile(t, oldNvcc, "")
+	writeCUDAFile(t, newNvcc, "")
+
+	runCmd := func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case newNvcc:
+			return []byte(nvccVersionOutput), nil
+		case oldNvcc:
+			return []byte("Cuda compilation tools, release 9.0, V9.0.176"), nil
+		}
+		return nil, fmt.Errorf("unexpected command %q %v", name, args)
+	}
+
+	if got := detectCUDAVersionIn(usrLocal, noLookPath, runCmd); got != "13.2" {
+		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "13.2")
+	}
+}
+
+func TestDetectCUDAVersion_NvidiaSmiFallback(t *testing.T) {
+	usrLocal := t.TempDir()
+	lookPath := func(name string) (string, error) {
+		if name == "nvidia-smi" {
+			return "/usr/sbin/nvidia-smi", nil
+		}
+		return "", fmt.Errorf("not found")
+	}
+	runCmd := func(name string, args ...string) ([]byte, error) {
+		if name == "/usr/sbin/nvidia-smi" && len(args) == 0 {
+			return []byte(nvidiaSmiBanner), nil
+		}
+		return nil, fmt.Errorf("unexpected command %q %v", name, args)
+	}
+
+	if got := detectCUDAVersionIn(usrLocal, lookPath, runCmd); got != "13.2" {
+		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "13.2")
+	}
+}
+
+func TestDetectCUDAVersion_VersionFileWinsOverNvcc(t *testing.T) {
+	usrLocal := t.TempDir()
+	writeCUDAFile(t, filepath.Join(usrLocal, "cuda", "version.json"),
+		`{"cuda": {"version": "12.6.68"}}`)
+	writeCUDAFile(t, filepath.Join(usrLocal, "cuda-13.2", "bin", "nvcc"), "")
+
+	if got := detectCUDAVersionIn(usrLocal, noLookPath, noRunCmd); got != "12.6.68" {
+		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "12.6.68")
+	}
+}
+
+func TestDetectCUDAVersion_NothingFound(t *testing.T) {
+	usrLocal := t.TempDir()
+
+	if got := detectCUDAVersionIn(usrLocal, noLookPath, noRunCmd); got != "" {
+		t.Errorf("detectCUDAVersionIn = %q, want empty", got)
+	}
+}

--- a/go/internal/agent/services/agent_service_test.go
+++ b/go/internal/agent/services/agent_service_test.go
@@ -672,12 +672,6 @@ Cuda compilation tools, release 13.2, V13.2.78
 Build cuda_13.2.r13.2/compiler.36123456_0
 `
 
-const nvidiaSmiBanner = `Thu Jul  2 12:00:00 2026
-+-----------------------------------------------------------------------------+
-| NVIDIA-SMI 580.00                 Driver Version: 580.00  CUDA Version: 13.2 |
-+-----------------------------------------------------------------------------+
-`
-
 func noLookPath(string) (string, error) {
 	return "", fmt.Errorf("not found")
 }
@@ -750,50 +744,6 @@ func TestDetectCUDAVersion_JetPack7VersionedDir(t *testing.T) {
 	}
 
 	if got := detectCUDAVersionIn(usrLocal, noLookPath, runCmd); got != "13.2" {
-		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "13.2")
-	}
-}
-
-// Several versioned toolkits: the highest version wins, compared numerically
-// (cuda-13.2 beats cuda-9.0 even though it sorts lower lexically).
-func TestDetectCUDAVersion_PrefersNewestVersionedDir(t *testing.T) {
-	usrLocal := t.TempDir()
-	oldNvcc := filepath.Join(usrLocal, "cuda-9.0", "bin", "nvcc")
-	newNvcc := filepath.Join(usrLocal, "cuda-13.2", "bin", "nvcc")
-	writeCUDAFile(t, oldNvcc, "")
-	writeCUDAFile(t, newNvcc, "")
-
-	runCmd := func(name string, args ...string) ([]byte, error) {
-		switch name {
-		case newNvcc:
-			return []byte(nvccVersionOutput), nil
-		case oldNvcc:
-			return []byte("Cuda compilation tools, release 9.0, V9.0.176"), nil
-		}
-		return nil, fmt.Errorf("unexpected command %q %v", name, args)
-	}
-
-	if got := detectCUDAVersionIn(usrLocal, noLookPath, runCmd); got != "13.2" {
-		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "13.2")
-	}
-}
-
-func TestDetectCUDAVersion_NvidiaSmiFallback(t *testing.T) {
-	usrLocal := t.TempDir()
-	lookPath := func(name string) (string, error) {
-		if name == "nvidia-smi" {
-			return "/usr/sbin/nvidia-smi", nil
-		}
-		return "", fmt.Errorf("not found")
-	}
-	runCmd := func(name string, args ...string) ([]byte, error) {
-		if name == "/usr/sbin/nvidia-smi" && len(args) == 0 {
-			return []byte(nvidiaSmiBanner), nil
-		}
-		return nil, fmt.Errorf("unexpected command %q %v", name, args)
-	}
-
-	if got := detectCUDAVersionIn(usrLocal, lookPath, runCmd); got != "13.2" {
 		t.Errorf("detectCUDAVersionIn = %q, want %q", got, "13.2")
 	}
 }


### PR DESCRIPTION
## Summary
- Populate the `WENDY_CUDA_VERSION` build-arg hint on Jetson AGX Thor (JetPack 7.2), where it previously always arrived empty.
- Thor's image defeats all three existing probes: there is no `/usr/local/cuda` symlink (only `cuda-13.2`), modern CUDA ships no `version.txt`/`version.json`, and `nvcc` is not on PATH. Templates pinning by CUDA version silently kept their CUDA-12 default on the one device generation that needs CUDA-13.
- One new fallback probe fixes this: `nvcc` inside versioned toolkit dirs (`/usr/local/cuda-X.Y/bin/nvcc`). Probe order for existing layouts is unchanged, so Orin/JetPack 6 detection behaves exactly as before.
- Detection is now injectable (root dir, PATH lookup, command runner) so the layouts are unit-testable.

## Tests
- `go test ./internal/agent/services/` — new tests covering the legacy `version.txt`/`version.json` layouts, `nvcc` on PATH, the JetPack 7 versioned-dir layout, probe precedence, and the nothing-found case.
- Live on the shared Thor (`wendyos-curious-meteor.local`, WendyOS-0.16.1, JetPack 7.2): before the fix `wendy device info` reported no `cudaVersion`; after deploying this agent it reports `"cudaVersion": "13.2"`, and the issue's repro app (Dockerfile with `ARG WENDY_CUDA_VERSION`) receives `PROBE_CUDA=13.2` at runtime.

Closes WDY-1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)
