### PR TITLE
fix(cli): report OS-update rollback as failure in `wendy device update`

### DIFF
--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1887,6 +1887,13 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 	}
 	defer conn.Close()
 
+	// The OS version running before this update, for the post-reboot outcome
+	// check (reportOSUpdateOutcome). The agent update just applied does not
+	// change the OS, so the version carried in preUpdateVersion is the
+	// pre-OS-update OS; the auto-select branch below refreshes it from the
+	// just-restarted agent.
+	preUpdateOSVersion := preUpdateVersion.GetOsVersion()
+
 	var otaURL string
 	if artifactURLOverride != "" {
 		// Explicit artifact: apply it as-is, no manifest lookup or version
@@ -1925,6 +1932,7 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 		}
 
 		currentOS := versionResp.GetOsVersion()
+		preUpdateOSVersion = currentOS
 		fromVer := strings.TrimPrefix(currentOS, "WendyOS-")
 		if fromVer == "" {
 			fromVer = "unknown"
@@ -1962,6 +1970,13 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 		return osUpdateOutcome{applied: true}, err
 	}
 	fmt.Println("Device is back online.")
+	// The device coming back online does NOT mean the update stuck — a rollback
+	// also reboots and reconnects. Query the recorded outcome and surface a
+	// rollback as an error so `wendy device update` exits non-zero instead of
+	// silently reporting success (mirrors `wendy os update`).
+	if err := reportOSUpdateOutcome(ctx, priorConn.Host, preUpdateOSVersion); err != nil {
+		return osUpdateOutcome{applied: true, online: true}, err
+	}
 	return osUpdateOutcome{applied: true, online: true}, nil
 }
 


### PR DESCRIPTION
## Bug

`wendy device update` reports **success even when the OS update rolls back**.

Its post-reboot check `maybeCheckOSUpdate` (`internal/cli/commands/device.go`) waited for the device to come back online with `waitForDeviceOnline` and then returned `osUpdateOutcome{applied: true, online: true}, nil` **unconditionally**. But a rollback *also* reboots and reconnects — "is the agent answering again?" can't tell a committed update from a rolled-back one. `RunE` then falls through to `return nil`, having already printed "Agent updated successfully", so the command exits `0` on a real rollback.

The underlying telemetry is correct — the agent records `OUTCOME_ROLLED_BACK`, and both `wendy os update` and the MCP `os_update_status` tool report it properly. `wendy device update` was simply never calling `GetOSUpdateStatus`.

## Fix

After the device is back online, call the existing `reportOSUpdateOutcome` helper — the same one `wendy os update` uses (`os_cmd.go`) — and propagate its error. That helper queries `GetOSUpdateStatus` and runs `evaluateOSUpdateOutcome`, which already handles `OUTCOME_ROLLED_BACK` / `OUTCOME_ROLLBACK_FAILED` (prints the rollback + reason, returns a non-nil error). So `wendy device update` now exits non-zero and prints the rollback details, matching `wendy os update`. No new machinery — just wiring in the tested helper, plus capturing the pre-update OS version to pass it.

## Scope

- Only the local (tunneled) device-update path. The cloud-asset branch already tells the user the device is rebooting and to reconnect (it doesn't claim the update stuck), so it's left as-is.
- `evaluateOSUpdateOutcome` is already unit-tested; this change is the wiring. Easy to verify end-to-end: run `wendy device update` against a device whose update rolls back — it now exits non-zero with the rollback reason instead of "updated successfully".

## Testing

`go build` / `go vet` / `gofmt` clean; full `internal/cli/commands` test suite passes (incl. the existing `maybeCheckOSUpdate` skip-gate tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnDjyn5AM3p6oTcyqHbe3K