### PR TITLE
cli: prompt for name and location when init flags are partial

### DIFF
--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -768,9 +768,21 @@ func templateNextSteps(cwd, destDir, appID string) []string {
 	return []string{"cd " + shellQuote(appID), "wendy run"}
 }
 
-// resolveInitDestAndID determines the destination directory and app ID for template flow.
-// In fully interactive mode it asks whether to initialize in the current directory
-// or create a new project subdirectory.
+// confirmInitCurrentDir and promptInitProjectName are variables so tests can
+// replace the Bubble Tea prompts with canned answers.
+var confirmInitCurrentDir = func() (bool, error) {
+	return tui.ConfirmDefaultYes("Initialize in the current directory?")
+}
+
+var promptInitProjectName = func() (string, error) {
+	return tui.PromptText("Project name", "directory name and app identifier", validateNewProjectName)
+}
+
+// resolveInitDestAndID determines the destination directory and app ID for
+// the template flow. An explicit app ID (positional or --app-id) answers
+// both; otherwise the user is asked on an interactive terminal. Flags that
+// answer other questions (--target, entitlement flags, ...) never suppress
+// these prompts (WDY-1805).
 func resolveInitDestAndID(cwd string, args []string, opts initOptions) (string, string, error) {
 	// Explicit app ID provided: always create a new subdirectory.
 	if len(args) > 0 || opts.appIDSet {
@@ -781,28 +793,30 @@ func resolveInitDestAndID(cwd string, args []string, opts initOptions) (string, 
 		return filepath.Join(cwd, appID), appID, nil
 	}
 
-	// Fully interactive (no directive flags): ask where to set up the project.
-	if !opts.targetSet && !opts.entitlementsSet && !opts.allEntitlements && !opts.noExtraEntitlements {
-		fmt.Println()
-		useCurrentDir, err := tui.ConfirmDefaultYes("Initialize in the current directory?")
-		if err != nil {
-			return "", "", err
-		}
-		if useCurrentDir {
-			return cwd, strings.TrimSpace(filepath.Base(cwd)), nil
-		}
-
-		fmt.Println()
-		appID, err := tui.PromptText("Project name", "directory name and app identifier", validateNewProjectName)
-		if err != nil {
-			return "", "", err
-		}
-		appID = strings.TrimSpace(appID)
-		return filepath.Join(cwd, appID), appID, nil
+	if !isInteractiveTerminal() {
+		return "", "", fmt.Errorf("an app ID is required when running non-interactively; pass --app-id or an [app-id] argument")
 	}
 
-	// Semi-interactive or non-interactive without explicit app ID: infer from cwd.
-	return cwd, strings.TrimSpace(filepath.Base(cwd)), nil
+	fmt.Println()
+	useCurrentDir, err := confirmInitCurrentDir()
+	if err != nil {
+		return "", "", err
+	}
+	if useCurrentDir {
+		appID := strings.TrimSpace(filepath.Base(cwd))
+		if err := validateNewProjectName(appID); err != nil {
+			return "", "", fmt.Errorf("current directory name %q cannot be used as the app ID: %w; rerun with --app-id", appID, err)
+		}
+		return cwd, appID, nil
+	}
+
+	fmt.Println()
+	appID, err := promptInitProjectName()
+	if err != nil {
+		return "", "", err
+	}
+	appID = strings.TrimSpace(appID)
+	return filepath.Join(cwd, appID), appID, nil
 }
 
 func validateNewProjectName(value string) error {

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -89,6 +89,96 @@ func TestResolveInitAppID_TrimsExplicitFlag(t *testing.T) {
 	}
 }
 
+// stubInitDestPrompts replaces the TTY detection and the destination/name
+// prompts used by resolveInitDestAndID with canned answers.
+func stubInitDestPrompts(t *testing.T, interactive, useCurrentDir bool, projectName string) {
+	t.Helper()
+	origInteractive := isInteractiveTerminalFn
+	origConfirm := confirmInitCurrentDir
+	origPrompt := promptInitProjectName
+	isInteractiveTerminalFn = func() bool { return interactive }
+	confirmInitCurrentDir = func() (bool, error) { return useCurrentDir, nil }
+	promptInitProjectName = func() (string, error) { return projectName, nil }
+	t.Cleanup(func() {
+		isInteractiveTerminalFn = origInteractive
+		confirmInitCurrentDir = origConfirm
+		promptInitProjectName = origPrompt
+	})
+}
+
+func TestResolveInitDestAndID_ExplicitAppIDCreatesSubdirectory(t *testing.T) {
+	stubInitDestPrompts(t, false, false, "")
+
+	destDir, appID, err := resolveInitDestAndID("/tmp/workspace", nil, initOptions{
+		appID:    "demo-app",
+		appIDSet: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveInitDestAndID: %v", err)
+	}
+	if destDir != filepath.Join("/tmp/workspace", "demo-app") || appID != "demo-app" {
+		t.Fatalf("destDir, appID = %q, %q, want subdirectory demo-app", destDir, appID)
+	}
+}
+
+// The WDY-1805 repro: partial flags like --target must not suppress the
+// destination and name questions on a TTY.
+func TestResolveInitDestAndID_PromptsDespiteDirectiveFlags(t *testing.T) {
+	stubInitDestPrompts(t, true, false, "demo-app")
+
+	destDir, appID, err := resolveInitDestAndID("/tmp/Build", nil, initOptions{
+		targetSet:   true,
+		languageSet: true,
+		templateSet: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveInitDestAndID: %v", err)
+	}
+	if destDir != filepath.Join("/tmp/Build", "demo-app") || appID != "demo-app" {
+		t.Fatalf("destDir, appID = %q, %q, want prompted demo-app subdirectory", destDir, appID)
+	}
+}
+
+func TestResolveInitDestAndID_CurrentDirUsesValidatedBasename(t *testing.T) {
+	stubInitDestPrompts(t, true, true, "")
+
+	destDir, appID, err := resolveInitDestAndID("/tmp/demo-app", nil, initOptions{targetSet: true})
+	if err != nil {
+		t.Fatalf("resolveInitDestAndID: %v", err)
+	}
+	if destDir != "/tmp/demo-app" || appID != "demo-app" {
+		t.Fatalf("destDir, appID = %q, %q, want current dir demo-app", destDir, appID)
+	}
+}
+
+func TestResolveInitDestAndID_CurrentDirRejectsInvalidBasename(t *testing.T) {
+	stubInitDestPrompts(t, true, true, "")
+
+	_, _, err := resolveInitDestAndID("/tmp/Demo App", nil, initOptions{})
+	if err == nil {
+		t.Fatal("expected invalid directory basename to fail as app ID")
+	}
+	if !strings.Contains(err.Error(), `"Demo App"`) || !strings.Contains(err.Error(), "--app-id") {
+		t.Fatalf("error = %q, want mention of basename and --app-id", err)
+	}
+}
+
+func TestResolveInitDestAndID_NonInteractiveWithoutAppIDFails(t *testing.T) {
+	stubInitDestPrompts(t, false, false, "")
+
+	_, _, err := resolveInitDestAndID("/tmp/Build", nil, initOptions{
+		targetSet:   true,
+		languageSet: true,
+		templateSet: true,
+	})
+	if err == nil {
+		t.Fatal("expected non-interactive template init without app ID to fail")
+	}
+	if !strings.Contains(err.Error(), "--app-id") {
+		t.Fatalf("error = %q, want mention of --app-id", err)
+	}
+}
+
 func TestPathHasPrefix_IsCaseSensitiveOnUnix(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows paths are intentionally compared case-insensitively")


### PR DESCRIPTION
## Summary
- `wendy init --template ...` with partial flags (e.g. `--target wendyos --language python --template audio`) used to scaffold silently into the current folder — even a non-empty one — name the app after the folder, and run `git init`, all without prompting or validating the name.
- Flags now answer only their own questions: when no app ID is given (positional or `--app-id`), the destination and project-name prompts still run. The gate is terminal detection instead of unrelated flags like `--target`.
- Non-interactive runs without an explicit app ID now fail up front with a hint to pass `--app-id`, instead of quietly writing into cwd.
- Choosing "initialize in the current directory" now validates the folder-derived app ID, so a folder like `My App` no longer ends up verbatim in `wendy.json`.

## Tests
- `go test ./internal/cli/commands` — new unit tests for `resolveInitDestAndID` covering the explicit-app-id path, prompting despite directive flags, basename validation, and the non-interactive error.
- Live check with a dev build: the repro (`mkdir Build && cd Build && wendy init --target wendyos --language python --template audio` without a TTY) errors cleanly and leaves the folder untouched; the same command with `--app-id audio-demo` scaffolds into `audio-demo/` as before.

Closes WDY-1805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
