### PR TITLE
cli: detect empty apple-container build contexts

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -41,6 +41,10 @@ wendy --device my-wendy.local build
 
 Wendy automatically checks for the `container` CLI and offers to install it via Homebrew if missing, and starts the `system` and `builder` services if they are not running.
 
+If Apple Container reports an empty build context for a project under `/tmp` or
+`/private/tmp`, Wendy returns an error with the known workaround: move the
+project to a non-`/tmp` directory and retry.
+
 For local-only Dockerfile or Containerfile builds on the Mac itself, select the
 local provider with `--device apple-container`. Compose projects still require
 Docker for local provider runs.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -41,6 +41,10 @@ wendy --device my-wendy.local run
 
 Wendy automatically checks for the `container` CLI and offers to install it via Homebrew if missing, and starts the `system` and `builder` services if they are not running.
 
+If Apple Container reports an empty build context for a project under `/tmp` or
+`/private/tmp`, Wendy returns an error with the known workaround: move the
+project to a non-`/tmp` directory and retry.
+
 For local-only Dockerfile or Containerfile runs on the Mac itself, use `wendy run --device
 apple-container` instead. Compose projects still require the Docker provider for
 local runs, but compose service builds targeting a WendyOS device can use

--- a/go/internal/cli/commands/apple_context_diagnostics.go
+++ b/go/internal/cli/commands/apple_context_diagnostics.go
@@ -18,13 +18,13 @@ const (
 	// projects as the /tmp builder regression.
 	appleContainerSuspiciousContextBytes = 2
 	appleContainerContextFileScanLimit   = 128
+	appleContainerContextLineLimit       = 64 << 10
 )
 
 var errAppleContainerContextScanDone = errors.New("apple-container context scan done")
 
 type appleContainerContextStats struct {
 	fileCount int
-	totalSize int64
 	truncated bool
 }
 
@@ -63,6 +63,9 @@ func (m *appleContainerBuildContextMonitor) Write(p []byte) (int, error) {
 		line := strings.TrimRight(string(m.line[:i]), "\r")
 		m.line = m.line[i+1:]
 		m.observeLine(line)
+	}
+	if len(m.line) > appleContainerContextLineLimit {
+		m.line = m.line[:0]
 	}
 	return len(p), nil
 }
@@ -113,9 +116,6 @@ func scanAppleContainerBuildContext(contextPath string) appleContainerContextSta
 			return nil
 		}
 		stats.fileCount++
