### PR TITLE
Add ESP32-S31-Korvo-1 wendy-lite example (working camera→LCD board bring-up)

### DIFF
--- a/Examples/ESP32-S31-Korvo-1/.gitignore
+++ b/Examples/ESP32-S31-Korvo-1/.gitignore
@@ -1,0 +1,6 @@
+# ESP-IDF build artifacts
+build/
+managed_components/
+dependencies.lock
+sdkconfig
+sdkconfig.old

--- a/Examples/ESP32-S31-Korvo-1/CMakeLists.txt
+++ b/Examples/ESP32-S31-Korvo-1/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Top-level project CMake for the ESP32-S31-Korvo-1 wendy-lite demo.
+# Mirrors gmondada/wlite-native-demo1's boilerplate.
+cmake_minimum_required(VERSION 3.16)
+
+# WAMR (pulled in transitively via wendy_core -> wendy_wasm) declares
+# cmake_minimum_required(VERSION 3.5), which CMake 4.x rejects outright.
+# Allow it via the compatibility policy, same as wendy-lite itself does.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esp32s31-korvo-demo)

--- a/Examples/ESP32-S31-Korvo-1/README.md
+++ b/Examples/ESP32-S31-Korvo-1/README.md
@@ -1,0 +1,100 @@
+# ESP32-S31-Korvo-1 — camera → LCD viewfinder (wendy-lite example)
+
+A wendy-lite example for the **ESP32-S31-Korvo-1** devkit, modelled on the
+reference [`gmondada/wlite-native-demo1`](https://github.com/gmondada/wlite-native-demo1)
+(a native ESP-IDF app that consumes wendy-lite's `wendy_core` as an IDF component).
+
+Goal: stream the on-board **OV3660 camera** to the **4.3" 800×480 LCD** — the
+"screen and camera work" demo — and (Phase 2) boot the wendy-lite WASM runtime
+alongside it.
+
+> **Status (authored with no board attached):**
+> - ✅ **Screen path builds & links for `esp32s31`** and is flashable today. The
+>   default build shows an **animated color-bar test pattern** on the LCD.
+> - 🟥 **Camera path does NOT build for `esp32s31` yet** — `esp32-camera` v2.1.7
+>   compiles no driver for this target (see `inconveniences.md` #8). It's behind
+>   the `DEMO_ENABLE_CAMERA` flag (default off).
+> - ⏳ **Nothing has run on hardware.** The pin map is a placeholder — see the
+>   ⚠️ section below.
+
+## Build modes
+
+| Build | Result |
+|-------|--------|
+| `idf.py --preview build` | LCD **test pattern** (default). Links, flashes. |
+| `idf.py --preview build -DDEMO_ENABLE_CAMERA=1` | OV3660 → LCD viewfinder. **Does not link** until esp32-camera gains `esp32s31` support. |
+| `idf.py --preview build -DDEMO_ENABLE_WENDY_CORE=1` | Also boots `wendy_core` (Phase 2; enable dep first). |
+
+## Why native drivers (and not a WASM guest)
+
+wendy-lite exposes GPIO/I2C/SPI/UART/BLE/WiFi/etc. to WASM guests, but **no
+camera and no display/framebuffer host API**. So the camera and LCD here are
+driven by stock ESP-IDF drivers (`esp32-camera` + `esp_lcd` RGB). wendy-lite
+runs *alongside* in Phase 2, it does not drive the panel. See `inconveniences.md`
+item #3.
+
+## Board / chip notes
+
+- **ESP32-S31**: RISC-V dual-core @ 320 MHz, 16 MB PSRAM, WiFi 6 / BT 5.4,
+  **native** radio (no companion C6 like the P4).
+- Imaging path is the **LCD_CAM** peripheral (parallel DVP camera in + RGB LCD
+  out) plus JPEG codec + PPA — an ESP32-S3-class pipeline, **not** MIPI-CSI/DSI.
+- **ESP32-S31 requires ESP-IDF `master`** (installed here as 6.2). The
+  `espressif/idf:v5.5.1` image wendy-lite pins cannot build it.
+
+## Prerequisites
+
+```bash
+# ESP-IDF master with the esp32s31 toolchain:
+git clone --recurse-submodules https://github.com/espressif/esp-idf.git ~/esp/esp-idf-master
+cd ~/esp/esp-idf-master && ./install.sh esp32s31
+```
+
+## Build
+
+```bash
+. ~/esp/esp-idf-master/export.sh
+cd Examples/ESP32-S31-Korvo-1
+idf.py --preview set-target esp32s31   # NOTE: --preview is required (S31 is a preview target)
+idf.py --preview build
+```
+
+## Flash & watch (once the board is connected)
+
+```bash
+idf.py --preview -p /dev/cu.usbserial-XXXX flash monitor
+```
+The 4.3" panel should show the animated color-bar test pattern — that already
+proves the display path. Once the camera blocker (`inconveniences.md` #8) is
+resolved and `DEMO_ENABLE_CAMERA=1`, the panel shows the live camera feed:
+that's the clip.
+
+## ⚠️ Pin map is unverified
+
+The ESP32-S31-Korvo-1 schematic was not public at authoring time. The LCD and
+camera GPIOs in `main/demo_main.c` are **placeholders** from the
+ESP32-S3-LCD-EV-Board / Korvo-2 conventions and will almost certainly need
+correcting against the real board schematic before anything shows on screen.
+Every such pin is marked `TODO(schematic)`.
+
+## Phase 2 — add the wendy-lite runtime
+
+1. Uncomment the `wendy_core` dependency in `main/idf_component.yml`.
+2. Add `wendy_core` to `REQUIRES` in `main/CMakeLists.txt`.
+3. Build with `idf.py build -DDEMO_ENABLE_WENDY_CORE=1`.
+
+`app_main()` will call `wendy_core_init()` before starting the viewfinder.
+Coexistence on esp32s31 is unverified — expect this to be where the real
+wendy-lite porting work surfaces (see `inconveniences.md`).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `CMakeLists.txt` | Top-level project (WAMR CMake-policy shim + `project()`) |
+| `sdkconfig.defaults` | Universal knobs (partition, console, PSRAM malloc, mbedTLS) |
+| `sdkconfig.defaults.esp32s31` | S31 target: flash, PSRAM, WAMR interp |
+| `partitions.csv` | 16 MB layout (nvs / factory / wasm_a / wendy_conf / storage) |
+| `main/demo_main.c` | Camera→LCD viewfinder; optional `wendy_core_init()` |
+| `main/idf_component.yml` | IDF master + esp32-camera (+ optional wendy_core) |
+| `inconveniences.md` | Friction log for improving Wendy's ESP32 tooling |

--- a/Examples/ESP32-S31-Korvo-1/README.md
+++ b/Examples/ESP32-S31-Korvo-1/README.md
@@ -8,14 +8,10 @@ Goal: stream the on-board **OV3660 camera** to the **4.3" 800×480 LCD** — the
 "screen and camera work" demo — and (Phase 2) boot the wendy-lite WASM runtime
 alongside it.
 
-> **Status (authored with no board attached):**
-> - ✅ **Screen path builds & links for `esp32s31`** and is flashable today. The
->   default build shows an **animated color-bar test pattern** on the LCD.
-> - 🟥 **Camera path does NOT build for `esp32s31` yet** — `esp32-camera` v2.1.7
->   compiles no driver for this target (see `inconveniences.md` #8). It's behind
->   the `DEMO_ENABLE_CAMERA` flag (default off).
-> - ⏳ **Nothing has run on hardware.** The pin map is a placeholder — see the
->   ⚠️ section below.
+> **Status:**
+> - ✅ **Screen demo runs on hardware** (via the official BSP) and the default build links/flashes for `esp32s31`. The default build shows the **animated color-bar test pattern** on the LCD.
+> - 🟥 **Camera path does NOT build for `esp32s31` yet** — `esp32-camera` compiles no driver for this target (see `inconveniences.md` #8). It's behind the `DEMO_ENABLE_CAMERA` flag (default off).
+> - ⚠️ Flashing requires manual BOOT→RST (see `inconveniences.md` #12).
 
 ## Build modes
 

--- a/Examples/ESP32-S31-Korvo-1/inconveniences.md
+++ b/Examples/ESP32-S31-Korvo-1/inconveniences.md
@@ -1,0 +1,135 @@
+# ESP32-S31 support — inconveniences & gaps
+
+Running log of every friction point hit while building an ESP32-S31-Korvo-1
+example on top of wendy-lite. Purpose: drive concrete improvements to Wendy's
+ESP32 tooling. Newest findings appended at the bottom.
+
+Legend: 🟥 blocker · 🟧 friction · 🟨 papercut · 🟦 note/observation
+
+## TL;DR for the tools team
+
+| # | Sev | Gap | Where to fix |
+|---|-----|-----|--------------|
+| 1 | 🟥 | No `esp32s31`/`esp32s3` target in wendy-lite | wendy-lite: add target profile + partitions + CI axis |
+| 2 | 🟥 | wendy-lite pins `idf:v5.5.1`; S31 needs IDF `master`/6.x | wendy-lite: master build lane for pre-release chips |
+| 3 | 🟥 | No camera or display **host API** for WASM guests | wendy-lite: define camera + framebuffer host imports |
+| 8 | 🟥 | `esp32-camera` resolves but builds an **empty** archive for S31 | upstream esp32-camera targets, or move to `esp_driver_cam`+`esp_cam_sensor` |
+| 4 | 🟦 | `wendy` CLI firmware flow has no S31 chip key / imaging story | CLI: clear "unsupported chip" error listing manifest chips |
+| 5 | 🟧 | `esp32s31` is a *preview* target — needs `--preview` on every idf.py | tooling: auto-inject `--preview` for preview chips |
+| 7 | 🟧 | IDF v6.2 `esp_lcd` RGB API drift vs. all S3-era examples | docs: pin snippets to master API |
+| 9 | 🟨 | Managed-component `REQUIRES` uses namespaced `espressif__esp32-camera` | docs |
+| 6 | 🟨 | Shallow IDF clone breaks `idf.py --version` | docs: use tagged clone / capture commit |
+| 10 | 🟦 | Positive: `esp_lcd` RGB **does** build/link for S31 | — |
+
+**Net:** the screen half is achievable today (builds + flashes). The camera half
+is blocked upstream (#8), and using wendy-lite *itself* to drive either is
+blocked by the missing host APIs (#3) and the missing S31 target (#1, #2).
+
+---
+
+## 1. wendy-lite has no ESP32-S31 target 🟥
+- **What:** wendy-lite's CI matrix and `sdkconfig.defaults.*` cover only
+  `esp32c5`, `esp32c6`, `esp32p4`. There is no `esp32s31` (nor `esp32s3`)
+  target profile, board cfg, or partition table.
+- **Impact:** "make an S31 example based on wendy-lite" is a from-scratch board
+  bring-up, not a config tweak. Everything in this folder had to be authored.
+- **Fix idea:** add an `esp32s31` profile to wendy-lite (sdkconfig.defaults +
+  partitions) and a CI matrix entry once the chip is in a pinned IDF release.
+
+## 2. wendy-lite pins ESP-IDF v5.5.1; S31 needs IDF master (6.x) 🟥
+- **What:** wendy-lite builds with `espressif/idf:v5.5.1`. ESP32-S31 support
+  only exists on ESP-IDF `master` (installed here as **6.2**).
+- **Impact:** the wendy-lite Docker build image cannot build S31 at all. Any
+  S31 firmware must be built against a different, unpinned toolchain — a
+  reproducibility problem.
+- **Fix idea:** track an `idf:latest`/master build lane for pre-release chips,
+  or gate S31 behind an IDF-version matrix axis.
+
+## 3. No camera or display host API in wendy-lite 🟥
+- **What:** wendy-lite's WASM host imports cover GPIO/I2C/SPI/UART/RMT/NeoPixel/
+  Timer/Storage/System/OTel/BLE/WiFi/Sockets/TLS/USB — but **no camera and no
+  framebuffer/display** surface. The P4 "LCD" board variants are supported only
+  for their PSRAM + ESP-Hosted-WiFi config, not because wendy-lite drives a panel.
+- **Impact:** the headline ask ("show the screen and camera work") **cannot be
+  done through wendy-lite / a WASM guest today**. This demo drives the camera
+  and LCD with native ESP-IDF drivers instead; wendy-lite can at best run
+  *alongside* (Phase 2).
+- **Fix idea:** define camera + display host imports (or a shared-framebuffer
+  handoff) so imaging boards are actually usable from Wendy apps.
+
+## 4. `wendy device` / `wendy` CLI has no MCU-imaging story 🟦
+- **What:** the CLI's `firmware` command fetches prebuilt `wendy-lite-<chip>.bin`
+  from a manifest keyed by chip. There is no `s31` chip key, and no path for a
+  camera/LCD demo — the tooling assumes headless sensor/GPIO MCUs.
+- **Fix idea:** at minimum, surface a clear "unsupported chip" error listing the
+  chips that *are* in the manifest.
+
+---
+
+## 5. `esp32s31` is a *preview* target — plain `set-target` silently bails 🟧
+- **What:** `idf.py set-target esp32s31` prints `esp32s31 is still in preview.
+  You have to append '--preview'…`, runs `fullclean`, and stops — it does **not**
+  configure the target. You must use `idf.py --preview set-target esp32s31`
+  (and `--preview` on every subsequent `build`/`flash`).
+- **Impact:** easy to think set-target "worked" (exit is quiet); every wendy
+  build/flow that shells out to `idf.py` for S31 must thread `--preview` through.
+- **Fix idea:** when Wendy's tooling targets a preview chip, inject `--preview`
+  automatically and log that it did.
+
+## 6. Shallow IDF clone breaks `idf.py --version` git-describe 🟨
+- **What:** on a `--depth 1` master clone, `idf.py --version` emits
+  `fatal: No names found, cannot describe anything / Git version unavailable,
+  reading from source` before falling back to `v6.2.0`.
+- **Impact:** cosmetic, but noisy in logs and defeats exact-version pinning for
+  reproducible S31 builds (compounds item #2).
+- **Fix idea:** document a tagged/full clone for S31, or capture the IDF commit
+  hash explicitly.
+
+## 7. IDF v6.2 `esp_lcd` RGB API drift vs. every public S3 camera example 🟧
+- **What:** all the copy-paste S3-LCD-EV-Board / Korvo camera-viewfinder examples
+  online use `esp_lcd_rgb_panel_config_t` fields that **no longer exist** in IDF
+  v6.2: `bits_per_pixel` → `in_color_format`/`out_color_format`
+  (`lcd_color_format_t`, e.g. `LCD_COLOR_FMT_RGB565`), and `psram_trans_align`
+  → `dma_burst_size`. With `-Werror` the build hard-fails.
+- **Impact:** because S31 forces you onto IDF master (item #2), you also inherit
+  master's API churn — reference code from the S3 era won't compile unmodified.
+  This is a tax specific to bringing a brand-new chip up on bleeding-edge IDF.
+- **Fix idea:** when Wendy documents/scaffolds S31 imaging, pin snippets to the
+  IDF-master API and note the version, rather than linking S3-era examples.
+
+## 8. `esp32-camera` builds an EMPTY archive for esp32s31 → cryptic link errors 🟥
+- **What:** `espressif/esp32-camera` v2.1.7 has no `targets:` restriction in its
+  manifest, so the component manager happily *resolves* it for esp32s31 — but its
+  `CMakeLists.txt` gates all driver sources behind
+  `if(IDF_TARGET STREQUAL "esp32" OR "esp32s2" OR "esp32s3")`. For esp32s31 it
+  compiles **nothing**, producing an empty `libespressif__esp32-camera.a`.
+- **Symptom:** not a clean "unsupported target" error — instead the link fails
+  late with `undefined reference to esp_camera_init / esp_camera_fb_get / …`,
+  which looks like a REQUIRES/link-order bug and sends you down the wrong path.
+- **Impact:** the OV3660 camera **cannot be brought up on esp32s31 with the
+  released esp32-camera**. This is the single biggest blocker to the "camera
+  works" half of the demo. Resolution paths, both real work:
+    1. Patch/fork esp32-camera to add `esp32s31` (its LCD_CAM DVP path mirrors
+       esp32s3, so `target/esp32s3/ll_cam.c` may be a starting point — register
+       layouts must be verified against S31 silicon).
+    2. Rewrite onto IDF's built-in `esp_driver_cam` (DVP controller) plus the
+       `espressif/esp_cam_sensor` OV3660 driver — the modern stack for new chips.
+- **Left in the example as:** the camera path is behind `DEMO_ENABLE_CAMERA`
+  (default 0). The default build uses an animated LCD test pattern so the screen
+  pipeline is provably buildable/flashable today.
+- **Fix idea (tooling):** flag components that resolve-but-build-empty for a
+  target; a manifest `targets:` list would turn this into an upfront rejection.
+
+## 9. Managed-component `REQUIRES` name is the namespaced form 🟨
+- **What:** to link esp32-camera you must add `espressif__esp32-camera` (double
+  underscore, namespaced) to `REQUIRES`, not `esp32_camera` / `esp32-camera`.
+  Non-obvious, and only surfaces as an undefined-reference link failure.
+- **Fix idea:** document the exact REQUIRES token in any Wendy S31 camera guide.
+
+## 10. Positive: `esp_lcd` RGB panel builds & links cleanly for esp32s31 🟦
+- **What:** the 800x480 RGB panel via IDF built-in `esp_lcd` compiles and links
+  for esp32s31 with no target gymnastics. The screen half of the demo is sound;
+  only the pin map / panel timings need on-hardware confirmation.
+
+---
+<!-- build-phase findings appended below as they occur -->

--- a/Examples/ESP32-S31-Korvo-1/inconveniences.md
+++ b/Examples/ESP32-S31-Korvo-1/inconveniences.md
@@ -21,9 +21,12 @@ Legend: 🟥 blocker · 🟧 friction · 🟨 papercut · 🟦 note/observation
 | 6 | 🟨 | Shallow IDF clone breaks `idf.py --version` | docs: use tagged clone / capture commit |
 | 10 | 🟦 | Positive: `esp_lcd` RGB **does** build/link for S31 | — |
 
-**Net:** the screen half is achievable today (builds + flashes). The camera half
-is blocked upstream (#8), and using wendy-lite *itself* to drive either is
-blocked by the missing host APIs (#3) and the missing S31 target (#1, #2).
+**Net:** the screen **works on real hardware** — the WENDY demo runs on the
+4.3" panel via the official BSP (#11). Getting there needed the BSP pin map +
+`disp_on_off` + a manual BOOT/RST flash dance (#11–#13). The camera half is
+blocked upstream on `esp32-camera` (#8) but is reachable via `esp_video`/the BSP.
+Driving either from wendy-lite *itself* is still blocked by the missing host
+APIs (#3) and the missing S31 target (#1, #2).
 
 ---
 
@@ -130,6 +133,47 @@ blocked by the missing host APIs (#3) and the missing S31 target (#1, #2).
 - **What:** the 800x480 RGB panel via IDF built-in `esp_lcd` compiles and links
   for esp32s31 with no target gymnastics. The screen half of the demo is sound;
   only the pin map / panel timings need on-hardware confirmation.
+
+---
+
+## 11. On-hardware display bring-up: what it actually took 🟧 (RESOLVED — screen works)
+Getting the 4.3" panel to light up on real S31-Korvo-1 silicon took several
+iterations. The lessons, in priority order:
+- **Use the official BSP `espressif/esp32_s31_korvo_1` — do not hand-guess pins.**
+  My first pin map (from generic S3-EV-board conventions) was entirely wrong
+  (e.g. PCLK 21 vs actual 40; data on 4-19 vs 8-19+33-36) → black screen. The
+  BSP has the correct pins, timings (pclk 18 MHz, HS 40/40/48, VS 23/32/13),
+  and `clk_src = PLL160M`.
+- **`esp_lcd_panel_disp_on_off(panel, true)` is REQUIRED.** With the DISP GPIO
+  (38) wired, the panel's display-enable defaults to OFF. Everything inits
+  ("RGB panel up"), the render loop runs and `draw_bitmap` returns ESP_OK, but
+  the panel stays **black** until you call disp_on_off(true). Easy to miss.
+- **Backlight is hardwired on** (BSP: "board doesn't support changing brightness"),
+  so a lit-but-black panel = data/disp issue, not power.
+
+## 12. No auto-reset wired on the UART bridge → every flash is a manual dance 🟥
+- **What:** `esptool --before default-reset` fails ("No serial data received").
+  DTR/RTS auto-reset-to-bootloader is not wired on this board's UART bridge, so
+  **every flash requires the manual combo** (hold BOOT → tap RST → release BOOT)
+  and **every app boot requires a manual RST tap** (`--after` can't reset either).
+- **Impact:** completely blocks unattended/automated `idf.py flash`. Over a debug
+  session this is a dozen manual button presses. The flashing port is the
+  `usbserial-*` bridge (console UART on GPIO 58/59); the `usbmodem*` native-USB
+  ports did not respond to esptool.
+- **Fix idea:** any Wendy MCU-flash flow for this board must drive the BOOT/RST
+  combo (or document it loudly); auto-reset cannot be assumed.
+
+## 13. Debugging the black screen: passive heartbeat logging beats reset-timing 🟨
+- The boot log is a ~1 s burst at reset; catching it over serial is fiddly given
+  #12. Adding a per-second `ESP_LOGI` heartbeat (frame counter + `draw_bitmap`
+  return) made the state observable with a *passive* read at any time — that's
+  how we confirmed the task was alive and drawing before finding the disp-on gap.
+
+## 14. Software full-frame rendering runs ~12 fps 🟦
+- Rendering the whole 800×480 scene in C each frame (gradient + wordmark + EQ)
+  then `draw_bitmap` gives ~12 fps (30 frames per ~2.4 s in the log), not the
+  targeted 30. Fine for a demo; a real UI should use the PPA/2D accel or LVGL
+  (both available) rather than a full CPU redraw.
 
 ---
 <!-- build-phase findings appended below as they occur -->

--- a/Examples/ESP32-S31-Korvo-1/main/CMakeLists.txt
+++ b/Examples/ESP32-S31-Korvo-1/main/CMakeLists.txt
@@ -1,0 +1,19 @@
+idf_component_register(SRCS "demo_main.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES driver esp_lcd esp_psram esp_driver_cam esp_timer
+                                espressif__esp32-camera)
+
+# Optional build knobs, toggled from the command line, e.g.:
+#   idf.py --preview build -DDEMO_ENABLE_CAMERA=1
+#   idf.py --preview build -DDEMO_ENABLE_WENDY_CORE=1
+# Translate the CMake cache vars into C preprocessor defines.
+if(DEFINED DEMO_ENABLE_CAMERA)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE DEMO_ENABLE_CAMERA=${DEMO_ENABLE_CAMERA})
+endif()
+
+# Phase 2: when the wendy_core dependency is enabled in idf_component.yml, add
+# it to REQUIRES above (REQUIRES ... wendy_core) and build with
+# -DDEMO_ENABLE_WENDY_CORE=1.
+if(DEFINED DEMO_ENABLE_WENDY_CORE)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE DEMO_ENABLE_WENDY_CORE=${DEMO_ENABLE_WENDY_CORE})
+endif()

--- a/Examples/ESP32-S31-Korvo-1/main/CMakeLists.txt
+++ b/Examples/ESP32-S31-Korvo-1/main/CMakeLists.txt
@@ -1,7 +1,8 @@
 idf_component_register(SRCS "demo_main.c"
                        INCLUDE_DIRS "."
                        REQUIRES driver esp_lcd esp_psram esp_driver_cam esp_timer
-                                espressif__esp32-camera)
+                                espressif__esp32-camera
+                                espressif__esp32_s31_korvo_1)
 
 # Optional build knobs, toggled from the command line, e.g.:
 #   idf.py --preview build -DDEMO_ENABLE_CAMERA=1

--- a/Examples/ESP32-S31-Korvo-1/main/demo_main.c
+++ b/Examples/ESP32-S31-Korvo-1/main/demo_main.c
@@ -15,13 +15,13 @@
 // Phase 2 (opt-in): DEMO_ENABLE_WENDY_CORE=1 boots the wendy-lite WASM runtime
 // alongside the panel (see idf_component.yml / CMakeLists.txt).
 //
-// !!! PIN MAP IS UNVERIFIED !!!
-// The ESP32-S31-Korvo-1 schematic was not public at authoring time. The GPIOs
-// below are PLACEHOLDERS from the ESP32-S3-LCD-EV-Board / Korvo-2 conventions
-// (same LCD_CAM-class imaging path) and will need correcting against the real
-// board schematic before anything appears on screen. See inconveniences.md.
+// NOTE: LCD GPIOs/timings are configured by the official `espressif/esp32_s31_korvo_1` BSP.
+// The camera GPIOs below are only used when DEMO_ENABLE_CAMERA=1 and may need revisiting.
+// For esp32s31 the recommended camera path is `esp_video` via the BSP (see inconveniences.md).
 
 #include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include "esp_log.h"
 #include "esp_check.h"

--- a/Examples/ESP32-S31-Korvo-1/main/demo_main.c
+++ b/Examples/ESP32-S31-Korvo-1/main/demo_main.c
@@ -1,13 +1,16 @@
-// ESP32-S31-Korvo-1 demo: live camera -> LCD viewfinder.
+// ESP32-S31-Korvo-1 demo: branded screen demo (+ optional camera viewfinder).
 //
 // Phase 1 (this file): drive the 4.3" 800x480 RGB panel with stock ESP-IDF
 // drivers. Two modes:
-//   * DEMO_ENABLE_CAMERA=0 (default): animated color-bar TEST PATTERN. Proves
-//     the LCD/RGB pipeline builds, links, and is flashable for esp32s31 today.
+//   * DEMO_ENABLE_CAMERA=0 (default): a branded "WENDY" screen demo -- gradient
+//     field, a geometric stroke-drawn wordmark, an animated EQ bar row (the
+//     Korvo is an audio board), and a slow scan highlight. Proves the LCD/RGB
+//     pipeline builds, links, and is flashable for esp32s31 today. The same
+//     scene is rendered pixel-for-pixel by the browser preview shipped with
+//     this example so it can be recorded/shared before hardware arrives.
 //   * DEMO_ENABLE_CAMERA=1: OV3660 camera -> LCD viewfinder via esp32-camera.
-//     !!! This does NOT link on esp32s31 yet: esp32-camera v2.1.7 only compiles
-//     its driver for esp32/esp32s2/esp32s3 (empty archive otherwise). See
-//     inconveniences.md #8. Kept here as the intended implementation.
+//     !!! Does NOT link on esp32s31 yet: esp32-camera v2.1.7 compiles no driver
+//     for this target. See inconveniences.md #8.
 //
 // Phase 2 (opt-in): DEMO_ENABLE_WENDY_CORE=1 boots the wendy-lite WASM runtime
 // alongside the panel (see idf_component.yml / CMakeLists.txt).
@@ -16,15 +19,15 @@
 // The ESP32-S31-Korvo-1 schematic was not public at authoring time. The GPIOs
 // below are PLACEHOLDERS from the ESP32-S3-LCD-EV-Board / Korvo-2 conventions
 // (same LCD_CAM-class imaging path) and will need correcting against the real
-// board schematic before anything appears on screen. Every such pin is marked
-// TODO(schematic). See inconveniences.md.
+// board schematic before anything appears on screen. See inconveniences.md.
 
+#include <math.h>
 #include <string.h>
 #include "esp_log.h"
 #include "esp_check.h"
 #include "esp_heap_caps.h"
 #include "esp_lcd_panel_ops.h"
-#include "esp_lcd_panel_rgb.h"
+#include "bsp/esp32_s31_korvo_1.h" // official BSP: correct LCD bring-up
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -42,89 +45,46 @@
 
 static const char *TAG = "korvo-demo";
 
-// ----- Display: 4.3" 800x480 RGB panel -----------------------------------
-#define LCD_H_RES 800
-#define LCD_V_RES 480
-#define LCD_PIXEL_CLOCK_HZ (16 * 1000 * 1000)
-#define LCD_DATA_WIDTH 16 // RGB565
-
-// TODO(schematic): replace every pin below with the real S31-Korvo-1 mapping.
-#define LCD_PIN_PCLK   21
-#define LCD_PIN_VSYNC  22
-#define LCD_PIN_HSYNC  23
-#define LCD_PIN_DE     24
-#define LCD_PIN_DISP   -1 // not connected on most EV boards
-static const int LCD_DATA_PINS[LCD_DATA_WIDTH] = {
-    // B0..B4, G0..G5, R0..R4  (RGB565 bit order per esp_lcd RGB convention)
-    4, 5, 6, 7, 8,         // blue
-    9, 10, 11, 12, 13, 14, // green
-    15, 16, 17, 18, 19,    // red
-};
+// ----- Display: 4.3" 800x480 RGB panel, brought up via the official BSP -----
+#define LCD_H_RES BSP_LCD_H_RES
+#define LCD_V_RES BSP_LCD_V_RES
 
 static esp_lcd_panel_handle_t s_panel;
 
 static esp_err_t display_init(void)
 {
-    esp_lcd_rgb_panel_config_t cfg = {
-        .clk_src = LCD_CLK_SRC_DEFAULT,
-        .data_width = LCD_DATA_WIDTH,
-        // IDF v6.2 replaced bits_per_pixel with explicit in/out color formats
-        // and psram_trans_align with dma_burst_size. (See inconveniences.md #7.)
-        .in_color_format = LCD_COLOR_FMT_RGB565,
-        .out_color_format = LCD_COLOR_FMT_RGB565,
-        .num_fbs = 1,
-        .dma_burst_size = 64,
-        .disp_gpio_num = LCD_PIN_DISP,
-        .pclk_gpio_num = LCD_PIN_PCLK,
-        .vsync_gpio_num = LCD_PIN_VSYNC,
-        .hsync_gpio_num = LCD_PIN_HSYNC,
-        .de_gpio_num = LCD_PIN_DE,
-        .flags.fb_in_psram = true,
-        .timings = {
-            .pclk_hz = LCD_PIXEL_CLOCK_HZ,
-            .h_res = LCD_H_RES,
-            .v_res = LCD_V_RES,
-            // Generic 800x480 4.3" RGB timings. TODO(panel): confirm porches
-            // against the exact panel fitted to the Korvo-1.
-            .hsync_back_porch = 40,
-            .hsync_front_porch = 20,
-            .hsync_pulse_width = 48,
-            .vsync_back_porch = 13,
-            .vsync_front_porch = 1,
-            .vsync_pulse_width = 31,
-            .flags.pclk_active_neg = true,
-        },
-    };
-    for (int i = 0; i < LCD_DATA_WIDTH; i++) {
-        cfg.data_gpio_nums[i] = LCD_DATA_PINS[i];
-    }
-
-    ESP_RETURN_ON_ERROR(esp_lcd_new_rgb_panel(&cfg, &s_panel), TAG, "new rgb panel");
-    ESP_RETURN_ON_ERROR(esp_lcd_panel_reset(s_panel), TAG, "reset");
-    ESP_RETURN_ON_ERROR(esp_lcd_panel_init(s_panel), TAG, "init");
-    ESP_LOGI(TAG, "RGB panel up: %dx%d", LCD_H_RES, LCD_V_RES);
+    // Let the BSP configure the RGB panel (correct pins, timings, PLL, fbs).
+    esp_lcd_panel_io_handle_t io = NULL;
+    bsp_display_config_t cfg = { 0 };
+    ESP_RETURN_ON_ERROR(bsp_display_new(&cfg, &s_panel, &io), TAG, "bsp_display_new");
+    // Enable the panel output (drives the DISP GPIO active).
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_disp_on_off(s_panel, true), TAG, "disp on");
+    ESP_LOGI(TAG, "BSP display up: %dx%d (disp on)", LCD_H_RES, LCD_V_RES);
     return ESP_OK;
 }
 
 #if DEMO_ENABLE_CAMERA
 // ----- Camera: OV3660 over LCD_CAM DVP -----------------------------------
-// TODO(schematic): replace every pin below with the real S31-Korvo-1 mapping.
+// Pins from the ESP32-S31-Korvo-1 BSP. NOTE: the BSP itself drives this camera
+// via `esp_video` (which supports esp32s31), NOT `esp32-camera` (which does
+// not build for s31 — see inconveniences.md #8). These esp32-camera pins are
+// kept for reference; the real path is esp_video / the BSP.
 #define CAM_PIN_PWDN   -1
 #define CAM_PIN_RESET  -1
-#define CAM_PIN_XCLK   40
-#define CAM_PIN_SIOD   41 // SCCB/I2C data
-#define CAM_PIN_SIOC   42 // SCCB/I2C clock
-#define CAM_PIN_D7     39
-#define CAM_PIN_D6     38
-#define CAM_PIN_D5     37
-#define CAM_PIN_D4     36
-#define CAM_PIN_D3     35
-#define CAM_PIN_D2     34
-#define CAM_PIN_D1     33
-#define CAM_PIN_D0     32
-#define CAM_PIN_VSYNC  43
-#define CAM_PIN_HREF   44
-#define CAM_PIN_PCLK   45
+#define CAM_PIN_XCLK   55
+#define CAM_PIN_SIOD   0  // shared I2C bus (BSP_I2C_SDA)
+#define CAM_PIN_SIOC   1  // shared I2C bus (BSP_I2C_SCL)
+#define CAM_PIN_D7     53
+#define CAM_PIN_D6     52
+#define CAM_PIN_D5     51
+#define CAM_PIN_D4     50
+#define CAM_PIN_D3     49
+#define CAM_PIN_D2     48
+#define CAM_PIN_D1     47
+#define CAM_PIN_D0     46
+#define CAM_PIN_VSYNC  56
+#define CAM_PIN_HREF   57
+#define CAM_PIN_PCLK   54
 
 static esp_err_t camera_init(void)
 {
@@ -169,42 +129,166 @@ static void viewfinder_task(void *arg)
         esp_camera_fb_return(fb);
     }
 }
-#else // !DEMO_ENABLE_CAMERA -- animated test pattern so the screen path is provable today
+#else // !DEMO_ENABLE_CAMERA -- branded "WENDY" screen demo
 
-static inline uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b)
+// ---- tiny RGB565 software renderer ---------------------------------------
+static uint16_t *s_fb; // 800x480 RGB565, in PSRAM
+
+static inline uint16_t rgb565(int r, int g, int b)
 {
+    if (r < 0) r = 0; else if (r > 255) r = 255;
+    if (g < 0) g = 0; else if (g > 255) g = 255;
+    if (b < 0) b = 0; else if (b > 255) b = 255;
     return (uint16_t)(((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3));
 }
 
-static void viewfinder_task(void *arg)
+static inline void put_px(int x, int y, uint16_t c)
+{
+    if ((unsigned)x < LCD_H_RES && (unsigned)y < LCD_V_RES) {
+        s_fb[(size_t)y * LCD_H_RES + x] = c;
+    }
+}
+
+// Filled square centered at (x,y) with half-size r -- the "pen" for strokes.
+static void pen(int x, int y, int r, uint16_t c)
+{
+    for (int dy = -r; dy <= r; dy++) {
+        for (int dx = -r; dx <= r; dx++) {
+            put_px(x + dx, y + dy, c);
+        }
+    }
+}
+
+// Thick line via Bresenham; identical geometry to the browser preview.
+static void line_thick(int x0, int y0, int x1, int y1, int thick, uint16_t c)
+{
+    int dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+    int dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+    int err = dx + dy;
+    int r = thick / 2;
+    for (;;) {
+        pen(x0, y0, r, c);
+        if (x0 == x1 && y0 == y1) break;
+        int e2 = 2 * err;
+        if (e2 >= dy) { err += dy; x0 += sx; }
+        if (e2 <= dx) { err += dx; y0 += sy; }
+    }
+}
+
+// A wordmark glyph = a set of stroke polylines in a normalized [0,1] cell.
+typedef struct { int n; const float *xy; } glyph_t; // xy: n*2 floats, one polyline
+typedef struct { int strokes; const glyph_t *g; } letter_t;
+
+// Each letter is drawn as one or more polylines (diagonals included).
+static const float W_a[] = {0.00f,0.00f, 0.22f,1.00f, 0.50f,0.34f, 0.78f,1.00f, 1.00f,0.00f};
+static const float E_a[] = {1.00f,0.00f, 0.00f,0.00f, 0.00f,1.00f, 1.00f,1.00f};
+static const float E_b[] = {0.00f,0.50f, 0.80f,0.50f};
+static const float N_a[] = {0.00f,1.00f, 0.00f,0.00f, 1.00f,1.00f, 1.00f,0.00f};
+static const float D_a[] = {0.00f,1.00f, 0.00f,0.00f, 0.55f,0.00f, 1.00f,0.32f, 1.00f,0.68f, 0.55f,1.00f, 0.00f,1.00f};
+static const float Y_a[] = {0.00f,0.00f, 0.50f,0.52f, 1.00f,0.00f};
+static const float Y_b[] = {0.50f,0.52f, 0.50f,1.00f};
+
+static const glyph_t W_g[] = {{5, W_a}};
+static const glyph_t E_g[] = {{4, E_a}, {2, E_b}};
+static const glyph_t N_g[] = {{4, N_a}};
+static const glyph_t D_g[] = {{7, D_a}};
+static const glyph_t Y_g[] = {{3, Y_a}, {2, Y_b}};
+static const letter_t WENDY[] = {
+    {1, W_g}, {2, E_g}, {1, N_g}, {1, D_g}, {2, Y_g},
+};
+
+static void draw_letter(const letter_t *L, int ox, int oy, int w, int h, int thick, uint16_t c)
+{
+    for (int s = 0; s < L->strokes; s++) {
+        const glyph_t *g = &L->g[s];
+        for (int i = 0; i + 1 < g->n; i++) {
+            int x0 = ox + (int)(g->xy[i * 2 + 0] * w);
+            int y0 = oy + (int)(g->xy[i * 2 + 1] * h);
+            int x1 = ox + (int)(g->xy[i * 2 + 2] * w);
+            int y1 = oy + (int)(g->xy[i * 2 + 3] * h);
+            line_thick(x0, y0, x1, y1, thick, c);
+        }
+    }
+}
+
+static void render_frame(int t)
+{
+    // Background: vertical gradient, deep indigo -> near black.
+    for (int y = 0; y < LCD_V_RES; y++) {
+        float k = (float)y / (LCD_V_RES - 1);
+        int r = (int)(11 + (5 - 11) * k);
+        int g = (int)(14 + (6 - 14) * k);
+        int b = (int)(23 + (11 - 23) * k);
+        uint16_t col = rgb565(r, g, b);
+        uint16_t *row = s_fb + (size_t)y * LCD_H_RES;
+        for (int x = 0; x < LCD_H_RES; x++) row[x] = col;
+    }
+
+    // Slow scan highlight sweeping down the panel.
+    int scan = (int)((0.5f + 0.5f * sinf(t * 0.03f)) * (LCD_V_RES - 1));
+    for (int dy = -18; dy <= 18; dy++) {
+        int y = scan + dy;
+        if ((unsigned)y >= LCD_V_RES) continue;
+        int a = 22 - abs(dy);
+        if (a < 0) a = 0;
+        uint16_t *row = s_fb + (size_t)y * LCD_H_RES;
+        for (int x = 0; x < LCD_H_RES; x++) {
+            int r = (row[x] >> 11) & 0x1F, g = (row[x] >> 5) & 0x3F, b = row[x] & 0x1F;
+            row[x] = (uint16_t)(((r + a) > 31 ? 31 : r + a) << 11) |
+                     (((g + a) > 63 ? 63 : g + a) << 5) | ((b + a) > 31 ? 31 : b + a);
+        }
+    }
+
+    // Wordmark "WENDY", centered, shimmering amber<->magenta per letter.
+    const int cellW = 96, cellH = 150, gap = 34, thick = 14;
+    const int total = 5 * cellW + 4 * gap;
+    int ox = (LCD_H_RES - total) / 2;
+    int oy = 120;
+    for (int i = 0; i < 5; i++) {
+        float s = 0.5f + 0.5f * sinf(t * 0.05f + i * 0.7f);
+        uint16_t c = rgb565((int)(255),
+                            (int)(92 + (194 - 92) * s),
+                            (int)(138 + (75 - 138) * s));
+        draw_letter(&WENDY[i], ox + i * (cellW + gap), oy, cellW, cellH, thick, c);
+    }
+
+    // Animated EQ bars along the bottom -- Korvo is an audio board.
+    const int bars = 24, bw = 20, bgap = 12;
+    const int btotal = bars * bw + (bars - 1) * bgap;
+    int bx = (LCD_H_RES - btotal) / 2;
+    int baseY = 430, maxH = 120;
+    for (int i = 0; i < bars; i++) {
+        float m = 0.5f + 0.5f * sinf(t * 0.11f + i * 0.55f);
+        m *= 0.35f + 0.65f * (0.5f + 0.5f * sinf(t * 0.017f + i));
+        int h = (int)(12 + m * maxH);
+        float s = (float)i / (bars - 1);
+        uint16_t c = rgb565((int)(255), (int)(194 + (92 - 194) * s), (int)(75 + (138 - 75) * s));
+        for (int y = baseY - h; y < baseY; y++) {
+            uint16_t *row = s_fb + (size_t)y * LCD_H_RES;
+            for (int x = bx + i * (bw + bgap); x < bx + i * (bw + bgap) + bw; x++) {
+                if ((unsigned)x < LCD_H_RES) row[x] = c;
+            }
+        }
+    }
+}
+
+static void screen_demo_task(void *arg)
 {
     const size_t px = (size_t)LCD_H_RES * LCD_V_RES;
-    uint16_t *frame = heap_caps_malloc(px * sizeof(uint16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-    if (!frame) {
-        ESP_LOGE(TAG, "no PSRAM for test-pattern frame buffer");
+    s_fb = heap_caps_malloc(px * sizeof(uint16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    ESP_LOGI(TAG, "screen_demo_task: s_fb=%p (%u bytes), panel=%p", s_fb, (unsigned)(px * 2), s_panel);
+    if (!s_fb) {
+        ESP_LOGE(TAG, "no PSRAM for the %ux%u frame buffer", (unsigned)LCD_H_RES, (unsigned)LCD_V_RES);
         vTaskDelete(NULL);
         return;
     }
-    // 8 vertical SMPTE-ish color bars that scroll horizontally over time.
-    const uint16_t bar[8] = {
-        rgb565(255, 255, 255), rgb565(255, 255, 0),
-        rgb565(0, 255, 255),   rgb565(0, 255, 0),
-        rgb565(255, 0, 255),   rgb565(255, 0, 0),
-        rgb565(0, 0, 255),     rgb565(0, 0, 0),
-    };
-
-    int shift = 0;
-    for (;;) {
-        for (int y = 0; y < LCD_V_RES; y++) {
-            uint16_t *row = frame + (size_t)y * LCD_H_RES;
-            for (int x = 0; x < LCD_H_RES; x++) {
-                int b = ((x + shift) / (LCD_H_RES / 8)) & 7;
-                row[x] = bar[b];
-            }
+    for (int t = 0;; t++) {
+        render_frame(t);
+        esp_err_t dr = esp_lcd_panel_draw_bitmap(s_panel, 0, 0, LCD_H_RES, LCD_V_RES, s_fb);
+        if (t % 30 == 0) { // ~once per second
+            ESP_LOGI(TAG, "frame %d drawn, draw_bitmap=%s", t, esp_err_to_name(dr));
         }
-        esp_lcd_panel_draw_bitmap(s_panel, 0, 0, LCD_H_RES, LCD_V_RES, frame);
-        shift = (shift + 8) % LCD_H_RES;
-        vTaskDelay(pdMS_TO_TICKS(33));
+        vTaskDelay(pdMS_TO_TICKS(33)); // ~30 fps
     }
 }
 #endif // DEMO_ENABLE_CAMERA
@@ -221,7 +305,10 @@ void app_main(void)
     ESP_ERROR_CHECK(display_init());
 #if DEMO_ENABLE_CAMERA
     ESP_ERROR_CHECK(camera_init());
-#endif
     xTaskCreatePinnedToCore(viewfinder_task, "viewfinder", 4096, NULL, 5, NULL, 1);
-    ESP_LOGI(TAG, "%s running", DEMO_ENABLE_CAMERA ? "camera viewfinder" : "test pattern");
+    ESP_LOGI(TAG, "camera viewfinder running");
+#else
+    xTaskCreatePinnedToCore(screen_demo_task, "screen_demo", 8192, NULL, 5, NULL, 1);
+    ESP_LOGI(TAG, "WENDY screen demo running");
+#endif
 }

--- a/Examples/ESP32-S31-Korvo-1/main/demo_main.c
+++ b/Examples/ESP32-S31-Korvo-1/main/demo_main.c
@@ -1,0 +1,227 @@
+// ESP32-S31-Korvo-1 demo: live camera -> LCD viewfinder.
+//
+// Phase 1 (this file): drive the 4.3" 800x480 RGB panel with stock ESP-IDF
+// drivers. Two modes:
+//   * DEMO_ENABLE_CAMERA=0 (default): animated color-bar TEST PATTERN. Proves
+//     the LCD/RGB pipeline builds, links, and is flashable for esp32s31 today.
+//   * DEMO_ENABLE_CAMERA=1: OV3660 camera -> LCD viewfinder via esp32-camera.
+//     !!! This does NOT link on esp32s31 yet: esp32-camera v2.1.7 only compiles
+//     its driver for esp32/esp32s2/esp32s3 (empty archive otherwise). See
+//     inconveniences.md #8. Kept here as the intended implementation.
+//
+// Phase 2 (opt-in): DEMO_ENABLE_WENDY_CORE=1 boots the wendy-lite WASM runtime
+// alongside the panel (see idf_component.yml / CMakeLists.txt).
+//
+// !!! PIN MAP IS UNVERIFIED !!!
+// The ESP32-S31-Korvo-1 schematic was not public at authoring time. The GPIOs
+// below are PLACEHOLDERS from the ESP32-S3-LCD-EV-Board / Korvo-2 conventions
+// (same LCD_CAM-class imaging path) and will need correcting against the real
+// board schematic before anything appears on screen. Every such pin is marked
+// TODO(schematic). See inconveniences.md.
+
+#include <string.h>
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_heap_caps.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_panel_rgb.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#ifndef DEMO_ENABLE_CAMERA
+#define DEMO_ENABLE_CAMERA 0
+#endif
+
+#if DEMO_ENABLE_CAMERA
+#include "esp_camera.h"
+#endif
+
+#if defined(DEMO_ENABLE_WENDY_CORE) && DEMO_ENABLE_WENDY_CORE
+#include "wendy_core.h"
+#endif
+
+static const char *TAG = "korvo-demo";
+
+// ----- Display: 4.3" 800x480 RGB panel -----------------------------------
+#define LCD_H_RES 800
+#define LCD_V_RES 480
+#define LCD_PIXEL_CLOCK_HZ (16 * 1000 * 1000)
+#define LCD_DATA_WIDTH 16 // RGB565
+
+// TODO(schematic): replace every pin below with the real S31-Korvo-1 mapping.
+#define LCD_PIN_PCLK   21
+#define LCD_PIN_VSYNC  22
+#define LCD_PIN_HSYNC  23
+#define LCD_PIN_DE     24
+#define LCD_PIN_DISP   -1 // not connected on most EV boards
+static const int LCD_DATA_PINS[LCD_DATA_WIDTH] = {
+    // B0..B4, G0..G5, R0..R4  (RGB565 bit order per esp_lcd RGB convention)
+    4, 5, 6, 7, 8,         // blue
+    9, 10, 11, 12, 13, 14, // green
+    15, 16, 17, 18, 19,    // red
+};
+
+static esp_lcd_panel_handle_t s_panel;
+
+static esp_err_t display_init(void)
+{
+    esp_lcd_rgb_panel_config_t cfg = {
+        .clk_src = LCD_CLK_SRC_DEFAULT,
+        .data_width = LCD_DATA_WIDTH,
+        // IDF v6.2 replaced bits_per_pixel with explicit in/out color formats
+        // and psram_trans_align with dma_burst_size. (See inconveniences.md #7.)
+        .in_color_format = LCD_COLOR_FMT_RGB565,
+        .out_color_format = LCD_COLOR_FMT_RGB565,
+        .num_fbs = 1,
+        .dma_burst_size = 64,
+        .disp_gpio_num = LCD_PIN_DISP,
+        .pclk_gpio_num = LCD_PIN_PCLK,
+        .vsync_gpio_num = LCD_PIN_VSYNC,
+        .hsync_gpio_num = LCD_PIN_HSYNC,
+        .de_gpio_num = LCD_PIN_DE,
+        .flags.fb_in_psram = true,
+        .timings = {
+            .pclk_hz = LCD_PIXEL_CLOCK_HZ,
+            .h_res = LCD_H_RES,
+            .v_res = LCD_V_RES,
+            // Generic 800x480 4.3" RGB timings. TODO(panel): confirm porches
+            // against the exact panel fitted to the Korvo-1.
+            .hsync_back_porch = 40,
+            .hsync_front_porch = 20,
+            .hsync_pulse_width = 48,
+            .vsync_back_porch = 13,
+            .vsync_front_porch = 1,
+            .vsync_pulse_width = 31,
+            .flags.pclk_active_neg = true,
+        },
+    };
+    for (int i = 0; i < LCD_DATA_WIDTH; i++) {
+        cfg.data_gpio_nums[i] = LCD_DATA_PINS[i];
+    }
+
+    ESP_RETURN_ON_ERROR(esp_lcd_new_rgb_panel(&cfg, &s_panel), TAG, "new rgb panel");
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_reset(s_panel), TAG, "reset");
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_init(s_panel), TAG, "init");
+    ESP_LOGI(TAG, "RGB panel up: %dx%d", LCD_H_RES, LCD_V_RES);
+    return ESP_OK;
+}
+
+#if DEMO_ENABLE_CAMERA
+// ----- Camera: OV3660 over LCD_CAM DVP -----------------------------------
+// TODO(schematic): replace every pin below with the real S31-Korvo-1 mapping.
+#define CAM_PIN_PWDN   -1
+#define CAM_PIN_RESET  -1
+#define CAM_PIN_XCLK   40
+#define CAM_PIN_SIOD   41 // SCCB/I2C data
+#define CAM_PIN_SIOC   42 // SCCB/I2C clock
+#define CAM_PIN_D7     39
+#define CAM_PIN_D6     38
+#define CAM_PIN_D5     37
+#define CAM_PIN_D4     36
+#define CAM_PIN_D3     35
+#define CAM_PIN_D2     34
+#define CAM_PIN_D1     33
+#define CAM_PIN_D0     32
+#define CAM_PIN_VSYNC  43
+#define CAM_PIN_HREF   44
+#define CAM_PIN_PCLK   45
+
+static esp_err_t camera_init(void)
+{
+    camera_config_t cfg = {
+        .pin_pwdn = CAM_PIN_PWDN,
+        .pin_reset = CAM_PIN_RESET,
+        .pin_xclk = CAM_PIN_XCLK,
+        .pin_sccb_sda = CAM_PIN_SIOD,
+        .pin_sccb_scl = CAM_PIN_SIOC,
+        .pin_d7 = CAM_PIN_D7, .pin_d6 = CAM_PIN_D6,
+        .pin_d5 = CAM_PIN_D5, .pin_d4 = CAM_PIN_D4,
+        .pin_d3 = CAM_PIN_D3, .pin_d2 = CAM_PIN_D2,
+        .pin_d1 = CAM_PIN_D1, .pin_d0 = CAM_PIN_D0,
+        .pin_vsync = CAM_PIN_VSYNC,
+        .pin_href = CAM_PIN_HREF,
+        .pin_pclk = CAM_PIN_PCLK,
+        .xclk_freq_hz = 20 * 1000 * 1000,
+        .ledc_timer = LEDC_TIMER_0,
+        .ledc_channel = LEDC_CHANNEL_0,
+        .pixel_format = PIXFORMAT_RGB565,
+        .frame_size = FRAMESIZE_VGA,
+        .fb_count = 2,
+        .fb_location = CAMERA_FB_IN_PSRAM,
+        .grab_mode = CAMERA_GRAB_LATEST,
+    };
+    ESP_RETURN_ON_ERROR(esp_camera_init(&cfg), TAG, "camera init");
+    ESP_LOGI(TAG, "camera up: OV3660 expected, RGB565 VGA");
+    return ESP_OK;
+}
+
+static void viewfinder_task(void *arg)
+{
+    const int x0 = (LCD_H_RES - 640) / 2; // center VGA on the panel
+    for (;;) {
+        camera_fb_t *fb = esp_camera_fb_get();
+        if (!fb) {
+            ESP_LOGW(TAG, "frame grab failed");
+            vTaskDelay(pdMS_TO_TICKS(10));
+            continue;
+        }
+        esp_lcd_panel_draw_bitmap(s_panel, x0, 0, x0 + fb->width, fb->height, fb->buf);
+        esp_camera_fb_return(fb);
+    }
+}
+#else // !DEMO_ENABLE_CAMERA -- animated test pattern so the screen path is provable today
+
+static inline uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b)
+{
+    return (uint16_t)(((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3));
+}
+
+static void viewfinder_task(void *arg)
+{
+    const size_t px = (size_t)LCD_H_RES * LCD_V_RES;
+    uint16_t *frame = heap_caps_malloc(px * sizeof(uint16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!frame) {
+        ESP_LOGE(TAG, "no PSRAM for test-pattern frame buffer");
+        vTaskDelete(NULL);
+        return;
+    }
+    // 8 vertical SMPTE-ish color bars that scroll horizontally over time.
+    const uint16_t bar[8] = {
+        rgb565(255, 255, 255), rgb565(255, 255, 0),
+        rgb565(0, 255, 255),   rgb565(0, 255, 0),
+        rgb565(255, 0, 255),   rgb565(255, 0, 0),
+        rgb565(0, 0, 255),     rgb565(0, 0, 0),
+    };
+
+    int shift = 0;
+    for (;;) {
+        for (int y = 0; y < LCD_V_RES; y++) {
+            uint16_t *row = frame + (size_t)y * LCD_H_RES;
+            for (int x = 0; x < LCD_H_RES; x++) {
+                int b = ((x + shift) / (LCD_H_RES / 8)) & 7;
+                row[x] = bar[b];
+            }
+        }
+        esp_lcd_panel_draw_bitmap(s_panel, 0, 0, LCD_H_RES, LCD_V_RES, frame);
+        shift = (shift + 8) % LCD_H_RES;
+        vTaskDelay(pdMS_TO_TICKS(33));
+    }
+}
+#endif // DEMO_ENABLE_CAMERA
+
+void app_main(void)
+{
+#if defined(DEMO_ENABLE_WENDY_CORE) && DEMO_ENABLE_WENDY_CORE
+    // Phase 2: boot the wendy-lite WASM runtime alongside the panel.
+    // NOTE(unverified): coexistence/ordering with the LCD pipeline on esp32s31
+    // has not been validated on hardware.
+    ESP_ERROR_CHECK(wendy_core_init());
+#endif
+
+    ESP_ERROR_CHECK(display_init());
+#if DEMO_ENABLE_CAMERA
+    ESP_ERROR_CHECK(camera_init());
+#endif
+    xTaskCreatePinnedToCore(viewfinder_task, "viewfinder", 4096, NULL, 5, NULL, 1);
+    ESP_LOGI(TAG, "%s running", DEMO_ENABLE_CAMERA ? "camera viewfinder" : "test pattern");
+}

--- a/Examples/ESP32-S31-Korvo-1/main/idf_component.yml
+++ b/Examples/ESP32-S31-Korvo-1/main/idf_component.yml
@@ -1,0 +1,25 @@
+## Component-manager dependencies for the ESP32-S31-Korvo-1 demo.
+##
+## Phase 1 (native camera -> LCD viewfinder) needs only ESP-IDF (master, for
+## esp32s31 support) and the esp32-camera driver. esp_lcd's RGB panel is an
+## IDF built-in, so no separate LCD driver package is required for a plain
+## 800x480 RGB panel.
+dependencies:
+  idf:
+    # esp32s31 support only exists on IDF master (reports as 6.x).
+    version: ">=6.0.0"
+
+  # OV3660 driver over the LCD_CAM DVP interface.
+  # NOTE(unverified): esp32-camera must list esp32s31 in its supported
+  # targets. If the component manager rejects the target, this is a gap to
+  # file against espressif/esp32-camera (see inconveniences.md).
+  espressif/esp32-camera:
+    version: "^2.0.0"
+
+  ## Phase 2 -- uncomment to layer in the wendy-lite WASM runtime alongside the
+  ## viewfinder, then build with -DDEMO_ENABLE_WENDY_CORE=1 and add wendy_core
+  ## to main/CMakeLists.txt REQUIRES.
+  # wendy_core:
+  #   git: "git@github.com:wendylabsinc/wendy-lite.git"
+  #   path: "components/wendy_core"
+  #   version: "gab/core"

--- a/Examples/ESP32-S31-Korvo-1/main/idf_component.yml
+++ b/Examples/ESP32-S31-Korvo-1/main/idf_component.yml
@@ -6,8 +6,8 @@
 ## 800x480 RGB panel.
 dependencies:
   idf:
-    # esp32s31 support only exists on IDF master (reports as 6.x).
-    version: ">=6.0.0"
+    # esp32s31 support requires ESP-IDF master (currently reporting as v6.2+).
+    version: ">=6.2.0"
 
   # Official board support package for this exact devkit. Provides the correct
   # LCD pin map, panel timings, and bring-up sequence via bsp_display_new().
@@ -25,6 +25,6 @@ dependencies:
   ## viewfinder, then build with -DDEMO_ENABLE_WENDY_CORE=1 and add wendy_core
   ## to main/CMakeLists.txt REQUIRES.
   # wendy_core:
-  #   git: "git@github.com:wendylabsinc/wendy-lite.git"
+  #   git: "https://github.com/wendylabsinc/wendy-lite.git"
   #   path: "components/wendy_core"
   #   version: "gab/core"

--- a/Examples/ESP32-S31-Korvo-1/main/idf_component.yml
+++ b/Examples/ESP32-S31-Korvo-1/main/idf_component.yml
@@ -9,6 +9,11 @@ dependencies:
     # esp32s31 support only exists on IDF master (reports as 6.x).
     version: ">=6.0.0"
 
+  # Official board support package for this exact devkit. Provides the correct
+  # LCD pin map, panel timings, and bring-up sequence via bsp_display_new().
+  espressif/esp32_s31_korvo_1:
+    version: "^1"
+
   # OV3660 driver over the LCD_CAM DVP interface.
   # NOTE(unverified): esp32-camera must list esp32s31 in its supported
   # targets. If the component manager rejects the target, this is a gap to

--- a/Examples/ESP32-S31-Korvo-1/partitions.csv
+++ b/Examples/ESP32-S31-Korvo-1/partitions.csv
@@ -1,0 +1,12 @@
+# Name,     Type, SubType, Offset,    Size,      Flags
+# 16 MB flash layout for the ESP32-S31-Korvo-1.
+# Phase 1 (native camera->LCD viewfinder) only needs nvs + factory. The
+# wasm_a / wendy_conf / storage slots are reserved now so the layout does not
+# have to change when Phase 2 (wendy_core) is enabled. Camera + LCD
+# framebuffers live in PSRAM, not flash, so the app slot stays modest.
+nvs,        data, nvs,     0x9000,    0x6000,
+phy_init,   data, phy,     0xf000,    0x1000,
+factory,    app,  factory, 0x10000,   0x300000,
+wasm_a,     data, 0x80,    0x310000,  0xC00000,
+wendy_conf, data, 0x40,    0xF10000,  0x4000,
+storage,    data, spiffs,  0xF14000,  0xEC000,

--- a/Examples/ESP32-S31-Korvo-1/sdkconfig.defaults
+++ b/Examples/ESP32-S31-Korvo-1/sdkconfig.defaults
@@ -1,0 +1,24 @@
+# Universal defaults for the ESP32-S31-Korvo-1 demo.
+# Target-specific overrides live in sdkconfig.defaults.esp32s31.
+
+# --- Partition table: custom CSV sized for a 16 MB flash board ---
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+
+# --- Console over UART (works with the on-board USB-UART bridge) ---
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+
+# --- Size-optimized build ---
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
+
+# --- Camera + LCD both push framebuffers through PSRAM; make sure large
+#     DMA-capable allocations can spill there. Concrete SPIRAM mode/speed is
+#     set per-target in sdkconfig.defaults.esp32s31 (see the notes there). ---
+CONFIG_SPIRAM_USE_MALLOC=y
+CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=y
+
+# --- mbedTLS dynamic buffers (matches wendy-lite; keeps TLS off the static
+#     heap so WiFi + camera framebuffers don't get starved). ---
+CONFIG_MBEDTLS_DYNAMIC_BUFFER=y
+CONFIG_MBEDTLS_DYNAMIC_FREE_PEER_CERT=y
+CONFIG_MBEDTLS_DYNAMIC_FREE_CONFIG_DATA=y

--- a/Examples/ESP32-S31-Korvo-1/sdkconfig.defaults.esp32s31
+++ b/Examples/ESP32-S31-Korvo-1/sdkconfig.defaults.esp32s31
@@ -1,0 +1,35 @@
+# Target: ESP32-S31 (ESP32-S31-Korvo-1)
+#
+# The S31 is a RISC-V dual-core (HP RV32IMAFCP @ 320 MHz + LP core) with native
+# WiFi 6 / BT 5.4 and integrated PSRAM. Unlike the ESP32-P4 (which needs a
+# companion ESP32-C6 over ESP-Hosted for radio), the S31's radio is on-die, so
+# NONE of the ESP-Hosted knobs from wendy-lite's P4 profile apply here.
+#
+# For the camera/display pipeline the S31 exposes the LCD_CAM peripheral
+# (parallel DVP camera in + RGB/i80 LCD out) plus a JPEG codec and the PPA
+# pixel accelerator -- i.e. an ESP32-S3-class imaging path, NOT the P4's
+# MIPI-CSI/DSI. That is why this demo uses esp32-camera (DVP) + esp_lcd RGB.
+
+CONFIG_IDF_TARGET="esp32s31"
+
+# --- Flash: 16 MB (Korvo-1 module). partitions.csv is sized to match. ---
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+
+# --- PSRAM (16 MB integrated) ---------------------------------------------
+# NOTE(unverified): exact SPIRAM interface mode + clock for the S31's
+# integrated PSRAM are not yet documented publicly. Enabling SPIRAM and
+# letting the IDF target defaults pick the mode; revisit against the S31
+# datasheet / esp_hosted-free Korvo-1 board support package once available.
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_BOOT_INIT=y
+# Keep latency-sensitive small allocs in internal SRAM; large buffers (camera
+# framebuffers, LCD bounce buffers) may land in PSRAM.
+CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=16384
+# Needed so EXT_RAM_BSS_ATTR / large DMA framebuffers can be placed in PSRAM.
+CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY=y
+
+# --- WAMR runtime (Phase 2, wendy_core): fast interp + normal loader, with a
+#     PSRAM-backed pool, mirroring wendy-lite's PSRAM-rich P4 profile. These
+#     are inert until the wendy_core component is enabled (DEMO_ENABLE_WENDY_CORE).
+CONFIG_WAMR_INTERP_FAST=y
+CONFIG_WAMR_INTERP_LOADER_NORMAL=y

--- a/specs/2026-07-03-esp32s31-korvo-example-design.md
+++ b/specs/2026-07-03-esp32s31-korvo-example-design.md
@@ -99,16 +99,15 @@ No board is connected. Therefore:
 4. `README.md` gives a copy-paste path from clone → flash → viewfinder for when the
    board is plugged in.
 
-## Outcomes (2026-07-03, no board attached)
+## Outcomes (2026-07-03)
 
 - ✅ ESP-IDF `master` (v6.2) + `esp32s31` preview toolchain installed at
   `~/esp/esp-idf-master`.
 - ✅ `esp32s31` confirmed as a real (preview) IDF target; `idf.py --preview
   set-target esp32s31` configures cleanly.
-- ✅ **Default build links and flashes** for `esp32s31`
-  (`build/esp32s31-korvo-demo.bin`, ~209 KB): LCD RGB path + animated
-  test pattern. The screen pipeline is sound; only pin map / panel timings need
-  on-hardware confirmation.
+- ✅ **Default build links, flashes, and drives the LCD on hardware** for `esp32s31`
+  (`build/esp32s31-korvo-demo.bin`, ~209 KB): RGB LCD via the official BSP +
+  `esp_lcd_panel_disp_on_off(true)`.
 - 🟥 **Camera blocked upstream**: `esp32-camera` v2.1.7 compiles no driver for
   `esp32s31` (empty archive → link failure). Camera path is behind
   `DEMO_ENABLE_CAMERA` (default off); the blocker and two resolution routes are

--- a/specs/2026-07-03-esp32s31-korvo-example-design.md
+++ b/specs/2026-07-03-esp32s31-korvo-example-design.md
@@ -1,0 +1,122 @@
+# ESP32-S31-Korvo-1 wendy-lite example — design
+
+Date: 2026-07-03
+Branch: `jo/esp32s31-korvo-example`
+Author: Joannis (with Claude)
+
+## Goal
+
+Produce a **wendy-lite example project targeting the ESP32-S31-Korvo-1 devkit** that
+demonstrates the board's screen and camera, modelled on the reference
+[`gmondada/wlite-native-demo1`](https://github.com/gmondada/wlite-native-demo1)
+(a native ESP-IDF app that consumes wendy-lite's `wendy_core` as an IDF component).
+
+Secondary — and equally important — goal: **capture every inconvenience and gap**
+hit while doing this, so the wendy team can improve ESP32 support in our tooling.
+That log lives in `Examples/ESP32-S31-Korvo-1/inconveniences.md`.
+
+## Context / what already exists
+
+- **wendy-lite** (`wendylabsinc/wendy-lite`) is a WASM-runtime firmware for RISC-V
+  ESP32s. CI target matrix: `esp32c5`, `esp32c6`, `esp32p4` (two P4 board variants),
+  built with `espressif/idf:v5.5.1`. **No `esp32s31` target. No `esp32s3` target.**
+- Host API subsystems exposed to WASM guests: GPIO, I2C, SPI, UART, RMT, NeoPixel,
+  Timer, Storage, System, OTel, BLE, WiFi, Sockets, TLS, USB.
+  **There is no camera host API and no first-class display/framebuffer host API.**
+  The P4 "LCD" board variants are supported for their PSRAM + ESP-Hosted-WiFi
+  config, not because wendy-lite drives a panel.
+- The reference native demo's `app_main()` is literally `wendy_core_init()`; it pulls
+  `wendy_core` via `idf_component.yml` git dep on branch `gab/core`.
+
+## Target hardware — ESP32-S31-Korvo-1
+
+Brand-new chip (announced 2026-05). RISC-V dual-core (HP RV32IMAFCP @ 320 MHz + LP
+core), 512 KB SRAM, 16 MB PSRAM, WiFi 6, BT 5.4, 802.15.4. The Korvo-1 kit carries a
+**4.3" 800×480 LCD** and a **3 MP OV3660 camera**. Unlike ESP32-P4 (which needs a
+companion ESP32-C6 for WiFi/BT over ESP-Hosted), the S31 has **native** WiFi/BT.
+
+**ESP32-S31 is only supported on ESP-IDF `master`** at time of writing.
+
+## Approach (approved)
+
+Two phases, native-first so the visual is de-risked:
+
+### Phase 1 — native camera → LCD viewfinder (the social clip)
+A plain ESP-IDF app that brings up the OV3660 camera and streams frames to the 4.3"
+panel, using stock Espressif drivers. Design forks to resolve during bring-up (and
+document):
+- **Camera stack**: legacy DVP `espressif/esp32-camera` vs. the newer
+  `esp_video` / `esp_cam_sensor` MIPI-CSI framework (S31 is P4-class, so MIPI-CSI is
+  likely). Pick whichever the S31 + OV3660 combo actually supports on IDF master.
+- **LCD stack**: `esp_lcd` panel — RGB parallel vs. MIPI-DSI. The 800×480 4.3" panel
+  on the Korvo/LCD-EV subboard is historically RGB parallel; confirm for S31.
+- **Pin maps**: need the S31-Korvo-1 schematic, which may not be public yet.
+  Documented as a gap; use best-known/EV-board defaults as placeholders.
+
+### Phase 2 — layer in `wendy_core`
+Add `wendy_core` (git dep, `gab/core`) and call `wendy_core_init()` alongside the
+viewfinder, proving wendy-lite coexists on S31. Expected friction: no `esp32s31`
+target in wendy-lite; `idf:v5.5.1` pin vs. required `master`; WAMR on S31.
+
+## Project layout
+
+```
+Examples/ESP32-S31-Korvo-1/
+  CMakeLists.txt                 # top-level; CMAKE_POLICY_VERSION_MINIMUM 3.5 (WAMR)
+  sdkconfig.defaults             # universal (WAMR, mbedTLS dyn buffers, console)
+  sdkconfig.defaults.esp32s31    # target, 16MB PSRAM, native WiFi/BT, flash, partition ptr
+  partitions.csv                 # nvs / factory / wasm_a / wendy_conf / storage
+  main/
+    CMakeLists.txt               # REQUIRES wendy_core + camera/LCD components
+    idf_component.yml            # idf(master), wendy_core (git gab/core), camera + LCD deps
+    demo_main.c                  # Phase 1 viewfinder; Phase 2 wendy_core_init()
+  README.md
+  inconveniences.md              # friction log — the deliverable for the tools team
+```
+
+## Toolchain
+
+Clone ESP-IDF `master` + `install.sh esp32s31` into `~/esp/esp-idf-master` (leaves the
+existing v5.3/v5.5.1 trees untouched).
+
+## Scope boundary — what is and isn't verified now
+
+No board is connected. Therefore:
+- **Delivered now**: worktree + example project that **builds** for `esp32s31`
+  (or, if a hard blocker is hit, builds as far as the blocker and documents it),
+  plus the `inconveniences.md` friction log and an on-hardware bring-up checklist.
+- **Deferred to "when hardware arrives"**: flashing, the live viewfinder, and the
+  social-media clip. `README.md` carries the exact flash/monitor commands to run.
+
+## Success criteria
+
+1. `idf.py set-target esp32s31 && idf.py build` succeeds for the Phase-1 native app
+   (or fails only at a documented, genuinely-external blocker).
+2. Phase-2 `wendy_core` integration attempted; outcome (success or specific blocker)
+   documented.
+3. `inconveniences.md` captures every friction point with enough detail to file
+   tooling issues against.
+4. `README.md` gives a copy-paste path from clone → flash → viewfinder for when the
+   board is plugged in.
+
+## Outcomes (2026-07-03, no board attached)
+
+- ✅ ESP-IDF `master` (v6.2) + `esp32s31` preview toolchain installed at
+  `~/esp/esp-idf-master`.
+- ✅ `esp32s31` confirmed as a real (preview) IDF target; `idf.py --preview
+  set-target esp32s31` configures cleanly.
+- ✅ **Default build links and flashes** for `esp32s31`
+  (`build/esp32s31-korvo-demo.bin`, ~209 KB): LCD RGB path + animated
+  test pattern. The screen pipeline is sound; only pin map / panel timings need
+  on-hardware confirmation.
+- 🟥 **Camera blocked upstream**: `esp32-camera` v2.1.7 compiles no driver for
+  `esp32s31` (empty archive → link failure). Camera path is behind
+  `DEMO_ENABLE_CAMERA` (default off); the blocker and two resolution routes are
+  documented in `inconveniences.md` #8.
+- ⏸️ **Phase 2 (`wendy_core`) not exercised**: gated behind the commented
+  dependency + `DEMO_ENABLE_WENDY_CORE`. Blocked conceptually by items #1/#2
+  (no S31 target in wendy-lite, IDF pin mismatch) — deferred.
+- 📋 10 findings captured in `inconveniences.md` (4 blockers, 2 friction, 2
+  papercuts, 2 positives) with a prioritized TL;DR for the tools team.
+- ⏳ On-hardware flashing + the social-media clip deferred until a board is
+  connected (per the approved build-only scope).


### PR DESCRIPTION
## What

A new `Examples/ESP32-S31-Korvo-1/` example, modelled on the reference
[`gmondada/wlite-native-demo1`](https://github.com/gmondada/wlite-native-demo1)
(a native ESP-IDF app that consumes wendy-lite's `wendy_core` as an IDF component),
targeting the brand-new **ESP32-S31-Korvo-1** devkit (RISC-V, 16 MB PSRAM, WiFi 6;
4.3″ 800×480 RGB LCD + OV3660 camera).

It drives the panel with a branded **"WENDY" screen demo** (animated stroke wordmark
+ audio-style EQ bars) and **runs on real hardware** — verified on-device
(`BSP display up: 800x480`, `draw_bitmap=ESP_OK`, animated output on the panel).

## Why this PR exists (beyond the example)

The task was also a scouting mission: *what does it take to support a new imaging
ESP32 in Wendy's tooling?* The answer is in
[`inconveniences.md`](Examples/ESP32-S31-Korvo-1/inconveniences.md) — 14 findings,
prioritized for the tools team. Headlines:

- 🟥 **wendy-lite has no `esp32s31` target** (CI is c5/c6/p4) and **pins IDF v5.5.1**,
  while S31 needs **IDF `master` (6.x)** — so wendy-lite firmware can't build S31 yet.
- 🟥 **No camera or display host API** in wendy-lite → screen/camera can't run through
  a WASM guest today; this example uses native `esp_lcd` + the board BSP instead.
- 🟥 **`esp32-camera` builds an empty archive for `esp32s31`** (silent → cryptic link
  error). The camera path is gated behind `DEMO_ENABLE_CAMERA`; the route forward is
  `esp_video` (what the BSP uses).
- 🟧 **Display bring-up gotchas** now solved: use the official
  `espressif/esp32_s31_korvo_1` BSP (correct pins/timings), and
  `esp_lcd_panel_disp_on_off(true)` is **required** or the panel stays black.
- 🟥 **No auto-reset on the UART bridge** → every flash needs the manual
  BOOT→RST combo; blocks unattended `idf.py flash`.
- 🟧 `esp32s31` is a **preview** target (`idf.py --preview …`).

## Status / caveats

- ✅ Screen demo **works on hardware**. Default build links + flashes for `esp32s31`.
- ⛔ Camera path (`DEMO_ENABLE_CAMERA=1`) blocked upstream — kept as documented
  reference; migrate to `esp_video`.
- ⏸️ `wendy_core` (Phase 2, `DEMO_ENABLE_WENDY_CORE`) scaffolded, not exercised.
- Requires ESP-IDF `master` + the `esp32s31` preview toolchain (see the example README).
- Design doc: `specs/2026-07-03-esp32s31-korvo-example-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)