### PR TITLE
fix(cli): fire postStart hook on attached chunk-diff runs

### DIFF
--- a/go/internal/cli/commands/deployfastpath_hooks_test.go
+++ b/go/internal/cli/commands/deployfastpath_hooks_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -178,11 +179,17 @@ func TestStreamRunContainer_AttachedFiresHostPostStartHook(t *testing.T) {
 	appCfg := &appconfig.AppConfig{
 		AppID: "attached-app",
 		Hooks: &appconfig.HooksConfig{
-			PostStart: &appconfig.HookCommand{CLI: "touch " + sentinel},
+			// Shell-quote the path so temp dirs with spaces or metacharacters
+			// can't split or alter the hook command.
+			PostStart: &appconfig.HookCommand{CLI: fmt.Sprintf("touch %q", sentinel)},
 		},
 	}
 	conn := &grpcclient.AgentConnection{Host: "localhost"}
-	stream := &attachedRunStream{waitFor: sentinel, deadline: time.Now().Add(5 * time.Second)}
+	// Generous deadline: the hook is a fire-and-forget child process, and the
+	// stream (and with it the hook's context) ends when the deadline passes,
+	// so a too-tight deadline on a loaded CI runner would kill the hook before
+	// it runs and flake the test.
+	stream := &attachedRunStream{waitFor: sentinel, deadline: time.Now().Add(15 * time.Second)}
 
 	if err := streamRunContainer(context.Background(), conn, stream, appCfg, runOptions{}); err != nil {
 		t.Fatalf("streamRunContainer returned error: %v", err)

--- a/go/internal/cli/commands/deployfastpath_hooks_test.go
+++ b/go/internal/cli/commands/deployfastpath_hooks_test.go
@@ -59,6 +59,36 @@ type fakeRunContainerStream struct {
 	grpc.ServerStreamingClient[agentpb.RunContainerLayersResponse] // embedded nil
 }
 
+// attachedRunStream drives streamRunContainer's attached path: it sends a
+// Started message, then keeps emitting stdout chunks until waitFor exists on
+// disk (or the deadline passes), then ends the stream. Gating EOF on the
+// sentinel file makes the "hook fires while logs stream" assertion
+// deterministic: the hook is killed when the stream ends, so ending too early
+// would race the hook process.
+type attachedRunStream struct {
+	grpc.ServerStreamingClient[agentpb.RunContainerLayersResponse] // embedded nil
+
+	waitFor     string
+	deadline    time.Time
+	startedSent bool
+}
+
+func (s *attachedRunStream) Recv() (*agentpb.RunContainerLayersResponse, error) {
+	if !s.startedSent {
+		s.startedSent = true
+		return &agentpb.RunContainerLayersResponse{
+			ResponseType: &agentpb.RunContainerLayersResponse_Started_{Started: &agentpb.RunContainerLayersResponse_Started{}},
+		}, nil
+	}
+	if _, err := os.Stat(s.waitFor); err == nil || time.Now().After(s.deadline) {
+		return nil, io.EOF
+	}
+	time.Sleep(20 * time.Millisecond)
+	return &agentpb.RunContainerLayersResponse{
+		ResponseType: &agentpb.RunContainerLayersResponse_StdoutOutput{StdoutOutput: &agentpb.RunContainerLayersResponse_ConsoleOutput{Data: []byte("log line\n")}},
+	}, nil
+}
+
 // isolateFingerprintCache points os.UserCacheDir() at a temp dir so the deploy
 // fingerprint the test writes is found by tryDeployFastPath, without touching the
 // real user cache.
@@ -132,6 +162,33 @@ func TestTryDeployFastPath_StoppedRunsPostStartHooks(t *testing.T) {
 	// Host-side CLI postStart hook must fire (fire-and-forget → poll briefly).
 	if runtime.GOOS != "windows" {
 		waitForFile(t, sentinel, 3*time.Second)
+	}
+}
+
+// TestStreamRunContainer_AttachedFiresHostPostStartHook verifies the attached
+// (default `wendy run`) chunk-diff path fires the host-side postStart hook once
+// the container reports Started (#1300: it previously only streamed logs, so
+// the hook fired only on runs that fell back to the registry-push path).
+func TestStreamRunContainer_AttachedFiresHostPostStartHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("host-side hook uses `touch`, unavailable on Windows")
+	}
+
+	sentinel := filepath.Join(t.TempDir(), "poststart-cli-ran")
+	appCfg := &appconfig.AppConfig{
+		AppID: "attached-app",
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{CLI: "touch " + sentinel},
+		},
+	}
+	conn := &grpcclient.AgentConnection{Host: "localhost"}
+	stream := &attachedRunStream{waitFor: sentinel, deadline: time.Now().Add(5 * time.Second)}
+
+	if err := streamRunContainer(context.Background(), conn, stream, appCfg, runOptions{}); err != nil {
+		t.Fatalf("streamRunContainer returned error: %v", err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("host-side postStart hook did not run: %v", err)
 	}
 }
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1832,8 +1832,16 @@ func resolveRestartPolicy(opts runOptions) *agentpb.RestartPolicy {
 // streamRunContainer drains a RunContainer server stream, writing stdout/stderr
 // to the corresponding OS streams. When opts.deploy or opts.detach is set the
 // function returns as soon as the Started message is received (mirroring the
-// behaviour of startAndStreamContainer for those flags).
+// behaviour of startAndStreamContainer for those flags). In attached mode the
+// Started message triggers readiness + the host-side postStart hook (again
+// mirroring startAndStreamContainer), then log streaming continues.
 func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, stream grpc.ServerStreamingClient[agentpb.RunContainerLayersResponse], appCfg *appconfig.AppConfig, opts runOptions) error {
+	// The attached-mode postStart hook is tied to hookCtx so it is terminated
+	// when the stream ends (matching startAndStreamContainer's runCtx handling).
+	hookCtx, hookCancel := context.WithCancel(ctx)
+	defer hookCancel()
+	var postStartCmd *exec.Cmd
+	hookFired := false
 	for {
 		resp, err := stream.Recv()
 		if err == io.EOF {
@@ -1860,6 +1868,18 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 				startPostStartHook(context.Background(), appCfg, conn.Host)
 				return nil
 			}
+			// Attached: mirror startAndStreamContainer's attached branch — wait
+			// for readiness, announce the URL, and fire the host-side postStart
+			// hook — then keep streaming logs. (#1300: this used to be skipped,
+			// so the hook only fired on runs that took the registry-push path.)
+			if !hookFired {
+				hookFired = true
+				if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
+					warnReadiness(ctx, conn, appCfg.AppID, err)
+				}
+				announceReachableURL(ctx, conn, appCfg)
+				postStartCmd = startPostStartHook(hookCtx, appCfg, conn.Host)
+			}
 			continue
 		}
 		if out := resp.GetStdoutOutput(); out != nil {
@@ -1868,6 +1888,12 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 		if out := resp.GetStderrOutput(); out != nil {
 			_, _ = os.Stderr.Write(out.GetData())
 		}
+	}
+	// Terminate the postStart hook if it's still running, then wait for it to
+	// exit so we don't leave orphan processes.
+	hookCancel()
+	if postStartCmd != nil {
+		_ = postStartCmd.Wait()
 	}
 	cliLogln("\nApplication %s stopped.", tui.App(appCfg.AppID))
 	return nil

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1838,9 +1838,16 @@ func resolveRestartPolicy(opts runOptions) *agentpb.RestartPolicy {
 func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, stream grpc.ServerStreamingClient[agentpb.RunContainerLayersResponse], appCfg *appconfig.AppConfig, opts runOptions) error {
 	// The attached-mode postStart hook is tied to hookCtx so it is terminated
 	// when the stream ends (matching startAndStreamContainer's runCtx handling).
+	// Cleanup runs in a defer so the hook is killed and reaped on every exit
+	// path, including stream errors.
 	hookCtx, hookCancel := context.WithCancel(ctx)
-	defer hookCancel()
 	var postStartCmd *exec.Cmd
+	defer func() {
+		hookCancel()
+		if postStartCmd != nil {
+			_ = postStartCmd.Wait()
+		}
+	}()
 	hookFired := false
 	for {
 		resp, err := stream.Recv()
@@ -1872,6 +1879,7 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 			// for readiness, announce the URL, and fire the host-side postStart
 			// hook — then keep streaming logs. (#1300: this used to be skipped,
 			// so the hook only fired on runs that took the registry-push path.)
+			// hookFired guards against a malformed stream sending Started twice.
 			if !hookFired {
 				hookFired = true
 				if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
@@ -1888,12 +1896,6 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 		if out := resp.GetStderrOutput(); out != nil {
 			_, _ = os.Stderr.Write(out.GetData())
 		}
-	}
-	// Terminate the postStart hook if it's still running, then wait for it to
-	// exit so we don't leave orphan processes.
-	hookCancel()
-	if postStartCmd != nil {
-		_ = postStartCmd.Wait()
 	}
 	cliLogln("\nApplication %s stopped.", tui.App(appCfg.AppID))
 	return nil


### PR DESCRIPTION
Fixes #1300.

- The attached (default) `wendy run` deploys via the chunk-diff path, whose `streamRunContainer` only streamed logs on `Started` — it never waited for readiness, announced the reachable URL, or fired the host-side `postStart` hook. The hook only fired on runs that fell back to registry push (typically just the first run) or on the `--detach` paths (#1299), which is exactly the behavior reported in #1300.
- `streamRunContainer`'s attached branch now mirrors `startAndStreamContainer`: on `Started` it waits for readiness, announces the URL, and fires the host-side `postStart` hook, then keeps streaming; the hook process is tied to a cancellable context and reaped when the stream ends so no orphans are left behind.
- Added `TestStreamRunContainer_AttachedFiresHostPostStartHook`, which drives the attached path with a fake stream that stays open until the hook lands (avoiding a race with the fire-and-forget hook); it and the full `go test ./internal/cli/commands` suite pass.