### PR TITLE
fix(cli): terminate registry TLS locally for deploys over cloud tunnel

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -2098,7 +2098,7 @@ func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentCon
 		if certInfo == nil {
 			return "", false, nil, fmt.Errorf("mTLS connection but no CLI certificates available")
 		}
-		tlsDial, tlsErr := tlsClientDialer(certInfo.PemCertificate, certInfo.PemPrivateKey, dial)
+		tlsDial, tlsErr := tlsClientDialer(certInfo.PemCertificate, certInfo.PemPrivateKey, certInfo.PemCertificateChain, dial)
 		if tlsErr != nil {
 			return "", false, nil, fmt.Errorf("preparing TLS dialer for tunneled registry: %w", tlsErr)
 		}
@@ -2112,12 +2112,49 @@ func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentCon
 	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), false, proxy.Close, nil
 }
 
+// wendyRegistryServerVerifier returns a VerifyConnection callback that
+// chain-validates the registry server's certificate against the Wendy CA.
+//
+// Wendy issues a single mutual-auth identity cert per principal, used for
+// mTLS in both directions; when a device serves its registry it presents
+// that identity cert, which carries clientAuth (mirrored by the agent-side
+// verifier in agent/mtls) and NOT serverAuth. Requiring serverAuth therefore
+// rejects a legitimately trusted device cert, so we accept either
+// authentication EKU — but still require an authentication cert (rejecting
+// e.g. codeSigning/emailProtection leaves) and full chain validation against
+// the Wendy CA. The residual exposure (a clientAuth identity-cert holder
+// impersonating the registry) requires MITM of the loopback-only proxy's
+// connection to the device and is identical to the gRPC channel's trust
+// model; the long-term fix is issuing device registry certs with a
+// serverAuth EKU at the PKI layer.
+func wendyRegistryServerVerifier(caPool *x509.CertPool) func(tls.ConnectionState) error {
+	return func(cs tls.ConnectionState) error {
+		if len(cs.PeerCertificates) == 0 {
+			return fmt.Errorf("server presented no certificates")
+		}
+		intermediates := x509.NewCertPool()
+		for _, c := range cs.PeerCertificates[1:] {
+			intermediates.AddCert(c)
+		}
+		opts := x509.VerifyOptions{
+			Roots:         caPool,
+			Intermediates: intermediates,
+			KeyUsages: []x509.ExtKeyUsage{
+				x509.ExtKeyUsageServerAuth,
+				x509.ExtKeyUsageClientAuth,
+			},
+		}
+		_, err := cs.PeerCertificates[0].Verify(opts)
+		return err
+	}
+}
+
 // tlsClientDialer wraps dial so every connection is upgraded to TLS with the
