### PR TITLE
cli: read a seekable-zstd main OS image (drop gzip-only assumption)

### DIFF
--- a/go/internal/cli/commands/cloud_forward_bug_test.go
+++ b/go/internal/cli/commands/cloud_forward_bug_test.go
@@ -43,6 +43,13 @@ func (h *halfCloseConn) CloseRead() {
 	h.mu.Lock()
 	h.readEOF = true
 	h.mu.Unlock()
+	// The readEOF flag is only checked at the top of Read, so it cannot
+	// interrupt a Read already parked inside the underlying net.Pipe. A real
+	// TCP half-close makes the peer's blocked Read return; mirror that here by
+	// expiring the read deadline, which unblocks any in-flight underlying Read.
+	// Without this, a relay goroutine that entered net.Pipe.Read before this
+	// flag was set would block forever (flaky "relay did not finish" hang).
+	_ = h.Conn.SetReadDeadline(time.Now().Add(-time.Second))
 }
 
 // CloseWrite signals an error to future Write calls without closing the underlying conn.

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1519,6 +1519,9 @@ func openOSImageStream(deviceKey string, img *imageInfo) (*imageStream, error) {
 	if isGzipFile(cachePath) {
 		return streamGzipImage(cachePath)
 	}
+	if isZstdFile(cachePath) {
+		return streamZstdImage(cachePath)
+	}
 	return openRawImageStream(cachePath)
 }
 
@@ -1531,6 +1534,9 @@ func openLocalImageStream(imagePath string) (*imageStream, error) {
 	}
 	if isGzipFile(imagePath) {
 		return streamGzipImage(imagePath)
+	}
+	if isZstdFile(imagePath) {
+		return streamZstdImage(imagePath)
 	}
 	return openRawImageStream(imagePath)
 }

--- a/go/internal/cli/commands/seekable_zstd.go
+++ b/go/internal/cli/commands/seekable_zstd.go
@@ -58,6 +58,42 @@ func newSeekableImage(rs io.ReadSeeker) (*seekableImage, error) {
 	return &seekableImage{r: r, dec: dec, size: int64(table.Size())}, nil
 }
 
+// zstdMagic is the 4-byte little-endian magic that begins every zstd frame,
+// and therefore every seekable-zstd image (its first frame is an ordinary zstd
+// frame). RFC 8878 §3.1.1.
+var zstdMagic = [4]byte{0x28, 0xB5, 0x2F, 0xFD}
+
+// isZstdFile reports whether path begins with the zstd magic. Detection is by
+// content, not extension — the publisher's OS image is a seekable .zst that may
+// be cached under an .img name, mirroring isGzipFile.
+func isZstdFile(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return false
+	}
+	return magic == zstdMagic
+}
+
+// streamZstdImage opens a seekable-zstd image as a sequential stream for the
+// full-image (non-bmap) flash path — --no-bmap, `wendy os download` then
+// install, or when no bmap is published. The seek table reports the exact
+// decompressed size up front, so no measuring pass is needed.
+func streamZstdImage(path string) (*imageStream, error) {
+	si, err := openSeekableZstd(path)
+	if err != nil {
+		return nil, err
+	}
+	return &imageStream{
+		ReadCloser:       si,
+		uncompressedSize: si.Size(),
+	}, nil
+}
+
 func (s *seekableImage) Size() int64 { return s.size }
 
 func (s *seekableImage) ReadAt(p []byte, off int64) (int, error) { return s.r.ReadAt(p, off) }

