### PR TITLE
agent: track volume ownership from app declarations, not name prefixes

### DIFF
--- a/go/integration_test.go
+++ b/go/integration_test.go
@@ -127,6 +127,10 @@ func (m *statefulContainerdClient) ListContainers(_ context.Context) ([]*agentpb
 	return result, nil
 }
 
+func (m *statefulContainerdClient) AppDeclaredVolumes(_ context.Context) (map[string][]string, error) {
+	return nil, nil
+}
+
 func (m *statefulContainerdClient) StopContainer(_ context.Context, appName string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/go/internal/agent/container/monitor_checkcontainers_test.go
+++ b/go/internal/agent/container/monitor_checkcontainers_test.go
@@ -115,6 +115,9 @@ func (f *fakeContainerd) GetContainerMCPPort(ctx context.Context, appName string
 func (f *fakeContainerd) GetContainerRestartPolicyLabel(ctx context.Context, appName string) (string, error) {
 	return "", nil
 }
+func (f *fakeContainerd) AppDeclaredVolumes(ctx context.Context) (map[string][]string, error) {
+	return nil, nil
+}
 
 func (f *fakeContainerd) MissingChunks(_ context.Context, hashes [][32]byte) ([][32]byte, error) {
 	return hashes, nil

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -9,8 +9,10 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2625,6 +2627,66 @@ func (c *Client) ListContainers(ctx context.Context) ([]*agentpb.AppContainer, e
 		})
 	}
 	return result, nil
+}
+
+// AppDeclaredVolumes maps every Wendy-managed app (bare appID) to the
+// persistent volume names its containers declare via persist entitlement
+// labels. Names are sanitized the same way applyPersist sanitizes them before
+// creating the host directory, so they match the directory names under
+// /var/lib/wendy/volumes. Multi-service apps are grouped under their appID
+// with the union of all services' declarations.
+//
+// This is the source of truth for volume ownership: volumes are shared across
+// apps by name, so a name may appear under several apps. Containers deployed
+// before entitlement labels existed carry no persist labels and contribute
+// nothing — callers must treat an app that is absent from the map as
+// "ownership unknown", not "owns nothing", and fail safe.
+func (c *Client) AppDeclaredVolumes(ctx context.Context) (map[string][]string, error) {
+	ctx = c.withNamespace(ctx)
+
+	ctrs, err := c.client.Containers(ctx, fmt.Sprintf("labels.%q", labelKeyAppVersion))
+	if err != nil {
+		return nil, fmt.Errorf("listing containers: %w", err)
+	}
+
+	declared := make(map[string]map[string]bool)
+	for _, ctr := range ctrs {
+		info, err := ctr.Info(ctx)
+		if err != nil {
+			// Propagate rather than skip: a container we cannot inspect might
+			// declare a volume another app is about to delete, and callers rely
+			// on a complete map to protect shared volumes.
+			return nil, fmt.Errorf("getting container info for %q: %w", ctr.ID(), err)
+		}
+		appID := info.Labels[labelKeyAppID]
+		if appID == "" {
+			appID = ctr.ID()
+		}
+		for _, ent := range parseEntitlementsFromAnnotations(info.Labels) {
+			if ent.Type != appconfig.EntitlementPersist {
+				continue
+			}
+			name := filepath.Base(ent.Name)
+			if name == "." || name == ".." || name == "/" || name == "" {
+				continue
+			}
+			if declared[appID] == nil {
+				declared[appID] = make(map[string]bool)
+			}
+			declared[appID][name] = true
+		}
+	}
+
+	out := make(map[string][]string, len(declared))
+	for app, names := range declared {
+		list := make([]string, 0, len(names))
+		for n := range names {
+			list = append(list, n)
+		}
+		sort.Strings(list)
+		out[app] = list
+	}
+	return out, nil
 }
 
 func (c *Client) GetContainerMCPPort(ctx context.Context, appName string) (uint32, error) {

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -778,15 +779,19 @@ func (s *ContainerService) DeleteContainer(ctx context.Context, req *agentpb.Del
 		}
 	}
 
