### PR TITLE
WDY-1820: migrate Swift E2E AI review to a hosted runner

### DIFF
--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -45,7 +45,7 @@ on:
     secrets:
       WENDY_E2E_SLACK_WEBHOOK_URL:
         required: false
-      WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN:
+      CLAUDE_CODE_OAUTH_TOKEN:
         required: false
       ANTHROPIC_API_KEY:
         required: false
@@ -597,7 +597,7 @@ jobs:
         id: review-auth
         shell: bash
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || '' }}
           SLACK_WEBHOOK_URL: ${{ secrets.WENDY_E2E_SLACK_WEBHOOK_URL || '' }}
         run: |
@@ -615,11 +615,11 @@ jobs:
               auth_mode="subscription"
               echo "Claude Code subscription auth verified."
             else
-              failure_reason="WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN is configured but failed an auth probe (expired or revoked?)"
+              failure_reason="CLAUDE_CODE_OAUTH_TOKEN is configured but failed an auth probe (expired or revoked?)"
               echo "::warning::Swift E2E AI review: ${failure_reason}."
             fi
           else
-            failure_reason="WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN secret is not configured"
+            failure_reason="CLAUDE_CODE_OAUTH_TOKEN secret is not configured"
             echo "::warning::Swift E2E AI review: ${failure_reason}."
           fi
 
@@ -671,7 +671,7 @@ jobs:
                       type: "section",
                       text: {
                         type: "mrkdwn",
-                        text: "Runbook: run `claude setup-token` while signed in as ci@wendy.sh, then update the `WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN` repository secret."
+                        text: "Runbook: run `claude setup-token` while signed in as ci@wendy.sh, then update the `CLAUDE_CODE_OAUTH_TOKEN` repository secret."
                       }
                     },
                     {
@@ -718,7 +718,7 @@ jobs:
         env:
           DIFF_BASE_REF: ${{ inputs.diff_base_ref || '' }}
           # Expose exactly one credential, chosen by the auth probe above.
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ steps.review-auth.outputs.auth_mode == 'subscription' && secrets.WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ steps.review-auth.outputs.auth_mode == 'subscription' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
           ANTHROPIC_API_KEY: ${{ steps.review-auth.outputs.auth_mode == 'api-key' && secrets.ANTHROPIC_API_KEY || '' }}
         run: |
           set -euo pipefail

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -495,7 +495,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache SwiftPM package resolution
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             swift/WendyE2ETests/.build/checkouts
@@ -671,7 +671,7 @@ jobs:
                       type: "section",
                       text: {
                         type: "mrkdwn",
-                        text: "Runbook: run `claude setup-token` while signed in as ci@wendy.sh, then update the `CLAUDE_CODE_OAUTH_TOKEN` repository secret."
+                        text: "Runbook: run `claude setup-token` while signed in with the CI Claude seat account, then update the `CLAUDE_CODE_OAUTH_TOKEN` GitHub Actions secret."
                       }
                     },
                     {

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -609,9 +609,9 @@ jobs:
           if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]]; then
             echo "==> Probing Claude Code subscription auth"
             # Probe output can quote fragments of the failing credential or the
-            # HTTP response; keep it out of the public Actions log.
+            # HTTP response; discard it entirely — only the exit status matters.
             if timeout 120 claude --model claude-haiku-4-5 --print 'Reply with: ok' \
-              > "${RUNNER_TEMP}/claude-auth-probe.log" 2>&1; then
+              > /dev/null 2>&1; then
               auth_mode="subscription"
               echo "Claude Code subscription auth verified."
             else

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -45,6 +45,10 @@ on:
     secrets:
       WENDY_E2E_SLACK_WEBHOOK_URL:
         required: false
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: false
+      ANTHROPIC_API_KEY:
+        required: false
 
 concurrency:
   group: swift-e2e-tests-${{ github.ref }}
@@ -423,12 +427,70 @@ jobs:
     needs:
       - swift-e2e-local-macos
       - swift-e2e-local-ubuntu
