### PR TITLE
wendy os install/update --pr N (install/OTA a wendyos-builder PR build)

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -31,6 +31,25 @@ wendy install path/to/image.img /dev/disk4 --force
 
 ---
 
+## Install a pull-request build
+
+```sh
+wendy install --pr 123
+```
+
+Downloads and flashes the WendyOS image built by wendyos-builder PR #123.
+PR images are **debug builds**: SSH is enabled, root login is passwordless,
+and the serial console is active. They are for testing the PR on hardware —
+**never flash a PR image to a production device.** Artifacts are deleted when
+the PR is closed.
+
+`--pr` is supported for Linux disk-image devices (Raspberry Pi, Jetson Orin
+Nano, Jetson AGX Orin). It is not supported for Jetson AGX Thor or ESP32 targets.
+`--pr` is mutually exclusive with `--nightly`, `--version`, a positional image
+path, and `--artifact-url`.
+
+---
+
 ## ESP32 (Wendy Lite) path
 
 ### 1. Device detection
@@ -166,6 +185,7 @@ Requires an active `wendy auth login` session. The CLI creates an enrollment tok
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--nightly` | false | Use nightly/pre-release builds |
+| `--pr` | — | Install from wendyos-builder PR #N (mutually exclusive with `--nightly`, `--version`, positional path, `--artifact-url`; Linux disk-image devices only) |
 | `--device-type` | — | Device type from manifest (Linux targets only, e.g. `raspberry-pi-5`) |
 | `--version` | latest | WendyOS version to install (Linux only) |
 | `--drive` | interactive | Target drive path (e.g. `/dev/disk4`) |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -34,7 +34,7 @@ wendy install path/to/image.img /dev/disk4 --force
 ## Install a pull-request build
 
 ```sh
-wendy os install --pr 123
+wendy install --pr 123
 ```
 
 Downloads and flashes the WendyOS image built by wendyos-builder PR #123.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -45,8 +45,8 @@ the PR is closed.
 
 `--pr` is supported for Linux disk-image devices (Raspberry Pi, Jetson Orin
 Nano, Jetson AGX Orin). It is not supported for Jetson AGX Thor or ESP32 targets.
-`--pr` is mutually exclusive with `--nightly`, `--version`, a positional image
-path, and `--artifact-url`.
+`--pr` is mutually exclusive with `--nightly`, `--version`, and a positional
+image path.
 
 ---
 
@@ -185,7 +185,7 @@ Requires an active `wendy auth login` session. The CLI creates an enrollment tok
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--nightly` | false | Use nightly/pre-release builds |
-| `--pr` | — | Install from wendyos-builder PR #N (mutually exclusive with `--nightly`, `--version`, positional path, `--artifact-url`; Linux disk-image devices only) |
+| `--pr` | — | Install from wendyos-builder PR #N (mutually exclusive with `--nightly`, `--version`, positional path; Linux disk-image devices only) |
 | `--device-type` | — | Device type from manifest (Linux targets only, e.g. `raspberry-pi-5`) |
 | `--version` | latest | WendyOS version to install (Linux only) |
 | `--drive` | interactive | Target drive path (e.g. `/dev/disk4`) |

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -34,7 +34,7 @@ wendy install path/to/image.img /dev/disk4 --force
 ## Install a pull-request build
 
 ```sh
-wendy install --pr 123
+wendy os install --pr 123
 ```
 
 Downloads and flashes the WendyOS image built by wendyos-builder PR #123.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/update.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/update.md
@@ -10,6 +10,9 @@ wendy os update
 # Use the latest nightly build
 wendy os update --nightly
 
+# OTA update to a pull-request build
+wendy os update --pr 123
+
 # Provide a specific artifact URL
 wendy os update --artifact-url https://example.com/update.wendy
 
@@ -83,10 +86,30 @@ Use `--nightly` to select nightly (pre-release) artifacts instead of stable ones
 
 ---
 
