### PR TITLE
fix(deps): remediate all 27 Dependabot vulnerabilities

### DIFF
--- a/Examples/project-optimize-samples/python-cuda-mismatch/requirements.txt
+++ b/Examples/project-optimize-samples/python-cuda-mismatch/requirements.txt
@@ -1,4 +1,4 @@
 # CPU-only torch wheel, but wendy.json declares the gpu entitlement.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.3.0+cpu
+torch==2.9.1+cpu
 numpy>=1.26

--- a/go/internal/cli/assets/docs/package-lock.json
+++ b/go/internal/cli/assets/docs/package-lock.json
@@ -2374,6 +2374,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -5698,34 +5758,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/npm-run-path": {

--- a/go/internal/cli/assets/docs/package.json
+++ b/go/internal/cli/assets/docs/package.json
@@ -34,5 +34,8 @@
     "serve": "14.2.6",
     "tailwindcss": "4.3.0",
     "typescript": "6.0.3"
+  },
+  "overrides": {
+    "postcss": "8.5.14"
   }
 }

--- a/screencast/package-lock.json
+++ b/screencast/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "screencast",
       "devDependencies": {
         "@slidev/cli": "52.16.0",
         "@slidev/theme-default": "0.25.0"
@@ -6636,9 +6635,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8605,16 +8604,6 @@
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
-      }
-    },
-    "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/monaco-editor/node_modules/marked": {

--- a/screencast/package.json
+++ b/screencast/package.json
@@ -11,5 +11,8 @@
   "devDependencies": {
     "@slidev/cli": "52.16.0",
     "@slidev/theme-default": "0.25.0"
+  },
+  "overrides": {
+    "dompurify": "3.4.11"
   }
 }


### PR DESCRIPTION
## Summary

Clears **all 27 open Dependabot alerts** on `main` (1 critical, 18 moderate, 8 low). Every alert was confined to **example code** or **dev/docs build tooling** — none are in the agent, CLI, or cloud runtime dependency graph. `npm audit` now reports **0 vulnerabilities** in both npm projects.

## Changes

| Area | Fix | Clears |
|---|---|---|
| `Examples/.../python-cuda-mismatch/requirements.txt` | `torch` `2.3.0+cpu` → `2.9.1+cpu` | The lone **critical** (GHSA-53q9-r3pm-6pq6, `torch.load` RCE, `<2.6.0`) + torch moderates/lows |
| `go/internal/cli/assets/docs` | add `overrides: { postcss: 8.5.14 }` | `next@16.2.6`'s hard-pinned nested `postcss@8.4.31` → deduped to patched `8.5.14` |
| `screencast` (Slidev renderer, dev-only) | add `overrides: { dompurify: 3.4.11 }` | `monaco-editor`'s bundled `dompurify@3.2.7` → deduped to patched `3.4.11` |

## Notes

- **torch**: the `python-cuda-mismatch` sample deliberately declares a CPU-only wheel against a `gpu` entitlement to demonstrate a mismatch. The version bump does not change what the demo illustrates. `2.9.1+cpu` verified to exist on the PyTorch CPU wheel index.
- **postcss / dompurify**: both parents pin an exact vulnerable version, so npm can't dedupe them without an `overrides` entry. Both overrides stay within the same major (patch/minor bump), so they're API-compatible — no breaking `next` or `monaco-editor` major bump. The already-present direct `postcss@8.5.14` and root `dompurify@3.4.11` are the dedupe targets.
- Remaining `@slidev/*` low alerts all funnelled through `monaco-editor → dompurify` and are resolved by the dompurify override.

## Verification

- `npm audit` → `found 0 vulnerabilities` in `go/internal/cli/assets/docs` and `screencast`.
- Lockfiles regenerated with `npm install --package-lock-only` (no `node_modules` churn committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9WSopyZUW36Mngx6XpnzW