### PR TITLE
cli: auto-elevate Thor flash under sudo before flashing (WDY-1843)

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -150,6 +150,16 @@ Jetson AGX Thor does not use the drive-writing flow. Selecting `jetson-agx-thor`
 
 The CLI prompts for confirmation before erasing the Thor. No external USB drive is selected, and `--drive` does not apply to this path. Thor flashing is supported on macOS and Linux; Windows returns an unsupported-platform error.
 
+### Privileges
+
+Thor flashing talks to the board's USB recovery device directly (an in-process libusb handle), so — unlike the SD/NVMe disk-image path, which shells out to `sudo` only for the disk write — the **whole command must run as root**.
+
+`wendy install` handles this for you: when it is not already running as root it re-executes itself under `sudo` **before** the recovery briefing, so you are prompted for your password up front rather than hitting a permission error partway through the flash. The elevated run reuses the already-downloaded flashpack (no re-download) and skips straight to the Thor flow.
+
+- **macOS** — always elevates when not run as root; the OS binds its own driver to the recovery device, so there is no non-root path.
+- **Linux** — if the wendy udev rule (`70-wendy-jetson.rules`, installed by the deb/rpm package or `wendy device usb-setup`) is present, the flash runs as your user with **no prompt**. Otherwise it re-execs under `sudo`.
+- **Non-interactive** (CI, piped input) — the CLI cannot prompt for a password, so it exits with instructions to re-run under `sudo` (Linux: or install the udev rule) instead of hanging.
+
 ### WiFi pre-configuration
 
 ```sh

--- a/go/internal/cli/commands/elevation_unix.go
+++ b/go/internal/cli/commands/elevation_unix.go
@@ -4,10 +4,13 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -122,4 +125,63 @@ func buildSudoReexecArgs(self string, origArgs []string) []string {
 		args = append(args, "--device-type", thorDeviceType)
 	}
 	return args
+}
+
+// thorElevationReason is the one-line explanation printed just before the sudo
+// re-exec, tailored per platform.
+func thorElevationReason(goos string) string {
+	if goos == "darwin" {
+		return "Flashing a Jetson AGX Thor needs administrator access — it talks to the board's USB recovery device directly, which requires root on macOS."
+	}
+	return "Flashing a Jetson AGX Thor needs USB access to the board's recovery device.\n  Tip: install the udev rule once to skip sudo next time — `wendy device usb-setup`."
+}
+
+// errThorNeedsRoot is returned when a Thor flash needs elevation but cannot obtain
+// it here (no interactive terminal to prompt on, or no sudo on PATH). It carries
+// the exact command to re-run, plus the Linux udev alternative.
+func errThorNeedsRoot() error {
+	msg := "flashing a Jetson AGX Thor requires administrator access — it opens the board's USB recovery device directly, which needs root.\n" +
+		"  Re-run:  sudo wendy install --device-type " + thorDeviceType
+	if runtime.GOOS == "linux" {
+		msg += "\n  (or install the udev rule once with `wendy device usb-setup`, then no sudo)"
+	}
+	return errors.New(msg)
+}
+
+// ensureThorRootAccess guarantees the Thor flash has the root privileges it needs
+// to open the USB recovery device. When elevation is required and possible it
+// prints a reason and re-execs the command under sudo, replacing this process
+// (single-process, so the stage-2 abort-guard and signal handling are unchanged) —
+// it does not return in that case. It returns nil when the caller may proceed
+// (already root, or Linux udev access), or errThorNeedsRoot when elevation is
+// needed but impossible here.
+func ensureThorRootAccess() error {
+	switch thorElevationDecision(
+		runtime.GOOS,
+		os.Geteuid(),
+		hasWendyJetsonUdevRule(wendyJetsonUdevRulePaths),
+		isInteractiveTerminal(),
+	) {
+	case thorElevationProceed:
+		return nil
+	case thorElevationFailEarly:
+		return errThorNeedsRoot()
+	}
+
+	// thorElevationReexec: re-run the whole command under sudo.
+	sudo, err := exec.LookPath("sudo")
+	if err != nil {
+		return errThorNeedsRoot() // no sudo to elevate with — instruct instead of failing to exec
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving wendy executable path for sudo re-exec: %w", err)
+	}
+
+	fmt.Println(thorElevationReason(runtime.GOOS))
+	fmt.Println("Re-running under sudo (you may be prompted for your password)…")
+
+	argv := append([]string{"sudo"}, buildSudoReexecArgs(self, os.Args[1:])...)
+	// syscall.Exec replaces this process image; on success it never returns.
+	return fmt.Errorf("re-executing under sudo: %w", syscall.Exec(sudo, argv, os.Environ()))
 }

--- a/go/internal/cli/commands/elevation_unix.go
+++ b/go/internal/cli/commands/elevation_unix.go
@@ -5,7 +5,9 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -39,4 +41,85 @@ func keepElevationAlive(ctx context.Context) {
 
 func elevationHint() string {
 	return "You may be prompted for your password (sudo is required)."
+}
+
+// thorElevationAction is how installThor should obtain the root privileges a Thor
+// flash needs before it opens the recovery device (an in-process libusb handle, so
+// the whole process must be root — a cached sudo timestamp is not enough).
+type thorElevationAction int
+
+const (
+	thorElevationProceed   thorElevationAction = iota // already privileged (root, or Linux udev access)
+	thorElevationReexec                               // re-exec the command under sudo
+	thorElevationFailEarly                            // elevation needed but impossible here — instruct the user
+)
+
+// wendyJetsonUdevRulePaths are the standard udev rules directories where the
+// 70-wendy-jetson.rules file (installed by the deb/rpm package or `wendy device
+// usb-setup`) grants non-root access to the Jetson recovery/flashing USB device.
+var wendyJetsonUdevRulePaths = []string{
+	"/etc/udev/rules.d/70-wendy-jetson.rules",
+	"/usr/lib/udev/rules.d/70-wendy-jetson.rules",
+	"/lib/udev/rules.d/70-wendy-jetson.rules",
+}
+
+// hasWendyJetsonUdevRule reports whether any of paths exists — i.e. the udev rule
+// granting non-root USB access to the Jetson is installed. paths is injectable so
+// the check is testable without touching /etc.
+func hasWendyJetsonUdevRule(paths []string) bool {
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// thorElevationDecision decides how installThor obtains root before opening the
+// Jetson's USB recovery device. macOS always needs root when unprivileged (the OS
+// binds its own driver to the recovery device, so there is no non-root path);
+// Linux can instead use the wendy udev rule, so an installed rule means proceed.
+// When elevation is needed it re-execs under sudo on an interactive terminal, or
+// fails early with instructions when there is no TTY to prompt on.
+func thorElevationDecision(goos string, euid int, hasUdevRule, interactive bool) thorElevationAction {
+	if euid == 0 {
+		return thorElevationProceed
+	}
+	if goos == "linux" && hasUdevRule {
+		return thorElevationProceed
+	}
+	if !interactive {
+		return thorElevationFailEarly
+	}
+	return thorElevationReexec
+}
+
+// thorSudoPreserveEnv keeps the elevated (sudo) re-exec pointed at the same
+// flashpack cache (HOME / XDG_CACHE_HOME feed os.UserCacheDir) and network config
+// (proxy vars) instead of re-downloading the ~3 GB flashpack under root's env.
+const thorSudoPreserveEnv = "--preserve-env=HOME,XDG_CACHE_HOME,HTTP_PROXY,HTTPS_PROXY,NO_PROXY,http_proxy,https_proxy,no_proxy"
+
+// hasDeviceTypeFlag reports whether args already carries a --device-type flag in
+// either "--device-type X" or "--device-type=X" form.
+func hasDeviceTypeFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--device-type" || strings.HasPrefix(a, "--device-type=") {
+			return true
+		}
+	}
+	return false
+}
+
+// buildSudoReexecArgs builds the arguments after "sudo" for re-running wendy
+// elevated. self is the absolute wendy path; origArgs is os.Args[1:]. It preserves
+// the cache/network env vars and, when the original invocation did not already
+// specify a device type, appends --device-type jetson-agx-thor so the elevated
+// process routes straight to the Thor flow instead of re-showing the device picker.
+func buildSudoReexecArgs(self string, origArgs []string) []string {
+	args := []string{thorSudoPreserveEnv, self}
+	args = append(args, origArgs...)
+	if !hasDeviceTypeFlag(origArgs) {
+		args = append(args, "--device-type", thorDeviceType)
+	}
+	return args
 }

