### PR TITLE
fix(agent): persist isolation mode so CNI + mesh egress survive reboot

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -198,6 +198,41 @@ func (c *Client) getIsolation(appID string) string {
 	return c.appIsolation[appID]
 }
 
+// hydrateIsolation warms c.appIsolation[appID] from a persisted container
+// label (labelKeyIsolation) when the in-memory cache has no value for appID
+// yet. This repopulates the cache after an agent restart or device reboot,
+// when c.appIsolation starts out empty even though isolated containers were
+// created (and labelled) in a previous process lifetime. It is idempotent and
+// safe to call repeatedly: once a value is set — whether by
+// CreateContainerWithProgress or a prior hydrate — it is never overwritten,
+// so a live create-time value always wins over a (necessarily identical,
+// since the label was written at create time) rehydrated one.
+//
+// Acquires c.mu; callers that already hold c.mu must use
+// hydrateIsolationLocked instead.
+func (c *Client) hydrateIsolation(appID string, labels map[string]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hydrateIsolationLocked(appID, labels)
+}
+
+// hydrateIsolationLocked is the lock-free core of hydrateIsolation. Caller
+// must hold c.mu.
+func (c *Client) hydrateIsolationLocked(appID string, labels map[string]string) {
+	if appID == "" {
+		return
+	}
+	if c.appIsolation == nil {
+		c.appIsolation = make(map[string]string)
+	}
+	if c.appIsolation[appID] != "" {
+		return // already set (live create or earlier hydrate) — never override
+	}
+	if v := labels[labelKeyIsolation]; v != "" {
+		c.appIsolation[appID] = v
+	}
+}
+
 // recordServiceIP stores the CNI-assigned IP for a service. Caller must hold c.mu.
 func (c *Client) recordServiceIP(appID, serviceName, ip string) {
 	if c.serviceIPs == nil {
@@ -788,7 +823,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 
 	report(&agentpb.CreateContainerProgress{Phase: agentpb.CreateContainerProgress_CREATING_CONTAINER})
 
-	labels := wendyLabels(appID, serviceName, version, req.GetRestartPolicy(), appCfg.Entitlements)
+	labels := wendyLabels(appID, serviceName, version, req.GetRestartPolicy(), appCfg.Entitlements, appCfg.Isolation)
 
 	// Publish the resolved ROS 2 configuration as a container label so the
 	// agent can discover ROS 2 containers at runtime and configure the CLI
@@ -1036,6 +1071,10 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 				appID, serviceName = id, svc
 			}
 		}
