### PR TITLE
feat(cli): detect storage medium from root partition for AGX Orin OTA routing

### DIFF
--- a/go/internal/cli/commands/storage_medium.go
+++ b/go/internal/cli/commands/storage_medium.go
@@ -1,0 +1,123 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+// agxOrinDeviceType is the OTA manifest key shared by the Jetson AGX Orin NVMe
+// and eMMC image variants. Both are published under this one key, distinguished
+// only by the reported storage medium (see resolveStorageMedium).
+const agxOrinDeviceType = "jetson-agx-orin"
+
+// mountedPartition is a device path and its mountpoint, as reported by the
+// agent's device-info partition list. It is the CLI-side, proto-free view of
+// agentpb.DiskPartition used to derive the storage medium from real hardware.
+type mountedPartition struct {
+	mountpoint string
+	device     string
+}
+
+// detectStorageMediumFromPartitions classifies the device's storage medium from
+// the block device backing the root ("/") filesystem — the ground truth for
+// "which disk am I running from". Only the root mount is examined: an AGX Orin
+// DevKit carries onboard eMMC even when booted from NVMe, so scanning every
+// partition would misclassify. Returns "" when the root device is not a
+// recognized physical disk (e.g. an overlay) so the caller can fall back.
+//
+// mmcblk is eMMC on the AGX Orin DevKit but a removable card on SD-booting
+// devices (Raspberry Pi, orin-nano SD), so the device type disambiguates it.
+func detectStorageMediumFromPartitions(deviceType string, parts []mountedPartition) string {
+	rootDev := ""
+	for _, p := range parts {
+		if p.mountpoint == "/" {
+			rootDev = p.device
+			break
+		}
+	}
+	if rootDev == "" {
+		return ""
+	}
+	switch {
+	case strings.Contains(rootDev, "nvme"):
+		return "nvme"
+	case strings.Contains(rootDev, "mmcblk"):
+		if deviceType == agxOrinDeviceType {
+			return "emmc"
+		}
+		return "sd"
+	default:
+		return ""
+	}
+}
+
+// resolveStorageMedium determines the storage medium used to select the OTA
+// artifact. Hardware truth (the root block device) wins over the agent's
+// self-reported medium, which is derived from /etc/wendyos/device-type and is
+// empty or stale on legacy images.
+//
+// jetson-agx-orin ships both NVMe and eMMC variants under one manifest key,
+// where the eMMC image is the top-level default. Every field device is NVMe, so
+// when nothing is conclusive we default AGX Orin to nvme "for now" — otherwise a
+// device that fails to report its medium is served the eMMC image and rejects
+// it (target mismatch). Remove the default once eMMC devices are deployed and
+// self-report reliably.
+func resolveStorageMedium(deviceType, reported string, parts []mountedPartition) string {
+	if m := detectStorageMediumFromPartitions(deviceType, parts); m != "" {
+		return m
+	}
+	if reported != "" {
+		return reported
+	}
+	if deviceType == agxOrinDeviceType {
+		return "nvme"
+	}
+	return ""
+}
+
+// diskTypeLabel renders a storage medium as a human-facing disk description.
+func diskTypeLabel(medium string) string {
+	switch medium {
+	case "nvme":
+		return "NVMe SSD"
+	case "emmc":
+		return "eMMC"
+	case "sd":
+		return "SD card"
+	default:
+		return "unknown"
+	}
+}
+
+// formatInstallSummary renders the "what we're installing" block shown before an
+// OS update is applied, so the operator can confirm the hardware, disk type,
+// target device, and version transition. currentVer and/or targetVer may be
+// empty (unknown OS version, or a local/URL artifact whose version is unknown);
+// the version line is omitted or shown without an arrow accordingly.
+func formatInstallSummary(deviceType, medium, hostname, currentVer, targetVer string) string {
+	hardware := humanizeDeviceKey(deviceType)
+	if hardware == "" {
+		hardware = "unknown"
+	}
+	// Normalize the OS version display: the agent reports "WendyOS-0.16.1" but
+	// manifest target versions are bare ("0.17.0"), so trim the prefix to keep
+	// the version transition consistent.
+	currentVer = strings.TrimPrefix(currentVer, "WendyOS-")
+	targetVer = strings.TrimPrefix(targetVer, "WendyOS-")
+	var b strings.Builder
+	b.WriteString("Installing WendyOS:\n")
+	fmt.Fprintf(&b, "  Hardware: %s\n", hardware)
+	fmt.Fprintf(&b, "  Disk:     %s\n", diskTypeLabel(medium))
+	if hostname != "" {
+		fmt.Fprintf(&b, "  Device:   %s\n", hostname)
+	}
+	switch {
+	case currentVer != "" && targetVer != "":
+		fmt.Fprintf(&b, "  Version:  %s → %s\n", currentVer, targetVer)
+	case targetVer != "":
+		fmt.Fprintf(&b, "  Version:  %s\n", targetVer)
+	case currentVer != "":
+		fmt.Fprintf(&b, "  Version:  %s (current)\n", currentVer)
+	}
+	return b.String()
+}

