### PR TITLE
fix(cli): truncate progress hints to terminal width to stop spinner garble

### DIFF
--- a/go/internal/cli/tui/buildsteps.go
+++ b/go/internal/cli/tui/buildsteps.go
@@ -32,6 +32,7 @@ type BuildStepsModel struct {
 	byID    map[int]int
 	spinner spinner.Model
 	hints   hintRotator
+	width   int
 	tally   BuildTally
 	done    bool
 	err     error
@@ -59,6 +60,9 @@ func (m BuildStepsModel) Init() tea.Cmd {
 // Update implements tea.Model.
 func (m BuildStepsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
 	case tea.KeyMsg:
 		if msg.String() == "ctrl+c" {
 			m.done = true
@@ -133,7 +137,7 @@ func (m BuildStepsModel) View() string {
 			sb.WriteString(fmt.Sprintf("  %s %s\n", bsCross.Render("✗"), label))
 		}
 	}
-	if hint := m.hints.view(); hint != "" {
+	if hint := m.hints.view(m.width); hint != "" {
 		sb.WriteString(hint)
 		sb.WriteString("\n")
 	}

--- a/go/internal/cli/tui/hints.go
+++ b/go/internal/cli/tui/hints.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // hintInterval is how often a running progress indicator rotates to a new hint.
@@ -72,9 +73,22 @@ func (r *hintRotator) next() {
 }
 
 // view renders the current hint as a dimmed line, or "" when there is no hint.
-func (r hintRotator) view() string {
+//
+// maxWidth is the terminal width in display columns. When it is > 0 the rendered
+// line is truncated (ANSI-aware, accounting for the width-2 "💡 " prefix) so it
+// occupies exactly one physical row. This matters because Bubble Tea redraws its
+// frames in place by counting logical lines: a hint longer than the terminal
+// width would soft-wrap onto a second physical row that Bubble Tea does not
+// account for, desyncing the redraw and leaving garbled/duplicated spinner
+// lines. A maxWidth <= 0 (no tea.WindowSizeMsg seen yet) disables truncation and
+// preserves the original behavior.
+func (r hintRotator) view(maxWidth int) string {
 	if r.current == "" {
 		return ""
 	}
-	return hintStyle.Render("💡 " + r.current)
+	rendered := hintStyle.Render("💡 " + r.current)
+	if maxWidth > 0 {
+		rendered = ansi.Truncate(rendered, maxWidth, "…")
+	}
+	return rendered
 }

--- a/go/internal/cli/tui/hints_test.go
+++ b/go/internal/cli/tui/hints_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestNewHintRotatorPicksHintFromList(t *testing.T) {
@@ -52,7 +54,7 @@ func TestHintRotatorNextNoopForEmpty(t *testing.T) {
 
 func TestHintRotatorViewRendersHint(t *testing.T) {
 	r := hintRotator{hints: []string{"do a thing"}, current: "do a thing"}
-	v := r.view()
+	v := r.view(0)
 	if !strings.Contains(v, "do a thing") {
 		t.Fatalf("view %q does not contain the hint text", v)
 	}
@@ -63,7 +65,49 @@ func TestHintRotatorViewRendersHint(t *testing.T) {
 
 func TestHintRotatorViewEmptyForNoHint(t *testing.T) {
 	r := hintRotator{}
-	if v := r.view(); v != "" {
+	if v := r.view(0); v != "" {
 		t.Fatalf("expected empty view for empty rotator, got %q", v)
+	}
+}
+
+// TestHintRotatorViewTruncatesToWidth verifies that a hint wider than the given
+// terminal width is truncated so its display width never exceeds that width.
+// Without this, the terminal would soft-wrap the hint onto a second physical
+// row that Bubble Tea does not count, desyncing its in-place frame redraw and
+// leaving garbled/duplicated spinner lines.
+func TestHintRotatorViewTruncatesToWidth(t *testing.T) {
+	long := "Grant hardware access (GPU, camera, GPIO) via entitlements in wendy.json"
+	r := hintRotator{hints: []string{long}, current: long}
+
+	const width = 30
+	v := r.view(width)
+	if got := ansi.StringWidth(v); got > width {
+		t.Fatalf("truncated hint width = %d, want <= %d (view=%q)", got, width, v)
+	}
+	// The rendered line must still be recognizably a hint and must have been
+	// shortened (an ellipsis tail is appended on truncation).
+	if !strings.Contains(v, "💡") {
+		t.Fatalf("truncated view %q lost the hint marker", v)
+	}
+	if !strings.Contains(v, "…") {
+		t.Fatalf("expected truncated view %q to end with an ellipsis", v)
+	}
+}
+
+// TestHintRotatorViewLeavesShortHintIntact verifies that a hint narrower than
+// the given width is not truncated (no ellipsis, full text preserved), and that
+// width 0 (no WindowSizeMsg yet) also leaves it intact.
+func TestHintRotatorViewLeavesShortHintIntact(t *testing.T) {
+	short := "short tip"
+	r := hintRotator{hints: []string{short}, current: short}
+
+	for _, width := range []int{0, 80} {
+		v := r.view(width)
+		if !strings.Contains(v, short) {
+			t.Fatalf("width %d: view %q dropped the hint text", width, v)
+		}
+		if strings.Contains(v, "…") {
+			t.Fatalf("width %d: short hint %q was unexpectedly truncated", width, v)
+		}
 	}
 }

--- a/go/internal/cli/tui/multispinner.go
+++ b/go/internal/cli/tui/multispinner.go
@@ -63,6 +63,7 @@ type MultiSpinnerModel struct {
 	byName  map[string]int
 	spinner spinner.Model
 	hints   hintRotator
+	width   int
 	done    bool
 	err     error
 }
@@ -96,6 +97,10 @@ func (m MultiSpinnerModel) Init() tea.Cmd {
 // Update implements tea.Model.
 func (m MultiSpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
+
 	case tea.KeyMsg:
 		if msg.String() == "ctrl+c" {
 			m.done = true
@@ -207,7 +212,7 @@ func (m MultiSpinnerModel) View() string {
 		}
 	}
 
-	if hint := m.hints.view(); hint != "" {
+	if hint := m.hints.view(m.width); hint != "" {
 		sb.WriteString(hint)
 		sb.WriteString("\n")
 	}

--- a/go/internal/cli/tui/progress.go
+++ b/go/internal/cli/tui/progress.go
@@ -34,6 +34,7 @@ type ProgressModel struct {
 	title    string
 	details  []string
 	hints    hintRotator
+	width    int
 	percent  float64
 	written  int64
 	total    int64
@@ -69,6 +70,10 @@ func (m ProgressModel) Init() tea.Cmd {
 // Update implements tea.Model.
 func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
+
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c":
@@ -139,7 +144,7 @@ func (m ProgressModel) View() string {
 		return fmt.Sprintf("%s\n%s%s%s\n", m.title, details, m.progress.ViewAs(1.0), byteInfo)
 	}
 	out := fmt.Sprintf("%s\n%s%s%s\n", m.title, details, m.progress.ViewAs(m.percent), byteInfo)
-	if hint := m.hints.view(); hint != "" {
+	if hint := m.hints.view(m.width); hint != "" {
 		out += hint + "\n"
 	}
 	return out

--- a/go/internal/cli/tui/spinner.go
+++ b/go/internal/cli/tui/spinner.go
@@ -25,6 +25,7 @@ type SpinnerModel struct {
 	spinner  spinner.Model
 	title    string
 	hints    hintRotator
+	width    int
 	done     bool
 	err      error
 	result   interface{}
@@ -50,6 +51,10 @@ func (m SpinnerModel) Init() tea.Cmd {
 // Update implements tea.Model.
 func (m SpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
+
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c":
@@ -92,7 +97,7 @@ func (m SpinnerModel) View() string {
 		return ""
 	}
 	out := fmt.Sprintf("%s %s\n", m.spinner.View(), m.title)
-	if hint := m.hints.view(); hint != "" {
+	if hint := m.hints.view(m.width); hint != "" {
 		out += hint + "\n"
 	}
 	return out


### PR DESCRIPTION
## The bug

The CLI's interactive progress TUI renders a multi-line frame: a spinner/step line **plus** a rotating `💡 Tip: …` hint line (`go/internal/cli/tui/hints.go`, `hintRotator.view`). Bubble Tea redraws these frames in place by counting **logical** lines.

When a hint string is longer than the terminal width, the terminal soft-wraps it onto **two physical rows**, but Bubble Tea still counts it as **one** line. The in-place redraw then desyncs and leaves garbled/duplicated spinner lines in the user's terminal, e.g.:

```
⣽  Building and pushing image for linux/arm64...
💡 Tip: Grant hardware access (GPU, camera, GPIO) via ent⣻  Building and pushing image for linux/⣟  Building and pushing image for linux/arm64...
```

## The fix

Make every progress model that renders a hint truncate the hint line to the current terminal width so each `View()` line occupies exactly one physical row and never wraps.

- The four models that render hints (`spinner.go`, `progress.go`, `multispinner.go`, `buildsteps.go`) now track terminal width, captured from `tea.WindowSizeMsg` in their `Update` into a new `width int` field.
- `hintRotator.view` takes a `maxWidth` and ANSI-aware-truncates the rendered hint with `ansi.Truncate` (already a dependency used elsewhere in this package), accounting for the width-2 `💡 ` prefix and lipgloss styling so it never cuts mid-escape-sequence.
- When width is `0`/unknown (no `WindowSizeMsg` seen yet), truncation is skipped, preserving the previous behavior.

## Tests

Added focused unit tests in `hints_test.go`:
- a long hint is truncated so its display width (`ansi.StringWidth`) never exceeds the given width, keeps the `💡` marker, and gains an ellipsis tail;
- a short hint is left intact (no ellipsis) at both `width 0` and a wide width.

`go build ./...` and `go test ./internal/cli/tui/...` pass; `gofmt -l` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E74ysReG2W7W3AJMrgnJQo