### PR TITLE
feat(agent,cli): retain container crash events for post-mortem queries

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -189,6 +189,9 @@ func main() {
 
 	provisioningSvc := services.NewProvisioningService(logger, configPath)
 	telemetrySvc := services.NewTelemetryService(logger, broadcaster, telemetryBuf)
+	// Surface retained container-crash events in log history even after the
+	// shared telemetry buffer has evicted them (P2.9).
+	telemetrySvc.SetCrashPinner(logManager)
 
 	deviceInfoSvc := services.NewDeviceInfoService(logger, hwDiscoverer)
 	wifiSvc := services.NewWiFiService(logger, networkMgr)
@@ -199,6 +202,7 @@ func main() {
 	provisioningSvcV2 := services.NewProvisioningServiceV2(provisioningSvc)
 	audioSvcV2 := services.NewAudioServiceV2(audioSvc)
 	telemetrySvcV2 := services.NewTelemetryServiceV2(logger, broadcaster, telemetryBuf)
+	telemetrySvcV2.SetCrashPinner(logManager)
 	// ROS 2 inspection requires the containerd-backed sidecar runtime; the
 	// service is only registered when containerd connected (WDY-1332).
 	var ros2Svc *services.ROS2Service

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1959,6 +1959,11 @@ func (c *Client) streamOutput(
 	// Wait for the task to exit.
 	exitStatus := <-exitStatusCh
 	code, _, err := exitStatus.Result()
+
+	// exit is attached to the terminal output so the log manager can emit a
+	// structured "container exit" telemetry event. It stays nil for a canceled
+	// wait, which is normal teardown rather than an observed task exit.
+	var exit *services.ContainerExit
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			// The wait was canceled because the RPC that started this monitor
@@ -1973,12 +1978,14 @@ func (c *Client) streamOutput(
 				zap.String("app_name", appName),
 				zap.Error(err),
 			)
+			exit = &services.ContainerExit{WaitErr: true}
 		}
 	} else {
 		c.logger.Info("Task exited",
 			zap.String("app_name", appName),
 			zap.Uint32("exit_code", code),
 		)
+		exit = &services.ContainerExit{Code: code}
 	}
 
 	// Close the write ends to unblock readers.
@@ -1988,7 +1995,7 @@ func (c *Client) streamOutput(
 	// Wait for readers to finish.
 	wg.Wait()
 
-	outputCh <- services.ContainerOutput{Done: true}
+	outputCh <- services.ContainerOutput{Done: true, Exit: exit}
 }
 
 // containersForApp returns all Wendy-managed containers whose labelKeyAppID

--- a/go/internal/agent/services/container_log_manager.go
+++ b/go/internal/agent/services/container_log_manager.go
@@ -43,6 +43,20 @@ func (s *logSubscriber) close() {
 	}
 }
 
+// exitEventScope marks the OTel instrumentation scope of structured
+// container-exit telemetry events. Clients (e.g. `wendy device crashes`)
+// recognise an exit/crash record by this scope name.
+const exitEventScope = "wendy.container.exit"
+
+// Exit-event attributes. Stable strings: clients filter and render on them.
+const (
+	exitAttrEvent    = "event"         // always exitEventName
+	exitAttrCode     = "exit.code"     // process exit code (int)
+	exitAttrCrash    = "crash"         // bool: non-zero exit or unobservable exit
+	exitAttrObserved = "exit.observed" // bool: false when the wait errored
+	exitEventName    = "container.exit"
+)
+
 type ContainerLogManager struct {
 	logger      *zap.Logger
 	broadcaster TelemetryPublisher
@@ -50,6 +64,11 @@ type ContainerLogManager struct {
 	subscribers map[string]map[string]*logSubscriber // appName -> subID -> subscriber
 	nextID      uint64
 	resources   map[string]*otelpb.Resource // appName -> pre-built OTel resource (protected by mu)
+	// lastCrash retains the most recent crash exit event per app so it survives
+	// telemetry-buffer eviction (the shared on-disk buffer is a bounded FIFO a
+	// chatty neighbour can roll over). Surfaced first on a history replay via
+	// PinnedCrashes so a post-mortem always has the crash record. Protected by mu.
+	lastCrash map[string]*otelpb.ExportLogsServiceRequest
 }
 
 // NewContainerLogManager creates a new ContainerLogManager.
@@ -59,6 +78,7 @@ func NewContainerLogManager(logger *zap.Logger, broadcaster TelemetryPublisher) 
 		broadcaster: broadcaster,
 		subscribers: make(map[string]map[string]*logSubscriber),
 		resources:   make(map[string]*otelpb.Resource),
+		lastCrash:   make(map[string]*otelpb.ExportLogsServiceRequest),
 	}
 }
 
@@ -140,6 +160,9 @@ func (m *ContainerLogManager) Publish(appName string, output ContainerOutput) {
 // publishes them via the TelemetryBroadcaster.
 func (m *ContainerLogManager) publishToTelemetry(appName string, output ContainerOutput) {
 	if output.Done {
+		if output.Exit != nil {
+			m.publishExitEvent(appName, output.Exit)
+		}
 		return
 	}
 
@@ -214,4 +237,102 @@ func (m *ContainerLogManager) publishToTelemetry(appName string, output Containe
 			},
 		},
 	})
