### PR TITLE
Docs: document shipped WendyOS features

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -1,12 +1,13 @@
 # `wendy install`
 
-Installs WendyOS onto an NVMe or SD card, or flashes Wendy Lite firmware onto an ESP32 over USB.
+Installs WendyOS onto an NVMe or SD card, flashes Jetson AGX Thor over USB recovery, or flashes Wendy Lite firmware onto an ESP32 over USB.
 
 > **Tip:** [`wendy install`](../install.md) is the recommended, surfaced entry point for this command. `wendy os install` remains available and behaves identically — it is kept for backward compatibility and for discoverability under the `wendy os` group.
 
-The command presents a unified device picker that lists both Linux targets (Raspberry Pi, Jetson, …) and ESP32 targets (C6, C5). Select the device type to take the appropriate path:
+The command presents a unified device picker that lists Linux targets (Raspberry Pi, Jetson, ...) and ESP32 targets (C6, C5). Select the device type to take the appropriate path:
 
-- **Linux targets** → download OS image → write to SD/NVMe → write config partition
+- **Raspberry Pi and Orin Jetson targets** -> download OS image -> write to SD/NVMe -> write config partition
+- **Jetson AGX Thor** -> download flashpack -> boot over USB recovery -> flash QSPI and internal NVMe
 - **ESP32 targets** → detect USB serial port → download firmware `.bin` → flash over serial
 
 ```sh
@@ -18,6 +19,9 @@ wendy install --nightly
 
 # Linux: non-interactive with all flags
 wendy install --device-type raspberry-pi-5 --version 0.10.4 --drive /dev/disk4 --force
+
+# Jetson AGX Thor: flash over USB recovery (macOS and Linux)
+wendy install --device-type jetson-agx-thor
 
 # Direct install from a local image (Linux only)
 wendy install path/to/image.img /dev/disk4 --force
@@ -104,6 +108,8 @@ To provision WiFi after first boot, use `wendy device setup` or the BLE provisio
 
 ## Linux (WendyOS) path
 
+For Raspberry Pi and Orin-class Jetson devices, the install path writes a disk image to a selected SD card, NVMe drive, or USB-attached enclosure:
+
 1. **Resolve version** — `--version` if provided, otherwise latest (or nightly with `--nightly`).
 2. **Resolve drive** — `--drive` if provided, otherwise an interactive picker of external drives. Internal drives require `--yes-overwrite-internal` in non-interactive mode; in interactive mode the user must type the device path to confirm.
 3. **Download image** — fetched from GCS with a progress bar. Downloaded to `~/Library/Caches/wendy/os-images/` (macOS) or `~/.cache/wendy/os-images/` (Linux). Zip archives are streamed through to the first `.img`, `.raw`, `.wic`, or `.sdimg` entry; gzip-compressed images (`.img.gz`, detected by magic bytes regardless of extension) are decompressed and streamed on the fly. Seekable-zstd images (`.img.zst`) are downloaded and cached directly; when a block map is present, only mapped ranges are decoded during the write step, skipping hole frames entirely. Parallel download (8 workers) is used when the server supports HTTP range requests.
@@ -114,6 +120,16 @@ To provision WiFi after first boot, use `wendy device setup` or the BLE provisio
 > **Exit code:** `wendy install` exits `0` as long as the OS image was written to the drive, regardless of whether the config-partition provisioning step succeeded. A non-zero exit indicates only that the image itself could not be written. When `--wifi`, `--device-name`, or `--pre-enroll` were requested but couldn't be applied, the warning calls this out explicitly so the values can be re-applied with another `wendy install`, or configured after the device boots.
 
 > **Provisioning retry:** When the config-partition write fails on an interactive terminal, the CLI asks `Retry writing provisioning data to the config partition?`. Answering yes re-attempts the write (download + config-partition write); answering no, or running non-interactively, prints guidance and exits successfully — the OS image is already on the drive.
+
+## Jetson AGX Thor recovery flash path
+
+Jetson AGX Thor does not use the drive-writing flow. Selecting `jetson-agx-thor` downloads the Thor flashpack, asks you to put the board into USB recovery mode, scans for the recovery-mode Jetson, then performs:
+
+1. **Stage 1 RCM boot** — sends the Thor recovery payload over USB.
+2. **Stage 2 partition flash** — flashes QSPI and the internal NVMe through the Thor flashing gadget.
+3. **Power-cycle** — after a successful flash, power-cycle the Thor out of recovery mode to boot WendyOS.
+
+The CLI prompts for confirmation before erasing the Thor. No external USB drive is selected, and `--drive` does not apply to this path. Thor flashing is supported on macOS and Linux; Windows returns an unsupported-platform error.
 
 ### WiFi pre-configuration
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -7,6 +7,21 @@ Runs your app on a Wendy-enabled device:
 5. [Starts the app](./device/apps/start.md)
 6. [Attaches the logs](./device/logs.md) if needed (when `--detach` is not provided)
 
+## Reachable app URLs
+
+After the app starts, `wendy run` prints an `App reachable at <url>` line when it can infer a browser URL from the app configuration:
+
+```text
+App reachable at http://192.168.123.222:3000
+```
+
+The CLI derives this URL from either:
+
+- `hooks.postStart.openURL`, when the URL contains `WENDY_HOSTNAME`
+- `readiness.tcpSocket.port`
+
+The printed URL uses a routable IP address reported by the device instead of the `.local` hostname, which makes it easier to open from browsers that do not resolve mDNS names reliably. If neither an `openURL` hook nor a TCP readiness port is configured, or if the device cannot report an IP address, `wendy run` skips this line.
+
 > **Note:** When `wendy.json` is absent, `wendy run` resolves the target device before prompting to create one. If the target is Headless Mac and the detected project type is unsupported, the project/target mismatch error is returned immediately without opening the config creation prompt.
 
 ## Headless Mac — supported project types

--- a/go/internal/cli/assets/docs/device/managing-apps.mdx
+++ b/go/internal/cli/assets/docs/device/managing-apps.mdx
@@ -34,6 +34,14 @@ The CLI will:
 3. Create and start the container
 4. Stream logs back to your terminal
 
+When the app exposes a web service, `wendy run` may also print a reachable URL:
+
+```text
+App reachable at http://192.168.123.222:3000
+```
+
+This appears when `wendy.json` defines either `hooks.postStart.openURL` with `WENDY_HOSTNAME` or a `readiness.tcpSocket.port`. The CLI prints a device IP address instead of a `.local` hostname so the URL is easier to open in a browser.
+
 ### First Run Performance
 
 The first time you run an app, the build and transfer process may take longer, especially for large applications with many dependencies. For the best experience:
@@ -52,8 +60,12 @@ wendy run
 # Detached mode - runs in background
 wendy run --detach
 
-# Deploy mode - auto-restarts on failure (up to 5 retries)
+# Deploy mode - create/update the container without starting it
 wendy run --deploy
+
+# Start with a restart policy
+wendy run --restart-on-failure
+wendy run --restart-unless-stopped
 ```
 
 ### Python Projects
