### PR TITLE
os install thor: guide the user on claim-time USB access denial

### DIFF
--- a/go/docs/superpowers/specs/2026-07-04-thor-usb-access-guidance-design.md
+++ b/go/docs/superpowers/specs/2026-07-04-thor-usb-access-guidance-design.md
@@ -1,0 +1,149 @@
+# Detect claim-time USB-access denial during Thor RCM flash
+
+**Date:** 2026-07-04
+**Repo:** wendyos
+**Status:** Design — approved, pending spec review
+
+## Problem
+
+Flashing an AGX Thor (T264) over USB recovery mode can fail with:
+
+```
+⚠ RCM boot failed — the Thor wasn't modified. Re-enter recovery mode and try again.
+✗ waiting for device: claiming config: Can't detach kernel driver of the device
+  vid=0955,pid=7026,bus=2,addr=1 and interface 0: libusb: bad access [code -3]
+```
+
+Two things are wrong with this output:
+
+1. **Misleading message.** The "RCM boot failed — the Thor wasn't modified" line implies
+   the RCM applet was sent and rejected. It wasn't — the failure happened *earlier*, while
+   claiming the USB interface. RCM boot was never attempted.
+2. **No actionable guidance.** `libusb: bad access [code -3]` is `LIBUSB_ERROR_ACCESS`. On
+   macOS this is a *seize* denial: the device enumerated fine (we successfully read its ECID
+   over EP0 — it appears in the target banner), but `dev.Config(1)` must detach macOS's own
+   `IOUSBHostDevice` driver to claim the interface, and macOS refuses that without root. It
+   is especially likely to occur on a retry after a failed RCM boot, because the
+   re-enumerated recovery device gets freshly re-matched by the kernel driver.
+
+The codebase already has the guidance machinery for this: `os_install_thor.go` has a branch
+`case errors.Is(err, rcm.ErrUSBAccess)` that renders `usbAccessHintBox()` (sudo / replug /
+another-process advice). The claim-time error simply never gets tagged with the
+`rcm.ErrUSBAccess` sentinel, so it bypasses that branch and falls through to the generic
+stage-1 message plus the raw libusb string.
+
+## Root cause
+
+In `go/internal/cli/tegraflash/rcm/device.go`, `openDevice` wraps every claim failure as a
+plain error:
+
+```go
+cfg, err := dev.Config(1)
+if err != nil {
+    return nil, fmt.Errorf("claiming config: %w", err)   // access denial not distinguished
+}
+```
+
+`WaitForDeviceAt` propagates this verbatim, and the top-level command switch in
+`os_install_thor.go` (around line 154) never matches `rcm.ErrUSBAccess`, so:
+
+- `case errors.Is(err, rcm.ErrUSBAccess)` (line 164) — **not taken**
+- `case failedID == stepStage1` (line 176) — taken, printing the misleading "RCM boot failed"
+- `return err` — prints the raw `bad access [code -3]` string
+
+Note there is already precedent in the codebase for detecting this exact libusb error by
+string: `flasher.go:269` does `strings.Contains(tail, "bad access [code")` at the later ADB
+stage. The RCM stage lacks the equivalent.
+
+## Design
+
+### 1. Classify the claim-time access error (`rcm/device.go`)
+
+Detect access denial from both claim steps (`dev.Config(1)` and `dev.DefaultInterface()`)
+and tag it with the existing `ErrUSBAccess` sentinel (defined in `select_usb.go`, same
+package, same `darwin || linux` build constraint):
+
+```go
+cfg, err := dev.Config(1)
+if err != nil {
+    if isUSBAccessErr(err) {
+        return nil, fmt.Errorf("%w: claiming USB interface: %v", ErrUSBAccess, err)
+    }
+    return nil, fmt.Errorf("claiming config: %w", err)
+}
+
+iface, done, err := dev.DefaultInterface()
+if err != nil {
+    cfg.Close()
+    if isUSBAccessErr(err) {
+        return nil, fmt.Errorf("%w: claiming USB interface: %v", ErrUSBAccess, err)
+    }
+    return nil, fmt.Errorf("claiming interface: %w", err)
+}
+```
+
+with a small helper:
+
+```go
+// isUSBAccessErr reports whether err is a libusb LIBUSB_ERROR_ACCESS (-3). gousb's
+// auto-detach path on macOS wraps the libusb error in a formatted string that
+// errors.Is may not see through, so we also match the "bad access [code" text —
+// the same fallback used at the ADB stage (flasher.go).
+func isUSBAccessErr(err error) bool {
+    return errors.Is(err, gousb.ErrorAccess) ||
+        strings.Contains(err.Error(), "bad access [code")
+}
+```
+
+Because the command switch is a `switch`, tagging the error also *suppresses* the misleading
+"RCM boot failed" line — only the `ErrUSBAccess` branch fires.
+
+### 2. Tune the macOS guidance wording (`usbAccessHintBox`)
+
+The current macOS branch assumes "another process is holding it" — correct for an
+*enumeration* denial, wrong for a *claim* denial where the device enumerated but couldn't be
+seized. Rewrite the macOS branch to lead with the two actions that actually resolve it:
+
+```
+A Jetson is in recovery mode, but macOS refused wendy access to its USB device —
+it enumerated but couldn't be claimed. macOS binds its own driver to the recovery
+device (often re-matched after a failed RCM boot), so wendy needs root to seize it:
+
+  • Re-run the flash with sudo.
+  • Or unplug the USB-C cable, re-enter recovery mode, and flash again.
+
+If another process holds it (a VM with USB passthrough, another flashing tool, or
+another wendy), quit that first.
+```
+
+The Linux branch (udev rule + plugdev group) is unchanged.
+
+### 3. Refactor for testability
+
+Extract the OS-specific body into `usbAccessHintLines(goos string) []string`, leaving
+`usbAccessHintBox()` a thin wrapper that renders `usbAccessHintLines(runtime.GOOS)` inside
+the border. This lets tests assert both OS branches regardless of the CI runner's platform.
+
+## Testing
+
+- `rcm/device_test.go` — table test for `isUSBAccessErr`:
+  - raw `gousb.ErrorAccess` → true
+  - `fmt.Errorf("claiming config: Can't detach kernel driver ...: libusb: bad access [code -3]")` → true
+  - a benign error (e.g. `gousb.ErrorTimeout` or `errors.New("busy")`) → false
+- `commands/os_install_thor_test.go` — assert `usbAccessHintLines("darwin")` contains `sudo`
+  and a re-enter-recovery phrase; `usbAccessHintLines("linux")` still contains the udev rule
+  string. The existing udev-rule-parity test is untouched.
+
+## Scope guards (explicitly out)
+
+- No proactive ioreg/IOKit `matched`-state probing before the claim (considered and declined
+  as fragile).
+- No change to the enumeration-time access paths beyond the shared wording tweak.
+- No change to the ADB-stage `bad access` handling in `flasher.go` (already handled there).
+
+## Affected files
+
+- `go/internal/cli/tegraflash/rcm/device.go` — classify claim-time access errors
+- `go/internal/cli/tegraflash/rcm/device_test.go` — `isUSBAccessErr` tests
+- `go/internal/cli/commands/os_install_thor.go` — `usbAccessHintLines` refactor + macOS wording
+- `go/internal/cli/commands/os_install_thor_test.go` — hint-lines tests

