### PR TITLE
fix(cli): surface Dockerfile-over-Package.swift precedence

### DIFF
--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -180,6 +180,12 @@ func newBuildCmd() *cobra.Command {
 				return err
 			}
 
+			// Surface Dockerfile-over-Package.swift precedence so it isn't silent
+			// for the common "Swift + Dockerfile side by side" layout.
+			if msg := dockerfilePreferredOverSwiftNotice(cwd, selected.Type, opts.buildType, opts.dockerfile); msg != "" {
+				cliNotice("%s", msg)
+			}
+
 			// Query the device OS and architecture when an agent connection is
 			// available and determine the target platform.
 			var cfgPlatform string

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -241,6 +241,34 @@ func detectProjectType(dir string) (string, error) {
 	return "unknown", nil
 }
 
+// dockerfilePreferredOverSwiftNotice returns a one-line notice (or "" for none)
+// for the common layout where a Swift package sits next to a Dockerfile.
+//
+// `wendy run` and `wendy build` build the Dockerfile by default in that case
+// (see detectProjectType / resolveDetectedBuildOption precedence), but that
+// choice used to be silent: a project with both Package.swift and a Dockerfile
+// would build the container image with no indication of which path ran. That
+// bit users with the common "Swift + Dockerfile side by side" layout — a stale
+// container build reads like the app is crashing when it is really just running
+// the wrong build path. Surfacing the precedence lets them pass --build-type
+// swift (or --dockerfile) deliberately.
+//
+// It stays silent when the user selected a build path explicitly (--build-type
+// or --dockerfile), when the resolved type is not docker, or when there is no
+// Package.swift to be shadowed.
+func dockerfilePreferredOverSwiftNotice(dir, resolvedType, requestedType, requestedDockerfile string) string {
+	if resolvedType != "docker" {
+		return ""
+	}
+	if strings.TrimSpace(requestedType) != "" || strings.TrimSpace(requestedDockerfile) != "" {
+		return ""
+	}
+	if _, err := os.Stat(filepath.Join(dir, "Package.swift")); err != nil {
+		return ""
+	}
+	return "Both Package.swift and a Dockerfile/Containerfile were found; building with the Dockerfile. Pass --build-type swift to build the Swift package instead."
+}
+
 // validDockerfileNameRe matches valid container build file names: "Dockerfile",
 // "Containerfile", or either base name followed by a dot or hyphen and one or
 // more safe characters.

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -903,6 +903,67 @@ func TestDetectProjectType_DockerfileTakesPrecedence(t *testing.T) {
 	}
 }
 
