### PR TITLE
cli: print the actual service container name in deploy output

### DIFF
--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -305,7 +305,7 @@ func tryDeployFastPath(ctx context.Context, conn *grpcclient.AgentConnection, ap
 	}
 
 	if state == agentpb.AppRunningState_RUNNING {
-		cliLogln("No changes detected; %s is already up to date and running.", appCfg.AppID)
+		cliLogln("No changes detected; %s is already up to date and running.", containerDisplayName(appCfg))
 		// The container is untouched, so the agent-side (in-container) hook can't
 		// be re-run, but fire the host-side postStart hook so `wendy run` behaves
 		// the same whether or not it took the fast path (e.g. re-opening the URL).
@@ -324,7 +324,7 @@ func tryDeployFastPath(ctx context.Context, conn *grpcclient.AgentConnection, ap
 		// Could not start the existing container; fall back to a full deploy.
 		return false, nil
 	}
-	cliLogln("No changes detected; started existing %s.", appCfg.AppID)
+	cliLogln("No changes detected; started existing %s.", containerDisplayName(appCfg))
 	runPostStartHostHook(ctx, conn, appCfg)
 	return true, nil
 }

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -156,6 +156,15 @@ func contextWithPostStartAgentHook(ctx context.Context, appCfg *appconfig.AppCon
 	return metadata.AppendToOutgoingContext(ctx, appconfig.PostStartAgentHookMetadataKey, hook)
 }
 
+// containerDisplayName returns the container identity for CLI lifecycle
+// messages (created/started/stopped), styled for terminal output. It is the
+// real container name — "{appID}_{serviceName}" when appCfg describes a single
+// service of a multi-service app — because printing the bare appID obscures
+// which service container a deploy just acted on (WDY-1828).
+func containerDisplayName(appCfg *appconfig.AppConfig) string {
+	return tui.App(appCfg.ContainerName())
+}
+
 func cliLog(format string, args ...any) {
 	fmt.Print(cliStyle.Render(fmt.Sprintf(format, args...)))
 }
@@ -861,7 +870,7 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		if appCfg.Brewfile != "" {
 			cliLogln("Brewfile applied.")
 		}
-		cliLogln("Container %s created (not started).", tui.App(appCfg.AppID))
+		cliLogln("Container %s created (not started).", containerDisplayName(appCfg))
 		return nil
 	}
 
@@ -871,7 +880,7 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 	if appCfg.Brewfile != "" {
 		cliLogln("Brewfile applied.")
 	}
-	cliLogln("Container %s created.", tui.App(appCfg.AppID))
+	cliLogln("Container %s created.", containerDisplayName(appCfg))
 
 	if opts.detach {
 		stream, err := conn.ContainerService.StartContainer(contextWithPostStartAgentHook(ctx, appCfg), &agentpb.StartContainerRequest{
@@ -883,7 +892,7 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		if _, err := stream.Recv(); err != nil && err != io.EOF {
 			return fmt.Errorf("waiting for container start: %w", err)
 		}
-		cliLogln("Application %s running in detached mode.", tui.App(appCfg.AppID))
+		cliLogln("Application %s running in detached mode.", containerDisplayName(appCfg))
 		return nil
 	}
 
@@ -897,7 +906,7 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		return fmt.Errorf("starting container: %w", err)
 	}
 
-	cliLogln("Application %s started.", tui.App(appCfg.AppID))
+	cliLogln("Application %s started.", containerDisplayName(appCfg))
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
@@ -929,7 +938,7 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		}
 	}
 
-	cliLogln("\nApplication %s stopped.", tui.App(appCfg.AppID))
+	cliLogln("\nApplication %s stopped.", containerDisplayName(appCfg))
 	return nil
 }
 
@@ -1537,7 +1546,7 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		if err != nil {
 			return fmt.Errorf("creating container: %w", err)
 		}
-		cliLogln("Container %s created (not started).", tui.App(appCfg.AppID))
+		cliLogln("Container %s created (not started).", containerDisplayName(appCfg))
 		return nil
 	}
 
@@ -1545,7 +1554,7 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 	if err := createContainerWithProgress(ctx, conn.ContainerService, createReq); err != nil {
 		return err
 	}
-	cliLogln("Container %s created.", tui.App(appCfg.AppID))
+	cliLogln("Container %s created.", containerDisplayName(appCfg))
 
 	if opts.detach {
 		stream, err := conn.ContainerService.StartContainer(contextWithPostStartAgentHook(ctx, appCfg), &agentpb.StartContainerRequest{
@@ -1557,7 +1566,7 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		if _, err := stream.Recv(); err != nil && err != io.EOF {
 			return fmt.Errorf("waiting for container start: %w", err)
 		}
-		cliLogln("Application %s running in detached mode.", tui.App(appCfg.AppID))
+		cliLogln("Application %s running in detached mode.", containerDisplayName(appCfg))
 		// Wait for readiness before firing hook.
 		if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
 			warnReadiness(ctx, conn, appCfg.AppID, err)
@@ -1577,7 +1586,7 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		return err
 	}
 
-	cliLogln("Application %s started.", tui.App(appCfg.AppID))
+	cliLogln("Application %s started.", containerDisplayName(appCfg))
 
 	// Set up Ctrl+C handler first so readiness polling is cancellable.
 	sigCh := make(chan os.Signal, 1)
@@ -1645,7 +1654,7 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 	if postStartCmd != nil {
 		_ = postStartCmd.Wait()
 	}
-	cliLogln("\nApplication %s stopped.", tui.App(appCfg.AppID))
+	cliLogln("\nApplication %s stopped.", containerDisplayName(appCfg))
 	return nil
 }
 
@@ -1844,7 +1853,7 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 		}
 		if resp.GetStarted() != nil {
 			if opts.deploy {
-				cliLogln("Container %s created (not started).", tui.App(appCfg.AppID))
+				cliLogln("Container %s created (not started).", containerDisplayName(appCfg))
 				return nil
 			}
 			if opts.detach {
@@ -1852,7 +1861,7 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 				// is started; wait for readiness, fire the host post-start hook,
 				// then return without tailing logs. The container keeps running
 				// independently of this (now-abandoned) output stream.
-				cliLogln("Application %s running in detached mode.", tui.App(appCfg.AppID))
+				cliLogln("Application %s running in detached mode.", containerDisplayName(appCfg))
 				if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
 					warnReadiness(ctx, conn, appCfg.AppID, err)
 				}
@@ -1869,7 +1878,7 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 			_, _ = os.Stderr.Write(out.GetData())
 		}
 	}
