### PR TITLE
feat(cli): multi-container AppStore install (paperless, immich)

### DIFF
--- a/go/internal/cli/commands/apps_install.go
+++ b/go/internal/cli/commands/apps_install.go
@@ -2,14 +2,10 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
-	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -17,21 +13,12 @@ import (
 )
 
 // defaultAppStoreAPIBase is the Wendy Cloud API that resolves AppStore app ids
-// to OCI image references. This is the deployed wendy-cloud-services Cloud Run
+// to install manifests. This is the deployed wendy-cloud-services Cloud Run
 // service (the same host as defaultCloudGRPC in auth.go); cloud.wendy.sh is the
 // web dashboard, not the API. The api.wendy.sh domain mapping will alias this
 // service once its DNS is live. Override with --api or the WENDY_APPSTORE_API
 // env var.
 const defaultAppStoreAPIBase = "https://wendy-cloud-services-114319063177.us-central1.run.app"
-
-// appImageResolution is the JSON returned by GET /v1/apps/{app_id}/image.
-type appImageResolution struct {
-	AppID      string `json:"app_id"`
-	Source     string `json:"source"`
-	Repository string `json:"repository"`
-	Tag        string `json:"tag"`
-	Reference  string `json:"reference"`
-}
 
 // resolveAppStoreAPIBase picks the AppStore API base, preferring the flag, then
 // the WENDY_APPSTORE_API env var, then the built-in default. The returned value
@@ -45,40 +32,6 @@ func resolveAppStoreAPIBase(flagVal string) string {
 		base = defaultAppStoreAPIBase
 	}
 	return strings.TrimRight(base, "/")
-}
-
-// resolveAppImage asks the AppStore API for the OCI image reference of an app id.
-func resolveAppImage(ctx context.Context, base, appID string) (appImageResolution, error) {
-	endpoint := fmt.Sprintf("%s/v1/apps/%s/image", base, url.PathEscape(appID))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return appImageResolution{}, err
-	}
-	req.Header.Set("Accept", "application/json")
-
-	client := &http.Client{Timeout: 15 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return appImageResolution{}, fmt.Errorf("contacting the AppStore: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return appImageResolution{}, fmt.Errorf("app %q is not in the AppStore", appID)
-	}
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return appImageResolution{}, fmt.Errorf("AppStore returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var out appImageResolution
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return appImageResolution{}, fmt.Errorf("parsing AppStore response: %w", err)
-	}
-	if out.Reference == "" {
-		return appImageResolution{}, fmt.Errorf("AppStore returned no image reference for %q", appID)
-	}
-	return out, nil
 }
 
 // newAppCmd is the top-level "app" command group, the AppStore-facing entry
@@ -102,56 +55,82 @@ func newAppsInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install <app-id>",
 		Short: "Install an app from the Wendy AppStore",
-		Long: "Resolves an AppStore app id to a container image (Docker Hub or the Wendy " +
-			"registry) and deploys it to the target device. See https://appstore.wendy.dev.",
+		Long: "Resolves an AppStore app id to an install manifest (one or more container " +
+			"services, wired together with dependency ordering, secrets, and shared /etc/hosts " +
+			"entries) and deploys it to the target device. See https://appstore.wendy.dev.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			appID := args[0]
 
 			base := resolveAppStoreAPIBase(apiBase)
-			res, err := resolveAppImage(ctx, base, appID)
+			manifest, err := resolveAppManifest(ctx, base, appID)
 			if err != nil {
 				return err
 			}
-			cliLogln("Resolved %s to %s", appID, res.Reference)
+			order, reqs, err := buildServiceInstall(manifest)
+			if err != nil {
+				return fmt.Errorf("preparing install for %s: %w", appID, err)
+			}
+			if len(order) == 1 {
+				cliLogln("Resolved %s to %s", appID, reqs[order[0]].ImageName)
+			} else {
+				cliLogln("Resolved %s to %d services: %s", appID, len(order), strings.Join(order, ", "))
+			}
 
 			target, err := resolveTarget(ctx)
 			if err != nil {
 				return err
 			}
 			defer target.Close()
