### PR TITLE
fix(cli): drop redundant distro prefix in device picker OS column

### DIFF
--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -96,7 +96,7 @@ func probeColumnValue(state ProbeState, version, frame string) string {
 func formatOSNameVersion(os, version string) string {
 	os = strings.TrimSpace(os)
 	version = strings.TrimSpace(version)
-	if os != "" && version != "" && strings.HasPrefix(strings.ToLower(version), strings.ToLower(os)) {
+	if os != "" && version != "" && len(version) >= len(os) && strings.EqualFold(version[:len(os)], os) {
 		return version
 	}
 	return strings.TrimSpace(os + " " + version)

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -88,8 +88,18 @@ func probeColumnValue(state ProbeState, version, frame string) string {
 // formatOSNameVersion joins an OS/distro name and its version into a single
 // display string (e.g. "ubuntu" + "24.04" -> "ubuntu 24.04"). Either part may
 // be empty; the result never has leading or trailing space.
+//
+// When the version string already begins with the OS name (case-insensitive),
+// the name is dropped to avoid a redundant prefix. WendyOS reports the distro
+// ID "wendyos" alongside a version like "WendyOS-0.16.2", which would otherwise
+// render as the ugly "wendyos WendyOS-0.16.2"; here it becomes "WendyOS-0.16.2".
 func formatOSNameVersion(os, version string) string {
-	return strings.TrimSpace(strings.TrimSpace(os) + " " + strings.TrimSpace(version))
+	os = strings.TrimSpace(os)
+	version = strings.TrimSpace(version)
+	if os != "" && version != "" && strings.HasPrefix(strings.ToLower(version), strings.ToLower(os)) {
+		return version
+	}
+	return strings.TrimSpace(os + " " + version)
 }
 
 // PickerItem represents a selectable row in the device picker.

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -519,6 +519,9 @@ func TestFormatOSNameVersion(t *testing.T) {
 		{name: "name only", os: "arch", version: "", want: "arch"},
 		{name: "both empty", os: "", version: "", want: ""},
 		{name: "trims surrounding space", os: " ubuntu ", version: " 24.04 ", want: "ubuntu 24.04"},
+		{name: "drops redundant distro prefix", os: "wendyos", version: "WendyOS-0.16.2", want: "WendyOS-0.16.2"},
+		{name: "drops redundant prefix case-insensitive", os: "WendyOS", version: "wendyos 1.0", want: "wendyos 1.0"},
+		{name: "keeps name when version is not a prefix match", os: "ubuntu", version: "24.04", want: "ubuntu 24.04"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

The `wendy discover` table and the interactive device picker show a merged **OS** column. On WendyOS devices it rendered like this:

```
 Name    Type             Address              Agent                OS
 ●  Pi5  USB, LAN, BLE    wendyos-pi5.local    2026.07.02-102729    wendyos WendyOS-0.16.2
```

`wendyos WendyOS-0.16.2` shows the brand name twice. The distro ID comes from `/etc/os-release` `ID` (`wendyos`) and the version string comes from `version.txt` (`WendyOS-0.16.2`), which already carries the brand — so `formatOSNameVersion` blindly concatenating them is redundant.

## Fix

`formatOSNameVersion` now drops the OS name when the version string already begins with it (case-insensitive):

```
 ●  Pi5  USB, LAN, BLE    wendyos-pi5.local    2026.07.02-102729    WendyOS-0.16.2
```

Non-redundant distros are unaffected — `ubuntu` + `24.04` still renders as `ubuntu 24.04`.

Both surfaces share the same `pickerDeviceColumnDefs` OS column, so this single change fixes discover and the picker at once.

## Test

Added cases to `TestFormatOSNameVersion` covering the redundant-prefix drop (incl. case-insensitive) and the unchanged non-matching case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)