### PR TITLE
fix(agent): resolve real user for brew bundle under Homebrew tap-trust

### DIFF
--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -428,17 +428,36 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         ["bundle", "--file", brewfilePath]
     }
 
+    nonisolated static func realUserName() -> String? {
+        guard let passwd = getpwuid(getuid()) else { return nil }
+        return String(cString: passwd.pointee.pw_name)
+    }
+
     nonisolated static func brewBundleEnvironment(
-        source: [String: String] = ProcessInfo.processInfo.environment
+        source: [String: String] = ProcessInfo.processInfo.environment,
+        realUserName: String? = realUserName()
     ) -> [String: String] {
         var environment: [String: String] = [:]
-        for key in ["HOME", "TMPDIR", "USER", "LOGNAME", "LANG", "LC_ALL", "LC_CTYPE"] {
+        for key in ["HOME", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE"] {
             if let value = source[key], !value.isEmpty {
                 environment[key] = value
             }
         }
         if environment["HOME"] == nil {
             environment["HOME"] = NSHomeDirectory()
+        }
+        // Homebrew's tap-trust resolves the invoking user's home via a passwd lookup
+        // of USER/LOGNAME, so these must name a real account — an env-only identity
+        // (as the E2E harness sets) makes every `brew install` abort.
+        if let realUserName, !realUserName.isEmpty {
+            environment["USER"] = realUserName
+            environment["LOGNAME"] = realUserName
+        } else {
+            for key in ["USER", "LOGNAME"] {
+                if let value = source[key], !value.isEmpty {
+                    environment[key] = value
+                }
+            }
         }
         environment["PATH"] = "/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
         environment["HOMEBREW_NO_ANALYTICS"] = "1"

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
@@ -692,7 +692,8 @@ struct ContainerServiceTests {
                 "AWS_SECRET_ACCESS_KEY": "secret",
                 "GITHUB_TOKEN": "token",
                 "DATABASE_PASSWORD": "secret",
-            ]
+            ],
+            realUserName: "wendy"
         )
 
         #expect(environment["HOME"] == "/Users/wendy")
@@ -706,6 +707,43 @@ struct ContainerServiceTests {
         #expect(environment["AWS_SECRET_ACCESS_KEY"] == nil)
         #expect(environment["GITHUB_TOKEN"] == nil)
         #expect(environment["DATABASE_PASSWORD"] == nil)
+    }
+
+    @Test("Brewfile command environment replaces synthetic USER/LOGNAME with the real user")
+    func brewfileCommandEnvironmentReplacesSyntheticUserWithRealUser() {
+        let environment = ContainerService.brewBundleEnvironment(
+            source: [
+                "HOME": "/tmp/wendy-e2e/home",
+                "USER": "wendy-e2e-agent",
+                "LOGNAME": "wendy-e2e-agent",
+            ],
+            realUserName: "runner"
+        )
+
+        #expect(environment["USER"] == "runner")
+        #expect(environment["LOGNAME"] == "runner")
+        #expect(environment["HOME"] == "/tmp/wendy-e2e/home")
+    }
+
+    @Test("Brewfile command environment falls back to source USER when real user is unknown")
+    func brewfileCommandEnvironmentFallsBackToSourceUserWhenRealUserIsUnknown() {
+        let environment = ContainerService.brewBundleEnvironment(
+            source: [
+                "HOME": "/Users/wendy",
+                "USER": "wendy",
+                "LOGNAME": "wendy",
+            ],
+            realUserName: nil
+        )
+
+        #expect(environment["USER"] == "wendy")
+        #expect(environment["LOGNAME"] == "wendy")
+    }
+
+    @Test("Real user name resolves to an existing account")
+    func realUserNameResolvesToAnExistingAccount() {
+        let name = ContainerService.realUserName()
+        #expect(name?.isEmpty == false)
     }
 
     @Test("Brewfile symlink escapes are rejected before launching Homebrew")


### PR DESCRIPTION
> **In plain terms (for PMs):** Our Mac test suite went red overnight because Homebrew (the tool that installs software on Macs) shipped a new security check that verifies the requesting user actually exists on the machine. Our tests run under a made-up user name, so Homebrew refused every install. The fix: when Wendy asks Homebrew to install things, it now identifies itself with the real user account it's actually running as. No customer-facing behavior changes.

# What

Fix the `Local: macOS 26` E2E failures in the `'wendy run' with native Mac Brewfiles` suite, red on `main` since 2026-07-08.

# Why

Homebrew's new [Tap Trust](https://docs.brew.sh/Tap-Trust) feature (picked up by the runner via `brew update`) calls `Dir.home` during preinstall checks, resolving the home directory of the user named by `USER`/`LOGNAME` through the passwd database. The E2E harness launches the managed agent with a synthetic identity (`USER=wendy-e2e-agent`), which the agent forwards to `brew bundle` — and since that user has no passwd entry, brew aborts:

```
Error: user wendy-e2e-agent doesn't exist
/opt/homebrew/Library/Homebrew/trust.rb:27:in 'Dir.home'
```

Every `wendy run` with a Brewfile then exits 1, blocking PR merges. First failing run: https://github.com/wendylabsinc/WendyOS/actions/runs/28943621344

# How

- `ContainerService.brewBundleEnvironment` now sets `USER`/`LOGNAME` from the process's real uid (`getpwuid(getuid())`) instead of forwarding whatever the agent was launched with, so Homebrew always resolves an account that exists. If the passwd lookup somehow fails, it falls back to the previous forwarding behavior.
- The synthetic `HOME` is still forwarded: it is a real writable directory, so Homebrew's per-user state (including the trust store on current Homebrew, which derives it from `HOME`) keeps working, and the isolation the synthetic identity gives the rest of the E2E suite is untouched.
- No behavior change outside the Brewfile path.

# Tests

- Unit tests for the new behavior in `ContainerServiceTests` (synthetic identity replaced, fallback when the real user is unknown, credentials still stripped): `swift test --filter brewfile` passes locally.
- CI is the real proof: the `Local: macOS 26` E2E job must go green, including the negative test (`brew bundle` failures still reported without starting the app).

Closes WDY-1861