+	// Resolve which volumes the app owns BEFORE deleting its containers: the
+	// persist entitlement labels that record ownership die with the container.
+	var volumesToDelete []string
+	if req.GetDeleteVolumes() {
+		volumesToDelete = s.resolveDeletableVolumes(ctx, appName)
+	}
+
 	if err := s.containerd.DeleteContainer(ctx, appName, req.GetDeleteImage()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete container: %v", err)
 	}
 
 	if req.GetDeleteVolumes() {
-		// Volumes are keyed by appID, not by per-service container ID, so we
-		// call deleteVolumes once with the app name rather than once per service
-		// container (which would be "appID_serviceName" and find nothing).
-		s.deleteVolumes(appName)
+		s.deleteVolumes(volumesToDelete)
 	}
 
 	s.logger.Info("App deleted",
@@ -801,36 +806,70 @@ func (s *ContainerService) DeleteContainer(ctx context.Context, req *agentpb.Del
 // (not const) so tests can override it with a temp directory.
 var volumesDir = "/var/lib/wendy/volumes"
 
-func (s *ContainerService) deleteVolumes(appName string) {
-	// Guard: volumes are always keyed by plain appID (no "/"). A slash-containing
-	// name would find no matching directories, but reject it explicitly to prevent
-	// any future path-construction change from introducing a traversal vector
-	// (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
-	if strings.Contains(appName, "/") {
-		s.logger.Warn("deleteVolumes: app name contains '/'; volumes are keyed by appID only — skipping")
-		return
-	}
-	entries, err := os.ReadDir(volumesDir)
+// resolveDeletableVolumes returns the persistent volumes to remove when
+// appName is deleted with --delete-volumes: exactly the volume names the app's
+// containers declare via persist entitlements, minus any name that another
+// deployed app also declares (volumes are shared across apps by name — see
+// oci.applyPersist). Ambiguity fails safe: when ownership cannot be resolved,
+// or for apps deployed before entitlement labels existed, nothing is deleted —
+// a leaked volume can still be removed with `wendy device volumes rm`, whereas
+// a wrongly deleted one is unrecoverable.
+func (s *ContainerService) resolveDeletableVolumes(ctx context.Context, appName string) []string {
+	declared, err := s.containerd.AppDeclaredVolumes(ctx)
 	if err != nil {
-		s.logger.Warn("Failed to read volumes directory",
-			zap.String("base", volumesDir),
-			zap.String("app_name", appName),
-			zap.Error(err),
-		)
-		return
+		s.logger.Warn("Skipping volume deletion: cannot resolve volume ownership",
+			zap.String("app_name", appName), zap.Error(err))
+		return nil
 	}
-	for _, e := range entries {
-		if !e.IsDir() {
+	owned := declared[appName]
+	if len(owned) == 0 {
+		s.logger.Info("App declares no persistent volumes; none deleted",
+			zap.String("app_name", appName))
+		return nil
+	}
+
+	otherOwners := make(map[string][]string) // volume name → other apps declaring it
+	for app, vols := range declared {
+		if app == appName {
 			continue
 		}
-		name := e.Name()
-		if name == appName || strings.HasPrefix(name, appName+"-") {
-			path := filepath.Join(volumesDir, name)
-			if err := os.RemoveAll(path); err != nil {
-				s.logger.Warn("Failed to remove volume", zap.String("path", path), zap.Error(err))
-			} else {
-				s.logger.Info("Volume removed", zap.String("path", path))
-			}
+		for _, v := range vols {
+			otherOwners[v] = append(otherOwners[v], app)
+		}
+	}
+
+	var deletable []string
+	for _, v := range owned {
+		if others := otherOwners[v]; len(others) > 0 {
+			s.logger.Warn("Keeping shared volume: also declared by other apps",
+				zap.String("volume", v),
+				zap.String("app_name", appName),
+				zap.Strings("also_declared_by", others))
+			continue
+		}
+		deletable = append(deletable, v)
+	}
+	return deletable
+}
+
+// deleteVolumes removes the given volume directories under volumesDir. The
+// names come from persist entitlement labels; re-apply the same base-name
+// sanitization applyPersist used when creating them so no label value can
+// escape the volumes directory (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
+func (s *ContainerService) deleteVolumes(names []string) {
+	for _, name := range names {
+		if name != filepath.Base(name) || name == "." || name == ".." || name == "/" || name == "" {
+			s.logger.Warn("Skipping volume with unsafe name", zap.String("volume", name))
+			continue
+		}
+		path := filepath.Join(volumesDir, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue // declared but never materialized on disk
+		}
+		if err := os.RemoveAll(path); err != nil {
+			s.logger.Warn("Failed to remove volume", zap.String("path", path), zap.Error(err))
+		} else {
+			s.logger.Info("Volume removed", zap.String("path", path))
 		}
 	}
 }
@@ -892,30 +931,25 @@ func (s *ContainerService) RemoveVolume(_ context.Context, req *agentpb.RemoveVo
 	return &agentpb.RemoveVolumeResponse{}, nil
 }
 
-// buildVolumeUsageMap heuristically maps volumes to apps by matching
-// container names. A volume "foo-data" is likely used by app "foo".
+// buildVolumeUsageMap maps each volume name to the apps that declare it via
+// persist entitlement labels — real ownership, not a name-prefix guess.
+// Volumes are shared across apps by name, so several apps may appear for one
+// volume. Volumes no deployed app declares (including those of apps deployed
+// before entitlement labels existed) get an empty usedBy.
 func (s *ContainerService) buildVolumeUsageMap(ctx context.Context) map[string][]string {
 	usage := make(map[string][]string)
-	containers, err := s.containerd.ListContainers(ctx)
+	declared, err := s.containerd.AppDeclaredVolumes(ctx)
 	if err != nil {
+		s.logger.Warn("Failed to resolve volume ownership", zap.Error(err))
 		return usage
 	}
-	var appNames []string
-	for _, c := range containers {
-		appNames = append(appNames, c.AppName)
+	for app, vols := range declared {
+		for _, v := range vols {
+			usage[v] = append(usage[v], app)
+		}
 	}
-
-	entries, _ := os.ReadDir(volumesDir)
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		volName := e.Name()
-		for _, app := range appNames {
-			if volName == app || strings.HasPrefix(volName, app+"-") {
-				usage[volName] = append(usage[volName], app)
-			}
-		}
+	for _, apps := range usage {
+		sort.Strings(apps)
 	}
 	return usage
 }

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -49,6 +49,8 @@ type mockContainerdClient struct {
 	listeningPorts        []*agentpb.PortEntry
 	listeningPortsErr     error
 	stoppedByUserCalls    []stoppedByUserCall
+	declaredVolumes       map[string][]string
+	declaredVolumesErr    error
 }
 
 type stoppedByUserCall struct {
@@ -71,6 +73,9 @@ func (m *mockContainerdClient) MigrateStoppedByUserOnce(_ context.Context) error
 
 func (m *mockContainerdClient) ListContainers(_ context.Context) ([]*agentpb.AppContainer, error) {
 	return m.containers, m.listErr
+}
+func (m *mockContainerdClient) AppDeclaredVolumes(_ context.Context) (map[string][]string, error) {
+	return m.declaredVolumes, m.declaredVolumesErr
 }
 func (m *mockContainerdClient) StopContainer(_ context.Context, _ string) error {
 	return m.stopErr
@@ -913,6 +918,239 @@ func TestListVolumes_WithVolumes(t *testing.T) {
 	}
 	if !found {
 		t.Error("app-data volume not found in response")
+	}
+}
+
+// TestListVolumes_UsedByFromDeclaredVolumes verifies that usedBy comes from
+// declared persist entitlements, not name prefixes (WDY-1807): a declared
+// volume is attributed to its app regardless of its name, a foreign volume
+// whose name merely starts with the app ID is not, and a volume declared by
+// two apps lists both.
+func TestListVolumes_UsedByFromDeclaredVolumes(t *testing.T) {
+	tmp := t.TempDir()
+	old := volumesDir
+	volumesDir = tmp
+	t.Cleanup(func() { volumesDir = old })
+
+	for _, dir := range []string{"autotest-churn-data", "autotest-orphanvol", "hellovlm-models", "shared-cache", "leaked-vol"} {
+		if err := os.MkdirAll(filepath.Join(tmp, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mock := &mockContainerdClient{
+		declaredVolumes: map[string][]string{
+			"autotest-churn":             {"autotest-churn-data", "autotest-orphanvol", "shared-cache"},
+			"sh.wendy.examples.hellovlm": {"hellovlm-models", "shared-cache"},
+		},
+	}
+	cl, cleanup := startContainerServer(t, mock)
+	defer cleanup()
+
+	resp, err := cl.ListVolumes(context.Background(), &agentpb.ListVolumesRequest{})
+	if err != nil {
+		t.Fatalf("ListVolumes: %v", err)
+	}
+
+	usedBy := make(map[string][]string)
+	for _, v := range resp.GetVolumes() {
+		usedBy[v.GetName()] = v.GetUsedBy()
+	}
+
+	wants := map[string][]string{
+		"autotest-churn-data": {"autotest-churn"},
+		// Declared but unprefixed: must still be attributed (was invisible before).
+		"autotest-orphanvol": {"autotest-churn"},
+		// Prefix collision with app "hellovlm": owned by the declaring app only.
+		"hellovlm-models": {"sh.wendy.examples.hellovlm"},
+		// Shared by name across two apps.
+		"shared-cache": {"autotest-churn", "sh.wendy.examples.hellovlm"},
+		// Declared by nobody: orphan, empty usedBy.
+		"leaked-vol": nil,
+	}
+	for vol, want := range wants {
+		got := usedBy[vol]
+		if len(got) != len(want) {
+			t.Errorf("usedBy[%q] = %v, want %v", vol, got, want)
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("usedBy[%q] = %v, want %v", vol, got, want)
+				break
+			}
+		}
+	}
+}
+
+// deleteVolumesTestSetup creates volume dirs and starts a server whose mock
+// reports the given declared-volumes map.
+func deleteVolumesTestSetup(t *testing.T, dirs []string, declared map[string][]string, declaredErr error) (agentpb.WendyContainerServiceClient, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	old := volumesDir
+	volumesDir = tmp
+	t.Cleanup(func() { volumesDir = old })
+
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(tmp, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mock := &mockContainerdClient{declaredVolumes: declared, declaredVolumesErr: declaredErr}
+	cl, cleanup := startContainerServer(t, mock)
+	t.Cleanup(cleanup)
+	return cl, tmp
+}
+
+func mustExist(t *testing.T, tmp string, dirs ...string) {
+	t.Helper()
+	for _, dir := range dirs {
+		if _, err := os.Stat(filepath.Join(tmp, dir)); err != nil {
+			t.Errorf("volume %q should still exist: %v", dir, err)
+		}
+	}
+}
+
+func mustNotExist(t *testing.T, tmp string, dirs ...string) {
+	t.Helper()
+	for _, dir := range dirs {
+		if _, err := os.Stat(filepath.Join(tmp, dir)); !os.IsNotExist(err) {
+			t.Errorf("volume %q should have been deleted (err=%v)", dir, err)
+		}
+	}
+}
+
+// TestDeleteContainer_DeleteVolumes_DeclaredNotPrefixed verifies the leak
+// direction of WDY-1807: --delete-volumes removes exactly what the app
+// declared, including volumes whose names don't start with the app ID.
+func TestDeleteContainer_DeleteVolumes_DeclaredNotPrefixed(t *testing.T) {
+	cl, tmp := deleteVolumesTestSetup(t,
+		[]string{"autotest-churn-data", "autotest-orphanvol", "hellovlm-models"},
+		map[string][]string{
+			"autotest-churn":             {"autotest-churn-data", "autotest-orphanvol"},
+			"sh.wendy.examples.hellovlm": {"hellovlm-models"},
+		}, nil)
+
+	_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
+		AppName:       "autotest-churn",
+		DeleteVolumes: true,
+	})
+	if err != nil {
+		t.Fatalf("DeleteContainer: %v", err)
+	}
+
+	mustNotExist(t, tmp, "autotest-churn-data", "autotest-orphanvol")
+	mustExist(t, tmp, "hellovlm-models")
+}
+
+// TestDeleteContainer_DeleteVolumes_PrefixCollision verifies the cross-delete
+// direction of WDY-1807: removing app "hellovlm" must not delete
+// "hellovlm-models", which belongs to a different app that happens to share
+// the name prefix.
+func TestDeleteContainer_DeleteVolumes_PrefixCollision(t *testing.T) {
+	cl, tmp := deleteVolumesTestSetup(t,
+		[]string{"hellovlm-data", "hellovlm-models"},
+		map[string][]string{
+			"hellovlm":                   {"hellovlm-data"},
+			"sh.wendy.examples.hellovlm": {"hellovlm-models"},
+		}, nil)
+
+	_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
+		AppName:       "hellovlm",
+		DeleteVolumes: true,
+	})
+	if err != nil {
+		t.Fatalf("DeleteContainer: %v", err)
+	}
+
+	mustNotExist(t, tmp, "hellovlm-data")
+	mustExist(t, tmp, "hellovlm-models")
+}
+
+// TestDeleteContainer_DeleteVolumes_SharedVolumeKept: a volume declared by
+// another deployed app too is shared by name and must survive.
+func TestDeleteContainer_DeleteVolumes_SharedVolumeKept(t *testing.T) {
+	cl, tmp := deleteVolumesTestSetup(t,
+		[]string{"app-a-data", "shared-cache"},
+		map[string][]string{
+			"app-a": {"app-a-data", "shared-cache"},
+			"app-b": {"shared-cache"},
+		}, nil)
+
+	_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
+		AppName:       "app-a",
+		DeleteVolumes: true,
+	})
+	if err != nil {
+		t.Fatalf("DeleteContainer: %v", err)
+	}
+
+	mustNotExist(t, tmp, "app-a-data")
+	mustExist(t, tmp, "shared-cache")
+}
+
+// TestDeleteContainer_DeleteVolumes_OwnershipUnknown: when ownership cannot be
+// resolved (lookup error, or an app deployed before entitlement labels
+// existed), nothing is deleted — fail safe, even for prefix-matching names.
+func TestDeleteContainer_DeleteVolumes_OwnershipUnknown(t *testing.T) {
+	t.Run("lookup error", func(t *testing.T) {
+		cl, tmp := deleteVolumesTestSetup(t,
+			[]string{"legacy-app-data"},
+			nil, fmt.Errorf("containerd unavailable"))
+
+		_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
+			AppName:       "legacy-app",
+			DeleteVolumes: true,
+		})
+		if err != nil {
+			t.Fatalf("DeleteContainer: %v", err)
+		}
+		mustExist(t, tmp, "legacy-app-data")
+	})
+
+	t.Run("no persist labels", func(t *testing.T) {
+		cl, tmp := deleteVolumesTestSetup(t,
+			[]string{"legacy-app-data"},
+			map[string][]string{}, nil)
+
+		_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
+			AppName:       "legacy-app",
+			DeleteVolumes: true,
+		})
+		if err != nil {
+			t.Fatalf("DeleteContainer: %v", err)
+		}
+		mustExist(t, tmp, "legacy-app-data")
+	})
+}
+
+// TestDeleteVolumes_UnsafeNames: names that would escape the volumes dir are
+// skipped even if they somehow appear in a declared-volumes list.
+func TestDeleteVolumes_UnsafeNames(t *testing.T) {
+	tmp := t.TempDir()
+	old := volumesDir
+	volumesDir = tmp
+	t.Cleanup(func() { volumesDir = old })
+
+	if err := os.MkdirAll(filepath.Join(tmp, "safe-vol"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(tmp, "..", "outside-"+filepath.Base(tmp))
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(outside) })
+
+	svc := NewContainerService(zap.NewNop(), &mockContainerdClient{})
+	svc.deleteVolumes([]string{"../" + filepath.Base(outside), ".", "..", "", "/", "safe-vol"})
+
+	if _, err := os.Stat(outside); err != nil {
+		t.Errorf("path outside volumes dir should not have been touched: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "safe-vol")); !os.IsNotExist(err) {
+		t.Error("safe-vol should have been deleted")
 	}
 }
 

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -62,6 +62,14 @@ type ContainerdClient interface {
 	// the monitor before issuing a stop or delete.
 	ContainerIDsForApp(ctx context.Context, appID string) ([]string, error)
 	ListContainers(ctx context.Context) ([]*agentpb.AppContainer, error)
+	// AppDeclaredVolumes maps every deployed app (bare appID) to the persistent
+	// volume names its containers declare via persist entitlement labels. This
+	// is the source of truth for volume ownership (volumes are shared across
+	// apps by name, so one name may appear under several apps). Apps deployed
+	// before entitlement labels existed are absent — callers must treat that as
+	// "ownership unknown" and fail safe rather than guess from name prefixes
+	// (WDY-1807).
+	AppDeclaredVolumes(ctx context.Context) (map[string][]string, error)
 	// ListBootContainers returns the containers that should be (re)started at
 	// agent boot: restart policy keeps them running (not "no") and they were not
 	// explicitly stopped by the user. Used by the boot reconcile.


### PR DESCRIPTION
## Summary

- `wendy device volumes list` now attributes each volume to the apps that actually declare it in their persist entitlements, and `apps remove --delete-volumes` deletes exactly the volumes the removed app declared. Previously both guessed ownership from name prefixes ("does the volume name start with the app ID?"), which was wrong in both directions (verified live on the Thor test device):
  - a declared volume whose name doesn't start with the app ID showed `usedBy: null` and silently leaked past `--delete-volumes`;
  - a foreign volume that merely shares the prefix (app `hellovlm` vs. `hellovlm-models`, owned by `sh.wendy.examples.hellovlm`) would have been cross-deleted.
- Ownership comes from the persist entitlement labels every container has carried since 2026-05 — the same declaration that creates the volume — so the "shared by name" semantics are preserved: a volume declared by several apps lists them all in `usedBy`, and `--delete-volumes` keeps any volume another deployed app also declares (with an agent-log warning).
- Deletion fails safe on ambiguity: if ownership can't be resolved (containerd lookup error, or an app deployed before entitlement labels existed), nothing is deleted — a leaked volume is recoverable with `wendy device volumes rm`, a wrongly deleted one is not.

## Behavior for pre-tracking volumes

Apps deployed before entitlement labels (pre-2026-05) carry no persist labels, so their volumes show an empty `usedBy` and are not touched by `--delete-volumes`. Redeploying the app restores ownership; until then cleanup is manual via `wendy device volumes rm`. No on-disk migration is attempted — inferring ownership for those volumes would require the same prefix guess this PR removes.

## Tests

- `go test ./internal/agent/... .` (includes new tests for both failure directions: declared-but-unprefixed volumes are attributed and cleaned up; prefix-colliding foreign volumes are never touched; shared volumes survive; lookup errors and label-less apps delete nothing; unsafe names from labels can't escape the volumes dir)
- Not run live on a device (the shared Thor device is in use by another lane); the reproduction from the issue maps 1:1 onto the new unit tests.

Closes WDY-1807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