-    runs-on: [self-hosted, AI]
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
+    env:
+      CLAUDE_CODE_VERSION: '2.1.199'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+
+      - name: Ensure Swift toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          for dir in "$HOME/.swiftly/bin" "$HOME/.local/share/swiftly/bin" /usr/share/swift/usr/bin; do
+            if [[ -d "$dir" ]]; then
+              echo "$dir" >> "$GITHUB_PATH"
+              export PATH="$dir:$PATH"
+            fi
+          done
+          if command -v swift >/dev/null 2>&1; then
+            swift --version
+            exit 0
+          fi
+
+          echo "==> Swift not preinstalled; installing via swiftly"
+          architecture="$(uname -m)"
+          temporary_dir="$(mktemp -d)"
+          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${architecture}.tar.gz" \
+            -o "$temporary_dir/swiftly.tar.gz"
+          tar -xzf "$temporary_dir/swiftly.tar.gz" -C "$temporary_dir"
+          (
+            cd "$temporary_dir"
+            ./swiftly init --assume-yes --quiet-shell-followup --platform ubuntu24.04
+          )
+          swiftly_env="${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh"
+          # shellcheck disable=SC1090
+          . "$swiftly_env"
+          (
+            cd "$HOME"
+            swiftly install --use latest --assume-yes
+          )
+          rm -rf "$temporary_dir"
+          echo "${SWIFTLY_BIN_DIR:-$HOME/.local/share/swiftly/bin}" >> "$GITHUB_PATH"
+          swift --version
+
+      - name: Capture Swift toolchain version
+        id: swift-toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(swift --version | head -n 1 | tr -cs '[:alnum:]._-' '-')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache SwiftPM package resolution
+        uses: actions/cache@v5
+        with:
+          path: |
+            swift/WendyE2ETests/.build/checkouts
+            swift/WendyE2ETests/.build/repositories
+            ~/.cache/org.swift.swiftpm
+          key: swift-e2e-swiftpm-${{ runner.os }}-${{ steps.swift-toolchain.outputs.version }}-${{ hashFiles('swift/WendyE2ETests/Package.resolved') }}
+          restore-keys: |
+            swift-e2e-swiftpm-${{ runner.os }}-${{ steps.swift-toolchain.outputs.version }}-
+            swift-e2e-swiftpm-${{ runner.os }}-
 
       - name: Compute Swift E2E run ID
         id: e2e-run
@@ -510,21 +572,113 @@ jobs:
             --output-dir "${RUNNER_TEMP}/wendy" \
             "${attempt_dirs[@]}"
 
-      - name: Configure self-hosted tool PATH
+      - name: Install Claude Code
         shell: bash
         run: |
           set -euo pipefail
-          for dir in \
-            /opt/homebrew/bin \
-            /usr/local/bin \
-            "$HOME/.local/bin" \
-            "$HOME/bin" \
-            "$HOME/.npm-global/bin"
-          do
-            if [[ -d "$dir" ]]; then
-              echo "$dir" >> "$GITHUB_PATH"
+          npm install --global "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+          claude --version
+
+      - name: Resolve AI review auth
+        id: review-auth
+        shell: bash
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || '' }}
+          SLACK_WEBHOOK_URL: ${{ secrets.WENDY_E2E_SLACK_WEBHOOK_URL || '' }}
+        run: |
+          set -euo pipefail
+
+          auth_mode="none"
+          failure_reason=""
+
+          if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]]; then
+            echo "==> Probing Claude Code subscription auth"
+            if probe_output="$(timeout 120 claude --model claude-haiku-4-5 --print 'Reply with: ok' 2>&1)"; then
+              auth_mode="subscription"
+              echo "Claude Code subscription auth verified."
+            else
+              failure_reason="CLAUDE_CODE_OAUTH_TOKEN is configured but failed an auth probe (expired or revoked?)"
+              echo "::warning::Swift E2E AI review: ${failure_reason}."
+              printf '%s\n' "${probe_output}" | tail -n 5
             fi
