### PR TITLE
cli: apply entitlement flags to template init

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -643,6 +643,13 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 		return err
 	}
 
+	// Resolve entitlement flags up front so an invalid combination fails
+	// before any files are scaffolded.
+	requestedEntitlements, err := templateEntitlementsFromFlags(target, opts)
+	if err != nil {
+		return err
+	}
+
 	// Parse --var overrides.
 	varOverrides, err := parseVarFlags(opts.vars)
 	if err != nil {
@@ -684,12 +691,20 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 		return err
 	}
 
+	addedEntitlements, err := mergeTemplateEntitlements(filepath.Join(destDir, "wendy.json"), requestedEntitlements)
+	if err != nil {
+		return err
+	}
+
 	cliSuccess("\nScaffolded %s project from template %q", language, tmpl)
 	cliLogln("  Directory: %s", tui.Path(destDir+"/"))
 	for _, v := range manifest.Variables {
 		if val, ok := vals[v.Name]; ok {
 			cliLogln("  %s: %v", v.Name, val)
 		}
+	}
+	if len(addedEntitlements) > 0 {
+		cliLogln("  Entitlements added from flags: %s", strings.Join(addedEntitlements, ", "))
 	}
 
 	// Offer git init.
@@ -1098,6 +1113,122 @@ func buildInitEntitlementsFromFlags(target string, opts initOptions) ([]appconfi
 	}
 
 	return entitlements, nil
