### PR TITLE
docs: make x86-64 (Intel/AMD) support explicit and clarify GPU acceleration

### DIFF
--- a/go/internal/cli/assets/docs/hardware/gpu.mdx
+++ b/go/internal/cli/assets/docs/hardware/gpu.mdx
@@ -5,7 +5,9 @@ description: Enable NVIDIA GPU access for CUDA, ML inference, and accelerated vi
 
 ## GPU Access
 
-GPU access is most common on NVIDIA Jetson devices for CUDA, ML inference, image processing, DeepStream, PyTorch, TensorRT, and MLX workloads. WendyOS does not expose GPU devices to apps unless the app declares the `gpu` entitlement.
+The `gpu` entitlement exposes the host GPU to your app for CUDA, ML inference, image processing, DeepStream, PyTorch, TensorRT, and MLX workloads. WendyOS does not expose GPU devices to apps unless the app declares the entitlement.
+
+Today this covers **NVIDIA GPUs (CUDA)** — both NVIDIA Jetson devices and x86 Intel/AMD machines with an NVIDIA card. **AMD GPU acceleration via ROCm is in progress.**
 
 Add the entitlement from your project directory:
 

--- a/go/internal/cli/assets/docs/hardware/index.mdx
+++ b/go/internal/cli/assets/docs/hardware/index.mdx
@@ -40,8 +40,12 @@ wendy run
 | Microphone | `audio` | Recording, voice commands, audio analysis |
 | Speaker or audio output | `audio` | Playback, alerts, voice responses |
 | Bluetooth adapter | `bluetooth` | BLE devices, Bluetooth sensors, paired accessories |
-| NVIDIA GPU | `gpu` | CUDA, ML inference, accelerated computer vision |
+| NVIDIA GPU | `gpu` | CUDA, ML inference, accelerated computer vision (Jetson and x86 NVIDIA GPUs) |
 | Web servers or network APIs | `network` | Serving HTTP, WebSockets, or accepting inbound connections |
+
+<Callout type="info">
+  AMD GPU (ROCm) support is in progress. Today the `gpu` entitlement accelerates NVIDIA GPUs via CUDA. See [GPU Access](/docs/hardware/gpu).
+</Callout>
 
 ## Feature Guides
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-linux.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-linux.mdx
@@ -5,7 +5,7 @@ description: Install wendy-agent on any Linux machine to turn it into a managed 
 
 ## Overview
 
-Install `wendy-agent` on **any existing Linux installation** — Ubuntu, Debian, Raspberry Pi OS, DGX Spark, NUCs, cloud VMs, or any other ARM64 or x86_64 distribution — to turn it into a managed Wendy device. Once installed, your `wendy` CLI and the device discover each other over the local network.
+Install `wendy-agent` on **any existing Linux installation** — Ubuntu, Debian, Raspberry Pi OS, DGX Spark, NUCs, cloud VMs, or any other ARM64 or x86-64 (Intel or AMD) machine — to turn it into a managed Wendy device. Once installed, your `wendy` CLI and the device discover each other over the local network.
 
 (`wendy-agent` is already built into [WendyOS](/docs/installation/wendyos-nvidia-jetson) — if you flashed WendyOS, skip this guide.)
 

--- a/go/internal/cli/assets/docs/wendyos/requirements.md
+++ b/go/internal/cli/assets/docs/wendyos/requirements.md
@@ -47,3 +47,23 @@ See the device-specific pages for full partition layouts:
 | Jetson AGX Orin | eMMC, NVME |
 | Jetson AGX Thor | Internal flash + NVME via USB recovery |
 | DGX Spark | Install `wendy-agent` on the existing Linux system (no image flash needed) |
+
+### x86-64 machines (Intel & AMD)
+
+Any 64-bit Intel or AMD PC, workstation, or server runs Wendy by installing `wendy-agent` on your existing Linux distribution (Ubuntu, Fedora, Arch, etc.) — no WendyOS image flash required. This is the same install path used for DGX Spark.
+
+| Machine | Setup |
+|---------|-------|
+| Intel x86-64 (Core, Xeon) | Install `wendy-agent` on existing Linux |
+| AMD x86-64 (Ryzen, EPYC) | Install `wendy-agent` on existing Linux |
+
+See [Install wendy-agent on Linux](/docs/installation/wendy-agent-linux).
+
+## GPU acceleration
+
+| GPU | Status |
+|-----|--------|
+| NVIDIA (CUDA) | Supported — Jetson and x86 systems with NVIDIA GPUs, via the `gpu` entitlement |
+| AMD (ROCm) | In progress |
+
+See [GPU Access](/docs/hardware/gpu).


### PR DESCRIPTION
## Summary

Makes Wendy's platform support explicit in the docs (`go/internal/cli/assets/docs`) and clarifies GPU acceleration status.

- **x86-64 Intel & AMD machines** — new section in `wendyos/requirements.md`: any Intel or AMD PC / workstation / server runs Wendy by installing `wendy-agent` on an existing Linux distro (no WendyOS flash — same path as DGX Spark).
- **GPU acceleration** — new table: **NVIDIA (CUDA)** supported today on Jetson and x86 NVIDIA GPUs; **AMD (ROCm)** in progress.
- `hardware/gpu.mdx` — broadened beyond Jetson to x86 NVIDIA; notes ROCm in progress.
- `hardware/index.mdx` — clarified the GPU entitlement row + a ROCm-in-progress callout.
- `installation/wendy-agent-linux.mdx` — spells out x86-64 as "Intel or AMD".

### Accuracy
Verified against the agent source before writing: the `gpu` entitlement binds `/dev/nvidia*` + CDI + CUDA (NVIDIA is real today) and there is no ROCm/`/dev/kfd` handling yet — so ROCm is documented as *in progress*, not supported.

Companion site PR: wendylabsinc/marketing-website#6.

> Note: an earlier version of this was opened against the generated `wendylabsinc/docs` mirror by mistake and has been closed; this is the correct source-of-truth PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)