### PR TITLE
feat(mcp): agent-support foundation — annotations, structured results, error codes (PR1/3)

### DIFF
--- a/go/internal/cli/mcp/annotations.go
+++ b/go/internal/cli/mcp/annotations.go
@@ -1,0 +1,27 @@
+package mcp
+
+import mcpgo "github.com/mark3labs/mcp-go/mcp"
+
+// readOnly marks a tool that does not modify device or host state.
+func readOnly() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithReadOnlyHintAnnotation(true)}
+}
+
+// destructive marks a tool that may perform irreversible or disruptive updates.
+func destructive() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{
+		mcpgo.WithDestructiveHintAnnotation(true),
+		mcpgo.WithReadOnlyHintAnnotation(false),
+	}
+}
+
+// idempotent marks a tool where repeated identical calls have no extra effect.
+func idempotent() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithIdempotentHintAnnotation(true)}
+}
+
+// openWorld marks a tool that interacts with external entities (network,
+// nearby radios, cloud broker) whose state the server does not own.
+func openWorld() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithOpenWorldHintAnnotation(true)}
+}

--- a/go/internal/cli/mcp/annotations.go
+++ b/go/internal/cli/mcp/annotations.go
@@ -2,26 +2,61 @@ package mcp
 
 import mcpgo "github.com/mark3labs/mcp-go/mcp"
 
-// readOnly marks a tool that does not modify device or host state.
-func readOnly() []mcpgo.ToolOption {
-	return []mcpgo.ToolOption{mcpgo.WithReadOnlyHintAnnotation(true)}
-}
+// mcp-go's NewTool applies the MCP spec's pessimistic default annotations to
+// every tool: ReadOnlyHint=false, DestructiveHint=true, IdempotentHint=false,
+// OpenWorldHint=true. Relying on "absence" therefore advertises every tool as
+// destructive and open-world. The helpers below set each axis EXPLICITLY so a
+// tool's advertised behavior never depends on those hidden defaults.
+//
+// Convention: every registered tool applies exactly one behavior helper
+// (readOnly / mutating / destructive) and exactly one world helper
+// (localOnly / openWorld); idempotent() is an optional modifier for mutating
+// tools (readOnly already implies idempotent).
 
-// destructive marks a tool that may perform irreversible or disruptive updates.
-func destructive() []mcpgo.ToolOption {
+// readOnly marks a tool that only reads state: not destructive, and idempotent
+// by nature (repeated reads have no additional effect).
+func readOnly() []mcpgo.ToolOption {
 	return []mcpgo.ToolOption{
-		mcpgo.WithDestructiveHintAnnotation(true),
-		mcpgo.WithReadOnlyHintAnnotation(false),
+		mcpgo.WithReadOnlyHintAnnotation(true),
+		mcpgo.WithDestructiveHintAnnotation(false),
+		mcpgo.WithIdempotentHintAnnotation(true),
 	}
 }
 
-// idempotent marks a tool where repeated identical calls have no extra effect.
+// mutating marks a tool that changes state but not destructively — it does not
+// remove or irreversibly alter existing data (e.g. starting an app, connecting).
+func mutating() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{
+		mcpgo.WithReadOnlyHintAnnotation(false),
+		mcpgo.WithDestructiveHintAnnotation(false),
+	}
+}
+
+// destructive marks a tool that may perform irreversible or disruptive updates
+// (e.g. deleting a container, updating the OS, dropping connectivity).
+func destructive() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{
+		mcpgo.WithReadOnlyHintAnnotation(false),
+		mcpgo.WithDestructiveHintAnnotation(true),
+	}
+}
+
+// idempotent marks a mutating tool where repeated identical calls have no extra
+// effect beyond the first. (readOnly already sets this; do not stack the two.)
 func idempotent() []mcpgo.ToolOption {
 	return []mcpgo.ToolOption{mcpgo.WithIdempotentHintAnnotation(true)}
 }
 
-// openWorld marks a tool that interacts with external entities (network,
-// nearby radios, cloud broker) whose state the server does not own.
+// openWorld marks a tool that interacts with an open set of external entities
+// the server does not own — the local network, nearby radios, or the cloud
+// broker (e.g. mDNS scans, Wi-Fi/Bluetooth, cloud discovery).
 func openWorld() []mcpgo.ToolOption {
 	return []mcpgo.ToolOption{mcpgo.WithOpenWorldHintAnnotation(true)}
+}
+
+// localOnly marks a tool whose domain of interaction is closed: it operates
+// only on the connected device or the local host (e.g. device info, container
+// operations, local config).
+func localOnly() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithOpenWorldHintAnnotation(false)}
 }

