### PR TITLE
refactor(cli): single Y/n confirmation implementation

### DIFF
--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -491,10 +491,7 @@ func newDeviceSetupCmd() *cobra.Command {
 				fmt.Println("Device is not enrolled.")
 				if loadCLICert() == nil {
 					fmt.Println("You are not logged in to Wendy Cloud.")
-					fmt.Print("Log in now? [Y/n] ")
-					answer, _ := reader.ReadString('\n')
-					answer = strings.TrimSpace(strings.ToLower(answer))
-					if answer == "" || answer == "y" || answer == "yes" {
+					if confirmFn("Log in now?") {
 						if loginErr := performLogin(ctx, defaultCloudDashboard, defaultCloudGRPC); loginErr != nil {
 							return fmt.Errorf("login failed: %w", loginErr)
 						}
@@ -615,11 +612,7 @@ func promptWifiIfNeeded(ctx context.Context, conn *grpcclient.AgentConnection) {
 	}
 
 	fmt.Println("No WiFi connection detected on the device.")
-	fmt.Print("Set up WiFi before enrolling? [Y/n] ")
-	reader := bufio.NewReader(os.Stdin)
-	line, _ := reader.ReadString('\n')
-	answer := strings.TrimSpace(strings.ToLower(line))
-	if answer != "" && answer != "y" && answer != "yes" {
+	if !confirmFn("Set up WiFi before enrolling?") {
 		return
 	}
 
@@ -812,11 +805,7 @@ func newDeviceUnenrollCmd() *cobra.Command {
 					return fmt.Errorf("unenroll is destructive; pass --yes to confirm when not running interactively")
 				}
 				fmt.Printf("This will unenroll the device (org: %d, asset: %d) and delete its asset in Wendy Cloud.\n", orgID, assetID)
-				fmt.Print("Continue? [y/N] ")
-				reader := bufio.NewReader(os.Stdin)
-				line, _ := reader.ReadString('\n')
-				answer := strings.TrimSpace(strings.ToLower(line))
-				if answer != "y" && answer != "yes" {
+				if !confirmDefaultNoFn("Continue?") {
 					fmt.Println("Aborted.")
 					return nil
 				}
@@ -1907,7 +1896,7 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 				fmt.Printf("OS artifact specified (%s). Re-run with --yes to apply.\n", artifactURLOverride)
 				return osUpdateOutcome{}, nil
 			}
-			if !promptYesNoDefaultNoFn(fmt.Sprintf("Apply OS update from %s? [y/N] ", artifactURLOverride)) {
+			if !confirmDefaultNoFn(fmt.Sprintf("Apply OS update from %s?", artifactURLOverride)) {
 				fmt.Println("Skipping OS update.")
 				return osUpdateOutcome{}, nil
 			}
@@ -1952,7 +1941,7 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 			// fall through to apply
 		case osActionPrompt:
 			ensureDeviceWiFiForOSUpdate(ctx, conn)
-			if !promptYesNoDefaultNoFn(fmt.Sprintf("OS update available (%s → %s). Apply now? [y/N] ", fromVer, latestVer)) {
+			if !confirmDefaultNoFn(fmt.Sprintf("OS update available (%s → %s). Apply now?", fromVer, latestVer)) {
 				fmt.Println("Skipping OS update. Run 'wendy os update' to apply later.")
 				return osUpdateOutcome{}, nil
 			}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bufio"
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
@@ -761,11 +760,7 @@ func ensureDockerDaemonForHostOS(ctx context.Context, hostOS dockerHostOS) error
 		if !cliOnPath {
 			if !hasRuntime {
 				if isInteractiveTerminalFn() {
-					fmt.Print("Docker runtime app and docker CLI were not found. Install Docker Desktop now with 'brew install --cask docker'? [Y/n] ")
-					reader := bufio.NewReader(os.Stdin)
-					answer, _ := reader.ReadString('\n')
-					answer = strings.TrimSpace(strings.ToLower(answer))
-					if answer != "" && answer != "y" && answer != "yes" {
+					if !confirmFn("Docker runtime app and docker CLI were not found. Install Docker Desktop now with 'brew install --cask docker'?") {
 						return fmt.Errorf("Docker runtime app is not installed — install Docker Desktop, OrbStack, or Rancher Desktop")
 					}
 					fmt.Fprintf(os.Stderr, "[docker] Installing Docker Desktop via Homebrew...\n")
@@ -800,11 +795,7 @@ func ensureDockerDaemonForHostOS(ctx context.Context, hostOS dockerHostOS) error
 		}
 
 		if isInteractiveTerminalFn() {
-			fmt.Printf("Docker daemon is not running or is still starting for %s. Open it now? [Y/n] ", rt.name)
-			reader := bufio.NewReader(os.Stdin)
-			answer, _ := reader.ReadString('\n')
-			answer = strings.TrimSpace(strings.ToLower(answer))
-			if answer != "" && answer != "y" && answer != "yes" {
+			if !confirmFn(fmt.Sprintf("Docker daemon is not running or is still starting for %s. Open it now?", rt.name)) {
 				return fmt.Errorf("docker daemon is not running — please start %s and try again", rt.name)
 			}
 		}
@@ -1744,7 +1735,7 @@ func ensureAppleContainerSystem(ctx context.Context, assumeYes bool) error {
 	}
 
 	if isInteractiveTerminalFn() && !assumeYes {
-		if !promptYesNoFn("Apple Container system is not running. Start it now? [Y/n] ") {
+		if !confirmFn("Apple Container system is not running. Start it now?") {
 			return appleContainerSystemStatus(ctx)
 		}
 	}

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -278,14 +278,14 @@ func TestBuildDockerProjectWithBuilderFallsBackToDockerWhenAutoAppleContainerSys
 	oldGOOS := imageBuilderHostGOOS
 	oldGOARCH := imageBuilderHostGOARCH
 	oldDockerBuild := buildDockerProjectWithDocker
-	oldPrompt := promptYesNoFn
+	oldPrompt := confirmFn
 	t.Cleanup(func() {
 		imageBuilderCommandContext = oldCommand
 		imageBuilderLookPath = oldLookPath
 		imageBuilderHostGOOS = oldGOOS
 		imageBuilderHostGOARCH = oldGOARCH
 		buildDockerProjectWithDocker = oldDockerBuild
-		promptYesNoFn = oldPrompt
+		confirmFn = oldPrompt
 	})
 
 	logFile := filepath.Join(t.TempDir(), "commands.log")
@@ -299,7 +299,7 @@ func TestBuildDockerProjectWithBuilderFallsBackToDockerWhenAutoAppleContainerSys
 	}
 	imageBuilderHostGOOS = func() string { return "darwin" }
 	imageBuilderHostGOARCH = func() string { return "arm64" }
-	promptYesNoFn = func(string) bool {
+	confirmFn = func(string) bool {
 		t.Fatal("auto Apple Container fallback must not prompt")
 		return false
 	}
@@ -377,7 +377,7 @@ func TestBuildDockerProjectWithBuilderFallsBackToDockerWhenAutoAppleContainerFai
 func TestBuildDockerProjectWithBuilderFallsBackWhenAutoAppleContainerStoppedOnAppleSilicon(t *testing.T) {
 	logFile := setupAppleContainerEnsureSeams(t)
 	isInteractiveTerminalFn = func() bool { return false }
-	promptYesNoFn = func(string) bool { t.Fatal("must not prompt in auto path"); return false }
+	confirmFn = func(string) bool { t.Fatal("must not prompt in auto path"); return false }
 	// System stays down because the auto path must not run "container system start".
 	t.Setenv("IMAGE_BUILDER_STATUS_READY_FILE", filepath.Join(t.TempDir(), "ready"))
 
@@ -509,7 +509,7 @@ func setupAppleContainerEnsureSeams(t *testing.T) string {
 	oldGOOS := imageBuilderHostGOOS
 	oldGOARCH := imageBuilderHostGOARCH
 	oldInteractive := isInteractiveTerminalFn
-	oldPrompt := promptYesNoFn
+	oldPrompt := confirmFn
 	oldTimeout := appleContainerStartTimeout
 	oldPoll := appleContainerStatusPollInterval
 	t.Cleanup(func() {
@@ -518,7 +518,7 @@ func setupAppleContainerEnsureSeams(t *testing.T) string {
 		imageBuilderHostGOOS = oldGOOS
 		imageBuilderHostGOARCH = oldGOARCH
 		isInteractiveTerminalFn = oldInteractive
-		promptYesNoFn = oldPrompt
+		confirmFn = oldPrompt
 		appleContainerStartTimeout = oldTimeout
 		appleContainerStatusPollInterval = oldPoll
 	})
@@ -555,7 +555,7 @@ func TestEnsureAppleContainerSystem_AlreadyRunning(t *testing.T) {
 func TestEnsureAppleContainerSystem_AutoStartsWhenAssumeYes(t *testing.T) {
 	logFile := setupAppleContainerEnsureSeams(t)
 	isInteractiveTerminalFn = func() bool { return false }
-	promptYesNoFn = func(string) bool { t.Fatal("must not prompt when assumeYes"); return false }
+	confirmFn = func(string) bool { t.Fatal("must not prompt when assumeYes"); return false }
 	// System is down until "container system start" creates the readiness file.
 	t.Setenv("IMAGE_BUILDER_STATUS_READY_FILE", filepath.Join(t.TempDir(), "ready"))
 
@@ -573,7 +573,7 @@ func TestEnsureAppleContainerSystem_InteractiveDeclined(t *testing.T) {
 	logFile := setupAppleContainerEnsureSeams(t)
 	t.Setenv("IMAGE_BUILDER_FAIL_STATUS", "1")
 	isInteractiveTerminalFn = func() bool { return true }
-	promptYesNoFn = func(string) bool { return false }
+	confirmFn = func(string) bool { return false }
 
 	err := ensureAppleContainerSystem(context.Background(), false)
 	if err == nil {

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1,14 +1,12 @@
 package commands
 
 import (
-	"bufio"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/netip"
 	"os"
@@ -154,49 +152,22 @@ func isCertRefreshableError(err error) bool {
 	return false
 }
 
-// promptYesNoFn reads a Y/n answer from the controlling terminal; empty input
-// counts as yes. Stubbed in tests.
-var promptYesNoFn = func(prompt string) bool {
-	return promptYesNoLine(prompt, true)
+// confirmFn asks a yes/no question defaulting to Yes (empty input / Enter
+// counts as yes), using the shared styled tui.Confirm prompt. It is a package
+// var so tests can stub it. The question must not carry a "[Y/n]" suffix — the
+// prompt renders its own hint. A cancelled prompt (Ctrl+C / q) counts as no.
+var confirmFn = func(question string) bool {
+	ok, err := tui.ConfirmDefaultYes(question, tea.WithOutput(os.Stderr))
+	return err == nil && ok
 }
 
-// promptYesNoDefaultNoFn reads a y/N answer from the controlling terminal;
-// empty input counts as no. Used for more speculative offers (e.g. a timeout
-// against an enrolled device, where refreshing certs is a guess rather than a
-// clear diagnosis). Stubbed in tests.
-var promptYesNoDefaultNoFn = func(prompt string) bool {
-	return promptYesNoLine(prompt, false)
-}
-
-func promptYesNoLine(prompt string, defaultYes bool) bool {
-	in, out, cleanup := promptTTYIO()
-	defer cleanup()
-
-	// Clear any stale spinner/hint line before printing the prompt. This keeps a
-	// simple line prompt from visually colliding with a previously-rendered TUI.
-	fmt.Fprint(out, "\r\x1b[2K")
-	fmt.Fprint(out, prompt)
-
-	answer, err := bufio.NewReader(in).ReadString('\n')
-	if err != nil && strings.TrimSpace(answer) == "" {
-		return false
-	}
-	return parseYesNoAnswer(answer, defaultYes)
-}
-
-func parseYesNoAnswer(answer string, defaultYes bool) bool {
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer == "" {
-		return defaultYes
-	}
-	return answer == "y" || answer == "yes"
-}
-
-func promptTTYIO() (io.Reader, io.Writer, func()) {
-	if tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err == nil {
-		return tty, tty, func() { _ = tty.Close() }
-	}
-	return os.Stdin, os.Stderr, func() {}
+// confirmDefaultNoFn asks a yes/no question defaulting to No (empty input /
+// Enter counts as no). Used for more speculative or destructive offers (e.g. a
+// timeout against an enrolled device, where refreshing certs is a guess rather
+// than a clear diagnosis, or applying an OS update). Stubbed in tests.
+var confirmDefaultNoFn = func(question string) bool {
+	ok, err := tui.Confirm(question, tea.WithOutput(os.Stderr))
+	return err == nil && ok
 }
 
 var refreshAllCertsFn = refreshAllCerts
@@ -217,13 +188,13 @@ func offerCertRefreshAndRetry(ctx context.Context, cause error, retry func() (*g
 	if certRejected {
 		// Clear diagnosis: the agent rejected the cert. Default to yes.
 		fmt.Fprintln(os.Stderr, "The device rejected your client certificate; it may be outdated.")
-		accepted = promptYesNoFn("Refresh certificates and retry? [Y/n] ")
+		accepted = confirmFn("Refresh certificates and retry?")
 	} else {
 		// Timeout against an enrolled (mTLS-only) device. Refreshing certs is a
 		// reasonable guess (e.g. clock skew stalling the handshake) but less
 		// certain, so default to no.
 		fmt.Fprintln(os.Stderr, "The device is enrolled and only responds on the secure (mTLS) port. Your certificates may be stale or your CLI too old.")
-		accepted = promptYesNoDefaultNoFn("Refresh certificates and retry? [y/N] ")
+		accepted = confirmDefaultNoFn("Refresh certificates and retry?")
 	}
 	if !accepted {
 		return nil, false
@@ -1258,11 +1229,8 @@ func checkAndOfferUpdate(ctx context.Context, conn *grpcclient.AgentConnection) 
 	}
 	warn := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
 
-	fmt.Fprintf(os.Stderr, warn.Render("Agent is behind the CLI (agent: %s, CLI: %s). Update now? [Y/n] "), agentVer, version.Version)
-	reader := bufio.NewReader(os.Stdin)
-	answer, _ := reader.ReadString('\n')
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer != "" && answer != "y" && answer != "yes" {
+	fmt.Fprintf(os.Stderr, warn.Render("Agent is behind the CLI (agent: %s, CLI: %s).")+"\n", agentVer, version.Version)
+	if !confirmFn("Update the agent now?") {
 		return conn, nil
 	}
 
@@ -1700,13 +1668,7 @@ func ensureAppConfig(cfgPath string, autoAccept bool) (*appconfig.AppConfig, err
 		}
 
 		fmt.Println("No wendy.json found in current directory.")
-		fmt.Printf("Create one with app ID %q? [Y/n] ", dirName)
-
-		reader := bufio.NewReader(os.Stdin)
-		answer, _ := reader.ReadString('\n')
-		answer = strings.TrimSpace(strings.ToLower(answer))
-
-		if answer != "" && answer != "y" && answer != "yes" {
+		if !confirmFn(fmt.Sprintf("Create one with app ID %q?", dirName)) {
 			return nil, fmt.Errorf("wendy.json is required; run 'wendy init <app-id>' to create one")
 		}
 	}

--- a/go/internal/cli/commands/helpers_certrefresh_test.go
+++ b/go/internal/cli/commands/helpers_certrefresh_test.go
@@ -80,15 +80,15 @@ func TestOfferCertRefreshAndRetry(t *testing.T) {
 	setup := func(interactive, accept bool, refreshErr error) (restore func(), refreshCalls, retryCalls *int) {
 		origInteractive := isInteractiveTerminalFn
 		origJSON := jsonOutput
-		origPrompt := promptYesNoFn
-		origPromptNo := promptYesNoDefaultNoFn
+		origPrompt := confirmFn
+		origPromptNo := confirmDefaultNoFn
 		origRefresh := refreshAllCertsFn
 		refreshCalls = new(int)
 		retryCalls = new(int)
 		isInteractiveTerminalFn = func() bool { return interactive }
 		jsonOutput = false
-		promptYesNoFn = func(string) bool { return accept }
-		promptYesNoDefaultNoFn = func(string) bool { return accept }
+		confirmFn = func(string) bool { return accept }
+		confirmDefaultNoFn = func(string) bool { return accept }
 		refreshAllCertsFn = func(context.Context) error {
 			*refreshCalls++
 			return refreshErr
@@ -96,8 +96,8 @@ func TestOfferCertRefreshAndRetry(t *testing.T) {
 		return func() {
 			isInteractiveTerminalFn = origInteractive
 			jsonOutput = origJSON
-			promptYesNoFn = origPrompt
-			promptYesNoDefaultNoFn = origPromptNo
+			confirmFn = origPrompt
+			confirmDefaultNoFn = origPromptNo
 			refreshAllCertsFn = origRefresh
 		}, refreshCalls, retryCalls
 	}

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -20,27 +20,6 @@ import (
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
-func TestParseYesNoAnswer(t *testing.T) {
-	tests := []struct {
-		answer     string
-		defaultYes bool
-		want       bool
-	}{
-		{"", true, true},
-		{"\n", true, true},
-		{"", false, false},
-		{"y", false, true},
-		{" YES \n", false, true},
-		{"n", true, false},
-		{"no", true, false},
-	}
-	for _, tt := range tests {
-		if got := parseYesNoAnswer(tt.answer, tt.defaultYes); got != tt.want {
-			t.Fatalf("parseYesNoAnswer(%q, %t) = %t, want %t", tt.answer, tt.defaultYes, got, tt.want)
-		}
-	}
-}
-
 // ── hostPort ────────────────────────────────────────────────────────
 
 func TestHostPort(t *testing.T) {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -1288,12 +1288,6 @@ func validateInitAssistantOptions(opts initOptions) error {
 	return nil
 }
 
-// promptYesNo displays a styled yes/no prompt. It is a variable so tests can
-// replace it with a non-TTY implementation.
-var promptYesNo = func(question string) (bool, error) {
-	return tui.Confirm(question)
-}
-
 func scaffoldProject(dir, appID, target, language string) error {
 	switch {
 	case language == langSwift:
@@ -1457,11 +1451,7 @@ func installWendySkills(autoInstall bool) error {
 	fmt.Println()
 
 	if !autoInstall {
-		install, err := promptYesNo("Install Wendy skills for Claude Code?")
-		if err != nil {
-			return err
-		}
-		if !install {
+		if !confirmDefaultNoFn("Install Wendy skills for Claude Code?") {
 			return nil
 		}
 

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -381,12 +380,7 @@ func newWifiConnectCmd() *cobra.Command {
 
 			if !cmd.Flags().Changed("password") && term.IsTerminal(int(os.Stdin.Fd())) {
 				if supportsKeychainLookup {
-					fmt.Printf("Look up password for '%s' from keychain? (macOS will ask for permission) [Y/n] ", ssid)
-					reader := bufio.NewReader(os.Stdin)
-					line, _ := reader.ReadString('\n')
-					answer := strings.TrimSpace(strings.ToLower(line))
-
-					if answer == "" || answer == "y" || answer == "yes" {
+					if confirmFn(fmt.Sprintf("Look up password for '%s' from keychain? (macOS will ask for permission)", ssid)) {
 						if kp, err := lookupKeychainPassword(ssid); err == nil && kp != "" {
 							cliLogln("Using saved password from keychain.")
 							password = kp

--- a/go/internal/cli/tui/confirm_test.go
+++ b/go/internal/cli/tui/confirm_test.go
@@ -48,6 +48,29 @@ func TestConfirmNoDefault_ResolvesOnKey(t *testing.T) {
 	}
 }
 
+func TestConfirmDefaultYes_EnterConfirms(t *testing.T) {
+	// Enter with no explicit key resolves to the default (Yes). This is the
+	// semantics commands.confirmFn relies on (empty input counts as yes).
+	next, _ := NewConfirmDefaultYes("Update?").Update(tea.KeyMsg{Type: tea.KeyEnter})
+	cm := next.(ConfirmModel)
+	if !cm.answered || !cm.Confirmed() {
+		t.Errorf("Enter on default-yes: answered=%v confirmed=%v; want both true", cm.answered, cm.Confirmed())
+	}
+}
+
+func TestConfirmDefaultNo_EnterDeclines(t *testing.T) {
+	// Enter resolves to the default (No). This is the semantics
+	// commands.confirmDefaultNoFn relies on (empty input counts as no).
+	next, _ := NewConfirm("Continue?").Update(tea.KeyMsg{Type: tea.KeyEnter})
+	cm := next.(ConfirmModel)
+	if !cm.answered {
+		t.Error("Enter on default-no should resolve the prompt")
+	}
+	if cm.Confirmed() {
+		t.Error("Enter on default-no should count as no")
+	}
+}
+
 func TestConfirmNoDefault_CtrlCCancels(t *testing.T) {
 	next, _ := NewConfirmNoDefault("Install?").Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	cm := next.(ConfirmModel)

--- a/specs/2026-07-03-single-yesno-confirm-design.md
+++ b/specs/2026-07-03-single-yesno-confirm-design.md
@@ -85,6 +85,18 @@ var confirmDefaultNoFn = func(question string) bool {
 From `helpers.go`: `promptYesNoFn`, `promptYesNoDefaultNoFn`, `promptYesNoLine`,
 `parseYesNoAnswer`, and `promptTTYIO` (only consumer was `promptYesNoLine`).
 
+From `init_cmd.go`: `promptYesNo` — a second command-layer wrapper that also
+delegated to `tui.Confirm` but duplicated `confirmDefaultNoFn`'s role. It had no
+test stub and one caller, which now uses `confirmDefaultNoFn` directly.
+
+Deliberately **kept**: `confirmProvisioningRetry` (`os_install.go`). It already
+delegates to `tui.Confirm`, but it is a zero-arg, fixed-question seam whose test
+stub (`os_provision_test.go`) relies on its `(bool, error)` signature to drive
+the provisioning retry loop and exercise the error path. Collapsing it into
+`confirmDefaultNoFn` (which returns only `bool`) would drop that coverage. It is
+a domain-specific test seam over the single implementation, not a competing
+implementation.
+
 ### Call-site migration
 
 Each site drops its inline `[Y/n]` / `[y/N]` suffix (the tui prompt renders its

--- a/specs/2026-07-03-single-yesno-confirm-design.md
+++ b/specs/2026-07-03-single-yesno-confirm-design.md
@@ -1,0 +1,132 @@
+# Single Y/n confirmation implementation for the CLI TUI
+
+Date: 2026-07-03
+Status: approved
+Branch: `worktree-jo+tui-single-confirm` (based off `worktree-orin-tegraflash`)
+
+## Problem
+
+The CLI has **three** competing ways to ask a yes/no question:
+
+1. `tui.Confirm*` — the styled Bubble Tea prompt family in
+   `internal/cli/tui/confirm.go` (`Confirm`, `ConfirmDefaultYes`,
+   `ConfirmNoDefault`, `ConfirmNoDefaultDanger`). Already the dominant
+   implementation with ~30 call sites.
+2. `promptYesNoFn` / `promptYesNoDefaultNoFn` / `promptYesNoLine` /
+   `parseYesNoAnswer` — a line-based reader in
+   `internal/cli/commands/helpers.go` (3 call sites + the cert-refresh helper).
+3. ~6 **inline ad-hoc** `bufio.NewReader(os.Stdin).ReadString('\n')` sites that
+   hand-roll the same `TrimSpace/ToLower == "y"/"yes"` parse
+   (`device.go`, `docker.go`, `wifi.go`, `helpers.go`).
+
+Three implementations means three different looks, three behaviours around
+defaults and cancellation, and three things to keep in sync.
+
+## Goal
+
+Exactly **one** yes/no implementation: the shared `tui.Confirm*` family. The
+line-based helpers and every inline read are migrated to it and deleted.
+
+Scope is **y/n prompts only** for this PR. Two y/n-shaped-but-different
+interactions are explicitly deferred to a follow-up:
+
+- The "type the device path exactly to confirm" destructive prompt in
+  `os_install.go` (a type-to-confirm, not a y/n).
+- The in-dashboard `confirmText` state in `apps_dashboard.go` (an embedded
+  state inside a running Bubble Tea model, not a blocking prompt).
+
+Broader TUI-component deduplication surfaced by the audit (shared text/password
+prompts, `tui.IsInteractive()`, exported theme styles, `recoveryModel` →
+picker, filesync progress, shared probe spinner) is tracked separately and is
+**out of scope** here.
+
+## Design
+
+### Single source of truth
+
+`internal/cli/tui/confirm.go` is unchanged. It already provides the four
+variants the codebase needs and renders its own `(y/n)` / `[y/n]` hint.
+
+### Stubbable wrappers in `commands`
+
+The line-based helpers were package `var`s so tests could stub them.
+`tui.Confirm*` takes `tea.ProgramOption` for I/O injection instead. To preserve
+the existing stub-based tests with minimal churn, `helpers.go` gains two thin
+package-var wrappers that map the old default-yes / default-no semantics onto
+`tui.Confirm*`:
+
+```go
+// confirmFn asks a yes/no question defaulting to Yes (empty/Enter = Yes).
+// Package var so tests can stub it. Replaces promptYesNoFn.
+var confirmFn = func(question string) bool {
+    ok, err := tui.ConfirmDefaultYes(question, tea.WithOutput(os.Stderr))
+    return err == nil && ok
+}
+
+// confirmDefaultNoFn asks a yes/no question defaulting to No (empty/Enter = No).
+// Used for speculative or destructive offers. Replaces promptYesNoDefaultNoFn.
+var confirmDefaultNoFn = func(question string) bool {
+    ok, err := tui.Confirm(question, tea.WithOutput(os.Stderr))
+    return err == nil && ok
+}
+```
+
+- Output goes to `os.Stderr`, matching the old `promptTTYIO` stderr fallback and
+  the several existing `tui.Confirm(..., tea.WithOutput(os.Stderr))` sites.
+- Input uses `tea`'s default (`os.Stdin`). Every migrated call site already
+  gates on `isInteractiveTerminal()` (stdin **and** stdout are TTYs), so
+  `os.Stdin` is the controlling terminal — no loss of the old `/dev/tty`
+  preference in practice.
+- `ErrCancelled` (Ctrl+C / q) collapses to `false`, matching the old readers
+  which treated a failed read as "no".
+
+### Deletions
+
+From `helpers.go`: `promptYesNoFn`, `promptYesNoDefaultNoFn`, `promptYesNoLine`,
+`parseYesNoAnswer`, and `promptTTYIO` (only consumer was `promptYesNoLine`).
+
+### Call-site migration
+
+Each site drops its inline `[Y/n]` / `[y/N]` suffix (the tui prompt renders its
+own hint) and its local `bufio.NewReader`:
+
+| File | Lines | New call |
+|------|-------|----------|
+| `docker.go` | 764, 803, 1747 | `confirmFn(...)` |
+| `wifi.go` | 384 | `confirmFn(...)` |
+| `helpers.go` | 1261 (agent-behind), 1703 (create wendy.json) | `confirmFn(...)` |
+| `device.go` | 463 (log in), 587 (WiFi setup), 784 (unenroll → default No) | `confirmFn` / `confirmDefaultNoFn` |
+| `device.go` | 1879, 1924 (OS update, default No) | `confirmDefaultNoFn(...)` |
+
+`device.go:784` ("Continue?" for the destructive unenroll) uses
+`confirmDefaultNoFn` to preserve its current `[y/N]` default-No semantics.
+
+Interleaving note: `device.go`'s enroll flow reads a device **name** (free text)
+from a shared `bufio.Reader` right after a y/n confirm. That text read stays
+line-based this PR — text/password-prompt consolidation is the deferred
+follow-up. Running a `tea` program and then reading `os.Stdin` line-wise is
+verified to still work during testing.
+
+### Tests
+
+- `helpers_certrefresh_test.go`: stub `confirmFn` / `confirmDefaultNoFn` instead
+  of `promptYesNoFn` / `promptYesNoDefaultNoFn`.
+- `docker_test.go`: stub `confirmFn` instead of `promptYesNoFn`.
+- `helpers_test.go`: the direct `parseYesNoAnswer` unit test is removed with the
+  function (its behaviour now lives in the tui confirm model, which has its own
+  tests).
+
+## Verification
+
+- `go build ./...`
+- `go test ./internal/cli/...`
+- Manual smoke of the migrated interactive flows where feasible (docker start,
+  wendy.json create prompt).
+
+## Non-goals / follow-ups
+
+- Text & password prompt consolidation (`tui.PromptText` / `PromptPassword`) —
+  the "terminal interactive follow-up".
+- `os_install.go` type-to-confirm and `apps_dashboard.go` `confirmText`.
+- Exported `tui.IsInteractive()`, exported theme styles, `recoveryModel` →
+  picker, filesync progress → `tui.Progress`, shared probe spinner.


### PR DESCRIPTION
## Why

The CLI had **three** competing ways to ask a yes/no question:

1. `tui.Confirm*` — the styled Bubble Tea family (~30 call sites). **The keeper.**
2. `promptYesNoFn` / `promptYesNoDefaultNoFn` / `promptYesNoLine` / `parseYesNoAnswer` — a separate line-based engine in `helpers.go`.
3. ~6 **inline ad-hoc** `bufio.NewReader(os.Stdin).ReadString('\n')` sites hand-rolling the same `TrimSpace/ToLower == "y"/"yes"` parse (`device.go`, `docker.go`, `wifi.go`, `helpers.go`).

Three implementations = three looks, three default/cancel behaviours, three things to keep in sync. This collapses everything onto the single shared `tui.Confirm*` implementation.

## What

- **Two thin stubbable wrappers** in `commands` over the shared prompt, preserving the existing test seam:
  - `confirmFn` → `tui.ConfirmDefaultYes` (empty/Enter = **Yes**), replacing `promptYesNoFn`
  - `confirmDefaultNoFn` → `tui.Confirm` (empty/Enter = **No**), replacing `promptYesNoDefaultNoFn`
- **Deleted** the parallel line-based engine: `promptYesNoLine`, `parseYesNoAnswer`, `promptTTYIO`.
- **Migrated** every inline y/n read to the wrappers, dropping the now-redundant `[Y/n]`/`[y/N]` suffixes (the tui prompt renders its own hint).
- **Folded** `init_cmd.go`'s duplicate `promptYesNo` wrapper (also delegating to `tui.Confirm`, no test stub) into `confirmDefaultNoFn`.
- **Added** tui confirm tests for the default-Yes / default-No **Enter** semantics the wrappers rely on (replacing the deleted `parseYesNoAnswer` test).

### Kept intentionally
`confirmProvisioningRetry` (`os_install.go`) already uses `tui.Confirm`; its `(bool, error)` seam drives a retry-loop test's error path, which `confirmDefaultNoFn` (bool-only) can't express. It's a domain-specific seam over the single implementation, not a competing one.

## Scope / follow-ups
Y/n prompts **only** this PR. A separate audit surfaced the natural follow-ups (deliberately out of scope here):
- **Text & password prompt** consolidation onto `tui.PromptText` / `PromptPassword` (the device-enroll flow that interleaves with these y/n reads) — the "terminal-interactive follow-up".
- `os_install.go` type-to-confirm and `apps_dashboard.go` in-model `confirmText`.
- Further cleanup: exported `tui.IsInteractive()`, exported theme styles, `recoveryModel` → picker, filesync progress → `tui.Progress`, shared probe spinner.

## Testing
- `go build ./...` ✅
- `go vet ./internal/cli/...` ✅
- `go test ./internal/cli/commands/ ./internal/cli/tui/` ✅

⚠️ **Manual verification pending:** the interactive prompts (docker start, wendy.json create, device enroll/unenroll, OS-update offers, keychain lookup) run a Bubble Tea program on a real TTY, which can't be driven headlessly. The device-enroll flow runs `confirmFn` and then reads the device name line-wise from stdin — the same tui-program-then-cooked-mode-read pattern already relied on elsewhere (see `device_usbsetup_offer_linux.go`), but worth a quick manual smoke.

Spec: `specs/2026-07-03-single-yesno-confirm-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)