@@ -157,15 +169,35 @@ wendy device apps list
 ╰───────────────┴─────────┴─────────┴──────────╯
 ```
 
-## Removing (or Deleting) an App
+## Removing an App
 
-To delete an app, run:
+To remove an app, run:
 
 ```bash
-wendy device apps delete <app-name>
+wendy device apps remove <app-name>
 ```
 
 An example output is:
 
 ```bash
-wendy device apps delete simple-server
+wendy device apps remove simple-server
+✔︎ Searching for WendyOS devices [5.2s]
+? Remove simple-server? This cannot be undone. Yes
+✔ Application simple-server removed.
+```
+
+Use `--force` to skip the confirmation prompt:
+
+```bash
+wendy device apps remove simple-server --force
+```
+
+When connected to a WendyOS agent, you can also clean up storage owned by the app:
+
+```bash
+# Delete the container image too
+wendy device apps remove simple-server --cleanup
+
+# Delete persistent volumes under /var/lib/wendy/volumes too
+wendy device apps remove simple-server --delete-volumes
+```

--- a/go/internal/cli/assets/docs/installation/wendyos-nvidia-jetson.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-nvidia-jetson.mdx
@@ -8,7 +8,7 @@ description: Install WendyOS on your NVIDIA Jetson device
   <h1 style={{ fontSize: '2.25rem', fontWeight: 'bold', margin: 0, lineHeight: '1' }}>NVIDIA Jetson Installation</h1>
 </div>
 
-You'll need an NVMe SSD to USB-C adapter to flash WendyOS onto your NVMe SSD.
+For Jetson Orin Nano and Jetson AGX Orin, you'll need an NVMe SSD to USB-C adapter to flash WendyOS onto your NVMe SSD. Jetson AGX Thor uses a separate USB recovery flash path and does not use an external drive.
 
 ## Installing WendyOS on NVIDIA Jetson
 
@@ -26,16 +26,23 @@ For DGX Spark, use [Wendy Agent — Linux](/docs/installation/wendy-agent-linux)
 
 <Steps>
   <Step>
-    ### Connect the NVMe SSD to Your Computer
+    ### Prepare Storage or Recovery Mode
 
-    Using an NVMe SSD to USB-C adapter, connect your NVMe SSD into the adapter and then the USB-C end to your MacBook.
+    <Tabs items={['Orin Nano / AGX Orin', 'AGX Thor']} groupId="jetson-model" persist>
+      <Tab value="Orin Nano / AGX Orin">
+        Using an NVMe SSD to USB-C adapter, connect your NVMe SSD into the adapter and then the USB-C end to your computer.
 
-    <video width="100%" autoPlay loop muted playsInline>
-      <source src="/videos/installation/jetson-nvme-mac-adapter.mp4" type="video/mp4" />
-      Your browser does not support the video tag.
-    </video>
+        <video width="100%" autoPlay loop muted playsInline>
+          <source src="/videos/installation/jetson-nvme-mac-adapter.mp4" type="video/mp4" />
+          Your browser does not support the video tag.
+        </video>
 
-    On macOS you'll be presented with a permission dialog to use the adapter. Press **Allow**.
+        On macOS you'll be presented with a permission dialog to use the adapter. Press **Allow**.
+      </Tab>
+      <Tab value="AGX Thor">
+        Start with the Thor powered off. Connect your computer to the USB-C port next to the HDMI port, then enter recovery mode: plug in power, hold **Force Recovery**, briefly tap **Reset**, then release **Force Recovery**. The other USB-C port is power-only.
+      </Tab>
+    </Tabs>
   </Step>
 
   <Step>
@@ -49,26 +56,36 @@ For DGX Spark, use [Wendy Agent — Linux](/docs/installation/wendy-agent-linux)
 
     <CliShot flow="os-install" step="select-device-type" alt="The Wendy CLI prompting you to choose a device type before flashing WendyOS" />
 
-    Select **NVIDIA Jetson Orin Nano**, then your drive. WendyOS downloads to the drive (this can take a while), and you'll enter your administrator password to write the image.
+    Select the Jetson model you are installing:
+
+    - **Jetson Orin Nano** or **Jetson AGX Orin**: select your target drive. WendyOS downloads to the drive, and you'll enter your administrator password to write the image.
+    - **Jetson AGX Thor**: the CLI downloads a Thor flashpack, scans for the board in USB recovery mode, and flashes QSPI plus the internal NVMe. No external drive is selected.
 
     The CLI also offers optional first-boot provisioning — joining WiFi, applying critical updates, and pre-enrolling the device to Wendy Cloud. Each can also be set up after the device boots. See [`wendy install`](/docs/advanced/clients/wendy-cli/commands/os/install) for more.
   </Step>
 
   <Step>
-    ### Install the NVMe SSD into Your Jetson
+    ### Install Storage or Reboot
 
-    Remove the NVMe SSD from your computer and insert it into your NVIDIA Jetson Orin Nano on the M.2 slot on the bottom of the board.
+    <Tabs items={['Orin Nano / AGX Orin', 'AGX Thor']} groupId="jetson-model" persist>
+      <Tab value="Orin Nano / AGX Orin">
+        Remove the NVMe SSD from your computer and insert it into your Jetson's M.2 slot.
 
-    <video width="100%" autoPlay loop muted playsInline>
-      <source src="/videos/installation/jetson-nvme-bottom-insertion.mp4" type="video/mp4" />
-      Your browser does not support the video tag.
-    </video>
+        <video width="100%" autoPlay loop muted playsInline>
+          <source src="/videos/installation/jetson-nvme-bottom-insertion.mp4" type="video/mp4" />
+          Your browser does not support the video tag.
+        </video>
+      </Tab>
+      <Tab value="AGX Thor">
+        After the CLI reports a successful flash, power-cycle the Thor out of recovery mode so it boots WendyOS from its internal storage.
+      </Tab>
+    </Tabs>
   </Step>
 
   <Step>
     ### Connect the Jetson to Your Computer
 
-    Connect your NVIDIA Jetson Orin Nano to your computer using a USB-C cable. This will allow you to deploy and manage apps on your device.
+    Connect your Jetson to your computer using the data-capable USB-C port. This will allow you to deploy and manage apps on your device.
 
     <video width="100%" autoPlay loop muted playsInline>
       <source src="/videos/installation/jetson-mac-usb-cable.mp4" type="video/mp4" />
@@ -79,7 +96,7 @@ For DGX Spark, use [Wendy Agent — Linux](/docs/installation/wendy-agent-linux)
   <Step>
     ### Power On the Device
 
-    With the supplied power supply, insert the power into the power slot on the NVIDIA Jetson Orin Nano and then plug into a power source like your wall outlet.
+    With the supplied power supply, insert the power into the power slot on your Jetson and then plug into a power source like your wall outlet.
 
     <video width="100%" autoPlay loop muted playsInline>
       <source src="/videos/installation/jetson-power-cable-insertion.mp4" type="video/mp4" />
@@ -96,7 +113,7 @@ For DGX Spark, use [Wendy Agent — Linux](/docs/installation/wendy-agent-linux)
     wendy discover
     ```
 
