### PR TITLE
thor: support installation with wifi and other settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.1
+	github.com/diskfs/go-diskfs v1.9.3
 	github.com/distribution/reference v0.6.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ebitengine/oto/v3 v3.4.0
@@ -50,6 +51,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 // indirect
 	github.com/Microsoft/hcsshim v0.15.0-rc.1 // indirect
 	github.com/alexflint/go-filemutex v1.3.0 // indirect
+	github.com/anchore/go-lzo v0.1.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -68,7 +70,9 @@ require (
 	github.com/containerd/ttrpc v1.2.8 // indirect
 	github.com/coreos/go-iptables v0.8.0 // indirect
 	github.com/creack/goselect v0.1.3 // indirect
+	github.com/djherbis/times v1.6.0 // indirect
 	github.com/ebitengine/purego v0.9.0 // indirect
+	github.com/elliotwutingfeng/asciiset v0.0.0-20260129054604-cfde2086bc57 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -90,13 +94,16 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/networkplumbing/go-nft v0.4.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/xattr v0.4.12 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/safchain/ethtool v0.6.2 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0 h1:LvK7+C6qgz8BPnmn7x
 github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0/go.mod h1:I28hc9eaiqKCoOB+9Wh/P1IOScfm0xCgyWC6DAo0lmo=
 github.com/alexflint/go-filemutex v1.3.0 h1:LgE+nTUWnQCyRKbpoceKZsPQbs84LivvgwUymZXdOcM=
 github.com/alexflint/go-filemutex v1.3.0/go.mod h1:U0+VA/i30mGBlLCrFPGtTe9y6wGQfNAWPBTekHQ+c8A=
+github.com/anchore/go-lzo v0.1.0 h1:NgAacnzqPeGH49Ky19QKLBZEuFRqtTG9cdaucc3Vncs=
+github.com/anchore/go-lzo v0.1.0/go.mod h1:3kLx0bve2oN1iDwgM1U5zGku1Tfbdb0No5qp1eL1fIk=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -88,8 +90,12 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/diskfs/go-diskfs v1.9.3 h1:cLciNCeZ4QAXVxyPJDr1ZJ9N9CCG3rQlQ/z/Cs/cNDM=
+github.com/diskfs/go-diskfs v1.9.3/go.mod h1:TePJORO83Adh5pb2SqsxAwaP0fofFxKLkxctiS/9OQc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
+github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -98,6 +104,8 @@ github.com/ebitengine/oto/v3 v3.4.0 h1:br0PgASsEWaoWn38b2Goe7m1GKFYfNgnsjSd5Gg+/
 github.com/ebitengine/oto/v3 v3.4.0/go.mod h1:IOleLVD0m+CMak3mRVwsYY8vTctQgOM0iiL6S7Ar7eI=
 github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A4k=
 github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/elliotwutingfeng/asciiset v0.0.0-20260129054604-cfde2086bc57 h1:x5yxNrq8XffV/OoNUeFPM6hxHVi5OTspSTBxr/9pemg=
+github.com/elliotwutingfeng/asciiset v0.0.0-20260129054604-cfde2086bc57/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -121,6 +129,8 @@ github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -216,8 +226,12 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opencontainers/runtime-spec v1.3.0 h1:YZupQUdctfhpZy3TM39nN9Ika5CBWT5diQ8ibYCRkxg=
 github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
+github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/xattr v0.4.12 h1:rRTkSyFNTRElv6pkA3zpjHpQ90p/OdHQC1GmGh1aTjM=
+github.com/pkg/xattr v0.4.12/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -254,6 +268,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
@@ -364,7 +380,9 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go/internal/agent/timesync/floor.go
+++ b/go/internal/agent/timesync/floor.go
@@ -20,11 +20,16 @@ func readFloor(configPath string) time.Time {
 	return time.Unix(sec, 0)
 }
 
+// FloorBytes encodes t as the 8-byte big-endian clock_floor payload.
+func FloorBytes(t time.Time) []byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(t.Unix())) //nolint:gosec — install-time timestamps are non-negative
+	return buf[:]
+}
+
 // WriteFloor writes t as a big-endian int64 Unix timestamp to
 // configPath/clock_floor. Called by the CLI at install time and during
 // config-partition provisioning.
 func WriteFloor(configPath string, t time.Time) error {
-	var buf [8]byte
-	binary.BigEndian.PutUint64(buf[:], uint64(t.Unix())) //nolint:gosec — Unix() is always non-negative for install-time timestamps
-	return os.WriteFile(filepath.Join(configPath, clockFloorFile), buf[:], 0o644)
+	return os.WriteFile(filepath.Join(configPath, clockFloorFile), FloorBytes(t), 0o644)
 }

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -265,7 +265,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	// AGX Thor flashes over USB recovery (not a drive), via its own flashpack
 	// artifact and device selection — a separate path from the disk-image flow below.
 	if flagDeviceType == thorDeviceType {
-		return installThor(ctx, flagVersion, nightly, force)
+		return installThor(ctx, flagVersion, nightly, force, wifi, deviceName, preOpts)
 	}
 
 	fmt.Println("Fetching available devices...")
