### PR TITLE
fix(cli): stop TUI commands from erasing the user's visible terminal

### DIFF
--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -43,7 +43,9 @@ func newCloudDiscoverCmd() *cobra.Command {
 			}
 
 			m := newCloudDiscoverModel(ctx, auth, brokerURL, all, false, nil)
-			p := tea.NewProgram(m)
+			// Alt screen restores the user's terminal content on exit. The
+			// picker-mode embedding in `wendy cloud tunnel` stays inline.
+			p := tea.NewProgram(m, tea.WithAltScreen())
 			if _, err := p.Run(); err != nil {
 				return fmt.Errorf("TUI error: %w", err)
 			}

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -212,7 +212,9 @@ func noDevicesHint() string {
 func discoverContinuous(ctx context.Context, opts discovery.DiscoveryOptions, includeLocal bool) error {
 	opts.Timeout = 3 * time.Second // per-scan timeout
 	m := newDiscoverModel(ctx, opts, includeLocal)
-	p := tea.NewProgram(m)
+	// Alt screen: the table grows to fill the window, and the alternate
+	// buffer restores the user's terminal content when the TUI exits.
+	p := tea.NewProgram(m, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		return fmt.Errorf("TUI error: %w", err)
 	}

--- a/go/internal/cli/tui/clearscreen_guard_test.go
+++ b/go/internal/cli/tui/clearscreen_guard_test.go
@@ -1,0 +1,81 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This guard exists because of a real incident: BubbleTable.Update once
+// answered tea.WindowSizeMsg with tea.ClearScreen. bubbletea sends a
+// WindowSizeMsg the moment every program starts, so every inline (non
+// alt-screen) TUI — wendy discover, cloud discover, the wifi/bluetooth tables,
+// and every picker — began by emitting CSI 2J, erasing the user's entire
+// visible terminal in place. Content erased that way never reaches scrollback,
+// so whatever the user was looking at was destroyed.
+//
+// Screen-clearing is almost never the right tool in this codebase:
+//   - On resize, bubbletea's standard renderer already invalidates its cache
+//     and repaints every line, erasing leftovers itself.
+//   - Full-screen TUIs should use tea.WithAltScreen(); clearing the alternate
+//     screen is then unnecessary, and the primary screen is restored on exit.
+//
+// If you believe you have a legitimate use (e.g. inside an alt-screen-only
+// program), add the file to the allowlist below with a comment explaining why
+// the user's terminal content is provably not at risk.
+func TestNoScreenClearingInCLISource(t *testing.T) {
+	forbidden := []string{
+		"tea.ClearScreen",
+		"EraseEntireScreen",
+		"\\x1b[2J",
+		"\\033[2J",
+	}
+	allowlist := map[string]bool{
+		// (empty — nothing in internal/cli may clear the user's screen today)
+	}
+
+	cliRoot := ".." // this package lives at internal/cli/tui
+	var violations []string
+	err := filepath.Walk(cliRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, err := filepath.Rel(cliRoot, path)
+		if err != nil {
+			return err
+		}
+		if allowlist[filepath.ToSlash(rel)] {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue // comments may mention the forbidden names
+			}
+			for _, f := range forbidden {
+				if strings.Contains(line, f) {
+					violations = append(violations, fmt.Sprintf("%s:%d: %s (matched %q)",
+						filepath.ToSlash(rel), i+1, strings.TrimSpace(line), f))
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking internal/cli: %v", err)
+	}
+	if len(violations) > 0 {
+		t.Fatalf("screen-clearing escape/command found in internal/cli source; "+
+			"this destroys the user's visible terminal content in inline TUIs "+
+			"(see this test's doc comment for the incident and alternatives):\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}

--- a/go/internal/cli/tui/spinner_test.go
+++ b/go/internal/cli/tui/spinner_test.go
@@ -137,8 +137,11 @@ func TestBubbleTable_CropsWideViewAndScrolls(t *testing.T) {
 	table.SetHeight(3)
 	updated, cmd := table.Update(tea.WindowSizeMsg{Width: 24, Height: 10})
 	table = updated
-	if cmd == nil {
-		t.Fatal("expected resize to request a screen clear")
+	if cmd != nil {
+		// A resize must not trigger commands — in particular not a screen
+		// clear, which destroys the user's visible terminal content (see
+		// TestBubbleTableWindowSizeMsgMustNotClearScreen).
+		t.Fatal("expected resize to request no command")
 	}
 
 	before := table.View()

--- a/go/internal/cli/tui/table.go
+++ b/go/internal/cli/tui/table.go
@@ -92,8 +92,14 @@ func NewBubbleTable(interactive bool, columns []bubbleTable.Column) BubbleTable 
 func (t BubbleTable) Update(msg tea.Msg) (BubbleTable, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		// Never answer a resize with tea.ClearScreen: bubbletea sends a
+		// WindowSizeMsg at every program start, and ClearScreen erases the
+		// user's entire visible terminal in place (CSI 2J) — destroyed lines
+		// never reach scrollback. The renderer already repaints all lines on
+		// WindowSizeMsg, so no command is needed. Guarded by
+		// TestNoScreenClearingInCLISource.
 		t.SetViewportWidth(msg.Width)
-		return t, tea.ClearScreen
+		return t, nil
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "left", "h":

--- a/go/internal/cli/tui/table_test.go
+++ b/go/internal/cli/tui/table_test.go
@@ -1,11 +1,33 @@
 package tui
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
 	bubbleTable "github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
 )
+
+// Regression test for the "wendy discover eats my terminal" bug: bubbletea
+// delivers a WindowSizeMsg at every program start, and BubbleTable.Update used
+// to answer it with tea.ClearScreen. That emits CSI 2J on the primary screen,
+// destroying the user's visible terminal content in place (erased lines never
+// reach scrollback). The renderer already repaints on WindowSizeMsg, so no
+// command is needed here at all.
+func TestBubbleTableWindowSizeMsgMustNotClearScreen(t *testing.T) {
+	cols := []bubbleTable.Column{{Title: "Name", Width: 20}}
+	tbl := NewBubbleTable(true, cols)
+
+	_, cmd := tbl.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	if cmd == nil {
+		return
+	}
+	if msg := cmd(); reflect.TypeOf(msg) == reflect.TypeOf(tea.ClearScreen()) {
+		t.Fatal("BubbleTable.Update answered WindowSizeMsg with tea.ClearScreen; " +
+			"this wipes the user's visible terminal content at TUI startup and on every resize")
+	}
+}
 
 // The underlying bubbles table.SetRows() drives its cursor to -1 whenever it is
 // called with an empty slice, and never restores it once rows reappear. A


### PR DESCRIPTION
## Problem

Users reported Wendy CLI commands "eating" terminal text: run `cat` on something large, run `wendy discover`, quit with `q` — the text that was visible in the viewport is gone, while text above it (already in scrollback) survives.

## Root cause

`tui.BubbleTable.Update` answered every `tea.WindowSizeMsg` with `tea.ClearScreen` (introduced in #811). bubbletea delivers a `WindowSizeMsg` the moment every program starts, so every inline TUI embedding the table — `wendy discover`, `wendy cloud discover`, the wifi/bluetooth tables, and **every picker** — began by emitting `CSI 2J`, which erases the entire visible screen *in place*. Content erased that way never reaches scrollback (only lines scrolled off the top do), so whatever the user was looking at was destroyed. The same wipe re-fired on every terminal resize.

The `ClearScreen` was also redundant: bubbletea's standard renderer already invalidates its cache and repaints every line when it receives a `WindowSizeMsg` (`standard_renderer.go:630` in v1.3.10).

## Fix

- Remove `tea.ClearScreen` from `BubbleTable.Update` — fixes all embedders at once.
- Run `wendy discover` (continuous) and `wendy cloud discover` in the alternate screen buffer, consistent with `device top`/`dashboard`: their tables grow to fill the window, and the alt screen restores the user's terminal content on exit. The picker-mode embedding in `cloud tunnel` stays inline.

## Future-proofing

- `TestBubbleTableWindowSizeMsgMustNotClearScreen` pins the resize contract.
- `TestNoScreenClearingInCLISource` scans all non-test Go sources under `internal/cli` and fails on `tea.ClearScreen`, `EraseEntireScreen`, or raw `CSI 2J` escapes, with the incident documented in its doc comment and an explicit allowlist for any future legitimate use.

## Verification

Emulated 80x24 PTY (pyte with alt-screen semantics): `seq 1 200`, run command, quit, then check scrollback + viewport.

| binary | command | naked 2J | lines lost |
|---|---|---|---|
| pre-fix | `device set-default` (picker) | yes | 23 (all visible rows) |
| fixed | `device set-default` (picker) | no | 0 |
| fixed | `discover` | no (alt screen) | 0, viewport restored on quit |

`gofmt` clean, `go vet` clean, `go test ./internal/cli/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)