-	cliLogln("\nApplication %s stopped.", tui.App(appCfg.AppID))
+	cliLogln("\nApplication %s stopped.", containerDisplayName(appCfg))
 	return nil
 }
 

--- a/go/internal/cli/commands/run_test.go
+++ b/go/internal/cli/commands/run_test.go
@@ -4,10 +4,36 @@ import (
 	"context"
 	"errors"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
+
+// containerDisplayName must print the real container identity in deploy
+// output: "{appID}_{serviceName}" when the config describes one service of a
+// multi-service app, not the bare appID (WDY-1828). Assertions use
+// strings.Contains so terminal styling (tui.App) cannot break them.
+func TestContainerDisplayName(t *testing.T) {
+	t.Run("single-container app prints bare appID", func(t *testing.T) {
+		cfg := &appconfig.AppConfig{AppID: "sh.wendy.examples.hellovlm"}
+		got := containerDisplayName(cfg)
+		if !strings.Contains(got, "sh.wendy.examples.hellovlm") {
+			t.Fatalf("containerDisplayName = %q, want it to contain %q", got, "sh.wendy.examples.hellovlm")
+		}
+		if strings.Contains(got, "_") {
+			t.Fatalf("containerDisplayName = %q, single-container app must not gain a service suffix", got)
+		}
+	})
+
+	t.Run("service of multi-service app prints appID_service", func(t *testing.T) {
+		cfg := &appconfig.AppConfig{AppID: "sh.wendy.examples.hellovlm", ServiceName: "llm"}
+		got := containerDisplayName(cfg)
+		if !strings.Contains(got, "sh.wendy.examples.hellovlm_llm") {
+			t.Fatalf("containerDisplayName = %q, want the full container name %q, not the bare appID", got, "sh.wendy.examples.hellovlm_llm")
+		}
+	})
+}
 
 func TestWendyPlatform(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
> **In plain terms (for PMs):** When deploying one service of a multi-service app, Wendy's output named the wrong thing, making it unclear which piece had actually been deployed or replaced. Now it prints the real container name. Display-only — no behavior change.

Closes WDY-1828

## What

`wendy run` (and its `--deploy`/`--detach`/attached lifecycle messages) printed the bare appId as the container name even when acting on a single service of a multi-service app:

```
Container sh.wendy.examples.hellovlm created.    <- actually sh.wendy.examples.hellovlm_llm
```

With HelloVLM/HelloMultiService-style apps (several services sharing one appId) this is misleading — during the 2026-07-03 llm-mlx debugging it repeatedly obscured which container a deploy had just created or replaced.

## How

All container lifecycle messages in `go/internal/cli/commands/run.go` (created / created-not-started / started / running-in-detached-mode / stopped, across `startAndStreamContainer`, `runMacOSNativeContainer`, and `streamRunContainer`) now go through a small `containerDisplayName` helper that prints `AppConfig.ContainerName()` — `{appId}_{serviceName}` when the config describes one service of a multi-service app. That is the same identity the agent derives at container-create time (it names the container from the marshaled `AppConfig`'s `AppID`+`ServiceName`, not from the RPC's `AppName`) and that start/stop resolve, so the CLI now reports the name that actually exists on the device.

The detached deploy **fast path** (`tryDeployFastPath` in `deployfastpath.go`) emits the same class of lifecycle output — "already up to date and running" / "started existing" — for the same single-container appCfg, so it was routed through the same helper in a follow-up commit. Without it the fast path kept printing the bare appId, reproducing the exact WDY-1828 symptom whenever a `--detach` deploy hit the no-rebuild path.

Single-container apps are unaffected: `ContainerName()` returns the bare appId there (verified by test). The compose and multi-service group paths already printed the correct per-service names and were not touched. gRPC requests are also untouched — the agent resolves bare appIds via its `sh.wendy/app.id` label fallback on start/stop — so this fix is output-only, per the issue scope.

## How tested

- New `TestContainerDisplayName` in `run_test.go` covers both the single-container (no service suffix) and service-of-multi-service (`appId_service`) cases; both run.go and the fast-path sites now call this tested helper.
- `go test ./internal/cli/commands/ ./internal/shared/appconfig/` — all pass.
- `go build ./...` — clean. `gofmt -l` on all changed files — clean.

Follow-up validation (not run here — needs hardware, local build + unit tests only): deploy one service of a multi-service app to a live device (`wendy run --service llm` or a service-scoped wendy.json) and confirm the output prints `Container <appId>_<service> created.`; then re-run the same `wendy run --detach` unchanged to exercise the fast path and confirm it prints `started existing <appId>_<service>` / `<appId>_<service> is already up to date and running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

