### PR TITLE
agent: reintroduce agent-run healthchecks alongside wendyos-update commit

### DIFF
--- a/go/internal/agent/oshealth/gate.go
+++ b/go/internal/agent/oshealth/gate.go
@@ -30,18 +30,26 @@ type UpdaterResult struct {
 }
 
 // Gate decides, at agent startup, whether a pending A/B update is committed or
-// rolled back. The update backend (wendyos-update) runs its own health gate
-// inside commit (/etc/wendyos-update/health.d), so the gate performs no
-// healthchecks itself: it drives commit and acts on the verdict, rolling back
-// when the backend rejects it. All side effects are injected so the decision
-// logic is testable.
+// rolled back. For a backend that runs its own health gate inside commit
+// (wendyos-update, DelegatedHealth) it acts on the commit verdict; otherwise
+// it bases the decision on agent-run healthchecks of critical services. All
+// side effects are injected so the decision logic is testable.
 type Gate struct {
 	Logger   *zap.Logger
 	StateDir string
+	Services []CriticalService
+	Checker  *Checker
 	// Commit runs `<backend> commit`.
 	Commit func() UpdaterResult
 	// Rollback runs `<backend> rollback`.
 	Rollback func() UpdaterResult
+	// DelegatedHealth is true when the update backend runs its own post-commit
+	// health gate (wendyos-update runs /etc/wendyos-update/health.d inside
+	// commit). The gate then skips its own CheckAll and lets the commit decide:
+	// a commit failure is the backend's health verdict, which drives the
+	// rollback. A backend without such a gate (false) keeps the agent-run
+	// CheckAll.
+	DelegatedHealth bool
 	// UpdaterLabel names the backend binary in user-facing notes
 	// (e.g. "wendyos-update"). Empty defaults to "wendyos-update".
 	UpdaterLabel string
@@ -55,9 +63,10 @@ type Gate struct {
 	Now func() time.Time
 }
 
-// Run executes the commit-or-rollback decision. It blocks until the backend's
-// commit (or rollback) returns; it never panics, and all errors are logged.
-func (g *Gate) Run() {
+// Run executes the commit-or-rollback decision. It blocks until the decision
+// is made: milliseconds on healthy boots, up to the largest service timeout
+// when services are unhealthy. It never panics; all errors are logged.
+func (g *Gate) Run(ctx context.Context) {
 	marker, found, err := ReadPendingMarker(g.StateDir)
 	if err != nil {
 		g.Logger.Warn("Pending OS update marker is unreadable, discarding it", zap.Error(err))
@@ -101,19 +110,71 @@ func (g *Gate) Run() {
 		CreatedAt:    g.now(),
 	}
 
-	g.Logger.Info("Pending OS update detected; delegating healthchecks to the updater's commit",
+	if g.DelegatedHealth {
+		// The backend (wendyos-update) runs /etc/wendyos-update/health.d inside
+		// `commit`, so the commit itself is the health verdict. Skip the agent's
+		// CheckAll and act on the commit result; a rejection rolls back.
+		g.Logger.Info("Pending OS update detected; delegating healthchecks to the updater's commit",
+			zap.String("old_os_version", marker.OldOSVersion))
+		g.commitDelegated(record)
+		return
+	}
+
+	g.Logger.Info("Pending OS update detected, healthchecking critical services before commit",
 		zap.String("old_os_version", marker.OldOSVersion))
+	results := g.Checker.CheckAll(ctx, g.Services)
+	record.Services = results
+
+	if failed := failedUnits(results); len(failed) > 0 {
+		// Log the full results too: if persisting the record fails, this
+		// journal line is the only evidence of why the device rolled back.
+		g.Logger.Error("Critical services unhealthy after OS update, rolling back",
+			zap.Strings("failed_units", failed), zap.Any("services", results))
+		g.rollBack(record)
+		return
+	}
+
+	g.Logger.Info("Critical services healthy after OS update, committing")
 	g.commit(record)
 }
 
-// commit drives the backend's commit for a pending update and interprets the
-// verdict. The backend runs its own health gate inside commit (wendyos-update
-// runs /etc/wendyos-update/health.d), so a commit the updater *rejected* is
-// the health verdict: it rolls back rather than retrying. The two "no verdict
-// was rendered" cases — a missing binary and the agent's own commit timeout —
-// keep the marker and retry instead, so a transient early-boot hiccup never
-// reverts a possibly-healthy slot.
 func (g *Gate) commit(record UpdateResult) {
+	res := g.Commit()
+	switch res.Status {
+	case UpdaterOK:
+		record.Outcome = OutcomeCommitted
+		record.FinalizedAt = g.now()
+		g.writeResult(record)
+		g.clearMarker()
+		g.Logger.Info("Committed OS update", zap.String("output", res.Output))
+	case UpdaterNothingPending:
+		// Already committed (e.g. by a previous agent start that died before
+		// clearing the marker). Treat as success.
+		record.Outcome = OutcomeCommitted
+		record.FinalizedAt = g.now()
+		record.Note = g.updaterLabel() + " reported nothing to commit (update was already committed)"
+		g.writeResult(record)
+		g.clearMarker()
+	default:
+		// Keep the marker so the commit is retried on the next agent start;
+		// the staleness window caps how long that goes on. Don't reboot: an
+		// uncommitted update means the bootloader reverts on the next reboot,
+		// and rebooting here would throw away a healthy slot.
+		record.Outcome = OutcomeCommitFailed
+		record.Note = updaterFailureReason(g.updaterLabel(), "commit", res)
+		g.writeResult(record)
+		g.Logger.Error("Failed to commit OS update", zap.String("reason", record.Note))
+	}
+}
+
+// commitDelegated handles the commit/rollback decision for a backend that runs
+// its own health gate inside `commit` (wendyos-update runs
+// /etc/wendyos-update/health.d). It diverges from commit() only in the failure
+// branch: a commit the updater *rejected* is the health verdict, so it rolls
+// back rather than retrying. The two "no verdict was rendered" cases — a missing
+// binary and the agent's own commit timeout — keep the marker and retry instead,
+// so a transient early-boot hiccup never reverts a possibly-healthy slot.
+func (g *Gate) commitDelegated(record UpdateResult) {
 	res := g.Commit()
 	switch res.Status {
 	case UpdaterOK:
@@ -275,6 +336,16 @@ func (g *Gate) updaterLabel() string {
 		return g.UpdaterLabel
 	}
 	return "wendyos-update"
+}
+
+func failedUnits(results []ServiceResult) []string {
+	var failed []string
+	for _, r := range results {
+		if r.Status == StatusFailed {
+			failed = append(failed, r.Unit)
+		}
+	}
+	return failed
 }
 
 func updaterFailureReason(label, subcommand string, res UpdaterResult) string {

--- a/go/internal/agent/oshealth/gate_test.go
+++ b/go/internal/agent/oshealth/gate_test.go
@@ -14,7 +14,10 @@ import (
 
 var gateNow = time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
 
-// gateFixture wires a Gate with recorders for every side effect.
+// gateFixture wires a Gate with recorders for every side effect. It defaults
+// to the delegated-health path (the real wendyos-update backend, the only
+// registered backend): tests that need the agent's own CheckAll instead call
+// useAgentHealthchecks.
 type gateFixture struct {
 	gate     *Gate
 	dir      string
@@ -29,8 +32,9 @@ func newGateFixture(t *testing.T, commitResult, rollbackResult UpdaterResult) *g
 		dir: t.TempDir(),
 	}
 	fx.gate = &Gate{
-		Logger:   zap.NewNop(),
-		StateDir: fx.dir,
+		Logger:          zap.NewNop(),
+		StateDir:        fx.dir,
+		DelegatedHealth: true,
 		Commit: func() UpdaterResult {
 			fx.commits++
 			return commitResult
@@ -48,6 +52,21 @@ func newGateFixture(t *testing.T, commitResult, rollbackResult UpdaterResult) *g
 		Now:       func() time.Time { return gateNow },
 	}
 	return fx
+}
+
+// useAgentHealthchecks switches a fixture's gate to the non-delegated path:
+// the agent runs CheckAll against the given fake systemd responses before
+// deciding commit vs rollback. Returns the fake so tests can assert call
+// counts or mutate sequences mid-test.
+func (fx *gateFixture) useAgentHealthchecks(sequences map[string][]map[string]string, services []CriticalService) *fakeSystemctl {
+	systemd := &fakeSystemctl{sequences: sequences}
+	checker := NewChecker(zap.NewNop())
+	checker.PollInterval = 5 * time.Millisecond
+	checker.SystemctlShow = systemd.show
+	fx.gate.DelegatedHealth = false
+	fx.gate.Services = services
+	fx.gate.Checker = checker
+	return systemd
 }
 
 func (fx *gateFixture) writeFreshMarker(t *testing.T) {
@@ -83,7 +102,7 @@ func (fx *gateFixture) readResult(t *testing.T) (UpdateResult, bool) {
 func TestGateNoMarkerPlainCommit(t *testing.T) {
 	fx := newGateFixture(t, UpdaterResult{Status: UpdaterNothingPending}, UpdaterResult{})
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.commits != 1 {
 		t.Errorf("commits = %d, want 1", fx.commits)
@@ -109,7 +128,7 @@ func TestGateNoMarkerFinalizesRolledBackRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	rec, found := fx.readResult(t)
 	if !found {
@@ -138,7 +157,7 @@ func TestGateNoMarkerDoesNotRefinalize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	rec, _ := fx.readResult(t)
 	if !rec.FinalizedAt.Equal(finalized) {
@@ -153,7 +172,7 @@ func TestGateStaleMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.markerExists(t) {
 		t.Error("stale marker should be cleared")
@@ -175,7 +194,7 @@ func TestGateCorruptMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.markerExists(t) {
 		t.Error("corrupt marker should be cleared")
@@ -196,7 +215,7 @@ func TestGateSameBootLeavesMarkerUntouched(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.commits != 0 || fx.rollback != 0 || fx.reboots != 0 {
 		t.Errorf("commits=%d rollback=%d reboots=%d, want 0/0/0 before the reboot",
@@ -225,7 +244,7 @@ func TestGateStaleSameBootLeavesMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.commits != 0 || fx.rollback != 0 || fx.reboots != 0 {
 		t.Errorf("commits=%d rollback=%d reboots=%d, want 0/0/0: a never-booted slot must not be committed",
@@ -236,13 +255,280 @@ func TestGateStaleSameBootLeavesMarker(t *testing.T) {
 	}
 }
 
-// The following three tests exercise every outcome branch of rollBack():
-// UpdaterNothingPending and UpdaterUnavailable here, UpdaterError (default) in
+// The following tests exercise the agent-run CheckAll path used when the
+// backend does not delegate healthchecking to its own commit.
+
+func TestGateDifferentBootRunsHealthchecks(t *testing.T) {
+	fx := newGateFixture(t, UpdaterResult{Status: UpdaterOK}, UpdaterResult{})
+	fx.useAgentHealthchecks(map[string][]map[string]string{
+		"a.service": {loaded("active")},
+		"b.service": {loaded("active")},
+	}, []CriticalService{
+		{Unit: "a.service", Timeout: 50 * time.Millisecond},
+		{Unit: "b.service", Timeout: 50 * time.Millisecond},
+	})
+	err := WritePendingMarker(fx.dir, PendingMarker{
+		CreatedAt:    gateNow.Add(-2 * time.Minute),
+		OldOSVersion: "WendyOS-0.10.4",
+		BootID:       "boot-before-update",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fx.gate.Run(context.Background())
+
+	if fx.commits != 1 {
+		t.Errorf("commits = %d, want 1", fx.commits)
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeCommitted {
+		t.Fatalf("expected committed record, got found=%v %+v", found, rec)
+	}
+}
+
+func TestGateHealthyCommitOK(t *testing.T) {
+	fx := newGateFixture(t, UpdaterResult{Status: UpdaterOK}, UpdaterResult{})
+	fx.useAgentHealthchecks(map[string][]map[string]string{
+		"a.service": {loaded("active")},
+		"b.service": {loaded("active")},
+	}, []CriticalService{
+		{Unit: "a.service", Timeout: 50 * time.Millisecond},
+		{Unit: "b.service", Timeout: 50 * time.Millisecond},
+	})
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.commits != 1 || fx.rollback != 0 || fx.reboots != 0 {
+		t.Errorf("commits=%d rollback=%d reboots=%d, want 1/0/0", fx.commits, fx.rollback, fx.reboots)
+	}
+	if fx.markerExists(t) {
+		t.Error("marker should be cleared after commit")
+	}
+	rec, found := fx.readResult(t)
+	if !found {
+		t.Fatal("expected a committed record")
+	}
+	if rec.Outcome != OutcomeCommitted {
+		t.Errorf("Outcome = %q, want committed", rec.Outcome)
+	}
+	if rec.OldOSVersion != "WendyOS-0.10.4" || rec.NewOSVersion != "WendyOS-0.11.0" {
+		t.Errorf("versions: %+v", rec)
+	}
+	if len(rec.Services) != 2 || rec.Services[0].Status != StatusHealthy {
+		t.Errorf("services: %+v", rec.Services)
+	}
+	if !rec.CreatedAt.Equal(gateNow) || rec.FinalizedAt.IsZero() {
+		t.Errorf("timestamps: created=%v finalized=%v", rec.CreatedAt, rec.FinalizedAt)
+	}
+}
+
+func TestGateHealthyCommitNothingPending(t *testing.T) {
+	fx := newGateFixture(t, UpdaterResult{Status: UpdaterNothingPending}, UpdaterResult{})
+	fx.useAgentHealthchecks(map[string][]map[string]string{
+		"a.service": {loaded("active")},
+		"b.service": {loaded("active")},
+	}, []CriticalService{
+		{Unit: "a.service", Timeout: 50 * time.Millisecond},
+		{Unit: "b.service", Timeout: 50 * time.Millisecond},
+	})
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.markerExists(t) {
+		t.Error("marker should be cleared")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeCommitted {
+		t.Fatalf("expected committed record, got found=%v %+v", found, rec)
+	}
+	if rec.Note == "" {
+		t.Error("expected a note explaining there was nothing to commit")
+	}
+}
+
+func TestGateHealthyCommitError(t *testing.T) {
+	fx := newGateFixture(t,
+		UpdaterResult{Status: UpdaterError, Err: errors.New("boom"), Output: "commit exploded"},
+		UpdaterResult{})
+	fx.useAgentHealthchecks(map[string][]map[string]string{
+		"a.service": {loaded("active")},
+		"b.service": {loaded("active")},
+	}, []CriticalService{
+		{Unit: "a.service", Timeout: 50 * time.Millisecond},
+		{Unit: "b.service", Timeout: 50 * time.Millisecond},
+	})
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if !fx.markerExists(t) {
+		t.Error("marker should be kept so the commit is retried next start")
+	}
+	if fx.reboots != 0 {
+		t.Error("must not reboot on commit failure")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeCommitFailed {
+		t.Fatalf("expected commit_failed record, got found=%v %+v", found, rec)
+	}
+	if !strings.Contains(rec.Note, "boom") && !strings.Contains(rec.Note, "commit exploded") {
+		t.Errorf("note should carry the commit error, got %q", rec.Note)
+	}
+}
+
+func TestGateAgentHealthcheckRollbackOK(t *testing.T) {
+	fx := newGateFixture(t, UpdaterResult{}, UpdaterResult{Status: UpdaterOK})
+	systemd := fx.useAgentHealthchecks(map[string][]map[string]string{
+		"a.service": {loaded("active")},
+		"b.service": {{
+			"LoadState": "loaded", "ActiveState": "failed", "SubState": "exited",
+			"Result": "exit-code", "UnitFileState": "enabled",
+		}},
+	}, []CriticalService{
+		{Unit: "a.service", Timeout: 50 * time.Millisecond},
+		{Unit: "b.service", Timeout: 50 * time.Millisecond},
+	})
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if systemd == nil {
+		t.Fatal("expected a fake systemd")
+	}
+	if fx.commits != 0 {
+		t.Error("must not commit when a healthcheck failed")
+	}
+	if fx.rollback != 1 || fx.reboots != 1 {
+		t.Errorf("rollback=%d reboots=%d, want 1/1", fx.rollback, fx.reboots)
+	}
+	if fx.markerExists(t) {
+		t.Error("marker should be cleared before rebooting into the old slot")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeRolledBack {
+		t.Fatalf("expected rolled_back record, got found=%v %+v", found, rec)
+	}
+	if !rec.FinalizedAt.IsZero() {
+		t.Error("rolled_back record must not be finalized until the old slot boots")
+	}
+	var failed *ServiceResult
+	for i := range rec.Services {
+		if rec.Services[i].Status == StatusFailed {
+			failed = &rec.Services[i]
+		}
+	}
+	if failed == nil || failed.Unit != "b.service" || !strings.Contains(failed.Reason, "timed out") {
+		t.Errorf("failure details missing: %+v", rec.Services)
+	}
+}
+
+func TestGateAgentHealthcheckRollbackNothingPending(t *testing.T) {
+	fx := newGateFixture(t, UpdaterResult{}, UpdaterResult{Status: UpdaterNothingPending})
+	fx.useAgentHealthchecks(map[string][]map[string]string{
+		"a.service": {loaded("inactive")},
+		"b.service": {loaded("inactive")},
+	}, []CriticalService{
+		{Unit: "a.service", Timeout: 50 * time.Millisecond},
+		{Unit: "b.service", Timeout: 50 * time.Millisecond},
+	})
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.reboots != 0 {
+		t.Error("must not reboot when there is nothing to roll back (no slot change would happen)")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeRollbackFailed {
+		t.Fatalf("expected rollback_failed record, got found=%v %+v", found, rec)
+	}
+	if !strings.Contains(rec.RollbackError, "nothing to roll back") {
+		t.Errorf("RollbackError = %q", rec.RollbackError)
+	}
+}
+
+func TestGateAgentHealthcheckRollbackError(t *testing.T) {
+	fx := newGateFixture(t, UpdaterResult{},
+		UpdaterResult{Status: UpdaterError, Err: errors.New("rollback exploded")})
+	fx.useAgentHealthchecks(map[string][]map[string]string{
+		"a.service": {loaded("inactive")},
+		"b.service": {loaded("inactive")},
+	}, []CriticalService{
+		{Unit: "a.service", Timeout: 50 * time.Millisecond},
+		{Unit: "b.service", Timeout: 50 * time.Millisecond},
+	})
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.reboots != 1 {
+		t.Error("should still reboot: the uncommitted update makes the bootloader fall back")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeRolledBack {
+		t.Fatalf("expected rolled_back record, got found=%v %+v", found, rec)
+	}
+	if !strings.Contains(rec.RollbackError, "rollback exploded") {
+		t.Errorf("RollbackError = %q", rec.RollbackError)
+	}
+}
+
+func TestGateAgentHealthcheckRollbackUnavailable(t *testing.T) {
+	fx := newGateFixture(t, UpdaterResult{}, UpdaterResult{Status: UpdaterUnavailable})
+	fx.useAgentHealthchecks(map[string][]map[string]string{
+		"a.service": {loaded("inactive")},
+		"b.service": {loaded("inactive")},
+	}, []CriticalService{
+		{Unit: "a.service", Timeout: 50 * time.Millisecond},
+		{Unit: "b.service", Timeout: 50 * time.Millisecond},
+	})
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.reboots != 0 {
+		t.Error("must not reboot when the updater is unavailable")
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeRollbackFailed {
+		t.Fatalf("expected rollback_failed record, got found=%v %+v", found, rec)
+	}
+}
+
+func TestGateAllSkippedCountsAsHealthy(t *testing.T) {
+	fx := newGateFixture(t, UpdaterResult{Status: UpdaterOK}, UpdaterResult{})
+	fx.useAgentHealthchecks(map[string][]map[string]string{
+		"a.service": {{"LoadState": "not-found", "ActiveState": "inactive"}},
+		"b.service": {{"LoadState": "not-found", "ActiveState": "inactive"}},
+	}, []CriticalService{
+		{Unit: "a.service", Timeout: 50 * time.Millisecond},
+		{Unit: "b.service", Timeout: 50 * time.Millisecond},
+	})
+	fx.writeFreshMarker(t)
+
+	fx.gate.Run(context.Background())
+
+	if fx.commits != 1 || fx.rollback != 0 {
+		t.Errorf("commits=%d rollback=%d, want 1/0", fx.commits, fx.rollback)
+	}
+	rec, found := fx.readResult(t)
+	if !found || rec.Outcome != OutcomeCommitted {
+		t.Fatalf("expected committed record, got found=%v %+v", found, rec)
+	}
+}
+
+// The following three tests exercise every outcome branch of rollBack() for a
+// backend that delegates healthchecking to its own commit (DelegatedHealth,
+// the default in this fixture, matching wendyos-update): UpdaterNothingPending
+// and UpdaterUnavailable here, UpdaterError (default) in
 // TestGateUnhealthyRollbackError, and UpdaterOK in
 // TestGateDelegatedCommitRejectedRollsBack. All three trigger the rollback via
-// a rejected commit, since that is the only way the gate now rolls back — the
-// updater runs its own health gate (/etc/wendyos-update/health.d) inside
-// commit.
+// a rejected commit — the updater runs its own health gate
+// (/etc/wendyos-update/health.d) inside commit, so there is no separate
+// CheckAll failure to trigger it on this path.
 
 func TestGateUnhealthyRollbackNothingPending(t *testing.T) {
 	fx := newGateFixture(t,
@@ -250,7 +536,7 @@ func TestGateUnhealthyRollbackNothingPending(t *testing.T) {
 		UpdaterResult{Status: UpdaterNothingPending})
 	fx.writeFreshMarker(t)
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.commits != 1 || fx.rollback != 1 {
 		t.Errorf("commits=%d rollback=%d, want 1/1", fx.commits, fx.rollback)
@@ -273,7 +559,7 @@ func TestGateUnhealthyRollbackError(t *testing.T) {
 		UpdaterResult{Status: UpdaterError, Err: errors.New("rollback exploded")})
 	fx.writeFreshMarker(t)
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.reboots != 1 {
 		t.Error("should still reboot: the uncommitted update makes the bootloader fall back")
@@ -293,7 +579,7 @@ func TestGateUnhealthyRollbackUnavailable(t *testing.T) {
 		UpdaterResult{Status: UpdaterUnavailable})
 	fx.writeFreshMarker(t)
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.reboots != 0 {
 		t.Error("must not reboot when the updater is unavailable")
@@ -311,7 +597,7 @@ func TestGateDelegatedHealthyCommitOK(t *testing.T) {
 	fx := newGateFixture(t, UpdaterResult{Status: UpdaterOK}, UpdaterResult{})
 	fx.writeFreshMarker(t)
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.commits != 1 || fx.rollback != 0 || fx.reboots != 0 {
 		t.Errorf("commits=%d rollback=%d reboots=%d, want 1/0/0", fx.commits, fx.rollback, fx.reboots)
@@ -324,7 +610,7 @@ func TestGateDelegatedHealthyCommitOK(t *testing.T) {
 		t.Fatalf("expected committed record, got found=%v %+v", found, rec)
 	}
 	if len(rec.Services) != 0 {
-		t.Errorf("commit must not record agent service results: %+v", rec.Services)
+		t.Errorf("delegated commit must not record agent service results: %+v", rec.Services)
 	}
 	if rec.FinalizedAt.IsZero() {
 		t.Error("committed record should be finalized")
@@ -335,7 +621,7 @@ func TestGateDelegatedCommitNothingPending(t *testing.T) {
 	fx := newGateFixture(t, UpdaterResult{Status: UpdaterNothingPending}, UpdaterResult{})
 	fx.writeFreshMarker(t)
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.rollback != 0 || fx.reboots != 0 {
 		t.Errorf("rollback=%d reboots=%d, want 0/0", fx.rollback, fx.reboots)
@@ -361,7 +647,7 @@ func TestGateDelegatedCommitRejectedRollsBack(t *testing.T) {
 		UpdaterResult{Status: UpdaterOK})
 	fx.writeFreshMarker(t)
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.commits != 1 || fx.rollback != 1 || fx.reboots != 1 {
 		t.Errorf("commits=%d rollback=%d reboots=%d, want 1/1/1", fx.commits, fx.rollback, fx.reboots)
@@ -388,7 +674,7 @@ func TestGateDelegatedCommitUnavailableNoRollback(t *testing.T) {
 	fx := newGateFixture(t, UpdaterResult{Status: UpdaterUnavailable}, UpdaterResult{Status: UpdaterOK})
 	fx.writeFreshMarker(t)
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.rollback != 0 || fx.reboots != 0 {
 		t.Errorf("rollback=%d reboots=%d, want 0/0 when the backend is unavailable", fx.rollback, fx.reboots)
@@ -414,7 +700,7 @@ func TestGateDelegatedCommitTimeoutRetries(t *testing.T) {
 		UpdaterResult{Status: UpdaterOK})
 	fx.writeFreshMarker(t)
 
-	fx.gate.Run()
+	fx.gate.Run(context.Background())
 
 	if fx.rollback != 0 || fx.reboots != 0 {
 		t.Errorf("rollback=%d reboots=%d, want 0/0 on a commit timeout", fx.rollback, fx.reboots)

--- a/go/internal/agent/oshealth/healthcheck.go
+++ b/go/internal/agent/oshealth/healthcheck.go
@@ -1,0 +1,151 @@
+package oshealth
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const defaultPollInterval = 500 * time.Millisecond
+
+// Checker polls systemd until critical services are active or their timeout
+// expires.
+type Checker struct {
+	Logger       *zap.Logger
+	PollInterval time.Duration
+	// SystemctlShow returns the properties of a systemd unit as reported by
+	// `systemctl show`; injectable for tests.
+	SystemctlShow func(ctx context.Context, unit string) (map[string]string, error)
+}
+
+// NewChecker returns a Checker that queries systemd via systemctl.
+func NewChecker(logger *zap.Logger) *Checker {
+	return &Checker{
+		Logger:        logger,
+		PollInterval:  defaultPollInterval,
+		SystemctlShow: systemctlShow,
+	}
+}
+
+// CheckAll checks all services concurrently (total wall time is the slowest
+// single check, not the sum) and returns one result per service, in input
+// order.
+func (c *Checker) CheckAll(ctx context.Context, services []CriticalService) []ServiceResult {
+	results := make([]ServiceResult, len(services))
+	var wg sync.WaitGroup
+	for i, svc := range services {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = c.checkOne(ctx, svc)
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+func (c *Checker) checkOne(ctx context.Context, svc CriticalService) ServiceResult {
+	interval := c.PollInterval
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	deadline := time.Now().Add(svc.Timeout)
+	// Bound SystemctlShow by the service deadline: systemctl itself can hang
+	// when systemd or D-Bus is unhealthy — exactly the boots this gate exists
+	// for — and an unbounded call would block agent startup forever.
+	checkCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	lastState := "no state observed"
+
+	for {
+		props, err := c.SystemctlShow(checkCtx, svc.Unit)
+		switch {
+		case err != nil:
+			// systemctl itself may be briefly unavailable early in boot;
+			// keep retrying until the timeout.
+			lastState = fmt.Sprintf("systemctl error: %v", err)
+		case props["LoadState"] == "not-found":
+			return ServiceResult{Unit: svc.Unit, Status: StatusSkipped, Reason: "unit not present on this device"}
+		case props["ActiveState"] == "active":
+			return ServiceResult{Unit: svc.Unit, Status: StatusHealthy}
+		case props["UnitFileState"] == "disabled" || props["UnitFileState"] == "masked" || props["LoadState"] == "masked":
+			// A unit that ships on the image but is intentionally not enabled
+			// must not block (and endlessly roll back) updates.
+			return ServiceResult{
+				Unit:   svc.Unit,
+				Status: StatusSkipped,
+				Reason: fmt.Sprintf("unit is %s on this device", props["UnitFileState"]),
+			}
+		default:
+			lastState = fmt.Sprintf("ActiveState=%s SubState=%s", props["ActiveState"], props["SubState"])
+			if result := props["Result"]; result != "" && result != "success" {
+				lastState += fmt.Sprintf(" Result=%s", result)
+			}
+		}
+
+		timedOut := ServiceResult{
+			Unit:   svc.Unit,
+			Status: StatusFailed,
+			Reason: fmt.Sprintf("timed out after %s waiting for active; last state: %s", svc.Timeout, lastState),
+		}
+		if time.Now().After(deadline) {
+			return timedOut
+		}
+		select {
+		case <-checkCtx.Done():
+			// checkCtx closes both when the caller cancels and when the
+			// service deadline expires; only the former is an abort.
+			if ctx.Err() != nil {
+				return ServiceResult{
+					Unit:   svc.Unit,
+					Status: StatusFailed,
+					Reason: fmt.Sprintf("check aborted: %v; last state: %s", ctx.Err(), lastState),
+				}
+			}
+			return timedOut
+		case <-time.After(interval):
+		}
+	}
+}
+
+// systemctlShow runs `systemctl show` for the unit and parses its KEY=VALUE
+// output. The absolute path matters: the agent runs under systemd with a
+// restricted PATH.
+func systemctlShow(ctx context.Context, unit string) (map[string]string, error) {
+	cmd := exec.CommandContext(ctx, "/usr/bin/systemctl", "show",
+		"--property=LoadState,ActiveState,SubState,Result,UnitFileState", unit)
+	cmd.Env = envWithPath("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+	// Don't wait forever for the killed process's pipes after cancellation.
+	cmd.WaitDelay = 5 * time.Second
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("systemctl show %s: %w", unit, err)
+	}
+	props := make(map[string]string)
+	for line := range strings.Lines(string(out)) {
+		key, value, found := strings.Cut(strings.TrimSpace(line), "=")
+		if found {
+			props[key] = value
+		}
+	}
+	return props, nil
+}
+
+// envWithPath returns os.Environ() with the PATH entry replaced by the given
+// value, mirroring the convention used for other system tools the agent execs.
+func envWithPath(path string) []string {
+	env := os.Environ()
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + path
+			return env
+		}
+	}
+	return append(env, "PATH="+path)
+}

--- a/go/internal/agent/oshealth/healthcheck_test.go
+++ b/go/internal/agent/oshealth/healthcheck_test.go
@@ -1,0 +1,263 @@
+package oshealth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// fakeSystemctl returns canned `systemctl show` property maps per unit. Each
+// call for a unit consumes the next entry in its sequence; the last entry
+// repeats once the sequence is exhausted.
+type fakeSystemctl struct {
+	mu        sync.Mutex
+	sequences map[string][]map[string]string
+	errs      map[string]error
+	calls     map[string]int
+}
+
+func (f *fakeSystemctl) show(_ context.Context, unit string) (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.calls == nil {
+		f.calls = make(map[string]int)
+	}
+	n := f.calls[unit]
+	f.calls[unit] = n + 1
+	if err := f.errs[unit]; err != nil {
+		return nil, err
+	}
+	seq := f.sequences[unit]
+	if len(seq) == 0 {
+		return map[string]string{"LoadState": "not-found", "ActiveState": "inactive"}, nil
+	}
+	if n >= len(seq) {
+		n = len(seq) - 1
+	}
+	return seq[n], nil
+}
+
+func (f *fakeSystemctl) callCount(unit string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[unit]
+}
+
+func newTestChecker(f *fakeSystemctl) *Checker {
+	c := NewChecker(zap.NewNop())
+	c.PollInterval = 5 * time.Millisecond
+	c.SystemctlShow = f.show
+	return c
+}
+
+func loaded(active string) map[string]string {
+	return map[string]string{"LoadState": "loaded", "ActiveState": active, "SubState": active, "UnitFileState": "enabled"}
+}
+
+func TestCheckOneActiveIsHealthy(t *testing.T) {
+	f := &fakeSystemctl{sequences: map[string][]map[string]string{
+		"avahi-daemon.service": {loaded("active")},
+	}}
+	c := newTestChecker(f)
+
+	got := c.CheckAll(context.Background(), []CriticalService{{Unit: "avahi-daemon.service", Timeout: time.Second}})
+
+	want := []ServiceResult{{Unit: "avahi-daemon.service", Status: StatusHealthy}}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestCheckOneActivatingThenActiveIsHealthy(t *testing.T) {
+	f := &fakeSystemctl{sequences: map[string][]map[string]string{
+		"containerd.service": {loaded("activating"), loaded("activating"), loaded("active")},
+	}}
+	c := newTestChecker(f)
+
+	got := c.CheckAll(context.Background(), []CriticalService{{Unit: "containerd.service", Timeout: time.Second}})
+
+	if got[0].Status != StatusHealthy {
+		t.Errorf("got %+v, want healthy", got[0])
+	}
+	if f.callCount("containerd.service") < 3 {
+		t.Errorf("expected at least 3 polls, got %d", f.callCount("containerd.service"))
+	}
+}
+
+func TestCheckOneFailedUntilTimeout(t *testing.T) {
+	f := &fakeSystemctl{sequences: map[string][]map[string]string{
+		"avahi-daemon.service": {{
+			"LoadState": "loaded", "ActiveState": "failed", "SubState": "exited",
+			"Result": "exit-code", "UnitFileState": "enabled",
+		}},
+	}}
+	c := newTestChecker(f)
+
+	got := c.CheckAll(context.Background(), []CriticalService{{Unit: "avahi-daemon.service", Timeout: 50 * time.Millisecond}})
+
+	if got[0].Status != StatusFailed {
+		t.Fatalf("got %+v, want failed", got[0])
+	}
+	for _, substr := range []string{"timed out", "failed", "exit-code"} {
+		if !strings.Contains(got[0].Reason, substr) {
+			t.Errorf("reason %q missing %q", got[0].Reason, substr)
+		}
+	}
+}
+
+func TestCheckOneNotFoundIsSkippedWithoutPolling(t *testing.T) {
+	f := &fakeSystemctl{sequences: map[string][]map[string]string{
+		"NetworkManager.service": {{"LoadState": "not-found", "ActiveState": "inactive"}},
+	}}
+	c := newTestChecker(f)
+
+	got := c.CheckAll(context.Background(), []CriticalService{{Unit: "NetworkManager.service", Timeout: time.Second}})
+
+	if got[0].Status != StatusSkipped {
+		t.Fatalf("got %+v, want skipped", got[0])
+	}
+	if n := f.callCount("NetworkManager.service"); n != 1 {
+		t.Errorf("expected exactly 1 systemctl call, got %d", n)
+	}
+}
+
+func TestCheckOneDisabledInactiveIsSkipped(t *testing.T) {
+	f := &fakeSystemctl{sequences: map[string][]map[string]string{
+		"NetworkManager.service": {{
+			"LoadState": "loaded", "ActiveState": "inactive", "SubState": "dead", "UnitFileState": "disabled",
+		}},
+	}}
+	c := newTestChecker(f)
+
+	got := c.CheckAll(context.Background(), []CriticalService{{Unit: "NetworkManager.service", Timeout: time.Second}})
+
+	if got[0].Status != StatusSkipped {
+		t.Errorf("got %+v, want skipped", got[0])
+	}
+}
+
+func TestCheckOneMaskedIsSkipped(t *testing.T) {
+	f := &fakeSystemctl{sequences: map[string][]map[string]string{
+		"NetworkManager.service": {{
+			"LoadState": "masked", "ActiveState": "inactive", "UnitFileState": "masked",
+		}},
+	}}
+	c := newTestChecker(f)
+
+	got := c.CheckAll(context.Background(), []CriticalService{{Unit: "NetworkManager.service", Timeout: time.Second}})
+
+	if got[0].Status != StatusSkipped {
+		t.Errorf("got %+v, want skipped", got[0])
+	}
+}
+
+func TestCheckOneDisabledButActiveIsHealthy(t *testing.T) {
+	f := &fakeSystemctl{sequences: map[string][]map[string]string{
+		"avahi-daemon.service": {{
+			"LoadState": "loaded", "ActiveState": "active", "SubState": "running", "UnitFileState": "disabled",
+		}},
+	}}
+	c := newTestChecker(f)
+
+	got := c.CheckAll(context.Background(), []CriticalService{{Unit: "avahi-daemon.service", Timeout: time.Second}})
+
+	if got[0].Status != StatusHealthy {
+		t.Errorf("got %+v, want healthy", got[0])
+	}
+}
+
+func TestCheckOneSystemctlErrorFailsAfterTimeout(t *testing.T) {
+	f := &fakeSystemctl{errs: map[string]error{
+		"containerd.service": errors.New("exec: systemctl: not found"),
+	}}
+	c := newTestChecker(f)
+
+	got := c.CheckAll(context.Background(), []CriticalService{{Unit: "containerd.service", Timeout: 30 * time.Millisecond}})
+
+	if got[0].Status != StatusFailed {
+		t.Fatalf("got %+v, want failed", got[0])
+	}
+	if !strings.Contains(got[0].Reason, "systemctl") {
+		t.Errorf("reason %q should mention the systemctl error", got[0].Reason)
+	}
+}
+
+func TestCheckOneHungSystemctlFailsAtTimeout(t *testing.T) {
+	c := NewChecker(zap.NewNop())
+	c.PollInterval = 5 * time.Millisecond
+	c.SystemctlShow = func(ctx context.Context, unit string) (map[string]string, error) {
+		// Simulate `systemctl show` hanging (e.g. D-Bus unresponsive during a
+		// bad boot): block until the context is cancelled.
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	start := time.Now()
+	got := c.CheckAll(context.Background(), []CriticalService{{Unit: "containerd.service", Timeout: 50 * time.Millisecond}})
+
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("hung systemctl blocked the check for %v, expected return at ~50ms timeout", elapsed)
+	}
+	if got[0].Status != StatusFailed {
+		t.Errorf("got %+v, want failed", got[0])
+	}
+	if !strings.Contains(got[0].Reason, "timed out") {
+		t.Errorf("reason %q should report the timeout", got[0].Reason)
+	}
+}
+
+func TestCheckOneContextCancelled(t *testing.T) {
+	f := &fakeSystemctl{sequences: map[string][]map[string]string{
+		"avahi-daemon.service": {loaded("activating")},
+	}}
+	c := newTestChecker(f)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	got := c.CheckAll(ctx, []CriticalService{{Unit: "avahi-daemon.service", Timeout: 10 * time.Second}})
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("cancelled check took %v, expected prompt return", elapsed)
+	}
+	if got[0].Status != StatusFailed {
+		t.Errorf("got %+v, want failed on cancellation", got[0])
+	}
+}
+
+func TestCheckAllRunsConcurrentlyAndPreservesOrder(t *testing.T) {
+	// Two units that never become active: serial execution would take the
+	// sum of the timeouts, concurrent execution roughly the max.
+	f := &fakeSystemctl{sequences: map[string][]map[string]string{
+		"a.service": {loaded("activating")},
+		"b.service": {loaded("activating")},
+		"c.service": {loaded("active")},
+	}}
+	c := newTestChecker(f)
+
+	start := time.Now()
+	got := c.CheckAll(context.Background(), []CriticalService{
+		{Unit: "a.service", Timeout: 200 * time.Millisecond},
+		{Unit: "b.service", Timeout: 200 * time.Millisecond},
+		{Unit: "c.service", Timeout: time.Second},
+	})
+	elapsed := time.Since(start)
+
+	if elapsed > 350*time.Millisecond {
+		t.Errorf("CheckAll took %v, expected concurrent execution (~200ms)", elapsed)
+	}
+	wantUnits := []string{"a.service", "b.service", "c.service"}
+	for i, w := range wantUnits {
+		if got[i].Unit != w {
+			t.Fatalf("result order %v, want %v", got, wantUnits)
+		}
+	}
+	if got[0].Status != StatusFailed || got[1].Status != StatusFailed || got[2].Status != StatusHealthy {
+		t.Errorf("unexpected statuses: %+v", got)
+	}
+}

--- a/go/internal/agent/oshealth/marker.go
+++ b/go/internal/agent/oshealth/marker.go
@@ -1,8 +1,8 @@
-// Package oshealth implements the post-OS-update commit-or-rollback decision
-// for pending A/B updates. The update backend runs its own health gate inside
-// commit (wendyos-update runs /etc/wendyos-update/health.d); this package
-// tracks the pending-update marker and persisted result across the reboot and
-// interprets the backend's commit/rollback verdict.
+// Package oshealth implements post-OS-update healthchecks for critical
+// system services and the commit-or-rollback decision for pending A/B
+// updates. A backend that runs its own health gate inside commit
+// (wendyos-update runs /etc/wendyos-update/health.d) delegates the verdict to
+// its commit result instead.
 package oshealth
 
 import (

--- a/go/internal/agent/oshealth/result.go
+++ b/go/internal/agent/oshealth/result.go
@@ -27,11 +27,10 @@ const (
 
 // ServiceStatus is the verdict of a single critical-service healthcheck.
 //
-// New gates no longer populate ServiceResult: healthchecking is delegated to
-// the update backend's own commit (wendyos-update runs
-// /etc/wendyos-update/health.d). ServiceStatus and ServiceResult remain only
-// because they are part of the persisted UpdateResult.Services schema, read by
-// GetOSUpdateStatus and by on-disk records written before delegation existed.
+// A gate only populates ServiceResult when it runs its own CheckAll — a
+// backend that delegates healthchecking to its own commit (wendyos-update
+// runs /etc/wendyos-update/health.d) renders its verdict through the commit
+// result instead, so its UpdateResult.Services is empty.
 type ServiceStatus string
 
 const (
@@ -42,8 +41,7 @@ const (
 	StatusFailed  ServiceStatus = "failed"
 )
 
-// ServiceResult is the outcome of checking one critical service. See
-// ServiceStatus for why this is no longer populated by new gates.
+// ServiceResult is the outcome of checking one critical service.
 type ServiceResult struct {
 	Unit   string        `json:"unit"`
 	Status ServiceStatus `json:"status"`

--- a/go/internal/agent/oshealth/services.go
+++ b/go/internal/agent/oshealth/services.go
@@ -1,0 +1,24 @@
+package oshealth
+
+import "time"
+
+// CriticalService is a systemd unit that must be healthy for an OS update to
+// be committed.
+type CriticalService struct {
+	// Unit is the systemd unit name, e.g. "avahi-daemon.service".
+	Unit string
+	// Timeout is how long to wait for the unit to become active before
+	// declaring the healthcheck failed. Units still start in parallel with
+	// the agent at boot, so this must absorb normal startup latency.
+	Timeout time.Duration
+}
+
+// DefaultCriticalServices is the healthcheck list applied after an OS update.
+// To protect an additional service, append an entry here. Units that are not
+// present on a device (or are intentionally disabled) are skipped, so entries
+// do not have to exist on every device type.
+var DefaultCriticalServices = []CriticalService{
+	{Unit: "avahi-daemon.service", Timeout: 30 * time.Second},
+	{Unit: "containerd.service", Timeout: 60 * time.Second},
+	{Unit: "NetworkManager.service", Timeout: 60 * time.Second},
+}

--- a/go/internal/agent/services/os_update_gate.go
+++ b/go/internal/agent/services/os_update_gate.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"net/url"
 	"time"
 
@@ -21,8 +22,8 @@ import (
 // just triggers commit and rolls back if it is rejected. If no backend binary
 // is present (e.g. a non-WendyOS host), commit/rollback degrade to no-ops
 // that report "unavailable", so the gate keeps a pending marker for retry
-// rather than committing or rolling back a slot with no health verdict (see
-// closuresForUpdater).
+// rather than committing or rolling back a slot with no health verdict — the
+// non-delegated (agent-run CheckAll) path (see closuresForUpdater).
 //
 // This must run before the gRPC server starts: the device must not appear back
 // online to a waiting `wendy os update` until the commit-or-rollback decision
@@ -35,21 +36,24 @@ func RunOSUpdateGate(logger *zap.Logger) {
 		logger.Warn("Pending OS update marker is unreadable; auto-selecting the update backend", zap.Error(err))
 	}
 	requested := requestedBackendFromMarker(marker, found && err == nil)
-	commit, rollback, label := commitClosures(logger, requested)
+	commit, rollback, delegatedHealth, label := commitClosures(logger, requested)
 
 	gate := &oshealth.Gate{
-		Logger:       logger,
-		StateDir:     oshealth.DefaultStateDir,
-		Commit:       commit,
-		Rollback:     rollback,
-		UpdaterLabel: label,
-		Reboot:       rebootSystem,
+		Logger:          logger,
+		StateDir:        oshealth.DefaultStateDir,
+		Services:        oshealth.DefaultCriticalServices,
+		Checker:         oshealth.NewChecker(logger),
+		Commit:          commit,
+		Rollback:        rollback,
+		DelegatedHealth: delegatedHealth,
+		UpdaterLabel:    label,
+		Reboot:          rebootSystem,
 		OSVersion: func() string {
 			v, _ := wendyOSVersion()
 			return v
 		},
 	}
-	gate.Run()
+	gate.Run(context.Background())
 }
 
 // requestedBackendFromMarker returns the backend the gate should drive: the one
@@ -63,13 +67,15 @@ func requestedBackendFromMarker(marker oshealth.PendingMarker, found bool) strin
 }
 
 // commitClosures resolves the backend for the gate and returns its
-// commit/rollback closures plus the binary label for user-facing failure
-// notes. It selects by binary presence (chooseUpdaterForCommit), not the
-// install-time connector probe: the update has already been installed, so a
-// transient probe failure must not block committing a healthy slot. If no
-// backend binary is present (e.g. a non-WendyOS host), it returns no-ops
-// reporting "unavailable" (see closuresForUpdater).
-func commitClosures(logger *zap.Logger, requested string) (commit, rollback func() oshealth.UpdaterResult, label string) {
+// commit/rollback plus the two policy bits the gate needs: whether the backend
+// delegates healthchecking to its own commit (wendyos-update) and the binary
+// label for user-facing failure notes. It selects by binary presence
+// (chooseUpdaterForCommit), not the install-time connector probe: the update has
+// already been installed, so a transient probe failure must not block committing
+// a healthy slot. If no backend binary is present (e.g. a non-WendyOS host), it
+// returns no-ops reporting "unavailable" so the gate falls back to the
+// non-delegated (agent-run CheckAll) path.
+func commitClosures(logger *zap.Logger, requested string) (commit, rollback func() oshealth.UpdaterResult, delegatedHealth bool, label string) {
 	updater := chooseUpdaterForCommit(requested, productionUpdaters(logger))
 	if updater == nil {
 		logger.Debug("No OS update backend available for the gate; commit/rollback are no-ops",
@@ -78,16 +84,16 @@ func commitClosures(logger *zap.Logger, requested string) (commit, rollback func
 	return closuresForUpdater(updater)
 }
 
-// closuresForUpdater maps a resolved backend (or nil) to the three values the
-// gate needs. A nil updater (no backend binary present) degrades to a no-op
-// commit/rollback that report "unavailable", under the "wendyos-update"
-// label.
-func closuresForUpdater(updater osUpdater) (commit, rollback func() oshealth.UpdaterResult, label string) {
+// closuresForUpdater maps a resolved backend (or nil) to the four values the
+// gate needs. A nil updater (no backend binary present) degrades to no-op
+// commit/rollback that report "unavailable", the non-delegated (agent-run)
+// healthcheck path, and the "wendyos-update" label.
+func closuresForUpdater(updater osUpdater) (commit, rollback func() oshealth.UpdaterResult, delegatedHealth bool, label string) {
 	if updater == nil {
 		noop := func() oshealth.UpdaterResult { return oshealth.UpdaterResult{Status: oshealth.UpdaterUnavailable} }
-		return noop, noop, "wendyos-update"
+		return noop, noop, false, "wendyos-update"
 	}
-	return updater.commit, updater.rollback, updater.commitCommand()
+	return updater.commit, updater.rollback, updater.delegatesHealthcheck(), updater.commitCommand()
 }
 
 // recordPendingOSUpdate persists the pending-update marker that the healthcheck

--- a/go/internal/agent/services/osupdater.go
+++ b/go/internal/agent/services/osupdater.go
@@ -45,6 +45,12 @@ type osUpdater interface {
 	commit() oshealth.UpdaterResult
 	// rollback reverts an uncommitted A/B update.
 	rollback() oshealth.UpdaterResult
+	// delegatesHealthcheck reports whether the backend runs its own post-commit
+	// health gate (wendyos-update runs /etc/wendyos-update/health.d inside
+	// commit), so the agent's boot-time gate must NOT run its own CheckAll for
+	// it. A backend without such a gate (false) keeps the agent gate owning the
+	// healthchecks.
+	delegatesHealthcheck() bool
 	// commitCommand is the binary name surfaced in user-facing commit/rollback
 	// failure notes (e.g. "wendyos-update").
 	commitCommand() string

--- a/go/internal/agent/services/osupdater_test.go
+++ b/go/internal/agent/services/osupdater_test.go
@@ -14,6 +14,7 @@ type fakeUpdater struct {
 	nameVal      string
 	detectVal    bool
 	availableVal bool
+	delegatesVal bool
 	commandVal   string
 }
 
@@ -25,6 +26,7 @@ func (f fakeUpdater) install(context.Context, string, func(string, int32)) error
 }
 func (f fakeUpdater) commit() oshealth.UpdaterResult   { return oshealth.UpdaterResult{} }
 func (f fakeUpdater) rollback() oshealth.UpdaterResult { return oshealth.UpdaterResult{} }
+func (f fakeUpdater) delegatesHealthcheck() bool       { return f.delegatesVal }
 func (f fakeUpdater) commitCommand() string            { return f.commandVal }
 
 func TestChooseUpdaterForCommit(t *testing.T) {
@@ -107,9 +109,12 @@ func TestChooseUpdaterForCommit(t *testing.T) {
 	}
 }
 
-func TestWendyOSCommitCommand(t *testing.T) {
+func TestWendyOSBackendPolicy(t *testing.T) {
 	wendyos := newWendyOSUpdater(zap.NewNop())
 
+	if !wendyos.delegatesHealthcheck() {
+		t.Error("wendyos-update must delegate healthchecking to its own commit (health.d)")
+	}
 	if wendyos.commitCommand() != "wendyos-update" {
 		t.Errorf("wendyos commitCommand = %q, want wendyos-update", wendyos.commitCommand())
 	}
@@ -117,26 +122,38 @@ func TestWendyOSCommitCommand(t *testing.T) {
 
 func TestClosuresForUpdater(t *testing.T) {
 	tests := []struct {
-		name      string
-		updater   osUpdater
-		wantLabel string
+		name          string
+		updater       osUpdater
+		wantDelegated bool
+		wantLabel     string
 	}{
 		{
-			name:      "a backend labels with its binary",
-			updater:   fakeUpdater{nameVal: updaterNameWendyOS, commandVal: "wendyos-update"},
-			wantLabel: "wendyos-update",
+			name:          "a backend that delegates health labels with its binary",
+			updater:       fakeUpdater{nameVal: updaterNameWendyOS, delegatesVal: true, commandVal: "wendyos-update"},
+			wantDelegated: true,
+			wantLabel:     "wendyos-update",
 		},
 		{
-			name:      "no backend degrades to the wendyos-update-labelled no-op path",
-			updater:   nil,
-			wantLabel: "wendyos-update",
+			name:          "a backend without a health gate keeps the agent healthcheck path",
+			updater:       fakeUpdater{nameVal: "other-backend", delegatesVal: false, commandVal: "other-backend"},
+			wantDelegated: false,
+			wantLabel:     "other-backend",
+		},
+		{
+			name:          "no backend degrades to the non-delegated wendyos-update-labelled path",
+			updater:       nil,
+			wantDelegated: false,
+			wantLabel:     "wendyos-update",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			commit, rollback, label := closuresForUpdater(tt.updater)
+			commit, rollback, delegated, label := closuresForUpdater(tt.updater)
 			if commit == nil || rollback == nil {
 				t.Fatal("commit/rollback closures must never be nil")
+			}
+			if delegated != tt.wantDelegated {
+				t.Errorf("delegated = %v, want %v", delegated, tt.wantDelegated)
 			}
 			if label != tt.wantLabel {
 				t.Errorf("label = %q, want %q", label, tt.wantLabel)

--- a/go/internal/agent/services/wendyos_backend.go
+++ b/go/internal/agent/services/wendyos_backend.go
@@ -34,6 +34,11 @@ func newWendyOSUpdater(logger *zap.Logger) wendyOSUpdater {
 
 func (w wendyOSUpdater) name() string { return updaterNameWendyOS }
 
+// delegatesHealthcheck is true: wendyos-update runs /etc/wendyos-update/health.d
+// inside `commit`, so the agent gate skips its own CheckAll and acts on the
+// commit verdict instead.
+func (w wendyOSUpdater) delegatesHealthcheck() bool { return true }
+
 func (w wendyOSUpdater) commitCommand() string { return "wendyos-update" }
 
 func (w wendyOSUpdater) available() bool {


### PR DESCRIPTION
## Summary
- `ed/remove-mender` collapsed `oshealth.Gate` to always delegate healthchecking to the backend's own `commit` when it removed the mender backend, deleting the `Checker`/`CriticalService` machinery and the non-delegated `CheckAll` path along with it.
- This restores that machinery (`oshealth/services.go`, `oshealth/healthcheck.go`, `Gate.Services`/`Gate.Checker`/`Gate.DelegatedHealth`, `osUpdater.delegatesHealthcheck()`) so a backend that doesn't run its own health gate — or the no-backend-available case — still gets agent-run critical-service healthchecks before commit/rollback.
- `wendyos-update` remains the only backend and still delegates to `/etc/wendyos-update/health.d` via its own `commit`; mender stays fully removed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/agent/...`
- [x] `go test ./internal/agent/oshealth/... ./internal/agent/services/...`
- [x] `go test ./...` (full module)
- [x] `gofmt -l` clean on touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RA1Qb5QxHuuwpGN1YZbxr