### PR TITLE
chore(swift): regenerate proto bindings against pinned toolchain

### DIFF
--- a/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/collector/logs/v1/logs_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/collector/logs/v1/logs_service.pb.swift
@@ -29,12 +29,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: Sendable {
+public nonisolated struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -51,7 +51,7 @@ public struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: Se
   public init() {}
 }
 
-public struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: Sendable {
+public nonisolated struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -87,7 +87,7 @@ public struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: S
   fileprivate var _partialSuccess: Opentelemetry_Proto_Collector_Logs_V1_ExportLogsPartialSuccess? = nil
 }
 
-public struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsPartialSuccess: Sendable {
+public nonisolated struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsPartialSuccess: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -114,9 +114,9 @@ public struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsPartialSuccess: Se
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "opentelemetry.proto.collector.logs.v1"
+fileprivate nonisolated let _protobuf_package = "opentelemetry.proto.collector.logs.v1"
 
-extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExportLogsServiceRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_logs\0")
 
@@ -146,7 +146,7 @@ extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: SwiftP
   }
 }
 
-extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExportLogsServiceResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}partial_success\0")
 
@@ -180,7 +180,7 @@ extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: Swift
   }
 }
 
-extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsPartialSuccess: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsPartialSuccess: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExportLogsPartialSuccess"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rejected_log_records\0\u{3}error_message\0")
 

--- a/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.swift
@@ -29,12 +29,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest: Sendable {
+public nonisolated struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -51,7 +51,7 @@ public struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceReque
   public init() {}
 }
 
-public struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse: Sendable {
+public nonisolated struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -87,7 +87,7 @@ public struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRespo
   fileprivate var _partialSuccess: Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsPartialSuccess? = nil
 }
 
-public struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsPartialSuccess: Sendable {
+public nonisolated struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsPartialSuccess: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -114,9 +114,9 @@ public struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsPartialSucce
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "opentelemetry.proto.collector.metrics.v1"
+fileprivate nonisolated let _protobuf_package = "opentelemetry.proto.collector.metrics.v1"
 
-extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExportMetricsServiceRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_metrics\0")
 
@@ -146,7 +146,7 @@ extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest: 
   }
 }
 
-extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExportMetricsServiceResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}partial_success\0")
 
@@ -180,7 +180,7 @@ extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse:
   }
 }
 
-extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsPartialSuccess: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsPartialSuccess: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExportMetricsPartialSuccess"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rejected_data_points\0\u{3}error_message\0")
 

--- a/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/collector/trace/v1/trace_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/collector/trace/v1/trace_service.pb.swift
@@ -29,12 +29,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public struct Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: Sendable {
+public nonisolated struct Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -51,7 +51,7 @@ public struct Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: 
   public init() {}
 }
 
-public struct Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse: Sendable {
+public nonisolated struct Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -87,7 +87,7 @@ public struct Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse:
   fileprivate var _partialSuccess: Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess? = nil
 }
 
-public struct Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess: Sendable {
+public nonisolated struct Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -114,9 +114,9 @@ public struct Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess: 
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "opentelemetry.proto.collector.trace.v1"
+fileprivate nonisolated let _protobuf_package = "opentelemetry.proto.collector.trace.v1"
 
-extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExportTraceServiceRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_spans\0")
 
@@ -146,7 +146,7 @@ extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: Swif
   }
 }
 
-extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExportTraceServiceResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}partial_success\0")
 
@@ -180,7 +180,7 @@ extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse: Swi
   }
 }
 
-extension Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExportTracePartialSuccess"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rejected_spans\0\u{3}error_message\0")
 

--- a/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/common/v1/common.pb.swift
+++ b/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/common/v1/common.pb.swift
@@ -34,7 +34,7 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -42,7 +42,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// Represents any type of attribute value. AnyValue may contain a
 /// primitive value such as a string or integer or it may contain an arbitrary nested
 /// object containing arrays, key-value lists and primitives.
-public struct Opentelemetry_Proto_Common_V1_AnyValue: Sendable {
+public nonisolated struct Opentelemetry_Proto_Common_V1_AnyValue: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -111,7 +111,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue: Sendable {
 
   /// The value is one of the listed fields. It is valid for all values to be unspecified
   /// in which case this AnyValue is considered to be "empty".
-  public enum OneOf_Value: Equatable, Sendable {
+  public nonisolated enum OneOf_Value: Equatable, Sendable {
     case stringValue(String)
     case boolValue(Bool)
     case intValue(Int64)
@@ -127,7 +127,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue: Sendable {
 
 /// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
 /// since oneof in AnyValue does not allow repeated fields.
-public struct Opentelemetry_Proto_Common_V1_ArrayValue: Sendable {
+public nonisolated struct Opentelemetry_Proto_Common_V1_ArrayValue: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -145,7 +145,7 @@ public struct Opentelemetry_Proto_Common_V1_ArrayValue: Sendable {
 /// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
 /// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
 /// are semantically equivalent.
-public struct Opentelemetry_Proto_Common_V1_KeyValueList: Sendable {
+public nonisolated struct Opentelemetry_Proto_Common_V1_KeyValueList: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -163,7 +163,7 @@ public struct Opentelemetry_Proto_Common_V1_KeyValueList: Sendable {
 
 /// Represents a key-value pair that is used to store Span attributes, Link
 /// attributes, etc.
-public struct Opentelemetry_Proto_Common_V1_KeyValue: Sendable {
+public nonisolated struct Opentelemetry_Proto_Common_V1_KeyValue: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -190,7 +190,7 @@ public struct Opentelemetry_Proto_Common_V1_KeyValue: Sendable {
 
 /// InstrumentationScope is a message representing the instrumentation scope information
 /// such as the fully qualified name and version. 
-public struct Opentelemetry_Proto_Common_V1_InstrumentationScope: Sendable {
+public nonisolated struct Opentelemetry_Proto_Common_V1_InstrumentationScope: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -222,7 +222,7 @@ public struct Opentelemetry_Proto_Common_V1_InstrumentationScope: Sendable {
 /// Entity represents an object of interest associated with produced telemetry: e.g spans, metrics, profiles, or logs.
 ///
 /// Status: [Development]
-public struct Opentelemetry_Proto_Common_V1_EntityRef: Sendable {
+public nonisolated struct Opentelemetry_Proto_Common_V1_EntityRef: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -262,9 +262,9 @@ public struct Opentelemetry_Proto_Common_V1_EntityRef: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "opentelemetry.proto.common.v1"
+fileprivate nonisolated let _protobuf_package = "opentelemetry.proto.common.v1"
 
-extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AnyValue"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}string_value\0\u{3}bool_value\0\u{3}int_value\0\u{3}double_value\0\u{3}array_value\0\u{3}kvlist_value\0\u{3}bytes_value\0")
 
@@ -391,7 +391,7 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Opentelemetry_Proto_Common_V1_ArrayValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Common_V1_ArrayValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ArrayValue"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
@@ -421,7 +421,7 @@ extension Opentelemetry_Proto_Common_V1_ArrayValue: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Opentelemetry_Proto_Common_V1_KeyValueList: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Common_V1_KeyValueList: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".KeyValueList"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
@@ -451,7 +451,7 @@ extension Opentelemetry_Proto_Common_V1_KeyValueList: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".KeyValue"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{1}value\0")
 
@@ -490,7 +490,7 @@ extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Opentelemetry_Proto_Common_V1_InstrumentationScope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Common_V1_InstrumentationScope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".InstrumentationScope"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}version\0\u{1}attributes\0\u{3}dropped_attributes_count\0")
 
@@ -535,7 +535,7 @@ extension Opentelemetry_Proto_Common_V1_InstrumentationScope: SwiftProtobuf.Mess
   }
 }
 
-extension Opentelemetry_Proto_Common_V1_EntityRef: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Common_V1_EntityRef: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EntityRef"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}schema_url\0\u{1}type\0\u{3}id_keys\0\u{3}description_keys\0")
 

--- a/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/logs/v1/logs.pb.swift
+++ b/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/logs/v1/logs.pb.swift
@@ -34,13 +34,13 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Possible values for LogRecord.SeverityNumber.
-public enum Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   /// UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.
@@ -175,7 +175,7 @@ public enum Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf.Enum, Swif
 /// expression like:
 ///
 ///   (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
-public enum Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   /// The zero value for the enum. Should not be used for comparisons.
@@ -224,7 +224,7 @@ public enum Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf.Enum, Swif
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
-public struct Opentelemetry_Proto_Logs_V1_LogsData: Sendable {
+public nonisolated struct Opentelemetry_Proto_Logs_V1_LogsData: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -242,7 +242,7 @@ public struct Opentelemetry_Proto_Logs_V1_LogsData: Sendable {
 }
 
 /// A collection of ScopeLogs from a Resource.
-public struct Opentelemetry_Proto_Logs_V1_ResourceLogs: Sendable {
+public nonisolated struct Opentelemetry_Proto_Logs_V1_ResourceLogs: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -277,7 +277,7 @@ public struct Opentelemetry_Proto_Logs_V1_ResourceLogs: Sendable {
 }
 
 /// A collection of Logs produced by a Scope.
-public struct Opentelemetry_Proto_Logs_V1_ScopeLogs: Sendable {
+public nonisolated struct Opentelemetry_Proto_Logs_V1_ScopeLogs: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -313,7 +313,7 @@ public struct Opentelemetry_Proto_Logs_V1_ScopeLogs: Sendable {
 
 /// A log record according to OpenTelemetry Log Data Model:
 /// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
-public struct Opentelemetry_Proto_Logs_V1_LogRecord: Sendable {
+public nonisolated struct Opentelemetry_Proto_Logs_V1_LogRecord: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -422,17 +422,17 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "opentelemetry.proto.logs.v1"
+fileprivate nonisolated let _protobuf_package = "opentelemetry.proto.logs.v1"
 
-extension Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SEVERITY_NUMBER_UNSPECIFIED\0\u{1}SEVERITY_NUMBER_TRACE\0\u{1}SEVERITY_NUMBER_TRACE2\0\u{1}SEVERITY_NUMBER_TRACE3\0\u{1}SEVERITY_NUMBER_TRACE4\0\u{1}SEVERITY_NUMBER_DEBUG\0\u{1}SEVERITY_NUMBER_DEBUG2\0\u{1}SEVERITY_NUMBER_DEBUG3\0\u{1}SEVERITY_NUMBER_DEBUG4\0\u{1}SEVERITY_NUMBER_INFO\0\u{1}SEVERITY_NUMBER_INFO2\0\u{1}SEVERITY_NUMBER_INFO3\0\u{1}SEVERITY_NUMBER_INFO4\0\u{1}SEVERITY_NUMBER_WARN\0\u{1}SEVERITY_NUMBER_WARN2\0\u{1}SEVERITY_NUMBER_WARN3\0\u{1}SEVERITY_NUMBER_WARN4\0\u{1}SEVERITY_NUMBER_ERROR\0\u{1}SEVERITY_NUMBER_ERROR2\0\u{1}SEVERITY_NUMBER_ERROR3\0\u{1}SEVERITY_NUMBER_ERROR4\0\u{1}SEVERITY_NUMBER_FATAL\0\u{1}SEVERITY_NUMBER_FATAL2\0\u{1}SEVERITY_NUMBER_FATAL3\0\u{1}SEVERITY_NUMBER_FATAL4\0")
 }
 
-extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0LOG_RECORD_FLAGS_DO_NOT_USE\0\u{2}\u{7f}\u{3}LOG_RECORD_FLAGS_TRACE_FLAGS_MASK\0")
 }
 
-extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".LogsData"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_logs\0")
 
@@ -462,7 +462,7 @@ extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ResourceLogs"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}resource\0\u{3}scope_logs\0\u{3}schema_url\0\u{c}h\u{f}\u{1}")
 
@@ -506,7 +506,7 @@ extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ScopeLogs"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}scope\0\u{3}log_records\0\u{3}schema_url\0")
 
@@ -550,7 +550,7 @@ extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".LogRecord"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}time_unix_nano\0\u{3}severity_number\0\u{3}severity_text\0\u{2}\u{2}body\0\u{1}attributes\0\u{3}dropped_attributes_count\0\u{1}flags\0\u{3}trace_id\0\u{3}span_id\0\u{3}observed_time_unix_nano\0\u{3}event_name\0\u{c}\u{4}\u{1}")
 

--- a/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/metrics/v1/metrics.pb.swift
+++ b/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/metrics/v1/metrics.pb.swift
@@ -34,7 +34,7 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -42,7 +42,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// AggregationTemporality defines how a metric aggregator reports aggregated
 /// values. It describes how those values relate to the time interval over
 /// which they are aggregated.
-public enum Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   /// UNSPECIFIED is the default AggregationTemporality, it MUST not be used.
@@ -149,7 +149,7 @@ public enum Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf
 /// a data point, for example, use an expression like:
 ///
 ///   (point.flags & DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK) == DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK
-public enum Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   /// The zero value for the enum. Should not be used for comparisons.
@@ -218,7 +218,7 @@ public enum Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf.Enum, S
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
-public struct Opentelemetry_Proto_Metrics_V1_MetricsData: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_MetricsData: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -236,7 +236,7 @@ public struct Opentelemetry_Proto_Metrics_V1_MetricsData: Sendable {
 }
 
 /// A collection of ScopeMetrics from a Resource.
-public struct Opentelemetry_Proto_Metrics_V1_ResourceMetrics: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_ResourceMetrics: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -271,7 +271,7 @@ public struct Opentelemetry_Proto_Metrics_V1_ResourceMetrics: Sendable {
 }
 
 /// A collection of Metrics produced by an Scope.
-public struct Opentelemetry_Proto_Metrics_V1_ScopeMetrics: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_ScopeMetrics: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -390,7 +390,7 @@ public struct Opentelemetry_Proto_Metrics_V1_ScopeMetrics: Sendable {
 /// to support correct rate calculation.  Although it may be omitted
 /// when the start time is truly unknown, setting StartTimeUnixNano is
 /// strongly encouraged.
-public struct Opentelemetry_Proto_Metrics_V1_Metric: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_Metric: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -465,7 +465,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric: Sendable {
   /// Data determines the aggregation type (if any) of the metric, what is the
   /// reported value type for the data points, as well as the relatationship to
   /// the time interval over which they are reported.
-  public enum OneOf_Data: Equatable, Sendable {
+  public nonisolated enum OneOf_Data: Equatable, Sendable {
     case gauge(Opentelemetry_Proto_Metrics_V1_Gauge)
     case sum(Opentelemetry_Proto_Metrics_V1_Sum)
     case histogram(Opentelemetry_Proto_Metrics_V1_Histogram)
@@ -486,7 +486,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric: Sendable {
 /// aggregation, regardless of aggregation temporalities. Therefore,
 /// AggregationTemporality is not included. Consequently, this also means
 /// "StartTimeUnixNano" is ignored for all data points.
-public struct Opentelemetry_Proto_Metrics_V1_Gauge: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_Gauge: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -502,7 +502,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Gauge: Sendable {
 
 /// Sum represents the type of a scalar metric that is calculated as a sum of all
 /// reported measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_Sum: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_Sum: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -525,7 +525,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Sum: Sendable {
 
 /// Histogram represents the type of a metric that is calculated by aggregating
 /// as a Histogram of all reported measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_Histogram: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_Histogram: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -545,7 +545,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Histogram: Sendable {
 
 /// ExponentialHistogram represents the type of a metric that is calculated by aggregating
 /// as a ExponentialHistogram of all reported double measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -572,7 +572,7 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: Sendable {
 /// Summary metrics do not have an aggregation temporality field. This is
 /// because the count and sum fields of a SummaryDataPoint are assumed to be
 /// cumulative values.
-public struct Opentelemetry_Proto_Metrics_V1_Summary: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_Summary: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -588,7 +588,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Summary: Sendable {
 
 /// NumberDataPoint is a single data point in a timeseries that describes the
 /// time-varying scalar value of a metric.
-public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -645,7 +645,7 @@ public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint: Sendable {
 
   /// The value itself.  A point is considered invalid when one of the recognized
   /// value fields is not present inside this oneof.
-  public enum OneOf_Value: Equatable, Sendable {
+  public nonisolated enum OneOf_Value: Equatable, Sendable {
     case asDouble(Double)
     case asInt(Int64)
 
@@ -664,7 +664,7 @@ public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint: Sendable {
 /// If the histogram does not contain the distribution of values, then both
 /// "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
 /// "sum" are known.
-public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -781,7 +781,7 @@ public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: Sendable {
 /// time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
 /// summary statistics for a population of values, it may optionally contain the
 /// distribution of those values across a set of buckets.
-public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -915,7 +915,7 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: Send
 
   /// Buckets are a set of bucket counts, encoded in a contiguous array
   /// of counts.
-  public struct Buckets: Sendable {
+  public nonisolated struct Buckets: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -953,7 +953,7 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: Send
 /// SummaryDataPoint is a single data point in a timeseries that describes the
 /// time-varying values of a Summary metric. The count and sum fields represent
 /// cumulative values.
-public struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1009,7 +1009,7 @@ public struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: Sendable {
   ///
   /// See the following issue for more context:
   /// https://github.com/open-telemetry/opentelemetry-proto/issues/125
-  public struct ValueAtQuantile: Sendable {
+  public nonisolated struct ValueAtQuantile: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1035,7 +1035,7 @@ public struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: Sendable {
 /// Exemplars also hold information about the environment when the measurement
 /// was recorded, for example the span and trace ID of the active span when the
 /// exemplar was recorded.
-public struct Opentelemetry_Proto_Metrics_V1_Exemplar: Sendable {
+public nonisolated struct Opentelemetry_Proto_Metrics_V1_Exemplar: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1087,7 +1087,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Exemplar: Sendable {
   /// The value of the measurement that was recorded. An exemplar is
   /// considered invalid when one of the recognized value fields is not present
   /// inside this oneof.
-  public enum OneOf_Value: Equatable, Sendable {
+  public nonisolated enum OneOf_Value: Equatable, Sendable {
     case asDouble(Double)
     case asInt(Int64)
 
@@ -1098,17 +1098,17 @@ public struct Opentelemetry_Proto_Metrics_V1_Exemplar: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "opentelemetry.proto.metrics.v1"
+fileprivate nonisolated let _protobuf_package = "opentelemetry.proto.metrics.v1"
 
-extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0AGGREGATION_TEMPORALITY_UNSPECIFIED\0\u{1}AGGREGATION_TEMPORALITY_DELTA\0\u{1}AGGREGATION_TEMPORALITY_CUMULATIVE\0")
 }
 
-extension Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DATA_POINT_FLAGS_DO_NOT_USE\0\u{1}DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK\0")
 }
 
-extension Opentelemetry_Proto_Metrics_V1_MetricsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_MetricsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".MetricsData"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_metrics\0")
 
@@ -1138,7 +1138,7 @@ extension Opentelemetry_Proto_Metrics_V1_MetricsData: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ResourceMetrics"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}resource\0\u{3}scope_metrics\0\u{3}schema_url\0\u{c}h\u{f}\u{1}")
 
@@ -1182,7 +1182,7 @@ extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message,
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ScopeMetrics"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}scope\0\u{1}metrics\0\u{3}schema_url\0")
 
@@ -1226,7 +1226,7 @@ extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Metric"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}description\0\u{1}unit\0\u{2}\u{2}gauge\0\u{2}\u{2}sum\0\u{2}\u{2}histogram\0\u{3}exponential_histogram\0\u{1}summary\0\u{1}metadata\0\u{c}\u{4}\u{1}\u{c}\u{6}\u{1}\u{c}\u{8}\u{1}")
 
@@ -1364,7 +1364,7 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_Gauge: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_Gauge: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Gauge"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0")
 
@@ -1394,7 +1394,7 @@ extension Opentelemetry_Proto_Metrics_V1_Gauge: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Sum"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0\u{3}aggregation_temporality\0\u{3}is_monotonic\0")
 
@@ -1434,7 +1434,7 @@ extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Histogram"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0\u{3}aggregation_temporality\0")
 
@@ -1469,7 +1469,7 @@ extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExponentialHistogram"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0\u{3}aggregation_temporality\0")
 
@@ -1504,7 +1504,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Mes
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_Summary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_Summary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Summary"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0")
 
@@ -1534,7 +1534,7 @@ extension Opentelemetry_Proto_Metrics_V1_Summary: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".NumberDataPoint"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}start_time_unix_nano\0\u{3}time_unix_nano\0\u{3}as_double\0\u{1}exemplars\0\u{3}as_int\0\u{1}attributes\0\u{1}flags\0\u{c}\u{1}\u{1}")
 
@@ -1611,7 +1611,7 @@ extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message,
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".HistogramDataPoint"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}start_time_unix_nano\0\u{3}time_unix_nano\0\u{1}count\0\u{1}sum\0\u{3}bucket_counts\0\u{3}explicit_bounds\0\u{1}exemplars\0\u{1}attributes\0\u{1}flags\0\u{1}min\0\u{1}max\0\u{c}\u{1}\u{1}")
 
@@ -1695,7 +1695,7 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExponentialHistogramDataPoint"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}attributes\0\u{3}start_time_unix_nano\0\u{3}time_unix_nano\0\u{1}count\0\u{1}sum\0\u{1}scale\0\u{3}zero_count\0\u{1}positive\0\u{1}negative\0\u{1}flags\0\u{1}exemplars\0\u{1}min\0\u{1}max\0\u{3}zero_threshold\0")
 
@@ -1794,7 +1794,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.protoMessageName + ".Buckets"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}offset\0\u{3}bucket_counts\0")
 
@@ -1829,7 +1829,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: 
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SummaryDataPoint"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}start_time_unix_nano\0\u{3}time_unix_nano\0\u{1}count\0\u{1}sum\0\u{3}quantile_values\0\u{1}attributes\0\u{1}flags\0\u{c}\u{1}\u{1}")
 
@@ -1889,7 +1889,7 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.protoMessageName + ".ValueAtQuantile"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}quantile\0\u{1}value\0")
 
@@ -1924,7 +1924,7 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: Swift
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_Exemplar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Metrics_V1_Exemplar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Exemplar"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}time_unix_nano\0\u{3}as_double\0\u{3}span_id\0\u{3}trace_id\0\u{3}as_int\0\u{3}filtered_attributes\0\u{c}\u{1}\u{1}")
 

--- a/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/resource/v1/resource.pb.swift
+++ b/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/resource/v1/resource.pb.swift
@@ -29,13 +29,13 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Resource information.
-public struct Opentelemetry_Proto_Resource_V1_Resource: Sendable {
+public nonisolated struct Opentelemetry_Proto_Resource_V1_Resource: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -73,9 +73,9 @@ public struct Opentelemetry_Proto_Resource_V1_Resource: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "opentelemetry.proto.resource.v1"
+fileprivate nonisolated let _protobuf_package = "opentelemetry.proto.resource.v1"
 
-extension Opentelemetry_Proto_Resource_V1_Resource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Resource_V1_Resource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Resource"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}attributes\0\u{3}dropped_attributes_count\0\u{3}entity_refs\0")
 

--- a/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/trace/v1/trace.pb.swift
+++ b/swift/WendyAgentCore/Sources/OpenTelemetryGRPC/Proto/opentelemetry/proto/trace/v1/trace.pb.swift
@@ -34,7 +34,7 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -53,7 +53,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// OpenTelemetry protocol.  Older Span producers do not set this
 /// field, consequently consumers should not rely on the absence of a
 /// particular flag bit to indicate the presence of a particular feature.
-public enum Opentelemetry_Proto_Trace_V1_SpanFlags: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Opentelemetry_Proto_Trace_V1_SpanFlags: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   /// The zero value for the enum. Should not be used for comparisons.
@@ -114,7 +114,7 @@ public enum Opentelemetry_Proto_Trace_V1_SpanFlags: SwiftProtobuf.Enum, Swift.Ca
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
-public struct Opentelemetry_Proto_Trace_V1_TracesData: Sendable {
+public nonisolated struct Opentelemetry_Proto_Trace_V1_TracesData: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -132,7 +132,7 @@ public struct Opentelemetry_Proto_Trace_V1_TracesData: Sendable {
 }
 
 /// A collection of ScopeSpans from a Resource.
-public struct Opentelemetry_Proto_Trace_V1_ResourceSpans: Sendable {
+public nonisolated struct Opentelemetry_Proto_Trace_V1_ResourceSpans: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -167,7 +167,7 @@ public struct Opentelemetry_Proto_Trace_V1_ResourceSpans: Sendable {
 }
 
 /// A collection of Spans produced by an InstrumentationScope.
-public struct Opentelemetry_Proto_Trace_V1_ScopeSpans: Sendable {
+public nonisolated struct Opentelemetry_Proto_Trace_V1_ScopeSpans: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -205,7 +205,7 @@ public struct Opentelemetry_Proto_Trace_V1_ScopeSpans: Sendable {
 /// A Span represents a single operation performed by a single component of the system.
 ///
 /// The next available field id is 17.
-public struct Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {
+public nonisolated struct Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -385,7 +385,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {
 
   /// SpanKind is the type of span. Can be used to specify additional relationships between spans
   /// in addition to a parent/child relationship.
-  public enum SpanKind: SwiftProtobuf.Enum, Swift.CaseIterable {
+  public nonisolated enum SpanKind: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Unspecified. Do NOT use as default.
@@ -457,7 +457,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {
 
   /// Event is a time-stamped annotation of the span, consisting of user-supplied
   /// text description and key-value pairs.
-  public struct Event: Sendable {
+  public nonisolated struct Event: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -488,7 +488,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {
   /// different trace. For example, this can be used in batching operations,
   /// where a single batch handler processes multiple requests from different
   /// traces or when the handler receives a request from a different project.
-  public struct Link: Sendable {
+  public nonisolated struct Link: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -544,7 +544,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {
 
 /// The Status type defines a logical error model that is suitable for different
 /// programming environments, including REST APIs and RPC APIs.
-public struct Opentelemetry_Proto_Trace_V1_Status: Sendable {
+public nonisolated struct Opentelemetry_Proto_Trace_V1_Status: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -559,7 +559,7 @@ public struct Opentelemetry_Proto_Trace_V1_Status: Sendable {
 
   /// For the semantics of status codes see
   /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
-  public enum StatusCode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  public nonisolated enum StatusCode: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// The default status.
@@ -609,13 +609,13 @@ public struct Opentelemetry_Proto_Trace_V1_Status: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "opentelemetry.proto.trace.v1"
+fileprivate nonisolated let _protobuf_package = "opentelemetry.proto.trace.v1"
 
-extension Opentelemetry_Proto_Trace_V1_SpanFlags: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_SpanFlags: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SPAN_FLAGS_DO_NOT_USE\0\u{2}\u{7f}\u{3}SPAN_FLAGS_TRACE_FLAGS_MASK\0\u{1}SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK\0\u{2}@\u{4}SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK\0")
 }
 
-extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".TracesData"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_spans\0")
 
@@ -645,7 +645,7 @@ extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ResourceSpans"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}resource\0\u{3}scope_spans\0\u{3}schema_url\0\u{c}h\u{f}\u{1}")
 
@@ -689,7 +689,7 @@ extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ScopeSpans"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}scope\0\u{1}spans\0\u{3}schema_url\0")
 
@@ -733,7 +733,7 @@ extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Span"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}trace_id\0\u{3}span_id\0\u{3}trace_state\0\u{3}parent_span_id\0\u{1}name\0\u{1}kind\0\u{3}start_time_unix_nano\0\u{3}end_time_unix_nano\0\u{1}attributes\0\u{3}dropped_attributes_count\0\u{1}events\0\u{3}dropped_events_count\0\u{1}links\0\u{3}dropped_links_count\0\u{1}status\0\u{1}flags\0")
 
@@ -908,11 +908,11 @@ extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Opentelemetry_Proto_Trace_V1_Span.SpanKind: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_Span.SpanKind: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SPAN_KIND_UNSPECIFIED\0\u{1}SPAN_KIND_INTERNAL\0\u{1}SPAN_KIND_SERVER\0\u{1}SPAN_KIND_CLIENT\0\u{1}SPAN_KIND_PRODUCER\0\u{1}SPAN_KIND_CONSUMER\0")
 }
 
-extension Opentelemetry_Proto_Trace_V1_Span.Event: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_Span.Event: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Opentelemetry_Proto_Trace_V1_Span.protoMessageName + ".Event"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}time_unix_nano\0\u{1}name\0\u{1}attributes\0\u{3}dropped_attributes_count\0")
 
@@ -957,7 +957,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Event: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Opentelemetry_Proto_Trace_V1_Span.protoMessageName + ".Link"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}trace_id\0\u{3}span_id\0\u{3}trace_state\0\u{1}attributes\0\u{3}dropped_attributes_count\0\u{1}flags\0")
 
@@ -1012,7 +1012,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Status"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\u{2}message\0\u{1}code\0\u{c}\u{1}\u{1}")
 
@@ -1047,6 +1047,6 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STATUS_CODE_UNSET\0\u{1}STATUS_CODE_OK\0\u{1}STATUS_CODE_ERROR\0")
 }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -187,6 +187,16 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
         )
     }
 
+    func dumpKernelLog(
+        request: ServerRequest<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+        context: ServerContext
+    ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse> {
+        throw RPCError(
+            code: .unimplemented,
+            message: "Dumping the kernel log is currently not supported by Wendy Agent for Mac."
+        )
+    }
+
     func updateOS(
         request: ServerRequest<Wendy_Agent_Services_V1_UpdateOSRequest>,
         context: ServerContext
@@ -197,6 +207,26 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
                 + "Use this machine’s normal OS update tools instead. "
                 + "To use WendyOS OTA updates, install WendyOS on supported hardware "
                 + "with wendy os install."
+        )
+    }
+
+    func getOSUpdateStatus(
+        request: ServerRequest<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+        context: ServerContext
+    ) async throws -> ServerResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse> {
+        throw RPCError(
+            code: .unimplemented,
+            message: "OS update status is currently not supported by Wendy Agent for Mac."
+        )
+    }
+
+    func setHostname(
+        request: ServerRequest<Wendy_Agent_Services_V1_SetHostnameRequest>,
+        context: ServerContext
+    ) async throws -> ServerResponse<Wendy_Agent_Services_V1_SetHostnameResponse> {
+        throw RPCError(
+            code: .unimplemented,
+            message: "Setting the hostname is currently not supported by Wendy Agent for Mac."
         )
     }
 }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -1098,6 +1098,66 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         )
     }
 
+    func getResourceStats(
+        request: ServerRequest<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+        context: ServerContext
+    ) async throws -> ServerResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse> {
+        throw RPCError(
+            code: .unimplemented,
+            message: "Resource stats are currently not supported by Wendy Agent for Mac."
+        )
+    }
+
+    func streamMCP(
+        request: StreamingServerRequest<Wendy_Agent_Services_V1_MCPChunk>,
+        context: ServerContext
+    ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_MCPChunk> {
+        throw RPCError(
+            code: .unimplemented,
+            message: "MCP streaming is currently not supported by Wendy Agent for Mac."
+        )
+    }
+
+    func getContainerPorts(
+        request: ServerRequest<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+        context: ServerContext
+    ) async throws -> ServerResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse> {
+        throw RPCError(
+            code: .unimplemented,
+            message: "Container port lookup is currently not supported by Wendy Agent for Mac."
+        )
+    }
+
+    func queryChunks(
+        request: ServerRequest<Wendy_Agent_Services_V1_QueryChunksRequest>,
+        context: ServerContext
+    ) async throws -> ServerResponse<Wendy_Agent_Services_V1_QueryChunksResponse> {
+        throw RPCError(
+            code: .unimplemented,
+            message: "Chunk-level layer transfer is currently not supported by Wendy Agent for Mac."
+        )
+    }
+
+    func writeChunks(
+        request: StreamingServerRequest<Wendy_Agent_Services_V1_WriteChunksRequest>,
+        context: ServerContext
+    ) async throws -> ServerResponse<Wendy_Agent_Services_V1_WriteChunksResponse> {
+        throw RPCError(
+            code: .unimplemented,
+            message: "Chunk-level layer transfer is currently not supported by Wendy Agent for Mac."
+        )
+    }
+
+    func queryLayers(
+        request: ServerRequest<Wendy_Agent_Services_V1_QueryLayersRequest>,
+        context: ServerContext
+    ) async throws -> ServerResponse<Wendy_Agent_Services_V1_QueryLayersResponse> {
+        throw RPCError(
+            code: .unimplemented,
+            message: "Layer content queries are currently not supported by Wendy Agent for Mac."
+        )
+    }
+
     func listLayers(
         request: ServerRequest<Wendy_Agent_Services_V1_ListLayersRequest>,
         context: ServerContext

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
@@ -17,4 +17,14 @@ struct ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Sim
         response.notProvisioned = Wendy_Agent_Services_V1_NotProvisionedResponse()
         return response
     }
+
+    func unprovision(
+        request: Wendy_Agent_Services_V1_UnprovisionRequest,
+        context: ServerContext
+    ) async throws -> Wendy_Agent_Services_V1_UnprovisionResponse {
+        throw RPCError(
+            code: .unimplemented,
+            message: "Unprovisioning is currently not supported by Wendy Agent for Mac."
+        )
+    }
 }

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/shared.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/shared.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public enum RestartPolicyMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum RestartPolicyMode: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   /// Agent chooses default (unless-stopped for normal runs)
@@ -70,7 +70,7 @@ public enum RestartPolicyMode: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-public enum AppRunningState: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum AppRunningState: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
   case stopped // = 0
   case running // = 1
@@ -104,7 +104,7 @@ public enum AppRunningState: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-public struct RestartPolicy: Sendable {
+public nonisolated struct RestartPolicy: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -119,18 +119,53 @@ public struct RestartPolicy: Sendable {
   public init() {}
 }
 
-public struct AppContainer: Sendable {
+/// ServiceEntry describes a single container within a services-map app group.
+/// Present in AppContainer.services for any app that declares named services
+/// (single- or multi-service); see AppContainer.services.
+public nonisolated struct ServiceEntry: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  public var name: String = String()
+
+  public var runningState: AppRunningState = .stopped
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct AppContainer: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// app ID (bare, without service suffix)
   public var appName: String = String()
 
   public var appVersion: String = String()
 
+  /// aggregate: RUNNING if any service is running
   public var runningState: AppRunningState = .stopped
 
   public var failureCount: UInt32 = 0
+
+  public var mcpPort: UInt32 = 0
+
+  /// One entry per service container for apps that declare named services
+  /// (single- or multi-service services-map apps). Empty for single-container
+  /// apps and flattened single-service apps (those with no service name).
+  public var services: [ServiceEntry] = []
+
+  /// Exit diagnostics for the last run, only meaningful when running_state is
+  /// STOPPED. Fields 7-10 are left for the in-flight provenance PR #1234, so
+  /// these start at 11 to guarantee no wire-number collision on either merge
+  /// order.
+  public var exitCode: Int32 = 0
+
+  /// exited | crashed | oom_killed | start_failed | entitlement_denied; empty if unknown.
+  public var terminationReason: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -139,15 +174,15 @@ public struct AppContainer: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-extension RestartPolicyMode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension RestartPolicyMode: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DEFAULT\0\u{1}UNLESS_STOPPED\0\u{1}NO\0\u{1}ON_FAILURE\0")
 }
 
-extension AppRunningState: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension AppRunningState: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STOPPED\0\u{1}RUNNING\0")
 }
 
-extension RestartPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension RestartPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "RestartPolicy"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}mode\0\u{3}on_failure_max_retries\0")
 
@@ -182,9 +217,44 @@ extension RestartPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
   }
 }
 
-extension AppContainer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension ServiceEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = "ServiceEntry"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}running_state\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.runningState) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if self.runningState != .stopped {
+      try visitor.visitSingularEnumField(value: self.runningState, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: ServiceEntry, rhs: ServiceEntry) -> Bool {
+    if lhs.name != rhs.name {return false}
+    if lhs.runningState != rhs.runningState {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension AppContainer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "AppContainer"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0\u{3}app_version\0\u{3}running_state\0\u{3}failure_count\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0\u{3}app_version\0\u{3}running_state\0\u{3}failure_count\0\u{3}mcp_port\0\u{1}services\0\u{4}\u{5}exit_code\0\u{3}termination_reason\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -196,6 +266,10 @@ extension AppContainer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
       case 2: try { try decoder.decodeSingularStringField(value: &self.appVersion) }()
       case 3: try { try decoder.decodeSingularEnumField(value: &self.runningState) }()
       case 4: try { try decoder.decodeSingularUInt32Field(value: &self.failureCount) }()
+      case 5: try { try decoder.decodeSingularUInt32Field(value: &self.mcpPort) }()
+      case 6: try { try decoder.decodeRepeatedMessageField(value: &self.services) }()
+      case 11: try { try decoder.decodeSingularInt32Field(value: &self.exitCode) }()
+      case 12: try { try decoder.decodeSingularStringField(value: &self.terminationReason) }()
       default: break
       }
     }
@@ -214,6 +288,18 @@ extension AppContainer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
     if self.failureCount != 0 {
       try visitor.visitSingularUInt32Field(value: self.failureCount, fieldNumber: 4)
     }
+    if self.mcpPort != 0 {
+      try visitor.visitSingularUInt32Field(value: self.mcpPort, fieldNumber: 5)
+    }
+    if !self.services.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.services, fieldNumber: 6)
+    }
+    if self.exitCode != 0 {
+      try visitor.visitSingularInt32Field(value: self.exitCode, fieldNumber: 11)
+    }
+    if !self.terminationReason.isEmpty {
+      try visitor.visitSingularStringField(value: self.terminationReason, fieldNumber: 12)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -222,6 +308,10 @@ extension AppContainer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
     if lhs.appVersion != rhs.appVersion {return false}
     if lhs.runningState != rhs.runningState {return false}
     if lhs.failureCount != rhs.failureCount {return false}
+    if lhs.mcpPort != rhs.mcpPort {return false}
+    if lhs.services != rhs.services {return false}
+    if lhs.exitCode != rhs.exitCode {return false}
+    if lhs.terminationReason != rhs.terminationReason {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_audio_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_audio_service.pb.swift
@@ -20,13 +20,13 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Type of audio device
-public enum Wendy_Agent_Services_V1_AudioDeviceType: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Wendy_Agent_Services_V1_AudioDeviceType: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
   case unspecified // = 0
 
@@ -69,7 +69,7 @@ public enum Wendy_Agent_Services_V1_AudioDeviceType: SwiftProtobuf.Enum, Swift.C
 }
 
 /// Request to list audio devices
-public struct Wendy_Agent_Services_V1_ListAudioDevicesRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListAudioDevicesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -92,7 +92,7 @@ public struct Wendy_Agent_Services_V1_ListAudioDevicesRequest: Sendable {
 }
 
 /// Response containing available audio devices
-public struct Wendy_Agent_Services_V1_ListAudioDevicesResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListAudioDevicesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -105,7 +105,7 @@ public struct Wendy_Agent_Services_V1_ListAudioDevicesResponse: Sendable {
 }
 
 /// Information about an audio device
-public struct Wendy_Agent_Services_V1_AudioDevice: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AudioDevice: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -131,7 +131,7 @@ public struct Wendy_Agent_Services_V1_AudioDevice: Sendable {
 }
 
 /// Request to set default audio device
-public struct Wendy_Agent_Services_V1_SetDefaultAudioDeviceRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_SetDefaultAudioDeviceRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -145,7 +145,7 @@ public struct Wendy_Agent_Services_V1_SetDefaultAudioDeviceRequest: Sendable {
 }
 
 /// Response for setting default device
-public struct Wendy_Agent_Services_V1_SetDefaultAudioDeviceResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_SetDefaultAudioDeviceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -169,7 +169,7 @@ public struct Wendy_Agent_Services_V1_SetDefaultAudioDeviceResponse: Sendable {
 }
 
 /// Request to stream audio levels
-public struct Wendy_Agent_Services_V1_StreamAudioLevelsRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StreamAudioLevelsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -186,7 +186,7 @@ public struct Wendy_Agent_Services_V1_StreamAudioLevelsRequest: Sendable {
 }
 
 /// Real-time audio level update
-public struct Wendy_Agent_Services_V1_AudioLevelUpdate: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AudioLevelUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -206,7 +206,7 @@ public struct Wendy_Agent_Services_V1_AudioLevelUpdate: Sendable {
 }
 
 /// Request to stream raw audio
-public struct Wendy_Agent_Services_V1_StreamAudioRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StreamAudioRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -226,7 +226,7 @@ public struct Wendy_Agent_Services_V1_StreamAudioRequest: Sendable {
 }
 
 /// Raw PCM audio chunk
-public struct Wendy_Agent_Services_V1_AudioChunk: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AudioChunk: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -250,13 +250,13 @@ public struct Wendy_Agent_Services_V1_AudioChunk: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendy.agent.services.v1"
+fileprivate nonisolated let _protobuf_package = "wendy.agent.services.v1"
 
-extension Wendy_Agent_Services_V1_AudioDeviceType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AudioDeviceType: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0AUDIO_DEVICE_TYPE_UNSPECIFIED\0\u{1}AUDIO_DEVICE_TYPE_INPUT\0\u{1}AUDIO_DEVICE_TYPE_OUTPUT\0")
 }
 
-extension Wendy_Agent_Services_V1_ListAudioDevicesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListAudioDevicesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAudioDevicesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_filter\0")
 
@@ -290,7 +290,7 @@ extension Wendy_Agent_Services_V1_ListAudioDevicesRequest: SwiftProtobuf.Message
   }
 }
 
-extension Wendy_Agent_Services_V1_ListAudioDevicesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListAudioDevicesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAudioDevicesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}devices\0")
 
@@ -320,7 +320,7 @@ extension Wendy_Agent_Services_V1_ListAudioDevicesResponse: SwiftProtobuf.Messag
   }
 }
 
-extension Wendy_Agent_Services_V1_AudioDevice: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AudioDevice: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AudioDevice"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}name\0\u{1}description\0\u{1}type\0\u{3}is_default\0")
 
@@ -370,7 +370,7 @@ extension Wendy_Agent_Services_V1_AudioDevice: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Wendy_Agent_Services_V1_SetDefaultAudioDeviceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_SetDefaultAudioDeviceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SetDefaultAudioDeviceRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}device_id\0")
 
@@ -400,7 +400,7 @@ extension Wendy_Agent_Services_V1_SetDefaultAudioDeviceRequest: SwiftProtobuf.Me
   }
 }
 
-extension Wendy_Agent_Services_V1_SetDefaultAudioDeviceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_SetDefaultAudioDeviceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SetDefaultAudioDeviceResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -439,7 +439,7 @@ extension Wendy_Agent_Services_V1_SetDefaultAudioDeviceResponse: SwiftProtobuf.M
   }
 }
 
-extension Wendy_Agent_Services_V1_StreamAudioLevelsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StreamAudioLevelsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StreamAudioLevelsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}device_id\0\u{3}update_rate_hz\0")
 
@@ -474,7 +474,7 @@ extension Wendy_Agent_Services_V1_StreamAudioLevelsRequest: SwiftProtobuf.Messag
   }
 }
 
-extension Wendy_Agent_Services_V1_AudioLevelUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AudioLevelUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AudioLevelUpdate"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}peak_db\0\u{3}rms_db\0\u{3}timestamp_ns\0")
 
@@ -514,7 +514,7 @@ extension Wendy_Agent_Services_V1_AudioLevelUpdate: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendy_Agent_Services_V1_StreamAudioRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StreamAudioRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StreamAudioRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}device_id\0\u{3}sample_rate\0\u{1}channels\0")
 
@@ -554,7 +554,7 @@ extension Wendy_Agent_Services_V1_StreamAudioRequest: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_AudioChunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AudioChunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AudioChunk"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}pcm_data\0\u{3}timestamp_ns\0\u{3}sample_rate\0\u{1}channels\0")
 

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_bluetooth.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_bluetooth.pb.swift
@@ -15,13 +15,13 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Bluetooth command sent from CLI to Agent over L2CAP
-public struct Wendy_Agent_Services_V1_BluetoothCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -166,7 +166,7 @@ public struct Wendy_Agent_Services_V1_BluetoothCommand: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_Command: Equatable, Sendable {
+  public nonisolated enum OneOf_Command: Equatable, Sendable {
     case wifiList(Wendy_Agent_Services_V1_WifiListCommand)
     case wifiConnect(Wendy_Agent_Services_V1_WifiConnectCommand)
     case wifiStatus(Wendy_Agent_Services_V1_WifiStatusCommand)
@@ -191,7 +191,7 @@ public struct Wendy_Agent_Services_V1_BluetoothCommand: Sendable {
 }
 
 /// Empty commands (no parameters needed)
-public struct Wendy_Agent_Services_V1_WifiListCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiListCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -201,7 +201,7 @@ public struct Wendy_Agent_Services_V1_WifiListCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_WifiStatusCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiStatusCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -211,7 +211,7 @@ public struct Wendy_Agent_Services_V1_WifiStatusCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_WifiDisconnectCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiDisconnectCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -221,7 +221,7 @@ public struct Wendy_Agent_Services_V1_WifiDisconnectCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_AppsListCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AppsListCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -231,7 +231,7 @@ public struct Wendy_Agent_Services_V1_AppsListCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_AgentVersionCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AgentVersionCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -241,7 +241,7 @@ public struct Wendy_Agent_Services_V1_AgentVersionCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_HardwareListCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_HardwareListCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -252,7 +252,7 @@ public struct Wendy_Agent_Services_V1_HardwareListCommand: Sendable {
 }
 
 /// Bluetooth device commands
-public struct Wendy_Agent_Services_V1_BluetoothListCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothListCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -264,7 +264,7 @@ public struct Wendy_Agent_Services_V1_BluetoothListCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_BluetoothConnectCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothConnectCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -276,7 +276,7 @@ public struct Wendy_Agent_Services_V1_BluetoothConnectCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_BluetoothDisconnectCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothDisconnectCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -288,7 +288,7 @@ public struct Wendy_Agent_Services_V1_BluetoothDisconnectCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_BluetoothForgetCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothForgetCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -301,7 +301,7 @@ public struct Wendy_Agent_Services_V1_BluetoothForgetCommand: Sendable {
 }
 
 /// Commands with parameters
-public struct Wendy_Agent_Services_V1_WifiConnectCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiConnectCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -336,7 +336,7 @@ public struct Wendy_Agent_Services_V1_WifiConnectCommand: Sendable {
   fileprivate var _hidden: Bool? = nil
 }
 
-public struct Wendy_Agent_Services_V1_WifiKnownListCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiKnownListCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -346,7 +346,7 @@ public struct Wendy_Agent_Services_V1_WifiKnownListCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_WifiSetPriorityCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiSetPriorityCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -360,7 +360,7 @@ public struct Wendy_Agent_Services_V1_WifiSetPriorityCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_WifiReorderCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiReorderCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -372,7 +372,7 @@ public struct Wendy_Agent_Services_V1_WifiReorderCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_WifiForgetCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiForgetCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -384,7 +384,7 @@ public struct Wendy_Agent_Services_V1_WifiForgetCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_AppsStopCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AppsStopCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -396,7 +396,7 @@ public struct Wendy_Agent_Services_V1_AppsStopCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_AppsRemoveCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AppsRemoveCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -411,7 +411,7 @@ public struct Wendy_Agent_Services_V1_AppsRemoveCommand: Sendable {
 }
 
 /// Bluetooth response sent from Agent to CLI over L2CAP
-public struct Wendy_Agent_Services_V1_BluetoothResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -564,7 +564,7 @@ public struct Wendy_Agent_Services_V1_BluetoothResponse: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_Response: Equatable, Sendable {
+  public nonisolated enum OneOf_Response: Equatable, Sendable {
     case wifiList(Wendy_Agent_Services_V1_WifiListResponse)
     case wifiConnect(Wendy_Agent_Services_V1_WifiConnectResponse)
     case wifiStatus(Wendy_Agent_Services_V1_WifiStatusResponse)
@@ -590,7 +590,7 @@ public struct Wendy_Agent_Services_V1_BluetoothResponse: Sendable {
 }
 
 /// WiFi responses
-public struct Wendy_Agent_Services_V1_WifiListResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiListResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -602,7 +602,7 @@ public struct Wendy_Agent_Services_V1_WifiListResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_WifiConnectResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiConnectResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -625,7 +625,7 @@ public struct Wendy_Agent_Services_V1_WifiConnectResponse: Sendable {
   fileprivate var _errorMessage: String? = nil
 }
 
-public struct Wendy_Agent_Services_V1_WifiStatusResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiStatusResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -658,7 +658,7 @@ public struct Wendy_Agent_Services_V1_WifiStatusResponse: Sendable {
   fileprivate var _errorMessage: String? = nil
 }
 
-public struct Wendy_Agent_Services_V1_WifiDisconnectResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiDisconnectResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -682,7 +682,7 @@ public struct Wendy_Agent_Services_V1_WifiDisconnectResponse: Sendable {
 }
 
 /// Apps responses
-public struct Wendy_Agent_Services_V1_AppsListResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AppsListResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -694,7 +694,7 @@ public struct Wendy_Agent_Services_V1_AppsListResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_AppsStopResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AppsStopResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -717,7 +717,7 @@ public struct Wendy_Agent_Services_V1_AppsStopResponse: Sendable {
   fileprivate var _errorMessage: String? = nil
 }
 
-public struct Wendy_Agent_Services_V1_AppsRemoveResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AppsRemoveResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -741,7 +741,7 @@ public struct Wendy_Agent_Services_V1_AppsRemoveResponse: Sendable {
 }
 
 /// Other responses
-public struct Wendy_Agent_Services_V1_AgentVersionResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AgentVersionResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -786,7 +786,7 @@ public struct Wendy_Agent_Services_V1_AgentVersionResponse: Sendable {
   fileprivate var _cpuArchitecture: String? = nil
 }
 
-public struct Wendy_Agent_Services_V1_HardwareListResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_HardwareListResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -798,7 +798,7 @@ public struct Wendy_Agent_Services_V1_HardwareListResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ErrorResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ErrorResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -811,7 +811,7 @@ public struct Wendy_Agent_Services_V1_ErrorResponse: Sendable {
 }
 
 /// Bluetooth device responses
-public struct Wendy_Agent_Services_V1_BluetoothListResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothListResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -823,7 +823,7 @@ public struct Wendy_Agent_Services_V1_BluetoothListResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_BluetoothConnectResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothConnectResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -846,7 +846,7 @@ public struct Wendy_Agent_Services_V1_BluetoothConnectResponse: Sendable {
   fileprivate var _errorMessage: String? = nil
 }
 
-public struct Wendy_Agent_Services_V1_BluetoothDisconnectResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothDisconnectResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -869,7 +869,7 @@ public struct Wendy_Agent_Services_V1_BluetoothDisconnectResponse: Sendable {
   fileprivate var _errorMessage: String? = nil
 }
 
-public struct Wendy_Agent_Services_V1_BluetoothForgetResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothForgetResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -892,7 +892,7 @@ public struct Wendy_Agent_Services_V1_BluetoothForgetResponse: Sendable {
   fileprivate var _errorMessage: String? = nil
 }
 
-public struct Wendy_Agent_Services_V1_WifiKnownListResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiKnownListResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -904,7 +904,7 @@ public struct Wendy_Agent_Services_V1_WifiKnownListResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_KnownWifiNetworkInfo: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_KnownWifiNetworkInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -922,7 +922,7 @@ public struct Wendy_Agent_Services_V1_KnownWifiNetworkInfo: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_WifiSetPriorityResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiSetPriorityResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -945,7 +945,7 @@ public struct Wendy_Agent_Services_V1_WifiSetPriorityResponse: Sendable {
   fileprivate var _errorMessage: String? = nil
 }
 
-public struct Wendy_Agent_Services_V1_WifiReorderResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiReorderResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -968,7 +968,7 @@ public struct Wendy_Agent_Services_V1_WifiReorderResponse: Sendable {
   fileprivate var _errorMessage: String? = nil
 }
 
-public struct Wendy_Agent_Services_V1_WifiForgetResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiForgetResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -992,7 +992,7 @@ public struct Wendy_Agent_Services_V1_WifiForgetResponse: Sendable {
 }
 
 /// Shared types
-public struct Wendy_Agent_Services_V1_WifiNetworkInfo: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WifiNetworkInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1041,7 +1041,7 @@ public struct Wendy_Agent_Services_V1_WifiNetworkInfo: Sendable {
   fileprivate var _rssiDbm: Int32? = nil
 }
 
-public struct Wendy_Agent_Services_V1_AppInfo: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AppInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1059,7 +1059,7 @@ public struct Wendy_Agent_Services_V1_AppInfo: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_HardwareInfo: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_HardwareInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1076,7 +1076,7 @@ public struct Wendy_Agent_Services_V1_HardwareInfo: Sendable {
 }
 
 /// Information about a Bluetooth device
-public struct Wendy_Agent_Services_V1_BluetoothDeviceInfo: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_BluetoothDeviceInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1121,9 +1121,9 @@ public struct Wendy_Agent_Services_V1_BluetoothDeviceInfo: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendy.agent.services.v1"
+fileprivate nonisolated let _protobuf_package = "wendy.agent.services.v1"
 
-extension Wendy_Agent_Services_V1_BluetoothCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}wifi_list\0\u{3}wifi_connect\0\u{3}wifi_status\0\u{3}wifi_disconnect\0\u{3}apps_list\0\u{3}apps_stop\0\u{3}apps_remove\0\u{3}agent_version\0\u{3}hardware_list\0\u{3}bluetooth_list\0\u{3}bluetooth_connect\0\u{3}bluetooth_disconnect\0\u{3}bluetooth_forget\0\u{3}wifi_known_list\0\u{3}wifi_set_priority\0\u{3}wifi_reorder\0\u{3}wifi_forget\0")
 
@@ -1445,7 +1445,7 @@ extension Wendy_Agent_Services_V1_BluetoothCommand: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiListCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1464,7 +1464,7 @@ extension Wendy_Agent_Services_V1_WifiListCommand: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiStatusCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiStatusCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiStatusCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1483,7 +1483,7 @@ extension Wendy_Agent_Services_V1_WifiStatusCommand: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiDisconnectCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiDisconnectCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiDisconnectCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1502,7 +1502,7 @@ extension Wendy_Agent_Services_V1_WifiDisconnectCommand: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendy_Agent_Services_V1_AppsListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AppsListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AppsListCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1521,7 +1521,7 @@ extension Wendy_Agent_Services_V1_AppsListCommand: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendy_Agent_Services_V1_AgentVersionCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AgentVersionCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AgentVersionCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1540,7 +1540,7 @@ extension Wendy_Agent_Services_V1_AgentVersionCommand: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_HardwareListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_HardwareListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".HardwareListCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1559,7 +1559,7 @@ extension Wendy_Agent_Services_V1_HardwareListCommand: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothListCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}paired_only\0")
 
@@ -1589,7 +1589,7 @@ extension Wendy_Agent_Services_V1_BluetoothListCommand: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothConnectCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothConnectCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothConnectCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}address\0")
 
@@ -1619,7 +1619,7 @@ extension Wendy_Agent_Services_V1_BluetoothConnectCommand: SwiftProtobuf.Message
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothDisconnectCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothDisconnectCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothDisconnectCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}address\0")
 
@@ -1649,7 +1649,7 @@ extension Wendy_Agent_Services_V1_BluetoothDisconnectCommand: SwiftProtobuf.Mess
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothForgetCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothForgetCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothForgetCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}address\0")
 
@@ -1679,7 +1679,7 @@ extension Wendy_Agent_Services_V1_BluetoothForgetCommand: SwiftProtobuf.Message,
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiConnectCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiConnectCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiConnectCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0\u{1}password\0\u{1}security\0\u{1}hidden\0")
 
@@ -1728,7 +1728,7 @@ extension Wendy_Agent_Services_V1_WifiConnectCommand: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiKnownListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiKnownListCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiKnownListCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1747,7 +1747,7 @@ extension Wendy_Agent_Services_V1_WifiKnownListCommand: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiSetPriorityCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiSetPriorityCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiSetPriorityCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0\u{1}priority\0")
 
@@ -1782,7 +1782,7 @@ extension Wendy_Agent_Services_V1_WifiSetPriorityCommand: SwiftProtobuf.Message,
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiReorderCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiReorderCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiReorderCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}order_ssids\0")
 
@@ -1812,7 +1812,7 @@ extension Wendy_Agent_Services_V1_WifiReorderCommand: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiForgetCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiForgetCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiForgetCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0")
 
@@ -1842,7 +1842,7 @@ extension Wendy_Agent_Services_V1_WifiForgetCommand: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Wendy_Agent_Services_V1_AppsStopCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AppsStopCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AppsStopCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0")
 
@@ -1872,7 +1872,7 @@ extension Wendy_Agent_Services_V1_AppsStopCommand: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendy_Agent_Services_V1_AppsRemoveCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AppsRemoveCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AppsRemoveCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0\u{3}purge_image\0")
 
@@ -1907,7 +1907,7 @@ extension Wendy_Agent_Services_V1_AppsRemoveCommand: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}wifi_list\0\u{3}wifi_connect\0\u{3}wifi_status\0\u{3}wifi_disconnect\0\u{3}apps_list\0\u{3}apps_stop\0\u{3}apps_remove\0\u{3}agent_version\0\u{3}hardware_list\0\u{1}error\0\u{3}bluetooth_list\0\u{3}bluetooth_connect\0\u{3}bluetooth_disconnect\0\u{3}bluetooth_forget\0\u{3}wifi_known_list\0\u{3}wifi_set_priority\0\u{3}wifi_reorder\0\u{3}wifi_forget\0")
 
@@ -2246,7 +2246,7 @@ extension Wendy_Agent_Services_V1_BluetoothResponse: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiListResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}networks\0")
 
@@ -2276,7 +2276,7 @@ extension Wendy_Agent_Services_V1_WifiListResponse: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiConnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiConnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiConnectResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2315,7 +2315,7 @@ extension Wendy_Agent_Services_V1_WifiConnectResponse: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiStatusResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}connected\0\u{1}ssid\0\u{3}error_message\0")
 
@@ -2359,7 +2359,7 @@ extension Wendy_Agent_Services_V1_WifiStatusResponse: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiDisconnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiDisconnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiDisconnectResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2398,7 +2398,7 @@ extension Wendy_Agent_Services_V1_WifiDisconnectResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Wendy_Agent_Services_V1_AppsListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AppsListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AppsListResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}apps\0")
 
@@ -2428,7 +2428,7 @@ extension Wendy_Agent_Services_V1_AppsListResponse: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendy_Agent_Services_V1_AppsStopResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AppsStopResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AppsStopResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2467,7 +2467,7 @@ extension Wendy_Agent_Services_V1_AppsStopResponse: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendy_Agent_Services_V1_AppsRemoveResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AppsRemoveResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AppsRemoveResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2506,7 +2506,7 @@ extension Wendy_Agent_Services_V1_AppsRemoveResponse: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_AgentVersionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AgentVersionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AgentVersionResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0\u{1}os\0\u{3}os_version\0\u{3}cpu_architecture\0\u{1}featureset\0")
 
@@ -2560,7 +2560,7 @@ extension Wendy_Agent_Services_V1_AgentVersionResponse: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_HardwareListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_HardwareListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".HardwareListResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}capabilities\0")
 
@@ -2590,7 +2590,7 @@ extension Wendy_Agent_Services_V1_HardwareListResponse: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_ErrorResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ErrorResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ErrorResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}message\0")
 
@@ -2620,7 +2620,7 @@ extension Wendy_Agent_Services_V1_ErrorResponse: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothListResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}devices\0")
 
@@ -2650,7 +2650,7 @@ extension Wendy_Agent_Services_V1_BluetoothListResponse: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothConnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothConnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothConnectResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2689,7 +2689,7 @@ extension Wendy_Agent_Services_V1_BluetoothConnectResponse: SwiftProtobuf.Messag
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothDisconnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothDisconnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothDisconnectResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2728,7 +2728,7 @@ extension Wendy_Agent_Services_V1_BluetoothDisconnectResponse: SwiftProtobuf.Mes
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothForgetResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothForgetResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothForgetResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2767,7 +2767,7 @@ extension Wendy_Agent_Services_V1_BluetoothForgetResponse: SwiftProtobuf.Message
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiKnownListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiKnownListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiKnownListResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}networks\0")
 
@@ -2797,7 +2797,7 @@ extension Wendy_Agent_Services_V1_WifiKnownListResponse: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendy_Agent_Services_V1_KnownWifiNetworkInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_KnownWifiNetworkInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".KnownWifiNetworkInfo"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0\u{1}uuid\0\u{1}priority\0\u{1}security\0")
 
@@ -2842,7 +2842,7 @@ extension Wendy_Agent_Services_V1_KnownWifiNetworkInfo: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiSetPriorityResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiSetPriorityResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiSetPriorityResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2881,7 +2881,7 @@ extension Wendy_Agent_Services_V1_WifiSetPriorityResponse: SwiftProtobuf.Message
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiReorderResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiReorderResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiReorderResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2920,7 +2920,7 @@ extension Wendy_Agent_Services_V1_WifiReorderResponse: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiForgetResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiForgetResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiForgetResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2959,7 +2959,7 @@ extension Wendy_Agent_Services_V1_WifiForgetResponse: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_WifiNetworkInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WifiNetworkInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WifiNetworkInfo"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0\u{3}signal_strength\0\u{1}security\0\u{3}is_known\0\u{3}is_connected\0\u{1}priority\0\u{3}rssi_dbm\0")
 
@@ -3023,7 +3023,7 @@ extension Wendy_Agent_Services_V1_WifiNetworkInfo: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendy_Agent_Services_V1_AppInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AppInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AppInfo"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0\u{3}app_version\0\u{1}state\0\u{3}failure_count\0")
 
@@ -3068,7 +3068,7 @@ extension Wendy_Agent_Services_V1_AppInfo: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Wendy_Agent_Services_V1_HardwareInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_HardwareInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".HardwareInfo"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}name\0\u{1}available\0")
 
@@ -3108,7 +3108,7 @@ extension Wendy_Agent_Services_V1_HardwareInfo: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Wendy_Agent_Services_V1_BluetoothDeviceInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_BluetoothDeviceInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BluetoothDeviceInfo"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}address\0\u{1}rssi\0\u{1}paired\0\u{1}connected\0\u{1}trusted\0\u{3}device_type\0\u{1}icon\0")
 

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.grpc.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.grpc.swift
@@ -189,6 +189,84 @@ public enum Wendy_Agent_Services_V1_WendyContainerService: Sendable {
                 type: .unary
             )
         }
+        /// Namespace for "GetResourceStats" metadata.
+        public enum GetResourceStats: Sendable {
+            /// Request type for "GetResourceStats".
+            public typealias Input = Wendy_Agent_Services_V1_GetResourceStatsRequest
+            /// Response type for "GetResourceStats".
+            public typealias Output = Wendy_Agent_Services_V1_GetResourceStatsResponse
+            /// Descriptor for "GetResourceStats".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyContainerService"),
+                method: "GetResourceStats",
+                type: .unary
+            )
+        }
+        /// Namespace for "GetContainerPorts" metadata.
+        public enum GetContainerPorts: Sendable {
+            /// Request type for "GetContainerPorts".
+            public typealias Input = Wendy_Agent_Services_V1_GetContainerPortsRequest
+            /// Response type for "GetContainerPorts".
+            public typealias Output = Wendy_Agent_Services_V1_GetContainerPortsResponse
+            /// Descriptor for "GetContainerPorts".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyContainerService"),
+                method: "GetContainerPorts",
+                type: .unary
+            )
+        }
+        /// Namespace for "StreamMCP" metadata.
+        public enum StreamMCP: Sendable {
+            /// Request type for "StreamMCP".
+            public typealias Input = Wendy_Agent_Services_V1_MCPChunk
+            /// Response type for "StreamMCP".
+            public typealias Output = Wendy_Agent_Services_V1_MCPChunk
+            /// Descriptor for "StreamMCP".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyContainerService"),
+                method: "StreamMCP",
+                type: .bidirectionalStreaming
+            )
+        }
+        /// Namespace for "QueryChunks" metadata.
+        public enum QueryChunks: Sendable {
+            /// Request type for "QueryChunks".
+            public typealias Input = Wendy_Agent_Services_V1_QueryChunksRequest
+            /// Response type for "QueryChunks".
+            public typealias Output = Wendy_Agent_Services_V1_QueryChunksResponse
+            /// Descriptor for "QueryChunks".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyContainerService"),
+                method: "QueryChunks",
+                type: .unary
+            )
+        }
+        /// Namespace for "WriteChunks" metadata.
+        public enum WriteChunks: Sendable {
+            /// Request type for "WriteChunks".
+            public typealias Input = Wendy_Agent_Services_V1_WriteChunksRequest
+            /// Response type for "WriteChunks".
+            public typealias Output = Wendy_Agent_Services_V1_WriteChunksResponse
+            /// Descriptor for "WriteChunks".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyContainerService"),
+                method: "WriteChunks",
+                type: .clientStreaming
+            )
+        }
+        /// Namespace for "QueryLayers" metadata.
+        public enum QueryLayers: Sendable {
+            /// Request type for "QueryLayers".
+            public typealias Input = Wendy_Agent_Services_V1_QueryLayersRequest
+            /// Response type for "QueryLayers".
+            public typealias Output = Wendy_Agent_Services_V1_QueryLayersResponse
+            /// Descriptor for "QueryLayers".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyContainerService"),
+                method: "QueryLayers",
+                type: .unary
+            )
+        }
         /// Descriptors for all methods in the "wendy.agent.services.v1.WendyContainerService" service.
         public static let descriptors: [GRPCCore.MethodDescriptor] = [
             ListLayers.descriptor,
@@ -203,7 +281,13 @@ public enum Wendy_Agent_Services_V1_WendyContainerService: Sendable {
             ListContainers.descriptor,
             ListVolumes.descriptor,
             RemoveVolume.descriptor,
-            ListContainerStats.descriptor
+            ListContainerStats.descriptor,
+            GetResourceStats.descriptor,
+            GetContainerPorts.descriptor,
+            StreamMCP.descriptor,
+            QueryChunks.descriptor,
+            WriteChunks.descriptor,
+            QueryLayers.descriptor
         ]
     }
 }
@@ -410,6 +494,97 @@ extension Wendy_Agent_Services_V1_WendyContainerService {
             request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_ListContainerStatsRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_ListContainerStatsResponse>
+
+        /// Handle the "GetResourceStats" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_GetResourceStatsRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_GetResourceStatsResponse` messages.
+        func getResourceStats(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse>
+
+        /// Handle the "GetContainerPorts" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_GetContainerPortsRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_GetContainerPortsResponse` messages.
+        func getContainerPorts(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse>
+
+        /// Handle the "StreamMCP" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_MCPChunk` messages.
+        func streamMCP(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_MCPChunk>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_MCPChunk>
+
+        /// Handle the "QueryChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_QueryChunksRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_QueryChunksResponse` messages.
+        func queryChunks(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_QueryChunksRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_QueryChunksResponse>
+
+        /// Handle the "WriteChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_WriteChunksRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_WriteChunksResponse` messages.
+        func writeChunks(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_WriteChunksRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_WriteChunksResponse>
+
+        /// Handle the "QueryLayers" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > QueryLayers reports which uncompressed layers (by diff ID) the device
+        /// > already has in its content store, with their sizes. The CLI uses this to
+        /// > skip decompressing and content-chunking layers the device can reuse as-is
+        /// > — for those layers no dedup is possible, so chunking would be pure waste.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_QueryLayersRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_QueryLayersResponse` messages.
+        func queryLayers(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_QueryLayersRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_QueryLayersResponse>
     }
 
     /// Service protocol for the "wendy.agent.services.v1.WendyContainerService" service.
@@ -601,6 +776,97 @@ extension Wendy_Agent_Services_V1_WendyContainerService {
             request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_ListContainerStatsRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_ListContainerStatsResponse>
+
+        /// Handle the "GetResourceStats" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetResourceStatsRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Wendy_Agent_Services_V1_GetResourceStatsResponse` message.
+        func getResourceStats(
+            request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse>
+
+        /// Handle the "GetContainerPorts" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetContainerPortsRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Wendy_Agent_Services_V1_GetContainerPortsResponse` message.
+        func getContainerPorts(
+            request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse>
+
+        /// Handle the "StreamMCP" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_MCPChunk` messages.
+        func streamMCP(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_MCPChunk>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_MCPChunk>
+
+        /// Handle the "QueryChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_QueryChunksRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Wendy_Agent_Services_V1_QueryChunksResponse` message.
+        func queryChunks(
+            request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_QueryChunksRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_QueryChunksResponse>
+
+        /// Handle the "WriteChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_WriteChunksRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Wendy_Agent_Services_V1_WriteChunksResponse` message.
+        func writeChunks(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_WriteChunksRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_WriteChunksResponse>
+
+        /// Handle the "QueryLayers" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > QueryLayers reports which uncompressed layers (by diff ID) the device
+        /// > already has in its content store, with their sizes. The CLI uses this to
+        /// > skip decompressing and content-chunking layers the device can reuse as-is
+        /// > — for those layers no dedup is possible, so chunking would be pure waste.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_QueryLayersRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Wendy_Agent_Services_V1_QueryLayersResponse` message.
+        func queryLayers(
+            request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_QueryLayersRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_QueryLayersResponse>
     }
 
     /// Simple service protocol for the "wendy.agent.services.v1.WendyContainerService" service.
@@ -797,6 +1063,98 @@ extension Wendy_Agent_Services_V1_WendyContainerService {
             request: Wendy_Agent_Services_V1_ListContainerStatsRequest,
             context: GRPCCore.ServerContext
         ) async throws -> Wendy_Agent_Services_V1_ListContainerStatsResponse
+
+        /// Handle the "GetResourceStats" method.
+        ///
+        /// - Parameters:
+        ///   - request: A `Wendy_Agent_Services_V1_GetResourceStatsRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Wendy_Agent_Services_V1_GetResourceStatsResponse` to respond with.
+        func getResourceStats(
+            request: Wendy_Agent_Services_V1_GetResourceStatsRequest,
+            context: GRPCCore.ServerContext
+        ) async throws -> Wendy_Agent_Services_V1_GetResourceStatsResponse
+
+        /// Handle the "GetContainerPorts" method.
+        ///
+        /// - Parameters:
+        ///   - request: A `Wendy_Agent_Services_V1_GetContainerPortsRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Wendy_Agent_Services_V1_GetContainerPortsResponse` to respond with.
+        func getContainerPorts(
+            request: Wendy_Agent_Services_V1_GetContainerPortsRequest,
+            context: GRPCCore.ServerContext
+        ) async throws -> Wendy_Agent_Services_V1_GetContainerPortsResponse
+
+        /// Handle the "StreamMCP" method.
+        ///
+        /// - Parameters:
+        ///   - request: A stream of `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - response: A response stream of `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        func streamMCP(
+            request: GRPCCore.RPCAsyncSequence<Wendy_Agent_Services_V1_MCPChunk, any Swift.Error>,
+            response: GRPCCore.RPCWriter<Wendy_Agent_Services_V1_MCPChunk>,
+            context: GRPCCore.ServerContext
+        ) async throws
+
+        /// Handle the "QueryChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A `Wendy_Agent_Services_V1_QueryChunksRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Wendy_Agent_Services_V1_QueryChunksResponse` to respond with.
+        func queryChunks(
+            request: Wendy_Agent_Services_V1_QueryChunksRequest,
+            context: GRPCCore.ServerContext
+        ) async throws -> Wendy_Agent_Services_V1_QueryChunksResponse
+
+        /// Handle the "WriteChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A stream of `Wendy_Agent_Services_V1_WriteChunksRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Wendy_Agent_Services_V1_WriteChunksResponse` to respond with.
+        func writeChunks(
+            request: GRPCCore.RPCAsyncSequence<Wendy_Agent_Services_V1_WriteChunksRequest, any Swift.Error>,
+            context: GRPCCore.ServerContext
+        ) async throws -> Wendy_Agent_Services_V1_WriteChunksResponse
+
+        /// Handle the "QueryLayers" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > QueryLayers reports which uncompressed layers (by diff ID) the device
+        /// > already has in its content store, with their sizes. The CLI uses this to
+        /// > skip decompressing and content-chunking layers the device can reuse as-is
+        /// > — for those layers no dedup is possible, so chunking would be pure waste.
+        ///
+        /// - Parameters:
+        ///   - request: A `Wendy_Agent_Services_V1_QueryLayersRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Wendy_Agent_Services_V1_QueryLayersResponse` to respond with.
+        func queryLayers(
+            request: Wendy_Agent_Services_V1_QueryLayersRequest,
+            context: GRPCCore.ServerContext
+        ) async throws -> Wendy_Agent_Services_V1_QueryLayersResponse
     }
 }
 
@@ -947,6 +1305,72 @@ extension Wendy_Agent_Services_V1_WendyContainerService.StreamingServiceProtocol
                 )
             }
         )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyContainerService.Method.GetResourceStats.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_GetResourceStatsRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_GetResourceStatsResponse>(),
+            handler: { request, context in
+                try await self.getResourceStats(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyContainerService.Method.GetContainerPorts.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_GetContainerPortsRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_GetContainerPortsResponse>(),
+            handler: { request, context in
+                try await self.getContainerPorts(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyContainerService.Method.StreamMCP.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_MCPChunk>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_MCPChunk>(),
+            handler: { request, context in
+                try await self.streamMCP(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyContainerService.Method.QueryChunks.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_QueryChunksRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_QueryChunksResponse>(),
+            handler: { request, context in
+                try await self.queryChunks(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyContainerService.Method.WriteChunks.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_WriteChunksRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_WriteChunksResponse>(),
+            handler: { request, context in
+                try await self.writeChunks(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyContainerService.Method.QueryLayers.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_QueryLayersRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_QueryLayersResponse>(),
+            handler: { request, context in
+                try await self.queryLayers(
+                    request: request,
+                    context: context
+                )
+            }
+        )
     }
 }
 
@@ -1068,6 +1492,61 @@ extension Wendy_Agent_Services_V1_WendyContainerService.ServiceProtocol {
         context: GRPCCore.ServerContext
     ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_ListContainerStatsResponse> {
         let response = try await self.listContainerStats(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
+    }
+
+    public func getResourceStats(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse> {
+        let response = try await self.getResourceStats(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
+    }
+
+    public func getContainerPorts(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse> {
+        let response = try await self.getContainerPorts(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
+    }
+
+    public func queryChunks(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_QueryChunksRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_QueryChunksResponse> {
+        let response = try await self.queryChunks(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
+    }
+
+    public func writeChunks(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_WriteChunksRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_WriteChunksResponse> {
+        let response = try await self.writeChunks(
+            request: request,
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
+    }
+
+    public func queryLayers(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_QueryLayersRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_QueryLayersResponse> {
+        let response = try await self.queryLayers(
             request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
@@ -1268,6 +1747,88 @@ extension Wendy_Agent_Services_V1_WendyContainerService.SimpleServiceProtocol {
     ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_ListContainerStatsResponse> {
         return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_ListContainerStatsResponse>(
             message: try await self.listContainerStats(
+                request: request.message,
+                context: context
+            ),
+            metadata: [:]
+        )
+    }
+
+    public func getResourceStats(
+        request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse> {
+        return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse>(
+            message: try await self.getResourceStats(
+                request: request.message,
+                context: context
+            ),
+            metadata: [:]
+        )
+    }
+
+    public func getContainerPorts(
+        request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse> {
+        return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse>(
+            message: try await self.getContainerPorts(
+                request: request.message,
+                context: context
+            ),
+            metadata: [:]
+        )
+    }
+
+    public func streamMCP(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_MCPChunk>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_MCPChunk> {
+        return GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_MCPChunk>(
+            metadata: [:],
+            producer: { writer in
+                try await self.streamMCP(
+                    request: request.messages,
+                    response: writer,
+                    context: context
+                )
+                return [:]
+            }
+        )
+    }
+
+    public func queryChunks(
+        request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_QueryChunksRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_QueryChunksResponse> {
+        return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_QueryChunksResponse>(
+            message: try await self.queryChunks(
+                request: request.message,
+                context: context
+            ),
+            metadata: [:]
+        )
+    }
+
+    public func writeChunks(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_WriteChunksRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_WriteChunksResponse> {
+        return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_WriteChunksResponse>(
+            message: try await self.writeChunks(
+                request: request.messages,
+                context: context
+            ),
+            metadata: [:]
+        )
+    }
+
+    public func queryLayers(
+        request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_QueryLayersRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_QueryLayersResponse> {
+        return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_QueryLayersResponse>(
+            message: try await self.queryLayers(
                 request: request.message,
                 context: context
             ),
@@ -1530,6 +2091,127 @@ extension Wendy_Agent_Services_V1_WendyContainerService {
             deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_ListContainerStatsResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_ListContainerStatsResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "GetResourceStats" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetResourceStatsRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_GetResourceStatsRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_GetResourceStatsResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func getResourceStats<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_GetResourceStatsResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "GetContainerPorts" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetContainerPortsRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_GetContainerPortsRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_GetContainerPortsResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func getContainerPorts<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_GetContainerPortsResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "StreamMCP" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request producing `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func streamMCP<Result>(
+            request: GRPCCore.StreamingClientRequest<Wendy_Agent_Services_V1_MCPChunk>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_MCPChunk>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_MCPChunk>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendy_Agent_Services_V1_MCPChunk>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "QueryChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_QueryChunksRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_QueryChunksRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_QueryChunksResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func queryChunks<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_QueryChunksRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_QueryChunksRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_QueryChunksResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_QueryChunksResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "WriteChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request producing `Wendy_Agent_Services_V1_WriteChunksRequest` messages.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_WriteChunksRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_WriteChunksResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func writeChunks<Result>(
+            request: GRPCCore.StreamingClientRequest<Wendy_Agent_Services_V1_WriteChunksRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_WriteChunksRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_WriteChunksResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_WriteChunksResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "QueryLayers" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > QueryLayers reports which uncompressed layers (by diff ID) the device
+        /// > already has in its content store, with their sizes. The CLI uses this to
+        /// > skip decompressing and content-chunking layers the device can reuse as-is
+        /// > — for those layers no dedup is possible, so chunking would be pure waste.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_QueryLayersRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_QueryLayersRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_QueryLayersResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func queryLayers<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_QueryLayersRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_QueryLayersRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_QueryLayersResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_QueryLayersResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
     }
 
@@ -1924,6 +2606,191 @@ extension Wendy_Agent_Services_V1_WendyContainerService {
                 onResponse: handleResponse
             )
         }
+
+        /// Call the "GetResourceStats" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetResourceStatsRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_GetResourceStatsRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_GetResourceStatsResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func getResourceStats<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_GetResourceStatsResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyContainerService.Method.GetResourceStats.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "GetContainerPorts" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetContainerPortsRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_GetContainerPortsRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_GetContainerPortsResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func getContainerPorts<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_GetContainerPortsResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyContainerService.Method.GetContainerPorts.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "StreamMCP" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request producing `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_MCPChunk` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func streamMCP<Result>(
+            request: GRPCCore.StreamingClientRequest<Wendy_Agent_Services_V1_MCPChunk>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_MCPChunk>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_MCPChunk>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendy_Agent_Services_V1_MCPChunk>) async throws -> Result
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.bidirectionalStreaming(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyContainerService.Method.StreamMCP.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "QueryChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_QueryChunksRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_QueryChunksRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_QueryChunksResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func queryChunks<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_QueryChunksRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_QueryChunksRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_QueryChunksResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_QueryChunksResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyContainerService.Method.QueryChunks.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "WriteChunks" method.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request producing `Wendy_Agent_Services_V1_WriteChunksRequest` messages.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_WriteChunksRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_WriteChunksResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func writeChunks<Result>(
+            request: GRPCCore.StreamingClientRequest<Wendy_Agent_Services_V1_WriteChunksRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_WriteChunksRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_WriteChunksResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_WriteChunksResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.clientStreaming(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyContainerService.Method.WriteChunks.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "QueryLayers" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > QueryLayers reports which uncompressed layers (by diff ID) the device
+        /// > already has in its content store, with their sizes. The CLI uses this to
+        /// > skip decompressing and content-chunking layers the device can reuse as-is
+        /// > — for those layers no dedup is possible, so chunking would be pure waste.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_QueryLayersRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_QueryLayersRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_QueryLayersResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func queryLayers<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_QueryLayersRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_QueryLayersRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_QueryLayersResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_QueryLayersResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyContainerService.Method.QueryLayers.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
     }
 }
 
@@ -2236,6 +3103,161 @@ extension Wendy_Agent_Services_V1_WendyContainerService.ClientProtocol {
             request: request,
             serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_ListContainerStatsRequest>(),
             deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_ListContainerStatsResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "GetResourceStats" method.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetResourceStatsRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func getResourceStats<Result>(
+        request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetResourceStatsRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.getResourceStats(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_GetResourceStatsRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_GetResourceStatsResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "GetContainerPorts" method.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetContainerPortsRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func getContainerPorts<Result>(
+        request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetContainerPortsRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.getContainerPorts(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_GetContainerPortsRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_GetContainerPortsResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "StreamMCP" method.
+    ///
+    /// - Parameters:
+    ///   - request: A streaming request producing `Wendy_Agent_Services_V1_MCPChunk` messages.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func streamMCP<Result>(
+        request: GRPCCore.StreamingClientRequest<Wendy_Agent_Services_V1_MCPChunk>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendy_Agent_Services_V1_MCPChunk>) async throws -> Result
+    ) async throws -> Result where Result: Sendable {
+        try await self.streamMCP(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_MCPChunk>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_MCPChunk>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "QueryChunks" method.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Wendy_Agent_Services_V1_QueryChunksRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func queryChunks<Result>(
+        request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_QueryChunksRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_QueryChunksResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.queryChunks(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_QueryChunksRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_QueryChunksResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "WriteChunks" method.
+    ///
+    /// - Parameters:
+    ///   - request: A streaming request producing `Wendy_Agent_Services_V1_WriteChunksRequest` messages.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func writeChunks<Result>(
+        request: GRPCCore.StreamingClientRequest<Wendy_Agent_Services_V1_WriteChunksRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_WriteChunksResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.writeChunks(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_WriteChunksRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_WriteChunksResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "QueryLayers" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > QueryLayers reports which uncompressed layers (by diff ID) the device
+    /// > already has in its content store, with their sizes. The CLI uses this to
+    /// > skip decompressing and content-chunking layers the device can reuse as-is
+    /// > — for those layers no dedup is possible, so chunking would be pure waste.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Wendy_Agent_Services_V1_QueryLayersRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func queryLayers<Result>(
+        request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_QueryLayersRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_QueryLayersResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.queryLayers(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_QueryLayersRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_QueryLayersResponse>(),
             options: options,
             onResponse: handleResponse
         )
@@ -2604,6 +3626,187 @@ extension Wendy_Agent_Services_V1_WendyContainerService.ClientProtocol {
             metadata: metadata
         )
         return try await self.listContainerStats(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "GetResourceStats" method.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func getResourceStats<Result>(
+        _ message: Wendy_Agent_Services_V1_GetResourceStatsRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetResourceStatsResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetResourceStatsRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.getResourceStats(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "GetContainerPorts" method.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func getContainerPorts<Result>(
+        _ message: Wendy_Agent_Services_V1_GetContainerPortsRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetContainerPortsResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetContainerPortsRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.getContainerPorts(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "StreamMCP" method.
+    ///
+    /// - Parameters:
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - producer: A closure producing request messages to send to the server. The request
+    ///       stream is closed when the closure returns.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func streamMCP<Result>(
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        requestProducer producer: @Sendable @escaping (GRPCCore.RPCWriter<Wendy_Agent_Services_V1_MCPChunk>) async throws -> Void,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendy_Agent_Services_V1_MCPChunk>) async throws -> Result
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.StreamingClientRequest<Wendy_Agent_Services_V1_MCPChunk>(
+            metadata: metadata,
+            producer: producer
+        )
+        return try await self.streamMCP(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "QueryChunks" method.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func queryChunks<Result>(
+        _ message: Wendy_Agent_Services_V1_QueryChunksRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_QueryChunksResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Wendy_Agent_Services_V1_QueryChunksRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.queryChunks(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "WriteChunks" method.
+    ///
+    /// - Parameters:
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - producer: A closure producing request messages to send to the server. The request
+    ///       stream is closed when the closure returns.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func writeChunks<Result>(
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        requestProducer producer: @Sendable @escaping (GRPCCore.RPCWriter<Wendy_Agent_Services_V1_WriteChunksRequest>) async throws -> Void,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_WriteChunksResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.StreamingClientRequest<Wendy_Agent_Services_V1_WriteChunksRequest>(
+            metadata: metadata,
+            producer: producer
+        )
+        return try await self.writeChunks(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "QueryLayers" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > QueryLayers reports which uncompressed layers (by diff ID) the device
+    /// > already has in its content store, with their sizes. The CLI uses this to
+    /// > skip decompressing and content-chunking layers the device can reuse as-is
+    /// > — for those layers no dedup is possible, so chunking would be pure waste.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func queryLayers<Result>(
+        _ message: Wendy_Agent_Services_V1_QueryLayersRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_QueryLayersResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Wendy_Agent_Services_V1_QueryLayersRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.queryLayers(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.pb.swift
@@ -20,12 +20,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public struct Wendy_Agent_Services_V1_ListContainersRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListContainersRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -35,7 +35,7 @@ public struct Wendy_Agent_Services_V1_ListContainersRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ListContainersResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListContainersResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -56,7 +56,7 @@ public struct Wendy_Agent_Services_V1_ListContainersResponse: Sendable {
   fileprivate var _container: AppContainer? = nil
 }
 
-public struct Wendy_Agent_Services_V1_ListLayersRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListLayersRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -66,7 +66,7 @@ public struct Wendy_Agent_Services_V1_ListLayersRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_WriteLayerRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WriteLayerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -80,7 +80,7 @@ public struct Wendy_Agent_Services_V1_WriteLayerRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_WriteLayerResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_WriteLayerResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -90,7 +90,104 @@ public struct Wendy_Agent_Services_V1_WriteLayerResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_LayerHeader: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_QueryChunksRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Candidate chunk hashes (raw 32-byte sha256 digests).
+  public var chunkHashes: [Data] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_QueryChunksResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Subset of the requested hashes that the device does NOT have.
+  public var missingHashes: [Data] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_WriteChunksRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// raw 32-byte sha256 of data
+  public var hash: Data = Data()
+
+  public var data: Data = Data()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_WriteChunksResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_QueryLayersRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Uncompressed layer digests (diff IDs, "sha256:<hex>") to check for
+  /// presence in the device's content store.
+  public var diffIds: [String] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_QueryLayersResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The subset of the requested layers the device already has. Layers absent
+  /// from this list are not present and must be pushed.
+  public var present: [Wendy_Agent_Services_V1_PresentLayer] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_PresentLayer: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The uncompressed layer digest (diff ID) that the device has.
+  public var diffID: String = String()
+
+  /// Uncompressed blob size as stored in the content store. The CLI puts this
+  /// in the reassembly header so AssembleImage references the layer correctly
+  /// without the CLI having to decompress it to learn its size.
+  public var size: Int64 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_LayerHeader: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -105,7 +202,7 @@ public struct Wendy_Agent_Services_V1_LayerHeader: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_RunContainerLayersRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_RunContainerLayersRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -139,6 +236,12 @@ public struct Wendy_Agent_Services_V1_RunContainerLayersRequest: Sendable {
   /// User-provided runtime arguments to append to the container entrypoint.
   public var userArgs: [String] = []
 
+  /// OCI image config JSON (the config blob produced by the image builder),
+  /// carrying Cmd/Entrypoint/Env/WorkingDir/User. Required by the chunk-diff
+  /// path so the assembled image preserves the original runtime config; when
+  /// empty the agent synthesises a minimal config (legacy behaviour).
+  public var imageConfig: Data = Data()
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -146,7 +249,7 @@ public struct Wendy_Agent_Services_V1_RunContainerLayersRequest: Sendable {
   fileprivate var _restartPolicy: RestartPolicy? = nil
 }
 
-public struct Wendy_Agent_Services_V1_CreateContainerRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_CreateContainerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -172,6 +275,11 @@ public struct Wendy_Agent_Services_V1_CreateContainerRequest: Sendable {
 
   public var userArgs: [String] = []
 
+  /// Additional environment variables to inject. Format: "KEY=VALUE".
+  /// Applied after the image's built-in env and before Wendy system env vars,
+  /// so Wendy vars always win.
+  public var env: [String] = []
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -179,7 +287,7 @@ public struct Wendy_Agent_Services_V1_CreateContainerRequest: Sendable {
   fileprivate var _restartPolicy: RestartPolicy? = nil
 }
 
-public struct Wendy_Agent_Services_V1_CreateContainerResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_CreateContainerResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -189,7 +297,7 @@ public struct Wendy_Agent_Services_V1_CreateContainerResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_CreateContainerProgress: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_CreateContainerProgress: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -206,7 +314,7 @@ public struct Wendy_Agent_Services_V1_CreateContainerProgress: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum Phase: SwiftProtobuf.Enum, Swift.CaseIterable {
+  public nonisolated enum Phase: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case unpacking // = 1
@@ -255,7 +363,7 @@ public struct Wendy_Agent_Services_V1_CreateContainerProgress: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_CreateContainerProgressResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_CreateContainerProgressResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -280,7 +388,7 @@ public struct Wendy_Agent_Services_V1_CreateContainerProgressResponse: Sendable 
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_ResponseType: Equatable, Sendable {
+  public nonisolated enum OneOf_ResponseType: Equatable, Sendable {
     case progress(Wendy_Agent_Services_V1_CreateContainerProgress)
     case completed(Wendy_Agent_Services_V1_CreateContainerResponse)
 
@@ -289,21 +397,33 @@ public struct Wendy_Agent_Services_V1_CreateContainerProgressResponse: Sendable 
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_StartContainerRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StartContainerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   public var appName: String = String()
 
+  /// Optional restart policy override. When unset the agent uses its default.
+  public var restartPolicy: RestartPolicy {
+    get {_restartPolicy ?? RestartPolicy()}
+    set {_restartPolicy = newValue}
+  }
+  /// Returns true if `restartPolicy` has been explicitly set.
+  public var hasRestartPolicy: Bool {self._restartPolicy != nil}
+  /// Clears the value of `restartPolicy`. Subsequent reads from it will return its default value.
+  public mutating func clearRestartPolicy() {self._restartPolicy = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _restartPolicy: RestartPolicy? = nil
 }
 
 /// AttachContainerRequest is the client-to-server message for AttachContainer.
 /// The first message must set app_name; subsequent messages carry stdin data.
-public struct Wendy_Agent_Services_V1_AttachContainerRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_AttachContainerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -328,7 +448,7 @@ public struct Wendy_Agent_Services_V1_AttachContainerRequest: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_RequestType: Equatable, Sendable {
+  public nonisolated enum OneOf_RequestType: Equatable, Sendable {
     case appName(String)
     case stdinData(Data)
 
@@ -337,7 +457,7 @@ public struct Wendy_Agent_Services_V1_AttachContainerRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_RunContainerLayerHeader: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_RunContainerLayerHeader: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -350,14 +470,65 @@ public struct Wendy_Agent_Services_V1_RunContainerLayerHeader: Sendable {
   public var diffID: String = String()
 
   /// Whether the layer is compressed with gzip.
+  /// Deprecated: use compression instead. Kept for backward compatibility with
+  /// older CLIs that do not send the compression field.
   public var gzip: Bool = false
 
+  /// Compression format of the layer blob. When set to a non-zero value,
+  /// takes precedence over the gzip field.
+  public var compression: Wendy_Agent_Services_V1_RunContainerLayerHeader.CompressionType = .compressionGzip
+
+  /// Ordered list of chunk hashes (raw 32-byte sha256) that, concatenated in
+  /// order, reconstruct the uncompressed layer tar. When set, the agent
+  /// reassembles the layer from chunks instead of receiving inline bytes.
+  public var chunkHashes: [Data] = []
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public nonisolated enum CompressionType: SwiftProtobuf.Enum, Swift.CaseIterable {
+    public typealias RawValue = Int
+
+    /// default; treated as gzip when gzip=true, uncompressed when gzip=false
+    case compressionGzip // = 0
+    case compressionZstd // = 1
+    case compressionNone // = 2
+    case UNRECOGNIZED(Int)
+
+    public init() {
+      self = .compressionGzip
+    }
+
+    public init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .compressionGzip
+      case 1: self = .compressionZstd
+      case 2: self = .compressionNone
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    public var rawValue: Int {
+      switch self {
+      case .compressionGzip: return 0
+      case .compressionZstd: return 1
+      case .compressionNone: return 2
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Wendy_Agent_Services_V1_RunContainerLayerHeader.CompressionType] = [
+      .compressionGzip,
+      .compressionZstd,
+      .compressionNone,
+    ]
+
+  }
 
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_RunContainerLayersResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_RunContainerLayersResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -390,14 +561,14 @@ public struct Wendy_Agent_Services_V1_RunContainerLayersResponse: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_ResponseType: Equatable, Sendable {
+  public nonisolated enum OneOf_ResponseType: Equatable, Sendable {
     case started(Wendy_Agent_Services_V1_RunContainerLayersResponse.Started)
     case stdoutOutput(Wendy_Agent_Services_V1_RunContainerLayersResponse.ConsoleOutput)
     case stderrOutput(Wendy_Agent_Services_V1_RunContainerLayersResponse.ConsoleOutput)
 
   }
 
-  public struct Started: Sendable {
+  public nonisolated struct Started: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -407,7 +578,7 @@ public struct Wendy_Agent_Services_V1_RunContainerLayersResponse: Sendable {
     public init() {}
   }
 
-  public struct ConsoleOutput: Sendable {
+  public nonisolated struct ConsoleOutput: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -422,7 +593,7 @@ public struct Wendy_Agent_Services_V1_RunContainerLayersResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_StopContainerRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StopContainerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -434,7 +605,7 @@ public struct Wendy_Agent_Services_V1_StopContainerRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_StopContainerResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StopContainerResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -444,7 +615,7 @@ public struct Wendy_Agent_Services_V1_StopContainerResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_DeleteContainerRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_DeleteContainerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -462,7 +633,7 @@ public struct Wendy_Agent_Services_V1_DeleteContainerRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_DeleteContainerResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_DeleteContainerResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -472,7 +643,7 @@ public struct Wendy_Agent_Services_V1_DeleteContainerResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ListVolumesRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListVolumesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -482,7 +653,7 @@ public struct Wendy_Agent_Services_V1_ListVolumesRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_VolumeInfo: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_VolumeInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -503,7 +674,7 @@ public struct Wendy_Agent_Services_V1_VolumeInfo: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ListVolumesResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListVolumesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -515,7 +686,7 @@ public struct Wendy_Agent_Services_V1_ListVolumesResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_RemoveVolumeRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_RemoveVolumeRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -527,7 +698,7 @@ public struct Wendy_Agent_Services_V1_RemoveVolumeRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_RemoveVolumeResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_RemoveVolumeResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -537,7 +708,7 @@ public struct Wendy_Agent_Services_V1_RemoveVolumeResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ContainerStats: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ContainerStats: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -555,7 +726,7 @@ public struct Wendy_Agent_Services_V1_ContainerStats: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ListContainerStatsRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListContainerStatsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -565,7 +736,7 @@ public struct Wendy_Agent_Services_V1_ListContainerStatsRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ListContainerStatsResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListContainerStatsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -577,11 +748,210 @@ public struct Wendy_Agent_Services_V1_ListContainerStatsResponse: Sendable {
   public init() {}
 }
 
+public nonisolated struct Wendy_Agent_Services_V1_GetResourceStatsRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_GetResourceStatsResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var host: Wendy_Agent_Services_V1_HostStats {
+    get {_host ?? Wendy_Agent_Services_V1_HostStats()}
+    set {_host = newValue}
+  }
+  /// Returns true if `host` has been explicitly set.
+  public var hasHost: Bool {self._host != nil}
+  /// Clears the value of `host`. Subsequent reads from it will return its default value.
+  public mutating func clearHost() {self._host = nil}
+
+  public var containers: [Wendy_Agent_Services_V1_ResourceContainerStats] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _host: Wendy_Agent_Services_V1_HostStats? = nil
+}
+
+/// HostStats carries cumulative host counters; the client computes percentages
+/// from deltas between consecutive samples.
+public nonisolated struct Wendy_Agent_Services_V1_HostStats: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// sum of all fields on the /proc/stat "cpu" line
+  public var cpuTotalJiffies: UInt64 = 0
+
+  /// idle + iowait fields
+  public var cpuIdleJiffies: UInt64 = 0
+
+  /// online logical CPUs
+  public var cpuCount: UInt32 = 0
+
+  public var memTotalBytes: Int64 = 0
+
+  public var memAvailableBytes: Int64 = 0
+
+  /// empty when no GPU / no sampler tool present
+  public var gpus: [Wendy_Agent_Services_V1_GpuStats] = []
+
+  /// Every readable thermal sensor on the device (CPU, GPU, SoC, junction, …),
+  /// from /sys/class/thermal. Empty when no zones are readable.
+  public var thermalZones: [Wendy_Agent_Services_V1_ThermalZone] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// ThermalZone is one temperature sensor read from /sys/class/thermal.
+public nonisolated struct Wendy_Agent_Services_V1_ThermalZone: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// sensor type, e.g. "cpu-thermal", "gpu-thermal", "soc0-thermal", "tj-thermal"
+  public var name: String = String()
+
+  /// current temperature in degrees Celsius
+  public var tempC: Double = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_GpuStats: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var index: UInt32 = 0
+
+  public var name: String = String()
+
+  /// instantaneous utilization as reported by the sampler
+  public var utilPercent: Double = 0
+
+  public var memUsedBytes: Int64 = 0
+
+  public var memTotalBytes: Int64 = 0
+
+  public var tempC: Double {
+    get {_tempC ?? 0}
+    set {_tempC = newValue}
+  }
+  /// Returns true if `tempC` has been explicitly set.
+  public var hasTempC: Bool {self._tempC != nil}
+  /// Clears the value of `tempC`. Subsequent reads from it will return its default value.
+  public mutating func clearTempC() {self._tempC = nil}
+
+  public var powerW: Double {
+    get {_powerW ?? 0}
+    set {_powerW = newValue}
+  }
+  /// Returns true if `powerW` has been explicitly set.
+  public var hasPowerW: Bool {self._powerW != nil}
+  /// Clears the value of `powerW`. Subsequent reads from it will return its default value.
+  public mutating func clearPowerW() {self._powerW = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _tempC: Double? = nil
+  fileprivate var _powerW: Double? = nil
+}
+
+/// ResourceContainerStats mirrors ContainerStats keying: app_name is the
+/// containerd container ID (appID, or appID_serviceName for multi-service apps).
+public nonisolated struct Wendy_Agent_Services_V1_ResourceContainerStats: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var appName: String = String()
+
+  /// cumulative user+sys CPU nanoseconds
+  public var cpuUsageNanos: UInt64 = 0
+
+  /// current cgroup memory usage
+  public var memoryBytes: Int64 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_GetContainerPortsRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var appName: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_GetContainerPortsResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var ports: [Wendy_Agent_Services_V1_PortEntry] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_PortEntry: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// "tcp", "tcp6", "udp", "udp6"
+  public var `protocol`: String = String()
+
+  /// local port the socket is bound to
+  public var port: UInt32 = 0
+
+  /// local bind address (e.g. "0.0.0.0", "::", "127.0.0.1")
+  public var address: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_MCPChunk: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var data: Data = Data()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendy.agent.services.v1"
+fileprivate nonisolated let _protobuf_package = "wendy.agent.services.v1"
 
-extension Wendy_Agent_Services_V1_ListContainersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListContainersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListContainersRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -600,7 +970,7 @@ extension Wendy_Agent_Services_V1_ListContainersRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendy_Agent_Services_V1_ListContainersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListContainersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListContainersResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}container\0")
 
@@ -634,7 +1004,7 @@ extension Wendy_Agent_Services_V1_ListContainersResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Wendy_Agent_Services_V1_ListLayersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListLayersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListLayersRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -653,7 +1023,7 @@ extension Wendy_Agent_Services_V1_ListLayersRequest: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Wendy_Agent_Services_V1_WriteLayerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WriteLayerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WriteLayerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}digest\0\u{1}data\0")
 
@@ -688,7 +1058,7 @@ extension Wendy_Agent_Services_V1_WriteLayerRequest: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Wendy_Agent_Services_V1_WriteLayerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WriteLayerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WriteLayerResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -707,7 +1077,216 @@ extension Wendy_Agent_Services_V1_WriteLayerResponse: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_LayerHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_QueryChunksRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".QueryChunksRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}chunk_hashes\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedBytesField(value: &self.chunkHashes) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.chunkHashes.isEmpty {
+      try visitor.visitRepeatedBytesField(value: self.chunkHashes, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_QueryChunksRequest, rhs: Wendy_Agent_Services_V1_QueryChunksRequest) -> Bool {
+    if lhs.chunkHashes != rhs.chunkHashes {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_QueryChunksResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".QueryChunksResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}missing_hashes\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedBytesField(value: &self.missingHashes) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.missingHashes.isEmpty {
+      try visitor.visitRepeatedBytesField(value: self.missingHashes, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_QueryChunksResponse, rhs: Wendy_Agent_Services_V1_QueryChunksResponse) -> Bool {
+    if lhs.missingHashes != rhs.missingHashes {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_WriteChunksRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".WriteChunksRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}hash\0\u{1}data\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBytesField(value: &self.hash) }()
+      case 2: try { try decoder.decodeSingularBytesField(value: &self.data) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.hash.isEmpty {
+      try visitor.visitSingularBytesField(value: self.hash, fieldNumber: 1)
+    }
+    if !self.data.isEmpty {
+      try visitor.visitSingularBytesField(value: self.data, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_WriteChunksRequest, rhs: Wendy_Agent_Services_V1_WriteChunksRequest) -> Bool {
+    if lhs.hash != rhs.hash {return false}
+    if lhs.data != rhs.data {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_WriteChunksResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".WriteChunksResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_WriteChunksResponse, rhs: Wendy_Agent_Services_V1_WriteChunksResponse) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_QueryLayersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".QueryLayersRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}diff_ids\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedStringField(value: &self.diffIds) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.diffIds.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.diffIds, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_QueryLayersRequest, rhs: Wendy_Agent_Services_V1_QueryLayersRequest) -> Bool {
+    if lhs.diffIds != rhs.diffIds {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_QueryLayersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".QueryLayersResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}present\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.present) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.present.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.present, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_QueryLayersResponse, rhs: Wendy_Agent_Services_V1_QueryLayersResponse) -> Bool {
+    if lhs.present != rhs.present {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_PresentLayer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".PresentLayer"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}diff_id\0\u{1}size\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.diffID) }()
+      case 2: try { try decoder.decodeSingularInt64Field(value: &self.size) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.diffID.isEmpty {
+      try visitor.visitSingularStringField(value: self.diffID, fieldNumber: 1)
+    }
+    if self.size != 0 {
+      try visitor.visitSingularInt64Field(value: self.size, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_PresentLayer, rhs: Wendy_Agent_Services_V1_PresentLayer) -> Bool {
+    if lhs.diffID != rhs.diffID {return false}
+    if lhs.size != rhs.size {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_LayerHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".LayerHeader"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}digest\0\u{1}size\0")
 
@@ -742,9 +1321,9 @@ extension Wendy_Agent_Services_V1_LayerHeader: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerLayersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerLayersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RunContainerLayersRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}image_name\0\u{3}app_name\0\u{1}cmd\0\u{1}layers\0\u{3}app_config\0\u{3}restart_policy\0\u{3}working_dir\0\u{3}user_args\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}image_name\0\u{3}app_name\0\u{1}cmd\0\u{1}layers\0\u{3}app_config\0\u{3}restart_policy\0\u{3}working_dir\0\u{3}user_args\0\u{3}image_config\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -760,6 +1339,7 @@ extension Wendy_Agent_Services_V1_RunContainerLayersRequest: SwiftProtobuf.Messa
       case 6: try { try decoder.decodeSingularMessageField(value: &self._restartPolicy) }()
       case 7: try { try decoder.decodeSingularStringField(value: &self.workingDir) }()
       case 8: try { try decoder.decodeRepeatedStringField(value: &self.userArgs) }()
+      case 9: try { try decoder.decodeSingularBytesField(value: &self.imageConfig) }()
       default: break
       }
     }
@@ -794,6 +1374,9 @@ extension Wendy_Agent_Services_V1_RunContainerLayersRequest: SwiftProtobuf.Messa
     if !self.userArgs.isEmpty {
       try visitor.visitRepeatedStringField(value: self.userArgs, fieldNumber: 8)
     }
+    if !self.imageConfig.isEmpty {
+      try visitor.visitSingularBytesField(value: self.imageConfig, fieldNumber: 9)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -806,14 +1389,15 @@ extension Wendy_Agent_Services_V1_RunContainerLayersRequest: SwiftProtobuf.Messa
     if lhs._restartPolicy != rhs._restartPolicy {return false}
     if lhs.workingDir != rhs.workingDir {return false}
     if lhs.userArgs != rhs.userArgs {return false}
+    if lhs.imageConfig != rhs.imageConfig {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_CreateContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_CreateContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateContainerRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}image_name\0\u{3}app_name\0\u{1}cmd\0\u{3}app_config\0\u{3}working_dir\0\u{3}restart_policy\0\u{3}user_args\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}image_name\0\u{3}app_name\0\u{1}cmd\0\u{3}app_config\0\u{3}working_dir\0\u{3}restart_policy\0\u{3}user_args\0\u{1}env\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -828,6 +1412,7 @@ extension Wendy_Agent_Services_V1_CreateContainerRequest: SwiftProtobuf.Message,
       case 5: try { try decoder.decodeSingularStringField(value: &self.workingDir) }()
       case 6: try { try decoder.decodeSingularMessageField(value: &self._restartPolicy) }()
       case 7: try { try decoder.decodeRepeatedStringField(value: &self.userArgs) }()
+      case 8: try { try decoder.decodeRepeatedStringField(value: &self.env) }()
       default: break
       }
     }
@@ -859,6 +1444,9 @@ extension Wendy_Agent_Services_V1_CreateContainerRequest: SwiftProtobuf.Message,
     if !self.userArgs.isEmpty {
       try visitor.visitRepeatedStringField(value: self.userArgs, fieldNumber: 7)
     }
+    if !self.env.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.env, fieldNumber: 8)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -870,12 +1458,13 @@ extension Wendy_Agent_Services_V1_CreateContainerRequest: SwiftProtobuf.Message,
     if lhs.workingDir != rhs.workingDir {return false}
     if lhs._restartPolicy != rhs._restartPolicy {return false}
     if lhs.userArgs != rhs.userArgs {return false}
+    if lhs.env != rhs.env {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_CreateContainerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_CreateContainerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateContainerResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -894,7 +1483,7 @@ extension Wendy_Agent_Services_V1_CreateContainerResponse: SwiftProtobuf.Message
   }
 }
 
-extension Wendy_Agent_Services_V1_CreateContainerProgress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_CreateContainerProgress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateContainerProgress"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phase\0\u{3}layer_index\0\u{3}total_layers\0\u{3}layer_size\0\u{3}reused_snapshot\0")
 
@@ -944,11 +1533,11 @@ extension Wendy_Agent_Services_V1_CreateContainerProgress: SwiftProtobuf.Message
   }
 }
 
-extension Wendy_Agent_Services_V1_CreateContainerProgress.Phase: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_CreateContainerProgress.Phase: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PHASE_UNSPECIFIED\0\u{1}UNPACKING\0\u{1}APPLYING_LAYER\0\u{1}CREATING_CONTAINER\0\u{1}COMPLETE\0")
 }
 
-extension Wendy_Agent_Services_V1_CreateContainerProgressResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_CreateContainerProgressResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateContainerProgressResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}progress\0\u{1}completed\0")
 
@@ -1015,9 +1604,9 @@ extension Wendy_Agent_Services_V1_CreateContainerProgressResponse: SwiftProtobuf
   }
 }
 
-extension Wendy_Agent_Services_V1_StartContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StartContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StartContainerRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0\u{3}restart_policy\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1026,26 +1615,35 @@ extension Wendy_Agent_Services_V1_StartContainerRequest: SwiftProtobuf.Message, 
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.appName) }()
+      case 2: try { try decoder.decodeSingularMessageField(value: &self._restartPolicy) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.appName.isEmpty {
       try visitor.visitSingularStringField(value: self.appName, fieldNumber: 1)
     }
+    try { if let v = self._restartPolicy {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Wendy_Agent_Services_V1_StartContainerRequest, rhs: Wendy_Agent_Services_V1_StartContainerRequest) -> Bool {
     if lhs.appName != rhs.appName {return false}
+    if lhs._restartPolicy != rhs._restartPolicy {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_AttachContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_AttachContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AttachContainerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0\u{3}stdin_data\0")
 
@@ -1102,9 +1700,9 @@ extension Wendy_Agent_Services_V1_AttachContainerRequest: SwiftProtobuf.Message,
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerLayerHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerLayerHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RunContainerLayerHeader"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}digest\0\u{1}size\0\u{3}diff_id\0\u{1}gzip\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}digest\0\u{1}size\0\u{3}diff_id\0\u{1}gzip\0\u{1}compression\0\u{4}\u{4}chunk_hashes\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1116,6 +1714,8 @@ extension Wendy_Agent_Services_V1_RunContainerLayerHeader: SwiftProtobuf.Message
       case 2: try { try decoder.decodeSingularInt64Field(value: &self.size) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.diffID) }()
       case 4: try { try decoder.decodeSingularBoolField(value: &self.gzip) }()
+      case 5: try { try decoder.decodeSingularEnumField(value: &self.compression) }()
+      case 9: try { try decoder.decodeRepeatedBytesField(value: &self.chunkHashes) }()
       default: break
       }
     }
@@ -1134,6 +1734,12 @@ extension Wendy_Agent_Services_V1_RunContainerLayerHeader: SwiftProtobuf.Message
     if self.gzip != false {
       try visitor.visitSingularBoolField(value: self.gzip, fieldNumber: 4)
     }
+    if self.compression != .compressionGzip {
+      try visitor.visitSingularEnumField(value: self.compression, fieldNumber: 5)
+    }
+    if !self.chunkHashes.isEmpty {
+      try visitor.visitRepeatedBytesField(value: self.chunkHashes, fieldNumber: 9)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1142,12 +1748,18 @@ extension Wendy_Agent_Services_V1_RunContainerLayerHeader: SwiftProtobuf.Message
     if lhs.size != rhs.size {return false}
     if lhs.diffID != rhs.diffID {return false}
     if lhs.gzip != rhs.gzip {return false}
+    if lhs.compression != rhs.compression {return false}
+    if lhs.chunkHashes != rhs.chunkHashes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerLayersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerLayerHeader.CompressionType: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0COMPRESSION_GZIP\0\u{1}COMPRESSION_ZSTD\0\u{1}COMPRESSION_NONE\0")
+}
+
+nonisolated extension Wendy_Agent_Services_V1_RunContainerLayersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RunContainerLayersResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}started\0\u{3}stdout_output\0\u{3}stderr_output\0")
 
@@ -1231,7 +1843,7 @@ extension Wendy_Agent_Services_V1_RunContainerLayersResponse: SwiftProtobuf.Mess
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerLayersResponse.Started: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerLayersResponse.Started: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_RunContainerLayersResponse.protoMessageName + ".Started"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1250,7 +1862,7 @@ extension Wendy_Agent_Services_V1_RunContainerLayersResponse.Started: SwiftProto
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerLayersResponse.ConsoleOutput: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerLayersResponse.ConsoleOutput: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_RunContainerLayersResponse.protoMessageName + ".ConsoleOutput"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0")
 
@@ -1280,7 +1892,7 @@ extension Wendy_Agent_Services_V1_RunContainerLayersResponse.ConsoleOutput: Swif
   }
 }
 
-extension Wendy_Agent_Services_V1_StopContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StopContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StopContainerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0")
 
@@ -1310,7 +1922,7 @@ extension Wendy_Agent_Services_V1_StopContainerRequest: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_StopContainerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StopContainerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StopContainerResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1329,7 +1941,7 @@ extension Wendy_Agent_Services_V1_StopContainerResponse: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendy_Agent_Services_V1_DeleteContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_DeleteContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteContainerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0\u{3}delete_image\0\u{3}delete_volumes\0")
 
@@ -1369,7 +1981,7 @@ extension Wendy_Agent_Services_V1_DeleteContainerRequest: SwiftProtobuf.Message,
   }
 }
 
-extension Wendy_Agent_Services_V1_DeleteContainerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_DeleteContainerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteContainerResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1388,7 +2000,7 @@ extension Wendy_Agent_Services_V1_DeleteContainerResponse: SwiftProtobuf.Message
   }
 }
 
-extension Wendy_Agent_Services_V1_ListVolumesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListVolumesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListVolumesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1407,7 +2019,7 @@ extension Wendy_Agent_Services_V1_ListVolumesRequest: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_VolumeInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_VolumeInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".VolumeInfo"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}path\0\u{3}size_bytes\0\u{3}created_at\0\u{3}used_by\0")
 
@@ -1457,7 +2069,7 @@ extension Wendy_Agent_Services_V1_VolumeInfo: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Wendy_Agent_Services_V1_ListVolumesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListVolumesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListVolumesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}volumes\0")
 
@@ -1487,7 +2099,7 @@ extension Wendy_Agent_Services_V1_ListVolumesResponse: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_RemoveVolumeRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RemoveVolumeRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RemoveVolumeRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0")
 
@@ -1517,7 +2129,7 @@ extension Wendy_Agent_Services_V1_RemoveVolumeRequest: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_RemoveVolumeResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RemoveVolumeResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RemoveVolumeResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1536,7 +2148,7 @@ extension Wendy_Agent_Services_V1_RemoveVolumeResponse: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_ContainerStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ContainerStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ContainerStats"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0\u{3}memory_bytes\0\u{3}storage_bytes\0")
 
@@ -1576,7 +2188,7 @@ extension Wendy_Agent_Services_V1_ContainerStats: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendy_Agent_Services_V1_ListContainerStatsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListContainerStatsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListContainerStatsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1595,7 +2207,7 @@ extension Wendy_Agent_Services_V1_ListContainerStatsRequest: SwiftProtobuf.Messa
   }
 }
 
-extension Wendy_Agent_Services_V1_ListContainerStatsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListContainerStatsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListContainerStatsResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}stats\0")
 
@@ -1620,6 +2232,393 @@ extension Wendy_Agent_Services_V1_ListContainerStatsResponse: SwiftProtobuf.Mess
 
   public static func ==(lhs: Wendy_Agent_Services_V1_ListContainerStatsResponse, rhs: Wendy_Agent_Services_V1_ListContainerStatsResponse) -> Bool {
     if lhs.stats != rhs.stats {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GetResourceStatsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GetResourceStatsRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_GetResourceStatsRequest, rhs: Wendy_Agent_Services_V1_GetResourceStatsRequest) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GetResourceStatsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GetResourceStatsResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}host\0\u{1}containers\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._host) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.containers) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._host {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.containers.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.containers, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_GetResourceStatsResponse, rhs: Wendy_Agent_Services_V1_GetResourceStatsResponse) -> Bool {
+    if lhs._host != rhs._host {return false}
+    if lhs.containers != rhs.containers {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_HostStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".HostStats"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}cpu_total_jiffies\0\u{3}cpu_idle_jiffies\0\u{3}cpu_count\0\u{3}mem_total_bytes\0\u{3}mem_available_bytes\0\u{1}gpus\0\u{3}thermal_zones\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt64Field(value: &self.cpuTotalJiffies) }()
+      case 2: try { try decoder.decodeSingularUInt64Field(value: &self.cpuIdleJiffies) }()
+      case 3: try { try decoder.decodeSingularUInt32Field(value: &self.cpuCount) }()
+      case 4: try { try decoder.decodeSingularInt64Field(value: &self.memTotalBytes) }()
+      case 5: try { try decoder.decodeSingularInt64Field(value: &self.memAvailableBytes) }()
+      case 6: try { try decoder.decodeRepeatedMessageField(value: &self.gpus) }()
+      case 7: try { try decoder.decodeRepeatedMessageField(value: &self.thermalZones) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.cpuTotalJiffies != 0 {
+      try visitor.visitSingularUInt64Field(value: self.cpuTotalJiffies, fieldNumber: 1)
+    }
+    if self.cpuIdleJiffies != 0 {
+      try visitor.visitSingularUInt64Field(value: self.cpuIdleJiffies, fieldNumber: 2)
+    }
+    if self.cpuCount != 0 {
+      try visitor.visitSingularUInt32Field(value: self.cpuCount, fieldNumber: 3)
+    }
+    if self.memTotalBytes != 0 {
+      try visitor.visitSingularInt64Field(value: self.memTotalBytes, fieldNumber: 4)
+    }
+    if self.memAvailableBytes != 0 {
+      try visitor.visitSingularInt64Field(value: self.memAvailableBytes, fieldNumber: 5)
+    }
+    if !self.gpus.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.gpus, fieldNumber: 6)
+    }
+    if !self.thermalZones.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.thermalZones, fieldNumber: 7)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_HostStats, rhs: Wendy_Agent_Services_V1_HostStats) -> Bool {
+    if lhs.cpuTotalJiffies != rhs.cpuTotalJiffies {return false}
+    if lhs.cpuIdleJiffies != rhs.cpuIdleJiffies {return false}
+    if lhs.cpuCount != rhs.cpuCount {return false}
+    if lhs.memTotalBytes != rhs.memTotalBytes {return false}
+    if lhs.memAvailableBytes != rhs.memAvailableBytes {return false}
+    if lhs.gpus != rhs.gpus {return false}
+    if lhs.thermalZones != rhs.thermalZones {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_ThermalZone: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ThermalZone"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}temp_c\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 2: try { try decoder.decodeSingularDoubleField(value: &self.tempC) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if self.tempC.bitPattern != 0 {
+      try visitor.visitSingularDoubleField(value: self.tempC, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_ThermalZone, rhs: Wendy_Agent_Services_V1_ThermalZone) -> Bool {
+    if lhs.name != rhs.name {return false}
+    if lhs.tempC != rhs.tempC {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GpuStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GpuStats"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}index\0\u{1}name\0\u{3}util_percent\0\u{3}mem_used_bytes\0\u{3}mem_total_bytes\0\u{3}temp_c\0\u{3}power_w\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt32Field(value: &self.index) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 3: try { try decoder.decodeSingularDoubleField(value: &self.utilPercent) }()
+      case 4: try { try decoder.decodeSingularInt64Field(value: &self.memUsedBytes) }()
+      case 5: try { try decoder.decodeSingularInt64Field(value: &self.memTotalBytes) }()
+      case 6: try { try decoder.decodeSingularDoubleField(value: &self._tempC) }()
+      case 7: try { try decoder.decodeSingularDoubleField(value: &self._powerW) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.index != 0 {
+      try visitor.visitSingularUInt32Field(value: self.index, fieldNumber: 1)
+    }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 2)
+    }
+    if self.utilPercent.bitPattern != 0 {
+      try visitor.visitSingularDoubleField(value: self.utilPercent, fieldNumber: 3)
+    }
+    if self.memUsedBytes != 0 {
+      try visitor.visitSingularInt64Field(value: self.memUsedBytes, fieldNumber: 4)
+    }
+    if self.memTotalBytes != 0 {
+      try visitor.visitSingularInt64Field(value: self.memTotalBytes, fieldNumber: 5)
+    }
+    try { if let v = self._tempC {
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 6)
+    } }()
+    try { if let v = self._powerW {
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 7)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_GpuStats, rhs: Wendy_Agent_Services_V1_GpuStats) -> Bool {
+    if lhs.index != rhs.index {return false}
+    if lhs.name != rhs.name {return false}
+    if lhs.utilPercent != rhs.utilPercent {return false}
+    if lhs.memUsedBytes != rhs.memUsedBytes {return false}
+    if lhs.memTotalBytes != rhs.memTotalBytes {return false}
+    if lhs._tempC != rhs._tempC {return false}
+    if lhs._powerW != rhs._powerW {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_ResourceContainerStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ResourceContainerStats"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0\u{3}cpu_usage_nanos\0\u{3}memory_bytes\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.appName) }()
+      case 2: try { try decoder.decodeSingularUInt64Field(value: &self.cpuUsageNanos) }()
+      case 3: try { try decoder.decodeSingularInt64Field(value: &self.memoryBytes) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.appName.isEmpty {
+      try visitor.visitSingularStringField(value: self.appName, fieldNumber: 1)
+    }
+    if self.cpuUsageNanos != 0 {
+      try visitor.visitSingularUInt64Field(value: self.cpuUsageNanos, fieldNumber: 2)
+    }
+    if self.memoryBytes != 0 {
+      try visitor.visitSingularInt64Field(value: self.memoryBytes, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_ResourceContainerStats, rhs: Wendy_Agent_Services_V1_ResourceContainerStats) -> Bool {
+    if lhs.appName != rhs.appName {return false}
+    if lhs.cpuUsageNanos != rhs.cpuUsageNanos {return false}
+    if lhs.memoryBytes != rhs.memoryBytes {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GetContainerPortsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GetContainerPortsRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_name\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.appName) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.appName.isEmpty {
+      try visitor.visitSingularStringField(value: self.appName, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_GetContainerPortsRequest, rhs: Wendy_Agent_Services_V1_GetContainerPortsRequest) -> Bool {
+    if lhs.appName != rhs.appName {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GetContainerPortsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GetContainerPortsResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ports\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.ports) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.ports.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.ports, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_GetContainerPortsResponse, rhs: Wendy_Agent_Services_V1_GetContainerPortsResponse) -> Bool {
+    if lhs.ports != rhs.ports {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_PortEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".PortEntry"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}protocol\0\u{1}port\0\u{1}address\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.`protocol`) }()
+      case 2: try { try decoder.decodeSingularUInt32Field(value: &self.port) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.address) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.`protocol`.isEmpty {
+      try visitor.visitSingularStringField(value: self.`protocol`, fieldNumber: 1)
+    }
+    if self.port != 0 {
+      try visitor.visitSingularUInt32Field(value: self.port, fieldNumber: 2)
+    }
+    if !self.address.isEmpty {
+      try visitor.visitSingularStringField(value: self.address, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_PortEntry, rhs: Wendy_Agent_Services_V1_PortEntry) -> Bool {
+    if lhs.`protocol` != rhs.`protocol` {return false}
+    if lhs.port != rhs.port {return false}
+    if lhs.address != rhs.address {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_MCPChunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".MCPChunk"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBytesField(value: &self.data) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.data.isEmpty {
+      try visitor.visitSingularBytesField(value: self.data, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_MCPChunk, rhs: Wendy_Agent_Services_V1_MCPChunk) -> Bool {
+    if lhs.data != rhs.data {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_file_sync_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_file_sync_service.pb.swift
@@ -20,13 +20,13 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// FileSyncEntry describes a single file in a manifest.
-public struct Wendy_Agent_Services_V1_FileSyncEntry: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncEntry: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -47,7 +47,7 @@ public struct Wendy_Agent_Services_V1_FileSyncEntry: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_FileSyncRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -96,7 +96,7 @@ public struct Wendy_Agent_Services_V1_FileSyncRequest: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_RequestType: Equatable, Sendable {
+  public nonisolated enum OneOf_RequestType: Equatable, Sendable {
     case start(Wendy_Agent_Services_V1_FileSyncStart)
     case chunk(Wendy_Agent_Services_V1_FileSyncChunk)
     case commit(Wendy_Agent_Services_V1_FileSyncCommit)
@@ -110,7 +110,7 @@ public struct Wendy_Agent_Services_V1_FileSyncRequest: Sendable {
 
 /// FileSyncStart opens a sync session for the given app. The CLI sends its
 /// local manifest so the agent can reply with what it already has.
-public struct Wendy_Agent_Services_V1_FileSyncStart: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncStart: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -135,7 +135,7 @@ public struct Wendy_Agent_Services_V1_FileSyncStart: Sendable {
 
 /// FileSyncChunk carries a slice of a file being transferred along with the
 /// cumulative post-chunk state for immediate validation.
-public struct Wendy_Agent_Services_V1_FileSyncChunk: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncChunk: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -158,7 +158,7 @@ public struct Wendy_Agent_Services_V1_FileSyncChunk: Sendable {
 }
 
 /// FileSyncCommit signals the end of a single file transfer.
-public struct Wendy_Agent_Services_V1_FileSyncCommit: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncCommit: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -176,7 +176,7 @@ public struct Wendy_Agent_Services_V1_FileSyncCommit: Sendable {
 }
 
 /// FileSyncChmod applies a metadata-only mode change for an unchanged file.
-public struct Wendy_Agent_Services_V1_FileSyncChmod: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncChmod: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -196,7 +196,7 @@ public struct Wendy_Agent_Services_V1_FileSyncChmod: Sendable {
 }
 
 /// FileSyncDelete removes the listed stale files from the app working directory.
-public struct Wendy_Agent_Services_V1_FileSyncDelete: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncDelete: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -208,7 +208,7 @@ public struct Wendy_Agent_Services_V1_FileSyncDelete: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_FileSyncResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -241,7 +241,7 @@ public struct Wendy_Agent_Services_V1_FileSyncResponse: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_ResponseType: Equatable, Sendable {
+  public nonisolated enum OneOf_ResponseType: Equatable, Sendable {
     case manifest(Wendy_Agent_Services_V1_FileSyncManifest)
     case ack(Wendy_Agent_Services_V1_FileSyncAck)
     case complete(Wendy_Agent_Services_V1_FileSyncComplete)
@@ -252,7 +252,7 @@ public struct Wendy_Agent_Services_V1_FileSyncResponse: Sendable {
 }
 
 /// FileSyncManifest is the agent's reply to FileSyncStart: what it already has.
-public struct Wendy_Agent_Services_V1_FileSyncManifest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncManifest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -265,7 +265,7 @@ public struct Wendy_Agent_Services_V1_FileSyncManifest: Sendable {
 }
 
 /// FileSyncAck confirms a file was written successfully.
-public struct Wendy_Agent_Services_V1_FileSyncAck: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncAck: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -279,7 +279,7 @@ public struct Wendy_Agent_Services_V1_FileSyncAck: Sendable {
 
 /// FileSyncComplete signals that the agent has applied all requested file
 /// operations and the session is done.
-public struct Wendy_Agent_Services_V1_FileSyncComplete: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_FileSyncComplete: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -291,9 +291,9 @@ public struct Wendy_Agent_Services_V1_FileSyncComplete: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendy.agent.services.v1"
+fileprivate nonisolated let _protobuf_package = "wendy.agent.services.v1"
 
-extension Wendy_Agent_Services_V1_FileSyncEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncEntry"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}size\0\u{1}sha256\0\u{1}mode\0")
 
@@ -338,7 +338,7 @@ extension Wendy_Agent_Services_V1_FileSyncEntry: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}start\0\u{1}chunk\0\u{1}commit\0\u{1}chmod\0\u{1}delete\0")
 
@@ -456,7 +456,7 @@ extension Wendy_Agent_Services_V1_FileSyncRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncStart: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncStart: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncStart"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_id\0\u{1}manifest\0")
 
@@ -495,7 +495,7 @@ extension Wendy_Agent_Services_V1_FileSyncStart: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncChunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncChunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncChunk"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}data\0\u{1}sequence\0\u{3}cumulative_size\0\u{1}sha256\0")
 
@@ -545,7 +545,7 @@ extension Wendy_Agent_Services_V1_FileSyncChunk: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncCommit: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncCommit: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncCommit"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}sha256\0\u{1}size\0")
 
@@ -585,7 +585,7 @@ extension Wendy_Agent_Services_V1_FileSyncCommit: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncChmod: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncChmod: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncChmod"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}mode\0\u{1}size\0\u{1}sha256\0")
 
@@ -630,7 +630,7 @@ extension Wendy_Agent_Services_V1_FileSyncChmod: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncDelete: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncDelete: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncDelete"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}paths\0")
 
@@ -660,7 +660,7 @@ extension Wendy_Agent_Services_V1_FileSyncDelete: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}manifest\0\u{1}ack\0\u{1}complete\0")
 
@@ -744,7 +744,7 @@ extension Wendy_Agent_Services_V1_FileSyncResponse: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncManifest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncManifest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncManifest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}files\0")
 
@@ -774,7 +774,7 @@ extension Wendy_Agent_Services_V1_FileSyncManifest: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncAck"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0")
 
@@ -804,7 +804,7 @@ extension Wendy_Agent_Services_V1_FileSyncAck: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Wendy_Agent_Services_V1_FileSyncComplete: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_FileSyncComplete: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileSyncComplete"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_provisioning_service.grpc.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_provisioning_service.grpc.swift
@@ -46,10 +46,24 @@ public enum Wendy_Agent_Services_V1_WendyProvisioningService: Sendable {
                 type: .unary
             )
         }
+        /// Namespace for "Unprovision" metadata.
+        public enum Unprovision: Sendable {
+            /// Request type for "Unprovision".
+            public typealias Input = Wendy_Agent_Services_V1_UnprovisionRequest
+            /// Response type for "Unprovision".
+            public typealias Output = Wendy_Agent_Services_V1_UnprovisionResponse
+            /// Descriptor for "Unprovision".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyProvisioningService"),
+                method: "Unprovision",
+                type: .unary
+            )
+        }
         /// Descriptors for all methods in the "wendy.agent.services.v1.WendyProvisioningService" service.
         public static let descriptors: [GRPCCore.MethodDescriptor] = [
             StartProvisioning.descriptor,
-            IsProvisioned.descriptor
+            IsProvisioned.descriptor,
+            Unprovision.descriptor
         ]
     }
 }
@@ -102,6 +116,26 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService {
             request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_IsProvisionedRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_IsProvisionedResponse>
+
+        /// Handle the "Unprovision" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Unprovision resets the device to an unprovisioned state: it deletes the
+        /// > stored enrollment certificates and provisioning state, then restarts the
+        /// > agent so it comes back up serving plaintext on the unprovisioned port.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_UnprovisionRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_UnprovisionResponse` messages.
+        func unprovision(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_UnprovisionRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_UnprovisionResponse>
     }
 
     /// Service protocol for the "wendy.agent.services.v1.WendyProvisioningService" service.
@@ -139,6 +173,26 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService {
             request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_IsProvisionedRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_IsProvisionedResponse>
+
+        /// Handle the "Unprovision" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Unprovision resets the device to an unprovisioned state: it deletes the
+        /// > stored enrollment certificates and provisioning state, then restarts the
+        /// > agent so it comes back up serving plaintext on the unprovisioned port.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_UnprovisionRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Wendy_Agent_Services_V1_UnprovisionResponse` message.
+        func unprovision(
+            request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_UnprovisionRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_UnprovisionResponse>
     }
 
     /// Simple service protocol for the "wendy.agent.services.v1.WendyProvisioningService" service.
@@ -174,6 +228,26 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService {
             request: Wendy_Agent_Services_V1_IsProvisionedRequest,
             context: GRPCCore.ServerContext
         ) async throws -> Wendy_Agent_Services_V1_IsProvisionedResponse
+
+        /// Handle the "Unprovision" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Unprovision resets the device to an unprovisioned state: it deletes the
+        /// > stored enrollment certificates and provisioning state, then restarts the
+        /// > agent so it comes back up serving plaintext on the unprovisioned port.
+        ///
+        /// - Parameters:
+        ///   - request: A `Wendy_Agent_Services_V1_UnprovisionRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Wendy_Agent_Services_V1_UnprovisionResponse` to respond with.
+        func unprovision(
+            request: Wendy_Agent_Services_V1_UnprovisionRequest,
+            context: GRPCCore.ServerContext
+        ) async throws -> Wendy_Agent_Services_V1_UnprovisionResponse
     }
 }
 
@@ -198,6 +272,17 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService.StreamingServiceProto
             serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_IsProvisionedResponse>(),
             handler: { request, context in
                 try await self.isProvisioned(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyProvisioningService.Method.Unprovision.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_UnprovisionRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_UnprovisionResponse>(),
+            handler: { request, context in
+                try await self.unprovision(
                     request: request,
                     context: context
                 )
@@ -230,6 +315,17 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService.ServiceProtocol {
         )
         return GRPCCore.StreamingServerResponse(single: response)
     }
+
+    public func unprovision(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_UnprovisionRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_UnprovisionResponse> {
+        let response = try await self.unprovision(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
+    }
 }
 
 // Default implementation of methods from 'ServiceProtocol'.
@@ -254,6 +350,19 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService.SimpleServiceProtocol
     ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_IsProvisionedResponse> {
         return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_IsProvisionedResponse>(
             message: try await self.isProvisioned(
+                request: request.message,
+                context: context
+            ),
+            metadata: [:]
+        )
+    }
+
+    public func unprovision(
+        request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_UnprovisionRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_UnprovisionResponse> {
+        return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_UnprovisionResponse>(
+            message: try await self.unprovision(
                 request: request.message,
                 context: context
             ),
@@ -307,6 +416,31 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService {
             deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_IsProvisionedResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_IsProvisionedResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "Unprovision" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Unprovision resets the device to an unprovisioned state: it deletes the
+        /// > stored enrollment certificates and provisioning state, then restarts the
+        /// > agent so it comes back up serving plaintext on the unprovisioned port.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_UnprovisionRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_UnprovisionRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_UnprovisionResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func unprovision<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_UnprovisionRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_UnprovisionRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_UnprovisionResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_UnprovisionResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
     }
 
@@ -385,6 +519,42 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService {
                 onResponse: handleResponse
             )
         }
+
+        /// Call the "Unprovision" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Unprovision resets the device to an unprovisioned state: it deletes the
+        /// > stored enrollment certificates and provisioning state, then restarts the
+        /// > agent so it comes back up serving plaintext on the unprovisioned port.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_UnprovisionRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_UnprovisionRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_UnprovisionResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func unprovision<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_UnprovisionRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_UnprovisionRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_UnprovisionResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_UnprovisionResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyProvisioningService.Method.Unprovision.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
     }
 }
 
@@ -436,6 +606,37 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService.ClientProtocol {
             request: request,
             serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_IsProvisionedRequest>(),
             deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_IsProvisionedResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "Unprovision" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Unprovision resets the device to an unprovisioned state: it deletes the
+    /// > stored enrollment certificates and provisioning state, then restarts the
+    /// > agent so it comes back up serving plaintext on the unprovisioned port.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Wendy_Agent_Services_V1_UnprovisionRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func unprovision<Result>(
+        request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_UnprovisionRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_UnprovisionResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.unprovision(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_UnprovisionRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_UnprovisionResponse>(),
             options: options,
             onResponse: handleResponse
         )
@@ -497,6 +698,41 @@ extension Wendy_Agent_Services_V1_WendyProvisioningService.ClientProtocol {
             metadata: metadata
         )
         return try await self.isProvisioned(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "Unprovision" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Unprovision resets the device to an unprovisioned state: it deletes the
+    /// > stored enrollment certificates and provisioning state, then restarts the
+    /// > agent so it comes back up serving plaintext on the unprovisioned port.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func unprovision<Result>(
+        _ message: Wendy_Agent_Services_V1_UnprovisionRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_UnprovisionResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Wendy_Agent_Services_V1_UnprovisionRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.unprovision(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_provisioning_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_provisioning_service.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public struct Wendy_Agent_Services_V1_IsProvisionedRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_IsProvisionedRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -30,7 +30,7 @@ public struct Wendy_Agent_Services_V1_IsProvisionedRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_IsProvisionedResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_IsProvisionedResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -55,7 +55,7 @@ public struct Wendy_Agent_Services_V1_IsProvisionedResponse: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_Response: Equatable, Sendable {
+  public nonisolated enum OneOf_Response: Equatable, Sendable {
     case notProvisioned(Wendy_Agent_Services_V1_NotProvisionedResponse)
     case provisioned(Wendy_Agent_Services_V1_ProvisionedResponse)
 
@@ -64,7 +64,7 @@ public struct Wendy_Agent_Services_V1_IsProvisionedResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_NotProvisionedResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_NotProvisionedResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -74,7 +74,7 @@ public struct Wendy_Agent_Services_V1_NotProvisionedResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ProvisionedResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ProvisionedResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -90,7 +90,7 @@ public struct Wendy_Agent_Services_V1_ProvisionedResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_StartProvisioningRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StartProvisioningRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -108,7 +108,27 @@ public struct Wendy_Agent_Services_V1_StartProvisioningRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_StartProvisioningResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StartProvisioningResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_UnprovisionRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_UnprovisionResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -120,9 +140,9 @@ public struct Wendy_Agent_Services_V1_StartProvisioningResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendy.agent.services.v1"
+fileprivate nonisolated let _protobuf_package = "wendy.agent.services.v1"
 
-extension Wendy_Agent_Services_V1_IsProvisionedRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_IsProvisionedRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".IsProvisionedRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -141,7 +161,7 @@ extension Wendy_Agent_Services_V1_IsProvisionedRequest: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_IsProvisionedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_IsProvisionedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".IsProvisionedResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}not_provisioned\0\u{1}provisioned\0")
 
@@ -208,7 +228,7 @@ extension Wendy_Agent_Services_V1_IsProvisionedResponse: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendy_Agent_Services_V1_NotProvisionedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_NotProvisionedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".NotProvisionedResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -227,7 +247,7 @@ extension Wendy_Agent_Services_V1_NotProvisionedResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Wendy_Agent_Services_V1_ProvisionedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ProvisionedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ProvisionedResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}cloud_host\0\u{3}organization_id\0\u{3}asset_id\0")
 
@@ -267,7 +287,7 @@ extension Wendy_Agent_Services_V1_ProvisionedResponse: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_StartProvisioningRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StartProvisioningRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StartProvisioningRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}enrollment_token\0\u{3}cloud_host\0\u{3}asset_id\0")
 
@@ -312,7 +332,7 @@ extension Wendy_Agent_Services_V1_StartProvisioningRequest: SwiftProtobuf.Messag
   }
 }
 
-extension Wendy_Agent_Services_V1_StartProvisioningResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StartProvisioningResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StartProvisioningResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -326,6 +346,44 @@ extension Wendy_Agent_Services_V1_StartProvisioningResponse: SwiftProtobuf.Messa
   }
 
   public static func ==(lhs: Wendy_Agent_Services_V1_StartProvisioningResponse, rhs: Wendy_Agent_Services_V1_StartProvisioningResponse) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_UnprovisionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".UnprovisionRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_UnprovisionRequest, rhs: Wendy_Agent_Services_V1_UnprovisionRequest) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_UnprovisionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".UnprovisionResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_UnprovisionResponse, rhs: Wendy_Agent_Services_V1_UnprovisionResponse) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_service.grpc.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_service.grpc.swift
@@ -241,6 +241,45 @@ public enum Wendy_Agent_Services_V1_WendyAgentService: Sendable {
                 type: .serverStreaming
             )
         }
+        /// Namespace for "DumpKernelLog" metadata.
+        public enum DumpKernelLog: Sendable {
+            /// Request type for "DumpKernelLog".
+            public typealias Input = Wendy_Agent_Services_V1_DumpKernelLogRequest
+            /// Response type for "DumpKernelLog".
+            public typealias Output = Wendy_Agent_Services_V1_DumpKernelLogResponse
+            /// Descriptor for "DumpKernelLog".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyAgentService"),
+                method: "DumpKernelLog",
+                type: .serverStreaming
+            )
+        }
+        /// Namespace for "GetOSUpdateStatus" metadata.
+        public enum GetOSUpdateStatus: Sendable {
+            /// Request type for "GetOSUpdateStatus".
+            public typealias Input = Wendy_Agent_Services_V1_GetOSUpdateStatusRequest
+            /// Response type for "GetOSUpdateStatus".
+            public typealias Output = Wendy_Agent_Services_V1_GetOSUpdateStatusResponse
+            /// Descriptor for "GetOSUpdateStatus".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyAgentService"),
+                method: "GetOSUpdateStatus",
+                type: .unary
+            )
+        }
+        /// Namespace for "SetHostname" metadata.
+        public enum SetHostname: Sendable {
+            /// Request type for "SetHostname".
+            public typealias Input = Wendy_Agent_Services_V1_SetHostnameRequest
+            /// Response type for "SetHostname".
+            public typealias Output = Wendy_Agent_Services_V1_SetHostnameResponse
+            /// Descriptor for "SetHostname".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendy.agent.services.v1.WendyAgentService"),
+                method: "SetHostname",
+                type: .unary
+            )
+        }
         /// Descriptors for all methods in the "wendy.agent.services.v1.WendyAgentService" service.
         public static let descriptors: [GRPCCore.MethodDescriptor] = [
             RunContainer.descriptor,
@@ -259,7 +298,10 @@ public enum Wendy_Agent_Services_V1_WendyAgentService: Sendable {
             ConnectBluetoothPeripheral.descriptor,
             DisconnectBluetoothPeripheral.descriptor,
             ForgetBluetoothPeripheral.descriptor,
-            UpdateOS.descriptor
+            UpdateOS.descriptor,
+            DumpKernelLog.descriptor,
+            GetOSUpdateStatus.descriptor,
+            SetHostname.descriptor
         ]
     }
 }
@@ -554,7 +596,7 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
         ///
         /// > Source IDL Documentation:
         /// >
-        /// > Update the operating system using a Mender artifact
+        /// > Update the operating system using an OS update artifact
         ///
         /// - Parameters:
         ///   - request: A streaming request of `Wendy_Agent_Services_V1_UpdateOSRequest` messages.
@@ -567,6 +609,70 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
             request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_UpdateOSRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_UpdateOSResponse>
+
+        /// Handle the "DumpKernelLog" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Dump the current kernel ring buffer (dmesg) for inspection. By default
+        /// > the agent streams the buffered records and then keeps following new
+        /// > kernel messages until the client disconnects (like `dmesg -w`); set
+        /// > follow=false for a one-shot dump that completes once the buffer drains.
+        /// > Records are NOT PII-redacted; this is a local diagnostic for an operator
+        /// > connected to their own device, distinct from the DPIA-gated OTel
+        /// > kernel-log streaming path.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_DumpKernelLogRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_DumpKernelLogResponse` messages.
+        func dumpKernelLog(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse>
+
+        /// Handle the "GetOSUpdateStatus" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Report the outcome of the most recent OS update attempt: committed
+        /// > after post-reboot healthchecks passed, or rolled back with details on
+        /// > which critical services failed and why.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_GetOSUpdateStatusRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_GetOSUpdateStatusResponse` messages.
+        func getOSUpdateStatus(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>
+
+        /// Handle the "SetHostname" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Set the device's hostname (and mDNS name) to a literal value. Unlike the
+        /// > first-boot device-name flow, no "wendyos-" prefix is derived: the hostname
+        /// > is applied exactly as given. The value is persisted so it survives reboots.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Wendy_Agent_Services_V1_SetHostnameRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_SetHostnameResponse` messages.
+        func setHostname(
+            request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_SetHostnameRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_SetHostnameResponse>
     }
 
     /// Service protocol for the "wendy.agent.services.v1.WendyAgentService" service.
@@ -846,7 +952,7 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
         ///
         /// > Source IDL Documentation:
         /// >
-        /// > Update the operating system using a Mender artifact
+        /// > Update the operating system using an OS update artifact
         ///
         /// - Parameters:
         ///   - request: A request containing a single `Wendy_Agent_Services_V1_UpdateOSRequest` message.
@@ -859,6 +965,70 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
             request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_UpdateOSRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_UpdateOSResponse>
+
+        /// Handle the "DumpKernelLog" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Dump the current kernel ring buffer (dmesg) for inspection. By default
+        /// > the agent streams the buffered records and then keeps following new
+        /// > kernel messages until the client disconnects (like `dmesg -w`); set
+        /// > follow=false for a one-shot dump that completes once the buffer drains.
+        /// > Records are NOT PII-redacted; this is a local diagnostic for an operator
+        /// > connected to their own device, distinct from the DPIA-gated OTel
+        /// > kernel-log streaming path.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_DumpKernelLogRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Wendy_Agent_Services_V1_DumpKernelLogResponse` messages.
+        func dumpKernelLog(
+            request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse>
+
+        /// Handle the "GetOSUpdateStatus" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Report the outcome of the most recent OS update attempt: committed
+        /// > after post-reboot healthchecks passed, or rolled back with details on
+        /// > which critical services failed and why.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetOSUpdateStatusRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Wendy_Agent_Services_V1_GetOSUpdateStatusResponse` message.
+        func getOSUpdateStatus(
+            request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>
+
+        /// Handle the "SetHostname" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Set the device's hostname (and mDNS name) to a literal value. Unlike the
+        /// > first-boot device-name flow, no "wendyos-" prefix is derived: the hostname
+        /// > is applied exactly as given. The value is persisted so it survives reboots.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_SetHostnameRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Wendy_Agent_Services_V1_SetHostnameResponse` message.
+        func setHostname(
+            request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_SetHostnameRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_SetHostnameResponse>
     }
 
     /// Simple service protocol for the "wendy.agent.services.v1.WendyAgentService" service.
@@ -1139,7 +1309,7 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
         ///
         /// > Source IDL Documentation:
         /// >
-        /// > Update the operating system using a Mender artifact
+        /// > Update the operating system using an OS update artifact
         ///
         /// - Parameters:
         ///   - request: A `Wendy_Agent_Services_V1_UpdateOSRequest` message.
@@ -1153,6 +1323,71 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
             response: GRPCCore.RPCWriter<Wendy_Agent_Services_V1_UpdateOSResponse>,
             context: GRPCCore.ServerContext
         ) async throws
+
+        /// Handle the "DumpKernelLog" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Dump the current kernel ring buffer (dmesg) for inspection. By default
+        /// > the agent streams the buffered records and then keeps following new
+        /// > kernel messages until the client disconnects (like `dmesg -w`); set
+        /// > follow=false for a one-shot dump that completes once the buffer drains.
+        /// > Records are NOT PII-redacted; this is a local diagnostic for an operator
+        /// > connected to their own device, distinct from the DPIA-gated OTel
+        /// > kernel-log streaming path.
+        ///
+        /// - Parameters:
+        ///   - request: A `Wendy_Agent_Services_V1_DumpKernelLogRequest` message.
+        ///   - response: A response stream of `Wendy_Agent_Services_V1_DumpKernelLogResponse` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        func dumpKernelLog(
+            request: Wendy_Agent_Services_V1_DumpKernelLogRequest,
+            response: GRPCCore.RPCWriter<Wendy_Agent_Services_V1_DumpKernelLogResponse>,
+            context: GRPCCore.ServerContext
+        ) async throws
+
+        /// Handle the "GetOSUpdateStatus" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Report the outcome of the most recent OS update attempt: committed
+        /// > after post-reboot healthchecks passed, or rolled back with details on
+        /// > which critical services failed and why.
+        ///
+        /// - Parameters:
+        ///   - request: A `Wendy_Agent_Services_V1_GetOSUpdateStatusRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Wendy_Agent_Services_V1_GetOSUpdateStatusResponse` to respond with.
+        func getOSUpdateStatus(
+            request: Wendy_Agent_Services_V1_GetOSUpdateStatusRequest,
+            context: GRPCCore.ServerContext
+        ) async throws -> Wendy_Agent_Services_V1_GetOSUpdateStatusResponse
+
+        /// Handle the "SetHostname" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Set the device's hostname (and mDNS name) to a literal value. Unlike the
+        /// > first-boot device-name flow, no "wendyos-" prefix is derived: the hostname
+        /// > is applied exactly as given. The value is persisted so it survives reboots.
+        ///
+        /// - Parameters:
+        ///   - request: A `Wendy_Agent_Services_V1_SetHostnameRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Wendy_Agent_Services_V1_SetHostnameResponse` to respond with.
+        func setHostname(
+            request: Wendy_Agent_Services_V1_SetHostnameRequest,
+            context: GRPCCore.ServerContext
+        ) async throws -> Wendy_Agent_Services_V1_SetHostnameResponse
     }
 }
 
@@ -1347,6 +1582,39 @@ extension Wendy_Agent_Services_V1_WendyAgentService.StreamingServiceProtocol {
                 )
             }
         )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyAgentService.Method.DumpKernelLog.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_DumpKernelLogRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_DumpKernelLogResponse>(),
+            handler: { request, context in
+                try await self.dumpKernelLog(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyAgentService.Method.GetOSUpdateStatus.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>(),
+            handler: { request, context in
+                try await self.getOSUpdateStatus(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+        router.registerHandler(
+            forMethod: Wendy_Agent_Services_V1_WendyAgentService.Method.SetHostname.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_SetHostnameRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_SetHostnameResponse>(),
+            handler: { request, context in
+                try await self.setHostname(
+                    request: request,
+                    context: context
+                )
+            }
+        )
     }
 }
 
@@ -1505,6 +1773,39 @@ extension Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
             context: context
         )
         return response
+    }
+
+    public func dumpKernelLog(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse> {
+        let response = try await self.dumpKernelLog(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return response
+    }
+
+    public func getOSUpdateStatus(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse> {
+        let response = try await self.getOSUpdateStatus(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
+    }
+
+    public func setHostname(
+        request: GRPCCore.StreamingServerRequest<Wendy_Agent_Services_V1_SetHostnameRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_SetHostnameResponse> {
+        let response = try await self.setHostname(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
     }
 }
 
@@ -1745,6 +2046,49 @@ extension Wendy_Agent_Services_V1_WendyAgentService.SimpleServiceProtocol {
                 )
                 return [:]
             }
+        )
+    }
+
+    public func dumpKernelLog(
+        request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse> {
+        return GRPCCore.StreamingServerResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse>(
+            metadata: [:],
+            producer: { writer in
+                try await self.dumpKernelLog(
+                    request: request.message,
+                    response: writer,
+                    context: context
+                )
+                return [:]
+            }
+        )
+    }
+
+    public func getOSUpdateStatus(
+        request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse> {
+        return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>(
+            message: try await self.getOSUpdateStatus(
+                request: request.message,
+                context: context
+            ),
+            metadata: [:]
+        )
+    }
+
+    public func setHostname(
+        request: GRPCCore.ServerRequest<Wendy_Agent_Services_V1_SetHostnameRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Wendy_Agent_Services_V1_SetHostnameResponse> {
+        return GRPCCore.ServerResponse<Wendy_Agent_Services_V1_SetHostnameResponse>(
+            message: try await self.setHostname(
+                request: request.message,
+                context: context
+            ),
+            metadata: [:]
         )
     }
 }
@@ -2107,7 +2451,7 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
         ///
         /// > Source IDL Documentation:
         /// >
-        /// > Update the operating system using a Mender artifact
+        /// > Update the operating system using an OS update artifact
         ///
         /// - Parameters:
         ///   - request: A request containing a single `Wendy_Agent_Services_V1_UpdateOSRequest` message.
@@ -2124,6 +2468,85 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
             deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_UpdateOSResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendy_Agent_Services_V1_UpdateOSResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "DumpKernelLog" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Dump the current kernel ring buffer (dmesg) for inspection. By default
+        /// > the agent streams the buffered records and then keeps following new
+        /// > kernel messages until the client disconnects (like `dmesg -w`); set
+        /// > follow=false for a one-shot dump that completes once the buffer drains.
+        /// > Records are NOT PII-redacted; this is a local diagnostic for an operator
+        /// > connected to their own device, distinct from the DPIA-gated OTel
+        /// > kernel-log streaming path.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_DumpKernelLogRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_DumpKernelLogRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_DumpKernelLogResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func dumpKernelLog<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_DumpKernelLogResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "GetOSUpdateStatus" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Report the outcome of the most recent OS update attempt: committed
+        /// > after post-reboot healthchecks passed, or rolled back with details on
+        /// > which critical services failed and why.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetOSUpdateStatusRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_GetOSUpdateStatusRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_GetOSUpdateStatusResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func getOSUpdateStatus<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "SetHostname" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Set the device's hostname (and mDNS name) to a literal value. Unlike the
+        /// > first-boot device-name flow, no "wendyos-" prefix is derived: the hostname
+        /// > is applied exactly as given. The value is persisted so it survives reboots.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_SetHostnameRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_SetHostnameRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_SetHostnameResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func setHostname<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_SetHostnameRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_SetHostnameRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_SetHostnameResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_SetHostnameResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
     }
 
@@ -2662,7 +3085,7 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
         ///
         /// > Source IDL Documentation:
         /// >
-        /// > Update the operating system using a Mender artifact
+        /// > Update the operating system using an OS update artifact
         ///
         /// - Parameters:
         ///   - request: A request containing a single `Wendy_Agent_Services_V1_UpdateOSRequest` message.
@@ -2683,6 +3106,116 @@ extension Wendy_Agent_Services_V1_WendyAgentService {
             try await self.client.serverStreaming(
                 request: request,
                 descriptor: Wendy_Agent_Services_V1_WendyAgentService.Method.UpdateOS.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "DumpKernelLog" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Dump the current kernel ring buffer (dmesg) for inspection. By default
+        /// > the agent streams the buffered records and then keeps following new
+        /// > kernel messages until the client disconnects (like `dmesg -w`); set
+        /// > follow=false for a one-shot dump that completes once the buffer drains.
+        /// > Records are NOT PII-redacted; this is a local diagnostic for an operator
+        /// > connected to their own device, distinct from the DPIA-gated OTel
+        /// > kernel-log streaming path.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_DumpKernelLogRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_DumpKernelLogRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_DumpKernelLogResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func dumpKernelLog<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_DumpKernelLogResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.serverStreaming(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyAgentService.Method.DumpKernelLog.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "GetOSUpdateStatus" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Report the outcome of the most recent OS update attempt: committed
+        /// > after post-reboot healthchecks passed, or rolled back with details on
+        /// > which critical services failed and why.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetOSUpdateStatusRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_GetOSUpdateStatusRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_GetOSUpdateStatusResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func getOSUpdateStatus<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyAgentService.Method.GetOSUpdateStatus.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "SetHostname" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Set the device's hostname (and mDNS name) to a literal value. Unlike the
+        /// > first-boot device-name flow, no "wendyos-" prefix is derived: the hostname
+        /// > is applied exactly as given. The value is persisted so it survives reboots.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Wendy_Agent_Services_V1_SetHostnameRequest` message.
+        ///   - serializer: A serializer for `Wendy_Agent_Services_V1_SetHostnameRequest` messages.
+        ///   - deserializer: A deserializer for `Wendy_Agent_Services_V1_SetHostnameResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func setHostname<Result>(
+            request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_SetHostnameRequest>,
+            serializer: some GRPCCore.MessageSerializer<Wendy_Agent_Services_V1_SetHostnameRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Wendy_Agent_Services_V1_SetHostnameResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_SetHostnameResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Wendy_Agent_Services_V1_WendyAgentService.Method.SetHostname.descriptor,
                 serializer: serializer,
                 deserializer: deserializer,
                 options: options,
@@ -3134,7 +3667,7 @@ extension Wendy_Agent_Services_V1_WendyAgentService.ClientProtocol {
     ///
     /// > Source IDL Documentation:
     /// >
-    /// > Update the operating system using a Mender artifact
+    /// > Update the operating system using an OS update artifact
     ///
     /// - Parameters:
     ///   - request: A request containing a single `Wendy_Agent_Services_V1_UpdateOSRequest` message.
@@ -3152,6 +3685,101 @@ extension Wendy_Agent_Services_V1_WendyAgentService.ClientProtocol {
             request: request,
             serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_UpdateOSRequest>(),
             deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_UpdateOSResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "DumpKernelLog" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Dump the current kernel ring buffer (dmesg) for inspection. By default
+    /// > the agent streams the buffered records and then keeps following new
+    /// > kernel messages until the client disconnects (like `dmesg -w`); set
+    /// > follow=false for a one-shot dump that completes once the buffer drains.
+    /// > Records are NOT PII-redacted; this is a local diagnostic for an operator
+    /// > connected to their own device, distinct from the DPIA-gated OTel
+    /// > kernel-log streaming path.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Wendy_Agent_Services_V1_DumpKernelLogRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func dumpKernelLog<Result>(
+        request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_DumpKernelLogRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse>) async throws -> Result
+    ) async throws -> Result where Result: Sendable {
+        try await self.dumpKernelLog(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_DumpKernelLogRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_DumpKernelLogResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "GetOSUpdateStatus" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Report the outcome of the most recent OS update attempt: committed
+    /// > after post-reboot healthchecks passed, or rolled back with details on
+    /// > which critical services failed and why.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Wendy_Agent_Services_V1_GetOSUpdateStatusRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func getOSUpdateStatus<Result>(
+        request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.getOSUpdateStatus(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "SetHostname" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Set the device's hostname (and mDNS name) to a literal value. Unlike the
+    /// > first-boot device-name flow, no "wendyos-" prefix is derived: the hostname
+    /// > is applied exactly as given. The value is persisted so it survives reboots.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Wendy_Agent_Services_V1_SetHostnameRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func setHostname<Result>(
+        request: GRPCCore.ClientRequest<Wendy_Agent_Services_V1_SetHostnameRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_SetHostnameResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.setHostname(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Wendy_Agent_Services_V1_SetHostnameRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Wendy_Agent_Services_V1_SetHostnameResponse>(),
             options: options,
             onResponse: handleResponse
         )
@@ -3667,7 +4295,7 @@ extension Wendy_Agent_Services_V1_WendyAgentService.ClientProtocol {
     ///
     /// > Source IDL Documentation:
     /// >
-    /// > Update the operating system using a Mender artifact
+    /// > Update the operating system using an OS update artifact
     ///
     /// - Parameters:
     ///   - message: request message to send.
@@ -3688,6 +4316,113 @@ extension Wendy_Agent_Services_V1_WendyAgentService.ClientProtocol {
             metadata: metadata
         )
         return try await self.updateOS(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "DumpKernelLog" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Dump the current kernel ring buffer (dmesg) for inspection. By default
+    /// > the agent streams the buffered records and then keeps following new
+    /// > kernel messages until the client disconnects (like `dmesg -w`); set
+    /// > follow=false for a one-shot dump that completes once the buffer drains.
+    /// > Records are NOT PII-redacted; this is a local diagnostic for an operator
+    /// > connected to their own device, distinct from the DPIA-gated OTel
+    /// > kernel-log streaming path.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func dumpKernelLog<Result>(
+        _ message: Wendy_Agent_Services_V1_DumpKernelLogRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendy_Agent_Services_V1_DumpKernelLogResponse>) async throws -> Result
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Wendy_Agent_Services_V1_DumpKernelLogRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.dumpKernelLog(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "GetOSUpdateStatus" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Report the outcome of the most recent OS update attempt: committed
+    /// > after post-reboot healthchecks passed, or rolled back with details on
+    /// > which critical services failed and why.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func getOSUpdateStatus<Result>(
+        _ message: Wendy_Agent_Services_V1_GetOSUpdateStatusRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_GetOSUpdateStatusResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Wendy_Agent_Services_V1_GetOSUpdateStatusRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.getOSUpdateStatus(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "SetHostname" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Set the device's hostname (and mDNS name) to a literal value. Unlike the
+    /// > first-boot device-name flow, no "wendyos-" prefix is derived: the hostname
+    /// > is applied exactly as given. The value is persisted so it survives reboots.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func setHostname<Result>(
+        _ message: Wendy_Agent_Services_V1_SetHostnameRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendy_Agent_Services_V1_SetHostnameResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Wendy_Agent_Services_V1_SetHostnameRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.setHostname(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_service.pb.swift
@@ -20,13 +20,13 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Security type advertised by or used for a WiFi network.
-public enum Wendy_Agent_Services_V1_WiFiSecurityType: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Wendy_Agent_Services_V1_WiFiSecurityType: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
   case unspecified // = 0
   case `open` // = 1
@@ -80,7 +80,7 @@ public enum Wendy_Agent_Services_V1_WiFiSecurityType: SwiftProtobuf.Enum, Swift.
 
 }
 
-public struct Wendy_Agent_Services_V1_RunContainerRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_RunContainerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -116,7 +116,7 @@ public struct Wendy_Agent_Services_V1_RunContainerRequest: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_RequestType: Equatable, Sendable {
+  public nonisolated enum OneOf_RequestType: Equatable, Sendable {
     //// The first message in the stream MUST be the header.
     case header(Wendy_Agent_Services_V1_RunContainerRequest.Header)
     //// A chunk of the container tarball.
@@ -126,7 +126,7 @@ public struct Wendy_Agent_Services_V1_RunContainerRequest: Sendable {
 
   }
 
-  public struct Header: Sendable {
+  public nonisolated struct Header: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -145,7 +145,7 @@ public struct Wendy_Agent_Services_V1_RunContainerRequest: Sendable {
     public init() {}
   }
 
-  public struct Chunk: Sendable {
+  public nonisolated struct Chunk: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -161,7 +161,7 @@ public struct Wendy_Agent_Services_V1_RunContainerRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ControlCommand: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ControlCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -186,13 +186,13 @@ public struct Wendy_Agent_Services_V1_ControlCommand: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_Command: Equatable, Sendable {
+  public nonisolated enum OneOf_Command: Equatable, Sendable {
     case run(Wendy_Agent_Services_V1_ControlCommand.Run)
     case stop(Wendy_Agent_Services_V1_ControlCommand.Stop)
 
   }
 
-  public struct Run: Sendable {
+  public nonisolated struct Run: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -218,7 +218,7 @@ public struct Wendy_Agent_Services_V1_ControlCommand: Sendable {
   }
 
   /// No fields needed; acts on the current container in this stream
-  public struct Stop: Sendable {
+  public nonisolated struct Stop: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -231,7 +231,7 @@ public struct Wendy_Agent_Services_V1_ControlCommand: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_RunContainerResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_RunContainerResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -272,7 +272,7 @@ public struct Wendy_Agent_Services_V1_RunContainerResponse: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_ResponseType: Equatable, Sendable {
+  public nonisolated enum OneOf_ResponseType: Equatable, Sendable {
     case started(Wendy_Agent_Services_V1_RunContainerResponse.Started)
     case stopped(Wendy_Agent_Services_V1_RunContainerResponse.Stopped)
     case stdoutOutput(Wendy_Agent_Services_V1_RunContainerResponse.ConsoleOutput)
@@ -280,7 +280,7 @@ public struct Wendy_Agent_Services_V1_RunContainerResponse: Sendable {
 
   }
 
-  public struct Started: Sendable {
+  public nonisolated struct Started: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -295,7 +295,7 @@ public struct Wendy_Agent_Services_V1_RunContainerResponse: Sendable {
   }
 
   /// No fields; indicates container has been stopped
-  public struct Stopped: Sendable {
+  public nonisolated struct Stopped: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -305,7 +305,7 @@ public struct Wendy_Agent_Services_V1_RunContainerResponse: Sendable {
     public init() {}
   }
 
-  public struct ConsoleOutput: Sendable {
+  public nonisolated struct ConsoleOutput: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -321,7 +321,7 @@ public struct Wendy_Agent_Services_V1_RunContainerResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_UpdateAgentRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_UpdateAgentRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -346,13 +346,13 @@ public struct Wendy_Agent_Services_V1_UpdateAgentRequest: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_RequestType: Equatable, Sendable {
+  public nonisolated enum OneOf_RequestType: Equatable, Sendable {
     case chunk(Wendy_Agent_Services_V1_UpdateAgentRequest.Chunk)
     case control(Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand)
 
   }
 
-  public struct Chunk: Sendable {
+  public nonisolated struct Chunk: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -364,7 +364,7 @@ public struct Wendy_Agent_Services_V1_UpdateAgentRequest: Sendable {
     public init() {}
   }
 
-  public struct ControlCommand: Sendable {
+  public nonisolated struct ControlCommand: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -382,13 +382,13 @@ public struct Wendy_Agent_Services_V1_UpdateAgentRequest: Sendable {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Command: Equatable, Sendable {
+    public nonisolated enum OneOf_Command: Equatable, Sendable {
       /// Triggers the replacement of the running agent with the new binary.
       case update(Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand.Update)
 
     }
 
-    public struct Update: Sendable {
+    public nonisolated struct Update: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -406,7 +406,7 @@ public struct Wendy_Agent_Services_V1_UpdateAgentRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_UpdateAgentResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_UpdateAgentResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -423,12 +423,12 @@ public struct Wendy_Agent_Services_V1_UpdateAgentResponse: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_ResponseType: Equatable, Sendable {
+  public nonisolated enum OneOf_ResponseType: Equatable, Sendable {
     case updated(Wendy_Agent_Services_V1_UpdateAgentResponse.Updated)
 
   }
 
-  public struct Updated: Sendable {
+  public nonisolated struct Updated: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -441,7 +441,7 @@ public struct Wendy_Agent_Services_V1_UpdateAgentResponse: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_GetAgentVersionRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_GetAgentVersionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -451,111 +451,225 @@ public struct Wendy_Agent_Services_V1_GetAgentVersionRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_GetAgentVersionResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_GetAgentVersionResponse: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var version: String = String()
+  public var version: String {
+    get {_storage._version}
+    set {_uniqueStorage()._version = newValue}
+  }
 
   /// OS version read from /etc/wendy/version.txt (only present on WendyOS)
   public var osVersion: String {
-    get {_osVersion ?? String()}
-    set {_osVersion = newValue}
+    get {_storage._osVersion ?? String()}
+    set {_uniqueStorage()._osVersion = newValue}
   }
   /// Returns true if `osVersion` has been explicitly set.
-  public var hasOsVersion: Bool {self._osVersion != nil}
+  public var hasOsVersion: Bool {_storage._osVersion != nil}
   /// Clears the value of `osVersion`. Subsequent reads from it will return its default value.
-  public mutating func clearOsVersion() {self._osVersion = nil}
+  public mutating func clearOsVersion() {_uniqueStorage()._osVersion = nil}
 
-  public var os: String = String()
+  public var os: String {
+    get {_storage._os}
+    set {_uniqueStorage()._os = newValue}
+  }
 
-  public var cpuArchitecture: String = String()
+  public var cpuArchitecture: String {
+    get {_storage._cpuArchitecture}
+    set {_uniqueStorage()._cpuArchitecture = newValue}
+  }
 
   public var publicKey: String {
-    get {_publicKey ?? String()}
-    set {_publicKey = newValue}
+    get {_storage._publicKey ?? String()}
+    set {_uniqueStorage()._publicKey = newValue}
   }
   /// Returns true if `publicKey` has been explicitly set.
-  public var hasPublicKey: Bool {self._publicKey != nil}
+  public var hasPublicKey: Bool {_storage._publicKey != nil}
   /// Clears the value of `publicKey`. Subsequent reads from it will return its default value.
-  public mutating func clearPublicKey() {self._publicKey = nil}
+  public mutating func clearPublicKey() {_uniqueStorage()._publicKey = nil}
 
-  public var featureset: [String] = []
+  public var featureset: [String] {
+    get {_storage._featureset}
+    set {_uniqueStorage()._featureset = newValue}
+  }
 
-  /// Hardware platform identifier read from /etc/wendyos/device-type (only present on WendyOS)
+  /// MACHINE/BOARD value from /etc/wendyos/device-type (only present on WendyOS)
   public var deviceType: String {
-    get {_deviceType ?? String()}
-    set {_deviceType = newValue}
+    get {_storage._deviceType ?? String()}
+    set {_uniqueStorage()._deviceType = newValue}
   }
   /// Returns true if `deviceType` has been explicitly set.
-  public var hasDeviceType: Bool {self._deviceType != nil}
+  public var hasDeviceType: Bool {_storage._deviceType != nil}
   /// Clears the value of `deviceType`. Subsequent reads from it will return its default value.
-  public mutating func clearDeviceType() {self._deviceType = nil}
+  public mutating func clearDeviceType() {_uniqueStorage()._deviceType = nil}
 
   /// Whether the device has a GPU.
   public var hasGpu_p: Bool {
-    get {_hasGpu_p ?? false}
-    set {_hasGpu_p = newValue}
+    get {_storage._hasGpu_p ?? false}
+    set {_uniqueStorage()._hasGpu_p = newValue}
   }
   /// Returns true if `hasGpu_p` has been explicitly set.
-  public var hasHasGpu_p: Bool {self._hasGpu_p != nil}
+  public var hasHasGpu_p: Bool {_storage._hasGpu_p != nil}
   /// Clears the value of `hasGpu_p`. Subsequent reads from it will return its default value.
-  public mutating func clearHasGpu_p() {self._hasGpu_p = nil}
+  public mutating func clearHasGpu_p() {_uniqueStorage()._hasGpu_p = nil}
 
   /// GPU vendor identifier (e.g. "nvidia"). Only present when has_gpu is true.
   public var gpuVendor: String {
-    get {_gpuVendor ?? String()}
-    set {_gpuVendor = newValue}
+    get {_storage._gpuVendor ?? String()}
+    set {_uniqueStorage()._gpuVendor = newValue}
   }
   /// Returns true if `gpuVendor` has been explicitly set.
-  public var hasGpuVendor: Bool {self._gpuVendor != nil}
+  public var hasGpuVendor: Bool {_storage._gpuVendor != nil}
   /// Clears the value of `gpuVendor`. Subsequent reads from it will return its default value.
-  public mutating func clearGpuVendor() {self._gpuVendor = nil}
+  public mutating func clearGpuVendor() {_uniqueStorage()._gpuVendor = nil}
 
   /// JetPack version (e.g. "6.2"). Only present on NVIDIA Jetson devices.
   public var jetpackVersion: String {
-    get {_jetpackVersion ?? String()}
-    set {_jetpackVersion = newValue}
+    get {_storage._jetpackVersion ?? String()}
+    set {_uniqueStorage()._jetpackVersion = newValue}
   }
   /// Returns true if `jetpackVersion` has been explicitly set.
-  public var hasJetpackVersion: Bool {self._jetpackVersion != nil}
+  public var hasJetpackVersion: Bool {_storage._jetpackVersion != nil}
   /// Clears the value of `jetpackVersion`. Subsequent reads from it will return its default value.
-  public mutating func clearJetpackVersion() {self._jetpackVersion = nil}
+  public mutating func clearJetpackVersion() {_uniqueStorage()._jetpackVersion = nil}
 
   /// CUDA version string (e.g. "12.2.0"). Only present when CUDA is installed.
   public var cudaVersion: String {
-    get {_cudaVersion ?? String()}
-    set {_cudaVersion = newValue}
+    get {_storage._cudaVersion ?? String()}
+    set {_uniqueStorage()._cudaVersion = newValue}
   }
   /// Returns true if `cudaVersion` has been explicitly set.
-  public var hasCudaVersion: Bool {self._cudaVersion != nil}
+  public var hasCudaVersion: Bool {_storage._cudaVersion != nil}
   /// Clears the value of `cudaVersion`. Subsequent reads from it will return its default value.
-  public mutating func clearCudaVersion() {self._cudaVersion = nil}
+  public mutating func clearCudaVersion() {_uniqueStorage()._cudaVersion = nil}
+
+  /// STORAGE value from /etc/wendyos/device-type (e.g. "sd", "nvme"). Only present on WendyOS.
+  public var storageMedium: String {
+    get {_storage._storageMedium ?? String()}
+    set {_uniqueStorage()._storageMedium = newValue}
+  }
+  /// Returns true if `storageMedium` has been explicitly set.
+  public var hasStorageMedium: Bool {_storage._storageMedium != nil}
+  /// Clears the value of `storageMedium`. Subsequent reads from it will return its default value.
+  public mutating func clearStorageMedium() {_uniqueStorage()._storageMedium = nil}
+
+  /// Root filesystem bytes currently used by the device. Only present when the agent can inspect disk usage.
+  public var diskUsedBytes: Int64 {
+    get {_storage._diskUsedBytes ?? 0}
+    set {_uniqueStorage()._diskUsedBytes = newValue}
+  }
+  /// Returns true if `diskUsedBytes` has been explicitly set.
+  public var hasDiskUsedBytes: Bool {_storage._diskUsedBytes != nil}
+  /// Clears the value of `diskUsedBytes`. Subsequent reads from it will return its default value.
+  public mutating func clearDiskUsedBytes() {_uniqueStorage()._diskUsedBytes = nil}
+
+  /// Root filesystem total bytes on the device. Only present when the agent can inspect disk usage.
+  public var diskTotalBytes: Int64 {
+    get {_storage._diskTotalBytes ?? 0}
+    set {_uniqueStorage()._diskTotalBytes = newValue}
+  }
+  /// Returns true if `diskTotalBytes` has been explicitly set.
+  public var hasDiskTotalBytes: Bool {_storage._diskTotalBytes != nil}
+  /// Clears the value of `diskTotalBytes`. Subsequent reads from it will return its default value.
+  public mutating func clearDiskTotalBytes() {_uniqueStorage()._diskTotalBytes = nil}
+
+  /// Usage for every real (disk-backed) filesystem mounted on the device. The
+  /// root filesystem is included here as well; disk_used_bytes/disk_total_bytes
+  /// are retained for backwards compatibility. Empty when the agent cannot
+  /// enumerate mounts.
+  public var partitions: [Wendy_Agent_Services_V1_DiskPartition] {
+    get {_storage._partitions}
+    set {_uniqueStorage()._partitions = newValue}
+  }
+
+  /// GPU architecture identifier. Format is vendor-specific (e.g. "sm_87" for NVIDIA).
+  public var gpuArch: String {
+    get {_storage._gpuArch ?? String()}
+    set {_uniqueStorage()._gpuArch = newValue}
+  }
+  /// Returns true if `gpuArch` has been explicitly set.
+  public var hasGpuArch: Bool {_storage._gpuArch != nil}
+  /// Clears the value of `gpuArch`. Subsequent reads from it will return its default value.
+  public mutating func clearGpuArch() {_uniqueStorage()._gpuArch = nil}
+
+  /// Network interfaces and their assigned IP addresses, as observed on the
+  /// device. Loopback, down, and container/virtual bridge interfaces are
+  /// omitted, and link-local addresses are excluded. Empty when the agent
+  /// cannot enumerate interfaces.
+  public var networkInterfaces: [Wendy_Agent_Services_V1_NetworkInterface] {
+    get {_storage._networkInterfaces}
+    set {_uniqueStorage()._networkInterfaces = newValue}
+  }
 
   /// Total physical memory (RAM) in bytes, from /proc/meminfo. Zero when the
   /// agent cannot read it (a real host never has 0 bytes of RAM).
-  public var memTotalBytes: Int64 = 0
+  public var memTotalBytes: Int64 {
+    get {_storage._memTotalBytes}
+    set {_uniqueStorage()._memTotalBytes = newValue}
+  }
 
   /// Number of online logical CPU cores, from /proc/stat. Zero when the
   /// agent cannot read it.
-  public var cpuCount: UInt32 = 0
+  public var cpuCount: UInt32 {
+    get {_storage._cpuCount}
+    set {_uniqueStorage()._cpuCount = newValue}
+  }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _osVersion: String? = nil
-  fileprivate var _publicKey: String? = nil
-  fileprivate var _deviceType: String? = nil
-  fileprivate var _hasGpu_p: Bool? = nil
-  fileprivate var _gpuVendor: String? = nil
-  fileprivate var _jetpackVersion: String? = nil
-  fileprivate var _cudaVersion: String? = nil
+  fileprivate var _storage = _StorageClass.defaultInstance
+}
+
+/// A network interface on the device and the IP addresses assigned to it.
+public nonisolated struct Wendy_Agent_Services_V1_NetworkInterface: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Interface name (e.g. "eth0", "wlan0").
+  public var name: String = String()
+
+  /// Routable IPv4 and IPv6 addresses assigned to the interface, without any
+  /// CIDR prefix suffix (e.g. "192.168.1.42").
+  public var ipAddresses: [String] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Usage information for a single mounted filesystem.
+public nonisolated struct Wendy_Agent_Services_V1_DiskPartition: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Mount point (e.g. "/", "/boot", "/data").
+  public var mountpoint: String = String()
+
+  /// Filesystem type (e.g. "ext4", "vfat").
+  public var filesystem: String = String()
+
+  /// Backing block device (e.g. "/dev/mmcblk0p2").
+  public var device: String = String()
+
+  /// Bytes currently used on the filesystem.
+  public var usedBytes: Int64 = 0
+
+  /// Total bytes on the filesystem.
+  public var totalBytes: Int64 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
 }
 
 /// Request message for listing WiFi networks
-public struct Wendy_Agent_Services_V1_ListWiFiNetworksRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListWiFiNetworksRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -566,7 +680,7 @@ public struct Wendy_Agent_Services_V1_ListWiFiNetworksRequest: Sendable {
 }
 
 /// Response message for listing WiFi networks
-public struct Wendy_Agent_Services_V1_ListWiFiNetworksResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListWiFiNetworksResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -577,7 +691,7 @@ public struct Wendy_Agent_Services_V1_ListWiFiNetworksResponse: Sendable {
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Information about a WiFi network
-  public struct WiFiNetwork: Sendable {
+  public nonisolated struct WiFiNetwork: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -639,7 +753,7 @@ public struct Wendy_Agent_Services_V1_ListWiFiNetworksResponse: Sendable {
 }
 
 /// Request message for connecting to a WiFi network
-public struct Wendy_Agent_Services_V1_ConnectToWiFiRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ConnectToWiFiRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -680,7 +794,7 @@ public struct Wendy_Agent_Services_V1_ConnectToWiFiRequest: Sendable {
 }
 
 /// Response message for connecting to a WiFi network
-public struct Wendy_Agent_Services_V1_ConnectToWiFiResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ConnectToWiFiResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -706,7 +820,7 @@ public struct Wendy_Agent_Services_V1_ConnectToWiFiResponse: Sendable {
 }
 
 /// Request message for getting WiFi status
-public struct Wendy_Agent_Services_V1_GetWiFiStatusRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_GetWiFiStatusRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -717,7 +831,7 @@ public struct Wendy_Agent_Services_V1_GetWiFiStatusRequest: Sendable {
 }
 
 /// Response message for getting WiFi status
-public struct Wendy_Agent_Services_V1_GetWiFiStatusResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_GetWiFiStatusResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -754,7 +868,7 @@ public struct Wendy_Agent_Services_V1_GetWiFiStatusResponse: Sendable {
 }
 
 /// Request message for disconnecting from WiFi
-public struct Wendy_Agent_Services_V1_DisconnectWiFiRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_DisconnectWiFiRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -765,7 +879,7 @@ public struct Wendy_Agent_Services_V1_DisconnectWiFiRequest: Sendable {
 }
 
 /// Response message for disconnecting from WiFi
-public struct Wendy_Agent_Services_V1_DisconnectWiFiResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_DisconnectWiFiResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -791,7 +905,7 @@ public struct Wendy_Agent_Services_V1_DisconnectWiFiResponse: Sendable {
 }
 
 /// Request message for listing known (saved) WiFi networks.
-public struct Wendy_Agent_Services_V1_ListKnownWiFiNetworksRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListKnownWiFiNetworksRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -802,7 +916,7 @@ public struct Wendy_Agent_Services_V1_ListKnownWiFiNetworksRequest: Sendable {
 }
 
 /// Response message for listing known (saved) WiFi networks.
-public struct Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -811,7 +925,7 @@ public struct Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public struct KnownWiFiNetwork: Sendable {
+  public nonisolated struct KnownWiFiNetwork: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -837,7 +951,7 @@ public struct Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse: Sendable {
 }
 
 /// Request to set the priority of a single saved network.
-public struct Wendy_Agent_Services_V1_SetWiFiNetworkPriorityRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_SetWiFiNetworkPriorityRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -853,7 +967,7 @@ public struct Wendy_Agent_Services_V1_SetWiFiNetworkPriorityRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_SetWiFiNetworkPriorityResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_SetWiFiNetworkPriorityResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -879,7 +993,7 @@ public struct Wendy_Agent_Services_V1_SetWiFiNetworkPriorityResponse: Sendable {
 /// Request to bulk-reorder saved networks. The first SSID in `order_ssids`
 /// gets the highest priority, the last gets the lowest. SSIDs not listed
 /// are left untouched.
-public struct Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -891,7 +1005,7 @@ public struct Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksRequest: Sendable 
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -915,7 +1029,7 @@ public struct Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksResponse: Sendable
 }
 
 /// Request to remove a saved network profile.
-public struct Wendy_Agent_Services_V1_ForgetWiFiNetworkRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ForgetWiFiNetworkRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -927,7 +1041,7 @@ public struct Wendy_Agent_Services_V1_ForgetWiFiNetworkRequest: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ForgetWiFiNetworkResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ForgetWiFiNetworkResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -951,7 +1065,7 @@ public struct Wendy_Agent_Services_V1_ForgetWiFiNetworkResponse: Sendable {
 }
 
 /// Request message for listing hardware capabilities
-public struct Wendy_Agent_Services_V1_ListHardwareCapabilitiesRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListHardwareCapabilitiesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -974,7 +1088,7 @@ public struct Wendy_Agent_Services_V1_ListHardwareCapabilitiesRequest: Sendable 
 }
 
 /// Response message for listing hardware capabilities
-public struct Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -985,7 +1099,7 @@ public struct Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse: Sendable
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Information about a hardware capability
-  public struct HardwareCapability: Sendable {
+  public nonisolated struct HardwareCapability: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1010,7 +1124,7 @@ public struct Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse: Sendable
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ScanBluetoothPeripheralsRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ScanBluetoothPeripheralsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1020,7 +1134,7 @@ public struct Wendy_Agent_Services_V1_ScanBluetoothPeripheralsRequest: Sendable 
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_DiscoveredBluetoothPeripheral: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_DiscoveredBluetoothPeripheral: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1044,7 +1158,7 @@ public struct Wendy_Agent_Services_V1_DiscoveredBluetoothPeripheral: Sendable {
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ScanBluetoothPeripheralsResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ScanBluetoothPeripheralsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1056,7 +1170,7 @@ public struct Wendy_Agent_Services_V1_ScanBluetoothPeripheralsResponse: Sendable
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ConnectBluetoothPeripheralRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ConnectBluetoothPeripheralRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1072,7 +1186,7 @@ public struct Wendy_Agent_Services_V1_ConnectBluetoothPeripheralRequest: Sendabl
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ConnectBluetoothPeripheralResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_ConnectBluetoothPeripheralResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1082,29 +1196,7 @@ public struct Wendy_Agent_Services_V1_ConnectBluetoothPeripheralResponse: Sendab
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralRequest: Sendable {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  public var address: String = String()
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
-public struct Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralResponse: Sendable {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
-public struct Wendy_Agent_Services_V1_ForgetBluetoothPeripheralRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1116,7 +1208,29 @@ public struct Wendy_Agent_Services_V1_ForgetBluetoothPeripheralRequest: Sendable
   public init() {}
 }
 
-public struct Wendy_Agent_Services_V1_ForgetBluetoothPeripheralResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_ForgetBluetoothPeripheralRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var address: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_ForgetBluetoothPeripheralResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1127,13 +1241,16 @@ public struct Wendy_Agent_Services_V1_ForgetBluetoothPeripheralResponse: Sendabl
 }
 
 /// Request message for updating the OS
-public struct Wendy_Agent_Services_V1_UpdateOSRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_UpdateOSRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// URL to download the Mender artifact from
+  /// URL to download the OS update artifact from (a .wendy artifact)
   public var artifactURL: String = String()
+
+  /// Optional. Empty/'auto' selects the wendyos-update engine; 'wendyos'/'wendyos-update' force it. Retained for wire compatibility.
+  public var updaterBackend: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1141,7 +1258,7 @@ public struct Wendy_Agent_Services_V1_UpdateOSRequest: Sendable {
 }
 
 /// Response message for OS update progress
-public struct Wendy_Agent_Services_V1_UpdateOSResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_UpdateOSResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1174,14 +1291,14 @@ public struct Wendy_Agent_Services_V1_UpdateOSResponse: Sendable {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_ResponseType: Equatable, Sendable {
+  public nonisolated enum OneOf_ResponseType: Equatable, Sendable {
     case progress(Wendy_Agent_Services_V1_UpdateOSResponse.Progress)
     case completed(Wendy_Agent_Services_V1_UpdateOSResponse.Completed)
     case failed(Wendy_Agent_Services_V1_UpdateOSResponse.Failed)
 
   }
 
-  public struct Progress: Sendable {
+  public nonisolated struct Progress: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1197,7 +1314,7 @@ public struct Wendy_Agent_Services_V1_UpdateOSResponse: Sendable {
     public init() {}
   }
 
-  public struct Completed: Sendable {
+  public nonisolated struct Completed: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1210,7 +1327,7 @@ public struct Wendy_Agent_Services_V1_UpdateOSResponse: Sendable {
     public init() {}
   }
 
-  public struct Failed: Sendable {
+  public nonisolated struct Failed: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1226,15 +1343,431 @@ public struct Wendy_Agent_Services_V1_UpdateOSResponse: Sendable {
   public init() {}
 }
 
+/// Request to dump the kernel ring buffer.
+public nonisolated struct Wendy_Agent_Services_V1_DumpKernelLogRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// When true (the default when the field is omitted), the agent streams the
+  /// currently-buffered records and then follows new kernel messages until the
+  /// client disconnects (like `dmesg -w`). When explicitly false, the agent
+  /// streams the buffered records and completes once the ring buffer is drained
+  /// (like `dmesg`). Sent as optional so an unset request defaults to follow.
+  public var follow: Bool {
+    get {_follow ?? false}
+    set {_follow = newValue}
+  }
+  /// Returns true if `follow` has been explicitly set.
+  public var hasFollow: Bool {self._follow != nil}
+  /// Clears the value of `follow`. Subsequent reads from it will return its default value.
+  public mutating func clearFollow() {self._follow = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _follow: Bool? = nil
+}
+
+/// A batch of kernel log records. The agent sends records in batches to keep
+/// individual messages well under the gRPC message-size limit, regardless of
+/// how large the kernel ring buffer is.
+public nonisolated struct Wendy_Agent_Services_V1_DumpKernelLogResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var records: [Wendy_Agent_Services_V1_KernelLogRecord] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// A single kernel ring buffer record (one /dev/kmsg line).
+public nonisolated struct Wendy_Agent_Services_V1_KernelLogRecord: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Timestamp in microseconds since boot, as reported by the kernel.
+  public var timestampUs: Int64 = 0
+
+  /// Kernel syslog level (0=EMERG .. 7=DEBUG).
+  public var level: Int32 = 0
+
+  /// Message text. Control characters are stripped; the body is NOT
+  /// PII-redacted.
+  public var message: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_GetOSUpdateStatusRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// When true, the agent additionally probes the OS updater's live status
+  /// (`wendyos-update status --json`) and returns it in engine_status. Off by
+  /// default because the probe execs a binary on the device.
+  public var includeEngineStatus: Bool = false
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Live A/B-slot snapshot from `wendyos-update status --json` (frozen v1 CLI
+/// contract of github.com/wendylabsinc/wendyos-update). Mirrors that contract's
+/// field names; all fields are best-effort and may be empty.
+public nonisolated struct Wendy_Agent_Services_V1_OSUpdateEngineStatus: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Platform connector driving the A/B scheme, e.g. "tegrauefi" or "ubootenv".
+  public var connector: String = String()
+
+  /// Slot the device is currently booted from ("A" or "B").
+  public var currentSlot: String = String()
+
+  public var slots: [Wendy_Agent_Services_V1_OSUpdateEngineStatus.Slot] = []
+
+  public var system: [Wendy_Agent_Services_V1_OSUpdateEngineStatus.SystemEntry] = []
+
+  public var pending: Wendy_Agent_Services_V1_OSUpdateEngineStatus.PendingUpdate {
+    get {_pending ?? Wendy_Agent_Services_V1_OSUpdateEngineStatus.PendingUpdate()}
+    set {_pending = newValue}
+  }
+  /// Returns true if `pending` has been explicitly set.
+  public var hasPending: Bool {self._pending != nil}
+  /// Clears the value of `pending`. Subsequent reads from it will return its default value.
+  public mutating func clearPending() {self._pending = nil}
+
+  /// Raw, display-only engine diagnostics from `wendyos-update status
+  /// --verbose` (the connector's Diagnostics map: e.g. the tegra
+  /// RootfsStatusSlot{A,B} bytes, boot-chain and capsule EFI variables, or
+  /// the uboot env). Present only when the caller asked for engine status;
+  /// keys and values are connector-specific and additive.
+  public var diagnostics: Dictionary<String,String> = [:]
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public nonisolated struct Slot: Sendable {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    /// Slot name ("A" or "B").
+    public var slot: String = String()
+
+    /// True for the slot the device is booted from.
+    public var booted: Bool = false
+
+    /// Rootfs partition device, e.g. "/dev/nvme0n1p1".
+    public var partition: String = String()
+
+    /// Distro version installed in the slot; "" when unreadable.
+    public var distro: String = String()
+
+    /// Kernel version installed in the slot; "" when unreadable.
+    public var kernel: String = String()
+
+    /// Slot health as reported by the bootloader, e.g. "normal".
+    public var rootfsHealth: String = String()
+
+    /// Remaining boot-trial retries, when the platform tracks them.
+    public var retries: String = String()
+
+    /// Free-form platform note about the slot.
+    public var note: String = String()
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  /// Ordered system-wide key/value pairs (bootloader version, capsule
+  /// status, ...) exactly as the engine reports them.
+  public nonisolated struct SystemEntry: Sendable {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    public var key: String = String()
+
+    public var value: String = String()
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  /// In-flight (uncommitted) update, absent when none is pending.
+  public nonisolated struct PendingUpdate: Sendable {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    public var artifactName: String = String()
+
+    public var artifactVersion: String = String()
+
+    /// Engine phase, e.g. "installed" (awaiting reboot + commit).
+    public var phase: String = String()
+
+    /// Slot the update was written to ("A" or "B").
+    public var targetSlot: String = String()
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  public init() {}
+
+  fileprivate var _pending: Wendy_Agent_Services_V1_OSUpdateEngineStatus.PendingUpdate? = nil
+}
+
+/// Outcome of the most recent OS update attempt, produced by the agent's
+/// post-reboot healthcheck gate and persisted on the device's data partition
+/// (so it survives an A/B slot rollback).
+public nonisolated struct Wendy_Agent_Services_V1_GetOSUpdateStatusResponse: @unchecked Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// False when no update-result record exists on the device.
+  public var hasResult_p: Bool {
+    get {_storage._hasResult_p}
+    set {_uniqueStorage()._hasResult_p = newValue}
+  }
+
+  public var outcome: Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.Outcome {
+    get {_storage._outcome}
+    set {_uniqueStorage()._outcome = newValue}
+  }
+
+  public var services: [Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.ServiceResult] {
+    get {_storage._services}
+    set {_uniqueStorage()._services = newValue}
+  }
+
+  /// OS version before the update was applied.
+  public var oldOsVersion: String {
+    get {_storage._oldOsVersion}
+    set {_uniqueStorage()._oldOsVersion = newValue}
+  }
+
+  /// OS version the update attempted to boot into.
+  public var newOsVersion: String {
+    get {_storage._newOsVersion}
+    set {_uniqueStorage()._newOsVersion = newValue}
+  }
+
+  /// When the healthcheck gate produced this record (unix seconds).
+  public var createdAtUnix: Int64 {
+    get {_storage._createdAtUnix}
+    set {_uniqueStorage()._createdAtUnix = newValue}
+  }
+
+  /// When the post-rollback boot confirmed the record (unix seconds);
+  /// 0 until then.
+  public var finalizedAtUnix: Int64 {
+    get {_storage._finalizedAtUnix}
+    set {_uniqueStorage()._finalizedAtUnix = newValue}
+  }
+
+  /// Non-empty when the rollback command itself errored.
+  public var rollbackError: String {
+    get {_storage._rollbackError}
+    set {_uniqueStorage()._rollbackError = newValue}
+  }
+
+  /// Human-readable detail for the outcome. For OUTCOME_COMMIT_FAILED this is
+  /// the commit command's failure reason, including the OS updater's output,
+  /// so the failure is diagnosable without shell access to the device.
+  public var note: String {
+    get {_storage._note}
+    set {_uniqueStorage()._note = newValue}
+  }
+
+  /// Live updater snapshot; set only when the request asked for it via
+  /// include_engine_status AND the device uses the wendyos-update engine AND
+  /// the probe succeeded. Independent of has_result.
+  public var engineStatus: Wendy_Agent_Services_V1_OSUpdateEngineStatus {
+    get {_storage._engineStatus ?? Wendy_Agent_Services_V1_OSUpdateEngineStatus()}
+    set {_uniqueStorage()._engineStatus = newValue}
+  }
+  /// Returns true if `engineStatus` has been explicitly set.
+  public var hasEngineStatus: Bool {_storage._engineStatus != nil}
+  /// Clears the value of `engineStatus`. Subsequent reads from it will return its default value.
+  public mutating func clearEngineStatus() {_uniqueStorage()._engineStatus = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public nonisolated enum Outcome: SwiftProtobuf.Enum, Swift.CaseIterable {
+    public typealias RawValue = Int
+    case unspecified // = 0
+
+    /// Healthchecks passed and the update was committed.
+    case committed // = 1
+
+    /// Healthchecks failed and the previous OS was restored.
+    case rolledBack // = 2
+
+    /// Healthchecks failed but the rollback could not be performed.
+    case rollbackFailed // = 3
+
+    /// Healthchecks passed but committing the update failed.
+    case commitFailed // = 4
+    case UNRECOGNIZED(Int)
+
+    public init() {
+      self = .unspecified
+    }
+
+    public init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .unspecified
+      case 1: self = .committed
+      case 2: self = .rolledBack
+      case 3: self = .rollbackFailed
+      case 4: self = .commitFailed
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    public var rawValue: Int {
+      switch self {
+      case .unspecified: return 0
+      case .committed: return 1
+      case .rolledBack: return 2
+      case .rollbackFailed: return 3
+      case .commitFailed: return 4
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.Outcome] = [
+      .unspecified,
+      .committed,
+      .rolledBack,
+      .rollbackFailed,
+      .commitFailed,
+    ]
+
+  }
+
+  public nonisolated struct ServiceResult: Sendable {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    /// systemd unit name, e.g. "avahi-daemon.service"
+    public var unit: String = String()
+
+    public var status: Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.ServiceResult.Status = .unspecified
+
+    /// Failure reason; empty for healthy/skipped services.
+    public var reason: String = String()
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public nonisolated enum Status: SwiftProtobuf.Enum, Swift.CaseIterable {
+      public typealias RawValue = Int
+      case unspecified // = 0
+      case healthy // = 1
+
+      /// Unit not present on this device or intentionally disabled.
+      case skipped // = 2
+      case failed // = 3
+      case UNRECOGNIZED(Int)
+
+      public init() {
+        self = .unspecified
+      }
+
+      public init?(rawValue: Int) {
+        switch rawValue {
+        case 0: self = .unspecified
+        case 1: self = .healthy
+        case 2: self = .skipped
+        case 3: self = .failed
+        default: self = .UNRECOGNIZED(rawValue)
+        }
+      }
+
+      public var rawValue: Int {
+        switch self {
+        case .unspecified: return 0
+        case .healthy: return 1
+        case .skipped: return 2
+        case .failed: return 3
+        case .UNRECOGNIZED(let i): return i
+        }
+      }
+
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.ServiceResult.Status] = [
+        .unspecified,
+        .healthy,
+        .skipped,
+        .failed,
+      ]
+
+    }
+
+    public init() {}
+  }
+
+  public init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_SetHostnameRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The literal hostname to apply. Must be a valid DNS label: starts with a
+  /// lowercase letter, followed by lowercase letters, digits, or hyphens, not
+  /// ending in a hyphen, at most 63 characters. No prefix is added.
+  public var hostname: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Wendy_Agent_Services_V1_SetHostnameResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The hostname that was applied.
+  public var hostname: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendy.agent.services.v1"
+fileprivate nonisolated let _protobuf_package = "wendy.agent.services.v1"
 
-extension Wendy_Agent_Services_V1_WiFiSecurityType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_WiFiSecurityType: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0WIFI_SECURITY_TYPE_UNSPECIFIED\0\u{1}WIFI_SECURITY_TYPE_OPEN\0\u{1}WIFI_SECURITY_TYPE_WEP\0\u{1}WIFI_SECURITY_TYPE_WPA_PSK\0\u{1}WIFI_SECURITY_TYPE_WPA2_PSK\0\u{1}WIFI_SECURITY_TYPE_WPA3_SAE\0\u{1}WIFI_SECURITY_TYPE_WPA2_ENTERPRISE\0")
 }
 
-extension Wendy_Agent_Services_V1_RunContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RunContainerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}header\0\u{1}chunk\0\u{1}control\0")
 
@@ -1318,7 +1851,7 @@ extension Wendy_Agent_Services_V1_RunContainerRequest: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerRequest.Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerRequest.Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_RunContainerRequest.protoMessageName + ".Header"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}image_name\0\u{1}cmd\0\u{3}app_config\0")
 
@@ -1358,7 +1891,7 @@ extension Wendy_Agent_Services_V1_RunContainerRequest.Header: SwiftProtobuf.Mess
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerRequest.Chunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerRequest.Chunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_RunContainerRequest.protoMessageName + ".Chunk"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0")
 
@@ -1388,7 +1921,7 @@ extension Wendy_Agent_Services_V1_RunContainerRequest.Chunk: SwiftProtobuf.Messa
   }
 }
 
-extension Wendy_Agent_Services_V1_ControlCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ControlCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ControlCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}run\0\u{1}stop\0")
 
@@ -1455,7 +1988,7 @@ extension Wendy_Agent_Services_V1_ControlCommand: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendy_Agent_Services_V1_ControlCommand.Run: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ControlCommand.Run: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_ControlCommand.protoMessageName + ".Run"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}debug\0\u{3}restart_policy\0")
 
@@ -1494,7 +2027,7 @@ extension Wendy_Agent_Services_V1_ControlCommand.Run: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_ControlCommand.Stop: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ControlCommand.Stop: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_ControlCommand.protoMessageName + ".Stop"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1513,7 +2046,7 @@ extension Wendy_Agent_Services_V1_ControlCommand.Stop: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RunContainerResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}started\0\u{1}stopped\0\u{3}stdout_output\0\u{3}stderr_output\0")
 
@@ -1614,7 +2147,7 @@ extension Wendy_Agent_Services_V1_RunContainerResponse: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerResponse.Started: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerResponse.Started: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_RunContainerResponse.protoMessageName + ".Started"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}debug_port\0")
 
@@ -1644,7 +2177,7 @@ extension Wendy_Agent_Services_V1_RunContainerResponse.Started: SwiftProtobuf.Me
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerResponse.Stopped: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerResponse.Stopped: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_RunContainerResponse.protoMessageName + ".Stopped"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1663,7 +2196,7 @@ extension Wendy_Agent_Services_V1_RunContainerResponse.Stopped: SwiftProtobuf.Me
   }
 }
 
-extension Wendy_Agent_Services_V1_RunContainerResponse.ConsoleOutput: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_RunContainerResponse.ConsoleOutput: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_RunContainerResponse.protoMessageName + ".ConsoleOutput"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0")
 
@@ -1693,7 +2226,7 @@ extension Wendy_Agent_Services_V1_RunContainerResponse.ConsoleOutput: SwiftProto
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateAgentRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateAgentRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateAgentRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}chunk\0\u{1}control\0")
 
@@ -1760,7 +2293,7 @@ extension Wendy_Agent_Services_V1_UpdateAgentRequest: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateAgentRequest.Chunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateAgentRequest.Chunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_UpdateAgentRequest.protoMessageName + ".Chunk"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0")
 
@@ -1790,7 +2323,7 @@ extension Wendy_Agent_Services_V1_UpdateAgentRequest.Chunk: SwiftProtobuf.Messag
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_UpdateAgentRequest.protoMessageName + ".ControlCommand"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}update\0")
 
@@ -1836,7 +2369,7 @@ extension Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand: SwiftProtob
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand.Update: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand.Update: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand.protoMessageName + ".Update"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sha256\0")
 
@@ -1866,7 +2399,7 @@ extension Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand.Update: Swif
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateAgentResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateAgentResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateAgentResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}updated\0")
 
@@ -1912,7 +2445,7 @@ extension Wendy_Agent_Services_V1_UpdateAgentResponse: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateAgentResponse.Updated: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateAgentResponse.Updated: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_UpdateAgentResponse.protoMessageName + ".Updated"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1931,7 +2464,7 @@ extension Wendy_Agent_Services_V1_UpdateAgentResponse.Updated: SwiftProtobuf.Mes
   }
 }
 
-extension Wendy_Agent_Services_V1_GetAgentVersionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_GetAgentVersionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetAgentVersionRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1950,9 +2483,205 @@ extension Wendy_Agent_Services_V1_GetAgentVersionRequest: SwiftProtobuf.Message,
   }
 }
 
-extension Wendy_Agent_Services_V1_GetAgentVersionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_GetAgentVersionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetAgentVersionResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0\u{3}os_version\0\u{1}os\0\u{3}cpu_architecture\0\u{3}public_key\0\u{1}featureset\0\u{3}device_type\0\u{3}has_gpu\0\u{3}gpu_vendor\0\u{3}jetpack_version\0\u{3}cuda_version\0\u{3}storage_medium\0\u{3}disk_used_bytes\0\u{3}disk_total_bytes\0\u{1}partitions\0\u{3}gpu_arch\0\u{3}network_interfaces\0\u{3}mem_total_bytes\0\u{3}cpu_count\0")
+
+  fileprivate class _StorageClass {
+    var _version: String = String()
+    var _osVersion: String? = nil
+    var _os: String = String()
+    var _cpuArchitecture: String = String()
+    var _publicKey: String? = nil
+    var _featureset: [String] = []
+    var _deviceType: String? = nil
+    var _hasGpu_p: Bool? = nil
+    var _gpuVendor: String? = nil
+    var _jetpackVersion: String? = nil
+    var _cudaVersion: String? = nil
+    var _storageMedium: String? = nil
+    var _diskUsedBytes: Int64? = nil
+    var _diskTotalBytes: Int64? = nil
+    var _partitions: [Wendy_Agent_Services_V1_DiskPartition] = []
+    var _gpuArch: String? = nil
+    var _networkInterfaces: [Wendy_Agent_Services_V1_NetworkInterface] = []
+    var _memTotalBytes: Int64 = 0
+    var _cpuCount: UInt32 = 0
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _version = source._version
+      _osVersion = source._osVersion
+      _os = source._os
+      _cpuArchitecture = source._cpuArchitecture
+      _publicKey = source._publicKey
+      _featureset = source._featureset
+      _deviceType = source._deviceType
+      _hasGpu_p = source._hasGpu_p
+      _gpuVendor = source._gpuVendor
+      _jetpackVersion = source._jetpackVersion
+      _cudaVersion = source._cudaVersion
+      _storageMedium = source._storageMedium
+      _diskUsedBytes = source._diskUsedBytes
+      _diskTotalBytes = source._diskTotalBytes
+      _partitions = source._partitions
+      _gpuArch = source._gpuArch
+      _networkInterfaces = source._networkInterfaces
+      _memTotalBytes = source._memTotalBytes
+      _cpuCount = source._cpuCount
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularStringField(value: &_storage._version) }()
+        case 2: try { try decoder.decodeSingularStringField(value: &_storage._osVersion) }()
+        case 3: try { try decoder.decodeSingularStringField(value: &_storage._os) }()
+        case 4: try { try decoder.decodeSingularStringField(value: &_storage._cpuArchitecture) }()
+        case 5: try { try decoder.decodeSingularStringField(value: &_storage._publicKey) }()
+        case 6: try { try decoder.decodeRepeatedStringField(value: &_storage._featureset) }()
+        case 7: try { try decoder.decodeSingularStringField(value: &_storage._deviceType) }()
+        case 8: try { try decoder.decodeSingularBoolField(value: &_storage._hasGpu_p) }()
+        case 9: try { try decoder.decodeSingularStringField(value: &_storage._gpuVendor) }()
+        case 10: try { try decoder.decodeSingularStringField(value: &_storage._jetpackVersion) }()
+        case 11: try { try decoder.decodeSingularStringField(value: &_storage._cudaVersion) }()
+        case 12: try { try decoder.decodeSingularStringField(value: &_storage._storageMedium) }()
+        case 13: try { try decoder.decodeSingularInt64Field(value: &_storage._diskUsedBytes) }()
+        case 14: try { try decoder.decodeSingularInt64Field(value: &_storage._diskTotalBytes) }()
+        case 15: try { try decoder.decodeRepeatedMessageField(value: &_storage._partitions) }()
+        case 16: try { try decoder.decodeSingularStringField(value: &_storage._gpuArch) }()
+        case 17: try { try decoder.decodeRepeatedMessageField(value: &_storage._networkInterfaces) }()
+        case 18: try { try decoder.decodeSingularInt64Field(value: &_storage._memTotalBytes) }()
+        case 19: try { try decoder.decodeSingularUInt32Field(value: &_storage._cpuCount) }()
+        default: break
+        }
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      if !_storage._version.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._version, fieldNumber: 1)
+      }
+      try { if let v = _storage._osVersion {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      } }()
+      if !_storage._os.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._os, fieldNumber: 3)
+      }
+      if !_storage._cpuArchitecture.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._cpuArchitecture, fieldNumber: 4)
+      }
+      try { if let v = _storage._publicKey {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+      } }()
+      if !_storage._featureset.isEmpty {
+        try visitor.visitRepeatedStringField(value: _storage._featureset, fieldNumber: 6)
+      }
+      try { if let v = _storage._deviceType {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+      } }()
+      try { if let v = _storage._hasGpu_p {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 8)
+      } }()
+      try { if let v = _storage._gpuVendor {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 9)
+      } }()
+      try { if let v = _storage._jetpackVersion {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 10)
+      } }()
+      try { if let v = _storage._cudaVersion {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 11)
+      } }()
+      try { if let v = _storage._storageMedium {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 12)
+      } }()
+      try { if let v = _storage._diskUsedBytes {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 13)
+      } }()
+      try { if let v = _storage._diskTotalBytes {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 14)
+      } }()
+      if !_storage._partitions.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._partitions, fieldNumber: 15)
+      }
+      try { if let v = _storage._gpuArch {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 16)
+      } }()
+      if !_storage._networkInterfaces.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._networkInterfaces, fieldNumber: 17)
+      }
+      if _storage._memTotalBytes != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._memTotalBytes, fieldNumber: 18)
+      }
+      if _storage._cpuCount != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._cpuCount, fieldNumber: 19)
+      }
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_GetAgentVersionResponse, rhs: Wendy_Agent_Services_V1_GetAgentVersionResponse) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._version != rhs_storage._version {return false}
+        if _storage._osVersion != rhs_storage._osVersion {return false}
+        if _storage._os != rhs_storage._os {return false}
+        if _storage._cpuArchitecture != rhs_storage._cpuArchitecture {return false}
+        if _storage._publicKey != rhs_storage._publicKey {return false}
+        if _storage._featureset != rhs_storage._featureset {return false}
+        if _storage._deviceType != rhs_storage._deviceType {return false}
+        if _storage._hasGpu_p != rhs_storage._hasGpu_p {return false}
+        if _storage._gpuVendor != rhs_storage._gpuVendor {return false}
+        if _storage._jetpackVersion != rhs_storage._jetpackVersion {return false}
+        if _storage._cudaVersion != rhs_storage._cudaVersion {return false}
+        if _storage._storageMedium != rhs_storage._storageMedium {return false}
+        if _storage._diskUsedBytes != rhs_storage._diskUsedBytes {return false}
+        if _storage._diskTotalBytes != rhs_storage._diskTotalBytes {return false}
+        if _storage._partitions != rhs_storage._partitions {return false}
+        if _storage._gpuArch != rhs_storage._gpuArch {return false}
+        if _storage._networkInterfaces != rhs_storage._networkInterfaces {return false}
+        if _storage._memTotalBytes != rhs_storage._memTotalBytes {return false}
+        if _storage._cpuCount != rhs_storage._cpuCount {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_NetworkInterface: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".NetworkInterface"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}ip_addresses\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1960,91 +2689,82 @@ extension Wendy_Agent_Services_V1_GetAgentVersionResponse: SwiftProtobuf.Message
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.version) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self._osVersion) }()
-      case 3: try { try decoder.decodeSingularStringField(value: &self.os) }()
-      case 4: try { try decoder.decodeSingularStringField(value: &self.cpuArchitecture) }()
-      case 5: try { try decoder.decodeSingularStringField(value: &self._publicKey) }()
-      case 6: try { try decoder.decodeRepeatedStringField(value: &self.featureset) }()
-      case 7: try { try decoder.decodeSingularStringField(value: &self._deviceType) }()
-      case 8: try { try decoder.decodeSingularBoolField(value: &self._hasGpu_p) }()
-      case 9: try { try decoder.decodeSingularStringField(value: &self._gpuVendor) }()
-      case 10: try { try decoder.decodeSingularStringField(value: &self._jetpackVersion) }()
-      case 11: try { try decoder.decodeSingularStringField(value: &self._cudaVersion) }()
-      case 18: try { try decoder.decodeSingularInt64Field(value: &self.memTotalBytes) }()
-      case 19: try { try decoder.decodeSingularUInt32Field(value: &self.cpuCount) }()
+      case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 2: try { try decoder.decodeRepeatedStringField(value: &self.ipAddresses) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    if !self.version.isEmpty {
-      try visitor.visitSingularStringField(value: self.version, fieldNumber: 1)
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
-    try { if let v = self._osVersion {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    } }()
-    if !self.os.isEmpty {
-      try visitor.visitSingularStringField(value: self.os, fieldNumber: 3)
-    }
-    if !self.cpuArchitecture.isEmpty {
-      try visitor.visitSingularStringField(value: self.cpuArchitecture, fieldNumber: 4)
-    }
-    try { if let v = self._publicKey {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-    } }()
-    if !self.featureset.isEmpty {
-      try visitor.visitRepeatedStringField(value: self.featureset, fieldNumber: 6)
-    }
-    try { if let v = self._deviceType {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-    } }()
-    try { if let v = self._hasGpu_p {
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 8)
-    } }()
-    try { if let v = self._gpuVendor {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 9)
-    } }()
-    try { if let v = self._jetpackVersion {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 10)
-    } }()
-    try { if let v = self._cudaVersion {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 11)
-    } }()
-    if self.memTotalBytes != 0 {
-      try visitor.visitSingularInt64Field(value: self.memTotalBytes, fieldNumber: 18)
-    }
-    if self.cpuCount != 0 {
-      try visitor.visitSingularUInt32Field(value: self.cpuCount, fieldNumber: 19)
+    if !self.ipAddresses.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.ipAddresses, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Wendy_Agent_Services_V1_GetAgentVersionResponse, rhs: Wendy_Agent_Services_V1_GetAgentVersionResponse) -> Bool {
-    if lhs.version != rhs.version {return false}
-    if lhs._osVersion != rhs._osVersion {return false}
-    if lhs.os != rhs.os {return false}
-    if lhs.cpuArchitecture != rhs.cpuArchitecture {return false}
-    if lhs._publicKey != rhs._publicKey {return false}
-    if lhs.featureset != rhs.featureset {return false}
-    if lhs._deviceType != rhs._deviceType {return false}
-    if lhs._hasGpu_p != rhs._hasGpu_p {return false}
-    if lhs._gpuVendor != rhs._gpuVendor {return false}
-    if lhs._jetpackVersion != rhs._jetpackVersion {return false}
-    if lhs._cudaVersion != rhs._cudaVersion {return false}
-    if lhs.memTotalBytes != rhs.memTotalBytes {return false}
-    if lhs.cpuCount != rhs.cpuCount {return false}
+  public static func ==(lhs: Wendy_Agent_Services_V1_NetworkInterface, rhs: Wendy_Agent_Services_V1_NetworkInterface) -> Bool {
+    if lhs.name != rhs.name {return false}
+    if lhs.ipAddresses != rhs.ipAddresses {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_ListWiFiNetworksRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_DiskPartition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DiskPartition"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}mountpoint\0\u{1}filesystem\0\u{1}device\0\u{3}used_bytes\0\u{3}total_bytes\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.mountpoint) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.filesystem) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.device) }()
+      case 4: try { try decoder.decodeSingularInt64Field(value: &self.usedBytes) }()
+      case 5: try { try decoder.decodeSingularInt64Field(value: &self.totalBytes) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.mountpoint.isEmpty {
+      try visitor.visitSingularStringField(value: self.mountpoint, fieldNumber: 1)
+    }
+    if !self.filesystem.isEmpty {
+      try visitor.visitSingularStringField(value: self.filesystem, fieldNumber: 2)
+    }
+    if !self.device.isEmpty {
+      try visitor.visitSingularStringField(value: self.device, fieldNumber: 3)
+    }
+    if self.usedBytes != 0 {
+      try visitor.visitSingularInt64Field(value: self.usedBytes, fieldNumber: 4)
+    }
+    if self.totalBytes != 0 {
+      try visitor.visitSingularInt64Field(value: self.totalBytes, fieldNumber: 5)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_DiskPartition, rhs: Wendy_Agent_Services_V1_DiskPartition) -> Bool {
+    if lhs.mountpoint != rhs.mountpoint {return false}
+    if lhs.filesystem != rhs.filesystem {return false}
+    if lhs.device != rhs.device {return false}
+    if lhs.usedBytes != rhs.usedBytes {return false}
+    if lhs.totalBytes != rhs.totalBytes {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_ListWiFiNetworksRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListWiFiNetworksRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2063,7 +2783,7 @@ extension Wendy_Agent_Services_V1_ListWiFiNetworksRequest: SwiftProtobuf.Message
   }
 }
 
-extension Wendy_Agent_Services_V1_ListWiFiNetworksResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListWiFiNetworksResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListWiFiNetworksResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}networks\0")
 
@@ -2093,7 +2813,7 @@ extension Wendy_Agent_Services_V1_ListWiFiNetworksResponse: SwiftProtobuf.Messag
   }
 }
 
-extension Wendy_Agent_Services_V1_ListWiFiNetworksResponse.WiFiNetwork: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListWiFiNetworksResponse.WiFiNetwork: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_ListWiFiNetworksResponse.protoMessageName + ".WiFiNetwork"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0\u{3}signal_strength\0\u{1}security\0\u{3}is_known\0\u{3}is_connected\0\u{1}priority\0\u{3}rssi_dbm\0")
 
@@ -2157,7 +2877,7 @@ extension Wendy_Agent_Services_V1_ListWiFiNetworksResponse.WiFiNetwork: SwiftPro
   }
 }
 
-extension Wendy_Agent_Services_V1_ConnectToWiFiRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ConnectToWiFiRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ConnectToWiFiRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0\u{1}password\0\u{1}security\0\u{1}hidden\0")
 
@@ -2206,7 +2926,7 @@ extension Wendy_Agent_Services_V1_ConnectToWiFiRequest: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_ConnectToWiFiResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ConnectToWiFiResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ConnectToWiFiResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2245,7 +2965,7 @@ extension Wendy_Agent_Services_V1_ConnectToWiFiResponse: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendy_Agent_Services_V1_GetWiFiStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_GetWiFiStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetWiFiStatusRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2264,7 +2984,7 @@ extension Wendy_Agent_Services_V1_GetWiFiStatusRequest: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendy_Agent_Services_V1_GetWiFiStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_GetWiFiStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetWiFiStatusResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}connected\0\u{1}ssid\0\u{3}error_message\0")
 
@@ -2308,7 +3028,7 @@ extension Wendy_Agent_Services_V1_GetWiFiStatusResponse: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendy_Agent_Services_V1_DisconnectWiFiRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_DisconnectWiFiRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DisconnectWiFiRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2327,7 +3047,7 @@ extension Wendy_Agent_Services_V1_DisconnectWiFiRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendy_Agent_Services_V1_DisconnectWiFiResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_DisconnectWiFiResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DisconnectWiFiResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2366,7 +3086,7 @@ extension Wendy_Agent_Services_V1_DisconnectWiFiResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Wendy_Agent_Services_V1_ListKnownWiFiNetworksRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListKnownWiFiNetworksRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListKnownWiFiNetworksRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2385,7 +3105,7 @@ extension Wendy_Agent_Services_V1_ListKnownWiFiNetworksRequest: SwiftProtobuf.Me
   }
 }
 
-extension Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListKnownWiFiNetworksResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}networks\0")
 
@@ -2415,7 +3135,7 @@ extension Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse: SwiftProtobuf.M
   }
 }
 
-extension Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse.KnownWiFiNetwork: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse.KnownWiFiNetwork: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse.protoMessageName + ".KnownWiFiNetwork"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0\u{1}uuid\0\u{1}priority\0\u{1}security\0")
 
@@ -2460,7 +3180,7 @@ extension Wendy_Agent_Services_V1_ListKnownWiFiNetworksResponse.KnownWiFiNetwork
   }
 }
 
-extension Wendy_Agent_Services_V1_SetWiFiNetworkPriorityRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_SetWiFiNetworkPriorityRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SetWiFiNetworkPriorityRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0\u{1}priority\0")
 
@@ -2495,7 +3215,7 @@ extension Wendy_Agent_Services_V1_SetWiFiNetworkPriorityRequest: SwiftProtobuf.M
   }
 }
 
-extension Wendy_Agent_Services_V1_SetWiFiNetworkPriorityResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_SetWiFiNetworkPriorityResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SetWiFiNetworkPriorityResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2534,7 +3254,7 @@ extension Wendy_Agent_Services_V1_SetWiFiNetworkPriorityResponse: SwiftProtobuf.
   }
 }
 
-extension Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReorderKnownWiFiNetworksRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}order_ssids\0")
 
@@ -2564,7 +3284,7 @@ extension Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksRequest: SwiftProtobuf
   }
 }
 
-extension Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReorderKnownWiFiNetworksResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2603,7 +3323,7 @@ extension Wendy_Agent_Services_V1_ReorderKnownWiFiNetworksResponse: SwiftProtobu
   }
 }
 
-extension Wendy_Agent_Services_V1_ForgetWiFiNetworkRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ForgetWiFiNetworkRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ForgetWiFiNetworkRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ssid\0")
 
@@ -2633,7 +3353,7 @@ extension Wendy_Agent_Services_V1_ForgetWiFiNetworkRequest: SwiftProtobuf.Messag
   }
 }
 
-extension Wendy_Agent_Services_V1_ForgetWiFiNetworkResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ForgetWiFiNetworkResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ForgetWiFiNetworkResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0")
 
@@ -2672,7 +3392,7 @@ extension Wendy_Agent_Services_V1_ForgetWiFiNetworkResponse: SwiftProtobuf.Messa
   }
 }
 
-extension Wendy_Agent_Services_V1_ListHardwareCapabilitiesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListHardwareCapabilitiesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListHardwareCapabilitiesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}category_filter\0")
 
@@ -2706,7 +3426,7 @@ extension Wendy_Agent_Services_V1_ListHardwareCapabilitiesRequest: SwiftProtobuf
   }
 }
 
-extension Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListHardwareCapabilitiesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}capabilities\0")
 
@@ -2736,7 +3456,7 @@ extension Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse: SwiftProtobu
   }
 }
 
-extension Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse.HardwareCapability: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse.HardwareCapability: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse.protoMessageName + ".HardwareCapability"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}category\0\u{3}device_path\0\u{1}description\0\u{1}properties\0")
 
@@ -2781,7 +3501,7 @@ extension Wendy_Agent_Services_V1_ListHardwareCapabilitiesResponse.HardwareCapab
   }
 }
 
-extension Wendy_Agent_Services_V1_ScanBluetoothPeripheralsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ScanBluetoothPeripheralsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ScanBluetoothPeripheralsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2800,7 +3520,7 @@ extension Wendy_Agent_Services_V1_ScanBluetoothPeripheralsRequest: SwiftProtobuf
   }
 }
 
-extension Wendy_Agent_Services_V1_DiscoveredBluetoothPeripheral: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_DiscoveredBluetoothPeripheral: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DiscoveredBluetoothPeripheral"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}address\0\u{1}rssi\0\u{1}deviceType\0\u{1}paired\0\u{1}connected\0\u{1}trusted\0")
 
@@ -2860,7 +3580,7 @@ extension Wendy_Agent_Services_V1_DiscoveredBluetoothPeripheral: SwiftProtobuf.M
   }
 }
 
-extension Wendy_Agent_Services_V1_ScanBluetoothPeripheralsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ScanBluetoothPeripheralsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ScanBluetoothPeripheralsResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}discovered_devices\0")
 
@@ -2890,7 +3610,7 @@ extension Wendy_Agent_Services_V1_ScanBluetoothPeripheralsResponse: SwiftProtobu
   }
 }
 
-extension Wendy_Agent_Services_V1_ConnectBluetoothPeripheralRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ConnectBluetoothPeripheralRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ConnectBluetoothPeripheralRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}address\0\u{1}pair\0\u{1}trust\0")
 
@@ -2930,7 +3650,7 @@ extension Wendy_Agent_Services_V1_ConnectBluetoothPeripheralRequest: SwiftProtob
   }
 }
 
-extension Wendy_Agent_Services_V1_ConnectBluetoothPeripheralResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ConnectBluetoothPeripheralResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ConnectBluetoothPeripheralResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2949,7 +3669,7 @@ extension Wendy_Agent_Services_V1_ConnectBluetoothPeripheralResponse: SwiftProto
   }
 }
 
-extension Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DisconnectBluetoothPeripheralRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}address\0")
 
@@ -2979,7 +3699,7 @@ extension Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralRequest: SwiftPro
   }
 }
 
-extension Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DisconnectBluetoothPeripheralResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2998,7 +3718,7 @@ extension Wendy_Agent_Services_V1_DisconnectBluetoothPeripheralResponse: SwiftPr
   }
 }
 
-extension Wendy_Agent_Services_V1_ForgetBluetoothPeripheralRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ForgetBluetoothPeripheralRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ForgetBluetoothPeripheralRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}address\0")
 
@@ -3028,7 +3748,7 @@ extension Wendy_Agent_Services_V1_ForgetBluetoothPeripheralRequest: SwiftProtobu
   }
 }
 
-extension Wendy_Agent_Services_V1_ForgetBluetoothPeripheralResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_ForgetBluetoothPeripheralResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ForgetBluetoothPeripheralResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -3047,9 +3767,9 @@ extension Wendy_Agent_Services_V1_ForgetBluetoothPeripheralResponse: SwiftProtob
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateOSRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateOSRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateOSRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}artifact_url\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}artifact_url\0\u{3}updater_backend\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3058,6 +3778,7 @@ extension Wendy_Agent_Services_V1_UpdateOSRequest: SwiftProtobuf.Message, SwiftP
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.artifactURL) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.updaterBackend) }()
       default: break
       }
     }
@@ -3067,17 +3788,21 @@ extension Wendy_Agent_Services_V1_UpdateOSRequest: SwiftProtobuf.Message, SwiftP
     if !self.artifactURL.isEmpty {
       try visitor.visitSingularStringField(value: self.artifactURL, fieldNumber: 1)
     }
+    if !self.updaterBackend.isEmpty {
+      try visitor.visitSingularStringField(value: self.updaterBackend, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Wendy_Agent_Services_V1_UpdateOSRequest, rhs: Wendy_Agent_Services_V1_UpdateOSRequest) -> Bool {
     if lhs.artifactURL != rhs.artifactURL {return false}
+    if lhs.updaterBackend != rhs.updaterBackend {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateOSResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateOSResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateOSResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}progress\0\u{1}completed\0\u{1}failed\0")
 
@@ -3161,7 +3886,7 @@ extension Wendy_Agent_Services_V1_UpdateOSResponse: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateOSResponse.Progress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateOSResponse.Progress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_UpdateOSResponse.protoMessageName + ".Progress"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phase\0\u{1}percent\0")
 
@@ -3196,7 +3921,7 @@ extension Wendy_Agent_Services_V1_UpdateOSResponse.Progress: SwiftProtobuf.Messa
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateOSResponse.Completed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateOSResponse.Completed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_UpdateOSResponse.protoMessageName + ".Completed"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}reboot_required\0")
 
@@ -3226,7 +3951,7 @@ extension Wendy_Agent_Services_V1_UpdateOSResponse.Completed: SwiftProtobuf.Mess
   }
 }
 
-extension Wendy_Agent_Services_V1_UpdateOSResponse.Failed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_UpdateOSResponse.Failed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Wendy_Agent_Services_V1_UpdateOSResponse.protoMessageName + ".Failed"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}error_message\0")
 
@@ -3251,6 +3976,585 @@ extension Wendy_Agent_Services_V1_UpdateOSResponse.Failed: SwiftProtobuf.Message
 
   public static func ==(lhs: Wendy_Agent_Services_V1_UpdateOSResponse.Failed, rhs: Wendy_Agent_Services_V1_UpdateOSResponse.Failed) -> Bool {
     if lhs.errorMessage != rhs.errorMessage {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_DumpKernelLogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DumpKernelLogRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}follow\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self._follow) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._follow {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 1)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_DumpKernelLogRequest, rhs: Wendy_Agent_Services_V1_DumpKernelLogRequest) -> Bool {
+    if lhs._follow != rhs._follow {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_DumpKernelLogResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DumpKernelLogResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}records\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.records) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.records.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.records, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_DumpKernelLogResponse, rhs: Wendy_Agent_Services_V1_DumpKernelLogResponse) -> Bool {
+    if lhs.records != rhs.records {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_KernelLogRecord: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".KernelLogRecord"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}timestamp_us\0\u{1}level\0\u{1}message\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularInt64Field(value: &self.timestampUs) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.level) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.message) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.timestampUs != 0 {
+      try visitor.visitSingularInt64Field(value: self.timestampUs, fieldNumber: 1)
+    }
+    if self.level != 0 {
+      try visitor.visitSingularInt32Field(value: self.level, fieldNumber: 2)
+    }
+    if !self.message.isEmpty {
+      try visitor.visitSingularStringField(value: self.message, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_KernelLogRecord, rhs: Wendy_Agent_Services_V1_KernelLogRecord) -> Bool {
+    if lhs.timestampUs != rhs.timestampUs {return false}
+    if lhs.level != rhs.level {return false}
+    if lhs.message != rhs.message {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GetOSUpdateStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GetOSUpdateStatusRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}include_engine_status\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.includeEngineStatus) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.includeEngineStatus != false {
+      try visitor.visitSingularBoolField(value: self.includeEngineStatus, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_GetOSUpdateStatusRequest, rhs: Wendy_Agent_Services_V1_GetOSUpdateStatusRequest) -> Bool {
+    if lhs.includeEngineStatus != rhs.includeEngineStatus {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_OSUpdateEngineStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".OSUpdateEngineStatus"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}connector\0\u{3}current_slot\0\u{1}slots\0\u{1}system\0\u{1}pending\0\u{1}diagnostics\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.connector) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.currentSlot) }()
+      case 3: try { try decoder.decodeRepeatedMessageField(value: &self.slots) }()
+      case 4: try { try decoder.decodeRepeatedMessageField(value: &self.system) }()
+      case 5: try { try decoder.decodeSingularMessageField(value: &self._pending) }()
+      case 6: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.diagnostics) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if !self.connector.isEmpty {
+      try visitor.visitSingularStringField(value: self.connector, fieldNumber: 1)
+    }
+    if !self.currentSlot.isEmpty {
+      try visitor.visitSingularStringField(value: self.currentSlot, fieldNumber: 2)
+    }
+    if !self.slots.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.slots, fieldNumber: 3)
+    }
+    if !self.system.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.system, fieldNumber: 4)
+    }
+    try { if let v = self._pending {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    } }()
+    if !self.diagnostics.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.diagnostics, fieldNumber: 6)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_OSUpdateEngineStatus, rhs: Wendy_Agent_Services_V1_OSUpdateEngineStatus) -> Bool {
+    if lhs.connector != rhs.connector {return false}
+    if lhs.currentSlot != rhs.currentSlot {return false}
+    if lhs.slots != rhs.slots {return false}
+    if lhs.system != rhs.system {return false}
+    if lhs._pending != rhs._pending {return false}
+    if lhs.diagnostics != rhs.diagnostics {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_OSUpdateEngineStatus.Slot: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Wendy_Agent_Services_V1_OSUpdateEngineStatus.protoMessageName + ".Slot"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}slot\0\u{1}booted\0\u{1}partition\0\u{1}distro\0\u{1}kernel\0\u{3}rootfs_health\0\u{1}retries\0\u{1}note\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.slot) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.booted) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.partition) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.distro) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self.kernel) }()
+      case 6: try { try decoder.decodeSingularStringField(value: &self.rootfsHealth) }()
+      case 7: try { try decoder.decodeSingularStringField(value: &self.retries) }()
+      case 8: try { try decoder.decodeSingularStringField(value: &self.note) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.slot.isEmpty {
+      try visitor.visitSingularStringField(value: self.slot, fieldNumber: 1)
+    }
+    if self.booted != false {
+      try visitor.visitSingularBoolField(value: self.booted, fieldNumber: 2)
+    }
+    if !self.partition.isEmpty {
+      try visitor.visitSingularStringField(value: self.partition, fieldNumber: 3)
+    }
+    if !self.distro.isEmpty {
+      try visitor.visitSingularStringField(value: self.distro, fieldNumber: 4)
+    }
+    if !self.kernel.isEmpty {
+      try visitor.visitSingularStringField(value: self.kernel, fieldNumber: 5)
+    }
+    if !self.rootfsHealth.isEmpty {
+      try visitor.visitSingularStringField(value: self.rootfsHealth, fieldNumber: 6)
+    }
+    if !self.retries.isEmpty {
+      try visitor.visitSingularStringField(value: self.retries, fieldNumber: 7)
+    }
+    if !self.note.isEmpty {
+      try visitor.visitSingularStringField(value: self.note, fieldNumber: 8)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_OSUpdateEngineStatus.Slot, rhs: Wendy_Agent_Services_V1_OSUpdateEngineStatus.Slot) -> Bool {
+    if lhs.slot != rhs.slot {return false}
+    if lhs.booted != rhs.booted {return false}
+    if lhs.partition != rhs.partition {return false}
+    if lhs.distro != rhs.distro {return false}
+    if lhs.kernel != rhs.kernel {return false}
+    if lhs.rootfsHealth != rhs.rootfsHealth {return false}
+    if lhs.retries != rhs.retries {return false}
+    if lhs.note != rhs.note {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_OSUpdateEngineStatus.SystemEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Wendy_Agent_Services_V1_OSUpdateEngineStatus.protoMessageName + ".SystemEntry"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{1}value\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.key) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.value) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.key.isEmpty {
+      try visitor.visitSingularStringField(value: self.key, fieldNumber: 1)
+    }
+    if !self.value.isEmpty {
+      try visitor.visitSingularStringField(value: self.value, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_OSUpdateEngineStatus.SystemEntry, rhs: Wendy_Agent_Services_V1_OSUpdateEngineStatus.SystemEntry) -> Bool {
+    if lhs.key != rhs.key {return false}
+    if lhs.value != rhs.value {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_OSUpdateEngineStatus.PendingUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Wendy_Agent_Services_V1_OSUpdateEngineStatus.protoMessageName + ".PendingUpdate"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}artifact_name\0\u{3}artifact_version\0\u{1}phase\0\u{3}target_slot\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.artifactName) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.artifactVersion) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.phase) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.targetSlot) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.artifactName.isEmpty {
+      try visitor.visitSingularStringField(value: self.artifactName, fieldNumber: 1)
+    }
+    if !self.artifactVersion.isEmpty {
+      try visitor.visitSingularStringField(value: self.artifactVersion, fieldNumber: 2)
+    }
+    if !self.phase.isEmpty {
+      try visitor.visitSingularStringField(value: self.phase, fieldNumber: 3)
+    }
+    if !self.targetSlot.isEmpty {
+      try visitor.visitSingularStringField(value: self.targetSlot, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_OSUpdateEngineStatus.PendingUpdate, rhs: Wendy_Agent_Services_V1_OSUpdateEngineStatus.PendingUpdate) -> Bool {
+    if lhs.artifactName != rhs.artifactName {return false}
+    if lhs.artifactVersion != rhs.artifactVersion {return false}
+    if lhs.phase != rhs.phase {return false}
+    if lhs.targetSlot != rhs.targetSlot {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GetOSUpdateStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GetOSUpdateStatusResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}has_result\0\u{1}outcome\0\u{1}services\0\u{3}old_os_version\0\u{3}new_os_version\0\u{3}created_at_unix\0\u{3}finalized_at_unix\0\u{3}rollback_error\0\u{1}note\0\u{3}engine_status\0")
+
+  fileprivate class _StorageClass {
+    var _hasResult_p: Bool = false
+    var _outcome: Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.Outcome = .unspecified
+    var _services: [Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.ServiceResult] = []
+    var _oldOsVersion: String = String()
+    var _newOsVersion: String = String()
+    var _createdAtUnix: Int64 = 0
+    var _finalizedAtUnix: Int64 = 0
+    var _rollbackError: String = String()
+    var _note: String = String()
+    var _engineStatus: Wendy_Agent_Services_V1_OSUpdateEngineStatus? = nil
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _hasResult_p = source._hasResult_p
+      _outcome = source._outcome
+      _services = source._services
+      _oldOsVersion = source._oldOsVersion
+      _newOsVersion = source._newOsVersion
+      _createdAtUnix = source._createdAtUnix
+      _finalizedAtUnix = source._finalizedAtUnix
+      _rollbackError = source._rollbackError
+      _note = source._note
+      _engineStatus = source._engineStatus
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularBoolField(value: &_storage._hasResult_p) }()
+        case 2: try { try decoder.decodeSingularEnumField(value: &_storage._outcome) }()
+        case 3: try { try decoder.decodeRepeatedMessageField(value: &_storage._services) }()
+        case 4: try { try decoder.decodeSingularStringField(value: &_storage._oldOsVersion) }()
+        case 5: try { try decoder.decodeSingularStringField(value: &_storage._newOsVersion) }()
+        case 6: try { try decoder.decodeSingularInt64Field(value: &_storage._createdAtUnix) }()
+        case 7: try { try decoder.decodeSingularInt64Field(value: &_storage._finalizedAtUnix) }()
+        case 8: try { try decoder.decodeSingularStringField(value: &_storage._rollbackError) }()
+        case 9: try { try decoder.decodeSingularStringField(value: &_storage._note) }()
+        case 10: try { try decoder.decodeSingularMessageField(value: &_storage._engineStatus) }()
+        default: break
+        }
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      if _storage._hasResult_p != false {
+        try visitor.visitSingularBoolField(value: _storage._hasResult_p, fieldNumber: 1)
+      }
+      if _storage._outcome != .unspecified {
+        try visitor.visitSingularEnumField(value: _storage._outcome, fieldNumber: 2)
+      }
+      if !_storage._services.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._services, fieldNumber: 3)
+      }
+      if !_storage._oldOsVersion.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._oldOsVersion, fieldNumber: 4)
+      }
+      if !_storage._newOsVersion.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._newOsVersion, fieldNumber: 5)
+      }
+      if _storage._createdAtUnix != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._createdAtUnix, fieldNumber: 6)
+      }
+      if _storage._finalizedAtUnix != 0 {
+        try visitor.visitSingularInt64Field(value: _storage._finalizedAtUnix, fieldNumber: 7)
+      }
+      if !_storage._rollbackError.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._rollbackError, fieldNumber: 8)
+      }
+      if !_storage._note.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._note, fieldNumber: 9)
+      }
+      try { if let v = _storage._engineStatus {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+      } }()
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_GetOSUpdateStatusResponse, rhs: Wendy_Agent_Services_V1_GetOSUpdateStatusResponse) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._hasResult_p != rhs_storage._hasResult_p {return false}
+        if _storage._outcome != rhs_storage._outcome {return false}
+        if _storage._services != rhs_storage._services {return false}
+        if _storage._oldOsVersion != rhs_storage._oldOsVersion {return false}
+        if _storage._newOsVersion != rhs_storage._newOsVersion {return false}
+        if _storage._createdAtUnix != rhs_storage._createdAtUnix {return false}
+        if _storage._finalizedAtUnix != rhs_storage._finalizedAtUnix {return false}
+        if _storage._rollbackError != rhs_storage._rollbackError {return false}
+        if _storage._note != rhs_storage._note {return false}
+        if _storage._engineStatus != rhs_storage._engineStatus {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.Outcome: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OUTCOME_UNSPECIFIED\0\u{1}OUTCOME_COMMITTED\0\u{1}OUTCOME_ROLLED_BACK\0\u{1}OUTCOME_ROLLBACK_FAILED\0\u{1}OUTCOME_COMMIT_FAILED\0")
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.ServiceResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.protoMessageName + ".ServiceResult"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}unit\0\u{1}status\0\u{1}reason\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.unit) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.status) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.reason) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.unit.isEmpty {
+      try visitor.visitSingularStringField(value: self.unit, fieldNumber: 1)
+    }
+    if self.status != .unspecified {
+      try visitor.visitSingularEnumField(value: self.status, fieldNumber: 2)
+    }
+    if !self.reason.isEmpty {
+      try visitor.visitSingularStringField(value: self.reason, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.ServiceResult, rhs: Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.ServiceResult) -> Bool {
+    if lhs.unit != rhs.unit {return false}
+    if lhs.status != rhs.status {return false}
+    if lhs.reason != rhs.reason {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_GetOSUpdateStatusResponse.ServiceResult.Status: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STATUS_UNSPECIFIED\0\u{1}STATUS_HEALTHY\0\u{1}STATUS_SKIPPED\0\u{1}STATUS_FAILED\0")
+}
+
+nonisolated extension Wendy_Agent_Services_V1_SetHostnameRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SetHostnameRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}hostname\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.hostname) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.hostname.isEmpty {
+      try visitor.visitSingularStringField(value: self.hostname, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_SetHostnameRequest, rhs: Wendy_Agent_Services_V1_SetHostnameRequest) -> Bool {
+    if lhs.hostname != rhs.hostname {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Wendy_Agent_Services_V1_SetHostnameResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SetHostnameResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}hostname\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.hostname) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.hostname.isEmpty {
+      try visitor.visitSingularStringField(value: self.hostname, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Wendy_Agent_Services_V1_SetHostnameResponse, rhs: Wendy_Agent_Services_V1_SetHostnameResponse) -> Bool {
+    if lhs.hostname != rhs.hostname {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_telemetry_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_telemetry_service.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public struct Wendy_Agent_Services_V1_StreamLogsRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StreamLogsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -55,6 +55,16 @@ public struct Wendy_Agent_Services_V1_StreamLogsRequest: Sendable {
   /// Clears the value of `appName`. Subsequent reads from it will return its default value.
   public mutating func clearAppName() {self._appName = nil}
 
+  /// Replay last N log batches before going live
+  public var lastN: Int32 {
+    get {_lastN ?? 0}
+    set {_lastN = newValue}
+  }
+  /// Returns true if `lastN` has been explicitly set.
+  public var hasLastN: Bool {self._lastN != nil}
+  /// Clears the value of `lastN`. Subsequent reads from it will return its default value.
+  public mutating func clearLastN() {self._lastN = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -62,9 +72,10 @@ public struct Wendy_Agent_Services_V1_StreamLogsRequest: Sendable {
   fileprivate var _serviceName: String? = nil
   fileprivate var _minSeverity: Int32? = nil
   fileprivate var _appName: String? = nil
+  fileprivate var _lastN: Int32? = nil
 }
 
-public struct Wendy_Agent_Services_V1_StreamLogsResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StreamLogsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -80,6 +91,9 @@ public struct Wendy_Agent_Services_V1_StreamLogsResponse: Sendable {
   /// Clears the value of `logs`. Subsequent reads from it will return its default value.
   public mutating func clearLogs() {self._logs = nil}
 
+  /// true for replayed records; false for live
+  public var isHistory: Bool = false
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -87,7 +101,7 @@ public struct Wendy_Agent_Services_V1_StreamLogsResponse: Sendable {
   fileprivate var _logs: Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest? = nil
 }
 
-public struct Wendy_Agent_Services_V1_StreamMetricsRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StreamMetricsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -122,6 +136,16 @@ public struct Wendy_Agent_Services_V1_StreamMetricsRequest: Sendable {
   /// Clears the value of `appName`. Subsequent reads from it will return its default value.
   public mutating func clearAppName() {self._appName = nil}
 
+  /// Replay last N metric batches before going live
+  public var lastN: Int32 {
+    get {_lastN ?? 0}
+    set {_lastN = newValue}
+  }
+  /// Returns true if `lastN` has been explicitly set.
+  public var hasLastN: Bool {self._lastN != nil}
+  /// Clears the value of `lastN`. Subsequent reads from it will return its default value.
+  public mutating func clearLastN() {self._lastN = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -129,9 +153,10 @@ public struct Wendy_Agent_Services_V1_StreamMetricsRequest: Sendable {
   fileprivate var _serviceName: String? = nil
   fileprivate var _metricNamePrefix: String? = nil
   fileprivate var _appName: String? = nil
+  fileprivate var _lastN: Int32? = nil
 }
 
-public struct Wendy_Agent_Services_V1_StreamMetricsResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StreamMetricsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -147,6 +172,9 @@ public struct Wendy_Agent_Services_V1_StreamMetricsResponse: Sendable {
   /// Clears the value of `metrics`. Subsequent reads from it will return its default value.
   public mutating func clearMetrics() {self._metrics = nil}
 
+  /// true for replayed records; false for live
+  public var isHistory: Bool = false
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -154,7 +182,7 @@ public struct Wendy_Agent_Services_V1_StreamMetricsResponse: Sendable {
   fileprivate var _metrics: Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest? = nil
 }
 
-public struct Wendy_Agent_Services_V1_StreamTracesRequest: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StreamTracesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -189,6 +217,16 @@ public struct Wendy_Agent_Services_V1_StreamTracesRequest: Sendable {
   /// Clears the value of `spanNamePrefix`. Subsequent reads from it will return its default value.
   public mutating func clearSpanNamePrefix() {self._spanNamePrefix = nil}
 
+  /// Replay last N trace batches before going live
+  public var lastN: Int32 {
+    get {_lastN ?? 0}
+    set {_lastN = newValue}
+  }
+  /// Returns true if `lastN` has been explicitly set.
+  public var hasLastN: Bool {self._lastN != nil}
+  /// Clears the value of `lastN`. Subsequent reads from it will return its default value.
+  public mutating func clearLastN() {self._lastN = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -196,9 +234,10 @@ public struct Wendy_Agent_Services_V1_StreamTracesRequest: Sendable {
   fileprivate var _serviceName: String? = nil
   fileprivate var _appName: String? = nil
   fileprivate var _spanNamePrefix: String? = nil
+  fileprivate var _lastN: Int32? = nil
 }
 
-public struct Wendy_Agent_Services_V1_StreamTracesResponse: Sendable {
+public nonisolated struct Wendy_Agent_Services_V1_StreamTracesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -214,6 +253,9 @@ public struct Wendy_Agent_Services_V1_StreamTracesResponse: Sendable {
   /// Clears the value of `traces`. Subsequent reads from it will return its default value.
   public mutating func clearTraces() {self._traces = nil}
 
+  /// true for replayed records; false for live
+  public var isHistory: Bool = false
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -223,11 +265,11 @@ public struct Wendy_Agent_Services_V1_StreamTracesResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendy.agent.services.v1"
+fileprivate nonisolated let _protobuf_package = "wendy.agent.services.v1"
 
-extension Wendy_Agent_Services_V1_StreamLogsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StreamLogsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StreamLogsRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}service_name\0\u{3}min_severity\0\u{3}app_name\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}service_name\0\u{3}min_severity\0\u{3}app_name\0\u{3}last_n\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -238,6 +280,7 @@ extension Wendy_Agent_Services_V1_StreamLogsRequest: SwiftProtobuf.Message, Swif
       case 1: try { try decoder.decodeSingularStringField(value: &self._serviceName) }()
       case 2: try { try decoder.decodeSingularInt32Field(value: &self._minSeverity) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self._appName) }()
+      case 4: try { try decoder.decodeSingularInt32Field(value: &self._lastN) }()
       default: break
       }
     }
@@ -257,6 +300,9 @@ extension Wendy_Agent_Services_V1_StreamLogsRequest: SwiftProtobuf.Message, Swif
     try { if let v = self._appName {
       try visitor.visitSingularStringField(value: v, fieldNumber: 3)
     } }()
+    try { if let v = self._lastN {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -264,14 +310,15 @@ extension Wendy_Agent_Services_V1_StreamLogsRequest: SwiftProtobuf.Message, Swif
     if lhs._serviceName != rhs._serviceName {return false}
     if lhs._minSeverity != rhs._minSeverity {return false}
     if lhs._appName != rhs._appName {return false}
+    if lhs._lastN != rhs._lastN {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_StreamLogsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StreamLogsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StreamLogsResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}logs\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}logs\0\u{3}is_history\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -280,6 +327,7 @@ extension Wendy_Agent_Services_V1_StreamLogsResponse: SwiftProtobuf.Message, Swi
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._logs) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.isHistory) }()
       default: break
       }
     }
@@ -293,19 +341,23 @@ extension Wendy_Agent_Services_V1_StreamLogsResponse: SwiftProtobuf.Message, Swi
     try { if let v = self._logs {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     } }()
+    if self.isHistory != false {
+      try visitor.visitSingularBoolField(value: self.isHistory, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Wendy_Agent_Services_V1_StreamLogsResponse, rhs: Wendy_Agent_Services_V1_StreamLogsResponse) -> Bool {
     if lhs._logs != rhs._logs {return false}
+    if lhs.isHistory != rhs.isHistory {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_StreamMetricsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StreamMetricsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StreamMetricsRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}service_name\0\u{3}metric_name_prefix\0\u{3}app_name\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}service_name\0\u{3}metric_name_prefix\0\u{3}app_name\0\u{3}last_n\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -316,6 +368,7 @@ extension Wendy_Agent_Services_V1_StreamMetricsRequest: SwiftProtobuf.Message, S
       case 1: try { try decoder.decodeSingularStringField(value: &self._serviceName) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self._metricNamePrefix) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self._appName) }()
+      case 4: try { try decoder.decodeSingularInt32Field(value: &self._lastN) }()
       default: break
       }
     }
@@ -335,6 +388,9 @@ extension Wendy_Agent_Services_V1_StreamMetricsRequest: SwiftProtobuf.Message, S
     try { if let v = self._appName {
       try visitor.visitSingularStringField(value: v, fieldNumber: 3)
     } }()
+    try { if let v = self._lastN {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -342,14 +398,15 @@ extension Wendy_Agent_Services_V1_StreamMetricsRequest: SwiftProtobuf.Message, S
     if lhs._serviceName != rhs._serviceName {return false}
     if lhs._metricNamePrefix != rhs._metricNamePrefix {return false}
     if lhs._appName != rhs._appName {return false}
+    if lhs._lastN != rhs._lastN {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_StreamMetricsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StreamMetricsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StreamMetricsResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}metrics\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}metrics\0\u{3}is_history\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -358,6 +415,7 @@ extension Wendy_Agent_Services_V1_StreamMetricsResponse: SwiftProtobuf.Message, 
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._metrics) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.isHistory) }()
       default: break
       }
     }
@@ -371,19 +429,23 @@ extension Wendy_Agent_Services_V1_StreamMetricsResponse: SwiftProtobuf.Message, 
     try { if let v = self._metrics {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     } }()
+    if self.isHistory != false {
+      try visitor.visitSingularBoolField(value: self.isHistory, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Wendy_Agent_Services_V1_StreamMetricsResponse, rhs: Wendy_Agent_Services_V1_StreamMetricsResponse) -> Bool {
     if lhs._metrics != rhs._metrics {return false}
+    if lhs.isHistory != rhs.isHistory {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_StreamTracesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StreamTracesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StreamTracesRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}service_name\0\u{3}app_name\0\u{3}span_name_prefix\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}service_name\0\u{3}app_name\0\u{3}span_name_prefix\0\u{3}last_n\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -394,6 +456,7 @@ extension Wendy_Agent_Services_V1_StreamTracesRequest: SwiftProtobuf.Message, Sw
       case 1: try { try decoder.decodeSingularStringField(value: &self._serviceName) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self._appName) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self._spanNamePrefix) }()
+      case 4: try { try decoder.decodeSingularInt32Field(value: &self._lastN) }()
       default: break
       }
     }
@@ -413,6 +476,9 @@ extension Wendy_Agent_Services_V1_StreamTracesRequest: SwiftProtobuf.Message, Sw
     try { if let v = self._spanNamePrefix {
       try visitor.visitSingularStringField(value: v, fieldNumber: 3)
     } }()
+    try { if let v = self._lastN {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -420,14 +486,15 @@ extension Wendy_Agent_Services_V1_StreamTracesRequest: SwiftProtobuf.Message, Sw
     if lhs._serviceName != rhs._serviceName {return false}
     if lhs._appName != rhs._appName {return false}
     if lhs._spanNamePrefix != rhs._spanNamePrefix {return false}
+    if lhs._lastN != rhs._lastN {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendy_Agent_Services_V1_StreamTracesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendy_Agent_Services_V1_StreamTracesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StreamTracesResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}traces\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}traces\0\u{3}is_history\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -436,6 +503,7 @@ extension Wendy_Agent_Services_V1_StreamTracesResponse: SwiftProtobuf.Message, S
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._traces) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.isHistory) }()
       default: break
       }
     }
@@ -449,11 +517,15 @@ extension Wendy_Agent_Services_V1_StreamTracesResponse: SwiftProtobuf.Message, S
     try { if let v = self._traces {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     } }()
+    if self.isHistory != false {
+      try visitor.visitSingularBoolField(value: self.isHistory, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Wendy_Agent_Services_V1_StreamTracesResponse, rhs: Wendy_Agent_Services_V1_StreamTracesResponse) -> Bool {
     if lhs._traces != rhs._traces {return false}
+    if lhs.isHistory != rhs.isHistory {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/apps.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/apps.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public struct Wendycloud_V1_App: Sendable {
+public nonisolated struct Wendycloud_V1_App: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -59,7 +59,7 @@ public struct Wendycloud_V1_App: Sendable {
   fileprivate var _updatedAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-public struct Wendycloud_V1_AppVersion: Sendable {
+public nonisolated struct Wendycloud_V1_AppVersion: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -102,7 +102,7 @@ public struct Wendycloud_V1_AppVersion: Sendable {
   fileprivate var _updatedAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-public struct Wendycloud_V1_AssetContainer: Sendable {
+public nonisolated struct Wendycloud_V1_AssetContainer: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -145,7 +145,7 @@ public struct Wendycloud_V1_AssetContainer: Sendable {
   fileprivate var _updatedAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-public struct Wendycloud_V1_CreateAppRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateAppRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -161,7 +161,7 @@ public struct Wendycloud_V1_CreateAppRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetAppRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetAppRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -173,7 +173,7 @@ public struct Wendycloud_V1_GetAppRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_UpdateAppRequest: Sendable {
+public nonisolated struct Wendycloud_V1_UpdateAppRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -206,7 +206,7 @@ public struct Wendycloud_V1_UpdateAppRequest: Sendable {
   fileprivate var _details: String? = nil
 }
 
-public struct Wendycloud_V1_DeleteAppRequest: Sendable {
+public nonisolated struct Wendycloud_V1_DeleteAppRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -218,7 +218,7 @@ public struct Wendycloud_V1_DeleteAppRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_DeleteAppResponse: Sendable {
+public nonisolated struct Wendycloud_V1_DeleteAppResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -230,7 +230,7 @@ public struct Wendycloud_V1_DeleteAppResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListAppsRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListAppsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -258,7 +258,7 @@ public struct Wendycloud_V1_ListAppsRequest: Sendable {
   fileprivate var _filter: String? = nil
 }
 
-public struct Wendycloud_V1_ListAppsResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListAppsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -272,7 +272,7 @@ public struct Wendycloud_V1_ListAppsResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_CreateAppVersionRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateAppVersionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -292,7 +292,7 @@ public struct Wendycloud_V1_CreateAppVersionRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetAppVersionRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetAppVersionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -304,7 +304,7 @@ public struct Wendycloud_V1_GetAppVersionRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListAppVersionsRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListAppVersionsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -320,7 +320,7 @@ public struct Wendycloud_V1_ListAppVersionsRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListAppVersionsResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListAppVersionsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -334,7 +334,7 @@ public struct Wendycloud_V1_ListAppVersionsResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_CreateAssetContainerRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateAssetContainerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -354,7 +354,7 @@ public struct Wendycloud_V1_CreateAssetContainerRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetAssetContainerRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetAssetContainerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -366,7 +366,7 @@ public struct Wendycloud_V1_GetAssetContainerRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_UpdateAssetContainerRequest: Sendable {
+public nonisolated struct Wendycloud_V1_UpdateAssetContainerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -399,7 +399,7 @@ public struct Wendycloud_V1_UpdateAssetContainerRequest: Sendable {
   fileprivate var _status: String? = nil
 }
 
-public struct Wendycloud_V1_ListAssetContainersRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListAssetContainersRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -415,7 +415,7 @@ public struct Wendycloud_V1_ListAssetContainersRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListAssetContainersResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListAssetContainersResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -429,7 +429,7 @@ public struct Wendycloud_V1_ListAssetContainersResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListAssetContainersByAppRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListAssetContainersByAppRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -445,7 +445,7 @@ public struct Wendycloud_V1_ListAssetContainersByAppRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListAssetContainersByAppResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListAssetContainersByAppResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -461,9 +461,9 @@ public struct Wendycloud_V1_ListAssetContainersByAppResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendycloud.v1"
+fileprivate nonisolated let _protobuf_package = "wendycloud.v1"
 
-extension Wendycloud_V1_App: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_App: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".App"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}organization_id\0\u{1}name\0\u{1}details\0\u{3}created_at\0\u{3}updated_at\0")
 
@@ -522,7 +522,7 @@ extension Wendycloud_V1_App: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   }
 }
 
-extension Wendycloud_V1_AppVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_AppVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AppVersion"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}app_id\0\u{1}version\0\u{3}container_image\0\u{3}container_registry\0\u{1}details\0\u{3}created_at\0\u{3}updated_at\0")
 
@@ -591,7 +591,7 @@ extension Wendycloud_V1_AppVersion: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Wendycloud_V1_AssetContainer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_AssetContainer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AssetContainer"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}asset_id\0\u{3}app_version_id\0\u{3}container_name\0\u{3}container_id\0\u{1}status\0\u{3}created_at\0\u{3}updated_at\0")
 
@@ -660,7 +660,7 @@ extension Wendycloud_V1_AssetContainer: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Wendycloud_V1_CreateAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateAppRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{1}name\0\u{1}details\0")
 
@@ -700,7 +700,7 @@ extension Wendycloud_V1_CreateAppRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Wendycloud_V1_GetAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetAppRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -730,7 +730,7 @@ extension Wendycloud_V1_GetAppRequest: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Wendycloud_V1_UpdateAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_UpdateAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateAppRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}name\0\u{1}details\0")
 
@@ -774,7 +774,7 @@ extension Wendycloud_V1_UpdateAppRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Wendycloud_V1_DeleteAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DeleteAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteAppRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -804,7 +804,7 @@ extension Wendycloud_V1_DeleteAppRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Wendycloud_V1_DeleteAppResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DeleteAppResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteAppResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0")
 
@@ -834,7 +834,7 @@ extension Wendycloud_V1_DeleteAppResponse: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Wendycloud_V1_ListAppsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAppsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAppsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}page_size\0\u{3}page_token\0\u{1}filter\0")
 
@@ -883,7 +883,7 @@ extension Wendycloud_V1_ListAppsRequest: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Wendycloud_V1_ListAppsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAppsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAppsResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}apps\0\u{3}next_page_token\0")
 
@@ -918,7 +918,7 @@ extension Wendycloud_V1_ListAppsResponse: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Wendycloud_V1_CreateAppVersionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateAppVersionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateAppVersionRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_id\0\u{1}version\0\u{3}container_image\0\u{3}container_registry\0\u{1}details\0")
 
@@ -968,7 +968,7 @@ extension Wendycloud_V1_CreateAppVersionRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_GetAppVersionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetAppVersionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetAppVersionRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -998,7 +998,7 @@ extension Wendycloud_V1_GetAppVersionRequest: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Wendycloud_V1_ListAppVersionsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAppVersionsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAppVersionsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_id\0\u{3}page_size\0\u{3}page_token\0")
 
@@ -1038,7 +1038,7 @@ extension Wendycloud_V1_ListAppVersionsRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Wendycloud_V1_ListAppVersionsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAppVersionsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAppVersionsResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_versions\0\u{3}next_page_token\0")
 
@@ -1073,7 +1073,7 @@ extension Wendycloud_V1_ListAppVersionsResponse: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_CreateAssetContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateAssetContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateAssetContainerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}asset_id\0\u{3}app_version_id\0\u{3}container_name\0\u{3}container_id\0\u{1}status\0")
 
@@ -1123,7 +1123,7 @@ extension Wendycloud_V1_CreateAssetContainerRequest: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Wendycloud_V1_GetAssetContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetAssetContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetAssetContainerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -1153,7 +1153,7 @@ extension Wendycloud_V1_GetAssetContainerRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendycloud_V1_UpdateAssetContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_UpdateAssetContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateAssetContainerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}container_id\0\u{1}status\0")
 
@@ -1197,7 +1197,7 @@ extension Wendycloud_V1_UpdateAssetContainerRequest: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Wendycloud_V1_ListAssetContainersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAssetContainersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAssetContainersRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}asset_id\0\u{3}page_size\0\u{3}page_token\0")
 
@@ -1237,7 +1237,7 @@ extension Wendycloud_V1_ListAssetContainersRequest: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendycloud_V1_ListAssetContainersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAssetContainersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAssetContainersResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}containers\0\u{3}next_page_token\0")
 
@@ -1272,7 +1272,7 @@ extension Wendycloud_V1_ListAssetContainersResponse: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Wendycloud_V1_ListAssetContainersByAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAssetContainersByAppRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAssetContainersByAppRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_id\0\u{3}page_size\0\u{3}page_token\0")
 
@@ -1312,7 +1312,7 @@ extension Wendycloud_V1_ListAssetContainersByAppRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendycloud_V1_ListAssetContainersByAppResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAssetContainersByAppResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAssetContainersByAppResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}containers\0\u{3}next_page_token\0")
 

--- a/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/assets.grpc.swift
+++ b/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/assets.grpc.swift
@@ -82,7 +82,7 @@ public enum Wendycloud_V1_AssetService: Sendable {
             public static let descriptor = GRPCCore.MethodDescriptor(
                 service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendycloud.v1.AssetService"),
                 method: "ListAssets",
-                type: .unary
+                type: .serverStreaming
             )
         }
         /// Namespace for "ListAssetChildren" metadata.
@@ -95,7 +95,7 @@ public enum Wendycloud_V1_AssetService: Sendable {
             public static let descriptor = GRPCCore.MethodDescriptor(
                 service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "wendycloud.v1.AssetService"),
                 method: "ListAssetChildren",
-                type: .unary
+                type: .serverStreaming
             )
         }
         /// Namespace for "GetAssetLineage" metadata.
@@ -316,11 +316,11 @@ extension Wendycloud_V1_AssetService {
         /// - Throws: Any error which occurred during the processing of the request. Thrown errors
         ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
         ///     to an internal error.
-        /// - Returns: A response containing a single `Wendycloud_V1_ListAssetsResponse` message.
+        /// - Returns: A streaming response of `Wendycloud_V1_ListAssetsResponse` messages.
         func listAssets(
             request: GRPCCore.ServerRequest<Wendycloud_V1_ListAssetsRequest>,
             context: GRPCCore.ServerContext
-        ) async throws -> GRPCCore.ServerResponse<Wendycloud_V1_ListAssetsResponse>
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendycloud_V1_ListAssetsResponse>
 
         /// Handle the "ListAssetChildren" method.
         ///
@@ -330,11 +330,11 @@ extension Wendycloud_V1_AssetService {
         /// - Throws: Any error which occurred during the processing of the request. Thrown errors
         ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
         ///     to an internal error.
-        /// - Returns: A response containing a single `Wendycloud_V1_ListAssetChildrenResponse` message.
+        /// - Returns: A streaming response of `Wendycloud_V1_ListAssetChildrenResponse` messages.
         func listAssetChildren(
             request: GRPCCore.ServerRequest<Wendycloud_V1_ListAssetChildrenRequest>,
             context: GRPCCore.ServerContext
-        ) async throws -> GRPCCore.ServerResponse<Wendycloud_V1_ListAssetChildrenResponse>
+        ) async throws -> GRPCCore.StreamingServerResponse<Wendycloud_V1_ListAssetChildrenResponse>
 
         /// Handle the "GetAssetLineage" method.
         ///
@@ -417,29 +417,31 @@ extension Wendycloud_V1_AssetService {
         ///
         /// - Parameters:
         ///   - request: A `Wendycloud_V1_ListAssetsRequest` message.
+        ///   - response: A response stream of `Wendycloud_V1_ListAssetsResponse` messages.
         ///   - context: Context providing information about the RPC.
         /// - Throws: Any error which occurred during the processing of the request. Thrown errors
         ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
         ///     to an internal error.
-        /// - Returns: A `Wendycloud_V1_ListAssetsResponse` to respond with.
         func listAssets(
             request: Wendycloud_V1_ListAssetsRequest,
+            response: GRPCCore.RPCWriter<Wendycloud_V1_ListAssetsResponse>,
             context: GRPCCore.ServerContext
-        ) async throws -> Wendycloud_V1_ListAssetsResponse
+        ) async throws
 
         /// Handle the "ListAssetChildren" method.
         ///
         /// - Parameters:
         ///   - request: A `Wendycloud_V1_ListAssetChildrenRequest` message.
+        ///   - response: A response stream of `Wendycloud_V1_ListAssetChildrenResponse` messages.
         ///   - context: Context providing information about the RPC.
         /// - Throws: Any error which occurred during the processing of the request. Thrown errors
         ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
         ///     to an internal error.
-        /// - Returns: A `Wendycloud_V1_ListAssetChildrenResponse` to respond with.
         func listAssetChildren(
             request: Wendycloud_V1_ListAssetChildrenRequest,
+            response: GRPCCore.RPCWriter<Wendycloud_V1_ListAssetChildrenResponse>,
             context: GRPCCore.ServerContext
-        ) async throws -> Wendycloud_V1_ListAssetChildrenResponse
+        ) async throws
 
         /// Handle the "GetAssetLineage" method.
         ///
@@ -596,7 +598,7 @@ extension Wendycloud_V1_AssetService.ServiceProtocol {
             request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.StreamingServerResponse(single: response)
+        return response
     }
 
     public func listAssetChildren(
@@ -607,7 +609,7 @@ extension Wendycloud_V1_AssetService.ServiceProtocol {
             request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.StreamingServerResponse(single: response)
+        return response
     }
 
     public func getAssetLineage(
@@ -680,26 +682,34 @@ extension Wendycloud_V1_AssetService.SimpleServiceProtocol {
     public func listAssets(
         request: GRPCCore.ServerRequest<Wendycloud_V1_ListAssetsRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse<Wendycloud_V1_ListAssetsResponse> {
-        return GRPCCore.ServerResponse<Wendycloud_V1_ListAssetsResponse>(
-            message: try await self.listAssets(
-                request: request.message,
-                context: context
-            ),
-            metadata: [:]
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendycloud_V1_ListAssetsResponse> {
+        return GRPCCore.StreamingServerResponse<Wendycloud_V1_ListAssetsResponse>(
+            metadata: [:],
+            producer: { writer in
+                try await self.listAssets(
+                    request: request.message,
+                    response: writer,
+                    context: context
+                )
+                return [:]
+            }
         )
     }
 
     public func listAssetChildren(
         request: GRPCCore.ServerRequest<Wendycloud_V1_ListAssetChildrenRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse<Wendycloud_V1_ListAssetChildrenResponse> {
-        return GRPCCore.ServerResponse<Wendycloud_V1_ListAssetChildrenResponse>(
-            message: try await self.listAssetChildren(
-                request: request.message,
-                context: context
-            ),
-            metadata: [:]
+    ) async throws -> GRPCCore.StreamingServerResponse<Wendycloud_V1_ListAssetChildrenResponse> {
+        return GRPCCore.StreamingServerResponse<Wendycloud_V1_ListAssetChildrenResponse>(
+            metadata: [:],
+            producer: { writer in
+                try await self.listAssetChildren(
+                    request: request.message,
+                    response: writer,
+                    context: context
+                )
+                return [:]
+            }
         )
     }
 
@@ -818,7 +828,7 @@ extension Wendycloud_V1_AssetService {
             serializer: some GRPCCore.MessageSerializer<Wendycloud_V1_ListAssetsRequest>,
             deserializer: some GRPCCore.MessageDeserializer<Wendycloud_V1_ListAssetsResponse>,
             options: GRPCCore.CallOptions,
-            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendycloud_V1_ListAssetsResponse>) async throws -> Result
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendycloud_V1_ListAssetsResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
 
         /// Call the "ListAssetChildren" method.
@@ -837,7 +847,7 @@ extension Wendycloud_V1_AssetService {
             serializer: some GRPCCore.MessageSerializer<Wendycloud_V1_ListAssetChildrenRequest>,
             deserializer: some GRPCCore.MessageDeserializer<Wendycloud_V1_ListAssetChildrenResponse>,
             options: GRPCCore.CallOptions,
-            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendycloud_V1_ListAssetChildrenResponse>) async throws -> Result
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendycloud_V1_ListAssetChildrenResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
 
         /// Call the "GetAssetLineage" method.
@@ -1012,11 +1022,9 @@ extension Wendycloud_V1_AssetService {
             serializer: some GRPCCore.MessageSerializer<Wendycloud_V1_ListAssetsRequest>,
             deserializer: some GRPCCore.MessageDeserializer<Wendycloud_V1_ListAssetsResponse>,
             options: GRPCCore.CallOptions = .defaults,
-            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendycloud_V1_ListAssetsResponse>) async throws -> Result = { response in
-                try response.message
-            }
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendycloud_V1_ListAssetsResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable {
-            try await self.client.unary(
+            try await self.client.serverStreaming(
                 request: request,
                 descriptor: Wendycloud_V1_AssetService.Method.ListAssets.descriptor,
                 serializer: serializer,
@@ -1042,11 +1050,9 @@ extension Wendycloud_V1_AssetService {
             serializer: some GRPCCore.MessageSerializer<Wendycloud_V1_ListAssetChildrenRequest>,
             deserializer: some GRPCCore.MessageDeserializer<Wendycloud_V1_ListAssetChildrenResponse>,
             options: GRPCCore.CallOptions = .defaults,
-            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendycloud_V1_ListAssetChildrenResponse>) async throws -> Result = { response in
-                try response.message
-            }
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendycloud_V1_ListAssetChildrenResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable {
-            try await self.client.unary(
+            try await self.client.serverStreaming(
                 request: request,
                 descriptor: Wendycloud_V1_AssetService.Method.ListAssetChildren.descriptor,
                 serializer: serializer,
@@ -1203,9 +1209,7 @@ extension Wendycloud_V1_AssetService.ClientProtocol {
     public func listAssets<Result>(
         request: GRPCCore.ClientRequest<Wendycloud_V1_ListAssetsRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendycloud_V1_ListAssetsResponse>) async throws -> Result = { response in
-            try response.message
-        }
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendycloud_V1_ListAssetsResponse>) async throws -> Result
     ) async throws -> Result where Result: Sendable {
         try await self.listAssets(
             request: request,
@@ -1228,9 +1232,7 @@ extension Wendycloud_V1_AssetService.ClientProtocol {
     public func listAssetChildren<Result>(
         request: GRPCCore.ClientRequest<Wendycloud_V1_ListAssetChildrenRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendycloud_V1_ListAssetChildrenResponse>) async throws -> Result = { response in
-            try response.message
-        }
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendycloud_V1_ListAssetChildrenResponse>) async throws -> Result
     ) async throws -> Result where Result: Sendable {
         try await self.listAssetChildren(
             request: request,
@@ -1400,9 +1402,7 @@ extension Wendycloud_V1_AssetService.ClientProtocol {
         _ message: Wendycloud_V1_ListAssetsRequest,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendycloud_V1_ListAssetsResponse>) async throws -> Result = { response in
-            try response.message
-        }
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendycloud_V1_ListAssetsResponse>) async throws -> Result
     ) async throws -> Result where Result: Sendable {
         let request = GRPCCore.ClientRequest<Wendycloud_V1_ListAssetsRequest>(
             message: message,
@@ -1429,9 +1429,7 @@ extension Wendycloud_V1_AssetService.ClientProtocol {
         _ message: Wendycloud_V1_ListAssetChildrenRequest,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Wendycloud_V1_ListAssetChildrenResponse>) async throws -> Result = { response in
-            try response.message
-        }
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Wendycloud_V1_ListAssetChildrenResponse>) async throws -> Result
     ) async throws -> Result where Result: Sendable {
         let request = GRPCCore.ClientRequest<Wendycloud_V1_ListAssetChildrenRequest>(
             message: message,

--- a/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/assets.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/assets.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public struct Wendycloud_V1_Asset: @unchecked Sendable {
+public nonisolated struct Wendycloud_V1_Asset: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -214,7 +214,7 @@ public struct Wendycloud_V1_Asset: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-public struct Wendycloud_V1_CreateAssetRequest: @unchecked Sendable {
+public nonisolated struct Wendycloud_V1_CreateAssetRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -382,7 +382,7 @@ public struct Wendycloud_V1_CreateAssetRequest: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-public struct Wendycloud_V1_GetAssetRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetAssetRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -394,7 +394,7 @@ public struct Wendycloud_V1_GetAssetRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_UpdateAssetRequest: @unchecked Sendable {
+public nonisolated struct Wendycloud_V1_UpdateAssetRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -551,7 +551,7 @@ public struct Wendycloud_V1_UpdateAssetRequest: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-public struct Wendycloud_V1_DeleteAssetRequest: Sendable {
+public nonisolated struct Wendycloud_V1_DeleteAssetRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -563,7 +563,7 @@ public struct Wendycloud_V1_DeleteAssetRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_DeleteAssetResponse: Sendable {
+public nonisolated struct Wendycloud_V1_DeleteAssetResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -575,7 +575,7 @@ public struct Wendycloud_V1_DeleteAssetResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListAssetsRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListAssetsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -591,9 +591,23 @@ public struct Wendycloud_V1_ListAssetsRequest: Sendable {
   /// Clears the value of `isComputeDevice`. Subsequent reads from it will return its default value.
   public mutating func clearIsComputeDevice() {self._isComputeDevice = nil}
 
-  public var pageSize: Int32 = 0
+  public var offset: Int32 {
+    get {_offset ?? 0}
+    set {_offset = newValue}
+  }
+  /// Returns true if `offset` has been explicitly set.
+  public var hasOffset: Bool {self._offset != nil}
+  /// Clears the value of `offset`. Subsequent reads from it will return its default value.
+  public mutating func clearOffset() {self._offset = nil}
 
-  public var pageToken: String = String()
+  public var limit: Int32 {
+    get {_limit ?? 0}
+    set {_limit = newValue}
+  }
+  /// Returns true if `limit` has been explicitly set.
+  public var hasLimit: Bool {self._limit != nil}
+  /// Clears the value of `limit`. Subsequent reads from it will return its default value.
+  public mutating func clearLimit() {self._limit = nil}
 
   /// Filter by name, details, asset_type, device_type, or tags
   public var filter: String {
@@ -605,59 +619,107 @@ public struct Wendycloud_V1_ListAssetsRequest: Sendable {
   /// Clears the value of `filter`. Subsequent reads from it will return its default value.
   public mutating func clearFilter() {self._filter = nil}
 
+  /// If true, only return assets with active broker presence
+  public var onlineOnly: Bool {
+    get {_onlineOnly ?? false}
+    set {_onlineOnly = newValue}
+  }
+  /// Returns true if `onlineOnly` has been explicitly set.
+  public var hasOnlineOnly: Bool {self._onlineOnly != nil}
+  /// Clears the value of `onlineOnly`. Subsequent reads from it will return its default value.
+  public mutating func clearOnlineOnly() {self._onlineOnly = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _isComputeDevice: Bool? = nil
+  fileprivate var _offset: Int32? = nil
+  fileprivate var _limit: Int32? = nil
   fileprivate var _filter: String? = nil
+  fileprivate var _onlineOnly: Bool? = nil
 }
 
-public struct Wendycloud_V1_ListAssetsResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListAssetsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var assets: [Wendycloud_V1_Asset] = []
+  public var asset: Wendycloud_V1_Asset {
+    get {_asset ?? Wendycloud_V1_Asset()}
+    set {_asset = newValue}
+  }
+  /// Returns true if `asset` has been explicitly set.
+  public var hasAsset: Bool {self._asset != nil}
+  /// Clears the value of `asset`. Subsequent reads from it will return its default value.
+  public mutating func clearAsset() {self._asset = nil}
 
-  public var nextPageToken: String = String()
+  public var total: Int32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _asset: Wendycloud_V1_Asset? = nil
 }
 
-public struct Wendycloud_V1_ListAssetChildrenRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListAssetChildrenRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   public var parentAssetID: Int32 = 0
 
-  public var pageSize: Int32 = 0
+  public var offset: Int32 {
+    get {_offset ?? 0}
+    set {_offset = newValue}
+  }
+  /// Returns true if `offset` has been explicitly set.
+  public var hasOffset: Bool {self._offset != nil}
+  /// Clears the value of `offset`. Subsequent reads from it will return its default value.
+  public mutating func clearOffset() {self._offset = nil}
 
-  public var pageToken: String = String()
+  public var limit: Int32 {
+    get {_limit ?? 0}
+    set {_limit = newValue}
+  }
+  /// Returns true if `limit` has been explicitly set.
+  public var hasLimit: Bool {self._limit != nil}
+  /// Clears the value of `limit`. Subsequent reads from it will return its default value.
+  public mutating func clearLimit() {self._limit = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _offset: Int32? = nil
+  fileprivate var _limit: Int32? = nil
 }
 
-public struct Wendycloud_V1_ListAssetChildrenResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListAssetChildrenResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var assets: [Wendycloud_V1_Asset] = []
+  public var asset: Wendycloud_V1_Asset {
+    get {_asset ?? Wendycloud_V1_Asset()}
+    set {_asset = newValue}
+  }
+  /// Returns true if `asset` has been explicitly set.
+  public var hasAsset: Bool {self._asset != nil}
+  /// Clears the value of `asset`. Subsequent reads from it will return its default value.
+  public mutating func clearAsset() {self._asset = nil}
 
-  public var nextPageToken: String = String()
+  public var total: Int32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _asset: Wendycloud_V1_Asset? = nil
 }
 
-public struct Wendycloud_V1_GetAssetLineageRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetAssetLineageRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -669,7 +731,7 @@ public struct Wendycloud_V1_GetAssetLineageRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetAssetLineageResponse: Sendable {
+public nonisolated struct Wendycloud_V1_GetAssetLineageResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -699,9 +761,9 @@ public struct Wendycloud_V1_GetAssetLineageResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendycloud.v1"
+fileprivate nonisolated let _protobuf_package = "wendycloud.v1"
 
-extension Wendycloud_V1_Asset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_Asset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Asset"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}organization_id\0\u{3}parent_asset_id\0\u{1}name\0\u{1}details\0\u{3}asset_type\0\u{3}blob_storage_url\0\u{3}blob_content_type\0\u{3}blob_size_bytes\0\u{3}blob_metadata\0\u{3}is_compute_device\0\u{3}device_type\0\u{1}architecture\0\u{3}cpu_cores\0\u{3}ram_mb\0\u{3}storage_gb\0\u{3}os_type\0\u{3}os_version\0\u{3}ip_address\0\u{3}mac_address\0\u{3}created_at\0\u{3}updated_at\0\u{1}tags\0")
 
@@ -925,7 +987,7 @@ extension Wendycloud_V1_Asset: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Wendycloud_V1_CreateAssetRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateAssetRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateAssetRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}parent_asset_id\0\u{1}name\0\u{1}details\0\u{3}asset_type\0\u{3}blob_storage_url\0\u{3}blob_content_type\0\u{3}blob_size_bytes\0\u{3}blob_metadata\0\u{3}is_compute_device\0\u{3}device_type\0\u{1}architecture\0\u{3}cpu_cores\0\u{3}ram_mb\0\u{3}storage_gb\0\u{3}os_type\0\u{3}os_version\0\u{3}ip_address\0\u{3}mac_address\0\u{1}tags\0")
 
@@ -1128,7 +1190,7 @@ extension Wendycloud_V1_CreateAssetRequest: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Wendycloud_V1_GetAssetRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetAssetRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetAssetRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -1158,7 +1220,7 @@ extension Wendycloud_V1_GetAssetRequest: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Wendycloud_V1_UpdateAssetRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_UpdateAssetRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateAssetRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}name\0\u{1}details\0\u{3}blob_storage_url\0\u{3}blob_content_type\0\u{3}blob_size_bytes\0\u{3}blob_metadata\0\u{3}device_type\0\u{1}architecture\0\u{3}cpu_cores\0\u{3}ram_mb\0\u{3}storage_gb\0\u{3}os_type\0\u{3}os_version\0\u{3}ip_address\0\u{3}mac_address\0\u{1}tags\0")
 
@@ -1340,7 +1402,7 @@ extension Wendycloud_V1_UpdateAssetRequest: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Wendycloud_V1_DeleteAssetRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DeleteAssetRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteAssetRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -1370,7 +1432,7 @@ extension Wendycloud_V1_DeleteAssetRequest: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Wendycloud_V1_DeleteAssetResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DeleteAssetResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteAssetResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0")
 
@@ -1400,9 +1462,9 @@ extension Wendycloud_V1_DeleteAssetResponse: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Wendycloud_V1_ListAssetsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAssetsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAssetsRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}is_compute_device\0\u{3}page_size\0\u{3}page_token\0\u{1}filter\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}is_compute_device\0\u{1}offset\0\u{1}limit\0\u{1}filter\0\u{3}online_only\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1412,9 +1474,10 @@ extension Wendycloud_V1_ListAssetsRequest: SwiftProtobuf.Message, SwiftProtobuf.
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularInt32Field(value: &self.organizationID) }()
       case 2: try { try decoder.decodeSingularBoolField(value: &self._isComputeDevice) }()
-      case 3: try { try decoder.decodeSingularInt32Field(value: &self.pageSize) }()
-      case 4: try { try decoder.decodeSingularStringField(value: &self.pageToken) }()
+      case 3: try { try decoder.decodeSingularInt32Field(value: &self._offset) }()
+      case 4: try { try decoder.decodeSingularInt32Field(value: &self._limit) }()
       case 5: try { try decoder.decodeSingularStringField(value: &self._filter) }()
+      case 6: try { try decoder.decodeSingularBoolField(value: &self._onlineOnly) }()
       default: break
       }
     }
@@ -1431,14 +1494,17 @@ extension Wendycloud_V1_ListAssetsRequest: SwiftProtobuf.Message, SwiftProtobuf.
     try { if let v = self._isComputeDevice {
       try visitor.visitSingularBoolField(value: v, fieldNumber: 2)
     } }()
-    if self.pageSize != 0 {
-      try visitor.visitSingularInt32Field(value: self.pageSize, fieldNumber: 3)
-    }
-    if !self.pageToken.isEmpty {
-      try visitor.visitSingularStringField(value: self.pageToken, fieldNumber: 4)
-    }
+    try { if let v = self._offset {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
+    } }()
+    try { if let v = self._limit {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 4)
+    } }()
     try { if let v = self._filter {
       try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    } }()
+    try { if let v = self._onlineOnly {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 6)
     } }()
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1446,17 +1512,18 @@ extension Wendycloud_V1_ListAssetsRequest: SwiftProtobuf.Message, SwiftProtobuf.
   public static func ==(lhs: Wendycloud_V1_ListAssetsRequest, rhs: Wendycloud_V1_ListAssetsRequest) -> Bool {
     if lhs.organizationID != rhs.organizationID {return false}
     if lhs._isComputeDevice != rhs._isComputeDevice {return false}
-    if lhs.pageSize != rhs.pageSize {return false}
-    if lhs.pageToken != rhs.pageToken {return false}
+    if lhs._offset != rhs._offset {return false}
+    if lhs._limit != rhs._limit {return false}
     if lhs._filter != rhs._filter {return false}
+    if lhs._onlineOnly != rhs._onlineOnly {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendycloud_V1_ListAssetsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAssetsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAssetsResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}assets\0\u{3}next_page_token\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}asset\0\u{1}total\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1464,34 +1531,38 @@ extension Wendycloud_V1_ListAssetsResponse: SwiftProtobuf.Message, SwiftProtobuf
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.assets) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self.nextPageToken) }()
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._asset) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.total) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.assets.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.assets, fieldNumber: 1)
-    }
-    if !self.nextPageToken.isEmpty {
-      try visitor.visitSingularStringField(value: self.nextPageToken, fieldNumber: 2)
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._asset {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if self.total != 0 {
+      try visitor.visitSingularInt32Field(value: self.total, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Wendycloud_V1_ListAssetsResponse, rhs: Wendycloud_V1_ListAssetsResponse) -> Bool {
-    if lhs.assets != rhs.assets {return false}
-    if lhs.nextPageToken != rhs.nextPageToken {return false}
+    if lhs._asset != rhs._asset {return false}
+    if lhs.total != rhs.total {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendycloud_V1_ListAssetChildrenRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAssetChildrenRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAssetChildrenRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_asset_id\0\u{3}page_size\0\u{3}page_token\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_asset_id\0\u{1}offset\0\u{1}limit\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1500,38 +1571,42 @@ extension Wendycloud_V1_ListAssetChildrenRequest: SwiftProtobuf.Message, SwiftPr
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularInt32Field(value: &self.parentAssetID) }()
-      case 2: try { try decoder.decodeSingularInt32Field(value: &self.pageSize) }()
-      case 3: try { try decoder.decodeSingularStringField(value: &self.pageToken) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self._offset) }()
+      case 3: try { try decoder.decodeSingularInt32Field(value: &self._limit) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.parentAssetID != 0 {
       try visitor.visitSingularInt32Field(value: self.parentAssetID, fieldNumber: 1)
     }
-    if self.pageSize != 0 {
-      try visitor.visitSingularInt32Field(value: self.pageSize, fieldNumber: 2)
-    }
-    if !self.pageToken.isEmpty {
-      try visitor.visitSingularStringField(value: self.pageToken, fieldNumber: 3)
-    }
+    try { if let v = self._offset {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    } }()
+    try { if let v = self._limit {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Wendycloud_V1_ListAssetChildrenRequest, rhs: Wendycloud_V1_ListAssetChildrenRequest) -> Bool {
     if lhs.parentAssetID != rhs.parentAssetID {return false}
-    if lhs.pageSize != rhs.pageSize {return false}
-    if lhs.pageToken != rhs.pageToken {return false}
+    if lhs._offset != rhs._offset {return false}
+    if lhs._limit != rhs._limit {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendycloud_V1_ListAssetChildrenResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAssetChildrenResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAssetChildrenResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}assets\0\u{3}next_page_token\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}asset\0\u{1}total\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1539,32 +1614,36 @@ extension Wendycloud_V1_ListAssetChildrenResponse: SwiftProtobuf.Message, SwiftP
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.assets) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self.nextPageToken) }()
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._asset) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.total) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.assets.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.assets, fieldNumber: 1)
-    }
-    if !self.nextPageToken.isEmpty {
-      try visitor.visitSingularStringField(value: self.nextPageToken, fieldNumber: 2)
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._asset {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if self.total != 0 {
+      try visitor.visitSingularInt32Field(value: self.total, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Wendycloud_V1_ListAssetChildrenResponse, rhs: Wendycloud_V1_ListAssetChildrenResponse) -> Bool {
-    if lhs.assets != rhs.assets {return false}
-    if lhs.nextPageToken != rhs.nextPageToken {return false}
+    if lhs._asset != rhs._asset {return false}
+    if lhs.total != rhs.total {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Wendycloud_V1_GetAssetLineageRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetAssetLineageRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetAssetLineageRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}asset_id\0")
 
@@ -1594,7 +1673,7 @@ extension Wendycloud_V1_GetAssetLineageRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Wendycloud_V1_GetAssetLineageResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetAssetLineageResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetAssetLineageResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}root_asset\0\u{3}all_assets\0\u{3}requested_asset_id\0")
 

--- a/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/certificates.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/certificates.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public enum Wendycloud_V1_CertificateStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Wendycloud_V1_CertificateStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
   case unspecified // = 0
   case active // = 1
@@ -63,7 +63,7 @@ public enum Wendycloud_V1_CertificateStatus: SwiftProtobuf.Enum, Swift.CaseItera
 }
 
 /// Error codes for certificate operations
-public enum Wendycloud_V1_CertificateErrorCode: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Wendycloud_V1_CertificateErrorCode: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
   case certificateErrorUnspecified // = 0
 
@@ -159,7 +159,7 @@ public enum Wendycloud_V1_CertificateErrorCode: SwiftProtobuf.Enum, Swift.CaseIt
 
 }
 
-public struct Wendycloud_V1_GetCertificateMetadataRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetCertificateMetadataRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -169,7 +169,7 @@ public struct Wendycloud_V1_GetCertificateMetadataRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetCertificateMetadataResponse: Sendable {
+public nonisolated struct Wendycloud_V1_GetCertificateMetadataResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -211,7 +211,7 @@ public struct Wendycloud_V1_GetCertificateMetadataResponse: Sendable {
 /// The asset_id and user_id are mutually exclusive.
 /// If there is a certificate for `wendy-agent`, it will have an asset_id and organization_id.
 /// If there is a certificate for a user, it will have a user_id and organization_id.
-public struct Wendycloud_V1_Certificate: @unchecked Sendable {
+public nonisolated struct Wendycloud_V1_Certificate: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -329,7 +329,7 @@ public struct Wendycloud_V1_Certificate: @unchecked Sendable {
 
 /// Required for issuing a certificate for the first time for an asset
 /// you can look up the assetId and organizationId by the enrollment token
-public struct Wendycloud_V1_IssueCertificateRequest: Sendable {
+public nonisolated struct Wendycloud_V1_IssueCertificateRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -346,7 +346,7 @@ public struct Wendycloud_V1_IssueCertificateRequest: Sendable {
 }
 
 /// Response wrapper with structured error handling for certificate issuance
-public struct Wendycloud_V1_IssueCertificateResponse: Sendable {
+public nonisolated struct Wendycloud_V1_IssueCertificateResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -411,7 +411,7 @@ public struct Wendycloud_V1_IssueCertificateResponse: Sendable {
 /// The server extracts organization_id and asset_id from the client's current
 /// certificate SAN (Subject Alternative Name), so they don't need to be provided.
 /// The agent should refresh ~2/3 through the current certificate's lifetime.
-public struct Wendycloud_V1_RefreshCertificateRequest: Sendable {
+public nonisolated struct Wendycloud_V1_RefreshCertificateRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -425,7 +425,7 @@ public struct Wendycloud_V1_RefreshCertificateRequest: Sendable {
 }
 
 /// Response wrapper with structured error handling for certificate refresh
-public struct Wendycloud_V1_RefreshCertificateResponse: Sendable {
+public nonisolated struct Wendycloud_V1_RefreshCertificateResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -461,7 +461,7 @@ public struct Wendycloud_V1_RefreshCertificateResponse: Sendable {
   fileprivate var _error: Wendycloud_V1_CertificateError? = nil
 }
 
-public struct Wendycloud_V1_RevokeCertificateRequest: Sendable {
+public nonisolated struct Wendycloud_V1_RevokeCertificateRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -475,7 +475,7 @@ public struct Wendycloud_V1_RevokeCertificateRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_RevokeCertificateResponse: Sendable {
+public nonisolated struct Wendycloud_V1_RevokeCertificateResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -487,7 +487,7 @@ public struct Wendycloud_V1_RevokeCertificateResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetCertificateRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetCertificateRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -499,7 +499,7 @@ public struct Wendycloud_V1_GetCertificateRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListCertificatesRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListCertificatesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -533,7 +533,7 @@ public struct Wendycloud_V1_ListCertificatesRequest: Sendable {
   fileprivate var _limit: Int32? = nil
 }
 
-public struct Wendycloud_V1_ListCertificatesResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListCertificatesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -557,7 +557,7 @@ public struct Wendycloud_V1_ListCertificatesResponse: Sendable {
   fileprivate var _certificate: Wendycloud_V1_Certificate? = nil
 }
 
-public struct Wendycloud_V1_GetCaBundleRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetCaBundleRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -567,7 +567,7 @@ public struct Wendycloud_V1_GetCaBundleRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetCaBundleResponse: Sendable {
+public nonisolated struct Wendycloud_V1_GetCaBundleResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -582,7 +582,7 @@ public struct Wendycloud_V1_GetCaBundleResponse: Sendable {
 
 /// Asset Enrollment Token RPCs
 /// This DOES use the Authorization: Bearer token since it's generated primarily by a user logged into the dashboard
-public struct Wendycloud_V1_CreateAssetEnrollmentTokenRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateAssetEnrollmentTokenRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -599,7 +599,7 @@ public struct Wendycloud_V1_CreateAssetEnrollmentTokenRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_CreateAssetEnrollmentTokenResponse: Sendable {
+public nonisolated struct Wendycloud_V1_CreateAssetEnrollmentTokenResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -635,7 +635,7 @@ public struct Wendycloud_V1_CreateAssetEnrollmentTokenResponse: Sendable {
 /// User Enrollment Token RPCs
 /// This DOES use the Authorization: Bearer token since it's generated primarily by a user logged into the dashboard
 /// The user_id is derived from the Authorization: Bearer token (Firebase ID token)
-public struct Wendycloud_V1_CreateUserEnrollmentTokenRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateUserEnrollmentTokenRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -650,7 +650,7 @@ public struct Wendycloud_V1_CreateUserEnrollmentTokenRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_CreateUserEnrollmentTokenResponse: Sendable {
+public nonisolated struct Wendycloud_V1_CreateUserEnrollmentTokenResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -681,7 +681,7 @@ public struct Wendycloud_V1_CreateUserEnrollmentTokenResponse: Sendable {
 }
 
 /// Structured error information for certificate operations
-public struct Wendycloud_V1_CertificateError: Sendable {
+public nonisolated struct Wendycloud_V1_CertificateError: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -702,17 +702,17 @@ public struct Wendycloud_V1_CertificateError: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendycloud.v1"
+fileprivate nonisolated let _protobuf_package = "wendycloud.v1"
 
-extension Wendycloud_V1_CertificateStatus: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CertificateStatus: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CERTIFICATE_STATUS_UNSPECIFIED\0\u{1}CERTIFICATE_STATUS_ACTIVE\0\u{1}CERTIFICATE_STATUS_REVOKED\0\u{1}CERTIFICATE_STATUS_EXPIRED\0")
 }
 
-extension Wendycloud_V1_CertificateErrorCode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CertificateErrorCode: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CERTIFICATE_ERROR_UNSPECIFIED\0\u{1}CERTIFICATE_ERROR_INVALID_CSR\0\u{1}CERTIFICATE_ERROR_INVALID_ENROLLMENT_TOKEN\0\u{1}CERTIFICATE_ERROR_UNAUTHORIZED\0\u{1}CERTIFICATE_ERROR_ORGANIZATION_NOT_FOUND\0\u{1}CERTIFICATE_ERROR_ASSET_NOT_FOUND\0\u{1}CERTIFICATE_ERROR_CA_SERVICE_UNAVAILABLE\0\u{1}CERTIFICATE_ERROR_QUOTA_EXCEEDED\0\u{1}CERTIFICATE_ERROR_CERTIFICATE_REVOKED\0\u{1}CERTIFICATE_ERROR_CERTIFICATE_EXPIRED\0\u{1}CERTIFICATE_ERROR_INVALID_COMMON_NAME\0\u{1}CERTIFICATE_ERROR_INTERNAL\0")
 }
 
-extension Wendycloud_V1_GetCertificateMetadataRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetCertificateMetadataRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetCertificateMetadataRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -731,7 +731,7 @@ extension Wendycloud_V1_GetCertificateMetadataRequest: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Wendycloud_V1_GetCertificateMetadataResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetCertificateMetadataResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetCertificateMetadataResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}asset_id\0\u{3}user_id\0")
 
@@ -775,7 +775,7 @@ extension Wendycloud_V1_GetCertificateMetadataResponse: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendycloud_V1_Certificate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_Certificate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Certificate"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}organization_id\0\u{3}asset_id\0\u{3}serial_number\0\u{3}pem_certificate\0\u{3}pem_certificate_chain\0\u{3}not_before\0\u{3}not_after\0\u{1}status\0\u{3}revoked_at\0\u{3}revocation_reason\0\u{3}created_at\0\u{3}updated_at\0\u{3}user_id\0")
 
@@ -936,7 +936,7 @@ extension Wendycloud_V1_Certificate: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Wendycloud_V1_IssueCertificateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_IssueCertificateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".IssueCertificateRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{3}pem_csr\0\u{4}\u{2}enrollment_token\0")
 
@@ -971,7 +971,7 @@ extension Wendycloud_V1_IssueCertificateRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_IssueCertificateResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_IssueCertificateResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".IssueCertificateResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}certificate\0\u{1}error\0\u{1}warnings\0\u{3}organization_id\0\u{3}asset_id\0\u{3}user_id\0")
 
@@ -1030,7 +1030,7 @@ extension Wendycloud_V1_IssueCertificateResponse: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendycloud_V1_RefreshCertificateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_RefreshCertificateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RefreshCertificateRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{3}pem_csr\0")
 
@@ -1060,7 +1060,7 @@ extension Wendycloud_V1_RefreshCertificateRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_RefreshCertificateResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_RefreshCertificateResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RefreshCertificateResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}certificate\0\u{1}error\0\u{1}warnings\0")
 
@@ -1104,7 +1104,7 @@ extension Wendycloud_V1_RefreshCertificateResponse: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendycloud_V1_RevokeCertificateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_RevokeCertificateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RevokeCertificateRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}certificate_id\0\u{1}reason\0")
 
@@ -1139,7 +1139,7 @@ extension Wendycloud_V1_RevokeCertificateRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendycloud_V1_RevokeCertificateResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_RevokeCertificateResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RevokeCertificateResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0")
 
@@ -1169,7 +1169,7 @@ extension Wendycloud_V1_RevokeCertificateResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_GetCertificateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetCertificateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetCertificateRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}certificate_id\0")
 
@@ -1199,7 +1199,7 @@ extension Wendycloud_V1_GetCertificateRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Wendycloud_V1_ListCertificatesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListCertificatesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListCertificatesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}asset_id\0\u{1}offset\0\u{1}limit\0")
 
@@ -1243,7 +1243,7 @@ extension Wendycloud_V1_ListCertificatesRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_ListCertificatesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListCertificatesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListCertificatesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}certificate\0\u{1}total\0")
 
@@ -1282,7 +1282,7 @@ extension Wendycloud_V1_ListCertificatesResponse: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendycloud_V1_GetCaBundleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetCaBundleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetCaBundleRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1301,7 +1301,7 @@ extension Wendycloud_V1_GetCaBundleRequest: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Wendycloud_V1_GetCaBundleResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetCaBundleResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetCaBundleResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}pem_bundle\0")
 
@@ -1331,7 +1331,7 @@ extension Wendycloud_V1_GetCaBundleResponse: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Wendycloud_V1_CreateAssetEnrollmentTokenRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateAssetEnrollmentTokenRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateAssetEnrollmentTokenRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{1}name\0\u{3}ttl_seconds\0")
 
@@ -1371,7 +1371,7 @@ extension Wendycloud_V1_CreateAssetEnrollmentTokenRequest: SwiftProtobuf.Message
   }
 }
 
-extension Wendycloud_V1_CreateAssetEnrollmentTokenResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateAssetEnrollmentTokenResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateAssetEnrollmentTokenResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}enrollment_token\0\u{1}jti\0\u{3}expires_at\0\u{3}organization_id\0\u{3}asset_id\0")
 
@@ -1425,7 +1425,7 @@ extension Wendycloud_V1_CreateAssetEnrollmentTokenResponse: SwiftProtobuf.Messag
   }
 }
 
-extension Wendycloud_V1_CreateUserEnrollmentTokenRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateUserEnrollmentTokenRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateUserEnrollmentTokenRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}ttl_seconds\0\u{3}organization_id\0")
 
@@ -1460,7 +1460,7 @@ extension Wendycloud_V1_CreateUserEnrollmentTokenRequest: SwiftProtobuf.Message,
   }
 }
 
-extension Wendycloud_V1_CreateUserEnrollmentTokenResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateUserEnrollmentTokenResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateUserEnrollmentTokenResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}enrollment_token\0\u{1}jti\0\u{3}expires_at\0\u{4}\u{2}user_id\0")
 
@@ -1509,7 +1509,7 @@ extension Wendycloud_V1_CreateUserEnrollmentTokenResponse: SwiftProtobuf.Message
   }
 }
 
-extension Wendycloud_V1_CertificateError: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CertificateError: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CertificateError"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}details\0")
 

--- a/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/deployments.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/deployments.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public enum Wendycloud_V1_Running: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Wendycloud_V1_Running: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
   case absent // = 0
   case running // = 1
@@ -59,7 +59,7 @@ public enum Wendycloud_V1_Running: SwiftProtobuf.Enum, Swift.CaseIterable {
 }
 
 /// ==================== App Releases ====================
-public struct Wendycloud_V1_AppRelease: Sendable {
+public nonisolated struct Wendycloud_V1_AppRelease: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -110,7 +110,7 @@ public struct Wendycloud_V1_AppRelease: Sendable {
   fileprivate var _updatedAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-public struct Wendycloud_V1_CreateAppReleaseRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateAppReleaseRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -130,7 +130,7 @@ public struct Wendycloud_V1_CreateAppReleaseRequest: Sendable {
 
 /// Use this to assign a image_digest to an app_release after it has been pushed to the registry
 /// Note, verify that the image_digest exists in the registry before updating the app_release
-public struct Wendycloud_V1_UpdateAppReleaseRequest: Sendable {
+public nonisolated struct Wendycloud_V1_UpdateAppReleaseRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -148,7 +148,7 @@ public struct Wendycloud_V1_UpdateAppReleaseRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListAppReleasesRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListAppReleasesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -166,7 +166,7 @@ public struct Wendycloud_V1_ListAppReleasesRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListAppReleasesResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListAppReleasesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -182,7 +182,7 @@ public struct Wendycloud_V1_ListAppReleasesResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetPushImageCredentialsRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetPushImageCredentialsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -196,7 +196,7 @@ public struct Wendycloud_V1_GetPushImageCredentialsRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetPushImageCredentialsResponse: Sendable {
+public nonisolated struct Wendycloud_V1_GetPushImageCredentialsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -225,7 +225,7 @@ public struct Wendycloud_V1_GetPushImageCredentialsResponse: Sendable {
   fileprivate var _expiresAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-public struct Wendycloud_V1_Deployment: Sendable {
+public nonisolated struct Wendycloud_V1_Deployment: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -259,7 +259,7 @@ public struct Wendycloud_V1_Deployment: Sendable {
 }
 
 /// infer the created_by_user_id from the authService
-public struct Wendycloud_V1_CreateDeploymentRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateDeploymentRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -288,7 +288,7 @@ public struct Wendycloud_V1_CreateDeploymentRequest: Sendable {
   fileprivate var _jqFilter: String? = nil
 }
 
-public struct Wendycloud_V1_GetDeploymentRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetDeploymentRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -300,7 +300,7 @@ public struct Wendycloud_V1_GetDeploymentRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListDeploymentsRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListDeploymentsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -318,7 +318,7 @@ public struct Wendycloud_V1_ListDeploymentsRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListDeploymentsResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListDeploymentsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -334,7 +334,7 @@ public struct Wendycloud_V1_ListDeploymentsResponse: Sendable {
 
 /// this is to be called by the wendy-agent to update the reported state of an apps on an asset
 /// asset_id and organization_id are derived from the client certificate
-public struct Wendycloud_V1_UpdateReportedStateRequest: Sendable {
+public nonisolated struct Wendycloud_V1_UpdateReportedStateRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -346,7 +346,7 @@ public struct Wendycloud_V1_UpdateReportedStateRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_CurrentState: Sendable {
+public nonisolated struct Wendycloud_V1_CurrentState: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -377,7 +377,7 @@ public struct Wendycloud_V1_CurrentState: Sendable {
 
 /// this is to be called by the wendy-agent to get the desired state of an app on an asset
 /// if the app_id does not exist, wendy-agent should remove the container from the asset
-public struct Wendycloud_V1_DesiredStateResponse: Sendable {
+public nonisolated struct Wendycloud_V1_DesiredStateResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -389,7 +389,7 @@ public struct Wendycloud_V1_DesiredStateResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_DesiredAppState: Sendable {
+public nonisolated struct Wendycloud_V1_DesiredAppState: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -416,13 +416,13 @@ public struct Wendycloud_V1_DesiredAppState: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendycloud.v1"
+fileprivate nonisolated let _protobuf_package = "wendycloud.v1"
 
-extension Wendycloud_V1_Running: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_Running: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0ABSENT\0\u{1}RUNNING\0\u{1}STOPPED\0")
 }
 
-extension Wendycloud_V1_AppRelease: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_AppRelease: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AppRelease"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}organization_id\0\u{3}app_id\0\u{1}name\0\u{1}details\0\u{3}image_digest\0\u{3}created_at\0\u{3}updated_at\0")
 
@@ -491,7 +491,7 @@ extension Wendycloud_V1_AppRelease: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Wendycloud_V1_CreateAppReleaseRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateAppReleaseRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateAppReleaseRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_id\0\u{3}organization_id\0\u{1}name\0\u{1}details\0")
 
@@ -536,7 +536,7 @@ extension Wendycloud_V1_CreateAppReleaseRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_UpdateAppReleaseRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_UpdateAppReleaseRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateAppReleaseRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}name\0\u{1}details\0\u{3}image_digest\0")
 
@@ -581,7 +581,7 @@ extension Wendycloud_V1_UpdateAppReleaseRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_ListAppReleasesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAppReleasesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAppReleasesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}app_id\0\u{1}offset\0\u{1}limit\0")
 
@@ -626,7 +626,7 @@ extension Wendycloud_V1_ListAppReleasesRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Wendycloud_V1_ListAppReleasesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListAppReleasesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListAppReleasesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_releases\0\u{1}total\0\u{1}offset\0")
 
@@ -666,7 +666,7 @@ extension Wendycloud_V1_ListAppReleasesResponse: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_GetPushImageCredentialsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetPushImageCredentialsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetPushImageCredentialsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}app_id\0")
 
@@ -701,7 +701,7 @@ extension Wendycloud_V1_GetPushImageCredentialsRequest: SwiftProtobuf.Message, S
   }
 }
 
-extension Wendycloud_V1_GetPushImageCredentialsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetPushImageCredentialsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetPushImageCredentialsResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}registry_url\0\u{3}full_image_path\0\u{3}access_token\0\u{3}expires_at\0\u{1}username\0")
 
@@ -755,7 +755,7 @@ extension Wendycloud_V1_GetPushImageCredentialsResponse: SwiftProtobuf.Message, 
   }
 }
 
-extension Wendycloud_V1_Deployment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_Deployment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Deployment"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}organization_id\0\u{3}jq_filter\0\u{3}app_release_id\0\u{1}details\0\u{3}created_by_user_id\0\u{3}created_at\0")
 
@@ -819,7 +819,7 @@ extension Wendycloud_V1_Deployment: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Wendycloud_V1_CreateDeploymentRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateDeploymentRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateDeploymentRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}jq_filter\0\u{3}app_release_id\0\u{1}details\0\u{1}running\0")
 
@@ -873,7 +873,7 @@ extension Wendycloud_V1_CreateDeploymentRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_GetDeploymentRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetDeploymentRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetDeploymentRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -903,7 +903,7 @@ extension Wendycloud_V1_GetDeploymentRequest: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Wendycloud_V1_ListDeploymentsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListDeploymentsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListDeploymentsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}app_id\0\u{1}offset\0\u{1}limit\0")
 
@@ -948,7 +948,7 @@ extension Wendycloud_V1_ListDeploymentsRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Wendycloud_V1_ListDeploymentsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListDeploymentsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListDeploymentsResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}deployments\0\u{1}total\0")
 
@@ -983,7 +983,7 @@ extension Wendycloud_V1_ListDeploymentsResponse: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_UpdateReportedStateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_UpdateReportedStateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateReportedStateRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}current_states\0")
 
@@ -1013,7 +1013,7 @@ extension Wendycloud_V1_UpdateReportedStateRequest: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendycloud_V1_CurrentState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CurrentState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CurrentState"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_id\0\u{3}app_release_id\0\u{3}reported_state\0\u{3}reported_restart_count\0\u{3}reported_last_exit_signal\0")
 
@@ -1067,7 +1067,7 @@ extension Wendycloud_V1_CurrentState: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Wendycloud_V1_DesiredStateResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DesiredStateResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DesiredStateResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}desired_app_states\0")
 
@@ -1097,7 +1097,7 @@ extension Wendycloud_V1_DesiredStateResponse: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Wendycloud_V1_DesiredAppState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DesiredAppState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DesiredAppState"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}app_id\0\u{3}app_release_id\0\u{3}desired_state\0")
 

--- a/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/notifications.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/notifications.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public enum Wendycloud_V1_NotificationSeverity: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Wendycloud_V1_NotificationSeverity: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
   case unspecified // = 0
   case info // = 1
@@ -66,7 +66,7 @@ public enum Wendycloud_V1_NotificationSeverity: SwiftProtobuf.Enum, Swift.CaseIt
 
 }
 
-public struct Wendycloud_V1_Notification: Sendable {
+public nonisolated struct Wendycloud_V1_Notification: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -117,7 +117,7 @@ public struct Wendycloud_V1_Notification: Sendable {
   fileprivate var _deletedAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-public struct Wendycloud_V1_CreateNotificationRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateNotificationRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -146,7 +146,7 @@ public struct Wendycloud_V1_CreateNotificationRequest: Sendable {
   fileprivate var _relatedEntities: SwiftProtobuf.Google_Protobuf_Struct? = nil
 }
 
-public struct Wendycloud_V1_ListNotificationsRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListNotificationsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -177,7 +177,7 @@ public struct Wendycloud_V1_ListNotificationsRequest: Sendable {
   fileprivate var _severityFilter: Wendycloud_V1_NotificationSeverity? = nil
 }
 
-public struct Wendycloud_V1_ListNotificationsResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListNotificationsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -193,7 +193,7 @@ public struct Wendycloud_V1_ListNotificationsResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetNotificationRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetNotificationRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -205,7 +205,7 @@ public struct Wendycloud_V1_GetNotificationRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_DeleteNotificationRequest: Sendable {
+public nonisolated struct Wendycloud_V1_DeleteNotificationRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -217,7 +217,7 @@ public struct Wendycloud_V1_DeleteNotificationRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_DeleteNotificationResponse: Sendable {
+public nonisolated struct Wendycloud_V1_DeleteNotificationResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -229,7 +229,7 @@ public struct Wendycloud_V1_DeleteNotificationResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_MarkAsReadRequest: Sendable {
+public nonisolated struct Wendycloud_V1_MarkAsReadRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -241,7 +241,7 @@ public struct Wendycloud_V1_MarkAsReadRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_MarkAsReadResponse: Sendable {
+public nonisolated struct Wendycloud_V1_MarkAsReadResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -255,7 +255,7 @@ public struct Wendycloud_V1_MarkAsReadResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetUnreadCountRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetUnreadCountRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -269,7 +269,7 @@ public struct Wendycloud_V1_GetUnreadCountRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetUnreadCountResponse: Sendable {
+public nonisolated struct Wendycloud_V1_GetUnreadCountResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -283,13 +283,13 @@ public struct Wendycloud_V1_GetUnreadCountResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendycloud.v1"
+fileprivate nonisolated let _protobuf_package = "wendycloud.v1"
 
-extension Wendycloud_V1_NotificationSeverity: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_NotificationSeverity: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0NOTIFICATION_SEVERITY_UNSPECIFIED\0\u{1}NOTIFICATION_SEVERITY_INFO\0\u{1}NOTIFICATION_SEVERITY_WARNING\0\u{1}NOTIFICATION_SEVERITY_ERROR\0\u{1}NOTIFICATION_SEVERITY_CRITICAL\0")
 }
 
-extension Wendycloud_V1_Notification: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_Notification: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Notification"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}user_id\0\u{3}organization_id\0\u{1}body\0\u{1}severity\0\u{3}related_entities\0\u{3}created_at\0\u{3}deleted_at\0")
 
@@ -358,7 +358,7 @@ extension Wendycloud_V1_Notification: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Wendycloud_V1_CreateNotificationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateNotificationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateNotificationRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}user_id\0\u{3}organization_id\0\u{1}body\0\u{1}severity\0\u{3}related_entities\0")
 
@@ -412,7 +412,7 @@ extension Wendycloud_V1_CreateNotificationRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_ListNotificationsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListNotificationsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListNotificationsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}user_id\0\u{3}page_size\0\u{3}page_token\0\u{3}severity_filter\0\u{3}include_deleted\0")
 
@@ -471,7 +471,7 @@ extension Wendycloud_V1_ListNotificationsRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendycloud_V1_ListNotificationsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListNotificationsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListNotificationsResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}notifications\0\u{3}next_page_token\0\u{3}total_count\0")
 
@@ -511,7 +511,7 @@ extension Wendycloud_V1_ListNotificationsResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_GetNotificationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetNotificationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetNotificationRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -541,7 +541,7 @@ extension Wendycloud_V1_GetNotificationRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Wendycloud_V1_DeleteNotificationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DeleteNotificationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteNotificationRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -571,7 +571,7 @@ extension Wendycloud_V1_DeleteNotificationRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_DeleteNotificationResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DeleteNotificationResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteNotificationResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0")
 
@@ -601,7 +601,7 @@ extension Wendycloud_V1_DeleteNotificationResponse: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendycloud_V1_MarkAsReadRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_MarkAsReadRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".MarkAsReadRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}notification_ids\0")
 
@@ -631,7 +631,7 @@ extension Wendycloud_V1_MarkAsReadRequest: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Wendycloud_V1_MarkAsReadResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_MarkAsReadResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".MarkAsReadResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}marked_count\0")
 
@@ -666,7 +666,7 @@ extension Wendycloud_V1_MarkAsReadResponse: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Wendycloud_V1_GetUnreadCountRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetUnreadCountRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetUnreadCountRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}user_id\0")
 
@@ -701,7 +701,7 @@ extension Wendycloud_V1_GetUnreadCountRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Wendycloud_V1_GetUnreadCountResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetUnreadCountResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetUnreadCountResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}unread_count\0")
 

--- a/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/organizations.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/organizations.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public enum Wendycloud_V1_OrganizationRole: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Wendycloud_V1_OrganizationRole: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
   case unspecified // = 0
   case owner // = 1
@@ -70,7 +70,7 @@ public enum Wendycloud_V1_OrganizationRole: SwiftProtobuf.Enum, Swift.CaseIterab
 
 }
 
-public struct Wendycloud_V1_Organization: Sendable {
+public nonisolated struct Wendycloud_V1_Organization: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -117,7 +117,7 @@ public struct Wendycloud_V1_Organization: Sendable {
   fileprivate var _updatedAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-public struct Wendycloud_V1_OrganizationMember: Sendable {
+public nonisolated struct Wendycloud_V1_OrganizationMember: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -156,7 +156,7 @@ public struct Wendycloud_V1_OrganizationMember: Sendable {
   fileprivate var _updatedAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-public struct Wendycloud_V1_CreateOrganizationRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateOrganizationRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -181,7 +181,7 @@ public struct Wendycloud_V1_CreateOrganizationRequest: Sendable {
   fileprivate var _domain: String? = nil
 }
 
-public struct Wendycloud_V1_GetOrganizationRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetOrganizationRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -193,7 +193,7 @@ public struct Wendycloud_V1_GetOrganizationRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_UpdateOrganizationRequest: Sendable {
+public nonisolated struct Wendycloud_V1_UpdateOrganizationRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -236,7 +236,7 @@ public struct Wendycloud_V1_UpdateOrganizationRequest: Sendable {
   fileprivate var _domain: String? = nil
 }
 
-public struct Wendycloud_V1_DeleteOrganizationRequest: Sendable {
+public nonisolated struct Wendycloud_V1_DeleteOrganizationRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -248,7 +248,7 @@ public struct Wendycloud_V1_DeleteOrganizationRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_DeleteOrganizationResponse: Sendable {
+public nonisolated struct Wendycloud_V1_DeleteOrganizationResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -260,7 +260,7 @@ public struct Wendycloud_V1_DeleteOrganizationResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListOrganizationsRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListOrganizationsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -291,7 +291,7 @@ public struct Wendycloud_V1_ListOrganizationsRequest: Sendable {
   fileprivate var _limit: Int32? = nil
 }
 
-public struct Wendycloud_V1_ListOrganizationsResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListOrganizationsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -314,7 +314,7 @@ public struct Wendycloud_V1_ListOrganizationsResponse: Sendable {
   fileprivate var _organization: Wendycloud_V1_Organization? = nil
 }
 
-public struct Wendycloud_V1_AddMemberRequest: Sendable {
+public nonisolated struct Wendycloud_V1_AddMemberRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -330,7 +330,7 @@ public struct Wendycloud_V1_AddMemberRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_UpdateMemberRoleRequest: Sendable {
+public nonisolated struct Wendycloud_V1_UpdateMemberRoleRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -344,7 +344,7 @@ public struct Wendycloud_V1_UpdateMemberRoleRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_RemoveMemberRequest: Sendable {
+public nonisolated struct Wendycloud_V1_RemoveMemberRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -356,7 +356,7 @@ public struct Wendycloud_V1_RemoveMemberRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_RemoveMemberResponse: Sendable {
+public nonisolated struct Wendycloud_V1_RemoveMemberResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -368,7 +368,7 @@ public struct Wendycloud_V1_RemoveMemberResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListMembersRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListMembersRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -384,7 +384,7 @@ public struct Wendycloud_V1_ListMembersRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListMembersResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListMembersResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -398,7 +398,7 @@ public struct Wendycloud_V1_ListMembersResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_EmailWithRole: Sendable {
+public nonisolated struct Wendycloud_V1_EmailWithRole: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -412,7 +412,7 @@ public struct Wendycloud_V1_EmailWithRole: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_AddMembersByEmailsRequest: Sendable {
+public nonisolated struct Wendycloud_V1_AddMembersByEmailsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -426,7 +426,7 @@ public struct Wendycloud_V1_AddMembersByEmailsRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_AddMemberResult: Sendable {
+public nonisolated struct Wendycloud_V1_AddMemberResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -453,7 +453,7 @@ public struct Wendycloud_V1_AddMemberResult: Sendable {
   fileprivate var _member: Wendycloud_V1_OrganizationMember? = nil
 }
 
-public struct Wendycloud_V1_AddMembersByEmailsResponse: Sendable {
+public nonisolated struct Wendycloud_V1_AddMembersByEmailsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -467,13 +467,13 @@ public struct Wendycloud_V1_AddMembersByEmailsResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendycloud.v1"
+fileprivate nonisolated let _protobuf_package = "wendycloud.v1"
 
-extension Wendycloud_V1_OrganizationRole: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_OrganizationRole: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0ORGANIZATION_ROLE_UNSPECIFIED\0\u{1}ORGANIZATION_ROLE_OWNER\0\u{1}ORGANIZATION_ROLE_ADMIN\0\u{1}ORGANIZATION_ROLE_BILLING_MANAGER\0\u{1}ORGANIZATION_ROLE_MEMBER\0\u{1}ORGANIZATION_ROLE_VIEWER\0")
 }
 
-extension Wendycloud_V1_Organization: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_Organization: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Organization"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}name\0\u{1}details\0\u{1}domain\0\u{3}created_at\0\u{3}updated_at\0")
 
@@ -532,7 +532,7 @@ extension Wendycloud_V1_Organization: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Wendycloud_V1_OrganizationMember: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_OrganizationMember: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".OrganizationMember"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}organization_id\0\u{3}user_id\0\u{1}role\0\u{3}created_at\0\u{3}updated_at\0")
 
@@ -591,7 +591,7 @@ extension Wendycloud_V1_OrganizationMember: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Wendycloud_V1_CreateOrganizationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateOrganizationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateOrganizationRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}details\0\u{1}domain\0")
 
@@ -635,7 +635,7 @@ extension Wendycloud_V1_CreateOrganizationRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_GetOrganizationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetOrganizationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetOrganizationRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -665,7 +665,7 @@ extension Wendycloud_V1_GetOrganizationRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Wendycloud_V1_UpdateOrganizationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_UpdateOrganizationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateOrganizationRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}name\0\u{1}details\0\u{1}domain\0")
 
@@ -714,7 +714,7 @@ extension Wendycloud_V1_UpdateOrganizationRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_DeleteOrganizationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DeleteOrganizationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteOrganizationRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -744,7 +744,7 @@ extension Wendycloud_V1_DeleteOrganizationRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_DeleteOrganizationResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_DeleteOrganizationResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DeleteOrganizationResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0")
 
@@ -774,7 +774,7 @@ extension Wendycloud_V1_DeleteOrganizationResponse: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Wendycloud_V1_ListOrganizationsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListOrganizationsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListOrganizationsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}offset\0\u{1}limit\0")
 
@@ -813,7 +813,7 @@ extension Wendycloud_V1_ListOrganizationsRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Wendycloud_V1_ListOrganizationsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListOrganizationsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListOrganizationsResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}organization\0\u{1}total\0")
 
@@ -852,7 +852,7 @@ extension Wendycloud_V1_ListOrganizationsResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_AddMemberRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_AddMemberRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddMemberRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}user_id\0\u{1}role\0")
 
@@ -892,7 +892,7 @@ extension Wendycloud_V1_AddMemberRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Wendycloud_V1_UpdateMemberRoleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_UpdateMemberRoleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateMemberRoleRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}role\0")
 
@@ -927,7 +927,7 @@ extension Wendycloud_V1_UpdateMemberRoleRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_RemoveMemberRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_RemoveMemberRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RemoveMemberRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -957,7 +957,7 @@ extension Wendycloud_V1_RemoveMemberRequest: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Wendycloud_V1_RemoveMemberResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_RemoveMemberResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RemoveMemberResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0")
 
@@ -987,7 +987,7 @@ extension Wendycloud_V1_RemoveMemberResponse: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Wendycloud_V1_ListMembersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListMembersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListMembersRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}page_size\0\u{3}page_token\0")
 
@@ -1027,7 +1027,7 @@ extension Wendycloud_V1_ListMembersRequest: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Wendycloud_V1_ListMembersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListMembersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListMembersResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}members\0\u{3}next_page_token\0")
 
@@ -1062,7 +1062,7 @@ extension Wendycloud_V1_ListMembersResponse: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Wendycloud_V1_EmailWithRole: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_EmailWithRole: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EmailWithRole"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}email\0\u{1}role\0")
 
@@ -1097,7 +1097,7 @@ extension Wendycloud_V1_EmailWithRole: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Wendycloud_V1_AddMembersByEmailsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_AddMembersByEmailsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddMembersByEmailsRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{1}members\0")
 
@@ -1132,7 +1132,7 @@ extension Wendycloud_V1_AddMembersByEmailsRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Wendycloud_V1_AddMemberResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_AddMemberResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddMemberResult"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}email\0\u{1}success\0\u{1}error\0\u{1}member\0")
 
@@ -1181,7 +1181,7 @@ extension Wendycloud_V1_AddMemberResult: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Wendycloud_V1_AddMembersByEmailsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_AddMembersByEmailsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddMembersByEmailsResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}results\0")
 

--- a/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/remote_logging.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/remote_logging.pb.swift
@@ -15,13 +15,13 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Log severity levels aligned with common syslog/Cloud Logging values.
-public enum Wendycloud_V1_LogSeverity: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum Wendycloud_V1_LogSeverity: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
   case unspecified // = 0
   case debug // = 1
@@ -85,7 +85,7 @@ public enum Wendycloud_V1_LogSeverity: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 /// A single log record. Designed to map cleanly to Google Cloud Logging's
 /// LogEntry (textPayload/jsonPayload), plus trace context fields.
-public struct Wendycloud_V1_LogEntry: Sendable {
+public nonisolated struct Wendycloud_V1_LogEntry: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -186,7 +186,7 @@ public struct Wendycloud_V1_LogEntry: Sendable {
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Payload (choose one). text_payload maps to textPayload; json_payload to jsonPayload.
-  public enum OneOf_Payload: Equatable, Sendable {
+  public nonisolated enum OneOf_Payload: Equatable, Sendable {
     case textPayload(String)
     case jsonPayload(SwiftProtobuf.Google_Protobuf_Struct)
 
@@ -205,7 +205,7 @@ public struct Wendycloud_V1_LogEntry: Sendable {
 /// Batch write request for log entries originating from a specific app running
 /// on an asset within an organization. All fields must be set and the
 /// caller is authenticated via mTLS client certificates.
-public struct Wendycloud_V1_WriteLogEntriesRequest: Sendable {
+public nonisolated struct Wendycloud_V1_WriteLogEntriesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -258,7 +258,7 @@ public struct Wendycloud_V1_WriteLogEntriesRequest: Sendable {
   fileprivate var _logName: String? = nil
 }
 
-public struct Wendycloud_V1_WriteLogEntriesResponse: Sendable {
+public nonisolated struct Wendycloud_V1_WriteLogEntriesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -277,7 +277,7 @@ public struct Wendycloud_V1_WriteLogEntriesResponse: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_RejectedEntry: Sendable {
+public nonisolated struct Wendycloud_V1_RejectedEntry: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -294,7 +294,7 @@ public struct Wendycloud_V1_RejectedEntry: Sendable {
 }
 
 /// Request to tail logs for a specific app running on an asset.
-public struct Wendycloud_V1_TailLogEntriesRequest: Sendable {
+public nonisolated struct Wendycloud_V1_TailLogEntriesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -366,7 +366,7 @@ public struct Wendycloud_V1_TailLogEntriesRequest: Sendable {
   fileprivate var _deploymentID: Int32? = nil
 }
 
-public struct Wendycloud_V1_TailLogEntriesResponse: Sendable {
+public nonisolated struct Wendycloud_V1_TailLogEntriesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -392,13 +392,13 @@ public struct Wendycloud_V1_TailLogEntriesResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendycloud.v1"
+fileprivate nonisolated let _protobuf_package = "wendycloud.v1"
 
-extension Wendycloud_V1_LogSeverity: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_LogSeverity: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0LOG_SEVERITY_UNSPECIFIED\0\u{1}LOG_SEVERITY_DEBUG\0\u{1}LOG_SEVERITY_INFO\0\u{1}LOG_SEVERITY_NOTICE\0\u{1}LOG_SEVERITY_WARNING\0\u{1}LOG_SEVERITY_ERROR\0\u{1}LOG_SEVERITY_CRITICAL\0\u{1}LOG_SEVERITY_ALERT\0\u{1}LOG_SEVERITY_EMERGENCY\0")
 }
 
-extension Wendycloud_V1_LogEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_LogEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".LogEntry"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}timestamp\0\u{3}observed_at\0\u{1}severity\0\u{3}trace_id\0\u{3}span_id\0\u{3}trace_sampled\0\u{3}logger_name\0\u{1}file\0\u{1}function\0\u{1}line\0\u{1}labels\0\u{3}text_payload\0\u{3}json_payload\0\u{3}deployment_id\0")
 
@@ -520,7 +520,7 @@ extension Wendycloud_V1_LogEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Wendycloud_V1_WriteLogEntriesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_WriteLogEntriesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WriteLogEntriesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}asset_id\0\u{3}app_id\0\u{1}collector\0\u{3}collector_version\0\u{1}entries\0\u{3}log_name\0")
 
@@ -584,7 +584,7 @@ extension Wendycloud_V1_WriteLogEntriesRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Wendycloud_V1_WriteLogEntriesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_WriteLogEntriesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WriteLogEntriesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}accepted_count\0\u{1}rejections\0\u{3}ingestion_id\0")
 
@@ -624,7 +624,7 @@ extension Wendycloud_V1_WriteLogEntriesResponse: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Wendycloud_V1_RejectedEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_RejectedEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RejectedEntry"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}index\0\u{1}reason\0")
 
@@ -659,7 +659,7 @@ extension Wendycloud_V1_RejectedEntry: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Wendycloud_V1_TailLogEntriesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_TailLogEntriesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".TailLogEntriesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}organization_id\0\u{3}asset_id\0\u{3}app_id\0\u{3}start_time\0\u{3}poll_interval_seconds\0\u{3}page_size\0\u{3}log_name\0\u{3}deployment_id\0")
 
@@ -728,7 +728,7 @@ extension Wendycloud_V1_TailLogEntriesRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Wendycloud_V1_TailLogEntriesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_TailLogEntriesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".TailLogEntriesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}entries\0\u{3}read_through\0")
 

--- a/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/users.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyCloudGRPC/Proto/cloud/users.pb.swift
@@ -15,12 +15,12 @@ public import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-public struct Wendycloud_V1_User: Sendable {
+public nonisolated struct Wendycloud_V1_User: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -59,7 +59,7 @@ public struct Wendycloud_V1_User: Sendable {
   fileprivate var _updatedAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-public struct Wendycloud_V1_CreateUserRequest: Sendable {
+public nonisolated struct Wendycloud_V1_CreateUserRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -75,7 +75,7 @@ public struct Wendycloud_V1_CreateUserRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_GetUserRequest: Sendable {
+public nonisolated struct Wendycloud_V1_GetUserRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -87,7 +87,7 @@ public struct Wendycloud_V1_GetUserRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_UpdateUserRequest: Sendable {
+public nonisolated struct Wendycloud_V1_UpdateUserRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -120,7 +120,7 @@ public struct Wendycloud_V1_UpdateUserRequest: Sendable {
   fileprivate var _isSuperAdmin: Bool? = nil
 }
 
-public struct Wendycloud_V1_ListUsersRequest: Sendable {
+public nonisolated struct Wendycloud_V1_ListUsersRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -134,7 +134,7 @@ public struct Wendycloud_V1_ListUsersRequest: Sendable {
   public init() {}
 }
 
-public struct Wendycloud_V1_ListUsersResponse: Sendable {
+public nonisolated struct Wendycloud_V1_ListUsersResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -150,9 +150,9 @@ public struct Wendycloud_V1_ListUsersResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "wendycloud.v1"
+fileprivate nonisolated let _protobuf_package = "wendycloud.v1"
 
-extension Wendycloud_V1_User: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_User: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".User"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}email\0\u{1}name\0\u{3}is_super_admin\0\u{3}created_at\0\u{3}updated_at\0")
 
@@ -211,7 +211,7 @@ extension Wendycloud_V1_User: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Wendycloud_V1_CreateUserRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_CreateUserRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateUserRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}email\0\u{1}name\0\u{3}is_super_admin\0")
 
@@ -251,7 +251,7 @@ extension Wendycloud_V1_CreateUserRequest: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Wendycloud_V1_GetUserRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_GetUserRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetUserRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 
@@ -281,7 +281,7 @@ extension Wendycloud_V1_GetUserRequest: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Wendycloud_V1_UpdateUserRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_UpdateUserRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpdateUserRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}name\0\u{3}is_super_admin\0")
 
@@ -325,7 +325,7 @@ extension Wendycloud_V1_UpdateUserRequest: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Wendycloud_V1_ListUsersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListUsersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListUsersRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}page_size\0\u{3}page_token\0")
 
@@ -360,7 +360,7 @@ extension Wendycloud_V1_ListUsersRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Wendycloud_V1_ListUsersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Wendycloud_V1_ListUsersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListUsersResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}users\0\u{3}next_page_token\0")
 


### PR DESCRIPTION
> **In plain terms (for PMs):** No behavior change — this refreshes auto-generated code that had fallen out of date, so upcoming feature PRs show only their real changes.

## Summary

- Regenerate all Swift proto bindings (`make proto` in `swift/`) against the protos on main and the pinned generator toolchain.
- The committed bindings had drifted twice over:
  - `v1/shared.pb.swift` was **missing fields that already exist in the `.proto`** — `ServiceEntry`, `mcp_port`, `exit_code`, `termination_reason` were never regenerated into Swift, so the Swift agent couldn't see them.
  - All bindings predate the pinned swift-protobuf generator, which now emits `nonisolated` declarations — so every regen in a feature branch drags in 27 files of unrelated churn.
- Landing the catch-up once on main means feature PRs (first consumer: #1341, stacked on this) carry only their own proto delta.

## Notes

- The drift was larger than fields: **ten RPCs** had been added to the `.proto` files while the bindings were stale (`Unprovision`, `DumpKernelLog`, `GetOSUpdateStatus`, `SetHostname`, `GetResourceStats`, `StreamMCP`, `GetContainerPorts`, `QueryChunks`, `WriteChunks`, `QueryLayers`). The regenerated service protocols require them, so the Mac agent's services no longer compiled (the first CI run here caught this).
- Second commit stubs each new method with `RPCError(.unimplemented)`, following the file's existing "not supported by Wendy Agent for Mac" pattern. Wire behavior is unchanged: with the stale bindings these methods were never registered, so callers already received `UNIMPLEMENTED` — now they get the same status with a readable message.
- To verify the regen is mechanical: on a clean checkout of the merge-base, `cd swift && make proto` — the diff against the first commit of this branch should be empty.

## Tests

- `swift build` and `swift test` in `swift/WendyAgentCore` (70 tests pass).
- Wire format unaffected; CI's Swift jobs validate the Xcode app build and E2E.
