### PR TITLE
Embed video on CLI and Agent Relationship page

### DIFF
--- a/go/internal/cli/assets/docs/device/cli-agent-relationship.mdx
+++ b/go/internal/cli/assets/docs/device/cli-agent-relationship.mdx
@@ -10,6 +10,7 @@ description: How the Wendy CLI discovers devices and deploys apps through wendy-
   loading="lazy"
   referrerPolicy="strict-origin-when-cross-origin"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowFullScreen
 />
 
 The diagram below illustrates the relationship between the `wendy` CLI on your developer machine and the `wendy-agent` running on your target hardware.

--- a/go/internal/cli/assets/docs/device/cli-agent-relationship.mdx
+++ b/go/internal/cli/assets/docs/device/cli-agent-relationship.mdx
@@ -3,6 +3,14 @@ title: CLI and Agent Relationship
 description: How the Wendy CLI discovers devices and deploys apps through wendy-agent
 ---
 
+<iframe
+  className="aspect-video w-full rounded-lg"
+  src="https://www.youtube.com/embed/c_UujqFIqT4"
+  title="Wendy CLI and wendy-agent relationship"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowFullScreen
+/>
+
 The diagram below illustrates the relationship between the `wendy` CLI on your developer machine and the `wendy-agent` running on your target hardware.
 
 The `wendy` CLI is the developer-facing tool you install on your Mac, Linux, or Windows machine. It handles project scaffolding, cross-compilation, device discovery, and deployment. The `wendy-agent` is a service that runs on the target device and manages the container lifecycle, hardware access (GPU, audio, Bluetooth, GPIO), networking, and telemetry. When you run `wendy run`, the CLI cross-compiles your app, pushes the container image to the agent, and streams logs back to your terminal.

--- a/go/internal/cli/assets/docs/device/cli-agent-relationship.mdx
+++ b/go/internal/cli/assets/docs/device/cli-agent-relationship.mdx
@@ -4,11 +4,12 @@ description: How the Wendy CLI discovers devices and deploys apps through wendy-
 ---
 
 <iframe
-  className="aspect-video w-full rounded-lg"
+  className="aspect-video w-full rounded-lg border-0"
   src="https://www.youtube.com/embed/c_UujqFIqT4"
   title="Wendy CLI and wendy-agent relationship"
+  loading="lazy"
+  referrerPolicy="strict-origin-when-cross-origin"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowFullScreen
 />
 
 The diagram below illustrates the relationship between the `wendy` CLI on your developer machine and the `wendy-agent` running on your target hardware.


### PR DESCRIPTION
## Summary
- embed the Wendy CLI and wendy-agent relationship video at the top of the page
- keep the player responsive at 16:9 and full content width
- enable fullscreen and standard YouTube playback capabilities

## Validation
- `NEXT_PUBLIC_SITE_URL=https://docs.wendy.dev NEXT_PUBLIC_BASE_PATH=/latest npm run build`
- visually verified the page in the local docs preview
- confirmed the exported HTML contains the expected YouTube embed