### PR TITLE
fix(mesh): reclaim stale CNI IPAM allocation before ADD (WDY-1834)

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1426,6 +1426,26 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	// On Linux the bind-mount is used; on other platforms the fd path is the fallback.
 	if isolation == "isolated" && serviceName != "" && netnsRef != nil {
 		netnsPath, cleanupNetns := bindNetnsForCNI(appName, netnsRef)
+		// Release any stale host-local IPAM reservation for this container ID
+		// before ADD (WDY-1834). The CNI allocation is keyed by container ID
+		// (== appName, which is stable across restart/redeploy), and
+		// deleteStaleTask above removes the old containerd task but NOT the CNI
+		// reservation. A previous teardown can be skipped entirely — the health
+		// monitor's restartSingle path calls StartContainer with no intervening
+		// stopOne/CNIDel — or fail (a bridge-plugin DEL error leaves the
+		// host-local allocation behind). Either way the next ADD for the same
+		// container ID collides with "duplicate allocation is not allowed",
+		// leaving the container with no mesh netns: its resolv.conf gateway is
+		// unreachable (DNS "Temporary failure in name resolution") and the
+		// ingress DNAT points at an IP nothing answers on ("no route to host").
+		// CNIDel is idempotent and best-effort — a no-op on a clean first deploy
+		// (the fresh netns has no eth0 to remove and host-local has no
+		// reservation for this ID) — so a pre-ADD DEL makes ADD collision-proof
+		// no matter how the previous instance was (or wasn't) torn down.
+		if delErr := c.CNIDel(ctx, appID, appName, netnsPath); delErr != nil {
+			c.logger.Warn("CNI DEL before ADD (stale-allocation reclaim) failed (non-fatal)",
+				zap.String(logfields.AppID, appID), zap.Error(delErr))
+		}
 		ip, cniErr := c.CNIAdd(ctx, appID, appName, netnsPath)
 		if cniErr != nil {
 			// Roll back any partial state the failed ADD left behind (e.g. a


### PR DESCRIPTION
## WDY-1834 — mesh containers don't survive restart/redeploy

Bug in the mesh CNI lifecycle (surfaced during fleet-on-mesh testing, but the defect is here in the mesh data plane, independent of fleet). Two independent contributors; **this PR fixes the primary one (Part A)** and diagnoses the second (Part B) for review.

### Part A — host-local IPAM allocation leaks across restart/redeploy ✅ fixed here
The CNI allocation is keyed by container ID (`== appName`, stable across restart/redeploy). `deleteStaleTask` recreates the containerd task but never releases the CNI reservation, so the next `CNIAdd` for the same container ID collides with `duplicate allocation is not allowed` whenever a prior teardown was **skipped** (the monitor's `restartSingle` calls `StartContainer` with no `stopOne`/`CNIDel`) or **failed** (a bridge-plugin DEL error leaves the reservation behind). A failed ADD → no mesh netns → resolv.conf gateway unreachable (`Temporary failure in name resolution`) and ingress DNAT pointing at a dead IP (`no route to host`). Sticky: only `apps remove --force` or an agent restart clears it.

**Fix:** DEL-before-ADD at the single `CNIAdd` site — reclaim any stale reservation for the container ID immediately before ADD (standard CNI GC). `CNIDel` is idempotent/best-effort: a no-op on a clean first deploy, and on restart it clears whatever leaked, regardless of which teardown path was skipped or failed. Guarding the one ADD site is path-independent and self-heals allocations already leaked in the field.

### Part B — mesh DNS listener never rebinds after a teardown-less restart 🔎 diagnosed, not implemented
The listener is keyed by gateway IP and refcounted; `EnsureListener` never checks whether the serve goroutine is still alive, and `ensureMeshDNS`'s `alreadyHeld` guard skips rebinding on the `restartSingle` path. So a dead listener is never re-established (independent of Part A, though a failed `CNIAdd` makes it worse). **Left for @Joannis** — it changes the DNS server's refcount/lifecycle contract; two shapes proposed:
- drop the map entry when the serve goroutine exits, so a later `EnsureListener` rebinds; and/or
- track `bound` separately from `refs` so a dead socket can be re-bound without disturbing per-container refcounts, plus have `ensureMeshDNS` re-verify liveness on the `alreadyHeld` path.

### Verification ⚠️ needs hardware (2× Jetson on one LAN) — not yet run
Deploy `Examples/HelloMesh` to two devices; `stop`+`start`, repeated `wendy run` redeploy, and a monitor-driven `restartSingle` should each recover (no `duplicate allocation`, no `no route to host`). No unit seam exists — `CNIAdd`/`CNIDel` exec the real bridge + host-local plugins, so this path is integration/hardware-tested like the rest of mesh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