--- a/go/internal/cli/commands/storage_medium_test.go
+++ b/go/internal/cli/commands/storage_medium_test.go
@@ -1,0 +1,151 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectStorageMediumFromPartitions(t *testing.T) {
+	cases := []struct {
+		name       string
+		deviceType string
+		parts      []mountedPartition
+		want       string
+	}{
+		{
+			name:       "nvme root device",
+			deviceType: "jetson-agx-orin",
+			parts:      []mountedPartition{{mountpoint: "/", device: "/dev/nvme0n1p1"}},
+			want:       "nvme",
+		},
+		{
+			name:       "emmc root device on agx orin",
+			deviceType: "jetson-agx-orin",
+			parts:      []mountedPartition{{mountpoint: "/", device: "/dev/mmcblk0p1"}},
+			want:       "emmc",
+		},
+		{
+			name:       "mmcblk root device on a pi is an SD card",
+			deviceType: "raspberry-pi-5",
+			parts:      []mountedPartition{{mountpoint: "/", device: "/dev/mmcblk0p2"}},
+			want:       "sd",
+		},
+		{
+			name:       "only the root mount is classified, not other disks",
+			deviceType: "jetson-agx-orin",
+			parts: []mountedPartition{
+				{mountpoint: "/boot", device: "/dev/mmcblk0p11"},
+				{mountpoint: "/", device: "/dev/nvme0n1p1"},
+				{mountpoint: "/data", device: "/dev/nvme0n1p17"},
+			},
+			want: "nvme",
+		},
+		{
+			name:       "no root mount is inconclusive",
+			deviceType: "jetson-agx-orin",
+			parts:      []mountedPartition{{mountpoint: "/data", device: "/dev/nvme0n1p17"}},
+			want:       "",
+		},
+		{
+			name:       "overlay root is inconclusive",
+			deviceType: "jetson-agx-orin",
+			parts:      []mountedPartition{{mountpoint: "/", device: "overlay"}},
+			want:       "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectStorageMediumFromPartitions(tc.deviceType, tc.parts); got != tc.want {
+				t.Errorf("detectStorageMediumFromPartitions() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveStorageMedium(t *testing.T) {
+	cases := []struct {
+		name       string
+		deviceType string
+		reported   string
+		parts      []mountedPartition
+		want       string
+	}{
+		{
+			name:       "hardware nvme overrides a stale reported emmc",
+			deviceType: "jetson-agx-orin",
+			reported:   "emmc",
+			parts:      []mountedPartition{{mountpoint: "/", device: "/dev/nvme0n1p1"}},
+			want:       "nvme",
+		},
+		{
+			name:       "falls back to reported medium when hardware is inconclusive",
+			deviceType: "jetson-orin-nano",
+			reported:   "nvme",
+			parts:      nil,
+			want:       "nvme",
+		},
+		{
+			name:       "agx orin defaults to nvme when nothing is conclusive",
+			deviceType: "jetson-agx-orin",
+			reported:   "",
+			parts:      nil,
+			want:       "nvme",
+		},
+		{
+			name:       "legacy agx orin image reporting no medium still resolves to nvme",
+			deviceType: "jetson-agx-orin",
+			reported:   "",
+			parts:      []mountedPartition{{mountpoint: "/", device: "overlay"}},
+			want:       "nvme",
+		},
+		{
+			name:       "non-agx device with no signal stays empty (uses default artifact)",
+			deviceType: "raspberry-pi-5",
+			reported:   "",
+			parts:      nil,
+			want:       "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveStorageMedium(tc.deviceType, tc.reported, tc.parts); got != tc.want {
+				t.Errorf("resolveStorageMedium() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiskTypeLabel(t *testing.T) {
+	cases := map[string]string{
+		"nvme":  "NVMe SSD",
+		"emmc":  "eMMC",
+		"sd":    "SD card",
+		"":      "unknown",
+		"weird": "unknown",
+	}
+	for medium, want := range cases {
+		if got := diskTypeLabel(medium); got != want {
+			t.Errorf("diskTypeLabel(%q) = %q, want %q", medium, got, want)
+		}
+	}
+}
+
+func TestFormatInstallSummary(t *testing.T) {
+	got := formatInstallSummary("jetson-agx-orin", "nvme", "orin-1234.local", "WendyOS-0.16.1", "0.17.0")
+	t.Logf("summary:\n%s", got)
+	for _, want := range []string{"Jetson Agx Orin", "NVMe SSD", "orin-1234.local", "0.16.1", "0.17.0"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary missing %q:\n%s", want, got)
+		}
+	}
+	// The WendyOS- prefix is trimmed so the version transition is consistent.
+	if strings.Contains(got, "WendyOS-") {
+		t.Errorf("expected WendyOS- prefix to be trimmed:\n%s", got)
+	}
+
+	// Target version unknown (local file / --artifact-url): no version arrow.
+	noTarget := formatInstallSummary("jetson-agx-orin", "nvme", "orin.local", "WendyOS-0.16.1", "")
+	if strings.Contains(noTarget, "→") {
+		t.Errorf("expected no version arrow when target is unknown:\n%s", noTarget)
+	}
+}


### PR DESCRIPTION
## What

Adds CLI-side storage-medium detection (`detectStorageMediumFromPartitions`) that classifies a device's storage from the block device backing the root (`/`) filesystem.

## Why

The Jetson AGX Orin NVMe and eMMC image variants are published under a single OTA manifest key (`jetson-agx-orin`) and are distinguished only by the reported storage medium. The CLI must derive that medium from real hardware to route OTA updates to the correct image variant. Only the root mount is examined — an AGX Orin DevKit carries onboard eMMC even when booted from NVMe, so scanning every partition would misclassify (`mmcblk` is eMMC on the DevKit but a removable card on SD-booting devices).

Follow-on to the honest-failures OTA work merged in #1282.

## Tests

`storage_medium_test.go` — table-driven classification cases. `go test ./internal/cli/commands` passes on top of current `main`.

## Status

Draft — capturing in-progress work for review.