--- a/go/internal/cli/commands/elevation_unix.go
+++ b/go/internal/cli/commands/elevation_unix.go
@@ -127,6 +127,31 @@ func buildSudoReexecArgs(self string, origArgs []string) []string {
 	return args
 }
 
+// pinCacheDirEnv returns environ with XDG_CACHE_HOME set to cacheBase so the
+// sudo-elevated re-exec resolves the same wendy cache directory — and reuses the
+// already-downloaded flashpack — even when a distro's sudoers forces HOME=/root
+// (always_set_home), which would otherwise send os.UserCacheDir() to /root/.cache
+// on Linux. cacheBase is the invoking user's os.UserCacheDir(). XDG_CACHE_HOME is
+// already in thorSudoPreserveEnv, so sudo passes it through. Harmless on macOS,
+// where os.UserCacheDir() ignores XDG_CACHE_HOME.
+func pinCacheDirEnv(environ []string, cacheBase string) []string {
+	const key = "XDG_CACHE_HOME="
+	out := make([]string, 0, len(environ)+1)
+	replaced := false
+	for _, e := range environ {
+		if strings.HasPrefix(e, key) {
+			out = append(out, key+cacheBase)
+			replaced = true
+			continue
+		}
+		out = append(out, e)
+	}
+	if !replaced {
+		out = append(out, key+cacheBase)
+	}
+	return out
+}
+
 // thorElevationReason is the one-line explanation printed just before the sudo
 // re-exec, tailored per platform.
 func thorElevationReason(goos string) string {
@@ -182,6 +207,12 @@ func ensureThorRootAccess() error {
 	fmt.Println("Re-running under sudo (you may be prompted for your password)…")
 
 	argv := append([]string{"sudo"}, buildSudoReexecArgs(self, os.Args[1:])...)
+	// Pin XDG_CACHE_HOME to this (unprivileged) user's cache base so the elevated
+	// run reuses the already-downloaded flashpack even if sudo rewrites HOME.
+	env := os.Environ()
+	if base, cerr := os.UserCacheDir(); cerr == nil {
+		env = pinCacheDirEnv(env, base)
+	}
 	// syscall.Exec replaces this process image; on success it never returns.
-	return fmt.Errorf("re-executing under sudo: %w", syscall.Exec(sudo, argv, os.Environ()))
+	return fmt.Errorf("re-executing under sudo: %w", syscall.Exec(sudo, argv, env))
 }

--- a/go/internal/cli/commands/elevation_unix_test.go
+++ b/go/internal/cli/commands/elevation_unix_test.go
@@ -74,6 +74,29 @@ func TestHasDeviceTypeFlag(t *testing.T) {
 	}
 }
 