@@ -389,7 +389,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	// installThor here as well — otherwise it falls through to the disk-image
 	// flow and dd's the wrong artifact onto an external drive.
 	if selected == thorDeviceType {
-		return installThor(ctx, flagVersion, nightly, force)
+		return installThor(ctx, flagVersion, nightly, force, wifi, deviceName, preOpts)
 	}
 
 	if selected == linuxDesktopValue {
@@ -484,27 +484,11 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		return err
 	}
 
-	// Resolve pre-enrollment — must happen before provisionConfigPartition because
-	// the config partition is mounted and unmounted inside that call.
-	var provisioningJSON []byte
-	if preOpts.mode != preEnrollSkip {
-		cfg, cfgErr := config.Load()
-		if cfgErr != nil {
-			if preOpts.mode == preEnrollForced {
-				return fmt.Errorf("--pre-enroll: loading config: %w", cfgErr)
-			}
-			cfg = &config.Config{} // auto mode: treat an unreadable config as not logged in
-		}
-		provisioning, resolveErr := resolvePreEnrollment(ctx, cfg, preOpts, isInteractiveTerminal(), provDeviceName)
-		if resolveErr != nil {
-			return resolveErr
-		}
-		if provisioning != nil {
-			provisioningJSON, err = json.Marshal(provisioning)
-			if err != nil {
-				return fmt.Errorf("marshaling provisioning state: %w", err)
-			}
-		}
+	// Resolve pre-enrollment before provisioning — the config partition is mounted
+	// and unmounted inside provisionConfigWithRetry below.
+	provisioningJSON, err := resolveProvisioningJSON(ctx, preOpts, provDeviceName)
+	if err != nil {
+		return err
 	}
 
 	// Step 5: Resolve image metadata for the target storage. A USB-attached
@@ -1997,6 +1981,26 @@ func resolveDeviceName(flagName string) (string, error) {
 		return "", fmt.Errorf("device-name prompt: %w", err)
 	}
 	return strings.TrimSpace(name), nil
+}
+
+// resolveProvisioningJSON runs pre-enrollment per preOpts and returns the
+// marshaled provisioning.json, or nil when enrollment is skipped or not available.
+func resolveProvisioningJSON(ctx context.Context, preOpts preEnrollOptions, deviceName string) ([]byte, error) {
+	if preOpts.mode == preEnrollSkip {
+		return nil, nil
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		if preOpts.mode == preEnrollForced {
+			return nil, fmt.Errorf("--pre-enroll: loading config: %w", err)
+		}
+		cfg = &config.Config{} // auto mode: treat an unreadable config as not logged in
+	}
+	prov, err := resolvePreEnrollment(ctx, cfg, preOpts, isInteractiveTerminal(), deviceName)
+	if err != nil || prov == nil {
+		return nil, err
+	}
+	return json.Marshal(prov)
 }
 
 // confirmOverwriteInternalDrive guards against accidentally wiping internal