-		if info, infoErr := d.Info(); infoErr == nil && info.Mode().IsRegular() {
-			stats.totalSize += info.Size()
-		}
 		if stats.fileCount >= appleContainerContextFileScanLimit {
 			stats.truncated = true
 			return errAppleContainerContextScanDone

--- a/go/internal/cli/commands/apple_context_diagnostics.go
+++ b/go/internal/cli/commands/apple_context_diagnostics.go
@@ -1,0 +1,142 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+const (
+	// Apple Container reports an empty context transfer as 2B. Keep the threshold
+	// deliberately tiny to avoid diagnosing legitimate, heavily-.dockerignored
+	// projects as the /tmp builder regression.
+	appleContainerSuspiciousContextBytes = 2
+	appleContainerContextFileScanLimit   = 128
+)
+
+var errAppleContainerContextScanDone = errors.New("apple-container context scan done")
+
+type appleContainerContextStats struct {
+	fileCount int
+	totalSize int64
+	truncated bool
+}
+
+type appleContainerBuildContextMonitor struct {
+	contextPath string
+	pathInTmp   bool
+	stats       appleContainerContextStats
+
+	line               []byte
+	sawContextTransfer bool
+	contextBytes       int64
+}
+
+func newAppleContainerBuildContextMonitor(contextPath string) *appleContainerBuildContextMonitor {
+	return &appleContainerBuildContextMonitor{
+		contextPath: contextPath,
+		pathInTmp:   appleContainerPathInTmp(contextPath),
+		stats:       scanAppleContainerBuildContext(contextPath),
+	}
+}
+
+func (m *appleContainerBuildContextMonitor) wrapStream(w io.Writer) io.Writer {
+	if m == nil {
+		return w
+	}
+	return io.MultiWriter(w, m)
+}
+
+func (m *appleContainerBuildContextMonitor) Write(p []byte) (int, error) {
+	m.line = append(m.line, p...)
+	for {
+		i := bytes.IndexByte(m.line, '\n')
+		if i < 0 {
+			break
+		}
+		line := strings.TrimRight(string(m.line[:i]), "\r")
+		m.line = m.line[i+1:]
+		m.observeLine(line)
+	}
+	return len(p), nil
+}
+
+func (m *appleContainerBuildContextMonitor) observeLine(line string) {
+	bytes, ok := tui.ParseBuildContextTransferBytes(line)
+	if !ok {
+		return
+	}
+	m.sawContextTransfer = true
+	m.contextBytes = bytes
+}
+
+func (m *appleContainerBuildContextMonitor) wrapBuildError(err error) error {
+	if err == nil || m == nil {
+		return err
+	}
+	if diagnosis := m.diagnosis(); diagnosis != "" {
+		return fmt.Errorf("%s: %w", diagnosis, err)
+	}
+	return err
+}
+
+func (m *appleContainerBuildContextMonitor) diagnosis() string {
+	if m == nil || !m.pathInTmp || m.stats.fileCount == 0 || !m.sawContextTransfer || m.contextBytes > appleContainerSuspiciousContextBytes {
+		return ""
+	}
+	files := fmt.Sprintf("%d files", m.stats.fileCount)
+	if m.stats.fileCount == 1 {
+		files = "1 file"
+	}
+	if m.stats.truncated {
+		files = "at least " + files
+	}
+	return fmt.Sprintf("Apple Container transferred an empty build context (%s) even though %s contains %s. This matches a known apple-container issue with /tmp and /private/tmp paths; move the project to a non-/tmp directory and retry", tui.FormatBytes(m.contextBytes), m.contextPath, files)
+}
+
+func scanAppleContainerBuildContext(contextPath string) appleContainerContextStats {
+	var stats appleContainerContextStats
+	if contextPath == "" {
+		return stats
+	}
+	err := filepath.WalkDir(contextPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		stats.fileCount++
+		if info, infoErr := d.Info(); infoErr == nil && info.Mode().IsRegular() {
+			stats.totalSize += info.Size()
+		}
+		if stats.fileCount >= appleContainerContextFileScanLimit {
+			stats.truncated = true
+			return errAppleContainerContextScanDone
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errAppleContainerContextScanDone) {
+		return appleContainerContextStats{}
+	}
+	return stats
+}
+
+func appleContainerPathInTmp(path string) bool {
+	if isTmpPath(path) {
+		return true
+	}
+	canonical, err := filepath.EvalSymlinks(path)
+	return err == nil && isTmpPath(canonical)
+}
+
+func isTmpPath(path string) bool {
+	clean := filepath.Clean(path)
+	return clean == "/tmp" || strings.HasPrefix(clean, "/tmp/") || clean == "/private/tmp" || strings.HasPrefix(clean, "/private/tmp/")
+}

--- a/go/internal/cli/commands/buildprogress_test.go
+++ b/go/internal/cli/commands/buildprogress_test.go
@@ -118,6 +118,61 @@ func TestChunkDiffBuildLogDumpedForImageBuildFailureUnderAutoChunking(t *testing
 	}
 }
 
+func TestAppleContainerContextMonitorDiagnosesEmptyTmpTransfer(t *testing.T) {
+	m := &appleContainerBuildContextMonitor{
+		contextPath: "/tmp/ctxprobe",
+		pathInTmp:   true,
+		stats:       appleContainerContextStats{fileCount: 2, totalSize: 40},
+	}
+	if _, err := m.Write([]byte("#4 [internal] load build context\n#4 transferring context: 2")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Write([]byte("B\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	diagnosis := m.diagnosis()
+	for _, want := range []string{"transferred an empty build context", "known apple-container issue", "non-/tmp directory"} {
+		if !strings.Contains(diagnosis, want) {
+			t.Fatalf("diagnosis missing %q:\n%s", want, diagnosis)
+		}
+	}
+}
+
+func TestAppleContainerContextMonitorIgnoresNonTmpOrNonEmptyTransfer(t *testing.T) {
+	cases := []struct {
+		name string
+		m    appleContainerBuildContextMonitor
+		line string
+	}{
+		{
+			name: "non tmp path",
+			m:    appleContainerBuildContextMonitor{contextPath: "/Users/me/app", pathInTmp: false, stats: appleContainerContextStats{fileCount: 2}},
+			line: "#4 transferring context: 2B\n",
+		},
+		{
+			name: "normal context transfer",
+			m:    appleContainerBuildContextMonitor{contextPath: "/tmp/app", pathInTmp: true, stats: appleContainerContextStats{fileCount: 2}},
+			line: "#4 transferring context: 40B\n",
+		},
+		{
+			name: "empty local project",
+			m:    appleContainerBuildContextMonitor{contextPath: "/tmp/app", pathInTmp: true, stats: appleContainerContextStats{}},
+			line: "#4 transferring context: 2B\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tc.m.Write([]byte(tc.line)); err != nil {
+				t.Fatal(err)
+			}
+			if got := tc.m.diagnosis(); got != "" {
+				t.Fatalf("diagnosis = %q, want empty", got)
+			}
+		})
+	}
+}
+
 func TestShouldDumpChunkDiffBuildLog(t *testing.T) {
 	buildErr := &imageBuildFailedError{errors.New("boom")}
 	setupErr := errors.New("creating buildx builder: boom")

--- a/go/internal/cli/commands/buildprogress_test.go
+++ b/go/internal/cli/commands/buildprogress_test.go
@@ -122,7 +122,7 @@ func TestAppleContainerContextMonitorDiagnosesEmptyTmpTransfer(t *testing.T) {
 	m := &appleContainerBuildContextMonitor{
 		contextPath: "/tmp/ctxprobe",
 		pathInTmp:   true,
-		stats:       appleContainerContextStats{fileCount: 2, totalSize: 40},
+		stats:       appleContainerContextStats{fileCount: 2},
 	}
 	if _, err := m.Write([]byte("#4 [internal] load build context\n#4 transferring context: 2")); err != nil {
 		t.Fatal(err)

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1646,6 +1646,8 @@ func buildImageWithAppleContainer(ctx context.Context, dir, imageName, platform,
 	if err != nil {
 		return fmt.Errorf("resolving project path: %w", err)
 	}
+	contextMonitor := newAppleContainerBuildContextMonitor(buildContext)
+	streamOutput = contextMonitor.wrapStream(streamOutput)
 	// --progress plain emits the deterministic BuildKit log format (#N, DONE Ns,
 	// [stage N/M]) that the shared build parser understands; the default
 	// (--progress auto) renders an interactive [+] Building UI the parser cannot
@@ -1673,7 +1675,7 @@ func buildImageWithAppleContainer(ctx context.Context, dir, imageName, platform,
 	cmd.Stdout = streamOutput
 	cmd.Stderr = streamOutput
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("container build failed: %w", err)
+		return fmt.Errorf("container build failed: %w", contextMonitor.wrapBuildError(err))
 	}
 	return nil
 }

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -628,6 +628,7 @@ func buildImageToOCILayoutWithAppleContainer(ctx context.Context, cwd, dockerfil
 	}
 	contextMonitor := newAppleContainerBuildContextMonitor(buildContext)
 	stdout = contextMonitor.wrapStream(stdout)
+	stderr = contextMonitor.wrapStream(stderr)
 
 	// Unique per-build tag: dest is a fresh wendy-oci-* tempdir, so concurrent
 	// invocations and watch cycles never collide on the temporary image.
@@ -657,7 +658,7 @@ func buildImageToOCILayoutWithAppleContainer(ctx context.Context, cwd, dockerfil
 	buildCmd := imageBuilderCommandContext(ctx, "container", args...)
 	buildCmd.Dir = buildContext
 	buildCmd.Stdout = stdout
-	buildCmd.Stderr = stdout
+	buildCmd.Stderr = stderr
 	if err := buildCmd.Run(); err != nil {
 		return &imageBuildFailedError{fmt.Errorf("container build (OCI layout) failed: %w", contextMonitor.wrapBuildError(err))}
 	}

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -626,6 +626,8 @@ func buildImageToOCILayoutWithAppleContainer(ctx context.Context, cwd, dockerfil
 	if err != nil {
 		return fmt.Errorf("resolving project path: %w", err)
 	}
+	contextMonitor := newAppleContainerBuildContextMonitor(buildContext)
+	stdout = contextMonitor.wrapStream(stdout)
 
 	// Unique per-build tag: dest is a fresh wendy-oci-* tempdir, so concurrent
 	// invocations and watch cycles never collide on the temporary image.
@@ -655,9 +657,9 @@ func buildImageToOCILayoutWithAppleContainer(ctx context.Context, cwd, dockerfil
 	buildCmd := imageBuilderCommandContext(ctx, "container", args...)
 	buildCmd.Dir = buildContext
 	buildCmd.Stdout = stdout
-	buildCmd.Stderr = stderr
+	buildCmd.Stderr = stdout
 	if err := buildCmd.Run(); err != nil {
-		return &imageBuildFailedError{fmt.Errorf("container build (OCI layout) failed: %w", err)}
+		return &imageBuildFailedError{fmt.Errorf("container build (OCI layout) failed: %w", contextMonitor.wrapBuildError(err))}
 	}
 	// The image is in the store now — remove the temporary tag once we are done,
 	// even if the export below is cancelled.

--- a/go/internal/cli/tui/buildparser.go
+++ b/go/internal/cli/tui/buildparser.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"bytes"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -49,10 +50,11 @@ type BuildStepEvent struct {
 }
 
 var (
-	buildVertexLineRe = regexp.MustCompile(`^#(\d+) (.*)$`)
-	buildDoneRe       = regexp.MustCompile(`^DONE (\d+(?:\.\d+)?)s$`)
-	buildLogLineRe    = regexp.MustCompile(`^\d+\.\d+ `)          // "1.563 Collecting ..."
-	buildStepLabelRe  = regexp.MustCompile(`^\[[^\]]*\d+/\d+\] `) // "[4/6] ", "[stage 2/3] "
+	buildVertexLineRe      = regexp.MustCompile(`^#(\d+) (.*)$`)
+	buildDoneRe            = regexp.MustCompile(`^DONE (\d+(?:\.\d+)?)s$`)
+	buildLogLineRe         = regexp.MustCompile(`^\d+\.\d+ `)          // "1.563 Collecting ..."
+	buildStepLabelRe       = regexp.MustCompile(`^\[[^\]]*\d+/\d+\] `) // "[4/6] ", "[stage 2/3] "
+	buildContextTransferRe = regexp.MustCompile(`\btransferring context:\s*([0-9]+(?:\.[0-9]+)?)\s*([KMGT]?i?B|[kKmMgGtT]?B)\b`)
 )
 
 type buildVertexState struct {
@@ -90,6 +92,44 @@ func (p *BuildParser) Write(b []byte) (int, error) {
 		p.parseLine(line)
 	}
 	return len(b), nil
+}
+
+// ParseBuildContextTransferBytes returns the byte count from a BuildKit plain
+// progress line such as "#4 transferring context: 2B".
+func ParseBuildContextTransferBytes(line string) (int64, bool) {
+	m := buildContextTransferRe.FindStringSubmatch(line)
+	if m == nil {
+		return 0, false
+	}
+	value, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0, false
+	}
+	unit := strings.ToLower(m[2])
+	var multiplier float64
+	switch unit {
+	case "b":
+		multiplier = 1
+	case "kb":
+		multiplier = 1000
+	case "kib":
+		multiplier = 1024
+	case "mb":
+		multiplier = 1000 * 1000
+	case "mib":
+		multiplier = 1024 * 1024
+	case "gb":
+		multiplier = 1000 * 1000 * 1000
+	case "gib":
+		multiplier = 1024 * 1024 * 1024
+	case "tb":
+		multiplier = 1000 * 1000 * 1000 * 1000
+	case "tib":
+		multiplier = 1024 * 1024 * 1024 * 1024
+	default:
+		return 0, false
+	}
+	return int64(math.Round(value * multiplier)), true
 }
 
 func (p *BuildParser) parseLine(line string) {

--- a/go/internal/cli/tui/buildparser.go
+++ b/go/internal/cli/tui/buildparser.go
@@ -97,6 +97,9 @@ func (p *BuildParser) Write(b []byte) (int, error) {
 // ParseBuildContextTransferBytes returns the byte count from a BuildKit plain
 // progress line such as "#4 transferring context: 2B".
 func ParseBuildContextTransferBytes(line string) (int64, bool) {
+	if len(line) > 512 {
+		return 0, false
+	}
 	m := buildContextTransferRe.FindStringSubmatch(line)
 	if m == nil {
 		return 0, false

--- a/go/internal/cli/tui/buildparser_test.go
+++ b/go/internal/cli/tui/buildparser_test.go
@@ -91,6 +91,28 @@ func TestParserMarksFailedStep(t *testing.T) {
 	}
 }
 
+func TestParseBuildContextTransferBytes(t *testing.T) {
+	cases := []struct {
+		line string
+		want int64
+	}{
+		{"#4 transferring context: 2B", 2},
+		{"#4 transferring context: 2B done", 2},
+		{"#4 transferring context: 40B", 40},
+		{"#4 transferring context: 1.5kB", 1500},
+		{"#4 transferring context: 1.0 MiB", 1024 * 1024},
+	}
+	for _, tc := range cases {
+		got, ok := ParseBuildContextTransferBytes(tc.line)
+		if !ok || got != tc.want {
+			t.Fatalf("ParseBuildContextTransferBytes(%q) = %d, %v; want %d, true", tc.line, got, ok, tc.want)
+		}
+	}
+	if _, ok := ParseBuildContextTransferBytes("#4 DONE 0.0s"); ok {
+		t.Fatal("unexpected context transfer match")
+	}
+}
+
 func TestParserHandlesSplitWrites(t *testing.T) {
 	var got []BuildStepEvent
 	p := NewBuildParser(func(e BuildStepEvent) { got = append(got, e) })


### PR DESCRIPTION
## Summary
- Detect Apple Container builds where a `/tmp` or `/private/tmp` project transfers as an empty `2 B` build context even though local files exist.
- Add a clear failure diagnosis that points to the known apple-container `/tmp` regression and tells users to move the project to a non-`/tmp` directory.
- Reuse the plain BuildKit progress stream so the diagnosis works in both registry-push and chunk-diff OCI build paths.

## Tests
- `go test ./internal/cli/commands ./internal/cli/tui`
- Live probe: `container build --progress plain --platform linux/arm64` from `/tmp/wendy-ctxprobe.*` still reproduces upstream with `transferring context: 2B` and `"/hello.txt": not found`.

Closes WDY-1814.