+func TestErrThorNeedsRoot(t *testing.T) {
+	err := errThorNeedsRoot()
+	if err == nil {
+		t.Fatal("errThorNeedsRoot() must return a non-nil error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "administrator access") {
+		t.Errorf("error should explain the privilege need: %q", msg)
+	}
+	if !strings.Contains(msg, "sudo wendy install --device-type "+thorDeviceType) {
+		t.Errorf("error should give the exact re-run command: %q", msg)
+	}
+}
+
+func TestThorElevationReason(t *testing.T) {
+	if !strings.Contains(thorElevationReason("darwin"), "root on macOS") {
+		t.Errorf("darwin reason should mention macOS root: %q", thorElevationReason("darwin"))
+	}
+	if !strings.Contains(thorElevationReason("linux"), "wendy device usb-setup") {
+		t.Errorf("linux reason should mention the udev-setup tip: %q", thorElevationReason("linux"))
+	}
+}
+
 func TestBuildSudoReexecArgs(t *testing.T) {
 	self := "/usr/local/bin/wendy"
 

--- a/go/internal/cli/commands/elevation_unix_test.go
+++ b/go/internal/cli/commands/elevation_unix_test.go
@@ -128,3 +128,40 @@ func TestBuildSudoReexecArgs(t *testing.T) {
 		t.Errorf("device-type duplicated for equals form: %v", got)
 	}
 }
+
+func TestPinCacheDirEnv(t *testing.T) {
+	base := "/home/alice/.cache"
+
+	// XDG_CACHE_HOME absent -> appended.
+	got := pinCacheDirEnv([]string{"HOME=/home/alice", "PATH=/usr/bin"}, base)
+	if !containsEnv(got, "XDG_CACHE_HOME="+base) {
+		t.Errorf("XDG_CACHE_HOME not pinned when absent: %v", got)
+	}
+	if !containsEnv(got, "HOME=/home/alice") || !containsEnv(got, "PATH=/usr/bin") {
+		t.Errorf("existing env vars not preserved: %v", got)
+	}
+
+	// XDG_CACHE_HOME present -> overridden, exactly once.
+	got = pinCacheDirEnv([]string{"XDG_CACHE_HOME=/old", "HOME=/home/alice"}, base)
+	n := 0
+	for _, e := range got {
+		if strings.HasPrefix(e, "XDG_CACHE_HOME=") {
+			n++
+			if e != "XDG_CACHE_HOME="+base {
+				t.Errorf("XDG_CACHE_HOME not overridden: %q", e)
+			}
+		}
+	}
+	if n != 1 {
+		t.Errorf("want exactly one XDG_CACHE_HOME entry, got %d: %v", n, got)
+	}
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/cli/commands/elevation_unix_test.go
+++ b/go/internal/cli/commands/elevation_unix_test.go
@@ -1,0 +1,107 @@
+//go:build darwin || linux
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestThorElevationDecision(t *testing.T) {
+	tests := []struct {
+		name        string
+		goos        string
+		euid        int
+		hasUdevRule bool
+		interactive bool
+		want        thorElevationAction
+	}{
+		{"root proceeds (darwin)", "darwin", 0, false, true, thorElevationProceed},
+		{"root proceeds (linux, no rule)", "linux", 0, false, false, thorElevationProceed},
+		{"darwin non-root interactive re-execs", "darwin", 501, false, true, thorElevationReexec},
+		{"darwin non-root non-interactive fails early", "darwin", 501, false, false, thorElevationFailEarly},
+		{"darwin ignores udev rule", "darwin", 501, true, true, thorElevationReexec},
+		{"linux with rule proceeds", "linux", 1000, true, true, thorElevationProceed},
+		{"linux no rule interactive re-execs", "linux", 1000, false, true, thorElevationReexec},
+		{"linux no rule non-interactive fails early", "linux", 1000, false, false, thorElevationFailEarly},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := thorElevationDecision(tt.goos, tt.euid, tt.hasUdevRule, tt.interactive)
+			if got != tt.want {
+				t.Errorf("thorElevationDecision(%q,%d,%v,%v) = %v, want %v",
+					tt.goos, tt.euid, tt.hasUdevRule, tt.interactive, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasWendyJetsonUdevRule(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "70-wendy-jetson.rules")
+	if err := os.WriteFile(present, []byte("rule"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	absent := filepath.Join(dir, "does-not-exist.rules")
+
+	if !hasWendyJetsonUdevRule([]string{absent, present}) {
+		t.Error("want true when at least one rule path exists")
+	}
+	if hasWendyJetsonUdevRule([]string{absent}) {
+		t.Error("want false when no rule path exists")
+	}
+	if hasWendyJetsonUdevRule(nil) {
+		t.Error("want false for empty path list")
+	}
+}
+
+func TestHasDeviceTypeFlag(t *testing.T) {
+	tests := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"install", "--device-type", "jetson-agx-thor"}, true},
+		{[]string{"install", "--device-type=jetson-agx-thor"}, true},
+		{[]string{"install", "--nightly"}, false},
+		{nil, false},
+	}
+	for _, tt := range tests {
+		if got := hasDeviceTypeFlag(tt.args); got != tt.want {
+			t.Errorf("hasDeviceTypeFlag(%v) = %v, want %v", tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestBuildSudoReexecArgs(t *testing.T) {
+	self := "/usr/local/bin/wendy"
+
+	// Interactive picker case: no --device-type in original args -> inject it.
+	got := buildSudoReexecArgs(self, []string{"install", "--nightly"})
+	if got[0] != thorSudoPreserveEnv {
+		t.Errorf("arg[0] = %q, want preserve-env %q", got[0], thorSudoPreserveEnv)
+	}
+	if got[1] != self {
+		t.Errorf("arg[1] = %q, want self %q", got[1], self)
+	}
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "install --nightly") {
+		t.Errorf("original args not preserved: %v", got)
+	}
+	if !strings.Contains(joined, "--device-type "+thorDeviceType) {
+		t.Errorf("device-type not injected: %v", got)
+	}
+
+	// Flag case: --device-type already present -> do not duplicate.
+	got = buildSudoReexecArgs(self, []string{"install", "--device-type", thorDeviceType, "--force"})
+	if n := strings.Count(strings.Join(got, " "), thorDeviceType); n != 1 {
+		t.Errorf("device-type duplicated (%d occurrences): %v", n, got)
+	}
+
+	// Equals form is also recognized as present.
+	got = buildSudoReexecArgs(self, []string{"install", "--device-type=" + thorDeviceType})
+	if n := strings.Count(strings.Join(got, " "), "--device-type"); n != 1 {
+		t.Errorf("device-type duplicated for equals form: %v", got)
+	}
+}

--- a/go/internal/cli/commands/os_install_thor.go
+++ b/go/internal/cli/commands/os_install_thor.go
@@ -43,6 +43,15 @@ const (
 // as a live BuildKit-style step list whose verbose output surfaces only on
 // failure. macOS and Linux.
 func installThor(ctx context.Context, version string, nightly, force bool) error {
+	// Thor's USB recovery access is an in-process libusb handle, so the whole
+	// process must be root — unlike the disk-image path, caching the sudo
+	// timestamp is not enough. Elevate up front, before the briefing, so a
+	// missing-permission failure never surprises the user mid-flash (WDY-1843).
+	// On a successful sudo re-exec this replaces the process and does not return.
+	if err := ensureThorRootAccess(); err != nil {
+		return err
+	}
+
 	cacheDir, err := osCacheDir()
 	if err != nil {
 		return fmt.Errorf("resolving cache dir: %w", err)


### PR DESCRIPTION
## Problem (WDY-1843)

Flashing a Jetson AGX Thor with `wendy install` could fail **partway through** with a confusing "USB access denied" error when the command wasn't run as root. Every other install target elevates/prompts for `sudo` *before* flashing begins, but the Thor path did no elevation — so a non-root user completed the whole briefing → cabling → recovery-scan sequence only to hit a permission wall at the scan.

### Why Thor is different

The disk-image path only *caches* the sudo timestamp (`sudo -v`) and shells out to `sudo dd` / `sudo wendy __bmap-write` subprocesses. Thor is not like that: both stage 1 (RCM boot) and stage 2 (flashing gadget) open the USB recovery device **in-process via libusb (`gousb`)**, so the **entire `wendy` process must be root**. A cached timestamp does nothing here — the fix has to actually run the process elevated (re-exec under `sudo`), like the Windows UAC path already does for every target.

## What changed

A new `ensureThorRootAccess()` guard runs as the first statement of `installThor` and, when elevation is needed, re-execs the command under `sudo` **before** the recovery briefing via `syscall.Exec` (single-process, so the stage-2 Ctrl-C abort-guard and signal handling are unchanged).

**Elevation policy:**
- **Already root** → proceed.
- **Linux with the `70-wendy-jetson.rules` udev rule installed** (deb/rpm or `wendy device usb-setup`) → proceed with **no prompt** — the existing no-sudo path is preserved.
- **macOS non-root, or Linux non-root without the rule** → re-exec under `sudo` (interactive), or **fail early** with clear re-run instructions when there's no TTY (CI/piped) or no `sudo` on PATH — never hangs.

**Details:**
- Injects `--device-type jetson-agx-thor` into the elevated re-exec so it routes straight to the Thor flow — **no second device picker**.
- Preserves `HOME`/`XDG_CACHE_HOME` (and proxy vars) so the elevated run **reuses the already-downloaded ~3 GB flashpack** instead of re-downloading as root. `XDG_CACHE_HOME` is explicitly pinned to the invoking user's cache base so reuse holds even on Linux distros whose sudoers forces `HOME=/root` (`always_set_home`).
- If the Linux udev heuristic guesses "present" but access is actually denied (e.g. headless SSH without `plugdev`), the flow degrades gracefully to the existing scan-time `usbAccessHintBox` + rescan — no regression.

## Docs / user-facing output

- New up-front elevation message before the briefing (platform-specific; Linux points at `wendy device usb-setup`).
- New **Privileges** subsection in `os/install.md` documenting the macOS / Linux-udev / non-interactive behavior.

## Testing

- Pure policy layer (`thorElevationDecision`, udev-rule detection, sudo-argv construction, cache-env pinning) is fully unit-tested; the side-effectful glue (`os.Geteuid`/TTY/`os.Args`/`syscall.Exec`) is isolated behind those tested helpers.
- Full `internal/cli/commands` package tests, `go vet`, and `gofmt` all green.
- **On-device verification pending** (needs hardware): non-root `wendy install` → Thor → confirm the sudo prompt appears *before* the briefing and the elevated run skips straight to it; on a Linux box with the udev rule, confirm no prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)