--- a/go/internal/cli/commands/os_install_thor_config_test.go
+++ b/go/internal/cli/commands/os_install_thor_config_test.go
@@ -1,0 +1,99 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	diskfs "github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/disk"
+	"github.com/diskfs/go-diskfs/filesystem"
+	"github.com/wendylabsinc/wendy/go/internal/shared/wendyconf"
+)
+
+// newFATImage returns a path to a freshly-formatted bare FAT32 image labelled
+// "config" — the shape make-thor-flashpack.sh ships as config-partition.fat32.img.
+func newFATImage(t *testing.T) string {
+	t.Helper()
+	img := filepath.Join(t.TempDir(), "config-partition.fat32.img")
+	d, err := diskfs.Create(img, 33*1024*1024, diskfs.SectorSizeDefault)
+	if err != nil {
+		t.Fatalf("create image: %v", err)
+	}
+	if _, err := d.CreateFilesystem(disk.FilesystemSpec{Partition: 0, FSType: filesystem.TypeFat32, VolumeLabel: "config"}); err != nil {
+		t.Fatalf("format fat32: %v", err)
+	}
+	d.Close()
+	return img
+}
+
+func readFATFile(t *testing.T, img, name string) ([]byte, error) {
+	t.Helper()
+	d, err := diskfs.Open(img)
+	if err != nil {
+		t.Fatalf("open image: %v", err)
+	}
+	defer d.Close()
+	fs, err := d.GetFilesystem(0)
+	if err != nil {
+		t.Fatalf("get filesystem: %v", err)
+	}
+	return fs.ReadFile("/" + name)
+}
+
+// writeFAT wraps a fresh open of img in fatWriter and runs writeConfigFilesTo,
+// mirroring injectConfigPartition minus the network agent download.
+func writeFAT(t *testing.T, img string, agent []byte, creds []wendyconf.WifiCredential, name string, provJSON []byte) {
+	t.Helper()
+	d, err := diskfs.Open(img)
+	if err != nil {
+		t.Fatalf("open image: %v", err)
+	}
+	fs, err := d.GetFilesystem(0)
+	if err != nil {
+		t.Fatalf("get filesystem: %v", err)
+	}
+	if err := writeConfigFilesTo(fatWriter{fs}, agent, creds, name, provJSON); err != nil {
+		t.Fatalf("writeConfigFilesTo: %v", err)
+	}
+	d.Close()
+}
+
+func TestInjectConfigPartitionFAT(t *testing.T) {
+	img := newFATImage(t)
+	creds := []wendyconf.WifiCredential{{SSID: "Home", Password: "hunter2"}}
+	writeFAT(t, img, []byte("BINARY"), creds, "brave-dolphin", []byte(`{"enrolled":true}`))
+
+	conf, err := readFATFile(t, img, "wendy.conf")
+	if err != nil {
+		t.Fatalf("read wendy.conf: %v", err)
+	}
+	if got := string(conf); !strings.Contains(got, "ssid = Home") || !strings.Contains(got, "name = brave-dolphin") {
+		t.Errorf("wendy.conf missing expected content:\n%s", got)
+	}
+	if b, err := readFATFile(t, img, "provisioning.json"); err != nil || string(b) != `{"enrolled":true}` {
+		t.Errorf("provisioning.json = %q, %v", b, err)
+	}
+	if b, err := readFATFile(t, img, "wendy-agent"); err != nil || string(b) != "BINARY" {
+		t.Errorf("wendy-agent = %q, %v", b, err)
+	}
+	// clock_floor is always written (8-byte payload).
+	if b, err := readFATFile(t, img, "clock_floor"); err != nil || len(b) != 8 {
+		t.Errorf("clock_floor len = %d, %v", len(b), err)
+	}
+}
+
+// A re-run with different flags must not leave a stale tail from the prior write.
+func TestInjectConfigPartitionRewriteIsClean(t *testing.T) {
+	img := newFATImage(t)
+	writeFAT(t, img, nil, nil, "a-longer-device-name", nil)
+	writeFAT(t, img, nil, nil, "short-name", nil)
+
+	b, err := readFATFile(t, img, "wendy.conf")
+	if err != nil {
+		t.Fatalf("read wendy.conf: %v", err)
+	}
+	if strings.Contains(string(b), "a-longer-device-name") {
+		t.Errorf("stale content from prior write survived:\n%s", b)
+	}
+}

--- a/go/internal/cli/commands/os_install_thor_shared.go
+++ b/go/internal/cli/commands/os_install_thor_shared.go
@@ -23,15 +23,19 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	diskfs "github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/filesystem"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashengine"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashpack"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/wendyconf"
 )
 
 // Step IDs for the flashing progress list.
 const (
 	stepDownload = iota
+	stepProvision
 	stepStage1
 	stepStage2
 )
