### PR TITLE
feat(mcp): reliability — progress, output bounding, proxy diagnostics (PR2/3)

### DIFF
--- a/go/internal/cli/mcp/diagnostics.go
+++ b/go/internal/cli/mcp/diagnostics.go
@@ -1,0 +1,38 @@
+package mcp
+
+import "time"
+
+// proxyDiagEntry records a single container-MCP proxy failure so it can be
+// surfaced to callers instead of vanishing to stderr.
+type proxyDiagEntry struct {
+	AppName string `json:"app_name"`
+	Stage   string `json:"stage"`
+	Error   string `json:"error"`
+	Time    string `json:"time"`
+}
+
+// recordProxyDiag appends a diagnostic entry for a container-MCP proxy
+// failure. No-op if err is nil.
+func (s *mcpServer) recordProxyDiag(appName, stage string, err error) {
+	if err == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.proxyDiag = append(s.proxyDiag, proxyDiagEntry{
+		AppName: appName,
+		Stage:   stage,
+		Error:   err.Error(),
+		Time:    time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+// proxyDiagnostics returns a copy of all recorded container-MCP proxy
+// diagnostics.
+func (s *mcpServer) proxyDiagnostics() []proxyDiagEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]proxyDiagEntry, len(s.proxyDiag))
+	copy(out, s.proxyDiag)
+	return out
+}

--- a/go/internal/cli/mcp/diagnostics_test.go
+++ b/go/internal/cli/mcp/diagnostics_test.go
@@ -1,0 +1,26 @@
+package mcp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+func TestProxyDiag_RecordAndRead(t *testing.T) {
+	s := New(&config.Config{}, nil)
+	s.recordProxyDiag("paperless", "initialize", errors.New("boom"))
+	d := s.proxyDiagnostics()
+	if len(d) != 1 || d[0].AppName != "paperless" || d[0].Stage != "initialize" || d[0].Error != "boom" {
+		t.Fatalf("unexpected diagnostics: %+v", d)
+	}
+}
+
+func TestProxyDiag_NilErrorNotRecorded(t *testing.T) {
+	s := New(&config.Config{}, nil)
+	s.recordProxyDiag("paperless", "initialize", nil)
+	d := s.proxyDiagnostics()
+	if len(d) != 0 {
+		t.Fatalf("expected no diagnostics recorded for nil error, got: %+v", d)
+	}
+}

