### PR TITLE
feat(network): bridge network mode (isolated NAT egress) + host-default deprecation warning

### DIFF
--- a/go/internal/agent/containerd/bridge_wiring.go
+++ b/go/internal/agent/containerd/bridge_wiring.go
@@ -1,0 +1,70 @@
+package containerd
+
+import (
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// findBridgeEntitlement returns the network entitlement with mode "bridge"
+// from entitlements, if one is present. ok == false means no bridge-mode
+// wiring should happen for this container — callers must treat that as a
+// complete no-op, mirroring findMeshEntitlement.
+func findBridgeEntitlement(entitlements []appconfig.Entitlement) (ent appconfig.Entitlement, ok bool) {
+	for _, e := range entitlements {
+		if e.Type == appconfig.EntitlementNetwork && e.Mode == "bridge" {
+			return e, true
+		}
+	}
+	return appconfig.Entitlement{}, false
+}
+
+// needsCNIBridgeWiring is the single predicate that decides whether a
+// container's networking requires attachment to the per-app CNI bridge (ADD
+// on start, DEL on stop): either a service within a multi-service isolated
+// app group (isolation == "isolated" && serviceName != ""), which already
+// relies on the bridge for its CNI-assigned IP and cross-service /etc/hosts
+// resolution, or a single-service app whose network entitlement mode is
+// "bridge" (isolated namespace + NAT egress, no /etc/hosts).
+//
+// Both StartContainer (CNI ADD) and stopOne/deleteOne (CNI DEL) call this
+// exact function so the two sides of the wiring can never drift apart (see
+// specs/2026-07-05-network-bridge-default-design.md, "factor the shared
+// block"). Host, none, mesh-without-isolation, and apps with neither
+// condition all return false.
+func needsCNIBridgeWiring(isolation, serviceName string, entitlements []appconfig.Entitlement) bool {
+	if isolation == "isolated" && serviceName != "" {
+		return true
+	}
+	_, ok := findBridgeEntitlement(entitlements)
+	return ok
+}
+
+// needsGatewayDNS reports whether a container should get the per-app mesh-DNS
+// resolv.conf + listener at its CNI bridge gateway: the existing case of a
+// multi-service isolated app service with a "mesh" network entitlement, and
+// now also a single-service "bridge"-mode app. Both need a resolver reachable
+// from inside their isolated namespace; the host's own /etc/resolv.conf is
+// often not reachable there (e.g. a systemd-resolved stub bound to loopback),
+// so both reuse the mesh DNS server's per-gateway forwarding listener instead
+// of a host bind-mount (see writeMeshResolvConf, ensureMeshDNS).
+func needsGatewayDNS(isolation string, entitlements []appconfig.Entitlement) bool {
+	if _, ok := findMeshEntitlement(entitlements); ok && isolation == "isolated" {
+		return true
+	}
+	_, ok := findBridgeEntitlement(entitlements)
+	return ok
+}
+
+// hasImplicitHostNetworkMode reports whether entitlements contains a network
+// entitlement with an omitted/empty mode — the implicit-host default flagged
+// for deprecation by specs/2026-07-05-network-bridge-default-design.md.
+// Explicit modes ("host", "host-admin", "bridge", "mesh", "none") and apps
+// with no network entitlement at all return false: the deprecation warning is
+// about the *omission*, not about host networking itself.
+func hasImplicitHostNetworkMode(entitlements []appconfig.Entitlement) bool {
+	for _, e := range entitlements {
+		if e.Type == appconfig.EntitlementNetwork && e.Mode == "" {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/agent/containerd/bridge_wiring_test.go
+++ b/go/internal/agent/containerd/bridge_wiring_test.go
@@ -1,0 +1,269 @@
+package containerd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func TestFindBridgeEntitlement(t *testing.T) {
+	tests := []struct {
+		name         string
+		entitlements []appconfig.Entitlement
+		wantFound    bool
+		wantEnt      appconfig.Entitlement
+	}{
+		{
+			name:         "no entitlements",
+			entitlements: nil,
+			wantFound:    false,
+		},
+		{
+			name: "bridge mode present",
+			entitlements: []appconfig.Entitlement{
+				{Type: appconfig.EntitlementNetwork, Mode: "bridge"},
+			},
+			wantFound: true,
+			wantEnt:   appconfig.Entitlement{Type: appconfig.EntitlementNetwork, Mode: "bridge"},
+		},
+		{
+			name: "host mode is not bridge",
+			entitlements: []appconfig.Entitlement{
+				{Type: appconfig.EntitlementNetwork, Mode: "host"},
+			},
+			wantFound: false,
+		},
+		{
+			name: "none mode is not bridge",
+			entitlements: []appconfig.Entitlement{
+				{Type: appconfig.EntitlementNetwork, Mode: "none"},
+			},
+			wantFound: false,
+		},
+		{
+			name: "mesh mode is not bridge",
+			entitlements: []appconfig.Entitlement{
+				{Type: appconfig.EntitlementNetwork, Mode: "mesh", ServiceCIDR: "10.99.0.0/16"},
+			},
+			wantFound: false,
+		},
+		{
+			name: "unrelated entitlements only",
+			entitlements: []appconfig.Entitlement{
+				{Type: appconfig.EntitlementBluetooth},
+				{Type: appconfig.EntitlementGPU},
+			},
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ent, ok := findBridgeEntitlement(tt.entitlements)
+			if ok != tt.wantFound {
+				t.Fatalf("findBridgeEntitlement() ok = %v, want %v", ok, tt.wantFound)
+			}
+			if ok && !reflect.DeepEqual(ent, tt.wantEnt) {
+				t.Errorf("findBridgeEntitlement() ent = %+v, want %+v", ent, tt.wantEnt)
+			}
+		})
+	}
+}
+
+// TestNeedsCNIBridgeWiring verifies the single predicate that gates CNI
+// ADD/DEL: multi-service isolated app services and single-service bridge-mode
+// apps are selected; host, none, and non-isolated multi-service apps are not
+// (specs/2026-07-05-network-bridge-default-design.md, "Testing").
+func TestNeedsCNIBridgeWiring(t *testing.T) {
+	bridgeEnt := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "bridge"}}
+	hostEnt := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "host"}}
+	noneEnt := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "none"}}
+	meshEnt := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "mesh", ServiceCIDR: "10.99.0.0/16"}}
+
+	tests := []struct {
+		name         string
+		isolation    string
+		serviceName  string
+		entitlements []appconfig.Entitlement
+		want         bool
+	}{
+		{
+			name:        "multi-service isolated app service",
+			isolation:   "isolated",
+			serviceName: "api",
+			want:        true,
+		},
+		{
+			name:         "multi-service isolated app service with mesh entitlement",
+			isolation:    "isolated",
+			serviceName:  "api",
+			entitlements: meshEnt,
+			want:         true,
+		},
+		{
+			name:         "single-service bridge-mode app",
+			isolation:    "",
+			serviceName:  "",
+			entitlements: bridgeEnt,
+			want:         true,
+		},
+		{
+			name:         "single-service host-mode app excluded",
+			isolation:    "",
+			serviceName:  "",
+			entitlements: hostEnt,
+			want:         false,
+		},
+		{
+			name:         "single-service none-mode app excluded",
+			isolation:    "",
+			serviceName:  "",
+			entitlements: noneEnt,
+			want:         false,
+		},
+		{
+			name:        "multi-service shared-net (non-isolated) app excluded",
+			isolation:   "shared-net",
+			serviceName: "api",
+			want:        false,
+		},
+		{
+			name:        "isolated app with no serviceName (single-container isolated) excluded",
+			isolation:   "isolated",
+			serviceName: "",
+			want:        false,
+		},
+		{
+			name:         "no isolation, no serviceName, no entitlements excluded",
+			isolation:    "",
+			serviceName:  "",
+			entitlements: nil,
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := needsCNIBridgeWiring(tt.isolation, tt.serviceName, tt.entitlements)
+			if got != tt.want {
+				t.Errorf("needsCNIBridgeWiring(%q, %q, %+v) = %v, want %v",
+					tt.isolation, tt.serviceName, tt.entitlements, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNeedsGatewayDNS(t *testing.T) {
+	bridgeEnt := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "bridge"}}
+	meshEnt := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "mesh", ServiceCIDR: "10.99.0.0/16"}}
+	hostEnt := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "host"}}
+
+	tests := []struct {
+		name         string
+		isolation    string
+		entitlements []appconfig.Entitlement
+		want         bool
+	}{
+		{
+			name:         "bridge mode always gets gateway DNS",
+			isolation:    "",
+			entitlements: bridgeEnt,
+			want:         true,
+		},
+		{
+			name:         "mesh entitlement with isolated app gets gateway DNS",
+			isolation:    "isolated",
+			entitlements: meshEnt,
+			want:         true,
+		},
+		{
+			name:         "mesh entitlement without isolated app does not get gateway DNS",
+			isolation:    "",
+			entitlements: meshEnt,
+			want:         false,
+		},
+		{
+			name:         "host mode does not get gateway DNS",
+			isolation:    "isolated",
+			entitlements: hostEnt,
+			want:         false,
+		},
+		{
+			name:         "no entitlements does not get gateway DNS",
+			isolation:    "isolated",
+			entitlements: nil,
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := needsGatewayDNS(tt.isolation, tt.entitlements)
+			if got != tt.want {
+				t.Errorf("needsGatewayDNS(%q, %+v) = %v, want %v", tt.isolation, tt.entitlements, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHasImplicitHostNetworkMode covers the deprecation-warning predicate:
+// it fires only for a network entitlement with an omitted/empty mode, not for
+// any explicit mode, and not for apps without a network entitlement at all.
+func TestHasImplicitHostNetworkMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		entitlements []appconfig.Entitlement
+		want         bool
+	}{
+		{
+			name:         "omitted mode fires the warning",
+			entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: ""}},
+			want:         true,
+		},
+		{
+			name:         "explicit host mode does not fire",
+			entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "host"}},
+			want:         false,
+		},
+		{
+			name:         "explicit host-admin mode does not fire",
+			entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "host-admin"}},
+			want:         false,
+		},
+		{
+			name:         "explicit bridge mode does not fire",
+			entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "bridge"}},
+			want:         false,
+		},
+		{
+			name:         "explicit mesh mode does not fire",
+			entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "mesh", ServiceCIDR: "10.99.0.0/16"}},
+			want:         false,
+		},
+		{
+			name:         "explicit none mode does not fire",
+			entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "none"}},
+			want:         false,
+		},
+		{
+			name:         "no network entitlement at all does not fire",
+			entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementGPU}},
+			want:         false,
+		},
+		{
+			name:         "no entitlements does not fire",
+			entitlements: nil,
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasImplicitHostNetworkMode(tt.entitlements)
+			if got != tt.want {
+				t.Errorf("hasImplicitHostNetworkMode(%+v) = %v, want %v", tt.entitlements, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -879,6 +879,18 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		return fmt.Errorf("applying entitlements: %w", err)
 	}
 
+	// DEPRECATION (specs/2026-07-05-network-bridge-default-design.md): warn,
+	// but do not change behavior, when a network entitlement omits "mode" — it
+	// currently maps to host networking (every port the app binds becomes
+	// reachable on the device's real interfaces), which is being deprecated in
+	// favor of an eventual isolated "bridge" default. This never affects
+	// container creation; it only informs.
+	if hasImplicitHostNetworkMode(entCfg.Entitlements) {
+		c.logger.Warn(fmt.Sprintf(
+			`app %q: network entitlement without an explicit "mode" currently uses host networking (ports are publicly reachable). This default will change to isolated "bridge" networking in a future release. Set "mode": "host" to keep host networking, or "mode": "bridge" for isolated networking with outbound internet.`,
+			appID))
+	}
+
 	// Set the cgroup path here — client.go is the sole authority so there is
 	// no risk of divergence with entitlements.go. SetDeviceCapabilities only
 	// adds the cgroup namespace and mount; it no longer sets CgroupsPath.
@@ -953,21 +965,27 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		localoci.InjectHostsMount(spec, hostsPath)
 	}
 
-	// Inject a read-only /etc/resolv.conf bind-mount for meshed containers so
-	// device-N.cloud.wendy.dev hostnames resolve via the mesh DNS listener on
-	// this app's bridge gateway. appCfg.Entitlements is the same per-service
-	// entitlement slice ApplyEntitlements above already consumed (entCfg is a
-	// shallow copy of appCfg), so this sees exactly the entitlements this
-	// specific service was granted. Isolation is required because meshGateway
-	// depends on the per-app CNI bridge subnet, which only exists for isolated
-	// apps (StartContainer only runs CNI ADD when isolation=="isolated"); a
-	// resolv.conf writer failure only degrades DNS (VIP literals still work
-	// via the REDIRECT rule applied at start), so it is logged, not fatal.
-	if _, ok := findMeshEntitlement(appCfg.Entitlements); ok && appCfg.Isolation == "isolated" {
+	// Inject a read-only /etc/resolv.conf bind-mount for containers that need
+	// gateway DNS: meshed multi-service isolated apps (device-N.cloud.wendy.dev
+	// hostnames resolve via the mesh DNS listener on this app's bridge
+	// gateway) and, per specs/2026-07-05-network-bridge-default-design.md,
+	// single-service "bridge"-mode apps too — their isolated namespace has no
+	// other way to reach a working upstream resolver (a host resolv.conf bind
+	// mount is not reachable from inside an isolated netns when it points at a
+	// loopback-scoped stub like systemd-resolved's). appCfg.Entitlements is the
+	// same per-service entitlement slice ApplyEntitlements above already
+	// consumed (entCfg is a shallow copy of appCfg), so this sees exactly the
+	// entitlements this specific service was granted. needsGatewayDNS requires
+	// isolation=="isolated" for the mesh case because meshGateway depends on
+	// the per-app CNI bridge subnet, which only exists once CNI ADD has run
+	// (see needsCNIBridgeWiring in StartContainer); a resolv.conf writer
+	// failure only degrades DNS (VIP literals still work via the REDIRECT rule
+	// applied at start, for meshed apps), so it is logged, not fatal.
+	if needsGatewayDNS(appCfg.Isolation, appCfg.Entitlements) {
 		if resolvPath, err := writeMeshResolvConf(appID); err == nil {
 			localoci.InjectResolvMount(spec, resolvPath)
 		} else {
-			c.logger.Warn("mesh: resolv.conf setup failed; container keeps image resolv.conf",
+			c.logger.Warn("bridge/mesh: resolv.conf setup failed; container keeps image resolv.conf",
 				zap.String("app_id", appID), zap.Error(err))
 		}
 	}
@@ -1281,12 +1299,25 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 		}
 	}
 
+	// Entitlements are read back from the container's own labels (written at
+	// create time via wendyLabels/BuildEntitlementAnnotations) rather than
+	// threaded through as a parameter, since StartContainer is only given an
+	// app/container name by its callers. Needed up front (before the netns
+	// anchor below), because needsCNIBridgeWiring must also recognise a
+	// single-service "bridge"-mode app, which isolation+serviceName alone
+	// cannot detect (unlike a multi-service isolated app service).
+	var entitlements []appconfig.Entitlement
+	if labels, lerr := container.Labels(ctx); lerr == nil {
+		entitlements = parseEntitlementsFromAnnotations(labels)
+	}
+	needsBridge := needsCNIBridgeWiring(isolation, serviceName, entitlements)
+
 	// Anchor the network namespace with an open fd BEFORE releasing the mutex.
 	// This eliminates the TOCTOU race where a concurrent StopContainer could
 	// recycle the PID between mutex release and CNI ADD, causing the plugin to
 	// operate on the wrong process's netns (SOC2-CC6, NIST-SC-7, ISO27001-A.8).
 	var netnsRef *os.File
-	if isolation == "isolated" && serviceName != "" {
+	if needsBridge {
 		nsPath := fmt.Sprintf("/proc/%d/ns/net", task.Pid())
 		var nsErr error
 		netnsRef, nsErr = os.Open(nsPath)
@@ -1301,13 +1332,18 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	muHeld = false
 	c.mu.Unlock()
 
-	// CNI ADD for isolated multi-service apps: assign IP and update /etc/hosts.
+	// CNI ADD for containers that need bridge wiring — see needsCNIBridgeWiring
+	// for the two cases this covers: multi-service isolated app services
+	// (assign IP, then update /etc/hosts below) and single-service
+	// "bridge"-mode apps (assign IP for NAT egress only; no /etc/hosts, since
+	// there are no sibling services to resolve). Both share this block rather
+	// than duplicating it (specs/2026-07-05-network-bridge-default-design.md).
 	// bindNetnsForCNI creates a stable bind-mount under /run/wendy/netns/ so
 	// CNI_NETNS is a real filesystem path as required by the CNI spec — not a
 	// /proc/self/fd/<n> reference that third-party CNI plugins may not honour.
 	// It also closes the fd (the bind-mount anchors the namespace independently).
 	// On Linux the bind-mount is used; on other platforms the fd path is the fallback.
-	if isolation == "isolated" && serviceName != "" && netnsRef != nil {
+	if needsBridge && netnsRef != nil {
 		netnsPath, cleanupNetns := bindNetnsForCNI(appName, netnsRef)
 		ip, cniErr := c.CNIAdd(ctx, appID, appName, netnsPath)
 		if cniErr != nil {
@@ -1332,48 +1368,64 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 			// route via nsenter (SetMeshRoute). It is unmounted at the end of
 			// this branch, after mesh wiring has had a chance to use it.
 			defer cleanupNetns()
-			c.mu.Lock()
-			// Guard against a concurrent StopContainer that may have deleted
-			// c.appIsolation[appID] during the window between CNI ADD and this
-			// re-lock. If the app is already gone, discard the IP silently rather
-			// than writing stale state (SOC2-CC6, NIST-SI-16, ISO27001-A.8).
-			if c.appIsolation[appID] == "" {
-				c.mu.Unlock()
-				c.logger.Warn("CNI ADD: app already stopped before IP could be recorded, discarding IP",
-					zap.String(logfields.AppID, appID), zap.String("ip", ip))
-				_, _ = task.Delete(ctx, containerd.WithProcessKill)
-				return nil, fmt.Errorf("app %q stopped during CNI ADD; container not started", appID)
-			}
-			c.recordServiceIP(appID, serviceName, ip)
-			hostsPath, pathErr := safeJoin("/run/wendy/hosts", appID)
-			if pathErr != nil {
-				// Hard error: a validated appID must never produce an unsafe path.
-				// Remove the just-recorded IP so it cannot pollute future writeHostsFile
-				// calls for the same appID (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
-				if c.serviceIPs != nil {
-					delete(c.serviceIPs[appID], serviceName)
+
+			// /etc/hosts bookkeeping is specific to multi-service isolated app
+			// groups (sibling services resolve each other by name); a
+			// single-service bridge-mode app has no siblings, so serviceName is
+			// empty and this whole block — including the concurrent-stop
+			// discard guard below, which is keyed on the isolated-group cache
+			// c.appIsolation and would misfire for a bridge app that never sets
+			// it — is skipped entirely for bridge mode.
+			if serviceName != "" {
+				c.mu.Lock()
+				// Guard against a concurrent StopContainer that may have deleted
+				// c.appIsolation[appID] during the window between CNI ADD and this
+				// re-lock. If the app is already gone, discard the IP silently rather
+				// than writing stale state (SOC2-CC6, NIST-SI-16, ISO27001-A.8).
+				if c.appIsolation[appID] == "" {
+					c.mu.Unlock()
+					c.logger.Warn("CNI ADD: app already stopped before IP could be recorded, discarding IP",
+						zap.String(logfields.AppID, appID), zap.String("ip", ip))
+					_, _ = task.Delete(ctx, containerd.WithProcessKill)
+					return nil, fmt.Errorf("app %q stopped during CNI ADD; container not started", appID)
 				}
-				c.logger.Error("security: appID produces unsafe hosts path",
-					zap.String(logfields.AppID, appID), zap.Error(pathErr))
+				c.recordServiceIP(appID, serviceName, ip)
+				hostsPath, pathErr := safeJoin("/run/wendy/hosts", appID)
+				if pathErr != nil {
+					// Hard error: a validated appID must never produce an unsafe path.
+					// Remove the just-recorded IP so it cannot pollute future writeHostsFile
+					// calls for the same appID (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
+					if c.serviceIPs != nil {
+						delete(c.serviceIPs[appID], serviceName)
+					}
+					c.logger.Error("security: appID produces unsafe hosts path",
+						zap.String(logfields.AppID, appID), zap.Error(pathErr))
+					c.mu.Unlock()
+					_, _ = task.Delete(ctx, containerd.WithProcessKill)
+					return nil, fmt.Errorf("security: appID %q produces unsafe hosts path: %w", appID, pathErr)
+				}
+				_ = writeHostsFile(hostsPath, c.serviceIPs[appID])
 				c.mu.Unlock()
-				_, _ = task.Delete(ctx, containerd.WithProcessKill)
-				return nil, fmt.Errorf("security: appID %q produces unsafe hosts path: %w", appID, pathErr)
 			}
-			_ = writeHostsFile(hostsPath, c.serviceIPs[appID])
-			c.mu.Unlock()
+
+			// Gateway DNS listener: covers both meshed multi-service isolated
+			// apps and single-service bridge-mode apps (see needsGatewayDNS).
+			// Best-effort — without it, DNS lookups fail inside the namespace
+			// but the container still starts (NAT egress by IP literal still
+			// works), mirroring the rest of this block's error handling.
+			if needsGatewayDNS(isolation, entitlements) {
+				if gw, gwErr := meshGateway(appID); gwErr == nil {
+					c.ensureMeshDNS(appName, gw)
+				} else {
+					c.logger.Warn("bridge/mesh: could not derive gateway for DNS listener",
+						zap.String(logfields.AppID, appID), zap.Error(gwErr))
+				}
+			}
 
 			// Mesh egress (fail-closed): a container with the network/mesh
 			// entitlement must never start believing it has mesh egress it
 			// does not actually have. applyMeshEgress is a complete no-op for
-			// apps without that entitlement. Entitlements are read back from
-			// the container's own labels (written at create time via
-			// wendyLabels/BuildEntitlementAnnotations) rather than threaded
-			// through as a parameter, since StartContainer is only given an
-			// app/container name by its callers.
-			var entitlements []appconfig.Entitlement
-			if labels, lerr := container.Labels(ctx); lerr == nil {
-				entitlements = parseEntitlementsFromAnnotations(labels)
-			}
+			// apps without that entitlement (including bridge-mode apps).
 			if meshErr := c.applyMeshEgress(entitlements, appName, appID, netnsPath, ip); meshErr != nil {
 				c.logger.Error("mesh egress setup failed; failing container start",
 					zap.String("app_id", appID), zap.Error(meshErr))
@@ -2275,40 +2327,56 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 		return fmt.Errorf("getting task for %q: %w", containerID, err)
 	}
 
-	// For isolated multi-service containers, call CNI DEL while the task's
-	// network namespace still exists (the PID is live, so /proc/PID/ns/net is
-	// valid). After SIGTERM/SIGKILL the netns reference disappears. CNI DEL is
-	// best-effort — failure is logged but does not block the stop path.
-	if appID, svcName, parseErr := ParseContainerName(containerID); parseErr == nil && svcName != "" {
-		netnsPath := fmt.Sprintf("/proc/%d/ns/net", task.Pid())
-		if cniErr := c.CNIDel(ctx, appID, containerID, netnsPath); cniErr != nil {
-			c.logger.Warn("CNI DEL failed during stop (non-fatal)",
-				zap.String("container_id", containerID), zap.Error(cniErr))
-		}
-
-		// Mesh egress teardown: remove the host iptables rule installed by
-		// applyMeshEgress at start (StartContainer). teardownMeshEgress is a
-		// no-op for apps without the network/mesh entitlement. The netns route
-		// itself needs no cleanup — it is destroyed with the namespace when the
-		// task exits below.
-		//
-		// The container's IP is recovered from c.serviceIPs (populated by
-		// recordServiceIP after CNI ADD, keyed by appID/serviceName), not from
-		// the CNI host-local IPAM on-disk state — that state lives under
-		// cniStateDir/<appID> keyed by allocated IP, not by containerID, so
-		// recovering "this container's IP" from it would require an extra
-		// reverse-index the plugin does not provide as a stable public format.
-		// c.serviceIPs already carries exactly this mapping for isolated
-		// multi-service apps (the only apps that reach this branch), so it is
-		// used here instead of introducing a second, redundant IP-recovery path.
+	// For containers with bridge wiring — multi-service isolated app services
+	// and single-service bridge-mode apps, per needsCNIBridgeWiring — call CNI
+	// DEL while the task's network namespace still exists (the PID is live, so
+	// /proc/PID/ns/net is valid). After SIGTERM/SIGKILL the netns reference
+	// disappears. CNI DEL is best-effort — failure is logged but does not
+	// block the stop path.
+	if appID, svcName, parseErr := ParseContainerName(containerID); parseErr == nil {
 		var entitlements []appconfig.Entitlement
 		if labels, lerr := container.Labels(ctx); lerr == nil {
 			entitlements = parseEntitlementsFromAnnotations(labels)
 		}
 		c.mu.Lock()
-		ip := c.serviceIPs[appID][svcName]
+		isolation := c.getIsolation(appID)
 		c.mu.Unlock()
-		c.teardownMeshEgress(entitlements, containerID, appID, ip)
+
+		if needsCNIBridgeWiring(isolation, svcName, entitlements) {
+			netnsPath := fmt.Sprintf("/proc/%d/ns/net", task.Pid())
+			if cniErr := c.CNIDel(ctx, appID, containerID, netnsPath); cniErr != nil {
+				c.logger.Warn("CNI DEL failed during stop (non-fatal)",
+					zap.String("container_id", containerID), zap.Error(cniErr))
+			}
+
+			// Release the gateway DNS listener reference this container held,
+			// if any (see needsGatewayDNS / ensureMeshDNS in StartContainer).
+			// releaseMeshDNS is idempotent (held-map guarded), so calling it
+			// here AND from teardownMeshEgress below for a meshed app is safe —
+			// the second call is a no-op.
+			if needsGatewayDNS(isolation, entitlements) {
+				c.releaseMeshDNS(containerID, appID)
+			}
+
+			// Mesh egress teardown: remove the host iptables rule installed by
+			// applyMeshEgress at start (StartContainer). teardownMeshEgress is a
+			// no-op for apps without the network/mesh entitlement (including
+			// bridge-mode apps). The netns route itself needs no cleanup — it
+			// is destroyed with the namespace when the task exits below.
+			//
+			// The container's IP is recovered from c.serviceIPs (populated by
+			// recordServiceIP after CNI ADD, keyed by appID/serviceName — empty
+			// for single-service bridge apps, which is fine: teardownMeshEgress
+			// no-ops for them regardless of ip), not from the CNI host-local
+			// IPAM on-disk state — that state lives under cniStateDir/<appID>
+			// keyed by allocated IP, not by containerID, so recovering "this
+			// container's IP" from it would require an extra reverse-index the
+			// plugin does not provide as a stable public format.
+			c.mu.Lock()
+			ip := c.serviceIPs[appID][svcName]
+			c.mu.Unlock()
+			c.teardownMeshEgress(entitlements, containerID, appID, ip)
+		}
 	}
 
 	// Send SIGTERM first for graceful shutdown.
@@ -2548,22 +2616,29 @@ func ensureSharedSHM(appID string) (string, error) {
 // can batch image deletions across services. ctx must have the namespace set
 // and the caller must hold c.mu.
 func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantImg bool) (imgName string, err error) {
-	// Mesh egress teardown for delete-without-stop: `wendy device apps remove`
-	// on a RUNNING meshed app goes DeleteContainer → deleteOne without ever
-	// passing through stopOne, which would otherwise leak the DNS-listener
-	// refcount and the ACCEPT/REDIRECT iptables rules for this container's IP
-	// until agent restart. Mirrors the stopOne teardown block; safe to run
-	// after a stop too — teardownMeshEgress is idempotent (rule removal
-	// tolerates absent rules; the DNS release is guarded by the held map, so
-	// a stopOne-then-deleteOne sequence releases exactly once).
-	// c.serviceIPs is read without locking because deleteOne's only caller,
-	// DeleteContainer, holds c.mu for its full duration.
+	// Mesh/bridge teardown for delete-without-stop: `wendy device apps remove`
+	// on a RUNNING meshed or bridge-mode app goes DeleteContainer → deleteOne
+	// without ever passing through stopOne, which would otherwise leak the
+	// DNS-listener refcount and the ACCEPT/REDIRECT iptables rules for this
+	// container's IP until agent restart. Mirrors the stopOne teardown block;
+	// safe to run after a stop too — teardownMeshEgress and releaseMeshDNS are
+	// both idempotent (rule removal tolerates absent rules; the DNS release is
+	// guarded by the held map), so a stopOne-then-deleteOne sequence releases
+	// exactly once. c.serviceIPs and c.getIsolation are read without locking
+	// because deleteOne's only caller, DeleteContainer, holds c.mu for its
+	// full duration.
 	appID, svcName, parseErr := ParseContainerName(ctr.ID())
-	isolatedSvc := parseErr == nil && svcName != ""
-	if isolatedSvc {
-		var entitlements []appconfig.Entitlement
+	var entitlements []appconfig.Entitlement
+	needsBridge := false
+	if parseErr == nil {
 		if labels, lerr := ctr.Labels(ctx); lerr == nil {
 			entitlements = parseEntitlementsFromAnnotations(labels)
+		}
+		needsBridge = needsCNIBridgeWiring(c.getIsolation(appID), svcName, entitlements)
+	}
+	if needsBridge {
+		if needsGatewayDNS(c.getIsolation(appID), entitlements) {
+			c.releaseMeshDNS(ctr.ID(), appID)
 		}
 		ip := c.serviceIPs[appID][svcName]
 		c.teardownMeshEgress(entitlements, ctr.ID(), appID, ip)
@@ -2578,7 +2653,7 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 		// create for the same appID/serviceName then fails CNI ADD with
 		// "duplicate allocation is not allowed" (WDY mesh: found via repeated
 		// remove+redeploy cycles during RemoteCam demo debugging).
-		if isolatedSvc {
+		if needsBridge {
 			netnsPath := fmt.Sprintf("/proc/%d/ns/net", task.Pid())
 			if cniErr := c.CNIDel(ctx, appID, ctr.ID(), netnsPath); cniErr != nil {
 				c.logger.Warn("CNI DEL failed during delete (non-fatal)",

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -886,9 +886,9 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	// favor of an eventual isolated "bridge" default. This never affects
 	// container creation; it only informs.
 	if hasImplicitHostNetworkMode(entCfg.Entitlements) {
-		c.logger.Warn(fmt.Sprintf(
-			`app %q: network entitlement without an explicit "mode" currently uses host networking (ports are publicly reachable). This default will change to isolated "bridge" networking in a future release. Set "mode": "host" to keep host networking, or "mode": "bridge" for isolated networking with outbound internet.`,
-			appID))
+		c.logger.Warn(
+			`network entitlement without an explicit "mode" currently uses host networking (ports are publicly reachable). This default will change to isolated "bridge" networking in a future release. Set "mode": "host" to keep host networking, or "mode": "bridge" for isolated networking with outbound internet.`,
+			zap.String(logfields.AppID, appID))
 	}
 
 	// Set the cgroup path here — client.go is the sole authority so there is
@@ -1375,7 +1375,12 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 			// empty and this whole block — including the concurrent-stop
 			// discard guard below, which is keyed on the isolated-group cache
 			// c.appIsolation and would misfire for a bridge app that never sets
-			// it — is skipped entirely for bridge mode.
+			// it — is skipped entirely for bridge mode. This is an accepted
+			// gap, not an oversight: a concurrent StopContainer racing a
+			// bridge-mode app's CNI ADD is left to self-heal via the CNI DEL
+			// issued at stop time (stopOne/deleteOne, gated by
+			// needsCNIBridgeWiring), instead of duplicating this guard for
+			// serviceName == "".
 			if serviceName != "" {
 				c.mu.Lock()
 				// Guard against a concurrent StopContainer that may have deleted
@@ -1408,16 +1413,29 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 				c.mu.Unlock()
 			}
 
-			// Gateway DNS listener: covers both meshed multi-service isolated
-			// apps and single-service bridge-mode apps (see needsGatewayDNS).
+			// Gateway DNS listener for single-service bridge-mode apps only
+			// (see needsGatewayDNS, findBridgeEntitlement). Meshed multi-service
+			// isolated apps are intentionally excluded here: applyMeshEgress
+			// below acquires their DNS listener itself, as its last fallible
+			// step, only after route/rule/redirect setup has already
+			// succeeded (see applyMeshEgress). Acquiring it here too, before
+			// applyMeshEgress runs, would hold a DNS-listener ref across a
+			// window where a later applyMeshEgress failure returns without
+			// ever releasing it (the failure path below only deletes the
+			// task) — a refcount leak. ensureMeshDNS is idempotent per
+			// container so this is not about avoiding a double-acquire; it is
+			// about keeping the mesh acquire ordered strictly after mesh
+			// egress's fallible steps, as applyMeshEgress's own comment
+			// requires.
+			//
 			// Best-effort — without it, DNS lookups fail inside the namespace
 			// but the container still starts (NAT egress by IP literal still
 			// works), mirroring the rest of this block's error handling.
-			if needsGatewayDNS(isolation, entitlements) {
+			if _, ok := findBridgeEntitlement(entitlements); ok {
 				if gw, gwErr := meshGateway(appID); gwErr == nil {
 					c.ensureMeshDNS(appName, gw)
 				} else {
-					c.logger.Warn("bridge/mesh: could not derive gateway for DNS listener",
+					c.logger.Warn("bridge: could not derive gateway for DNS listener",
 						zap.String(logfields.AppID, appID), zap.Error(gwErr))
 				}
 			}
@@ -2335,12 +2353,26 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 	// block the stop path.
 	if appID, svcName, parseErr := ParseContainerName(containerID); parseErr == nil {
 		var entitlements []appconfig.Entitlement
-		if labels, lerr := container.Labels(ctx); lerr == nil {
-			entitlements = parseEntitlementsFromAnnotations(labels)
-		}
 		c.mu.Lock()
 		isolation := c.getIsolation(appID)
 		c.mu.Unlock()
+		if labels, lerr := container.Labels(ctx); lerr == nil {
+			entitlements = parseEntitlementsFromAnnotations(labels)
+			// Prefer this container's own persisted label
+			// (labelKeyIsolation, written at create) over the in-memory
+			// c.appIsolation cache. The cache is only best-effort rebuilt
+			// from container labels at agent boot (rebuildCachesFromLabels);
+			// if that warm-up missed this appID, c.getIsolation silently
+			// returns "" and needsCNIBridgeWiring below would wrongly skip
+			// CNI DEL / DNS-listener release / mesh egress teardown for a
+			// container that is actually isolated — leaking its IP,
+			// iptables rules, and DNS refcount until agent restart. The
+			// label is written once at create and never goes stale, so it
+			// is authoritative here even when the cache is not.
+			if iso, ok := labels[labelKeyIsolation]; ok {
+				isolation = iso
+			}
+		}
 
 		if needsCNIBridgeWiring(isolation, svcName, entitlements) {
 			netnsPath := fmt.Sprintf("/proc/%d/ns/net", task.Pid())
@@ -2624,20 +2656,28 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 	// safe to run after a stop too — teardownMeshEgress and releaseMeshDNS are
 	// both idempotent (rule removal tolerates absent rules; the DNS release is
 	// guarded by the held map), so a stopOne-then-deleteOne sequence releases
-	// exactly once. c.serviceIPs and c.getIsolation are read without locking
-	// because deleteOne's only caller, DeleteContainer, holds c.mu for its
-	// full duration.
+	// exactly once. c.serviceIPs is read without locking because deleteOne's
+	// only caller, DeleteContainer, holds c.mu for its full duration.
+	// isolation is read from the container's own persisted label
+	// (labelKeyIsolation) rather than c.getIsolation's in-memory cache, for
+	// the same reason as stopOne above: the cache is only best-effort warmed
+	// at boot, and a miss there must not silently skip CNI DEL / DNS release
+	// / mesh teardown for a container that is actually isolated.
 	appID, svcName, parseErr := ParseContainerName(ctr.ID())
 	var entitlements []appconfig.Entitlement
+	isolation := c.getIsolation(appID)
 	needsBridge := false
 	if parseErr == nil {
 		if labels, lerr := ctr.Labels(ctx); lerr == nil {
 			entitlements = parseEntitlementsFromAnnotations(labels)
+			if iso, ok := labels[labelKeyIsolation]; ok {
+				isolation = iso
+			}
 		}
-		needsBridge = needsCNIBridgeWiring(c.getIsolation(appID), svcName, entitlements)
+		needsBridge = needsCNIBridgeWiring(isolation, svcName, entitlements)
 	}
 	if needsBridge {
-		if needsGatewayDNS(c.getIsolation(appID), entitlements) {
+		if needsGatewayDNS(isolation, entitlements) {
 			c.releaseMeshDNS(ctr.ID(), appID)
 		}
 		ip := c.serviceIPs[appID][svcName]

--- a/go/internal/agent/containerd/mesh_wiring_test.go
+++ b/go/internal/agent/containerd/mesh_wiring_test.go
@@ -628,3 +628,102 @@ func TestTeardownMeshEgressReleasesHeldListener(t *testing.T) {
 		t.Fatalf("teardown of never-held listener must not release: got %d releases, want 1", r)
 	}
 }
+
+// TestStartContainerGatewayDNSAcquireOrdering locks in the fix for the
+// mesh-egress-failure DNS-refcount leak (code review on jo/network-bridge-mode):
+// StartContainer's gateway-DNS block must gate its *explicit* ensureMeshDNS
+// acquire on findBridgeEntitlement, not the broader needsGatewayDNS, precisely
+// because applyMeshEgress acquires DNS for mesh apps itself, as its own last
+// fallible step (see applyMeshEgress's doc comment). If the explicit block
+// also fired for mesh apps, a container would hold a DNS ref *before*
+// applyMeshEgress's route/rule/redirect steps run; when one of those later
+// fails, StartContainer deletes the task and returns without ever calling
+// releaseMeshDNS, permanently leaking the ref (and, on the real DNS server,
+// the listener).
+//
+// This test replays the exact decision StartContainer makes for both a mesh
+// app and a bridge app, using the real findBridgeEntitlement/
+// resolveMeshEgress predicates, and asserts the resulting ensure/release
+// counts on the fake:
+//   - mesh app: the explicit block must not fire at all (findBridgeEntitlement
+//     is false for a "mesh" entitlement — regression-tested independently in
+//     TestFindBridgeEntitlement), so a mesh-egress failure that occurs before
+//     applyMeshEgress reaches its own ensureMeshDNS call leaves zero refs
+//     held — nothing to leak.
+//   - bridge app: the explicit block is the only acquire path (applyMeshEgress
+//     no-ops for bridge apps, since resolveMeshEgress requires a "mesh"
+//     entitlement), so it must fire exactly once, and that one ref must be
+//     fully releasable on teardown.
+func TestStartContainerGatewayDNSAcquireOrdering(t *testing.T) {
+	withTempSubnetRegistry(t)
+
+	t.Run("mesh app: explicit acquire is skipped, no ref to leak on egress failure", func(t *testing.T) {
+		appID := "com.example.meshleaktest"
+		containerName := appID + "_svc"
+		meshEnts := []appconfig.Entitlement{
+			{Type: appconfig.EntitlementNetwork, Mode: "mesh", ServiceCIDR: "10.99.0.0/16"},
+		}
+
+		fake := &fakeMeshDNS{}
+		c := &Client{logger: zap.NewNop(), meshDNS: fake}
+
+		// Replay StartContainer's explicit gateway-DNS gate: must be false for
+		// a mesh entitlement, so this must NOT call ensureMeshDNS.
+		if _, ok := findBridgeEntitlement(meshEnts); ok {
+			t.Fatalf("findBridgeEntitlement must be false for a mesh entitlement")
+		}
+
+		// Simulate applyMeshEgress failing on one of its steps that runs
+		// *before* its own internal ensureMeshDNS call (route/rule/redirect) —
+		// i.e. StartContainer's failure branch runs having never acquired DNS.
+		if e, r := fake.counts(); e != 0 || r != 0 {
+			t.Fatalf("before any acquire attempt: ensures=%d releases=%d, want 0/0", e, r)
+		}
+
+		// The failure path in StartContainer only deletes the task; it does
+		// not call releaseMeshDNS (nor should it need to, since nothing was
+		// acquired). Confirm there is genuinely nothing held to leak.
+		c.releaseMeshDNS(containerName, appID)
+		if e, r := fake.counts(); e != 0 || r != 0 {
+			t.Fatalf("after simulated egress failure: ensures=%d releases=%d, want 0/0 (nothing should have been acquired or released)", e, r)
+		}
+	})
+
+	t.Run("bridge app: explicit acquire fires once and is fully releasable", func(t *testing.T) {
+		appID := "com.example.bridgeacquiretest"
+		containerName := appID + "_svc"
+		gw, err := meshGateway(appID)
+		if err != nil {
+			t.Fatalf("meshGateway: %v", err)
+		}
+		bridgeEnts := []appconfig.Entitlement{
+			{Type: appconfig.EntitlementNetwork, Mode: "bridge"},
+		}
+
+		fake := &fakeMeshDNS{}
+		c := &Client{logger: zap.NewNop(), meshDNS: fake}
+
+		// Replay StartContainer's explicit gateway-DNS gate: true for a bridge
+		// entitlement, so this acquires the one ref bridge apps need.
+		if _, ok := findBridgeEntitlement(bridgeEnts); !ok {
+			t.Fatalf("findBridgeEntitlement must be true for a bridge entitlement")
+		}
+		c.ensureMeshDNS(containerName, gw)
+		if e, r := fake.counts(); e != 1 || r != 0 {
+			t.Fatalf("after explicit bridge acquire: ensures=%d releases=%d, want 1/0", e, r)
+		}
+
+		// applyMeshEgress must be a complete no-op for a bridge-only
+		// entitlement set (no "mesh" entitlement present), so it must not
+		// attempt a second acquire.
+		if _, ok, err := resolveMeshEgress(bridgeEnts, appID); ok || err != nil {
+			t.Fatalf("resolveMeshEgress(bridgeEnts) = ok=%v err=%v, want ok=false err=nil", ok, err)
+		}
+
+		// Teardown releases exactly the one ref that was actually acquired.
+		c.releaseMeshDNS(containerName, appID)
+		if e, r := fake.counts(); e != 1 || r != 1 {
+			t.Fatalf("after teardown: ensures=%d releases=%d, want 1/1", e, r)
+		}
+	})
+}

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -429,6 +429,13 @@ func applyAdmin(spec *Spec) {
 }
 
 // applyNetwork configures the network namespace.
+//
+// DEPRECATION (specs/2026-07-05-network-bridge-default-design.md): an omitted
+// mode maps to "host" below, which is the implicit default that design
+// deprecates in favor of an eventual "bridge" default. That mapping is
+// intentionally unchanged here — only a WARN log at container create (in the
+// containerd package, see hasImplicitHostNetworkMode) flags it. This function
+// only gains the new "bridge" mode itself.
 func applyNetwork(spec *Spec, ent appconfig.Entitlement) {
 	mode := ent.Mode
 	if mode == "" {
@@ -504,10 +511,17 @@ func applyNetwork(spec *Spec, ent appconfig.Entitlement) {
 				})
 			}
 		}
-	} else if mode == "none" {
+	} else if mode == "none" || mode == "bridge" {
 		// Ensure the network namespace is present (container gets its own isolated network).
 		// The default spec already has a network namespace, so this is a no-op in most cases,
 		// but we add it explicitly in case it was removed previously.
+		//
+		// "bridge" mirrors "none" here deliberately: this function adds no host
+		// mounts (no /sys bind, no host resolv.conf) and no CAP_NET_ADMIN for
+		// bridge mode. What makes "bridge" different from "none" — a private IP,
+		// NAT egress, and working DNS — is wired up by the containerd layer
+		// attaching the container to the per-app CNI bridge (see
+		// needsCNIBridgeWiring in the containerd package), not here.
 		hasNetworkNS := false
 		for _, ns := range spec.Linux.Namespaces {
 			if ns.Type == "network" {

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -372,6 +372,49 @@ func TestApplyEntitlements_Network_Default(t *testing.T) {
 	}
 }
 
+// TestApplyEntitlements_Network_Bridge covers the "bridge" mode added by
+// specs/2026-07-05-network-bridge-default-design.md. applyNetwork's job for
+// bridge mode is limited to keeping the container's own network namespace,
+// mirroring "none": no host mounts (no /sys bind, no host resolv.conf) and no
+// CAP_NET_ADMIN. The private IP, NAT egress, and DNS that make "bridge"
+// different from "none" are wired up by the containerd layer attaching the
+// container to the per-app CNI bridge, which this oci-package-only test
+// cannot exercise (no live containerd/CNI here).
+func TestApplyEntitlements_Network_Bridge(t *testing.T) {
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "test-app",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementNetwork, Mode: "bridge"},
+		},
+	}
+
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+
+	if !hasNamespace(spec, "network") {
+		t.Error("network mode 'bridge' should keep network namespace")
+	}
+	if hasMountDest(spec, "/etc/resolv.conf") {
+		t.Error("network mode 'bridge' must not add a host resolv.conf mount (DNS is wired by the containerd layer)")
+	}
+	for _, m := range spec.Mounts {
+		if m.Destination == "/sys" && m.Type == "bind" {
+			t.Error("network mode 'bridge' must not replace /sys with a host bind mount (that is host-networking-only)")
+		}
+	}
+	for _, set := range [][]string{
+		spec.Process.Capabilities.Bounding,
+		spec.Process.Capabilities.Effective,
+		spec.Process.Capabilities.Permitted,
+	} {
+		if slices.Contains(set, "CAP_NET_ADMIN") {
+			t.Error("network mode 'bridge' must not grant CAP_NET_ADMIN")
+		}
+	}
+}
+
 func TestApplyEntitlements_Audio(t *testing.T) {
 	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 	cfg := &appconfig.AppConfig{

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -190,16 +190,21 @@ IP networking access.
 ```json
 { "type": "network" }
 { "type": "network", "mode": "host" }
+{ "type": "network", "mode": "bridge" }
 ```
 
 | `mode` | Description |
 |--------|-------------|
-| *(omitted)* | Default isolated network |
+| *(omitted)* | **Currently the same as `"host"`** — shares the host network stack, so every port the app binds is reachable on the device's real interfaces (LAN/internet). This implicit default is **deprecated**: see the note below. |
 | `"host"` | Shares the host network stack (visibility: bind host ports, see interfaces). Does **not** grant the ability to reconfigure host networking. |
 | `"host-admin"` | Host networking **plus** `CAP_NET_ADMIN` — allows reconfiguring interfaces, routes, and netfilter. Only request this if your app genuinely manages the network; it is a high-privilege capability. |
-| `"none"` | Networking fully disabled |
+| `"none"` | Networking fully disabled — no namespace connectivity of any kind. |
+| `"bridge"` | Isolated network namespace with a private IP, outbound internet via NAT, and working DNS — but **no** host/LAN-published ports. Use this for apps that need to reach the internet without exposing anything locally. Cross-device access to a bridge app is via a `mesh` entitlement, not this one. |
+| `"mesh"` | Isolated network namespace chained into the wendy-mesh CNI, with a route to a `serviceCIDR` (required for this mode — a valid CIDR string) so the app can reach other meshed devices/services. Optionally set `ports` (host→container mappings) so mesh peers can dial in. |
 
 > **Security note:** `CAP_NET_ADMIN` (host network reconfiguration) is granted only by `"host-admin"`, never by plain `"host"`. Apps that previously relied on `CAP_NET_ADMIN` under `"host"` must switch to `"host-admin"`.
+
+> **Deprecation notice:** an omitted `mode` maps to host networking today, and the agent logs a `WARN` at container create for any `network` entitlement without an explicit `mode`, flagging that its ports are publicly reachable. This default will change to isolated `"bridge"` networking in a future major release. If you want to keep host networking going forward, set `"mode": "host"` explicitly now; if you want isolated networking with outbound internet, opt in early with `"mode": "bridge"`.
 
 ### `gpu`
 

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -318,8 +318,8 @@ func validateEntitlements(entitlements []Entitlement, prefix string) error {
 
 		switch e.Type {
 		case EntitlementNetwork:
-			if e.Mode != "" && e.Mode != "host" && e.Mode != "host-admin" && e.Mode != "none" && e.Mode != "mesh" {
-				return fmt.Errorf("%s[%d]: network mode must be \"host\", \"host-admin\", \"none\", or \"mesh\", got %q", prefix, i, e.Mode)
+			if e.Mode != "" && e.Mode != "host" && e.Mode != "host-admin" && e.Mode != "none" && e.Mode != "mesh" && e.Mode != "bridge" {
+				return fmt.Errorf("%s[%d]: network mode must be \"host\", \"host-admin\", \"none\", \"bridge\", or \"mesh\", got %q", prefix, i, e.Mode)
 			}
 			if e.Mode == "mesh" {
 				if e.ServiceCIDR == "" {

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -202,6 +202,49 @@ func TestValidate_NetworkMeshMode(t *testing.T) {
 	}
 }
 
+// TestValidate_NetworkBridgeMode covers the "bridge" network mode added by
+// specs/2026-07-05-network-bridge-default-design.md: an isolated network
+// namespace with NAT egress. Unlike "mesh", "bridge" takes no serviceCIDR.
+func TestValidate_NetworkBridgeMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		ent     Entitlement
+		wantErr bool
+	}{
+		{
+			name:    "bridge mode without serviceCIDR is valid",
+			ent:     Entitlement{Type: EntitlementNetwork, Mode: "bridge"},
+			wantErr: false,
+		},
+		{
+			name:    "serviceCIDR on bridge mode errors",
+			ent:     Entitlement{Type: EntitlementNetwork, Mode: "bridge", ServiceCIDR: "10.42.0.0/16"},
+			wantErr: true,
+		},
+		{
+			name:    "an unrelated unknown mode is still rejected",
+			ent:     Entitlement{Type: EntitlementNetwork, Mode: "bridged"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &AppConfig{
+				AppID:        "com.example.app",
+				Entitlements: []Entitlement{tt.ent},
+			}
+			err := cfg.Validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("Validate() expected error for %+v, got nil", tt.ent)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("Validate() unexpected error for %+v: %v", tt.ent, err)
+			}
+		})
+	}
+}
+
 func TestValidate_MissingAppID(t *testing.T) {
 	cfg := &AppConfig{}
 	err := cfg.Validate()
@@ -1498,7 +1541,7 @@ func TestServiceConfigValidation(t *testing.T) {
 				"svc": {
 					Context: "svc",
 					Entitlements: []Entitlement{
-						{Type: EntitlementNetwork, Mode: "bridge"},
+						{Type: EntitlementNetwork, Mode: "bogus"},
 					},
 				},
 			},
@@ -1509,6 +1552,23 @@ func TestServiceConfigValidation(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "mode") {
 			t.Fatalf("expected error to mention mode, got: %v", err)
+		}
+	})
+
+	t.Run("network entitlement bridge mode in service is valid", func(t *testing.T) {
+		cfg := &AppConfig{
+			AppID: "com.example.app",
+			Services: map[string]*ServiceConfig{
+				"svc": {
+					Context: "svc",
+					Entitlements: []Entitlement{
+						{Type: EntitlementNetwork, Mode: "bridge"},
+					},
+				},
+			},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate() rejected bridge network mode in service: %v", err)
 		}
 	})
 

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -91,8 +91,8 @@
             "type": { "const": "network" },
             "mode": {
               "type": "string",
-              "enum": ["host", "host-admin", "none", "mesh"],
-              "description": "Network mode. \"host\" shares the host network stack (visibility only); \"host-admin\" additionally grants CAP_NET_ADMIN to reconfigure host networking; \"none\" disables networking; \"mesh\" chains the wendy-mesh CNI plugin, giving the container its own network namespace with a route to a mesh service CIDR."
+              "enum": ["host", "host-admin", "none", "bridge", "mesh"],
+              "description": "Network mode. Omitted (and \"host\") shares the host network stack (visibility only) — this implicit default is deprecated and will change to \"bridge\" in a future release; \"host-admin\" additionally grants CAP_NET_ADMIN to reconfigure host networking; \"none\" disables networking; \"bridge\" gives the container its own network namespace with a private IP and outbound internet via NAT, but no host-published ports; \"mesh\" chains the wendy-mesh CNI plugin, giving the container its own network namespace with a route to a mesh service CIDR."
             },
             "serviceCIDR": {
               "type": "string",


### PR DESCRIPTION
## Summary

Introduces a new `network` entitlement mode `bridge`: an isolated network namespace with a private IP, outbound internet via NAT, and working DNS, but **no** publicly-published ports. Rolled out as a **deprecation path**, not a hard default flip:

- `bridge` is a new opt-in mode apps can request today.
- A `network` entitlement with an **omitted** `mode` now logs a `WARN` at container create explaining that it currently maps to host networking (ports publicly reachable) and that this default will change to `bridge` in a future release.
- **The default is unchanged in this PR.** Omitted `mode` still means `host`, exactly as before. Only the new opt-in mode and the warning are added.

### What changed

1. `internal/agent/oci/entitlements.go` — `applyNetwork` gains a `bridge` branch that mirrors `none` (keeps the container's own network namespace; no host mounts, no `CAP_NET_ADMIN`). The private IP / NAT / DNS come entirely from the containerd layer attaching the container to the CNI bridge, not from this function.
2. `internal/agent/containerd/bridge_wiring.go` (new) — the shared predicates: `needsCNIBridgeWiring` (does this container need CNI ADD/DEL — true for multi-service isolated app services *and* single-service bridge-mode apps), `needsGatewayDNS` (does it need the mesh DNS server's per-gateway resolver), `hasImplicitHostNetworkMode` (the deprecation-warning trigger), and `findBridgeEntitlement`.
3. `internal/agent/containerd/client.go`:
   - `StartContainer`'s CNI ADD block, previously gated on `isolation=="isolated" && serviceName!=""` (multi-service isolated apps only), now uses `needsCNIBridgeWiring`, so single-service bridge apps share the exact same ADD/rollback implementation instead of a duplicate. Multi-service-only bookkeeping (`/etc/hosts`, the concurrent-stop discard guard) stays scoped to `serviceName != ""`.
   - `stopOne` / `deleteOne`'s CNI DEL gate is likewise switched to `needsCNIBridgeWiring` so ADD and DEL can never drift apart.
   - Bridge-mode apps reuse the mesh DNS server's per-gateway forwarding resolver (`writeMeshResolvConf` + `ensureMeshDNS`/`releaseMeshDNS`) for DNS inside their isolated namespace — a host `/etc/resolv.conf` bind mount is often unreachable from inside an isolated netns (e.g. a loopback-scoped systemd-resolved stub).
   - New deprecation `WARN` log at container create for entitlements with an omitted `mode`.
   - Entitlements are read from persisted container labels (as mesh egress already does), so this is correct across the reboot/reconcile path (`ReconcileBootContainers` restarts containers via `StartContainer` directly).
4. `internal/shared/appconfig/appconfig.go` + `wendy.schema.json` — `bridge` accepted as a valid network mode.
5. `internal/cli/assets/docs/apps/wendy.json.md` — fixes the wrong "omitted = isolated" claim (it's actually host), documents `bridge` and the previously-undocumented `mesh` mode, and notes the upcoming default change.

Design doc: `specs/2026-07-05-network-bridge-default-design.md`.

## Test plan

**Unit-tested (all passing — `go build ./...`, `go vet ./internal/...`, package tests below):**
- [x] Network-mode validation accepts `bridge` and still rejects unknown modes (`TestValidate_NetworkBridgeMode`, `appconfig_test.go`)
- [x] `applyNetwork("bridge")` keeps a network namespace and adds no host `/sys` bind, no host resolv.conf mount, and no `CAP_NET_ADMIN` (`TestApplyEntitlements_Network_Bridge`, `entitlements_test.go`)
- [x] The deprecation warning predicate fires only for an omitted/empty mode, not for explicit `host`/`host-admin`/`bridge`/`mesh`/`none`, and not when there's no network entitlement at all (`TestHasImplicitHostNetworkMode`, `bridge_wiring_test.go`)
- [x] The shared CNI-wiring predicate selects `bridge`-mode apps and multi-service-isolated apps, and excludes `host`/`none`/non-isolated multi-service apps (`TestNeedsCNIBridgeWiring`, `bridge_wiring_test.go`)
- [x] The gateway-DNS predicate selects `bridge` mode and mesh-entitled isolated apps, excludes everything else (`TestNeedsGatewayDNS`, `bridge_wiring_test.go`)
- [x] Full existing `internal/agent/oci`, `internal/agent/containerd`, `internal/shared/appconfig` suites still pass (141 tests in `containerd` alone, 0 regressions)

**Hardware-dependent — cannot be unit-verified in this environment (no live containerd/CNI/root), flagging explicitly as the reason this PR is a draft:**
- [ ] Actual CNI bridge attachment for a single-service bridge-mode app
- [ ] Private IP assignment via the bridge's host-local IPAM
- [ ] Outbound internet reachability via NAT (`ipMasq`) from inside a bridge-mode container
- [ ] DNS resolution inside the bridge-mode namespace via the reused mesh DNS server
- [ ] CNI DEL / DNS-listener teardown on stop and on `wendy device apps remove`
- [ ] Reboot/reconcile path recreating bridge wiring for a surviving bridge-mode container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWERTiJ3qvVnBxEYsXJtQq