--- a/go/internal/cli/commands/os_install_thor.go
+++ b/go/internal/cli/commands/os_install_thor.go
@@ -726,16 +726,23 @@ const (
 )
 
 // usbAccessHintBox explains how to regain USB access to the Jetson when the OS
-// refuses to open it: on Linux, udev permissions; on macOS, almost always
-// another process holding the device.
+// refuses to open it: on Linux, udev permissions; on macOS, its own kernel driver
+// bound to the recovery device (root needed to seize it).
 func usbAccessHintBox() string {
+	return thorHintBorder.Render(strings.Join(usbAccessHintLines(runtime.GOOS), "\n"))
+}
+
+// usbAccessHintLines builds the body of the USB-access-denied hint for the given
+// GOOS. Split out from usbAccessHintBox so both OS branches are testable without
+// depending on the runner's platform.
+func usbAccessHintLines(goos string) []string {
 	lines := []string{
 		thorHintTitle.Render("⚠  USB access denied"),
 		"",
 		"A Jetson is in recovery mode, but the OS refused wendy access to its USB device.",
 	}
-	if runtime.GOOS == "linux" {
-		lines = append(lines,
+	if goos == "linux" {
+		return append(lines,
 			"Grant access with a udev rule (one-time; the wendy deb/rpm packages install it):",
 			"",
 			thorHintCmd.Render("  echo '"+usbUdevRule+"' \\"),
@@ -746,14 +753,21 @@ func usbAccessHintBox() string {
 			"("+thorHintCmd.Render("sudo groupadd plugdev && sudo usermod -aG plugdev $USER")+", then log in",
 			"again) — replug the USB-C cable and rescan. Or re-run the flash with sudo.",
 		)
-	} else {
-		lines = append(lines,
-			"Another process is likely holding it (another flashing tool, a VM with USB",
-			"passthrough, or another wendy). Quit it, unplug/replug the USB-C cable, and",
-			"rescan.",
-		)
 	}
-	return thorHintBorder.Render(strings.Join(lines, "\n"))
+	// macOS: the device enumerated but couldn't be claimed. macOS binds its own
+	// driver to the recovery device (often re-matched after a failed RCM boot), so
+	// wendy needs root to seize it — lead with the two fixes that actually work.
+	return append(lines,
+		"It enumerated but couldn't be claimed: macOS binds its own driver to the",
+		"recovery device (often re-matched after a failed RCM boot), so wendy needs",
+		"root to seize it. Try, in order:",
+		"",
+		"  "+thorHintEmph.Render("•")+" Re-run the flash with "+thorHintCmd.Render("sudo")+".",
+		"  "+thorHintEmph.Render("•")+" Or unplug the USB-C cable, re-enter recovery mode, and flash again.",
+		"",
+		"If another process holds it (a VM with USB passthrough, another flashing",
+		"tool, or another wendy), quit that first.",
+	)
 }
 
 // readQuit reads a single line and reports whether the user asked to quit

--- a/go/internal/cli/commands/os_install_thor_test.go
+++ b/go/internal/cli/commands/os_install_thor_test.go
@@ -36,6 +36,28 @@ func TestUsbUdevRuleMatchesPackagedRule(t *testing.T) {
 	}
 }
 
+func TestUsbAccessHintLines(t *testing.T) {
+	// macOS: a claim-time seize denial. The device enumerated, so the guidance must
+	// point at the two fixes that work — running as root and re-entering recovery —
+	// not the Linux udev rule.
+	mac := strings.ToLower(strings.Join(usbAccessHintLines("darwin"), "\n"))
+	if !strings.Contains(mac, "sudo") {
+		t.Errorf("darwin hint should mention sudo, got:\n%s", mac)
+	}
+	if !strings.Contains(mac, "recovery mode") {
+		t.Errorf("darwin hint should tell the user to re-enter recovery mode, got:\n%s", mac)
+	}
+	if strings.Contains(mac, usbUdevRule) {
+		t.Errorf("darwin hint should not contain the Linux udev rule, got:\n%s", mac)
+	}
+
+	// Linux: keep the udev-rule guidance verbatim so the parity test stays meaningful.
+	lin := strings.Join(usbAccessHintLines("linux"), "\n")
+	if !strings.Contains(lin, usbUdevRule) {
+		t.Errorf("linux hint should contain the udev rule %q, got:\n%s", usbUdevRule, lin)
+	}
+}
+
 func TestStopADBServer(t *testing.T) {
 	// No server listening → no-op, false.
 	if stopADBServer("127.0.0.1:1") {

--- a/go/internal/cli/tegraflash/rcm/device.go
+++ b/go/internal/cli/tegraflash/rcm/device.go
@@ -7,12 +7,24 @@ package rcm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/gousb"
 )
+
+// isUSBAccessErr reports whether err is a libusb LIBUSB_ERROR_ACCESS (-3), raised
+// when the OS refuses to let wendy seize the recovery device — on macOS because
+// its own kernel driver is bound to the re-enumerated device (root needed), on
+// Linux because of udev permissions. gousb's macOS auto-detach path wraps the
+// libusb error in a formatted string that errors.Is cannot see through, so we also
+// match the "bad access [code" text — the same fallback used at the ADB stage.
+func isUSBAccessErr(err error) bool {
+	return errors.Is(err, gousb.ErrorAccess) ||
+		strings.Contains(err.Error(), "bad access [code")
+}
 
 // Device represents a Jetson in RCM mode.
 type Device struct {
@@ -26,17 +38,25 @@ type Device struct {
 
 func openDevice(ctx *gousb.Context, dev *gousb.Device) (*Device, error) {
 	// On Linux a kernel driver bound to the interface makes the claim fail with
-	// "busy"; auto-detach clears it. No-op on macOS (gousb swallows NOT_SUPPORTED).
+	// "busy"; auto-detach clears it. On macOS the detach can instead fail with
+	// LIBUSB_ERROR_ACCESS (the OS won't let a non-root process seize its driver) —
+	// that surfaces at Config/DefaultInterface below, classified via isUSBAccessErr.
 	_ = dev.SetAutoDetach(true)
 
 	cfg, err := dev.Config(1)
 	if err != nil {
+		if isUSBAccessErr(err) {
+			return nil, fmt.Errorf("%w: claiming USB interface: %v", ErrUSBAccess, err)
+		}
 		return nil, fmt.Errorf("claiming config: %w", err)
 	}
 
 	iface, done, err := dev.DefaultInterface()
 	if err != nil {
 		cfg.Close()
+		if isUSBAccessErr(err) {
+			return nil, fmt.Errorf("%w: claiming USB interface: %v", ErrUSBAccess, err)
+		}
 		return nil, fmt.Errorf("claiming interface: %w", err)
 	}
 

--- a/go/internal/cli/tegraflash/rcm/device_test.go
+++ b/go/internal/cli/tegraflash/rcm/device_test.go
@@ -2,7 +2,56 @@
 
 package rcm
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/gousb"
+)
+
+func TestIsUSBAccessErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "raw gousb access error",
+			err:  gousb.ErrorAccess,
+			want: true,
+		},
+		{
+			name: "wrapped gousb access error",
+			err:  fmt.Errorf("claiming config: %w", gousb.ErrorAccess),
+			want: true,
+		},
+		{
+			// The exact shape gousb's macOS auto-detach path produces: a formatted
+			// string that errors.Is cannot see through, so the text fallback matters.
+			name: "libusb bad-access string",
+			err:  errors.New("Can't detach kernel driver of the device vid=0955,pid=7026,bus=2,addr=1 and interface 0: libusb: bad access [code -3]"),
+			want: true,
+		},
+		{
+			name: "unrelated gousb error",
+			err:  gousb.ErrorTimeout,
+			want: false,
+		},
+		{
+			name: "unrelated plain error",
+			err:  errors.New("device missing bulk IN or OUT endpoints"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUSBAccessErr(tt.err); got != tt.want {
+				t.Errorf("isUSBAccessErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
 
 // utf16Desc builds a USB string descriptor (bLength, 0x03, then UTF-16LE of s).
 func utf16Desc(s string) []byte {


### PR DESCRIPTION
## Problem

Flashing an AGX Thor over USB recovery mode could fail with a raw, misleading message:

```
⚠ RCM boot failed — the Thor wasn't modified. Re-enter recovery mode and try again.
✗ waiting for device: claiming config: Can't detach kernel driver of the device
  vid=0955,pid=7026,bus=2,addr=1 and interface 0: libusb: bad access [code -3]
```

The device had in fact enumerated fine (its ECID is read over EP0 and shown in the target banner). The failure was `LIBUSB_ERROR_ACCESS` while **claiming the USB interface** — on macOS, the OS won't let a non-root process seize its own kernel driver bound to the (re-matched) recovery device, which is especially likely on a retry after a failed RCM boot. RCM boot was never attempted, so the "RCM boot failed" line is wrong.

The guidance machinery for this already exists (`os_install_thor.go` has a `case errors.Is(err, rcm.ErrUSBAccess)` branch rendering `usbAccessHintBox()`), but the claim-time error was never tagged with the `rcm.ErrUSBAccess` sentinel, so it bypassed that branch and fell through to the misleading stage-1 message plus the raw libusb string.

## Change

- **Classify** the claim-time access denial in `rcm.openDevice` (`dev.Config(1)` and `DefaultInterface()`) as `rcm.ErrUSBAccess`, matching both the gousb sentinel and the `"bad access [code"` text (gousb's macOS auto-detach path wraps the libusb error in an opaque string that `errors.Is` can't see through — same fallback already used at the ADB stage in `flasher.go`).
- Because the command handler is a `switch`, tagging the error routes it into the existing hint box **and** suppresses the misleading "RCM boot failed" line.
- **Tune the macOS guidance** for the seize-denied case (device enumerated but couldn't be claimed): lead with "re-run with `sudo`" and "unplug/replug + re-enter recovery", with the process-conflict note demoted. Split `usbAccessHintBox` into a testable `usbAccessHintLines(goos)`.
- Corrected the now-inaccurate comment claiming `SetAutoDetach` is a silent no-op on macOS.

Design doc: `go/docs/superpowers/specs/2026-07-04-thor-usb-access-guidance-design.md`.

## Tests

Written test-first (watched fail, then pass):
- `rcm.TestIsUSBAccessErr` — raw/wrapped gousb access error and the libusb `bad access [code -3]` string classify true; unrelated errors classify false.
- `commands.TestUsbAccessHintLines` — the `darwin` hint mentions `sudo` + re-entering recovery and omits the Linux udev rule; the `linux` hint still carries the udev rule.

Ran locally (all pass, `gofmt`/`go vet`/`go build ./go/internal/cli/...` clean):
`go test ./go/internal/cli/tegraflash/rcm ./go/internal/cli/commands`

## Out of scope

- No proactive ioreg/IOKit `matched`-state probing before the claim.
- Does **not** address the separate Stage-2 `wendy adb` shim SIGSEGV in `libusb_claim_interface` (a distinct, harder bug — tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kC98i9fmZVKUCJtUUR24Z