### PR TITLE
agent: close remaining pipe_write freeze path for detached apps

### DIFF
--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -293,15 +293,19 @@ func (m *ContainerMonitor) restartGroup(ctx context.Context, appID string) {
 		m.mu.Unlock()
 	}()
 	channels, err := gr.RestartGroup(ctx, appID)
+	// RestartGroup can return partially-started services together with an
+	// error (e.g. the primary started but a secondary failed). Drain every
+	// returned channel even on error: an abandoned channel back-pressures
+	// through the agent's pipes into the service's stdout FIFO and freezes
+	// the process in pipe_write once the buffers fill (WDY-1822).
+	for name, ch := range channels {
+		go m.drainOutput(name, ch)
+	}
 	if err != nil {
 		m.logger.Error("Failed to restart app group",
 			zap.String("app_id", appID),
 			zap.Error(err),
 		)
-		return
-	}
-	for name, ch := range channels {
-		go m.drainOutput(name, ch)
 	}
 }
 

--- a/go/internal/agent/container/monitor_test.go
+++ b/go/internal/agent/container/monitor_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,6 +11,9 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/agent/services"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
+
+// errRestartGroup is a stand-in for a partial group-restart failure.
+var errRestartGroup = errors.New("secondary failed to start")
 
 // fakeContainerdClient implements services.ContainerdClient by embedding it
 // (so unimplemented methods panic if called) and also satisfies the
@@ -310,6 +314,50 @@ func TestRestartGroup_RunsAndClearsFlag(t *testing.T) {
 	m.mu.Unlock()
 	if inProgress {
 		t.Error("groupRestarting flag not cleared after restartGroup returned")
+	}
+}
+
+// TestRestartGroup_DrainsChannelsOnError is the WDY-1822 regression guard.
+// RestartGroup can return partially-started services together with an error
+// (e.g. the primary started but a secondary failed). If the monitor returns
+// early on error instead of draining the returned channels, the abandoned
+// channel back-pressures through the agent's pipes into the service's stdout
+// FIFO and freezes the process in pipe_write once the buffers fill. This test
+// hands restartGroup a live channel alongside an error and asserts the channel
+// is fully consumed; it fails (times out) if the drain-on-error fix is reverted.
+func TestRestartGroup_DrainsChannelsOnError(t *testing.T) {
+	// Unbuffered: the sender only completes if a drain consumes every item, so
+	// an undrained channel leaves the sender blocked and the test detects it.
+	ch := make(chan services.ContainerOutput)
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for i := 0; i < 3; i++ {
+			ch <- services.ContainerOutput{Stdout: []byte("line")}
+		}
+		close(ch)
+	}()
+
+	fake := &fakeContainerdClient{
+		groupOf: map[string]string{},
+		restartGroupChans: map[string]<-chan services.ContainerOutput{
+			"app_talker": ch,
+		},
+		restartGroupErr: errRestartGroup,
+	}
+	m := NewContainerMonitor(zap.NewNop(), fake, nil, time.Second)
+
+	m.restartGroup(context.Background(), "app")
+
+	select {
+	case <-drained:
+		// Channel fully consumed: the monitor drained output despite the error.
+	case <-time.After(2 * time.Second):
+		t.Fatal("restartGroup did not drain the returned channel on error (WDY-1822 back-pressure regression)")
+	}
+
+	if len(fake.groupRestarts) != 1 || fake.groupRestarts[0] != "app" {
+		t.Errorf("RestartGroup calls = %v; want [app]", fake.groupRestarts)
 	}
 }
 