-          done
+          else
+            failure_reason="CLAUDE_CODE_OAUTH_TOKEN secret is not configured"
+            echo "::warning::Swift E2E AI review: ${failure_reason}."
+          fi
+
+          if [[ "${auth_mode}" == "subscription" ]]; then
+            echo "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}" >> "$GITHUB_ENV"
+          elif [[ -n "${ANTHROPIC_API_KEY}" ]]; then
+            auth_mode="api-key"
+            echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" >> "$GITHUB_ENV"
+            echo "::warning::Swift E2E AI review: falling back to ANTHROPIC_API_KEY (per-token billing)."
+          else
+            echo "::warning::Swift E2E AI review: no ANTHROPIC_API_KEY fallback configured; the review will be skipped."
+          fi
+          echo "auth_mode=${auth_mode}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${auth_mode}" == "subscription" ]]; then
+            exit 0
+          fi
+          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+            echo "WENDY_E2E_SLACK_WEBHOOK_URL is not configured; skipping Slack auth warning."
+            exit 0
+          fi
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          fallback_note="Falling back to ANTHROPIC_API_KEY (per-token billing)."
+          if [[ "${auth_mode}" == "none" ]]; then
+            fallback_note="No ANTHROPIC_API_KEY fallback configured either; the AI review was skipped."
+          fi
+          jq -n \
+            --arg reason "${failure_reason}" \
+            --arg fallback "${fallback_note}" \
+            --arg run_url "${run_url}" \
+            '{
+              attachments: [
+                {
+                  color: "#f59e0b",
+                  blocks: [
+                    {
+                      type: "header",
+                      text: {
+                        type: "plain_text",
+                        text: "⚠️ Swift E2E AI review subscription auth",
+                        emoji: true
+                      }
+                    },
+                    {
+                      type: "section",
+                      text: { type: "mrkdwn", text: "\($reason).\n\($fallback)" }
+                    },
+                    {
+                      type: "section",
+                      text: {
+                        type: "mrkdwn",
+                        text: "Runbook: run `claude setup-token` while signed in as ci@wendy.sh, then update the `CLAUDE_CODE_OAUTH_TOKEN` repository secret."
+                      }
+                    },
+                    {
+                      type: "actions",
+                      elements: [
+                        {
+                          type: "button",
+                          text: { type: "plain_text", text: "Open GitHub Actions" },
+                          url: $run_url
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }' > "${RUNNER_TEMP}/slack-auth-warning.json"
+          curl --fail --silent --show-error \
+            -X POST \
+            -H 'Content-type: application/json' \
+            --data @"${RUNNER_TEMP}/slack-auth-warning.json" \
+            "${SLACK_WEBHOOK_URL}" \
+            || echo "::warning::Failed to post the Slack auth warning."
 
       - name: Verify AI review harness
         shell: bash

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -452,10 +452,24 @@ jobs:
           fi
 
           echo "==> Swift not preinstalled; installing via swiftly"
+          swiftly_version="1.1.3"
           architecture="$(uname -m)"
+          case "$architecture" in
+            x86_64)
+              swiftly_sha256="4c4adb7b7ad7910f38c52b94a938c309586fe395e1fe1538c397384ee36bfff0"
+              ;;
+            aarch64)
+              swiftly_sha256="cc4f912fff6c7f53704fc6d22f9e8ee7fdf6bd574ad276998f7502418bf5a45a"
+              ;;
+            *)
+              echo "::error::No pinned swiftly checksum for architecture: ${architecture}"
+              exit 1
+              ;;
+          esac
           temporary_dir="$(mktemp -d)"
-          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${architecture}.tar.gz" \
+          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${swiftly_version}-${architecture}.tar.gz" \
             -o "$temporary_dir/swiftly.tar.gz"
+          echo "${swiftly_sha256}  $temporary_dir/swiftly.tar.gz" | sha256sum --check --strict
           tar -xzf "$temporary_dir/swiftly.tar.gz" -C "$temporary_dir"
           (
             cd "$temporary_dir"
@@ -594,27 +608,28 @@ jobs:
 
           if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]]; then
             echo "==> Probing Claude Code subscription auth"
-            if probe_output="$(timeout 120 claude --model claude-haiku-4-5 --print 'Reply with: ok' 2>&1)"; then
+            # Probe output can quote fragments of the failing credential or the
+            # HTTP response; keep it out of the public Actions log.
+            if timeout 120 claude --model claude-haiku-4-5 --print 'Reply with: ok' \
+              > "${RUNNER_TEMP}/claude-auth-probe.log" 2>&1; then
               auth_mode="subscription"
               echo "Claude Code subscription auth verified."
             else
               failure_reason="CLAUDE_CODE_OAUTH_TOKEN is configured but failed an auth probe (expired or revoked?)"
               echo "::warning::Swift E2E AI review: ${failure_reason}."
-              printf '%s\n' "${probe_output}" | tail -n 5
             fi
           else
             failure_reason="CLAUDE_CODE_OAUTH_TOKEN secret is not configured"
             echo "::warning::Swift E2E AI review: ${failure_reason}."
           fi
 
-          if [[ "${auth_mode}" == "subscription" ]]; then
-            echo "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}" >> "$GITHUB_ENV"
-          elif [[ -n "${ANTHROPIC_API_KEY}" ]]; then
-            auth_mode="api-key"
-            echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" >> "$GITHUB_ENV"
-            echo "::warning::Swift E2E AI review: falling back to ANTHROPIC_API_KEY (per-token billing)."
-          else
-            echo "::warning::Swift E2E AI review: no ANTHROPIC_API_KEY fallback configured; the review will be skipped."
+          if [[ "${auth_mode}" != "subscription" ]]; then
+            if [[ -n "${ANTHROPIC_API_KEY}" ]]; then
+              auth_mode="api-key"
+              echo "::warning::Swift E2E AI review: falling back to ANTHROPIC_API_KEY (per-token billing)."
+            else
+              echo "::warning::Swift E2E AI review: no ANTHROPIC_API_KEY fallback configured; the review will be skipped."
+            fi
           fi
           echo "auth_mode=${auth_mode}" >> "$GITHUB_OUTPUT"
 
@@ -672,12 +687,12 @@ jobs:
                   ]
                 }
               ]