+func TestDetectProjectType_DockerfileTakesPrecedenceOverSwift(t *testing.T) {
+	dir := t.TempDir()
+	// The common "Swift + Dockerfile side by side" layout: Dockerfile should win.
+	for _, name := range []string{"Dockerfile", "Package.swift"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := mustDetectProjectType(t, dir); got != "docker" {
+		t.Errorf("detectProjectType = %q; want %q (Dockerfile should take precedence over Package.swift)", got, "docker")
+	}
+}
+
+func TestDockerfilePreferredOverSwiftNotice(t *testing.T) {
+	withFiles := func(t *testing.T, names ...string) string {
+		t.Helper()
+		dir := t.TempDir()
+		for _, name := range names {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return dir
+	}
+
+	t.Run("both present, no explicit selection, warns", func(t *testing.T) {
+		dir := withFiles(t, "Dockerfile", "Package.swift")
+		if got := dockerfilePreferredOverSwiftNotice(dir, "docker", "", ""); got == "" {
+			t.Fatal("expected a notice when Package.swift and a Dockerfile coexist")
+		}
+	})
+
+	t.Run("no Package.swift, silent", func(t *testing.T) {
+		dir := withFiles(t, "Dockerfile")
+		if got := dockerfilePreferredOverSwiftNotice(dir, "docker", "", ""); got != "" {
+			t.Fatalf("expected no notice without Package.swift; got %q", got)
+		}
+	})
+
+	t.Run("resolved type not docker, silent", func(t *testing.T) {
+		dir := withFiles(t, "Package.swift")
+		if got := dockerfilePreferredOverSwiftNotice(dir, "swift", "", ""); got != "" {
+			t.Fatalf("expected no notice when the Swift path was chosen; got %q", got)
+		}
+	})
+
+	t.Run("explicit --build-type, silent", func(t *testing.T) {
+		dir := withFiles(t, "Dockerfile", "Package.swift")
+		if got := dockerfilePreferredOverSwiftNotice(dir, "docker", "docker", ""); got != "" {
+			t.Fatalf("expected no notice when --build-type is explicit; got %q", got)
+		}
+	})
+
+	t.Run("explicit --dockerfile, silent", func(t *testing.T) {
+		dir := withFiles(t, "Dockerfile", "Package.swift")
+		if got := dockerfilePreferredOverSwiftNotice(dir, "docker", "", "Dockerfile"); got != "" {
+			t.Fatalf("expected no notice when --dockerfile is explicit; got %q", got)
+		}
+	})
+}
+
 func TestDetectProjectType_DockerfileVariantOnly(t *testing.T) {
 	dir := t.TempDir()
 	// No base Dockerfile — only variants.

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -655,6 +655,12 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		return runComposeCommand(ctx, cwd, opts)
 	}
 
+	// Surface Dockerfile-over-Package.swift precedence so it isn't silent for the
+	// common "Swift + Dockerfile side by side" layout.
+	if msg := dockerfilePreferredOverSwiftNotice(cwd, projectType, opts.buildType, opts.dockerfile); msg != "" {
+		cliNotice("%s", msg)
+	}
+
 	// For docker-type projects, resolve which build file to use before
 	// connecting to the target — so the picker shows regardless of whether
 	// we end up on the agent path or a provider path (Docker, etc.).


### PR DESCRIPTION
## Problem

Reported from a real Raspberry Pi 5 bring-up of a Hello-World Swift app. A project that contains **both** a `Package.swift` and a `Dockerfile` builds the Dockerfile by default (correct precedence), but the CLI did this **silently** — nothing told the user which build path ran.

For the very common "Swift + Dockerfile side by side" layout this is a real trap: a stale/wrong build reads like the app is crashing when it's actually just running the wrong build path, and it cost real diagnostic time.

## What this does

Adds a one-line notice (stderr) when an auto-selected Dockerfile shadows a `Package.swift`:

> Both Package.swift and a Dockerfile/Containerfile were found; building with the Dockerfile. Pass `--build-type swift` to build the Swift package instead.

Wired into both `wendy run` and `wendy build`. The notice stays quiet when:
- the user selected a path explicitly (`--build-type` or `--dockerfile`),
- the Swift path was actually chosen (resolved type ≠ docker), or
- there is no `Package.swift` to be shadowed.

Behavior is otherwise unchanged — Dockerfile precedence was already correct in `detectProjectType` / `resolveDetectedBuildOption`; this only makes it **visible**.

## Tests

- New `TestDetectProjectType_DockerfileTakesPrecedenceOverSwift` — the Swift+Dockerfile pair was previously only covered against Python markers.
- New `TestDockerfilePreferredOverSwiftNotice` table covering all warn/silent branches.
- Full `internal/cli/commands` package suite passes; `gofmt` and `go vet` clean.

## Out of scope (follow-up)

The same report also flagged a **change-detection / stale-cache** issue on the Swift build path (`0 cached, 0 rebuilt` / "No changes detected" after a real `.swift` edit, needing a `wendy.json` version bump to force a fresh build). That's a separate, deeper fingerprint bug and is not addressed here — filing separately. This PR reduces its blast radius by making sure users aren't unknowingly parked on the Swift path when a Dockerfile is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TN5CQ8SiVpzhbx1Cw2zqx