--- a/go/internal/agent/container/monitor_test.go
+++ b/go/internal/agent/container/monitor_test.go
@@ -17,8 +17,10 @@ import (
 // group restarts. It records which appIDs were group-restarted.
 type fakeContainerdClient struct {
 	services.ContainerdClient
-	groupOf       map[string]string // full container name -> bare appID for grouped members
-	groupRestarts []string
+	groupOf           map[string]string // full container name -> bare appID for grouped members
+	groupRestarts     []string
+	restartGroupChans map[string]<-chan services.ContainerOutput
+	restartGroupErr   error
 }
 
 func (f *fakeContainerdClient) GroupRestartAppID(_ context.Context, appName string) (string, bool) {
@@ -28,7 +30,7 @@ func (f *fakeContainerdClient) GroupRestartAppID(_ context.Context, appName stri
 
 func (f *fakeContainerdClient) RestartGroup(_ context.Context, appID string) (map[string]<-chan services.ContainerOutput, error) {
 	f.groupRestarts = append(f.groupRestarts, appID)
-	return nil, nil
+	return f.restartGroupChans, f.restartGroupErr
 }
 
 func TestRestartPolicy_String(t *testing.T) {

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -488,6 +488,40 @@ func (s *ContainerService) registerContainerWithMonitor(ctx context.Context, app
 	}
 }
 
+// guaranteeOutputDrain wires outputCh — a running task's only output drain —
+// to a consumer that lives for the full task lifetime, independent of the RPC
+// handler that started the task. If outputCh is ever abandoned, back-pressure
+// propagates through the agent's io.Pipes into the container's stdout FIFO and
+// the app freezes in pipe_write once the buffers fill (WDY-1822). Callers must
+// invoke this immediately after a successful start, before anything that can
+// return early (monitor bookkeeping, sends to a client that may already be
+// gone). It returns the channel the handler should stream from and a cleanup
+// function to defer.
+func (s *ContainerService) guaranteeOutputDrain(appName string, outputCh <-chan ContainerOutput) (<-chan ContainerOutput, func()) {
+	if s.logManager != nil {
+		subID, subCh := s.logManager.Subscribe(appName)
+		// Pump containerd output into the log manager (which never blocks:
+		// slow subscribers drop) until the task exits and closes outputCh.
+		go func() {
+			for output := range outputCh {
+				s.logManager.Publish(appName, output)
+			}
+			// When the containerd channel closes, publish a Done marker.
+			s.logManager.Publish(appName, ContainerOutput{Done: true})
+		}()
+		return subCh, func() { s.logManager.Unsubscribe(appName, subID) }
+	}
+	// Without a log manager the handler is the only consumer: hand whatever it
+	// has not consumed to a background drainer when it returns, so a client
+	// disconnect cannot leave the task's output pipeline undrained.
+	return outputCh, func() {
+		go func() {
+			for range outputCh {
+			}
+		}()
+	}
+}
+
 // When a ContainerLogManager is configured, reads from the log manager subscription
 // instead of directly from containerd, enabling multi-subscriber fan-out and telemetry bridging.
 func (s *ContainerService) streamContainerOutput(
@@ -501,6 +535,11 @@ func (s *ContainerService) streamContainerOutput(
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to start container: %v", err)
 	}
+
+	// Attach the task-lifetime drainer before any early return below can
+	// abandon outputCh and wedge the app (WDY-1822).
+	readCh, releaseDrain := s.guaranteeOutputDrain(appName, outputCh)
+	defer releaseDrain()
 
 	// The container started successfully. If it was previously explicitly
 	// stopped, clear that mark so automatic restarts are re-enabled.
@@ -526,23 +565,6 @@ func (s *ContainerService) streamContainerOutput(
 		},
 	}); err != nil {
 		return err
-	}
-
-	var readCh <-chan ContainerOutput
-	if s.logManager != nil {
-		subID, subCh := s.logManager.Subscribe(appName)
-		defer s.logManager.Unsubscribe(appName, subID)
-		readCh = subCh
-
-		go func() {
-			for output := range outputCh {
-				s.logManager.Publish(appName, output)
-			}
-			// When containerd channel closes, publish a Done marker.
-			s.logManager.Publish(appName, ContainerOutput{Done: true})
-		}()
-	} else {
-		readCh = outputCh
 	}
 
 	for {
@@ -620,6 +642,11 @@ func (s *ContainerService) AttachContainer(stream grpc.BidiStreamingServer[agent
 		return status.Errorf(codes.Internal, "failed to start container: %v", err)
 	}
 
+	// Attach the task-lifetime drainer before any early return below can
+	// abandon outputCh and wedge the app (WDY-1822).
+	readCh, releaseDrain := s.guaranteeOutputDrain(appName, outputCh)
+	defer releaseDrain()
+
 	// Mirror the same monitor bookkeeping as streamContainerOutput: clear any
 	// prior explicit-stop mark and register with the persisted restart policy.
 	if s.monitor != nil {
@@ -637,22 +664,6 @@ func (s *ContainerService) AttachContainer(stream grpc.BidiStreamingServer[agent
 		},
 	}); err != nil {
 		return err
-	}
-
-	var readCh <-chan ContainerOutput
-	if s.logManager != nil {
-		subID, subCh := s.logManager.Subscribe(appName)
-		defer s.logManager.Unsubscribe(appName, subID)
-		readCh = subCh
-
-		go func() {
-			for output := range outputCh {
-				s.logManager.Publish(appName, output)
-			}
-			s.logManager.Publish(appName, ContainerOutput{Done: true})
-		}()
-	} else {
-		readCh = outputCh
 	}
 
 	for {

--- a/go/internal/agent/services/container_service_drain_test.go
+++ b/go/internal/agent/services/container_service_drain_test.go
@@ -1,0 +1,117 @@
+package services
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// WDY-1822 regression tests: a running task's output channel is its only
+// drain. If the RPC handler that started the task stops consuming it (client
+// disconnect, failed Send), back-pressure propagates through the agent's
+// io.Pipes into the container's stdout FIFO and the app freezes in pipe_write
+// once the buffers fill. These tests rebuild the containerd client's pipe
+// chain (cio copier -> io.Pipe -> streamReader -> outputCh), fill it well past
+// every buffer, and prove the app-side writes keep completing.
+
+// disconnectedRunStream simulates a client that vanished before the Started
+// response could be delivered: every Send fails.
+type disconnectedRunStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *disconnectedRunStream) Send(*agentpb.RunContainerLayersResponse) error {
+	return io.ErrClosedPipe
+}
+
+func (s *disconnectedRunStream) Context() context.Context { return s.ctx }
+
+// pipeChainMock mirrors containerd.Client.StartContainer's IO wiring: the
+// app's stdout is written into an io.Pipe (standing in for the cio copier
+// reading the task FIFO) and a streamReader-style goroutine forwards it into
+// a 64-slot output channel, exactly like streamOutput does.
+type pipeChainMock struct {
+	mockContainerdClient
+	stdoutW *io.PipeWriter
+}
+
+func (m *pipeChainMock) StartContainer(_ context.Context, _ string, _ string, _ *agentpb.RestartPolicy) (<-chan ContainerOutput, error) {
+	stdoutR, stdoutW := io.Pipe()
+	m.stdoutW = stdoutW
+	outputCh := make(chan ContainerOutput, 64)
+	go func() {
+		defer close(outputCh)
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := stdoutR.Read(buf)
+			if n > 0 {
+				data := make([]byte, n)
+				copy(data, buf[:n])
+				outputCh <- ContainerOutput{Stdout: data}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return outputCh, nil
+}
+
+// writeAppStdout plays the container: it writes chunks x 32 KiB to stdout —
+// far more than the pipe plus the 64-slot channel can absorb — and fails the
+// test if any write blocks, which is exactly how the real app freezes.
+func writeAppStdout(t *testing.T, w *io.PipeWriter, chunks int) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		chunk := make([]byte, 32*1024)
+		for i := 0; i < chunks; i++ {
+			if _, err := w.Write(chunk); err != nil {
+				done <- err
+				return
+			}
+		}
+		done <- w.Close()
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("app stdout write failed: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("app stdout writes blocked: task output pipeline is not drained after client disconnect (WDY-1822)")
+	}
+}
+
+func TestStreamContainerOutput_DrainsAfterImmediateClientDisconnect(t *testing.T) {
+	mock := &pipeChainMock{}
+	lm := NewContainerLogManager(zap.NewNop(), NewTelemetryBroadcaster())
+	svc := NewContainerService(zap.NewNop(), mock, WithLogManager(lm))
+
+	stream := &disconnectedRunStream{ctx: context.Background()}
+	if err := svc.streamContainerOutput(context.Background(), "chatty-app", "", nil, stream); err == nil {
+		t.Fatal("expected streamContainerOutput to fail when the client is gone")
+	}
+
+	// The detached app keeps logging long after the handler returned.
+	writeAppStdout(t, mock.stdoutW, 256) // 8 MiB
+}
+
+func TestStreamContainerOutput_DrainsAfterDisconnectWithoutLogManager(t *testing.T) {
+	mock := &pipeChainMock{}
+	svc := NewContainerService(zap.NewNop(), mock) // no log manager configured
+
+	stream := &disconnectedRunStream{ctx: context.Background()}
+	if err := svc.streamContainerOutput(context.Background(), "chatty-app", "", nil, stream); err == nil {
+		t.Fatal("expected streamContainerOutput to fail when the client is gone")
+	}
+
+	writeAppStdout(t, mock.stdoutW, 256) // 8 MiB
+}


### PR DESCRIPTION
> **In plain terms (for PMs):** Apps left running in the background could freeze after a while — still "alive" but completely unresponsive (dead web UI, no new work) — once they had produced enough log output. This closes the remaining cause of that freeze so long-running background apps keep working.

Fixes the remaining detached-app `pipe_write` freeze.

## Root cause & scope

The freeze had two links. The **reader-side** half — binding the containerd task IO (`NewTask`/`Wait`/`Start`/`streamOutput`) to a task-scoped `context.Background()` context so the FIFO reader outlives the starting RPC — **already landed on `main`** via a separate commit, so this PR does **not** re-touch `client.go`.

What remains here is the **consumer-side** half:

- `guaranteeOutputDrain` in `container_service.go`: attach a task-lifetime drainer immediately after start, so a client that has already disconnected can't orphan the output channel with nobody draining it.
- `monitor.go`: `restartGroup` now drains every member channel even on error, instead of returning on the first error and dropping the channels of members that did start.

## Tests

- `container_service_drain_test.go`: drains after an immediate client disconnect (with and without a log manager).
- `monitor_test.go`: `TestRestartGroup_DrainsChannelsOnError` — a real regression guard that hands `restartGroup` a live unbuffered channel plus an error and asserts full drain (fails if the early-return regression returns). Replaces earlier mock fields that were never set.
- `go test ./internal/agent/container/ ./internal/agent/services/` — pass; `go build ./...` — clean.

## Follow-up

Live-device validation on an AGX Thor (multi-hour detached HelloVLM soak) to confirm the freeze is gone — not runnable in CI.

Closes WDY-1822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

