### PR TITLE
WDY-1817 Darken docs sidebar active text in light mode

### DIFF
--- a/go/internal/cli/assets/docs/app/global.css
+++ b/go/internal/cli/assets/docs/app/global.css
@@ -5,6 +5,7 @@
 @theme {
   --color-wendy-seafoam: #9fe2bf;
   --color-wendy-seafoam-hover: #86d3a8;
+  --color-wendy-seafoam-strong: #1f6f4a;
 }
 
 html {
@@ -37,6 +38,16 @@ html > body[data-scroll-locked] {
 .dark {
   --color-fd-primary: var(--color-wendy-seafoam);
   --color-fd-primary-foreground: hsl(0, 0%, 9%);
+}
+
+#nd-sidebar,
+#nd-sidebar-mobile {
+  --color-fd-primary: var(--color-wendy-seafoam-strong);
+}
+
+.dark #nd-sidebar,
+.dark #nd-sidebar-mobile {
+  --color-fd-primary: var(--color-wendy-seafoam);
 }
 
 *,


### PR DESCRIPTION
## Summary

- Adds a stronger Wendy seafoam token for docs sidebar active states in light mode.
- Scopes the darker token to `#nd-sidebar` and `#nd-sidebar-mobile` only.
- Keeps dark-mode sidebar active text on the existing seafoam color.

## Linear

- https://linear.app/wendylabsinc/issue/WDY-1817/darken-docs-sidebar-active-text-in-light-mode

## Validation

- `npm run types:check`
- `git diff --check`
- `npm run dev` served at `http://localhost:3004` because port 3000 was occupied
- Verified light-mode active sidebar text computed to `#1f6f4a`
- Verified dark-mode active sidebar text remained seafoam