@@ -55,7 +59,7 @@ type thorDevice struct {
 // the device, then run download → stage-1 RCM boot → stage-2 partition flash as a
 // BuildKit-style step list. Stage-2 is the shared Go engine (flashengine) on all
 // platforms.
-func installThor(ctx context.Context, version string, nightly, force bool) error {
+func installThor(ctx context.Context, version string, nightly, force bool, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions) error {
 	// Thor's USB recovery access is an in-process libusb handle, so the whole
 	// process must be root on macOS/Linux — caching the sudo timestamp is not
 	// enough. Elevate up front, before the briefing, so a missing-permission
@@ -78,6 +82,23 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 
 	// Fail fast on a full disk, before the user starts cabling the Thor.
 	if err := checkThorDiskSpace(cacheDir, plan); err != nil {
+		return err
+	}
+
+	// Resolve provisioning up front: interactive prompts and pre-enrollment run
+	// before the flash UI takes over the terminal, and a bad flag or failed
+	// enrollment aborts before we touch USB. Written to the config image in
+	// stepProvision, then flashed like a disk install's config partition.
+	creds, err := resolveWiFiCredentialsList(wifi)
+	if err != nil {
+		return err
+	}
+	name, err := resolveDeviceName(deviceName)
+	if err != nil {
+		return err
+	}
+	provJSON, err := resolveProvisioningJSON(ctx, preOpts, name)
+	if err != nil {
 		return err
 	}
 
@@ -140,6 +161,9 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 			fp = resolved
 			return cached, err
 		}},
+		{id: stepProvision, label: "Write config partition", run: func(out io.Writer, detail func(string)) (bool, error) {
+			return false, injectConfigPartition(fp, creds, name, provJSON, out, detail)
+		}},
 		{id: stepStage1, label: "Stage 1  RCM boot", run: func(out io.Writer, _ func(string)) (bool, error) {
 			return false, thorStageOne(fp, dev, out)
 		}},
@@ -198,6 +222,50 @@ func installThor(ctx context.Context, version string, nightly, force bool) error
 
 	fmt.Println(tui.SuccessMessage(fmt.Sprintf("Flashed WendyOS %s — power-cycle the Thor out of recovery to boot it. (press the right button once)", plan.version)))
 	return nil
+}
+
+// fatWriter writes config-partition files into a mounted FAT32 filesystem image
+// (Thor's config-partition.fat32.img) — the analog of dirTarget for a drive.
+type fatWriter struct{ fs filesystem.FileSystem }
+
+func (w fatWriter) WriteFile(name string, data []byte, _ os.FileMode) error {
+	f, err := w.fs.OpenFile("/"+name, os.O_CREATE|os.O_RDWR|os.O_TRUNC) // FAT has no perms; O_TRUNC keeps re-runs clean
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	return err
+}
+
+// injectConfigPartition populates the flashpack's FAT32 config image with the
+// same files a disk install writes to a drive's config partition — agent binary,
+// wendy.conf, provisioning.json, clock_floor — so first boot applies them via the
+// identical on-device path. Runs before stage-2, so a failure aborts with nothing
+// written to the Thor.
+func injectConfigPartition(fp *flashpack.Flashpack, creds []wendyconf.WifiCredential, deviceName string, provJSON []byte, out io.Writer, detail func(string)) error {
+	// Freshen the agent like a disk install, but best-effort: resolveAgentBinary is
+	// the only network step here, so an offline re-flash of a cached flashpack still
+	// provisions wifi/enrollment, falling back to the agent baked into the image.
+	detail("downloading agent")
+	agentBinary, agentVer, _, err := resolveAgentBinary("arm64", false)
+	if err != nil {
+		fmt.Fprintf(out, "warning: could not download wendy-agent (%v); using the agent baked into the image\n", err)
+	} else {
+		detail("agent " + agentVer)
+	}
+
+	img := filepath.Join(fp.FlashWorkspaceDir(), "flash-images", "config-partition.fat32.img")
+	d, err := diskfs.Open(img)
+	if err != nil {
+		return fmt.Errorf("opening config image: %w", err)
+	}
+	defer d.Close()
+	fs, err := d.GetFilesystem(0) // bare FAT32, no partition table
+	if err != nil {
+		return fmt.Errorf("reading config filesystem: %w", err)
+	}
+	return writeConfigFilesTo(fatWriter{fs}, agentBinary, creds, deviceName, provJSON)
 }
 
 // ---- flashpack plan / download (cross-platform) ----

