### PR TITLE
feat(cli): wendy device foxglove serve — deploy foxglove_bridge + tunnel

### DIFF
--- a/Examples/FoxgloveBridge/Dockerfile
+++ b/Examples/FoxgloveBridge/Dockerfile
@@ -1,0 +1,12 @@
+# foxglove_bridge as a Wendy app. Runs the upstream ROS 2 node and serves the
+# Foxglove WebSocket on :8765. With host networking (see wendy.json) it joins
+# the device's ROS 2 graph — including a robot's native host ROS 2 (e.g. Go2).
+FROM ros:humble
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ros-humble-foxglove-bridge \
+      ros-humble-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*
+# Add the robot's custom message packages here so their schemas render, e.g.:
+#   ros-humble-unitree-go  (if available via apt)  — otherwise custom types
+#   show up but can't be deserialized by Studio.
+CMD ["bash","-lc","source /opt/ros/humble/setup.bash && exec ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765 address:=0.0.0.0"]

--- a/Examples/FoxgloveBridge/wendy.json
+++ b/Examples/FoxgloveBridge/wendy.json
@@ -1,0 +1,14 @@
+{
+  "appId": "sh.wendy.examples.foxglovebridge",
+  "platform": "linux",
+  "version": "1.0.0",
+  "frameworks": {
+    "ros2": { "domainId": 0, "rmw": "rmw_cyclonedds_cpp", "distro": "humble" }
+  },
+  "entitlements": [
+    { "type": "network", "mode": "host" }
+  ],
+  "services": {
+    "foxglove": { "context": "." }
+  }
+}

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -62,6 +62,7 @@ func newDeviceCmd() *cobra.Command {
 		newDeviceLogsCmd(),
 		newDeviceOSLogsCmd(),
 		newROS2Cmd(),
+		newFoxgloveCmd(),
 		newDeviceDashboardCmd(),
 		newTopCmd(),
 	)