--- a/go/internal/cli/mcp/annotations_test.go
+++ b/go/internal/cli/mcp/annotations_test.go
@@ -1,0 +1,21 @@
+package mcp
+
+import (
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestAnnotations_ReadOnlyAndDestructive(t *testing.T) {
+	ro := mcpgo.NewTool("t_ro", readOnly()...)
+	if ro.Annotations.ReadOnlyHint == nil || !*ro.Annotations.ReadOnlyHint {
+		t.Error("readOnly() should set ReadOnlyHint=true")
+	}
+	de := mcpgo.NewTool("t_de", destructive()...)
+	if de.Annotations.DestructiveHint == nil || !*de.Annotations.DestructiveHint {
+		t.Error("destructive() should set DestructiveHint=true")
+	}
+	if de.Annotations.ReadOnlyHint == nil || *de.Annotations.ReadOnlyHint {
+		t.Error("destructive() should set ReadOnlyHint=false")
+	}
+}

--- a/go/internal/cli/mcp/annotations_test.go
+++ b/go/internal/cli/mcp/annotations_test.go
@@ -6,16 +6,55 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
 
-func TestAnnotations_ReadOnlyAndDestructive(t *testing.T) {
-	ro := mcpgo.NewTool("t_ro", readOnly()...)
-	if ro.Annotations.ReadOnlyHint == nil || !*ro.Annotations.ReadOnlyHint {
+func boolVal(t *testing.T, p *bool, name string) bool {
+	t.Helper()
+	if p == nil {
+		t.Fatalf("%s hint is nil (unset)", name)
+	}
+	return *p
+}
+
+func TestReadOnly_NotDestructiveAndIdempotent(t *testing.T) {
+	// readOnly must override mcp-go's pessimistic DestructiveHint=true default.
+	tool := mcpgo.NewTool("t_ro", readOnly()...)
+	if !boolVal(t, tool.Annotations.ReadOnlyHint, "ReadOnlyHint") {
 		t.Error("readOnly() should set ReadOnlyHint=true")
 	}
-	de := mcpgo.NewTool("t_de", destructive()...)
-	if de.Annotations.DestructiveHint == nil || !*de.Annotations.DestructiveHint {
+	if boolVal(t, tool.Annotations.DestructiveHint, "DestructiveHint") {
+		t.Error("readOnly() should set DestructiveHint=false")
+	}
+	if !boolVal(t, tool.Annotations.IdempotentHint, "IdempotentHint") {
+		t.Error("readOnly() should set IdempotentHint=true")
+	}
+}
+
+func TestMutating_NotReadOnlyNotDestructive(t *testing.T) {
+	tool := mcpgo.NewTool("t_mu", mutating()...)
+	if boolVal(t, tool.Annotations.ReadOnlyHint, "ReadOnlyHint") {
+		t.Error("mutating() should set ReadOnlyHint=false")
+	}
+	if boolVal(t, tool.Annotations.DestructiveHint, "DestructiveHint") {
+		t.Error("mutating() should set DestructiveHint=false")
+	}
+}
+
+func TestDestructive_ReadOnlyFalseDestructiveTrue(t *testing.T) {
+	tool := mcpgo.NewTool("t_de", destructive()...)
+	if boolVal(t, tool.Annotations.ReadOnlyHint, "ReadOnlyHint") {
+		t.Error("destructive() should set ReadOnlyHint=false")
+	}
+	if !boolVal(t, tool.Annotations.DestructiveHint, "DestructiveHint") {
 		t.Error("destructive() should set DestructiveHint=true")
 	}
-	if de.Annotations.ReadOnlyHint == nil || *de.Annotations.ReadOnlyHint {
-		t.Error("destructive() should set ReadOnlyHint=false")
+}
+
+func TestWorldHints(t *testing.T) {
+	local := mcpgo.NewTool("t_local", localOnly()...)
+	if boolVal(t, local.Annotations.OpenWorldHint, "OpenWorldHint") {
+		t.Error("localOnly() should set OpenWorldHint=false")
+	}
+	open := mcpgo.NewTool("t_open", openWorld()...)
+	if !boolVal(t, open.Annotations.OpenWorldHint, "OpenWorldHint") {
+		t.Error("openWorld() should set OpenWorldHint=true")
 	}
 }

--- a/go/internal/cli/mcp/errors.go
+++ b/go/internal/cli/mcp/errors.go
@@ -1,0 +1,60 @@
+package mcp
+
+import (
+	"fmt"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type errorCode string
+
+const (
+	errCodeNotConnected      errorCode = "NOT_CONNECTED"
+	errCodeInvalidArgument   errorCode = "INVALID_ARGUMENT"
+	errCodeDeviceUnreachable errorCode = "DEVICE_UNREACHABLE"
+	errCodeEntitlementDenied errorCode = "ENTITLEMENT_DENIED"
+	errCodeMultipleSessions  errorCode = "MULTIPLE_SESSIONS"
+	errCodeNotFound          errorCode = "NOT_FOUND"
+	errCodeTimeout           errorCode = "TIMEOUT"
+	errCodeUnsupported       errorCode = "UNSUPPORTED"
+	errCodeInternal          errorCode = "INTERNAL"
+)
+
+// errResult builds an error tool result with a machine-readable code and a
+// human-readable "[CODE] message" text fallback.
+func errResult(code errorCode, msg string) *mcpgo.CallToolResult {
+	r := mcpgo.NewToolResultStructured(
+		map[string]any{"error_code": string(code), "message": msg},
+		fmt.Sprintf("[%s] %s", code, msg),
+	)
+	r.IsError = true
+	return r
+}
+
+func errResultf(code errorCode, format string, a ...any) *mcpgo.CallToolResult {
+	return errResult(code, fmt.Sprintf(format, a...))
+}
+
+// codeFromGRPC maps a gRPC status error to an errorCode.
+func codeFromGRPC(err error) errorCode {
+	st, ok := status.FromError(err)
+	if !ok {
+		return errCodeInternal
+	}
+	switch st.Code() {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return errCodeDeviceUnreachable
+	case codes.PermissionDenied:
+		return errCodeEntitlementDenied
+	case codes.NotFound:
+		return errCodeNotFound
+	case codes.InvalidArgument:
+		return errCodeInvalidArgument
+	case codes.Unimplemented:
+		return errCodeUnsupported
+	default:
+		return errCodeInternal
+	}
+}

--- a/go/internal/cli/mcp/errors_test.go
+++ b/go/internal/cli/mcp/errors_test.go
@@ -1,0 +1,42 @@
+package mcp
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestErrResult_StructuredAndText(t *testing.T) {
+	r := errResult(errCodeNotConnected, "no device connected")
+	if !r.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	sc, ok := r.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map structured content, got %T", r.StructuredContent)
+	}
+	if sc["error_code"] != "NOT_CONNECTED" {
+		t.Errorf("error_code = %v, want NOT_CONNECTED", sc["error_code"])
+	}
+	text := toolResultText(t, r)
+	if text != "[NOT_CONNECTED] no device connected" {
+		t.Errorf("text = %q", text)
+	}
+}
+
+func TestCodeFromGRPC(t *testing.T) {
+	cases := map[codes.Code]errorCode{
+		codes.Unavailable:      errCodeDeviceUnreachable,
+		codes.PermissionDenied: errCodeEntitlementDenied,
+		codes.NotFound:         errCodeNotFound,
+		codes.InvalidArgument:  errCodeInvalidArgument,
+		codes.Unimplemented:    errCodeUnsupported,
+		codes.Internal:         errCodeInternal,
+	}
+	for c, want := range cases {
+		if got := codeFromGRPC(status.Error(c, "x")); got != want {
+			t.Errorf("codeFromGRPC(%v) = %v, want %v", c, got, want)
+		}
+	}
+}

--- a/go/internal/cli/mcp/results.go
+++ b/go/internal/cli/mcp/results.go
@@ -1,0 +1,22 @@
+package mcp
+
+import (
+	"encoding/json"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+// okResult returns a success result carrying v as structuredContent plus an
+// indented-JSON text fallback for hosts that do not render structured content.
+func okResult(v any) *mcpgo.CallToolResult {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResultf(errCodeInternal, "marshaling result: %s", err.Error())
+	}
+	return mcpgo.NewToolResultStructured(v, string(b))
+}
+
+// okText returns a plain-text success result (for simple confirmations).
+func okText(msg string) *mcpgo.CallToolResult {
+	return mcpgo.NewToolResultText(msg)
+}

--- a/go/internal/cli/mcp/results_test.go
+++ b/go/internal/cli/mcp/results_test.go
@@ -1,0 +1,23 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOkResult_HasStructuredAndJSONText(t *testing.T) {
+	r := okResult(map[string]any{"version": "1.2.3"})
+	if r.IsError {
+		t.Fatal("expected success result")
+	}
+	if r.StructuredContent == nil {
+		t.Fatal("expected structured content")
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(toolResultText(t, r)), &m); err != nil {
+		t.Fatalf("text fallback is not valid JSON: %v", err)
+	}
+	if m["version"] != "1.2.3" {
+		t.Errorf("version = %v", m["version"])
+	}
+}

--- a/go/internal/cli/mcp/server.go
+++ b/go/internal/cli/mcp/server.go
@@ -116,7 +116,7 @@ func (s *mcpServer) Start(ctx context.Context) error {
 }
 
 func errNotConnected() *mcpgo.CallToolResult {
-	return mcpgo.NewToolResultError("no device connected — use device_connect first")
+	return errResult(errCodeNotConnected, "no device connected — use device_connect first")
 }
 
 // grpcErrString unwraps a gRPC status error into a human-readable string.

--- a/go/internal/cli/mcp/server_test.go
+++ b/go/internal/cli/mcp/server_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -43,5 +44,8 @@ func TestGuideResource_ReturnsText(t *testing.T) {
 	}
 	if len(tc.Text) < 100 {
 		t.Errorf("expected guide text to be at least 100 chars, got %d", len(tc.Text))
+	}
+	if !strings.Contains(tc.Text, "error_code") {
+		t.Errorf("expected guide text to mention error_code, got %q", tc.Text)
 	}
 }

--- a/go/internal/cli/mcp/tools_bluetooth.go
+++ b/go/internal/cli/mcp/tools_bluetooth.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -13,14 +12,17 @@ import (
 )
 
 func (s *mcpServer) registerBluetoothTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("bluetooth_scan",
+	scanOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Scan for Bluetooth peripherals near the connected device"),
 		mcpgo.WithNumber("timeout_seconds",
 			mcpgo.Description("Scan duration in seconds (default 5)"),
 		),
-	), s.handleBluetoothScan)
+	}
+	scanOpts = append(scanOpts, readOnly()...)
+	scanOpts = append(scanOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("bluetooth_scan", scanOpts...), s.handleBluetoothScan)
 
-	srv.AddTool(mcpgo.NewTool("bluetooth_connect",
+	connectOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Connect to a Bluetooth peripheral by address"),
 		mcpgo.WithString("address",
 			mcpgo.Required(),
@@ -32,15 +34,23 @@ func (s *mcpServer) registerBluetoothTools(srv *server.MCPServer) {
 		mcpgo.WithBoolean("trust",
 			mcpgo.Description("Trust the peripheral after connecting"),
 		),
-	), s.handleBluetoothConnect)
+	}
+	connectOpts = append(connectOpts, mutating()...)
+	connectOpts = append(connectOpts, openWorld()...)
+	connectOpts = append(connectOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("bluetooth_connect", connectOpts...), s.handleBluetoothConnect)
 
-	srv.AddTool(mcpgo.NewTool("bluetooth_disconnect",
+	disconnectOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Disconnect from a Bluetooth peripheral by address"),
 		mcpgo.WithString("address",
 			mcpgo.Required(),
 			mcpgo.Description("Bluetooth peripheral address"),
 		),
-	), s.handleBluetoothDisconnect)
+	}
+	disconnectOpts = append(disconnectOpts, destructive()...)
+	disconnectOpts = append(disconnectOpts, openWorld()...)
+	disconnectOpts = append(disconnectOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("bluetooth_disconnect", disconnectOpts...), s.handleBluetoothDisconnect)
 }
 
 func (s *mcpServer) handleBluetoothScan(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -55,10 +65,10 @@ func (s *mcpServer) handleBluetoothScan(ctx context.Context, req mcpgo.CallToolR
 
 	stream, err := conn.AgentService.ScanBluetoothPeripherals(ctx)
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	if err := stream.Send(&agentpb.ScanBluetoothPeripheralsRequest{}); err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	_ = stream.CloseSend()
 
@@ -72,7 +82,7 @@ func (s *mcpServer) handleBluetoothScan(ctx context.Context, req mcpgo.CallToolR
 			if ctx.Err() != nil {
 				break
 			}
-			return mcpgo.NewToolResultError(grpcErrString(err)), nil
+			return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 		}
 		for _, d := range resp.GetDiscoveredDevices() {
 			seen[d.GetAddress()] = map[string]any{
@@ -94,8 +104,7 @@ func (s *mcpServer) handleBluetoothScan(ctx context.Context, req mcpgo.CallToolR
 	if devices == nil {
 		devices = []map[string]any{}
 	}
-	b, _ := json.MarshalIndent(devices, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(devices), nil
 }
 
 func (s *mcpServer) handleBluetoothConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -105,7 +114,7 @@ func (s *mcpServer) handleBluetoothConnect(ctx context.Context, req mcpgo.CallTo
 	}
 	address := stringParam(req, "address")
 	if address == "" {
-		return mcpgo.NewToolResultError("address is required"), nil
+		return errResult(errCodeInvalidArgument, "address is required"), nil
 	}
 	_, err := conn.AgentService.ConnectBluetoothPeripheral(ctx, &agentpb.ConnectBluetoothPeripheralRequest{
 		Address: address,
@@ -113,9 +122,9 @@ func (s *mcpServer) handleBluetoothConnect(ctx context.Context, req mcpgo.CallTo
 		Trust:   req.GetBool("trust", false),
 	})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return mcpgo.NewToolResultText(fmt.Sprintf("connected to %s", address)), nil
+	return okText(fmt.Sprintf("connected to %s", address)), nil
 }
 
 func (s *mcpServer) handleBluetoothDisconnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -125,13 +134,13 @@ func (s *mcpServer) handleBluetoothDisconnect(ctx context.Context, req mcpgo.Cal
 	}
 	address := stringParam(req, "address")
 	if address == "" {
-		return mcpgo.NewToolResultError("address is required"), nil
+		return errResult(errCodeInvalidArgument, "address is required"), nil
 	}
 	_, err := conn.AgentService.DisconnectBluetoothPeripheral(ctx, &agentpb.DisconnectBluetoothPeripheralRequest{
 		Address: address,
 	})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return mcpgo.NewToolResultText(fmt.Sprintf("disconnected from %s", address)), nil
+	return okText(fmt.Sprintf("disconnected from %s", address)), nil
 }

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -396,7 +396,7 @@ func (s *mcpServer) handleRun(ctx context.Context, req mcpgo.CallToolRequest) (*
 		if text == "" {
 			text = runCtx.Err().Error()
 		}
-		return errResultf(errCodeInternal, "%s", text), nil
+		return errResultf(errCodeTimeout, "%s", text), nil
 	}
 	if err != nil {
 		if text == "" {

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -410,25 +410,14 @@ func (s *mcpServer) handleRun(ctx context.Context, req mcpgo.CallToolRequest) (*
 	return okText(text), nil
 }
 
-// cloudMultipleSessionsErr, cloudAssetNotFoundErr, cloudAssetAmbiguousErr, and
-// cloudAssetCapExceededErr tag specific actionable failure modes so
-// cloudErrResult can map them to a precise error_code without disturbing
-// their human-readable message text.
-type cloudMultipleSessionsErr struct{ msg string }
+// cloudResolveErr is returned by the cloud auth/asset-resolution helpers
+// carrying the precise error_code the MCP layer should surface.
+type cloudResolveErr struct {
+	code errorCode
+	msg  string
+}
 
-func (e *cloudMultipleSessionsErr) Error() string { return e.msg }
-
-type cloudAssetNotFoundErr struct{ msg string }
-
-func (e *cloudAssetNotFoundErr) Error() string { return e.msg }
-
-type cloudAssetAmbiguousErr struct{ msg string }
-
-func (e *cloudAssetAmbiguousErr) Error() string { return e.msg }
-
-type cloudAssetCapExceededErr struct{ msg string }
-
-func (e *cloudAssetCapExceededErr) Error() string { return e.msg }
+func (e *cloudResolveErr) Error() string { return e.msg }
 
 // cloudErrResult maps an error from the cloud auth/asset-resolution helpers
 // (cloudAuthEntry, pickCloudAsset, connectToCloudAgent, mcpListCloudAssets) to
@@ -436,21 +425,9 @@ func (e *cloudAssetCapExceededErr) Error() string { return e.msg }
 // specific code; anything else (including real gRPC errors, which may be
 // wrapped with fmt.Errorf %w) falls back to codeFromGRPC.
 func cloudErrResult(err error) *mcpgo.CallToolResult {
-	var multi *cloudMultipleSessionsErr
-	if errors.As(err, &multi) {
-		return errResult(errCodeMultipleSessions, multi.msg)
-	}
-	var notFound *cloudAssetNotFoundErr
-	if errors.As(err, &notFound) {
-		return errResult(errCodeNotFound, notFound.msg)
-	}
-	var ambiguous *cloudAssetAmbiguousErr
-	if errors.As(err, &ambiguous) {
-		return errResult(errCodeInvalidArgument, ambiguous.msg)
-	}
-	var capExceeded *cloudAssetCapExceededErr
-	if errors.As(err, &capExceeded) {
-		return errResult(errCodeInvalidArgument, capExceeded.msg)
+	var re *cloudResolveErr
+	if errors.As(err, &re) {
+		return errResult(re.code, re.msg)
 	}
 	return errResult(codeFromGRPC(err), grpcErrString(err))
 }
@@ -460,7 +437,7 @@ func (s *mcpServer) cloudAuthEntry(cloudGRPC string) (*config.AuthConfig, error)
 	// persisted default (or errors when several sessions remain ambiguous).
 	auth, err := config.ResolveAuth(s.cfg, cloudGRPC, nil)
 	if errors.Is(err, config.ErrMultipleSessions) {
-		return nil, &cloudMultipleSessionsErr{msg: "multiple auth sessions exist; pass cloud_grpc to select one, or set a default with 'wendy auth use'"}
+		return nil, &cloudResolveErr{code: errCodeMultipleSessions, msg: "multiple auth sessions exist; pass cloud_grpc to select one, or set a default with 'wendy auth use'"}
 	}
 	return auth, err
 }
@@ -537,26 +514,26 @@ func (s *mcpServer) pickCloudAsset(ctx context.Context, auth *config.AuthConfig,
 		return nil, err
 	}
 	if len(assets) == 0 {
-		return nil, &cloudAssetNotFoundErr{msg: "no enrolled devices found for this org; enroll a device with cloud_enroll_device"}
+		return nil, &cloudResolveErr{code: errCodeNotFound, msg: "no enrolled devices found for this org; enroll a device with cloud_enroll_device"}
 	}
 	if deviceName == "" {
 		if len(assets) == 1 {
 			return assets[0], nil
 		}
-		return nil, &cloudAssetAmbiguousErr{msg: "multiple cloud devices found; pass device_name"}
+		return nil, &cloudResolveErr{code: errCodeInvalidArgument, msg: "multiple cloud devices found; pass device_name"}
 	}
 	lower := strings.ToLower(deviceName)
 	var matched *cloudpb.Asset
 	for _, a := range assets {
 		if strings.ToLower(a.GetName()) == lower {
 			if matched != nil {
-				return nil, &cloudAssetAmbiguousErr{msg: fmt.Sprintf("multiple devices match %q; use a more specific name", deviceName)}
+				return nil, &cloudResolveErr{code: errCodeInvalidArgument, msg: fmt.Sprintf("multiple devices match %q; use a more specific name", deviceName)}
 			}
 			matched = a
 		}
 	}
 	if matched == nil {
-		return nil, &cloudAssetNotFoundErr{msg: fmt.Sprintf("no device named %q found; call cloud_discover to list devices", deviceName)}
+		return nil, &cloudResolveErr{code: errCodeNotFound, msg: fmt.Sprintf("no device named %q found; call cloud_discover to list devices", deviceName)}
 	}
 	return matched, nil
 }
@@ -610,7 +587,7 @@ func mcpListCloudAssets(ctx context.Context, auth *config.AuthConfig, filter str
 			return nil, fmt.Errorf("listing devices: %w", err)
 		}
 		if len(assets) >= maxAssets {
-			return nil, &cloudAssetCapExceededErr{msg: fmt.Sprintf("cloud returned more than %d devices", maxAssets)}
+			return nil, &cloudResolveErr{code: errCodeInvalidArgument, msg: fmt.Sprintf("cloud returned more than %d devices", maxAssets)}
 		}
 		assets = append(assets, resp.GetAsset())
 	}

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -63,7 +62,7 @@ func (t *mcpCloudTunnel) Close() error {
 }
 
 func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("cloud_discover",
+	discoverOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("List enrolled cloud devices for the selected Wendy Cloud auth session"),
 		mcpgo.WithString("cloud_grpc",
 			mcpgo.Description("Cloud gRPC endpoint to use (optional when a default session is set via 'wendy auth use')"),
@@ -74,9 +73,12 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithString("filter",
 			mcpgo.Description("Optional cloud-side asset filter"),
 		),
-	), s.handleCloudDiscover)
+	}
+	discoverOpts = append(discoverOpts, readOnly()...)
+	discoverOpts = append(discoverOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("cloud_discover", discoverOpts...), s.handleCloudDiscover)
 
-	srv.AddTool(mcpgo.NewTool("cloud_connect",
+	connectOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Connect the MCP session to a cloud-enrolled device through the Wendy Cloud tunnel"),
 		mcpgo.WithString("device_name",
 			mcpgo.Description("Device name; optional only when exactly one cloud device is available"),
@@ -87,9 +89,13 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithString("broker_url",
 			mcpgo.Description("Tunnel broker host:port (default: cloud :443 endpoint, otherwise <cloud-host>:50052)"),
 		),
-	), s.handleCloudConnect)
+	}
+	connectOpts = append(connectOpts, mutating()...)
+	connectOpts = append(connectOpts, idempotent()...)
+	connectOpts = append(connectOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("cloud_connect", connectOpts...), s.handleCloudConnect)
 
-	srv.AddTool(mcpgo.NewTool("cloud_device_connect",
+	deviceConnectOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Alias for cloud_connect; connects existing MCP device tools through the Wendy Cloud tunnel"),
 		mcpgo.WithString("device_name",
 			mcpgo.Description("Device name; optional only when exactly one cloud device is available"),
@@ -100,9 +106,13 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithString("broker_url",
 			mcpgo.Description("Tunnel broker host:port (default: cloud :443 endpoint, otherwise <cloud-host>:50052)"),
 		),
-	), s.handleCloudConnect)
+	}
+	deviceConnectOpts = append(deviceConnectOpts, mutating()...)
+	deviceConnectOpts = append(deviceConnectOpts, idempotent()...)
+	deviceConnectOpts = append(deviceConnectOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("cloud_device_connect", deviceConnectOpts...), s.handleCloudConnect)
 
-	srv.AddTool(mcpgo.NewTool("cloud_enroll_device",
+	enrollOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Enroll the currently connected device with Wendy Cloud"),
 		mcpgo.WithString("name",
 			mcpgo.Required(),
@@ -111,9 +121,13 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithString("cloud_grpc",
 			mcpgo.Description("Cloud gRPC endpoint to use (optional when a default session is set via 'wendy auth use')"),
 		),
-	), s.handleCloudEnrollDevice)
+	}
+	enrollOpts = append(enrollOpts, mutating()...)
+	enrollOpts = append(enrollOpts, idempotent()...)
+	enrollOpts = append(enrollOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("cloud_enroll_device", enrollOpts...), s.handleCloudEnrollDevice)
 
-	srv.AddTool(mcpgo.NewTool("cloud_tunnel",
+	tunnelOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Forward a local TCP port to a port on a cloud-enrolled device"),
 		mcpgo.WithNumber("local_port",
 			mcpgo.Required(),
@@ -131,9 +145,13 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithString("broker_url",
 			mcpgo.Description("Tunnel broker host:port (default: cloud :443 endpoint, otherwise <cloud-host>:50052)"),
 		),
-	), s.handleCloudTunnel)
+	}
+	tunnelOpts = append(tunnelOpts, mutating()...)
+	tunnelOpts = append(tunnelOpts, idempotent()...)
+	tunnelOpts = append(tunnelOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("cloud_tunnel", tunnelOpts...), s.handleCloudTunnel)
 
-	srv.AddTool(mcpgo.NewTool("run",
+	runOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Build and deploy a local project to a cloud-enrolled device. Runs 'wendy cloud run' with your configured cloud credentials."),
 		mcpgo.WithString("project_path",
 			mcpgo.Required(),
@@ -166,9 +184,12 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("timeout_seconds",
 			mcpgo.Description("Maximum command runtime in seconds (default 300)"),
 		),
-	), s.handleRun)
+	}
+	runOpts = append(runOpts, mutating()...)
+	runOpts = append(runOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("run", runOpts...), s.handleRun)
 
-	srv.AddTool(mcpgo.NewTool("cloud_run",
+	cloudRunOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Deprecated: use run instead. Run 'wendy cloud run' for a local project and return bounded command output"),
 		mcpgo.WithString("project_path",
 			mcpgo.Required(),
@@ -201,34 +222,36 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("timeout_seconds",
 			mcpgo.Description("Maximum command runtime in seconds (default 300)"),
 		),
-	), s.handleRun)
+	}
+	cloudRunOpts = append(cloudRunOpts, mutating()...)
+	cloudRunOpts = append(cloudRunOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("cloud_run", cloudRunOpts...), s.handleRun)
 }
 
 func (s *mcpServer) handleCloudDiscover(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	auth, err := s.cloudAuthEntry(stringParam(req, "cloud_grpc"))
 	if err != nil {
-		return mcpgo.NewToolResultError(err.Error()), nil
+		return cloudErrResult(err), nil
 	}
 	assets, err := mcpListCloudAssets(ctx, auth, stringParam(req, "filter"), req.GetBool("online_only", true))
 	if err != nil {
-		return mcpgo.NewToolResultError(err.Error()), nil
+		return cloudErrResult(err), nil
 	}
 	out := make([]map[string]any, 0, len(assets))
 	for _, a := range assets {
 		out = append(out, cloudAssetToMap(a))
 	}
-	b, _ := json.MarshalIndent(out, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(out), nil
 }
 
 func (s *mcpServer) handleCloudConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	conn, asset, err := s.connectToCloudAgent(ctx, stringParam(req, "cloud_grpc"), stringParam(req, "device_name"), stringParam(req, "broker_url"))
 	if err != nil {
-		return mcpgo.NewToolResultError(err.Error()), nil
+		return cloudErrResult(err), nil
 	}
 	s.SetConn(conn)
 	s.SetConnType("cloud")
-	return mcpgo.NewToolResultText(fmt.Sprintf("connected to %s via cloud", asset.GetName())), nil
+	return okText(fmt.Sprintf("connected to %s via cloud", asset.GetName())), nil
 }
 
 func (s *mcpServer) handleCloudEnrollDevice(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -238,15 +261,15 @@ func (s *mcpServer) handleCloudEnrollDevice(ctx context.Context, req mcpgo.CallT
 	}
 	name := stringParam(req, "name")
 	if name == "" {
-		return mcpgo.NewToolResultError("name is required"), nil
+		return errResult(errCodeInvalidArgument, "name is required"), nil
 	}
 	auth, err := s.cloudAuthEntry(stringParam(req, "cloud_grpc"))
 	if err != nil {
-		return mcpgo.NewToolResultError(err.Error()), nil
+		return cloudErrResult(err), nil
 	}
 	tokenResp, err := mcpCreateAssetEnrollmentToken(ctx, auth, name)
 	if err != nil {
-		return mcpgo.NewToolResultError(err.Error()), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	_, err = conn.ProvisioningService.StartProvisioning(ctx, &agentpb.StartProvisioningRequest{
 		OrganizationId:  tokenResp.GetOrganizationId(),
@@ -255,45 +278,44 @@ func (s *mcpServer) handleCloudEnrollDevice(ctx context.Context, req mcpgo.CallT
 		CloudHost:       auth.CloudGRPC,
 	})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	out := map[string]any{
 		"organization_id": tokenResp.GetOrganizationId(),
 		"asset_id":        tokenResp.GetAssetId(),
 		"cloud_host":      auth.CloudGRPC,
 	}
-	b, _ := json.MarshalIndent(out, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(out), nil
 }
 
 func (s *mcpServer) handleCloudTunnel(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	localPort := intParam(req, "local_port", 0)
 	remotePort := intParam(req, "remote_port", localPort)
 	if err := validatePort(localPort); err != nil {
-		return mcpgo.NewToolResultError("local_port " + err.Error()), nil
+		return errResult(errCodeInvalidArgument, "local_port "+err.Error()), nil
 	}
 	if err := validatePort(remotePort); err != nil {
-		return mcpgo.NewToolResultError("remote_port " + err.Error()), nil
+		return errResult(errCodeInvalidArgument, "remote_port "+err.Error()), nil
 	}
 
 	auth, err := s.cloudAuthEntry(stringParam(req, "cloud_grpc"))
 	if err != nil {
-		return mcpgo.NewToolResultError(err.Error()), nil
+		return cloudErrResult(err), nil
 	}
 	asset, err := s.pickCloudAsset(ctx, auth, stringParam(req, "device_name"))
 	if err != nil {
-		return mcpgo.NewToolResultError(err.Error()), nil
+		return cloudErrResult(err), nil
 	}
 	brokerConn, err := mcpDialCloudBroker(auth, stringParam(req, "broker_url"))
 	if err != nil {
-		return mcpgo.NewToolResultError(err.Error()), nil
+		return errResult(errCodeDeviceUnreachable, err.Error()), nil
 	}
 
 	listenAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(localPort))
 	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		_ = brokerConn.Close()
-		return mcpgo.NewToolResultError(fmt.Sprintf("listening on %s: %s", listenAddr, err.Error())), nil
+		return errResultf(errCodeInternal, "listening on %s: %s", listenAddr, err.Error()), nil
 	}
 	tunnelCtx, cancel := context.WithCancel(context.Background())
 	tunnel := &mcpCloudTunnel{cancel: cancel, listener: ln, brokerConn: brokerConn}
@@ -322,14 +344,13 @@ func (s *mcpServer) handleCloudTunnel(ctx context.Context, req mcpgo.CallToolReq
 		"asset_id":    asset.GetId(),
 		"remote_port": remotePort,
 	}
-	b, _ := json.MarshalIndent(out, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(out), nil
 }
 
 func (s *mcpServer) handleRun(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	projectPath := stringParam(req, "project_path")
 	if projectPath == "" {
-		return mcpgo.NewToolResultError("project_path is required"), nil
+		return errResult(errCodeInvalidArgument, "project_path is required"), nil
 	}
 	timeout := time.Duration(intParam(req, "timeout_seconds", 300)) * time.Second
 	if timeout <= 0 {
@@ -375,18 +396,63 @@ func (s *mcpServer) handleRun(ctx context.Context, req mcpgo.CallToolRequest) (*
 		if text == "" {
 			text = runCtx.Err().Error()
 		}
-		return mcpgo.NewToolResultError(text), nil
+		return errResultf(errCodeInternal, "%s", text), nil
 	}
 	if err != nil {
 		if text == "" {
 			text = err.Error()
 		}
-		return mcpgo.NewToolResultError(text), nil
+		return errResultf(errCodeInternal, "%s", text), nil
 	}
 	if text == "" {
 		text = "cloud run completed"
 	}
-	return mcpgo.NewToolResultText(text), nil
+	return okText(text), nil
+}
+
+// cloudMultipleSessionsErr, cloudAssetNotFoundErr, cloudAssetAmbiguousErr, and
+// cloudAssetCapExceededErr tag specific actionable failure modes so
+// cloudErrResult can map them to a precise error_code without disturbing
+// their human-readable message text.
+type cloudMultipleSessionsErr struct{ msg string }
+
+func (e *cloudMultipleSessionsErr) Error() string { return e.msg }
+
+type cloudAssetNotFoundErr struct{ msg string }
+
+func (e *cloudAssetNotFoundErr) Error() string { return e.msg }
+
+type cloudAssetAmbiguousErr struct{ msg string }
+
+func (e *cloudAssetAmbiguousErr) Error() string { return e.msg }
+
+type cloudAssetCapExceededErr struct{ msg string }
+
+func (e *cloudAssetCapExceededErr) Error() string { return e.msg }
+
+// cloudErrResult maps an error from the cloud auth/asset-resolution helpers
+// (cloudAuthEntry, pickCloudAsset, connectToCloudAgent, mcpListCloudAssets) to
+// an MCP error result with the correct error_code. Tagged errors get their
+// specific code; anything else (including real gRPC errors, which may be
+// wrapped with fmt.Errorf %w) falls back to codeFromGRPC.
+func cloudErrResult(err error) *mcpgo.CallToolResult {
+	var multi *cloudMultipleSessionsErr
+	if errors.As(err, &multi) {
+		return errResult(errCodeMultipleSessions, multi.msg)
+	}
+	var notFound *cloudAssetNotFoundErr
+	if errors.As(err, &notFound) {
+		return errResult(errCodeNotFound, notFound.msg)
+	}
+	var ambiguous *cloudAssetAmbiguousErr
+	if errors.As(err, &ambiguous) {
+		return errResult(errCodeInvalidArgument, ambiguous.msg)
+	}
+	var capExceeded *cloudAssetCapExceededErr
+	if errors.As(err, &capExceeded) {
+		return errResult(errCodeInvalidArgument, capExceeded.msg)
+	}
+	return errResult(codeFromGRPC(err), grpcErrString(err))
 }
 
 func (s *mcpServer) cloudAuthEntry(cloudGRPC string) (*config.AuthConfig, error) {
@@ -394,7 +460,7 @@ func (s *mcpServer) cloudAuthEntry(cloudGRPC string) (*config.AuthConfig, error)
 	// persisted default (or errors when several sessions remain ambiguous).
 	auth, err := config.ResolveAuth(s.cfg, cloudGRPC, nil)
 	if errors.Is(err, config.ErrMultipleSessions) {
-		return nil, fmt.Errorf("multiple auth sessions exist; pass cloud_grpc to select one, or set a default with 'wendy auth use'")
+		return nil, &cloudMultipleSessionsErr{msg: "multiple auth sessions exist; pass cloud_grpc to select one, or set a default with 'wendy auth use'"}
 	}
 	return auth, err
 }
@@ -471,26 +537,26 @@ func (s *mcpServer) pickCloudAsset(ctx context.Context, auth *config.AuthConfig,
 		return nil, err
 	}
 	if len(assets) == 0 {
-		return nil, fmt.Errorf("no enrolled devices found for this org; enroll a device with cloud_enroll_device")
+		return nil, &cloudAssetNotFoundErr{msg: "no enrolled devices found for this org; enroll a device with cloud_enroll_device"}
 	}
 	if deviceName == "" {
 		if len(assets) == 1 {
 			return assets[0], nil
 		}
-		return nil, fmt.Errorf("multiple cloud devices found; pass device_name")
+		return nil, &cloudAssetAmbiguousErr{msg: "multiple cloud devices found; pass device_name"}
 	}
 	lower := strings.ToLower(deviceName)
 	var matched *cloudpb.Asset
 	for _, a := range assets {
 		if strings.ToLower(a.GetName()) == lower {
 			if matched != nil {
-				return nil, fmt.Errorf("multiple devices match %q; use a more specific name", deviceName)
+				return nil, &cloudAssetAmbiguousErr{msg: fmt.Sprintf("multiple devices match %q; use a more specific name", deviceName)}
 			}
 			matched = a
 		}
 	}
 	if matched == nil {
-		return nil, fmt.Errorf("no device named %q found; call cloud_discover to list devices", deviceName)
+		return nil, &cloudAssetNotFoundErr{msg: fmt.Sprintf("no device named %q found; call cloud_discover to list devices", deviceName)}
 	}
 	return matched, nil
 }
@@ -544,7 +610,7 @@ func mcpListCloudAssets(ctx context.Context, auth *config.AuthConfig, filter str
 			return nil, fmt.Errorf("listing devices: %w", err)
 		}
 		if len(assets) >= maxAssets {
-			return nil, fmt.Errorf("cloud returned more than %d devices", maxAssets)
+			return nil, &cloudAssetCapExceededErr{msg: fmt.Sprintf("cloud returned more than %d devices", maxAssets)}
 		}
 		assets = append(assets, resp.GetAsset())
 	}

--- a/go/internal/cli/mcp/tools_cloud_test.go
+++ b/go/internal/cli/mcp/tools_cloud_test.go
@@ -90,6 +90,63 @@ func TestCloudDiscover_ReturnsConfiguredCloudDevices(t *testing.T) {
 	}
 }
 
+func TestCloudDiscover_HasStructuredContent(t *testing.T) {
+	fake := &fakeCloudAssetServer{
+		assets: []*cloudpb.Asset{
+			{
+				Id:              42,
+				OrganizationId:  7,
+				Name:            "edge-one",
+				AssetType:       "device",
+				IsComputeDevice: true,
+			},
+		},
+	}
+	addr := startFakeCloudAssetServer(t, fake)
+	srv := New(&config.Config{
+		Auth: []config.AuthConfig{{
+			CloudGRPC: addr,
+			Certificates: []config.CertificateInfo{{
+				OrganizationID: 7,
+			}},
+		}},
+	}, nil)
+
+	result, err := srv.callTool(context.Background(), "cloud_discover", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("cloud_discover should return structuredContent")
+	}
+}
+
+func TestCloud_MultipleSessions_Code(t *testing.T) {
+	srv := New(&config.Config{
+		Auth: []config.AuthConfig{
+			{CloudGRPC: "one:123", Certificates: []config.CertificateInfo{{OrganizationID: 1}}},
+			{CloudGRPC: "two:123", Certificates: []config.CertificateInfo{{OrganizationID: 1}}},
+		},
+	}, nil)
+	result, err := srv.callTool(context.Background(), "cloud_discover", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result")
+	}
+	sc, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map structured content, got %T", result.StructuredContent)
+	}
+	if sc["error_code"] != string(errCodeMultipleSessions) {
+		t.Errorf("error_code = %v, want %s", sc["error_code"], errCodeMultipleSessions)
+	}
+}
+
 func TestCloudDiscover_RequiresAuth(t *testing.T) {
 	srv := New(&config.Config{}, nil)
 	result, err := srv.callTool(context.Background(), "cloud_discover", nil)

--- a/go/internal/cli/mcp/tools_container.go
+++ b/go/internal/cli/mcp/tools_container.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -14,9 +13,11 @@ import (
 )
 
 func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("container_list",
+	listOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("List all containers on the connected device"),
-	), s.handleContainerList)
+	}
+	listOpts = append(listOpts, readOnly()...)
+	srv.AddTool(mcpgo.NewTool("container_list", listOpts...), s.handleContainerList)
 
 	srv.AddTool(mcpgo.NewTool("container_start",
 		mcpgo.WithDescription("Start a container and stream its output (bounded snapshot)"),
@@ -26,15 +27,18 @@ func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
 		),
 	), s.handleContainerStart)
 