+## Update to a pull-request build
+
+```sh
+wendy os update --pr 123
+```
+
+OTA-updates the connected device to the WendyOS image built by wendyos-builder
+PR #123. PR images are **debug builds**: SSH is enabled, root login is
+passwordless, and the serial console is active. They are for testing the PR on
+hardware — **never install a PR image on a production device.** Artifacts are
+deleted when the PR is closed.
+
+`--pr` is supported for Linux disk-image devices (Raspberry Pi, Jetson Orin
+Nano, Jetson AGX Orin) with OTA support. It is not supported for Jetson AGX
+Thor or ESP32 targets. `--pr` is mutually exclusive with `--nightly`,
+`--artifact-url`, and a positional artifact file path.
+
+---
+
 ## Flags reference
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--pr` | — | Update to wendyos-builder PR #N (mutually exclusive with `--nightly`, `--artifact-url`, positional path; Linux disk-image devices only) |
 | `--artifact-url` | — | URL of an artifact (`.wendy`) to install directly |
 | `--nightly` | false | Use nightly/pre-release builds for auto-selection |
 

--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -350,6 +350,37 @@ func getLatestOTAInfoForDeviceType(deviceType string, storageMedium string, nigh
 	return u, latest, nil
 }
 
+// getPROTAInfoForDeviceType mirrors getLatestOTAInfoForDeviceType but resolves
+// against a PR build's manifest (fetchPRMainManifest) instead of the master
+// manifest. It selects the PR device's Latest version, falling back to
+// LatestNightly when the PR only published a nightly-style build.
+func getPROTAInfoForDeviceType(pr int, deviceType, storageMedium string) (artifactURL, version string, err error) {
+	main, err := fetchPRMainManifest(pr)
+	if err != nil {
+		return "", "", err
+	}
+	dev, ok := main.Devices[deviceType]
+	if !ok || dev.ManifestPath == "" {
+		return "", "", fmt.Errorf("device type %q not built by PR %d", deviceType, pr)
+	}
+	dm, err := fetchDeviceManifest(dev.ManifestPath)
+	if err != nil {
+		return "", "", err
+	}
+	ver := dev.Latest
+	if ver == "" {
+		ver = dev.LatestNightly
+	}
+	if ver == "" {
+		return "", "", fmt.Errorf("no version for %q in PR %d", deviceType, pr)
+	}
+	u, err := getOTAUpdateURL(dm, ver, storageMedium)
+	if err != nil {
+		return "", "", err
+	}
+	return u, ver, nil
+}
+
 // thorDeviceType is the manifest key / --device-type for the AGX Thor.
 const thorDeviceType = "jetson-agx-thor"
 

--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -211,6 +211,20 @@ func fetchPRMainManifest(pr int) (*mainManifest, error) {
 	return &m, nil
 }
 
+// prDeviceVersion resolves the version tag to install/update for a PR device
+// entry: the PR's Latest version, falling back to LatestNightly when the PR
+// only published a nightly-style build. The publish-pr job always writes with
+// --nightly, so Latest is empty and LatestNightly carries the "pr-N" tag —
+// every PR device entry hits the fallback in practice. Shared by
+// getAvailablePRDevices and getPROTAInfoForDeviceType so the two stay
+// consistent.
+func prDeviceVersion(dev manifestDevice) string {
+	if dev.Latest != "" {
+		return dev.Latest
+	}
+	return dev.LatestNightly
+}
+
 // getAvailablePRDevices mirrors getAvailableDevices for a per-PR manifest.
 // The master entries' ManifestPath values are already "pr/<N>/manifests/<device>.json"
 // (written by the publish-pr job), so fetchDeviceManifest works unchanged.
@@ -235,7 +249,7 @@ func getAvailablePRDevices(pr int) ([]deviceInfo, error) {
 		info := deviceInfo{
 			Key:            key,
 			Name:           humanizeDeviceKey(key),
-			LatestVersion:  dev.Latest,
+			LatestVersion:  prDeviceVersion(dev),
 			NightlyVersion: dev.LatestNightly,
 			Stability:      dev.Stability,
 			Manifest:       dm,
@@ -367,10 +381,7 @@ func getPROTAInfoForDeviceType(pr int, deviceType, storageMedium string) (artifa
 	if err != nil {
 		return "", "", err
 	}
-	ver := dev.Latest
-	if ver == "" {
-		ver = dev.LatestNightly
-	}
+	ver := prDeviceVersion(dev)
 	if ver == "" {
 		return "", "", fmt.Errorf("no version for %q in PR %d", deviceType, pr)
 	}

--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -180,6 +180,75 @@ func getAvailableDevices() ([]deviceInfo, error) {
 	return devices, nil
 }
 
+// prBasePath returns the GCS path prefix under which a PR build's manifests
+// and images are published, e.g. "pr/123/".
+func prBasePath(pr int) string {
+	return fmt.Sprintf("pr/%d/", pr)
+}
+
+// fetchPRMainManifest fetches the per-PR master manifest written by the
+// wendyos-builder publish-pr job.
+func fetchPRMainManifest(pr int) (*mainManifest, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	url := gcsBaseURL + "/" + prBasePath(pr) + "manifests/master.json"
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching PR %d manifest: %w", pr, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("no build found for PR %d — is the build still running or the PR closed?", pr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("PR %d manifest returned status %d", pr, resp.StatusCode)
+	}
+
+	var m mainManifest
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, fmt.Errorf("decoding PR %d manifest: %w", pr, err)
+	}
+	return &m, nil
+}
+
+// getAvailablePRDevices mirrors getAvailableDevices for a per-PR manifest.
+// The master entries' ManifestPath values are already "pr/<N>/manifests/<device>.json"
+// (written by the publish-pr job), so fetchDeviceManifest works unchanged.
+func getAvailablePRDevices(pr int) ([]deviceInfo, error) {
+	main, err := fetchPRMainManifest(pr)
+	if err != nil {
+		return nil, err
+	}
+
+	var devices []deviceInfo
+	for key, dev := range main.Devices {
+		if dev.ManifestPath == "" {
+			continue
+		}
+
+		dm, err := fetchDeviceManifest(dev.ManifestPath)
+		if err != nil {
+			// Skip devices whose manifest can't be fetched.
+			continue
+		}
+
+		info := deviceInfo{
+			Key:            key,
+			Name:           humanizeDeviceKey(key),
+			LatestVersion:  dev.Latest,
+			NightlyVersion: dev.LatestNightly,
+			Stability:      dev.Stability,
+			Manifest:       dm,
+		}
+
+		devices = append(devices, info)
+	}
+
+	sort.Slice(devices, func(i, j int) bool { return devices[i].Name < devices[j].Name })
+
+	return devices, nil
+}
+
 // imageTriple is the resolved (image, bmap, zst) path set for one storage.
 type imageTriple struct {
 	imagePath string

--- a/go/internal/cli/commands/manifest_pr_test.go
+++ b/go/internal/cli/commands/manifest_pr_test.go
@@ -1,0 +1,9 @@
+package commands
+
+import "testing"
+
+func TestPRBasePath(t *testing.T) {
+	if got := prBasePath(123); got != "pr/123/" {
+		t.Fatalf("prBasePath(123) = %q", got)
+	}
+}

--- a/go/internal/cli/commands/manifest_pr_test.go
+++ b/go/internal/cli/commands/manifest_pr_test.go
@@ -7,3 +7,43 @@ func TestPRBasePath(t *testing.T) {
 		t.Fatalf("prBasePath(123) = %q", got)
 	}
 }
+
+// TestPRDeviceVersion pins the version-resolution rule that getAvailablePRDevices
+// (install path) and getPROTAInfoForDeviceType (update path) must share: prefer
+// Latest, falling back to LatestNightly. The publish-pr job always writes PR
+// master manifests with --nightly, so every real PR device entry has
+// Latest == "" and LatestNightly == "pr-N" — hitting the fallback branch is the
+// common case, not an edge case. Before the fix, getAvailablePRDevices read
+// dev.Latest directly with no fallback, so every PR device's LatestVersion came
+// back "" and installLinuxImage's `if rawVersion == ""  { continue }` filtered
+// every device out of the picker, making `install --pr` resolve zero devices.
+func TestPRDeviceVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		dev  manifestDevice
+		want string
+	}{
+		{
+			name: "nightly-only PR manifest falls back to LatestNightly",
+			dev:  manifestDevice{Latest: "", LatestNightly: "pr-123"},
+			want: "pr-123",
+		},
+		{
+			name: "Latest takes priority when both are set",
+			dev:  manifestDevice{Latest: "0.12.0", LatestNightly: "pr-123"},
+			want: "0.12.0",
+		},
+		{
+			name: "neither set resolves to empty",
+			dev:  manifestDevice{Latest: "", LatestNightly: ""},
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := prDeviceVersion(tc.dev); got != tc.want {
+				t.Fatalf("prDeviceVersion(%+v) = %q, want %q", tc.dev, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -156,6 +156,17 @@ func osAlreadyCurrent(currentOSVersion, latestVersion string, nightly bool) bool
 		!nightly && version.CompareVersions(latestVersion, normalized) <= 0
 }
 
+// osUpdateShouldSkipAlreadyCurrent reports whether `os update`'s auto-detect
+// path should treat the device as already up to date and skip flashing. It
+// never short-circuits for --pr requests (prNumber > 0): a PR's resolved
+// version tag ("pr-N") is constant across rebuilds, so honoring
+// osAlreadyCurrent there would silently no-op a re-test after pushing a new
+// commit to the same PR and re-running `os update --pr N`. Non-PR behavior is
+// unchanged — it defers entirely to osAlreadyCurrent.
+func osUpdateShouldSkipAlreadyCurrent(prNumber int, currentOSVersion, latestVersion string, nightly bool) bool {
+	return prNumber == 0 && osAlreadyCurrent(currentOSVersion, latestVersion, nightly)
+}
+
 // osUpdateAction is the decision for the OS-update step of `device update`.
 type osUpdateAction int
 
@@ -294,7 +305,7 @@ The device uses its in-house wendyos-update engine to apply the update.`,
 					artifactURL = picked
 				} else {
 					if osVer := versionResp.GetOsVersion(); osVer != "" && latestVer != "" {
-						if osAlreadyCurrent(osVer, latestVer, nightly) {
+						if osUpdateShouldSkipAlreadyCurrent(prNumber, osVer, latestVer, nightly) {
 							fmt.Printf("OS is already at the latest version (%s).\n", osVer)
 							return nil
 						}

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -186,6 +186,7 @@ func decideOSUpdate(currentOSVersion, latestVersion string, nightly, assumeYes, 
 func newOSUpdateCmd() *cobra.Command {
 	var artifactURL string
 	var nightly bool
+	var prNumber int
 
 	cmd := &cobra.Command{
 		Use:   "update [artifact-path]",
@@ -204,6 +205,13 @@ The device uses its in-house wendyos-update engine to apply the update.`,
 			// Determine the artifact URL: local path, remote URL, or manifest picker.
 			if len(args) > 0 && artifactURL != "" {
 				return fmt.Errorf("provide either a local artifact path or --artifact-url, not both")
+			}
+
+			if prNumber > 0 {
+				if len(args) > 0 || artifactURL != "" {
+					return fmt.Errorf("--pr cannot be combined with a local artifact path or --artifact-url")
+				}
+				fmt.Fprintln(cmd.ErrOrStderr(), "⚠ PR images are unhardened debug builds (passwordless root, SSH on). Do not use in production.")
 			}
 
 			conn, err := connectToAgent(ctx, SuppressUpdateCheck())
@@ -254,10 +262,20 @@ The device uses its in-house wendyos-update engine to apply the update.`,
 					if deviceType == "" {
 						return "", "", fmt.Errorf("device type not reported")
 					}
+					if prNumber > 0 {
+						return getPROTAInfoForDeviceType(prNumber, deviceType, storageMedium)
+					}
 					return getLatestOTAInfoForDeviceType(deviceType, storageMedium, nightly)
 				}()
 
 				if autoErr != nil {
+					// A --pr update must resolve to that PR's build or fail outright —
+					// falling back to the interactive (non-PR) device picker below would
+					// silently serve a stable/nightly artifact instead of the requested
+					// PR build.
+					if prNumber > 0 {
+						return autoErr
+					}
 					// Device type is missing or not in the update catalog — fall back to
 					// a device picker so the user can force the correct device type.
 					// The latest version (or latest nightly with --nightly) is then chosen
@@ -357,6 +375,7 @@ The device uses its in-house wendyos-update engine to apply the update.`,
 
 	cmd.Flags().StringVar(&artifactURL, "artifact-url", "", "OS update artifact URL (remote)")
 	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use the latest nightly (prerelease) build for both agent and OS")
+	cmd.Flags().IntVar(&prNumber, "pr", 0, "OTA-update to the image built by wendyos-builder PR #N (debug build; mutually exclusive with a positional artifact path and --artifact-url)")
 
 	return cmd
 }

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -222,7 +222,7 @@ The device uses its in-house wendyos-update engine to apply the update.`,
 				if len(args) > 0 || artifactURL != "" {
 					return fmt.Errorf("--pr cannot be combined with a local artifact path or --artifact-url")
 				}
-				fmt.Fprintln(cmd.ErrOrStderr(), "⚠ PR images are unhardened debug builds (passwordless root, SSH on). Do not use in production.")
+				fmt.Fprintln(cmd.ErrOrStderr(), tui.WarningMessage("PR images are unhardened debug builds (passwordless root, SSH on). Do not use in production."))
 			}
 
 			conn, err := connectToAgent(ctx, SuppressUpdateCheck())

--- a/go/internal/cli/commands/os_cmd_test.go
+++ b/go/internal/cli/commands/os_cmd_test.go
@@ -38,6 +38,36 @@ func TestOSAlreadyCurrent(t *testing.T) {
 	}
 }
 
+// TestOSUpdateShouldSkipAlreadyCurrent pins the fix for the `os update --pr N`
+// re-flash bug: a PR's resolved version tag ("pr-N") is constant across
+// rebuilds, so before this fix a second `update --pr N` after pushing a new
+// commit to the same PR would compare "pr-N" == "pr-N" and silently no-op with
+// "already at latest" instead of re-flashing. The non-PR path (prNumber == 0)
+// must keep deferring entirely to osAlreadyCurrent.
+func TestOSUpdateShouldSkipAlreadyCurrent(t *testing.T) {
+	tests := []struct {
+		name     string
+		prNumber int
+		current  string
+		latest   string
+		nightly  bool
+		want     bool
+	}{
+		{"non-PR already current still short-circuits", 0, "WendyOS-0.10.4", "0.10.4", false, true},
+		{"non-PR newer available does not short-circuit", 0, "WendyOS-0.10.4", "0.12.0", false, false},
+		{"PR re-test with identical pr-N tag never short-circuits", 123, "WendyOS-pr-123", "pr-123", false, false},
+		{"PR first-time install never short-circuits even when versions differ", 123, "WendyOS-0.10.4", "pr-123", false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := osUpdateShouldSkipAlreadyCurrent(tc.prNumber, tc.current, tc.latest, tc.nightly); got != tc.want {
+				t.Fatalf("osUpdateShouldSkipAlreadyCurrent(%d,%q,%q,%v) = %v, want %v",
+					tc.prNumber, tc.current, tc.latest, tc.nightly, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDecideOSUpdate(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -97,7 +97,7 @@ Flags can be provided progressively — omitted values trigger interactive picke
 				if deviceType == thorDeviceType {
 					return fmt.Errorf("--pr does not support jetson-agx-thor yet")
 				}
-				fmt.Fprintln(cmd.ErrOrStderr(), "⚠ PR images are unhardened debug builds (passwordless root, SSH on). Do not use in production.")
+				fmt.Fprintln(cmd.ErrOrStderr(), tui.WarningMessage("PR images are unhardened debug builds (passwordless root, SSH on). Do not use in production."))
 			}
 			// Positional direct-install mode is incompatible with manifest-backed flags.
 			if len(args) > 0 && (deviceType != "" || versionFlag != "" || driveFlag != "" || wifiSSID != "" || wifiPassword != "" || len(wifiEntries) > 0 || noWifi || deviceName != "" || enrollCloudGRPC != "") {

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -94,6 +94,9 @@ Flags can be provided progressively — omitted values trigger interactive picke
 				if nightly || versionFlag != "" || len(args) > 0 {
 					return fmt.Errorf("--pr cannot be combined with --nightly, --version, or positional image/drive arguments")
 				}
+				if deviceType == thorDeviceType {
+					return fmt.Errorf("--pr does not support jetson-agx-thor yet")
+				}
 				fmt.Fprintln(cmd.ErrOrStderr(), "⚠ PR images are unhardened debug builds (passwordless root, SSH on). Do not use in production.")
 			}
 			// Positional direct-install mode is incompatible with manifest-backed flags.
@@ -313,7 +316,10 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	}
 
 	// When --device-type is not provided, also offer ESP32 entries in the picker.
-	if flagDeviceType == "" {
+	// Never under --pr: firmware isn't a PR build target and installESP32Firmware
+	// ignores prNumber, so offering ESP32 here would silently install release
+	// firmware instead of a PR build.
+	if flagDeviceType == "" && prNumber == 0 {
 		espVersion := "(latest)"
 		for _, esp := range []struct {
 			key, name, chip string

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -59,6 +59,7 @@ func newOSInstallCmd() *cobra.Command {
 	var noWifi bool
 	var deviceName string
 	var enrollCloudGRPC string
+	var prNumber int
 
 	cmd := &cobra.Command{
 		Use:   "install [image] [drive]",
@@ -89,6 +90,12 @@ Flags can be provided progressively — omitted values trigger interactive picke
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if prNumber > 0 {
+				if nightly || versionFlag != "" || len(args) > 0 {
+					return fmt.Errorf("--pr cannot be combined with --nightly, --version, or positional image/drive arguments")
+				}
+				fmt.Fprintln(cmd.ErrOrStderr(), "⚠ PR images are unhardened debug builds (passwordless root, SSH on). Do not use in production.")
+			}
 			// Positional direct-install mode is incompatible with manifest-backed flags.
 			if len(args) > 0 && (deviceType != "" || versionFlag != "" || driveFlag != "" || wifiSSID != "" || wifiPassword != "" || len(wifiEntries) > 0 || noWifi || deviceName != "" || enrollCloudGRPC != "") {
 				return fmt.Errorf("positional [image] [drive] arguments cannot be combined with --device-type, --version, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, or --cloud-grpc")
@@ -115,7 +122,7 @@ Flags can be provided progressively — omitted values trigger interactive picke
 					mode = preEnrollSkip
 				}
 			}
-			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, noBmap, storageOverride, opts, deviceName, preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC})
+			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, noBmap, storageOverride, opts, deviceName, preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC}, prNumber)
 		},
 	}
 
@@ -134,6 +141,7 @@ Flags can be provided progressively — omitted values trigger interactive picke
 	cmd.Flags().StringVar(&deviceName, "device-name", "", "Set device name on first boot (e.g. brave-dolphin)")
 	cmd.Flags().BoolVar(&preEnroll, "pre-enroll", false, "Pre-enroll this device with Wendy Cloud during imaging (requires 'wendy auth login')")
 	cmd.Flags().StringVar(&enrollCloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint of the auth session to use for pre-enrollment (optional when a default is set via 'wendy auth use')")
+	cmd.Flags().IntVar(&prNumber, "pr", 0, "Install the image built by wendyos-builder PR #N (debug build; mutually exclusive with --nightly, --version, and positional [image] [drive])")
 
 	return cmd
 }
@@ -246,7 +254,7 @@ func pickLinuxDevice() (string, deviceInfo, error) {
 	return key, deviceMap[key], nil
 }
 
-func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap bool, storageOverride string, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
+func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap bool, storageOverride string, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions, prNumber int) error {
 	if storageOverride != "" && storageOverride != "nvme" && storageOverride != "sd" {
 		return fmt.Errorf("invalid --storage %q: must be \"nvme\" or \"sd\"", storageOverride)
 	}
@@ -259,8 +267,15 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 
 	fmt.Println("Fetching available devices...")
 
-	// Fetch Linux devices from GCS manifest.
-	linuxDevices, err := getAvailableDevices()
+	// Fetch Linux devices from GCS manifest — the per-PR manifest when --pr is
+	// set, otherwise the standard release manifest.
+	var linuxDevices []deviceInfo
+	var err error
+	if prNumber > 0 {
+		linuxDevices, err = getAvailablePRDevices(prNumber)
+	} else {
+		linuxDevices, err = getAvailableDevices()
+	}
 	if err != nil {
 		log.Printf("WARNING: could not fetch Linux device manifest: %v", err)
 	}
@@ -337,6 +352,9 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 				}
 			}
 			sort.Strings(available)
+			if prNumber > 0 {
+				return fmt.Errorf("device %q not built by PR %d (built: %s)", flagDeviceType, prNumber, strings.Join(available, ", "))
+			}
 			return fmt.Errorf("device type %q not found in manifest; available: %s", flagDeviceType, strings.Join(available, ", "))
 		}
 		selected = flagDeviceType

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -27,7 +27,7 @@ func TestNewOSInstallCmd_Flags(t *testing.T) {
 		t.Errorf("Use = %q; want %q", cmd.Use, "install [image] [drive]")
 	}
 
-	expectedFlags := []string{"nightly", "force", "yes-overwrite-internal", "device-type", "version", "drive", "wifi-ssid", "wifi-password", "wifi", "no-wifi", "device-name", "storage", "no-bmap"}
+	expectedFlags := []string{"nightly", "force", "yes-overwrite-internal", "device-type", "version", "drive", "wifi-ssid", "wifi-password", "wifi", "no-wifi", "device-name", "storage", "no-bmap", "pr"}
 	for _, name := range expectedFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("missing flag %q", name)
@@ -48,10 +48,29 @@ func TestNewOSInstallCmd_NightlyVersionMutualExclusion(t *testing.T) {
 }
 
 func TestOSInstallPRMutualExclusion(t *testing.T) {
-	cmd := newOSInstallCmd()
-	cmd.SetArgs([]string{"--pr", "123", "--nightly"})
-	if err := cmd.Execute(); err == nil {
-		t.Fatal("expected error for --pr with --nightly")
+	const mutexErr = "--pr cannot be combined with --nightly, --version, or positional image/drive arguments"
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"pr with nightly", []string{"--pr", "123", "--nightly"}, mutexErr},
+		{"pr with version", []string{"--pr", "123", "--version", "0.10.0"}, mutexErr},
+		{"pr with positional args", []string{"--pr", "123", "image.img", "/dev/disk4"}, mutexErr},
+		{"pr with thor device", []string{"--pr", "123", "--device-type", "jetson-agx-thor"}, "--pr does not support jetson-agx-thor yet"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newOSInstallCmd()
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error for args %v", tc.args)
+			}
+			if got := err.Error(); got != tc.wantErr {
+				t.Errorf("unexpected error: %q; want %q", got, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -47,6 +47,14 @@ func TestNewOSInstallCmd_NightlyVersionMutualExclusion(t *testing.T) {
 	}
 }
 
+func TestOSInstallPRMutualExclusion(t *testing.T) {
+	cmd := newOSInstallCmd()
+	cmd.SetArgs([]string{"--pr", "123", "--nightly"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for --pr with --nightly")
+	}
+}
+
 func TestNewOSInstallCmd_PositionalArgsIncompatibleWithFlags(t *testing.T) {
 	tests := []struct {
 		name string

--- a/go/internal/cli/commands/os_update_pr_test.go
+++ b/go/internal/cli/commands/os_update_pr_test.go
@@ -1,0 +1,35 @@
+package commands
+
+import "testing"
+
+func TestOSUpdatePRFlag(t *testing.T) {
+	cmd := newOSUpdateCmd()
+	if cmd.Flags().Lookup("pr") == nil {
+		t.Fatal("expected --pr flag on os update")
+	}
+}
+
+func TestOSUpdatePRMutualExclusion(t *testing.T) {
+	const mutexErr = "--pr cannot be combined with a local artifact path or --artifact-url"
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"pr with positional artifact path", []string{"--pr", "123", "image.wendy"}, mutexErr},
+		{"pr with artifact-url", []string{"--pr", "123", "--artifact-url", "https://example.com/image.wendy"}, mutexErr},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newOSUpdateCmd()
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error for args %v", tc.args)
+			}
+			if got := err.Error(); got != tc.wantErr {
+				t.Errorf("unexpected error: %q; want %q", got, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Add `wendy os install --pr N` and `wendy os update --pr N` — flash or OTA a device to the WendyOS image built by a specific `wendyos-builder` PR. Pairs with the builder-side PR (see below).

## How it works

- New manifest resolvers (`fetchPRMainManifest`, `getAvailablePRDevices`, `getPROTAInfoForDeviceType`) read `pr/<N>/manifests/master.json` under the same public bucket — no GitHub API. Reuses the existing download path; the PR device manifests already carry `pr/<N>/`-prefixed paths.
- `--pr` is mutually exclusive with `--nightly`/`--version`/positional args (install) and the artifact path/`--artifact-url` (update), with exact-error tests.
- Every `--pr` install/update prints an unhardened-debug-build warning to stderr; PR images are passwordless-root + SSH-on and deleted when the PR closes.

## Scope

`--pr` supports Linux disk-image devices (Raspberry Pi, Jetson Orin Nano, Jetson AGX Orin). It rejects Jetson AGX Thor (separate flashpack path, not yet PR-aware) and hides ESP32. **No silent fallback**: with `--pr` set there is no code path that serves a release/nightly artifact (verified end-to-end in review).

## Notable fixes caught in review

- PR builds publish with a nightly-style tag (`latest=""`, `latest_nightly="pr-N"`), so version resolution falls back to `LatestNightly` (shared `prDeviceVersion` helper) — otherwise `install --pr` resolved nothing.
- `update --pr` bypasses the "already at latest" short-circuit (the `pr-N` tag is constant across rebuilds, so the push→re-OTA dev loop would otherwise silently no-op).

## Verification

`go build`/`go vet`/`go test ./internal/cli/commands/` green, incl. new tests for version resolution, the re-flash guard, and all mutual-exclusion cases. End-to-end against a live PR manifest is a post-merge check.

## Depends on

`wendylabsinc/WendyOS-Builder#180` — **must merge first** (this CLI can't resolve `--pr` until the builder publishes `pr/<N>/` manifests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