-// given CLI client certificate before use. Server verification matches
-// startMTLSRegistryProxy: chain validation is skipped because device registry
-// certs are Wendy-CA-signed identity certs that never carry the dialed
-// address as a SAN (pinning is tracked separately).
-func tlsClientDialer(certPEM, keyPEM string, dial func(context.Context) (net.Conn, error)) (func(context.Context) (net.Conn, error), error) {
+// given CLI client certificate before use. Hostname verification is skipped —
+// device registry certs never carry the dialed (loopback/tunnel) address as a
+// SAN — but the server chain is fully validated against the Wendy CA via
+// wendyRegistryServerVerifier, matching startMTLSRegistryHTTPProxy.
+func tlsClientDialer(certPEM, keyPEM, caPEM string, dial func(context.Context) (net.Conn, error)) (func(context.Context) (net.Conn, error), error) {
 	leafPEM, err := certs.LeafCertificatePEM(certPEM)
 	if err != nil {
 		return nil, fmt.Errorf("extracting leaf certificate: %w", err)
@@ -2126,10 +2163,16 @@ func tlsClientDialer(certPEM, keyPEM string, dial func(context.Context) (net.Con
 	if err != nil {
 		return nil, fmt.Errorf("loading client certificate: %w", err)
 	}
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM([]byte(caPEM)) {
+		return nil, fmt.Errorf("no valid CA certificates found in caPEM")
+	}
 	tlsCfg := &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec // device registries use self-signed certs; pinning is tracked separately
+		// Hostname check only; full chain validation happens in VerifyConnection.
+		InsecureSkipVerify: true, //nolint:gosec
 		MinVersion:         tls.VersionTLS12,
 		Certificates:       []tls.Certificate{tlsCert},
+		VerifyConnection:   wendyRegistryServerVerifier(caPool),
 	}
 	return func(ctx context.Context) (net.Conn, error) {
 		raw, dialErr := dial(ctx)
@@ -2220,39 +2263,7 @@ func startMTLSRegistryHTTPProxy(target, certPEM, keyPEM, caPEM string) (*mtlsReg
 				// CA instead.
 				InsecureSkipVerify: true, //nolint:gosec
 				MinVersion:         tls.VersionTLS12,
-				VerifyConnection: func(cs tls.ConnectionState) error {
-					if len(cs.PeerCertificates) == 0 {
-						return fmt.Errorf("server presented no certificates")
-					}
-					intermediates := x509.NewCertPool()
-					for _, c := range cs.PeerCertificates[1:] {
-						intermediates.AddCert(c)
-					}
-					// Wendy issues a single mutual-auth identity cert per principal,
-					// used for mTLS in both directions; when a device serves its
-					// registry it presents that identity cert, which carries
-					// clientAuth (mirrored by the agent-side verifier in
-					// agent/mtls) and NOT serverAuth. Requiring serverAuth therefore
-					// rejects a legitimately trusted device cert, so we accept either
-					// authentication EKU — but still require an authentication cert
-					// (rejecting e.g. codeSigning/emailProtection leaves) and full
-					// chain validation against the Wendy CA. The residual exposure
-					// (a clientAuth identity-cert holder impersonating the registry)
-					// requires MITM of the loopback-only proxy's connection to the
-					// device and is identical to the gRPC channel's trust model; the
-					// long-term fix is issuing device registry certs with a
-					// serverAuth EKU at the PKI layer.
-					opts := x509.VerifyOptions{
-						Roots:         caPool,
-						Intermediates: intermediates,
-						KeyUsages: []x509.ExtKeyUsage{
-							x509.ExtKeyUsageServerAuth,
-							x509.ExtKeyUsageClientAuth,
-						},
-					}
-					_, err := cs.PeerCertificates[0].Verify(opts)
-					return err
-				},
+				VerifyConnection:   wendyRegistryServerVerifier(caPool),
 			},
 		},
 	}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -2080,13 +2080,69 @@ func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentCon
 		return addr, false, addrCleanup, addrErr
 	}
 
-	proxy, proxyErr := startRegistryProxyWithDialer(ctx, "127.0.0.1:0", func(ctx context.Context) (net.Conn, error) {
+	// Cloud tunnel. On a provisioned device the registry itself speaks TLS,
+	// but registry tooling (containertool, Apple Container) treats a
+	// 127.0.0.1 registry as plain HTTP — and the device's Wendy-CA cert
+	// could never verify for the loopback address anyway. So terminate TLS
+	// in the proxy: upgrade each tunneled connection with the CLI's client
+	// certificate and hand the plugin a plain-HTTP loopback address
+	// (swiftUseMTLS=false), mirroring the provisioned-LAN branch above.
+	// Previously the raw TCP forward returned swiftUseMTLS=true, so the
+	// plugin sent plain HTTP straight into the TLS listener and every
+	// tunnel deploy to an enrolled device hung on GET /v2/ (WDY-1868).
+	dial := func(ctx context.Context) (net.Conn, error) {
 		return conn.RegistryDialer(ctx, port)
-	})
+	}
+	if conn.IsMTLS {
+		certInfo := loadCLICert()
+		if certInfo == nil {
+			return "", false, nil, fmt.Errorf("mTLS connection but no CLI certificates available")
+		}
+		tlsDial, tlsErr := tlsClientDialer(certInfo.PemCertificate, certInfo.PemPrivateKey, dial)
+		if tlsErr != nil {
+			return "", false, nil, fmt.Errorf("preparing TLS dialer for tunneled registry: %w", tlsErr)
+		}
+		dial = tlsDial
+	}
+
+	proxy, proxyErr := startRegistryProxyWithDialer(ctx, "127.0.0.1:0", dial)
 	if proxyErr != nil {
 		return "", false, nil, fmt.Errorf("starting cloud registry proxy for Swift: %w", proxyErr)
 	}
-	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), conn.IsMTLS, proxy.Close, nil
+	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), false, proxy.Close, nil
+}
+
+// tlsClientDialer wraps dial so every connection is upgraded to TLS with the
+// given CLI client certificate before use. Server verification matches
+// startMTLSRegistryProxy: chain validation is skipped because device registry
+// certs are Wendy-CA-signed identity certs that never carry the dialed
+// address as a SAN (pinning is tracked separately).
+func tlsClientDialer(certPEM, keyPEM string, dial func(context.Context) (net.Conn, error)) (func(context.Context) (net.Conn, error), error) {
+	leafPEM, err := certs.LeafCertificatePEM(certPEM)
+	if err != nil {
+		return nil, fmt.Errorf("extracting leaf certificate: %w", err)
+	}
+	tlsCert, err := tls.X509KeyPair([]byte(leafPEM), []byte(keyPEM))
+	if err != nil {
+		return nil, fmt.Errorf("loading client certificate: %w", err)
+	}
+	tlsCfg := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // device registries use self-signed certs; pinning is tracked separately
+		MinVersion:         tls.VersionTLS12,
+		Certificates:       []tls.Certificate{tlsCert},
+	}
+	return func(ctx context.Context) (net.Conn, error) {
+		raw, dialErr := dial(ctx)
+		if dialErr != nil {
+			return nil, dialErr
+		}
+		tlsConn := tls.Client(raw, tlsCfg)
+		if hsErr := tlsConn.HandshakeContext(ctx); hsErr != nil {
+			raw.Close()
+			return nil, fmt.Errorf("TLS handshake with device registry: %w", hsErr)
+		}
+		return tlsConn, nil
+	}, nil
 }
 
 func resolveRegistryForAppleContainer(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), useMTLS bool, err error) {

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -2317,3 +2317,48 @@ func TestResolveDockerfile_AutoSelectionRejectsSymlinkEscape(t *testing.T) {
 		t.Fatal("expected error for auto-selected symlink escape, got nil")
 	}
 }
