### PR TITLE
feat(cli): scale mTLS probe budget by org count + resolve org names in mismatch

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -60,16 +60,30 @@ const agentPlaintextProbeTimeout = 3 * time.Second
 // top of this budget).
 const mtlsProbeTimeout = 7 * time.Second
 
-// lanAddressProbeTimeout bounds a single candidate address in the discover/
+// lanAddressProbeBudget bounds a single candidate address in the discover/
 // picker version probe (resolveLANAgentVersion). It wraps connectWithAutoTLS,
 // whose successful path for a provisioned device costs a TCP+TLS handshake plus
-// one mtlsProbeTimeout GetAgentVersion probe. A budget shorter than
-// mtlsProbeTimeout therefore cancelled the mTLS probe before it could
-// answer, leaving provisioned rows — especially USB devices, probed via .local
-// first — stuck on the failure glyph even though `wendy device info` (which
-// connects with the un-capped root context) succeeded. Derive it from
-// mtlsProbeTimeout with headroom so the two budgets can't silently invert again.
-const lanAddressProbeTimeout = mtlsProbeTimeout + 2*time.Second
+// one mtlsProbeTimeout GetAgentVersion probe (~2.2s observed). A budget shorter
+// than mtlsProbeTimeout cancelled the mTLS probe before it could answer, leaving
+// provisioned rows — especially USB devices, probed via .local first — stuck on
+// the failure glyph even though `wendy device info` (which connects with the
+// un-capped root context) succeeded (PR #1297).
+//
+// connectWithAutoTLSDiagnostics also tries every stored org cert in turn, so a
+// user logged into N orgs pays up to N sequential mTLS probes before the cert
+// matching the device's org connects. When that cert is not the first one tried
+// (e.g. the device is in the user's second org), a fixed single-probe budget
+// expires before it is reached — so the picker showed a failure glyph for
+// devices in a non-first org while `wendy device info` (uncapped) still worked.
+// Scale the budget by the cert count so the outer and inner budgets can't
+// silently invert regardless of how many orgs the user is logged into.
+func lanAddressProbeBudget(numCerts int) time.Duration {
+	if numCerts < 1 {
+		numCerts = 1
+	}
+	return time.Duration(numCerts)*mtlsProbeTimeout + 2*time.Second
+}
+
 const provisionedAgentMetadataDiscoveryTimeout = 500 * time.Millisecond
 
 const provisionedAgentUnauthorizedMessage = "Unauthorized. Run 'wendy auth login' with an account that can access this provisioned wendy-agent."