-
 			if target.Agent == nil {
 				return fmt.Errorf("selected device does not support installing apps")
 			}
+			svc := target.Agent.ContainerService
 
-			req := &agentpb.CreateContainerRequest{
-				ImageName:     res.Reference,
-				AppName:       appID,
-				RestartPolicy: &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED},
+			// Create + start each service in dependency order. Each service's Started
+			// ack must complete before the next is created so the next service's
+			// /etc/hosts already resolves its dependencies (the agent records a
+			// service's bridge IP at StartContainer time).
+			for _, name := range order {
+				cliLogln("Installing service %s...", name)
+				if err := createContainerWithProgress(ctx, svc, reqs[name]); err != nil {
+					return fmt.Errorf("installing service %s: %w", name, err)
+				}
+				if noStart {
+					continue
+				}
+				if err := startInstalledService(ctx, svc, reqs[name].AppName); err != nil {
+					return fmt.Errorf("starting service %s: %w", name, err)
+				}
 			}
-			if err := createContainerWithProgress(ctx, target.Agent.ContainerService, req); err != nil {
-				return fmt.Errorf("installing %s: %w", appID, err)
-			}
-
 			if noStart {
-				cliSuccess("Installed %s (not started).", appID)
+				cliSuccess("Installed %s (%d service(s), not started).", appID, len(order))
 				return nil
 			}
-
-			if _, err := target.Agent.ContainerService.StartContainer(ctx, &agentpb.StartContainerRequest{
-				AppName:       appID,
-				RestartPolicy: &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED},
-			}); err != nil {
-				return fmt.Errorf("starting %s: %w", appID, err)
-			}
-			cliSuccess("Installed and started %s.", appID)
+			cliSuccess("Installed and started %s (%d service(s)).", appID, len(order))
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&apiBase, "api", "", "Wendy AppStore API base URL (default: $WENDY_APPSTORE_API or "+defaultAppStoreAPIBase+")")
-	cmd.Flags().BoolVar(&noStart, "no-start", false, "Create the app container but do not start it")
+	cmd.Flags().BoolVar(&noStart, "no-start", false, "Create the app container(s) but do not start them")
 	return cmd
+}
+
+// startInstalledService starts a single installed service and waits for the
+// agent's Started ack. StartContainer is server-streaming; the first Recv is
+// that ack (mirrors the drain in multibuild.go's startAndStreamServices).
+func startInstalledService(ctx context.Context, svc agentpb.WendyContainerServiceClient, appName string) error {
+	stream, err := svc.StartContainer(ctx, &agentpb.StartContainerRequest{
+		AppName:       appName,
+		RestartPolicy: &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED},
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := stream.Recv(); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
 }

--- a/go/internal/cli/commands/apps_install_test.go
+++ b/go/internal/cli/commands/apps_install_test.go
@@ -1,9 +1,6 @@
 package commands
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -19,34 +16,5 @@ func TestResolveAppStoreAPIBase(t *testing.T) {
 	t.Setenv("WENDY_APPSTORE_API", "")
 	if got := resolveAppStoreAPIBase(""); got != defaultAppStoreAPIBase {
 		t.Errorf("default: got %q", got)
-	}
-}
-
-func TestResolveAppImage(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/apps/jellyfin/image" {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"app_id":"jellyfin","source":"dockerhub","repository":"jellyfin/jellyfin","tag":"latest","reference":"docker.io/jellyfin/jellyfin:latest"}`))
-			return
-		}
-		http.NotFound(w, r)
-	}))
-	defer srv.Close()
-
-	ctx := context.Background()
-
-	res, err := resolveAppImage(ctx, srv.URL, "jellyfin")
-	if err != nil {
-		t.Fatalf("resolveAppImage: %v", err)
-	}
-	if res.Reference != "docker.io/jellyfin/jellyfin:latest" {
-		t.Errorf("reference = %q", res.Reference)
-	}
-	if res.Source != "dockerhub" {
-		t.Errorf("source = %q", res.Source)
-	}
-
-	if _, err := resolveAppImage(ctx, srv.URL, "does-not-exist"); err == nil {
-		t.Error("expected error for unknown app, got nil")
 	}
 }

