### PR TITLE
fix(agent): create config dir before writing clock_floor at boot

### DIFF
--- a/go/internal/agent/configpartition/apply.go
+++ b/go/internal/agent/configpartition/apply.go
@@ -589,8 +589,10 @@ func Apply(logger *zap.Logger, configPath string) {
 	applyClockFloor(logger, configDir, configPath)
 }
 
-// applyClockFloor copies clock_floor from the config partition directory to
-// the agent config path, so the agent can read it as a startup time floor.
+// applyClockFloor copies clock_floor from cfgDir (the FAT32 config partition,
+// written by the CLI at flash time) into configPath (the agent's private config
+// directory, e.g. /etc/wendy-agent), so the agent can read it as a startup time
+// floor.
 func applyClockFloor(logger *zap.Logger, cfgDir, configPath string) {
 	src := filepath.Join(cfgDir, "clock_floor")
 	data, err := os.ReadFile(src)
@@ -602,14 +604,14 @@ func applyClockFloor(logger *zap.Logger, cfgDir, configPath string) {
 	// and without the floor a no-RTC device boots months in the past.
 	if err := os.MkdirAll(configPath, 0o700); err != nil {
 		if logger != nil {
-			logger.Warn("configpartition: failed to create config dir for clock_floor", zap.Error(err))
+			logger.Error("configpartition: failed to create config dir for clock_floor", zap.Error(err))
 		}
 		return
 	}
 	dst := filepath.Join(configPath, "clock_floor")
-	if err := os.WriteFile(dst, data, 0o644); err != nil {
+	if err := os.WriteFile(dst, data, 0o600); err != nil {
 		if logger != nil {
-			logger.Warn("configpartition: failed to write clock_floor", zap.Error(err))
+			logger.Error("configpartition: failed to write clock_floor", zap.Error(err))
 		}
 	}
 }

--- a/go/internal/agent/configpartition/apply.go
+++ b/go/internal/agent/configpartition/apply.go
@@ -597,6 +597,15 @@ func applyClockFloor(logger *zap.Logger, cfgDir, configPath string) {
 	if err != nil {
 		return // file absent — not an error on images that predate this feature
 	}
+	// The config directory may not exist yet on first boot: provisioning
+	// (which creates it) can run after us or not at all on a fresh image,
+	// and without the floor a no-RTC device boots months in the past.
+	if err := os.MkdirAll(configPath, 0o700); err != nil {
+		if logger != nil {
+			logger.Warn("configpartition: failed to create config dir for clock_floor", zap.Error(err))
+		}
+		return
+	}
 	dst := filepath.Join(configPath, "clock_floor")
 	if err := os.WriteFile(dst, data, 0o644); err != nil {
 		if logger != nil {

--- a/go/internal/agent/configpartition/apply_test.go
+++ b/go/internal/agent/configpartition/apply_test.go
@@ -558,3 +558,37 @@ func TestUpdateAvahiService_UnprovisioningRemovesAssetID(t *testing.T) {
 		t.Errorf("expected assetid TXT record removed from service file:\n%s", got)
 	}
 }
+
+func TestApplyClockFloor_CreatesConfigDir(t *testing.T) {
+	cfgDir := t.TempDir()
+	// Reproduces WDY-1868: on a fresh (or not-yet-provisioned) image the agent
+	// config dir does not exist, and the floor copy must create it rather than
+	// fail — without the floor a no-RTC device boots with a months-old clock.
+	configPath := filepath.Join(t.TempDir(), "subdir", "wendy-agent")
+
+	payload := []byte{0, 0, 0, 0, 0x68, 0x6e, 0xda, 0x80}
+	if err := os.WriteFile(filepath.Join(cfgDir, "clock_floor"), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger, _ := zap.NewDevelopment()
+	applyClockFloor(logger, cfgDir, configPath)
+
+	got, err := os.ReadFile(filepath.Join(configPath, "clock_floor"))
+	if err != nil {
+		t.Fatalf("clock_floor not written to configPath: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("clock_floor content = %v, want %v", got, payload)
+	}
+}
+
+func TestApplyClockFloor_NoFile(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	// Should return without side effects when the partition has no floor file.
+	configPath := filepath.Join(t.TempDir(), "wendy-agent")
+	applyClockFloor(logger, t.TempDir(), configPath)
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Error("configPath should not be created when there is no clock_floor to copy")
+	}
+}

--- a/go/internal/agent/configpartition/apply_test.go
+++ b/go/internal/agent/configpartition/apply_test.go
@@ -566,6 +566,8 @@ func TestApplyClockFloor_CreatesConfigDir(t *testing.T) {
 	// fail — without the floor a no-RTC device boots with a months-old clock.
 	configPath := filepath.Join(t.TempDir(), "subdir", "wendy-agent")
 
+	// 8-byte big-endian Unix-seconds payload (FloorBytes format); the value is
+	// arbitrary — the test only asserts a byte-for-byte copy.
 	payload := []byte{0, 0, 0, 0, 0x68, 0x6e, 0xda, 0x80}
 	if err := os.WriteFile(filepath.Join(cfgDir, "clock_floor"), payload, 0o644); err != nil {
 		t.Fatal(err)
@@ -580,6 +582,17 @@ func TestApplyClockFloor_CreatesConfigDir(t *testing.T) {
 	}
 	if !bytes.Equal(got, payload) {
 		t.Errorf("clock_floor content = %v, want %v", got, payload)
+	}
+
+	if info, err := os.Stat(filepath.Join(configPath, "clock_floor")); err != nil {
+		t.Fatal(err)
+	} else if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("clock_floor mode = %o, want 0600", perm)
+	}
+	if info, err := os.Stat(configPath); err != nil {
+		t.Fatal(err)
+	} else if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("config dir mode = %o, want 0700", perm)
 	}
 }
 


### PR DESCRIPTION
> **In plain terms:** A Raspberry Pi has no battery-backed clock, so Wendy writes a "the time is at least X" file to the SD card when flashing it, and the device is supposed to read it at boot so its clock starts out roughly right. That hand-off has been silently failing — the device booted thinking it was *months in the past*, and until it managed to reach a time server it rejected every secure connection, locking the owner out (part of the WDY-1868 Pi 4 investigation). This fixes the hand-off so the clock floor always lands. It is a *prerequisite*, not the whole cure: the floor is only as fresh as the day the card was flashed, so a device rebooted months later can still be locked out until it reaches a time server — keeping the floor up to date ([WDY-1877](https://linear.app/wendylabsinc/issue/WDY-1877)) and relaxing the lockout rule ([WDY-1878](https://linear.app/wendylabsinc/issue/WDY-1878)) are the follow-ups that finish the job.

## Summary
- `applyClockFloor` wrote into the agent config directory without creating it first; on a fresh (or not-yet-provisioned) image the directory doesn't exist yet, so the copy failed with ENOENT — observed live on the [WDY-1868](https://linear.app/wendylabsinc/issue/WDY-1868) Pi 4 (`configpartition: failed to write clock_floor`, boot clock 2026-03-13 on a boot that really happened 2026-07-09).
- Create the directory first (0o700, matching how provisioning creates it).
- Regression test covers the missing-directory case; a second test pins down that no directory is created when there is no floor file to copy.

## How the directory ends up missing

`/etc/wendy-agent` is only ever created by enrollment-related code
(`WritePEMFiles`, `ensureDeviceKey`, `saveState`), and `configpartition.Apply`
runs before any service starts. Three ways to reach the failing state:

1. **Default "Nearby" flash (the common case).** The device is flashed without
   pre-enrollment: `/config` gets `wendy.conf` + `clock_floor` but no
   `provisioning.json`, so nothing ever creates the directory. The copy fails
   on *every* boot for as long as the device stays unenrolled — which is the
   intended configuration for demo/App Review devices.
2. **Re-flash of a previously enrolled device.** The directory lives on the
   rootfs, so re-flashing WendyOS wipes it; every boot fails until the device
   is re-enrolled. This is what the [WDY-1868](https://linear.app/wendylabsinc/issue/WDY-1868) Pi 4 hit: ENOENT logged at boot
   07:43Z, directory only came into existence when the device was enrolled
   after 08:00Z. (Whether A/B OS updates lose it the same way is [WDY-1884](https://linear.app/wendylabsinc/issue/WDY-1884).)
3. **Pre-enrolled flash is the one path that worked** — `provisioning.json`
   on `/config` makes `applyPreProvisioning` run one line earlier and create
   the directory as a side effect. That masking is why the bug stayed hidden.

This is the first (smallest) fix out of [WDY-1868](https://linear.app/wendylabsinc/issue/WDY-1868); the deeper hardening — persisting the floor after each successful time sync, and the 24-hour skew cap in the mTLS verifier — is tracked separately in the investigation.

Linear: [WDY-1868](https://linear.app/wendylabsinc/issue/WDY-1868/investigate-raspberry-pi-4-reliability-app-deployment-issues)

## Tests
- `go test ./internal/agent/configpartition/`
- `gofmt` / `go vet` clean.
