### PR TITLE
fix(agent): default mTLS org enforcement to strict (M1)

### DIFF
--- a/go/internal/agent/interceptor/mtls.go
+++ b/go/internal/agent/interceptor/mtls.go
@@ -46,14 +46,16 @@ func (m OrgMode) String() string {
 }
 
 // ParseOrgMode maps the WENDY_MTLS_ORG_ENFORCEMENT env value to a mode.
-// An empty string yields (OrgModeGrace, true) — grace is the default. The values
-// "grace", "strict", and "off" (case-insensitive, surrounding whitespace trimmed)
-// yield the corresponding mode and true. Any other value yields (OrgModeGrace,
-// false) so the caller can warn and fall back to grace.
+// An empty string yields (OrgModeStrict, true) — strict is the secure default:
+// a client cert with no org identity is rejected. The values "grace", "strict",
+// and "off" (case-insensitive, surrounding whitespace trimmed) yield the
+// corresponding mode and true. Any other value yields (OrgModeStrict, false) so
+// the caller can warn and still fail safe (reject no-org certs) rather than
+// silently downgrading enforcement.
 func ParseOrgMode(s string) (OrgMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "":
-		return OrgModeGrace, true
+		return OrgModeStrict, true
 	case "grace":
 		return OrgModeGrace, true
 	case "strict":
@@ -61,7 +63,7 @@ func ParseOrgMode(s string) (OrgMode, bool) {
 	case "off":
 		return OrgModeOff, true
 	default:
-		return OrgModeGrace, false
+		return OrgModeStrict, false
 	}
 }
 

--- a/go/internal/agent/interceptor/mtls_test.go
+++ b/go/internal/agent/interceptor/mtls_test.go
@@ -185,14 +185,14 @@ func TestParseOrgMode(t *testing.T) {
 		wantMode OrgMode
 		wantOK   bool
 	}{
-		{"", OrgModeGrace, true},
+		{"", OrgModeStrict, true},
 		{"grace", OrgModeGrace, true},
 		{"GRACE", OrgModeGrace, true},
 		{" strict ", OrgModeStrict, true},
 		{"strict", OrgModeStrict, true},
 		{"off", OrgModeOff, true},
 		{"OFF", OrgModeOff, true},
-		{"bogus", OrgModeGrace, false},
+		{"bogus", OrgModeStrict, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.in, func(t *testing.T) {


### PR DESCRIPTION
## What

Default the agent's mTLS **organization enforcement to `strict`** instead of `grace`.

`interceptor.ParseOrgMode("")` now returns `OrgModeStrict` (was `OrgModeGrace`), and an **unrecognized** `WENDY_MTLS_ORG_ENFORCEMENT` value also fails safe to `strict` (was `grace`). A client certificate that carries **no organization identity** is therefore rejected by default, closing the cross-tenant gap where a no-org (legacy) cert was accepted by any device.

## Why

From the 2026-07-12 security review: `grace` was a migration accommodation, but leaving it as the *default* meant a validly-CA-signed cert with no org claim was accepted regardless of the device's org. Issued certs already carry org identity, so `strict` is safe now. This is finding **M1**.

This also makes `main` self-consistent: the `main.go` startup log/comment already says "defaulting to strict" (landed earlier), while `ParseOrgMode` still defaulted to grace — this PR makes the code match the log.

## Safety / rollout

- **Escape hatch retained:** `WENDY_MTLS_ORG_ENFORCEMENT=grace` for fleets whose certs predate org identity.
- **Fail-safe on unknown values:** an unrecognized env value defaults to `strict` (restrictive), and the caller still logs a warning.
- **Cannot brick a device that can't determine its own org:** `startMTLSServer` already drops to `OrgModeOff` (with a loud log) when the device's own leaf has no org — unchanged.

## Tests

- `TestParseOrgMode`: `""` → `strict`, unrecognized → `strict`; grace/strict/off unchanged.
- `TestCheckMTLS_OrgEnforcement` (existing) already covers `strict` rejecting a no-org leaf.
- Builds verified on darwin and linux/arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
