### PR TITLE
agent: derive log severity from line content instead of stderr=WARN

### DIFF
--- a/go/internal/agent/services/container_log_manager.go
+++ b/go/internal/agent/services/container_log_manager.go
@@ -1,7 +1,9 @@
 package services
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -147,47 +149,11 @@ func (m *ContainerLogManager) publishToTelemetry(appName string, output Containe
 	var records []*otelpb.LogRecord
 
 	if len(output.Stdout) > 0 {
-		records = append(records, &otelpb.LogRecord{
-			TimeUnixNano:         now,
-			ObservedTimeUnixNano: now,
-			SeverityNumber:       otelpb.SeverityNumber_SEVERITY_NUMBER_INFO,
-			SeverityText:         "INFO",
-			Body: &otelpb.AnyValue{
-				Value: &otelpb.AnyValue_StringValue{
-					StringValue: string(output.Stdout),
-				},
-			},
-			Attributes: []*otelpb.KeyValue{
-				{
-					Key: "stream",
-					Value: &otelpb.AnyValue{
-						Value: &otelpb.AnyValue_StringValue{StringValue: "stdout"},
-					},
-				},
-			},
-		})
+		records = append(records, containerLogRecord(now, "stdout", output.Stdout))
 	}
 
 	if len(output.Stderr) > 0 {
-		records = append(records, &otelpb.LogRecord{
-			TimeUnixNano:         now,
-			ObservedTimeUnixNano: now,
-			SeverityNumber:       otelpb.SeverityNumber_SEVERITY_NUMBER_WARN,
-			SeverityText:         "WARN",
-			Body: &otelpb.AnyValue{
-				Value: &otelpb.AnyValue_StringValue{
-					StringValue: string(output.Stderr),
-				},
-			},
-			Attributes: []*otelpb.KeyValue{
-				{
-					Key: "stream",
-					Value: &otelpb.AnyValue{
-						Value: &otelpb.AnyValue_StringValue{StringValue: "stderr"},
-					},
-				},
-			},
-		})
+		records = append(records, containerLogRecord(now, "stderr", output.Stderr))
 	}
 
 	if len(records) == 0 {
@@ -214,4 +180,171 @@ func (m *ContainerLogManager) publishToTelemetry(appName string, output Containe
 			},
 		},
 	})