--- a/go/internal/cli/commands/seekable_zstd_test.go
+++ b/go/internal/cli/commands/seekable_zstd_test.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"bytes"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
@@ -62,5 +64,63 @@ func TestSeekableImageReadAtAndSize(t *testing.T) {
 		if !bytes.Equal(got, data[tc.off:tc.off+tc.n]) {
 			t.Fatalf("ReadAt(%d,%d) mismatch", tc.off, tc.n)
 		}
+	}
+}
+
+// TestIsZstdFile checks content-based detection against the zstd magic, and
+// that gzip/raw files are not misclassified.
+func TestIsZstdFile(t *testing.T) {
+	dir := t.TempDir()
+	zst := filepath.Join(dir, "image.img") // .img name on purpose (cached form)
+	if err := os.WriteFile(zst, encodeSeekable(t, []byte("hello wendyos image"), 8), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !isZstdFile(zst) {
+		t.Errorf("isZstdFile(seekable-zst) = false, want true")
+	}
+	gz := filepath.Join(dir, "g.bin")
+	if err := os.WriteFile(gz, []byte{0x1f, 0x8b, 0x08, 0x00}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isZstdFile(gz) {
+		t.Errorf("isZstdFile(gzip) = true, want false")
+	}
+	raw := filepath.Join(dir, "raw.bin")
+	if err := os.WriteFile(raw, bytes.Repeat([]byte{0}, 16), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isZstdFile(raw) {
+		t.Errorf("isZstdFile(raw) = true, want false")
+	}
+}
+
+// TestStreamZstdImage verifies the full-image stream path decompresses a
+// seekable-zstd file back to the exact source and reports the exact size.
+func TestStreamZstdImage(t *testing.T) {
+	data := make([]byte, 20_000)
+	for i := range data {
+		data[i] = byte((i * 7) % 253)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "image.img.zst")
+	if err := os.WriteFile(path, encodeSeekable(t, data, 4096), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stream, err := streamZstdImage(path)
+	if err != nil {
+		t.Fatalf("streamZstdImage: %v", err)
+	}
+	defer stream.Close()
+
+	if stream.uncompressedSize != int64(len(data)) {
+		t.Errorf("uncompressedSize = %d, want %d", stream.uncompressedSize, len(data))
+	}
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("streamed bytes != source (%d vs %d)", len(got), len(data))
 	}
 }

--- a/go/internal/cli/commands/storage_medium.go
+++ b/go/internal/cli/commands/storage_medium.go
@@ -1,0 +1,123 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+// agxOrinDeviceType is the OTA manifest key shared by the Jetson AGX Orin NVMe
+// and eMMC image variants. Both are published under this one key, distinguished
+// only by the reported storage medium (see resolveStorageMedium).
+const agxOrinDeviceType = "jetson-agx-orin"
+
+// mountedPartition is a device path and its mountpoint, as reported by the
+// agent's device-info partition list. It is the CLI-side, proto-free view of
+// agentpb.DiskPartition used to derive the storage medium from real hardware.
+type mountedPartition struct {
+	mountpoint string
+	device     string
+}
+
+// detectStorageMediumFromPartitions classifies the device's storage medium from
+// the block device backing the root ("/") filesystem — the ground truth for
+// "which disk am I running from". Only the root mount is examined: an AGX Orin
+// DevKit carries onboard eMMC even when booted from NVMe, so scanning every
+// partition would misclassify. Returns "" when the root device is not a
+// recognized physical disk (e.g. an overlay) so the caller can fall back.
+//
+// mmcblk is eMMC on the AGX Orin DevKit but a removable card on SD-booting
+// devices (Raspberry Pi, orin-nano SD), so the device type disambiguates it.
+func detectStorageMediumFromPartitions(deviceType string, parts []mountedPartition) string {
+	rootDev := ""
+	for _, p := range parts {
+		if p.mountpoint == "/" {
+			rootDev = p.device
+			break
+		}
+	}
+	if rootDev == "" {
+		return ""
+	}
+	switch {
+	case strings.Contains(rootDev, "nvme"):
+		return "nvme"
+	case strings.Contains(rootDev, "mmcblk"):
+		if deviceType == agxOrinDeviceType {
+			return "emmc"
+		}
+		return "sd"
+	default:
+		return ""
+	}
+}
+
+// resolveStorageMedium determines the storage medium used to select the OTA
+// artifact. Hardware truth (the root block device) wins over the agent's
+// self-reported medium, which is derived from /etc/wendyos/device-type and is
+// empty or stale on legacy images.
+//
+// jetson-agx-orin ships both NVMe and eMMC variants under one manifest key,
+// where the eMMC image is the top-level default. Every field device is NVMe, so
+// when nothing is conclusive we default AGX Orin to nvme "for now" — otherwise a
+// device that fails to report its medium is served the eMMC image and rejects
+// it (target mismatch). Remove the default once eMMC devices are deployed and
+// self-report reliably.
+func resolveStorageMedium(deviceType, reported string, parts []mountedPartition) string {
+	if m := detectStorageMediumFromPartitions(deviceType, parts); m != "" {
+		return m
+	}
+	if reported != "" {
+		return reported
+	}
+	if deviceType == agxOrinDeviceType {
+		return "nvme"
+	}
+	return ""
+}
+
+// diskTypeLabel renders a storage medium as a human-facing disk description.
+func diskTypeLabel(medium string) string {
+	switch medium {
+	case "nvme":
+		return "NVMe SSD"
+	case "emmc":
+		return "eMMC"
+	case "sd":
+		return "SD card"
+	default:
+		return "unknown"
+	}
+}
+
+// formatInstallSummary renders the "what we're installing" block shown before an
+// OS update is applied, so the operator can confirm the hardware, disk type,
+// target device, and version transition. currentVer and/or targetVer may be
+// empty (unknown OS version, or a local/URL artifact whose version is unknown);
+// the version line is omitted or shown without an arrow accordingly.
+func formatInstallSummary(deviceType, medium, hostname, currentVer, targetVer string) string {
+	hardware := humanizeDeviceKey(deviceType)
+	if hardware == "" {
+		hardware = "unknown"
+	}
+	// Normalize the OS version display: the agent reports "WendyOS-0.16.1" but
+	// manifest target versions are bare ("0.17.0"), so trim the prefix to keep
+	// the version transition consistent.
+	currentVer = strings.TrimPrefix(currentVer, "WendyOS-")
+	targetVer = strings.TrimPrefix(targetVer, "WendyOS-")
+	var b strings.Builder
+	b.WriteString("Installing WendyOS:\n")
+	fmt.Fprintf(&b, "  Hardware: %s\n", hardware)
+	fmt.Fprintf(&b, "  Disk:     %s\n", diskTypeLabel(medium))
+	if hostname != "" {
+		fmt.Fprintf(&b, "  Device:   %s\n", hostname)
+	}
+	switch {
+	case currentVer != "" && targetVer != "":
+		fmt.Fprintf(&b, "  Version:  %s → %s\n", currentVer, targetVer)
+	case targetVer != "":
+		fmt.Fprintf(&b, "  Version:  %s\n", targetVer)
+	case currentVer != "":
+		fmt.Fprintf(&b, "  Version:  %s (current)\n", currentVer)
+	}
+	return b.String()
+}

--- a/go/internal/cli/commands/storage_medium_test.go
+++ b/go/internal/cli/commands/storage_medium_test.go
@@ -1,0 +1,151 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectStorageMediumFromPartitions(t *testing.T) {
+	cases := []struct {
+		name       string
+		deviceType string
+		parts      []mountedPartition
+		want       string
+	}{
+		{
+			name:       "nvme root device",
+			deviceType: "jetson-agx-orin",
+			parts:      []mountedPartition{{mountpoint: "/", device: "/dev/nvme0n1p1"}},
+			want:       "nvme",
+		},
+		{
+			name:       "emmc root device on agx orin",
+			deviceType: "jetson-agx-orin",
+			parts:      []mountedPartition{{mountpoint: "/", device: "/dev/mmcblk0p1"}},
+			want:       "emmc",
+		},
+		{
+			name:       "mmcblk root device on a pi is an SD card",
+			deviceType: "raspberry-pi-5",
+			parts:      []mountedPartition{{mountpoint: "/", device: "/dev/mmcblk0p2"}},
+			want:       "sd",
+		},
+		{
+			name:       "only the root mount is classified, not other disks",
+			deviceType: "jetson-agx-orin",
+			parts: []mountedPartition{
+				{mountpoint: "/boot", device: "/dev/mmcblk0p11"},
+				{mountpoint: "/", device: "/dev/nvme0n1p1"},
+				{mountpoint: "/data", device: "/dev/nvme0n1p17"},
+			},
+			want: "nvme",
+		},
+		{
+			name:       "no root mount is inconclusive",
+			deviceType: "jetson-agx-orin",
+			parts:      []mountedPartition{{mountpoint: "/data", device: "/dev/nvme0n1p17"}},
+			want:       "",
+		},
+		{
+			name:       "overlay root is inconclusive",
+			deviceType: "jetson-agx-orin",
+			parts:      []mountedPartition{{mountpoint: "/", device: "overlay"}},
+			want:       "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectStorageMediumFromPartitions(tc.deviceType, tc.parts); got != tc.want {
+				t.Errorf("detectStorageMediumFromPartitions() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveStorageMedium(t *testing.T) {
+	cases := []struct {
+		name       string
+		deviceType string
+		reported   string
+		parts      []mountedPartition
+		want       string
+	}{
+		{
+			name:       "hardware nvme overrides a stale reported emmc",
+			deviceType: "jetson-agx-orin",
+			reported:   "emmc",
+			parts:      []mountedPartition{{mountpoint: "/", device: "/dev/nvme0n1p1"}},
+			want:       "nvme",
+		},
+		{
+			name:       "falls back to reported medium when hardware is inconclusive",
+			deviceType: "jetson-orin-nano",
+			reported:   "nvme",
+			parts:      nil,
+			want:       "nvme",
+		},
+		{
+			name:       "agx orin defaults to nvme when nothing is conclusive",
+			deviceType: "jetson-agx-orin",
+			reported:   "",
+			parts:      nil,
+			want:       "nvme",
+		},
+		{
+			name:       "legacy agx orin image reporting no medium still resolves to nvme",
+			deviceType: "jetson-agx-orin",
+			reported:   "",
+			parts:      []mountedPartition{{mountpoint: "/", device: "overlay"}},
+			want:       "nvme",
+		},
+		{
+			name:       "non-agx device with no signal stays empty (uses default artifact)",
+			deviceType: "raspberry-pi-5",
+			reported:   "",
+			parts:      nil,
+			want:       "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveStorageMedium(tc.deviceType, tc.reported, tc.parts); got != tc.want {
+				t.Errorf("resolveStorageMedium() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiskTypeLabel(t *testing.T) {
+	cases := map[string]string{
+		"nvme":  "NVMe SSD",
+		"emmc":  "eMMC",
+		"sd":    "SD card",
+		"":      "unknown",
+		"weird": "unknown",
+	}
+	for medium, want := range cases {
+		if got := diskTypeLabel(medium); got != want {
+			t.Errorf("diskTypeLabel(%q) = %q, want %q", medium, got, want)
+		}
+	}
+}
+
+func TestFormatInstallSummary(t *testing.T) {
+	got := formatInstallSummary("jetson-agx-orin", "nvme", "orin-1234.local", "WendyOS-0.16.1", "0.17.0")
+	t.Logf("summary:\n%s", got)
+	for _, want := range []string{"Jetson Agx Orin", "NVMe SSD", "orin-1234.local", "0.16.1", "0.17.0"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary missing %q:\n%s", want, got)
+		}
+	}
+	// The WendyOS- prefix is trimmed so the version transition is consistent.
+	if strings.Contains(got, "WendyOS-") {
+		t.Errorf("expected WendyOS- prefix to be trimmed:\n%s", got)
+	}
+
+	// Target version unknown (local file / --artifact-url): no version arrow.
+	noTarget := formatInstallSummary("jetson-agx-orin", "nvme", "orin.local", "WendyOS-0.16.1", "")
+	if strings.Contains(noTarget, "→") {
+		t.Errorf("expected no version arrow when target is unknown:\n%s", noTarget)
+	}
+}

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -46,6 +46,10 @@ type Config struct {
 	// answering at that hostname is caught. Renewal/re-enrollment within the
 	// same org+cloud does not trip it. Keyed by normalized hostname.
 	DevicePins map[string]DevicePin `json:"devicePins,omitempty"`
+	// CrashReport holds opt-in crash-reporting state: the suppression flag,
+	// tracking ids awaiting a fix, the last status-poll time, and pending
+	// fix notices to surface on the next run. Nil until first used.
+	CrashReport *CrashReportConfig `json:"crashReport,omitempty"`
 	// DefaultOrgID is the organization used when a command needs to target a
 	// specific org and the user belongs to more than one. Zero means no default;
 	// the CLI will then show a picker or use the sole available org.
@@ -73,6 +77,20 @@ type CertificateInfo struct {
 // AnalyticsConfig holds analytics preferences.
 type AnalyticsConfig struct {
 	Enabled bool `json:"enabled"`
+}
+
+// CrashReportConfig holds opt-in crash-reporting preferences and state.
+type CrashReportConfig struct {
+	Suppressed           bool        `json:"suppressed,omitempty"`
+	SubscribedReports    []string    `json:"subscribedReports,omitempty"`
+	LastCrashStatusCheck string      `json:"lastCrashStatusCheck,omitempty"` // RFC3339 UTC
+	PendingFixNotices    []FixNotice `json:"pendingFixNotices,omitempty"`
+}
+
+// FixNotice records that a reported crash was fixed in a given release.
+type FixNotice struct {
+	TrackingID     string `json:"trackingId"`
+	FixedInRelease string `json:"fixedInRelease,omitempty"`
 }
 
 // ConfigDir returns the path to the ~/.wendy directory, creating it if necessary.

--- a/go/internal/shared/config/config_test.go
+++ b/go/internal/shared/config/config_test.go
@@ -199,6 +199,27 @@ func TestAddAuth_DifferentOrgAppends(t *testing.T) {
 	}
 }
 
+func TestCrashReportConfigRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg := &Config{CrashReport: &CrashReportConfig{
+		Suppressed:        true,
+		SubscribedReports: []string{"WDY-ABC123"},
+		PendingFixNotices: []FixNotice{{TrackingID: "WDY-ABC123", FixedInRelease: "v1.4.0"}},
+	}}
+	if err := Save(cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.CrashReport == nil || !loaded.CrashReport.Suppressed ||
+		len(loaded.CrashReport.SubscribedReports) != 1 ||
+		len(loaded.CrashReport.PendingFixNotices) != 1 {
+		t.Errorf("round-trip mismatch: %+v", loaded.CrashReport)
+	}
+}
+
 func TestConfigDir(t *testing.T) {
 	home := overrideHome(t)
 


### PR DESCRIPTION
## What

Paired with **[WendyOS-Builder #178](https://github.com/wendylabsinc/WendyOS-Builder/pull/178)**, which switches the Jetson OS image from a gzip `.img.gz` to the seekable `.zst` the publisher already generates (killing a ~6m42s gzip pass + halving upload volume per Jetson build).

The mainstream `wendy os install` is **unaffected** — it flashes via the `zst_path` + bmap fast path and never reads the main image `path`. But the full-image path (`openOSImageStream` / `openLocalImageStream`) — used by:
- `wendy os install --no-bmap`
- `wendy os download` then install from cache
- any device with no published bmap

— only recognized `.zip` / gzip / raw, so it would fail on a `.zst` main image.

## Change

- Add `isZstdFile` — content-based detection of the zstd magic (`28 B5 2F FD`), mirroring `isGzipFile` (images may be cached under an `.img` name).
- Add `streamZstdImage` — wraps the existing `seekableImage` reader as an `imageStream`. The seek table reports the **exact** decompressed size, so no measuring pass is needed (unlike gzip).
- Dispatch to it in both stream openers, after the gzip check.

## Ordering

This is backward-compatible (still reads gzip/raw/zip), so it can land and ship **before** the publisher PR to avoid a breakage window for `--no-bmap` / `os download`.

## Test

New `TestIsZstdFile` (magic detection incl. gzip/raw negatives) and `TestStreamZstdImage` (round-trips a seekable `.zst` to exact source bytes + exact size). Full `internal/cli/commands` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)