-            }' > "${RUNNER_TEMP}/slack-auth-warning.json"
-          curl --fail --silent --show-error \
-            -X POST \
-            -H 'Content-type: application/json' \
-            --data @"${RUNNER_TEMP}/slack-auth-warning.json" \
-            "${SLACK_WEBHOOK_URL}" \
+            }' \
+            | curl --fail --silent --show-error \
+                -X POST \
+                -H 'Content-type: application/json' \
+                --data @- \
+                "${SLACK_WEBHOOK_URL}" \
             || echo "::warning::Failed to post the Slack auth warning."
 
       - name: Verify AI review harness
@@ -702,6 +717,9 @@ jobs:
         shell: bash
         env:
           DIFF_BASE_REF: ${{ inputs.diff_base_ref || '' }}
+          # Expose exactly one credential, chosen by the auth probe above.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ steps.review-auth.outputs.auth_mode == 'subscription' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          ANTHROPIC_API_KEY: ${{ steps.review-auth.outputs.auth_mode == 'api-key' && secrets.ANTHROPIC_API_KEY || '' }}
         run: |
           set -euo pipefail
           review_args=(--run-dir "${{ steps.e2e-run.outputs.run_dir }}")

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -45,7 +45,7 @@ on:
     secrets:
       WENDY_E2E_SLACK_WEBHOOK_URL:
         required: false
-      CLAUDE_CODE_OAUTH_TOKEN:
+      WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN:
         required: false
       ANTHROPIC_API_KEY:
         required: false
@@ -597,7 +597,7 @@ jobs:
         id: review-auth
         shell: bash
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN || '' }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || '' }}
           SLACK_WEBHOOK_URL: ${{ secrets.WENDY_E2E_SLACK_WEBHOOK_URL || '' }}
         run: |