+		// Defensive rehydrate: covers StartContainer calls not preceded by
+		// ListBootContainers (e.g. a direct restart of a single container).
+		// c.mu is already held here (muHeld), so use the lock-free core.
+		c.hydrateIsolationLocked(appID, labels)
 	}
 
 	if restartPolicy != nil {
@@ -2398,6 +2437,21 @@ func (c *Client) ListBootContainers(ctx context.Context) ([]services.BootContain
 			c.logger.Warn("Failed to get container info", zap.String("id", ctr.ID()), zap.Error(err))
 			continue
 		}
+
+		// Rehydrate c.appIsolation from the persisted label BEFORE the monitor's
+		// planRestartActions runs GroupRestartAppID/RestartGroup for this
+		// container, so the reboot restart path sees the isolation mode this
+		// container was created with instead of the empty in-memory default
+		// (WDY reboot-fix). Best-effort: an unlabelled or malformed appID just
+		// skips hydration for this one container; it must never fail the whole
+		// reconcile.
+		if appID := info.Labels[labelKeyAppID]; appID != "" && appconfig.ValidateAppID(appID) == nil {
+			c.hydrateIsolation(appID, info.Labels)
+		} else {
+			c.logger.Warn("ListBootContainers: missing/invalid app id label, skipping isolation hydration",
+				zap.String("id", ctr.ID()))
+		}
+
 		if info.Labels[labelKeyStoppedByUser] == "true" {
 			continue // user stopped it on purpose — stay down across reboot
 		}

--- a/go/internal/agent/containerd/helpers.go
+++ b/go/internal/agent/containerd/helpers.go
@@ -81,6 +81,16 @@ const labelKeyAppID = "sh.wendy/app.id"
 // Set whenever appCfg.ServiceName is non-empty.
 const labelKeyServiceName = "sh.wendy/service"
 
+// labelKeyIsolation persists the app's isolation mode (e.g. "isolated",
+// "shared-network", "shared-ipc") on the container. appconfig.AppConfig.Isolation
+// is otherwise only held in-memory (c.appIsolation), so without this label a
+// device reboot loses the isolation mode: the boot reconcile path
+// (ListBootContainers -> GroupRestartAppID/RestartGroup -> StartContainer)
+// would treat every restarted container as unisolated, skipping CNI ADD and
+// leaving isolated containers without networking (WDY reboot-fix). Set only
+// when the app declares an isolation mode.
+const labelKeyIsolation = "sh.wendy/isolation"
+
 // labelKeyStoppedByUser records that an app was explicitly stopped by the user
 // (wendy device apps stop). Set to "true" on stop, removed on start. The boot
 // reconcile skips containers carrying it, so a deliberate stop survives a
@@ -226,8 +236,10 @@ func sanitizeForLog(s string, maxLen int) string {
 // container. These labels are used to identify, filter, and manage containers.
 //
 // When serviceName is non-empty (multi-service app), labelKeyServiceName is
-// additionally set to serviceName.
-func wendyLabels(appName, serviceName, version string, restartPolicy *agentpb.RestartPolicy, entitlements []appconfig.Entitlement) map[string]string {
+// additionally set to serviceName. When isolation is non-empty, labelKeyIsolation
+// is additionally set to isolation, so the isolation mode survives a reboot
+// (see labelKeyIsolation).
+func wendyLabels(appName, serviceName, version string, restartPolicy *agentpb.RestartPolicy, entitlements []appconfig.Entitlement, isolation string) map[string]string {
 	labels := map[string]string{
 		labelKeyAppVersion: version,
 		labelKeyAppID:      appName,
@@ -235,6 +247,10 @@ func wendyLabels(appName, serviceName, version string, restartPolicy *agentpb.Re
 
 	if serviceName != "" {
 		labels[labelKeyServiceName] = serviceName
+	}
+
+	if isolation != "" {
+		labels[labelKeyIsolation] = isolation
 	}
 
 	if restartPolicy != nil {

--- a/go/internal/agent/containerd/helpers_test.go
+++ b/go/internal/agent/containerd/helpers_test.go
@@ -264,7 +264,7 @@ func TestGCTimestamp_IsUTC(t *testing.T) {
 }
 
 func TestWendyLabels_Basic(t *testing.T) {
-	labels := wendyLabels("myapp", "", "1.0.0", nil, nil)
+	labels := wendyLabels("myapp", "", "1.0.0", nil, nil, "")
 
 	if v, ok := labels[labelKeyAppVersion]; !ok {
 		t.Error("missing app version label")
@@ -284,7 +284,7 @@ func TestWendyLabels_Basic(t *testing.T) {
 }
 
 func TestWendyLabels_MultiService(t *testing.T) {
-	labels := wendyLabels("com.example.app", "api", "2.0", nil, nil)
+	labels := wendyLabels("com.example.app", "api", "2.0", nil, nil, "")
 
 	if v := labels[labelKeyServiceName]; v != "api" {
 		t.Errorf("service label = %q; want %q", v, "api")
@@ -294,9 +294,33 @@ func TestWendyLabels_MultiService(t *testing.T) {
 	}
 }
 
+// TestWendyLabels_WithIsolation is the regression test for the reboot-networking
+// bug: isolation mode must be persisted as a container label so it survives an
+// agent restart / device reboot, when c.appIsolation (in-memory only) starts
+// out empty (WDY reboot-fix).
+func TestWendyLabels_WithIsolation(t *testing.T) {
+	labels := wendyLabels("app", "", "1.0", nil, nil, "isolated")
+	if v, ok := labels[labelKeyIsolation]; !ok {
+		t.Error("missing isolation label")
+	} else if v != "isolated" {
+		t.Errorf("isolation label = %q; want %q", v, "isolated")
+	}
+}
+
+// TestWendyLabels_EmptyIsolationOmitsLabel mirrors the "no service label for
+// single-container apps" behavior: an app with no declared isolation mode must
+// not carry the label at all (distinguishing "not isolated" from "isolated
+// mode not yet known").
+func TestWendyLabels_EmptyIsolationOmitsLabel(t *testing.T) {
+	labels := wendyLabels("app", "", "1.0", nil, nil, "")
+	if v, ok := labels[labelKeyIsolation]; ok {
+		t.Errorf("should not have isolation label when isolation is empty, got %q", v)
+	}
+}
+
 func TestWendyLabels_WithRestartPolicyUnlessStopped(t *testing.T) {
 	rp := &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED}
-	labels := wendyLabels("app", "", "2.0", rp, nil)
+	labels := wendyLabels("app", "", "2.0", rp, nil, "")
 
 	if v, ok := labels[labelKeyRestartPolicy]; !ok {
 		t.Error("missing restart policy label")
@@ -310,7 +334,7 @@ func TestWendyLabels_WithRestartPolicyOnFailure(t *testing.T) {
 		Mode:                agentpb.RestartPolicyMode_ON_FAILURE,
 		OnFailureMaxRetries: 3,
 	}
-	labels := wendyLabels("app", "", "1.0", rp, nil)
+	labels := wendyLabels("app", "", "1.0", rp, nil, "")
 
 	if v := labels[labelKeyRestartPolicy]; v != "on-failure:3" {
 		t.Errorf("restart policy = %q; want %q", v, "on-failure:3")
@@ -319,7 +343,7 @@ func TestWendyLabels_WithRestartPolicyOnFailure(t *testing.T) {
 
 func TestWendyLabels_WithRestartPolicyNo(t *testing.T) {
 	rp := &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_NO}
-	labels := wendyLabels("app", "", "1.0", rp, nil)
+	labels := wendyLabels("app", "", "1.0", rp, nil, "")
 
 	if v := labels[labelKeyRestartPolicy]; v != "no" {
 		t.Errorf("restart policy = %q; want %q", v, "no")
@@ -328,7 +352,7 @@ func TestWendyLabels_WithRestartPolicyNo(t *testing.T) {
 
 func TestWendyLabels_WithRestartPolicyDefault(t *testing.T) {
 	rp := &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_DEFAULT}
-	labels := wendyLabels("app", "", "1.0", rp, nil)
+	labels := wendyLabels("app", "", "1.0", rp, nil, "")
 
 	if v := labels[labelKeyRestartPolicy]; v != "unless-stopped" {
 		t.Errorf("restart policy = %q; want %q (DEFAULT maps to unless-stopped)", v, "unless-stopped")
@@ -337,7 +361,7 @@ func TestWendyLabels_WithRestartPolicyDefault(t *testing.T) {
 
 func TestWendyLabels_WithMCPEntitlement(t *testing.T) {
 	entitlements := []appconfig.Entitlement{{Type: appconfig.EntitlementMCP, Port: 3000}}
-	labels := wendyLabels("app", "", "1.0", nil, entitlements)
+	labels := wendyLabels("app", "", "1.0", nil, entitlements, "")
 	if v, ok := labels[labelKeyMCPPort]; !ok {
 		t.Error("missing mcp port label")
 	} else if v != "3000" {
@@ -347,7 +371,7 @@ func TestWendyLabels_WithMCPEntitlement(t *testing.T) {
 
 func TestWendyLabels_WithMCPPortZero(t *testing.T) {
 	entitlements := []appconfig.Entitlement{{Type: appconfig.EntitlementMCP, Port: 0}}
-	labels := wendyLabels("app", "", "1.0", nil, entitlements)
+	labels := wendyLabels("app", "", "1.0", nil, entitlements, "")
 	if _, ok := labels[labelKeyMCPPort]; ok {
 		t.Error("should not have mcp port label when port is 0")
 	}
@@ -358,7 +382,7 @@ func TestWendyLabels_EntitlementsStoredAsKeyValue(t *testing.T) {
 		{Type: appconfig.EntitlementNetwork, Mode: "host"},
 		{Type: appconfig.EntitlementGPU},
 	}
-	labels := wendyLabels("app", "", "1.0", nil, entitlements)
+	labels := wendyLabels("app", "", "1.0", nil, entitlements, "")
 
 	cases := []struct {
 		key     string
@@ -383,7 +407,7 @@ func TestWendyLabels_DuplicateEntitlementType(t *testing.T) {
 		{Type: appconfig.EntitlementPersist, Name: "data", Path: "/data"},
 		{Type: appconfig.EntitlementPersist, Name: "logs", Path: "/logs"},
 	}
-	labels := wendyLabels("app", "", "1.0", nil, entitlements)
+	labels := wendyLabels("app", "", "1.0", nil, entitlements, "")
 
 	for i, want := range entitlements {
 		key := fmt.Sprintf("%s%s.%d", appconfig.EntitlementAnnotationKeyPrefix, appconfig.EntitlementPersist, i)
@@ -399,7 +423,7 @@ func TestWendyLabels_DuplicateEntitlementType(t *testing.T) {
 }
 
 func TestWendyLabels_NoEntitlementsLabel(t *testing.T) {
-	labels := wendyLabels("app", "", "1.0", nil, nil)
+	labels := wendyLabels("app", "", "1.0", nil, nil, "")
 	for k := range labels {
 		if strings.HasPrefix(k, appconfig.EntitlementAnnotationKeyPrefix) {
 			t.Errorf("should not have entitlement label when entitlements are empty, got %q", k)
@@ -467,7 +491,7 @@ func TestParseEntitlementsFromAnnotations_RoundTrip(t *testing.T) {
 		{Type: appconfig.EntitlementGPU},
 	}
 
-	labels := wendyLabels("app", "", "1.0", nil, original)
+	labels := wendyLabels("app", "", "1.0", nil, original, "")
 	annotations := make(map[string]string)
 	for k, v := range labels {
 		if strings.HasPrefix(k, appconfig.EntitlementAnnotationKeyPrefix) {

--- a/go/internal/agent/containerd/isolation_hydrate_test.go
+++ b/go/internal/agent/containerd/isolation_hydrate_test.go
@@ -159,7 +159,7 @@ func TestReconcileRoundTrip_LabelPersistsAcrossSimulatedReboot(t *testing.T) {
 	// Step 4: this is exactly what StartContainer's CNI-ADD gate (~client.go:1211),
 	// GroupRestartAppID (~client.go:1827), and RestartGroup (~client.go:1854) read.
 	c.mu.Lock()
-	got := c.getIsolation(appID)
+	got = c.getIsolation(appID)
 	c.mu.Unlock()
 	if got != "isolated" {
 		t.Fatalf("after simulated reboot + reconcile hydrate, getIsolation(%q) = %q; want %q (isolated networking path would be skipped)", appID, got, "isolated")

--- a/go/internal/agent/containerd/isolation_hydrate_test.go
+++ b/go/internal/agent/containerd/isolation_hydrate_test.go
@@ -1,0 +1,167 @@
+package containerd
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// TestHydrateIsolation_SetsFromLabelWhenEmpty is the RED test for the reboot bug:
+// after a fresh process start (or right after ListBootContainers reads a
+// container's persisted labels), the in-memory appIsolation cache is empty for
+// that appID. hydrateIsolation must populate it from the label so downstream
+// reads (getIsolation, used by StartContainer/GroupRestartAppID/RestartGroup)
+// see the isolation mode the container was actually created with.
+func TestHydrateIsolation_SetsFromLabelWhenEmpty(t *testing.T) {
+	c := &Client{logger: zap.NewNop(), appIsolation: make(map[string]string)}
+
+	labels := map[string]string{labelKeyAppID: "myapp", labelKeyIsolation: "isolated"}
+	c.hydrateIsolation("myapp", labels)
+
+	c.mu.Lock()
+	got := c.getIsolation("myapp")
+	c.mu.Unlock()
+	if got != "isolated" {
+		t.Fatalf("getIsolation(%q) = %q; want %q", "myapp", got, "isolated")
+	}
+}
+
+// TestHydrateIsolation_NilCacheMap verifies hydrateIsolation initializes
+// c.appIsolation lazily, matching the nil-map pattern used elsewhere in Client
+// (e.g. CreateContainerWithProgress).
+func TestHydrateIsolation_NilCacheMap(t *testing.T) {
+	c := &Client{logger: zap.NewNop()} // appIsolation left nil, as it would be on a freshly constructed Client
+
+	labels := map[string]string{labelKeyAppID: "myapp", labelKeyIsolation: "shared-network"}
+	c.hydrateIsolation("myapp", labels)
+
+	c.mu.Lock()
+	got := c.getIsolation("myapp")
+	c.mu.Unlock()
+	if got != "shared-network" {
+		t.Fatalf("getIsolation(%q) = %q; want %q", "myapp", got, "shared-network")
+	}
+}
+
+// TestHydrateIsolation_DoesNotOverrideLiveValue is the idempotency guarantee:
+// a value already present in the cache — whether written by a live
+// CreateContainerWithProgress in this process, or by an earlier hydrate call —
+// must never be clobbered by a later hydrate call, even if the label disagrees
+// (which should not happen in practice, but the guarantee must hold regardless).
+func TestHydrateIsolation_DoesNotOverrideLiveValue(t *testing.T) {
+	c := &Client{logger: zap.NewNop(), appIsolation: map[string]string{"myapp": "isolated"}}
+
+	labels := map[string]string{labelKeyAppID: "myapp", labelKeyIsolation: "shared-ipc"}
+	c.hydrateIsolation("myapp", labels)
+
+	c.mu.Lock()
+	got := c.getIsolation("myapp")
+	c.mu.Unlock()
+	if got != "isolated" {
+		t.Fatalf("hydrateIsolation overrode a live value: getIsolation(%q) = %q; want unchanged %q", "myapp", got, "isolated")
+	}
+}
+
+// TestHydrateIsolation_CalledTwiceIsIdempotent covers the ListBootContainers
+// call pattern directly: hydrateIsolation runs once per container seen during
+// boot reconcile, and a device may enumerate the same appID's containers more
+// than once (multi-service apps). A second call with the same label must be a
+// no-op, not an error and not a redundant map write that could race with a
+// concurrent StartContainer.
+func TestHydrateIsolation_CalledTwiceIsIdempotent(t *testing.T) {
+	c := &Client{logger: zap.NewNop(), appIsolation: make(map[string]string)}
+	labels := map[string]string{labelKeyAppID: "myapp", labelKeyIsolation: "isolated"}
+
+	c.hydrateIsolation("myapp", labels)
+	c.hydrateIsolation("myapp", labels)
+
+	c.mu.Lock()
+	got := c.getIsolation("myapp")
+	c.mu.Unlock()
+	if got != "isolated" {
+		t.Fatalf("getIsolation(%q) = %q; want %q", "myapp", got, "isolated")
+	}
+}
+
+// TestHydrateIsolation_EmptyLabelValueLeavesCacheEmpty ensures a container with
+// no isolation label (i.e. it was never isolated) does not get spuriously
+// populated — getIsolation must keep returning "" so IsSharedNamespaceIsolation
+// and the "isolated" checks in StartContainer correctly treat it as unisolated.
+func TestHydrateIsolation_EmptyLabelValueLeavesCacheEmpty(t *testing.T) {
+	c := &Client{logger: zap.NewNop(), appIsolation: make(map[string]string)}
+	labels := map[string]string{labelKeyAppID: "myapp"} // no labelKeyIsolation
+
+	c.hydrateIsolation("myapp", labels)
+
+	c.mu.Lock()
+	got := c.getIsolation("myapp")
+	c.mu.Unlock()
+	if got != "" {
+		t.Fatalf("getIsolation(%q) = %q; want empty (no isolation label present)", "myapp", got)
+	}
+}
+
+// TestHydrateIsolation_EmptyAppIDIsNoop guards against accidentally keying the
+// cache under "" when a caller (e.g. ListBootContainers on a malformed
+// container) passes an empty appID.
+func TestHydrateIsolation_EmptyAppIDIsNoop(t *testing.T) {
+	c := &Client{logger: zap.NewNop(), appIsolation: make(map[string]string)}
+	labels := map[string]string{labelKeyIsolation: "isolated"}
+
+	c.hydrateIsolation("", labels)
+
+	c.mu.Lock()
+	_, ok := c.appIsolation[""]
+	c.mu.Unlock()
+	if ok {
+		t.Fatal("hydrateIsolation must not create an entry for an empty appID")
+	}
+}
+
+// TestReconcileRoundTrip_LabelPersistsAcrossSimulatedReboot is the end-to-end
+// regression test for the bug: it drives the exact label shape
+// CreateContainerWithProgress persists (via wendyLabels) through a *fresh*
+// Client — standing in for the agent process that comes up after a reboot,
+// where c.appIsolation starts out empty — and verifies that once the boot
+// reconcile path hydrates from that label (as ListBootContainers now does for
+// every container it enumerates), getIsolation reports the original isolation
+// mode. That is precisely the value GroupRestartAppID/RestartGroup and
+// StartContainer's CNI-ADD gate read, so a correct result here means the
+// isolated networking path is taken again after reboot instead of silently
+// skipped.
+func TestReconcileRoundTrip_LabelPersistsAcrossSimulatedReboot(t *testing.T) {
+	appID := "camera-app"
+
+	// Step 1: simulate CreateContainerWithProgress persisting labels at create
+	// time (client.go:826) for an isolated multi-service app.
+	createTimeLabels := wendyLabels(appID, "streamer", "1.0.0", nil, nil, "isolated")
+	if createTimeLabels[labelKeyIsolation] != "isolated" {
+		t.Fatalf("precondition: wendyLabels did not persist isolation label, got %+v", createTimeLabels)
+	}
+
+	// Step 2: simulate the agent restarting. A brand new Client has an empty
+	// appIsolation cache, exactly like the real agent after a device reboot.
+	c := &Client{logger: zap.NewNop(), appIsolation: make(map[string]string)}
+	if got := c.getIsolation(appID); got != "" {
+		t.Fatalf("precondition: fresh Client must start with no cached isolation, got %q", got)
+	}
+
+	// Step 3: simulate what ListBootContainers now does for each enumerated
+	// container: read its persisted labels (here, the same labels containerd
+	// would return from ctr.Info(ctx).Labels) and hydrate.
+	c.hydrateIsolation(appID, createTimeLabels)
+
+	// Step 4: this is exactly what StartContainer's CNI-ADD gate (~client.go:1211),
+	// GroupRestartAppID (~client.go:1827), and RestartGroup (~client.go:1854) read.
+	c.mu.Lock()
+	got := c.getIsolation(appID)
+	c.mu.Unlock()
+	if got != "isolated" {
+		t.Fatalf("after simulated reboot + reconcile hydrate, getIsolation(%q) = %q; want %q (isolated networking path would be skipped)", appID, got, "isolated")
+	}
+	if !appconfig.IsSharedNamespaceIsolation("shared-network") {
+		t.Fatal("sanity check: IsSharedNamespaceIsolation helper behaves unexpectedly")
+	}
+}

--- a/go/internal/agent/containerd/isolation_hydrate_test.go
+++ b/go/internal/agent/containerd/isolation_hydrate_test.go
@@ -144,7 +144,10 @@ func TestReconcileRoundTrip_LabelPersistsAcrossSimulatedReboot(t *testing.T) {
 	// Step 2: simulate the agent restarting. A brand new Client has an empty
 	// appIsolation cache, exactly like the real agent after a device reboot.
 	c := &Client{logger: zap.NewNop(), appIsolation: make(map[string]string)}
-	if got := c.getIsolation(appID); got != "" {
+	c.mu.Lock()
+	got := c.getIsolation(appID)
+	c.mu.Unlock()
+	if got != "" {
 		t.Fatalf("precondition: fresh Client must start with no cached isolation, got %q", got)
 	}
 


### PR DESCRIPTION
## What

Fixes a pre-existing bug where **isolated containers lose their networking after a device reboot** (or any agent restart): they come back up with no CNI bridge/IP, and — for mesh apps — no mesh egress. Surfaced while verifying the mesh data plane's reboot behaviour; it affects **all** isolated apps, not just meshed ones.

## Root cause

`Client.appIsolation` (`go/internal/agent/containerd/client.go`) is an in-memory map written **only** in `CreateContainerWithProgress` and deleted in `StopContainer`. `StartContainer` reads it via `getIsolation(appID)` to gate CNI ADD, `applyMeshEgress`, netns anchoring, and a race guard that otherwise discards the CNI IP and kills the task. The reboot reconcile path — `ReconcileBootContainers → ListBootContainers → GroupRestartAppID/RestartGroup → StartContainer` — never repopulates the map, so after a reboot `getIsolation` returns `""`, the isolated-networking block is skipped, and the container starts with no network. The isolation mode was not persisted anywhere (`AppConfig.Isolation` was in-memory only).

## Fix

1. **Persist** the isolation mode as a container label `sh.wendy/isolation` at create time (via `wendyLabels` → the existing `containerd.WithContainerLabels`), set only when the app declares one.
2. **Rehydrate** `appIsolation` from that label on the reconcile path — in `ListBootContainers` (runs before `GroupRestartAppID`/`RestartGroup`) and defensively in `StartContainer` (before the first `getIsolation` read, for direct restarts). Hydration is idempotent and **never overrides** a live create-time value; per-container failures are logged and skipped, never failing the whole reconcile.
3. `serviceIPs` self-heals: once the isolation gate passes on the reconcile `StartContainer`, `CNIAdd` re-runs and `recordServiceIP` repopulates it (verified by inspection; no change needed).

Complements the mesh branch's separate fix that recreates the tmpfs `resolv.conf` bind source on reboot — that stopped the `NewTask` crash; this restores the actual networking.

## Testing

- `TestWendyLabels_WithIsolation` / `TestWendyLabels_EmptyIsolationOmitsLabel` — label persistence.
- 6 `TestHydrateIsolation_*` — set-when-empty, nil-map init, no-override-of-live-value, idempotency, empty-label/appID no-ops.
- `TestReconcileRoundTrip_LabelPersistsAcrossSimulatedReboot` — create → simulated reboot (fresh Client, empty cache) → hydrate → `getIsolation` returns the persisted mode.

All RED against a temporarily no-op'd hydrate, then GREEN. Full package suite + `go vet` + `-race` pass; `go build ./go/...` and `GOOS=linux GOARCH=arm64 go build ./go/cmd/wendy-agent` pass; `gofmt` clean.

## Known limitations

- **No backfill:** containers already running *before* this ships won't have the `sh.wendy/isolation` label until they're recreated (`wendy run`). A one-time reflash/recreate closes the gap; no backfill migration was added (out of scope).
- `ListBootContainers`' containerd plumbing has no real-containerd integration test in this package (none existed before); the hydration logic it calls is unit-tested with a hand-built label map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
