### PR TITLE
Default to strict org enforcement within a cloud, ending the grace period for PKI

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -391,12 +391,12 @@ func main() {
 	}
 
 	// mTLS organization-equality enforcement mode. Read once here so the
-	// startMTLSServer closure can capture it. The default (empty value) is grace,
-	// which enforces org-equality for certs that carry an org identity but allows
-	// legacy certs without one — easing migration before cert rotation completes.
+	// startMTLSServer closure can capture it. The default (empty value) is strict,
+	// which rejects client certs that carry no org identity. Set to grace for
+	// migration mode, which allows legacy certs without org identity.
 	orgMode, ok := interceptor.ParseOrgMode(os.Getenv("WENDY_MTLS_ORG_ENFORCEMENT"))
 	if !ok {
-		logger.Warn("WENDY_MTLS_ORG_ENFORCEMENT has unrecognised value; defaulting to grace",
+		logger.Warn("WENDY_MTLS_ORG_ENFORCEMENT has unrecognised value; defaulting to strict",
 			zap.String("value", os.Getenv("WENDY_MTLS_ORG_ENFORCEMENT")))
 	}
 	logger.Info("mTLS org enforcement mode", zap.String("mode", orgMode.String()))


### PR DESCRIPTION
…flip

The org-enforcement default is now strict; the main.go caller comment and the unrecognized-value warning log still said grace, which would mislead an operator about the active enforcement mode during an incident.


Claude-Session: https://claude.ai/code/session_01Y6BDdXL33UcrefFoM7sgqE