### PR TITLE
agent: preserve the image PATH instead of appending a duplicate

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -714,8 +714,11 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	}
 
 	// Build environment variables.
-	// Order: image built-in env → user-provided env (from request) → Wendy system env → OTEL injection.
-	// Wendy vars appear last so they always win in OCI semantics (last KEY wins).
+	// Order: image built-in env → user-provided env (from request) → PATH/TERM
+	// defaults (only when absent) → Wendy system env → OTEL injection.
+	// WENDY_* vars appear last so they always win in OCI semantics (last KEY
+	// wins); PATH and TERM are generic fallbacks that must not clobber values
+	// the image or the caller already set (WDY-1825).
 	wendyEnv, err := buildContainerBaseEnv(appID, serviceName)
 	if err != nil {
 		return fmt.Errorf("building container env: %w", err)
@@ -728,6 +731,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		env = append(env, imageSpec.Config.Env...)
 	}
 	env = append(env, req.GetEnv()...)
+	env = appendFallbackEnv(env)
 	env = append(env, wendyEnv...)
 	env = append(env, buildROS2Env(appCfg, appID, serviceName)...)
 	env = injectOTELEnvIfNeeded(env, appCfg, appID)
@@ -1291,7 +1295,47 @@ var deviceHostnameWithSuffix = func() string {
 	return h + ".local"
 }
 
-// buildContainerBaseEnv builds the base environment variables for a container.
+// fallbackContainerEnv holds generic default env entries that are injected
+// only when neither the image config nor the caller defines the same key.
+// Unlike the WENDY_* identity vars (which are appended last so they always
+// win), these are plain fallbacks: appending them unconditionally after the
+// image env would silently clobber image-set values under OCI last-one-wins
+// semantics — e.g. CUDA images ship PATH=/usr/local/cuda/bin:… which a
+// trailing generic PATH discarded (WDY-1825).
+var fallbackContainerEnv = []string{
+	"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	"TERM=xterm",
+}
+
+// appendFallbackEnv appends each fallbackContainerEnv entry to env unless env
+// already defines the same key. It must be called after the image env and the
+// caller-supplied env have been merged.
+func appendFallbackEnv(env []string) []string {
+	for _, def := range fallbackContainerEnv {
+		key, _, _ := strings.Cut(def, "=")
+		if !envHasKey(env, key) {
+			env = append(env, def)
+		}
+	}
+	return env
+}
+
+// envHasKey reports whether env contains an entry that sets key (an exact
+// "KEY=" prefix match).
+func envHasKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildContainerBaseEnv builds the Wendy identity environment variables for a
+// container. These are appended after the image/user env so they always win
+// (last KEY wins in OCI semantics); generic defaults like PATH and TERM live
+// in fallbackContainerEnv instead so they never clobber image values.
 //
 // Precondition: appID must pass ValidateAppID and serviceName (when non-empty)
 // must pass ValidateServiceName. CreateContainerWithProgress enforces this at
@@ -1328,10 +1372,7 @@ func buildContainerBaseEnv(appID, serviceName string) ([]string, error) {
 		}
 	}
 
-	env := []string{
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-		"TERM=xterm",
-	}
+	var env []string
 	deviceHost := deviceHostnameWithSuffix()
 	if serviceName != "" {
 		// Multi-service: hostname is the service name, not the device hostname.

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -366,6 +366,92 @@ func TestBuildContainerBaseEnvIdentityVars(t *testing.T) {
 	}
 }
 