--- a/go/internal/cli/commands/foxglove.go
+++ b/go/internal/cli/commands/foxglove.go
@@ -1,0 +1,181 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+// foxgloveBridgePort is the port foxglove_bridge listens on inside the app.
+const foxgloveBridgePort = 8765
+
+// foxgloveAppID is the appId of the generated foxglove_bridge app; used both in
+// the generated wendy.json and to remove a prior instance before redeploy.
+const foxgloveAppID = "sh.wendy.foxglovebridge"
+
+// newFoxgloveCmd builds the `wendy device foxglove` command group.
+func newFoxgloveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "foxglove",
+		Short: "Bridge the device's ROS 2 graph to Foxglove Studio",
+	}
+	cmd.AddCommand(newFoxgloveServeCmd())
+	return cmd
+}
+
+func newFoxgloveServeCmd() *cobra.Command {
+	var (
+		port   int
+		domain int
+		rmw    string
+		distro string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Deploy foxglove_bridge to the device and open a tunnel for Foxglove Studio",
+		Long: `Generates a foxglove_bridge app, deploys it to the target device with
+'wendy run' (host networking, so it joins the device's ROS 2 graph — including a
+robot's native host ROS 2), then forwards its WebSocket port to your machine.
+
+Connect Foxglove Studio to the printed ws:// URL. For a robot whose ROS 2 uses a
+non-default domain or RMW (e.g. a Unitree Go2 on CycloneDDS), pass --domain and
+--rmw so the bridge matches it.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return foxgloveServe(ctx, foxgloveServeOpts{
+				localPort: port,
+				domain:    domain,
+				rmw:       rmw,
+				distro:    distro,
+				device:    deviceFlag,
+			})
+		},
+	}
+
+	cmd.Flags().IntVar(&port, "port", foxgloveBridgePort, "Local port to forward foxglove_bridge to")
+	cmd.Flags().IntVar(&domain, "domain", 0, "ROS_DOMAIN_ID the device's ROS 2 uses")
+	cmd.Flags().StringVar(&rmw, "rmw", "rmw_cyclonedds_cpp", "RMW implementation the device's ROS 2 uses")
+	cmd.Flags().StringVar(&distro, "distro", "humble", "ROS 2 distro to build foxglove_bridge from")
+
+	return cmd
+}
+
+type foxgloveServeOpts struct {
+	localPort int
+	domain    int
+	rmw       string
+	distro    string
+	device    string // global --device; "" = default device
+}
+
+// foxgloveServe generates a foxglove_bridge app in a temp dir, deploys it to the
+// device via `wendy run --detach`, then forwards the bridge's WebSocket port to
+// localhost via `wendy cloud tunnel`. The tunnel runs until ctx is cancelled.
+func foxgloveServe(ctx context.Context, opts foxgloveServeOpts) error {
+	dir, err := os.MkdirTemp("", "wendy-foxglove-*")
+	if err != nil {
+		return fmt.Errorf("creating temp app dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := writeFoxgloveApp(dir, opts); err != nil {
+		return err
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locating wendy binary: %w", err)
+	}
+
+	// Deploy the app to the device (build locally, push to the device, start
+	// detached). Reuses the full `wendy run` pipeline.
+	//
+	// First best-effort remove any prior foxglove_bridge instance so re-running
+	// is idempotent — a previously-deployed app (it stays running detached after
+	// the tunnel is Ctrl-C'd) otherwise collides on redeploy ("snapshot already
+	// exists"). Errors (e.g. nothing deployed yet) are ignored.
+	rmArgs := []string{"device", "apps", "remove", foxgloveAppID, "--force", "--cleanup"}
+	if opts.device != "" {
+		rmArgs = append(rmArgs, "--device", opts.device)
+	}
+	rm := exec.CommandContext(ctx, self, rmArgs...)
+	_ = rm.Run() // best-effort; ignore "not found" etc.
+
+	cliLogln("Deploying foxglove_bridge to the device...")
+	runArgs := []string{"run", "--detach"}
+	if opts.device != "" {
+		runArgs = append(runArgs, "--device", opts.device)
+	}
+	run := exec.CommandContext(ctx, self, runArgs...)
+	run.Dir = dir
+	run.Stdout = os.Stdout
+	run.Stderr = os.Stderr
+	run.Stdin = os.Stdin
+	if err := run.Run(); err != nil {
+		return fmt.Errorf("deploying foxglove_bridge (wendy run): %w", err)
+	}
+
+	// Forward the bridge's WebSocket port. `cloud tunnel` listens on the local
+	// port and blocks until ctx is cancelled (Ctrl-C).
+	cliSuccess("foxglove_bridge deployed. Connect Foxglove Studio to ws://localhost:%d", opts.localPort)
+	tunArgs := []string{"cloud", "tunnel", fmt.Sprintf("%d:%d", opts.localPort, foxgloveBridgePort)}
+	if opts.device != "" {
+		tunArgs = append(tunArgs, "--device", opts.device)
+	}
+	tun := exec.CommandContext(ctx, self, tunArgs...)
+	tun.Stdout = os.Stdout
+	tun.Stderr = os.Stderr
+	if err := tun.Run(); err != nil {
+		if ctx.Err() != nil {
+			return nil // clean Ctrl-C
+		}
+		return fmt.Errorf("forwarding foxglove_bridge port (wendy cloud tunnel): %w", err)
+	}
+	return nil
+}
+
+// writeFoxgloveApp writes the Dockerfile + wendy.json for a foxglove_bridge app
+// into dir, templated for the requested distro/domain/rmw.
+func writeFoxgloveApp(dir string, opts foxgloveServeOpts) error {
+	dockerfile := fmt.Sprintf(`# Auto-generated by 'wendy device foxglove serve'.
+FROM ros:%[1]s
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ros-%[1]s-foxglove-bridge \
+      ros-%[1]s-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*
+CMD ["bash","-lc","source /opt/ros/%[1]s/setup.bash && exec ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=%[2]d address:=0.0.0.0"]
+`, opts.distro, foxgloveBridgePort)
+
+	wendyJSON := fmt.Sprintf(`{
+  "appId": %[4]q,
+  "platform": "linux",
+  "version": "1.0.0",
+  "frameworks": {
+    "ros2": { "domainId": %[1]d, "rmw": %[2]q, "distro": %[3]q }
+  },
+  "entitlements": [
+    { "type": "network", "mode": "host" }
+  ],
+  "services": {
+    "foxglove": { "context": "." }
+  }
+}
+`, opts.domain, opts.rmw, opts.distro, foxgloveAppID)
+
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		return fmt.Errorf("writing Dockerfile: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "wendy.json"), []byte(wendyJSON), 0o644); err != nil {
+		return fmt.Errorf("writing wendy.json: %w", err)
+	}
+	return nil
+}

--- a/go/internal/cli/commands/foxglove_test.go
+++ b/go/internal/cli/commands/foxglove_test.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteFoxgloveApp(t *testing.T) {
+	dir := t.TempDir()
+	opts := foxgloveServeOpts{domain: 3, rmw: "rmw_cyclonedds_cpp", distro: "humble"}
+	if err := writeFoxgloveApp(dir, opts); err != nil {
+		t.Fatalf("writeFoxgloveApp: %v", err)
+	}
+
+	df, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dfs := string(df)
+	for _, want := range []string{
+		"FROM ros:humble",
+		"ros-humble-foxglove-bridge",
+		"ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765 address:=0.0.0.0",
+	} {
+		if !strings.Contains(dfs, want) {
+			t.Fatalf("Dockerfile missing %q:\n%s", want, dfs)
+		}
+	}
+
+	wj, err := os.ReadFile(filepath.Join(dir, "wendy.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wjs := string(wj)
+	for _, want := range []string{
+		`"domainId": 3`,
+		`"rmw": "rmw_cyclonedds_cpp"`,
+		`"distro": "humble"`,
+		`"type": "network", "mode": "host"`,
+	} {
+		if !strings.Contains(wjs, want) {
+			t.Fatalf("wendy.json missing %q:\n%s", want, wjs)
+		}
+	}
+}
+
+func TestWriteFoxgloveAppDistroTemplated(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFoxgloveApp(dir, foxgloveServeOpts{domain: 0, rmw: "rmw_fastrtps_cpp", distro: "jazzy"}); err != nil {
+		t.Fatal(err)
+	}
+	df, _ := os.ReadFile(filepath.Join(dir, "Dockerfile"))
+	if !strings.Contains(string(df), "FROM ros:jazzy") || !strings.Contains(string(df), "ros-jazzy-foxglove-bridge") {
+		t.Fatalf("distro not templated into Dockerfile:\n%s", df)
+	}
+}

--- a/specs/2026-07-08-foxglove-serve-design.md
+++ b/specs/2026-07-08-foxglove-serve-design.md
@@ -1,0 +1,65 @@
+# `wendy device foxglove serve` — deploy foxglove_bridge + tunnel
+
+**Status:** Shipped (2026-07-08)
+**Branch:** `jo/foxglove-upstream-bridge`
+
+## What it does
+
+`wendy device foxglove serve` bridges a WendyOS device's ROS 2 graph to Foxglove
+Studio by deploying the upstream `foxglove_bridge` node to the device and
+forwarding its WebSocket to the developer's machine. One command:
+
+1. Generates a `foxglove_bridge` app (Dockerfile + `wendy.json`) in a temp dir,
+   templated by `--distro` / `--domain` / `--rmw`. The app uses **host
+   networking** so the container joins the device's ROS 2 graph — including a
+   robot's **native host ROS 2** (e.g. a Unitree Go2 running ROS 2 on its Ubuntu
+   host, not as a Wendy container).
+2. Deploys it with `wendy run --detach` (build locally → push to the device →
+   start), reusing the entire existing deploy pipeline.
+3. Forwards the bridge's WebSocket port with `wendy cloud tunnel <port>:8765`,
+   printing `ws://localhost:<port>` for Foxglove Studio. Runs until Ctrl-C.
+
+The command is a thin orchestrator over `wendy run` + `wendy cloud tunnel`; it
+re-uses proven paths rather than adding agent-side machinery. It best-effort
+removes any prior instance before deploying, so re-runs are idempotent.
+
+## Why this shape
+
+Earlier iterations built an in-agent bridge (a custom `FoxgloveConnect` gRPC
+relay + a Wendy `foxglove_bridge` sidecar image + a host-native launch path).
+That was dropped in favor of the far smaller "generate an app + `wendy run` +
+tunnel" approach, which:
+
+- reuses the mature upstream `foxglove_bridge` (services/params/actions/MCAP,
+  Studio-tested) — nothing reimplemented;
+- reuses the existing deploy + tunnel infrastructure — no proto RPC, no sidecar,
+  no agent changes;
+- handles the host-native robot case via **host networking** on a normal
+  `wendy run` app, which is exactly what a Go2 needs.
+
+## Files
+
+- `go/internal/cli/commands/foxglove.go` — the command + temp-app generation.
+- `go/internal/cli/commands/device.go` — registers it under `device`.
+- `Examples/FoxgloveBridge/` — a standalone reference app equivalent to what the
+  command generates (for users who prefer to `wendy run` it directly).
+
+## Flags
+
+`--port` (local forward port, default 8765), `--domain` (device's
+`ROS_DOMAIN_ID`), `--rmw` (device's RMW; default `rmw_cyclonedds_cpp`),
+`--distro` (ROS distro to build from; default `humble`). Global `--device`
+selects the target.
+
+## Known limitations
+
+- **Custom message types** (e.g. `unitree_*`) render in Studio only if their
+  message packages are added to the generated Dockerfile — the base image ships
+  stock ROS message packages only.
+- **DDS discovery** between the host-networked container and the host's native
+  ROS 2 depends on matching `--domain`/`--rmw` and the host's DDS config; if
+  topics don't appear, that pairing is the first thing to check.
+- The underlying **orphaned-snapshot-on-partial-deploy** rough edge in
+  `wendy run` (a failed deploy can leave a snapshot with no container, colliding
+  on the next create) is worked around here by the idempotent pre-remove; a
+  proper fix belongs in the deploy path.


### PR DESCRIPTION
## Summary

Adds `wendy device foxglove serve`, a thin orchestrator that bridges a WendyOS device's ROS 2 graph to [Foxglove Studio](https://foxglove.dev) with one command:

1. **Generates** a `foxglove_bridge` app (Dockerfile + `wendy.json`) in a temp dir, templated by `--distro` / `--domain` / `--rmw`. The app uses **host networking**, so the container joins the device's ROS 2 graph — including a robot's **native host ROS 2** (e.g. a Unitree Go2 running ROS 2 on its Ubuntu host rather than as a Wendy container).
2. **Deploys** it with `wendy run --detach` (build locally → push → start detached), reusing the entire existing deploy pipeline.
3. **Forwards** the bridge's WebSocket port with `wendy cloud tunnel <port>:8765`, printing `ws://localhost:<port>` for Foxglove Studio. Runs until Ctrl-C.

It best-effort removes any prior instance before redeploy, so re-runs are idempotent.

## Why this shape

Earlier iterations built an in-agent bridge (a custom `FoxgloveConnect` gRPC relay + a Wendy `foxglove_bridge` sidecar image + a host-native launch path). All of that was **dropped** in favor of the much smaller "generate an app + `wendy run` + tunnel" approach, which:

- reuses the mature upstream `foxglove_bridge` (services / params / actions / MCAP, Studio-tested) — nothing reimplemented;
- reuses the existing deploy + tunnel infrastructure — no proto RPC, no sidecar, no agent changes;
- handles the host-native robot case via host networking on a normal `wendy run` app.

## Changes

- `go/internal/cli/commands/foxglove.go` — the command + temp-app generation
- `go/internal/cli/commands/device.go` — registers it under `device`
- `go/internal/cli/commands/foxglove_test.go` — unit tests for app templating
- `Examples/FoxgloveBridge/` — standalone reference app equivalent to what the command generates
- `specs/2026-07-08-foxglove-serve-design.md` — design doc

## Testing

- `go build ./internal/cli/...` ✅
- `go test ./internal/cli/commands/ -run Foxglove` ✅ (`TestWriteFoxgloveApp`, `TestWriteFoxgloveAppDistroTemplated`)
- gofmt / go vet clean
- On-device hardware verification (real robot ROS 2 graph → Studio) still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxF22g5QsyKEM1T9UuSECd