### PR TITLE
feat(agent): present device client cert to the tunnel broker (mTLS phase 1)

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -429,12 +429,16 @@ func main() {
 			if brokerURL == "" {
 				brokerURL = brokerURLForCloudHost(cloudHost)
 			}
-			_, chainPEM, _ := provisioningSvc.ProvisioningCerts()
+			certPEM, chainPEM, keyData := provisioningSvc.ProvisioningCerts()
+			keyPEM := string(keyData)
+			for i := range keyData {
+				keyData[i] = 0
+			}
 			if chainPEM == "" {
 				logger.Warn("CA chain PEM unavailable; cannot start tunnel broker (re-provision if this persists)")
 				return
 			}
-			client := services.NewTunnelBrokerClient(logger, brokerURL, orgID, assetID, chainPEM, mtlsPortNum)
+			client := services.NewTunnelBrokerClient(logger, brokerURL, orgID, assetID, certPEM, keyPEM, chainPEM, mtlsPortNum)
 			client.Run(ctx)
 		}()
 	}

--- a/go/internal/agent/services/mesh_dialer.go
+++ b/go/internal/agent/services/mesh_dialer.go
@@ -299,7 +299,7 @@ func (d *MeshDialer) meshDialLAN(ctx context.Context, hostport string, deviceID 
 // opening the tunnel; once established the stream survives past ctx.
 func (d *MeshDialer) meshDialBroker(ctx context.Context, deviceID int32, port uint16) (net.Conn, error) {
 	ident := d.identity()
-	opts, md, err := brokerDialOpts(d.logger, ident.orgID, ident.assetID, ident.chainPEM)
+	opts, md, err := brokerDialOpts(d.logger, ident.orgID, ident.assetID, ident.certPEM, ident.keyPEM, ident.chainPEM)
 	if err != nil {
 		return nil, err
 	}

--- a/go/internal/agent/services/tunnel_broker_client.go
+++ b/go/internal/agent/services/tunnel_broker_client.go
@@ -153,30 +153,25 @@ func (c *TunnelBrokerClient) buildDialOpts() ([]grpc.DialOption, metadata.MD, er
 }
 
 // brokerDialOpts returns gRPC dial options and identity metadata for any
-// agent-originated connection to the tunnel broker. Shared by the presence
-// client (serving side) and the mesh dialer (dialing side).
-func brokerDialOpts(logger *zap.Logger, orgID, assetID int32, certPEM, keyPEM, chainPEM string) ([]grpc.DialOption, metadata.MD, error) {
-	// Identity is asserted two ways during the mTLS rollout:
-	//
-	//   1. The device's client certificate (mTLS). We present the ECDSA leaf +
-	//      key below so the broker can authenticate us cryptographically once it
-	//      starts requesting client certs (rollout phase 2). Only the leaf is
-	//      presented, never the ML-DSA CA chain — Go's TLS stack rejects ML-DSA
-	//      certs at parse time, but the leaf itself is ECDSA and parses fine.
-	//   2. The XFCC header (below). Today the broker still runs NoClientCert and
-	//      authenticates on the header, so presenting the cert is a no-op on the
-	//      wire (the server never sends a CertificateRequest). Presenting it now
-	//      makes the deployed fleet ready for the broker to require client certs
-	//      without a flag-day cutover.
-	//
-	// Broker cert CN is localhost and won't match the cloud host — skip hostname
-	// verification but still validate the chain against the Wendy CA.
+// brokerTLSConfig builds the TLS config for a broker connection: it validates
+// the broker's chain against the Wendy CA (hostname verification is skipped —
+// the broker cert CN is localhost, not the cloud host) and presents the
+// device's ECDSA leaf for mTLS.
+//
+// Loading the client cert is non-fatal: today's broker runs NoClientCert and
+// authenticates on the XFCC header, so a failed load still yields a working
+// certless connection. The failure is logged with a stable, greppable
+// event key and an explicit client_cert_presented=false field so the rollout
+// to a cert-requiring broker (phase 2) — where a load failure WILL break
+// authentication — can be alerted on from logs. Extracted from brokerDialOpts
+// so the cert-load / fallback behavior is unit-testable without a live dial.
+func brokerTLSConfig(logger *zap.Logger, certPEM, keyPEM, chainPEM string) (*tls.Config, error) {
 	caPool, err := x509.SystemCertPool()
 	if err != nil {
 		caPool = x509.NewCertPool()
 	}
 	if chainPEM != "" && !caPool.AppendCertsFromPEM([]byte(chainPEM)) {
-		return nil, metadata.MD{}, fmt.Errorf("no valid CA certificates in chainPEM")
+		return nil, fmt.Errorf("no valid CA certificates in chainPEM")
 	}
 	tlsCfg := &tls.Config{
 		InsecureSkipVerify: true, //nolint:gosec
@@ -206,16 +201,41 @@ func brokerDialOpts(logger *zap.Logger, orgID, assetID int32, certPEM, keyPEM, c
 	// Present the device's ECDSA leaf certificate so the broker can authenticate
 	// this connection via mTLS once it starts requesting client certs. Loading
 	// only the leaf (not the ML-DSA CA chain) keeps Go's TLS stack from tripping
-	// over ML-DSA parse failures. A load failure is non-fatal: today's broker
-	// runs NoClientCert and authenticates on the XFCC header, so the connection
-	// still succeeds certless.
+	// over ML-DSA parse failures.
 	if certPEM != "" && keyPEM != "" {
 		if clientCert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM)); err != nil {
 			logger.Warn("failed to load device client certificate for broker mTLS; presenting none (XFCC header identity still applies)",
+				zap.String("event", "broker_mtls_client_cert_load_failed"),
+				zap.Bool("client_cert_presented", false),
 				zap.Error(err))
 		} else {
 			tlsCfg.Certificates = []tls.Certificate{clientCert}
 		}
+	}
+	return tlsCfg, nil
+}
+
+// agent-originated connection to the tunnel broker. Shared by the presence
+// client (serving side) and the mesh dialer (dialing side).
+func brokerDialOpts(logger *zap.Logger, orgID, assetID int32, certPEM, keyPEM, chainPEM string) ([]grpc.DialOption, metadata.MD, error) {
+	// Identity is asserted two ways during the mTLS rollout:
+	//
+	//   1. The device's client certificate (mTLS). We present the ECDSA leaf +
+	//      key below so the broker can authenticate us cryptographically once it
+	//      starts requesting client certs (rollout phase 2). Only the leaf is
+	//      presented, never the ML-DSA CA chain — Go's TLS stack rejects ML-DSA
+	//      certs at parse time, but the leaf itself is ECDSA and parses fine.
+	//   2. The XFCC header (below). Today the broker still runs NoClientCert and
+	//      authenticates on the header, so presenting the cert is a no-op on the
+	//      wire (the server never sends a CertificateRequest). Presenting it now
+	//      makes the deployed fleet ready for the broker to require client certs
+	//      without a flag-day cutover.
+	//
+	// Broker cert CN is localhost and won't match the cloud host — skip hostname
+	// verification but still validate the chain against the Wendy CA.
+	tlsCfg, err := brokerTLSConfig(logger, certPEM, keyPEM, chainPEM)
+	if err != nil {
+		return nil, metadata.MD{}, err
 	}
 
 	certHeader := fmt.Sprintf("URI=urn:wendy:org:%d:asset:%d", orgID, assetID)

--- a/go/internal/agent/services/tunnel_broker_client.go
+++ b/go/internal/agent/services/tunnel_broker_client.go
@@ -36,16 +36,20 @@ type TunnelBrokerClient struct {
 	url      string
 	orgID    int32
 	assetID  int32
+	certPEM  string
+	keyPEM   string
 	chainPEM string
 	mtlsPort int
 }
 
-func NewTunnelBrokerClient(logger *zap.Logger, url string, orgID, assetID int32, chainPEM string, mtlsPort int) *TunnelBrokerClient {
+func NewTunnelBrokerClient(logger *zap.Logger, url string, orgID, assetID int32, certPEM, keyPEM, chainPEM string, mtlsPort int) *TunnelBrokerClient {
 	return &TunnelBrokerClient{
 		logger:   logger,
 		url:      url,
 		orgID:    orgID,
 		assetID:  assetID,
+		certPEM:  certPEM,
+		keyPEM:   keyPEM,
 		chainPEM: chainPEM,
 		mtlsPort: mtlsPort,
 	}
@@ -145,17 +149,25 @@ func (c *TunnelBrokerClient) runOnce(ctx context.Context) error {
 }
 
 func (c *TunnelBrokerClient) buildDialOpts() ([]grpc.DialOption, metadata.MD, error) {
-	return brokerDialOpts(c.logger, c.orgID, c.assetID, c.chainPEM)
+	return brokerDialOpts(c.logger, c.orgID, c.assetID, c.certPEM, c.keyPEM, c.chainPEM)
 }
 
 // brokerDialOpts returns gRPC dial options and identity metadata for any
 // agent-originated connection to the tunnel broker. Shared by the presence
 // client (serving side) and the mesh dialer (dialing side).
-func brokerDialOpts(logger *zap.Logger, orgID, assetID int32, chainPEM string) ([]grpc.DialOption, metadata.MD, error) {
-	// The broker uses tls.NoClientCert because Go's TLS library rejects ML-DSA
-	// client certs (produced by pki-core) at the parsing stage regardless of
-	// ClientAuth level. Identity is verified via the XFCC header at the application
-	// layer instead.
+func brokerDialOpts(logger *zap.Logger, orgID, assetID int32, certPEM, keyPEM, chainPEM string) ([]grpc.DialOption, metadata.MD, error) {
+	// Identity is asserted two ways during the mTLS rollout:
+	//
+	//   1. The device's client certificate (mTLS). We present the ECDSA leaf +
+	//      key below so the broker can authenticate us cryptographically once it
+	//      starts requesting client certs (rollout phase 2). Only the leaf is
+	//      presented, never the ML-DSA CA chain — Go's TLS stack rejects ML-DSA
+	//      certs at parse time, but the leaf itself is ECDSA and parses fine.
+	//   2. The XFCC header (below). Today the broker still runs NoClientCert and
+	//      authenticates on the header, so presenting the cert is a no-op on the
+	//      wire (the server never sends a CertificateRequest). Presenting it now
+	//      makes the deployed fleet ready for the broker to require client certs
+	//      without a flag-day cutover.
 	//
 	// Broker cert CN is localhost and won't match the cloud host — skip hostname
 	// verification but still validate the chain against the Wendy CA.
@@ -190,6 +202,22 @@ func brokerDialOpts(logger *zap.Logger, orgID, assetID int32, chainPEM string) (
 			return err
 		},
 	}
+
+	// Present the device's ECDSA leaf certificate so the broker can authenticate
+	// this connection via mTLS once it starts requesting client certs. Loading
+	// only the leaf (not the ML-DSA CA chain) keeps Go's TLS stack from tripping
+	// over ML-DSA parse failures. A load failure is non-fatal: today's broker
+	// runs NoClientCert and authenticates on the XFCC header, so the connection
+	// still succeeds certless.
+	if certPEM != "" && keyPEM != "" {
+		if clientCert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM)); err != nil {
+			logger.Warn("failed to load device client certificate for broker mTLS; presenting none (XFCC header identity still applies)",
+				zap.Error(err))
+		} else {
+			tlsCfg.Certificates = []tls.Certificate{clientCert}
+		}
+	}
+
 	certHeader := fmt.Sprintf("URI=urn:wendy:org:%d:asset:%d", orgID, assetID)
 	md := metadata.Pairs(
 		"x-wendy-client-cert", certHeader,

--- a/go/internal/agent/services/tunnel_broker_tls_test.go
+++ b/go/internal/agent/services/tunnel_broker_tls_test.go
@@ -1,0 +1,86 @@
+package services
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// ecdsaCertKeyPEM returns a valid self-signed ECDSA leaf cert + key in PEM form.
+func ecdsaCertKeyPEM(t *testing.T) (certPEM, keyPEM string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-device"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("creating cert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshaling key: %v", err)
+	}
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyPEM = string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+	return certPEM, keyPEM
+}
+
+// A valid ECDSA leaf/key is presented as the client certificate.
+func TestBrokerTLSConfig_PresentsValidClientCert(t *testing.T) {
+	certPEM, keyPEM := ecdsaCertKeyPEM(t)
+	cfg, err := brokerTLSConfig(zap.NewNop(), certPEM, keyPEM, "")
+	if err != nil {
+		t.Fatalf("brokerTLSConfig returned error: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("expected 1 client certificate, got %d", len(cfg.Certificates))
+	}
+}
+
+// A malformed key must NOT fail the dial: the broker authenticates on the XFCC
+// header today, so a cert-load failure falls back to presenting no client cert
+// (no error), rather than blocking the connection.
+func TestBrokerTLSConfig_MalformedKeyFallsBackToNoClientCert(t *testing.T) {
+	certPEM, _ := ecdsaCertKeyPEM(t)
+	cfg, err := brokerTLSConfig(zap.NewNop(), certPEM, "-----BEGIN EC PRIVATE KEY-----\nnot a key\n-----END EC PRIVATE KEY-----\n", "")
+	if err != nil {
+		t.Fatalf("cert-load failure must be non-fatal, got error: %v", err)
+	}
+	if len(cfg.Certificates) != 0 {
+		t.Fatalf("expected no client certificate on load failure, got %d", len(cfg.Certificates))
+	}
+}
+
+// With no cert/key material at all, no client cert is presented and no error.
+func TestBrokerTLSConfig_EmptyCertKeyPresentsNoClientCert(t *testing.T) {
+	cfg, err := brokerTLSConfig(zap.NewNop(), "", "", "")
+	if err != nil {
+		t.Fatalf("empty cert/key must be non-fatal, got error: %v", err)
+	}
+	if len(cfg.Certificates) != 0 {
+		t.Fatalf("expected no client certificate, got %d", len(cfg.Certificates))
+	}
+}
+
+// A malformed CA chain is a hard error (the broker's server cert can't be
+// validated without it) — unlike the client-cert fallback.
+func TestBrokerTLSConfig_MalformedChainErrors(t *testing.T) {
+	if _, err := brokerTLSConfig(zap.NewNop(), "", "", "not-a-pem-chain"); err == nil {
+		t.Fatal("expected error for a malformed CA chain, got nil")
+	}
+}


### PR DESCRIPTION
Phase 1 of the broker mTLS rollout designed in #1410 (**agents update first, PKI-Core + broker mTLS next**).

## What
The `wendy-agent` now presents its **ECDSA leaf certificate** on every tunnel-broker connection — `RegisterPresence` / `AgentTunnel` (presence client) and the mesh dialer's `ClientTunnel`. `certPEM`/`keyPEM` are threaded through `brokerDialOpts` and `TunnelBrokerClient`.

## Why it's safe to ship now (no-op on the wire)
Today's broker runs `NoClientCert` and authenticates on the XFCC header, so it never sends a `CertificateRequest` and the cert is **not transmitted** — behavior is unchanged (the `wendy` CLI has presented its cert this way for a while). Presenting it now means that when the broker later starts *requiring* client certs (phase 2), the already-deployed fleet is ready — no flag-day cutover, no stranded agents.

Only the ECDSA leaf is loaded (not the ML-DSA CA chain), so Go's TLS stack doesn't hit ML-DSA parse failures; a key-pair load failure is non-fatal and falls back to header identity.

## Rollout
1. **This PR** — agents present certs (no-op today).
2. Later — PKI-Core + broker requires/verifies client certs and derives identity from the cert instead of the header (see #1410; needs a two-listener broker or optional-client-cert support, since grpc-swift has no request-but-optional mode).

## Test
`go build ./cmd/wendy-agent ./internal/agent/services`, `go vet`, and `go test ./internal/agent/services` all pass; gofmt + `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)