### PR TITLE
fix(cli): allow spaces/slashes in build-arg values

### DIFF
--- a/Examples/WendyMC/docker-compose.yml
+++ b/Examples/WendyMC/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         VERSION: "LATEST"
         MEMORY: "4G"
         MAX_PLAYERS: "10"
-        MOTD: "WendyMC - hosted by Wendy"
+        MOTD: "WendyMC — hosted by Wendy"
         ONLINE_MODE: "TRUE"
         ENABLE_RCON: "true"
         RCON_PASSWORD: "wendymc-local"

--- a/Examples/WendyMC/docker-compose.yml
+++ b/Examples/WendyMC/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         VERSION: "LATEST"
         MEMORY: "4G"
         MAX_PLAYERS: "10"
-        MOTD: "WendyMC — hosted by Wendy"
+        MOTD: "WendyMC - hosted by Wendy"
         ONLINE_MODE: "TRUE"
         ENABLE_RCON: "true"
         RCON_PASSWORD: "wendymc-local"

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/swifttoolchain"
@@ -246,11 +247,12 @@ func detectProjectType(dir string) (string, error) {
 var validDockerfileNameRe = regexp.MustCompile(`^(Dockerfile|Containerfile)([.\-][a-zA-Z0-9][a-zA-Z0-9._-]*)?$`)
 var validBuildArgNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
-// Build-arg values are passed to exec.Command as a single KEY=VALUE argument,
-// but keep a narrow allowlist so shell-like metacharacters, whitespace,
-// digests, embedded key separators, and flag-looking values cannot cross into
-// builder CLIs.
-var validBuildArgValueRe = regexp.MustCompile(`^[A-Za-z0-9_.-]*$`)
+// Device-reported build-arg hints (see applyDeviceBuildArgHints) are meant to be
+// clean identifier/version tokens, never free text, so they keep a narrow
+// allowlist. It lets an unmappable agent fallback like "L4T 38.2.0" (note the
+// space) be dropped with a warning instead of injected as a bogus version.
+// User-authored build args are NOT held to this — see validateBuildArgPair.
+var validBuildArgHintValueRe = regexp.MustCompile(`^[A-Za-z0-9_.-]*$`)
 
 func isContainerBuildFileName(name string) bool {
 	if strings.HasSuffix(name, ".dockerignore") {
@@ -284,6 +286,19 @@ func validateDockerfileName(name string) error {
 	return nil
 }
 
+// validateBuildArgPair gates a KEY=VALUE build arg headed for a builder CLI.
+// Values are user-authored (docker-compose args, wendy.json) and legitimately
+// hold spaces, slashes, and other punctuation — a Minecraft MOTD or a log path,
+// say. Their content is not dangerous: each pair is handed to exec.Command as a
+// single "KEY=VALUE" argv element (no shell is involved), and because KEY is
+// validated to [A-Za-z_][A-Za-z0-9_]* the token always starts with a letter, so
+// a builder CLI can never mistake the value for a flag. So the rejections are
+// only:
+//   - a leading '-', kept as defense-in-depth so a value can never look like a
+//     flag even if a future call site passed it as a standalone argv token; and
+//   - control characters, which are genuinely unsafe regardless: NUL truncates
+//     C strings (Go's exec rejects it outright) and CR/LF/escape sequences can
+//     inject lines or terminal escapes into the streamed build log.
 func validateBuildArgPair(key, value string) error {
 	if !validBuildArgNameRe.MatchString(key) {
 		return fmt.Errorf("invalid build arg name %q: must match [A-Za-z_][A-Za-z0-9_]*", key)
@@ -291,8 +306,8 @@ func validateBuildArgPair(key, value string) error {
 	if strings.HasPrefix(value, "-") {
 		return fmt.Errorf("invalid build arg %q: value must not start with '-'", key)
 	}
-	if !validBuildArgValueRe.MatchString(value) {
-		return fmt.Errorf("invalid build arg %q: value must contain only safe ASCII characters", key)
+	if strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return fmt.Errorf("invalid build arg %q: value must not contain control characters", key)
 	}
 	return nil
 }
@@ -301,15 +316,23 @@ func validateBuildArgPair(key, value string) error {
 // agent reports (WENDY_DEVICE_TYPE, WENDY_HAS_GPU, WENDY_GPU_VENDOR,
 // WENDY_JETPACK_VERSION, WENDY_JETPACK_MAJOR, WENDY_CUDA_VERSION) into
 // buildArgs. Each hint is only set when the agent reports it, so Dockerfiles
-// keep their own ARG defaults on older agents. These values are device-reported
-// and feed straight into a builder CLI, so any hint that fails build-arg
-// validation is skipped with a warning rather than failing the whole deploy —
-// e.g. a Jetson running an L4T release the agent's JetPack table doesn't map
-// reports a fallback like "L4T 38.2.0", whose space is rejected by
-// validBuildArgValueRe.
+// keep their own ARG defaults on older agents. These are meant to be clean
+// identifier/version tokens, so a hint that isn't one (validBuildArgHintValueRe)
+// is skipped with a warning rather than injected — e.g. a Jetson running an L4T
+// release the agent's JetPack table doesn't map reports a fallback like
+// "L4T 38.2.0", whose space fails the token check, so it is dropped and the
+// Dockerfile keeps its ARG default instead of receiving a bogus version.
 func applyDeviceBuildArgHints(buildArgs map[string]string, versionResp *agentpb.GetAgentVersionResponse) {
 	setHint := func(key, value string) {
 		if value == "" {
+			return
+		}
+		// A hint must be a clean identifier/version token AND clear the build-arg
+		// safety gate. Anything else — an unmappable "L4T 38.2.0" fallback, say —
+		// is skipped with a warning rather than injected as a bogus hint or left to
+		// abort the deploy at the final build-arg check.
+		if !validBuildArgHintValueRe.MatchString(value) {
+			cliLogln("Warning: ignoring device-reported build arg %s=%q: not a clean identifier/version token", key, value)
 			return
 		}
 		if err := validateBuildArgPair(key, value); err != nil {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -2146,10 +2146,29 @@ func TestValidateDockerfileName(t *testing.T) {
 }
 
 func TestValidateBuildArgPair(t *testing.T) {
+	// User-authored build args (docker-compose args, wendy.json) can hold any
+	// printable text. They are safe: each pair is one "KEY=VALUE" argv element
+	// passed to exec.Command (no shell), and the validated KEY prefix means the
+	// value can never be read as a flag. So the only rule is "no control chars".
 	valid := map[string]string{
 		"WENDY_PLATFORM":    "nvidia-jetson",
 		"_PRIVATE_ARG":      "value-without-equals",
 		"WENDY_DEVICE_TYPE": "jetson-agx-orin",
+		// Real WendyMC example values the old allowlist wrongly rejected.
+		"MOTD":     "WendyMC - hosted by Wendy", // spaces
+		"MOTD_UNI": "WendyMC — hosted by Wendy", // non-ASCII em-dash
+		"LOG_PATH": "/mc-data/logs/latest.log",  // slashes
+		// Harmless as a single KEY=VALUE token — there is no shell to interpret
+		// them and the KEY= prefix keeps a builder CLI from seeing a flag.
+		"SHELL":     "$(echo bad)",
+		"DIGEST":    "image@sha256:abc",
+		"PLUS":      "v1+metadata",
+		"EQUALS":    "value=with=equals",
+		"SLASH":     "linux/arm64",
+		"COLON":     "8080:80",
+		"COMMA":     "left,right",
+		"COMMAFLAG": ",--cache", // '-' is mid-token, not a leading flag
+		"EMPTY":     "",
 	}
 	for k, v := range valid {
 		if err := validateBuildArgPair(k, v); err != nil {
@@ -2158,22 +2177,17 @@ func TestValidateBuildArgPair(t *testing.T) {
 	}
 
 	invalid := map[string]string{
-		"":          "value",
-		"BAD-NAME":  "value",
-		"1BAD":      "value",
-		"BAD=NAME":  "value",
-		"BAD\nKEY":  "value",
-		"GOOD":      "bad\nvalue",
-		"ALSO_GOOD": "bad\x00value",
-		"LEADING":   "--flag-like",
-		"SHELL":     "$(echo bad)",
-		"DIGEST":    "image@sha256:abc",
-		"PLUS":      "v1+metadata",
-		"EQUALS":    "value=with=equals",
-		"SLASH":     "linux/arm64",
-		"COLON":     "8080:80",
-		"COMMA":     "left,right",
-		"COMMAFLAG": ",--cache",
+		"":         "value",            // empty key
+		"BAD-NAME": "value",            // hyphen in key
+		"1BAD":     "value",            // leading digit in key
+		"BAD=NAME": "value",            // equals in key
+		"BAD\nKEY": "value",            // newline in key
+		"LEADING":  "--flag-like",      // value looks like a flag
+		"NEWLINE":  "bad\nvalue",       // newline in value
+		"CR":       "bad\rvalue",       // carriage return in value
+		"NUL":      "bad\x00value",     // NUL in value
+		"ESC":      "bad\x1b[31mvalue", // ANSI escape in value
+		"TAB":      "bad\tvalue",       // tab is a control char
 	}
 	for k, v := range invalid {
 		if err := validateBuildArgPair(k, v); err == nil {


### PR DESCRIPTION
## Problem

Running the WendyMC example (`wendy run` in `Examples/WendyMC`) fails with:

```
value must contain only safe ASCII characters
```

on ordinary build args like `MOTD: "WendyMC — hosted by Wendy"` (spaces / em-dash) and `LOG_PATH: "/mc-data/logs/latest.log"` (slashes).

## Root cause

The build-arg value validator (`validateBuildArgPair`) had been narrowed to an allowlist `^[A-Za-z0-9_.-]*$`, rejecting spaces, slashes, and colons. Git history shows this was a progressive over-tightening: the original check only rejected `\x00\r\n` (correct), then it became an allowlist, then `/ : , = @ +` were stripped out inside a commit about warning-text sanitization — with no threat-model justification.

That allowlist guards against a threat that doesn't exist on this path. Every build arg goes to `exec.Command(...)` — **no shell** — emitted as a separate `--build-arg` token followed by `KEY=VALUE`. Since `KEY` is already validated to start with a letter/underscore, the `KEY=VALUE` token can never be reinterpreted as a flag or a shell metacharacter, regardless of the value's content. So Docker, buildx, and Apple Container all accept these values fine — only Wendy's validator rejected them.

## Fix

- `validateBuildArgPair` now rejects only what is genuinely unsafe:
  - **control characters** (`unicode.IsControl`) — NUL truncates C strings (Go's exec rejects it anyway); CR/LF and terminal escapes can inject lines/escapes into the streamed build log;
  - a **leading `-`**, kept as defense-in-depth (covered by `TestBuildkitRejectsFlagInjectionBuildArg`).
- Spaces, slashes, colons, and non-ASCII Unicode now validate, for **both** the Docker and Apple Container builder paths (they share this gate).
- **Device-reported hints unchanged in spirit:** the old strict regex is repurposed as `validBuildArgHintValueRe` and still applied to agent hints, so an unmappable `"L4T 38.2.0"` fallback is still skipped-with-warning rather than injected as a bogus version.
- Restored the em-dash MOTD in the WendyMC example now that Unicode validates (matches the README).

## Verification

- `TestValidateBuildArgPair` updated to assert the exact example values (em-dash MOTD, slashed LOG_PATH) are valid and control chars are invalid.
- Device-hint tests and the flag-injection security test still pass.
- Drove the real `Examples/WendyMC/docker-compose.yml` through the actual parse → validate pipeline — all 11 minecraft + 7 webui build args validated.
- Full `internal/cli/commands` package green; whole Go module builds; `gofmt` clean.

## Notes

- Stacked on #1380 (`ed/wendy-mc-example`); base is that branch so the diff is just this fix.
- On-device `wendy run` confirmation still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