+// TestBuildContainerBaseEnvOmitsPathAndTerm guards against reintroducing
+// generic PATH/TERM into the always-wins Wendy env: buildContainerBaseEnv is
+// appended after the image env, so any PATH there clobbers image-defined
+// values under OCI last-one-wins semantics (WDY-1825). PATH/TERM defaults
+// belong in fallbackContainerEnv via appendFallbackEnv.
+func TestBuildContainerBaseEnvOmitsPathAndTerm(t *testing.T) {
+	old := deviceHostnameWithSuffix
+	t.Cleanup(func() { deviceHostnameWithSuffix = old })
+	deviceHostnameWithSuffix = func() string { return "device.local" }
+
+	env, err := buildContainerBaseEnv("demo-app", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") || strings.HasPrefix(kv, "TERM=") {
+			t.Errorf("base env must not contain generic defaults (WDY-1825); got %q in %v", kv, env)
+		}
+	}
+}
+
+func TestAppendFallbackEnvPreservesImagePATH(t *testing.T) {
+	imagePATH := "PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	env := appendFallbackEnv([]string{imagePATH, "NVIDIA_VISIBLE_DEVICES=all"})
+
+	var paths []string
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			paths = append(paths, kv)
+		}
+	}
+	if len(paths) != 1 {
+		t.Fatalf("want exactly one PATH entry, got %d: %v", len(paths), env)
+	}
+	if paths[0] != imagePATH {
+		t.Errorf("PATH = %q, want image PATH %q preserved", paths[0], imagePATH)
+	}
+	// TERM was not set by the image, so the fallback must still be appended.
+	if !envHasKey(env, "TERM") {
+		t.Errorf("env missing TERM fallback; got %v", env)
+	}
+}
+
+func TestAppendFallbackEnvAddsPATHWhenImageHasNone(t *testing.T) {
+	env := appendFallbackEnv([]string{"FOO=bar"})
+
+	wantPATH := "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	wantTERM := "TERM=xterm"
+	foundPATH, foundTERM := false, false
+	for _, kv := range env {
+		switch kv {
+		case wantPATH:
+			foundPATH = true
+		case wantTERM:
+			foundTERM = true
+		}
+	}
+	if !foundPATH {
+		t.Errorf("env missing fallback %q; got %v", wantPATH, env)
+	}
+	if !foundTERM {
+		t.Errorf("env missing fallback %q; got %v", wantTERM, env)
+	}
+}
+
+func TestAppendFallbackEnvEmptyInput(t *testing.T) {
+	env := appendFallbackEnv(nil)
+	if !envHasKey(env, "PATH") || !envHasKey(env, "TERM") {
+		t.Errorf("fallbacks missing on empty input; got %v", env)
+	}
+}
+
+// TestAppendFallbackEnvKeyMatchIsExact ensures the presence check matches the
+// whole key, not a prefix: an image setting PATHEXT (or TERMINFO) must not
+// suppress the PATH (or TERM) fallback.
+func TestAppendFallbackEnvKeyMatchIsExact(t *testing.T) {
+	env := appendFallbackEnv([]string{"PATHEXT=.sh", "TERMINFO=/usr/share/terminfo"})
+	if !envHasKey(env, "PATH") {
+		t.Errorf("PATHEXT must not suppress the PATH fallback; got %v", env)
+	}
+	if !envHasKey(env, "TERM") {
+		t.Errorf("TERMINFO must not suppress the TERM fallback; got %v", env)
+	}
+}
+
 func hostNetworkCfg() *appconfig.AppConfig {
 	return &appconfig.AppConfig{
 		Entitlements: []appconfig.Entitlement{


### PR DESCRIPTION
> **In plain terms (for PMs):** Some apps — especially GPU/CUDA ones — could fail to find their own programs because Wendy overwrote a setting the app's image had deliberately configured. Now Wendy keeps the image's setting, so these apps behave the same on Wendy as they do under plain Docker.

The agent composed the container env as image env → user env → Wendy base env, and the base env unconditionally included a generic `PATH=/usr/local/sbin:…` and `TERM=xterm`. Under OCI last-one-wins semantics the trailing generic PATH silently discarded any PATH the image defined — observed on `sh.wendy.examples.hellovlm_llm` (2026-07-03), whose CUDA-aware `PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:…` was replaced, a confusing compatibility delta versus running the same image under docker/nerdctl.

## What changed

- Moved `PATH` and `TERM` out of `buildContainerBaseEnv` (whose entries are appended last so they always win) into a new `fallbackContainerEnv`, applied via `appendFallbackEnv` **only when the merged image/user env does not already define the key**. Image-defined (and caller-supplied) PATH/TERM now survive; images without a PATH still get the generic default.
- Audited the other agent-injected vars for the same duplicate problem:
  - `WENDY_*` identity vars: intentionally appended last (reserved prefix, callers cannot set them) — unchanged.
  - OTEL vars (`injectOTELEnvIfNeeded`): already do presence checks — unchanged.
  - ROS2 vars (`buildROS2Env`): driven by explicit `wendy.json` config, so the configured value winning is intended — unchanged.

## How tested

- `go test ./internal/agent/containerd/` — all pass, including new unit tests:
  - image PATH preserved (exactly one PATH entry, the image's CUDA one; TERM fallback still added)
  - generic PATH/TERM added when the image defines none (and on empty env)
  - exact key matching (`PATHEXT`/`TERMINFO` do not suppress the fallbacks)
  - `buildContainerBaseEnv` no longer emits PATH/TERM (regression guard)
- `go build ./internal/agent/...`, `go vet ./internal/agent/...`, `go test ./internal/agent/oci/` — clean.

## Follow-up validation (live device)

Deploy `sh.wendy.examples.hellovlm_llm` to a Jetson/Thor device and confirm the finalized OCI spec contains a single, CUDA-aware PATH (`nerdctl inspect` / spec dump) and that `wendy run` behavior matches plain container runs. Not run here — no hardware access from this branch.

Closes WDY-1825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