@@ -109,12 +123,27 @@ func (e tlsHandshakeRejectedError) Error() string {
 type orgMismatchDeviceError struct {
 	deviceOrg int32
 	userOrgs  []int32 // distinct orgs the CLI has credentials for
+	// userOrgNames is a best-effort org ID -> name map for the user's own orgs,
+	// resolved live from the cloud when the error is built. It may be nil or
+	// partial (offline, or a name couldn't be fetched); missing entries render as
+	// the bare numeric ID. The device's org is deliberately not resolved — the
+	// account has no access to it, so its name isn't obtainable here.
+	userOrgNames map[int32]string
+}
+
+// formatOrg renders an org as "Name (org N)" when a name was resolved, else the
+// bare "org N".
+func (e orgMismatchDeviceError) formatOrg(id int32) string {
+	if name := e.userOrgNames[id]; name != "" {
+		return fmt.Sprintf("%s (org %d)", name, id)
+	}
+	return fmt.Sprintf("org %d", id)
 }
 
 func (e orgMismatchDeviceError) Error() string {
 	parts := make([]string, len(e.userOrgs))
 	for i, o := range e.userOrgs {
-		parts[i] = fmt.Sprintf("org %d", o)
+		parts[i] = e.formatOrg(o)
 	}
 	have := "none"
 	if len(parts) > 0 {
@@ -137,8 +166,10 @@ func orgInCerts(org int32, certs []config.CertificateInfo) bool {
 }
 
 // newOrgMismatchDeviceError builds an orgMismatchDeviceError, deduplicating the
-// user's org IDs (in first-seen order) for the message.
-func newOrgMismatchDeviceError(deviceOrg int32, userCerts []config.CertificateInfo) error {
+// user's org IDs (in first-seen order) for the message. orgNames is a best-effort
+// ID -> name map for those orgs (may be nil/partial); it only enriches the
+// display and never gates the error.
+func newOrgMismatchDeviceError(deviceOrg int32, userCerts []config.CertificateInfo, orgNames map[int32]string) error {
 	var userOrgs []int32
 	seen := map[int32]bool{}
 	for i := range userCerts {
@@ -149,7 +180,61 @@ func newOrgMismatchDeviceError(deviceOrg int32, userCerts []config.CertificateIn
 		seen[o] = true
 		userOrgs = append(userOrgs, o)
 	}
-	return orgMismatchDeviceError{deviceOrg: deviceOrg, userOrgs: userOrgs}
+	return orgMismatchDeviceError{deviceOrg: deviceOrg, userOrgs: userOrgs, userOrgNames: orgNames}
+}
+
+// orgNameResolveTimeout bounds the best-effort ListOrganizations lookup that
+// turns numeric org IDs into names in the cross-org mismatch message. The lookup
+// runs on an already-failed connection path, so keep it tight and non-fatal.
+const orgNameResolveTimeout = 2 * time.Second
+
+// resolveUserOrgNamesFn resolves the user's own org IDs to human-readable names.
+// Indirected so tests don't hit the network.
+var resolveUserOrgNamesFn = resolveUserOrgNames
+
+// resolveUserOrgNames returns a best-effort org ID -> name map for the orgs the
+// user holds credentials for. Names come from the cloud (ListOrganizations), so
+// this needs connectivity; on any error it returns whatever it resolved (possibly
+// nil) and the message falls back to the bare numeric ID. Only the user's own
+// orgs are resolved — the device's org is one the account has no access to, so
+// its name isn't obtainable here.
+func resolveUserOrgNames(ctx context.Context, userCerts []config.CertificateInfo) map[int32]string {
+	want := map[int32]bool{}
+	for i := range userCerts {
+		if o := int32(userCerts[i].OrganizationID); o != 0 {
+			want[o] = true
+		}
+	}
+	if len(want) == 0 {
+		return nil
+	}
+	cfg, err := config.Load()
+	if err != nil || len(cfg.Auth) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, orgNameResolveTimeout)
+	defer cancel()
+
+	names := map[int32]string{}
+	for i := range cfg.Auth {
+		orgs, err := listOrgsFromCloud(ctx, &cfg.Auth[i])
+		if err != nil {
+			continue
+		}
+		for _, org := range orgs {
+			if id := org.GetId(); want[id] && org.GetName() != "" {
+				names[id] = org.GetName()
+			}
+		}
+		if len(names) == len(want) {
+			break // every org resolved; skip the remaining cloud sessions
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	return names
 }
 
 type orgMismatchWithCause struct {
@@ -174,10 +259,10 @@ func (e orgMismatchWithCause) Unwrap() []error {
 // other case (same-org failure such as clock skew, or no org observed) falls
 // through to errTLSHandshakeRejected, whose downstream handling offers the
 // clock-skew and refresh-certs remedies.
-func chooseRejectionError(observedDeviceOrg int32, allCerts []config.CertificateInfo, cause error) error {
+func chooseRejectionError(ctx context.Context, observedDeviceOrg int32, allCerts []config.CertificateInfo, cause error) error {
 	if observedDeviceOrg != 0 && !orgInCerts(observedDeviceOrg, allCerts) {
 		return orgMismatchWithCause{
-			mismatch: newOrgMismatchDeviceError(observedDeviceOrg, allCerts),
+			mismatch: newOrgMismatchDeviceError(observedDeviceOrg, allCerts, resolveUserOrgNamesFn(ctx, allCerts)),
 			cause:    cause,
 		}
 	}
@@ -562,9 +647,14 @@ func preferredLANAddress(dev models.LANDevice) string {
 // returns the first one that answers GetAgentVersion, along with whether that
 // connection used mTLS.
 func resolveLANAgentVersion(ctx context.Context, dev models.LANDevice) (string, bool, *agentpb.GetAgentVersionResponse, error) {
+	// connectWithAutoTLSDiagnostics tries every stored org cert in turn, so the
+	// per-address budget must cover all of them — otherwise a device whose org
+	// isn't the user's first cert is cancelled before its cert is reached, even
+	// though `wendy device info` (uncapped context) connects to it fine.
+	budget := lanAddressProbeBudget(len(loadAllCLICerts()))
 	var lastErr error
 	for _, address := range lanAgentAddresses(dev) {
-		attemptCtx, cancel := context.WithTimeout(ctx, lanAddressProbeTimeout)
+		attemptCtx, cancel := context.WithTimeout(ctx, budget)
 		isMTLS, resp, err := getAgentVersionAtAddress(attemptCtx, address)
 		cancel()
 		if err == nil {
@@ -1225,7 +1315,7 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 				// falls through to the generic handshake-rejected error, which
 				// connectToAgent already post-processes with clock-skew and
 				// refresh-certs remedies.
-				return nil, lastMTLSErr, chooseRejectionError(observedDeviceOrg, allCerts, lastMTLSErr)
+				return nil, lastMTLSErr, chooseRejectionError(ctx, observedDeviceOrg, allCerts, lastMTLSErr)
 			}
 		}
 	}

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -355,7 +355,7 @@ func TestResolveLANAgentVersionFallsBackAcrossAddresses(t *testing.T) {
 // TestResolveLANAgentVersionAllowsMTLSHandshakeTime guards against the
 // nested-timeout inversion that left provisioned devices stuck on the failure
 // glyph in the discover picker: the per-address probe budget
-// (lanAddressProbeTimeout) must comfortably contain a single autoTLS
+// (lanAddressProbeBudget) must comfortably contain a single autoTLS
 // connect+probe, whose own budget is mtlsProbeTimeout. A provisioned device's
 // handshake takes ~2.2s, so a per-address budget shorter than mtlsProbeTimeout
 // cancelled the mTLS probe before it could answer — even though `wendy device
@@ -388,7 +388,7 @@ func TestResolveLANAgentVersionAllowsMTLSHandshakeTime(t *testing.T) {
 }
 
 // TestMTLSBudgetInvariants guards the timeout-budget relationships explained
-// in the comments on mtlsProbeTimeout/lanAddressProbeTimeout, so a future edit
+// in the comments on mtlsProbeTimeout/lanAddressProbeBudget, so a future edit
 // can't silently invert or shrink them below what a slow post-quantum ML-DSA
 // handshake on constrained hardware (Jetson, Raspberry Pi) needs. Regressing
 // any of these was the direct cause of two prior flakes: provisioned LAN rows
@@ -401,11 +401,15 @@ func TestMTLSBudgetInvariants(t *testing.T) {
 	if mtlsProbeTimeout < minTolerableHandshake {
 		t.Fatalf("mtlsProbeTimeout = %s, want >= %s to tolerate a slow ML-DSA handshake on constrained hardware", mtlsProbeTimeout, minTolerableHandshake)
 	}
-	if lanAddressProbeTimeout <= mtlsProbeTimeout {
-		t.Fatalf("lanAddressProbeTimeout (%s) must be strictly greater than mtlsProbeTimeout (%s), or a single mTLS probe can be cancelled before it answers", lanAddressProbeTimeout, mtlsProbeTimeout)
+	// Evaluate the single-cert budget (the old lanAddressProbeTimeout) against
+	// mtlsProbeTimeout — a single mTLS probe must never be cancelled before it
+	// can answer.
+	singleCertBudget := lanAddressProbeBudget(1)
+	if singleCertBudget <= mtlsProbeTimeout {
+		t.Fatalf("lanAddressProbeBudget(1) (%s) must be strictly greater than mtlsProbeTimeout (%s), or a single mTLS probe can be cancelled before it answers", singleCertBudget, mtlsProbeTimeout)
 	}
-	if headroom := lanAddressProbeTimeout - mtlsProbeTimeout; headroom < time.Second {
-		t.Fatalf("lanAddressProbeTimeout headroom over mtlsProbeTimeout = %s, want >= 1s so the two budgets can't converge to the point of flaking again", headroom)
+	if headroom := singleCertBudget - mtlsProbeTimeout; headroom < time.Second {
+		t.Fatalf("lanAddressProbeBudget(1) headroom over mtlsProbeTimeout = %s, want >= 1s so the two budgets can't converge to the point of flaking again", headroom)
 	}
 
 	// A truly-unreachable device must still fail in a bounded time, not
@@ -425,6 +429,33 @@ func TestMTLSBudgetInvariants(t *testing.T) {
 	worstCasePerCert := time.Duration(maxHandshakeTimeoutRetries+1) * singleCertAttempt
 	if worstCasePerCert > maxSanePerCertBudget {
 		t.Fatalf("worst-case per-certificate direct-connect budget = %s ((retries+1) * (2*mtlsProbeTimeout + agentPlaintextProbeTimeout)), want <= %s so a genuinely-down device with one stored cert fails in bounded time", worstCasePerCert, maxSanePerCertBudget)
+	}
+}
+
+// TestLANAddressProbeBudgetScalesWithOrgCount pins the multi-org fix:
+// connectWithAutoTLSDiagnostics tries every stored org cert in turn, so the
+// per-address budget must grow with the number of orgs. A user logged into
+// orgs [57, 2] whose device is in org 2 has its matching cert tried *second*;
+// with the old fixed single-probe budget the org-2 probe was cancelled before
+// it answered, so the picker showed a failure glyph even though `wendy device
+// info` (uncapped) connected fine.
+func TestLANAddressProbeBudgetScalesWithOrgCount(t *testing.T) {
+	single := lanAddressProbeBudget(1)
+	if want := mtlsProbeTimeout + 2*time.Second; single != want {
+		t.Fatalf("lanAddressProbeBudget(1) = %v, want %v", single, want)
+	}
+	// Zero/negative cert counts clamp to the single-probe budget.
+	if got := lanAddressProbeBudget(0); got != single {
+		t.Fatalf("lanAddressProbeBudget(0) = %v, want %v (clamped)", got, single)
+	}
+	// Each additional org must add at least one mTLS probe of headroom, so the
+	// last cert tried still has a full mtlsProbeTimeout to answer.
+	if got := lanAddressProbeBudget(2); got < single+mtlsProbeTimeout {
+		t.Fatalf("lanAddressProbeBudget(2) = %v, want >= %v", got, single+mtlsProbeTimeout)
+	}
+	// Budget must be strictly monotonic in the org count.
+	if lanAddressProbeBudget(3) <= lanAddressProbeBudget(2) {
+		t.Fatal("lanAddressProbeBudget must increase with org count")
 	}
 }
 

--- a/go/internal/cli/commands/org_mismatch_error_test.go
+++ b/go/internal/cli/commands/org_mismatch_error_test.go
@@ -1,12 +1,25 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 )
+
+// stubOrgNameResolver replaces the live ListOrganizations lookup with a fixed
+// map (or nil) so tests never touch the network, restoring the original when
+// the test finishes.
+func stubOrgNameResolver(t *testing.T, names map[int32]string) {
+	t.Helper()
+	orig := resolveUserOrgNamesFn
+	t.Cleanup(func() { resolveUserOrgNamesFn = orig })
+	resolveUserOrgNamesFn = func(context.Context, []config.CertificateInfo) map[int32]string {
+		return names
+	}
+}
 
 func TestOrgInCerts(t *testing.T) {
 	certs := []config.CertificateInfo{{OrganizationID: 3}, {OrganizationID: 8}}
@@ -23,7 +36,7 @@ func TestOrgInCerts(t *testing.T) {
 
 func TestOrgMismatchDeviceError_Message(t *testing.T) {
 	userCerts := []config.CertificateInfo{{OrganizationID: 3}, {OrganizationID: 8}}
-	err := newOrgMismatchDeviceError(42, userCerts)
+	err := newOrgMismatchDeviceError(42, userCerts, nil)
 	msg := err.Error()
 
 	for _, want := range []string{"org 42", "org 3", "org 8", "wendy cloud login"} {
@@ -38,16 +51,43 @@ func TestOrgMismatchDeviceError_Message(t *testing.T) {
 }
 
 func TestOrgMismatchDeviceError_SingleUserOrg(t *testing.T) {
-	err := newOrgMismatchDeviceError(42, []config.CertificateInfo{{OrganizationID: 3}})
+	err := newOrgMismatchDeviceError(42, []config.CertificateInfo{{OrganizationID: 3}}, nil)
 	msg := err.Error()
 	if !strings.Contains(msg, "org 42") || !strings.Contains(msg, "org 3") {
 		t.Errorf("message %q missing device org 42 or user org 3", msg)
 	}
 }
 
+// TestOrgMismatchDeviceError_ShowsOrgNames verifies that resolved org names are
+// rendered as "Name (org N)" for the user's own orgs, while an org with no
+// resolved name falls back to the bare ID and the device's org stays numeric.
+func TestOrgMismatchDeviceError_ShowsOrgNames(t *testing.T) {
+	userCerts := []config.CertificateInfo{{OrganizationID: 57}, {OrganizationID: 2}}
+	names := map[int32]string{57: "Acme Robotics", 2: "Contoso"}
+	err := newOrgMismatchDeviceError(9, userCerts, names)
+	msg := err.Error()
+
+	for _, want := range []string{"Acme Robotics (org 57)", "Contoso (org 2)"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q missing %q", msg, want)
+		}
+	}
+
+	// A partial map: only one name resolved. The other renders as a bare ID.
+	partial := newOrgMismatchDeviceError(9, userCerts, map[int32]string{57: "Acme Robotics"})
+	pmsg := partial.Error()
+	if !strings.Contains(pmsg, "Acme Robotics (org 57)") {
+		t.Errorf("message %q missing resolved name", pmsg)
+	}
+	if !strings.Contains(pmsg, "org 2") || strings.Contains(pmsg, "(org 2)") {
+		t.Errorf("unresolved org should render as bare %q, got %q", "org 2", pmsg)
+	}
+}
+
 func TestChooseRejectionError_CrossOrgMismatch(t *testing.T) {
+	stubOrgNameResolver(t, map[int32]string{3: "Acme", 8: "Contoso"})
 	certs := []config.CertificateInfo{{OrganizationID: 3}, {OrganizationID: 8}}
-	err := chooseRejectionError(42, certs, errors.New("boom"))
+	err := chooseRejectionError(context.Background(), 42, certs, errors.New("boom"))
 	var mismatch orgMismatchDeviceError
 	if !errors.As(err, &mismatch) {
 		t.Fatalf("expected orgMismatchDeviceError, got %T: %v", err, err)
@@ -55,11 +95,16 @@ func TestChooseRejectionError_CrossOrgMismatch(t *testing.T) {
 	if mismatch.deviceOrg != 42 {
 		t.Errorf("deviceOrg = %d, want 42", mismatch.deviceOrg)
 	}
+	// The resolved names must flow through to the rendered message.
+	if msg := err.Error(); !strings.Contains(msg, "Acme (org 3)") {
+		t.Errorf("message %q missing resolved org name", msg)
+	}
 }
 
 func TestChooseRejectionError_SameOrgFallsThrough(t *testing.T) {
+	stubOrgNameResolver(t, nil)
 	certs := []config.CertificateInfo{{OrganizationID: 3}, {OrganizationID: 8}}
-	err := chooseRejectionError(3, certs, errors.New("boom"))
+	err := chooseRejectionError(context.Background(), 3, certs, errors.New("boom"))
 	if !errors.Is(err, errTLSHandshakeRejected) {
 		t.Errorf("same-org failure: expected errTLSHandshakeRejected, got %T: %v", err, err)
 	}
@@ -70,8 +115,9 @@ func TestChooseRejectionError_SameOrgFallsThrough(t *testing.T) {
 }
 
 func TestChooseRejectionError_NoObservedOrgFallsThrough(t *testing.T) {
+	stubOrgNameResolver(t, nil)
 	certs := []config.CertificateInfo{{OrganizationID: 3}}
-	err := chooseRejectionError(0, certs, errors.New("boom"))
+	err := chooseRejectionError(context.Background(), 0, certs, errors.New("boom"))
 	if !errors.Is(err, errTLSHandshakeRejected) {
 		t.Errorf("no observed org: expected errTLSHandshakeRejected, got %T: %v", err, err)
 	}


### PR DESCRIPTION
## What

Follow-up to the merged org-mismatch work (#1297 / #1309):

- Replaces the fixed `lanAddressProbeTimeout` with **`lanAddressProbeBudget(numCerts)`**, scaling the per-address discover/picker probe budget by the number of stored org certs.
- Adds best-effort **org-name resolution** (`resolveUserOrgNames` / `orgNameResolveTimeout`) so the cross-org mismatch message shows human org names instead of bare numeric IDs.

## Why

`connectWithAutoTLSDiagnostics` tries every stored org cert in turn. A device in the user's *second* org had its matching cert tried after a fixed single-probe budget expired, so the picker showed a failure glyph even though `wendy device info` (uncapped) connected fine. The budget must grow with org count so the last cert tried still gets a full `mtlsProbeTimeout`.

## Tests

- `TestMTLSBudgetInvariants` migrated to the new budget function (still guards the mtls/handshake/retry invariants).
- New `TestLANAddressProbeBudgetScalesWithOrgCount`.

`go build ./internal/cli/commands` + targeted tests pass on current `main`.

## Status

Draft — capturing in-progress work. Rebased cleanly onto current `main` (two `helpers.go`/`helpers_test.go` conflicts resolved by keeping both the invariant guard and the new scaling test).