--- a/go/internal/cli/mcp/progress.go
+++ b/go/internal/cli/mcp/progress.go
@@ -1,0 +1,41 @@
+package mcp
+
+import (
+	"context"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// progressToken returns the client-supplied progress token for this request,
+// or nil if the client did not request progress.
+func progressToken(req mcpgo.CallToolRequest) any {
+	if req.Params.Meta == nil {
+		return nil
+	}
+	return req.Params.Meta.ProgressToken
+}
+
+// reportProgress emits an MCP progress notification for token. It is a silent
+// no-op when token is nil or no server is bound to ctx, and it never returns an
+// error — progress is best-effort telemetry, not part of a tool's contract.
+func reportProgress(ctx context.Context, token any, progress, total float64, message string) {
+	if token == nil {
+		return
+	}
+	srv := server.ServerFromContext(ctx)
+	if srv == nil {
+		return
+	}
+	params := map[string]any{
+		"progressToken": token,
+		"progress":      progress,
+	}
+	if total > 0 {
+		params["total"] = total
+	}
+	if message != "" {
+		params["message"] = message
+	}
+	_ = srv.SendNotificationToClient(ctx, "notifications/progress", params)
+}

--- a/go/internal/cli/mcp/progress_test.go
+++ b/go/internal/cli/mcp/progress_test.go
@@ -1,0 +1,24 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestProgressToken_NilWhenNoMeta(t *testing.T) {
+	if progressToken(mcpgo.CallToolRequest{}) != nil {
+		t.Error("expected nil token when no _meta")
+	}
+}
+
+func TestReportProgress_NoTokenNoPanic(t *testing.T) {
+	// nil token + no server in ctx must be a safe no-op.
+	reportProgress(context.Background(), nil, 1, 2, "x")
+}
+
+func TestReportProgress_NoServerNoPanic(t *testing.T) {
+	// non-nil token but no server bound to ctx must not panic.
+	reportProgress(context.Background(), "tok-1", 1, 2, "x")
+}

--- a/go/internal/cli/mcp/results.go
+++ b/go/internal/cli/mcp/results.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
@@ -19,4 +20,39 @@ func okResult(v any) *mcpgo.CallToolResult {
 // okText returns a plain-text success result (for simple confirmations).
 func okText(msg string) *mcpgo.CallToolResult {
 	return mcpgo.NewToolResultText(msg)
+}
+
+// okResultBounded is okResult with a byte ceiling on the JSON text fallback.
+// gRPC streams are not resumable, so when the payload exceeds maxBytes we do
+// not paginate — we return a truncation envelope telling the agent to narrow
+// the query. maxBytes <= 0 disables the cap (behaves as okResult).
+func okResultBounded(v any, maxBytes int) *mcpgo.CallToolResult {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResultf(errCodeInternal, "marshaling result: %s", err.Error())
+	}
+	if maxBytes > 0 && len(b) > maxBytes {
+		env := map[string]any{
+			"truncated": true,
+			"max_bytes": maxBytes,
+			"bytes":     len(b),
+			"note":      "output exceeded max_bytes; narrow the query (reduce max_batches / max_chunks, add filters, or raise max_bytes)",
+		}
+		eb, _ := json.MarshalIndent(env, "", "  ")
+		return mcpgo.NewToolResultStructured(env, string(eb))
+	}
+	return mcpgo.NewToolResultStructured(v, string(b))
+}
+
+// okTextBounded returns a plain-text success result like okText, but clamps s
+// to maxBytes bytes and appends a truncation note when it exceeds the cap.
+// Kept separate from okResultBounded because JSON-marshaling a plain string
+// (as okResultBounded would) quotes and escapes it, changing the text output
+// format for tools whose callers rely on the raw, unquoted text. maxBytes <=
+// 0 disables the cap (behaves as okText).
+func okTextBounded(s string, maxBytes int) *mcpgo.CallToolResult {
+	if maxBytes > 0 && len(s) > maxBytes {
+		s = s[:maxBytes] + fmt.Sprintf("\n[truncated: output exceeded max_bytes=%d; narrow the query (reduce max_chunks, add filters, or raise max_bytes)]", maxBytes)
+	}
+	return okText(s)
 }

--- a/go/internal/cli/mcp/results.go
+++ b/go/internal/cli/mcp/results.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"unicode/utf8"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
@@ -45,14 +46,24 @@ func okResultBounded(v any, maxBytes int) *mcpgo.CallToolResult {
 }
 
 // okTextBounded returns a plain-text success result like okText, but clamps s
-// to maxBytes bytes and appends a truncation note when it exceeds the cap.
-// Kept separate from okResultBounded because JSON-marshaling a plain string
-// (as okResultBounded would) quotes and escapes it, changing the text output
-// format for tools whose callers rely on the raw, unquoted text. maxBytes <=
-// 0 disables the cap (behaves as okText).
-func okTextBounded(s string, maxBytes int) *mcpgo.CallToolResult {
+// to maxBytes bytes and appends a truncation note when it exceeds the cap. The
+// cut is backed off to the nearest UTF-8 rune boundary so the result is never
+// invalid UTF-8 (which some hosts reject when serializing TextContent). hint is
+// a tool-specific suggestion for narrowing output; a generic one is used when
+// empty. Kept separate from okResultBounded because JSON-marshaling a plain
+// string (as okResultBounded would) quotes and escapes it, changing the text
+// output format for tools whose callers rely on the raw, unquoted text.
+// maxBytes <= 0 disables the cap (behaves as okText).
+func okTextBounded(s, hint string, maxBytes int) *mcpgo.CallToolResult {
 	if maxBytes > 0 && len(s) > maxBytes {
-		s = s[:maxBytes] + fmt.Sprintf("\n[truncated: output exceeded max_bytes=%d; narrow the query (reduce max_chunks, add filters, or raise max_bytes)]", maxBytes)
+		cut := maxBytes
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		if hint == "" {
+			hint = "narrow the query (reduce max_chunks, add filters, or raise max_bytes)"
+		}
+		s = s[:cut] + fmt.Sprintf("\n[truncated: output exceeded max_bytes=%d; %s]", maxBytes, hint)
 	}
 	return okText(s)
 }

--- a/go/internal/cli/mcp/results_test.go
+++ b/go/internal/cli/mcp/results_test.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestOkResult_HasStructuredAndJSONText(t *testing.T) {
@@ -45,5 +47,26 @@ func TestOkResultBounded_PassesSmall(t *testing.T) {
 	sc, _ := r.StructuredContent.(map[string]any)
 	if sc["truncated"] == true {
 		t.Error("small payload should not be truncated")
+	}
+}
+
+func TestOkTextBounded_TruncatesOnRuneBoundary(t *testing.T) {
+	// A string of 3-byte runes (each "世" is 3 bytes). Cutting at a byte cap
+	// that lands mid-rune must back off so the result stays valid UTF-8.
+	s := strings.Repeat("世", 20)  // 60 bytes
+	r := okTextBounded(s, "", 10) // 10 is not a multiple of 3 → mid-rune cut
+	text := toolResultText(t, r)
+	if !utf8.ValidString(text) {
+		t.Fatalf("truncated output is not valid UTF-8: %q", text)
+	}
+	if !strings.Contains(text, "truncated") {
+		t.Error("expected a truncation note in the output")
+	}
+}
+
+func TestOkTextBounded_PassesSmall(t *testing.T) {
+	r := okTextBounded("hello", "", 100000)
+	if toolResultText(t, r) != "hello" {
+		t.Error("under-cap text should be returned verbatim")
 	}
 }

--- a/go/internal/cli/mcp/results_test.go
+++ b/go/internal/cli/mcp/results_test.go
@@ -21,3 +21,29 @@ func TestOkResult_HasStructuredAndJSONText(t *testing.T) {
 		t.Errorf("version = %v", m["version"])
 	}
 }
+
+func TestOkResultBounded_TruncatesOversize(t *testing.T) {
+	big := make([]string, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		big = append(big, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	}
+	r := okResultBounded(big, 200)
+	if r.IsError {
+		t.Fatal("truncation is not an error result")
+	}
+	sc, ok := r.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected truncation envelope map, got %T", r.StructuredContent)
+	}
+	if sc["truncated"] != true {
+		t.Errorf("expected truncated=true, got %v", sc["truncated"])
+	}
+}
+
+func TestOkResultBounded_PassesSmall(t *testing.T) {
+	r := okResultBounded(map[string]any{"k": "v"}, 100000)
+	sc, _ := r.StructuredContent.(map[string]any)
+	if sc["truncated"] == true {
+		t.Error("small payload should not be truncated")
+	}
+}

--- a/go/internal/cli/mcp/server.go
+++ b/go/internal/cli/mcp/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"sync"
 	"time"
@@ -141,7 +142,10 @@ func intParam(req mcpgo.CallToolRequest, name string, defaultVal int) int {
 
 // intParamAlias reads primary, falling back to alias, then defaultVal.
 func intParamAlias(req mcpgo.CallToolRequest, primary, alias string, defaultVal int) int {
-	if v := req.GetInt(primary, -1<<62); v != -1<<62 {
+	// math.MinInt is a sentinel no realistic caller supplies; using it (rather
+	// than an int-overflowing constant like -1<<62) keeps this portable across
+	// 32- and 64-bit build targets.
+	if v := req.GetInt(primary, math.MinInt); v != math.MinInt {
 		return v
 	}
 	return req.GetInt(alias, defaultVal)

--- a/go/internal/cli/mcp/server.go
+++ b/go/internal/cli/mcp/server.go
@@ -137,6 +137,14 @@ func intParam(req mcpgo.CallToolRequest, name string, defaultVal int) int {
 	return req.GetInt(name, defaultVal)
 }
 
+// intParamAlias reads primary, falling back to alias, then defaultVal.
+func intParamAlias(req mcpgo.CallToolRequest, primary, alias string, defaultVal int) int {
+	if v := req.GetInt(primary, -1<<62); v != -1<<62 {
+		return v
+	}
+	return req.GetInt(alias, defaultVal)
+}
+
 // registerContainerMCPTools scans running containers for mcp_port > 0 and
 // registers each container's tools on srv, prefixed with the app name.
 // Errors per-container are warnings; they do not prevent the session from starting.

--- a/go/internal/cli/mcp/server.go
+++ b/go/internal/cli/mcp/server.go
@@ -31,6 +31,7 @@ type mcpServer struct {
 	cloudTunnels  map[string]*mcpCloudTunnel
 	discoverLANFn func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error)
 	mu            sync.RWMutex
+	proxyDiag     []proxyDiagEntry
 }
 
 func New(cfg *config.Config, connectFn ConnectFunc) *mcpServer {
@@ -96,6 +97,7 @@ func (s *mcpServer) Start(ctx context.Context) error {
 	)
 	s.registerStatusTools(srv)
 	s.registerGuideResource(srv)
+	s.registerDiagnosticsResource(srv)
 	s.registerDeviceTools(srv)
 	s.registerContainerTools(srv)
 	s.registerTelemetryTools(srv)
@@ -156,6 +158,7 @@ func (s *mcpServer) registerContainerMCPTools(ctx context.Context, srv *server.M
 
 	stream, err := conn.ContainerService.ListContainers(ctx, &agentpb.ListContainersRequest{})
 	if err != nil {
+		s.recordProxyDiag("", "list-containers", err)
 		fmt.Fprintf(os.Stderr, "Warning: listing containers for MCP tools: %v\n", err)
 		return nil
 	}
@@ -167,6 +170,7 @@ func (s *mcpServer) registerContainerMCPTools(ctx context.Context, srv *server.M
 			break
 		}
 		if err != nil {
+			s.recordProxyDiag("", "read-container-list", err)
 			fmt.Fprintf(os.Stderr, "Warning: reading container list: %v\n", err)
 			return cleanups
 		}
@@ -188,6 +192,7 @@ func (s *mcpServer) registerContainerMCPTools(ctx context.Context, srv *server.M
 func (s *mcpServer) connectContainerMCPTools(ctx context.Context, srv *server.MCPServer, conn *grpcclient.AgentConnection, appName string) func() {
 	addr, closeProxy, err := startMCPProxy(ctx, conn, appName)
 	if err != nil {
+		s.recordProxyDiag(appName, "proxy", err)
 		fmt.Fprintf(os.Stderr, "Warning: MCP proxy for %s: %v\n", appName, err)
 		return nil
 	}
@@ -195,6 +200,7 @@ func (s *mcpServer) connectContainerMCPTools(ctx context.Context, srv *server.MC
 	mcpCli, err := mcpclient.NewStreamableHttpClient("http://" + addr)
 	if err != nil {
 		closeProxy()
+		s.recordProxyDiag(appName, "client", err)
 		fmt.Fprintf(os.Stderr, "Warning: MCP client for %s: %v\n", appName, err)
 		return nil
 	}
@@ -216,6 +222,7 @@ func (s *mcpServer) connectContainerMCPTools(ctx context.Context, srv *server.MC
 	}
 	if initErr != nil {
 		closeProxy()
+		s.recordProxyDiag(appName, "initialize", initErr)
 		fmt.Fprintf(os.Stderr, "Warning: MCP init for %s: %v\n", appName, initErr)
 		return nil
 	}
@@ -223,6 +230,7 @@ func (s *mcpServer) connectContainerMCPTools(ctx context.Context, srv *server.MC
 	result, err := mcpCli.ListTools(ctx, mcpgo.ListToolsRequest{})
 	if err != nil {
 		closeProxy()
+		s.recordProxyDiag(appName, "list-tools", err)
 		fmt.Fprintf(os.Stderr, "Warning: listing MCP tools for %s: %v\n", appName, err)
 		return nil
 	}

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -416,11 +416,7 @@ func (s *mcpServer) handleRun(ctx context.Context, req mcpgo.CallToolRequest) (*
 	if text == "" {
 		text = "cloud run completed"
 	}
-	maxBytes := intParam(req, "max_bytes", 100000)
-	if maxBytes > 0 && len(text) > maxBytes {
-		text = text[:maxBytes] + fmt.Sprintf("\n[truncated: output exceeded max_bytes=%d; narrow the query (e.g. reduce timeout_seconds, redirect the app's own output, or raise max_bytes)]", maxBytes)
-	}
-	return okText(text), nil
+	return okTextBounded(text, "reduce timeout_seconds, redirect the app's own output, or raise max_bytes", intParam(req, "max_bytes", 100000)), nil
 }
 
 // cloudResolveErr is returned by the cloud auth/asset-resolution helpers

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -184,6 +184,9 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("timeout_seconds",
 			mcpgo.Description("Maximum command runtime in seconds (default 300)"),
 		),
+		mcpgo.WithNumber("max_bytes",
+			mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)"),
+		),
 	}
 	runOpts = append(runOpts, mutating()...)
 	runOpts = append(runOpts, openWorld()...)
@@ -221,6 +224,9 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		),
 		mcpgo.WithNumber("timeout_seconds",
 			mcpgo.Description("Maximum command runtime in seconds (default 300)"),
+		),
+		mcpgo.WithNumber("max_bytes",
+			mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)"),
 		),
 	}
 	cloudRunOpts = append(cloudRunOpts, mutating()...)
@@ -409,6 +415,10 @@ func (s *mcpServer) handleRun(ctx context.Context, req mcpgo.CallToolRequest) (*
 	}
 	if text == "" {
 		text = "cloud run completed"
+	}
+	maxBytes := intParam(req, "max_bytes", 100000)
+	if maxBytes > 0 && len(text) > maxBytes {
+		text = text[:maxBytes] + fmt.Sprintf("\n[truncated: output exceeded max_bytes=%d; narrow the query (e.g. reduce timeout_seconds, redirect the app's own output, or raise max_bytes)]", maxBytes)
 	}
 	return okText(text), nil
 }

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -389,8 +389,11 @@ func (s *mcpServer) handleRun(ctx context.Context, req mcpgo.CallToolRequest) (*
 		args = append(args, "--detach")
 	}
 
+	tok := progressToken(req)
 	cmd := exec.CommandContext(runCtx, bin, args...)
+	reportProgress(ctx, tok, 0, 0, "running wendy…")
 	out, err := cmd.CombinedOutput()
+	reportProgress(ctx, tok, 1, 1, "done")
 	text := strings.TrimSpace(string(out))
 	if runCtx.Err() != nil {
 		if text == "" {

--- a/go/internal/cli/mcp/tools_container.go
+++ b/go/internal/cli/mcp/tools_container.go
@@ -181,7 +181,7 @@ func (s *mcpServer) handleContainerStart(ctx context.Context, req mcpgo.CallTool
 	if out == "" {
 		out = fmt.Sprintf("container %s started", appName)
 	}
-	return okTextBounded(out, intParam(req, "max_bytes", 100000)), nil
+	return okTextBounded(out, "", intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleContainerStop(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -290,5 +290,5 @@ func (s *mcpServer) handleContainerAttach(ctx context.Context, req mcpgo.CallToo
 			collected++
 		}
 	}
-	return okTextBounded(sb.String(), intParam(req, "max_bytes", 100000)), nil
+	return okTextBounded(sb.String(), "", intParam(req, "max_bytes", 100000)), nil
 }

--- a/go/internal/cli/mcp/tools_container.go
+++ b/go/internal/cli/mcp/tools_container.go
@@ -26,6 +26,12 @@ func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
 			mcpgo.Required(),
 			mcpgo.Description("App name of the container to start"),
 		),
+		mcpgo.WithNumber("max_chunks",
+			mcpgo.Description("Maximum output chunks to collect (default 200)"),
+		),
+		mcpgo.WithNumber("max_bytes",
+			mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)"),
+		),
 	}
 	startOpts = append(startOpts, mutating()...)
 	startOpts = append(startOpts, localOnly()...)
@@ -74,8 +80,14 @@ func (s *mcpServer) registerContainerTools(srv *server.MCPServer) {
 			mcpgo.Required(),
 			mcpgo.Description("App name of the container to attach to"),
 		),
-		mcpgo.WithNumber("max_lines",
+		mcpgo.WithNumber("max_chunks",
 			mcpgo.Description("Maximum output chunks to collect (default 100)"),
+		),
+		mcpgo.WithNumber("max_lines",
+			mcpgo.Description("Deprecated alias for max_chunks (maximum output chunks to collect, default 100)"),
+		),
+		mcpgo.WithNumber("max_bytes",
+			mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)"),
 		),
 	}
 	attachOpts = append(attachOpts, readOnly()...)
@@ -142,9 +154,10 @@ func (s *mcpServer) handleContainerStart(ctx context.Context, req mcpgo.CallTool
 	if err != nil {
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
+	maxChunks := intParam(req, "max_chunks", 200)
 	var sb strings.Builder
 	chunks := 0
-	for chunks < 200 {
+	for chunks < maxChunks {
 		resp, err := stream.Recv()
 		if err == io.EOF {
 			break
@@ -168,7 +181,7 @@ func (s *mcpServer) handleContainerStart(ctx context.Context, req mcpgo.CallTool
 	if out == "" {
 		out = fmt.Sprintf("container %s started", appName)
 	}
-	return okText(out), nil
+	return okTextBounded(out, intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleContainerStop(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -239,7 +252,7 @@ func (s *mcpServer) handleContainerAttach(ctx context.Context, req mcpgo.CallToo
 	if appName == "" {
 		return errResult(errCodeInvalidArgument, "app_name is required"), nil
 	}
-	maxChunks := intParam(req, "max_lines", 100)
+	maxChunks := intParamAlias(req, "max_chunks", "max_lines", 100)
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -277,5 +290,5 @@ func (s *mcpServer) handleContainerAttach(ctx context.Context, req mcpgo.CallToo
 			collected++
 		}
 	}
-	return okText(sb.String()), nil
+	return okTextBounded(sb.String(), intParam(req, "max_bytes", 100000)), nil
 }

--- a/go/internal/cli/mcp/tools_container_test.go
+++ b/go/internal/cli/mcp/tools_container_test.go
@@ -46,6 +46,12 @@ type fakeContainerServer struct {
 	stats      []*agentpb.ContainerStats
 	stopErr    error
 	deleteErr  error
+	// startOutputs/attachOutputs override the default single-chunk output for
+	// StartContainer/AttachContainer, letting tests assert chunk-capping
+	// (max_chunks / max_lines) behavior. Nil means "use the single default
+	// chunk" (preserves pre-existing test expectations).
+	startOutputs  [][]byte
+	attachOutputs [][]byte
 }
 
 func (s *fakeContainerServer) ListContainers(_ *agentpb.ListContainersRequest, stream agentpb.WendyContainerService_ListContainersServer) error {
@@ -70,11 +76,19 @@ func (s *fakeContainerServer) ListContainerStats(_ context.Context, _ *agentpb.L
 }
 
 func (s *fakeContainerServer) StartContainer(req *agentpb.StartContainerRequest, stream agentpb.WendyContainerService_StartContainerServer) error {
-	_ = stream.Send(&agentpb.RunContainerLayersResponse{
-		ResponseType: &agentpb.RunContainerLayersResponse_StdoutOutput{
-			StdoutOutput: &agentpb.RunContainerLayersResponse_ConsoleOutput{Data: []byte("started\n")},
-		},
-	})
+	outputs := s.startOutputs
+	if outputs == nil {
+		outputs = [][]byte{[]byte("started\n")}
+	}
+	for _, o := range outputs {
+		if err := stream.Send(&agentpb.RunContainerLayersResponse{
+			ResponseType: &agentpb.RunContainerLayersResponse_StdoutOutput{
+				StdoutOutput: &agentpb.RunContainerLayersResponse_ConsoleOutput{Data: o},
+			},
+		}); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -83,11 +97,19 @@ func (s *fakeContainerServer) AttachContainer(stream agentpb.WendyContainerServi
 	if err != nil {
 		return err
 	}
-	_ = stream.Send(&agentpb.RunContainerLayersResponse{
-		ResponseType: &agentpb.RunContainerLayersResponse_StdoutOutput{
-			StdoutOutput: &agentpb.RunContainerLayersResponse_ConsoleOutput{Data: []byte("hello from container\n")},
-		},
-	})
+	outputs := s.attachOutputs
+	if outputs == nil {
+		outputs = [][]byte{[]byte("hello from container\n")}
+	}
+	for _, o := range outputs {
+		if err := stream.Send(&agentpb.RunContainerLayersResponse{
+			ResponseType: &agentpb.RunContainerLayersResponse_StdoutOutput{
+				StdoutOutput: &agentpb.RunContainerLayersResponse_ConsoleOutput{Data: o},
+			},
+		}); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -268,5 +290,115 @@ func TestContainerAttach_ReturnsOutput(t *testing.T) {
 	text := result.Content[0].(mcpgo.TextContent).Text
 	if text != "hello from container\n" {
 		t.Errorf("text = %q, want %q", text, "hello from container\n")
+	}
+}
+
+func TestContainerAttach_MaxLinesAlias_LimitsChunks(t *testing.T) {
+	fake := &fakeContainerServer{
+		attachOutputs: [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d"), []byte("e")},
+	}
+	conn := startFakeContainerServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	// max_lines is the deprecated alias for max_chunks; it must keep working.
+	result, err := srv.callTool(context.Background(), "container_attach", map[string]any{"app_name": "myapp", "max_lines": 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	text := result.Content[0].(mcpgo.TextContent).Text
+	if text != "ab" {
+		t.Errorf("text = %q, want %q (max_lines alias should cap at 2 chunks)", text, "ab")
+	}
+}
+
+func TestContainerAttach_MaxChunks_LimitsChunks(t *testing.T) {
+	fake := &fakeContainerServer{
+		attachOutputs: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+	}
+	conn := startFakeContainerServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "container_attach", map[string]any{"app_name": "myapp", "max_chunks": 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	text := result.Content[0].(mcpgo.TextContent).Text
+	if text != "a" {
+		t.Errorf("text = %q, want %q (max_chunks should cap at 1 chunk)", text, "a")
+	}
+}
+
+func TestContainerAttach_MaxChunksTakesPriorityOverMaxLines(t *testing.T) {
+	fake := &fakeContainerServer{
+		attachOutputs: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+	}
+	conn := startFakeContainerServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	// When both are passed, the new name wins per intParamAlias semantics.
+	result, err := srv.callTool(context.Background(), "container_attach", map[string]any{"app_name": "myapp", "max_chunks": 1, "max_lines": 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	text := result.Content[0].(mcpgo.TextContent).Text
+	if text != "a" {
+		t.Errorf("text = %q, want %q (max_chunks should take priority over max_lines)", text, "a")
+	}
+}
+
+func TestContainerStart_MaxChunks_LimitsChunks(t *testing.T) {
+	fake := &fakeContainerServer{
+		startOutputs: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+	}
+	conn := startFakeContainerServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "container_start", map[string]any{"app_name": "myapp", "max_chunks": 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	text := result.Content[0].(mcpgo.TextContent).Text
+	if text != "ab" {
+		t.Errorf("text = %q, want %q (max_chunks should cap at 2 chunks)", text, "ab")
+	}
+}
+
+func TestContainerAttach_MaxBytes_TruncatesOversizeOutput(t *testing.T) {
+	fake := &fakeContainerServer{
+		attachOutputs: [][]byte{[]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
+	}
+	conn := startFakeContainerServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "container_attach", map[string]any{"app_name": "myapp", "max_bytes": 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	text := result.Content[0].(mcpgo.TextContent).Text
+	if len(text) <= 10 {
+		t.Errorf("expected truncated text with an appended note (len > 10), got %q", text)
+	}
+	if text[:10] != "aaaaaaaaaa" {
+		t.Errorf("expected truncated text to start with the original bytes, got %q", text)
 	}
 }

--- a/go/internal/cli/mcp/tools_guide.go
+++ b/go/internal/cli/mcp/tools_guide.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"path"
@@ -80,6 +81,28 @@ func (s *mcpServer) registerGuideResource(srv *server.MCPServer) {
 func (s *mcpServer) handleGuideResource(_ context.Context, _ mcpgo.ReadResourceRequest) ([]mcpgo.ResourceContents, error) {
 	return []mcpgo.ResourceContents{
 		mcpgo.TextResourceContents{URI: "wendy://guide", MIMEType: "text/plain", Text: guideText},
+	}, nil
+}
+
+// registerDiagnosticsResource registers wendy://diagnostics, which reports
+// container-MCP proxy failures that would otherwise only appear on stderr.
+func (s *mcpServer) registerDiagnosticsResource(srv *server.MCPServer) {
+	srv.AddResource(
+		mcpgo.NewResource("wendy://diagnostics", "Wendy MCP Diagnostics",
+			mcpgo.WithResourceDescription("Container-MCP proxy failures recorded during this session (app name, stage, error, time), as JSON."),
+			mcpgo.WithMIMEType("application/json"),
+		),
+		s.handleDiagnosticsResource,
+	)
+}
+
+func (s *mcpServer) handleDiagnosticsResource(_ context.Context, _ mcpgo.ReadResourceRequest) ([]mcpgo.ResourceContents, error) {
+	data, err := json.Marshal(s.proxyDiagnostics())
+	if err != nil {
+		return nil, err
+	}
+	return []mcpgo.ResourceContents{
+		mcpgo.TextResourceContents{URI: "wendy://diagnostics", MIMEType: "application/json", Text: string(data)},
 	}, nil
 }
 

--- a/go/internal/cli/mcp/tools_os.go
+++ b/go/internal/cli/mcp/tools_os.go
@@ -88,6 +88,7 @@ func (s *mcpServer) handleOSUpdate(ctx context.Context, req mcpgo.CallToolReques
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 
+	tok := progressToken(req)
 	var sb strings.Builder
 	for {
 		resp, err := stream.Recv()
@@ -101,6 +102,7 @@ func (s *mcpServer) handleOSUpdate(ctx context.Context, req mcpgo.CallToolReques
 		case *agentpb.UpdateOSResponse_Progress_:
 			p := resp.GetProgress()
 			sb.WriteString(fmt.Sprintf("[%s] %d%%\n", p.GetPhase(), p.GetPercent()))
+			reportProgress(ctx, tok, float64(p.GetPercent()), 100, fmt.Sprintf("[%s] %d%%", p.GetPhase(), p.GetPercent()))
 		case *agentpb.UpdateOSResponse_Completed_:
 			c := resp.GetCompleted()
 			if c.GetRebootRequired() {

--- a/go/internal/cli/mcp/tools_provisioning.go
+++ b/go/internal/cli/mcp/tools_provisioning.go
@@ -86,6 +86,7 @@ func (s *mcpServer) handleProvisioningStart(ctx context.Context, req mcpgo.CallT
 	if orgID == 0 {
 		return errResult(errCodeInvalidArgument, "organization_id is required"), nil
 	}
+	tok := progressToken(req)
 	_, err := conn.ProvisioningService.StartProvisioning(ctx, &agentpb.StartProvisioningRequest{
 		EnrollmentToken: token,
 		CloudHost:       cloudHost,
@@ -106,6 +107,7 @@ func (s *mcpServer) handleProvisioningStart(ctx context.Context, req mcpgo.CallT
 		case <-pollCtx.Done():
 			return errResult(errCodeTimeout, "provisioning timed out — check status with provisioning_status"), nil
 		case <-ticker.C:
+			reportProgress(ctx, tok, 0, 0, "waiting for device to finish provisioning…")
 			statusResp, err := conn.ProvisioningService.IsProvisioned(ctx, &agentpb.IsProvisionedRequest{})
 			if err != nil {
 				return errResult(codeFromGRPC(err), grpcErrString(err)), nil

--- a/go/internal/cli/mcp/tools_provisioning.go
+++ b/go/internal/cli/mcp/tools_provisioning.go
@@ -102,12 +102,16 @@ func (s *mcpServer) handleProvisioningStart(ctx context.Context, req mcpgo.CallT
 	defer cancel()
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
+	var tick float64
 	for {
 		select {
 		case <-pollCtx.Done():
 			return errResult(errCodeTimeout, "provisioning timed out — check status with provisioning_status"), nil
 		case <-ticker.C:
-			reportProgress(ctx, tok, 0, 0, "waiting for device to finish provisioning…")
+			// Indeterminate progress: total unknown, but the value must advance
+			// monotonically per the MCP spec, so emit the tick count.
+			tick++
+			reportProgress(ctx, tok, tick, 0, "waiting for device to finish provisioning…")
 			statusResp, err := conn.ProvisioningService.IsProvisioned(ctx, &agentpb.IsProvisionedRequest{})
 			if err != nil {
 				return errResult(codeFromGRPC(err), grpcErrString(err)), nil

--- a/go/internal/cli/mcp/tools_status.go
+++ b/go/internal/cli/mcp/tools_status.go
@@ -25,6 +25,7 @@ func (s *mcpServer) handleWendyStatus(_ context.Context, _ mcpgo.CallToolRequest
 		out := map[string]any{
 			"connected":           false,
 			"suggested_next_step": "not connected — call device_list to see available devices then device_connect, or cloud_discover + cloud_connect for cloud-enrolled devices",
+			"proxy_diagnostics":   s.proxyDiagnostics(),
 		}
 		return okResult(out), nil
 	}
@@ -38,6 +39,7 @@ func (s *mcpServer) handleWendyStatus(_ context.Context, _ mcpgo.CallToolRequest
 		"device":              host,
 		"connection_type":     connType,
 		"suggested_next_step": fmt.Sprintf("connected to %s via %s — ready to use container, wifi, hardware, telemetry, and os tools", host, connType),
+		"proxy_diagnostics":   s.proxyDiagnostics(),
 	}
 	return okResult(out), nil
 }

--- a/go/internal/cli/mcp/tools_telemetry.go
+++ b/go/internal/cli/mcp/tools_telemetry.go
@@ -34,6 +34,9 @@ func (s *mcpServer) registerTelemetryTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("max_batches",
 			mcpgo.Description("Maximum OTLP batches to collect (default 10)"),
 		),
+		mcpgo.WithNumber("max_bytes",
+			mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)"),
+		),
 	}
 	logsOpts = append(logsOpts, readOnly()...)
 	logsOpts = append(logsOpts, localOnly()...)
@@ -53,6 +56,9 @@ func (s *mcpServer) registerTelemetryTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("max_batches",
 			mcpgo.Description("Maximum OTLP batches to collect (default 10)"),
 		),
+		mcpgo.WithNumber("max_bytes",
+			mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)"),
+		),
 	}
 	metricsOpts = append(metricsOpts, readOnly()...)
 	metricsOpts = append(metricsOpts, localOnly()...)
@@ -71,6 +77,9 @@ func (s *mcpServer) registerTelemetryTools(srv *server.MCPServer) {
 		),
 		mcpgo.WithNumber("max_batches",
 			mcpgo.Description("Maximum OTLP batches to collect (default 10)"),
+		),
+		mcpgo.WithNumber("max_bytes",
+			mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)"),
 		),
 	}
 	tracesOpts = append(tracesOpts, readOnly()...)
@@ -140,7 +149,7 @@ func (s *mcpServer) handleTelemetryLogs(ctx context.Context, req mcpgo.CallToolR
 	if err != nil {
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return okResult(result), nil
+	return okResultBounded(result, intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleTelemetryMetrics(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -174,7 +183,7 @@ func (s *mcpServer) handleTelemetryMetrics(ctx context.Context, req mcpgo.CallTo
 	if err != nil {
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return okResult(result), nil
+	return okResultBounded(result, intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleTelemetryTraces(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -208,5 +217,5 @@ func (s *mcpServer) handleTelemetryTraces(ctx context.Context, req mcpgo.CallToo
 	if err != nil {
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return okResult(result), nil
+	return okResultBounded(result, intParam(req, "max_bytes", 100000)), nil
 }

--- a/specs/2026-07-12-mcp-agent-improvements-pr2-reliability.md
+++ b/specs/2026-07-12-mcp-agent-improvements-pr2-reliability.md
@@ -1,0 +1,281 @@
+# MCP Agent-Support PR2 — Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add output bounding (#3), progress notifications for long operations (#4), and visible proxy diagnostics (#5) to the `wendy mcp serve` server.
+
+**Architecture:** Builds on PR1's shared helpers. Adds `progress.go` (progress-notification helper), extends `results.go` (byte-clamping), adds `diagnostics.go` (+ a field on `mcpServer`). Handlers keep their signatures; they reach the server for notifications via `server.ServerFromContext(ctx)`.
+
+**Tech Stack:** Go, `mark3labs/mcp-go` v0.54.0, gRPC. Base branch: `jo/mcp-agent-support-1-foundation` (stacked on PR1).
+
+## Global Constraints
+
+- Import aliases: `mcpgo "github.com/mark3labs/mcp-go/mcp"`, `"github.com/mark3labs/mcp-go/server"`.
+- Backward compatibility: no tool renames; the `max_lines` parameter must keep working as an accepted alias when renamed to `max_chunks`. Results keep a text fallback; errors keep `IsError=true`.
+- No new dependencies. gofmt/vet clean; `go test ./internal/cli/mcp/...` green after every task.
+- gRPC streams are NOT resumable — bounding is a byte cap + explicit `truncated` signal + narrower-query guidance, NOT a resumable cursor. Say so in the PR body; do not fake a cursor.
+- Progress notifications are best-effort: when no `progressToken` is supplied by the client, or no server is in context, `reportProgress` is a silent no-op. Never fail a tool because a progress send failed.
+- `time.Now()` is allowed in this runtime code (not a workflow script).
+
+---
+
+## Task 1: Progress-notification helper + wiring
+
+**Files:**
+- Create: `go/internal/cli/mcp/progress.go`
+- Create: `go/internal/cli/mcp/progress_test.go`
+- Modify: `tools_os.go` (handleOSUpdate), `tools_provisioning.go` (handleProvisioningStart), `tools_cloud.go` (handleRun)
+
+**Interfaces:**
+- Produces: `progressToken(req mcpgo.CallToolRequest) any`; `reportProgress(ctx context.Context, token any, progress, total float64, message string)`.
+
+- [ ] **Step 1: Write `progress.go`**
+
+```go
+package mcp
+
+import (
+	"context"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// progressToken returns the client-supplied progress token for this request,
+// or nil if the client did not request progress.
+func progressToken(req mcpgo.CallToolRequest) any {
+	if req.Params.Meta == nil {
+		return nil
+	}
+	return req.Params.Meta.ProgressToken
+}
+
+// reportProgress emits an MCP progress notification for token. It is a silent
+// no-op when token is nil or no server is bound to ctx, and it never returns an
+// error — progress is best-effort telemetry, not part of a tool's contract.
+func reportProgress(ctx context.Context, token any, progress, total float64, message string) {
+	if token == nil {
+		return
+	}
+	srv := server.ServerFromContext(ctx)
+	if srv == nil {
+		return
+	}
+	params := map[string]any{
+		"progressToken": token,
+		"progress":      progress,
+	}
+	if total > 0 {
+		params["total"] = total
+	}
+	if message != "" {
+		params["message"] = message
+	}
+	_ = srv.SendNotificationToClient(ctx, "notifications/progress", params)
+}
+```
+
+- [ ] **Step 2: Write `progress_test.go`** (tests the no-op paths — the only paths unit-testable without a live transport)
+
+```go
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestProgressToken_NilWhenNoMeta(t *testing.T) {
+	if progressToken(mcpgo.CallToolRequest{}) != nil {
+		t.Error("expected nil token when no _meta")
+	}
+}
+
+func TestReportProgress_NoTokenNoPanic(t *testing.T) {
+	// nil token + no server in ctx must be a safe no-op.
+	reportProgress(context.Background(), nil, 1, 2, "x")
+}
+
+func TestReportProgress_NoServerNoPanic(t *testing.T) {
+	// non-nil token but no server bound to ctx must not panic.
+	reportProgress(context.Background(), "tok-1", 1, 2, "x")
+}
+```
+
+- [ ] **Step 3: Run — verify fail** (`undefined: progressToken`/`reportProgress`). `go test ./internal/cli/mcp/... -run 'TestProgress|TestReportProgress' -v`
+- [ ] **Step 4: Verify pass** after writing progress.go.
+- [ ] **Step 5: Wire into `handleOSUpdate`** (`tools_os.go`). Capture the token once and emit on each progress frame. In the loop's `UpdateOSResponse_Progress_` case, after `sb.WriteString(...)`, add `reportProgress(ctx, tok, float64(p.GetPercent()), 100, fmt.Sprintf("[%s] %d%%", p.GetPhase(), p.GetPercent()))`. Define `tok := progressToken(req)` just before the loop. (Handler already receives `req`.)
+- [ ] **Step 6: Wire into `handleProvisioningStart`** (`tools_provisioning.go`). `tok := progressToken(req)` after param validation; in the `case <-ticker.C:` branch, before/after the IsProvisioned call, emit `reportProgress(ctx, tok, 0, 0, "waiting for device to finish provisioning…")` (indeterminate — progress 0, no total).
+- [ ] **Step 7: Wire into `handleRun`** (`tools_cloud.go`). `tok := progressToken(req)`; emit `reportProgress(ctx, tok, 0, 0, "running wendy…")` right before `cmd.CombinedOutput()`, and `reportProgress(ctx, tok, 1, 1, "done")` right after it returns (before building the result). Keep all existing behavior.
+- [ ] **Step 8: Run full suite** `go test ./internal/cli/mcp/...` → green. `gofmt -w` changed files.
+- [ ] **Step 9: Commit** `feat(mcp): emit MCP progress notifications for os_update, provisioning_start, run`
+
+**Testing note to record in report:** the send path (token present + server in ctx) is not unit-testable without a live stdio session; only the no-op guards are covered. State this honestly.
+
+---
+
+## Task 2: Output bounding (byte cap + truncation signal + max_chunks rename)
+
+**Files:**
+- Modify: `results.go` (+ `results_test.go`) — add `clampStructured`.
+- Modify: `tools_telemetry.go`, `tools_container.go` (attach + start), `tools_cloud.go` (run).
+
+**Interfaces:**
+- Produces: `okResultBounded(v any, maxBytes int) *mcpgo.CallToolResult` — like `okResult`, but if the JSON text fallback would exceed `maxBytes`, returns a truncation envelope instead.
+- Produces: `intParamAlias(req, primary, alias string, def int) int` (added to `server.go` helpers) — reads `primary`, else `alias`, else `def`.
+
+- [ ] **Step 1: Write failing test** in `results_test.go`
+
+```go
+func TestOkResultBounded_TruncatesOversize(t *testing.T) {
+	big := make([]string, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		big = append(big, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	}
+	r := okResultBounded(big, 200)
+	if r.IsError {
+		t.Fatal("truncation is not an error result")
+	}
+	sc, ok := r.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected truncation envelope map, got %T", r.StructuredContent)
+	}
+	if sc["truncated"] != true {
+		t.Errorf("expected truncated=true, got %v", sc["truncated"])
+	}
+}
+
+func TestOkResultBounded_PassesSmall(t *testing.T) {
+	r := okResultBounded(map[string]any{"k": "v"}, 100000)
+	sc, _ := r.StructuredContent.(map[string]any)
+	if sc["truncated"] == true {
+		t.Error("small payload should not be truncated")
+	}
+}
+```
+
+- [ ] **Step 2: Run — verify fail.**
+- [ ] **Step 3: Add `okResultBounded` to `results.go`**
+
+```go
+// okResultBounded is okResult with a byte ceiling on the JSON text fallback.
+// gRPC streams are not resumable, so when the payload exceeds maxBytes we do
+// not paginate — we return a truncation envelope telling the agent to narrow
+// the query. maxBytes <= 0 disables the cap (behaves as okResult).
+func okResultBounded(v any, maxBytes int) *mcpgo.CallToolResult {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResultf(errCodeInternal, "marshaling result: %s", err.Error())
+	}
+	if maxBytes > 0 && len(b) > maxBytes {
+		env := map[string]any{
+			"truncated": true,
+			"max_bytes": maxBytes,
+			"bytes":     len(b),
+			"note":      "output exceeded max_bytes; narrow the query (reduce max_batches / max_chunks, add filters, or raise max_bytes)",
+		}
+		eb, _ := json.MarshalIndent(env, "", "  ")
+		return mcpgo.NewToolResultStructured(env, string(eb))
+	}
+	return mcpgo.NewToolResultStructured(v, string(b))
+}
+```
+
+- [ ] **Step 4: Add `intParamAlias` to `server.go`** (near `intParam`):
+
+```go
+// intParamAlias reads primary, falling back to alias, then defaultVal.
+func intParamAlias(req mcpgo.CallToolRequest, primary, alias string, defaultVal int) int {
+	if v := req.GetInt(primary, -1<<62); v != -1<<62 {
+		return v
+	}
+	return req.GetInt(alias, defaultVal)
+}
+```
+
+- [ ] **Step 5: Apply bounding.**
+  - `telemetry_logs/metrics/traces`: add optional `max_bytes` number param (default 100000) to each tool registration; in the handlers, replace `okResult(parts)` with `okResultBounded(parts, intParam(req, "max_bytes", 100000))`.
+  - `container_attach` (`tools_container.go`): register a new `max_chunks` number param (description "max output chunks") **and keep `max_lines`**; change `maxChunks := intParam(req, "max_lines", 100)` → `maxChunks := intParamAlias(req, "max_chunks", "max_lines", 100)`. Wrap its final data result in `okResultBounded(..., intParam(req, "max_bytes", 100000))` (add `max_bytes` param). Update the `max_lines` description to note it is a deprecated alias for `max_chunks`.
+  - `container_start`: add optional `max_chunks` number param (default 200) and use `intParam(req, "max_chunks", 200)` for the loop cap instead of the hardcoded 200; add `max_bytes` bound on its result.
+  - `run` (`handleRun`): add optional `max_bytes` param (default 100000); the success text blob → if over cap, return the truncation envelope (reuse `okResultBounded` on `map[string]any{"output": text}` OR clamp the string and note truncation — pick the string-clamp: if `len(text) > maxBytes`, set `text = text[:maxBytes]` and append a truncation note line, still `okText`). Keep failure branches unchanged.
+- [ ] **Step 6: Tests.** Add a `container_start` test asserting `max_chunks` alias works if a fake supports it; otherwise rely on the results_test coverage + full suite. Run `go test ./internal/cli/mcp/...` → green.
+- [ ] **Step 7: Commit** `feat(mcp): bound tool output by bytes + rename max_lines→max_chunks (alias kept)`
+
+---
+
+## Task 3: Proxy diagnostics
+
+**Files:**
+- Create: `go/internal/cli/mcp/diagnostics.go` (+ `diagnostics_test.go`)
+- Modify: `server.go` (add field + record calls, replace stderr-only warnings), `tools_guide.go` or wherever `wendy://` resources register (add `wendy://diagnostics`), `tools_status.go` (add proxy diag to wendy_status structured content).
+
+**Interfaces:**
+- Produces on `mcpServer`: `recordProxyDiag(appName, stage string, err error)`; `proxyDiagnostics() []proxyDiagEntry`.
+- `type proxyDiagEntry struct { AppName, Stage, Error string; Time string }`.
+
+- [ ] **Step 1: Write failing test** in `diagnostics_test.go`
+
+```go
+func TestProxyDiag_RecordAndRead(t *testing.T) {
+	s := New(&config.Config{}, nil)
+	s.recordProxyDiag("paperless", "initialize", errors.New("boom"))
+	d := s.proxyDiagnostics()
+	if len(d) != 1 || d[0].AppName != "paperless" || d[0].Stage != "initialize" || d[0].Error != "boom" {
+		t.Fatalf("unexpected diagnostics: %+v", d)
+	}
+}
+```
+
+- [ ] **Step 2: Run — verify fail.**
+- [ ] **Step 3: Write `diagnostics.go`**
+
+```go
+package mcp
+
+type proxyDiagEntry struct {
+	AppName string `json:"app_name"`
+	Stage   string `json:"stage"`
+	Error   string `json:"error"`
+	Time    string `json:"time"`
+}
+
+func (s *mcpServer) recordProxyDiag(appName, stage string, err error) {
+	if err == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.proxyDiag = append(s.proxyDiag, proxyDiagEntry{
+		AppName: appName,
+		Stage:   stage,
+		Error:   err.Error(),
+		Time:    time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func (s *mcpServer) proxyDiagnostics() []proxyDiagEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]proxyDiagEntry, len(s.proxyDiag))
+	copy(out, s.proxyDiag)
+	return out
+}
+```
+
+Add `proxyDiag []proxyDiagEntry` to the `mcpServer` struct in `server.go` and import `time` there if not already.
+
+- [ ] **Step 4: Replace stderr-only warnings** in `server.go` `connectContainerMCPTools`/`registerContainerMCPTools`: at each of the six `fmt.Fprintf(os.Stderr, "Warning: ...")` sites, add `s.recordProxyDiag(appName, "<stage>", err)` (stages: "list-containers", "read-container-list", "proxy", "client", "initialize", "list-tools"). Keep one concise stderr line for humans. For the two list-container sites that have no appName, use `""`.
+- [ ] **Step 5: Expose.** Register a `wendy://diagnostics` resource (mirror `registerGuideResource`) returning `okResult`-style JSON of `s.proxyDiagnostics()` — as a resource, marshal to JSON text. Also add `"proxy_diagnostics": s.proxyDiagnostics()` to the `wendy_status` structured-content map in `tools_status.go`.
+- [ ] **Step 6: Tests + full suite** green. gofmt.
+- [ ] **Step 7: Commit** `feat(mcp): surface container-MCP proxy failures via diagnostics resource + wendy_status`
+
+---
+
+## Self-Review (PR2)
+
+- #3: byte cap + `truncated` envelope + `max_chunks` rename with `max_lines` alias — applied to telemetry/attach/start/run; no fake cursor.
+- #4: `reportProgress` best-effort, wired into the three long ops; no-op guards tested; send path documented as manual-verify.
+- #5: proxy failures recorded + exposed; stderr retained for humans.
+- Backward compat: `max_lines` still accepted; no renames; text fallbacks preserved.


### PR DESCRIPTION
## MCP agent-support improvements — PR2 of 3 (Reliability)

Stacked on #1413 (PR1). **Base this PR on `jo/mcp-agent-support-1-foundation`; review/merge PR1 first.** Design: `specs/2026-07-12-mcp-agent-improvements-pr2-reliability.md`.

### What this PR does
- **Progress notifications (#4):** long-running tools (`os_update`, `provisioning_start`, `run`/`cloud_run`) now emit MCP `notifications/progress` so an agent sees live progress instead of a frozen call. Best-effort: no-op when the client supplies no progress token, and a failed send never fails the tool. Provisioning progress advances monotonically per the MCP spec.
- **Output bounding (#3):** every large-output tool takes an optional `max_bytes` (default 100000). Over-cap telemetry returns a `{truncated:true,…}` envelope; over-cap text tools (`container_attach/start`, `run`) get a UTF-8-safe byte clamp + an inline truncation note with tool-specific guidance. gRPC streams aren't resumable, so this is a cap + explicit signal, **not** a fake cursor. Renamed the chunk knob `max_lines`→`max_chunks` (with `max_lines` kept as a working alias); `container_start`'s hardcoded 200-chunk cap is now the `max_chunks` param.
- **Proxy diagnostics (#5):** container-MCP proxy failures used to vanish to stderr. They're now recorded (thread-safe) and surfaced via a new `wendy://diagnostics` resource and a `proxy_diagnostics` field in `wendy_status`, so an agent can see why an app's tools didn't load.

### Backward compatibility
`max_lines` still works; no tool renames; all results keep their text fallback and errors keep `error_code`/`IsError`. Proxy changes are purely additive (retry/backoff/non-fatal semantics unchanged).

### Testing
Full `go test ./internal/cli/mcp/...` green, vet/gofmt clean, module builds. Subagent-driven with per-task review + an Opus whole-branch review (0 critical/0 important; the few Minors were fixed — portable sentinel, monotonic progress, UTF-8-safe truncation).

### Remaining
**PR3 (Discoverability):** workflow prompts (#7), richer descriptions (#8), filesync resolution (#10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
