### PR TITLE
cli: keep the fallback error in the chain and abort cleanly on Ctrl-C

### DIFF
--- a/go/internal/cli/commands/flash_error.go
+++ b/go/internal/cli/commands/flash_error.go
@@ -76,10 +76,11 @@ func framePrimaryFlashError(label string, written, total int64, primaryErr error
 }
 
 // combineFlashFailure builds the error returned when the fast path failed and
-// the full-image dd fallback also failed: both errors, clearly labeled, with
-// the primary (real) error preserved in the chain and the fallback's appended.
+// the full-image dd fallback also failed: both errors, clearly labeled, and
+// both preserved in the errors.Is chain (e.g. a context.Canceled from a
+// cancelled fallback must stay matchable upstream).
 func combineFlashFailure(primary, fallback error) error {
-	return fmt.Errorf("%w; full-image fallback also failed: %v", primary, fallback)
+	return fmt.Errorf("%w; full-image fallback also failed: %w", primary, fallback)
 }
 
 // flashDeviceFailureHint is appended to a device-level flash failure. The dd

--- a/go/internal/cli/commands/flash_error_test.go
+++ b/go/internal/cli/commands/flash_error_test.go
@@ -115,6 +115,11 @@ func TestCombineFlashFailure_BothErrorsPresent(t *testing.T) {
 	if !errors.Is(combined, primaryCause) {
 		t.Fatalf("combined error dropped the primary cause: %v", combined)
 	}
+	// The fallback must stay in the chain too — a context.Canceled from a
+	// cancelled fallback has to remain errors.Is-matchable upstream.
+	if !errors.Is(combined, fallback) {
+		t.Fatalf("combined error dropped the fallback cause: %v", combined)
+	}
 	// Primary (real failure) present, with offset.
 	if !strings.Contains(msg, "seekable block-map write failed") || !strings.Contains(msg, "input/output error") {
 		t.Errorf("combined error %q missing the primary failure", msg)

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -663,6 +663,13 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 
 	writeModel := writeFinal.(tui.ProgressModel)
 	if primaryErr := writeModel.Err(); primaryErr != nil {
+		// User cancellation is not a write failure: don't classify it, and
+		// don't start a full-image fallback write on a flash the user just
+		// cancelled (same handling as the measure step above).
+		if errors.Is(primaryErr, context.Canceled) {
+			return primaryErr
+		}
+
 		// Frame the primary (fast-path) error with the offset it reached. This
 		// error is never discarded again below — it is the real failure, and
 		// WDY-1841 was caused by dropping it in favor of the fallback's error.


### PR DESCRIPTION
> **In plain terms (for PMs):** Two small polish fixes on the flash-error reporting that just shipped in #1367: cancelling a flash with Ctrl-C now aborts cleanly instead of kicking off a fresh multi-gigabyte retry, and cancellations are counted correctly in our error analytics.

Follow-up to #1367 (WDY-1841) — two one-line review findings that were identified after the PR merged.

## What

1. **Abort cleanly on Ctrl-C.** Cancelling the fast-path write fell through the new failure classification into a brand-new full-image fallback write on the drive the user had just cancelled. Now `context.Canceled` returns directly before classification, mirroring the measure step's existing handling. (Pre-existing behavior, but the classification block was the right place to fix it.)
2. **Keep the fallback error in the `errors.Is` chain.** `combineFlashFailure` wrapped the fallback error with `%v`, dropping it from the chain — a regression against the pre-#1367 return, which preserved it. A `context.Canceled` from a cancelled fallback write was misbucketed as `"other"` by `main.go`'s `errorClass`. Both errors are now wrapped with `%w`.

## How tested

- `TestCombineFlashFailure_BothErrorsPresent` extended to assert the fallback error stays `errors.Is`-matchable.
- `go test ./internal/cli/commands/` passes; `go vet`, `gofmt` clean; `GOOS=windows` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