--- a/go/internal/cli/commands/apps_manifest.go
+++ b/go/internal/cli/commands/apps_manifest.go
@@ -10,8 +10,12 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
 // appManifest is the JSON returned by GET /v1/apps/{app_id}/manifest. A manifest
@@ -122,4 +126,89 @@ func substituteSecrets(env map[string]string, secrets map[string]string) (map[st
 		}
 	}
 	return out, nil
+}
+
+// buildServiceInstall turns a resolved manifest into an ordered set of
+// per-service CreateContainerRequests. Services are ordered so every service
+// follows its dependsOn entries (create+start must happen in this order so each
+// service's /etc/hosts already resolves its dependencies). Secrets are generated
+// once and shared across services by name.
+func buildServiceInstall(m appManifest) ([]string, map[string]*agentpb.CreateContainerRequest, error) {
+	secrets, err := generateSecrets(m.Secrets)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Build the appconfig.ServiceConfig map for topo ordering and for the agent's
+	// group awareness (len(Services) > 1 triggers /etc/hosts injection).
+	svcConfigs := make(map[string]*appconfig.ServiceConfig, len(m.Services))
+	byName := make(map[string]manifestService, len(m.Services))
+	for _, s := range m.Services {
+		svcConfigs[s.Name] = &appconfig.ServiceConfig{DependsOn: s.DependsOn}
+		byName[s.Name] = s
+	}
+
+	order, err := appconfig.ServiceTopoOrder(svcConfigs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	multi := len(m.Services) > 1
+	reqs := make(map[string]*agentpb.CreateContainerRequest, len(m.Services))
+	for _, name := range order {
+		svc := byName[name]
+
+		env, err := substituteSecrets(svc.Env, secrets)
+		if err != nil {
+			return nil, nil, err
+		}
+		envList := make([]string, 0, len(env))
+		for k, v := range env {
+			envList = append(envList, k+"="+v)
+		}
+		sort.Strings(envList) // stable order for reproducible requests/tests
+
+		var entitlements []appconfig.Entitlement
+		if len(svc.Ports) > 0 {
+			ports := make([]appconfig.PortMapping, 0, len(svc.Ports))
+			for _, p := range svc.Ports {
+				ports = append(ports, appconfig.PortMapping{Host: p.Host, Container: p.Container})
+			}
+			entitlements = append(entitlements, appconfig.Entitlement{
+				Type:  appconfig.EntitlementNetwork,
+				Ports: ports,
+			})
+		}
+		for _, v := range svc.Volumes {
+			entitlements = append(entitlements, appconfig.Entitlement{
+				Type: appconfig.EntitlementPersist,
+				Name: v.Name,
+				Path: v.Path,
+			})
+		}
+
+		cfg := &appconfig.AppConfig{
+			AppID:        m.AppID,
+			Entitlements: entitlements,
+		}
+		if multi {
+			cfg.ServiceName = name
+			cfg.Isolation = "isolated"
+			cfg.Services = svcConfigs
+		}
+
+		cfgData, err := json.Marshal(cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshaling config for service %s: %w", name, err)
+		}
+
+		reqs[name] = &agentpb.CreateContainerRequest{
+			ImageName:     normalizeImageRef(svc.Image),
+			AppName:       cfg.ContainerName(),
+			AppConfig:     cfgData,
+			Env:           envList,
+			RestartPolicy: &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED},
+		}
+	}
+	return order, reqs, nil
 }