--- a/go/internal/cli/commands/os_provision.go
+++ b/go/internal/cli/commands/os_provision.go
@@ -188,10 +188,30 @@ func provisioningRequired(creds []wendyconf.WifiCredential, deviceName string, p
 	return len(creds) > 0 || deviceName != "" || len(provisioningJSON) > 0
 }
 
+// configTarget receives the config-partition files: a mounted directory (disk
+// installs) or a FAT32 image (Thor).
+type configTarget interface {
+	WriteFile(name string, data []byte, perm os.FileMode) error
+}
+
+// dirTarget writes into a mounted config-partition directory.
+type dirTarget string
+
+func (d dirTarget) WriteFile(name string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(filepath.Join(string(d), name), data, perm)
+}
+
 func writeConfigFiles(mountPoint string, agentBinary []byte, creds []wendyconf.WifiCredential, deviceName string, provisioningJSON []byte) error {
-	binPath := filepath.Join(mountPoint, "wendy-agent")
-	if err := os.WriteFile(binPath, agentBinary, 0o755); err != nil {
-		return fmt.Errorf("writing wendy-agent to config partition: %w", err)
+	return writeConfigFilesTo(dirTarget(mountPoint), agentBinary, creds, deviceName, provisioningJSON)
+}
+
+// writeConfigFilesTo writes the config-partition files to any target. agentBinary
+// is skipped when empty (Thor omits it only if a caller passes none).
+func writeConfigFilesTo(t configTarget, agentBinary []byte, creds []wendyconf.WifiCredential, deviceName string, provisioningJSON []byte) error {
+	if len(agentBinary) > 0 {
+		if err := t.WriteFile("wendy-agent", agentBinary, 0o755); err != nil {
+			return fmt.Errorf("writing wendy-agent to config partition: %w", err)
+		}
 	}
 
 	if len(creds) > 0 || deviceName != "" {
@@ -215,22 +235,19 @@ func writeConfigFiles(mountPoint string, agentBinary []byte, creds []wendyconf.W
 			conf = append(conf, []byte(fmt.Sprintf("[device]\nname = %s\n", deviceName))...)
 		}
 
-		confPath := filepath.Join(mountPoint, "wendy.conf")
-		if err := os.WriteFile(confPath, conf, 0o644); err != nil {
+		if err := t.WriteFile("wendy.conf", conf, 0o644); err != nil {
 			return fmt.Errorf("writing wendy.conf to config partition: %w", err)
 		}
 	}
 
 	if len(provisioningJSON) > 0 {
-		provPath := filepath.Join(mountPoint, "provisioning.json")
-		if err := os.WriteFile(provPath, provisioningJSON, 0o600); err != nil {
+		if err := t.WriteFile("provisioning.json", provisioningJSON, 0o600); err != nil {
 			return fmt.Errorf("writing provisioning.json to config partition: %w", err)
 		}
 	}
 
-	// Write current time as a clock floor so the device boots with a sane clock
-	// even before NTP or Roughtime sync completes.
-	if err := timesync.WriteFloor(mountPoint, time.Now()); err != nil {
+	// Clock floor so the device boots with a sane clock even before NTP/Roughtime sync.
+	if err := t.WriteFile("clock_floor", timesync.FloorBytes(time.Now()), 0o644); err != nil {
 		return fmt.Errorf("writing clock_floor to config partition: %w", err)
 	}
 


### PR DESCRIPTION
Based on `jo/wendy-next` (#1381)

Adds support for setting the WiFi credentials, device name and pre-enrollment information when installing WendyOS onto a Thor via USB flashing. A best-effort attempt is made to update the wendy-agent like on other platforms.

This works by editing the FAT image (new dependency https://github.com/diskfs/go-diskfs) and writing the correct config before flashing it. All of the actual provisioning logic already exists.

Tested by flashing a Thor with specific device name and WiFi network information, where it appeared after reboot.