### PR TITLE
discover: merge BLE rows with LAN/USB/WiFi by hostname; drop port from list

### DIFF
--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -1080,7 +1080,7 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 				Address:      d.Hostname,
 				AgentVersion: discoverAgentVersionDisplay(d.AgentVersion),
 				DedupKey:     d.DisplayName,
-				SortKey:      usbFirstSortKey(d.DisplayName, d.USBVersion),
+				SortKey:      deviceSortKey(d.DisplayName, d.USBVersion),
 			},
 			info: discoverDeviceInfo{
 				Name:    d.DisplayName,
@@ -1119,7 +1119,7 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 				Provisioned:  provisioned,
 				Hint:         lanNoAccessHint(d.LAN, d.AgentVersion),
 				DedupKey:     d.DisplayName,
-				SortKey:      usbFirstSortKey(d.DisplayName, usb),
+				SortKey:      deviceSortKey(d.DisplayName, usb),
 			},
 			info: discoverDeviceInfo{
 				Name:        d.DisplayName,

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -333,10 +333,14 @@ func TestRenderDeviceTable(t *testing.T) {
 	}
 
 	output := renderDeviceTable(collection)
-	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS", "wendy-alpha", "1.2.3", "WendyOS-0.10.4", "LAN", "192.168.1.10:8443", tui.DeviceTableLegend} {
+	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS", "wendy-alpha", "1.2.3", "WendyOS-0.10.4", "LAN", "192.168.1.10", tui.DeviceTableLegend} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, output)
 		}