-    You should see your NVIDIA Jetson Orin Nano appear in the list of discovered devices.
+    You should see your Jetson appear in the list of discovered devices.
 
     <CliShot flow="discover" step="devices" alt="The Wendy CLI listing discovered WendyOS devices on the network" />
 

--- a/go/internal/cli/assets/docs/wendyos/requirements.md
+++ b/go/internal/cli/assets/docs/wendyos/requirements.md
@@ -15,14 +15,15 @@ WendyOS requires at least **64 GB** of storage. This covers the OS partitions (r
 
 A larger drive is not required by WendyOS itself, but running large container images (for example, ML inference containers with bundled model weights) can consume significant space. If your workload pulls images above a few gigabytes, a 128 GB or larger drive is recommended.
 
-The 64 GB minimum applies to both NVME and SD card installations. On the Jetson Orin Nano the `mender_data` partition auto-expands on first boot to fill any remaining space, so a larger drive is automatically used.
+The 64 GB minimum applies to removable NVME and SD card installations. On Jetson Orin Nano and Jetson AGX Orin, the `mender_data` partition auto-expands on first boot to fill any remaining space, so a larger drive is automatically used. Jetson AGX Thor is flashed over USB recovery to its internal storage instead of to a removable target drive.
 
 ### Partition sizes at a glance
 
 | Device | Root FS (A+B) | Config | Other |
 |--------|--------------|--------|-------|
 | Raspberry Pi (SD / NVME) | 8 GB | 64 MB | — |
-| Jetson Orin Nano (SD / NVME) | 8 GB + 8 GB | 64 MB | 512 MB mender_data (auto-expands) |
+| Jetson Orin Nano / AGX Orin (SD / NVME) | 8 GB + 8 GB | 64 MB | 512 MB mender_data (auto-expands) |
+| Jetson AGX Thor | Flashpack-managed internal partitions | N/A | Flashed over USB recovery; no external SD/NVME target |
 
 See the device-specific pages for full partition layouts:
 - [WendyOS on Raspberry Pi](pi/README.md)
@@ -43,6 +44,6 @@ See the device-specific pages for full partition layouts:
 | Device | Boot media |
 |--------|-----------|
 | Jetson Orin Nano | SD card, NVME |
-| Jetson AGX Orin | Coming soon |
-| Jetson AGX Thor | In progress |
+| Jetson AGX Orin | eMMC, NVME |
+| Jetson AGX Thor | Internal flash + NVME via USB recovery |
 | DGX Spark | Install `wendy-agent` on the existing Linux system (no image flash needed) |


### PR DESCRIPTION
## Summary

- Document the `wendy run` reachable URL output and when it appears.
- Add the Jetson AGX Thor USB recovery flash path to `wendy install` docs.
- Make the NVIDIA Jetson install guide model-aware for Orin Nano, AGX Orin, and AGX Thor.
- Refresh WendyOS requirements for shipped AGX Orin and Thor support.
- Repair the truncated managing-apps removal section while correcting `wendy device apps remove` and run-mode examples.

Fixes WDY-1816.

## Validation

- `git diff --check`
- `npm audit --audit-level=high`
- `npm run build`
- `NEXT_PUBLIC_BASE_PATH=/branch-wdy-1816 npm run build`

Note: `npm run types:check` currently fails because the standalone `fumadocs-mdx` step leaves `.source/server.ts` empty before `tsc`; the CI docs workflow runs `npm run build`, which regenerates valid source files and passed locally.