### PR TITLE
fix(agent): wire mesh bridge for single-service mesh apps (WDY-1853)

### DIFF
--- a/go/internal/agent/containerd/bridge_wiring.go
+++ b/go/internal/agent/containerd/bridge_wiring.go
@@ -19,20 +19,33 @@ func findBridgeEntitlement(entitlements []appconfig.Entitlement) (ent appconfig.
 
 // needsCNIBridgeWiring is the single predicate that decides whether a
 // container's networking requires attachment to the per-app CNI bridge (ADD
-// on start, DEL on stop): either a service within a multi-service isolated
-// app group (isolation == "isolated" && serviceName != ""), which already
-// relies on the bridge for its CNI-assigned IP and cross-service /etc/hosts
-// resolution, or a single-service app whose network entitlement mode is
-// "bridge" (isolated namespace + NAT egress, no /etc/hosts).
+// on start, DEL on stop): a service within a multi-service isolated app group
+// (isolation == "isolated" && serviceName != ""), which relies on the bridge
+// for its CNI-assigned IP and cross-service /etc/hosts resolution; a
+// single-service isolated app with a "mesh" entitlement, whose mesh
+// reachability (ingress DNAT + egress route + gateway DNS) all hangs off the
+// per-app bridge/netns; or a single-service app whose network entitlement mode
+// is "bridge" (isolated namespace + NAT egress, no /etc/hosts).
 //
 // Both StartContainer (CNI ADD) and stopOne/deleteOne (CNI DEL) call this
 // exact function so the two sides of the wiring can never drift apart (see
 // specs/2026-07-05-network-bridge-default-design.md, "factor the shared
-// block"). Host, none, mesh-without-isolation, and apps with neither
-// condition all return false.
+// block"). Host, none, mesh-without-isolation, and apps with none of these
+// conditions all return false. This stays aligned with needsGatewayDNS, which
+// already recognises the single-service isolated mesh case (WDY-1853).
 func needsCNIBridgeWiring(isolation, serviceName string, entitlements []appconfig.Entitlement) bool {
 	if isolation == "isolated" && serviceName != "" {
 		return true
+	}
+	// A single-service isolated app with a "mesh" entitlement (top-level
+	// entitlements, serviceName == "") still needs the bridge. Without this it
+	// deploys and runs but is silently unreachable over the mesh — no netns, no
+	// ingress DNAT (WDY-1853). Gated on isolation because mesh requires the
+	// container's own network namespace.
+	if isolation == "isolated" {
+		if _, ok := findMeshEntitlement(entitlements); ok {
+			return true
+		}
 	}
 	_, ok := findBridgeEntitlement(entitlements)
 	return ok

--- a/go/internal/agent/containerd/bridge_wiring_test.go
+++ b/go/internal/agent/containerd/bridge_wiring_test.go
@@ -135,6 +135,20 @@ func TestNeedsCNIBridgeWiring(t *testing.T) {
 			want:        false,
 		},
 		{
+			name:         "single-service isolated mesh app (WDY-1853)",
+			isolation:    "isolated",
+			serviceName:  "",
+			entitlements: meshEnt,
+			want:         true,
+		},
+		{
+			name:         "mesh without isolation excluded",
+			isolation:    "",
+			serviceName:  "",
+			entitlements: meshEnt,
+			want:         false,
+		},
+		{
 			name:         "no isolation, no serviceName, no entitlements excluded",
 			isolation:    "",
 			serviceName:  "",

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1614,6 +1614,15 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 				}
 				_ = writeHostsFile(hostsPath, c.serviceIPs[appID])
 				c.mu.Unlock()
+			} else if _, ok := findMeshEntitlement(entitlements); ok {
+				// Single-service mesh app (serviceName == ""): record the
+				// CNI-assigned IP under the empty service key so
+				// teardownMeshEgress (stopOne/deleteOne) can find it to remove
+				// this container's ingress port-forward. No sibling services
+				// means no /etc/hosts and no isolated-group guard (WDY-1853).
+				c.mu.Lock()
+				c.recordServiceIP(appID, serviceName, ip)
+				c.mu.Unlock()
 			}
 
 			// Gateway DNS listener for single-service bridge-mode apps only


### PR DESCRIPTION
Fixes **WDY-1853**: a single-container app with a top-level `mode:"mesh"` entitlement got **no mesh networking** — silently. It deployed and ran (uvicorn bound), but was **unreachable** over the mesh (peer `MeshDial` → `dial 127.0.0.1:<port>: connection refused`, `device-<id>` names didn't resolve).

## Root cause
`needsCNIBridgeWiring` only wired the CNI bridge/netns for a multi-service isolated app (`isolation=="isolated" && serviceName != ""`) or an explicit `mode:"bridge"` entitlement. A top-level mesh app has `serviceName == ""` and isn't `mode:"bridge"` → no bridge → no netns → no ingress DNAT / egress route / gateway DNS. `needsGatewayDNS` already recognised this case, so the two predicates had drifted apart.

## Fix
- **`needsCNIBridgeWiring`**: also return true for an isolated app with a mesh entitlement, regardless of `serviceName` — realigning it with `needsGatewayDNS`. The rest of the start path already supports a single container: the netns is anchored from `task.Pid()` (as for `mode:"bridge"`), and `applyMeshEgress` keys on the mesh entitlement, not `serviceName`.
- **`StartContainer`**: record the CNI-assigned IP under the empty service key for single-service mesh apps, so `teardownMeshEgress` (stop/delete) can find it to remove the ingress port-forward.
- **test**: cover single-service isolated mesh (true) and mesh-without-isolation (false).

## Validation (hardware, over the cloud tunnel)
Deployed a **top-level** `mode:"mesh"` camera to a Jetson and probed it from a peer over the mesh:

```
before fix:  MeshDial → dial 127.0.0.1:8000: connect: connection refused   (unreachable)
after fix:   GET device-197.cloud.wendy.dev:8000/health -> 200 {"device":"/dev/video0","fps":15.0}
             GET device-197.cloud.wendy.dev:8000/stream -> 200  →  14.2 MB, 11.4 Mbps, 15.1 fps
```

Live camera video now flows over the mesh from a single-container top-level mesh app.

Also lets the camera-fleet template work with either structure (though templates#59 now uses `services.{name}` regardless). Related: WDY-1834, WDY-1777; surfaced via #1361 / #1376.