+	}
+	// The agent port is an implementation detail and is stripped from the list.
+	if strings.Contains(output, "192.168.1.10:8443") {
+		t.Fatalf("expected port stripped from displayed address, got %q", output)
 	}
 	if strings.Contains(output, "wendy-alpha v1.2.3") {
 		t.Fatalf("expected version in dedicated column, got suffixed name in %q", output)
@@ -527,6 +531,68 @@ func TestMergePickerItemClearsNoAccessHintWhenVersionKnown(t *testing.T) {
 	if existing.Hint != "" {
 		t.Fatalf("Hint = %q, want cleared after BLE version backfill", existing.Hint)
 	}
+}
+
+// TestMergePickerItemMergesBLEIntoLANByHostname verifies the run-picker collapses
+// a BLE row (raw hostname) into the LAN row (friendly displayname) for the same
+// physical device, regardless of which transport is discovered first. This is the
+// picker-side counterpart to the MergedDevices hostname match.
+func TestMergePickerItemMergesBLEIntoLANByHostname(t *testing.T) {
+	lanDev := models.LANDevice{DisplayName: "Agx Orin", Hostname: "wendyos-agx-orin.local", IPAddress: "192.168.1.10", Port: 50051}
+	bleDev := models.BluetoothDevice{DisplayName: "wendyos-agx-orin", Address: "EE48983F-300C-3A22-395B-290A76741CA1", L2CAPPSM: 128}
+
+	lanItem := tui.PickerItem{
+		Name:     lanDev.DisplayName,
+		Type:     "LAN",
+		Address:  preferredLANAddress(lanDev),
+		DedupKey: deviceDedupKey(lanDev.HostKey(), lanDev.DisplayName),
+		SortKey:  deviceSortKey(lanDev.DisplayName, lanDev.USB),
+		Value:    &pickerEntry{mergedDevice: &models.DiscoveredDevice{DisplayName: lanDev.DisplayName, LAN: &lanDev}},
+	}
+	bleItem := tui.PickerItem{
+		Name:     bleDev.DisplayName,
+		Type:     "BLE",
+		Address:  bleDev.Address,
+		DedupKey: deviceDedupKey(bleDev.HostKey(), bleDev.DisplayName),
+		SortKey:  deviceSortKey(bleDev.DisplayName, ""),
+		Value:    &pickerEntry{mergedDevice: &models.DiscoveredDevice{DisplayName: bleDev.DisplayName, Bluetooth: &bleDev}},
+	}
+
+	// The picker dedups by DedupKey, so the shared hostname key is what collapses
+	// the two rows into one.
+	if lanItem.DedupKey != bleItem.DedupKey {
+		t.Fatalf("dedup keys differ: LAN=%q BLE=%q (should both be the hostname)", lanItem.DedupKey, bleItem.DedupKey)
+	}
+
+	// LAN discovered first, then BLE merges in.
+	t.Run("LANThenBLE", func(t *testing.T) {
+		existing := lanItem
+		existing.Value = &pickerEntry{mergedDevice: &models.DiscoveredDevice{DisplayName: lanDev.DisplayName, LAN: &lanDev}}
+		mergePickerItem(&existing, bleItem)
+		if existing.Type != "LAN, BLE" {
+			t.Errorf("Type = %q, want %q", existing.Type, "LAN, BLE")
+		}
+		if existing.Name != "Agx Orin" {
+			t.Errorf("Name = %q, want friendly LAN name %q", existing.Name, "Agx Orin")
+		}
+	})
+
+	// BLE discovered first, then LAN merges in: the friendly name and LAN address
+	// must win.
+	t.Run("BLEThenLAN", func(t *testing.T) {
+		existing := bleItem
+		existing.Value = &pickerEntry{mergedDevice: &models.DiscoveredDevice{DisplayName: bleDev.DisplayName, Bluetooth: &bleDev}}
+		mergePickerItem(&existing, lanItem)
+		if existing.Type != "LAN, BLE" {
+			t.Errorf("Type = %q, want %q", existing.Type, "LAN, BLE")
+		}
+		if existing.Name != "Agx Orin" {
+			t.Errorf("Name = %q, want friendly LAN name to win over BLE hostname", existing.Name)
+		}
+		if existing.Address != preferredLANAddress(lanDev) {
+			t.Errorf("Address = %q, want LAN address %q", existing.Address, preferredLANAddress(lanDev))
+		}
+	})
 }
 
 func TestDiscoverModelViewShowsNoAccessHintForHighlightedDevice(t *testing.T) {

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1816,6 +1816,13 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 	if nd.LAN != nil && md.LAN == nil {
 		md.LAN = nd.LAN
 		existing.Address = incoming.Address
+		// A LAN entry carries the friendly displayname TXT record; prefer it over
+		// a BLE-advertised hostname for both the visible name and the sort order.
+		if incoming.Name != "" {
+			existing.Name = incoming.Name
+			md.DisplayName = nd.DisplayName
+			existing.SortKey = deviceSortKey(existing.Name, existing.USB)
+		}
 	}
 	if nd.LAN != nil && md.LAN != nil && nd.LAN.USB != "" && md.LAN.USB == "" {
 		md.LAN.USB = nd.LAN.USB
@@ -1823,11 +1830,7 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 	}
 	if nd.LAN != nil && nd.LAN.USB != "" && existing.USB == "" {
 		existing.USB = nd.LAN.USB
-		key := existing.DedupKey
-		if key == "" {
-			key = existing.Name
-		}
-		existing.SortKey = usbFirstSortKey(key, nd.LAN.USB)
+		existing.SortKey = deviceSortKey(existing.Name, nd.LAN.USB)
 	}
 	if nd.Bluetooth != nil && md.Bluetooth == nil {
 		md.Bluetooth = nd.Bluetooth
@@ -1888,11 +1891,28 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 	existing.Probe = nextProbeState(existing.Probe, incoming.Probe)
 }
 
-func usbFirstSortKey(name, usb string) string {
-	if usb == "" {
-		return ""
+// deviceSortKey orders device rows by display name, floating USB-tethered
+// devices ("0_") above everything else ("1_"). It sorts on the human-facing
+// name rather than the dedup key so rows stay ordered by name even though
+// deduplication now keys on the hostname (see deviceDedupKey).
+func deviceSortKey(name, usb string) string {
+	prefix := "1_"
+	if usb != "" {
+		prefix = "0_"
 	}
-	return "0_" + strings.ToLower(name)
+	return prefix + strings.ToLower(name)
+}
+
+// deviceDedupKey returns the cross-transport dedup key for a picker row: the
+// device's normalized hostname when known, so an mDNS entry (friendly
+// displayname) and a BLE entry (raw hostname) for the same physical device
+// collapse into a single row. Falls back to the display name when no hostname
+// is available.
+func deviceDedupKey(hostKey, displayName string) string {
+	if hostKey != "" {
+		return hostKey
+	}
+	return strings.ToLower(displayName)
 }
 
 // hideLocalProviders returns a copy of excludes that additionally hides the
@@ -1978,8 +1998,8 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 			Provisioned:  lanProvisionedDisplay(&devCopy),
 			Hint:         hint,
 			Probe:        probe,
-			DedupKey:     dev.DisplayName,
-			SortKey:      usbFirstSortKey(dev.DisplayName, dev.USB),
+			DedupKey:     deviceDedupKey(dev.HostKey(), dev.DisplayName),
+			SortKey:      deviceSortKey(dev.DisplayName, dev.USB),
 			Insecure:     insecure,
 			Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
 				DisplayName:     dev.DisplayName,
@@ -2093,7 +2113,8 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 						}
 						items = append(items, tui.PickerItem{
 							Name:         bleDevices[i].DisplayName,
-							DedupKey:     bleDevices[i].DisplayName,
+							DedupKey:     deviceDedupKey(bleDevices[i].HostKey(), bleDevices[i].DisplayName),
+							SortKey:      deviceSortKey(bleDevices[i].DisplayName, ""),
 							Type:         connType,
 							Address:      bleDevices[i].Address,
 							AgentVersion: bleDevices[i].AgentVersion,

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -1,7 +1,9 @@
 package tui
 
 import (
+	"net"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -9,6 +11,22 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
+
+// displayAddress strips a trailing numeric port from an address for display in
+// the device list — the agent port (50051/50052) is an implementation detail and
+// the same for every device. The full host:port is still used to connect and is
+// copied to the clipboard. Values that aren't host:<number> (BLE UUIDs,
+// "provider: id") are returned unchanged.
+func displayAddress(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return addr
+	}
+	return host
+}
 
 // newProbeSpinner builds the spinner that animates the Agent/OS columns while a
 // device probe is in flight. Its Style is intentionally empty so View() returns
@@ -692,7 +710,7 @@ var pickerColumnDefs = []pickerColumnDef{
 		title:    "Address",
 		minWidth: 14,
 		value: func(item PickerItem) string {
-			return item.Address
+			return displayAddress(item.Address)
 		},
 	},
 	{

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -163,11 +163,33 @@ func TestPickerTableData_KeepsFullColumnContentForScrolling(t *testing.T) {
 			t.Fatalf("expected %s column to remain scrollable", want)
 		}
 	}
-	if width := columnWidth(cols, "Address"); width < len("wendyos-sunny-daisy.local:50052") {
+	// The port is stripped for display, so the column need only fit the host.
+	if width := columnWidth(cols, "Address"); width < len("wendyos-sunny-daisy.local") {
 		t.Fatalf("address column width = %d, want enough for full hostname", width)
 	}
 	if len(rows) != 1 || len(rows[0]) != len(cols) {
 		t.Fatalf("row/column mismatch: rows=%v cols=%v", rows, cols)
+	}
+	if addr := rows[0][columnIndex(cols, "Address")]; strings.TrimSpace(addr) != "wendyos-sunny-daisy.local" {
+		t.Fatalf("address cell = %q, want port stripped for display", addr)
+	}
+}
+
+func TestDisplayAddress(t *testing.T) {
+	cases := map[string]string{
+		"wendyos-thor.local:50051":             "wendyos-thor.local",
+		"wendyos-agx-orin.local:50052":         "wendyos-agx-orin.local",
+		"192.168.1.10:50051":                   "192.168.1.10",
+		"[fe80::1%en0]:50051":                  "fe80::1%en0",
+		"wendyos-thor.local":                   "wendyos-thor.local", // no port
+		"EE48983F-300C-3A22-395B-290A76741CA1": "EE48983F-300C-3A22-395B-290A76741CA1",
+		"docker: my-container":                 "docker: my-container", // non-numeric "port"
+		"":                                     "",
+	}
+	for in, want := range cases {
+		if got := displayAddress(in); got != want {
+			t.Errorf("displayAddress(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 
@@ -343,8 +365,10 @@ func TestPickerModel_WindowWidthControlsColumns(t *testing.T) {
 			t.Fatalf("cropped line width = %d, want <= 24: %q", got, line)
 		}
 	}
-	if table := pm.table.FullView(); !strings.Contains(table, "wendyos-sunny-daisy.local:50052") {
-		t.Fatalf("underlying table should preserve full address without ellipsis, got %q", table)
+	// The port is stripped for display, but the (port-less) address must still be
+	// preserved in full without ellipsis for horizontal scrolling.
+	if table := pm.table.FullView(); !strings.Contains(table, "wendyos-sunny-daisy.local") || strings.Contains(table, ":50052") {
+		t.Fatalf("underlying table should preserve full port-less address without ellipsis, got %q", table)
 	}
 
 	updated, _ = pm.Update(tea.WindowSizeMsg{Width: 120, Height: 20})
@@ -850,6 +874,15 @@ func columnWidth(cols []bubbleTable.Column, title string) int {
 		}
 	}
 	return 0
+}
+
+func columnIndex(cols []bubbleTable.Column, title string) int {
+	for i, col := range cols {
+		if col.Title == title {
+			return i
+		}
+	}
+	return -1
 }
 
 func lastNonEmptyLine(view string) string {

--- a/go/internal/shared/models/devices.go
+++ b/go/internal/shared/models/devices.go
@@ -74,6 +74,15 @@ func (d LANDevice) HumanReadable() string {
 	return strings.TrimSpace(s)
 }
 
+// HostKey returns this device's stable cross-transport identity: its lowercased
+// mDNS hostname without the trailing ".local" (or ".local.") suffix. This is the
+// value BLE advertises verbatim as its local name, so it lets a LAN entry merge
+// with the same physical device seen over Bluetooth. Empty when the hostname is
+// unknown.
+func (d LANDevice) HostKey() string {
+	return normalizeHostKey(d.Hostname)
+}
+
 // BluetoothDevice represents a Bluetooth-discovered Wendy device.
 type BluetoothDevice struct {
 	ID              string `json:"id"`
@@ -93,6 +102,15 @@ type BluetoothDevice struct {
 // protobuf-over-L2CAP protocol (as opposed to Wendy Lite GATT provisioning).
 func (d BluetoothDevice) IsWendyAgent() bool {
 	return d.L2CAPPSM > 0
+}
+
+// HostKey returns this device's stable cross-transport identity derived from the
+// advertised BLE local name, which WendyOS sets to the raw os.Hostname(). It
+// matches LANDevice.HostKey for the same physical device. Empty when no usable
+// name was advertised (e.g. the "WendyOS Device" fallback normalizes to a value
+// that simply won't match any LAN hostname, leaving the device as its own row).
+func (d BluetoothDevice) HostKey() string {
+	return normalizeHostKey(d.DisplayName)
 }
 
 func (d BluetoothDevice) HumanReadable() string {
@@ -204,17 +222,50 @@ func (d *DiscoveredDevice) Port() int {
 	return 0
 }
 
-// MergedDevices returns a deduplicated slice of DiscoveredDevice by merging
-// LAN and Bluetooth entries that share the same DisplayName (case-insensitive).
-// LAN metadata takes precedence; BLE backfills missing fields.
+// normalizeHostKey lowercases a name and strips the mDNS ".local" (or ".local.")
+// suffix so an mDNS hostname and a BLE local name for the same device produce the
+// same key.
+func normalizeHostKey(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimSuffix(s, ".local.")
+	s = strings.TrimSuffix(s, ".local")
+	return s
+}
+
+// MergedDevices returns a deduplicated slice of DiscoveredDevice by merging LAN,
+// Bluetooth, and wendy-lite entries that refer to the same physical device. Two
+// transports match when they share a normalized hostname (the stable identity
+// BLE and mDNS both carry) or, failing that, a case-insensitive DisplayName. LAN
+// metadata takes precedence; other transports backfill missing fields.
 func (c *DevicesCollection) MergedDevices() []DiscoveredDevice {
-	// Index by normalized (lower-case) display name.
-	byName := make(map[string]*DiscoveredDevice)
-	var order []string // preserve insertion order
+	// A device is indexed under every key it can be matched by (hostname and
+	// display name), so a later transport finds it regardless of which key it
+	// shares. order holds one pointer per physical device to preserve insertion
+	// order without double-counting multi-keyed entries.
+	byKey := make(map[string]*DiscoveredDevice)
+	var order []*DiscoveredDevice
+
+	register := func(d *DiscoveredDevice, keys ...string) {
+		for _, k := range keys {
+			if k != "" {
+				byKey[k] = d
+			}
+		}
+	}
+	lookup := func(keys ...string) *DiscoveredDevice {
+		for _, k := range keys {
+			if k == "" {
+				continue
+			}
+			if d, ok := byKey[k]; ok {
+				return d
+			}
+		}
+		return nil
+	}
 
 	for i := range c.LANDevices {
 		d := &c.LANDevices[i]
-		key := strings.ToLower(d.DisplayName)
 		merged := &DiscoveredDevice{
 			DisplayName:     d.DisplayName,
 			AgentVersion:    d.AgentVersion,
@@ -223,17 +274,19 @@ func (c *DevicesCollection) MergedDevices() []DiscoveredDevice {
 			CPUArchitecture: d.CPUArchitecture,
 			LAN:             d,
 		}
-		byName[key] = merged
-		order = append(order, key)
+		register(merged, d.HostKey(), strings.ToLower(d.DisplayName))
+		order = append(order, merged)
 	}
 
 	for i := range c.BluetoothDevices {
 		d := &c.BluetoothDevices[i]
-		key := strings.ToLower(d.DisplayName)
-		if existing, ok := byName[key]; ok {
-			// Merge BLE into existing LAN entry.
+		if existing := lookup(d.HostKey(), strings.ToLower(d.DisplayName)); existing != nil {
+			// Merge BLE into the existing entry.
 			existing.Bluetooth = d
-			// Backfill any fields the LAN entry is missing.
+			// Index the existing device under the BLE key too so a later
+			// transport can still find it by hostname.
+			register(existing, d.HostKey())
+			// Backfill any fields the existing entry is missing.
 			if existing.AgentVersion == "" {
 				existing.AgentVersion = d.AgentVersion
 			}
@@ -246,19 +299,19 @@ func (c *DevicesCollection) MergedDevices() []DiscoveredDevice {
 			if existing.CPUArchitecture == "" {
 				existing.CPUArchitecture = d.CPUArchitecture
 			}
-		} else {
-			// BLE-only device.
-			merged := &DiscoveredDevice{
-				DisplayName:     d.DisplayName,
-				AgentVersion:    d.AgentVersion,
-				OS:              d.OS,
-				OSVersion:       d.OSVersion,
-				CPUArchitecture: d.CPUArchitecture,
-				Bluetooth:       d,
-			}
-			byName[key] = merged
-			order = append(order, key)
+			continue
 		}
+		// BLE-only device.
+		merged := &DiscoveredDevice{
+			DisplayName:     d.DisplayName,
+			AgentVersion:    d.AgentVersion,
+			OS:              d.OS,
+			OSVersion:       d.OSVersion,
+			CPUArchitecture: d.CPUArchitecture,
+			Bluetooth:       d,
+		}
+		register(merged, d.HostKey(), strings.ToLower(d.DisplayName))
+		order = append(order, merged)
 	}
 
 	// Merge wendy-lite external devices by name. These represent the same
@@ -268,26 +321,25 @@ func (c *DevicesCollection) MergedDevices() []DiscoveredDevice {
 		if d.ProviderKey != "wendy-lite" {
 			continue
 		}
-		key := strings.ToLower(d.DisplayName)
-		if existing, ok := byName[key]; ok {
+		if existing := lookup(strings.ToLower(d.DisplayName)); existing != nil {
 			existing.External = d
 			if existing.CPUArchitecture == "" {
 				existing.CPUArchitecture = d.CPUArchitecture
 			}
-		} else {
-			merged := &DiscoveredDevice{
-				DisplayName:     d.DisplayName,
-				CPUArchitecture: d.CPUArchitecture,
-				External:        d,
-			}
-			byName[key] = merged
-			order = append(order, key)
+			continue
 		}
+		merged := &DiscoveredDevice{
+			DisplayName:     d.DisplayName,
+			CPUArchitecture: d.CPUArchitecture,
+			External:        d,
+		}
+		register(merged, strings.ToLower(d.DisplayName))
+		order = append(order, merged)
 	}
 
 	result := make([]DiscoveredDevice, 0, len(order))
-	for _, key := range order {
-		result = append(result, *byName[key])
+	for _, d := range order {
+		result = append(result, *d)
 	}
 	return result
 }

--- a/go/internal/shared/models/devices_test.go
+++ b/go/internal/shared/models/devices_test.go
@@ -198,6 +198,59 @@ func TestMergedDevices_LANAndBLESameName(t *testing.T) {
 	}
 }
 
+// TestMergedDevices_LANAndBLEByHostname reproduces the real-world duplicate:
+// mDNS advertises a friendly displayname TXT record ("Agx Orin") while BLE only
+// advertises the raw hostname ("wendyos-agx-orin"). The two must still merge
+// into one device via their shared hostname.
+func TestMergedDevices_LANAndBLEByHostname(t *testing.T) {
+	c := &DevicesCollection{
+		LANDevices: []LANDevice{
+			{DisplayName: "Agx Orin", Hostname: "wendyos-agx-orin.local", IPAddress: "192.168.1.10", Port: 50051, AgentVersion: "1.0.0", OS: "linux"},
+		},
+		BluetoothDevices: []BluetoothDevice{
+			{DisplayName: "wendyos-agx-orin", Address: "EE48983F-300C-3A22-395B-290A76741CA1", RSSI: -50, L2CAPPSM: 128},
+		},
+	}
+
+	merged := c.MergedDevices()
+	if len(merged) != 1 {
+		t.Fatalf("MergedDevices() returned %d entries, want 1 (BLE should merge into LAN by hostname)", len(merged))
+	}
+	d := merged[0]
+	if d.LAN == nil || d.Bluetooth == nil {
+		t.Fatalf("expected both LAN and Bluetooth set; got LAN=%v Bluetooth=%v", d.LAN, d.Bluetooth)
+	}
+	// LAN's friendly display name takes precedence.
+	if d.DisplayName != "Agx Orin" {
+		t.Errorf("DisplayName = %q, want %q", d.DisplayName, "Agx Orin")
+	}
+	if d.ConnectionTypes() != "LAN, BLE" {
+		t.Errorf("ConnectionTypes() = %q, want %q", d.ConnectionTypes(), "LAN, BLE")
+	}
+}
+
+// TestMergedDevices_BLEBeforeLANByHostname covers the same match when the BLE
+// entry is processed and the LAN entry arrives via hostname regardless of the
+// order the transports are registered in.
+func TestMergedDevices_HostnameCaseAndTrailingDot(t *testing.T) {
+	c := &DevicesCollection{
+		LANDevices: []LANDevice{
+			{DisplayName: "Jetson Orin Nano", Hostname: "WendyOS-Jetson-Orin-Nano.local.", Port: 50051},
+		},
+		BluetoothDevices: []BluetoothDevice{
+			{DisplayName: "wendyos-jetson-orin-nano", Address: "9B1BB406-E1B2-69D7-F678-DE3F2BB66B68", L2CAPPSM: 128},
+		},
+	}
+
+	merged := c.MergedDevices()
+	if len(merged) != 1 {
+		t.Fatalf("MergedDevices() returned %d entries, want 1 (case/trailing-dot insensitive hostname match)", len(merged))
+	}
+	if merged[0].LAN == nil || merged[0].Bluetooth == nil {
+		t.Error("expected both LAN and Bluetooth to be set")
+	}
+}
+
 func TestMergedDevices_CaseInsensitive(t *testing.T) {
 	c := &DevicesCollection{
 		LANDevices: []LANDevice{


### PR DESCRIPTION
## What

Two fixes to the device discovery list (both `wendy discover` and the `wendy run`/device-selection picker):

1. **BLE rows now merge into the LAN/USB/WiFi row for the same device.** Previously a device showed up twice — once via LAN (friendly name, e.g. `Agx Orin`) and once via BLE (raw hostname, e.g. `wendyos-agx-orin`).
2. **The agent port (`:50051`/`:50052`) is stripped from the displayed address.** It's an implementation detail that's identical for every device.

### Before
```
 ●    Agx Orin              LAN     wendyos-agx-orin.local:50051   2026.07.02   WendyOS-0.16.2
      wendyos-agx-orin      BLE     EE48983F-300C-3A22-395B-...
```
### After
```
 ○    Agx Orin              LAN, BLE   wendyos-agx-orin.local   2026.07.02   WendyOS-0.16.2
```

## Why it was duplicating

Both merge sites keyed on `DisplayName`. mDNS advertises a friendly `displayname` TXT record (`Agx Orin`), while BLE advertises the raw `os.Hostname()` (`wendyos-agx-orin`), so the keys never matched. The stable shared identity is the **hostname**: BLE's local name *is* the hostname, and `LANDevice.Hostname` is `<host>.local`.

## How

- `models`: add `LANDevice.HostKey()` / `BluetoothDevice.HostKey()` (lowercased, `.local`-stripped). `MergedDevices()` indexes each device under both its hostname and DisplayName and matches a later transport by either — the DisplayName match is kept so nothing regresses.
- run picker (`helpers.go`): `DedupKey` is now the hostname; the LAN friendly name wins over a BLE hostname regardless of arrival order; `deviceSortKey` keeps rows ordered by display name despite the new dedup key.
- `displayAddress` (tui): trims a trailing numeric port for **display only** — the full `host:port` is still used to connect and copied to the clipboard.

BLE-only devices, and Linux's rare BLE `Alias`/`"WendyOS Device"` fallback, simply don't match a hostname and stay their own row (same as today).

## Testing

- New unit tests: hostname merge in `MergedDevices` (incl. case/trailing-dot), picker merge in both arrival orders, and `displayAddress` cases.
- Updated tests that asserted the port was shown.
- Verified end-to-end against live hardware: real BLE names (`wendyos-agx-orin`, `wendyos-pi5`) collapse into their LAN rows and addresses render without the port.
- `go test ./internal/cli/... ./internal/shared/...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)