### PR TITLE
fix(registry): stop 5-min body timeout from killing large blob uploads

### DIFF
--- a/go/internal/agent/registry/registry.go
+++ b/go/internal/agent/registry/registry.go
@@ -102,12 +102,19 @@ func Start(ctx context.Context, containerdAddr, listenAddr string, logger *zap.L
 		serveListener = tls.NewListener(tcpLis, tlsConfig)
 	}
 
+	// NB: ReadTimeout/WriteTimeout are absolute deadlines on the whole request
+	// body read / whole response body write, NOT idle timeouts. Setting them
+	// caps a single blob transfer to that duration even while bytes are actively
+	// streaming, so a large layer (multi-GB Jetson image) over a slow or tunneled
+	// link gets its connection torn down mid-upload — surfacing to BuildKit as the
+	// misleading "tls: bad record MAC". Leave the body read/write uncapped and use
+	// ReadHeaderTimeout to bound header stalls (slowloris) instead. IdleTimeout
+	// still bounds idle keep-alive connections between requests.
 	srv := &http.Server{
-		Handler:        handler,
-		ReadTimeout:    5 * time.Minute,
-		WriteTimeout:   5 * time.Minute,
-		IdleTimeout:    120 * time.Second,
-		MaxHeaderBytes: 1 << 20,
+		Handler:           handler,
+		ReadHeaderTimeout: 30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20,
 	}
 
 	s := &Server{httpServer: srv, client: client, logger: logger}


### PR DESCRIPTION
## Problem

Large Jetson image pushes to a device fail ~5 minutes after BuildKit begins image export, with the misleading error:

```
tls: bad record MAC
```

## Root cause

The embedded OCI registry configured `ReadTimeout` and `WriteTimeout` to 5 minutes (`go/internal/agent/registry/registry.go`):

```go
ReadTimeout:  5 * time.Minute,
WriteTimeout: 5 * time.Minute,
```

In Go's `net/http`, these are **absolute wall-clock deadlines on the entire request-body read / entire response-body write** — **not** idle timeouts. A multi-GB layer pushed over a slow or tunneled link legitimately takes more than 5 minutes of *continuous* transfer, so `ReadTimeout` fires mid-stream, the TLS connection is torn down, and BuildKit surfaces it as `tls: bad record MAC`. The ~5-minutes-to-failure timing matches the timeout exactly.

`IdleTimeout` (120s) is the only idle-based knob, and it only applies *between* requests on a keep-alive connection — never during a body transfer. So the "5 minutes of no activity" behavior we assumed we had never existed.

## Fix

- Remove the `ReadTimeout`/`WriteTimeout` body caps (upload *and* download — `WriteTimeout` would similarly cut off large pulls).
- Add `ReadHeaderTimeout: 30s` to still bound slowloris-style header stalls — this is the Go-provided knob for exactly this, and it does not cap the body.
- Keep `IdleTimeout` to bound idle keep-alive connections between requests.

## Testing

- `go build ./internal/agent/registry/` — OK
- `go test ./internal/agent/registry/` — pass
- `gofmt` clean

Root-cause credit: Sam / Codex-luna. Not yet verified against a live large-image push on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcW5kMuTpYCKaTipsF6BRS