@@ -615,11 +615,11 @@ jobs:
               auth_mode="subscription"
               echo "Claude Code subscription auth verified."
             else
-              failure_reason="CLAUDE_CODE_OAUTH_TOKEN is configured but failed an auth probe (expired or revoked?)"
+              failure_reason="WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN is configured but failed an auth probe (expired or revoked?)"
               echo "::warning::Swift E2E AI review: ${failure_reason}."
             fi
           else
-            failure_reason="CLAUDE_CODE_OAUTH_TOKEN secret is not configured"
+            failure_reason="WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN secret is not configured"
             echo "::warning::Swift E2E AI review: ${failure_reason}."
           fi
 
@@ -671,7 +671,7 @@ jobs:
                       type: "section",
                       text: {
                         type: "mrkdwn",
-                        text: "Runbook: run `claude setup-token` while signed in as ci@wendy.sh, then update the `CLAUDE_CODE_OAUTH_TOKEN` repository secret."
+                        text: "Runbook: run `claude setup-token` while signed in as ci@wendy.sh, then update the `WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN` repository secret."
                       }
                     },
                     {
@@ -718,7 +718,7 @@ jobs:
         env:
           DIFF_BASE_REF: ${{ inputs.diff_base_ref || '' }}
           # Expose exactly one credential, chosen by the auth probe above.
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ steps.review-auth.outputs.auth_mode == 'subscription' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ steps.review-auth.outputs.auth_mode == 'subscription' && secrets.WENDY_CI_CLAUDE_CODE_OAUTH_TOKEN || '' }}
           ANTHROPIC_API_KEY: ${{ steps.review-auth.outputs.auth_mode == 'api-key' && secrets.ANTHROPIC_API_KEY || '' }}
         run: |
           set -euo pipefail

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
@@ -459,6 +459,13 @@ private func codexSubscriptionConfigured() -> Bool {
 }
 
 private func claudeCodeSubscriptionConfigured() -> Bool {
+    // Ephemeral CI runners have no signed-in credentials file; they export a
+    // long-lived subscription token minted by `claude setup-token` instead.
+    let oauthToken = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN", default: ""]
+    if !oauthToken.isEmpty {
+        return true
+    }
+
     if claudeCredentialsContainSubscriptionAuth() {
         return true
     }

--- a/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
+++ b/swift/WendyE2ETests/Sources/SwiftE2ETestingCLI/ReviewCommand.swift
@@ -461,8 +461,10 @@ private func codexSubscriptionConfigured() -> Bool {
 private func claudeCodeSubscriptionConfigured() -> Bool {
     // Ephemeral CI runners have no signed-in credentials file; they export a
     // long-lived subscription token minted by `claude setup-token` instead.
+    // Require the setup-token prefix so an arbitrary non-empty value cannot
+    // masquerade as subscription auth.
     let oauthToken = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN", default: ""]
-    if !oauthToken.isEmpty {
+    if oauthToken.hasPrefix("sk-ant-oat") {
         return true
     }
 


### PR DESCRIPTION
## Summary

- `swift-e2e-analyze` now runs on `ubuntu-24.04` instead of `[self-hosted, AI]`, so a flaky or offline self-hosted runner can no longer block PR validation.
- The job keeps subscription pricing: it installs a pinned Claude Code (`2.1.199`) at job start and authenticates with a long-lived OAuth token from the dedicated CI Claude subscription seat, stored in the `CLAUDE_CODE_OAUTH_TOKEN` secret.
- If the token is missing or fails a live auth probe, the job does not fail — it posts a warning to Slack (via the existing `WENDY_E2E_SLACK_WEBHOOK_URL` webhook) and continues the review with `ANTHROPIC_API_KEY` at per-token billing. With neither secret configured, the review is skipped (warned in Slack and in the job log) and the rest of the job still runs.
- The review harness (`swift-e2e-testing review`) now treats a `CLAUDE_CODE_OAUTH_TOKEN` carrying the `claude setup-token` prefix (`sk-ant-oat…`) as Claude subscription auth; previously it only recognized a signed-in credentials file, which ephemeral runners don't have.
- Review gating (WDY-1574), report output, and PR comment posting are unchanged. The hosted job builds the SwiftPM CLI itself (the self-hosted box had it prebuilt), reusing the same cache key as the local-ubuntu job; the hosted image's preinstalled Swift is used, with a swiftly install as fallback.

## Secrets

Repository secrets on `wendylabsinc/WendyOS` — all three are configured:

1. `CLAUDE_CODE_OAUTH_TOKEN` ✅ — minted with `claude setup-token` while signed in with the CI Claude seat account (`sk-ant-oat01-…`, lasts about a year; account name in the internal runbook).
2. `ANTHROPIC_API_KEY` ✅ — fallback when the OAuth token is missing/expired.
3. `WENDY_E2E_SLACK_WEBHOOK_URL` ✅ — already used by this workflow for E2E Slack reports.

## Runbook: refreshing the token

When the "Swift E2E AI review subscription auth" warning appears in Slack: run `claude setup-token` while signed in with the CI Claude seat account and update the `CLAUDE_CODE_OAUTH_TOKEN` repository secret. Until then, reviews run on `ANTHROPIC_API_KEY` (per-token billing) — nothing is blocked.

## Tests

- `actionlint` and a YAML parse of `.github/workflows/swift-e2e-tests.yml`
- `swift build --product swift-e2e-testing` (harness change compiles)
- `bash -n swift/Scripts/E2EReview.sh` (unchanged, syntax-checked)

### Validation run ([Analyze E2E Results job](https://github.com/wendylabsinc/WendyOS/actions/runs/28664881608/job/85017027943), run 28664881608)

The analyze job ran green on `ubuntu-24.04` and exercised the fallback path end-to-end (the OAuth token secret doesn't exist yet, while `ANTHROPIC_API_KEY` already does):

- Hosted image's preinstalled Swift (6.3.2) was used — the swiftly fallback wasn't needed.
- Claude Code 2.1.199 installed in ~4s.
- Auth resolution warned `CLAUDE_CODE_OAUTH_TOKEN secret is not configured`, posted the Slack warning (webhook returned `ok`), and fell back to `ANTHROPIC_API_KEY`.
- The review harness ran with API-key auth and applied WDY-1574 gating unchanged: the run was fully green (117/117 attempts passed), so no review files were written — as designed, no tokens spent.

### Subscription-path run ([Analyze E2E Results job](https://github.com/wendylabsinc/WendyOS/actions/runs/28667342056/job/85025706862), run 28667342056 re-run)

After the `CLAUDE_CODE_OAUTH_TOKEN` secret was populated, a re-run of the analyze job validated the subscription path end-to-end:

- Auth probe logged `Claude Code subscription auth verified` — no fallback warnings, no Slack post.
- The review ran in subscription mode (no `--bare`), applied WDY-1574 gating unchanged, and wrote no review files for a fully green run (117/117 passed) with no diff-related findings.

Together with the fallback run above, both auth paths are demonstrated on hosted runners. The final commit's own E2E round ([analyze job](https://github.com/wendylabsinc/WendyOS/actions/runs/28668795428/job/85029448254)) re-confirmed the subscription path natively (`Claude Code subscription auth verified`, all jobs green). The forced-invalid-token drill (set the secret to a garbage value for one run → Slack warning + API-key review) can be run any time; the no-token variant of that degradation already ran green above.

## Notes

- The **Claude Security Review check is red on disputed grounds, not unaddressed ones**: across four passes it produced mutually contradictory HIGHs (each disposition of the auth-probe output — log, temp file, discard — was rated HIGH by a different pass; the token prefix check was demanded by one pass and flagged by the next two). All concrete, non-contradictory findings were applied; see the disposition comments on this PR for the full record.

Closes WDY-1820

🤖 Generated with [Claude Code](https://claude.com/claude-code)