+}
+
+func containerLogRecord(now uint64, stream string, body []byte) *otelpb.LogRecord {
+	severityNumber, severityText := inferContainerLogSeverity(body)
+	return &otelpb.LogRecord{
+		TimeUnixNano:         now,
+		ObservedTimeUnixNano: now,
+		SeverityNumber:       severityNumber,
+		SeverityText:         severityText,
+		Body: &otelpb.AnyValue{
+			Value: &otelpb.AnyValue_StringValue{
+				StringValue: string(body),
+			},
+		},
+		Attributes: []*otelpb.KeyValue{
+			{
+				Key: "stream",
+				Value: &otelpb.AnyValue{
+					Value: &otelpb.AnyValue_StringValue{StringValue: stream},
+				},
+			},
+		},
+	}
+}
+
+func inferContainerLogSeverity(body []byte) (otelpb.SeverityNumber, string) {
+	line := strings.TrimSpace(string(body))
+	if line == "" {
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_INFO, "INFO"
+	}
+
+	if severity, text, ok := severityFromJSONLine(line); ok {
+		return severity, text
+	}
+	if severity, text, ok := severityFromLeadingLevel(line); ok {
+		return severity, text
+	}
+	if severity, text, ok := severityFromISOLevel(line); ok {
+		return severity, text
+	}
+	if severity, text, ok := severityFromLlamaPrefix(line); ok {
+		return severity, text
+	}
+
+	// stderr is not inherently a warning stream: many runtimes put routine
+	// diagnostics there. Keep the raw stream as an attribute and use INFO as the
+	// neutral default so warning/error filters only surface content that actually
+	// advertises a warning or error level.
+	return otelpb.SeverityNumber_SEVERITY_NUMBER_INFO, "INFO"
+}
+
+func severityFromJSONLine(line string) (otelpb.SeverityNumber, string, bool) {
+	if !strings.HasPrefix(line, "{") {
+		return 0, "", false
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(line), &obj); err != nil {
+		return 0, "", false
+	}
+	for _, key := range []string{"severity", "level"} {
+		value, ok := obj[key]
+		if !ok {
+			continue
+		}
+		if s, ok := value.(string); ok {
+			if severity, text, ok := containerLogSeverityFromToken(s); ok {
+				return severity, text, true
+			}
+		}
+	}
+	return 0, "", false
+}
+
+func severityFromLeadingLevel(line string) (otelpb.SeverityNumber, string, bool) {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return 0, "", false
+	}
+	return containerLogSeverityFromToken(fields[0])
+}
+
+func severityFromISOLevel(line string) (otelpb.SeverityNumber, string, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 || !looksLikeISOTimestamp(fields[0]) {
+		return 0, "", false
+	}
+	for _, field := range fields[1:min(len(fields), 4)] {
+		if severity, text, ok := containerLogSeverityFromToken(field); ok {
+			return severity, text, true
+		}
+	}
+	return 0, "", false
+}
+
+func severityFromLlamaPrefix(line string) (otelpb.SeverityNumber, string, bool) {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return 0, "", false
+	}
+	if severity, text, ok := containerLogSeverityFromLlamaToken(fields[0]); ok {
+		return severity, text, true
+	}
+	if len(fields) >= 2 && looksLikeTimestampPrefix(fields[0]) {
+		return containerLogSeverityFromLlamaToken(fields[1])
+	}
+	return 0, "", false
+}
+
+func looksLikeISOTimestamp(s string) bool {
+	return len(s) >= len("2006-01-02T") && s[4] == '-' && s[7] == '-' && (s[10] == 'T' || s[10] == 't')
+}
+
+func looksLikeTimestampPrefix(s string) bool {
+	hasDigit := false
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r == '.' || r == ':' || r == '-' || r == 'T' || r == 't' || r == 'Z' || r == 'z' || r == '+':
+		default:
+			return false
+		}
+	}
+	return hasDigit
+}
+
+func containerLogSeverityFromToken(token string) (otelpb.SeverityNumber, string, bool) {
+	token = strings.TrimSpace(token)
+	if idx := strings.IndexAny(token, "="); idx >= 0 && idx+1 < len(token) {
+		token = token[idx+1:]
+	}
+	token = strings.ToLower(strings.Trim(token, "[](){}:;,|\"'"))
+	return containerLogSeverityFromLevel(token)
+}
+
+func containerLogSeverityFromLlamaToken(token string) (otelpb.SeverityNumber, string, bool) {
+	switch strings.Trim(token, "[](){}:;,|\"'") {
+	case "I":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_INFO, "INFO", true
+	case "W":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_WARN, "WARN", true
+	case "E":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR, "ERROR", true
+	case "D":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_DEBUG, "DEBUG", true
+	default:
+		return 0, "", false
+	}
+}
+
+func containerLogSeverityFromLevel(level string) (otelpb.SeverityNumber, string, bool) {
+	switch level {
+	case "trace":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_TRACE, "TRACE", true
+	case "debug", "dbg":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_DEBUG, "DEBUG", true
+	case "info", "information", "notice":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_INFO, "INFO", true
+	case "warn", "warning", "wrn":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_WARN, "WARN", true
+	case "error", "err":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR, "ERROR", true
+	case "fatal", "panic", "critical", "crit":
+		return otelpb.SeverityNumber_SEVERITY_NUMBER_FATAL, "FATAL", true
+	default:
+		return 0, "", false
+	}
 }

--- a/go/internal/agent/services/container_log_manager_test.go
+++ b/go/internal/agent/services/container_log_manager_test.go
@@ -126,14 +126,40 @@ func TestContainerLogManager_PublishBridgesToTelemetry(t *testing.T) {
 	}
 }
 