--- a/go/internal/cli/commands/apps_manifest.go
+++ b/go/internal/cli/commands/apps_manifest.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// appManifest is the JSON returned by GET /v1/apps/{app_id}/manifest. A manifest
+// describes one or more services that together make up an installable app.
+type appManifest struct {
+	AppID    string            `json:"app_id"`
+	Secrets  []string          `json:"secrets,omitempty"`
+	Services []manifestService `json:"services"`
+}
+
+type manifestService struct {
+	Name      string            `json:"name"`
+	Image     string            `json:"image"`
+	Env       map[string]string `json:"env,omitempty"`
+	Volumes   []manifestVolume  `json:"volumes,omitempty"`
+	Ports     []manifestPort    `json:"ports,omitempty"`
+	DependsOn []string          `json:"dependsOn,omitempty"`
+}
+
+type manifestVolume struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type manifestPort struct {
+	Host      uint16 `json:"host"`
+	Container uint16 `json:"container"`
+	Proto     string `json:"proto,omitempty"`
+}
+
+// resolveAppManifest asks the AppStore API for the multi-service manifest of an
+// app id. Single-image apps come back as a one-service manifest.
+func resolveAppManifest(ctx context.Context, base, appID string) (appManifest, error) {
+	endpoint := fmt.Sprintf("%s/v1/apps/%s/manifest", base, url.PathEscape(appID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return appManifest{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return appManifest{}, fmt.Errorf("contacting the AppStore: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return appManifest{}, fmt.Errorf("app %q is not in the AppStore", appID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return appManifest{}, fmt.Errorf("AppStore returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var out appManifest
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return appManifest{}, fmt.Errorf("parsing AppStore manifest: %w", err)
+	}
+	if len(out.Services) == 0 {
+		return appManifest{}, fmt.Errorf("AppStore returned an empty manifest for %q", appID)
+	}
+	return out, nil
+}

--- a/go/internal/cli/commands/apps_manifest.go
+++ b/go/internal/cli/commands/apps_manifest.go
@@ -2,11 +2,14 @@ package commands
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -70,6 +73,53 @@ func resolveAppManifest(ctx context.Context, base, appID string) (appManifest, e
 	}
 	if len(out.Services) == 0 {
 		return appManifest{}, fmt.Errorf("AppStore returned an empty manifest for %q", appID)
+	}
+	return out, nil
+}
+
+// secretRefPattern matches ${secret:NAME} tokens in manifest env values.
+var secretRefPattern = regexp.MustCompile(`\$\{secret:([a-zA-Z0-9_]+)\}`)
+
+// generateSecrets returns one random 32-hex-character value per (deduplicated)
+// name. Values are stable within a single install so services sharing a secret
+// name receive the same value.
+func generateSecrets(names []string) (map[string]string, error) {
+	out := make(map[string]string, len(names))
+	for _, name := range names {
+		if _, ok := out[name]; ok {
+			continue
+		}
+		buf := make([]byte, 16)
+		if _, err := rand.Read(buf); err != nil {
+			return nil, fmt.Errorf("generating secret %q: %w", name, err)
+		}
+		out[name] = hex.EncodeToString(buf)
+	}
+	return out, nil
+}
+
+// substituteSecrets replaces every ${secret:NAME} token in the env values with
+// the corresponding generated secret. It errors if a referenced name has no
+// generated value (a manifest bug). The input map is not modified.
+func substituteSecrets(env map[string]string, secrets map[string]string) (map[string]string, error) {
+	if env == nil {
+		return nil, nil
+	}
+	out := make(map[string]string, len(env))
+	for k, v := range env {
+		var subErr error
+		out[k] = secretRefPattern.ReplaceAllStringFunc(v, func(match string) string {
+			name := secretRefPattern.FindStringSubmatch(match)[1]
+			val, ok := secrets[name]
+			if !ok {
+				subErr = fmt.Errorf("env %q references unknown secret %q", k, name)
+				return match
+			}
+			return val
+		})
+		if subErr != nil {
+			return nil, subErr
+		}
 	}
 	return out, nil
 }

--- a/go/internal/cli/commands/apps_manifest_test.go
+++ b/go/internal/cli/commands/apps_manifest_test.go
@@ -51,3 +51,33 @@ func TestResolveAppManifestNotFound(t *testing.T) {
 		t.Fatal("expected error for 404")
 	}
 }
+
+func TestSubstituteSecretsSharedValue(t *testing.T) {
+	secrets, err := generateSecrets([]string{"db_password"})
+	if err != nil {
+		t.Fatalf("generateSecrets: %v", err)
+	}
+	pg, err := substituteSecrets(map[string]string{"POSTGRES_PASSWORD": "${secret:db_password}"}, secrets)
+	if err != nil {
+		t.Fatalf("substituteSecrets pg: %v", err)
+	}
+	srv, err := substituteSecrets(map[string]string{"DB_PASSWORD": "${secret:db_password}", "DB_HOSTNAME": "postgres"}, secrets)
+	if err != nil {
+		t.Fatalf("substituteSecrets srv: %v", err)
+	}
+	if pg["POSTGRES_PASSWORD"] == "${secret:db_password}" || pg["POSTGRES_PASSWORD"] == "" {
+		t.Fatalf("secret not substituted: %q", pg["POSTGRES_PASSWORD"])
+	}
+	if pg["POSTGRES_PASSWORD"] != srv["DB_PASSWORD"] {
+		t.Fatalf("shared secret differs across services: %q vs %q", pg["POSTGRES_PASSWORD"], srv["DB_PASSWORD"])
+	}
+	if srv["DB_HOSTNAME"] != "postgres" {
+		t.Fatalf("non-secret value mangled: %q", srv["DB_HOSTNAME"])
+	}
+}
+
+func TestSubstituteSecretsMissingName(t *testing.T) {
+	if _, err := substituteSecrets(map[string]string{"X": "${secret:absent}"}, map[string]string{}); err == nil {
+		t.Fatal("expected error for missing secret name")
+	}
+}

--- a/go/internal/cli/commands/apps_manifest_test.go
+++ b/go/internal/cli/commands/apps_manifest_test.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolveAppManifest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/apps/immich/manifest" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"app_id":"immich","secrets":["db_password"],
+			"services":[
+			  {"name":"postgres","image":"ghcr.io/immich-app/postgres:14",
+			   "env":{"POSTGRES_PASSWORD":"${secret:db_password}"},
+			   "volumes":[{"name":"pg","path":"/var/lib/postgresql/data"}]},
+			  {"name":"server","image":"ghcr.io/immich-app/immich-server:release",
+			   "env":{"DB_HOSTNAME":"postgres","DB_PASSWORD":"${secret:db_password}"},
+			   "ports":[{"host":2283,"container":2283,"proto":"tcp"}],
+			   "dependsOn":["postgres"]}
+			]}`))
+	}))
+	defer srv.Close()
+
+	m, err := resolveAppManifest(context.Background(), srv.URL, "immich")
+	if err != nil {
+		t.Fatalf("resolveAppManifest: %v", err)
+	}
+	if m.AppID != "immich" || len(m.Services) != 2 {
+		t.Fatalf("got app_id=%q services=%d", m.AppID, len(m.Services))
+	}
+	if m.Services[1].Ports[0].Host != 2283 {
+		t.Fatalf("server host port = %d, want 2283", m.Services[1].Ports[0].Host)
+	}
+	if got := m.Services[0].Env["POSTGRES_PASSWORD"]; got != "${secret:db_password}" {
+		t.Fatalf("env not preserved: %q", got)
+	}
+}
+
+func TestResolveAppManifestNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	if _, err := resolveAppManifest(context.Background(), srv.URL, "nope"); err == nil {
+		t.Fatal("expected error for 404")
+	}
+}

--- a/go/internal/cli/commands/apps_manifest_test.go
+++ b/go/internal/cli/commands/apps_manifest_test.go
@@ -2,9 +2,13 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
 
 func TestResolveAppManifest(t *testing.T) {
@@ -79,5 +83,117 @@ func TestSubstituteSecretsSharedValue(t *testing.T) {
 func TestSubstituteSecretsMissingName(t *testing.T) {
 	if _, err := substituteSecrets(map[string]string{"X": "${secret:absent}"}, map[string]string{}); err == nil {
 		t.Fatal("expected error for missing secret name")
+	}
+}
+
+func TestBuildServiceInstallMultiService(t *testing.T) {
+	m := appManifest{
+		AppID:   "immich",
+		Secrets: []string{"db_password"},
+		Services: []manifestService{
+			{Name: "server", Image: "ghcr.io/immich-app/immich-server:release",
+				Env:       map[string]string{"DB_PASSWORD": "${secret:db_password}", "DB_HOSTNAME": "postgres"},
+				Volumes:   []manifestVolume{{Name: "upload", Path: "/data"}},
+				Ports:     []manifestPort{{Host: 2283, Container: 2283, Proto: "tcp"}},
+				DependsOn: []string{"postgres"}},
+			{Name: "postgres", Image: "ghcr.io/immich-app/postgres:14",
+				Env:     map[string]string{"POSTGRES_PASSWORD": "${secret:db_password}"},
+				Volumes: []manifestVolume{{Name: "pg", Path: "/var/lib/postgresql/data"}}},
+		},
+	}
+	order, reqs, err := buildServiceInstall(m)
+	if err != nil {
+		t.Fatalf("buildServiceInstall: %v", err)
+	}
+	// postgres has no deps; server depends on postgres -> postgres first.
+	if len(order) != 2 || order[0] != "postgres" || order[1] != "server" {
+		t.Fatalf("topo order = %v, want [postgres server]", order)
+	}
+
+	srv := reqs["server"]
+	if srv.AppName != "immich_server" {
+		t.Fatalf("server AppName = %q, want immich_server", srv.AppName)
+	}
+	if srv.ImageName != "ghcr.io/immich-app/immich-server:release" {
+		t.Fatalf("server image = %q", srv.ImageName)
+	}
+	// Env carries the substituted secret and the literal hostname.
+	var dbPass, dbHost string
+	for _, kv := range srv.Env {
+		if strings.HasPrefix(kv, "DB_PASSWORD=") {
+			dbPass = strings.TrimPrefix(kv, "DB_PASSWORD=")
+		}
+		if strings.HasPrefix(kv, "DB_HOSTNAME=") {
+			dbHost = strings.TrimPrefix(kv, "DB_HOSTNAME=")
+		}
+	}
+	if dbHost != "postgres" {
+		t.Fatalf("DB_HOSTNAME = %q, want postgres", dbHost)
+	}
+	if dbPass == "" || strings.Contains(dbPass, "${secret") {
+		t.Fatalf("DB_PASSWORD not substituted: %q", dbPass)
+	}
+
+	// AppConfig: isolated, ServiceName set, Services fully populated, port+volume entitlements.
+	var cfg appconfig.AppConfig
+	if err := json.Unmarshal(srv.AppConfig, &cfg); err != nil {
+		t.Fatalf("unmarshal AppConfig: %v", err)
+	}
+	if cfg.Isolation != "isolated" {
+		t.Fatalf("isolation = %q, want isolated", cfg.Isolation)
+	}
+	if cfg.ServiceName != "server" {
+		t.Fatalf("ServiceName = %q", cfg.ServiceName)
+	}
+	if len(cfg.Services) != 2 {
+		t.Fatalf("Services len = %d, want 2 (agent needs >1 to inject /etc/hosts)", len(cfg.Services))
+	}
+	var haveNet, havePersist bool
+	for _, e := range cfg.Entitlements {
+		if e.Type == appconfig.EntitlementNetwork && len(e.Ports) == 1 && e.Ports[0].Host == 2283 {
+			haveNet = true
+		}
+		if e.Type == appconfig.EntitlementPersist && e.Name == "upload" && e.Path == "/data" {
+			havePersist = true
+		}
+	}
+	if !haveNet || !havePersist {
+		t.Fatalf("missing entitlements: net=%v persist=%v", haveNet, havePersist)
+	}
+
+	// The shared secret is identical in postgres.
+	var pgPass string
+	for _, kv := range reqs["postgres"].Env {
+		if strings.HasPrefix(kv, "POSTGRES_PASSWORD=") {
+			pgPass = strings.TrimPrefix(kv, "POSTGRES_PASSWORD=")
+		}
+	}
+	if pgPass != dbPass {
+		t.Fatalf("shared secret differs: server=%q postgres=%q", dbPass, pgPass)
+	}
+}
+
+func TestBuildServiceInstallSingleService(t *testing.T) {
+	m := appManifest{
+		AppID:    "jellyfin",
+		Services: []manifestService{{Name: "jellyfin", Image: "docker.io/jellyfin/jellyfin:latest"}},
+	}
+	order, reqs, err := buildServiceInstall(m)
+	if err != nil {
+		t.Fatalf("buildServiceInstall: %v", err)
+	}
+	if len(order) != 1 {
+		t.Fatalf("order = %v", order)
+	}
+	r := reqs["jellyfin"]
+	if r.AppName != "jellyfin" {
+		t.Fatalf("AppName = %q, want jellyfin (plain, no service suffix)", r.AppName)
+	}
+	var cfg appconfig.AppConfig
+	if err := json.Unmarshal(r.AppConfig, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.Isolation != "" || cfg.ServiceName != "" {
+		t.Fatalf("single service must not set isolation/serviceName: iso=%q svc=%q", cfg.Isolation, cfg.ServiceName)
 	}
 }


### PR DESCRIPTION
## What

`wendy device install <app-id>` can now install **multi-service** apps. It resolves a structured manifest from `GET /v1/apps/{id}/manifest` (cloud PR wendylabsinc/cloud#262), generates per-install secrets, and creates+starts each service **in dependency order** in `isolation:"isolated"` mode so services reach each other by name via the agent's CNI bridge + `/etc/hosts`.

- **`apps_manifest.go`** (new) — manifest types + `resolveAppManifest`; `generateSecrets`/`substituteSecrets` (`crypto/rand`, `${secret:NAME}` shared by name); `buildServiceInstall` → topo-order via `ServiceTopoOrder`; per-service `AppConfig` with `Isolation:"isolated"` + `ServiceName` + a fully-populated `Services` map for multi-service (the agent injects `/etc/hosts` only when `isolated && len(Services)>1`), plain `AppConfig` for single-service. Ports → `Network` entitlement, volumes → `Persist` entitlements.
- **`apps_install.go`** — RunE now drives the manifest install: each service is `create → start → wait-for-Started-ack` before the next. **Load-bearing:** the agent records a service's bridge IP at `StartContainer`, so a dependent's `/etc/hosts` only resolves deps already started — hence strict sequential ordering. The now-unused single-image `resolveAppImage`/`appImageResolution` are removed; single-service apps (synthesized manifest from `app_images`) take the same path as a plain single container.

## Dependencies

- Needs **cloud PR #262** (`/v1/apps/{id}/manifest` + curated `paperless`/`immich` manifests) deployed for real installs. Cloud #262 itself should merge after cloud #261 (migration ordering).

## Verification

- `go build ./...`, `go vet`, `go test ./internal/cli/commands/` all pass. Unit tests: manifest resolution (httptest), secret gen/substitution (shared value + missing-name error), `buildServiceInstall` (isolated+ServiceName+populated Services for multi; plain for single; topo order; port/volume entitlements). Each task was TDD'd and independently reviewed; whole-branch reviewed.
- **Deferred (environment-gated):** resolve-smoke against the deployed endpoint (needs #262 live) and on-device E2E (`install paperless` → both containers up → web reachable on device IP → data survives restart).

## Known minor follow-ups (non-blocking)

- `manifestPort.Proto` is dropped — `appconfig.PortMapping` has no `Proto` field (TCP default).
- No CLI-side `ValidateServiceName`/duplicate-name check on manifest services (server-controlled input; fails agent-side today).
- No rollback of already-started services on a mid-loop failure (matches prior single-service behavior; failing service is named).
- Pre-existing `apps_install_env.go` config-prompt scaffolding is dead code (zero callers on `main`) — orthogonal to this PR; author to delete-or-wire separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)