### PR TITLE
cli: surface the real flash-write error instead of the fallback's

### DIFF
--- a/go/internal/cli/commands/flash_error.go
+++ b/go/internal/cli/commands/flash_error.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+// deviceMarkers are substrings that indicate a flash failure came from the
+// target device or its file descriptor — the canonical errno strings the OS
+// prints plus our own short-write guard. Text matching (not just errors.Is) is
+// required because the elevated __bmap-write child's device errors reach the
+// parent only as stderr text, and dd reports them as plain strings
+// ("Permission denied").
+var deviceMarkers = []string{
+	"permission denied",         // EACCES
+	"operation not permitted",   // EPERM
+	"read-only file system",     // EROFS
+	"no space left",             // ENOSPC
+	"no such device or address", // ENXIO (Linux)
+	"device not configured",     // ENXIO (macOS)
+	"no such device",            // ENODEV
+	"input/output error",        // EIO
+	"short write",               // our own truncated-write guard
+}
+
+// isDeviceFlashFailure reports whether a fast-path (bmap/seekable) write failed
+// because the target device rejected or lost the write — permissions, a
+// read-only card lock, no space, the device vanished, an I/O error, a short
+// write. The dd fallback writes to the same device and cannot succeed, so these
+// failures skip it and fail fast with the real error (WDY-1841). Every other
+// cause — a bmap checksum/size mismatch, or an unrecognized failure — still
+// falls back, preserving the historical behavior.
+func isDeviceFlashFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, m := range deviceMarkers {
+		if strings.Contains(msg, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// describeFlashOffset renders how far a write got before it failed, so the
+// primary error tells the user (and us) where it stopped rather than only that
+// it stopped. total is the fast path's total (mapped bytes for the seekable
+// path, uncompressed size otherwise); written is the last progress value.
+func describeFlashOffset(written, total int64) string {
+	switch {
+	case total > 0 && written > 0:
+		pct := float64(written) / float64(total) * 100
+		return fmt.Sprintf("at %.1f%% (%s / %s)", pct, tui.FormatBytes(written), tui.FormatBytes(total))
+	case written > 0:
+		return fmt.Sprintf("after %s", tui.FormatBytes(written))
+	default:
+		return "before any bytes were written"
+	}
+}
+
+// framePrimaryFlashError wraps the fast-path (primary) write error with the
+// path that failed and the offset it reached. The returned error keeps
+// primaryErr in its chain (so errors.Is/As and isDeviceFlashFailure still see
+// the original cause), and it is the error the fallback logic must never
+// discard — dropping it is the WDY-1841 bug.
+func framePrimaryFlashError(label string, written, total int64, primaryErr error) error {
+	return fmt.Errorf("%s failed %s: %w", label, describeFlashOffset(written, total), primaryErr)
+}
+
+// combineFlashFailure builds the error returned when the fast path failed and
+// the full-image dd fallback also failed: both errors, clearly labeled, with
+// the primary (real) error preserved in the chain and the fallback's appended.
+func combineFlashFailure(primary, fallback error) error {
+	return fmt.Errorf("%w; full-image fallback also failed: %v", primary, fallback)
+}
+
+// flashDeviceFailureHint is appended to a device-level flash failure. The dd
+// fallback is skipped in this case, so point at the physical causes worth
+// checking instead of leaving the user to wonder why nothing retried.
+const flashDeviceFailureHint = "The target device rejected or lost the write, so retrying the full image would fail the same way. " +
+	"Check the SD card's write-protect lock, the card's health, and the reader, cable, and USB port, " +
+	"then re-list drives (`diskutil list` on macOS, `lsblk` on Linux) to confirm the device still appears."

--- a/go/internal/cli/commands/flash_error_test.go
+++ b/go/internal/cli/commands/flash_error_test.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestIsDeviceFlashFailure_Table pins which fast-path failures skip the futile
+// dd fallback (device-level → true) versus which keep falling back (bmap
+// integrity / unknown → false). The device cases include the real WDY-1841
+// incident string and the canonical errno text the elevated __bmap-write child
+// relays over stderr.
+func TestIsDeviceFlashFailure_Table(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// Not device-level — the silent fallback exists to recover integrity
+		// failures, and unknown causes fall back too (historical behavior).
+		{"nil", nil, false},
+		{"checksum mismatch text", errors.New("bmap: checksum mismatch for blocks 0-1 (got a, want b)"), false},
+		{"seekable size mismatch", errors.New("seekable image size 100 != bmap image size 200"), false},
+		{"bmap parse failure", errors.New("parsing bmap: XML syntax error"), false},
+		{"opaque exit status", errors.New("writing image: exit status 1"), false},
+		{"unrelated error", errors.New("some other failure"), false},
+
+		// Device-level failures — the fallback writes to the same broken device.
+		{"real incident (dd permission denied)", errors.New("writing image: exit status 1\ndd: /dev/rdisk12: Permission denied"), true},
+		{"os.ErrPermission wrapped", fmt.Errorf("opening device /dev/rdisk12: %w", os.ErrPermission), true},
+		{"operation not permitted", errors.New("opening device: operation not permitted"), true},
+		{"read-only file system", errors.New("writing at 4096: read-only file system"), true},
+		{"no space left", errors.New("writing at 4096: no space left on device"), true},
+		{"device not configured (darwin ENXIO)", errors.New("writing at 4096: device not configured"), true},
+		{"no such device or address (linux ENXIO)", errors.New("writing at 4096: no such device or address"), true},
+		{"input/output error", errors.New("writing at 8192: input/output error"), true},
+		{"short write guard", errors.New("short write at offset 512: wrote 256 of 512 bytes"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDeviceFlashFailure(tt.err); got != tt.want {
+				t.Fatalf("isDeviceFlashFailure(%q) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDescribeFlashOffset covers the three offset-rendering modes: known total
+// (percentage + bytes), unknown total (bytes only), and nothing written.
+func TestDescribeFlashOffset(t *testing.T) {
+	tests := []struct {
+		name            string
+		written, total  int64
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{"known total", 16_300_000_000, 16_400_000_000, []string{"99.", "%", "GiB /"}, nil},
+		{"unknown total", 500 << 20, 0, []string{"after", "MiB"}, []string{"%"}},
+		{"nothing written", 0, 16_400_000_000, []string{"before any bytes"}, []string{"%"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := describeFlashOffset(tt.written, tt.total)
+			for _, sub := range tt.wantContains {
+				if !strings.Contains(got, sub) {
+					t.Errorf("describeFlashOffset(%d,%d) = %q; want substring %q", tt.written, tt.total, got, sub)
+				}
+			}
+			for _, sub := range tt.wantNotContains {
+				if strings.Contains(got, sub) {
+					t.Errorf("describeFlashOffset(%d,%d) = %q; must not contain %q", tt.written, tt.total, got, sub)
+				}
+			}
+		})
+	}
+}
+
+// TestFramePrimaryFlashError_PreservesCauseAndOffset asserts the primary error
+// keeps the original cause in its chain (errors.Is) and names the path + offset.
+func TestFramePrimaryFlashError_PreservesCauseAndOffset(t *testing.T) {
+	cause := errors.New("dd: /dev/rdisk12: Permission denied")
+	framed := framePrimaryFlashError("seekable block-map write", 16_300_000_000, 16_400_000_000, cause)
+
+	if !errors.Is(framed, cause) {
+		t.Fatalf("framed error dropped the primary cause: %v", framed)
+	}
+	msg := framed.Error()
+	for _, sub := range []string{"seekable block-map write failed", "99.", "%", "Permission denied"} {
+		if !strings.Contains(msg, sub) {
+			t.Errorf("framed error %q missing substring %q", msg, sub)
+		}
+	}
+	// The framed error must still read as device-level so the caller skips the
+	// fallback — framing must not mask the underlying cause.
+	if !isDeviceFlashFailure(framed) {
+		t.Errorf("framed device error no longer classifies as device-level: %v", framed)
+	}
+}
+
+// TestCombineFlashFailure_BothErrorsPresent is the core WDY-1841 regression: the
+// combined error must contain BOTH the primary (real) error and the fallback's,
+// clearly labeled, with the primary preserved in the errors.Is chain.
+func TestCombineFlashFailure_BothErrorsPresent(t *testing.T) {
+	primaryCause := errors.New("seekable write: input/output error")
+	primary := framePrimaryFlashError("seekable block-map write", 16_300_000_000, 16_400_000_000, primaryCause)
+	fallback := errors.New("writing image: exit status 1\ndd: /dev/rdisk12: Permission denied")
+
+	combined := combineFlashFailure(primary, fallback)
+	msg := combined.Error()
+
+	if !errors.Is(combined, primaryCause) {
+		t.Fatalf("combined error dropped the primary cause: %v", combined)
+	}
+	// Primary (real failure) present, with offset.
+	if !strings.Contains(msg, "seekable block-map write failed") || !strings.Contains(msg, "input/output error") {
+		t.Errorf("combined error %q missing the primary failure", msg)
+	}
+	// Fallback present and clearly labeled as the fallback.
+	if !strings.Contains(msg, "full-image fallback also failed") || !strings.Contains(msg, "Permission denied") {
+		t.Errorf("combined error %q missing the labeled fallback failure", msg)
+	}
+	// Offset survives into the final message.
+	if !strings.Contains(msg, "%") {
+		t.Errorf("combined error %q lost the failure offset", msg)
+	}
+}

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -606,12 +606,27 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	}
 	wp := tui.NewProgressProgram(writeProg)
 
+	// Track how far the fast path got and which path ran, so a failure can
+	// report the offset it reached and frame the primary error (WDY-1841).
+	var lastWritten atomic.Int64
+	var writeTotal int64
+	var fastPathLabel string
+	switch {
+	case seekableZst != "":
+		writeTotal, fastPathLabel = seekableTotal, "seekable block-map write"
+	case bmapPath != "":
+		writeTotal, fastPathLabel = stream.uncompressedSize, "block-map write"
+	default:
+		writeTotal, fastPathLabel = stream.uncompressedSize, "image write"
+	}
+
 	go func() {
 		var writeErr error
 		switch {
 		case seekableZst != "":
 			fmt.Println("Using seekable block map for faster flashing.")
 			writeErr = writeImageWithBmapSeekable(seekableZst, seekableBmap, targetDrive, func(written int64) {
+				lastWritten.Store(written)
 				var pct float64
 				if seekableTotal > 0 {
 					pct = float64(written) / float64(seekableTotal)
@@ -625,12 +640,14 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		case bmapPath != "":
 			fmt.Println("Using block map for faster flashing.")
 			writeErr = writeImageWithBmap(stream, stream.uncompressedSize, targetDrive, bmapPath, func(written int64) {
+				lastWritten.Store(written)
 				if msg, ok := stream.writeProgressMsg(written); ok {
 					wp.Send(msg)
 				}
 			})
 		default:
 			writeErr = writeImageToDisk(stream, stream.uncompressedSize, targetDrive, func(written int64) {
+				lastWritten.Store(written)
 				if msg, ok := stream.writeProgressMsg(written); ok {
 					wp.Send(msg)
 				}
@@ -645,7 +662,21 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	}
 
 	writeModel := writeFinal.(tui.ProgressModel)
-	if writeModel.Err() != nil {
+	if primaryErr := writeModel.Err(); primaryErr != nil {
+		// Frame the primary (fast-path) error with the offset it reached. This
+		// error is never discarded again below — it is the real failure, and
+		// WDY-1841 was caused by dropping it in favor of the fallback's error.
+		primary := framePrimaryFlashError(fastPathLabel, lastWritten.Load(), writeTotal, primaryErr)
+
+		// A device-level failure (permissions, a read-only card lock, no space,
+		// the device vanished, an I/O error, a short write) means the dd fallback
+		// writes to the same broken device and cannot succeed — skip it and fail
+		// fast with the real error plus actionable hints. Integrity failures
+		// (bmap checksum/size mismatch) and unrecognized causes still fall back.
+		if isDeviceFlashFailure(primaryErr) {
+			return fmt.Errorf("%w\n%s", primary, flashDeviceFailureHint)
+		}
+
 		// Bmap write failed (typically a checksum mismatch between the published
 		// bmap and the actual image). Fall back to a full sequential dd write.
 		// For the seekable-zstd path the .zst is already on disk — open it as a
@@ -658,17 +689,19 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		case seekableZst != "":
 			si, ferr := openSeekableZstd(seekableZst)
 			if ferr != nil {
-				return fmt.Errorf("writing image: %w", writeModel.Err())
+				return fmt.Errorf("%w; could not open image for full-image fallback: %v", primary, ferr)
 			}
 			fallbackReader, fallbackSize, fallbackCloser = si, si.Size(), si
 		case bmapPath != "":
 			fs, ferr := openOSImageStream(deviceKey, imgInfo)
 			if ferr != nil {
-				return fmt.Errorf("writing image: %w", writeModel.Err())
+				return fmt.Errorf("%w; could not open image for full-image fallback: %v", primary, ferr)
 			}
 			fallbackReader, fallbackSize, fallbackCloser = fs, fs.uncompressedSize, fs
 		default:
-			return fmt.Errorf("writing image: %w", writeModel.Err())
+			// Plain dd primary (no bmap): there is no faster path to fall back
+			// from, so surface the framed primary error directly.
+			return primary
 		}
 		defer fallbackCloser.Close()
 		fallbackProg := tui.NewProgress(fmt.Sprintf("Writing to %s...", targetDrive.DevicePath))
@@ -689,7 +722,9 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 			return fmt.Errorf("progress TUI: %w", ferr)
 		}
 		if fm := fallbackFinal.(tui.ProgressModel); fm.Err() != nil {
-			return fmt.Errorf("writing image: %w", fm.Err())
+			// Both writes failed: surface the primary (real) error AND the
+			// fallback's, clearly labeled, so we never again debug the wrong one.
+			return combineFlashFailure(primary, fm.Err())
 		}
 	}
 


### PR DESCRIPTION
> **In plain terms (for PMs):** When flashing an OS image fails, the error shown could be about the *retry*, not the real failure — sending users (and us) down the wrong debugging path. This makes flash failures report what actually went wrong, where it stopped, and skips a pointless multi-gigabyte retry when the device itself is the problem.

Closes WDY-1841.

## What

Flash writes take a bmap/seekable fast path and, on failure, silently fall back to a full `dd` write — a design that assumes the failure is a bmap checksum mismatch the fallback recovers from. When the fallback *also* failed, `os install` returned only the fallback's error and dropped the real (primary) one. This PR:

1. **Never discards the primary error.** When the fast path fails and the fallback also fails, the returned error carries **both**, clearly labeled (`… failed at 99.4% (…): <primary>; full-image fallback also failed: <fallback>`), with the primary kept in the `errors.Is` chain. The earlier fallback-opener returns that dropped the opener's context are fixed too.
2. **Fails fast on device-level failures.** A new `isDeviceFlashFailure` recognizes when the primary failure came from the target device (EACCES/EPERM/EROFS/ENOSPC/ENXIO/ENODEV/EIO, short write, dd exiting after the device vanished) and **skips the futile fallback**, failing immediately with the real error plus actionable hints (check the SD write-protect lock, card health, reader/cable/port, re-list drives). Every other cause — a bmap checksum/size/parse mismatch, or an unrecognized failure — still falls back, exactly as before.
3. **Includes the failure offset/percentage** in the primary error by threading the last progress value into the message.

## Why

An RPi5 flash died at 99% when the card/reader dropped off the USB bus, but the CLI reported only the fallback dd's `Permission denied` — the real seekable-write failure was suppressed by the silent-fallback design. See WDY-1841 for the full trace.

## How it's built

The classification/framing plumbing lives in a new `flash_error.go` (portable). The fallback-worth decision is a single boolean: device-level failure → skip the fallback, anything else → fall back. Because the elevated `__bmap-write` child communicates over stderr, its device-write errors are recognized by **matching the relayed error text** (canonical errno strings + our own short-write marker) plus `errors.Is` on `os.ErrPermission`. This keeps the fix proportionate — **the sudo child protocol was not changed, and no other write path was touched.**

Kept deliberately simple: an earlier revision distinguished *integrity* failures from *unknown* ones with a dedicated `errBmapIntegrity` sentinel wrapped through `bmap.go`, but both classes behaved identically (fall back), so the distinction was collapsed to the one decision that actually changes behavior. `bmap.go` is left untouched.

## How tested

**Manually verified on real hardware (2026-07-06):** hit a live flash failure and observed the new reporting end to end — the CLI now surfaces the primary (fast-path) error with the failure offset and fails fast with the actionable device hints, instead of the old behavior of burying the real failure under the fallback dd's error. This is exactly the WDY-1841 incident path.

**Unit tests** (`go/internal/cli/commands/flash_error_test.go`) — no writes to any `/dev` node:
- `TestIsDeviceFlashFailure_Table` — device-vs-fallback table incl. the real incident string, each errno, and the integrity/unknown cases that must keep falling back.
- `TestDescribeFlashOffset` — offset rendering (known/unknown total, nothing written).
- `TestFramePrimaryFlashError_PreservesCauseAndOffset` and `TestCombineFlashFailure_BothErrorsPresent` — the WDY-1841 regression: both errors present, labeled, primary preserved in the chain, offset carried through.

`go test ./internal/cli/commands/` passes; `go vet` clean; `gofmt` clean on touched files. Cross-platform: `GOOS=windows` builds the commands package clean; native `darwin` builds `./...` and tests pass. `GOOS=linux` cross-build of the package is blocked only by the pre-existing `gousb`/libusb CGO toolchain gap on macOS (unrelated to this change; `disklister_linux.go` is untouched and the changed code is portable Go).

## Known limitations (follow-up)

- **Locale:** device-error recognition for errno classes other than permissions relies on matching English errno text, because the elevated child and `dd` surface those as plain stderr strings. The bmap/seekable paths are safe (Go's errno table is locale-independent English); only the plain-dd path classifies libc-localized text, and a miss there merely omits the hint — no futile retry can result.
- **Source-vs-target:** the text match cannot tell a device error reading the *source* image (e.g. a host-disk EIO mid-stream) from one writing the *target*, so a rare source-side I/O error would skip the fallback and point the hint at the SD card. Distinguishing them needs typed errors through the sudo child protocol — deliberately out of scope here.
- **Windows:** `ERROR_WRITE_PROTECT`/`ERROR_NOT_READY` don't map to the Unix marker text, so on Windows those degrade to the old always-fall-back behavior (the primary error is still preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
