### PR TITLE
feat(fleet): fleet feature on the mesh (discovery via device-<id> names)

### DIFF
--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -482,6 +482,12 @@ func cloudDiscoverJSON(ctx context.Context, auth *config.AuthConfig, all bool) e
 
 // fetchCloudAssetsFiltered retrieves compute-device assets for the org.
 // When onlineOnly is true, only online (enrolled and reachable) assets are returned.
+//
+// ListAssets is paginated server-side: a single request returns only the first
+// page (capped well below a large fleet), so we page through with offset/limit
+// until we've collected every asset the server reports via total. Without this,
+// callers silently see only the first page — e.g. fleet group operations could
+// not target devices that fell outside it.
 func fetchCloudAssetsFiltered(ctx context.Context, auth *config.AuthConfig, onlineOnly bool) ([]*cloudpb.Asset, error) {
 	cert := auth.Certificates[0]
 	cloudConn, err := dialCloudGRPC(auth)
@@ -491,32 +497,49 @@ func fetchCloudAssetsFiltered(ctx context.Context, auth *config.AuthConfig, onli
 	defer cloudConn.Close()
 
 	assetClient := cloudpb.NewAssetServiceClient(cloudConn)
-	req := &cloudpb.ListAssetsRequest{
-		OrganizationId:  int32(cert.OrganizationID),
-		IsComputeDevice: boolPtr(true),
-	}
-	if onlineOnly {
-		req.OnlineOnly = boolPtr(true)
-	}
 
-	stream, err := assetClient.ListAssets(cloudContext(ctx, auth), req)
-	if err != nil {
-		return nil, fmt.Errorf("listing devices: %w", err)
-	}
-
+	const pageSize = 200
 	var assets []*cloudpb.Asset
-	for {
-		resp, err := stream.Recv()
-		if err == io.EOF {
-			break
+	for offset := int32(0); ; {
+		req := &cloudpb.ListAssetsRequest{
+			OrganizationId:  int32(cert.OrganizationID),
+			IsComputeDevice: boolPtr(true),
+			Offset:          int32Ptr(offset),
+			Limit:           int32Ptr(pageSize),
 		}
+		if onlineOnly {
+			req.OnlineOnly = boolPtr(true)
+		}
+
+		stream, err := assetClient.ListAssets(cloudContext(ctx, auth), req)
 		if err != nil {
 			return nil, fmt.Errorf("listing devices: %w", err)
 		}
-		if len(assets) >= maxCloudAssets {
-			return nil, fmt.Errorf("cloud returned more than %d devices", maxCloudAssets)
+
+		page := 0
+		var total int32
+		for {
+			resp, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("listing devices: %w", err)
+			}
+			if len(assets) >= maxCloudAssets {
+				return nil, fmt.Errorf("cloud returned more than %d devices", maxCloudAssets)
+			}
+			assets = append(assets, resp.GetAsset())
+			page++
+			total = resp.GetTotal()
 		}
-		assets = append(assets, resp.GetAsset())
+
+		offset += int32(page)
+		// Done when the server reports we've seen every asset, or a page makes
+		// no progress (guards against a missing/inconsistent total).
+		if page == 0 || offset >= total {
+			break
+		}
 	}
 	return assets, nil
 }

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -465,6 +465,8 @@ func pickCloudDevice(ctx context.Context, auth *config.AuthConfig, deviceName, b
 
 func boolPtr(b bool) *bool { return &b }
 
+func int32Ptr(i int32) *int32 { return &i }
+
 func dialCloudGRPC(auth *config.AuthConfig) (*grpc.ClientConn, error) {
 	if len(auth.Certificates) == 0 {
 		return nil, fmt.Errorf("auth entry has no certificates; re-run 'wendy auth login'")

--- a/go/internal/cli/commands/fleet.go
+++ b/go/internal/cli/commands/fleet.go
@@ -1,0 +1,331 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// groupNamePattern restricts a device-group name (an Asset tag used as a group):
+// start with an alphanumeric, then alphanumerics, '.', '_', or '-'. This keeps
+// group names safe to pass as CLI args, embed in tables, and round-trip through
+// the cloud filter (which treats commas/spaces specially).
+var groupNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$`)
+
+// validateGroupName reports whether name is a well-formed device-group name.
+func validateGroupName(name string) error {
+	if name == "" {
+		return fmt.Errorf("group name is required")
+	}
+	if !groupNamePattern.MatchString(name) {
+		return fmt.Errorf("group name %q is invalid: start with a letter or digit, then letters, digits, '.', '_', or '-' (max 63 chars)", name)
+	}
+	return nil
+}
+
+// addTag returns tags with tag appended. changed is false when the tag was
+// already present (the returned slice is then equivalent to the input).
+func addTag(tags []string, tag string) (result []string, changed bool) {
+	for _, t := range tags {
+		if t == tag {
+			return tags, false
+		}
+	}
+	out := make([]string, 0, len(tags)+1)
+	out = append(out, tags...)
+	out = append(out, tag)
+	return out, true
+}
+
+// removeTag returns tags with every occurrence of tag removed. changed is false
+// when the tag was not present.
+func removeTag(tags []string, tag string) (result []string, changed bool) {
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t != tag {
+			out = append(out, t)
+		}
+	}
+	return out, len(out) != len(tags)
+}
+
+// groupCounts maps each tag (group) to the number of assets that carry it.
+func groupCounts(assets []*cloudpb.Asset) map[string]int {
+	counts := map[string]int{}
+	for _, a := range assets {
+		for _, t := range a.GetTags() {
+			counts[t]++
+		}
+	}
+	return counts
+}
+
+// assetsInGroup returns the assets carrying the given tag, preserving input order.
+func assetsInGroup(assets []*cloudpb.Asset, group string) []*cloudpb.Asset {
+	var out []*cloudpb.Asset
+	for _, a := range assets {
+		for _, t := range a.GetTags() {
+			if t == group {
+				out = append(out, a)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func newFleetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fleet",
+		Short: "Manage groups of WendyOS devices",
+		Long: "Operate across many devices at once.\n\n" +
+			"A device group is a tag on the cloud Asset: a device is in group \"cameras\" when it\n" +
+			"carries that tag. Group membership is the targeting primitive that fleet-wide\n" +
+			"operations (deploying to a whole group, fleet inventory) build on.",
+	}
+	cmd.AddCommand(newFleetGroupCmd())
+	return cmd
+}
+
+func newFleetGroupCmd() *cobra.Command {
+	var cloudGRPC string
+
+	cmd := &cobra.Command{
+		Use:   "group",
+		Short: "Define and inspect device groups",
+	}
+	cmd.PersistentFlags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
+
+	cmd.AddCommand(
+		&cobra.Command{
+			Use:   "ls",
+			Short: "List device groups and their member counts",
+			Args:  cobra.NoArgs,
+			RunE: func(cmd *cobra.Command, _ []string) error {
+				return runFleetGroupLs(cmd.Context(), cloudGRPC)
+			},
+		},
+		&cobra.Command{
+			Use:   "show <group>",
+			Short: "List the devices in a group",
+			Args:  cobra.ExactArgs(1),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runFleetGroupShow(cmd.Context(), cloudGRPC, args[0])
+			},
+		},
+		&cobra.Command{
+			Use:   "add <group> <device>...",
+			Short: "Add one or more devices to a group",
+			Args:  cobra.MinimumNArgs(2),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runFleetGroupMembership(cmd.Context(), cloudGRPC, args[0], args[1:], true)
+			},
+		},
+		&cobra.Command{
+			Use:   "rm <group> <device>...",
+			Short: "Remove one or more devices from a group",
+			Args:  cobra.MinimumNArgs(2),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runFleetGroupMembership(cmd.Context(), cloudGRPC, args[0], args[1:], false)
+			},
+		},
+	)
+	return cmd
+}
+
+// fleetGroupSummary is the --json shape for `fleet group ls`.
+type fleetGroupSummary struct {
+	Group   string `json:"group"`
+	Devices int    `json:"devices"`
+}
+
+func runFleetGroupLs(ctx context.Context, cloudGRPC string) error {
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+
+	counts := groupCounts(assets)
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if jsonOutput || !isInteractiveTerminal() {
+		out := make([]fleetGroupSummary, 0, len(names))
+		for _, name := range names {
+			out = append(out, fleetGroupSummary{Group: name, Devices: counts[name]})
+		}
+		return printJSON(out)
+	}
+
+	if len(names) == 0 {
+		fmt.Println("No device groups yet. Create one with 'wendy fleet group add <group> <device>...'.")
+		return nil
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "GROUP\tDEVICES")
+	for _, name := range names {
+		fmt.Fprintf(tw, "%s\t%d\n", name, counts[name])
+	}
+	return tw.Flush()
+}
+
+func runFleetGroupShow(ctx context.Context, cloudGRPC, group string) error {
+	if err := validateGroupName(group); err != nil {
+		return err
+	}
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+	members := assetsInGroup(assets, group)
+
+	if jsonOutput || !isInteractiveTerminal() {
+		infos := make([]discoverDeviceInfo, 0, len(members))
+		for _, a := range members {
+			infos = append(infos, cloudDeviceInfoFromAsset(a, nil))
+		}
+		return printJSON(infos)
+	}
+
+	if len(members) == 0 {
+		fmt.Printf("Group %q has no devices (or does not exist).\n", group)
+		return nil
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "ID\tNAME\tTYPE\tADDRESS")
+	for _, a := range members {
+		info := cloudDeviceInfoFromAsset(a, nil)
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\n", info.ID, info.Name, info.Type, info.Address)
+	}
+	return tw.Flush()
+}
+
+// fleetMembershipResult is the per-device outcome of an add/rm, used for --json.
+type fleetMembershipResult struct {
+	Device  string `json:"device"`
+	AssetID int32  `json:"assetId,omitempty"`
+	Changed bool   `json:"changed"`
+	Error   string `json:"error,omitempty"`
+}
+
+func runFleetGroupMembership(ctx context.Context, cloudGRPC, group string, devices []string, add bool) error {
+	if err := validateGroupName(group); err != nil {
+		return err
+	}
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+
+	conn, err := dialCloudGRPC(auth)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	client := cloudpb.NewAssetServiceClient(conn)
+
+	results := make([]fleetMembershipResult, 0, len(devices))
+	failures := 0
+	for _, dev := range devices {
+		res := fleetMembershipResult{Device: dev}
+		asset, rErr := resolveCloudAsset(assets, dev)
+		if rErr != nil {
+			res.Error = rErr.Error()
+			failures++
+			results = append(results, res)
+			continue
+		}
+		res.AssetID = asset.GetId()
+
+		var newTags []string
+		var changed bool
+		if add {
+			newTags, changed = addTag(asset.GetTags(), group)
+		} else {
+			newTags, changed = removeTag(asset.GetTags(), group)
+		}
+		res.Changed = changed
+		if !changed {
+			// Already in the desired state — skip the round-trip.
+			results = append(results, res)
+			continue
+		}
+
+		// UpdateAsset replaces the tags list with the value sent; other (optional)
+		// fields left unset are not modified.
+		if _, uErr := client.UpdateAsset(cloudContext(ctx, auth), &cloudpb.UpdateAssetRequest{
+			Id:   asset.GetId(),
+			Tags: newTags,
+		}); uErr != nil {
+			res.Changed = false
+			res.Error = uErr.Error()
+			failures++
+		}
+		results = append(results, res)
+	}
+
+	if jsonOutput || !isInteractiveTerminal() {
+		if err := printJSON(results); err != nil {
+			return err
+		}
+	} else {
+		verb := "Added"
+		prep := "to"
+		if !add {
+			verb = "Removed"
+			prep = "from"
+		}
+		for _, r := range results {
+			switch {
+			case r.Error != "":
+				fmt.Fprintf(os.Stderr, "  ✗ %s: %s\n", r.Device, r.Error)
+			case r.Changed:
+				fmt.Printf("  ✓ %s %s %s %q\n", verb, r.Device, prep, group)
+			default:
+				state := "already in"
+				if !add {
+					state = "not in"
+				}
+				fmt.Printf("  • %s %s group %q\n", r.Device, state, group)
+			}
+		}
+	}
+
+	if failures > 0 {
+		return fmt.Errorf("%d of %d device(s) failed", failures, len(devices))
+	}
+	return nil
+}
+
+// printJSON writes v as indented JSON to stdout.
+func printJSON(v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}

--- a/go/internal/cli/commands/fleet.go
+++ b/go/internal/cli/commands/fleet.go
@@ -91,7 +91,11 @@ func newFleetCmd() *cobra.Command {
 			"carries that tag. Group membership is the targeting primitive that fleet-wide\n" +
 			"operations (deploying to a whole group, fleet inventory) build on.",
 	}
-	cmd.AddCommand(newFleetGroupCmd())
+	cmd.AddCommand(
+		newFleetGroupCmd(),
+		newFleetAppsCmd(),
+		newFleetRunCmd(),
+	)
 	return cmd
 }
 

--- a/go/internal/cli/commands/fleet.go
+++ b/go/internal/cli/commands/fleet.go
@@ -82,6 +82,25 @@ func assetsInGroup(assets []*cloudpb.Asset, group string) []*cloudpb.Asset {
 	return out
 }
 
+// assetsWithAnyTag returns the assets carrying any of the given tags (exact
+// match — cloud tags are assigned labels, not globs), preserving input order.
+func assetsWithAnyTag(assets []*cloudpb.Asset, tags []string) []*cloudpb.Asset {
+	want := make(map[string]bool, len(tags))
+	for _, t := range tags {
+		want[t] = true
+	}
+	var out []*cloudpb.Asset
+	for _, a := range assets {
+		for _, t := range a.GetTags() {
+			if want[t] {
+				out = append(out, a)
+				break
+			}
+		}
+	}
+	return out
+}
+
 func newFleetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fleet",

--- a/go/internal/cli/commands/fleet_apps.go
+++ b/go/internal/cli/commands/fleet_apps.go
@@ -1,0 +1,195 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"sync"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// fleetAppsMaxConcurrency bounds how many device tunnels we open at once when
+// gathering inventory across a group.
+const fleetAppsMaxConcurrency = 8
+
+func newFleetAppsCmd() *cobra.Command {
+	var group string
+	var cloudGRPC, brokerURL string
+
+	cmd := &cobra.Command{
+		Use:   "apps",
+		Short: "List the apps running across a group (or the whole org)",
+		Long: "Fans out to every device in a group (or all enrolled devices when --group is\n" +
+			"omitted) and prints one row per app: which device it runs on, its version, and\n" +
+			"its state. Devices that can't be reached are reported inline rather than failing\n" +
+			"the whole command.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runFleetApps(cmd.Context(), group, cloudGRPC, brokerURL)
+		},
+	}
+	cmd.Flags().StringVar(&group, "group", "", "Limit to devices in this group (default: all enrolled devices)")
+	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
+	cmd.Flags().StringVar(&brokerURL, "broker-url", os.Getenv("WENDY_BROKER_URL"), "Tunnel broker host:port")
+	return cmd
+}
+
+// fleetAppRow is one row of fleet inventory (a single app on a single device),
+// and the --json element shape. A row with Error set and App empty represents a
+// device that could not be reached.
+type fleetAppRow struct {
+	Device  string `json:"device"`
+	AssetID int32  `json:"assetId"`
+	App     string `json:"app,omitempty"`
+	Version string `json:"version,omitempty"`
+	State   string `json:"state,omitempty"`
+	Errors  uint32 `json:"errors,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+func runFleetApps(ctx context.Context, group, cloudGRPC, brokerURL string) error {
+	if group != "" {
+		if err := validateGroupName(group); err != nil {
+			return err
+		}
+	}
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+	if group != "" {
+		assets = assetsInGroup(assets, group)
+	}
+	if len(assets) == 0 {
+		if group != "" {
+			return fmt.Errorf("group %q has no devices", group)
+		}
+		return fmt.Errorf("no enrolled devices found for this org")
+	}
+
+	rows := gatherFleetApps(ctx, auth, assets, brokerURL)
+	sortFleetAppRows(rows)
+
+	if jsonOutput || !isInteractiveTerminal() {
+		return printJSON(rows)
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "DEVICE\tAPP\tVERSION\tSTATE\tERRORS")
+	for _, r := range rows {
+		if r.Error != "" {
+			fmt.Fprintf(tw, "%s\t(unreachable: %s)\t\t\t\n", r.Device, r.Error)
+			continue
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\n", r.Device, r.App, dash(r.Version), r.State, r.Errors)
+	}
+	return tw.Flush()
+}
+
+// gatherFleetApps queries every asset's container list concurrently and flattens
+// the result into per-app rows. A device that errors contributes a single row
+// with its Error set; one bad device never fails the whole sweep.
+func gatherFleetApps(ctx context.Context, auth *config.AuthConfig, assets []*cloudpb.Asset, brokerURL string) []fleetAppRow {
+	var (
+		mu   sync.Mutex
+		rows []fleetAppRow
+	)
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(fleetAppsMaxConcurrency)
+
+	for _, asset := range assets {
+		asset := asset
+		g.Go(func() error {
+			containers, err := listAssetContainers(ctx, auth, asset, brokerURL)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				rows = append(rows, fleetAppRow{Device: asset.GetName(), AssetID: asset.GetId(), Error: err.Error()})
+				return nil
+			}
+			if len(containers) == 0 {
+				// Reachable but no apps — still worth a row so the device shows up.
+				rows = append(rows, fleetAppRow{Device: asset.GetName(), AssetID: asset.GetId(), App: "—", State: "—"})
+				return nil
+			}
+			for _, c := range containers {
+				rows = append(rows, fleetAppRow{
+					Device:  asset.GetName(),
+					AssetID: asset.GetId(),
+					App:     c.GetAppName(),
+					Version: c.GetAppVersion(),
+					State:   runningStateString(c.GetRunningState()),
+					Errors:  c.GetFailureCount(),
+				})
+			}
+			return nil
+		})
+	}
+	_ = g.Wait() // per-device errors are captured as rows; Wait never returns one.
+	return rows
+}
+
+// listAssetContainers opens a tunnel to one asset and drains its container list.
+func listAssetContainers(ctx context.Context, auth *config.AuthConfig, asset *cloudpb.Asset, brokerURL string) ([]*agentpb.AppContainer, error) {
+	conn, err := connectCloudAsset(ctx, auth, asset, brokerURL)
+	if err != nil {
+		return nil, fmt.Errorf("connecting: %w", err)
+	}
+	defer conn.Close()
+
+	stream, err := conn.ContainerService.ListContainers(ctx, &agentpb.ListContainersRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("listing containers: %w", err)
+	}
+	var containers []*agentpb.AppContainer
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("receiving container list: %w", err)
+		}
+		if c := resp.GetContainer(); c != nil {
+			containers = append(containers, c)
+		}
+	}
+	return containers, nil
+}
+
+// sortFleetAppRows orders rows by device, then app, for stable output.
+func sortFleetAppRows(rows []fleetAppRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Device != rows[j].Device {
+			return rows[i].Device < rows[j].Device
+		}
+		return rows[i].App < rows[j].App
+	})
+}
+
+func runningStateString(s agentpb.AppRunningState) string {
+	if s == agentpb.AppRunningState_RUNNING {
+		return "running"
+	}
+	return "stopped"
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}

--- a/go/internal/cli/commands/fleet_apps.go
+++ b/go/internal/cli/commands/fleet_apps.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"text/tabwriter"
@@ -14,6 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
@@ -24,25 +27,26 @@ const fleetAppsMaxConcurrency = 8
 func newFleetAppsCmd() *cobra.Command {
 	var group string
 	var cloudGRPC, brokerURL string
-	var lan bool
+	var lan, all bool
 	var timeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "apps",
-		Short: "List the apps running across a group (or every device)",
-		Long: "Fans out to every device in a group (or all devices when --group is omitted)\n" +
-			"and prints one row per app: which device it runs on, its version, and its\n" +
-			"state. Devices that can't be reached are reported inline rather than failing\n" +
-			"the whole command.\n\n" +
-			"With --lan the group is resolved over the local network via mDNS instead of the\n" +
-			"cloud: a group is a glob over device names (e.g. 'camera-*' or 'camera'), no\n" +
-			"enrollment or cloud session required.",
+		Short: "List this fleet's apps across its devices (or every app with --all)",
+		Long: "Prints one row per app: which device it runs on, its version, and its state.\n" +
+			"Devices that can't be reached are reported inline rather than failing the sweep.\n\n" +
+			"Run inside a fleet project (a directory with a wendy-fleet.json) and it scopes to\n" +
+			"that fleet's own components, on the devices its tags match. Pass --all to instead\n" +
+			"list every app on the matched devices, or --group <glob> to pick devices directly.\n\n" +
+			"With --lan the devices are resolved over the local network via mDNS (a glob over\n" +
+			"device names, e.g. 'camera-*'); no enrollment or cloud session required.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runFleetApps(cmd.Context(), group, cloudGRPC, brokerURL, lan, timeout)
+			return runFleetApps(cmd.Context(), group, cloudGRPC, brokerURL, lan, all, timeout)
 		},
 	}
-	cmd.Flags().StringVar(&group, "group", "", "Limit to devices in this group (default: all devices)")
+	cmd.Flags().StringVar(&group, "group", "", "Limit to devices matching this group/glob (default: the fleet's devices, or all)")
+	cmd.Flags().BoolVar(&all, "all", false, "List every app on the matched devices, not just this fleet's components")
 	cmd.Flags().BoolVar(&lan, "lan", false, "Resolve the group over the LAN (mDNS) instead of the cloud")
 	cmd.Flags().DurationVar(&timeout, "discover-timeout", fleetLANDiscoverTimeout, "How long to browse for LAN devices (with --lan)")
 	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
@@ -62,10 +66,27 @@ type fleetAppRow struct {
 	Error   string `json:"error,omitempty"`
 }
 