+
+// TestTLSClientDialer_TunneledRegistry reproduces WDY-1868's tunnel-deploy
+// failure: a provisioned device's registry speaks TLS, so a raw TCP forward
+// of the tunnel plus a plain-HTTP push client hangs on GET /v2/. The fix
+// upgrades each tunneled connection to TLS inside the local proxy; this test
+// drives plain HTTP through startRegistryProxyWithDialer + tlsClientDialer
+// against a mutual-TLS registry stand-in and expects 200.
+func TestTLSClientDialer_TunneledRegistry(t *testing.T) {
+	ca := generateTestCA(t)
+	serverLeaf := generateTestLeaf(t, ca, x509.ExtKeyUsageServerAuth)
+	clientLeaf := generateTestLeaf(t, ca, x509.ExtKeyUsageClientAuth)
+
+	serverTLSCert, err := tls.X509KeyPair([]byte(serverLeaf.pemStr), []byte(marshalKeyPEM(t, serverLeaf.key)))
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	// clientCA enforces mutual TLS, asserting the dialer presents the CLI cert.
+	addr := startTestTLSServer(t, serverTLSCert, ca)
+
+	// The "tunnel": a plain TCP dial to the TLS registry, as RegistryDialer does.
+	rawDial := func(ctx context.Context) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+	}
+	dial, err := tlsClientDialer(clientLeaf.pemStr, marshalKeyPEM(t, clientLeaf.key), rawDial)
+	if err != nil {
+		t.Fatalf("tlsClientDialer: %v", err)
+	}
+
+	proxy, err := startRegistryProxyWithDialer(context.Background(), "127.0.0.1:0", dial)
+	if err != nil {
+		t.Fatalf("startRegistryProxyWithDialer: %v", err)
+	}
+	defer proxy.Close()
+
+	resp, err := http.Get("http://" + net.JoinHostPort("127.0.0.1", strconv.Itoa(proxy.Port())) + "/v2/")
+	if err != nil {
+		t.Fatalf("plain-HTTP request through TLS-wrapping proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -2340,7 +2340,7 @@ func TestTLSClientDialer_TunneledRegistry(t *testing.T) {
 	rawDial := func(ctx context.Context) (net.Conn, error) {
 		return (&net.Dialer{}).DialContext(ctx, "tcp", addr)
 	}
-	dial, err := tlsClientDialer(clientLeaf.pemStr, marshalKeyPEM(t, clientLeaf.key), rawDial)
+	dial, err := tlsClientDialer(clientLeaf.pemStr, marshalKeyPEM(t, clientLeaf.key), ca.pemStr, rawDial)
 	if err != nil {
 		t.Fatalf("tlsClientDialer: %v", err)
 	}
@@ -2360,5 +2360,33 @@ func TestTLSClientDialer_TunneledRegistry(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestTLSClientDialer_RejectsWrongCA asserts the dialer's chain validation:
+// a registry presenting a cert from an unrelated CA must fail the handshake
+// rather than receive the CLI's client credential silently.
+func TestTLSClientDialer_RejectsWrongCA(t *testing.T) {
+	serverCA := generateTestCA(t)
+	trustedCA := generateTestCA(t)
+	serverLeaf := generateTestLeaf(t, serverCA, x509.ExtKeyUsageServerAuth)
+	clientLeaf := generateTestLeaf(t, trustedCA, x509.ExtKeyUsageClientAuth)
+
+	serverTLSCert, err := tls.X509KeyPair([]byte(serverLeaf.pemStr), []byte(marshalKeyPEM(t, serverLeaf.key)))
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	addr := startTestTLSServer(t, serverTLSCert, nil)
+
+	rawDial := func(ctx context.Context) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+	}
+	dial, err := tlsClientDialer(clientLeaf.pemStr, marshalKeyPEM(t, clientLeaf.key), trustedCA.pemStr, rawDial)
+	if err != nil {
+		t.Fatalf("tlsClientDialer: %v", err)
+	}
+
+	if _, err := dial(context.Background()); err == nil {
+		t.Fatal("expected handshake failure against a server signed by an untrusted CA")
 	}
 }


### PR DESCRIPTION
> **In plain terms:** Pushing an app image to an enrolled device's registry through the cloud tunnel has been broken since registries went TLS-on-enrollment (April): the registry speaks TLS while the push tooling talks plain HTTP to what it sees as a localhost registry, so the push hangs and times out. In practice this breaks Swift-package deploys over the tunnel entirely, and anyone without Docker — Dockerfile deploys mostly dodge it because their default fast path ships layers over the agent connection instead of the registry, and Apple Container over tunnel was already blocked with a "use docker" error. Deploys over the LAN already handled TLS correctly; the tunnel registry path was the combination that didn't. Found while re-running the WDY-1868 Pi 4 checks over the tunnel; with this fix, the same deploy completes end to end on real hardware.

## Scope — who actually hits this
- **Swift-package projects (no Dockerfile):** always broken over the tunnel — that path pushes via swift-container-plugin to the registry, never chunk-diff.
- **Apple Container builder:** previously hard-rejected over the tunnel ("cannot push directly to an mTLS registry over this connection; use --builder docker"); works with this fix since the resolver now returns a plain-HTTP local endpoint.
- **Dockerfile deploys with Docker:** unaffected in the common case — the default chunk-diff path deploys over agent gRPC; only their registry-push *fallback* was broken (buildx fails cert verification against the raw forward) — split out as [WDY-1887](https://linear.app/wendylabsinc/issue/WDY-1887), out of scope here because buildx needs insecure-registry plumbing rather than a plain-HTTP local proxy.
- Broken since 2026-04-25/29, when TLS-on-provisioning registries and the cloud RegistryDialer first coexisted.

## Summary
- `resolveRegistryForSwiftAgent`'s cloud-tunnel branch forwarded the device registry as **raw TCP** and returned `swiftUseMTLS=true`; containertool (and Apple Container) treat a `127.0.0.1` registry as plain HTTP, so every push against an enrolled device hung on the initial `GET /v2/` (NSURLError -1001, reproduced twice on the WDY-1868 Pi 4). Even HTTPS couldn't work — the device's Wendy-CA identity cert never verifies for the loopback address.
- Fix: upgrade each tunneled connection to TLS with the CLI's client certificate inside the local proxy (new `tlsClientDialer`), and hand the plugin a plain-HTTP loopback address — exactly what the provisioned-LAN branch already does. Server trust matches the LAN path's `startMTLSRegistryHTTPProxy`: hostname verification skipped (device certs never carry the loopback address), full chain validation against the Wendy CA via the shared `wendyRegistryServerVerifier`. Covers the Swift and Apple Container paths (the latter routes through the same resolver).
- Regression test drives plain HTTP through `startRegistryProxyWithDialer` + `tlsClientDialer` against a mutual-TLS registry stand-in.

## Validation
- Live on hardware: fresh-build HelloHTTP deployed over the cloud tunnel to the WDY-1868 Pi 4 (enrolled, on a different WiFi) — push, pull, and run all succeeded; failed with the timeout before the fix.
- `go test ./internal/cli/commands/ -run "TLSClientDialer|MTLSRegistry|RegistryProxy"` green; `gofmt` clean.

Linear: [WDY-1868](https://linear.app/wendylabsinc/issue/WDY-1868) (follow-up found during tunnel re-validation)