-	srv.AddTool(mcpgo.NewTool("container_stop",
+	stopOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Stop a running container"),
 		mcpgo.WithString("app_name",
 			mcpgo.Required(),
 			mcpgo.Description("App name of the container to stop"),
 		),
-	), s.handleContainerStop)
+	}
+	stopOpts = append(stopOpts, destructive()...)
+	stopOpts = append(stopOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("container_stop", stopOpts...), s.handleContainerStop)
 
-	srv.AddTool(mcpgo.NewTool("container_delete",
+	deleteOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Delete a container, optionally removing its image and volumes"),
 		mcpgo.WithString("app_name",
 			mcpgo.Required(),
@@ -46,13 +50,18 @@ func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
 		mcpgo.WithBoolean("delete_volumes",
 			mcpgo.Description("Also delete persistent volumes"),
 		),
-	), s.handleContainerDelete)
+	}
+	deleteOpts = append(deleteOpts, destructive()...)
+	deleteOpts = append(deleteOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("container_delete", deleteOpts...), s.handleContainerDelete)
 
-	srv.AddTool(mcpgo.NewTool("container_stats",
+	statsOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Get memory and storage stats for all containers"),
-	), s.handleContainerStats)
+	}
+	statsOpts = append(statsOpts, readOnly()...)
+	srv.AddTool(mcpgo.NewTool("container_stats", statsOpts...), s.handleContainerStats)
 