-func TestContainerLogManager_StderrBridgesAsWarn(t *testing.T) {
+func TestContainerLogManager_StderrDefaultsToInfo(t *testing.T) {
 	broadcaster := NewTelemetryBroadcaster()
 	lm := NewContainerLogManager(zap.NewNop(), broadcaster)
 
 	telID, telCh := broadcaster.SubscribeLogs()
 	defer broadcaster.UnsubscribeLogs(telID)
 
-	lm.Publish("my-app", ContainerOutput{Stderr: []byte("error output")})
+	lm.Publish("my-app", ContainerOutput{Stderr: []byte("routine diagnostic output")})
+
+	select {
+	case got := <-telCh:
+		records := got.ResourceLogs[0].ScopeLogs[0].LogRecords
+		if len(records) != 1 {
+			t.Fatalf("expected 1 log record, got %d", len(records))
+		}
+		if records[0].SeverityNumber != otelpb.SeverityNumber_SEVERITY_NUMBER_INFO {
+			t.Errorf("severity = %v; want INFO", records[0].SeverityNumber)
+		}
+		if records[0].Body.GetStringValue() != "routine diagnostic output" {
+			t.Errorf("log body = %q; want %q", records[0].Body.GetStringValue(), "routine diagnostic output")
+		}
+	case <-time.After(time.Second):
+		t.Error("did not receive telemetry log")
+	}
+}
+
+func TestContainerLogManager_StderrSniffsWarning(t *testing.T) {
+	broadcaster := NewTelemetryBroadcaster()
+	lm := NewContainerLogManager(zap.NewNop(), broadcaster)
+
+	telID, telCh := broadcaster.SubscribeLogs()
+	defer broadcaster.UnsubscribeLogs(telID)
+
+	lm.Publish("my-app", ContainerOutput{Stderr: []byte("WARNING: disk almost full")})
 
 	select {
 	case got := <-telCh:
@@ -144,11 +170,105 @@ func TestContainerLogManager_StderrBridgesAsWarn(t *testing.T) {
 		if records[0].SeverityNumber != otelpb.SeverityNumber_SEVERITY_NUMBER_WARN {
 			t.Errorf("severity = %v; want WARN", records[0].SeverityNumber)
 		}
-		if records[0].Body.GetStringValue() != "error output" {
-			t.Errorf("log body = %q; want %q", records[0].Body.GetStringValue(), "error output")
+		if records[0].Body.GetStringValue() != "WARNING: disk almost full" {
+			t.Errorf("log body = %q; want %q", records[0].Body.GetStringValue(), "WARNING: disk almost full")
 		}
 	case <-time.After(time.Second):
 		t.Error("did not receive telemetry log")
+	}
+}
+
+func TestInferContainerLogSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		wantNum  otelpb.SeverityNumber
+		wantText string
+	}{
+		{
+			name:     "uvicorn info",
+			line:     "INFO:     Started server process [1]",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_INFO,
+			wantText: "INFO",
+		},
+		{
+			name:     "uvicorn warning",
+			line:     "WARNING:  Retrying request",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_WARN,
+			wantText: "WARN",
+		},
+		{
+			name:     "uvicorn error",
+			line:     "ERROR:    Exception in ASGI application",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR,
+			wantText: "ERROR",
+		},
+		{
+			name:     "llama info prefix",
+			line:     "I slot print_timing: id 0 | prompt eval time = 10.00 ms",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_INFO,
+			wantText: "INFO",
+		},
+		{
+			name:     "llama warning prefix",
+			line:     "W slot update_slots: slot unavailable",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_WARN,
+			wantText: "WARN",
+		},
+		{
+			name:     "llama error prefix",
+			line:     "E server failed to load model",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR,
+			wantText: "ERROR",
+		},
+		{
+			name:     "llama timestamped info prefix",
+			line:     "35.12.761.535 I slot print_timing: id 0 | generation eval time = 84.18 ms",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_INFO,
+			wantText: "INFO",
+		},
+		{
+			name:     "swift log info",
+			line:     "2026-07-02T14:09:34+0000 info swift-otel: component=bootstrap ready=true",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_INFO,
+			wantText: "INFO",
+		},
+		{
+			name:     "zap timestamped warn",
+			line:     "2026-07-02T14:09:34Z warn app/component.go:42 retrying after transient failure",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_WARN,
+			wantText: "WARN",
+		},
+		{
+			name:     "json level info",
+			line:     `{"level":"info","msg":"server started"}`,
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_INFO,
+			wantText: "INFO",
+		},
+		{
+			name:     "json severity error",
+			line:     `{"severity":"ERROR","message":"request failed"}`,
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR,
+			wantText: "ERROR",
+		},
+		{
+			name:     "plain stderr line defaults neutral",
+			line:     "routine diagnostic output with no level token",
+			wantNum:  otelpb.SeverityNumber_SEVERITY_NUMBER_INFO,
+			wantText: "INFO",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNum, gotText := inferContainerLogSeverity([]byte(tt.line))
+			if gotNum != tt.wantNum {
+				t.Errorf("SeverityNumber = %v; want %v", gotNum, tt.wantNum)
+			}
+			if gotText != tt.wantText {
+				t.Errorf("SeverityText = %q; want %q", gotText, tt.wantText)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Derive container log severity from log content instead of treating stderr as WARN.
- Recognize common level formats: JSON `level`/`severity`, leading `INFO:`/`WARNING:`/`ERROR:`, ISO-timestamped level tokens, and llama.cpp `I`/`W`/`E` prefixes.
- Default unrecognized lines to INFO as the neutral severity; the original stream remains available as `attributes.stream` for consumers that need it.

## Tests
- `go test ./go/internal/agent/services`

Closes WDY-1812.