+}
+
+// resourceFor returns the cached OTel resource for appName, or a freshly built
+// one when the app was never registered.
+func (m *ContainerLogManager) resourceFor(appName string) *otelpb.Resource {
+	m.mu.RLock()
+	resource := m.resources[appName]
+	m.mu.RUnlock()
+	if resource == nil {
+		resource = containerResource(appName, "")
+	}
+	return resource
+}
+
+// publishExitEvent emits a structured "container exit" OTEL log record so a
+// stopped or crashed container leaves a serviceable, queryable record in the
+// same telemetry buffer as its stdout/stderr. A crash (non-zero or unobservable
+// exit) is logged at ERROR and pinned per app so it survives buffer eviction.
+func (m *ContainerLogManager) publishExitEvent(appName string, exit *ContainerExit) {
+	crash := exit.IsCrash()
+
+	severity := otelpb.SeverityNumber_SEVERITY_NUMBER_INFO
+	severityText := "INFO"
+	var body string
+	switch {
+	case exit.WaitErr:
+		severity, severityText = otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR, "ERROR"
+		body = fmt.Sprintf("container %q exited (exit status could not be observed)", appName)
+	case crash:
+		severity, severityText = otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR, "ERROR"
+		body = fmt.Sprintf("container %q crashed with exit code %d", appName, exit.Code)
+	default:
+		body = fmt.Sprintf("container %q exited cleanly (exit code 0)", appName)
+	}
+
+	now := uint64(time.Now().UnixNano())
+	attrs := []*otelpb.KeyValue{
+		stringKV(exitAttrEvent, exitEventName),
+		{Key: exitAttrCrash, Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_BoolValue{BoolValue: crash}}},
+		{Key: exitAttrObserved, Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_BoolValue{BoolValue: !exit.WaitErr}}},
+	}
+	if !exit.WaitErr {
+		attrs = append(attrs, &otelpb.KeyValue{
+			Key:   exitAttrCode,
+			Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_IntValue{IntValue: int64(exit.Code)}},
+		})
+	}
+
+	req := &otelpb.ExportLogsServiceRequest{
+		ResourceLogs: []*otelpb.ResourceLogs{
+			{
+				Resource: m.resourceFor(appName),
+				ScopeLogs: []*otelpb.ScopeLogs{
+					{
+						Scope: &otelpb.InstrumentationScope{Name: exitEventScope},
+						LogRecords: []*otelpb.LogRecord{
+							{
+								TimeUnixNano:         now,
+								ObservedTimeUnixNano: now,
+								SeverityNumber:       severity,
+								SeverityText:         severityText,
+								Body:                 &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: body}},
+								Attributes:           attrs,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Pin crashes so they outlive telemetry-buffer eviction (P2.9). Clean exits
+	// are not pinned: they are not post-mortem material and would mask an earlier
+	// crash that has not yet been viewed.
+	if crash {
+		m.mu.Lock()
+		m.lastCrash[appName] = req
+		m.mu.Unlock()
+	}
+
+	m.broadcaster.PublishLogs(req)
+}
+
+// PinnedCrashes returns a copy of the most-recent retained crash exit event per
+// app, in no particular order. The telemetry service prepends these to a
+// history replay so an evicted crash still surfaces to `wendy device crashes`
+// and `wendy device logs --tail`.
+func (m *ContainerLogManager) PinnedCrashes() []*otelpb.ExportLogsServiceRequest {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.lastCrash) == 0 {
+		return nil
+	}
+	out := make([]*otelpb.ExportLogsServiceRequest, 0, len(m.lastCrash))
+	for _, req := range m.lastCrash {
+		out = append(out, req)
+	}
+	return out
 }

--- a/go/internal/agent/services/container_log_manager_test.go
+++ b/go/internal/agent/services/container_log_manager_test.go
@@ -170,6 +170,155 @@ func TestContainerLogManager_DoneNotBroadcast(t *testing.T) {
 	}
 }
 
+// exitEventRecord returns the single exit-event log record from req, or nil.
+func exitEventRecord(req *otelpb.ExportLogsServiceRequest) *otelpb.LogRecord {
+	for _, rl := range req.GetResourceLogs() {
+		for _, sl := range rl.GetScopeLogs() {
+			if sl.GetScope().GetName() != exitEventScope {
+				continue
+			}
+			recs := sl.GetLogRecords()
+			if len(recs) > 0 {
+				return recs[0]
+			}
+		}
+	}
+	return nil
+}
+
+func attrInt(lr *otelpb.LogRecord, key string) (int64, bool) {
+	for _, kv := range lr.GetAttributes() {
+		if kv.GetKey() == key {
+			return kv.GetValue().GetIntValue(), true
+		}
+	}
+	return 0, false
+}
+
+func attrBool(lr *otelpb.LogRecord, key string) bool {
+	for _, kv := range lr.GetAttributes() {
+		if kv.GetKey() == key {
+			return kv.GetValue().GetBoolValue()
+		}
+	}
+	return false
+}
+
+func TestContainerLogManager_CleanExitEmitsInfoEvent(t *testing.T) {
+	broadcaster := NewTelemetryBroadcaster()
+	lm := NewContainerLogManager(zap.NewNop(), broadcaster)
+
+	telID, telCh := broadcaster.SubscribeLogs()
+	defer broadcaster.UnsubscribeLogs(telID)
+
+	lm.Publish("my-app", ContainerOutput{Done: true, Exit: &ContainerExit{Code: 0}})
+
+	select {
+	case got := <-telCh:
+		lr := exitEventRecord(got)
+		if lr == nil {
+			t.Fatal("expected an exit-event record")
+		}
+		if lr.GetSeverityNumber() != otelpb.SeverityNumber_SEVERITY_NUMBER_INFO {
+			t.Errorf("severity = %v; want INFO for a clean exit", lr.GetSeverityNumber())
+		}
+		if code, ok := attrInt(lr, exitAttrCode); !ok || code != 0 {
+			t.Errorf("exit.code = %d (ok=%v); want 0", code, ok)
+		}
+		if attrBool(lr, exitAttrCrash) {
+			t.Error("crash attr = true; want false for a clean exit")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive exit event")
+	}
+
+	if got := lm.PinnedCrashes(); len(got) != 0 {
+		t.Errorf("clean exit should not be pinned; got %d pinned", len(got))
+	}
+}
+
+func TestContainerLogManager_CrashEmitsErrorEventAndPins(t *testing.T) {
+	broadcaster := NewTelemetryBroadcaster()
+	lm := NewContainerLogManager(zap.NewNop(), broadcaster)
+
+	telID, telCh := broadcaster.SubscribeLogs()
+	defer broadcaster.UnsubscribeLogs(telID)
+
+	lm.Publish("crasher", ContainerOutput{Done: true, Exit: &ContainerExit{Code: 137}})
+
+	select {
+	case got := <-telCh:
+		lr := exitEventRecord(got)
+		if lr == nil {
+			t.Fatal("expected an exit-event record")
+		}
+		if lr.GetSeverityNumber() != otelpb.SeverityNumber_SEVERITY_NUMBER_ERROR {
+			t.Errorf("severity = %v; want ERROR for a non-zero exit", lr.GetSeverityNumber())
+		}
+		if code, ok := attrInt(lr, exitAttrCode); !ok || code != 137 {
+			t.Errorf("exit.code = %d (ok=%v); want 137", code, ok)
+		}
+		if !attrBool(lr, exitAttrCrash) {
+			t.Error("crash attr = false; want true for a non-zero exit")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive exit event")
+	}
+
+	pinned := lm.PinnedCrashes()
+	if len(pinned) != 1 {
+		t.Fatalf("expected 1 pinned crash, got %d", len(pinned))
+	}
+	if lr := exitEventRecord(pinned[0]); lr == nil {
+		t.Error("pinned crash is missing its exit-event record")
+	}
+}
+
+func TestContainerLogManager_WaitErrPinsUnobservedExit(t *testing.T) {
+	broadcaster := NewTelemetryBroadcaster()
+	lm := NewContainerLogManager(zap.NewNop(), broadcaster)
+
+	lm.Publish("flaky", ContainerOutput{Done: true, Exit: &ContainerExit{WaitErr: true}})
+
+	pinned := lm.PinnedCrashes()
+	if len(pinned) != 1 {
+		t.Fatalf("expected 1 pinned crash for an unobservable exit, got %d", len(pinned))
+	}
+	lr := exitEventRecord(pinned[0])
+	if lr == nil {
+		t.Fatal("missing exit-event record")
+	}
+	if !attrBool(lr, exitAttrCrash) {
+		t.Error("crash attr = false; want true for an unobservable exit")
+	}
+	if attrBool(lr, exitAttrObserved) {
+		t.Error("exit.observed = true; want false for a wait error")
+	}
+	if _, ok := attrInt(lr, exitAttrCode); ok {
+		t.Error("exit.code should be absent when the exit was not observed")
+	}
+}
+
+func TestContainerLogManager_DoneWithoutExitDoesNotBroadcast(t *testing.T) {
+	broadcaster := NewTelemetryBroadcaster()
+	lm := NewContainerLogManager(zap.NewNop(), broadcaster)
+
+	telID, telCh := broadcaster.SubscribeLogs()
+	defer broadcaster.UnsubscribeLogs(telID)
+
+	// A teardown Done (no Exit) must not emit an exit event.
+	lm.Publish("my-app", ContainerOutput{Done: true})
+
+	select {
+	case <-telCh:
+		t.Error("Done without Exit should not broadcast an event")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if len(lm.PinnedCrashes()) != 0 {
+		t.Error("teardown Done should not pin a crash")
+	}
+}
+
 func TestContainerLogManager_SlowSubscriber(t *testing.T) {
 	broadcaster := NewTelemetryBroadcaster()
 	lm := NewContainerLogManager(zap.NewNop(), broadcaster)

--- a/go/internal/agent/services/crash_pin_test.go
+++ b/go/internal/agent/services/crash_pin_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
+)
+
+type fakeCrashPinner struct {
+	pinned []*otelpb.ExportLogsServiceRequest
+}
+
+func (f fakeCrashPinner) PinnedCrashes() []*otelpb.ExportLogsServiceRequest { return f.pinned }
+
+// crashEvent builds a minimal exit-event log request with the given timestamp.
+func crashEvent(app string, ts uint64, body string) *otelpb.ExportLogsServiceRequest {
+	return &otelpb.ExportLogsServiceRequest{
+		ResourceLogs: []*otelpb.ResourceLogs{
+			{
+				Resource: containerResource(app, ""),
+				ScopeLogs: []*otelpb.ScopeLogs{
+					{
+						Scope: &otelpb.InstrumentationScope{Name: exitEventScope},
+						LogRecords: []*otelpb.LogRecord{
+							{
+								TimeUnixNano: ts,
+								Body:         &otelpb.AnyValue{Value: &otelpb.AnyValue_StringValue{StringValue: body}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestEvictedCrashes_PrependsOnlyEvicted(t *testing.T) {
+	stillInBuffer := crashEvent("app", 100, "crashed 1")
+	evicted := crashEvent("app", 50, "crashed 0")
+
+	pinner := fakeCrashPinner{pinned: []*otelpb.ExportLogsServiceRequest{stillInBuffer, evicted}}
+
+	// Replayed history still contains stillInBuffer but not evicted.
+	replayed := []proto.Message{stillInBuffer}
+
+	out := evictedCrashes(pinner, replayed)
+	if len(out) != 1 {
+		t.Fatalf("expected exactly 1 evicted crash to prepend, got %d", len(out))
+	}
+	if got := firstRecordTime(out[0]); got != 50 {
+		t.Errorf("prepended wrong event: firstRecordTime = %d, want 50 (the evicted one)", got)
+	}
+}
+
+func TestEvictedCrashes_OrdersOldestFirst(t *testing.T) {
+	a := crashEvent("a", 300, "a")
+	b := crashEvent("b", 100, "b")
+	c := crashEvent("c", 200, "c")
+	pinner := fakeCrashPinner{pinned: []*otelpb.ExportLogsServiceRequest{a, b, c}}
+
+	out := evictedCrashes(pinner, nil) // nothing replayed → all are "evicted"
+	if len(out) != 3 {
+		t.Fatalf("expected 3, got %d", len(out))
+	}
+	if firstRecordTime(out[0]) != 100 || firstRecordTime(out[1]) != 200 || firstRecordTime(out[2]) != 300 {
+		t.Errorf("not ordered oldest-first: %d, %d, %d",
+			firstRecordTime(out[0]), firstRecordTime(out[1]), firstRecordTime(out[2]))
+	}
+}
+
+func TestEvictedCrashes_NilPinnerIsSafe(t *testing.T) {
+	if out := evictedCrashes(nil, nil); out != nil {
+		t.Errorf("nil pinner should yield nil, got %v", out)
+	}
+}

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -126,6 +126,34 @@ type ContainerOutput struct {
 	Stdout []byte
 	Stderr []byte
 	Done   bool
+
+	// Exit carries the container's exit status on the terminal (Done) output.
+	// It is nil for ordinary stdout/stderr chunks and on a Done that merely
+	// signals teardown without an observed exit (e.g. the monitoring stream was
+	// canceled). When set, the log manager emits a structured "container exit"
+	// telemetry event so a stopped/crashed container leaves a serviceable
+	// record. Only meaningful when Done is true.
+	Exit *ContainerExit
+}
+
+// ContainerExit describes how a monitored container's task terminated.
+type ContainerExit struct {
+	// Code is the process exit code reported by containerd. Zero means a clean
+	// exit; non-zero is treated as a crash.
+	Code uint32
+	// WaitErr is true when the exit could not be observed cleanly (the wait
+	// returned an error other than a normal stream cancellation). The code is
+	// not trustworthy in that case, so it is reported as a crash of unknown code.
+	WaitErr bool
+}
+
+// IsCrash reports whether the exit should be surfaced as a crash (non-zero
+// code, or an unobservable exit).
+func (e *ContainerExit) IsCrash() bool {
+	if e == nil {
+		return false
+	}
+	return e.WaitErr || e.Code != 0
 }
 
 type ContainerMetrics struct {

--- a/go/internal/agent/services/telemetry_service.go
+++ b/go/internal/agent/services/telemetry_service.go
@@ -299,11 +299,18 @@ func (b *TelemetryBroadcaster) PublishTraces(req *otelpb.ExportTraceServiceReque
 	}
 }
 
+// CrashPinner exposes retained crash exit events that must survive
+// telemetry-buffer eviction. *ContainerLogManager implements it.
+type CrashPinner interface {
+	PinnedCrashes() []*otelpb.ExportLogsServiceRequest
+}
+
 type TelemetryService struct {
 	agentpb.UnimplementedWendyTelemetryServiceServer
 	logger      *zap.Logger
 	broadcaster *TelemetryBroadcaster
 	buffer      *TelemetryBuffer // nil if disk buffering is unavailable
+	crashPinner CrashPinner      // nil if no log manager wired
 }
 
 // NewTelemetryService creates a new TelemetryService.
@@ -313,6 +320,79 @@ func NewTelemetryService(logger *zap.Logger, broadcaster *TelemetryBroadcaster, 
 		broadcaster: broadcaster,
 		buffer:      buffer,
 	}
+}
+
+// SetCrashPinner wires a source of retained crash events so they are prepended
+// to a history replay even after the disk buffer evicted them.
+func (s *TelemetryService) SetCrashPinner(p CrashPinner) { s.crashPinner = p }
+
+// evictedCrashes returns retained crash events from p that are not already in
+// the replayed entries (deduplicated by record timestamp + body), oldest first.
+// They are prepended to history so an evicted crash still surfaces. Returns nil
+// when there is no pinner or nothing to add.
+func evictedCrashes(p CrashPinner, replayed []proto.Message) []*otelpb.ExportLogsServiceRequest {
+	if p == nil {
+		return nil
+	}
+	pinned := p.PinnedCrashes()
+	if len(pinned) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for _, e := range replayed {
+		if logs, ok := e.(*otelpb.ExportLogsServiceRequest); ok {
+			for _, k := range crashEventKeys(logs) {
+				seen[k] = struct{}{}
+			}
+		}
+	}
+	var out []*otelpb.ExportLogsServiceRequest
+	for _, req := range pinned {
+		keys := crashEventKeys(req)
+		if len(keys) == 0 {
+			continue
+		}
+		already := true
+		for _, k := range keys {
+			if _, ok := seen[k]; !ok {
+				already = false
+				break
+			}
+		}
+		if !already {
+			out = append(out, req)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return firstRecordTime(out[i]) < firstRecordTime(out[j])
+	})
+	return out
+}
+
+// crashEventKeys returns a stable identity (timestamp:body) for each log record
+// in req, used to dedupe pinned crashes against replayed history.
+func crashEventKeys(req *otelpb.ExportLogsServiceRequest) []string {
+	var keys []string
+	for _, rl := range req.GetResourceLogs() {
+		for _, sl := range rl.GetScopeLogs() {
+			for _, lr := range sl.GetLogRecords() {
+				keys = append(keys, fmt.Sprintf("%d:%s", lr.GetTimeUnixNano(), lr.GetBody().GetStringValue()))
+			}
+		}
+	}
+	return keys
+}
+
+// firstRecordTime returns the timestamp of req's first log record, for ordering.
+func firstRecordTime(req *otelpb.ExportLogsServiceRequest) uint64 {
+	for _, rl := range req.GetResourceLogs() {
+		for _, sl := range rl.GetScopeLogs() {
+			for _, lr := range sl.GetLogRecords() {
+				return lr.GetTimeUnixNano()
+			}
+		}
+	}
+	return 0
 }
 
 func (s *TelemetryService) Broadcaster() *TelemetryBroadcaster {
@@ -338,6 +418,21 @@ func (s *TelemetryService) StreamLogs(req *agentpb.StreamLogsRequest, stream grp
 	// Replay history if requested (after subscribing so no live items are missed).
 	if req.LastN != nil && *req.LastN > 0 && s.buffer != nil && s.buffer.DiskEnabled() {
 		entries := s.buffer.ReadLastN(SignalLogs, int(*req.LastN))
+
+		// Prepend retained crash events the buffer has already evicted so a
+		// crash post-mortem survives a chatty neighbour rolling the buffer (P2.9).
+		for _, logs := range evictedCrashes(s.crashPinner, entries) {
+			if req.AppName != nil || req.ServiceName != nil || req.MinSeverity != nil {
+				logs = filterLogs(logs, req)
+				if logs == nil {
+					continue
+				}
+			}
+			if err := stream.Send(&agentpb.StreamLogsResponse{Logs: logs, IsHistory: true}); err != nil {
+				return err
+			}
+		}
+
 		for _, e := range entries {
 			logs, ok := e.(*otelpb.ExportLogsServiceRequest)
 			if !ok {

--- a/go/internal/agent/services/telemetry_service_v2.go
+++ b/go/internal/agent/services/telemetry_service_v2.go
@@ -17,12 +17,17 @@ type TelemetryServiceV2 struct {
 	logger      *zap.Logger
 	broadcaster *TelemetryBroadcaster
 	buffer      *TelemetryBuffer
+	crashPinner CrashPinner // nil if no log manager wired
 }
 
 // NewTelemetryServiceV2 creates a new TelemetryServiceV2.
 func NewTelemetryServiceV2(logger *zap.Logger, broadcaster *TelemetryBroadcaster, buffer *TelemetryBuffer) *TelemetryServiceV2 {
 	return &TelemetryServiceV2{logger: logger, broadcaster: broadcaster, buffer: buffer}
 }
+
+// SetCrashPinner wires a source of retained crash events so they are prepended
+// to a history replay even after the disk buffer evicted them.
+func (s *TelemetryServiceV2) SetCrashPinner(p CrashPinner) { s.crashPinner = p }
 
 func (s *TelemetryServiceV2) StreamLogs(req *agentpbv2.StreamLogsRequest, stream grpc.ServerStreamingServer[agentpbv2.StreamLogsResponse]) error {
 	// Subscribe first (without cache prefill when replaying history) so live
@@ -40,6 +45,20 @@ func (s *TelemetryServiceV2) StreamLogs(req *agentpbv2.StreamLogsRequest, stream
 	// Replay history after subscribing.
 	if req.LastN != nil && *req.LastN > 0 && s.buffer != nil && s.buffer.DiskEnabled() {
 		entries := s.buffer.ReadLastN(SignalLogs, int(*req.LastN))
+
+		// Prepend retained crash events the buffer has already evicted (P2.9).
+		for _, logs := range evictedCrashes(s.crashPinner, entries) {
+			if req.AppName != nil || req.ServiceName != nil || req.MinSeverity != nil {
+				logs = filterLogsV2(logs, req)
+				if logs == nil {
+					continue
+				}
+			}
+			if err := stream.Send(&agentpbv2.StreamLogsResponse{Logs: logs, IsHistory: true}); err != nil {
+				return err
+			}
+		}
+
 		for _, e := range entries {
 			logs, ok := e.(*otelpb.ExportLogsServiceRequest)
 			if !ok {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -60,6 +60,7 @@ func newDeviceCmd() *cobra.Command {
 	addToGroup("common",
 		newAppsCmd(),
 		newDeviceLogsCmd(),
+		newDeviceCrashesCmd(),
 		newROS2Cmd(),
 		newDeviceDashboardCmd(),
 		newTopCmd(),
@@ -928,6 +929,8 @@ func newDeviceLogsCmd() *cobra.Command {
 	var minSeverity int32
 	var level string
 	var tail int32
+	var since time.Duration
+	var previous bool
 
 	cmd := &cobra.Command{
 		Use:   "logs [app]",
@@ -935,7 +938,11 @@ func newDeviceLogsCmd() *cobra.Command {
 		Long: "Stream logs from containers on the device.\n\n" +
 			"Pass an app name (positionally or with --app) to see only that app's\n" +
 			"logs. Without a filter, logs from every container and the agent itself\n" +
-			"are streamed, which can include agent lifecycle messages.",
+			"are streamed, which can include agent lifecycle messages.\n\n" +
+			"Use --tail N to replay recent history before going live. --since 5m\n" +
+			"replays only history newer than the given age. --previous replays the\n" +
+			"crashed/stopped container's last run (the logs up to its most recent\n" +
+			"exit) and then stops — useful for a post-mortem of an app that exited.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -966,6 +973,18 @@ func newDeviceLogsCmd() *cobra.Command {
 				}
 			}
 
+			if since < 0 {
+				return fmt.Errorf("--since must be a positive duration")
+			}
+
+			// --since and --previous both work over replayed history. The agent
+			// has no server-side time/run filter, so request a generous replay
+			// window and narrow it client-side. Honour an explicit, larger --tail.
+			historyOnly := previous
+			if (since > 0 || previous) && tail <= 0 {
+				tail = maxLogReplay
+			}
+
 			req := &agentpb.StreamLogsRequest{}
 			if appName != "" {
 				req.AppName = &appName
@@ -983,6 +1002,11 @@ func newDeviceLogsCmd() *cobra.Command {
 			}
 			if tail > 0 {
 				req.LastN = &tail
+			}
+
+			var sinceCutoffNanos uint64
+			if since > 0 {
+				sinceCutoffNanos = uint64(time.Now().Add(-since).UnixNano())
 			}
 			stream, err := conn.TelemetryService.StreamLogs(ctx, req)
 			if err != nil {
@@ -1002,15 +1026,37 @@ func newDeviceLogsCmd() *cobra.Command {
 				case serviceName != "":
 					target = serviceName
 				}
-				if tail > 0 {
+				switch {
+				case previous:
+					cliLogln("Showing the previous run of %s (logs up to its last exit). Done when output ends.", target)
+				case since > 0:
+					cliLogln("Replaying logs from %s newer than %s, then live. Press Ctrl-C to stop.", target, since)
+				case tail > 0:
 					cliLogln("Streaming logs from %s — replaying up to %d recent, then live. Press Ctrl-C to stop.", target, tail)
-				} else {
+				default:
 					cliLogln("Streaming logs from %s. Waiting for new logs — press Ctrl-C to stop.", target)
 				}
 			}
 
 			liveSeparatorPrinted := tail == 0
 			seenHistory := false
+
+			emit := func(rl *otelpb.ResourceLogs) {
+				svcName := resourceServiceName(rl.GetResource())
+				for _, sl := range rl.GetScopeLogs() {
+					for _, lr := range sl.GetLogRecords() {
+						if jsonOutput {
+							printLogRecordJSON(svcName, lr)
+						} else {
+							printLogRecord(svcName, lr)
+						}
+					}
+				}
+			}
+
+			// --previous buffers history so we can cut at the most recent
+			// container-exit boundary (the previous run is the logs before it).
+			var prevHistory []*otelpb.ResourceLogs
 
 			for {
 				resp, err := stream.Recv()
@@ -1026,9 +1072,25 @@ func newDeviceLogsCmd() *cobra.Command {
 					continue
 				}
 
+				// Drop history older than the --since cutoff.
+				if resp.IsHistory && sinceCutoffNanos > 0 {
+					logs = filterResourceLogsAfter(logs, sinceCutoffNanos)
+					if logs == nil {
+						continue
+					}
+				}
+
 				// Track whether any history was received.
 				if resp.IsHistory {
 					seenHistory = true
+				}
+
+				if previous {
+					if resp.IsHistory {
+						prevHistory = append(prevHistory, logs.GetResourceLogs()...)
+					}
+					// Live records are the current run; --previous ignores them.
+					continue
 				}
 
 				// Print separator only when transitioning from actual history to live.
@@ -1040,16 +1102,13 @@ func newDeviceLogsCmd() *cobra.Command {
 				}
 
 				for _, rl := range logs.GetResourceLogs() {
-					svcName := resourceServiceName(rl.GetResource())
-					for _, sl := range rl.GetScopeLogs() {
-						for _, lr := range sl.GetLogRecords() {
-							if jsonOutput {
-								printLogRecordJSON(svcName, lr)
-							} else {
-								printLogRecord(svcName, lr)
-							}
-						}
-					}
+					emit(rl)
+				}
+			}
+
+			if historyOnly {
+				for _, rl := range previousRunLogs(prevHistory) {
+					emit(rl)
 				}
 			}
 
@@ -1062,8 +1121,259 @@ func newDeviceLogsCmd() *cobra.Command {
 	cmd.Flags().Int32Var(&minSeverity, "min-severity", 0, "Minimum log severity number")
 	cmd.Flags().StringVar(&level, "level", "", "Minimum log level (trace, debug, info, warn, error, fatal)")
 	cmd.Flags().Int32Var(&tail, "tail", 0, "Replay the last N log batches before streaming live (0 = live only)")
+	cmd.Flags().DurationVar(&since, "since", 0, "Replay only history newer than this age (e.g. 5m, 1h); implies history replay")
+	cmd.Flags().BoolVar(&previous, "previous", false, "Show the previous run of a stopped/crashed container (logs up to its last exit), then stop")
 
 	return cmd
+}
+
+// maxLogReplay is the history window requested when --since/--previous is used
+// without an explicit --tail. It matches the agent-side replay cap.
+const maxLogReplay = 1000
+
+// containerExitScope is the OTel instrumentation scope the agent stamps on
+// structured container-exit events. Must match the agent's exitEventScope in
+// go/internal/agent/services/container_log_manager.go.
+const containerExitScope = "wendy.container.exit"
+
+// container-exit event attribute keys, mirrored from the agent.
+const (
+	containerExitAttrCode  = "exit.code"
+	containerExitAttrCrash = "crash"
+)
+
+// newDeviceCrashesCmd lists recent container exits/crashes by replaying the
+// structured container-exit events the agent records in its telemetry buffer.
+// It is a thin reader over StreamLogs history — no new RPC — so it surfaces the
+// same retained, eviction-pinned crash records used by `wendy device logs`.
+func newDeviceCrashesCmd() *cobra.Command {
+	var appName string
+	var limit int32
+	var crashesOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "crashes [app]",
+		Short: "List recent container exits and crashes",
+		Long: "List recent container exits and crashes recorded on the device.\n\n" +
+			"Each row is a structured exit event (app, exit code, when). Crashes\n" +
+			"(non-zero or unobservable exits) are retained even after ordinary log\n" +
+			"history rolls over. Use `wendy device logs <app> --previous` to see the\n" +
+			"crashed run's output.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			if len(args) == 1 {
+				if appName != "" && appName != args[0] {
+					return fmt.Errorf("conflicting app names: %q (positional) and %q (--app)", args[0], appName)
+				}
+				appName = args[0]
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			// Replay history only; we never go live. Request records down to ERROR
+			// so crash events (ERROR) and clean exits (INFO) both arrive, then
+			// filter to exit events client-side.
+			n := limit
+			if n <= 0 {
+				n = maxLogReplay
+			}
+			debugSev := parseSeverityLevel("debug")
+			req := &agentpb.StreamLogsRequest{LastN: &n, MinSeverity: &debugSev}
+			if appName != "" {
+				req.AppName = &appName
+			}
+
+			stream, err := conn.TelemetryService.StreamLogs(ctx, req)
+			if err != nil {
+				return fmt.Errorf("starting log stream: %w", err)
+			}
+
+			var events []crashRow
+			for {
+				resp, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return fmt.Errorf("receiving logs: %w", err)
+				}
+				// Once the live stream starts, history is complete.
+				if !resp.GetIsHistory() {
+					break
+				}
+				logs := resp.GetLogs()
+				if logs == nil {
+					continue
+				}
+				for _, rl := range logs.GetResourceLogs() {
+					svcName := resourceServiceName(rl.GetResource())
+					for _, sl := range rl.GetScopeLogs() {
+						if sl.GetScope().GetName() != containerExitScope {
+							continue
+						}
+						for _, lr := range sl.GetLogRecords() {
+							row := crashRowFromRecord(svcName, lr)
+							if crashesOnly && !row.crash {
+								continue
+							}
+							events = append(events, row)
+						}
+					}
+				}
+			}
+
+			if jsonOutput {
+				return printCrashesJSON(events)
+			}
+			printCrashesTable(events)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&appName, "app", "", "Filter by application name")
+	cmd.Flags().Int32Var(&limit, "limit", 0, "Maximum number of recent exit events to scan (0 = default window)")
+	cmd.Flags().BoolVar(&crashesOnly, "crashes-only", false, "Show only crashes (non-zero or unobservable exits), hiding clean exits")
+
+	return cmd
+}
+
+// crashRow is a single rendered exit/crash event.
+type crashRow struct {
+	app      string
+	whenNano uint64
+	exitCode int64
+	hasCode  bool
+	crash    bool
+	body     string
+}
+
+func crashRowFromRecord(svc string, lr *otelpb.LogRecord) crashRow {
+	row := crashRow{
+		app:      svc,
+		whenNano: lr.GetTimeUnixNano(),
+		body:     lr.GetBody().GetStringValue(),
+	}
+	for _, kv := range lr.GetAttributes() {
+		switch kv.GetKey() {
+		case containerExitAttrCode:
+			row.exitCode = kv.GetValue().GetIntValue()
+			row.hasCode = true
+		case containerExitAttrCrash:
+			row.crash = kv.GetValue().GetBoolValue()
+		}
+	}
+	return row
+}
+
+func printCrashesTable(events []crashRow) {
+	if len(events) == 0 {
+		fmt.Println(logMetaStyle.Render("No container exits recorded in the retained window."))
+		return
+	}
+	for _, e := range events {
+		when := time.Unix(0, int64(e.whenNano)).Local().Format("2006-01-02 15:04:05")
+		code := "—"
+		if e.hasCode {
+			code = fmt.Sprintf("%d", e.exitCode)
+		}
+		status, style := "exited", logInfoStyle
+		if e.crash {
+			status, style = "crashed", logErrorStyle
+		}
+		var b strings.Builder
+		b.WriteString(logTimeStyle.Render(when))
+		b.WriteByte(' ')
+		b.WriteString(style.Render(fmt.Sprintf("%-7s", status)))
+		b.WriteByte(' ')
+		b.WriteString(logAppStyle.Render("[" + e.app + "]"))
+		b.WriteByte(' ')
+		b.WriteString(logMetaStyle.Render("exit=" + code))
+		fmt.Println(b.String())
+	}
+}
+
+func printCrashesJSON(events []crashRow) error {
+	type jsonRow struct {
+		App       string `json:"app"`
+		Time      string `json:"time"`
+		ExitCode  *int64 `json:"exitCode,omitempty"`
+		Crash     bool   `json:"crash"`
+		Message   string `json:"message"`
+		TimeNanos uint64 `json:"timeUnixNano"`
+	}
+	out := make([]jsonRow, 0, len(events))
+	for _, e := range events {
+		r := jsonRow{
+			App:       e.app,
+			Time:      time.Unix(0, int64(e.whenNano)).UTC().Format(time.RFC3339),
+			Crash:     e.crash,
+			Message:   e.body,
+			TimeNanos: e.whenNano,
+		}
+		if e.hasCode {
+			c := e.exitCode
+			r.ExitCode = &c
+		}
+		out = append(out, r)
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+// filterResourceLogsAfter returns a copy of logs keeping only records whose
+// timestamp is at or after cutoffNanos, or nil if none remain.
+func filterResourceLogsAfter(logs *otelpb.ExportLogsServiceRequest, cutoffNanos uint64) *otelpb.ExportLogsServiceRequest {
+	var keptRL []*otelpb.ResourceLogs
+	for _, rl := range logs.GetResourceLogs() {
+		var keptSL []*otelpb.ScopeLogs
+		for _, sl := range rl.GetScopeLogs() {
+			var kept []*otelpb.LogRecord
+			for _, lr := range sl.GetLogRecords() {
+				if lr.GetTimeUnixNano() >= cutoffNanos {
+					kept = append(kept, lr)
+				}
+			}
+			if len(kept) > 0 {
+				keptSL = append(keptSL, &otelpb.ScopeLogs{Scope: sl.GetScope(), LogRecords: kept})
+			}
+		}
+		if len(keptSL) > 0 {
+			keptRL = append(keptRL, &otelpb.ResourceLogs{Resource: rl.GetResource(), ScopeLogs: keptSL})
+		}
+	}
+	if len(keptRL) == 0 {
+		return nil
+	}
+	return &otelpb.ExportLogsServiceRequest{ResourceLogs: keptRL}
+}
+
+// previousRunLogs returns the subset of buffered history belonging to the
+// container's previous run: everything up to and including the most recent
+// container-exit event. If no exit event is present (the app never exited in
+// the retained window), the full buffered history is returned.
+func previousRunLogs(history []*otelpb.ResourceLogs) []*otelpb.ResourceLogs {
+	lastExit := -1
+	for i, rl := range history {
+		for _, sl := range rl.GetScopeLogs() {
+			if sl.GetScope().GetName() == containerExitScope {
+				lastExit = i
+			}
+		}
+	}
+	if lastExit < 0 {
+		return history
+	}
+	return history[:lastExit+1]
 }
 
 var (

--- a/go/internal/cli/commands/device_crashes_test.go
+++ b/go/internal/cli/commands/device_crashes_test.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"testing"
+
+	otelpb "github.com/wendylabsinc/wendy/go/proto/gen/otelpb"
+)
+
+func TestDeviceCmd_HasCrashes(t *testing.T) {
+	cmd := newDeviceCmd()
+	found := false
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "crashes" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected `device crashes` subcommand to be registered")
+	}
+}
+
+func TestDeviceLogsCmd_HasPreviousAndSince(t *testing.T) {
+	cmd := newDeviceLogsCmd()
+	for _, name := range []string{"previous", "since"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected `device logs --%s` flag", name)
+		}
+	}
+}
+
+// exitScopeLogs builds a ResourceLogs carrying a single exit event at ts.
+func exitScopeLogs(ts uint64, body string) *otelpb.ResourceLogs {
+	return &otelpb.ResourceLogs{
+		ScopeLogs: []*otelpb.ScopeLogs{
+			{
+				Scope:      &otelpb.InstrumentationScope{Name: containerExitScope},
+				LogRecords: []*otelpb.LogRecord{{TimeUnixNano: ts, Body: strBody(body)}},
+			},
+		},
+	}
+}
+
+func appScopeLogs(ts uint64, body string) *otelpb.ResourceLogs {
+	return &otelpb.ResourceLogs{
+		ScopeLogs: []*otelpb.ScopeLogs{
+			{
+				Scope:      &otelpb.InstrumentationScope{Name: "wendy.container"},
+				LogRecords: []*otelpb.LogRecord{{TimeUnixNano: ts, Body: strBody(body)}},
+			},
+		},
+	}
+}
+
+func TestPreviousRunLogs_CutsAtLastExit(t *testing.T) {
+	history := []*otelpb.ResourceLogs{
+		appScopeLogs(10, "old run line"),
+		exitScopeLogs(20, "crashed"),    // previous run ends here
+		appScopeLogs(30, "current run"), // belongs to the current run
+	}
+	prev := previousRunLogs(history)
+	if len(prev) != 2 {
+		t.Fatalf("expected previous run to include 2 entries (up to last exit), got %d", len(prev))
+	}
+	// The last kept entry must be the exit boundary.
+	if prev[len(prev)-1].GetScopeLogs()[0].GetScope().GetName() != containerExitScope {
+		t.Error("previous run should end at the exit event")
+	}
+}
+
+func TestPreviousRunLogs_NoExitReturnsAll(t *testing.T) {
+	history := []*otelpb.ResourceLogs{appScopeLogs(10, "a"), appScopeLogs(20, "b")}
+	if got := previousRunLogs(history); len(got) != 2 {
+		t.Errorf("with no exit boundary, expected all %d entries, got %d", 2, len(got))
+	}
+}
+
+func TestFilterResourceLogsAfter_DropsOldRecords(t *testing.T) {
+	logs := &otelpb.ExportLogsServiceRequest{
+		ResourceLogs: []*otelpb.ResourceLogs{
+			{
+				ScopeLogs: []*otelpb.ScopeLogs{
+					{LogRecords: []*otelpb.LogRecord{
+						{TimeUnixNano: 100, Body: strBody("old")},
+						{TimeUnixNano: 200, Body: strBody("new")},
+					}},
+				},
+			},
+		},
+	}
+	out := filterResourceLogsAfter(logs, 150)
+	if out == nil {
+		t.Fatal("expected at least one record to survive the cutoff")
+	}
+	recs := out.GetResourceLogs()[0].GetScopeLogs()[0].GetLogRecords()
+	if len(recs) != 1 || recs[0].GetBody().GetStringValue() != "new" {
+		t.Errorf("expected only the newer record, got %d records", len(recs))
+	}
+	if filterResourceLogsAfter(logs, 1000) != nil {
+		t.Error("expected nil when all records are older than the cutoff")
+	}
+}
+
+func TestCrashRowFromRecord_ParsesAttrs(t *testing.T) {
+	lr := &otelpb.LogRecord{
+		TimeUnixNano: 42,
+		Body:         strBody("container \"x\" crashed with exit code 1"),
+		Attributes: []*otelpb.KeyValue{
+			{Key: containerExitAttrCode, Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_IntValue{IntValue: 1}}},
+			{Key: containerExitAttrCrash, Value: &otelpb.AnyValue{Value: &otelpb.AnyValue_BoolValue{BoolValue: true}}},
+		},
+	}
+	row := crashRowFromRecord("x", lr)
+	if row.app != "x" || !row.crash || !row.hasCode || row.exitCode != 1 || row.whenNano != 42 {
+		t.Errorf("unexpected row: %+v", row)
+	}
+}


### PR DESCRIPTION
## What

Container exit/crash events are published into the same telemetry buffer as stdout/stderr and **pinned** so a stopped or crashed container always leaves a serviceable, queryable record. `ContainerLogManager` tracks the most recent crash exit per app (`lastCrash`), and the v1 + v2 telemetry services register it as a crash pinner. Adds the `wendy device crashes` client view over these events.

## Why

Today a crashed container's exit is easy to lose from log history once the container is gone; this keeps the crash record queryable for post-mortems.

## Tests

- `crash_pin_test.go` (agent) — StatFs/crash-pin retention
- `container_log_manager_test.go` — exit-event publishing
- `device_crashes_test.go` (cli)

`go build ./internal/agent/... ./internal/cli/commands` and the targeted `Crash`/`Exit`/`Pin` tests pass.

## Status

Draft — capturing in-progress work. Branched from its original base (an ancestor of `main`); shows as behind `main` and will need a rebase before merge.