-	srv.AddTool(mcpgo.NewTool("container_attach",
+	attachOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Attach to a running container and collect a bounded snapshot of its output"),
 		mcpgo.WithString("app_name",
 			mcpgo.Required(),
@@ -61,7 +70,9 @@ func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("max_lines",
 			mcpgo.Description("Maximum output chunks to collect (default 100)"),
 		),
-	), s.handleContainerAttach)
+	}
+	attachOpts = append(attachOpts, readOnly()...)
+	srv.AddTool(mcpgo.NewTool("container_attach", attachOpts...), s.handleContainerAttach)
 }
 
 func (s *mcpServer) handleContainerList(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -71,7 +82,7 @@ func (s *mcpServer) handleContainerList(ctx context.Context, _ mcpgo.CallToolReq
 	}
 	stream, err := conn.ContainerService.ListContainers(ctx, &agentpb.ListContainersRequest{})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	var containers []map[string]any
 	for {
@@ -80,7 +91,7 @@ func (s *mcpServer) handleContainerList(ctx context.Context, _ mcpgo.CallToolReq
 			break
 		}
 		if err != nil {
-			return mcpgo.NewToolResultError(grpcErrString(err)), nil
+			return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 		}
 		c := resp.GetContainer()
 		if c == nil {
@@ -103,8 +114,7 @@ func (s *mcpServer) handleContainerList(ctx context.Context, _ mcpgo.CallToolReq
 	if containers == nil {
 		containers = []map[string]any{}
 	}
-	b, _ := json.MarshalIndent(containers, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(containers), nil
 }
 
 func (s *mcpServer) handleContainerStart(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -114,7 +124,7 @@ func (s *mcpServer) handleContainerStart(ctx context.Context, req mcpgo.CallTool
 	}
 	appName := stringParam(req, "app_name")
 	if appName == "" {
-		return mcpgo.NewToolResultError("app_name is required"), nil
+		return errResult(errCodeInvalidArgument, "app_name is required"), nil
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -122,7 +132,7 @@ func (s *mcpServer) handleContainerStart(ctx context.Context, req mcpgo.CallTool
 
 	stream, err := conn.ContainerService.StartContainer(ctx, &agentpb.StartContainerRequest{AppName: appName})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	var sb strings.Builder
 	chunks := 0
@@ -135,7 +145,7 @@ func (s *mcpServer) handleContainerStart(ctx context.Context, req mcpgo.CallTool
 			if ctx.Err() != nil {
 				break
 			}
-			return mcpgo.NewToolResultError(grpcErrString(err)), nil
+			return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 		}
 		switch resp.ResponseType.(type) {
 		case *agentpb.RunContainerLayersResponse_StdoutOutput:
@@ -150,7 +160,7 @@ func (s *mcpServer) handleContainerStart(ctx context.Context, req mcpgo.CallTool
 	if out == "" {
 		out = fmt.Sprintf("container %s started", appName)
 	}
-	return mcpgo.NewToolResultText(out), nil
+	return okText(out), nil
 }
 
 func (s *mcpServer) handleContainerStop(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -160,13 +170,13 @@ func (s *mcpServer) handleContainerStop(ctx context.Context, req mcpgo.CallToolR
 	}
 	appName := stringParam(req, "app_name")
 	if appName == "" {
-		return mcpgo.NewToolResultError("app_name is required"), nil
+		return errResult(errCodeInvalidArgument, "app_name is required"), nil
 	}
 	_, err := conn.ContainerService.StopContainer(ctx, &agentpb.StopContainerRequest{AppName: appName})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return mcpgo.NewToolResultText(fmt.Sprintf("container %s stopped", appName)), nil
+	return okText(fmt.Sprintf("container %s stopped", appName)), nil
 }
 
 func (s *mcpServer) handleContainerDelete(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -176,7 +186,7 @@ func (s *mcpServer) handleContainerDelete(ctx context.Context, req mcpgo.CallToo
 	}
 	appName := stringParam(req, "app_name")
 	if appName == "" {
-		return mcpgo.NewToolResultError("app_name is required"), nil
+		return errResult(errCodeInvalidArgument, "app_name is required"), nil
 	}
 	_, err := conn.ContainerService.DeleteContainer(ctx, &agentpb.DeleteContainerRequest{
 		AppName:       appName,
@@ -184,9 +194,9 @@ func (s *mcpServer) handleContainerDelete(ctx context.Context, req mcpgo.CallToo
 		DeleteVolumes: req.GetBool("delete_volumes", false),
 	})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return mcpgo.NewToolResultText(fmt.Sprintf("container %s deleted", appName)), nil
+	return okText(fmt.Sprintf("container %s deleted", appName)), nil
 }
 
 func (s *mcpServer) handleContainerStats(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -196,7 +206,7 @@ func (s *mcpServer) handleContainerStats(ctx context.Context, _ mcpgo.CallToolRe
 	}
 	resp, err := conn.ContainerService.ListContainerStats(ctx, &agentpb.ListContainerStatsRequest{})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	var stats []map[string]any
 	for _, cs := range resp.GetStats() {
@@ -209,8 +219,7 @@ func (s *mcpServer) handleContainerStats(ctx context.Context, _ mcpgo.CallToolRe
 	if stats == nil {
 		stats = []map[string]any{}
 	}
-	b, _ := json.MarshalIndent(stats, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(stats), nil
 }
 
 func (s *mcpServer) handleContainerAttach(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -220,7 +229,7 @@ func (s *mcpServer) handleContainerAttach(ctx context.Context, req mcpgo.CallToo
 	}
 	appName := stringParam(req, "app_name")
 	if appName == "" {
-		return mcpgo.NewToolResultError("app_name is required"), nil
+		return errResult(errCodeInvalidArgument, "app_name is required"), nil
 	}
 	maxChunks := intParam(req, "max_lines", 100)
 
@@ -229,12 +238,12 @@ func (s *mcpServer) handleContainerAttach(ctx context.Context, req mcpgo.CallToo
 
 	stream, err := conn.ContainerService.AttachContainer(ctx)
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	if err := stream.Send(&agentpb.AttachContainerRequest{
 		RequestType: &agentpb.AttachContainerRequest_AppName{AppName: appName},
 	}); err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	_ = stream.CloseSend()
 
@@ -249,7 +258,7 @@ func (s *mcpServer) handleContainerAttach(ctx context.Context, req mcpgo.CallToo
 			if ctx.Err() != nil {
 				break
 			}
-			return mcpgo.NewToolResultError(grpcErrString(err)), nil
+			return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 		}
 		switch resp.ResponseType.(type) {
 		case *agentpb.RunContainerLayersResponse_StdoutOutput:
@@ -260,5 +269,5 @@ func (s *mcpServer) handleContainerAttach(ctx context.Context, req mcpgo.CallToo
 			collected++
 		}
 	}
-	return mcpgo.NewToolResultText(sb.String()), nil
+	return okText(sb.String()), nil
 }

--- a/go/internal/cli/mcp/tools_container.go
+++ b/go/internal/cli/mcp/tools_container.go
@@ -17,15 +17,19 @@ func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
 		mcpgo.WithDescription("List all containers on the connected device"),
 	}
 	listOpts = append(listOpts, readOnly()...)
+	listOpts = append(listOpts, localOnly()...)
 	srv.AddTool(mcpgo.NewTool("container_list", listOpts...), s.handleContainerList)
 
-	srv.AddTool(mcpgo.NewTool("container_start",
+	startOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Start a container and stream its output (bounded snapshot)"),
 		mcpgo.WithString("app_name",
 			mcpgo.Required(),
 			mcpgo.Description("App name of the container to start"),
 		),
-	), s.handleContainerStart)
+	}
+	startOpts = append(startOpts, mutating()...)
+	startOpts = append(startOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("container_start", startOpts...), s.handleContainerStart)
 
 	stopOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Stop a running container"),
@@ -36,6 +40,7 @@ func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
 	}
 	stopOpts = append(stopOpts, destructive()...)
 	stopOpts = append(stopOpts, idempotent()...)
+	stopOpts = append(stopOpts, localOnly()...)
 	srv.AddTool(mcpgo.NewTool("container_stop", stopOpts...), s.handleContainerStop)
 
 	deleteOpts := []mcpgo.ToolOption{
@@ -53,12 +58,14 @@ func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
 	}
 	deleteOpts = append(deleteOpts, destructive()...)
 	deleteOpts = append(deleteOpts, idempotent()...)
+	deleteOpts = append(deleteOpts, localOnly()...)
 	srv.AddTool(mcpgo.NewTool("container_delete", deleteOpts...), s.handleContainerDelete)
 
 	statsOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Get memory and storage stats for all containers"),
 	}
 	statsOpts = append(statsOpts, readOnly()...)
+	statsOpts = append(statsOpts, localOnly()...)
 	srv.AddTool(mcpgo.NewTool("container_stats", statsOpts...), s.handleContainerStats)
 
 	attachOpts := []mcpgo.ToolOption{
@@ -72,6 +79,7 @@ func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
 		),
 	}
 	attachOpts = append(attachOpts, readOnly()...)
+	attachOpts = append(attachOpts, localOnly()...)
 	srv.AddTool(mcpgo.NewTool("container_attach", attachOpts...), s.handleContainerAttach)
 }
 

--- a/go/internal/cli/mcp/tools_container_test.go
+++ b/go/internal/cli/mcp/tools_container_test.go
@@ -15,17 +15,27 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func TestContainerDelete_AnnotatedDestructive(t *testing.T) {
+func TestContainerAnnotations_ReadOnlyNotDestructive(t *testing.T) {
 	srv := server.NewMCPServer("t", "0")
 	s := New(&config.Config{}, nil)
 	s.registerContainerTools(srv)
-	tools := srv.ListTools() // returns map[string]*server.ServerTool
-	tool, ok := tools["container_delete"]
+	tools := srv.ListTools()
+	list, ok := tools["container_list"]
+	if !ok {
+		t.Fatal("container_list not registered")
+	}
+	if list.Tool.Annotations.DestructiveHint == nil || *list.Tool.Annotations.DestructiveHint {
+		t.Error("container_list (readOnly) must have DestructiveHint=false")
+	}
+	if list.Tool.Annotations.OpenWorldHint == nil || *list.Tool.Annotations.OpenWorldHint {
+		t.Error("container_list must have OpenWorldHint=false (localOnly)")
+	}
+	del, ok := tools["container_delete"]
 	if !ok {
 		t.Fatal("container_delete not registered")
 	}
-	if tool.Tool.Annotations.DestructiveHint == nil || !*tool.Tool.Annotations.DestructiveHint {
-		t.Error("container_delete should be annotated destructive")
+	if del.Tool.Annotations.DestructiveHint == nil || !*del.Tool.Annotations.DestructiveHint {
+		t.Error("container_delete must have DestructiveHint=true")
 	}
 }
 

--- a/go/internal/cli/mcp/tools_container_test.go
+++ b/go/internal/cli/mcp/tools_container_test.go
@@ -7,12 +7,27 @@ import (
 	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+func TestContainerDelete_AnnotatedDestructive(t *testing.T) {
+	srv := server.NewMCPServer("t", "0")
+	s := New(&config.Config{}, nil)
+	s.registerContainerTools(srv)
+	tools := srv.ListTools() // returns map[string]*server.ServerTool
+	tool, ok := tools["container_delete"]
+	if !ok {
+		t.Fatal("container_delete not registered")
+	}
+	if tool.Tool.Annotations.DestructiveHint == nil || !*tool.Tool.Annotations.DestructiveHint {
+		t.Error("container_delete should be annotated destructive")
+	}
+}
 
 // fakeContainerServer implements WendyContainerServiceServer for container tests.
 type fakeContainerServer struct {

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -13,36 +12,34 @@ import (
 )
 
 func (s *mcpServer) registerDeviceTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("device_list",
+	listOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("List wendy devices from config and known addresses. Pass scan=true to also run a live 3-second mDNS scan for devices on the local network."),
-		mcpgo.WithBoolean("scan",
-			mcpgo.Description("If true, run a live mDNS scan (3 s) in addition to returning configured devices"),
-		),
-	), s.handleDeviceList)
+		mcpgo.WithBoolean("scan", mcpgo.Description("If true, run a live mDNS scan (3 s) in addition to returning configured devices")),
+	}
+	listOpts = append(listOpts, readOnly()...)
+	listOpts = append(listOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("device_list", listOpts...), s.handleDeviceList)
 
-	srv.AddTool(mcpgo.NewTool("device_connect",
+	connectOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Connect to a wendy device by address (host:port)"),
-		mcpgo.WithString("address",
-			mcpgo.Required(),
-			mcpgo.Description("Device address, e.g. mydevice.local:50051 or 192.168.1.10:50051"),
-		),
-	), s.handleDeviceConnect)
+		mcpgo.WithString("address", mcpgo.Required(), mcpgo.Description("Device address, e.g. mydevice.local:50051 or 192.168.1.10:50051")),
+	}
+	connectOpts = append(connectOpts, idempotent()...)
+	connectOpts = append(connectOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("device_connect", connectOpts...), s.handleDeviceConnect)
 
-	srv.AddTool(mcpgo.NewTool("device_disconnect",
-		mcpgo.WithDescription("Disconnect from the currently connected device"),
-	), s.handleDeviceDisconnect)
+	disconnectOpts := append([]mcpgo.ToolOption{mcpgo.WithDescription("Disconnect from the currently connected device")}, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("device_disconnect", disconnectOpts...), s.handleDeviceDisconnect)
 
-	srv.AddTool(mcpgo.NewTool("device_info",
-		mcpgo.WithDescription("Get agent version, OS, CPU architecture, GPU info, and feature set of connected device"),
-	), s.handleDeviceInfo)
+	infoOpts := append([]mcpgo.ToolOption{mcpgo.WithDescription("Get agent version, OS, CPU architecture, GPU info, and feature set of connected device")}, readOnly()...)
+	srv.AddTool(mcpgo.NewTool("device_info", infoOpts...), s.handleDeviceInfo)
 
-	srv.AddTool(mcpgo.NewTool("device_set_default",
+	setDefaultOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Save an address as the default device in ~/.wendy/config.json"),
-		mcpgo.WithString("address",
-			mcpgo.Required(),
-			mcpgo.Description("Device address to save as default"),
-		),
-	), s.handleDeviceSetDefault)
+		mcpgo.WithString("address", mcpgo.Required(), mcpgo.Description("Device address to save as default")),
+	}
+	setDefaultOpts = append(setDefaultOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("device_set_default", setDefaultOpts...), s.handleDeviceSetDefault)
 }
 
 func (s *mcpServer) handleDeviceList(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -96,20 +93,19 @@ func (s *mcpServer) handleDeviceList(ctx context.Context, req mcpgo.CallToolRequ
 	if len(devices) == 0 {
 		devices = []map[string]any{}
 	}
-	b, _ := json.MarshalIndent(devices, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(devices), nil
 }
 
 func (s *mcpServer) handleDeviceConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	address := stringParam(req, "address")
 	if address == "" {
-		return mcpgo.NewToolResultError("address is required"), nil
+		return errResult(errCodeInvalidArgument, "address is required"), nil
 	}
 	if err := s.ConnectTo(ctx, address); err != nil {
-		return mcpgo.NewToolResultError(fmt.Sprintf("connecting to %s: %s", address, err.Error())), nil
+		return errResultf(errCodeDeviceUnreachable, "connecting to %s: %s", address, err.Error()), nil
 	}
 	s.SetConnType("direct")
-	return mcpgo.NewToolResultText(fmt.Sprintf("connected to %s", address)), nil
+	return okText(fmt.Sprintf("connected to %s", address)), nil
 }
 
 func (s *mcpServer) handleDeviceDisconnect(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -128,7 +124,7 @@ func (s *mcpServer) handleDeviceInfo(ctx context.Context, _ mcpgo.CallToolReques
 	}
 	resp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	info := map[string]any{
 		"version":          resp.GetVersion(),
@@ -177,18 +173,17 @@ func (s *mcpServer) handleDeviceInfo(ctx context.Context, _ mcpgo.CallToolReques
 	if resp.GpuArch != nil {
 		info["gpu_arch"] = resp.GetGpuArch()
 	}
-	b, _ := json.MarshalIndent(info, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(info), nil
 }
 
 func (s *mcpServer) handleDeviceSetDefault(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	address := stringParam(req, "address")
 	if address == "" {
-		return mcpgo.NewToolResultError("address is required"), nil
+		return errResult(errCodeInvalidArgument, "address is required"), nil
 	}
 	s.cfg.DefaultDevice = address
 	if err := config.Save(s.cfg); err != nil {
-		return mcpgo.NewToolResultError(fmt.Sprintf("saving config: %s", err.Error())), nil
+		return errResultf(errCodeInternal, "saving config: %s", err.Error()), nil
 	}
-	return mcpgo.NewToolResultText(fmt.Sprintf("default device set to %s", address)), nil
+	return okText(fmt.Sprintf("default device set to %s", address)), nil
 }

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -24,21 +24,29 @@ func (s *mcpServer) registerDeviceTools(srv *server.MCPServer) {
 		mcpgo.WithDescription("Connect to a wendy device by address (host:port)"),
 		mcpgo.WithString("address", mcpgo.Required(), mcpgo.Description("Device address, e.g. mydevice.local:50051 or 192.168.1.10:50051")),
 	}
+	connectOpts = append(connectOpts, mutating()...)
 	connectOpts = append(connectOpts, idempotent()...)
 	connectOpts = append(connectOpts, openWorld()...)
 	srv.AddTool(mcpgo.NewTool("device_connect", connectOpts...), s.handleDeviceConnect)
 
-	disconnectOpts := append([]mcpgo.ToolOption{mcpgo.WithDescription("Disconnect from the currently connected device")}, idempotent()...)
+	disconnectOpts := []mcpgo.ToolOption{mcpgo.WithDescription("Disconnect from the currently connected device")}
+	disconnectOpts = append(disconnectOpts, mutating()...)
+	disconnectOpts = append(disconnectOpts, idempotent()...)
+	disconnectOpts = append(disconnectOpts, localOnly()...)
 	srv.AddTool(mcpgo.NewTool("device_disconnect", disconnectOpts...), s.handleDeviceDisconnect)
 
-	infoOpts := append([]mcpgo.ToolOption{mcpgo.WithDescription("Get agent version, OS, CPU architecture, GPU info, and feature set of connected device")}, readOnly()...)
+	infoOpts := []mcpgo.ToolOption{mcpgo.WithDescription("Get agent version, OS, CPU architecture, GPU info, and feature set of connected device")}
+	infoOpts = append(infoOpts, readOnly()...)
+	infoOpts = append(infoOpts, localOnly()...)
 	srv.AddTool(mcpgo.NewTool("device_info", infoOpts...), s.handleDeviceInfo)
 
 	setDefaultOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Save an address as the default device in ~/.wendy/config.json"),
 		mcpgo.WithString("address", mcpgo.Required(), mcpgo.Description("Device address to save as default")),
 	}
+	setDefaultOpts = append(setDefaultOpts, mutating()...)
 	setDefaultOpts = append(setDefaultOpts, idempotent()...)
+	setDefaultOpts = append(setDefaultOpts, localOnly()...)
 	srv.AddTool(mcpgo.NewTool("device_set_default", setDefaultOpts...), s.handleDeviceSetDefault)
 }
 

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -119,10 +119,10 @@ func (s *mcpServer) handleDeviceConnect(ctx context.Context, req mcpgo.CallToolR
 func (s *mcpServer) handleDeviceDisconnect(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	conn := s.GetConn()
 	if conn == nil {
-		return mcpgo.NewToolResultText("not connected"), nil
+		return okText("not connected"), nil
 	}
 	s.SetConn(nil)
-	return mcpgo.NewToolResultText("disconnected"), nil
+	return okText("disconnected"), nil
 }
 
 func (s *mcpServer) handleDeviceInfo(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/go/internal/cli/mcp/tools_device_test.go
+++ b/go/internal/cli/mcp/tools_device_test.go
@@ -88,6 +88,20 @@ func TestDeviceInfo_ReturnsJSON(t *testing.T) {
 	}
 }
 
+func TestDeviceInfo_HasStructuredContent(t *testing.T) {
+	fake := &fakeAgentServer{versionResp: &agentpb.GetAgentVersionResponse{Version: "9.9.9", Os: "linux"}}
+	conn, _ := startFakeAgentServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+	result, err := srv.callTool(context.Background(), "device_info", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("device_info should return structuredContent")
+	}
+}
+
 func TestDeviceList_ReturnsConfiguredDevices(t *testing.T) {
 	cfg := &config.Config{
 		Auth: []config.AuthConfig{

--- a/go/internal/cli/mcp/tools_filesync.go
+++ b/go/internal/cli/mcp/tools_filesync.go
@@ -8,14 +8,15 @@ import (
 )
 
 func (s *mcpServer) registerFileSyncTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("filesync_sync",
+	syncOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Sync files to a container app on the connected device (requires binary file data; not available via MCP)"),
-	), s.handleFileSyncSync)
+	}
+	syncOpts = append(syncOpts, mutating()...)
+	syncOpts = append(syncOpts, localOnly()...)
+	syncOpts = append(syncOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("filesync_sync", syncOpts...), s.handleFileSyncSync)
 }
 
 func (s *mcpServer) handleFileSyncSync(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-	return mcpgo.NewToolResultError(
-		"filesync_sync requires binary file transfer and is not available via the MCP interface. " +
-			"Use the wendy CLI directly: wendy run <path>",
-	), nil
+	return errResult(errCodeUnsupported, "filesync over MCP is not supported; run the equivalent from the wendy CLI"), nil
 }

--- a/go/internal/cli/mcp/tools_guide.go
+++ b/go/internal/cli/mcp/tools_guide.go
@@ -51,6 +51,15 @@ Use the run tool to build and deploy a local project to a cloud-enrolled device:
 
 device_disconnect — closes the active connection and frees resources.
 
+## Result shape & error codes
+
+Tools that return data include a machine-readable structuredContent object
+alongside human-readable text. Errors include an error_code you can branch
+on — e.g. NOT_CONNECTED, DEVICE_UNREACHABLE, ENTITLEMENT_DENIED,
+INVALID_ARGUMENT, NOT_FOUND, MULTIPLE_SESSIONS, UNSUPPORTED, TIMEOUT,
+INTERNAL. Tool annotations mark read-only vs destructive vs mutating
+operations and whether a tool reaches beyond the connected device (open-world).
+
 ## Documentation
 
 Detailed documentation is available as MCP resources under wendy://docs/.

--- a/go/internal/cli/mcp/tools_hardware.go
+++ b/go/internal/cli/mcp/tools_hardware.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -10,12 +9,15 @@ import (
 )
 
 func (s *mcpServer) registerHardwareTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("hardware_capabilities",
+	capsOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("List hardware capabilities (GPUs, cameras, I2C buses, USB devices, etc.) on the connected device"),
 		mcpgo.WithString("category",
 			mcpgo.Description("Filter by category, e.g. gpu, usb, i2c, gpio, camera (optional)"),
 		),
-	), s.handleHardwareCapabilities)
+	}
+	capsOpts = append(capsOpts, readOnly()...)
+	capsOpts = append(capsOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("hardware_capabilities", capsOpts...), s.handleHardwareCapabilities)
 }
 
 func (s *mcpServer) handleHardwareCapabilities(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -29,7 +31,7 @@ func (s *mcpServer) handleHardwareCapabilities(ctx context.Context, req mcpgo.Ca
 	}
 	resp, err := conn.AgentService.ListHardwareCapabilities(ctx, hwReq)
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	var caps []map[string]any
 	for _, c := range resp.GetCapabilities() {
@@ -46,6 +48,5 @@ func (s *mcpServer) handleHardwareCapabilities(ctx context.Context, req mcpgo.Ca
 	if caps == nil {
 		caps = []map[string]any{}
 	}
-	b, _ := json.MarshalIndent(caps, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(caps), nil
 }

--- a/go/internal/cli/mcp/tools_hardware_provisioning_test.go
+++ b/go/internal/cli/mcp/tools_hardware_provisioning_test.go
@@ -234,6 +234,44 @@ func TestProvisioningStatus_Provisioned(t *testing.T) {
 	}
 }
 
+func TestProvisioningStatus_HasStructuredContent(t *testing.T) {
+	fake := &fakeHWProvisioningOSServer{
+		isProvisioned: &agentpb.IsProvisionedResponse{
+			Response: &agentpb.IsProvisionedResponse_Provisioned{
+				Provisioned: &agentpb.ProvisionedResponse{
+					CloudHost:      "cloud.wendy.sh",
+					OrganizationId: 42,
+					AssetId:        7,
+				},
+			},
+		},
+	}
+	conn := startFakeHWProvisioningServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "provisioning_status", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("provisioning_status should return structuredContent")
+	}
+	sc, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structuredContent has unexpected type %T", result.StructuredContent)
+	}
+	if sc["provisioned"] != true {
+		t.Errorf("provisioned = %v, want true", sc["provisioned"])
+	}
+	if sc["cloud_host"] != "cloud.wendy.sh" {
+		t.Errorf("cloud_host = %v, want cloud.wendy.sh", sc["cloud_host"])
+	}
+}
+
 func TestProvisioningStart_Success(t *testing.T) {
 	fake := &fakeHWProvisioningOSServer{
 		isProvisioned: &agentpb.IsProvisionedResponse{
@@ -295,8 +333,20 @@ func TestFileSyncSync_AlwaysReturnsError(t *testing.T) {
 		t.Fatal("expected IsError=true — filesync is unavailable via MCP")
 	}
 	text := result.Content[0].(mcpgo.TextContent).Text
-	if !strings.Contains(text, "wendy run") {
+	if !strings.Contains(text, "wendy CLI") {
 		t.Errorf("expected CLI redirect hint in error, got %q", text)
+	}
+}
+
+func TestFileSyncSync_UnsupportedCode(t *testing.T) {
+	srv := New(&config.Config{}, nil)
+	r, _ := srv.callTool(context.Background(), "filesync_sync", nil)
+	if !r.IsError {
+		t.Fatal("filesync_sync should error")
+	}
+	sc, _ := r.StructuredContent.(map[string]any)
+	if sc == nil || sc["error_code"] != "UNSUPPORTED" {
+		t.Errorf("want UNSUPPORTED, got %v", sc)
 	}
 }
 

--- a/go/internal/cli/mcp/tools_hardware_provisioning_test.go
+++ b/go/internal/cli/mcp/tools_hardware_provisioning_test.go
@@ -121,6 +121,28 @@ func TestHardwareCapabilities_ReturnsList(t *testing.T) {
 	}
 }
 
+func TestHardwareCapabilities_HasStructuredContent(t *testing.T) {
+	fake := &fakeHWProvisioningOSServer{
+		capabilities: []*agentpb.ListHardwareCapabilitiesResponse_HardwareCapability{
+			{Category: "gpu", DevicePath: "/dev/gpu0", Description: "NVIDIA GPU"},
+		},
+	}
+	conn := startFakeHWProvisioningServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "hardware_capabilities", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("hardware_capabilities should return structuredContent")
+	}
+}
+
 func TestHardwareCapabilities_EmptyList(t *testing.T) {
 	fake := &fakeHWProvisioningOSServer{}
 	conn := startFakeHWProvisioningServer(t, fake)

--- a/go/internal/cli/mcp/tools_os.go
+++ b/go/internal/cli/mcp/tools_os.go
@@ -12,16 +12,22 @@ import (
 )
 
 func (s *mcpServer) registerOSTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("os_update",
+	updateOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Trigger an OS update on the connected device and stream progress"),
 		mcpgo.WithString("artifact_url",
 			mcpgo.Description("URL of the OS update artifact (leave empty to use the device's configured update channel)"),
 		),
-	), s.handleOSUpdate)
+	}
+	updateOpts = append(updateOpts, destructive()...)
+	updateOpts = append(updateOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("os_update", updateOpts...), s.handleOSUpdate)
 
-	srv.AddTool(mcpgo.NewTool("os_update_status",
+	statusOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Report the outcome of the device's most recent OS update: committed after post-reboot healthchecks, or rolled back with the services that failed"),
-	), s.handleOSUpdateStatus)
+	}
+	statusOpts = append(statusOpts, readOnly()...)
+	statusOpts = append(statusOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("os_update_status", statusOpts...), s.handleOSUpdateStatus)
 }
 
 func (s *mcpServer) handleOSUpdateStatus(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -31,33 +37,42 @@ func (s *mcpServer) handleOSUpdateStatus(ctx context.Context, _ mcpgo.CallToolRe
 	}
 	resp, err := conn.AgentService.GetOSUpdateStatus(ctx, &agentpb.GetOSUpdateStatusRequest{})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	if !resp.GetHasResult() {
-		return mcpgo.NewToolResultText("no OS update result recorded on this device"), nil
+		return okResult(map[string]any{"has_result": false}), nil
 	}
 
-	var sb strings.Builder
-	outcome := strings.TrimPrefix(resp.GetOutcome().String(), "OUTCOME_")
-	sb.WriteString(fmt.Sprintf("outcome: %s\n", strings.ToLower(outcome)))
+	outcome := strings.ToLower(strings.TrimPrefix(resp.GetOutcome().String(), "OUTCOME_"))
+	result := map[string]any{
+		"has_result": true,
+		"outcome":    outcome,
+	}
 	if v := resp.GetOldOsVersion(); v != "" {
-		sb.WriteString(fmt.Sprintf("old OS version: %s\n", v))
+		result["old_os_version"] = v
 	}
 	if v := resp.GetNewOsVersion(); v != "" {
-		sb.WriteString(fmt.Sprintf("new OS version: %s\n", v))
+		result["new_os_version"] = v
 	}
+	var services []map[string]any
 	for _, svc := range resp.GetServices() {
 		status := strings.ToLower(strings.TrimPrefix(svc.GetStatus().String(), "STATUS_"))
-		if reason := svc.GetReason(); reason != "" {
-			sb.WriteString(fmt.Sprintf("service %s: %s (%s)\n", svc.GetUnit(), status, reason))
-		} else {
-			sb.WriteString(fmt.Sprintf("service %s: %s\n", svc.GetUnit(), status))
+		entry := map[string]any{
+			"unit":   svc.GetUnit(),
+			"status": status,
 		}
+		if reason := svc.GetReason(); reason != "" {
+			entry["reason"] = reason
+		}
+		services = append(services, entry)
+	}
+	if services != nil {
+		result["services"] = services
 	}
 	if re := resp.GetRollbackError(); re != "" {
-		sb.WriteString(fmt.Sprintf("rollback error: %s\n", re))
+		result["rollback_error"] = re
 	}
-	return mcpgo.NewToolResultText(strings.TrimRight(sb.String(), "\n")), nil
+	return okResult(result), nil
 }
 
 func (s *mcpServer) handleOSUpdate(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -70,7 +85,7 @@ func (s *mcpServer) handleOSUpdate(ctx context.Context, req mcpgo.CallToolReques
 		UpdaterBackend: "",
 	})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 
 	var sb strings.Builder
@@ -80,7 +95,7 @@ func (s *mcpServer) handleOSUpdate(ctx context.Context, req mcpgo.CallToolReques
 			break
 		}
 		if err != nil {
-			return mcpgo.NewToolResultError(grpcErrString(err)), nil
+			return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 		}
 		switch resp.ResponseType.(type) {
 		case *agentpb.UpdateOSResponse_Progress_:
@@ -94,12 +109,12 @@ func (s *mcpServer) handleOSUpdate(ctx context.Context, req mcpgo.CallToolReques
 				sb.WriteString("update complete\n")
 			}
 		case *agentpb.UpdateOSResponse_Failed_:
-			return mcpgo.NewToolResultError(fmt.Sprintf("update failed: %s", resp.GetFailed().GetErrorMessage())), nil
+			return errResultf(errCodeInternal, "update failed: %s", resp.GetFailed().GetErrorMessage()), nil
 		}
 	}
 	out := sb.String()
 	if out == "" {
 		out = "OS update initiated"
 	}
-	return mcpgo.NewToolResultText(out), nil
+	return okText(out), nil
 }

--- a/go/internal/cli/mcp/tools_provisioning.go
+++ b/go/internal/cli/mcp/tools_provisioning.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -11,11 +10,14 @@ import (
 )
 
 func (s *mcpServer) registerProvisioningTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("provisioning_status",
+	statusOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Check whether the connected device is provisioned with Wendy Cloud"),
-	), s.handleProvisioningStatus)
+	}
+	statusOpts = append(statusOpts, readOnly()...)
+	statusOpts = append(statusOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("provisioning_status", statusOpts...), s.handleProvisioningStatus)
 
-	srv.AddTool(mcpgo.NewTool("provisioning_start",
+	startOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Provision the device with Wendy Cloud and wait for completion (up to 2 minutes)"),
 		mcpgo.WithString("enrollment_token",
 			mcpgo.Required(),
@@ -32,7 +34,11 @@ func (s *mcpServer) registerProvisioningTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("asset_id",
 			mcpgo.Description("Asset ID to assign to this device (optional)"),
 		),
-	), s.handleProvisioningStart)
+	}
+	startOpts = append(startOpts, mutating()...)
+	startOpts = append(startOpts, openWorld()...)
+	startOpts = append(startOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("provisioning_start", startOpts...), s.handleProvisioningStart)
 }
 
 func (s *mcpServer) handleProvisioningStatus(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -42,7 +48,7 @@ func (s *mcpServer) handleProvisioningStatus(ctx context.Context, _ mcpgo.CallTo
 	}
 	resp, err := conn.ProvisioningService.IsProvisioned(ctx, &agentpb.IsProvisionedRequest{})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	var result map[string]any
 	switch r := resp.GetResponse().(type) {
@@ -60,8 +66,7 @@ func (s *mcpServer) handleProvisioningStatus(ctx context.Context, _ mcpgo.CallTo
 	default:
 		result = map[string]any{"provisioned": false}
 	}
-	b, _ := json.MarshalIndent(result, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(result), nil
 }
 
 func (s *mcpServer) handleProvisioningStart(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -72,8 +77,14 @@ func (s *mcpServer) handleProvisioningStart(ctx context.Context, req mcpgo.CallT
 	token := stringParam(req, "enrollment_token")
 	cloudHost := stringParam(req, "cloud_host")
 	orgID := intParam(req, "organization_id", 0)
-	if token == "" || cloudHost == "" || orgID == 0 {
-		return mcpgo.NewToolResultError("enrollment_token, cloud_host, and organization_id are required"), nil
+	if token == "" {
+		return errResult(errCodeInvalidArgument, "enrollment_token is required"), nil
+	}
+	if cloudHost == "" {
+		return errResult(errCodeInvalidArgument, "cloud_host is required"), nil
+	}
+	if orgID == 0 {
+		return errResult(errCodeInvalidArgument, "organization_id is required"), nil
 	}
 	_, err := conn.ProvisioningService.StartProvisioning(ctx, &agentpb.StartProvisioningRequest{
 		EnrollmentToken: token,
@@ -82,7 +93,7 @@ func (s *mcpServer) handleProvisioningStart(ctx context.Context, req mcpgo.CallT
 		AssetId:         int32(intParam(req, "asset_id", 0)),
 	})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 
 	// Poll until provisioned, caller cancelled, or 2-minute timeout.
@@ -93,11 +104,11 @@ func (s *mcpServer) handleProvisioningStart(ctx context.Context, req mcpgo.CallT
 	for {
 		select {
 		case <-pollCtx.Done():
-			return mcpgo.NewToolResultError("provisioning timed out — check status with provisioning_status"), nil
+			return errResult(errCodeTimeout, "provisioning timed out — check status with provisioning_status"), nil
 		case <-ticker.C:
 			statusResp, err := conn.ProvisioningService.IsProvisioned(ctx, &agentpb.IsProvisionedRequest{})
 			if err != nil {
-				return mcpgo.NewToolResultError(grpcErrString(err)), nil
+				return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 			}
 			if p, ok := statusResp.GetResponse().(*agentpb.IsProvisionedResponse_Provisioned); ok {
 				result := map[string]any{
@@ -106,8 +117,7 @@ func (s *mcpServer) handleProvisioningStart(ctx context.Context, req mcpgo.CallT
 					"organization_id": p.Provisioned.GetOrganizationId(),
 					"asset_id":        p.Provisioned.GetAssetId(),
 				}
-				b, _ := json.MarshalIndent(result, "", "  ")
-				return mcpgo.NewToolResultText(string(b)), nil
+				return okResult(result), nil
 			}
 		}
 	}

--- a/go/internal/cli/mcp/tools_status.go
+++ b/go/internal/cli/mcp/tools_status.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -10,9 +9,10 @@ import (
 )
 
 func (s *mcpServer) registerStatusTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("wendy_status",
+	statusOpts := append([]mcpgo.ToolOption{
 		mcpgo.WithDescription("Return current MCP session connection state and a plain-English suggested next step. Call this first to orient yourself."),
-	), s.handleWendyStatus)
+	}, readOnly()...)
+	srv.AddTool(mcpgo.NewTool("wendy_status", statusOpts...), s.handleWendyStatus)
 }
 
 func (s *mcpServer) handleWendyStatus(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -24,8 +24,7 @@ func (s *mcpServer) handleWendyStatus(_ context.Context, _ mcpgo.CallToolRequest
 			"connected":           false,
 			"suggested_next_step": "not connected — call device_list to see available devices then device_connect, or cloud_discover + cloud_connect for cloud-enrolled devices",
 		}
-		b, _ := json.Marshal(out)
-		return mcpgo.NewToolResultText(string(b)), nil
+		return okResult(out), nil
 	}
 
 	host := conn.Host
@@ -38,6 +37,5 @@ func (s *mcpServer) handleWendyStatus(_ context.Context, _ mcpgo.CallToolRequest
 		"connection_type":     connType,
 		"suggested_next_step": fmt.Sprintf("connected to %s via %s — ready to use container, wifi, hardware, telemetry, and os tools", host, connType),
 	}
-	b, _ := json.Marshal(out)
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(out), nil
 }

--- a/go/internal/cli/mcp/tools_status.go
+++ b/go/internal/cli/mcp/tools_status.go
@@ -9,9 +9,11 @@ import (
 )
 
 func (s *mcpServer) registerStatusTools(srv *server.MCPServer) {
-	statusOpts := append([]mcpgo.ToolOption{
+	statusOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Return current MCP session connection state and a plain-English suggested next step. Call this first to orient yourself."),
-	}, readOnly()...)
+	}
+	statusOpts = append(statusOpts, readOnly()...)
+	statusOpts = append(statusOpts, localOnly()...)
 	srv.AddTool(mcpgo.NewTool("wendy_status", statusOpts...), s.handleWendyStatus)
 }
 

--- a/go/internal/cli/mcp/tools_telemetry.go
+++ b/go/internal/cli/mcp/tools_telemetry.go
@@ -2,8 +2,8 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"io"
-	"strings"
 	"time"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -20,7 +20,7 @@ var telemetryProtoJSON = protojson.MarshalOptions{
 }
 
 func (s *mcpServer) registerTelemetryTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("telemetry_logs",
+	logsOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Stream a bounded snapshot of OTLP logs from the connected device"),
 		mcpgo.WithString("app_name",
 			mcpgo.Description("Filter by app/container name (optional)"),
@@ -34,9 +34,12 @@ func (s *mcpServer) registerTelemetryTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("max_batches",
 			mcpgo.Description("Maximum OTLP batches to collect (default 10)"),
 		),
-	), s.handleTelemetryLogs)
+	}
+	logsOpts = append(logsOpts, readOnly()...)
+	logsOpts = append(logsOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("telemetry_logs", logsOpts...), s.handleTelemetryLogs)
 
-	srv.AddTool(mcpgo.NewTool("telemetry_metrics",
+	metricsOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Stream a bounded snapshot of OTLP metrics from the connected device"),
 		mcpgo.WithString("app_name",
 			mcpgo.Description("Filter by app/container name (optional)"),
@@ -50,9 +53,12 @@ func (s *mcpServer) registerTelemetryTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("max_batches",
 			mcpgo.Description("Maximum OTLP batches to collect (default 10)"),
 		),
-	), s.handleTelemetryMetrics)
+	}
+	metricsOpts = append(metricsOpts, readOnly()...)
+	metricsOpts = append(metricsOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("telemetry_metrics", metricsOpts...), s.handleTelemetryMetrics)
 
-	srv.AddTool(mcpgo.NewTool("telemetry_traces",
+	tracesOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Stream a bounded snapshot of OTLP traces from the connected device"),
 		mcpgo.WithString("app_name",
 			mcpgo.Description("Filter by app/container name (optional)"),
@@ -66,18 +72,22 @@ func (s *mcpServer) registerTelemetryTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("max_batches",
 			mcpgo.Description("Maximum OTLP batches to collect (default 10)"),
 		),
-	), s.handleTelemetryTraces)
+	}
+	tracesOpts = append(tracesOpts, readOnly()...)
+	tracesOpts = append(tracesOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("telemetry_traces", tracesOpts...), s.handleTelemetryTraces)
 }
 
 // collectProtoStream receives up to maxBatches messages from stream, marshals
-// each to JSON with protojson, and returns them as a JSON array string.
-// Returns an error string on non-EOF stream failures.
+// each to JSON with protojson, and returns them as a slice of raw JSON
+// messages suitable for structured results. Returns an error on non-EOF
+// stream failures.
 func collectProtoStream[T proto.Message](
 	ctx context.Context,
 	recv func() (T, error),
 	maxBatches int,
-) (string, error) {
-	var parts []string
+) ([]json.RawMessage, error) {
+	parts := []json.RawMessage{}
 	for len(parts) < maxBatches {
 		msg, err := recv()
 		if err == io.EOF {
@@ -87,18 +97,15 @@ func collectProtoStream[T proto.Message](
 			if ctx.Err() != nil {
 				break
 			}
-			return "", err
+			return nil, err
 		}
 		b, err := telemetryProtoJSON.Marshal(msg)
 		if err != nil {
 			continue
 		}
-		parts = append(parts, string(b))
+		parts = append(parts, json.RawMessage(b))
 	}
-	if len(parts) == 0 {
-		return "[]", nil
-	}
-	return "[" + strings.Join(parts, ",\n") + "]", nil
+	return parts, nil
 }
 
 func (s *mcpServer) handleTelemetryLogs(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -125,15 +132,15 @@ func (s *mcpServer) handleTelemetryLogs(ctx context.Context, req mcpgo.CallToolR
 
 	stream, err := conn.TelemetryService.StreamLogs(ctx, logsReq)
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	result, err := collectProtoStream(ctx, func() (*agentpb.StreamLogsResponse, error) {
 		return stream.Recv()
 	}, maxBatches)
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return mcpgo.NewToolResultText(result), nil
+	return okResult(result), nil
 }
 
 func (s *mcpServer) handleTelemetryMetrics(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -159,15 +166,15 @@ func (s *mcpServer) handleTelemetryMetrics(ctx context.Context, req mcpgo.CallTo
 
 	stream, err := conn.TelemetryService.StreamMetrics(ctx, metricsReq)
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	result, err := collectProtoStream(ctx, func() (*agentpb.StreamMetricsResponse, error) {
 		return stream.Recv()
 	}, maxBatches)
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return mcpgo.NewToolResultText(result), nil
+	return okResult(result), nil
 }
 
 func (s *mcpServer) handleTelemetryTraces(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -193,13 +200,13 @@ func (s *mcpServer) handleTelemetryTraces(ctx context.Context, req mcpgo.CallToo
 
 	stream, err := conn.TelemetryService.StreamTraces(ctx, tracesReq)
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	result, err := collectProtoStream(ctx, func() (*agentpb.StreamTracesResponse, error) {
 		return stream.Recv()
 	}, maxBatches)
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return mcpgo.NewToolResultText(result), nil
+	return okResult(result), nil
 }

--- a/go/internal/cli/mcp/tools_telemetry_test.go
+++ b/go/internal/cli/mcp/tools_telemetry_test.go
@@ -108,6 +108,28 @@ func TestTelemetryLogs_ReturnsJSON(t *testing.T) {
 	}
 }
 
+func TestTelemetryLogs_HasStructuredContent(t *testing.T) {
+	fake := &fakeTelemetryServer{
+		logBatches: []*agentpb.StreamLogsResponse{
+			{Logs: &otelpb.ExportLogsServiceRequest{}},
+		},
+	}
+	conn := startFakeTelemetryServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "telemetry_logs", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("telemetry_logs should return structuredContent")
+	}
+}
+
 func TestTelemetryLogs_EmptyReturnsEmptyArray(t *testing.T) {
 	fake := &fakeTelemetryServer{}
 	conn := startFakeTelemetryServer(t, fake)

--- a/go/internal/cli/mcp/tools_wifi.go
+++ b/go/internal/cli/mcp/tools_wifi.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -11,11 +10,14 @@ import (
 )
 
 func (s *mcpServer) registerWiFiTools(srv *server.MCPServer) {
-	srv.AddTool(mcpgo.NewTool("wifi_list",
+	listOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("List available WiFi networks visible to the connected device"),
-	), s.handleWiFiList)
+	}
+	listOpts = append(listOpts, readOnly()...)
+	listOpts = append(listOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("wifi_list", listOpts...), s.handleWiFiList)
 
-	srv.AddTool(mcpgo.NewTool("wifi_connect",
+	connectOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Connect the device to a WiFi network"),
 		mcpgo.WithString("ssid",
 			mcpgo.Required(),
@@ -24,19 +26,33 @@ func (s *mcpServer) registerWiFiTools(srv *server.MCPServer) {
 		mcpgo.WithString("password",
 			mcpgo.Description("WiFi password (leave empty for open networks)"),
 		),
-	), s.handleWiFiConnect)
+	}
+	connectOpts = append(connectOpts, mutating()...)
+	connectOpts = append(connectOpts, openWorld()...)
+	connectOpts = append(connectOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("wifi_connect", connectOpts...), s.handleWiFiConnect)
 
-	srv.AddTool(mcpgo.NewTool("wifi_status",
+	statusOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Get the current WiFi connection status of the connected device"),
-	), s.handleWiFiStatus)
+	}
+	statusOpts = append(statusOpts, readOnly()...)
+	statusOpts = append(statusOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("wifi_status", statusOpts...), s.handleWiFiStatus)
 
-	srv.AddTool(mcpgo.NewTool("wifi_disconnect",
+	disconnectOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Disconnect the device from its current WiFi network"),
-	), s.handleWiFiDisconnect)
+	}
+	disconnectOpts = append(disconnectOpts, destructive()...)
+	disconnectOpts = append(disconnectOpts, openWorld()...)
+	disconnectOpts = append(disconnectOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("wifi_disconnect", disconnectOpts...), s.handleWiFiDisconnect)
 
-	srv.AddTool(mcpgo.NewTool("wifi_known_networks",
+	knownOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("List WiFi networks with saved profiles on the connected device"),
-	), s.handleWiFiKnownNetworks)
+	}
+	knownOpts = append(knownOpts, readOnly()...)
+	knownOpts = append(knownOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("wifi_known_networks", knownOpts...), s.handleWiFiKnownNetworks)
 }
 
 func (s *mcpServer) handleWiFiList(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -46,7 +62,7 @@ func (s *mcpServer) handleWiFiList(ctx context.Context, _ mcpgo.CallToolRequest)
 	}
 	resp, err := conn.AgentService.ListWiFiNetworks(ctx, &agentpb.ListWiFiNetworksRequest{})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	var networks []map[string]any
 	for _, n := range resp.GetNetworks() {
@@ -63,8 +79,7 @@ func (s *mcpServer) handleWiFiList(ctx context.Context, _ mcpgo.CallToolRequest)
 	if networks == nil {
 		networks = []map[string]any{}
 	}
-	b, _ := json.MarshalIndent(networks, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(networks), nil
 }
 
 func (s *mcpServer) handleWiFiConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -74,19 +89,19 @@ func (s *mcpServer) handleWiFiConnect(ctx context.Context, req mcpgo.CallToolReq
 	}
 	ssid := stringParam(req, "ssid")
 	if ssid == "" {
-		return mcpgo.NewToolResultError("ssid is required"), nil
+		return errResult(errCodeInvalidArgument, "ssid is required"), nil
 	}
 	resp, err := conn.AgentService.ConnectToWiFi(ctx, &agentpb.ConnectToWiFiRequest{
 		Ssid:     ssid,
 		Password: stringParam(req, "password"),
 	})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	if !resp.GetSuccess() {
-		return mcpgo.NewToolResultError(fmt.Sprintf("connect failed: %s", resp.GetErrorMessage())), nil
+		return errResultf(errCodeInternal, "connect failed: %s", resp.GetErrorMessage()), nil
 	}
-	return mcpgo.NewToolResultText(fmt.Sprintf("connected to %s", ssid)), nil
+	return okText(fmt.Sprintf("connected to %s", ssid)), nil
 }
 
 func (s *mcpServer) handleWiFiStatus(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -96,7 +111,7 @@ func (s *mcpServer) handleWiFiStatus(ctx context.Context, _ mcpgo.CallToolReques
 	}
 	resp, err := conn.AgentService.GetWiFiStatus(ctx, &agentpb.GetWiFiStatusRequest{})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	status := map[string]any{
 		"connected": resp.GetConnected(),
@@ -105,8 +120,7 @@ func (s *mcpServer) handleWiFiStatus(ctx context.Context, _ mcpgo.CallToolReques
 	if msg := resp.GetErrorMessage(); msg != "" {
 		status["error"] = msg
 	}
-	b, _ := json.MarshalIndent(status, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(status), nil
 }
 
 func (s *mcpServer) handleWiFiDisconnect(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -116,12 +130,12 @@ func (s *mcpServer) handleWiFiDisconnect(ctx context.Context, _ mcpgo.CallToolRe
 	}
 	resp, err := conn.AgentService.DisconnectWiFi(ctx, &agentpb.DisconnectWiFiRequest{})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	if !resp.GetSuccess() {
-		return mcpgo.NewToolResultError(fmt.Sprintf("disconnect failed: %s", resp.GetErrorMessage())), nil
+		return errResultf(errCodeInternal, "disconnect failed: %s", resp.GetErrorMessage()), nil
 	}
-	return mcpgo.NewToolResultText("disconnected from WiFi"), nil
+	return okText("disconnected from WiFi"), nil
 }
 
 func (s *mcpServer) handleWiFiKnownNetworks(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -131,7 +145,7 @@ func (s *mcpServer) handleWiFiKnownNetworks(ctx context.Context, _ mcpgo.CallToo
 	}
 	resp, err := conn.AgentService.ListKnownWiFiNetworks(ctx, &agentpb.ListKnownWiFiNetworksRequest{})
 	if err != nil {
-		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	var networks []map[string]any
 	for _, n := range resp.GetNetworks() {
@@ -145,6 +159,5 @@ func (s *mcpServer) handleWiFiKnownNetworks(ctx context.Context, _ mcpgo.CallToo
 	if networks == nil {
 		networks = []map[string]any{}
 	}
-	b, _ := json.MarshalIndent(networks, "", "  ")
-	return mcpgo.NewToolResultText(string(b)), nil
+	return okResult(networks), nil
 }

--- a/go/internal/cli/mcp/tools_wifi_bluetooth_test.go
+++ b/go/internal/cli/mcp/tools_wifi_bluetooth_test.go
@@ -133,6 +133,28 @@ func TestWiFiList_ReturnsNetworks(t *testing.T) {
 	}
 }
 
+func TestWiFiList_HasStructuredContent(t *testing.T) {
+	fake := &fakeWiFiBluetoothServer{
+		wifiNetworks: []*agentpb.ListWiFiNetworksResponse_WiFiNetwork{
+			{Ssid: "MyNetwork", IsConnected: true},
+		},
+	}
+	conn := startFakeAgentWiFiServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "wifi_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("wifi_list should return structuredContent")
+	}
+}
+
 func TestWiFiConnect_Success(t *testing.T) {
 	fake := &fakeWiFiBluetoothServer{
 		wifiConnectResp: &agentpb.ConnectToWiFiResponse{Success: true},
@@ -273,6 +295,28 @@ func TestBluetoothScan_ReturnsPeripherals(t *testing.T) {
 	}
 	if devices[0]["name"] != "HeadPhones" {
 		t.Errorf("name = %v, want HeadPhones", devices[0]["name"])
+	}
+}
+
+func TestBluetoothScan_HasStructuredContent(t *testing.T) {
+	fake := &fakeWiFiBluetoothServer{
+		btPeripherals: []*agentpb.DiscoveredBluetoothPeripheral{
+			{Name: "HeadPhones", Address: "AA:BB:CC:DD:EE:FF", Rssi: -60},
+		},
+	}
+	conn := startFakeAgentWiFiServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "bluetooth_scan", map[string]any{"timeout_seconds": 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("bluetooth_scan should return structuredContent")
 	}
 }
 

--- a/specs/2026-07-12-mcp-agent-improvements-plan.md
+++ b/specs/2026-07-12-mcp-agent-improvements-plan.md
@@ -98,20 +98,32 @@ Formal per-tool `WithOutputSchema[T]()` is **deferred** (needs concrete Go resul
 
 ### Annotation matrix (`annotations.go`)
 
-Helpers return option slices spread into `NewTool`:
+**CRITICAL:** `mcp-go`'s `NewTool` applies pessimistic MCP defaults to every tool —
+`ReadOnlyHint=false`, `DestructiveHint=true`, `IdempotentHint=false`, `OpenWorldHint=true`.
+"Absence" therefore advertises a tool as destructive + open-world. Helpers must set
+each axis **explicitly**. Every tool applies exactly one behavior helper
+(`readOnly`/`mutating`/`destructive`) and exactly one world helper
+(`localOnly`/`openWorld`); `idempotent()` is an optional modifier for mutating tools
+(`readOnly` already implies idempotent — do not stack them).
 
 ```go
-func readOnly() []mcpgo.ToolOption {
-	return []mcpgo.ToolOption{mcpgo.WithReadOnlyHintAnnotation(true)}
+func readOnly() []mcpgo.ToolOption { // reads only: not destructive, idempotent
+	return []mcpgo.ToolOption{mcpgo.WithReadOnlyHintAnnotation(true), mcpgo.WithDestructiveHintAnnotation(false), mcpgo.WithIdempotentHintAnnotation(true)}
 }
-func destructive() []mcpgo.ToolOption {
-	return []mcpgo.ToolOption{mcpgo.WithDestructiveHintAnnotation(true), mcpgo.WithReadOnlyHintAnnotation(false)}
+func mutating() []mcpgo.ToolOption { // changes state, not destructively
+	return []mcpgo.ToolOption{mcpgo.WithReadOnlyHintAnnotation(false), mcpgo.WithDestructiveHintAnnotation(false)}
+}
+func destructive() []mcpgo.ToolOption { // irreversible/disruptive updates
+	return []mcpgo.ToolOption{mcpgo.WithReadOnlyHintAnnotation(false), mcpgo.WithDestructiveHintAnnotation(true)}
 }
 func idempotent() []mcpgo.ToolOption {
 	return []mcpgo.ToolOption{mcpgo.WithIdempotentHintAnnotation(true)}
 }
-func openWorld() []mcpgo.ToolOption {
+func openWorld() []mcpgo.ToolOption { // external network/radios/cloud broker
 	return []mcpgo.ToolOption{mcpgo.WithOpenWorldHintAnnotation(true)}
+}
+func localOnly() []mcpgo.ToolOption { // closed world: connected device/local host
+	return []mcpgo.ToolOption{mcpgo.WithOpenWorldHintAnnotation(false)}
 }
 ```
 
@@ -124,44 +136,42 @@ opts = append(opts, openWorld()...)
 srv.AddTool(mcpgo.NewTool("device_list", opts...), s.handleDeviceList)
 ```
 
-Per-tool classification (readOnly / destructive / idempotent / openWorld):
+Per-tool classification — apply the named behavior helper + world helper (+ `idempotent()` where shown). `readOnly` already implies idempotent, so those rows show "—":
 
-| Tool | readOnly | destructive | idempotent | openWorld |
-|------|:--:|:--:|:--:|:--:|
-| wendy_status | ✓ | | | |
-| device_list | ✓ | | | ✓ |
-| device_connect | | | ✓ | ✓ |
-| device_disconnect | | | ✓ | |
-| device_info | ✓ | | | |
-| device_set_default | | | ✓ | |
-| container_list | ✓ | | | |
-| container_start | | | | |
-| container_stop | | ✓ | ✓ | |
-| container_delete | | ✓ | ✓ | |
-| container_stats | ✓ | | | |
-| container_attach | ✓ | | | |
-| telemetry_logs / _metrics / _traces | ✓ | | | |
-| wifi_list | ✓ | | | ✓ |
-| wifi_connect | | | ✓ | ✓ |
-| wifi_status | ✓ | | | |
-| wifi_disconnect | | ✓ | ✓ | ✓ |
-| wifi_known_networks | ✓ | | | |
-| bluetooth_scan | ✓ | | | ✓ |
-| bluetooth_connect | | | ✓ | ✓ |
-| bluetooth_disconnect | | ✓ | ✓ | ✓ |
-| hardware_capabilities | ✓ | | | |
-| filesync_sync | | | ✓ | |
-| provisioning_status | ✓ | | | |
-| provisioning_start | | | ✓ | ✓ |
-| os_update | | ✓ | | ✓ |
-| os_update_status | ✓ | | | |
-| cloud_discover | ✓ | | | ✓ |
-| cloud_connect / cloud_device_connect | | | ✓ | ✓ |
-| cloud_enroll_device | | | ✓ | ✓ |
-| cloud_tunnel | | | ✓ | ✓ |
-| run / cloud_run | | | | ✓ |
-
-(`readOnly=false` is the mcp-go default, so a blank cell = leave unset, except `destructive()` explicitly sets `ReadOnlyHint=false` for clarity.)
+| Tool | behavior | world | +idempotent() |
+|------|----------|-------|:--:|
+| wendy_status | readOnly | localOnly | — |
+| device_list | readOnly | openWorld | — |
+| device_connect | mutating | openWorld | ✓ |
+| device_disconnect | mutating | localOnly | ✓ |
+| device_info | readOnly | localOnly | — |
+| device_set_default | mutating | localOnly | ✓ |
+| container_list | readOnly | localOnly | — |
+| container_start | mutating | localOnly | |
+| container_stop | destructive | localOnly | ✓ |
+| container_delete | destructive | localOnly | ✓ |
+| container_stats | readOnly | localOnly | — |
+| container_attach | readOnly | localOnly | — |
+| telemetry_logs / _metrics / _traces | readOnly | localOnly | — |
+| wifi_list | readOnly | openWorld | — |
+| wifi_connect | mutating | openWorld | ✓ |
+| wifi_status | readOnly | localOnly | — |
+| wifi_disconnect | destructive | openWorld | ✓ |
+| wifi_known_networks | readOnly | localOnly | — |
+| bluetooth_scan | readOnly | openWorld | — |
+| bluetooth_connect | mutating | openWorld | ✓ |
+| bluetooth_disconnect | destructive | openWorld | ✓ |
+| hardware_capabilities | readOnly | localOnly | — |
+| filesync_sync | mutating | localOnly | ✓ |
+| provisioning_status | readOnly | localOnly | — |
+| provisioning_start | mutating | openWorld | ✓ |
+| os_update | destructive | openWorld | |
+| os_update_status | readOnly | localOnly | — |
+| cloud_discover | readOnly | openWorld | — |
+| cloud_connect / cloud_device_connect | mutating | openWorld | ✓ |
+| cloud_enroll_device | mutating | openWorld | ✓ |
+| cloud_tunnel | mutating | openWorld | ✓ |
+| run / cloud_run | mutating | openWorld | |
 
 ---
 

--- a/specs/2026-07-12-mcp-agent-improvements-plan.md
+++ b/specs/2026-07-12-mcp-agent-improvements-plan.md
@@ -1,0 +1,734 @@
+# MCP Agent-Support Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `wendy mcp serve` server materially better for AI/coding agents: safety annotations, machine-readable errors, structured (parseable) results, output bounding, progress on long ops, visible proxy diagnostics, workflow prompts, richer descriptions, and resolving the dead `filesync_sync` tool.
+
+**Architecture:** The MCP server lives in `go/internal/cli/mcp/` (~40 hand-written tools over `github.com/mark3labs/mcp-go v0.54.0`, stdio transport). We do **not** rewrite it into a DSL — we follow the existing functional-options idiom (`mcpgo.NewTool(name, opts...)`) and introduce a small set of shared helpers (`results.go`, `errors.go`, `annotations.go`, `progress.go`, `diagnostics.go`) that make the cross-cutting concerns consistent and hard to omit. Handlers keep their current signatures.
+
+**Tech Stack:** Go, `mark3labs/mcp-go` v0.54.0, gRPC (`google.golang.org/grpc`), `google.golang.org/grpc/status`, Go standard `testing`.
+
+## Global Constraints
+
+- Module path: `github.com/wendylabsinc/wendy/go`; MCP package import prefix `mcpgo "github.com/mark3labs/mcp-go/mcp"`, `"github.com/mark3labs/mcp-go/server"`.
+- Transport stays **stdio only** (`server.ServeStdio`). HTTP/SSE is explicitly out of scope (separate future design).
+- No new third-party dependencies. `mcp-go` stays pinned at v0.54.0.
+- Backward compatibility: existing tool **names and parameters must keep working**. Any renamed parameter keeps its old name as an accepted alias.
+- Every result an agent can receive carries a **text fallback** (`Content[0]` `TextContent`) in addition to any structured content, because not all MCP hosts render `structuredContent`. Existing tests read `result.Content[0].(mcpgo.TextContent).Text` — that must keep working.
+- Run gofmt on every changed file before committing. Baseline (`go test ./internal/cli/mcp/...`) is green today; keep it green after every task.
+- Test invocation from `go/`: `go test ./internal/cli/mcp/... -run <Name> -v`.
+
+---
+
+## Delivery Staging
+
+- **PR1 — Foundation (this plan, full detail):** shared helpers + apply across all tools. Items #1 (annotations), #2 (structured content), #6 (error codes), #9 (shared helpers / de-boilerplate). Tasks 1–9 below.
+- **PR2 — Reliability (roadmap locked, §Appendix A):** #3 (output bounding), #4 (progress notifications), #5 (proxy diagnostics).
+- **PR3 — Discoverability (roadmap locked, §Appendix B):** #7 (prompts), #8 (descriptions), #10 (filesync resolution).
+
+Each PR is independently mergeable and leaves tests green. Write the PR2 and PR3 step-level plans (same format) when starting them; their design is fixed in the appendices.
+
+---
+
+## File Structure (PR1)
+
+- Create: `go/internal/cli/mcp/errors.go` — `errorCode` type, constants, `errResult`, `errResultf`, `codeFromGRPC`.
+- Create: `go/internal/cli/mcp/errors_test.go`
+- Create: `go/internal/cli/mcp/results.go` — `okResult` (structured + JSON text fallback), `okText`.
+- Create: `go/internal/cli/mcp/results_test.go`
+- Create: `go/internal/cli/mcp/annotations.go` — annotation option bundles (`readOnly`, `destructive`, `idempotent`, `openWorld` helpers returning `[]mcpgo.ToolOption`).
+- Create: `go/internal/cli/mcp/annotations_test.go`
+- Modify: `server.go` — keep `errNotConnected`/`grpcErrString` (now delegating to new helpers); no signature changes.
+- Modify: every `tools_*.go` — add annotation options to each `NewTool`; replace `json.MarshalIndent(...)+NewToolResultText` with `okResult`; replace `NewToolResultError(...)` with `errResult(code, ...)`.
+
+## Design decisions locked (PR1)
+
+### Error-code taxonomy (`errors.go`)
+
+```go
+type errorCode string
+
+const (
+	errCodeNotConnected     errorCode = "NOT_CONNECTED"
+	errCodeInvalidArgument  errorCode = "INVALID_ARGUMENT"
+	errCodeDeviceUnreachable errorCode = "DEVICE_UNREACHABLE"
+	errCodeEntitlementDenied errorCode = "ENTITLEMENT_DENIED"
+	errCodeMultipleSessions errorCode = "MULTIPLE_SESSIONS"
+	errCodeNotFound         errorCode = "NOT_FOUND"
+	errCodeTimeout          errorCode = "TIMEOUT"
+	errCodeUnsupported      errorCode = "UNSUPPORTED"
+	errCodeInternal         errorCode = "INTERNAL"
+)
+```
+
+An error result carries structured content `{"error_code": "<CODE>", "message": "<msg>"}` **and** a text fallback `"[CODE] msg"`, with `IsError = true`. This preserves the current human-readable behavior (existing tests match substrings of the message) while adding a machine-readable code.
+
+```go
+func errResult(code errorCode, msg string) *mcpgo.CallToolResult {
+	r := mcpgo.NewToolResultStructured(
+		map[string]any{"error_code": string(code), "message": msg},
+		fmt.Sprintf("[%s] %s", code, msg),
+	)
+	r.IsError = true
+	return r
+}
+func errResultf(code errorCode, format string, a ...any) *mcpgo.CallToolResult {
+	return errResult(code, fmt.Sprintf(format, a...))
+}
+```
+
+gRPC status → error code mapping (`codeFromGRPC`): `Unavailable/DeadlineExceeded→DEVICE_UNREACHABLE` (DeadlineExceeded also acceptable as TIMEOUT; we map transport deadline to DEVICE_UNREACHABLE and use TIMEOUT only for our own context timeouts), `PermissionDenied→ENTITLEMENT_DENIED`, `NotFound→NOT_FOUND`, `InvalidArgument→INVALID_ARGUMENT`, `Unimplemented→UNSUPPORTED`, default→`INTERNAL`. The message stays the unwrapped gRPC message (current `grpcErrString` behavior).
+
+### Structured results (`results.go`)
+
+```go
+// okResult returns a result carrying v as structuredContent plus an indented-JSON text fallback.
+func okResult(v any) *mcpgo.CallToolResult {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResultf(errCodeInternal, "marshaling result: %s", err.Error())
+	}
+	return mcpgo.NewToolResultStructured(v, string(b))
+}
+// okText returns a plain text success result (for simple string confirmations).
+func okText(msg string) *mcpgo.CallToolResult { return mcpgo.NewToolResultText(msg) }
+```
+
+Formal per-tool `WithOutputSchema[T]()` is **deferred** (needs concrete Go result types; handlers currently build `map[string]any`). PR1 delivers `structuredContent` on every data-returning tool, which is the high-value part for agents. Note this deferral in the PR description.
+
+### Annotation matrix (`annotations.go`)
+
+Helpers return option slices spread into `NewTool`:
+
+```go
+func readOnly() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithReadOnlyHintAnnotation(true)}
+}
+func destructive() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithDestructiveHintAnnotation(true), mcpgo.WithReadOnlyHintAnnotation(false)}
+}
+func idempotent() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithIdempotentHintAnnotation(true)}
+}
+func openWorld() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithOpenWorldHintAnnotation(true)}
+}
+```
+
+Usage pattern (options spread):
+
+```go
+opts := []mcpgo.ToolOption{mcpgo.WithDescription("...")}
+opts = append(opts, readOnly()...)
+opts = append(opts, openWorld()...)
+srv.AddTool(mcpgo.NewTool("device_list", opts...), s.handleDeviceList)
+```
+
+Per-tool classification (readOnly / destructive / idempotent / openWorld):
+
+| Tool | readOnly | destructive | idempotent | openWorld |
+|------|:--:|:--:|:--:|:--:|
+| wendy_status | ✓ | | | |
+| device_list | ✓ | | | ✓ |
+| device_connect | | | ✓ | ✓ |
+| device_disconnect | | | ✓ | |
+| device_info | ✓ | | | |
+| device_set_default | | | ✓ | |
+| container_list | ✓ | | | |
+| container_start | | | | |
+| container_stop | | ✓ | ✓ | |
+| container_delete | | ✓ | ✓ | |
+| container_stats | ✓ | | | |
+| container_attach | ✓ | | | |
+| telemetry_logs / _metrics / _traces | ✓ | | | |
+| wifi_list | ✓ | | | ✓ |
+| wifi_connect | | | ✓ | ✓ |
+| wifi_status | ✓ | | | |
+| wifi_disconnect | | ✓ | ✓ | ✓ |
+| wifi_known_networks | ✓ | | | |
+| bluetooth_scan | ✓ | | | ✓ |
+| bluetooth_connect | | | ✓ | ✓ |
+| bluetooth_disconnect | | ✓ | ✓ | ✓ |
+| hardware_capabilities | ✓ | | | |
+| filesync_sync | | | ✓ | |
+| provisioning_status | ✓ | | | |
+| provisioning_start | | | ✓ | ✓ |
+| os_update | | ✓ | | ✓ |
+| os_update_status | ✓ | | | |
+| cloud_discover | ✓ | | | ✓ |
+| cloud_connect / cloud_device_connect | | | ✓ | ✓ |
+| cloud_enroll_device | | | ✓ | ✓ |
+| cloud_tunnel | | | ✓ | ✓ |
+| run / cloud_run | | | | ✓ |
+
+(`readOnly=false` is the mcp-go default, so a blank cell = leave unset, except `destructive()` explicitly sets `ReadOnlyHint=false` for clarity.)
+
+---
+
+## Task 1: Error-code helpers
+
+**Files:**
+- Create: `go/internal/cli/mcp/errors.go`
+- Test: `go/internal/cli/mcp/errors_test.go`
+
+**Interfaces:**
+- Produces: `type errorCode string`; constants above; `errResult(code errorCode, msg string) *mcpgo.CallToolResult`; `errResultf(code errorCode, format string, a ...any) *mcpgo.CallToolResult`; `codeFromGRPC(err error) errorCode`.
+
+- [ ] **Step 1: Write failing test** in `errors_test.go`
+
+```go
+package mcp
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestErrResult_StructuredAndText(t *testing.T) {
+	r := errResult(errCodeNotConnected, "no device connected")
+	if !r.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	sc, ok := r.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map structured content, got %T", r.StructuredContent)
+	}
+	if sc["error_code"] != "NOT_CONNECTED" {
+		t.Errorf("error_code = %v, want NOT_CONNECTED", sc["error_code"])
+	}
+	text := toolResultText(t, r)
+	if text != "[NOT_CONNECTED] no device connected" {
+		t.Errorf("text = %q", text)
+	}
+}
+
+func TestCodeFromGRPC(t *testing.T) {
+	cases := map[codes.Code]errorCode{
+		codes.Unavailable:      errCodeDeviceUnreachable,
+		codes.PermissionDenied: errCodeEntitlementDenied,
+		codes.NotFound:         errCodeNotFound,
+		codes.InvalidArgument:  errCodeInvalidArgument,
+		codes.Unimplemented:    errCodeUnsupported,
+		codes.Internal:         errCodeInternal,
+	}
+	for c, want := range cases {
+		if got := codeFromGRPC(status.Error(c, "x")); got != want {
+			t.Errorf("codeFromGRPC(%v) = %v, want %v", c, got, want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cli/mcp/... -run 'TestErrResult_StructuredAndText|TestCodeFromGRPC' -v`
+Expected: FAIL — `undefined: errResult` / `errCodeNotConnected` / `codeFromGRPC`.
+
+- [ ] **Step 3: Write `errors.go`**
+
+```go
+package mcp
+
+import (
+	"fmt"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type errorCode string
+
+const (
+	errCodeNotConnected      errorCode = "NOT_CONNECTED"
+	errCodeInvalidArgument   errorCode = "INVALID_ARGUMENT"
+	errCodeDeviceUnreachable errorCode = "DEVICE_UNREACHABLE"
+	errCodeEntitlementDenied errorCode = "ENTITLEMENT_DENIED"
+	errCodeMultipleSessions  errorCode = "MULTIPLE_SESSIONS"
+	errCodeNotFound          errorCode = "NOT_FOUND"
+	errCodeTimeout           errorCode = "TIMEOUT"
+	errCodeUnsupported       errorCode = "UNSUPPORTED"
+	errCodeInternal          errorCode = "INTERNAL"
+)
+
+// errResult builds an error tool result with a machine-readable code and a
+// human-readable "[CODE] message" text fallback.
+func errResult(code errorCode, msg string) *mcpgo.CallToolResult {
+	r := mcpgo.NewToolResultStructured(
+		map[string]any{"error_code": string(code), "message": msg},
+		fmt.Sprintf("[%s] %s", code, msg),
+	)
+	r.IsError = true
+	return r
+}
+
+func errResultf(code errorCode, format string, a ...any) *mcpgo.CallToolResult {
+	return errResult(code, fmt.Sprintf(format, a...))
+}
+
+// codeFromGRPC maps a gRPC status error to an errorCode.
+func codeFromGRPC(err error) errorCode {
+	st, ok := status.FromError(err)
+	if !ok {
+		return errCodeInternal
+	}
+	switch st.Code() {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return errCodeDeviceUnreachable
+	case codes.PermissionDenied:
+		return errCodeEntitlementDenied
+	case codes.NotFound:
+		return errCodeNotFound
+	case codes.InvalidArgument:
+		return errCodeInvalidArgument
+	case codes.Unimplemented:
+		return errCodeUnsupported
+	default:
+		return errCodeInternal
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cli/mcp/... -run 'TestErrResult_StructuredAndText|TestCodeFromGRPC' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/cli/mcp/errors.go internal/cli/mcp/errors_test.go
+git add internal/cli/mcp/errors.go internal/cli/mcp/errors_test.go
+git commit -m "feat(mcp): add machine-readable error codes for tool results"
+```
+
+---
+
+## Task 2: Structured-result helpers
+
+**Files:**
+- Create: `go/internal/cli/mcp/results.go`
+- Test: `go/internal/cli/mcp/results_test.go`
+
+**Interfaces:**
+- Consumes: `errResultf` (Task 1).
+- Produces: `okResult(v any) *mcpgo.CallToolResult`; `okText(msg string) *mcpgo.CallToolResult`.
+
+- [ ] **Step 1: Write failing test** in `results_test.go`
+
+```go
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOkResult_HasStructuredAndJSONText(t *testing.T) {
+	r := okResult(map[string]any{"version": "1.2.3"})
+	if r.IsError {
+		t.Fatal("expected success result")
+	}
+	if r.StructuredContent == nil {
+		t.Fatal("expected structured content")
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(toolResultText(t, r)), &m); err != nil {
+		t.Fatalf("text fallback is not valid JSON: %v", err)
+	}
+	if m["version"] != "1.2.3" {
+		t.Errorf("version = %v", m["version"])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cli/mcp/... -run TestOkResult -v`
+Expected: FAIL — `undefined: okResult`.
+
+- [ ] **Step 3: Write `results.go`**
+
+```go
+package mcp
+
+import (
+	"encoding/json"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+// okResult returns a success result carrying v as structuredContent plus an
+// indented-JSON text fallback for hosts that do not render structured content.
+func okResult(v any) *mcpgo.CallToolResult {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResultf(errCodeInternal, "marshaling result: %s", err.Error())
+	}
+	return mcpgo.NewToolResultStructured(v, string(b))
+}
+
+// okText returns a plain-text success result (for simple confirmations).
+func okText(msg string) *mcpgo.CallToolResult {
+	return mcpgo.NewToolResultText(msg)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cli/mcp/... -run TestOkResult -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/cli/mcp/results.go internal/cli/mcp/results_test.go
+git add internal/cli/mcp/results.go internal/cli/mcp/results_test.go
+git commit -m "feat(mcp): add structured-content result helper"
+```
+
+---
+
+## Task 3: Annotation option bundles
+
+**Files:**
+- Create: `go/internal/cli/mcp/annotations.go`
+- Test: `go/internal/cli/mcp/annotations_test.go`
+
+**Interfaces:**
+- Produces: `readOnly()`, `destructive()`, `idempotent()`, `openWorld()` each returning `[]mcpgo.ToolOption`.
+
+- [ ] **Step 1: Write failing test** in `annotations_test.go`
+
+```go
+package mcp
+
+import (
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestAnnotations_ReadOnlyAndDestructive(t *testing.T) {
+	ro := mcpgo.NewTool("t_ro", readOnly()...)
+	if ro.Annotations.ReadOnlyHint == nil || !*ro.Annotations.ReadOnlyHint {
+		t.Error("readOnly() should set ReadOnlyHint=true")
+	}
+	de := mcpgo.NewTool("t_de", destructive()...)
+	if de.Annotations.DestructiveHint == nil || !*de.Annotations.DestructiveHint {
+		t.Error("destructive() should set DestructiveHint=true")
+	}
+	if de.Annotations.ReadOnlyHint == nil || *de.Annotations.ReadOnlyHint {
+		t.Error("destructive() should set ReadOnlyHint=false")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cli/mcp/... -run TestAnnotations -v`
+Expected: FAIL — `undefined: readOnly`.
+
+- [ ] **Step 3: Write `annotations.go`**
+
+```go
+package mcp
+
+import mcpgo "github.com/mark3labs/mcp-go/mcp"
+
+// readOnly marks a tool that does not modify device or host state.
+func readOnly() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithReadOnlyHintAnnotation(true)}
+}
+
+// destructive marks a tool that may perform irreversible or disruptive updates.
+func destructive() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{
+		mcpgo.WithDestructiveHintAnnotation(true),
+		mcpgo.WithReadOnlyHintAnnotation(false),
+	}
+}
+
+// idempotent marks a tool where repeated identical calls have no extra effect.
+func idempotent() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithIdempotentHintAnnotation(true)}
+}
+
+// openWorld marks a tool that interacts with external entities (network,
+// nearby radios, cloud broker) whose state the server does not own.
+func openWorld() []mcpgo.ToolOption {
+	return []mcpgo.ToolOption{mcpgo.WithOpenWorldHintAnnotation(true)}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cli/mcp/... -run TestAnnotations -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/cli/mcp/annotations.go internal/cli/mcp/annotations_test.go
+git add internal/cli/mcp/annotations.go internal/cli/mcp/annotations_test.go
+git commit -m "feat(mcp): add tool annotation option bundles"
+```
+
+---
+
+## Task 4: Adopt helpers in device + status tools; add annotations
+
+**Files:**
+- Modify: `go/internal/cli/mcp/tools_device.go`
+- Modify: `go/internal/cli/mcp/tools_status.go`
+- Modify: `go/internal/cli/mcp/server.go` (`errNotConnected` now returns `errResult(errCodeNotConnected, ...)`)
+- Test: `go/internal/cli/mcp/tools_device_test.go` (add structured-content assertion)
+
+**Interfaces:**
+- Consumes: `okResult`, `errResult`, `codeFromGRPC`, annotation bundles.
+
+- [ ] **Step 1: Add a failing test** to `tools_device_test.go`
+
+```go
+func TestDeviceInfo_HasStructuredContent(t *testing.T) {
+	fake := &fakeAgentServer{versionResp: &agentpb.GetAgentVersionResponse{Version: "9.9.9", Os: "linux"}}
+	conn, _ := startFakeAgentServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+	result, err := srv.callTool(context.Background(), "device_info", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("device_info should return structuredContent")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cli/mcp/... -run TestDeviceInfo_HasStructuredContent -v`
+Expected: FAIL — `StructuredContent` is nil (handler still uses `NewToolResultText`).
+
+- [ ] **Step 3: Update `server.go` `errNotConnected`**
+
+```go
+func errNotConnected() *mcpgo.CallToolResult {
+	return errResult(errCodeNotConnected, "no device connected — use device_connect first")
+}
+```
+
+- [ ] **Step 4: Update `tools_device.go`** — registration adds annotations; handlers use helpers. Replace the `registerDeviceTools` body with option-spread form and swap result constructors. Examples:
+
+```go
+func (s *mcpServer) registerDeviceTools(srv *server.MCPServer) {
+	listOpts := []mcpgo.ToolOption{
+		mcpgo.WithDescription("List wendy devices from config and known addresses. Pass scan=true to also run a live 3-second mDNS scan for devices on the local network."),
+		mcpgo.WithBoolean("scan", mcpgo.Description("If true, run a live mDNS scan (3 s) in addition to returning configured devices")),
+	}
+	listOpts = append(listOpts, readOnly()...)
+	listOpts = append(listOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("device_list", listOpts...), s.handleDeviceList)
+
+	connectOpts := []mcpgo.ToolOption{
+		mcpgo.WithDescription("Connect to a wendy device by address (host:port)"),
+		mcpgo.WithString("address", mcpgo.Required(), mcpgo.Description("Device address, e.g. mydevice.local:50051 or 192.168.1.10:50051")),
+	}
+	connectOpts = append(connectOpts, idempotent()...)
+	connectOpts = append(connectOpts, openWorld()...)
+	srv.AddTool(mcpgo.NewTool("device_connect", connectOpts...), s.handleDeviceConnect)
+
+	disconnectOpts := append([]mcpgo.ToolOption{mcpgo.WithDescription("Disconnect from the currently connected device")}, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("device_disconnect", disconnectOpts...), s.handleDeviceDisconnect)
+
+	infoOpts := append([]mcpgo.ToolOption{mcpgo.WithDescription("Get agent version, OS, CPU architecture, GPU info, and feature set of connected device")}, readOnly()...)
+	srv.AddTool(mcpgo.NewTool("device_info", infoOpts...), s.handleDeviceInfo)
+
+	setDefaultOpts := []mcpgo.ToolOption{
+		mcpgo.WithDescription("Save an address as the default device in ~/.wendy/config.json"),
+		mcpgo.WithString("address", mcpgo.Required(), mcpgo.Description("Device address to save as default")),
+	}
+	setDefaultOpts = append(setDefaultOpts, idempotent()...)
+	srv.AddTool(mcpgo.NewTool("device_set_default", setDefaultOpts...), s.handleDeviceSetDefault)
+}
+```
+
+Handler result swaps in `tools_device.go`:
+- `handleDeviceList`: final `return mcpgo.NewToolResultText(string(b)), nil` → `return okResult(devices), nil` (drop the manual `json.MarshalIndent`; keep the `if len(devices)==0 { devices = []map[string]any{} }` guard).
+- `handleDeviceConnect`: `address == ""` branch → `return errResult(errCodeInvalidArgument, "address is required"), nil`; connect-failure branch → `return errResultf(errCodeDeviceUnreachable, "connecting to %s: %s", address, err.Error()), nil`; success → `return okText(fmt.Sprintf("connected to %s", address)), nil`.
+- `handleDeviceInfo`: gRPC error branch → `return errResult(codeFromGRPC(err), grpcErrString(err)), nil`; final → `return okResult(info), nil`.
+- `handleDeviceSetDefault`: empty → `errResult(errCodeInvalidArgument, "address is required")`; save error → `errResultf(errCodeInternal, "saving config: %s", err.Error())`; success → `okText(...)`.
+
+Remove now-unused `encoding/json` import from `tools_device.go` **only if** no other use remains (handleDeviceList/Info no longer marshal). Verify with `go build`.
+
+- [ ] **Step 5: Update `tools_status.go`** analogously — add `readOnly()` to `wendy_status`, swap its data result to `okResult` and any error to `errResult`. (Read the file first; apply the same mechanical swaps.)
+
+- [ ] **Step 6: Run tests**
+
+Run: `go test ./internal/cli/mcp/... -run 'TestDevice|TestWendyStatus' -v`
+Expected: PASS (including the new structured-content test and all pre-existing device/status tests, which read `Content[0].Text`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+gofmt -w internal/cli/mcp/tools_device.go internal/cli/mcp/tools_status.go internal/cli/mcp/server.go internal/cli/mcp/tools_device_test.go
+git add -A internal/cli/mcp/
+git commit -m "feat(mcp): annotations + structured results for device and status tools"
+```
+
+---
+
+## Task 5: Adopt helpers in container tools
+
+**Files:**
+- Modify: `go/internal/cli/mcp/tools_container.go`
+- Test: `go/internal/cli/mcp/tools_container_test.go`
+
+**Interfaces:** Consumes helpers from Tasks 1–3.
+
+- [ ] **Step 1: Add failing test** asserting `container_delete` is annotated destructive at registration. Because tests call handlers directly (not via a registered server), assert the annotation through a tiny registration probe:
+
+```go
+func TestContainerDelete_AnnotatedDestructive(t *testing.T) {
+	srv := server.NewMCPServer("t", "0")
+	s := New(&config.Config{}, nil)
+	s.registerContainerTools(srv)
+	tools := srv.ListTools() // returns map[string]ServerTool
+	tool, ok := tools["container_delete"]
+	if !ok {
+		t.Fatal("container_delete not registered")
+	}
+	if tool.Tool.Annotations.DestructiveHint == nil || !*tool.Tool.Annotations.DestructiveHint {
+		t.Error("container_delete should be annotated destructive")
+	}
+}
+```
+
+Note: confirm the accessor name for registered tools on `*server.MCPServer` in v0.54.0 before finalizing (grep `func (s \*MCPServer) ListTools` in the module cache; if the accessor differs, adjust — do not invent one). If no public accessor exists, drop this probe test and instead assert annotations via a unit test on the option bundle already covered in Task 3, and rely on manual verification for wiring.
+
+- [ ] **Step 2: Run — verify fail.** `go test ./internal/cli/mcp/... -run TestContainerDelete_AnnotatedDestructive -v`
+
+- [ ] **Step 3: Update `tools_container.go`** — add annotations per matrix (`container_list`/`container_stats`/`container_attach` readOnly; `container_stop`/`container_delete` destructive+idempotent; `container_start` none). Swap every `NewToolResultError(...)` → `errResult(code, ...)` using `codeFromGRPC` for gRPC failures and `errCodeInvalidArgument` for bad params; swap data results (`container_list`, `container_stats`) → `okResult(...)`. Preserve the entitlement-denied text in `container_list` termination handling but wrap as `errResult(errCodeEntitlementDenied, msg)` where the code returns an error for that case.
+
+- [ ] **Step 4: Run tests.** `go test ./internal/cli/mcp/... -run TestContainer -v` — Expected PASS.
+
+- [ ] **Step 5: Commit.** `feat(mcp): annotations + structured results for container tools`
+
+---
+
+## Task 6: Adopt helpers in telemetry, wifi, bluetooth, hardware tools
+
+**Files:** Modify `tools_telemetry.go`, `tools_wifi.go`, `tools_bluetooth.go`, `tools_hardware.go`; touch matching `_test.go` where an assertion strengthens (structured content on a list tool each).
+
+- [ ] **Step 1:** Add one structured-content test per domain (e.g. `TestWiFiList_HasStructuredContent`, `TestHardwareCapabilities_HasStructuredContent`) following the Task 4 pattern, using the existing fakes in each `_test.go`.
+- [ ] **Step 2:** Run — verify fail.
+- [ ] **Step 3:** Apply annotations per matrix and swap result constructors (`okResult` for data; `errResult`+`codeFromGRPC` for gRPC errors; `errCodeInvalidArgument` for missing required params like `ssid`, `mac`).
+- [ ] **Step 4:** Run `go test ./internal/cli/mcp/... -run 'TestTelemetry|TestWiFi|TestBluetooth|TestHardware' -v` — Expected PASS.
+- [ ] **Step 5:** Commit `feat(mcp): annotations + structured results for telemetry/wifi/bluetooth/hardware tools`.
+
+---
+
+## Task 7: Adopt helpers in provisioning, os, filesync tools
+
+**Files:** Modify `tools_provisioning.go`, `tools_os.go`, `tools_filesync.go`; matching `_test.go`.
+
+- [ ] **Step 1:** Add structured-content test for `provisioning_status`; keep the `filesync_sync` error test but assert its code is `errCodeUnsupported` now:
+
+```go
+func TestFileSyncSync_UnsupportedCode(t *testing.T) {
+	srv := New(&config.Config{}, nil)
+	r, _ := srv.callTool(context.Background(), "filesync_sync", nil)
+	if !r.IsError {
+		t.Fatal("filesync_sync should error")
+	}
+	sc, _ := r.StructuredContent.(map[string]any)
+	if sc == nil || sc["error_code"] != "UNSUPPORTED" {
+		t.Errorf("want error_code UNSUPPORTED, got %v", sc)
+	}
+}
+```
+
+- [ ] **Step 2:** Run — verify fail.
+- [ ] **Step 3:** Apply annotations (`provisioning_status`/`os_update_status` readOnly; `provisioning_start` idempotent+openWorld; `os_update` destructive+openWorld; `filesync_sync` idempotent). Swap result constructors; `filesync_sync` returns `errResult(errCodeUnsupported, "filesync over MCP is not supported; run `wendy device sync` from the CLI")`. (Full resolution of filesync is PR3 Task; here we only migrate to the code.)
+- [ ] **Step 4:** Run `go test ./internal/cli/mcp/... -run 'TestProvisioning|TestOS|TestFileSync|TestHardware' -v` — Expected PASS.
+- [ ] **Step 5:** Commit `feat(mcp): annotations + structured results for provisioning/os/filesync tools`.
+
+---
+
+## Task 8: Adopt helpers in cloud tools
+
+**Files:** Modify `tools_cloud.go`; `tools_cloud_test.go`.
+
+- [ ] **Step 1:** Add a structured-content test for `cloud_discover` (using its existing fake); keep the multi-session error test but assert code `errCodeMultipleSessions`.
+- [ ] **Step 2:** Run — verify fail.
+- [ ] **Step 3:** Apply annotations per matrix. Swap constructors. Map the multi-session error (`ErrMultipleSessions`) to `errResult(errCodeMultipleSessions, <existing actionable message>)`; `pickCloudAsset` "run cloud_discover" → `errResult(errCodeNotFound, ...)`; `run`/`cloud_run` shell-out failures → `errResultf(errCodeInternal, ...)` preserving combined output in the message; `cloud_discover` over-cap → `errResultf(errCodeInvalidArgument, ...)`.
+- [ ] **Step 4:** Run `go test ./internal/cli/mcp/... -run TestCloud -v` — Expected PASS.
+- [ ] **Step 5:** Commit `feat(mcp): annotations + structured results for cloud tools`.
+
+---
+
+## Task 9: Full-package verification + guide-resource note
+
+**Files:** Modify `go/internal/cli/assets/docs/` guide source if the guide text lives there, or `tools_guide.go` inline text — add a short "Result shape & error codes" paragraph documenting that data tools return `structuredContent` and errors carry `error_code`.
+
+- [ ] **Step 1:** Run the whole package: `go test ./internal/cli/mcp/... -v` — Expected: all PASS, zero skips of previously-passing tests.
+- [ ] **Step 2:** `go vet ./internal/cli/mcp/...` — Expected: clean.
+- [ ] **Step 3:** `gofmt -l internal/cli/mcp` — Expected: no files listed.
+- [ ] **Step 4:** Add the guide paragraph (read `tools_guide.go` first; append to the guide text constant). Text: *"Tools that return data include a machine-readable `structuredContent` object alongside human-readable text. Errors include an `error_code` (e.g. NOT_CONNECTED, ENTITLEMENT_DENIED, DEVICE_UNREACHABLE) you can branch on. Tool annotations mark read-only vs destructive operations."*
+- [ ] **Step 5:** Commit `docs(mcp): document structured results and error codes in guide`.
+
+---
+
+## Self-Review (PR1)
+
+- **Coverage:** #1 annotations → Task 3 bundles + Tasks 4–8 apply the matrix (every tool row assigned). #2 structured content → `okResult` (Task 2) applied Tasks 4–8; formal outputSchema explicitly deferred and noted. #6 error codes → Task 1 + applied Tasks 4–8; taxonomy maps every current error site. #9 de-boilerplate → `errors.go`/`results.go`/`annotations.go` replace the repeated `json.MarshalIndent`+`NewToolResultText`+`NewToolResultError` triples; no DSL rewrite (follows codebase idiom).
+- **Placeholders:** none — every code step shows the code; the one uncertain accessor (`ListTools`) has an explicit "verify or drop" instruction rather than an invented API.
+- **Type consistency:** `errorCode` constants, `errResult`/`errResultf`/`codeFromGRPC`, `okResult`/`okText`, `readOnly/destructive/idempotent/openWorld` names are used identically in every task.
+- **Backward-compat:** text fallback preserved on every result (existing `Content[0].Text` tests unaffected); no tool/param renames in PR1.
+
+---
+
+# Appendix A — PR2 (Reliability) design lock
+
+Write the step-level plan (same TDD format) at PR2 start. Design is fixed:
+
+**#3 Output bounding — `results.go` additions.**
+- `clampJSON(v any, maxBytes int) (any, bool)`: marshal, and if over `maxBytes`, return a truncation envelope `{"truncated": true, "max_bytes": N, "note": "output exceeded N bytes; narrow the query (reduce max_batches / max_chunks or filter)"}` with as much head data as fits, plus `truncated=true`. Default `maxBytes = 100_000`, overridable per call via a new optional `max_bytes` number param on `telemetry_logs`, `container_attach`, `container_start`, `run`.
+- Rename `max_lines` → `max_chunks` on `container_attach`/`container_start`, **accepting `max_lines` as an alias** (`intParam` with fallback to the other key). Update descriptions to say "chunks".
+- Every bounded result sets a top-level `truncated` bool in structured content so an agent knows data was cut.
+- Honest limitation to log in PR body: gRPC streams are **not resumable**, so there is no true cursor; bounding = byte cap + explicit `truncated` signal + narrower-query guidance.
+
+**#4 Progress notifications — new `progress.go`.**
+- `reportProgress(ctx, progressToken, progress, total float64, message string)` uses `server.ServerFromContext(ctx).SendNotificationToClient(ctx, "notifications/progress", params)`; no-op when `progressToken == nil`.
+- Extract `progressToken` from `req.Params.Meta` (guard nil Meta). Wire into `handleOSUpdate` (emit per `[phase] N%`), `handleProvisioningStart` (emit each 3s poll), `handleRun` (emit on start/end). Final return unchanged (still the summary blob).
+- Handlers get the server via `server.ServerFromContext(ctx)` — no struct change needed.
+
+**#5 Proxy diagnostics — new `diagnostics.go` + `mcpServer` field.**
+- Add `proxyDiag []proxyDiagEntry` (guarded by existing `mu`) with `{app_name, stage, error, time}`; `time` supplied by caller (avoid `time.Now()` inside pure helpers is unnecessary here — this is runtime, `time.Now()` is fine in non-workflow code).
+- Replace the six `fmt.Fprintf(os.Stderr, "Warning: ...")` sites in `server.go` with `s.recordProxyDiag(appName, stage, err)` (keep a single stderr line too for humans).
+- Surface via (a) a new `wendy://diagnostics` resource listing entries as JSON, and (b) a `proxy_diagnostics` array in `wendy_status` structured content.
+- Add `WithResourceCapabilities(true, true)` only in PR that adds listChanged; leave as-is here.
+
+---
+
+# Appendix B — PR3 (Discoverability) design lock
+
+**#7 Prompts — new `prompts.go`, registered in `Start`.**
+- `AddPrompt` three workflow prompts: `deploy_app` (args: `app_path`, `device?`), `diagnose_container` (args: `app_name?`), `provision_device` (args: `address?`). Each handler returns `GetPromptResult` with a user-role message templating the known connect→act→verify tool sequence in prose. No device calls in the handler — pure templating.
+
+**#8 Descriptions — sweep across `tools_*.go`.**
+- Add a worked example line to `container_start`/`run` descriptions referencing `wendy.json` entitlements (e.g. gpu/network/persistence) the app may need, and note that entitlement failures surface as `error_code=ENTITLEMENT_DENIED`.
+- Ensure the `max_lines`→`max_chunks` rename (from PR2) descriptions read correctly.
+- Add example addresses/args where missing (audit each `WithString`/`WithNumber` `Description`).
+
+**#10 filesync resolution — decision: implement minimal or remove.**
+- `WendyFileSyncService.SyncFiles` is a bidi stream (FileSyncStart → chunks/commit → manifest/ack → complete). Implementing full host↔device dir sync over MCP is high-effort and awkward (agent-driven binary transfer). **Default: remove `filesync_sync` from the tool list** and add a guide note pointing at the CLII (`wendy device sync`), because a tool that only ever errors wastes an agent call. Alternative (only if product wants it): implement a **single-file push** MCP tool (`filesync_push` with `local_path`,`remote_path`) using the existing stream for one file. Pick at PR3 start; default is removal.
+
+---
+
+# Execution notes
+
+- Tasks 4–8 are mechanical and independent per file, but they share the three helper files (Tasks 1–3), so **Tasks 1–3 must land first**. 4–8 can then be done in any order / parallelized across subagents in this worktree (distinct files, no shared edits except each touches its own `tools_*` + `_test`).
+- Run the full `go test ./internal/cli/mcp/...` after each of Tasks 4–8, not just the filtered subset, to catch cross-file breakage from the shared helper adoption.


### PR DESCRIPTION
## MCP agent-support improvements — PR1 of 3 (Foundation)

Makes the `wendy mcp serve` server materially better for AI/coding agents. This is the first of three staged PRs; design + roadmap in `specs/2026-07-12-mcp-agent-improvements-plan.md`.

### What this PR does (all ~40 tools)
- **Tool annotations (#1):** every tool explicitly declares behavior (`readOnly`/`mutating`/`destructive`) + world (`localOnly`/`openWorld`) + `idempotent`, so hosts/agents can reason about safety (auto-approve reads, confirm destructive ops). Fixes a real trap: `mcp-go`'s `NewTool` defaults hints to `Destructive=true`+`OpenWorld=true`, so relying on "unset" was mis-advertising every tool — helpers now set each axis explicitly.
- **Structured content (#2):** data tools return `structuredContent` alongside a JSON text fallback (`okResult`), so agents parse structured data instead of scraping free text. (Formal per-tool `WithOutputSchema` is deferred — handlers build `map[string]any`; structured content ships now.)
- **Machine-readable error codes (#6):** every error carries `error_code` (`NOT_CONNECTED`, `ENTITLEMENT_DENIED`, `DEVICE_UNREACHABLE`, `INVALID_ARGUMENT`, `NOT_FOUND`, `MULTIPLE_SESSIONS`, `UNSUPPORTED`, `TIMEOUT`, `INTERNAL`) plus a `[CODE] message` text fallback, with gRPC status mapped via `codeFromGRPC`.
- **De-boilerplate (#9):** three shared helper files (`errors.go`, `results.go`, `annotations.go`) replace the hand-rolled `MarshalIndent`+`NewToolResultText`/`NewToolResultError` triples. Follows the existing functional-options idiom (deliberately not a DSL rewrite). No residual raw constructors remain in tool files.
- `filesync_sync` now returns a clean `UNSUPPORTED` code (full resolution in PR3); guide resource documents the new result/error conventions.

### Backward compatibility
No tool or parameter renames. Every result keeps a `TextContent` fallback and errors keep `IsError=true`, so existing consumers reading `Content[0].Text` are unaffected.

### Testing
Full `go test ./internal/cli/mcp/...` green (72 tests, incl. new structured-content + annotation tests), `go vet` clean, `gofmt` clean, module builds. Developed subagent-driven with per-task review + an Opus whole-branch review (0 critical/0 important).

### Out of scope / follow-ups
- **PR2 (Reliability):** output bounding (#3), progress notifications (#4), proxy diagnostics (#5).
- **PR3 (Discoverability):** workflow prompts (#7), richer descriptions (#8), filesync resolution (#10).
- HTTP/SSE transport intentionally deferred (separate security/design work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