+}
+
+// templateEntitlementsFromFlags resolves entitlement-related init flags for
+// the template flow. The template's wendy.json is scaffolded verbatim, so
+// requested entitlements must be merged in afterwards — without that step the
+// flags were silently ignored (WDY-1810).
+func templateEntitlementsFromFlags(target string, opts initOptions) ([]appconfig.Entitlement, error) {
+	if !initEntitlementsProvided(opts) {
+		return nil, nil
+	}
+	return buildInitEntitlementsFromFlags(target, opts)
+}
+
+// mergeTemplateEntitlements merges requested entitlements into the scaffolded
+// wendy.json at cfgPath and reports the entitlement types it added. Only the
+// entitlements key is rewritten; template entries are kept verbatim, and a
+// requested entitlement already covered by the template is skipped so the
+// template's more specific configuration (network mode, ports, ...) wins.
+func mergeTemplateEntitlements(cfgPath string, requested []appconfig.Entitlement) ([]string, error) {
+	if len(requested) == 0 {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading scaffolded wendy.json to merge entitlement flags: %w", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing scaffolded wendy.json: %w", err)
+	}
+
+	var existingRaw []json.RawMessage
+	if rawEnts, ok := raw["entitlements"]; ok {
+		if err := json.Unmarshal(rawEnts, &existingRaw); err != nil {
+			return nil, fmt.Errorf("parsing scaffolded wendy.json entitlements: %w", err)
+		}
+	}
+	existing := make([]appconfig.Entitlement, len(existingRaw))
+	for i, entRaw := range existingRaw {
+		if err := json.Unmarshal(entRaw, &existing[i]); err != nil {
+			return nil, fmt.Errorf("parsing scaffolded wendy.json entitlements[%d]: %w", i, err)
+		}
+	}
+
+	mergedRaw := existingRaw
+	var added []string
+	for _, req := range requested {
+		if templateEntitlementCovers(existing, req) {
+			continue
+		}
+		entRaw, err := json.Marshal(req)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling %q entitlement: %w", req.Type, err)
+		}
+		mergedRaw = append(mergedRaw, entRaw)
+		existing = append(existing, req)
+		added = append(added, req.Type)
+	}
+	if len(added) == 0 {
+		return nil, nil
+	}
+
+	rawMerged, err := json.Marshal(mergedRaw)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling merged entitlements: %w", err)
+	}
+	raw["entitlements"] = rawMerged
+
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling scaffolded wendy.json: %w", err)
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(cfgPath, out, 0o644); err != nil {
+		return nil, fmt.Errorf("writing scaffolded wendy.json: %w", err)
+	}
+	return added, nil
+}
+
+// templateEntitlementCovers reports whether the template's entitlements
+// already grant what req asks for.
+func templateEntitlementCovers(existing []appconfig.Entitlement, req appconfig.Entitlement) bool {
+	for _, e := range existing {
+		if e.Type != req.Type {
+			continue
+		}
+		switch req.Type {
+		case appconfig.EntitlementPersist:
+			if e.Name == req.Name {
+				return true
+			}
+		case appconfig.EntitlementI2C, appconfig.EntitlementSerial:
+			if e.Device == req.Device {
+				return true
+			}
+		case appconfig.EntitlementGPIO:
+			// A gpio entry without pins grants access to all GPIO chips.
+			if len(e.Pins) == 0 || pinsSubset(req.Pins, e.Pins) {
+				return true
+			}
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+func pinsSubset(sub, super []int) bool {
+	for _, p := range sub {
+		if !slices.Contains(super, p) {
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeInitChoice(value string) string {

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -741,5 +742,221 @@ func TestInitCommand_InstallClaudeSkillsFalseDoesNotRequireClaude(t *testing.T) 
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
+	}
+}
+
+func writeTemplateWendyJSON(t *testing.T, content string) string {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "wendy.json")
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing wendy.json: %v", err)
+	}
+	return cfgPath
+}
+
+func readEntitlements(t *testing.T, cfgPath string) []appconfig.Entitlement {
+	t.Helper()
+	cfg, err := appconfig.LoadFromFile(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	return cfg.Entitlements
+}
+
+// The WDY-1810 repro: --template simple-api --entitlement gpu must produce a
+// wendy.json containing both the template's network entitlement and gpu.
+func TestMergeTemplateEntitlements_AddsFlagEntitlementToTemplateConfig(t *testing.T) {
+	cfgPath := writeTemplateWendyJSON(t, `{
+  "appId": "autotest-gpu",
+  "version": "0.1.0",
+  "platform": "linux",
+  "language": "python",
+  "entitlements": [{"type": "network"}]
+}`)
+
+	requested, err := templateEntitlementsFromFlags(targetWendyOS, initOptions{
+		entitlementsSet: true,
+		entitlements:    []string{"gpu"},
+	})
+	if err != nil {
+		t.Fatalf("templateEntitlementsFromFlags: %v", err)
+	}
+
+	added, err := mergeTemplateEntitlements(cfgPath, requested)
+	if err != nil {
+		t.Fatalf("mergeTemplateEntitlements: %v", err)
+	}
+	if len(added) != 1 || added[0] != appconfig.EntitlementGPU {
+		t.Fatalf("added = %v, want [gpu]", added)
+	}
+
+	entitlements := readEntitlements(t, cfgPath)
+	gotTypes := map[string]bool{}
+	for _, ent := range entitlements {
+		gotTypes[ent.Type] = true
+	}
+	if !gotTypes[appconfig.EntitlementNetwork] || !gotTypes[appconfig.EntitlementGPU] {
+		t.Fatalf("entitlements = %+v, want network and gpu", entitlements)
+	}
+}
+
+func TestMergeTemplateEntitlements_NoFlagsIsNoOp(t *testing.T) {
+	requested, err := templateEntitlementsFromFlags(targetWendyOS, initOptions{})
+	if err != nil {
+		t.Fatalf("templateEntitlementsFromFlags: %v", err)
+	}
+	if requested != nil {
+		t.Fatalf("requested = %+v, want nil", requested)
+	}
+
+	// No requested entitlements: the file must not even be read.
+	added, err := mergeTemplateEntitlements(filepath.Join(t.TempDir(), "missing", "wendy.json"), nil)
+	if err != nil {
+		t.Fatalf("mergeTemplateEntitlements: %v", err)
+	}
+	if added != nil {
+		t.Fatalf("added = %v, want nil", added)
+	}
+}
+
+func TestMergeTemplateEntitlements_MissingConfigFails(t *testing.T) {
+	_, err := mergeTemplateEntitlements(
+		filepath.Join(t.TempDir(), "wendy.json"),
+		[]appconfig.Entitlement{{Type: appconfig.EntitlementGPU}},
+	)
+	if err == nil {
+		t.Fatal("expected merge into a missing wendy.json to fail")
+	}
+}
+
+func TestMergeTemplateEntitlements_CoveredEntitlementsLeaveFileUntouched(t *testing.T) {
+	content := `{
+  "appId": "demo",
+  "entitlements": [{"type": "network", "mode": "host"}, {"type": "gpu"}]
+}`
+	cfgPath := writeTemplateWendyJSON(t, content)
+
+	added, err := mergeTemplateEntitlements(cfgPath, []appconfig.Entitlement{
+		{Type: appconfig.EntitlementNetwork},
+		{Type: appconfig.EntitlementGPU},
+	})
+	if err != nil {
+		t.Fatalf("mergeTemplateEntitlements: %v", err)
+	}
+	if added != nil {
+		t.Fatalf("added = %v, want nil", added)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != content {
+		t.Fatalf("wendy.json was rewritten:\n%s", data)
+	}
+}
+
+func TestMergeTemplateEntitlements_PreservesUnknownKeysAndTemplateEntries(t *testing.T) {
+	cfgPath := writeTemplateWendyJSON(t, `{
+  "appId": "demo",
+  "futureKey": {"nested": true},
+  "entitlements": [{"type": "network", "mode": "host", "futureEntKey": 7}]
+}`)
+
+	added, err := mergeTemplateEntitlements(cfgPath, []appconfig.Entitlement{
+		{Type: appconfig.EntitlementNetwork},
+		{Type: appconfig.EntitlementAudio},
+	})
+	if err != nil {
+		t.Fatalf("mergeTemplateEntitlements: %v", err)
+	}
+	if len(added) != 1 || added[0] != appconfig.EntitlementAudio {
+		t.Fatalf("added = %v, want [audio]", added)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, ok := raw["futureKey"]; !ok {
+		t.Fatalf("unknown top-level key dropped: %s", data)
+	}
+	if !strings.Contains(string(raw["entitlements"]), "futureEntKey") {
+		t.Fatalf("unknown entitlement key dropped: %s", raw["entitlements"])
+	}
+
+	entitlements := readEntitlements(t, cfgPath)
+	if len(entitlements) != 2 {
+		t.Fatalf("entitlements = %+v, want template network + audio", entitlements)
+	}
+	if entitlements[0].Type != appconfig.EntitlementNetwork || entitlements[0].Mode != "host" {
+		t.Fatalf("template network entry changed: %+v", entitlements[0])
+	}
+	if entitlements[1].Type != appconfig.EntitlementAudio {
+		t.Fatalf("entitlements[1] = %+v, want audio", entitlements[1])
+	}
+}
+
+func TestMergeTemplateEntitlements_PersistDedupedByName(t *testing.T) {
+	cfgPath := writeTemplateWendyJSON(t, `{
+  "appId": "demo",
+  "entitlements": [
+    {"type": "network"},
+    {"type": "persist", "name": "data", "path": "/data"}
+  ]
+}`)
+
+	added, err := mergeTemplateEntitlements(cfgPath, []appconfig.Entitlement{
+		{Type: appconfig.EntitlementPersist, Name: "data", Path: "/other"},
+		{Type: appconfig.EntitlementPersist, Name: "cache", Path: "/cache"},
+	})
+	if err != nil {
+		t.Fatalf("mergeTemplateEntitlements: %v", err)
+	}
+	if len(added) != 1 || added[0] != appconfig.EntitlementPersist {
+		t.Fatalf("added = %v, want [persist]", added)
+	}
+
+	entitlements := readEntitlements(t, cfgPath)
+	var persistNames []string
+	for _, ent := range entitlements {
+		if ent.Type == appconfig.EntitlementPersist {
+			persistNames = append(persistNames, ent.Name)
+		}
+	}
+	if len(persistNames) != 2 || persistNames[0] != "data" || persistNames[1] != "cache" {
+		t.Fatalf("persist names = %v, want [data cache]", persistNames)
+	}
+}
+
+func TestTemplateEntitlementCovers_GPIOPins(t *testing.T) {
+	allPins := []appconfig.Entitlement{{Type: appconfig.EntitlementGPIO}}
+	somePins := []appconfig.Entitlement{{Type: appconfig.EntitlementGPIO, Pins: []int{17, 27}}}
+
+	req := appconfig.Entitlement{Type: appconfig.EntitlementGPIO, Pins: []int{17}}
+	if !templateEntitlementCovers(allPins, req) {
+		t.Fatal("pinless template gpio entry should cover any requested pins")
+	}
+	if !templateEntitlementCovers(somePins, req) {
+		t.Fatal("template gpio pins [17 27] should cover requested [17]")
+	}
+
+	req.Pins = []int{17, 22}
+	if templateEntitlementCovers(somePins, req) {
+		t.Fatal("template gpio pins [17 27] should not cover requested [17 22]")
+	}
+}
+
+func TestTemplateEntitlementsFromFlags_DarwinRejectsEntitlementFlags(t *testing.T) {
+	_, err := templateEntitlementsFromFlags(targetDarwin, initOptions{
+		entitlementsSet: true,
+		entitlements:    []string{"gpu"},
+	})
+	if err == nil {
+		t.Fatal("expected darwin + --entitlement to fail")
 	}
 }


### PR DESCRIPTION
## Summary
- `wendy init --template simple-api --entitlement gpu` used to print success but generate a `wendy.json` without the gpu entitlement: the template flow copied the template's `wendy.json` verbatim and never looked at entitlement flags. Scripts and agents doing non-interactive scaffolding (the documented use case) hit this silently every time.
- Entitlement flags (`--entitlement`, `--all-entitlements`, `--gpio-pins`, `--i2c-device`, `--persist-name/-path`, `--no-extra-entitlements`) are now merged into the scaffolded `wendy.json`, and the CLI reports what was added: `Entitlements added from flags: gpu`.
- The template keeps the upper hand where it is more specific: only the `entitlements` key is rewritten (unknown template keys survive byte-for-byte), and entries the template already grants are skipped — e.g. its `network` entry with `mode: host` is not clobbered by the flag-derived plain `network`. Persist entries dedupe by name, i2c/serial by device, gpio by pin coverage.
- Invalid combinations now fail before any files are written instead of being dropped (e.g. entitlement flags with `--target darwin`).

## Tests
- `go test ./internal/cli/commands` (includes new merge/coverage unit tests)
- Live repro from the Linear issue with a dev build: `wendy init --app-id autotest-gpu --target wendyos --language python --template simple-api --entitlement gpu --assistant skip --git-init no` now produces `wendy.json` with both `network` and `gpu`, template hooks/readiness untouched.

Closes WDY-1810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