-func runFleetApps(ctx context.Context, group, cloudGRPC, brokerURL string, lan bool, timeout time.Duration) error {
-	targets, err := resolveFleetTargets(ctx, group, lan, cloudGRPC, brokerURL, timeout)
-	if err != nil {
-		return err
+func runFleetApps(ctx context.Context, group, cloudGRPC, brokerURL string, lan, all bool, timeout time.Duration) error {
+	// When run inside a fleet project, scope to that fleet's own components (and,
+	// unless --group picks devices, to the devices its tags match). --all opts
+	// back into the full per-device inventory.
+	fleetApps, fleetTags := localFleetScope()
+
+	var targets []fleetTarget
+	var err error
+	if lan && group == "" && len(fleetTags) > 0 {
+		devices, dErr := lanDevicesForTags(ctx, fleetTags, timeout)
+		if dErr != nil {
+			return dErr
+		}
+		for _, dev := range devices {
+			targets = append(targets, targetForDevice(dev))
+		}
+	} else {
+		targets, err = resolveFleetTargets(ctx, group, lan, cloudGRPC, brokerURL, timeout)
+		if err != nil {
+			return err
+		}
 	}
 	if len(targets) == 0 {
 		if group != "" {
@@ -78,6 +99,9 @@ func runFleetApps(ctx context.Context, group, cloudGRPC, brokerURL string, lan b
 	}
 
 	rows := gatherFleetApps(ctx, targets)
+	if len(fleetApps) > 0 && !all {
+		rows = filterFleetAppRows(rows, fleetApps)
+	}
 	sortFleetAppRows(rows)
 
 	if jsonOutput || !isInteractiveTerminal() {
@@ -192,4 +216,52 @@ func dash(s string) string {
 		return "—"
 	}
 	return s
+}
+
+// localFleetScope loads a wendy-fleet.json from the current directory (a fleet
+// project) if present, returning the set of its component app ids and the union
+// of their device tags. Both are empty when there is no manifest here.
+func localFleetScope() (appIDs map[string]bool, tags []string) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, nil
+	}
+	manifest, err := appconfig.LoadFleetManifest(filepath.Join(cwd, appconfig.FleetManifestFileName))
+	if err != nil {
+		return nil, nil
+	}
+	appIDs = map[string]bool{}
+	tagSet := map[string]bool{}
+	for _, comp := range manifest.Components {
+		for _, t := range comp.Tags {
+			tagSet[t] = true
+		}
+		// Each component's own wendy.json carries its app id.
+		data, rerr := os.ReadFile(filepath.Join(cwd, comp.Path, "wendy.json"))
+		if rerr != nil {
+			continue
+		}
+		var app struct {
+			AppID string `json:"appId"`
+		}
+		if json.Unmarshal(data, &app) == nil && app.AppID != "" {
+			appIDs[app.AppID] = true
+		}
+	}
+	for t := range tagSet {
+		tags = append(tags, t)
+	}
+	return appIDs, tags
+}
+
+// filterFleetAppRows keeps only rows whose app is in keep, plus unreachable rows
+// (Error set) so connection failures still surface.
+func filterFleetAppRows(rows []fleetAppRow, keep map[string]bool) []fleetAppRow {
+	out := make([]fleetAppRow, 0, len(rows))
+	for _, r := range rows {
+		if r.Error != "" || keep[r.App] {
+			out = append(out, r)
+		}
+	}
+	return out
 }

--- a/go/internal/cli/commands/fleet_apps.go
+++ b/go/internal/cli/commands/fleet_apps.go
@@ -8,36 +8,43 @@ import (
 	"sort"
 	"sync"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
-	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 )
 
-// fleetAppsMaxConcurrency bounds how many device tunnels we open at once when
-// gathering inventory across a group.
+// fleetAppsMaxConcurrency bounds how many device connections we open at once
+// when gathering inventory across a group.
 const fleetAppsMaxConcurrency = 8
 
 func newFleetAppsCmd() *cobra.Command {
 	var group string
 	var cloudGRPC, brokerURL string
+	var lan bool
+	var timeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "apps",
-		Short: "List the apps running across a group (or the whole org)",
-		Long: "Fans out to every device in a group (or all enrolled devices when --group is\n" +
-			"omitted) and prints one row per app: which device it runs on, its version, and\n" +
-			"its state. Devices that can't be reached are reported inline rather than failing\n" +
-			"the whole command.",
+		Short: "List the apps running across a group (or every device)",
+		Long: "Fans out to every device in a group (or all devices when --group is omitted)\n" +
+			"and prints one row per app: which device it runs on, its version, and its\n" +
+			"state. Devices that can't be reached are reported inline rather than failing\n" +
+			"the whole command.\n\n" +
+			"With --lan the group is resolved over the local network via mDNS instead of the\n" +
+			"cloud: a group is a glob over device names (e.g. 'camera-*' or 'camera'), no\n" +
+			"enrollment or cloud session required.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runFleetApps(cmd.Context(), group, cloudGRPC, brokerURL)
+			return runFleetApps(cmd.Context(), group, cloudGRPC, brokerURL, lan, timeout)
 		},
 	}
-	cmd.Flags().StringVar(&group, "group", "", "Limit to devices in this group (default: all enrolled devices)")
+	cmd.Flags().StringVar(&group, "group", "", "Limit to devices in this group (default: all devices)")
+	cmd.Flags().BoolVar(&lan, "lan", false, "Resolve the group over the LAN (mDNS) instead of the cloud")
+	cmd.Flags().DurationVar(&timeout, "discover-timeout", fleetLANDiscoverTimeout, "How long to browse for LAN devices (with --lan)")
 	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
 	cmd.Flags().StringVar(&brokerURL, "broker-url", os.Getenv("WENDY_BROKER_URL"), "Tunnel broker host:port")
 	return cmd
@@ -48,7 +55,6 @@ func newFleetAppsCmd() *cobra.Command {
 // device that could not be reached.
 type fleetAppRow struct {
 	Device  string `json:"device"`
-	AssetID int32  `json:"assetId"`
 	App     string `json:"app,omitempty"`
 	Version string `json:"version,omitempty"`
 	State   string `json:"state,omitempty"`
@@ -56,31 +62,22 @@ type fleetAppRow struct {
 	Error   string `json:"error,omitempty"`
 }
 
-func runFleetApps(ctx context.Context, group, cloudGRPC, brokerURL string) error {
-	if group != "" {
-		if err := validateGroupName(group); err != nil {
-			return err
-		}
-	}
-	auth, err := pickAuthEntry(cloudGRPC)
+func runFleetApps(ctx context.Context, group, cloudGRPC, brokerURL string, lan bool, timeout time.Duration) error {
+	targets, err := resolveFleetTargets(ctx, group, lan, cloudGRPC, brokerURL, timeout)
 	if err != nil {
 		return err
 	}
-	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
-	if err != nil {
-		return err
-	}
-	if group != "" {
-		assets = assetsInGroup(assets, group)
-	}
-	if len(assets) == 0 {
+	if len(targets) == 0 {
 		if group != "" {
 			return fmt.Errorf("group %q has no devices", group)
+		}
+		if lan {
+			return fmt.Errorf("no WendyOS devices found on the LAN")
 		}
 		return fmt.Errorf("no enrolled devices found for this org")
 	}
 
-	rows := gatherFleetApps(ctx, auth, assets, brokerURL)
+	rows := gatherFleetApps(ctx, targets)
 	sortFleetAppRows(rows)
 
 	if jsonOutput || !isInteractiveTerminal() {
@@ -99,10 +96,10 @@ func runFleetApps(ctx context.Context, group, cloudGRPC, brokerURL string) error
 	return tw.Flush()
 }
 
-// gatherFleetApps queries every asset's container list concurrently and flattens
-// the result into per-app rows. A device that errors contributes a single row
-// with its Error set; one bad device never fails the whole sweep.
-func gatherFleetApps(ctx context.Context, auth *config.AuthConfig, assets []*cloudpb.Asset, brokerURL string) []fleetAppRow {
+// gatherFleetApps queries every target's container list concurrently and
+// flattens the result into per-app rows. A device that errors contributes a
+// single row with its Error set; one bad device never fails the whole sweep.
+func gatherFleetApps(ctx context.Context, targets []fleetTarget) []fleetAppRow {
 	var (
 		mu   sync.Mutex
 		rows []fleetAppRow
@@ -110,25 +107,24 @@ func gatherFleetApps(ctx context.Context, auth *config.AuthConfig, assets []*clo
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(fleetAppsMaxConcurrency)
 
-	for _, asset := range assets {
-		asset := asset
+	for _, target := range targets {
+		target := target
 		g.Go(func() error {
-			containers, err := listAssetContainers(ctx, auth, asset, brokerURL)
+			containers, err := listTargetContainers(ctx, target)
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {
-				rows = append(rows, fleetAppRow{Device: asset.GetName(), AssetID: asset.GetId(), Error: err.Error()})
+				rows = append(rows, fleetAppRow{Device: target.Name, Error: err.Error()})
 				return nil
 			}
 			if len(containers) == 0 {
 				// Reachable but no apps — still worth a row so the device shows up.
-				rows = append(rows, fleetAppRow{Device: asset.GetName(), AssetID: asset.GetId(), App: "—", State: "—"})
+				rows = append(rows, fleetAppRow{Device: target.Name, App: "—", State: "—"})
 				return nil
 			}
 			for _, c := range containers {
 				rows = append(rows, fleetAppRow{
-					Device:  asset.GetName(),
-					AssetID: asset.GetId(),
+					Device:  target.Name,
 					App:     c.GetAppName(),
 					Version: c.GetAppVersion(),
 					State:   runningStateString(c.GetRunningState()),
@@ -142,14 +138,18 @@ func gatherFleetApps(ctx context.Context, auth *config.AuthConfig, assets []*clo
 	return rows
 }
 
-// listAssetContainers opens a tunnel to one asset and drains its container list.
-func listAssetContainers(ctx context.Context, auth *config.AuthConfig, asset *cloudpb.Asset, brokerURL string) ([]*agentpb.AppContainer, error) {
-	conn, err := connectCloudAsset(ctx, auth, asset, brokerURL)
+// listTargetContainers connects to one target and drains its container list.
+func listTargetContainers(ctx context.Context, target fleetTarget) ([]*agentpb.AppContainer, error) {
+	conn, err := target.connect(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("connecting: %w", err)
 	}
-	defer conn.Close()
+	defer conn.Conn.Close()
+	return listContainersOnConn(ctx, conn)
+}
 
+// listContainersOnConn drains the agent's container list over an open connection.
+func listContainersOnConn(ctx context.Context, conn *grpcclient.AgentConnection) ([]*agentpb.AppContainer, error) {
 	stream, err := conn.ContainerService.ListContainers(ctx, &agentpb.ListContainersRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("listing containers: %w", err)

--- a/go/internal/cli/commands/fleet_lan.go
+++ b/go/internal/cli/commands/fleet_lan.go
@@ -10,9 +10,29 @@ import (
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 )
+
+// cloudTargetsForTags returns one connectable cloud target per enrolled asset
+// carrying any of the given tags (assigned via 'wendy fleet group add').
+func cloudTargetsForTags(auth *config.AuthConfig, assets []*cloudpb.Asset, tags []string, brokerURL string) []fleetTarget {
+	matched := assetsWithAnyTag(assets, tags)
+	targets := make([]fleetTarget, 0, len(matched))
+	for _, asset := range matched {
+		asset := asset
+		targets = append(targets, fleetTarget{
+			Name: asset.GetName(),
+			ID:   fmt.Sprintf("%d", asset.GetId()),
+			connect: func(ctx context.Context) (*grpcclient.AgentConnection, error) {
+				return connectCloudAsset(ctx, auth, asset, brokerURL)
+			},
+		})
+	}
+	return targets
+}
 
 // fleetLANDiscoverTimeout is the default mDNS browse window for a fleet
 // operation when no explicit timeout is given.

--- a/go/internal/cli/commands/fleet_lan.go
+++ b/go/internal/cli/commands/fleet_lan.go
@@ -120,6 +120,26 @@ func lanGroupDevices(ctx context.Context, group string, timeout time.Duration) (
 	return out, nil
 }
 
+// lanDevicesForTags discovers LAN devices and returns those whose name matches
+// any of the given tags (each a glob, e.g. "camera-*"). A device that matches
+// more than one tag appears once.
+func lanDevicesForTags(ctx context.Context, tags []string, timeout time.Duration) ([]models.LANDevice, error) {
+	devices, err := discoverFleetLAN(ctx, timeout)
+	if err != nil {
+		return nil, err
+	}
+	var out []models.LANDevice
+	for _, dev := range devices {
+		for _, tag := range tags {
+			if matchesGroupPattern(dev, tag) {
+				out = append(out, dev)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
 // targetForDevice wraps a discovered LAN device as a connectable fleet target.
 func targetForDevice(dev models.LANDevice) fleetTarget {
 	addr := preferredLANAddress(dev)

--- a/go/internal/cli/commands/fleet_lan.go
+++ b/go/internal/cli/commands/fleet_lan.go
@@ -1,0 +1,208 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// fleetLANDiscoverTimeout is the default mDNS browse window for a fleet
+// operation when no explicit timeout is given.
+const fleetLANDiscoverTimeout = 5 * time.Second
+
+// fleetTarget is one device a fleet operation acts on, regardless of whether it
+// was resolved over the LAN (mDNS) or the cloud. connect dials the device's
+// agent on demand so a target can be enumerated cheaply and only connected when
+// the operation actually touches it.
+type fleetTarget struct {
+	Name    string // display name (LAN: normalized short name; cloud: asset name)
+	ID      string // stable id (LAN: mDNS hostname; cloud: asset id as string)
+	Address string // LAN dial address (empty for cloud targets)
+	connect func(ctx context.Context) (*grpcclient.AgentConnection, error)
+}
+
+// groupPatternChars allows the same characters as a cloud group name plus the
+// glob metacharacters a dynamic LAN match may use.
+var groupPatternChars = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._*?\[\]-]{0,62}$`)
+
+// validateGroupPattern checks a LAN group pattern: a cloud-style group name
+// optionally containing glob metacharacters (* ? [ ]). Empty is rejected here;
+// callers treat an absent --group as "every device" before calling this.
+func validateGroupPattern(pattern string) error {
+	if pattern == "" {
+		return fmt.Errorf("group pattern is required")
+	}
+	if !groupPatternChars.MatchString(pattern) {
+		return fmt.Errorf("group pattern %q is invalid: start with a letter or digit, then letters, digits, '.', '_', '-', or glob characters '*?[]' (max 63 chars)", pattern)
+	}
+	return nil
+}
+
+// deviceShortName normalizes a LAN device's mDNS hostname to the bare device
+// name used for group matching: "wendyos-camera-01.local" -> "camera-01". Falls
+// back to a slugged display name when the hostname is empty.
+func deviceShortName(dev models.LANDevice) string {
+	name := strings.ToLower(strings.TrimSpace(dev.Hostname))
+	name = strings.TrimSuffix(name, ".")
+	name = strings.TrimSuffix(name, ".local")
+	name = strings.TrimPrefix(name, "wendyos-")
+	if name == "" {
+		name = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(dev.DisplayName), " ", "-"))
+	}
+	return name
+}
+
+// matchesGroupPattern reports whether a LAN device belongs to a dynamic group.
+// A group is a glob (path.Match) over the device's normalized short name; a
+// plain token (no glob metacharacters) matches exactly or as a "<token>-"
+// prefix, so "camera" matches camera-01..camera-04. An empty pattern, "*", or
+// "all" matches every WendyOS device.
+func matchesGroupPattern(dev models.LANDevice, pattern string) bool {
+	p := strings.ToLower(strings.TrimSpace(pattern))
+	if p == "" || p == "*" || p == "all" {
+		return true
+	}
+	name := deviceShortName(dev)
+	if strings.ContainsAny(p, "*?[") {
+		if ok, _ := path.Match(p, name); ok {
+			return true
+		}
+		ok, _ := path.Match(p, strings.ToLower(dev.Hostname))
+		return ok
+	}
+	return name == p || strings.HasPrefix(name, p+"-")
+}
+
+// discoverFleetLAN returns the WendyOS devices visible on the LAN via mDNS,
+// sorted by short name for stable output.
+func discoverFleetLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
+	if timeout <= 0 {
+		timeout = fleetLANDiscoverTimeout
+	}
+	devices, err := discovery.DiscoverLAN(ctx, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("discovering LAN devices: %w", err)
+	}
+	out := make([]models.LANDevice, 0, len(devices))
+	for _, d := range devices {
+		if d.IsWendyDevice {
+			out = append(out, d)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return deviceShortName(out[i]) < deviceShortName(out[j]) })
+	return out, nil
+}
+
+// lanGroupDevices discovers LAN devices and filters them to the group pattern
+// (all WendyOS devices when group is empty).
+func lanGroupDevices(ctx context.Context, group string, timeout time.Duration) ([]models.LANDevice, error) {
+	devices, err := discoverFleetLAN(ctx, timeout)
+	if err != nil {
+		return nil, err
+	}
+	if group == "" {
+		return devices, nil
+	}
+	var out []models.LANDevice
+	for _, dev := range devices {
+		if matchesGroupPattern(dev, group) {
+			out = append(out, dev)
+		}
+	}
+	return out, nil
+}
+
+// targetForDevice wraps a discovered LAN device as a connectable fleet target.
+func targetForDevice(dev models.LANDevice) fleetTarget {
+	addr := preferredLANAddress(dev)
+	return fleetTarget{
+		Name:    deviceShortName(dev),
+		ID:      dev.Hostname,
+		Address: addr,
+		connect: func(ctx context.Context) (*grpcclient.AgentConnection, error) {
+			return connectWithAutoTLS(ctx, addr)
+		},
+	}
+}
+
+// lanFleetTargets discovers LAN devices, filters them to the group pattern (all
+// WendyOS devices when group is empty), and returns one connectable target each.
+func lanFleetTargets(ctx context.Context, group string, timeout time.Duration) ([]fleetTarget, error) {
+	devices, err := lanGroupDevices(ctx, group, timeout)
+	if err != nil {
+		return nil, err
+	}
+	targets := make([]fleetTarget, 0, len(devices))
+	for _, dev := range devices {
+		targets = append(targets, targetForDevice(dev))
+	}
+	return targets, nil
+}
+
+// peerHost returns the address other components should use to reach dev's
+// exposed endpoint. It prefers the routable IP (resolvable from any peer,
+// including WendyOS devices that may not run an mDNS resolver) and falls back to
+// the mDNS hostname.
+func peerHost(dev models.LANDevice) string {
+	if dev.IPAddress != "" {
+		return dev.IPAddress
+	}
+	return strings.TrimSuffix(dev.Hostname, ".")
+}
+
+// cloudFleetTargets resolves a group's member devices from the cloud asset list
+// (tag membership) and returns one connectable target each, dialing over the
+// cloud tunnel.
+func cloudFleetTargets(ctx context.Context, group, cloudGRPC, brokerURL string) ([]fleetTarget, error) {
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return nil, err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return nil, err
+	}
+	if group != "" {
+		assets = assetsInGroup(assets, group)
+	}
+	targets := make([]fleetTarget, 0, len(assets))
+	for _, asset := range assets {
+		asset := asset
+		targets = append(targets, fleetTarget{
+			Name:    asset.GetName(),
+			ID:      fmt.Sprintf("%d", asset.GetId()),
+			connect: func(ctx context.Context) (*grpcclient.AgentConnection, error) {
+				return connectCloudAsset(ctx, auth, asset, brokerURL)
+			},
+		})
+	}
+	return targets, nil
+}
+
+// resolveFleetTargets returns the devices a fleet operation should act on,
+// choosing the LAN (mDNS) or cloud (asset tags) backend. group may be empty to
+// mean "every device" (LAN: all WendyOS devices; cloud: all enrolled assets).
+func resolveFleetTargets(ctx context.Context, group string, lan bool, cloudGRPC, brokerURL string, timeout time.Duration) ([]fleetTarget, error) {
+	if lan {
+		if group != "" {
+			if err := validateGroupPattern(group); err != nil {
+				return nil, err
+			}
+		}
+		return lanFleetTargets(ctx, group, timeout)
+	}
+	if group != "" {
+		if err := validateGroupName(group); err != nil {
+			return nil, err
+		}
+	}
+	return cloudFleetTargets(ctx, group, cloudGRPC, brokerURL)
+}

--- a/go/internal/cli/commands/fleet_lan_test.go
+++ b/go/internal/cli/commands/fleet_lan_test.go
@@ -85,7 +85,7 @@ func TestComputePeers(t *testing.T) {
 }
 
 func TestDiscoveryEnv(t *testing.T) {
-	appCfg := &appconfig.AppConfig{
+	manifest := &appconfig.FleetManifest{
 		AppID: "sh.wendy.fleet",
 		Components: map[string]*appconfig.ComponentConfig{
 			"camera": {
@@ -103,7 +103,7 @@ func TestDiscoveryEnv(t *testing.T) {
 	edge := map[string][]models.LANDevice{
 		"camera": {dev("wendyos-camera-01.local", "Camera 01", "10.0.0.4")},
 	}
-	env, err := discoveryEnv(appCfg.Components["dashboard"], appCfg, edge)
+	env, err := discoveryEnv(manifest.Components["dashboard"], manifest, edge)
 	if err != nil {
 		t.Fatalf("discoveryEnv error: %v", err)
 	}
@@ -124,30 +124,30 @@ func TestDiscoveryEnv(t *testing.T) {
 }
 
 func TestDiscoveryEnvErrors(t *testing.T) {
-	appCfg := &appconfig.AppConfig{
+	manifest := &appconfig.FleetManifest{
 		Components: map[string]*appconfig.ComponentConfig{
 			"noexpose": {Context: "x", Target: &appconfig.ComponentTarget{Group: "g"}},
 		},
 	}
 	// Unknown referenced component.
 	central := &appconfig.ComponentConfig{Discovers: []appconfig.DiscoverRef{{Component: "missing", As: "X"}}}
-	if _, err := discoveryEnv(central, appCfg, nil); err == nil {
+	if _, err := discoveryEnv(central, manifest, nil); err == nil {
 		t.Error("expected error for unknown discovered component")
 	}
 	// Referenced component without an expose endpoint.
 	central = &appconfig.ComponentConfig{Discovers: []appconfig.DiscoverRef{{Component: "noexpose", As: "X"}}}
-	if _, err := discoveryEnv(central, appCfg, nil); err == nil {
+	if _, err := discoveryEnv(central, manifest, nil); err == nil {
 		t.Error("expected error for discovered component without expose")
 	}
 }
 
 func TestComponentAppConfig(t *testing.T) {
-	appCfg := &appconfig.AppConfig{AppID: "sh.wendy.fleet", Version: "0.1.0", Platform: "linux"}
+	manifest := &appconfig.FleetManifest{AppID: "sh.wendy.fleet", Version: "0.1.0", Platform: "linux"}
 	comp := &appconfig.ComponentConfig{
 		Context:      "camera",
 		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "host"}},
 	}
-	got := componentAppConfig(appCfg, "camera", comp)
+	got := componentAppConfig(manifest, "camera", comp)
 	if got.AppID != "sh.wendy.fleet.camera" {
 		t.Errorf("AppID = %q, want sh.wendy.fleet.camera", got.AppID)
 	}

--- a/go/internal/cli/commands/fleet_lan_test.go
+++ b/go/internal/cli/commands/fleet_lan_test.go
@@ -1,0 +1,182 @@
+package commands
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+func dev(hostname, display, ip string) models.LANDevice {
+	return models.LANDevice{Hostname: hostname, DisplayName: display, IPAddress: ip, IsWendyDevice: true}
+}
+
+func TestDeviceShortName(t *testing.T) {
+	cases := []struct{ host, display, want string }{
+		{"wendyos-camera-01.local", "Camera 01", "camera-01"},
+		{"wendyos-camera-01.local.", "", "camera-01"},
+		{"WENDYOS-Thor.local", "", "thor"},
+		{"", "Camera 02", "camera-02"},
+	}
+	for _, c := range cases {
+		if got := deviceShortName(dev(c.host, c.display, "")); got != c.want {
+			t.Errorf("deviceShortName(%q,%q) = %q, want %q", c.host, c.display, got, c.want)
+		}
+	}
+}
+
+func TestMatchesGroupPattern(t *testing.T) {
+	d := dev("wendyos-camera-01.local", "Camera 01", "")
+	cases := []struct {
+		pattern string
+		want    bool
+	}{
+		{"", true},
+		{"*", true},
+		{"all", true},
+		{"camera", true},     // token prefix "camera-"
+		{"camera-*", true},   // glob
+		{"camera-01", true},  // exact
+		{"camera-0?", true},  // glob
+		{"cameras", false},   // no "cameras-" prefix, not exact
+		{"cam", false},       // not a "<token>-" boundary
+		{"thor", false},      // different device
+		{"camera-02", false}, // different unit
+	}
+	for _, c := range cases {
+		if got := matchesGroupPattern(d, c.pattern); got != c.want {
+			t.Errorf("matchesGroupPattern(camera-01, %q) = %v, want %v", c.pattern, got, c.want)
+		}
+	}
+}
+
+func TestPeerHostPrefersIP(t *testing.T) {
+	if got := peerHost(dev("wendyos-camera-01.local", "", "10.0.0.4")); got != "10.0.0.4" {
+		t.Errorf("peerHost with IP = %q, want 10.0.0.4", got)
+	}
+	if got := peerHost(dev("wendyos-camera-01.local.", "", "")); got != "wendyos-camera-01.local" {
+		t.Errorf("peerHost without IP = %q, want wendyos-camera-01.local", got)
+	}
+}
+
+func TestComputePeers(t *testing.T) {
+	comp := &appconfig.ComponentConfig{
+		Target: &appconfig.ComponentTarget{Group: "camera-*"},
+		Expose: &appconfig.ComponentExpose{Port: 8000, Path: "/stream"},
+	}
+	devices := []models.LANDevice{
+		dev("wendyos-camera-01.local", "Camera 01", "10.0.0.4"),
+		dev("wendyos-camera-02.local", "Camera 02", ""),
+	}
+	peers := computePeers(comp, devices)
+	if len(peers) != 2 {
+		t.Fatalf("computePeers returned %d peers, want 2", len(peers))
+	}
+	if peers[0].URL != "http://10.0.0.4:8000" {
+		t.Errorf("peer[0].URL = %q", peers[0].URL)
+	}
+	if peers[1].URL != "http://wendyos-camera-02.local:8000" {
+		t.Errorf("peer[1].URL = %q", peers[1].URL)
+	}
+	if peers[0].Name != "camera-01" || peers[0].Group != "camera-*" || peers[0].Status != "ready" {
+		t.Errorf("peer[0] = %+v", peers[0])
+	}
+}
+
+func TestDiscoveryEnv(t *testing.T) {
+	appCfg := &appconfig.AppConfig{
+		AppID: "sh.wendy.fleet",
+		Components: map[string]*appconfig.ComponentConfig{
+			"camera": {
+				Context: "camera",
+				Target:  &appconfig.ComponentTarget{Group: "camera-*"},
+				Expose:  &appconfig.ComponentExpose{Port: 8000, Path: "/stream"},
+			},
+			"dashboard": {
+				Context:   "dashboard",
+				Target:    &appconfig.ComponentTarget{Central: true},
+				Discovers: []appconfig.DiscoverRef{{Component: "camera", As: "WENDY_FLEET_PEERS"}},
+			},
+		},
+	}
+	edge := map[string][]models.LANDevice{
+		"camera": {dev("wendyos-camera-01.local", "Camera 01", "10.0.0.4")},
+	}
+	env, err := discoveryEnv(appCfg.Components["dashboard"], appCfg, edge)
+	if err != nil {
+		t.Fatalf("discoveryEnv error: %v", err)
+	}
+	if len(env) != 1 {
+		t.Fatalf("discoveryEnv returned %d entries, want 1", len(env))
+	}
+	const prefix = "WENDY_FLEET_PEERS="
+	if len(env[0]) <= len(prefix) || env[0][:len(prefix)] != prefix {
+		t.Fatalf("env entry %q does not start with %q", env[0], prefix)
+	}
+	var peers []fleetPeer
+	if err := json.Unmarshal([]byte(env[0][len(prefix):]), &peers); err != nil {
+		t.Fatalf("env value is not valid JSON: %v", err)
+	}
+	if len(peers) != 1 || peers[0].URL != "http://10.0.0.4:8000" {
+		t.Errorf("peers = %+v", peers)
+	}
+}
+
+func TestDiscoveryEnvErrors(t *testing.T) {
+	appCfg := &appconfig.AppConfig{
+		Components: map[string]*appconfig.ComponentConfig{
+			"noexpose": {Context: "x", Target: &appconfig.ComponentTarget{Group: "g"}},
+		},
+	}
+	// Unknown referenced component.
+	central := &appconfig.ComponentConfig{Discovers: []appconfig.DiscoverRef{{Component: "missing", As: "X"}}}
+	if _, err := discoveryEnv(central, appCfg, nil); err == nil {
+		t.Error("expected error for unknown discovered component")
+	}
+	// Referenced component without an expose endpoint.
+	central = &appconfig.ComponentConfig{Discovers: []appconfig.DiscoverRef{{Component: "noexpose", As: "X"}}}
+	if _, err := discoveryEnv(central, appCfg, nil); err == nil {
+		t.Error("expected error for discovered component without expose")
+	}
+}
+
+func TestComponentAppConfig(t *testing.T) {
+	appCfg := &appconfig.AppConfig{AppID: "sh.wendy.fleet", Version: "0.1.0", Platform: "linux"}
+	comp := &appconfig.ComponentConfig{
+		Context:      "camera",
+		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "host"}},
+	}
+	got := componentAppConfig(appCfg, "camera", comp)
+	if got.AppID != "sh.wendy.fleet.camera" {
+		t.Errorf("AppID = %q, want sh.wendy.fleet.camera", got.AppID)
+	}
+	if got.Version != "0.1.0" || got.Platform != "linux" {
+		t.Errorf("version/platform not carried: %+v", got)
+	}
+	if len(got.Entitlements) != 1 || got.Entitlements[0].Mode != "host" {
+		t.Errorf("entitlements not carried: %+v", got.Entitlements)
+	}
+}
+
+func TestShellQuoteEnv(t *testing.T) {
+	if got := shellQuoteEnv(`FOO=[{"a":1}]`); got != `FOO='[{"a":1}]'` {
+		t.Errorf("shellQuoteEnv = %q", got)
+	}
+	if got := shellQuoteEnv("noequals"); got != "noequals" {
+		t.Errorf("shellQuoteEnv(noequals) = %q", got)
+	}
+}
+
+func TestValidateGroupPattern(t *testing.T) {
+	for _, ok := range []string{"camera", "camera-*", "camera-0?", "grp_1", "a.b-c"} {
+		if err := validateGroupPattern(ok); err != nil {
+			t.Errorf("validateGroupPattern(%q) unexpected error: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "-leading", "has space", "weird$"} {
+		if err := validateGroupPattern(bad); err == nil {
+			t.Errorf("validateGroupPattern(%q) expected error", bad)
+		}
+	}
+}

--- a/go/internal/cli/commands/fleet_lan_test.go
+++ b/go/internal/cli/commands/fleet_lan_test.go
@@ -65,17 +65,18 @@ func TestComputePeers(t *testing.T) {
 		Tags:   []string{"camera-*"},
 		Expose: &appconfig.ComponentExpose{Port: 8000, Path: "/stream"},
 	}
-	devices := []models.LANDevice{
-		dev("wendyos-camera-01.local", "Camera 01", "10.0.0.4"),
-		dev("wendyos-camera-02.local", "Camera 02", ""),
-	}
-	peers := computePeers(comp, devices)
+	peers := computePeers(comp, []meshPeer{
+		{Name: "camera-01", AssetID: 42, Host: "10.0.0.4"},
+		{Name: "camera-02", AssetID: 0, Host: "wendyos-camera-02.local"},
+	})
 	if len(peers) != 2 {
 		t.Fatalf("computePeers returned %d peers, want 2", len(peers))
 	}
-	if peers[0].URL != "http://10.0.0.4:8000" {
+	// Known asset id -> mesh name (asset id wins over the LAN host).
+	if peers[0].URL != "http://device-42.cloud.wendy.dev:8000" {
 		t.Errorf("peer[0].URL = %q", peers[0].URL)
 	}
+	// Unknown asset id -> direct-LAN host fallback.
 	if peers[1].URL != "http://wendyos-camera-02.local:8000" {
 		t.Errorf("peer[1].URL = %q", peers[1].URL)
 	}
@@ -100,8 +101,8 @@ func TestDiscoveryEnv(t *testing.T) {
 			},
 		},
 	}
-	matched := map[string][]models.LANDevice{
-		"camera": {dev("wendyos-camera-01.local", "Camera 01", "10.0.0.4")},
+	matched := map[string][]meshPeer{
+		"camera": {{Name: "camera-01", AssetID: 42}},
 	}
 	env, err := discoveryEnv(manifest.Components["dashboard"], manifest, matched)
 	if err != nil {
@@ -118,7 +119,7 @@ func TestDiscoveryEnv(t *testing.T) {
 	if err := json.Unmarshal([]byte(env[0][len(prefix):]), &peers); err != nil {
 		t.Fatalf("env value is not valid JSON: %v", err)
 	}
-	if len(peers) != 1 || peers[0].URL != "http://10.0.0.4:8000" {
+	if len(peers) != 1 || peers[0].URL != "http://device-42.cloud.wendy.dev:8000" {
 		t.Errorf("peers = %+v", peers)
 	}
 }

--- a/go/internal/cli/commands/fleet_lan_test.go
+++ b/go/internal/cli/commands/fleet_lan_test.go
@@ -62,7 +62,7 @@ func TestPeerHostPrefersIP(t *testing.T) {
 
 func TestComputePeers(t *testing.T) {
 	comp := &appconfig.ComponentConfig{
-		Target: &appconfig.ComponentTarget{Group: "camera-*"},
+		Tags:   []string{"camera-*"},
 		Expose: &appconfig.ComponentExpose{Port: 8000, Path: "/stream"},
 	}
 	devices := []models.LANDevice{
@@ -89,21 +89,21 @@ func TestDiscoveryEnv(t *testing.T) {
 		AppID: "sh.wendy.fleet",
 		Components: map[string]*appconfig.ComponentConfig{
 			"camera": {
-				Context: "camera",
-				Target:  &appconfig.ComponentTarget{Group: "camera-*"},
-				Expose:  &appconfig.ComponentExpose{Port: 8000, Path: "/stream"},
+				Path:   "camera",
+				Tags:   []string{"camera-*"},
+				Expose: &appconfig.ComponentExpose{Port: 8000, Path: "/stream"},
 			},
 			"dashboard": {
-				Context:   "dashboard",
-				Target:    &appconfig.ComponentTarget{Central: true},
+				Path:      "dashboard",
+				Tags:      []string{"central"},
 				Discovers: []appconfig.DiscoverRef{{Component: "camera", As: "WENDY_FLEET_PEERS"}},
 			},
 		},
 	}
-	edge := map[string][]models.LANDevice{
+	matched := map[string][]models.LANDevice{
 		"camera": {dev("wendyos-camera-01.local", "Camera 01", "10.0.0.4")},
 	}
-	env, err := discoveryEnv(manifest.Components["dashboard"], manifest, edge)
+	env, err := discoveryEnv(manifest.Components["dashboard"], manifest, matched)
 	if err != nil {
 		t.Fatalf("discoveryEnv error: %v", err)
 	}
@@ -126,36 +126,18 @@ func TestDiscoveryEnv(t *testing.T) {
 func TestDiscoveryEnvErrors(t *testing.T) {
 	manifest := &appconfig.FleetManifest{
 		Components: map[string]*appconfig.ComponentConfig{
-			"noexpose": {Context: "x", Target: &appconfig.ComponentTarget{Group: "g"}},
+			"noexpose": {Path: "x", Tags: []string{"g"}},
 		},
 	}
 	// Unknown referenced component.
-	central := &appconfig.ComponentConfig{Discovers: []appconfig.DiscoverRef{{Component: "missing", As: "X"}}}
-	if _, err := discoveryEnv(central, manifest, nil); err == nil {
+	consumer := &appconfig.ComponentConfig{Discovers: []appconfig.DiscoverRef{{Component: "missing", As: "X"}}}
+	if _, err := discoveryEnv(consumer, manifest, nil); err == nil {
 		t.Error("expected error for unknown discovered component")
 	}
 	// Referenced component without an expose endpoint.
-	central = &appconfig.ComponentConfig{Discovers: []appconfig.DiscoverRef{{Component: "noexpose", As: "X"}}}
-	if _, err := discoveryEnv(central, manifest, nil); err == nil {
+	consumer = &appconfig.ComponentConfig{Discovers: []appconfig.DiscoverRef{{Component: "noexpose", As: "X"}}}
+	if _, err := discoveryEnv(consumer, manifest, nil); err == nil {
 		t.Error("expected error for discovered component without expose")
-	}
-}
-
-func TestComponentAppConfig(t *testing.T) {
-	manifest := &appconfig.FleetManifest{AppID: "sh.wendy.fleet", Version: "0.1.0", Platform: "linux"}
-	comp := &appconfig.ComponentConfig{
-		Context:      "camera",
-		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "host"}},
-	}
-	got := componentAppConfig(manifest, "camera", comp)
-	if got.AppID != "sh.wendy.fleet.camera" {
-		t.Errorf("AppID = %q, want sh.wendy.fleet.camera", got.AppID)
-	}
-	if got.Version != "0.1.0" || got.Platform != "linux" {
-		t.Errorf("version/platform not carried: %+v", got)
-	}
-	if len(got.Entitlements) != 1 || got.Entitlements[0].Mode != "host" {
-		t.Errorf("entitlements not carried: %+v", got.Entitlements)
 	}
 }
 

--- a/go/internal/cli/commands/fleet_manifest.go
+++ b/go/internal/cli/commands/fleet_manifest.go
@@ -25,20 +25,31 @@ type fleetPeer struct {
 	Status string `json:"status"`
 }
 
+// meshPeer is a discovered peer device for a component. When AssetID is known it
+// is addressed over the mesh as device-<AssetID>.cloud.wendy.dev (reachable
+// LAN-direct or cloud-relay); Host is a direct-LAN fallback for older agents
+// that don't advertise an asset id over mDNS.
+type meshPeer struct {
+	Name    string
+	AssetID int32
+	Host    string
+}
+
 // runFleetManifest deploys a wendy-fleet.json. Each component references an app
 // directory (its own wendy.json holds the build/runtime config) and lists tags.
 //
 // By default components are placed by CLOUD asset tags (assigned with
-// 'wendy fleet group add') and deployed over the cloud tunnel. With --lan they
-// are placed by matching device names over mDNS instead. Cross-component
-// discovery (discovers -> WENDY_FLEET_PEERS) is wired in LAN mode; over the
-// cloud it needs per-peer reachability (the mesh, WDY-1778) and is deferred, so
-// cloud mode does placement only.
+// 'wendy fleet group add') and deployed over the cloud tunnel; with --lan they
+// are placed by matching device names over mDNS. Cross-component discovery
+// (discovers -> WENDY_FLEET_PEERS) resolves peers to their mesh names
+// (device-<assetID>.cloud.wendy.dev), reachable LAN-direct or via cloud-relay by
+// Joannis's mesh — so discovery now works in both cloud and LAN mode. The
+// consuming component must run with a "mesh" network entitlement to reach them.
 func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, manifest *appconfig.FleetManifest, lan bool, central, cloudGRPC, brokerURL string, timeout time.Duration) error {
-	// Resolve targets per component from the chosen backend. In LAN mode also
-	// keep the matched devices, for the discovery snapshot.
+	// Resolve, per component, the deploy targets and the discovered peers (name +
+	// asset id, for mesh addressing).
 	targetsByComp := make(map[string][]fleetTarget, len(manifest.Components))
-	lanDevices := make(map[string][]models.LANDevice)
+	peersByComp := make(map[string][]meshPeer, len(manifest.Components))
 
 	if lan {
 		for name, comp := range manifest.Components {
@@ -46,9 +57,9 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, m
 			if err != nil {
 				return err
 			}
-			lanDevices[name] = devs
 			for _, dev := range devs {
 				targetsByComp[name] = append(targetsByComp[name], targetForDevice(dev))
+				peersByComp[name] = append(peersByComp[name], meshPeer{Name: deviceShortName(dev), AssetID: dev.AssetID, Host: peerHost(dev)})
 			}
 		}
 	} else {
@@ -62,6 +73,9 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, m
 		}
 		for name, comp := range manifest.Components {
 			targetsByComp[name] = cloudTargetsForTags(auth, assets, comp.Tags, brokerURL)
+			for _, a := range assetsWithAnyTag(assets, comp.Tags) {
+				peersByComp[name] = append(peersByComp[name], meshPeer{Name: a.GetName(), AssetID: a.GetId()})
+			}
 		}
 	}
 
@@ -87,22 +101,19 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, m
 		}
 
 		compOpts := opts
-		var lanEnv []string
+		var env []string
 		if len(comp.Discovers) > 0 {
-			if lan {
-				lanEnv, err = discoveryEnv(comp, manifest, lanDevices)
-				if err != nil {
-					return fmt.Errorf("component %q: %w", name, err)
-				}
-				if len(lanEnv) > 0 {
-					// Env injection rides on CreateContainerRequest.Env, carried by
-					// the registry (chunk-off) create path; force it so peers aren't
-					// dropped.
-					compOpts.env = lanEnv
-					compOpts.chunking = chunkingOff
-				}
-			} else {
-				fmt.Fprintf(os.Stderr, "  note: %q declares discovers; cross-device discovery over the cloud is deferred to the mesh (WDY-1778) — deploying placement only\n", name)
+			env, err = discoveryEnv(comp, manifest, peersByComp)
+			if err != nil {
+				return fmt.Errorf("component %q: %w", name, err)
+			}
+			if len(env) > 0 {
+				// Discovery env rides on CreateContainerRequest.Env, carried by the
+				// registry (chunk-off) create path; force it so peers aren't dropped.
+				// Peers are mesh names, so the consuming component needs a "mesh"
+				// network entitlement to reach them.
+				compOpts.env = env
+				compOpts.chunking = chunkingOff
 			}
 		}
 
@@ -123,7 +134,7 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, m
 			}
 			if lan && len(comp.Discovers) > 0 {
 				fmt.Printf("\n=== component %q (no device matched %v) ===\n", name, comp.Tags)
-				printCentralInstructions(name, comp, lanEnv)
+				printCentralInstructions(name, comp, env)
 				continue
 			}
 			fmt.Fprintf(os.Stderr, "  warning: no devices carry tags %v for %q; assign with 'wendy fleet group add <tag> <device>' and re-run\n", comp.Tags, name)
@@ -164,7 +175,7 @@ func loadComponentApp(appDir string, opts runOptions) (*appconfig.AppConfig, err
 // discoveryEnv builds the env vars injected into a component for its declared
 // discovers: each named var carries a JSON snapshot of the referenced
 // component's live peer endpoints (from the devices its tags matched).
-func discoveryEnv(consumer *appconfig.ComponentConfig, manifest *appconfig.FleetManifest, matched map[string][]models.LANDevice) ([]string, error) {
+func discoveryEnv(consumer *appconfig.ComponentConfig, manifest *appconfig.FleetManifest, peers map[string][]meshPeer) ([]string, error) {
 	var env []string
 	for _, d := range consumer.Discovers {
 		ref, ok := manifest.Components[d.Component]
@@ -174,7 +185,7 @@ func discoveryEnv(consumer *appconfig.ComponentConfig, manifest *appconfig.Fleet
 		if ref.Expose == nil {
 			return nil, fmt.Errorf("discovered component %q declares no 'expose' endpoint", d.Component)
 		}
-		data, err := json.Marshal(computePeers(ref, matched[d.Component]))
+		data, err := json.Marshal(computePeers(ref, peers[d.Component]))
 		if err != nil {
 			return nil, err
 		}
@@ -183,24 +194,31 @@ func discoveryEnv(consumer *appconfig.ComponentConfig, manifest *appconfig.Fleet
 	return env, nil
 }
 
-// computePeers turns a component's matched devices into peer endpoints using its
-// exposed port. url is the endpoint's base origin; consumers append their own
-// path (the discover contract — see the template dashboard's serve.py).
-func computePeers(comp *appconfig.ComponentConfig, devices []models.LANDevice) []fleetPeer {
+// computePeers turns a component's discovered peers into endpoint URLs using its
+// exposed port. A peer with a known asset id is addressed over the mesh
+// (device-<id>.cloud.wendy.dev), reachable LAN-direct or via cloud-relay;
+// otherwise it falls back to a direct-LAN host. url is the endpoint's base
+// origin; consumers append their own path (the discover contract — see the
+// template dashboard's serve.py).
+func computePeers(comp *appconfig.ComponentConfig, peers []meshPeer) []fleetPeer {
 	tag := ""
 	if len(comp.Tags) > 0 {
 		tag = comp.Tags[0]
 	}
-	peers := make([]fleetPeer, 0, len(devices))
-	for _, dev := range devices {
-		peers = append(peers, fleetPeer{
-			Name:   deviceShortName(dev),
-			URL:    fmt.Sprintf("http://%s:%d", peerHost(dev), comp.Expose.Port),
-			Group:  tag,
-			Status: "ready",
-		})
+	out := make([]fleetPeer, 0, len(peers))
+	for _, p := range peers {
+		var url string
+		switch {
+		case p.AssetID > 0:
+			url = fmt.Sprintf("http://device-%d.cloud.wendy.dev:%d", p.AssetID, comp.Expose.Port)
+		case p.Host != "":
+			url = fmt.Sprintf("http://%s:%d", p.Host, comp.Expose.Port)
+		default:
+			continue // no way to address this peer
+		}
+		out = append(out, fleetPeer{Name: p.Name, URL: url, Group: tag, Status: "ready"})
 	}
-	return peers
+	return out
 }
 
 // resolveCentralDevice resolves --central to exactly one LAN device.

--- a/go/internal/cli/commands/fleet_manifest.go
+++ b/go/internal/cli/commands/fleet_manifest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -14,9 +15,9 @@ import (
 )
 
 // fleetPeer is one discovered endpoint handed to a consuming component, matching
-// the snapshot shape the platform injects under a discovers "as" env var:
+// the snapshot shape injected under a discovers "as" env var:
 //
-//	[{"name":"camera-01","url":"http://10.0.0.4:8000/stream","group":"camera-*","status":"ready"}, ...]
+//	[{"name":"camera-01","url":"http://10.0.0.4:8000","group":"camera-*","status":"ready"}, ...]
 type fleetPeer struct {
 	Name   string `json:"name"`
 	URL    string `json:"url"`
@@ -24,89 +25,93 @@ type fleetPeer struct {
 	Status string `json:"status"`
 }
 
-// runFleetManifest deploys a wendy-fleet.json across the LAN: each "group"
-// component fans out to the devices matching its pattern, and each "central"
-// component is deployed once — to --central, or, if omitted, its peer snapshot
-// is printed so the operator can run it themselves.
+// runFleetManifest deploys a wendy-fleet.json across the LAN. Each component
+// references an app directory (its own wendy.json holds the build/runtime
+// config) and lists device tags; the component is deployed to every LAN device
+// whose name matches one of those tags. A component whose tags match no device
+// (e.g. a "central" dashboard) is deployed to --central if given, otherwise its
+// peer snapshot is printed so the operator can run it themselves.
 func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, manifest *appconfig.FleetManifest, lan bool, central, cloudGRPC, brokerURL string, timeout time.Duration) error {
 	if !lan {
 		return fmt.Errorf("fleet manifests are LAN-only for now; re-run with --lan")
 	}
 
-	var edgeNames, centralNames []string
+	// Resolve the devices matching each component's tags once (reused for both
+	// deploy and the discovery snapshot).
+	matched := make(map[string][]models.LANDevice, len(manifest.Components))
 	for name, comp := range manifest.Components {
-		if comp.Target != nil && comp.Target.Central {
-			centralNames = append(centralNames, name)
-		} else {
-			edgeNames = append(edgeNames, name)
-		}
-	}
-	sort.Strings(edgeNames)
-	sort.Strings(centralNames)
-
-	// Resolve each edge component's group members once; reused for both the edge
-	// deploy and the central component's discovery snapshot.
-	edgeDevices := make(map[string][]models.LANDevice, len(edgeNames))
-	for _, name := range edgeNames {
-		comp := manifest.Components[name]
-		devices, err := lanGroupDevices(ctx, comp.Target.Group, timeout)
+		devs, err := lanDevicesForTags(ctx, comp.Tags, timeout)
 		if err != nil {
 			return err
 		}
-		if len(devices) == 0 {
-			return fmt.Errorf("component %q targets group %q, but no matching WendyOS devices were found on the LAN", name, comp.Target.Group)
-		}
-		edgeDevices[name] = devices
+		matched[name] = devs
 	}
 
-	// 1. Edge components first, so their endpoints exist before a central
-	//    component starts discovering them.
-	for _, name := range edgeNames {
-		comp := manifest.Components[name]
-		devices := edgeDevices[name]
-		fmt.Printf("\n=== edge component %q → group %q (%d device(s)) ===\n", name, comp.Target.Group, len(devices))
+	// Deploy producers (no discovers) before consumers (with discovers) so the
+	// discovered endpoints are already up when a consumer starts.
+	var producers, consumers []string
+	for name, comp := range manifest.Components {
+		if len(comp.Discovers) > 0 {
+			consumers = append(consumers, name)
+		} else {
+			producers = append(producers, name)
+		}
+	}
+	sort.Strings(producers)
+	sort.Strings(consumers)
 
-		compCfg := componentAppConfig(manifest, name, comp)
-		compCwd := filepath.Join(projectCwd, comp.Context)
+	for _, name := range append(producers, consumers...) {
+		comp := manifest.Components[name]
+		appDir := filepath.Join(projectCwd, comp.Path)
+
+		appCfg, err := loadComponentApp(appDir, opts)
+		if err != nil {
+			return fmt.Errorf("component %q: %w", name, err)
+		}
+
+		env, err := discoveryEnv(comp, manifest, matched)
+		if err != nil {
+			return fmt.Errorf("component %q: %w", name, err)
+		}
+		compOpts := opts
+		if len(env) > 0 {
+			compOpts.env = env
+			// Env injection rides on CreateContainerRequest.Env, carried by the
+			// registry (chunk-off) create path; force it so peers aren't dropped.
+			compOpts.chunking = chunkingOff
+		}
+
+		devices := matched[name]
+		if len(devices) == 0 {
+			if central != "" {
+				dev, derr := resolveCentralDevice(ctx, central, timeout)
+				if derr != nil {
+					return derr
+				}
+				fmt.Printf("\n=== component %q (tags %v matched no device) → --central %s ===\n", name, comp.Tags, deviceShortName(dev))
+				if err := deployToTarget(ctx, targetForDevice(dev), appDir, appCfg, compOpts); err != nil {
+					return fmt.Errorf("component %q on %s: %w", name, deviceShortName(dev), err)
+				}
+				continue
+			}
+			// Nothing matched and no --central: if it consumes discovery it's a
+			// central-style app meant to run off-fleet — print how to run it.
+			fmt.Printf("\n=== component %q (tags %v matched no LAN device) ===\n", name, comp.Tags)
+			if len(comp.Discovers) > 0 {
+				printCentralInstructions(name, comp, env)
+			} else {
+				fmt.Fprintf(os.Stderr, "  warning: no devices matched tags %v; skipping %q\n", comp.Tags, name)
+			}
+			continue
+		}
+
+		fmt.Printf("\n=== component %q → tags %v (%d device(s)) ===\n", name, comp.Tags, len(devices))
 		targets := make([]fleetTarget, 0, len(devices))
 		for _, dev := range devices {
 			targets = append(targets, targetForDevice(dev))
 		}
-		if _, failures := deployToTargets(ctx, targets, compCwd, compCfg, opts); failures > 0 && !opts.keepGoing {
-			return fmt.Errorf("edge component %q: %d device(s) failed", name, failures)
-		}
-	}
-
-	// 2. Central components, with discovered peers injected as env vars.
-	for _, name := range centralNames {
-		comp := manifest.Components[name]
-		compCfg := componentAppConfig(manifest, name, comp)
-		compCwd := filepath.Join(projectCwd, comp.Context)
-
-		env, err := discoveryEnv(comp, manifest, edgeDevices)
-		if err != nil {
-			return fmt.Errorf("component %q: %w", name, err)
-		}
-		centralOpts := opts
-		centralOpts.env = env
-		// Env injection rides on CreateContainerRequest.Env, carried by the
-		// registry (chunk-off) create path; force it so peers aren't dropped by
-		// the chunk-diff RunContainer path.
-		centralOpts.chunking = chunkingOff
-
-		if central == "" {
-			fmt.Printf("\n=== central component %q (no --central device) ===\n", name)
-			printCentralInstructions(name, comp, env)
-			continue
-		}
-
-		dev, err := resolveCentralDevice(ctx, central, timeout)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("\n=== central component %q → %s ===\n", name, deviceShortName(dev))
-		if derr := deployToTarget(ctx, targetForDevice(dev), compCwd, compCfg, centralOpts); derr != nil {
-			return fmt.Errorf("central component %q on %s: %w", name, deviceShortName(dev), derr)
+		if _, failures := deployToTargets(ctx, targets, appDir, appCfg, compOpts); failures > 0 && !opts.keepGoing {
+			return fmt.Errorf("component %q: %d device(s) failed", name, failures)
 		}
 	}
 
@@ -114,28 +119,33 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, m
 	return nil
 }
 
-// componentAppConfig projects one fleet component into a standalone AppConfig
-// the single-device deploy pipeline understands. The app id is namespaced by
-// component so two components never collide on one device.
-func componentAppConfig(manifest *appconfig.FleetManifest, name string, comp *appconfig.ComponentConfig) *appconfig.AppConfig {
-	return &appconfig.AppConfig{
-		AppID:        manifest.AppID + "." + name,
-		Version:      manifest.Version,
-		Platform:     manifest.Platform,
-		Entitlements: comp.Entitlements,
-		Readiness:    comp.Readiness,
-		Hooks:        comp.Hooks,
-		Frameworks:   comp.Frameworks,
-		Resources:    comp.Resources,
+// loadComponentApp loads and validates the app's own wendy.json from its
+// directory — the fleet manifest references the app; the app defines itself.
+func loadComponentApp(appDir string, opts runOptions) (*appconfig.AppConfig, error) {
+	cfgPath := filepath.Join(appDir, "wendy.json")
+	missing, err := appConfigFileMissing(cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("checking %s: %w", cfgPath, err)
 	}
+	if missing {
+		return nil, fmt.Errorf("no wendy.json in app directory %s", appDir)
+	}
+	appCfg, err := ensureAppConfig(cfgPath, opts.yes)
+	if err != nil {
+		return nil, fmt.Errorf("loading %s: %w", cfgPath, err)
+	}
+	if err := appCfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", cfgPath, err)
+	}
+	return appCfg, nil
 }
 
-// discoveryEnv builds the env vars injected into a central component for its
-// declared discovers: each named var carries a JSON snapshot of the referenced
-// component's live peer endpoints.
-func discoveryEnv(central *appconfig.ComponentConfig, manifest *appconfig.FleetManifest, edgeDevices map[string][]models.LANDevice) ([]string, error) {
+// discoveryEnv builds the env vars injected into a component for its declared
+// discovers: each named var carries a JSON snapshot of the referenced
+// component's live peer endpoints (from the devices its tags matched).
+func discoveryEnv(consumer *appconfig.ComponentConfig, manifest *appconfig.FleetManifest, matched map[string][]models.LANDevice) ([]string, error) {
 	var env []string
-	for _, d := range central.Discovers {
+	for _, d := range consumer.Discovers {
 		ref, ok := manifest.Components[d.Component]
 		if !ok {
 			return nil, fmt.Errorf("discovers references unknown component %q", d.Component)
@@ -143,7 +153,7 @@ func discoveryEnv(central *appconfig.ComponentConfig, manifest *appconfig.FleetM
 		if ref.Expose == nil {
 			return nil, fmt.Errorf("discovered component %q declares no 'expose' endpoint", d.Component)
 		}
-		data, err := json.Marshal(computePeers(ref, edgeDevices[d.Component]))
+		data, err := json.Marshal(computePeers(ref, matched[d.Component]))
 		if err != nil {
 			return nil, err
 		}
@@ -152,23 +162,20 @@ func discoveryEnv(central *appconfig.ComponentConfig, manifest *appconfig.FleetM
 	return env, nil
 }
 
-// computePeers turns a discovered component's group members into peer endpoints
-// using its exposed port/path.
+// computePeers turns a component's matched devices into peer endpoints using its
+// exposed port. url is the endpoint's base origin; consumers append their own
+// path (the discover contract — see the template dashboard's serve.py).
 func computePeers(comp *appconfig.ComponentConfig, devices []models.LANDevice) []fleetPeer {
-	group := ""
-	if comp.Target != nil {
-		group = comp.Target.Group
+	tag := ""
+	if len(comp.Tags) > 0 {
+		tag = comp.Tags[0]
 	}
 	peers := make([]fleetPeer, 0, len(devices))
 	for _, dev := range devices {
-		// url is the exposed endpoint's base origin; consumers append their own
-		// paths (the discover contract — see the template dashboard's serve.py,
-		// which does url+"/stream" and url+"/health"). expose.Path documents the
-		// component's primary path but is not part of the discovery origin.
 		peers = append(peers, fleetPeer{
 			Name:   deviceShortName(dev),
 			URL:    fmt.Sprintf("http://%s:%d", peerHost(dev), comp.Expose.Port),
-			Group:  group,
+			Group:  tag,
 			Status: "ready",
 		})
 	}
@@ -195,11 +202,11 @@ func resolveCentralDevice(ctx context.Context, name string, timeout time.Duratio
 	}
 }
 
-// printCentralInstructions tells the operator how to run a central component
-// themselves (e.g. on their laptop) when no --central device was chosen.
+// printCentralInstructions tells the operator how to run a component themselves
+// (e.g. on their laptop) when its tags matched no device and no --central given.
 func printCentralInstructions(name string, comp *appconfig.ComponentConfig, env []string) {
-	fmt.Printf("No --central device given, so %q was not deployed. To run it yourself\n", name)
-	fmt.Printf("(e.g. on this machine) from %s/, export the discovered peers first:\n\n", comp.Context)
+	fmt.Printf("No device matched, so %q was not deployed. To run it yourself\n", name)
+	fmt.Printf("(e.g. on this machine) from %s/, export the discovered peers first:\n\n", comp.Path)
 	for _, e := range env {
 		fmt.Printf("  export %s\n", shellQuoteEnv(e))
 	}

--- a/go/internal/cli/commands/fleet_manifest.go
+++ b/go/internal/cli/commands/fleet_manifest.go
@@ -1,0 +1,217 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// fleetPeer is one discovered endpoint handed to a consuming component, matching
+// the snapshot shape the platform injects under a discovers "as" env var:
+//
+//	[{"name":"camera-01","url":"http://10.0.0.4:8000/stream","group":"camera-*","status":"ready"}, ...]
+type fleetPeer struct {
+	Name   string `json:"name"`
+	URL    string `json:"url"`
+	Group  string `json:"group"`
+	Status string `json:"status"`
+}
+
+// runFleetManifest deploys a fleet manifest (a wendy.json with a components map)
+// across the LAN: each "group" component fans out to the devices matching its
+// pattern, and each "central" component is deployed once — to --central, or, if
+// omitted, its peer snapshot is printed so the operator can run it themselves.
+func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, appCfg *appconfig.AppConfig, lan bool, central, cloudGRPC, brokerURL string, timeout time.Duration) error {
+	if !lan {
+		return fmt.Errorf("fleet manifests are LAN-only for now; re-run with --lan")
+	}
+
+	var edgeNames, centralNames []string
+	for name, comp := range appCfg.Components {
+		if comp.Target != nil && comp.Target.Central {
+			centralNames = append(centralNames, name)
+		} else {
+			edgeNames = append(edgeNames, name)
+		}
+	}
+	sort.Strings(edgeNames)
+	sort.Strings(centralNames)
+
+	// Resolve each edge component's group members once; reused for both the edge
+	// deploy and the central component's discovery snapshot.
+	edgeDevices := make(map[string][]models.LANDevice, len(edgeNames))
+	for _, name := range edgeNames {
+		comp := appCfg.Components[name]
+		devices, err := lanGroupDevices(ctx, comp.Target.Group, timeout)
+		if err != nil {
+			return err
+		}
+		if len(devices) == 0 {
+			return fmt.Errorf("component %q targets group %q, but no matching WendyOS devices were found on the LAN", name, comp.Target.Group)
+		}
+		edgeDevices[name] = devices
+	}
+
+	// 1. Edge components first, so their endpoints exist before a central
+	//    component starts discovering them.
+	for _, name := range edgeNames {
+		comp := appCfg.Components[name]
+		devices := edgeDevices[name]
+		fmt.Printf("\n=== edge component %q → group %q (%d device(s)) ===\n", name, comp.Target.Group, len(devices))
+
+		compCfg := componentAppConfig(appCfg, name, comp)
+		compCwd := filepath.Join(projectCwd, comp.Context)
+		targets := make([]fleetTarget, 0, len(devices))
+		for _, dev := range devices {
+			targets = append(targets, targetForDevice(dev))
+		}
+		if _, failures := deployToTargets(ctx, targets, compCwd, compCfg, opts); failures > 0 && !opts.keepGoing {
+			return fmt.Errorf("edge component %q: %d device(s) failed", name, failures)
+		}
+	}
+
+	// 2. Central components, with discovered peers injected as env vars.
+	for _, name := range centralNames {
+		comp := appCfg.Components[name]
+		compCfg := componentAppConfig(appCfg, name, comp)
+		compCwd := filepath.Join(projectCwd, comp.Context)
+
+		env, err := discoveryEnv(comp, appCfg, edgeDevices)
+		if err != nil {
+			return fmt.Errorf("component %q: %w", name, err)
+		}
+		centralOpts := opts
+		centralOpts.env = env
+		// Env injection rides on CreateContainerRequest.Env, carried by the
+		// registry (chunk-off) create path; force it so peers aren't dropped by
+		// the chunk-diff RunContainer path.
+		centralOpts.chunking = chunkingOff
+
+		if central == "" {
+			fmt.Printf("\n=== central component %q (no --central device) ===\n", name)
+			printCentralInstructions(name, comp, env)
+			continue
+		}
+
+		dev, err := resolveCentralDevice(ctx, central, timeout)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("\n=== central component %q → %s ===\n", name, deviceShortName(dev))
+		if derr := deployToTarget(ctx, targetForDevice(dev), compCwd, compCfg, centralOpts); derr != nil {
+			return fmt.Errorf("central component %q on %s: %w", name, deviceShortName(dev), derr)
+		}
+	}
+
+	fmt.Println("\nFleet deploy complete.")
+	return nil
+}
+
+// componentAppConfig projects one fleet component into a standalone AppConfig
+// the single-device deploy pipeline understands. The app id is namespaced by
+// component so two components never collide on one device.
+func componentAppConfig(appCfg *appconfig.AppConfig, name string, comp *appconfig.ComponentConfig) *appconfig.AppConfig {
+	return &appconfig.AppConfig{
+		AppID:        appCfg.AppID + "." + name,
+		Version:      appCfg.Version,
+		Platform:     appCfg.Platform,
+		Entitlements: comp.Entitlements,
+		Readiness:    comp.Readiness,
+		Hooks:        comp.Hooks,
+		Frameworks:   comp.Frameworks,
+		Resources:    comp.Resources,
+	}
+}
+
+// discoveryEnv builds the env vars injected into a central component for its
+// declared discovers: each named var carries a JSON snapshot of the referenced
+// component's live peer endpoints.
+func discoveryEnv(central *appconfig.ComponentConfig, appCfg *appconfig.AppConfig, edgeDevices map[string][]models.LANDevice) ([]string, error) {
+	var env []string
+	for _, d := range central.Discovers {
+		ref, ok := appCfg.Components[d.Component]
+		if !ok {
+			return nil, fmt.Errorf("discovers references unknown component %q", d.Component)
+		}
+		if ref.Expose == nil {
+			return nil, fmt.Errorf("discovered component %q declares no 'expose' endpoint", d.Component)
+		}
+		data, err := json.Marshal(computePeers(ref, edgeDevices[d.Component]))
+		if err != nil {
+			return nil, err
+		}
+		env = append(env, d.As+"="+string(data))
+	}
+	return env, nil
+}
+
+// computePeers turns a discovered component's group members into peer endpoints
+// using its exposed port/path.
+func computePeers(comp *appconfig.ComponentConfig, devices []models.LANDevice) []fleetPeer {
+	group := ""
+	if comp.Target != nil {
+		group = comp.Target.Group
+	}
+	peers := make([]fleetPeer, 0, len(devices))
+	for _, dev := range devices {
+		// url is the exposed endpoint's base origin; consumers append their own
+		// paths (the discover contract — see the template dashboard's serve.py,
+		// which does url+"/stream" and url+"/health"). expose.Path documents the
+		// component's primary path but is not part of the discovery origin.
+		peers = append(peers, fleetPeer{
+			Name:   deviceShortName(dev),
+			URL:    fmt.Sprintf("http://%s:%d", peerHost(dev), comp.Expose.Port),
+			Group:  group,
+			Status: "ready",
+		})
+	}
+	return peers
+}
+
+// resolveCentralDevice resolves --central to exactly one LAN device.
+func resolveCentralDevice(ctx context.Context, name string, timeout time.Duration) (models.LANDevice, error) {
+	devices, err := lanGroupDevices(ctx, name, timeout)
+	if err != nil {
+		return models.LANDevice{}, err
+	}
+	switch len(devices) {
+	case 0:
+		return models.LANDevice{}, fmt.Errorf("no LAN device matches --central %q", name)
+	case 1:
+		return devices[0], nil
+	default:
+		shorts := make([]string, 0, len(devices))
+		for _, d := range devices {
+			shorts = append(shorts, deviceShortName(d))
+		}
+		return models.LANDevice{}, fmt.Errorf("--central %q is ambiguous, matched %d devices (%s); name one exactly", name, len(devices), strings.Join(shorts, ", "))
+	}
+}
+
+// printCentralInstructions tells the operator how to run a central component
+// themselves (e.g. on their laptop) when no --central device was chosen.
+func printCentralInstructions(name string, comp *appconfig.ComponentConfig, env []string) {
+	fmt.Printf("No --central device given, so %q was not deployed. To run it yourself\n", name)
+	fmt.Printf("(e.g. on this machine) from %s/, export the discovered peers first:\n\n", comp.Context)
+	for _, e := range env {
+		fmt.Printf("  export %s\n", shellQuoteEnv(e))
+	}
+	fmt.Println("\nthen start the component's server (see its README/Dockerfile).")
+}
+
+// shellQuoteEnv renders a KEY=VALUE entry as a copy-pasteable `KEY='VALUE'`.
+func shellQuoteEnv(kv string) string {
+	i := strings.IndexByte(kv, '=')
+	if i < 0 {
+		return kv
+	}
+	key, val := kv[:i], kv[i+1:]
+	return key + "='" + strings.ReplaceAll(val, "'", `'\''`) + "'"
+}

--- a/go/internal/cli/commands/fleet_manifest.go
+++ b/go/internal/cli/commands/fleet_manifest.go
@@ -25,30 +25,48 @@ type fleetPeer struct {
 	Status string `json:"status"`
 }
 
-// runFleetManifest deploys a wendy-fleet.json across the LAN. Each component
-// references an app directory (its own wendy.json holds the build/runtime
-// config) and lists device tags; the component is deployed to every LAN device
-// whose name matches one of those tags. A component whose tags match no device
-// (e.g. a "central" dashboard) is deployed to --central if given, otherwise its
-// peer snapshot is printed so the operator can run it themselves.
+// runFleetManifest deploys a wendy-fleet.json. Each component references an app
+// directory (its own wendy.json holds the build/runtime config) and lists tags.
+//
+// By default components are placed by CLOUD asset tags (assigned with
+// 'wendy fleet group add') and deployed over the cloud tunnel. With --lan they
+// are placed by matching device names over mDNS instead. Cross-component
+// discovery (discovers -> WENDY_FLEET_PEERS) is wired in LAN mode; over the
+// cloud it needs per-peer reachability (the mesh, WDY-1778) and is deferred, so
+// cloud mode does placement only.
 func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, manifest *appconfig.FleetManifest, lan bool, central, cloudGRPC, brokerURL string, timeout time.Duration) error {
-	if !lan {
-		return fmt.Errorf("fleet manifests are LAN-only for now; re-run with --lan")
-	}
+	// Resolve targets per component from the chosen backend. In LAN mode also
+	// keep the matched devices, for the discovery snapshot.
+	targetsByComp := make(map[string][]fleetTarget, len(manifest.Components))
+	lanDevices := make(map[string][]models.LANDevice)
 
-	// Resolve the devices matching each component's tags once (reused for both
-	// deploy and the discovery snapshot).
-	matched := make(map[string][]models.LANDevice, len(manifest.Components))
-	for name, comp := range manifest.Components {
-		devs, err := lanDevicesForTags(ctx, comp.Tags, timeout)
+	if lan {
+		for name, comp := range manifest.Components {
+			devs, err := lanDevicesForTags(ctx, comp.Tags, timeout)
+			if err != nil {
+				return err
+			}
+			lanDevices[name] = devs
+			for _, dev := range devs {
+				targetsByComp[name] = append(targetsByComp[name], targetForDevice(dev))
+			}
+		}
+	} else {
+		auth, err := pickAuthEntry(cloudGRPC)
 		if err != nil {
 			return err
 		}
-		matched[name] = devs
+		assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+		if err != nil {
+			return err
+		}
+		for name, comp := range manifest.Components {
+			targetsByComp[name] = cloudTargetsForTags(auth, assets, comp.Tags, brokerURL)
+		}
 	}
 
-	// Deploy producers (no discovers) before consumers (with discovers) so the
-	// discovered endpoints are already up when a consumer starts.
+	// Producers (no discovers) before consumers (with discovers) so discovered
+	// endpoints are up first.
 	var producers, consumers []string
 	for name, comp := range manifest.Components {
 		if len(comp.Discovers) > 0 {
@@ -63,53 +81,56 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, m
 	for _, name := range append(producers, consumers...) {
 		comp := manifest.Components[name]
 		appDir := filepath.Join(projectCwd, comp.Path)
-
 		appCfg, err := loadComponentApp(appDir, opts)
 		if err != nil {
 			return fmt.Errorf("component %q: %w", name, err)
 		}
 
-		env, err := discoveryEnv(comp, manifest, matched)
-		if err != nil {
-			return fmt.Errorf("component %q: %w", name, err)
-		}
 		compOpts := opts
-		if len(env) > 0 {
-			compOpts.env = env
-			// Env injection rides on CreateContainerRequest.Env, carried by the
-			// registry (chunk-off) create path; force it so peers aren't dropped.
-			compOpts.chunking = chunkingOff
+		var lanEnv []string
+		if len(comp.Discovers) > 0 {
+			if lan {
+				lanEnv, err = discoveryEnv(comp, manifest, lanDevices)
+				if err != nil {
+					return fmt.Errorf("component %q: %w", name, err)
+				}
+				if len(lanEnv) > 0 {
+					// Env injection rides on CreateContainerRequest.Env, carried by
+					// the registry (chunk-off) create path; force it so peers aren't
+					// dropped.
+					compOpts.env = lanEnv
+					compOpts.chunking = chunkingOff
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "  note: %q declares discovers; cross-device discovery over the cloud is deferred to the mesh (WDY-1778) — deploying placement only\n", name)
+			}
 		}
 
-		devices := matched[name]
-		if len(devices) == 0 {
-			if central != "" {
+		targets := targetsByComp[name]
+		if len(targets) == 0 {
+			// LAN: a component matching no device can run on --central, or (if it
+			// consumes discovery) off-fleet — print how to run it.
+			if lan && central != "" {
 				dev, derr := resolveCentralDevice(ctx, central, timeout)
 				if derr != nil {
 					return derr
 				}
-				fmt.Printf("\n=== component %q (tags %v matched no device) → --central %s ===\n", name, comp.Tags, deviceShortName(dev))
+				fmt.Printf("\n=== component %q (no device matched %v) → --central %s ===\n", name, comp.Tags, deviceShortName(dev))
 				if err := deployToTarget(ctx, targetForDevice(dev), appDir, appCfg, compOpts); err != nil {
 					return fmt.Errorf("component %q on %s: %w", name, deviceShortName(dev), err)
 				}
 				continue
 			}
-			// Nothing matched and no --central: if it consumes discovery it's a
-			// central-style app meant to run off-fleet — print how to run it.
-			fmt.Printf("\n=== component %q (tags %v matched no LAN device) ===\n", name, comp.Tags)
-			if len(comp.Discovers) > 0 {
-				printCentralInstructions(name, comp, env)
-			} else {
-				fmt.Fprintf(os.Stderr, "  warning: no devices matched tags %v; skipping %q\n", comp.Tags, name)
+			if lan && len(comp.Discovers) > 0 {
+				fmt.Printf("\n=== component %q (no device matched %v) ===\n", name, comp.Tags)
+				printCentralInstructions(name, comp, lanEnv)
+				continue
 			}
+			fmt.Fprintf(os.Stderr, "  warning: no devices carry tags %v for %q; assign with 'wendy fleet group add <tag> <device>' and re-run\n", comp.Tags, name)
 			continue
 		}
 
-		fmt.Printf("\n=== component %q → tags %v (%d device(s)) ===\n", name, comp.Tags, len(devices))
-		targets := make([]fleetTarget, 0, len(devices))
-		for _, dev := range devices {
-			targets = append(targets, targetForDevice(dev))
-		}
+		fmt.Printf("\n=== component %q → tags %v (%d device(s)) ===\n", name, comp.Tags, len(targets))
 		if _, failures := deployToTargets(ctx, targets, appDir, appCfg, compOpts); failures > 0 && !opts.keepGoing {
 			return fmt.Errorf("component %q: %d device(s) failed", name, failures)
 		}

--- a/go/internal/cli/commands/fleet_manifest.go
+++ b/go/internal/cli/commands/fleet_manifest.go
@@ -24,17 +24,17 @@ type fleetPeer struct {
 	Status string `json:"status"`
 }
 
-// runFleetManifest deploys a fleet manifest (a wendy.json with a components map)
-// across the LAN: each "group" component fans out to the devices matching its
-// pattern, and each "central" component is deployed once — to --central, or, if
-// omitted, its peer snapshot is printed so the operator can run it themselves.
-func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, appCfg *appconfig.AppConfig, lan bool, central, cloudGRPC, brokerURL string, timeout time.Duration) error {
+// runFleetManifest deploys a wendy-fleet.json across the LAN: each "group"
+// component fans out to the devices matching its pattern, and each "central"
+// component is deployed once — to --central, or, if omitted, its peer snapshot
+// is printed so the operator can run it themselves.
+func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, manifest *appconfig.FleetManifest, lan bool, central, cloudGRPC, brokerURL string, timeout time.Duration) error {
 	if !lan {
 		return fmt.Errorf("fleet manifests are LAN-only for now; re-run with --lan")
 	}
 
 	var edgeNames, centralNames []string
-	for name, comp := range appCfg.Components {
+	for name, comp := range manifest.Components {
 		if comp.Target != nil && comp.Target.Central {
 			centralNames = append(centralNames, name)
 		} else {
@@ -48,7 +48,7 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, a
 	// deploy and the central component's discovery snapshot.
 	edgeDevices := make(map[string][]models.LANDevice, len(edgeNames))
 	for _, name := range edgeNames {
-		comp := appCfg.Components[name]
+		comp := manifest.Components[name]
 		devices, err := lanGroupDevices(ctx, comp.Target.Group, timeout)
 		if err != nil {
 			return err
@@ -62,11 +62,11 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, a
 	// 1. Edge components first, so their endpoints exist before a central
 	//    component starts discovering them.
 	for _, name := range edgeNames {
-		comp := appCfg.Components[name]
+		comp := manifest.Components[name]
 		devices := edgeDevices[name]
 		fmt.Printf("\n=== edge component %q → group %q (%d device(s)) ===\n", name, comp.Target.Group, len(devices))
 
-		compCfg := componentAppConfig(appCfg, name, comp)
+		compCfg := componentAppConfig(manifest, name, comp)
 		compCwd := filepath.Join(projectCwd, comp.Context)
 		targets := make([]fleetTarget, 0, len(devices))
 		for _, dev := range devices {
@@ -79,11 +79,11 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, a
 
 	// 2. Central components, with discovered peers injected as env vars.
 	for _, name := range centralNames {
-		comp := appCfg.Components[name]
-		compCfg := componentAppConfig(appCfg, name, comp)
+		comp := manifest.Components[name]
+		compCfg := componentAppConfig(manifest, name, comp)
 		compCwd := filepath.Join(projectCwd, comp.Context)
 
-		env, err := discoveryEnv(comp, appCfg, edgeDevices)
+		env, err := discoveryEnv(comp, manifest, edgeDevices)
 		if err != nil {
 			return fmt.Errorf("component %q: %w", name, err)
 		}
@@ -117,11 +117,11 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, a
 // componentAppConfig projects one fleet component into a standalone AppConfig
 // the single-device deploy pipeline understands. The app id is namespaced by
 // component so two components never collide on one device.
-func componentAppConfig(appCfg *appconfig.AppConfig, name string, comp *appconfig.ComponentConfig) *appconfig.AppConfig {
+func componentAppConfig(manifest *appconfig.FleetManifest, name string, comp *appconfig.ComponentConfig) *appconfig.AppConfig {
 	return &appconfig.AppConfig{
-		AppID:        appCfg.AppID + "." + name,
-		Version:      appCfg.Version,
-		Platform:     appCfg.Platform,
+		AppID:        manifest.AppID + "." + name,
+		Version:      manifest.Version,
+		Platform:     manifest.Platform,
 		Entitlements: comp.Entitlements,
 		Readiness:    comp.Readiness,
 		Hooks:        comp.Hooks,
@@ -133,10 +133,10 @@ func componentAppConfig(appCfg *appconfig.AppConfig, name string, comp *appconfi
 // discoveryEnv builds the env vars injected into a central component for its
 // declared discovers: each named var carries a JSON snapshot of the referenced
 // component's live peer endpoints.
-func discoveryEnv(central *appconfig.ComponentConfig, appCfg *appconfig.AppConfig, edgeDevices map[string][]models.LANDevice) ([]string, error) {
+func discoveryEnv(central *appconfig.ComponentConfig, manifest *appconfig.FleetManifest, edgeDevices map[string][]models.LANDevice) ([]string, error) {
 	var env []string
 	for _, d := range central.Discovers {
-		ref, ok := appCfg.Components[d.Component]
+		ref, ok := manifest.Components[d.Component]
 		if !ok {
 			return nil, fmt.Errorf("discovers references unknown component %q", d.Component)
 		}

--- a/go/internal/cli/commands/fleet_run.go
+++ b/go/internal/cli/commands/fleet_run.go
@@ -5,39 +5,46 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
-	"github.com/wendylabsinc/wendy/go/internal/shared/config"
-	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 )
 
 func newFleetRunCmd() *cobra.Command {
 	var opts runOptions
 	var group string
 	var cloudGRPC, brokerURL string
+	var lan bool
+	var central string
+	var timeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "run --group <group>",
 		Short: "Build and deploy the current project to every device in a group",
 		Long: "Deploys the current project (the wendy.json in the working directory) to every\n" +
 			"device in a named group, one invocation instead of a per-device loop.\n\n" +
+			"With --lan the group is resolved over the local network via mDNS (a glob over\n" +
+			"device names, e.g. 'camera-*'); no cloud session required.\n\n" +
+			"If the wendy.json is a fleet manifest (a 'components' map), each component is\n" +
+			"placed by its own target: group components fan out to the matching devices and\n" +
+			"the central component is deployed once (use --central <device>, or omit it to\n" +
+			"print the peer snapshot for running central yourself).\n\n" +
 			"Runs detached (it does not stream logs — there are many devices). With\n" +
-			"--keep-going a device that fails to deploy does not abort the rest.\n\n" +
-			"Note: v1 deploys to each device in turn, reusing the single-device pipeline.\n" +
-			"Build-once + parallel fan-out, and placement-aware deploys for fleet manifests\n" +
-			"(WDY-1755 components/target), are follow-ups.",
+			"--keep-going a device that fails to deploy does not abort the rest.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// A fleet deploy targets many devices: never prompt, never stream logs.
 			opts.yes = true
 			opts.detach = true
-			return runFleetRun(cmd.Context(), opts, group, cloudGRPC, brokerURL)
+			return runFleetRun(cmd.Context(), opts, group, cloudGRPC, brokerURL, lan, central, timeout)
 		},
 	}
 
-	cmd.Flags().StringVar(&group, "group", "", "Device group to deploy to (required)")
-	_ = cmd.MarkFlagRequired("group")
+	cmd.Flags().StringVar(&group, "group", "", "Device group to deploy to (required for a single-project deploy)")
+	cmd.Flags().BoolVar(&lan, "lan", false, "Resolve the group over the LAN (mDNS) instead of the cloud")
+	cmd.Flags().StringVar(&central, "central", "", "Device to deploy a fleet manifest's central component to (LAN device name)")
+	cmd.Flags().DurationVar(&timeout, "discover-timeout", fleetLANDiscoverTimeout, "How long to browse for LAN devices (with --lan)")
 	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
 	cmd.Flags().StringVar(&brokerURL, "broker-url", os.Getenv("WENDY_BROKER_URL"), "Tunnel broker host:port")
 	cmd.Flags().BoolVar(&opts.keepGoing, "keep-going", false, "Deploy to the remaining devices even if one fails, instead of stopping at the first error")
@@ -61,16 +68,12 @@ func newFleetRunCmd() *cobra.Command {
 
 // fleetRunResult is the per-device outcome of a fan-out deploy, for --json.
 type fleetRunResult struct {
-	Device  string `json:"device"`
-	AssetID int32  `json:"assetId"`
-	OK      bool   `json:"ok"`
-	Error   string `json:"error,omitempty"`
+	Device string `json:"device"`
+	OK     bool   `json:"ok"`
+	Error  string `json:"error,omitempty"`
 }
 
-func runFleetRun(ctx context.Context, opts runOptions, group, cloudGRPC, brokerURL string) error {
-	if err := validateGroupName(group); err != nil {
-		return err
-	}
+func runFleetRun(ctx context.Context, opts runOptions, group, cloudGRPC, brokerURL string, lan bool, central string, timeout time.Duration) error {
 	if _, err := normalizeImageBuilder(opts.builder); err != nil {
 		return err
 	}
@@ -84,21 +87,6 @@ func runFleetRun(ctx context.Context, opts runOptions, group, cloudGRPC, brokerU
 	if err != nil {
 		return fmt.Errorf("resolving working directory: %w", err)
 	}
-	projectType, err := resolveRunProjectType(cwd, opts.buildType)
-	if err != nil {
-		return err
-	}
-	if projectType == "compose" {
-		return fmt.Errorf("compose projects are not supported by 'wendy fleet run' yet")
-	}
-	if projectType == "docker" && opts.dockerfile == "" {
-		resolved, err := resolveDockerfile(cwd, opts.dockerfile, !opts.yes && isInteractiveTerminal())
-		if err != nil {
-			return err
-		}
-		opts.dockerfile = resolved
-	}
-
 	cfgPath := filepath.Join(cwd, "wendy.json")
 	missing, err := appConfigFileMissing(cfgPath)
 	if err != nil {
@@ -117,71 +105,95 @@ func runFleetRun(ctx context.Context, opts runOptions, group, cloudGRPC, brokerU
 	if err := warnAppConfigFile(cfgPath); err != nil {
 		return fmt.Errorf("reading wendy.json warnings: %w", err)
 	}
+
+	// A fleet manifest (components map) places each component by its own target;
+	// the single-project --group flag does not apply.
+	if appCfg.IsFleet() {
+		return runFleetManifest(ctx, opts, cwd, appCfg, lan, central, cloudGRPC, brokerURL, timeout)
+	}
+
 	if opts.debug {
 		applyDebugHostNetworking(appCfg)
 	}
 
-	// Resolve the group to its member devices.
-	auth, err := pickAuthEntry(cloudGRPC)
+	projectType, err := resolveRunProjectType(cwd, opts.buildType)
 	if err != nil {
 		return err
 	}
-	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
-	if err != nil {
-		return err
+	if projectType == "compose" {
+		return fmt.Errorf("compose projects are not supported by 'wendy fleet run' yet")
 	}
-	members := assetsInGroup(assets, group)
-	if len(members) == 0 {
-		return fmt.Errorf("group %q has no devices; add some with 'wendy fleet group add %s <device>...'", group, group)
-	}
-
-	fmt.Printf("Deploying %s to %d device(s) in group %q\n", appCfg.AppID, len(members), group)
-
-	// v1: deploy to each device in turn, reusing the proven single-device
-	// pipeline (build+push+create+start per device). Sequential keeps build
-	// output legible and avoids concurrent builder contention; build-once +
-	// parallel fan-out is a follow-up.
-	results := make([]fleetRunResult, 0, len(members))
-	failures := 0
-	for _, asset := range members {
-		res := fleetRunResult{Device: asset.GetName(), AssetID: asset.GetId()}
-		fmt.Printf("\n── %s (id %d) ──\n", asset.GetName(), asset.GetId())
-
-		if derr := deployToCloudAsset(ctx, auth, asset, brokerURL, cwd, appCfg, opts); derr != nil {
-			res.Error = derr.Error()
-			failures++
-			results = append(results, res)
-			fmt.Fprintf(os.Stderr, "  ✗ %s: %v\n", asset.GetName(), derr)
-			if !opts.keepGoing {
-				return fmt.Errorf("deploy to %s failed: %w (use --keep-going to continue past failures)", asset.GetName(), derr)
-			}
-			continue
+	if projectType == "docker" && opts.dockerfile == "" {
+		resolved, err := resolveDockerfile(cwd, opts.dockerfile, !opts.yes && isInteractiveTerminal())
+		if err != nil {
+			return err
 		}
-		res.OK = true
-		results = append(results, res)
+		opts.dockerfile = resolved
 	}
+
+	if group == "" {
+		return fmt.Errorf("--group is required (the device group to deploy to)")
+	}
+	targets, err := resolveFleetTargets(ctx, group, lan, cloudGRPC, brokerURL, timeout)
+	if err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		return fmt.Errorf("group %q has no devices; on the LAN check the name pattern, or add cloud devices with 'wendy fleet group add %s <device>...'", group, group)
+	}
+
+	fmt.Printf("Deploying %s to %d device(s) in group %q\n", appCfg.AppID, len(targets), group)
+
+	results, failures := deployToTargets(ctx, targets, cwd, appCfg, opts)
 
 	if jsonOutput {
 		if err := printJSON(results); err != nil {
 			return err
 		}
 	} else {
-		fmt.Printf("\nDeployed to %d/%d device(s) in group %q\n", len(members)-failures, len(members), group)
+		fmt.Printf("\nDeployed to %d/%d device(s) in group %q\n", len(targets)-failures, len(targets), group)
 	}
 	if failures > 0 {
-		return fmt.Errorf("%d of %d device(s) failed", failures, len(members))
+		return fmt.Errorf("%d of %d device(s) failed", failures, len(targets))
 	}
 	return nil
 }
 
-// deployToCloudAsset connects to one enrolled asset over the cloud tunnel and
-// runs the standard agent deploy pipeline against it.
-func deployToCloudAsset(ctx context.Context, auth *config.AuthConfig, asset *cloudpb.Asset, brokerURL, cwd string, appCfg *appconfig.AppConfig, opts runOptions) error {
-	conn, err := connectCloudAsset(ctx, auth, asset, brokerURL)
+// deployToTargets runs the standard single-device deploy pipeline against each
+// target in turn (sequential keeps build output legible and avoids concurrent
+// builder contention). It honors opts.keepGoing: when false it stops at the
+// first failure. Returns per-device results and a failure count.
+func deployToTargets(ctx context.Context, targets []fleetTarget, cwd string, appCfg *appconfig.AppConfig, opts runOptions) (results []fleetRunResult, failures int) {
+	results = make([]fleetRunResult, 0, len(targets))
+	for _, target := range targets {
+		res := fleetRunResult{Device: target.Name}
+		fmt.Printf("\n── %s ──\n", target.Name)
+
+		if derr := deployToTarget(ctx, target, cwd, appCfg, opts); derr != nil {
+			res.Error = derr.Error()
+			failures++
+			results = append(results, res)
+			fmt.Fprintf(os.Stderr, "  ✗ %s: %v\n", target.Name, derr)
+			if !opts.keepGoing {
+				// Surface the failure but return what we have so callers can report.
+				return results, failures
+			}
+			continue
+		}
+		res.OK = true
+		results = append(results, res)
+	}
+	return results, failures
+}
+
+// deployToTarget connects to one target and runs the standard agent deploy
+// pipeline against it.
+func deployToTarget(ctx context.Context, target fleetTarget, cwd string, appCfg *appconfig.AppConfig, opts runOptions) error {
+	conn, err := target.connect(ctx)
 	if err != nil {
 		return fmt.Errorf("connecting: %w", err)
 	}
-	defer conn.Close()
+	defer conn.Conn.Close()
 	return runWithAgent(ctx, conn, cwd, appCfg, opts)
 }
 

--- a/go/internal/cli/commands/fleet_run.go
+++ b/go/internal/cli/commands/fleet_run.go
@@ -1,0 +1,202 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func newFleetRunCmd() *cobra.Command {
+	var opts runOptions
+	var group string
+	var cloudGRPC, brokerURL string
+
+	cmd := &cobra.Command{
+		Use:   "run --group <group>",
+		Short: "Build and deploy the current project to every device in a group",
+		Long: "Deploys the current project (the wendy.json in the working directory) to every\n" +
+			"device in a named group, one invocation instead of a per-device loop.\n\n" +
+			"Runs detached (it does not stream logs — there are many devices). With\n" +
+			"--keep-going a device that fails to deploy does not abort the rest.\n\n" +
+			"Note: v1 deploys to each device in turn, reusing the single-device pipeline.\n" +
+			"Build-once + parallel fan-out, and placement-aware deploys for fleet manifests\n" +
+			"(WDY-1755 components/target), are follow-ups.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// A fleet deploy targets many devices: never prompt, never stream logs.
+			opts.yes = true
+			opts.detach = true
+			return runFleetRun(cmd.Context(), opts, group, cloudGRPC, brokerURL)
+		},
+	}
+
+	cmd.Flags().StringVar(&group, "group", "", "Device group to deploy to (required)")
+	_ = cmd.MarkFlagRequired("group")
+	cmd.Flags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
+	cmd.Flags().StringVar(&brokerURL, "broker-url", os.Getenv("WENDY_BROKER_URL"), "Tunnel broker host:port")
+	cmd.Flags().BoolVar(&opts.keepGoing, "keep-going", false, "Deploy to the remaining devices even if one fails, instead of stopping at the first error")
+
+	// A focused subset of `wendy run` build flags (logs/streaming/picker flags
+	// don't apply to a fan-out deploy).
+	cmd.Flags().StringVar(&opts.buildType, "build-type", "", "Build type when ambiguous: docker, swift, or python")
+	cmd.Flags().StringVar(&opts.dockerfile, "dockerfile", "", "Dockerfile/Containerfile to build from")
+	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to force: docker or apple-container")
+	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Enable debug logging + host networking")
+	cmd.Flags().StringVar(&opts.service, "service", "", "Build and deploy only the named service and its dependencies")
+	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
+	cmd.Flags().BoolVar(&opts.restartUnlessStopped, "restart-unless-stopped", false, "Restart unless manually stopped")
+	cmd.Flags().BoolVar(&opts.restartOnFailure, "restart-on-failure", false, "Restart on failure")
+	cmd.Flags().BoolVar(&opts.noRestart, "no-restart", false, "Do not restart on exit")
+	cmd.Flags().StringVar(&opts.prefix, "prefix", "", "Project directory to deploy from instead of the current working directory")
+	cmd.Flags().StringVar(&opts.chunking, "chunking", chunkingAuto, "Deploy path: auto, force (chunk-diff only), or off (registry push only)")
+
+	return cmd
+}
+
+// fleetRunResult is the per-device outcome of a fan-out deploy, for --json.
+type fleetRunResult struct {
+	Device  string `json:"device"`
+	AssetID int32  `json:"assetId"`
+	OK      bool   `json:"ok"`
+	Error   string `json:"error,omitempty"`
+}
+
+func runFleetRun(ctx context.Context, opts runOptions, group, cloudGRPC, brokerURL string) error {
+	if err := validateGroupName(group); err != nil {
+		return err
+	}
+	if _, err := normalizeImageBuilder(opts.builder); err != nil {
+		return err
+	}
+	if err := validateChunkingMode(opts.chunking); err != nil {
+		return err
+	}
+
+	// Load + validate the project once, before connecting to any device, so a
+	// bad project fails fast rather than once per device.
+	cwd, err := resolveRunWorkingDir(opts)
+	if err != nil {
+		return fmt.Errorf("resolving working directory: %w", err)
+	}
+	projectType, err := resolveRunProjectType(cwd, opts.buildType)
+	if err != nil {
+		return err
+	}
+	if projectType == "compose" {
+		return fmt.Errorf("compose projects are not supported by 'wendy fleet run' yet")
+	}
+	if projectType == "docker" && opts.dockerfile == "" {
+		resolved, err := resolveDockerfile(cwd, opts.dockerfile, !opts.yes && isInteractiveTerminal())
+		if err != nil {
+			return err
+		}
+		opts.dockerfile = resolved
+	}
+
+	cfgPath := filepath.Join(cwd, "wendy.json")
+	missing, err := appConfigFileMissing(cfgPath)
+	if err != nil {
+		return fmt.Errorf("checking wendy.json: %w", err)
+	}
+	if missing {
+		return fmt.Errorf("no wendy.json in %s — 'wendy fleet run' deploys an existing project to a group", cwd)
+	}
+	appCfg, err := ensureAppConfig(cfgPath, opts.yes)
+	if err != nil {
+		return fmt.Errorf("loading wendy.json: %w", err)
+	}
+	if err := appCfg.Validate(); err != nil {
+		return fmt.Errorf("invalid wendy.json: %w", err)
+	}
+	if err := warnAppConfigFile(cfgPath); err != nil {
+		return fmt.Errorf("reading wendy.json warnings: %w", err)
+	}
+	if opts.debug {
+		applyDebugHostNetworking(appCfg)
+	}
+
+	// Resolve the group to its member devices.
+	auth, err := pickAuthEntry(cloudGRPC)
+	if err != nil {
+		return err
+	}
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, false)
+	if err != nil {
+		return err
+	}
+	members := assetsInGroup(assets, group)
+	if len(members) == 0 {
+		return fmt.Errorf("group %q has no devices; add some with 'wendy fleet group add %s <device>...'", group, group)
+	}
+
+	fmt.Printf("Deploying %s to %d device(s) in group %q\n", appCfg.AppID, len(members), group)
+
+	// v1: deploy to each device in turn, reusing the proven single-device
+	// pipeline (build+push+create+start per device). Sequential keeps build
+	// output legible and avoids concurrent builder contention; build-once +
+	// parallel fan-out is a follow-up.
+	results := make([]fleetRunResult, 0, len(members))
+	failures := 0
+	for _, asset := range members {
+		res := fleetRunResult{Device: asset.GetName(), AssetID: asset.GetId()}
+		fmt.Printf("\n── %s (id %d) ──\n", asset.GetName(), asset.GetId())
+
+		if derr := deployToCloudAsset(ctx, auth, asset, brokerURL, cwd, appCfg, opts); derr != nil {
+			res.Error = derr.Error()
+			failures++
+			results = append(results, res)
+			fmt.Fprintf(os.Stderr, "  ✗ %s: %v\n", asset.GetName(), derr)
+			if !opts.keepGoing {
+				return fmt.Errorf("deploy to %s failed: %w (use --keep-going to continue past failures)", asset.GetName(), derr)
+			}
+			continue
+		}
+		res.OK = true
+		results = append(results, res)
+	}
+
+	if jsonOutput {
+		if err := printJSON(results); err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("\nDeployed to %d/%d device(s) in group %q\n", len(members)-failures, len(members), group)
+	}
+	if failures > 0 {
+		return fmt.Errorf("%d of %d device(s) failed", failures, len(members))
+	}
+	return nil
+}
+
+// deployToCloudAsset connects to one enrolled asset over the cloud tunnel and
+// runs the standard agent deploy pipeline against it.
+func deployToCloudAsset(ctx context.Context, auth *config.AuthConfig, asset *cloudpb.Asset, brokerURL, cwd string, appCfg *appconfig.AppConfig, opts runOptions) error {
+	conn, err := connectCloudAsset(ctx, auth, asset, brokerURL)
+	if err != nil {
+		return fmt.Errorf("connecting: %w", err)
+	}
+	defer conn.Close()
+	return runWithAgent(ctx, conn, cwd, appCfg, opts)
+}
+
+// applyDebugHostNetworking mirrors runCommand's --debug handling: enable debug
+// and ensure a host-mode network entitlement for remote debugger access.
+func applyDebugHostNetworking(appCfg *appconfig.AppConfig) {
+	appCfg.Debug = true
+	for i, e := range appCfg.Entitlements {
+		if e.Type == appconfig.EntitlementNetwork {
+			appCfg.Entitlements[i].Mode = "host"
+			return
+		}
+	}
+	appCfg.Entitlements = append(appCfg.Entitlements, appconfig.Entitlement{
+		Type: appconfig.EntitlementNetwork,
+		Mode: "host",
+	})
+}

--- a/go/internal/cli/commands/fleet_run.go
+++ b/go/internal/cli/commands/fleet_run.go
@@ -87,13 +87,27 @@ func runFleetRun(ctx context.Context, opts runOptions, group, cloudGRPC, brokerU
 	if err != nil {
 		return fmt.Errorf("resolving working directory: %w", err)
 	}
+
+	// A wendy-fleet.json drives a placement-aware fleet deploy: each component
+	// is built from its own context and placed by its own target. It's a
+	// separate file from any single-app wendy.json.
+	fleetPath := filepath.Join(cwd, appconfig.FleetManifestFileName)
+	if _, statErr := os.Stat(fleetPath); statErr == nil {
+		manifest, mErr := appconfig.LoadFleetManifest(fleetPath)
+		if mErr != nil {
+			return fmt.Errorf("loading %s: %w", appconfig.FleetManifestFileName, mErr)
+		}
+		return runFleetManifest(ctx, opts, cwd, manifest, lan, central, cloudGRPC, brokerURL, timeout)
+	}
+
+	// Single-project fan-out: deploy this project's wendy.json to a --group.
 	cfgPath := filepath.Join(cwd, "wendy.json")
 	missing, err := appConfigFileMissing(cfgPath)
 	if err != nil {
 		return fmt.Errorf("checking wendy.json: %w", err)
 	}
 	if missing {
-		return fmt.Errorf("no wendy.json in %s — 'wendy fleet run' deploys an existing project to a group", cwd)
+		return fmt.Errorf("no wendy.json or %s in %s — 'wendy fleet run' deploys a project to a group, or a fleet manifest across components", appconfig.FleetManifestFileName, cwd)
 	}
 	appCfg, err := ensureAppConfig(cfgPath, opts.yes)
 	if err != nil {
@@ -104,12 +118,6 @@ func runFleetRun(ctx context.Context, opts runOptions, group, cloudGRPC, brokerU
 	}
 	if err := warnAppConfigFile(cfgPath); err != nil {
 		return fmt.Errorf("reading wendy.json warnings: %w", err)
-	}
-
-	// A fleet manifest (components map) places each component by its own target;
-	// the single-project --group flag does not apply.
-	if appCfg.IsFleet() {
-		return runFleetManifest(ctx, opts, cwd, appCfg, lan, central, cloudGRPC, brokerURL, timeout)
 	}
 
 	if opts.debug {

--- a/go/internal/cli/commands/fleet_test.go
+++ b/go/internal/cli/commands/fleet_test.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func TestValidateGroupName(t *testing.T) {
+	tests := []struct {
+		name string
+		ok   bool
+	}{
+		{"cameras", true},
+		{"robots-east", true},
+		{"cam_01", true},
+		{"a", true},
+		{"", false},
+		{"-leading", false},
+		{"has space", false},
+		{"has,comma", false},
+		{"emoji😀", false},
+	}
+	for _, tt := range tests {
+		err := validateGroupName(tt.name)
+		if tt.ok && err != nil {
+			t.Errorf("validateGroupName(%q) = %v, want nil", tt.name, err)
+		}
+		if !tt.ok && err == nil {
+			t.Errorf("validateGroupName(%q) = nil, want error", tt.name)
+		}
+	}
+}
+
+func TestAddTag(t *testing.T) {
+	got, changed := addTag([]string{"a", "b"}, "cameras")
+	if !changed {
+		t.Error("addTag: changed = false, want true")
+	}
+	if want := []string{"a", "b", "cameras"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("addTag = %v, want %v", got, want)
+	}
+
+	got, changed = addTag([]string{"a", "cameras"}, "cameras")
+	if changed {
+		t.Error("addTag (already present): changed = true, want false")
+	}
+	if want := []string{"a", "cameras"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("addTag (already present) = %v, want %v", got, want)
+	}
+
+	// Adding to an empty/nil tag set.
+	got, changed = addTag(nil, "cameras")
+	if !changed || !reflect.DeepEqual(got, []string{"cameras"}) {
+		t.Errorf("addTag(nil) = %v, changed=%v", got, changed)
+	}
+}
+
+func TestRemoveTag(t *testing.T) {
+	got, changed := removeTag([]string{"a", "cameras", "b"}, "cameras")
+	if !changed {
+		t.Error("removeTag: changed = false, want true")
+	}
+	if want := []string{"a", "b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("removeTag = %v, want %v", got, want)
+	}
+
+	got, changed = removeTag([]string{"a", "b"}, "cameras")
+	if changed {
+		t.Error("removeTag (absent): changed = true, want false")
+	}
+	if want := []string{"a", "b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("removeTag (absent) = %v, want %v", got, want)
+	}
+
+	// Removing the only tag yields an empty (non-nil) slice.
+	got, changed = removeTag([]string{"cameras"}, "cameras")
+	if !changed {
+		t.Error("removeTag (last): changed = false, want true")
+	}
+	if len(got) != 0 {
+		t.Errorf("removeTag (last) = %v, want empty", got)
+	}
+}
+
+func TestGroupCountsAndMembers(t *testing.T) {
+	assets := []*cloudpb.Asset{
+		{Id: 1, Name: "cam-01", Tags: []string{"cameras", "prod"}},
+		{Id: 2, Name: "cam-02", Tags: []string{"cameras"}},
+		{Id: 3, Name: "robot-01", Tags: []string{"robots"}},
+		{Id: 4, Name: "spare", Tags: nil},
+	}
+
+	counts := groupCounts(assets)
+	if counts["cameras"] != 2 || counts["robots"] != 1 || counts["prod"] != 1 {
+		t.Errorf("groupCounts = %v", counts)
+	}
+	if _, ok := counts[""]; ok {
+		t.Error("groupCounts should not contain an empty group")
+	}
+
+	members := assetsInGroup(assets, "cameras")
+	if len(members) != 2 {
+		t.Fatalf("assetsInGroup(cameras) = %d members, want 2", len(members))
+	}
+	if members[0].GetName() != "cam-01" || members[1].GetName() != "cam-02" {
+		t.Errorf("assetsInGroup preserved order wrong: %q, %q", members[0].GetName(), members[1].GetName())
+	}
+
+	if got := assetsInGroup(assets, "nope"); len(got) != 0 {
+		t.Errorf("assetsInGroup(nope) = %v, want empty", got)
+	}
+}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -127,6 +127,8 @@ func NewRootCmd() *cobra.Command {
 	projectCmd.GroupID = "manage"
 	deviceCmd := newDeviceCmd()
 	deviceCmd.GroupID = "manage"
+	fleetCmd := newFleetCmd()
+	fleetCmd.GroupID = "manage"
 
 	// Cloud
 	cloudCmd := newCloudCmd()
@@ -206,6 +208,7 @@ func NewRootCmd() *cobra.Command {
 		// Manage
 		projectCmd,
 		deviceCmd,
+		fleetCmd,
 		// Cloud
 		cloudCmd,
 		// Settings

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -478,6 +478,10 @@ type runOptions struct {
 	keepGoing            bool
 	maxConcurrency       int
 	userArgs             []string
+	// env are extra KEY=VALUE environment variables injected into the container
+	// at create time (CreateContainerRequest.Env). Used by fleet deploys to wire
+	// cross-component discovery (e.g. WENDY_FLEET_PEERS) into a component.
+	env []string
 	// quietBuild suppresses the image build (buildx) output, surfacing it only
 	// when the build fails. Set by `wendy watch` to keep the redeploy loop quiet.
 	quietBuild bool
@@ -1009,6 +1013,7 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		AppConfig:     appConfigData,
 		RestartPolicy: restartPolicy,
 		UserArgs:      opts.userArgs,
+		Env:           opts.env,
 	}
 
 	return startAndStreamContainer(ctx, conn, appCfg, createReq, opts)
@@ -1530,6 +1535,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		AppConfig:     appConfigData,
 		RestartPolicy: restartPolicy,
 		UserArgs:      opts.userArgs,
+		Env:           opts.env,
 	}
 
 	return startAndStreamContainer(ctx, conn, appCfg, createReq, opts)

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -143,6 +143,59 @@ type ServiceConfig struct {
 	Resources *ResourceLimits `json:"resources,omitempty"`
 }
 
+// ComponentConfig describes one placed component of a fleet app (WDY-1755). A
+// wendy.json with a non-empty Components map is a "fleet manifest": each
+// component is built from its own context and placed independently — fanned out
+// to a device group (the edge tier) or run once centrally (the central tier).
+// Per-component Entitlements/Readiness/Hooks/Frameworks/Resources mirror the
+// single-app fields; in fleet mode they live here rather than at the top level.
+type ComponentConfig struct {
+	// Context is the build context directory, relative to wendy.json. Required.
+	Context      string            `json:"context"`
+	Target       *ComponentTarget  `json:"target,omitempty"`
+	Expose       *ComponentExpose  `json:"expose,omitempty"`
+	Discovers    []DiscoverRef     `json:"discovers,omitempty"`
+	Entitlements []Entitlement     `json:"entitlements,omitempty"`
+	Readiness    *ReadinessConfig  `json:"readiness,omitempty"`
+	Hooks        *HooksConfig      `json:"hooks,omitempty"`
+	Frameworks   *FrameworksConfig `json:"frameworks,omitempty"`
+	Resources    *ResourceLimits   `json:"resources,omitempty"`
+}
+
+// ComponentTarget places a component. Exactly one of Group or Central must be
+// set: Group fans the component out to every device in a named device group;
+// Central runs it once (on an edge device, a separate host, or the cloud).
+type ComponentTarget struct {
+	Group   string `json:"group,omitempty"`
+	Central bool   `json:"central,omitempty"`
+}
+
+// ComponentExpose declares the network endpoint a component serves so the
+// platform can advertise it for cross-device discovery. Named "expose" rather
+// than "service" to avoid collision with the multi-container Services map.
+type ComponentExpose struct {
+	Name string `json:"name,omitempty"`
+	Port int    `json:"port"`
+	Path string `json:"path,omitempty"`
+}
+
+// DiscoverRef wires one component's live endpoints into another. The resolved
+// peer list is injected into the consuming container as a JSON snapshot under
+// the env var named by As, plus a live discovery API under WENDY_DISCOVERY_URL.
+type DiscoverRef struct {
+	Component string `json:"component"`
+	As        string `json:"as"`
+}
+
+// DiscoveryURLEnvVar is the env var the platform auto-injects into any component
+// that declares a "discovers" entry, pointing at a local discovery API the app
+// can poll/subscribe to for live membership. It is reserved: a discovers[].as
+// may not reuse it.
+const DiscoveryURLEnvVar = "WENDY_DISCOVERY_URL"
+
+// envVarNamePattern matches a POSIX-portable environment variable name.
+var envVarNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // AppConfig represents the wendy.json application configuration.
 type AppConfig struct {
 	AppID string `json:"appId"`
@@ -175,6 +228,16 @@ type AppConfig struct {
 	// Resources optionally caps the app's CPU/memory/PID usage. For
 	// multi-service apps it is the default; a service may override it.
 	Resources *ResourceLimits `json:"resources,omitempty"`
+	// Components, when non-empty, makes this a fleet manifest (WDY-1755): a map
+	// of placed components fanned out to device groups and/or run centrally.
+	// Mutually exclusive with the single-app top-level fields.
+	Components map[string]*ComponentConfig `json:"components,omitempty"`
+}
+
+// IsFleet reports whether this is a fleet manifest, i.e. it declares a
+// components map rather than a single deployable app.
+func (c *AppConfig) IsFleet() bool {
+	return len(c.Components) > 0
 }
 
 // ContainerName returns the container identifier for this app config.
@@ -491,6 +554,176 @@ func (c *AppConfig) Validate() error {
 		}
 	}
 
+	if c.IsFleet() {
+		if err := c.validateComponents(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// singleAppFieldsSet returns the names of any top-level single-app fields that
+// are set. These are not permitted alongside a fleet "components" map — in
+// fleet mode each component carries its own build/runtime config.
+func (c *AppConfig) singleAppFieldsSet() []string {
+	var set []string
+	if c.ServiceName != "" {
+		set = append(set, "serviceName")
+	}
+	if c.Run != nil {
+		set = append(set, "run")
+	}
+	if len(c.Entitlements) > 0 {
+		set = append(set, "entitlements")
+	}
+	if c.Readiness != nil {
+		set = append(set, "readiness")
+	}
+	if c.Hooks != nil {
+		set = append(set, "hooks")
+	}
+	if c.Python != nil {
+		set = append(set, "python")
+	}
+	if c.Xcode != nil {
+		set = append(set, "xcode")
+	}
+	if len(c.Files) > 0 {
+		set = append(set, "files")
+	}
+	if c.Brewfile != "" {
+		set = append(set, "brewfile")
+	}
+	if c.Isolation != "" {
+		set = append(set, "isolation")
+	}
+	if c.Frameworks != nil {
+		set = append(set, "frameworks")
+	}
+	if c.Resources != nil {
+		set = append(set, "resources")
+	}
+	if len(c.Services) > 0 {
+		set = append(set, "services")
+	}
+	sort.Strings(set)
+	return set
+}
+
+// validateComponents validates a fleet manifest's components map: top-level
+// mutual exclusivity, per-component placement/build config, and discovers
+// wiring. Called only when IsFleet() is true.
+func (c *AppConfig) validateComponents() error {
+	if conflicting := c.singleAppFieldsSet(); len(conflicting) > 0 {
+		return fmt.Errorf("a fleet manifest (with \"components\") must not also set single-app field(s): %s — move them into the relevant component", strings.Join(conflicting, ", "))
+	}
+
+	for name, comp := range c.Components {
+		if comp == nil {
+			return fmt.Errorf("components[%q]: must not be null", name)
+		}
+		if comp.Context == "" {
+			return fmt.Errorf("components[%q]: context is required", name)
+		}
+		if filepath.IsAbs(comp.Context) {
+			return fmt.Errorf("components[%q]: context must be a relative path", name)
+		}
+		if cleaned := filepath.Clean(comp.Context); strings.HasPrefix(cleaned, "..") {
+			return fmt.Errorf("components[%q]: context must not contain '..' components", name)
+		}
+
+		if err := validateComponentTarget(name, comp.Target); err != nil {
+			return err
+		}
+		if err := validateComponentExpose(name, comp.Expose); err != nil {
+			return err
+		}
+		if err := validateEntitlements(comp.Entitlements, fmt.Sprintf("components[%q].entitlement", name)); err != nil {
+			return err
+		}
+		if comp.Readiness != nil {
+			if comp.Readiness.TCPSocket != nil {
+				port := comp.Readiness.TCPSocket.Port
+				if port < 1 || port > 65535 {
+					return fmt.Errorf("components[%q].readiness.tcpSocket.port must be between 1 and 65535, got %d", name, port)
+				}
+			}
+			if comp.Readiness.TimeoutSeconds < 0 {
+				return fmt.Errorf("components[%q].readiness.timeoutSeconds must not be negative, got %d", name, comp.Readiness.TimeoutSeconds)
+			}
+		}
+		if comp.Frameworks != nil {
+			if err := validateROS2Config(fmt.Sprintf("components[%q].frameworks.ros2", name), comp.Frameworks.ROS2); err != nil {
+				return err
+			}
+		}
+		if err := comp.Resources.validate(fmt.Sprintf("components[%q].resources", name)); err != nil {
+			return err
+		}
+	}
+
+	// discovers wiring is validated in a second pass so it can reference any
+	// declared component regardless of map iteration order.
+	for name, comp := range c.Components {
+		for i, d := range comp.Discovers {
+			if d.Component == "" {
+				return fmt.Errorf("components[%q].discovers[%d]: component is required", name, i)
+			}
+			target, ok := c.Components[d.Component]
+			if !ok {
+				return fmt.Errorf("components[%q].discovers[%d]: references unknown component %q", name, i, d.Component)
+			}
+			if target.Target == nil || target.Target.Group == "" {
+				return fmt.Errorf("components[%q].discovers[%d]: %q is not a group target — only group (edge) components can be discovered", name, i, d.Component)
+			}
+			if d.As == "" {
+				return fmt.Errorf("components[%q].discovers[%d]: as (env var name) is required", name, i)
+			}
+			if d.As == DiscoveryURLEnvVar {
+				return fmt.Errorf("components[%q].discovers[%d]: as must not be %q (reserved, auto-injected)", name, i, DiscoveryURLEnvVar)
+			}
+			if !envVarNamePattern.MatchString(d.As) {
+				return fmt.Errorf("components[%q].discovers[%d]: as %q is not a valid environment variable name", name, i, d.As)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateComponentTarget checks that a component declares exactly one
+// placement: a non-empty group, or central:true.
+func validateComponentTarget(name string, t *ComponentTarget) error {
+	if t == nil {
+		return fmt.Errorf("components[%q]: target is required (\"group\" or \"central\")", name)
+	}
+	hasGroup := t.Group != ""
+	if hasGroup && t.Central {
+		return fmt.Errorf("components[%q].target: set exactly one of \"group\" or \"central\", not both", name)
+	}
+	if !hasGroup && !t.Central {
+		return fmt.Errorf("components[%q].target: must set \"group\" (edge) or \"central\"", name)
+	}
+	return nil
+}
+
+// validateComponentExpose checks an optional exposed endpoint declaration.
+func validateComponentExpose(name string, e *ComponentExpose) error {
+	if e == nil {
+		return nil
+	}
+	if e.Port < 1 || e.Port > 65535 {
+		return fmt.Errorf("components[%q].expose.port must be between 1 and 65535, got %d", name, e.Port)
+	}
+	if e.Name != "" {
+		if err := ValidateServiceName(e.Name); err != nil {
+			return fmt.Errorf("components[%q].expose.name: %w", name, err)
+		}
+	}
+	if e.Path != "" && !strings.HasPrefix(e.Path, "/") {
+		return fmt.Errorf("components[%q].expose.path must start with '/', got %q", name, e.Path)
+	}
 	return nil
 }
 
@@ -646,6 +879,22 @@ func ValidateJSON(data []byte) []string {
 				prefix := fmt.Sprintf("services[%q].entitlement", name)
 				warnings = append(warnings, validateEntitlementsJSON(svc["entitlements"], prefix)...)
 				warnings = append(warnings, validateFrameworksJSON(svc["frameworks"], fmt.Sprintf("services[%q].frameworks", name))...)
+			}
+		}
+	}
+
+	// Validate component-level entitlements and frameworks for fleet manifests.
+	if componentsRaw, ok := raw["components"]; ok && len(componentsRaw) > 0 {
+		var componentEntries map[string]json.RawMessage
+		if err := json.Unmarshal(componentsRaw, &componentEntries); err == nil {
+			for name, compRaw := range componentEntries {
+				var comp map[string]json.RawMessage
+				if err := json.Unmarshal(compRaw, &comp); err != nil {
+					continue
+				}
+				prefix := fmt.Sprintf("components[%q].entitlement", name)
+				warnings = append(warnings, validateEntitlementsJSON(comp["entitlements"], prefix)...)
+				warnings = append(warnings, validateFrameworksJSON(comp["frameworks"], fmt.Sprintf("components[%q].frameworks", name))...)
 			}
 		}
 	}

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -228,16 +228,6 @@ type AppConfig struct {
 	// Resources optionally caps the app's CPU/memory/PID usage. For
 	// multi-service apps it is the default; a service may override it.
 	Resources *ResourceLimits `json:"resources,omitempty"`
-	// Components, when non-empty, makes this a fleet manifest (WDY-1755): a map
-	// of placed components fanned out to device groups and/or run centrally.
-	// Mutually exclusive with the single-app top-level fields.
-	Components map[string]*ComponentConfig `json:"components,omitempty"`
-}
-
-// IsFleet reports whether this is a fleet manifest, i.e. it declares a
-// components map rather than a single deployable app.
-func (c *AppConfig) IsFleet() bool {
-	return len(c.Components) > 0
 }
 
 // ContainerName returns the container identifier for this app config.
@@ -554,72 +544,58 @@ func (c *AppConfig) Validate() error {
 		}
 	}
 
-	if c.IsFleet() {
-		if err := c.validateComponents(); err != nil {
-			return err
-		}
-	}
 
 	return nil
 }
 
-// singleAppFieldsSet returns the names of any top-level single-app fields that
-// are set. These are not permitted alongside a fleet "components" map — in
-// fleet mode each component carries its own build/runtime config.
-func (c *AppConfig) singleAppFieldsSet() []string {
-	var set []string
-	if c.ServiceName != "" {
-		set = append(set, "serviceName")
-	}
-	if c.Run != nil {
-		set = append(set, "run")
-	}
-	if len(c.Entitlements) > 0 {
-		set = append(set, "entitlements")
-	}
-	if c.Readiness != nil {
-		set = append(set, "readiness")
-	}
-	if c.Hooks != nil {
-		set = append(set, "hooks")
-	}
-	if c.Python != nil {
-		set = append(set, "python")
-	}
-	if c.Xcode != nil {
-		set = append(set, "xcode")
-	}
-	if len(c.Files) > 0 {
-		set = append(set, "files")
-	}
-	if c.Brewfile != "" {
-		set = append(set, "brewfile")
-	}
-	if c.Isolation != "" {
-		set = append(set, "isolation")
-	}
-	if c.Frameworks != nil {
-		set = append(set, "frameworks")
-	}
-	if c.Resources != nil {
-		set = append(set, "resources")
-	}
-	if len(c.Services) > 0 {
-		set = append(set, "services")
-	}
-	sort.Strings(set)
-	return set
+
+// FleetManifestFileName is the conventional filename for a fleet manifest — a
+// placement/topology file kept separate from a project's single-app wendy.json.
+const FleetManifestFileName = "wendy-fleet.json"
+
+// FleetManifest is the parsed wendy-fleet.json: the fleet's identity plus which
+// components exist and where each is placed (fanned out to a device group, or
+// run once centrally). It lives in its own file so a project's single-app
+// wendy.json and its fleet topology stay separate.
+type FleetManifest struct {
+	AppID      string                      `json:"appId"`
+	Version    string                      `json:"version,omitempty"`
+	Platform   string                      `json:"platform,omitempty"`
+	Components map[string]*ComponentConfig `json:"components"`
 }
 
-// validateComponents validates a fleet manifest's components map: top-level
-// mutual exclusivity, per-component placement/build config, and discovers
-// wiring. Called only when IsFleet() is true.
-func (c *AppConfig) validateComponents() error {
-	if conflicting := c.singleAppFieldsSet(); len(conflicting) > 0 {
-		return fmt.Errorf("a fleet manifest (with \"components\") must not also set single-app field(s): %s — move them into the relevant component", strings.Join(conflicting, ", "))
+// LoadFleetManifest reads and validates a wendy-fleet.json from disk.
+func LoadFleetManifest(path string) (*FleetManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFleetManifest(data)
+}
+
+// ParseFleetManifest parses and validates a fleet manifest from raw JSON.
+func ParseFleetManifest(data []byte) (*FleetManifest, error) {
+	var m FleetManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", FleetManifestFileName, err)
+	}
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// Validate checks a fleet manifest: identity, per-component placement/build
+// config, and discovers wiring.
+func (m *FleetManifest) Validate() error {
+	if m.AppID == "" {
+		return fmt.Errorf("appId is required")
+	}
+	if len(m.Components) == 0 {
+		return fmt.Errorf("a fleet manifest must declare at least one component")
 	}
 
-	for name, comp := range c.Components {
+	for name, comp := range m.Components {
 		if comp == nil {
 			return fmt.Errorf("components[%q]: must not be null", name)
 		}
@@ -665,12 +641,12 @@ func (c *AppConfig) validateComponents() error {
 
 	// discovers wiring is validated in a second pass so it can reference any
 	// declared component regardless of map iteration order.
-	for name, comp := range c.Components {
+	for name, comp := range m.Components {
 		for i, d := range comp.Discovers {
 			if d.Component == "" {
 				return fmt.Errorf("components[%q].discovers[%d]: component is required", name, i)
 			}
-			target, ok := c.Components[d.Component]
+			target, ok := m.Components[d.Component]
 			if !ok {
 				return fmt.Errorf("components[%q].discovers[%d]: references unknown component %q", name, i, d.Component)
 			}

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -143,31 +143,23 @@ type ServiceConfig struct {
 	Resources *ResourceLimits `json:"resources,omitempty"`
 }
 
-// ComponentConfig describes one placed component of a fleet app (WDY-1755). A
-// wendy.json with a non-empty Components map is a "fleet manifest": each
-// component is built from its own context and placed independently — fanned out
-// to a device group (the edge tier) or run once centrally (the central tier).
-// Per-component Entitlements/Readiness/Hooks/Frameworks/Resources mirror the
-// single-app fields; in fleet mode they live here rather than at the top level.
+// ComponentConfig references one app of a fleet (WDY-1755/1776). The fleet
+// manifest describes topology, not app config: each component points at an app
+// directory (Path) whose own wendy.json defines the app's build/runtime config,
+// and lists the device Tags the app deploys to. There is no group/central
+// distinction — "central" is just a conventional tag.
 type ComponentConfig struct {
-	// Context is the build context directory, relative to wendy.json. Required.
-	Context      string            `json:"context"`
-	Target       *ComponentTarget  `json:"target,omitempty"`
-	Expose       *ComponentExpose  `json:"expose,omitempty"`
-	Discovers    []DiscoverRef     `json:"discovers,omitempty"`
-	Entitlements []Entitlement     `json:"entitlements,omitempty"`
-	Readiness    *ReadinessConfig  `json:"readiness,omitempty"`
-	Hooks        *HooksConfig      `json:"hooks,omitempty"`
-	Frameworks   *FrameworksConfig `json:"frameworks,omitempty"`
-	Resources    *ResourceLimits   `json:"resources,omitempty"`
-}
-
-// ComponentTarget places a component. Exactly one of Group or Central must be
-// set: Group fans the component out to every device in a named device group;
-// Central runs it once (on an edge device, a separate host, or the cloud).
-type ComponentTarget struct {
-	Group   string `json:"group,omitempty"`
-	Central bool   `json:"central,omitempty"`
+	// Path is the app directory, relative to wendy-fleet.json. It must contain a
+	// wendy.json defining the app. Required.
+	Path string `json:"path"`
+	// Tags select the devices this component deploys to: a device matches when
+	// any tag matches its name (glob, e.g. "camera-*"). Required, non-empty.
+	Tags []string `json:"tags"`
+	// Expose declares the endpoint this component serves, for cross-component
+	// discovery. Interim — WDY-1777 moves discovery to mDNS advertising.
+	Expose *ComponentExpose `json:"expose,omitempty"`
+	// Discovers wires another component's live endpoints into this one.
+	Discovers []DiscoverRef `json:"discovers,omitempty"`
 }
 
 // ComponentExpose declares the network endpoint a component serves so the
@@ -553,14 +545,13 @@ func (c *AppConfig) Validate() error {
 // placement/topology file kept separate from a project's single-app wendy.json.
 const FleetManifestFileName = "wendy-fleet.json"
 
-// FleetManifest is the parsed wendy-fleet.json: the fleet's identity plus which
-// components exist and where each is placed (fanned out to a device group, or
-// run once centrally). It lives in its own file so a project's single-app
-// wendy.json and its fleet topology stay separate.
+// FleetManifest is the parsed wendy-fleet.json: which components (apps) the
+// fleet is made of and, for each, the device tags it deploys to. It is topology
+// only — each component's build/runtime config lives in its app's own
+// wendy.json — kept in a separate file from any single-app wendy.json.
 type FleetManifest struct {
-	AppID      string                      `json:"appId"`
-	Version    string                      `json:"version,omitempty"`
-	Platform   string                      `json:"platform,omitempty"`
+	// AppID is an optional fleet-level label; each app carries its own appId.
+	AppID      string                      `json:"appId,omitempty"`
 	Components map[string]*ComponentConfig `json:"components"`
 }
 
@@ -585,12 +576,11 @@ func ParseFleetManifest(data []byte) (*FleetManifest, error) {
 	return &m, nil
 }
 
-// Validate checks a fleet manifest: identity, per-component placement/build
-// config, and discovers wiring.
+// Validate checks a fleet manifest: each component references an app directory,
+// lists the device tags it deploys to, and any discovers wiring is resolvable.
+// Per-app build/runtime config is validated separately when the app's own
+// wendy.json is loaded.
 func (m *FleetManifest) Validate() error {
-	if m.AppID == "" {
-		return fmt.Errorf("appId is required")
-	}
 	if len(m.Components) == 0 {
 		return fmt.Errorf("a fleet manifest must declare at least one component")
 	}
@@ -599,42 +589,24 @@ func (m *FleetManifest) Validate() error {
 		if comp == nil {
 			return fmt.Errorf("components[%q]: must not be null", name)
 		}
-		if comp.Context == "" {
-			return fmt.Errorf("components[%q]: context is required", name)
+		if comp.Path == "" {
+			return fmt.Errorf("components[%q]: path is required (the app directory)", name)
 		}
-		if filepath.IsAbs(comp.Context) {
-			return fmt.Errorf("components[%q]: context must be a relative path", name)
+		if filepath.IsAbs(comp.Path) {
+			return fmt.Errorf("components[%q]: path must be relative", name)
 		}
-		if cleaned := filepath.Clean(comp.Context); strings.HasPrefix(cleaned, "..") {
-			return fmt.Errorf("components[%q]: context must not contain '..' components", name)
+		if cleaned := filepath.Clean(comp.Path); strings.HasPrefix(cleaned, "..") {
+			return fmt.Errorf("components[%q]: path must not contain '..' components", name)
 		}
-
-		if err := validateComponentTarget(name, comp.Target); err != nil {
-			return err
+		if len(comp.Tags) == 0 {
+			return fmt.Errorf("components[%q]: at least one tag is required (the devices to deploy to)", name)
+		}
+		for i, tag := range comp.Tags {
+			if strings.TrimSpace(tag) == "" {
+				return fmt.Errorf("components[%q].tags[%d]: must not be empty", name, i)
+			}
 		}
 		if err := validateComponentExpose(name, comp.Expose); err != nil {
-			return err
-		}
-		if err := validateEntitlements(comp.Entitlements, fmt.Sprintf("components[%q].entitlement", name)); err != nil {
-			return err
-		}
-		if comp.Readiness != nil {
-			if comp.Readiness.TCPSocket != nil {
-				port := comp.Readiness.TCPSocket.Port
-				if port < 1 || port > 65535 {
-					return fmt.Errorf("components[%q].readiness.tcpSocket.port must be between 1 and 65535, got %d", name, port)
-				}
-			}
-			if comp.Readiness.TimeoutSeconds < 0 {
-				return fmt.Errorf("components[%q].readiness.timeoutSeconds must not be negative, got %d", name, comp.Readiness.TimeoutSeconds)
-			}
-		}
-		if comp.Frameworks != nil {
-			if err := validateROS2Config(fmt.Sprintf("components[%q].frameworks.ros2", name), comp.Frameworks.ROS2); err != nil {
-				return err
-			}
-		}
-		if err := comp.Resources.validate(fmt.Sprintf("components[%q].resources", name)); err != nil {
 			return err
 		}
 	}
@@ -650,8 +622,8 @@ func (m *FleetManifest) Validate() error {
 			if !ok {
 				return fmt.Errorf("components[%q].discovers[%d]: references unknown component %q", name, i, d.Component)
 			}
-			if target.Target == nil || target.Target.Group == "" {
-				return fmt.Errorf("components[%q].discovers[%d]: %q is not a group target — only group (edge) components can be discovered", name, i, d.Component)
+			if target.Expose == nil {
+				return fmt.Errorf("components[%q].discovers[%d]: %q declares no \"expose\" endpoint to discover", name, i, d.Component)
 			}
 			if d.As == "" {
 				return fmt.Errorf("components[%q].discovers[%d]: as (env var name) is required", name, i)
@@ -665,22 +637,6 @@ func (m *FleetManifest) Validate() error {
 		}
 	}
 
-	return nil
-}
-
-// validateComponentTarget checks that a component declares exactly one
-// placement: a non-empty group, or central:true.
-func validateComponentTarget(name string, t *ComponentTarget) error {
-	if t == nil {
-		return fmt.Errorf("components[%q]: target is required (\"group\" or \"central\")", name)
-	}
-	hasGroup := t.Group != ""
-	if hasGroup && t.Central {
-		return fmt.Errorf("components[%q].target: set exactly one of \"group\" or \"central\", not both", name)
-	}
-	if !hasGroup && !t.Central {
-		return fmt.Errorf("components[%q].target: must set \"group\" (edge) or \"central\"", name)
-	}
 	return nil
 }
 

--- a/go/internal/shared/appconfig/fleet_test.go
+++ b/go/internal/shared/appconfig/fleet_test.go
@@ -2,22 +2,21 @@ package appconfig
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 )
 
-// cameraFleetJSON mirrors the camera-fleet template's wendy.json (templates
-// PR #59) with template variables rendered to concrete values. It is the
-// canonical valid fleet manifest and acts as the acceptance fixture for the
-// Phase 1 schema work (WDY-1755).
+// cameraFleetJSON mirrors the camera-fleet template's wendy-fleet.json
+// (templates PR #59) with template variables rendered to concrete values. It is
+// the canonical valid fleet manifest and acts as the acceptance fixture for the
+// fleet placement schema (WDY-1755).
 const cameraFleetJSON = `{
   "appId": "sh.wendy.examples.camerafleet",
   "version": "0.1.0",
-  "platform": "linux",
+  "platform": "linux/arm64",
   "components": {
     "camera": {
       "context": "camera",
-      "target": { "group": "cameras" },
+      "target": { "group": "camera-*" },
       "expose": { "name": "usbcam", "port": 8000, "path": "/stream" },
       "entitlements": [
         { "type": "network", "mode": "host" },
@@ -37,27 +36,24 @@ const cameraFleetJSON = `{
 }`
 
 func TestFleetManifest_Valid(t *testing.T) {
-	cfg, err := LoadFromBytes([]byte(cameraFleetJSON))
+	m, err := ParseFleetManifest([]byte(cameraFleetJSON))
 	if err != nil {
-		t.Fatalf("LoadFromBytes: %v", err)
+		t.Fatalf("ParseFleetManifest: %v", err)
 	}
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("Validate: %v", err)
+	if m.AppID != "sh.wendy.examples.camerafleet" {
+		t.Errorf("appId = %q", m.AppID)
 	}
-	if !cfg.IsFleet() {
-		t.Fatal("IsFleet() = false, want true")
+	if len(m.Components) != 2 {
+		t.Fatalf("got %d components, want 2", len(m.Components))
 	}
-	if len(cfg.Components) != 2 {
-		t.Fatalf("got %d components, want 2", len(cfg.Components))
-	}
-	cam := cfg.Components["camera"]
-	if cam == nil || cam.Target == nil || cam.Target.Group != "cameras" {
+	cam := m.Components["camera"]
+	if cam == nil || cam.Target == nil || cam.Target.Group != "camera-*" {
 		t.Fatalf("camera component target group not parsed: %+v", cam)
 	}
 	if cam.Expose == nil || cam.Expose.Port != 8000 || cam.Expose.Path != "/stream" {
 		t.Fatalf("camera expose not parsed: %+v", cam.Expose)
 	}
-	dash := cfg.Components["dashboard"]
+	dash := m.Components["dashboard"]
 	if dash == nil || dash.Target == nil || !dash.Target.Central {
 		t.Fatalf("dashboard component target central not parsed: %+v", dash)
 	}
@@ -66,47 +62,12 @@ func TestFleetManifest_Valid(t *testing.T) {
 	}
 }
 
-func TestIsFleet_SingleApp(t *testing.T) {
-	cfg, err := LoadFromBytes([]byte(`{"appId":"sh.wendy.app","entitlements":[{"type":"gpu"}]}`))
-	if err != nil {
-		t.Fatalf("LoadFromBytes: %v", err)
+func TestFleetManifest_RequiresAppIDAndComponents(t *testing.T) {
+	if _, err := ParseFleetManifest([]byte(`{"components":{"c":{"context":"c","target":{"central":true}}}}`)); err == nil {
+		t.Error("expected error for missing appId")
 	}
-	if cfg.IsFleet() {
-		t.Fatal("IsFleet() = true for single-app config, want false")
-	}
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("single-app Validate regressed: %v", err)
-	}
-}
-
-func TestFleetManifest_RejectsSingleAppFields(t *testing.T) {
-	tests := []struct {
-		name      string
-		extra     string
-		wantField string
-	}{
-		{"services", `"services": { "a": { "context": "a" } },`, "services"},
-		{"entitlements", `"entitlements": [ { "type": "gpu" } ],`, "entitlements"},
-		{"run", `"run": { "args": ["x"] },`, "run"},
-		{"isolation", `"isolation": "shared-ipc",`, "isolation"},
-		{"resources", `"resources": { "cpus": "1" },`, "resources"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			raw := `{"appId":"sh.wendy.app",` + tt.extra +
-				`"components":{"c":{"context":"c","target":{"central":true}}}}`
-			cfg, err := LoadFromBytes([]byte(raw))
-			if err != nil {
-				t.Fatalf("LoadFromBytes: %v", err)
-			}
-			err = cfg.Validate()
-			if err == nil {
-				t.Fatalf("expected mutual-exclusivity error for %q", tt.wantField)
-			}
-			if !strings.Contains(err.Error(), tt.wantField) {
-				t.Errorf("error %q does not mention conflicting field %q", err, tt.wantField)
-			}
-		})
+	if _, err := ParseFleetManifest([]byte(`{"appId":"sh.wendy.app","components":{}}`)); err == nil {
+		t.Error("expected error for empty components")
 	}
 }
 
@@ -131,16 +92,12 @@ func TestComponentTarget_Validation(t *testing.T) {
 			}
 			comp += `}`
 			raw := `{"appId":"sh.wendy.app","components":{"c":` + comp + `}}`
-			cfg, err := LoadFromBytes([]byte(raw))
-			if err != nil {
-				t.Fatalf("LoadFromBytes: %v", err)
-			}
-			err = cfg.Validate()
+			_, err := ParseFleetManifest([]byte(raw))
 			if tt.ok && err != nil {
-				t.Errorf("Validate: unexpected error: %v", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 			if !tt.ok && err == nil {
-				t.Error("Validate: expected error, got nil")
+				t.Error("expected error, got nil")
 			}
 		})
 	}
@@ -161,16 +118,12 @@ func TestComponentExpose_Validation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			raw := `{"appId":"sh.wendy.app","components":{"c":{"context":"c","target":{"group":"g"},"expose":` + tt.expose + `}}}`
-			cfg, err := LoadFromBytes([]byte(raw))
-			if err != nil {
-				t.Fatalf("LoadFromBytes: %v", err)
-			}
-			err = cfg.Validate()
+			_, err := ParseFleetManifest([]byte(raw))
 			if tt.ok && err != nil {
-				t.Errorf("Validate: unexpected error: %v", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 			if !tt.ok && err == nil {
-				t.Error("Validate: expected error, got nil")
+				t.Error("expected error, got nil")
 			}
 		})
 	}
@@ -196,16 +149,12 @@ func TestDiscovers_Validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := LoadFromBytes([]byte(build(tt.discovers)))
-			if err != nil {
-				t.Fatalf("LoadFromBytes: %v", err)
-			}
-			err = cfg.Validate()
+			_, err := ParseFleetManifest([]byte(build(tt.discovers)))
 			if tt.ok && err != nil {
-				t.Errorf("Validate: unexpected error: %v", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 			if !tt.ok && err == nil {
-				t.Error("Validate: expected error, got nil")
+				t.Error("expected error, got nil")
 			}
 		})
 	}
@@ -216,44 +165,36 @@ func TestDiscovers_RejectsDiscoveringCentral(t *testing.T) {
 	raw := `{"appId":"sh.wendy.app","components":{` +
 		`"a":{"context":"a","target":{"central":true}},` +
 		`"b":{"context":"b","target":{"central":true},"discovers":[{"component":"a","as":"PEERS"}]}}}`
-	cfg, err := LoadFromBytes([]byte(raw))
-	if err != nil {
-		t.Fatalf("LoadFromBytes: %v", err)
-	}
-	if err := cfg.Validate(); err == nil {
+	if _, err := ParseFleetManifest([]byte(raw)); err == nil {
 		t.Fatal("expected error discovering a non-group component, got nil")
 	}
 }
 
-func TestFleetManifest_ComponentEntitlementWarnings(t *testing.T) {
-	// An unknown key on a component-level entitlement should surface as a warning.
-	raw := `{"appId":"sh.wendy.app","components":{"cam":{"context":"cam","target":{"group":"g"},` +
-		`"entitlements":[{"type":"gpu","bogus":true}]}}}`
-	warnings := ValidateJSON([]byte(raw))
-	found := false
-	for _, w := range warnings {
-		if strings.Contains(w, `components["cam"].entitlement`) && strings.Contains(w, "bogus") {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected a component entitlement warning about 'bogus', got %v", warnings)
-	}
-}
-
-func TestSchemaJSON_HasComponents(t *testing.T) {
+func TestFleetSchemaJSON_HasComponents(t *testing.T) {
 	var schema map[string]any
-	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
-		t.Fatalf("schema is not valid JSON: %v", err)
+	if err := json.Unmarshal([]byte(FleetSchemaJSON), &schema); err != nil {
+		t.Fatalf("fleet schema is not valid JSON: %v", err)
 	}
 	props, _ := schema["properties"].(map[string]any)
 	if _, ok := props["components"]; !ok {
-		t.Error("schema missing top-level 'components' property")
+		t.Error("fleet schema missing top-level 'components' property")
 	}
 	defs, _ := schema["$defs"].(map[string]any)
 	for _, def := range []string{"component", "componentTarget", "componentExpose", "discoverRef"} {
 		if _, ok := defs[def]; !ok {
-			t.Errorf("schema missing $defs.%s", def)
+			t.Errorf("fleet schema missing $defs.%s", def)
+		}
+	}
+}
+
+func TestWendySchemaJSON_NoLongerHasComponents(t *testing.T) {
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	if props, _ := schema["properties"].(map[string]any); props != nil {
+		if _, ok := props["components"]; ok {
+			t.Error("wendy.schema.json still has a 'components' property; it moved to wendy-fleet.schema.json")
 		}
 	}
 }

--- a/go/internal/shared/appconfig/fleet_test.go
+++ b/go/internal/shared/appconfig/fleet_test.go
@@ -6,31 +6,21 @@ import (
 )
 
 // cameraFleetJSON mirrors the camera-fleet template's wendy-fleet.json
-// (templates PR #59) with template variables rendered to concrete values. It is
-// the canonical valid fleet manifest and acts as the acceptance fixture for the
-// fleet placement schema (WDY-1755).
+// (templates PR #59): thin topology that references app directories and the
+// device tags each deploys to. It is the acceptance fixture for the fleet
+// placement schema (WDY-1755/1776).
 const cameraFleetJSON = `{
   "appId": "sh.wendy.examples.camerafleet",
-  "version": "0.1.0",
-  "platform": "linux/arm64",
   "components": {
     "camera": {
-      "context": "camera",
-      "target": { "group": "camera-*" },
-      "expose": { "name": "usbcam", "port": 8000, "path": "/stream" },
-      "entitlements": [
-        { "type": "network", "mode": "host" },
-        { "type": "camera" }
-      ],
-      "readiness": { "tcpSocket": { "port": 8000 }, "timeoutSeconds": 30 }
+      "path": "camera",
+      "tags": ["camera-*"],
+      "expose": { "name": "usbcam", "port": 8000, "path": "/stream" }
     },
     "dashboard": {
-      "context": "dashboard",
-      "target": { "central": true },
-      "discovers": [ { "component": "camera", "as": "WENDY_FLEET_PEERS" } ],
-      "entitlements": [ { "type": "network", "mode": "host" } ],
-      "readiness": { "tcpSocket": { "port": 9000 }, "timeoutSeconds": 30 },
-      "hooks": { "postStart": { "openURL": "http://${WENDY_HOSTNAME}:9000" } }
+      "path": "dashboard",
+      "tags": ["central"],
+      "discovers": [ { "component": "camera", "as": "WENDY_FLEET_PEERS" } ]
     }
   }
 }`
@@ -40,58 +30,49 @@ func TestFleetManifest_Valid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseFleetManifest: %v", err)
 	}
-	if m.AppID != "sh.wendy.examples.camerafleet" {
-		t.Errorf("appId = %q", m.AppID)
-	}
 	if len(m.Components) != 2 {
 		t.Fatalf("got %d components, want 2", len(m.Components))
 	}
 	cam := m.Components["camera"]
-	if cam == nil || cam.Target == nil || cam.Target.Group != "camera-*" {
-		t.Fatalf("camera component target group not parsed: %+v", cam)
+	if cam == nil || cam.Path != "camera" || len(cam.Tags) != 1 || cam.Tags[0] != "camera-*" {
+		t.Fatalf("camera path/tags not parsed: %+v", cam)
 	}
 	if cam.Expose == nil || cam.Expose.Port != 8000 || cam.Expose.Path != "/stream" {
 		t.Fatalf("camera expose not parsed: %+v", cam.Expose)
 	}
 	dash := m.Components["dashboard"]
-	if dash == nil || dash.Target == nil || !dash.Target.Central {
-		t.Fatalf("dashboard component target central not parsed: %+v", dash)
+	if dash == nil || dash.Path != "dashboard" || len(dash.Tags) != 1 || dash.Tags[0] != "central" {
+		t.Fatalf("dashboard path/tags not parsed: %+v", dash)
 	}
 	if len(dash.Discovers) != 1 || dash.Discovers[0].Component != "camera" || dash.Discovers[0].As != "WENDY_FLEET_PEERS" {
 		t.Fatalf("dashboard discovers not parsed: %+v", dash.Discovers)
 	}
 }
 
-func TestFleetManifest_RequiresAppIDAndComponents(t *testing.T) {
-	if _, err := ParseFleetManifest([]byte(`{"components":{"c":{"context":"c","target":{"central":true}}}}`)); err == nil {
-		t.Error("expected error for missing appId")
-	}
-	if _, err := ParseFleetManifest([]byte(`{"appId":"sh.wendy.app","components":{}}`)); err == nil {
+func TestFleetManifest_RequiresComponents(t *testing.T) {
+	if _, err := ParseFleetManifest([]byte(`{"components":{}}`)); err == nil {
 		t.Error("expected error for empty components")
 	}
 }
 
-func TestComponentTarget_Validation(t *testing.T) {
+func TestComponent_Validation(t *testing.T) {
 	tests := []struct {
-		name   string
-		target string
-		ok     bool
+		name string
+		comp string
+		ok   bool
 	}{
-		{"group only", `{ "group": "cameras" }`, true},
-		{"central only", `{ "central": true }`, true},
-		{"both set", `{ "group": "cameras", "central": true }`, false},
-		{"neither set", `{}`, false},
-		{"missing target", ``, false},
-		{"empty group", `{ "group": "" }`, false},
+		{"valid", `{ "path": "c", "tags": ["g"] }`, true},
+		{"multi-tag", `{ "path": "c", "tags": ["a", "b-*"] }`, true},
+		{"missing path", `{ "tags": ["g"] }`, false},
+		{"missing tags", `{ "path": "c" }`, false},
+		{"empty tags", `{ "path": "c", "tags": [] }`, false},
+		{"empty tag string", `{ "path": "c", "tags": [""] }`, false},
+		{"absolute path", `{ "path": "/c", "tags": ["g"] }`, false},
+		{"escaping path", `{ "path": "../c", "tags": ["g"] }`, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			comp := `{"context":"c"`
-			if tt.target != "" {
-				comp += `,"target":` + tt.target
-			}
-			comp += `}`
-			raw := `{"appId":"sh.wendy.app","components":{"c":` + comp + `}}`
+			raw := `{"components":{"c":` + tt.comp + `}}`
 			_, err := ParseFleetManifest([]byte(raw))
 			if tt.ok && err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -117,7 +98,7 @@ func TestComponentExpose_Validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			raw := `{"appId":"sh.wendy.app","components":{"c":{"context":"c","target":{"group":"g"},"expose":` + tt.expose + `}}}`
+			raw := `{"components":{"c":{"path":"c","tags":["g"],"expose":` + tt.expose + `}}}`
 			_, err := ParseFleetManifest([]byte(raw))
 			if tt.ok && err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -130,11 +111,11 @@ func TestComponentExpose_Validation(t *testing.T) {
 }
 
 func TestDiscovers_Validation(t *testing.T) {
-	// base has an edge "cam" (group) and a central "c" we attach discovers to.
+	// base has an exposing "cam" and a consumer "c" we attach discovers to.
 	build := func(discovers string) string {
-		return `{"appId":"sh.wendy.app","components":{` +
-			`"cam":{"context":"cam","target":{"group":"cams"}},` +
-			`"c":{"context":"c","target":{"central":true},"discovers":` + discovers + `}}}`
+		return `{"components":{` +
+			`"cam":{"path":"cam","tags":["cams"],"expose":{"port":8000}},` +
+			`"c":{"path":"c","tags":["central"],"discovers":` + discovers + `}}}`
 	}
 	tests := []struct {
 		name      string
@@ -160,13 +141,13 @@ func TestDiscovers_Validation(t *testing.T) {
 	}
 }
 
-func TestDiscovers_RejectsDiscoveringCentral(t *testing.T) {
-	// Discovering a central (non-group) component is meaningless and rejected.
-	raw := `{"appId":"sh.wendy.app","components":{` +
-		`"a":{"context":"a","target":{"central":true}},` +
-		`"b":{"context":"b","target":{"central":true},"discovers":[{"component":"a","as":"PEERS"}]}}}`
+func TestDiscovers_RejectsNonExposingComponent(t *testing.T) {
+	// Discovering a component that exposes nothing is meaningless and rejected.
+	raw := `{"components":{` +
+		`"a":{"path":"a","tags":["x"]},` +
+		`"b":{"path":"b","tags":["central"],"discovers":[{"component":"a","as":"PEERS"}]}}}`
 	if _, err := ParseFleetManifest([]byte(raw)); err == nil {
-		t.Fatal("expected error discovering a non-group component, got nil")
+		t.Fatal("expected error discovering a component with no expose, got nil")
 	}
 }
 
@@ -180,7 +161,7 @@ func TestFleetSchemaJSON_HasComponents(t *testing.T) {
 		t.Error("fleet schema missing top-level 'components' property")
 	}
 	defs, _ := schema["$defs"].(map[string]any)
-	for _, def := range []string{"component", "componentTarget", "componentExpose", "discoverRef"} {
+	for _, def := range []string{"component", "componentExpose", "discoverRef"} {
 		if _, ok := defs[def]; !ok {
 			t.Errorf("fleet schema missing $defs.%s", def)
 		}

--- a/go/internal/shared/appconfig/fleet_test.go
+++ b/go/internal/shared/appconfig/fleet_test.go
@@ -1,0 +1,259 @@
+package appconfig
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// cameraFleetJSON mirrors the camera-fleet template's wendy.json (templates
+// PR #59) with template variables rendered to concrete values. It is the
+// canonical valid fleet manifest and acts as the acceptance fixture for the
+// Phase 1 schema work (WDY-1755).
+const cameraFleetJSON = `{
+  "appId": "sh.wendy.examples.camerafleet",
+  "version": "0.1.0",
+  "platform": "linux",
+  "components": {
+    "camera": {
+      "context": "camera",
+      "target": { "group": "cameras" },
+      "expose": { "name": "usbcam", "port": 8000, "path": "/stream" },
+      "entitlements": [
+        { "type": "network", "mode": "host" },
+        { "type": "camera" }
+      ],
+      "readiness": { "tcpSocket": { "port": 8000 }, "timeoutSeconds": 30 }
+    },
+    "dashboard": {
+      "context": "dashboard",
+      "target": { "central": true },
+      "discovers": [ { "component": "camera", "as": "WENDY_FLEET_PEERS" } ],
+      "entitlements": [ { "type": "network", "mode": "host" } ],
+      "readiness": { "tcpSocket": { "port": 9000 }, "timeoutSeconds": 30 },
+      "hooks": { "postStart": { "openURL": "http://${WENDY_HOSTNAME}:9000" } }
+    }
+  }
+}`
+
+func TestFleetManifest_Valid(t *testing.T) {
+	cfg, err := LoadFromBytes([]byte(cameraFleetJSON))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !cfg.IsFleet() {
+		t.Fatal("IsFleet() = false, want true")
+	}
+	if len(cfg.Components) != 2 {
+		t.Fatalf("got %d components, want 2", len(cfg.Components))
+	}
+	cam := cfg.Components["camera"]
+	if cam == nil || cam.Target == nil || cam.Target.Group != "cameras" {
+		t.Fatalf("camera component target group not parsed: %+v", cam)
+	}
+	if cam.Expose == nil || cam.Expose.Port != 8000 || cam.Expose.Path != "/stream" {
+		t.Fatalf("camera expose not parsed: %+v", cam.Expose)
+	}
+	dash := cfg.Components["dashboard"]
+	if dash == nil || dash.Target == nil || !dash.Target.Central {
+		t.Fatalf("dashboard component target central not parsed: %+v", dash)
+	}
+	if len(dash.Discovers) != 1 || dash.Discovers[0].Component != "camera" || dash.Discovers[0].As != "WENDY_FLEET_PEERS" {
+		t.Fatalf("dashboard discovers not parsed: %+v", dash.Discovers)
+	}
+}
+
+func TestIsFleet_SingleApp(t *testing.T) {
+	cfg, err := LoadFromBytes([]byte(`{"appId":"sh.wendy.app","entitlements":[{"type":"gpu"}]}`))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	if cfg.IsFleet() {
+		t.Fatal("IsFleet() = true for single-app config, want false")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("single-app Validate regressed: %v", err)
+	}
+}
+
+func TestFleetManifest_RejectsSingleAppFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		extra     string
+		wantField string
+	}{
+		{"services", `"services": { "a": { "context": "a" } },`, "services"},
+		{"entitlements", `"entitlements": [ { "type": "gpu" } ],`, "entitlements"},
+		{"run", `"run": { "args": ["x"] },`, "run"},
+		{"isolation", `"isolation": "shared-ipc",`, "isolation"},
+		{"resources", `"resources": { "cpus": "1" },`, "resources"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := `{"appId":"sh.wendy.app",` + tt.extra +
+				`"components":{"c":{"context":"c","target":{"central":true}}}}`
+			cfg, err := LoadFromBytes([]byte(raw))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			err = cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected mutual-exclusivity error for %q", tt.wantField)
+			}
+			if !strings.Contains(err.Error(), tt.wantField) {
+				t.Errorf("error %q does not mention conflicting field %q", err, tt.wantField)
+			}
+		})
+	}
+}
+
+func TestComponentTarget_Validation(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		ok     bool
+	}{
+		{"group only", `{ "group": "cameras" }`, true},
+		{"central only", `{ "central": true }`, true},
+		{"both set", `{ "group": "cameras", "central": true }`, false},
+		{"neither set", `{}`, false},
+		{"missing target", ``, false},
+		{"empty group", `{ "group": "" }`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp := `{"context":"c"`
+			if tt.target != "" {
+				comp += `,"target":` + tt.target
+			}
+			comp += `}`
+			raw := `{"appId":"sh.wendy.app","components":{"c":` + comp + `}}`
+			cfg, err := LoadFromBytes([]byte(raw))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			err = cfg.Validate()
+			if tt.ok && err != nil {
+				t.Errorf("Validate: unexpected error: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Error("Validate: expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestComponentExpose_Validation(t *testing.T) {
+	tests := []struct {
+		name   string
+		expose string
+		ok     bool
+	}{
+		{"valid", `{ "name": "usbcam", "port": 8000, "path": "/stream" }`, true},
+		{"port zero", `{ "port": 0 }`, false},
+		{"port too high", `{ "port": 70000 }`, false},
+		{"path no slash", `{ "port": 8000, "path": "stream" }`, false},
+		{"bad name", `{ "port": 8000, "name": "Bad_Name" }`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := `{"appId":"sh.wendy.app","components":{"c":{"context":"c","target":{"group":"g"},"expose":` + tt.expose + `}}}`
+			cfg, err := LoadFromBytes([]byte(raw))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			err = cfg.Validate()
+			if tt.ok && err != nil {
+				t.Errorf("Validate: unexpected error: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Error("Validate: expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestDiscovers_Validation(t *testing.T) {
+	// base has an edge "cam" (group) and a central "c" we attach discovers to.
+	build := func(discovers string) string {
+		return `{"appId":"sh.wendy.app","components":{` +
+			`"cam":{"context":"cam","target":{"group":"cams"}},` +
+			`"c":{"context":"c","target":{"central":true},"discovers":` + discovers + `}}}`
+	}
+	tests := []struct {
+		name      string
+		discovers string
+		ok        bool
+	}{
+		{"valid", `[{ "component": "cam", "as": "WENDY_FLEET_PEERS" }]`, true},
+		{"unknown component", `[{ "component": "nope", "as": "PEERS" }]`, false},
+		{"reserved env var", `[{ "component": "cam", "as": "WENDY_DISCOVERY_URL" }]`, false},
+		{"bad env var name", `[{ "component": "cam", "as": "1bad" }]`, false},
+		{"missing as", `[{ "component": "cam" }]`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := LoadFromBytes([]byte(build(tt.discovers)))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			err = cfg.Validate()
+			if tt.ok && err != nil {
+				t.Errorf("Validate: unexpected error: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Error("Validate: expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestDiscovers_RejectsDiscoveringCentral(t *testing.T) {
+	// Discovering a central (non-group) component is meaningless and rejected.
+	raw := `{"appId":"sh.wendy.app","components":{` +
+		`"a":{"context":"a","target":{"central":true}},` +
+		`"b":{"context":"b","target":{"central":true},"discovers":[{"component":"a","as":"PEERS"}]}}}`
+	cfg, err := LoadFromBytes([]byte(raw))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error discovering a non-group component, got nil")
+	}
+}
+
+func TestFleetManifest_ComponentEntitlementWarnings(t *testing.T) {
+	// An unknown key on a component-level entitlement should surface as a warning.
+	raw := `{"appId":"sh.wendy.app","components":{"cam":{"context":"cam","target":{"group":"g"},` +
+		`"entitlements":[{"type":"gpu","bogus":true}]}}}`
+	warnings := ValidateJSON([]byte(raw))
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, `components["cam"].entitlement`) && strings.Contains(w, "bogus") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a component entitlement warning about 'bogus', got %v", warnings)
+	}
+}
+
+func TestSchemaJSON_HasComponents(t *testing.T) {
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if _, ok := props["components"]; !ok {
+		t.Error("schema missing top-level 'components' property")
+	}
+	defs, _ := schema["$defs"].(map[string]any)
+	for _, def := range []string{"component", "componentTarget", "componentExpose", "discoverRef"} {
+		if _, ok := defs[def]; !ok {
+			t.Errorf("schema missing $defs.%s", def)
+		}
+	}
+}

--- a/go/internal/shared/appconfig/schema.go
+++ b/go/internal/shared/appconfig/schema.go
@@ -4,3 +4,6 @@ import _ "embed"
 
 //go:embed wendy.schema.json
 var SchemaJSON string
+
+//go:embed wendy-fleet.schema.json
+var FleetSchemaJSON string

--- a/go/internal/shared/appconfig/wendy-fleet.schema.json
+++ b/go/internal/shared/appconfig/wendy-fleet.schema.json
@@ -3,16 +3,14 @@
   "title": "WendyOS fleet manifest (wendy-fleet.json)",
   "type": "object",
   "additionalProperties": false,
-  "required": ["appId", "components"],
-  "description": "A fleet placement/topology manifest kept separate from a project's single-app wendy.json: which components exist and where each is placed. The Go parser (appconfig.FleetManifest) is the source of truth; the per-component entitlements/readiness/hooks/frameworks/resources shapes mirror wendy.schema.json and are validated there.",
+  "required": ["components"],
+  "description": "A fleet placement/topology manifest kept separate from a project's single-app wendy.json. It describes topology only: each component references an app directory (whose own wendy.json defines the app) and the device tags it deploys to. The Go parser (appconfig.FleetManifest) is the source of truth.",
   "properties": {
-    "appId": { "type": "string", "minLength": 1, "description": "Reverse-DNS fleet identifier; each component deploys as \"<appId>.<componentName>\"." },
-    "version": { "type": "string", "description": "Fleet version." },
-    "platform": { "type": "string", "description": "Target platform, e.g. \"linux/arm64\"." },
+    "appId": { "type": "string", "description": "Optional fleet-level label; each app carries its own appId." },
     "components": {
       "type": "object",
       "minProperties": 1,
-      "description": "Placed components, each fanned out to a device group (edge tier) or run once centrally (central tier).",
+      "description": "The apps that make up the fleet, keyed by a label.",
       "additionalProperties": { "$ref": "#/$defs/component" }
     }
   },
@@ -20,42 +18,29 @@
     "component": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["context", "target"],
-      "description": "A single placed component of a fleet app.",
+      "required": ["path", "tags"],
+      "description": "One app of the fleet: an app directory plus the device tags it deploys to.",
       "properties": {
-        "context": { "type": "string", "minLength": 1, "description": "Build context directory relative to wendy-fleet.json." },
-        "target": { "$ref": "#/$defs/componentTarget" },
+        "path": { "type": "string", "minLength": 1, "description": "App directory relative to wendy-fleet.json; must contain the app's own wendy.json." },
+        "tags": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Device tags this component deploys to: a device matches when any tag matches its name (glob, e.g. \"camera-*\"). \"central\" is just a conventional tag.",
+          "items": { "type": "string", "minLength": 1 }
+        },
         "expose": { "$ref": "#/$defs/componentExpose" },
         "discovers": {
           "type": "array",
           "description": "Other components whose live endpoints are injected into this component.",
           "items": { "$ref": "#/$defs/discoverRef" }
-        },
-        "entitlements": { "type": "array", "items": { "type": "object" } },
-        "readiness": { "type": "object" },
-        "hooks": { "type": "object" },
-        "frameworks": { "type": "object" },
-        "resources": { "type": "object" }
+        }
       }
-    },
-    "componentTarget": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Where a component runs. Set exactly one of \"group\" or \"central\".",
-      "properties": {
-        "group": { "type": "string", "minLength": 1, "description": "Fan the component out to every device in this named device group (edge tier)." },
-        "central": { "type": "boolean", "description": "Run the component once (central tier) — on an edge device, a separate host, or the cloud." }
-      },
-      "oneOf": [
-        { "required": ["group"], "not": { "required": ["central"] } },
-        { "required": ["central"], "not": { "required": ["group"] } }
-      ]
     },
     "componentExpose": {
       "type": "object",
       "additionalProperties": false,
       "required": ["port"],
-      "description": "The network endpoint this component serves, advertised for cross-device discovery.",
+      "description": "The network endpoint this component serves, advertised for cross-component discovery.",
       "properties": {
         "name": { "type": "string", "description": "Optional endpoint name." },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "Port the component listens on." },
@@ -66,9 +51,9 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["component", "as"],
-      "description": "Inject another (group/edge) component's live endpoints into this component.",
+      "description": "Inject another component's live endpoints into this component.",
       "properties": {
-        "component": { "type": "string", "minLength": 1, "description": "Name of the group component to discover." },
+        "component": { "type": "string", "minLength": 1, "description": "Name of the exposing component to discover." },
         "as": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "description": "Environment variable to receive the JSON peer snapshot. WENDY_DISCOVERY_URL (live API) is auto-injected and reserved." }
       }
     }

--- a/go/internal/shared/appconfig/wendy-fleet.schema.json
+++ b/go/internal/shared/appconfig/wendy-fleet.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "WendyOS fleet manifest (wendy-fleet.json)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["appId", "components"],
+  "description": "A fleet placement/topology manifest kept separate from a project's single-app wendy.json: which components exist and where each is placed. The Go parser (appconfig.FleetManifest) is the source of truth; the per-component entitlements/readiness/hooks/frameworks/resources shapes mirror wendy.schema.json and are validated there.",
+  "properties": {
+    "appId": { "type": "string", "minLength": 1, "description": "Reverse-DNS fleet identifier; each component deploys as \"<appId>.<componentName>\"." },
+    "version": { "type": "string", "description": "Fleet version." },
+    "platform": { "type": "string", "description": "Target platform, e.g. \"linux/arm64\"." },
+    "components": {
+      "type": "object",
+      "minProperties": 1,
+      "description": "Placed components, each fanned out to a device group (edge tier) or run once centrally (central tier).",
+      "additionalProperties": { "$ref": "#/$defs/component" }
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["context", "target"],
+      "description": "A single placed component of a fleet app.",
+      "properties": {
+        "context": { "type": "string", "minLength": 1, "description": "Build context directory relative to wendy-fleet.json." },
+        "target": { "$ref": "#/$defs/componentTarget" },
+        "expose": { "$ref": "#/$defs/componentExpose" },
+        "discovers": {
+          "type": "array",
+          "description": "Other components whose live endpoints are injected into this component.",
+          "items": { "$ref": "#/$defs/discoverRef" }
+        },
+        "entitlements": { "type": "array", "items": { "type": "object" } },
+        "readiness": { "type": "object" },
+        "hooks": { "type": "object" },
+        "frameworks": { "type": "object" },
+        "resources": { "type": "object" }
+      }
+    },
+    "componentTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Where a component runs. Set exactly one of \"group\" or \"central\".",
+      "properties": {
+        "group": { "type": "string", "minLength": 1, "description": "Fan the component out to every device in this named device group (edge tier)." },
+        "central": { "type": "boolean", "description": "Run the component once (central tier) — on an edge device, a separate host, or the cloud." }
+      },
+      "oneOf": [
+        { "required": ["group"], "not": { "required": ["central"] } },
+        { "required": ["central"], "not": { "required": ["group"] } }
+      ]
+    },
+    "componentExpose": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["port"],
+      "description": "The network endpoint this component serves, advertised for cross-device discovery.",
+      "properties": {
+        "name": { "type": "string", "description": "Optional endpoint name." },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "Port the component listens on." },
+        "path": { "type": "string", "pattern": "^/", "description": "Optional URL path the component serves (e.g. \"/stream\"). The advertised discovery URL is the origin (scheme://host:port); consumers append their own paths." }
+      }
+    },
+    "discoverRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component", "as"],
+      "description": "Inject another (group/edge) component's live endpoints into this component.",
+      "properties": {
+        "component": { "type": "string", "minLength": 1, "description": "Name of the group component to discover." },
+        "as": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "description": "Environment variable to receive the JSON peer snapshot. WENDY_DISCOVERY_URL (live API) is auto-injected and reserved." }
+      }
+    }
+  }
+}

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -78,69 +78,9 @@
       "type": "object",
       "description": "Per-service build and runtime configuration for a multi-service app.",
       "additionalProperties": { "$ref": "#/$defs/service" }
-    },
-    "components": {
-      "type": "object",
-      "description": "Fleet manifest: a map of placed components, each fanned out to a device group (edge tier) or run once centrally (central tier). When set, the single-app top-level fields (run, services, entitlements, readiness, hooks, files, python, xcode, brewfile, isolation, resources) must not also be set — they move into each component.",
-      "additionalProperties": { "$ref": "#/$defs/component" }
     }
   },
   "$defs": {
-    "component": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["context", "target"],
-      "description": "A single placed component of a fleet app.",
-      "properties": {
-        "context": { "type": "string", "minLength": 1, "description": "Build context directory relative to wendy.json." },
-        "target": { "$ref": "#/$defs/componentTarget" },
-        "expose": { "$ref": "#/$defs/componentExpose" },
-        "discovers": {
-          "type": "array",
-          "description": "Other components whose live endpoints are injected into this component.",
-          "items": { "$ref": "#/$defs/discoverRef" }
-        },
-        "entitlements": { "type": "array", "items": { "$ref": "#/$defs/entitlement" } },
-        "readiness": { "$ref": "#/$defs/readiness" },
-        "hooks": { "$ref": "#/$defs/hooks" },
-        "frameworks": { "$ref": "#/$defs/frameworks" },
-        "resources": { "$ref": "#/$defs/resourceLimits" }
-      }
-    },
-    "componentTarget": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Where a component runs. Set exactly one of \"group\" or \"central\".",
-      "properties": {
-        "group": { "type": "string", "minLength": 1, "description": "Fan the component out to every device in this named device group (edge tier)." },
-        "central": { "type": "boolean", "description": "Run the component once (central tier) — on an edge device, a separate host, or the cloud." }
-      },
-      "oneOf": [
-        { "required": ["group"], "not": { "required": ["central"] } },
-        { "required": ["central"], "not": { "required": ["group"] } }
-      ]
-    },
-    "componentExpose": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["port"],
-      "description": "The network endpoint this component serves, advertised for cross-device discovery.",
-      "properties": {
-        "name": { "type": "string", "description": "Optional endpoint name." },
-        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "Port the component listens on." },
-        "path": { "type": "string", "pattern": "^/", "description": "Optional URL path the platform folds into the advertised endpoint URL (e.g. \"/stream\")." }
-      }
-    },
-    "discoverRef": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["component", "as"],
-      "description": "Inject another (group/edge) component's live endpoints into this component.",
-      "properties": {
-        "component": { "type": "string", "minLength": 1, "description": "Name of the group component to discover." },
-        "as": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "description": "Environment variable to receive the JSON peer snapshot. WENDY_DISCOVERY_URL (live API) is auto-injected and reserved." }
-      }
-    },
     "entitlement": {
       "type": "object",
       "required": ["type"],

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -78,9 +78,69 @@
       "type": "object",
       "description": "Per-service build and runtime configuration for a multi-service app.",
       "additionalProperties": { "$ref": "#/$defs/service" }
+    },
+    "components": {
+      "type": "object",
+      "description": "Fleet manifest: a map of placed components, each fanned out to a device group (edge tier) or run once centrally (central tier). When set, the single-app top-level fields (run, services, entitlements, readiness, hooks, files, python, xcode, brewfile, isolation, resources) must not also be set — they move into each component.",
+      "additionalProperties": { "$ref": "#/$defs/component" }
     }
   },
   "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["context", "target"],
+      "description": "A single placed component of a fleet app.",
+      "properties": {
+        "context": { "type": "string", "minLength": 1, "description": "Build context directory relative to wendy.json." },
+        "target": { "$ref": "#/$defs/componentTarget" },
+        "expose": { "$ref": "#/$defs/componentExpose" },
+        "discovers": {
+          "type": "array",
+          "description": "Other components whose live endpoints are injected into this component.",
+          "items": { "$ref": "#/$defs/discoverRef" }
+        },
+        "entitlements": { "type": "array", "items": { "$ref": "#/$defs/entitlement" } },
+        "readiness": { "$ref": "#/$defs/readiness" },
+        "hooks": { "$ref": "#/$defs/hooks" },
+        "frameworks": { "$ref": "#/$defs/frameworks" },
+        "resources": { "$ref": "#/$defs/resourceLimits" }
+      }
+    },
+    "componentTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Where a component runs. Set exactly one of \"group\" or \"central\".",
+      "properties": {
+        "group": { "type": "string", "minLength": 1, "description": "Fan the component out to every device in this named device group (edge tier)." },
+        "central": { "type": "boolean", "description": "Run the component once (central tier) — on an edge device, a separate host, or the cloud." }
+      },
+      "oneOf": [
+        { "required": ["group"], "not": { "required": ["central"] } },
+        { "required": ["central"], "not": { "required": ["group"] } }
+      ]
+    },
+    "componentExpose": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["port"],
+      "description": "The network endpoint this component serves, advertised for cross-device discovery.",
+      "properties": {
+        "name": { "type": "string", "description": "Optional endpoint name." },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "Port the component listens on." },
+        "path": { "type": "string", "pattern": "^/", "description": "Optional URL path the platform folds into the advertised endpoint URL (e.g. \"/stream\")." }
+      }
+    },
+    "discoverRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component", "as"],
+      "description": "Inject another (group/edge) component's live endpoints into this component.",
+      "properties": {
+        "component": { "type": "string", "minLength": 1, "description": "Name of the group component to discover." },
+        "as": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "description": "Environment variable to receive the JSON peer snapshot. WENDY_DISCOVERY_URL (live API) is auto-injected and reserved." }
+      }
+    },
     "entitlement": {
       "type": "object",
       "required": ["type"],


### PR DESCRIPTION
Stacked on `jo/mesh-foundation` so the fleet code can be reviewed **in context of** the mesh. **Not for merge** — this lands after #1336; base will be retargeted to `main` once mesh merges.

## What this is

The `wendy fleet` feature (#1238 + #1256) ported onto the mesh, with cross-component discovery rewired to use it.

`discovers → FLEET_PEERS` now resolves each peer to its **mesh name** (`device-<assetID>.cloud.wendy.dev:<port>`) in **both** cloud and LAN mode, instead of raw LAN IPs. The key change is one function — `fleet_manifest.go` `computePeers` (commit `40edd616`):

- LAN mode: asset id comes from the mDNS `assetid` TXT (`LANDevice.AssetID`); falls back to a direct-LAN host when it's absent (older agent).
- Cloud mode: asset id comes from the cloud asset. This is what lets discovery work over the cloud at all — it used to be "placement only".

The consuming component must run with a `mesh` network entitlement to reach those names (the camera-fleet template does — see wendylabsinc/templates#59).

## Validated on hardware

2× Jetson Orin Nano cameras (assets 194/197), this branch's `wendy-agent` side-loaded, `wendy fleet run --lan`:

- Placement: `camera` → both cameras, `dashboard` → camera-01. Mesh entitlements accepted, all containers created & running.
- Discovery injection: dashboard logged **`[fleet] seeded 2 camera(s) from FLEET_PEERS`** — both cameras resolved to their `device-<id>` mesh names.
- `Examples/HelloMesh` separately confirmed device-to-device works end-to-end (`OK 200 from device-194.cloud.wendy.dev`, via relay).

Nice result: **no OS image rebuild needed** — the mesh data plane comes up entirely from the side-loaded agent on a stock 0.16.0 image.

## Two things for you 🙏

### 1. 🐛 LAN-direct dial fails on link-local IPv6 (silently relays via cloud)

Every LAN dial fails and falls back to the cloud relay:

```
WARN mesh: LAN dial failed, falling back to cloud relay
     lan_addr=[fe80::1dc5:4d23:df52:fc45%wlan0]:50052
     error=parse "dns:///[fe80::…%wlan0]:50052": invalid URL escape "%wl"
INFO mesh connection  mesh.peer=197 mesh.mode=relay mesh.result=ok
```

mDNS resolves the peer to a **link-local IPv6 address with a zone id** (`fe80::…%wlan0`). The LAN-dial path builds a gRPC target `dns:///[<addr>]:<port>`, so `%wlan0` lands in a URL and Go's parser rejects `%wl` as an invalid percent-escape → dial errors → relay fallback. So "LAN-direct works without the cloud" isn't actually happening here; the relay is carrying it.

Suggested fixes (any of): prefer a routable IPv4/global address from mDNS, link-local last (related: `wendy discover` shows `ipAddress: null` for these cameras — the agent may only be surfacing the link-local IPv6); or don't feed a zoned address through the `dns:///` resolver — dial directly with the zone preserved, use `passthrough:///`, or percent-encode the zone (`%25wlan0`) per RFC 6874.

### 2. ❓ Mesh `ports` publish is loopback-only — how should a human reach a meshed service?

`hostnetwork/mesh_ports.go` DNATs `-d 127.0.0.1 --dport <hostPort>` → container (right for `MeshDial`, which lands on loopback). Consequence for the camera-fleet dashboard: it can dial cameras over the mesh fine, but **a LAN browser can't reach the dashboard** at `http://<device>:9000` (curl from the LAN = refused), and `readiness.tcpSocket` probes (which dial the host LAN IP) **always time out for mesh apps**. Is a LAN-facing publish option in scope, or is the intended path to reach a meshed UI via a tunnel / over the mesh?

## Also

- Overlap to sync on: your new `RemoteCam` mesh demo covers camera-over-mesh, same ground as our camera-fleet *fleet* template (many cameras + auto-discovering dashboard). Probably complementary, worth a quick align so we don't ship two competing examples.
