### PR TITLE
cli: filter device logs per app before applying the tail window

### DIFF
--- a/go/internal/agent/services/telemetry_buffer.go
+++ b/go/internal/agent/services/telemetry_buffer.go
@@ -600,6 +600,18 @@ func (b *TelemetryBuffer) SaveCursor(sig SignalType, cursor flushCursor) error {
 // It reads segment files newest-to-oldest and prepends older frames.
 // n is capped at maxReplayFrames to bound per-call disk I/O.
 func (b *TelemetryBuffer) ReadLastN(sig SignalType, n int) []proto.Message {
+	return b.ReadLastNMatching(sig, n, nil)
+}
+
+// ReadLastNMatching returns up to the last n entries for sig that match, in
+// ascending time order. match maps a frame to the (possibly reduced) message
+// to return, or nil to drop the frame; a nil match keeps every frame as-is.
+// Counting matching frames (rather than matching the last n frames overall)
+// keeps tail semantics per-filter: a chatty co-tenant cannot push the
+// requested entries out of the window. Segments are read newest-to-oldest and
+// reading stops once n matches are collected, so sparse matches cost at most
+// one pass over the buffer's bounded retention.
+func (b *TelemetryBuffer) ReadLastNMatching(sig SignalType, n int, match func(proto.Message) proto.Message) []proto.Message {
 	if b == nil {
 		return nil
 	}
@@ -614,6 +626,15 @@ func (b *TelemetryBuffer) ReadLastN(sig SignalType, n int) []proto.Message {
 	for i := len(segs) - 1; i >= 0 && len(result) < n; i-- {
 		// Read all frames in the segment so we can correctly take the trailing ones.
 		frames, _, _ := readFramesFrom(filepath.Join(b.cfg.Dir, segs[i]), 0, sig, math.MaxInt32)
+		if match != nil {
+			matched := make([]proto.Message, 0, len(frames))
+			for _, f := range frames {
+				if m := match(f); m != nil {
+					matched = append(matched, m)
+				}
+			}
+			frames = matched
+		}
 		need := n - len(result)
 		if len(frames) > need {
 			frames = frames[len(frames)-need:]

--- a/go/internal/agent/services/telemetry_buffer_test.go
+++ b/go/internal/agent/services/telemetry_buffer_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"encoding/binary"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -298,4 +299,61 @@ func TestTelemetryBuffer_Cursor(t *testing.T) {
 	}
 
 	_ = dir
+}
+
+func TestTelemetryBuffer_ReadLastNMatching(t *testing.T) {
+	// Tiny segments force rotation so the scan for matches spans segment files.
+	buf, _ := makeTestBuffer(t, 10*1024*1024, 100)
+
+	logBody := func(m proto.Message) string {
+		logs, ok := m.(*otelpb.ExportLogsServiceRequest)
+		if !ok {
+			return ""
+		}
+		return logs.GetResourceLogs()[0].GetScopeLogs()[0].GetLogRecords()[0].GetBody().GetStringValue()
+	}
+	matchQuiet := func(m proto.Message) proto.Message {
+		if strings.HasPrefix(logBody(m), "quiet-") {
+			return m
+		}
+		return nil
+	}
+
+	// A quiet producer's entries interleaved with a chatty one that dominates
+	// the tail of the buffer.
+	for i := 0; i < 3; i++ {
+		buf.PublishLogs(makeLogReq(fmt.Sprintf("quiet-%d", i)))
+		for j := 0; j < 10; j++ {
+			buf.PublishLogs(makeLogReq(fmt.Sprintf("chatty-%d-%d", i, j)))
+		}
+	}
+
+	// The window counts matching frames: the last 2 quiet entries come back
+	// even though the most recent frames overall are all chatty.
+	got := buf.ReadLastNMatching(SignalLogs, 2, matchQuiet)
+	if len(got) != 2 || logBody(got[0]) != "quiet-1" || logBody(got[1]) != "quiet-2" {
+		bodies := make([]string, len(got))
+		for i, m := range got {
+			bodies[i] = logBody(m)
+		}
+		t.Errorf("want [quiet-1 quiet-2], got %v", bodies)
+	}
+
+	// n larger than the matching history returns everything that matches.
+	got = buf.ReadLastNMatching(SignalLogs, 50, matchQuiet)
+	if len(got) != 3 {
+		t.Errorf("want all 3 quiet entries, got %d", len(got))
+	}
+
+	// No matches at all returns an empty result.
+	got = buf.ReadLastNMatching(SignalLogs, 5, func(proto.Message) proto.Message { return nil })
+	if len(got) != 0 {
+		t.Errorf("want no entries for non-matching filter, got %d", len(got))
+	}
+
+	// A nil match behaves like ReadLastN.
+	got = buf.ReadLastNMatching(SignalLogs, 2, nil)
+	if len(got) != 2 || logBody(got[1]) != "chatty-2-9" {
+		t.Errorf("nil match: want last 2 frames overall ending in chatty-2-9, got %d entries", len(got))
+	}
 }

--- a/go/internal/agent/services/telemetry_service.go
+++ b/go/internal/agent/services/telemetry_service.go
@@ -337,17 +337,25 @@ func (s *TelemetryService) StreamLogs(req *agentpb.StreamLogsRequest, stream grp
 
 	// Replay history if requested (after subscribing so no live items are missed).
 	if req.LastN != nil && *req.LastN > 0 && s.buffer != nil && s.buffer.DiskEnabled() {
-		entries := s.buffer.ReadLastN(SignalLogs, int(*req.LastN))
+		// Count the tail window against batches that survive the filter: the
+		// last N batches device-wide may all belong to a chatty co-tenant,
+		// which would replay nothing for the requested app.
+		entries := s.buffer.ReadLastNMatching(SignalLogs, int(*req.LastN), func(m proto.Message) proto.Message {
+			logs, ok := m.(*otelpb.ExportLogsServiceRequest)
+			if !ok {
+				return nil
+			}
+			if req.AppName != nil || req.ServiceName != nil || req.MinSeverity != nil {
+				if logs = filterLogs(logs, req); logs == nil {
+					return nil
+				}
+			}
+			return logs
+		})
 		for _, e := range entries {
 			logs, ok := e.(*otelpb.ExportLogsServiceRequest)
 			if !ok {
 				continue
-			}
-			if req.AppName != nil || req.ServiceName != nil || req.MinSeverity != nil {
-				logs = filterLogs(logs, req)
-				if logs == nil {
-					continue
-				}
 			}
 			if err := stream.Send(&agentpb.StreamLogsResponse{Logs: logs, IsHistory: true}); err != nil {
 				return err
@@ -397,19 +405,25 @@ func (s *TelemetryService) StreamMetrics(req *agentpb.StreamMetricsRequest, stre
 	}
 	defer s.broadcaster.UnsubscribeMetrics(id)
 
-	// Replay history after subscribing.
+	// Replay history after subscribing. As with logs, the tail window counts
+	// batches that survive the filter, not the last N device-wide.
 	if req.LastN != nil && *req.LastN > 0 && s.buffer != nil && s.buffer.DiskEnabled() {
-		entries := s.buffer.ReadLastN(SignalMetrics, int(*req.LastN))
+		entries := s.buffer.ReadLastNMatching(SignalMetrics, int(*req.LastN), func(m proto.Message) proto.Message {
+			metrics, ok := m.(*otelpb.ExportMetricsServiceRequest)
+			if !ok {
+				return nil
+			}
+			if req.ServiceName != nil || req.AppName != nil || req.MetricNamePrefix != nil {
+				if metrics = filterMetrics(metrics, req); metrics == nil {
+					return nil
+				}
+			}
+			return metrics
+		})
 		for _, e := range entries {
 			metrics, ok := e.(*otelpb.ExportMetricsServiceRequest)
 			if !ok {
 				continue
-			}
-			if req.ServiceName != nil || req.AppName != nil || req.MetricNamePrefix != nil {
-				metrics = filterMetrics(metrics, req)
-				if metrics == nil {
-					continue
-				}
 			}
 			if err := stream.Send(&agentpb.StreamMetricsResponse{Metrics: metrics, IsHistory: true}); err != nil {
 				return err
@@ -454,19 +468,25 @@ func (s *TelemetryService) StreamTraces(req *agentpb.StreamTracesRequest, stream
 	id, ch := s.broadcaster.SubscribeTraces()
 	defer s.broadcaster.UnsubscribeTraces(id)
 
-	// Replay history after subscribing.
+	// Replay history after subscribing. As with logs, the tail window counts
+	// batches that survive the filter, not the last N device-wide.
 	if req.LastN != nil && *req.LastN > 0 && s.buffer != nil && s.buffer.DiskEnabled() {
-		entries := s.buffer.ReadLastN(SignalTraces, int(*req.LastN))
+		entries := s.buffer.ReadLastNMatching(SignalTraces, int(*req.LastN), func(m proto.Message) proto.Message {
+			traces, ok := m.(*otelpb.ExportTraceServiceRequest)
+			if !ok {
+				return nil
+			}
+			if req.ServiceName != nil || req.AppName != nil || req.SpanNamePrefix != nil {
+				if traces = filterTraces(traces, req); traces == nil {
+					return nil
+				}
+			}
+			return traces
+		})
 		for _, e := range entries {
 			traces, ok := e.(*otelpb.ExportTraceServiceRequest)
 			if !ok {
 				continue
-			}
-			if req.ServiceName != nil || req.AppName != nil || req.SpanNamePrefix != nil {
-				traces = filterTraces(traces, req)
-				if traces == nil {
-					continue
-				}
 			}
 			if err := stream.Send(&agentpb.StreamTracesResponse{Traces: traces, IsHistory: true}); err != nil {
 				return err

--- a/go/internal/agent/services/telemetry_service_test.go
+++ b/go/internal/agent/services/telemetry_service_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
 )
 
@@ -689,5 +690,232 @@ func TestStreamTraces_LastN(t *testing.T) {
 	}
 	if historyCount != 3 {
 		t.Errorf("want 3 history records, got %d", historyCount)
+	}
+}
+
+// makeLogReqForService builds a single-record log batch attributed to the
+// given service.name, which is what --app/--service filtering matches on.
+func makeLogReqForService(svc, body string) *otelpb.ExportLogsServiceRequest {
+	return &otelpb.ExportLogsServiceRequest{
+		ResourceLogs: []*otelpb.ResourceLogs{{
+			Resource: &otelpb.Resource{Attributes: []*otelpb.KeyValue{{
+				Key:   "service.name",
+				Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: svc}},
+			}}},
+			ScopeLogs: []*otelpb.ScopeLogs{{
+				LogRecords: []*otelpb.LogRecord{{
+					Body: &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: body}},
+				}},
+			}},
+		}},
+	}
+}
+
+func firstLogBody(req *otelpb.ExportLogsServiceRequest) string {
+	return req.GetResourceLogs()[0].GetScopeLogs()[0].GetLogRecords()[0].GetBody().GetStringValue()
+}
+
+// newTelemetryTestConn serves the given registration over bufconn and returns
+// a client connection to it.
+func newTelemetryTestConn(t *testing.T, register func(*grpc.Server)) *grpc.ClientConn {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	register(srv)
+	go srv.Serve(lis) //nolint:errcheck
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return conn
+}
+
+// newChattyQuietBuffer seeds a buffer where a quiet app's 3 batches are
+// followed by 50 batches from a chatty app, so the last N batches
+// device-wide never include the quiet app.
+func newChattyQuietBuffer(t *testing.T) (*TelemetryBroadcaster, *TelemetryBuffer) {
+	t.Helper()
+	broadcaster := NewTelemetryBroadcaster()
+	buf := NewTelemetryBuffer(TelemetryBufferConfig{
+		Dir:           t.TempDir(),
+		MaxTotalBytes: 10 * 1024 * 1024,
+		SegmentBytes:  1 * 1024 * 1024,
+	}, broadcaster, zap.NewNop())
+
+	for i := 0; i < 3; i++ {
+		buf.PublishLogs(makeLogReqForService("quiet", fmt.Sprintf("quiet-%d", i)))
+	}
+	for i := 0; i < 50; i++ {
+		buf.PublishLogs(makeLogReqForService("chatty", fmt.Sprintf("chatty-%d", i)))
+	}
+	return broadcaster, buf
+}
+
+func TestStreamLogs_LastN_FilterBeforeWindow(t *testing.T) {
+	broadcaster, buf := newChattyQuietBuffer(t)
+	svc := NewTelemetryService(zap.NewNop(), broadcaster, buf)
+	conn := newTelemetryTestConn(t, func(srv *grpc.Server) {
+		agentpb.RegisterWendyTelemetryServiceServer(srv, svc)
+	})
+	client := agentpb.NewWendyTelemetryServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	appName := "quiet"
+	lastN := int32(2)
+	stream, err := client.StreamLogs(ctx, &agentpb.StreamLogsRequest{LastN: &lastN, AppName: &appName})
+	if err != nil {
+		t.Fatalf("StreamLogs: %v", err)
+	}
+
+	for _, want := range []string{"quiet-1", "quiet-2"} {
+		resp, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv(%s): %v", want, err)
+		}
+		if !resp.IsHistory {
+			t.Errorf("want history record %s, got live", want)
+		}
+		if got := firstLogBody(resp.GetLogs()); got != want {
+			t.Errorf("want body %s, got %s", want, got)
+		}
+	}
+
+	// History is fully replayed before live delivery starts, so a live batch
+	// arriving next proves no extra history records were sent.
+	broadcaster.PublishLogs(makeLogReqForService("quiet", "live-sentinel"))
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv(sentinel): %v", err)
+	}
+	if resp.IsHistory || firstLogBody(resp.GetLogs()) != "live-sentinel" {
+		t.Errorf("want live sentinel after 2 history records, got history=%v body=%s",
+			resp.IsHistory, firstLogBody(resp.GetLogs()))
+	}
+}
+
+func TestStreamLogs_LastN_FilterLargerThanHistory(t *testing.T) {
+	broadcaster, buf := newChattyQuietBuffer(t)
+	svc := NewTelemetryService(zap.NewNop(), broadcaster, buf)
+	conn := newTelemetryTestConn(t, func(srv *grpc.Server) {
+		agentpb.RegisterWendyTelemetryServiceServer(srv, svc)
+	})
+	client := agentpb.NewWendyTelemetryServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	appName := "quiet"
+	lastN := int32(10)
+	stream, err := client.StreamLogs(ctx, &agentpb.StreamLogsRequest{LastN: &lastN, AppName: &appName})
+	if err != nil {
+		t.Fatalf("StreamLogs: %v", err)
+	}
+
+	for _, want := range []string{"quiet-0", "quiet-1", "quiet-2"} {
+		resp, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv(%s): %v", want, err)
+		}
+		if !resp.IsHistory {
+			t.Errorf("want history record %s, got live", want)
+		}
+		if got := firstLogBody(resp.GetLogs()); got != want {
+			t.Errorf("want body %s, got %s", want, got)
+		}
+	}
+
+	broadcaster.PublishLogs(makeLogReqForService("quiet", "live-sentinel"))
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv(sentinel): %v", err)
+	}
+	if resp.IsHistory || firstLogBody(resp.GetLogs()) != "live-sentinel" {
+		t.Errorf("want live sentinel after 3 history records, got history=%v body=%s",
+			resp.IsHistory, firstLogBody(resp.GetLogs()))
+	}
+}
+
+func TestStreamLogs_LastN_FilterWithNoHistory(t *testing.T) {
+	broadcaster, buf := newChattyQuietBuffer(t)
+	svc := NewTelemetryService(zap.NewNop(), broadcaster, buf)
+	conn := newTelemetryTestConn(t, func(srv *grpc.Server) {
+		agentpb.RegisterWendyTelemetryServiceServer(srv, svc)
+	})
+	client := agentpb.NewWendyTelemetryServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	appName := "ghost"
+	lastN := int32(5)
+	stream, err := client.StreamLogs(ctx, &agentpb.StreamLogsRequest{LastN: &lastN, AppName: &appName})
+	if err != nil {
+		t.Fatalf("StreamLogs: %v", err)
+	}
+
+	// Publish live batches until the stream delivers one; the subscription
+	// may not be registered yet when the first publish happens.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(10 * time.Millisecond):
+				broadcaster.PublishLogs(makeLogReqForService("ghost", "live-sentinel"))
+			}
+		}
+	}()
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if resp.IsHistory {
+		t.Errorf("app with no logged history must replay nothing, got history record %s",
+			firstLogBody(resp.GetLogs()))
+	}
+}
+
+func TestStreamLogsV2_LastN_FilterBeforeWindow(t *testing.T) {
+	broadcaster, buf := newChattyQuietBuffer(t)
+	svc := NewTelemetryServiceV2(zap.NewNop(), broadcaster, buf)
+	conn := newTelemetryTestConn(t, func(srv *grpc.Server) {
+		agentpbv2.RegisterWendyTelemetryServiceServer(srv, svc)
+	})
+	client := agentpbv2.NewWendyTelemetryServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	appName := "quiet"
+	lastN := int32(2)
+	stream, err := client.StreamLogs(ctx, &agentpbv2.StreamLogsRequest{LastN: &lastN, AppName: &appName})
+	if err != nil {
+		t.Fatalf("StreamLogs: %v", err)
+	}
+
+	for _, want := range []string{"quiet-1", "quiet-2"} {
+		resp, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv(%s): %v", want, err)
+		}
+		if !resp.IsHistory {
+			t.Errorf("want history record %s, got live", want)
+		}
+		if got := firstLogBody(resp.GetLogs()); got != want {
+			t.Errorf("want body %s, got %s", want, got)
+		}
 	}
 }

--- a/go/internal/agent/services/telemetry_service_v2.go
+++ b/go/internal/agent/services/telemetry_service_v2.go
@@ -5,6 +5,7 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
@@ -37,20 +38,26 @@ func (s *TelemetryServiceV2) StreamLogs(req *agentpbv2.StreamLogsRequest, stream
 	}
 	defer s.broadcaster.UnsubscribeLogs(subID)
 
-	// Replay history after subscribing.
+	// Replay history after subscribing. Count the tail window against batches
+	// that survive the filter: the last N batches device-wide may all belong
+	// to a chatty co-tenant, which would replay nothing for the requested app.
 	if req.LastN != nil && *req.LastN > 0 && s.buffer != nil && s.buffer.DiskEnabled() {
-		entries := s.buffer.ReadLastN(SignalLogs, int(*req.LastN))
+		entries := s.buffer.ReadLastNMatching(SignalLogs, int(*req.LastN), func(m proto.Message) proto.Message {
+			logs, ok := m.(*otelpb.ExportLogsServiceRequest)
+			if !ok {
+				return nil
+			}
+			if req.AppName != nil || req.ServiceName != nil || req.MinSeverity != nil {
+				if logs = filterLogsV2(logs, req); logs == nil {
+					return nil
+				}
+			}
+			return logs
+		})
 		for _, e := range entries {
 			logs, ok := e.(*otelpb.ExportLogsServiceRequest)
 			if !ok {
 				continue
-			}
-			// Apply filters if set.
-			if req.AppName != nil || req.ServiceName != nil || req.MinSeverity != nil {
-				logs = filterLogsV2(logs, req)
-				if logs == nil {
-					continue
-				}
 			}
 			if err := stream.Send(&agentpbv2.StreamLogsResponse{Logs: logs, IsHistory: true}); err != nil {
 				return err
@@ -92,19 +99,25 @@ func (s *TelemetryServiceV2) StreamMetrics(req *agentpbv2.StreamMetricsRequest, 
 	}
 	defer s.broadcaster.UnsubscribeMetrics(subID)
 
-	// Replay history after subscribing.
+	// Replay history after subscribing. As with logs, the tail window counts
+	// batches that survive the filter, not the last N device-wide.
 	if req.LastN != nil && *req.LastN > 0 && s.buffer != nil && s.buffer.DiskEnabled() {
-		entries := s.buffer.ReadLastN(SignalMetrics, int(*req.LastN))
+		entries := s.buffer.ReadLastNMatching(SignalMetrics, int(*req.LastN), func(m proto.Message) proto.Message {
+			metrics, ok := m.(*otelpb.ExportMetricsServiceRequest)
+			if !ok {
+				return nil
+			}
+			if req.ServiceName != nil || req.AppName != nil || req.MetricNamePrefix != nil {
+				if metrics = filterMetricsV2(metrics, req); metrics == nil {
+					return nil
+				}
+			}
+			return metrics
+		})
 		for _, e := range entries {
 			metrics, ok := e.(*otelpb.ExportMetricsServiceRequest)
 			if !ok {
 				continue
-			}
-			if req.ServiceName != nil || req.AppName != nil || req.MetricNamePrefix != nil {
-				metrics = filterMetricsV2(metrics, req)
-				if metrics == nil {
-					continue
-				}
 			}
 			if err := stream.Send(&agentpbv2.StreamMetricsResponse{Metrics: metrics, IsHistory: true}); err != nil {
 				return err
@@ -139,19 +152,25 @@ func (s *TelemetryServiceV2) StreamTraces(req *agentpbv2.StreamTracesRequest, st
 	subID, ch := s.broadcaster.SubscribeTraces()
 	defer s.broadcaster.UnsubscribeTraces(subID)
 
-	// Replay history after subscribing.
+	// Replay history after subscribing. As with logs, the tail window counts
+	// batches that survive the filter, not the last N device-wide.
 	if req.LastN != nil && *req.LastN > 0 && s.buffer != nil && s.buffer.DiskEnabled() {
-		entries := s.buffer.ReadLastN(SignalTraces, int(*req.LastN))
+		entries := s.buffer.ReadLastNMatching(SignalTraces, int(*req.LastN), func(m proto.Message) proto.Message {
+			traces, ok := m.(*otelpb.ExportTraceServiceRequest)
+			if !ok {
+				return nil
+			}
+			if req.ServiceName != nil || req.AppName != nil || req.SpanNamePrefix != nil {
+				if traces = filterTracesV2(traces, req); traces == nil {
+					return nil
+				}
+			}
+			return traces
+		})
 		for _, e := range entries {
 			traces, ok := e.(*otelpb.ExportTraceServiceRequest)
 			if !ok {
 				continue
-			}
-			if req.ServiceName != nil || req.AppName != nil || req.SpanNamePrefix != nil {
-				traces = filterTracesV2(traces, req)
-				if traces == nil {
-					continue
-				}
 			}
 			if err := stream.Send(&agentpbv2.StreamTracesResponse{Traces: traces, IsHistory: true}); err != nil {
 				return err

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/logs.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/logs.md
@@ -1,7 +1,17 @@
 Tails the OTel logs from a wendy-agent, rendering them in the terminal. By default it shows all apps **and the agent**'s logs.
 
-With `--app`, you can filter on a per-app basis. You an also set a minimum log level using, for example, `--level error`.
+With `--app`, you can filter on a per-app basis. You can also set a minimum log level using, for example, `--level error`.
 
 If you provide `--json`, the output will be JSONL, one line per log statement.
 
 To inspect the device's kernel ring buffer (`dmesg`) instead of container/agent logs, use [`wendy device os-logs`](./os-logs).
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--app <name>` | Only show logs from the named app. |
+| `--service <name>` | Only show logs from the named service. |
+| `--level <level>` | Minimum log level: `trace`, `debug`, `info`, `warn`, `error`, or `fatal`. |
+| `--min-severity <n>` | Minimum OTel severity number; a numeric alternative to `--level`. |
+| `--tail <N>` | Replay the last N log batches **matching the active filters** before streaming live (default `0`: live only). The window counts only batches that survive `--app`/`--service`/`--level`, so other apps logging at high volume on the same device cannot push the requested app's history out of the replay window. |

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1107,7 +1107,7 @@ func newDeviceLogsCmd() *cobra.Command {
 	cmd.Flags().StringVar(&serviceName, "service", "", "Filter by service name")
 	cmd.Flags().Int32Var(&minSeverity, "min-severity", 0, "Minimum log severity number")
 	cmd.Flags().StringVar(&level, "level", "", "Minimum log level (trace, debug, info, warn, error, fatal)")
-	cmd.Flags().Int32Var(&tail, "tail", 0, "Replay the last N log batches before streaming live (0 = live only)")
+	cmd.Flags().Int32Var(&tail, "tail", 0, "Replay the last N log batches matching the filters before streaming live (0 = live only)")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
- `wendy device logs --app X --tail N` now replays the app's own last N log batches. Previously tail grabbed the last N batches from the whole device and filtered afterwards, so on a busy device (e.g. the shared Thor with HelloVLM's LLM service logging constantly) the target app's lines fell out of the window before the filter ran and the command printed nothing — right when someone is debugging.
- The agent's telemetry buffer gained `ReadLastNMatching`: it scans segment files newest-to-oldest, applies the filter per batch, and stops as soon as N matching batches are found, so a sparse app costs at most one pass over the buffer's bounded retention (100 MB default) instead of scanning unbounded history.
- The same select-then-filter pattern existed in six replay paths — logs, metrics, and traces in both the v1 and v2 telemetry services — all are fixed. Live streaming is unchanged (it already filtered correctly).
- `--tail` help text now says the window counts batches *matching the filters*. Note N still counts batches, not lines; a batch can hold several lines.

## Tests
- `go test ./internal/agent/services ./internal/cli/commands`
- New coverage: buffer-level `ReadLastNMatching` (window spanning rotated segments, N larger than matching history, no matches, nil filter) and gRPC-level chatty/quiet scenarios for v1 and v2 `StreamLogs`, including the degenerate cases (N larger than the app's history, app with no logged history replays nothing but still streams live).

Closes WDY-1811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
