### PR TITLE
cli,agent: verify device image integrity instead of trusting push-skip

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -98,6 +98,8 @@ Use `--service <name>` to build and run only a specific service and its transiti
 
 See [Multi-Service Apps with `wendy.json`](../../../apps/wendy-services.md) for a full walkthrough.
 
+> **Note:** Every multi-service run rebuilds and re-pushes each service — the push-skip optimisation is currently inactive for multi-service deployments. See [Push-skip content verification](#push-skip-content-verification) for why.
+
 > **Headless Mac:** Multi-service `wendy.json` projects are not supported when the selected target is Headless Mac. `wendy run` returns an error immediately. Target a Linux/WendyOS device for multi-service workloads.
 
 ## Compose projects
@@ -191,6 +193,23 @@ period.
 > **Note:** When `--deploy` is also passed, `--chunking force` and `--chunking off` are no-ops — `--deploy` always uses the registry path because it must create the container without starting it.
 
 Any value other than `auto`, `force`, or `off` is rejected with an error before the build starts.
+
+## Push-skip content verification
+
+When a detached run (`--detach`) finds that nothing has changed since the last successful deploy to this device, `wendy run` can skip the build and push entirely and just ensure the existing container is running. So this never leaves the device on stale or partial content, the skip is content-verified — it happens only when **all** of the following hold:
+
+1. The build inputs (context, Dockerfile/Containerfile, platform, and build-args) hash the same as the last deploy.
+2. A local deploy record for this app on this device exists and lists the image layer diff IDs that were deployed.
+3. The device confirms it still holds every one of those recorded layers.
+
+If any check fails — an older agent that cannot answer the layer query, a layer garbage-collected on the device, a partial push, or a locally rebuilt base image that never changed the input hash — `wendy run` falls back to a full build and push, recording fresh layer IDs on success.
+
+Deploy records written before this version carry no layer IDs, so they cannot be verified and never skip. In practice:
+
+- The first deploy after upgrading always does a full build and push.
+- A legacy record (or any record without verifiable layer IDs) is treated as unverifiable rather than skipped, so you see a full rebuild with unchanged inputs instead of a silent skip onto possibly-stale content.
+
+> **Note:** Push-skip is currently inactive for multi-service deployments. Registry-push content cannot be verified via layer diff IDs, so every multi-service run rebuilds and re-pushes each service; a registry-digest pre-check to restore the optimisation is planned. Setting `WENDY_PUSH_SKIP=0` disables the multi-service push-skip planner (it does not affect the single-service fast path above). Because that planner is inactive today, the override has no observable effect and is reserved for when multi-service push-skip returns.
 
 ## postStart hooks
 

--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -38,6 +38,17 @@ type deployFingerprint struct {
 	// AppVersion is the wendy.json version at deploy time, used as a cheap
 	// cross-check against the version the device reports.
 	AppVersion string `json:"appVersion,omitempty"`
+	// LayerDiffIDs are the uncompressed layer diff IDs of the image content that
+	// was actually pushed to this device on the last successful deploy. A skip is
+	// only permitted when the device still holds every one of these layers (see
+	// deviceHasAllLayers): an unchanged input hash alone does not prove the device
+	// still has the content — blobs can be GC'd, a partial push can leave the
+	// manifest without its blobs, or the local base image can be rebuilt without
+	// changing the hash. Verifying the layers are present closes the WDY-1824 hole
+	// where the CLI skipped the push and reported success while the device kept
+	// running a stale/partial image. Empty (e.g. recorded by a path that doesn't
+	// surface diff IDs) means "cannot verify" → never skip.
+	LayerDiffIDs []string `json:"layerDiffIds,omitempty"`
 }
 
 // deployFingerprintPath returns the on-disk location for an app+device
@@ -298,6 +309,15 @@ func tryDeployFastPath(ctx context.Context, conn *grpcclient.AgentConnection, ap
 		return false, nil
 	}
 
+	// Unchanged inputs are necessary but not sufficient: the device must still
+	// hold the image content we pushed last time. Without this check a skip can
+	// leave the device running a stale/partial image while the CLI reports
+	// success (WDY-1824) — e.g. blobs GC'd, a half-completed push, or a rebuilt
+	// local base image that never changed the input hash.
+	if !deviceHasAllLayers(ctx, conn, fp.LayerDiffIDs) {
+		return false, nil
+	}
+
 	state, found, err := lookupAppState(ctx, conn, appCfg.AppID)
 	if err != nil || !found {
 		// Device unreachable for the query or app no longer present — rebuild.
@@ -381,6 +401,37 @@ func warnReadiness(ctx context.Context, conn *grpcclient.AgentConnection, appID 
 		msg += " — " + d
 	}
 	cliLogln("Warning: %s", msg)
+}
+
+// deviceHasAllLayers reports whether the device's content store still holds
+// every one of diffIDs — i.e. the actual image blobs, not just a container
+// record or a registry tag. It is the content check that gates every push-skip
+// (WDY-1824): the local fingerprint only proves the inputs are unchanged since
+// we last pushed, never that the device still has what we pushed.
+//
+// It is deliberately fail-closed: an empty diffID list (we never recorded what
+// was deployed, so we cannot verify it), an agent too old for QueryLayers
+// (Unimplemented), any RPC error, or a single missing layer all return false so
+// the caller falls back to a real build+push. Only a device that confirms every
+// layer is present authorizes a skip.
+func deviceHasAllLayers(ctx context.Context, conn *grpcclient.AgentConnection, diffIDs []string) bool {
+	if len(diffIDs) == 0 {
+		return false
+	}
+	resp, err := conn.ContainerService.QueryLayers(ctx, &agentpb.QueryLayersRequest{DiffIds: diffIDs})
+	if err != nil {
+		return false
+	}
+	present := make(map[string]bool, len(resp.GetPresent()))
+	for _, p := range resp.GetPresent() {
+		present[p.GetDiffId()] = true
+	}
+	for _, id := range diffIDs {
+		if !present[id] {
+			return false
+		}
+	}
+	return true
 }
 
 // lookupAppState queries the device for the running state of a single app.

--- a/go/internal/cli/commands/deployfastpath_hooks_test.go
+++ b/go/internal/cli/commands/deployfastpath_hooks_test.go
@@ -27,12 +27,27 @@ type fastPathContainerClient struct {
 	state      agentpb.AppRunningState
 	startCtx   context.Context
 	startCalls int
+	// presentLayers is the set of diff IDs the device reports holding via
+	// QueryLayers. The fast path only skips when every recorded layer is present
+	// (WDY-1824), so tests that expect a skip must list the fingerprint's layers
+	// here; leaving one out simulates a device missing that content.
+	presentLayers map[string]bool
 }
 
 func (f *fastPathContainerClient) ListContainers(_ context.Context, _ *agentpb.ListContainersRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[agentpb.ListContainersResponse], error) {
 	return &fakeListContainersStream{resp: &agentpb.ListContainersResponse{
 		Container: &agentpb.AppContainer{AppName: f.appName, RunningState: f.state},
 	}}, nil
+}
+
+func (f *fastPathContainerClient) QueryLayers(_ context.Context, in *agentpb.QueryLayersRequest, _ ...grpc.CallOption) (*agentpb.QueryLayersResponse, error) {
+	resp := &agentpb.QueryLayersResponse{}
+	for _, id := range in.GetDiffIds() {
+		if f.presentLayers[id] {
+			resp.Present = append(resp.Present, &agentpb.PresentLayer{DiffId: id, Size: 1})
+		}
+	}
+	return resp, nil
 }
 
 func (f *fastPathContainerClient) StartContainer(ctx context.Context, _ *agentpb.StartContainerRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[agentpb.RunContainerLayersResponse], error) {
@@ -91,8 +106,9 @@ func TestTryDeployFastPath_StoppedRunsPostStartHooks(t *testing.T) {
 		appID     = "fastpath-app"
 		deviceKey = "testdevice"
 		inputHash = "sha256:deadbeef"
+		layerID   = "sha256:layer0"
 	)
-	saveDeployFingerprint(appID, deviceKey, deployFingerprint{InputHash: inputHash})
+	saveDeployFingerprint(appID, deviceKey, deployFingerprint{InputHash: inputHash, LayerDiffIDs: []string{layerID}})
 
 	sentinel := filepath.Join(t.TempDir(), "poststart-cli-ran")
 	const agentHook = "wendy-agent utils open-browser http://localhost:3000"
@@ -106,7 +122,7 @@ func TestTryDeployFastPath_StoppedRunsPostStartHooks(t *testing.T) {
 		},
 	}
 
-	fake := &fastPathContainerClient{appName: appID, state: agentpb.AppRunningState_STOPPED}
+	fake := &fastPathContainerClient{appName: appID, state: agentpb.AppRunningState_STOPPED, presentLayers: map[string]bool{layerID: true}}
 	conn := &grpcclient.AgentConnection{Host: "localhost", ContainerService: fake}
 
 	done, err := tryDeployFastPath(context.Background(), conn, appCfg, deviceKey, inputHash, runOptions{detach: true})
@@ -149,8 +165,9 @@ func TestTryDeployFastPath_RunningFiresHostPostStartHook(t *testing.T) {
 		appID     = "fastpath-app"
 		deviceKey = "testdevice"
 		inputHash = "sha256:deadbeef"
+		layerID   = "sha256:layer0"
 	)
-	saveDeployFingerprint(appID, deviceKey, deployFingerprint{InputHash: inputHash})
+	saveDeployFingerprint(appID, deviceKey, deployFingerprint{InputHash: inputHash, LayerDiffIDs: []string{layerID}})
 
 	sentinel := filepath.Join(t.TempDir(), "poststart-cli-ran")
 	appCfg := &appconfig.AppConfig{
@@ -160,7 +177,7 @@ func TestTryDeployFastPath_RunningFiresHostPostStartHook(t *testing.T) {
 		},
 	}
 
-	fake := &fastPathContainerClient{appName: appID, state: agentpb.AppRunningState_RUNNING}
+	fake := &fastPathContainerClient{appName: appID, state: agentpb.AppRunningState_RUNNING, presentLayers: map[string]bool{layerID: true}}
 	conn := &grpcclient.AgentConnection{Host: "localhost", ContainerService: fake}
 
 	done, err := tryDeployFastPath(context.Background(), conn, appCfg, deviceKey, inputHash, runOptions{detach: true})

--- a/go/internal/cli/commands/deployskip_test.go
+++ b/go/internal/cli/commands/deployskip_test.go
@@ -85,8 +85,10 @@ func writeServiceContext(t *testing.T, cwd, rel, platform string) string {
 
 // TestPlanServicePushSkips_MissingLayersForcesRebuild is the multi-service side
 // of WDY-1824: a service whose inputs are unchanged AND whose container is
-// present must still NOT be skipped when the device no longer holds its recorded
-// image layers.
+// present must still NOT be skipped when its recorded image content is not
+// confirmed on the device. Here the fingerprint carries diff IDs (the state a
+// future content-verifiable multi-service push would produce) but the device no
+// longer holds them.
 func TestPlanServicePushSkips_MissingLayersForcesRebuild(t *testing.T) {
 	isolateFingerprintCache(t)
 
@@ -116,28 +118,69 @@ func TestPlanServicePushSkips_MissingLayersForcesRebuild(t *testing.T) {
 	}
 }
 
-// TestPlanServicePushSkips_ContentPresentSkips confirms the optimization still
-// fires when everything lines up: unchanged inputs, present container, and every
-// recorded layer confirmed present on the device.
-func TestPlanServicePushSkips_ContentPresentSkips(t *testing.T) {
+// TestPlanServicePushSkips_RegistryPushNeverSkips pins the current, deliberate
+// behavior of the multi-service (registry-push) path: even when inputs are
+// unchanged and the container is present, the planner declines the skip because
+// it cannot confirm the device still holds the pushed content (WDY-1824).
+//
+// This is the reachable production state: runMultiServiceWithAgent saves
+// fingerprints via saveDeployFingerprint(...deployFingerprint{InputHash, AppVersion})
+// with NO layer diff IDs (the registry-push builder never surfaces device-verifiable
+// content identity), so contentPresentForService fails closed. Restoring the
+// WDY-1692 skip here needs the deferred registry-digest pre-check; when that
+// lands this test should flip to assert a skip.
+func TestPlanServicePushSkips_RegistryPushNeverSkips(t *testing.T) {
 	isolateFingerprintCache(t)
 
 	const (
 		appID     = "grp"
 		deviceKey = "devkey"
 		platform  = "linux/arm64"
-		layerID   = "sha256:layer0"
 	)
 	cwd := t.TempDir()
 	hash := writeServiceContext(t, cwd, "llm", platform)
-	saveDeployFingerprint(serviceFingerprintKey(appID, "llm"), deviceKey, deployFingerprint{InputHash: hash, LayerDiffIDs: []string{layerID}})
+	// Save the fingerprint exactly as the multi-service deploy path does: input
+	// hash + app version, no layer diff IDs.
+	saveDeployFingerprint(serviceFingerprintKey(appID, "llm"), deviceKey, deployFingerprint{InputHash: hash, AppVersion: "1.0.0"})
 
 	services := map[string]*appconfig.ServiceConfig{"llm": {Context: "./llm"}}
-	fake := &multiSvcContainerClient{appName: appID, services: []string{"llm"}, presentLayers: map[string]bool{layerID: true}}
+	// Container present; the device would even report layers present if asked —
+	// but the fingerprint records none, so there is nothing to verify.
+	fake := &multiSvcContainerClient{appName: appID, services: []string{"llm"}, presentLayers: map[string]bool{"sha256:layer0": true}}
 	conn := &grpcclient.AgentConnection{ContainerService: fake}
 
-	skip, _ := planServicePushSkips(context.Background(), conn, cwd, appID, deviceKey, platform, services, nil)
-	if !skip["llm"] {
-		t.Fatal("expected llm to be skipped: inputs unchanged, container present, layers present")
+	skip, hashes := planServicePushSkips(context.Background(), conn, cwd, appID, deviceKey, platform, services, nil)
+	if skip["llm"] {
+		t.Fatal("registry-push service was skipped despite no verifiable recorded content (WDY-1824)")
+	}
+	if hashes["llm"] != hash {
+		t.Fatalf("hash for llm = %q, want %q", hashes["llm"], hash)
+	}
+}
+
+// TestContentPresentForService_VerifiesRecordedLayers documents the content-
+// verification primitive itself: should a multi-service push ever record
+// device-verifiable layer diff IDs (e.g. a future chunk-diff-based push), a skip
+// is authorized only when the device confirms every one of them, and declined
+// when any is missing.
+func TestContentPresentForService_VerifiesRecordedLayers(t *testing.T) {
+	const (
+		a = "sha256:aaaa"
+		b = "sha256:bbbb"
+	)
+
+	present := &multiSvcContainerClient{presentLayers: map[string]bool{a: true, b: true}}
+	if !contentPresentForService(context.Background(), &grpcclient.AgentConnection{ContainerService: present}, &deployFingerprint{LayerDiffIDs: []string{a, b}}) {
+		t.Fatal("expected content present when the device holds every recorded layer")
+	}
+
+	missing := &multiSvcContainerClient{presentLayers: map[string]bool{a: true}}
+	if contentPresentForService(context.Background(), &grpcclient.AgentConnection{ContainerService: missing}, &deployFingerprint{LayerDiffIDs: []string{a, b}}) {
+		t.Fatal("expected content absent when a recorded layer is missing")
+	}
+
+	// No recorded layers (the registry-push case): fail closed.
+	if contentPresentForService(context.Background(), &grpcclient.AgentConnection{ContainerService: present}, &deployFingerprint{}) {
+		t.Fatal("expected content absent when the fingerprint records no layers")
 	}
 }

--- a/go/internal/cli/commands/deployskip_test.go
+++ b/go/internal/cli/commands/deployskip_test.go
@@ -2,9 +2,13 @@ package commands
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc"
 )
 
 func TestServiceFingerprintKey(t *testing.T) {
@@ -32,5 +36,108 @@ func TestPlanServicePushSkipsDisabled(t *testing.T) {
 	}
 	if len(hashes) != 0 {
 		t.Fatalf("expected no hashes computed when disabled, got %v", hashes)
+	}
+}
+
+// multiSvcContainerClient reports one app group with a set of service names
+// present, and answers QueryLayers from a configurable present-layer set. It
+// drives planServicePushSkips end to end.
+type multiSvcContainerClient struct {
+	agentpb.WendyContainerServiceClient // embedded nil
+
+	appName       string
+	services      []string
+	presentLayers map[string]bool
+}
+
+func (f *multiSvcContainerClient) ListContainers(_ context.Context, _ *agentpb.ListContainersRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[agentpb.ListContainersResponse], error) {
+	svcs := make([]*agentpb.ServiceEntry, 0, len(f.services))
+	for _, s := range f.services {
+		svcs = append(svcs, &agentpb.ServiceEntry{Name: s})
+	}
+	return &fakeListContainersStream{resp: &agentpb.ListContainersResponse{
+		Container: &agentpb.AppContainer{AppName: f.appName, Services: svcs},
+	}}, nil
+}
+
+func (f *multiSvcContainerClient) QueryLayers(_ context.Context, in *agentpb.QueryLayersRequest, _ ...grpc.CallOption) (*agentpb.QueryLayersResponse, error) {
+	resp := &agentpb.QueryLayersResponse{}
+	for _, id := range in.GetDiffIds() {
+		if f.presentLayers[id] {
+			resp.Present = append(resp.Present, &agentpb.PresentLayer{DiffId: id, Size: 1})
+		}
+	}
+	return resp, nil
+}
+
+// writeServiceContext lays down a minimal buildable context (Dockerfile) under
+// cwd/<rel> so computeBuildInputHash succeeds, and returns the hash the planner
+// will compute for it.
+func writeServiceContext(t *testing.T, cwd, rel, platform string) string {
+	t.Helper()
+	writeFile(t, filepath.Join(cwd, rel), "Dockerfile", "FROM scratch\n")
+	h, err := computeBuildInputHash(filepath.Join(cwd, rel), "", platform, nil)
+	if err != nil {
+		t.Fatalf("computeBuildInputHash: %v", err)
+	}
+	return h
+}
+
+// TestPlanServicePushSkips_MissingLayersForcesRebuild is the multi-service side
+// of WDY-1824: a service whose inputs are unchanged AND whose container is
+// present must still NOT be skipped when the device no longer holds its recorded
+// image layers.
+func TestPlanServicePushSkips_MissingLayersForcesRebuild(t *testing.T) {
+	isolateFingerprintCache(t)
+
+	const (
+		appID     = "grp"
+		deviceKey = "devkey"
+		platform  = "linux/arm64"
+	)
+	cwd := t.TempDir()
+	hash := writeServiceContext(t, cwd, "llm", platform)
+
+	// Fingerprint recorded a layer; matching inputs; container is present.
+	saveDeployFingerprint(serviceFingerprintKey(appID, "llm"), deviceKey, deployFingerprint{InputHash: hash, LayerDiffIDs: []string{"sha256:layer0"}})
+
+	services := map[string]*appconfig.ServiceConfig{"llm": {Context: "./llm"}}
+
+	// Device: container present, but layer NOT present (stale/partial image).
+	fake := &multiSvcContainerClient{appName: appID, services: []string{"llm"}, presentLayers: map[string]bool{}}
+	conn := &grpcclient.AgentConnection{ContainerService: fake}
+
+	skip, hashes := planServicePushSkips(context.Background(), conn, cwd, appID, deviceKey, platform, services, nil)
+	if skip["llm"] {
+		t.Fatal("service skipped despite the device missing its image layers (WDY-1824)")
+	}
+	if hashes["llm"] != hash {
+		t.Fatalf("hash for llm = %q, want %q", hashes["llm"], hash)
+	}
+}
+
+// TestPlanServicePushSkips_ContentPresentSkips confirms the optimization still
+// fires when everything lines up: unchanged inputs, present container, and every
+// recorded layer confirmed present on the device.
+func TestPlanServicePushSkips_ContentPresentSkips(t *testing.T) {
+	isolateFingerprintCache(t)
+
+	const (
+		appID     = "grp"
+		deviceKey = "devkey"
+		platform  = "linux/arm64"
+		layerID   = "sha256:layer0"
+	)
+	cwd := t.TempDir()
+	hash := writeServiceContext(t, cwd, "llm", platform)
+	saveDeployFingerprint(serviceFingerprintKey(appID, "llm"), deviceKey, deployFingerprint{InputHash: hash, LayerDiffIDs: []string{layerID}})
+
+	services := map[string]*appconfig.ServiceConfig{"llm": {Context: "./llm"}}
+	fake := &multiSvcContainerClient{appName: appID, services: []string{"llm"}, presentLayers: map[string]bool{layerID: true}}
+	conn := &grpcclient.AgentConnection{ContainerService: fake}
+
+	skip, _ := planServicePushSkips(context.Background(), conn, cwd, appID, deviceKey, platform, services, nil)
+	if !skip["llm"] {
+		t.Fatal("expected llm to be skipped: inputs unchanged, container present, layers present")
 	}
 }

--- a/go/internal/cli/commands/deploystale_test.go
+++ b/go/internal/cli/commands/deploystale_test.go
@@ -1,0 +1,120 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// TestDeviceHasAllLayers covers the content check that gates every push-skip
+// (WDY-1824): a skip is only authorized when the device confirms it still holds
+// every recorded layer.
+func TestDeviceHasAllLayers(t *testing.T) {
+	const (
+		a = "sha256:aaaa"
+		b = "sha256:bbbb"
+	)
+
+	t.Run("all present", func(t *testing.T) {
+		fake := &fastPathContainerClient{presentLayers: map[string]bool{a: true, b: true}}
+		conn := &grpcclient.AgentConnection{ContainerService: fake}
+		if !deviceHasAllLayers(context.Background(), conn, []string{a, b}) {
+			t.Fatal("expected true when the device holds every layer")
+		}
+	})
+
+	t.Run("one missing", func(t *testing.T) {
+		// The device has the manifest's first layer but lost the second (the
+		// "content digest not found / missing blobs" case). This is the exact
+		// stale/partial-image condition WDY-1824 must never skip on.
+		fake := &fastPathContainerClient{presentLayers: map[string]bool{a: true}}
+		conn := &grpcclient.AgentConnection{ContainerService: fake}
+		if deviceHasAllLayers(context.Background(), conn, []string{a, b}) {
+			t.Fatal("expected false when the device is missing a layer")
+		}
+	})
+
+	t.Run("empty diff IDs fail closed", func(t *testing.T) {
+		// A fingerprint written by a push path that didn't surface diff IDs must
+		// not authorize a skip — we cannot prove the device holds the content.
+		fake := &fastPathContainerClient{presentLayers: map[string]bool{}}
+		conn := &grpcclient.AgentConnection{ContainerService: fake}
+		if deviceHasAllLayers(context.Background(), conn, nil) {
+			t.Fatal("expected false when no diff IDs were recorded")
+		}
+	})
+
+	t.Run("unimplemented fails closed", func(t *testing.T) {
+		// An agent too old for QueryLayers must fall back to a real build+push
+		// rather than blindly skip. fakeContainerClient (chunkpush_test) returns
+		// Unimplemented when its queryLayersFn is unset.
+		conn := &grpcclient.AgentConnection{ContainerService: &fakeContainerClient{}}
+		if deviceHasAllLayers(context.Background(), conn, []string{a}) {
+			t.Fatal("expected false when QueryLayers is unimplemented")
+		}
+	})
+}
+
+// TestTryDeployFastPath_StaleImageForcesRebuild is the WDY-1824 regression: the
+// input hash matches and the container is present, but the device no longer
+// holds the recorded image content. The fast path must decline (done=false) so
+// the caller rebuilds and re-pushes, instead of reporting success on a stale or
+// partial image.
+func TestTryDeployFastPath_StaleImageForcesRebuild(t *testing.T) {
+	isolateFingerprintCache(t)
+
+	const (
+		appID     = "stale-app"
+		deviceKey = "testdevice"
+		inputHash = "sha256:deadbeef"
+		layerID   = "sha256:layer0"
+	)
+	saveDeployFingerprint(appID, deviceKey, deployFingerprint{InputHash: inputHash, LayerDiffIDs: []string{layerID}})
+
+	appCfg := &appconfig.AppConfig{AppID: appID}
+
+	// Container is RUNNING and the input hash matches, but the device reports NO
+	// layers present — the stale/partial-image condition.
+	fake := &fastPathContainerClient{appName: appID, state: agentpb.AppRunningState_RUNNING, presentLayers: map[string]bool{}}
+	conn := &grpcclient.AgentConnection{Host: "localhost", ContainerService: fake}
+
+	done, err := tryDeployFastPath(context.Background(), conn, appCfg, deviceKey, inputHash, runOptions{detach: true})
+	if err != nil {
+		t.Fatalf("tryDeployFastPath returned error: %v", err)
+	}
+	if done {
+		t.Fatal("fast path skipped despite the device missing the image content (WDY-1824)")
+	}
+	if fake.startCalls != 0 {
+		t.Fatalf("StartContainer must not run when falling back to a full deploy, got %d calls", fake.startCalls)
+	}
+}
+
+// TestTryDeployFastPath_NoRecordedLayersForcesRebuild verifies that a legacy
+// fingerprint carrying no layer diff IDs never takes the skip: we cannot verify
+// the device holds the content, so we fall back to a real deploy.
+func TestTryDeployFastPath_NoRecordedLayersForcesRebuild(t *testing.T) {
+	isolateFingerprintCache(t)
+
+	const (
+		appID     = "legacy-app"
+		deviceKey = "testdevice"
+		inputHash = "sha256:deadbeef"
+	)
+	saveDeployFingerprint(appID, deviceKey, deployFingerprint{InputHash: inputHash})
+
+	appCfg := &appconfig.AppConfig{AppID: appID}
+	fake := &fastPathContainerClient{appName: appID, state: agentpb.AppRunningState_RUNNING, presentLayers: map[string]bool{}}
+	conn := &grpcclient.AgentConnection{Host: "localhost", ContainerService: fake}
+
+	done, err := tryDeployFastPath(context.Background(), conn, appCfg, deviceKey, inputHash, runOptions{detach: true})
+	if err != nil {
+		t.Fatalf("tryDeployFastPath returned error: %v", err)
+	}
+	if done {
+		t.Fatal("fast path skipped on a fingerprint with no recorded layers (cannot verify content)")
+	}
+}

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -169,18 +169,29 @@ func deviceContainerNames(ctx context.Context, conn *grpcclient.AgentConnection)
 // planServicePushSkips decides, per service, whether its build+push can be
 // skipped. A skip is only permitted when ALL of the following hold: the build
 // inputs are unchanged since the last successful push to this device, the
-// device still has that service's container, AND the device's content store
-// still holds every layer we recorded pushing (deviceHasAllLayers). It returns
+// device still has that service's container, AND we can confirm the device
+// still holds the exact image content we pushed (contentPresent). It returns
 // the skip set and the freshly computed per-service input hashes, so the caller
 // can persist fingerprints for the services it actually builds.
 //
-// The layer-presence check is the fix for WDY-1824: an unchanged input hash and
-// a present container do not prove the device still has the pushed image content
+// The content check is the fix for WDY-1824: an unchanged input hash and a
+// present container do not prove the device still has the pushed image content
 // (blobs can be GC'd, a push can half-complete, or a rebuilt local base image
-// never changes the hash), so skipping on those alone could leave the device
-// running a stale/partial image while the CLI reports success. Fingerprints
-// written by a push path that doesn't surface diff IDs carry none, so
-// deviceHasAllLayers fails closed and the service is rebuilt+pushed.
+// never changes the input hash), so skipping on those alone could leave the
+// device running a stale/partial image while the CLI reports success.
+//
+// Content verification for the multi-service builder path is a known gap: these
+// services are built and pushed to the *device registry* (buildAndPushImageForAgent),
+// whose compressed layer blobs are keyed by compressed digest, so the diff-ID
+// QueryLayers check that guards the single-service chunk-diff fast path
+// (deviceHasAllLayers) can never confirm them. The WDY-1692 commit already
+// called this out ("a device-registry digest pre-check is a planned follow-up
+// for full robustness against a wiped registry") and it is tracked as the
+// WDY-1824 follow-up. Until that registry-digest RPC lands, contentPresent
+// fails closed for every registry-push service, so this path never skips — the
+// safe behavior, at the cost of re-pushing unchanged images (the WDY-1692
+// optimization stays dormant for multi-service, deliberately and visibly, not
+// via a silently-unsatisfiable diff-ID check).
 //
 // Best-effort throughout: any error for a service (or WENDY_PUSH_SKIP=0) just
 // means "don't skip it".
@@ -214,12 +225,31 @@ func planServicePushSkips(ctx context.Context, conn *grpcclient.AgentConnection,
 		// Container presence is not enough: confirm the device still holds the
 		// image content we pushed. Without this a skip can leave a stale/partial
 		// image running while we report success (WDY-1824).
-		if !deviceHasAllLayers(ctx, conn, fp.LayerDiffIDs) {
+		if !contentPresentForService(ctx, conn, fp) {
 			continue
 		}
 		skip[name] = true
 	}
 	return skip, hashes
+}
+
+// contentPresentForService reports whether the device is confirmed to still hold
+// the image content recorded for a registry-push service, gating a push-skip
+// (WDY-1824).
+//
+// It is fail-closed. The multi-service builder pushes to the device registry,
+// whose layers the diff-ID QueryLayers check cannot see (compressed blobs are
+// keyed by compressed digest, not by uncompressed diff ID). So recorded layer
+// diff IDs are still verified via QueryLayers when present — a future
+// chunk-diff-based multi-service push would record verifiable IDs — but a
+// fingerprint without them (every registry push today) can never be confirmed
+// and returns false. Confirming registry-pushed content needs the device
+// registry-digest pre-check deferred from WDY-1692; see WDY-1824 follow-up.
+func contentPresentForService(ctx context.Context, conn *grpcclient.AgentConnection, fp *deployFingerprint) bool {
+	if fp == nil {
+		return false
+	}
+	return deviceHasAllLayers(ctx, conn, fp.LayerDiffIDs)
 }
 
 // runMultiServiceWithAgent orchestrates the full build → push → create →
@@ -268,10 +298,14 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Decide which services can skip build+push entirely: those whose build
-	// inputs are unchanged since the last successful push to this device and whose
-	// container is still present (so the image is in the device registry). This
-	// avoids re-pushing unchanged images — notably the multi-GB GPU base — and the
-	// HEAD-check storm that re-push triggers (WDY-1692).
+	// inputs are unchanged since the last successful push to this device, whose
+	// container is still present, AND whose image content the device is confirmed
+	// to still hold. This is the WDY-1692 optimization (avoid re-pushing unchanged
+	// images — notably the multi-GB GPU base — and the HEAD-check storm re-push
+	// triggers), tightened for WDY-1824 so it never skips onto stale/partial
+	// content. NOTE: the registry-push builder path can't yet prove content
+	// presence, so this currently skips nothing for multi-service; see
+	// planServicePushSkips / contentPresentForService.
 	deviceKey := deviceFingerprintKey(versionResp)
 	skip, hashes := planServicePushSkips(ctx, conn, cwd, appCfg.AppID, deviceKey, platform, services, buildArgs)
 	if n := len(skip); n > 0 {

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -167,15 +167,23 @@ func deviceContainerNames(ctx context.Context, conn *grpcclient.AgentConnection)
 }
 
 // planServicePushSkips decides, per service, whether its build+push can be
-// skipped because the build inputs are unchanged since the last successful push
-// to this device AND the device still has that service's container (so the image
-// is in the device registry). It returns the skip set and the freshly computed
-// per-service input hashes, so the caller can persist fingerprints for the
-// services it actually builds. Best-effort throughout: any error for a service
-// (or WENDY_PUSH_SKIP=0) just means "don't skip it". The single buildkitd content
-// store and the device registry are unaffected; a wrong "present" guess at worst
-// surfaces as a normal create-time pull failure (hardened with a registry digest
-// check in a follow-up, WDY-1692).
+// skipped. A skip is only permitted when ALL of the following hold: the build
+// inputs are unchanged since the last successful push to this device, the
+// device still has that service's container, AND the device's content store
+// still holds every layer we recorded pushing (deviceHasAllLayers). It returns
+// the skip set and the freshly computed per-service input hashes, so the caller
+// can persist fingerprints for the services it actually builds.
+//
+// The layer-presence check is the fix for WDY-1824: an unchanged input hash and
+// a present container do not prove the device still has the pushed image content
+// (blobs can be GC'd, a push can half-complete, or a rebuilt local base image
+// never changes the hash), so skipping on those alone could leave the device
+// running a stale/partial image while the CLI reports success. Fingerprints
+// written by a push path that doesn't surface diff IDs carry none, so
+// deviceHasAllLayers fails closed and the service is rebuilt+pushed.
+//
+// Best-effort throughout: any error for a service (or WENDY_PUSH_SKIP=0) just
+// means "don't skip it".
 func planServicePushSkips(ctx context.Context, conn *grpcclient.AgentConnection, cwd, appID, deviceKey, platform string, services map[string]*appconfig.ServiceConfig, buildArgs map[string]string) (skip map[string]bool, hashes map[string]string) {
 	skip = map[string]bool{}
 	hashes = map[string]string{}
@@ -201,6 +209,12 @@ func planServicePushSkips(ctx context.Context, conn *grpcclient.AgentConnection,
 			continue
 		}
 		if !present[strings.ToLower(multiServiceContainerName(appID, name))] {
+			continue
+		}
+		// Container presence is not enough: confirm the device still holds the
+		// image content we pushed. Without this a skip can leave a stale/partial
+		// image running while we report success (WDY-1824).
+		if !deviceHasAllLayers(ctx, conn, fp.LayerDiffIDs) {
 			continue
 		}
 		skip[name] = true

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1465,9 +1465,12 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// --chunking gates this path: "off" skips it entirely (registry push only),
 	// while "force" uses it with no registry-push fallback on failure.
 	if !opts.deploy && opts.chunking != chunkingOff {
-		if err := deployByChunkDiff(ctx, conn, cwd, appCfg, platform, opts.dockerfile, buildArgs, opts); err == nil {
+		if diffIDs, err := deployByChunkDiff(ctx, conn, cwd, appCfg, platform, opts.dockerfile, buildArgs, opts); err == nil {
 			if hashErr == nil {
-				saveDeployFingerprint(appCfg.AppID, deviceKey, deployFingerprint{InputHash: inputHash, AppVersion: appCfg.Version})
+				// Record the layer diff IDs we deployed so the next run's fast path
+				// can verify the device still holds this content before skipping the
+				// build (WDY-1824).
+				saveDeployFingerprint(appCfg.AppID, deviceKey, deployFingerprint{InputHash: inputHash, AppVersion: appCfg.Version, LayerDiffIDs: diffIDs})
 			}
 			return nil
 		} else if ctx.Err() != nil {
@@ -1903,12 +1906,15 @@ func shouldDumpChunkDiffBuildLog(chunking string) func(error) bool {
 
 // deployByChunkDiff builds the image to a local OCI layout tar, diffs the
 // layers against what the device already has via content-defined chunking, and
-// calls RunContainer with the resulting layer headers.
-func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, platform, dockerfile string, buildArgs map[string]string, opts runOptions) error {
+// calls RunContainer with the resulting layer headers. On success it returns the
+// uncompressed layer diff IDs it deployed, so the caller can record them in the
+// deploy fingerprint and later verify the device still holds this content before
+// skipping a rebuild (WDY-1824).
+func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, platform, dockerfile string, buildArgs map[string]string, opts runOptions) ([]string, error) {
 	mark := phaseTimer()
 	tmp, err := os.MkdirTemp("", "wendy-oci-*")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer os.RemoveAll(tmp)
 	ociTar := filepath.Join(tmp, "image.tar")
@@ -1922,32 +1928,32 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 			if ctx.Err() == nil {
 				_, _ = os.Stderr.Write(buildLog.Bytes())
 			}
-			return err
+			return nil, err
 		}
 	} else {
 		if err := runBuildWithProgress(ctx, buildTitle, shouldDumpChunkDiffBuildLog(opts.chunking), func(stream, logw io.Writer) error {
 			return buildImageToOCILayout(ctx, cwd, dockerfile, platform, buildArgs, opts.builder, ociTar, stream, logw)
 		}); err != nil {
-			return err
+			return nil, err
 		}
 	}
 	mark("build (oci export)")
 	layers, imageConfig, err := readOCILayoutLayers(ociTar, platform)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	mark("read+decompress layers")
 
 	cliLogln("Diffing %s layer(s) against device...", tui.Value(fmt.Sprintf("%d", len(layers))))
 	headers, err := pushLayersByChunks(ctx, conn.ContainerService, layers)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	mark("chunk+query+write")
 
 	appConfigData, err := json.Marshal(appCfg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	imageName := strings.ToLower(appCfg.AppID) + ":latest"
 	// Carry the post-start agent-hook metadata so the agent runs the in-container
@@ -1963,9 +1969,26 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		UserArgs:      opts.userArgs,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	err = streamRunContainer(ctx, conn, stream, appCfg, opts)
+	if err := streamRunContainer(ctx, conn, stream, appCfg, opts); err != nil {
+		mark("runcontainer (assemble+create+start[+readiness])")
+		return nil, err
+	}
 	mark("runcontainer (assemble+create+start[+readiness])")
-	return err
+	return layerDiffIDs(headers), nil
+}
+
+// layerDiffIDs extracts the ordered uncompressed diff IDs from the reassembly
+// headers that were deployed, for recording in the deploy fingerprint. Each
+// header's DiffId is the same content identity QueryLayers reports, so the next
+// run can verify the device still holds every layer before skipping (WDY-1824).
+func layerDiffIDs(headers []*agentpb.RunContainerLayerHeader) []string {
+	ids := make([]string, 0, len(headers))
+	for _, h := range headers {
+		if id := h.GetDiffId(); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }


### PR DESCRIPTION
> **In plain terms (for PMs):** When you redeploy an app, Wendy could report success while the device quietly kept running the *old* version — so a fix looks shipped but isn't, and a changed app can crash-loop with no hint the image is stale. This makes Wendy confirm the device actually holds the new image before claiming success; if it can't confirm, it re-uploads instead. Trade-off: multi-service apps now always re-upload (safe but slower) until a follow-up optimization lands.

## What

Make `wendy run`'s push-skip / fast-path optimizations verify the device actually holds the pushed image content before skipping a build+push, and never take the skip (nor report success) when it doesn't.

## Why

A Dockerfile service with a brand-new multi-GB base image (`--builder apple-container`) reported `✓ Built & pushed` and "Creating container…", but the device kept running the **previous day's** image manifest — `nerdctl images` showed a 27-hour-old digest plus `content digest sha256:… not found` warnings (missing blobs). A follow-up deploy skipped the pull step and recreated the container from the stale image again. Manually loading the image tar and pushing it into the device registry fixed everything.

Root cause: the push-skip optimization (WDY-1692/1699) concluded "the device already has this image" from a matching **local input-hash fingerprint** plus a **present container**. Neither proves the device still holds the pushed content:

- blobs can be GC'd, or a push can half-complete (manifest present, blobs missing → the "content digest not found" warnings);
- a rebuilt **local base image** (`FROM mlx-server:0.1`) never changes the Dockerfile/context, so the input hash is identical and the skip fires on stale content.

When that happened the CLI skipped the build/push and reported success while the device silently ran the old (or partial) image; with a changed entrypoint the service crash-loops with no hint the image is stale. The "registry digest check follow-up" the WDY-1692 code comment promised was never actually landed — this PR is that hardening.

## How

**Single-service (chunk-diff) fast path — content-verified skip:**

- Record the deployed image's **layer diff IDs** in the deploy fingerprint (`deployFingerprint.LayerDiffIDs`). `deployByChunkDiff` now returns the diff IDs it deployed so the caller persists them.
- Add `deviceHasAllLayers`: before skipping, call the existing `QueryLayers` RPC to confirm the device's content store still holds **every** recorded layer (the actual uncompressed blobs, keyed by diff ID — the chunk-diff path writes them `COMPRESSION_NONE`, so the content-store key *is* the diff ID). It **fails closed** — no recorded layers, any missing layer, an `Unimplemented` (old) agent, or any RPC error → don't skip, fall back to a real build+push.
- Gate `tryDeployFastPath` on this check.

**Multi-service (registry-push) planner — fail-closed, WDY-1692 optimization deliberately dormant:**

- `planServicePushSkips` now runs the skip through `contentPresentForService`. Multi-service services are built and pushed to the **device registry** (`buildAndPushImageForAgent`), whose compressed layer blobs are keyed by *compressed* digest — so the diff-ID `QueryLayers` check can never confirm them, and the deploy path records no diff IDs anyway.
- Therefore the multi-service path **skips nothing today**: fail-closed and safe, but the WDY-1692 optimization (avoid re-pushing unchanged multi-GB service images) stays dormant. This is now explicit and documented rather than hidden behind an always-unsatisfiable diff-ID check. `contentPresentForService` still verifies diff IDs when present, so a future content-verifiable multi-service push can opt in without further change.

Behavior change: the first run after upgrading (single-service, or any legacy fingerprint) rebuilds+pushes once and records diff IDs; subsequent runs skip only when the device confirms it holds the content. Multi-service deploys always rebuild+push until the follow-up below lands.

## Tested

- `go test ./internal/cli/commands/` — full package passes (~15s).
- `go build ./...` — clean; `gofmt -l` on changed files — clean.
- Focused tests:
  - `TestDeviceHasAllLayers` — all-present / one-missing / empty-diff-IDs / Unimplemented all decided correctly.
  - `TestTryDeployFastPath_StaleImageForcesRebuild` — input hash matches and container is RUNNING, but the device holds no layers → `done=false`, no `StartContainer` (the exact WDY-1824 condition).
  - `TestTryDeployFastPath_NoRecordedLayersForcesRebuild` — legacy fingerprint (no diff IDs) never skips.
  - `TestPlanServicePushSkips_RegistryPushNeverSkips` — the **reachable** production state: a multi-service fingerprint saved the way the deploy path actually saves it (input hash + version, no diff IDs) is never skipped, even with container present and layers reported present. Replaces the earlier `…_ContentPresentSkips`, which asserted an unreachable state (a multi-service fingerprint carrying diff IDs the deploy path never writes).
  - `TestPlanServicePushSkips_MissingLayersForcesRebuild` — a fingerprint with diff IDs (a future content-verifiable push) is declined when the device is missing a layer.
  - `TestContentPresentForService_VerifiesRecordedLayers` — the verification primitive: present / missing / no-recorded-layers all decided correctly.

## Follow-up (not done here — requires hardware)

- **Restore the WDY-1692 skip for multi-service** via the deferred device **registry-digest pre-check** (the WDY-1692 commit already flagged this: *"a device-registry digest pre-check is a planned follow-up for full robustness against a wiped registry"*). A small agent RPC that confirms the device registry still serves the exact manifest digest we pushed (and its blobs) would let the multi-service path content-verify and skip again. That RPC + agent implementation needs on-device validation, so it is out of scope for this unit-test-only change.
- **Live-device validation** on an AGX Thor with the HelloVLM `llm-mlx` service and a rebuilt local base image, confirming the single-service fast path declines the skip and pushes the fresh image, and that multi-service deploys re-push (no stale image). All work here is local build + unit tests only (no device access).

Closes WDY-1824

