### PR TITLE
cli: surface apple-container build output when a build fails

### DIFF
--- a/go/internal/cli/commands/buildprogress.go
+++ b/go/internal/cli/commands/buildprogress.go
@@ -39,17 +39,23 @@ const maxRawBuildCapture = 256 << 10
 // progress UI (the same renderer used by the buildx/buildctl paths).
 func runAppleContainerBuildWithProgress(ctx context.Context, dir, imageName, platform, dockerfile string) error {
 	title := fmt.Sprintf("Building Apple Container image %s for %s...", tui.Value(imageName), tui.Value(platform))
-	return runBuildWithProgress(ctx, title, true, func(stream, logw io.Writer) error {
+	return runBuildWithProgress(ctx, title, dumpRawAlways, func(stream, logw io.Writer) error {
 		return buildImageWithAppleContainer(ctx, dir, imageName, platform, dockerfile, nil, stream, logw)
 	})
 }
 
+// dumpRawAlways is the dumpRawOnFailure predicate for build paths whose
+// failures are always surfaced to the user (no fallback rebuild follows).
+func dumpRawAlways(error) bool { return true }
+
 // runBuildWithProgress runs build, rendering its buildx output as a clean live
 // step list (interactive) or concise per-step lines (non-interactive). The raw
-// buildx output is retained and printed if the build fails AND dumpRawOnFailure
-// is true (but never on cancellation). Setup-log chatter written to logw is
-// buffered and surfaced only on failure (when dumpRawOnFailure is true).
-func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure bool, build func(stream, logw io.Writer) error) error {
+// buildx output is retained and printed if the build fails AND
+// dumpRawOnFailure(err) is true (but never on cancellation). Setup-log chatter
+// written to logw is buffered and surfaced under the same condition. Callers
+// whose failures can trigger a fallback rebuild (which would replay the same
+// output) use the predicate to stay quiet in exactly those cases.
+func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure func(error) bool, build func(stream, logw io.Writer) error) error {
 	start := time.Now()
 	raw := &boundedBuffer{max: maxRawBuildCapture}
 	var setupLog bytes.Buffer
@@ -61,7 +67,7 @@ func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure bo
 		fmt.Fprintf(buildProgressOut, "%s\n", title)
 		err := build(stream, &setupLog)
 		if err != nil {
-			if dumpRawOnFailure && ctx.Err() == nil {
+			if ctx.Err() == nil && dumpRawOnFailure(err) {
 				buildProgressOut.Write(raw.Bytes())
 				buildProgressOut.Write(setupLog.Bytes())
 			}
@@ -96,7 +102,7 @@ func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure bo
 	}
 	buildErr := <-buildErrC
 	if buildErr != nil {
-		if dumpRawOnFailure && ctx.Err() == nil {
+		if ctx.Err() == nil && dumpRawOnFailure(buildErr) {
 			buildProgressOut.Write(raw.Bytes())
 			buildProgressOut.Write(setupLog.Bytes())
 		}

--- a/go/internal/cli/commands/buildprogress_test.go
+++ b/go/internal/cli/commands/buildprogress_test.go
@@ -16,7 +16,7 @@ func TestRunBuildWithProgressPlainSuccess(t *testing.T) {
 	restoreOut := setBuildProgressOut(&out)
 	defer restoreOut()
 
-	err := runBuildWithProgress(context.Background(), "Building image...", true, func(stream, logw io.Writer) error {
+	err := runBuildWithProgress(context.Background(), "Building image...", dumpRawAlways, func(stream, logw io.Writer) error {
 		io.WriteString(stream, "#9 [4/6] RUN pip install\n#9 DONE 4.3s\n")
 		io.WriteString(stream, "#6 [1/6] FROM python\n#6 CACHED\n")
 		return nil
@@ -41,7 +41,7 @@ func TestRunBuildWithProgressPrintsRawOnFailure(t *testing.T) {
 	defer restoreOut()
 
 	wantErr := errors.New("docker buildx build failed")
-	err := runBuildWithProgress(context.Background(), "Building image...", true, func(stream, logw io.Writer) error {
+	err := runBuildWithProgress(context.Background(), "Building image...", dumpRawAlways, func(stream, logw io.Writer) error {
 		io.WriteString(stream, "#9 [4/6] RUN pip install\n")
 		io.WriteString(stream, "#9 12.34 ERROR: could not find a version\n")
 		io.WriteString(logw, "[buildx] bootstrapping builder\n")
@@ -68,7 +68,7 @@ func TestRunBuildWithProgressSuppressesRawOnFailureWhenDumpDisabled(t *testing.T
 	defer restoreOut()
 
 	wantErr := errors.New("oci layout build failed")
-	err := runBuildWithProgress(context.Background(), "Building image (OCI layout)...", false, func(stream, logw io.Writer) error {
+	err := runBuildWithProgress(context.Background(), "Building image (OCI layout)...", func(error) bool { return false }, func(stream, logw io.Writer) error {
 		io.WriteString(stream, "#5 [3/5] RUN apt-get install\n")
 		io.WriteString(stream, "#5 12.34 ERROR: package not found\n")
 		io.WriteString(logw, "[buildx] starting builder instance\n")
@@ -84,5 +84,56 @@ func TestRunBuildWithProgressSuppressesRawOnFailureWhenDumpDisabled(t *testing.T
 	}
 	if strings.Contains(got, "starting builder instance") {
 		t.Errorf("setup log should be suppressed when dumpRawOnFailure=false, but got:\n%s", got)
+	}
+}
+
+// Regression test for WDY-1813: an apple-container (or buildx) image-build
+// failure on the default chunk-diff path is surfaced directly to the user
+// without a registry-push fallback, so the captured build log must be dumped —
+// previously it was discarded and the user saw only the ✗ line.
+func TestChunkDiffBuildLogDumpedForImageBuildFailureUnderAutoChunking(t *testing.T) {
+	restore := forceBuildProgressInteractive(false)
+	defer restore()
+	var out strings.Builder
+	restoreOut := setBuildProgressOut(&out)
+	defer restoreOut()
+
+	wantErr := &imageBuildFailedError{errors.New("container build (OCI layout) failed: exit status 1")}
+	err := runBuildWithProgress(context.Background(), "Building image (OCI layout)...", shouldDumpChunkDiffBuildLog(chunkingAuto), func(stream, logw io.Writer) error {
+		io.WriteString(stream, "#5 [3/5] COPY Package.swift .\n")
+		io.WriteString(stream, "#5 ERROR: failed to compute cache key: \"/Package.swift\": not found\n")
+		io.WriteString(logw, "[apple-container] building OCI image: container build --progress plain ...\n")
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	got := out.String()
+	if !strings.Contains(got, "failed to compute cache key") {
+		t.Errorf("raw build output not surfaced on image-build failure:\n%s", got)
+	}
+	// The setup log carries the exact builder command line for manual reproduction.
+	if !strings.Contains(got, "building OCI image: container build") {
+		t.Errorf("builder command line not surfaced on image-build failure:\n%s", got)
+	}
+}
+
+func TestShouldDumpChunkDiffBuildLog(t *testing.T) {
+	buildErr := &imageBuildFailedError{errors.New("boom")}
+	setupErr := errors.New("creating buildx builder: boom")
+	cases := []struct {
+		chunking string
+		err      error
+		want     bool
+	}{
+		{chunkingAuto, buildErr, true},  // surfaced directly (#1166) → dump
+		{chunkingAuto, setupErr, false}, // falls back to registry push → quiet
+		{chunkingForce, buildErr, true}, // no fallback → dump
+		{chunkingForce, setupErr, true}, // no fallback → dump
+	}
+	for _, c := range cases {
+		if got := shouldDumpChunkDiffBuildLog(c.chunking)(c.err); got != c.want {
+			t.Errorf("shouldDumpChunkDiffBuildLog(%q)(%v) = %v, want %v", c.chunking, c.err, got, c.want)
+		}
 	}
 }

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -656,7 +656,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		// Compose builds run sequentially, so they share the local cache dir
 		// (empty cache key) — no concurrent cache-export race to isolate.
 		composeBuildTitle := fmt.Sprintf("Building service %s for %s...", name, tui.Value(platform))
-		if err := runBuildWithProgress(ctx, composeBuildTitle, true, func(stream, logw io.Writer) error {
+		if err := runBuildWithProgress(ctx, composeBuildTitle, dumpRawAlways, func(stream, logw io.Writer) error {
 			return buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, ctxDir, repo, platform, dockerfile, allBuildArgs, "", stream, logw)
 		}); err != nil {
 			return fmt.Errorf("building service %s: %w", name, err)

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1502,7 +1502,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// Single-service build: no concurrency, so keep the shared local cache dir
 	// (empty cache key) for cross-run cache reuse.
 	buildTitle := fmt.Sprintf("Building and pushing image for %s...", tui.Value(platform))
-	if err := runBuildWithProgress(ctx, buildTitle, true, func(stream, logw io.Writer) error {
+	if err := runBuildWithProgress(ctx, buildTitle, dumpRawAlways, func(stream, logw io.Writer) error {
 		return buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, "", stream, logw)
 	}); err != nil {
 		return fmt.Errorf("building and pushing image: %w", err)
@@ -1855,6 +1855,19 @@ func phaseTimer() func(label string) {
 	}
 }
 
+// shouldDumpChunkDiffBuildLog decides whether the chunk-diff build replays its
+// captured build log when the build fails. The log must be shown whenever the
+// error is surfaced to the user directly: always under --chunking=force (no
+// fallback), and for image-build failures under auto chunking, which skip the
+// registry-push fallback (#1166). Only builder-setup failures under auto
+// chunking stay quiet — those fall back to a registry push whose own build
+// output supersedes the discarded log.
+func shouldDumpChunkDiffBuildLog(chunking string) func(error) bool {
+	return func(err error) bool {
+		return chunking == chunkingForce || isImageBuildFailure(err)
+	}
+}
+
 // deployByChunkDiff builds the image to a local OCI layout tar, diffs the
 // layers against what the device already has via content-defined chunking, and
 // calls RunContainer with the resulting layer headers.
@@ -1879,7 +1892,7 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 			return err
 		}
 	} else {
-		if err := runBuildWithProgress(ctx, buildTitle, opts.chunking == chunkingForce, func(stream, logw io.Writer) error {
+		if err := runBuildWithProgress(ctx, buildTitle, shouldDumpChunkDiffBuildLog(opts.chunking), func(stream, logw io.Writer) error {
 			return buildImageToOCILayout(ctx, cwd, dockerfile, platform, buildArgs, opts.builder, ociTar, stream, logw)
 		}); err != nil {
 			return err


### PR DESCRIPTION
## Summary

- A failed apple-container (or buildx) build on the default `wendy run` deploy path printed only `✗ container build (OCI layout) failed: exit status 1` — no Dockerfile step, no compiler error, and `--debug` added nothing. The only way to diagnose it was to reconstruct and re-run the `container build` command by hand.
- The progress UI already captures the builder's output and can replay it on failure, but the chunk-diff path only enabled that under `--chunking=force`. That quiet default dated from when auto chunking always fell back to a registry push (whose own build output would supersede the log); since #1166 image-build failures skip the fallback and are surfaced directly — silently discarding the captured log.
- The replay decision is now error-aware: the log is dumped whenever the failure reaches the user (force mode, or an image-build failure under auto chunking), and stays quiet only for builder-setup failures that genuinely fall back to the registry push. The dump includes the exact `container build ...` command line for manual reproduction.

Failure output before:

```
Building image (OCI layout) for linux/arm64...
✗ container build (OCI layout) failed: exit status 1
```

After:

```
Building image (OCI layout) for linux/arm64...
[apple-container] building OCI image: container build --progress plain --platform linux/arm64 -t wendy-oci-build:001 ...
#5 [linux/arm64/v8 1/2] COPY Package.swift /app/Package.swift
#5 ERROR: failed to calculate checksum of ref ...: "/Package.swift": not found
...
✗ container build (OCI layout) failed: exit status 1
```

Closes WDY-1813.

## Tests

- `go test ./internal/cli/commands` (includes a new regression test for the auto-chunking image-build failure case and a table test for the dump predicate)
- Verified against a real apple-container build with a broken `COPY`: the failing step, the underlying `"/Package.swift": not found` error, and the reproducible command line all appear in the failure output.

## Follow-ups

- WDY-1814 (empty /tmp build contexts) is stacked on this — the discarded output masked that bug.
- `--verbose` parity outside watch mode (the issue's "consider" item) is intentionally left out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
