### PR TITLE
fix(cli): cross-compile Swift container images in release by default

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -599,7 +599,7 @@ func generatePythonDockerfile(dir string, debug bool) (string, error) {
 	return dockerfilePath, nil
 }
 
-func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, architecture string, swiftUseMTLS bool, toolchainStdout, toolchainStderr io.Writer) error {
+func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, architecture string, swiftUseMTLS, debug bool, toolchainStdout, toolchainStderr io.Writer) error {
 	if err := ensureContainerPlugin(dir); err != nil {
 		return err
 	}
@@ -609,10 +609,21 @@ func buildSwiftContainerImage(ctx context.Context, dir, product, registryAddr, a
 		return err
 	}
 
+	// Build release by default so on-device apps are optimized; debug only on
+	// explicit opt-in (matches the native swift-build path). The container plugin
+	// builds with `configuration: .inherit`, i.e. whatever `swift package` is told
+	// here — without this it defaulted to debug, shipping unoptimized binaries
+	// (e.g. a software renderer ran ~30x slower on device).
+	buildConfig := "release"
+	if debug {
+		buildConfig = "debug"
+	}
+
 	// registryAddr is always a plain-HTTP address: either the device's own
 	// unprovisioned registry or a local proxy that handles TLS on our behalf.
 	swiftArgs := []string{
 		"package",
+		"-c", buildConfig,
 		"--swift-sdk=" + sdk,
 		"--allow-network-connections=all",
 		"build-container-image",

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -981,7 +981,7 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	defer proxyCleanup()
 
 	cliLogln("Building Swift container image for %s (%s)...", tui.App(product), tui.Value(architecture))
-	if err := buildSwiftContainerImage(ctx, cwd, product, registryAddr, architecture, swiftUseMTLS, &dimWriter{}, os.Stderr); err != nil {
+	if err := buildSwiftContainerImage(ctx, cwd, product, registryAddr, architecture, swiftUseMTLS, opts.debug, &dimWriter{}, os.Stderr); err != nil {
 		return fmt.Errorf("building Swift container image: %w", err)
 	}
 	cliLogln("Build and push completed.")


### PR DESCRIPTION
## Problem

`wendy run` cross-compiles Swift apps into container images via
`buildSwiftContainerImage`, which invokes the swift-container-plugin. That
plugin builds with `configuration: .inherit` — i.e. whatever `swift package`
was told — and we passed **no** configuration, so it defaulted to **debug**.
Every cross-compiled Swift edge app therefore shipped **unoptimized**.

The native `swift build` path (`runMacOSSwiftPMWithAgent`) already defaults to
release (`buildConfig := "release"` unless `--debug`), so the two deploy paths
were inconsistent.

## Impact

Real case: a software-rendered SwiftCrossUI UI on a Raspberry Pi 5. A
full-screen redraw took **~615 ms (~1.6 fps)** in the debug cross-build; the
same code built release renders a smooth frame. Any compute- or pixel-heavy
Swift app is affected.

## Fix

Pass `-c <configuration>` to the container-plugin invocation: **release by
default, debug only on `--debug`** — matching the native path.

```
swift package -c release --swift-sdk=… build-container-image …
```

One-line behavior change; `go build ./...` passes. Verified end-to-end: the
Pi 5 UI went from a visibly slow, scanning repaint to smooth after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrPiCsGJdSqFrfAxZ9FNYv
