### PR TITLE
agent: kill stale task processes when replacing a container

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -592,16 +592,29 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	// Delete any pre-existing container with the same name.
 	if existing, err := c.client.LoadContainer(ctx, containerName); err == nil {
 		c.logger.Info("Removing existing container", zap.String("container_name", containerName))
-		// Try to stop/kill the task first.
+		// Kill the old task's whole process group — not just init — and wait
+		// for it to exit. A surviving process keeps devices/ports the new
+		// container needs (WDY-1818: /dev/video0 held for hours after replace).
 		if task, taskErr := existing.Task(ctx, nil); taskErr == nil {
-			_ = task.Kill(ctx, syscall.SIGKILL)
-			_, _ = task.Delete(ctx, containerd.WithProcessKill)
+			if termErr := c.terminateTask(ctx, task, containerName, syscall.SIGKILL, killWaitTimeout, killWaitTimeout); termErr != nil {
+				c.logger.Error("Failed to delete old task during replace; forcing runtime delete",
+					zap.String("container_name", containerName),
+					zap.Error(termErr))
+				c.forceDeleteTask(ctx, containerName)
+			}
 		} else {
 			// Task may be orphaned (shim crashed). Force-delete via the task
 			// service directly so the runtime clears the old task ID.
 			c.forceDeleteTask(ctx, containerName)
 		}
-		_ = existing.Delete(ctx, containerd.WithSnapshotCleanup)
+		if delErr := existing.Delete(ctx, containerd.WithSnapshotCleanup); delErr != nil && !errdefs.IsNotFound(delErr) {
+			// Not fatal here — NewContainer below fails with AlreadyExists if
+			// the old record is truly stuck — but log the root cause so a
+			// failed replace is attributable (WDY-1818).
+			c.logger.Error("Failed to delete existing container during replace",
+				zap.String("container_name", containerName),
+				zap.Error(delErr))
+		}
 		// Stop old D-Bus proxy if any.
 		if c.proxyManager != nil {
 			_ = c.proxyManager.Stop(containerName)
@@ -1619,15 +1632,11 @@ func (c *Client) deleteStaleTask(ctx context.Context, container containerd.Conta
 	if taskErr != nil {
 		return // No task to clean up.
 	}
-	_ = existingTask.Kill(ctx, syscall.SIGKILL)
-	if waitCh, waitErr := existingTask.Wait(ctx); waitErr == nil {
-		select {
-		case <-waitCh:
-		case <-time.After(5 * time.Second):
-			c.logger.Warn("Timed out waiting for stale task to exit", zap.String("app_name", appName))
-		}
+	if err := c.terminateTask(ctx, existingTask, appName, syscall.SIGKILL, killWaitTimeout, killWaitTimeout); err != nil {
+		c.logger.Warn("Failed to delete stale task",
+			zap.String("app_name", appName),
+			zap.Error(err))
 	}
-	_, _ = existingTask.Delete(ctx, containerd.WithProcessKill)
 }
 
 // forceDeleteTask uses the low-level containerd task service to delete a task
@@ -2085,45 +2094,11 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 		}
 	}
 
-	// Send SIGTERM first for graceful shutdown.
-	if err := task.Kill(ctx, syscall.SIGTERM); err != nil {
-		if !errdefs.IsNotFound(err) {
-			c.logger.Warn("Failed to send SIGTERM",
-				zap.String("container_id", containerID),
-				zap.Error(err),
-			)
-		}
-	}
-
-	// Wait up to 10 seconds for graceful exit.
-	waitCh, err := task.Wait(ctx)
-	if err != nil {
-		c.logger.Warn("Failed to wait on task, sending SIGKILL",
-			zap.String("container_id", containerID),
-			zap.Error(err),
-		)
-	} else {
-		select {
-		case <-waitCh:
-			c.logger.Info("Container stopped gracefully", zap.String("container_id", containerID))
-		case <-time.After(10 * time.Second):
-			c.logger.Warn("Container did not stop within 10s, sending SIGKILL",
-				zap.String("container_id", containerID),
-			)
-			if err := task.Kill(ctx, syscall.SIGKILL); err != nil && !errdefs.IsNotFound(err) {
-				c.logger.Error("Failed to send SIGKILL",
-					zap.String("container_id", containerID),
-					zap.Error(err),
-				)
-			}
-			<-waitCh
-		}
-	}
-
-	// Delete the task.
-	_, err = task.Delete(ctx, containerd.WithProcessKill)
-	if err != nil && !errdefs.IsNotFound(err) {
-		return fmt.Errorf("deleting task for %q: %w", containerID, err)
+	// SIGTERM the whole process group for graceful shutdown, escalating to
+	// SIGKILL after the grace period. Group-wide signalling (not just init)
+	// ensures no descendant survives holding devices/ports (WDY-1818).
+	if err := c.terminateTask(ctx, task, containerID, syscall.SIGTERM, stopGracePeriod, killWaitTimeout); err != nil {
+		return err
 	}
 
 	if c.proxyManager != nil {
@@ -2323,8 +2298,14 @@ func ensureSharedSHM(appID string) (string, error) {
 // and the caller must hold c.mu.
 func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantImg bool) (imgName string, err error) {
 	if task, taskErr := ctr.Task(ctx, nil); taskErr == nil {
-		_ = task.Kill(ctx, syscall.SIGKILL)
-		_, _ = task.Delete(ctx, containerd.WithProcessKill)
+		if termErr := c.terminateTask(ctx, task, ctr.ID(), syscall.SIGKILL, killWaitTimeout, killWaitTimeout); termErr != nil {
+			// Keep going: the container Delete below surfaces a meaningful
+			// error if the task record is truly stuck, but log the root cause
+			// so leaked processes are attributable (WDY-1818).
+			c.logger.Warn("Failed to delete task during container delete",
+				zap.String("container_id", ctr.ID()),
+				zap.Error(termErr))
+		}
 	}
 	if wantImg {
 		if img, imgErr := ctr.Image(ctx); imgErr == nil {

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -695,8 +695,11 @@ func (c *Client) ReapOrphanedROS2Sidecars(ctx context.Context) error {
 
 func (c *Client) deleteROS2Sidecar(ctx context.Context, container containerd.Container) error {
 	if task, err := container.Task(ctx, nil); err == nil {
-		_ = task.Kill(ctx, syscall.SIGKILL)
-		_, _ = task.Delete(ctx, containerd.WithProcessKill)
+		if termErr := c.terminateTask(ctx, task, container.ID(), syscall.SIGKILL, killWaitTimeout, killWaitTimeout); termErr != nil {
+			c.logger.Warn("Failed to delete ROS 2 sidecar task",
+				zap.String("sidecar", container.ID()),
+				zap.Error(termErr))
+		}
 	}
 	if err := container.Delete(ctx, containerd.WithSnapshotCleanup); err != nil && !errdefs.IsNotFound(err) {
 		return err

--- a/go/internal/agent/containerd/task_teardown.go
+++ b/go/internal/agent/containerd/task_teardown.go
@@ -1,0 +1,127 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/errdefs"
+	"go.uber.org/zap"
+)
+
+const (
+	// stopGracePeriod is how long a task gets to exit after SIGTERM before
+	// teardown escalates to SIGKILL.
+	stopGracePeriod = 10 * time.Second
+	// killWaitTimeout bounds how long teardown waits for a task to exit after
+	// SIGKILL before proceeding to delete. Delete(WithProcessKill) re-kills the
+	// whole group and waits again, so a task that exits late is still reaped.
+	killWaitTimeout = 5 * time.Second
+)
+
+// teardownTask is the subset of containerd.Task the teardown helpers use,
+// factored out so the SIGTERM→SIGKILL escalation and group-kill fallback can
+// be unit-tested without a containerd daemon.
+type teardownTask interface {
+	Kill(ctx context.Context, signal syscall.Signal, opts ...containerd.KillOpts) error
+	Wait(ctx context.Context) (<-chan containerd.ExitStatus, error)
+	Delete(ctx context.Context, opts ...containerd.ProcessDeleteOpts) (*containerd.ExitStatus, error)
+}
+
+// Compile-time check that containerd.Task satisfies teardownTask.
+var _ teardownTask = containerd.Task(nil)
+
+// terminateTask stops a task and every process it spawned, then deletes it.
+//
+// It signals the task's whole process group (runc kill --all, which sweeps the
+// container cgroup) rather than only the init process. Killing just init lets
+// descendants that were double-forked or re-parented survive the teardown and
+// keep exclusive resources (device nodes such as /dev/video0, ports, file
+// locks) open indefinitely — the failure mode behind WDY-1818, where an app
+// process outlived its replaced container by hours and blocked the camera for
+// every later consumer.
+//
+// sig is the initial signal (SIGTERM for graceful stops, SIGKILL for forced
+// teardown). If the task has not exited grace after sig, it escalates to
+// SIGKILL and waits up to killWait more. The final Delete uses WithProcessKill,
+// which SIGKILLs the group once more and waits for exit before deleting, so it
+// is correct even when the bounded waits above expired. A failed delete is
+// returned to the caller — swallowing it would leave the old task's processes
+// alive with no trace in the logs.
+func (c *Client) terminateTask(ctx context.Context, task teardownTask, containerID string, sig syscall.Signal, grace, killWait time.Duration) error {
+	// Register the waiter before signalling so a fast exit is not missed.
+	waitCh, waitErr := task.Wait(ctx)
+	if waitErr != nil {
+		c.logger.Warn("Failed to wait on task; killing and deleting without exit confirmation",
+			zap.String("container_id", containerID),
+			zap.Error(waitErr))
+	}
+
+	c.signalTaskGroup(ctx, task, containerID, sig)
+
+	exited := false
+	if waitErr == nil {
+		select {
+		case <-waitCh:
+			exited = true
+		case <-time.After(grace):
+		}
+	}
+
+	if !exited && sig != syscall.SIGKILL {
+		c.logger.Warn("Task did not exit within grace period; escalating to SIGKILL",
+			zap.String("container_id", containerID),
+			zap.Duration("grace", grace))
+		c.signalTaskGroup(ctx, task, containerID, syscall.SIGKILL)
+		if waitErr == nil {
+			select {
+			case <-waitCh:
+				exited = true
+			case <-time.After(killWait):
+			}
+		}
+	}
+
+	if exited {
+		c.logger.Debug("Task exited after signal",
+			zap.String("container_id", containerID),
+			zap.String("signal", sig.String()))
+	} else {
+		c.logger.Warn("Task exit not confirmed; deleting with process kill",
+			zap.String("container_id", containerID))
+	}
+
+	if _, err := task.Delete(ctx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
+		return fmt.Errorf("deleting task for %q: %w", containerID, err)
+	}
+	return nil
+}
+
+// signalTaskGroup delivers sig to every process in the task (containerd's
+// WithKillAll). When the group kill fails for a reason other than the task
+// being gone, it falls back to signalling only the init process so a runtime
+// that rejects the all-flag still gets a best-effort kill.
+func (c *Client) signalTaskGroup(ctx context.Context, task teardownTask, containerID string, sig syscall.Signal) {
+	err := task.Kill(ctx, sig, containerd.WithKillAll)
+	if err == nil || taskGone(err) {
+		return
+	}
+	c.logger.Warn("Failed to signal task process group; falling back to init process only",
+		zap.String("container_id", containerID),
+		zap.String("signal", sig.String()),
+		zap.Error(err))
+	if err := task.Kill(ctx, sig); err != nil && !taskGone(err) {
+		c.logger.Warn("Failed to signal task init process",
+			zap.String("container_id", containerID),
+			zap.String("signal", sig.String()),
+			zap.Error(err))
+	}
+}
+
+// taskGone reports whether a kill error means the task (or its init process)
+// already exited, which teardown treats as success.
+func taskGone(err error) bool {
+	return errdefs.IsNotFound(err) || errdefs.IsFailedPrecondition(err)
+}

--- a/go/internal/agent/containerd/task_teardown_test.go
+++ b/go/internal/agent/containerd/task_teardown_test.go
@@ -1,0 +1,279 @@
+package containerd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/errdefs"
+	"go.uber.org/zap"
+)
+
+// recordedKill captures one Kill call: the signal and whether the whole
+// process group was targeted (containerd.WithKillAll).
+type recordedKill struct {
+	sig syscall.Signal
+	all bool
+}
+
+// fakeTeardownTask implements teardownTask for unit tests. It records every
+// Kill (signal + all-flag), closes its wait channel when killed with
+// exitOnSignal, and lets tests inject Wait/Kill/Delete failures.
+type fakeTeardownTask struct {
+	mu    sync.Mutex
+	kills []recordedKill
+
+	// killErr, when set, is consulted for every Kill call.
+	killErr func(sig syscall.Signal, all bool) error
+	// exitOnSignal closes waitCh (task exits) after a successful Kill with
+	// this signal. Zero means the task never exits from a signal.
+	exitOnSignal syscall.Signal
+
+	waitCh   chan containerd.ExitStatus
+	waitErr  error
+	exitOnce sync.Once
+
+	deleteErr error
+	deleted   bool
+}
+
+func newFakeTeardownTask() *fakeTeardownTask {
+	return &fakeTeardownTask{waitCh: make(chan containerd.ExitStatus, 1)}
+}
+
+func (f *fakeTeardownTask) exit() {
+	f.exitOnce.Do(func() { close(f.waitCh) })
+}
+
+func (f *fakeTeardownTask) Kill(ctx context.Context, sig syscall.Signal, opts ...containerd.KillOpts) error {
+	info := containerd.KillInfo{}
+	for _, o := range opts {
+		if err := o(ctx, &info); err != nil {
+			return err
+		}
+	}
+	f.mu.Lock()
+	f.kills = append(f.kills, recordedKill{sig: sig, all: info.All})
+	f.mu.Unlock()
+	if f.killErr != nil {
+		if err := f.killErr(sig, info.All); err != nil {
+			return err
+		}
+	}
+	if f.exitOnSignal != 0 && sig == f.exitOnSignal {
+		f.exit()
+	}
+	return nil
+}
+
+func (f *fakeTeardownTask) Wait(ctx context.Context) (<-chan containerd.ExitStatus, error) {
+	if f.waitErr != nil {
+		return nil, f.waitErr
+	}
+	return f.waitCh, nil
+}
+
+func (f *fakeTeardownTask) Delete(ctx context.Context, opts ...containerd.ProcessDeleteOpts) (*containerd.ExitStatus, error) {
+	// Do NOT run opts: the production code passes containerd.WithProcessKill,
+	// which would Wait+Kill against this fake and distort the recorded kill
+	// sequence the tests assert on. The fake models a delete that succeeds
+	// (or fails via deleteErr) regardless.
+	f.mu.Lock()
+	f.deleted = true
+	f.mu.Unlock()
+	return nil, f.deleteErr
+}
+
+func (f *fakeTeardownTask) recordedKills() []recordedKill {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]recordedKill(nil), f.kills...)
+}
+
+func newTeardownTestClient() *Client {
+	return &Client{logger: zap.NewNop()}
+}
+
+func TestTerminateTaskKillsWholeProcessGroup(t *testing.T) {
+	task := newFakeTeardownTask()
+	task.exitOnSignal = syscall.SIGKILL
+	c := newTeardownTestClient()
+
+	err := c.terminateTask(context.Background(), task, "app", syscall.SIGKILL, time.Second, time.Second)
+	if err != nil {
+		t.Fatalf("terminateTask returned error: %v", err)
+	}
+
+	kills := task.recordedKills()
+	if len(kills) != 1 {
+		t.Fatalf("expected exactly 1 kill, got %d: %v", len(kills), kills)
+	}
+	if kills[0].sig != syscall.SIGKILL || !kills[0].all {
+		t.Errorf("expected SIGKILL with all=true (whole cgroup), got sig=%v all=%v", kills[0].sig, kills[0].all)
+	}
+	if !task.deleted {
+		t.Error("expected task to be deleted")
+	}
+}
+
+func TestTerminateTaskEscalatesToSigkillAfterGrace(t *testing.T) {
+	task := newFakeTeardownTask()
+	task.exitOnSignal = syscall.SIGKILL // Ignores SIGTERM, dies on SIGKILL.
+	c := newTeardownTestClient()
+
+	err := c.terminateTask(context.Background(), task, "app", syscall.SIGTERM, 10*time.Millisecond, time.Second)
+	if err != nil {
+		t.Fatalf("terminateTask returned error: %v", err)
+	}
+
+	kills := task.recordedKills()
+	if len(kills) != 2 {
+		t.Fatalf("expected SIGTERM then SIGKILL, got %v", kills)
+	}
+	if kills[0].sig != syscall.SIGTERM || !kills[0].all {
+		t.Errorf("first kill: expected SIGTERM all=true, got sig=%v all=%v", kills[0].sig, kills[0].all)
+	}
+	if kills[1].sig != syscall.SIGKILL || !kills[1].all {
+		t.Errorf("second kill: expected SIGKILL all=true, got sig=%v all=%v", kills[1].sig, kills[1].all)
+	}
+	if !task.deleted {
+		t.Error("expected task to be deleted")
+	}
+}
+
+func TestTerminateTaskGracefulExitDoesNotEscalate(t *testing.T) {
+	task := newFakeTeardownTask()
+	task.exitOnSignal = syscall.SIGTERM
+	c := newTeardownTestClient()
+
+	err := c.terminateTask(context.Background(), task, "app", syscall.SIGTERM, time.Second, time.Second)
+	if err != nil {
+		t.Fatalf("terminateTask returned error: %v", err)
+	}
+
+	kills := task.recordedKills()
+	if len(kills) != 1 {
+		t.Fatalf("expected exactly 1 kill (no escalation), got %v", kills)
+	}
+	if kills[0].sig != syscall.SIGTERM || !kills[0].all {
+		t.Errorf("expected SIGTERM all=true, got sig=%v all=%v", kills[0].sig, kills[0].all)
+	}
+	if !task.deleted {
+		t.Error("expected task to be deleted")
+	}
+}
+
+func TestTerminateTaskFallsBackToInitKillWhenGroupKillFails(t *testing.T) {
+	task := newFakeTeardownTask()
+	task.exitOnSignal = syscall.SIGKILL
+	task.killErr = func(sig syscall.Signal, all bool) error {
+		if all {
+			return errors.New("kill --all unsupported")
+		}
+		return nil
+	}
+	c := newTeardownTestClient()
+
+	err := c.terminateTask(context.Background(), task, "app", syscall.SIGKILL, time.Second, time.Second)
+	if err != nil {
+		t.Fatalf("terminateTask returned error: %v", err)
+	}
+
+	kills := task.recordedKills()
+	if len(kills) != 2 {
+		t.Fatalf("expected group kill then init fallback, got %v", kills)
+	}
+	if !kills[0].all {
+		t.Errorf("first kill should target the whole group, got %v", kills[0])
+	}
+	if kills[1].all {
+		t.Errorf("fallback kill should target init only, got %v", kills[1])
+	}
+	if kills[1].sig != syscall.SIGKILL {
+		t.Errorf("fallback kill should preserve the signal, got %v", kills[1].sig)
+	}
+	if !task.deleted {
+		t.Error("expected task to be deleted")
+	}
+}
+
+func TestTerminateTaskTreatsGoneTaskAsSuccess(t *testing.T) {
+	for name, killErr := range map[string]error{
+		"not found":           fmt.Errorf("wrapped: %w", errdefs.ErrNotFound),
+		"failed precondition": fmt.Errorf("wrapped: %w", errdefs.ErrFailedPrecondition),
+	} {
+		t.Run(name, func(t *testing.T) {
+			task := newFakeTeardownTask()
+			task.exit() // Already exited.
+			task.killErr = func(syscall.Signal, bool) error { return killErr }
+			c := newTeardownTestClient()
+
+			err := c.terminateTask(context.Background(), task, "app", syscall.SIGKILL, time.Second, time.Second)
+			if err != nil {
+				t.Fatalf("terminateTask returned error: %v", err)
+			}
+
+			kills := task.recordedKills()
+			if len(kills) != 1 {
+				t.Fatalf("gone task must not trigger the init-only fallback, got %v", kills)
+			}
+			if !task.deleted {
+				t.Error("expected task to be deleted")
+			}
+		})
+	}
+}
+
+func TestTerminateTaskReturnsDeleteError(t *testing.T) {
+	task := newFakeTeardownTask()
+	task.exitOnSignal = syscall.SIGKILL
+	task.deleteErr = errors.New("shim wedged")
+	c := newTeardownTestClient()
+
+	err := c.terminateTask(context.Background(), task, "app", syscall.SIGKILL, time.Second, time.Second)
+	if err == nil {
+		t.Fatal("expected delete error to be surfaced, got nil")
+	}
+	if !strings.Contains(err.Error(), "deleting task") || !strings.Contains(err.Error(), "shim wedged") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestTerminateTaskNotFoundDeleteIsSuccess(t *testing.T) {
+	task := newFakeTeardownTask()
+	task.exitOnSignal = syscall.SIGKILL
+	task.deleteErr = fmt.Errorf("wrapped: %w", errdefs.ErrNotFound)
+	c := newTeardownTestClient()
+
+	if err := c.terminateTask(context.Background(), task, "app", syscall.SIGKILL, time.Second, time.Second); err != nil {
+		t.Fatalf("NotFound delete must be treated as success, got: %v", err)
+	}
+}
+
+func TestTerminateTaskWaitErrorStillKillsAndDeletes(t *testing.T) {
+	task := newFakeTeardownTask()
+	task.waitErr = errors.New("wait broken")
+	c := newTeardownTestClient()
+
+	err := c.terminateTask(context.Background(), task, "app", syscall.SIGTERM, time.Second, time.Second)
+	if err != nil {
+		t.Fatalf("terminateTask returned error: %v", err)
+	}
+
+	kills := task.recordedKills()
+	if len(kills) != 2 {
+		t.Fatalf("expected SIGTERM then immediate SIGKILL escalation when exit cannot be observed, got %v", kills)
+	}
+	if kills[0].sig != syscall.SIGTERM || kills[1].sig != syscall.SIGKILL {
+		t.Errorf("unexpected kill sequence: %v", kills)
+	}
+	if !task.deleted {
+		t.Error("expected task to be deleted despite wait failure")
+	}
+}


### PR DESCRIPTION
> **In plain terms (for PMs):** When you replaced or redeployed an app, the old copy could keep running invisibly for hours — in one case hogging the camera so nothing else could use it. Now replacing an app reliably shuts down everything the old version started, and a failed shutdown is reported instead of hidden.

## What

Make container teardown kill the **whole process group** of the old task — not just its init process — everywhere a container is replaced, stopped, or deleted, and stop silently swallowing kill/delete failures.

## Why

On the shared Thor (2026-07-02), a HelloVLM app process was found **still running ~8 hours after its container had been replaced** by a redeploy. It held `/dev/video0` open the entire time, so every later camera consumer — the redeployed app, the MLX vision probe — failed with device-busy, and it had to be tracked down with `fuser`/`ps` and killed by hand.

Root cause: teardown signalled only the container's **init** process. Any descendant that had been double-forked or re-parented away from init survived the teardown and kept exclusive resources (device nodes, ports, file locks) open indefinitely. Worse, the replace path discarded the task-delete and container-delete errors, so a failed kill/delete left the old app running while the redeploy still reported success.

## How

- Add `terminateTask`, a group-wide teardown helper: it signals the task's whole process group (containerd `WithKillAll` = `runc kill --all`, which sweeps the container cgroup), waits for exit with a **bounded deadline**, escalates SIGTERM→SIGKILL after the grace period, and does a final `Delete(WithProcessKill)` that re-kills the group once more before deleting — so it is correct even if a bounded wait expires. Failures are **returned/logged**, not swallowed. The helper takes a narrow `teardownTask` interface so the escalation and fallback logic is unit-testable without a containerd daemon.
- Route every teardown path through it:
  - **container replace** (`CreateContainerWithProgress`) — previously init-only SIGKILL with errors discarded; now group-wide, a failed task delete falls back to the low-level runtime force-delete, and a failed container delete is logged with its cause.
  - **`deleteStaleTask`** (StartContainer), **`deleteOne`** (DeleteContainer), and the **ROS 2 sidecar** delete — same init-only kill, now group-wide with failures logged.
  - **`stopOne`** (StopContainer) — keeps the SIGTERM grace period but signals the group and bounds the post-SIGKILL wait, which previously could block forever on a wedged shim.

## Tested

Local unit tests only — no device access (per ground rules).

- `go test ./internal/agent/containerd/` — passes, including `task_teardown_test.go` covering SIGTERM→SIGKILL escalation, the group-kill fallback, and delete-failure surfacing.
- `go build ./...` — clean; `go vet` + `gofmt -l` on changed files — clean.

## Follow-up (needs hardware)

Live validation on an AGX Thor: replace a running camera app and confirm no old process survives holding `/dev/video0`, and that a failed teardown now surfaces instead of reporting a successful redeploy over a still-running app.

Closes WDY-1818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

