### PR TITLE
macOS agent: device key in the Secure Enclave (mTLS sign-through)

### DIFF
--- a/specs/2026-07-14-mac-secure-enclave-device-key-design.md
+++ b/specs/2026-07-14-mac-secure-enclave-device-key-design.md
@@ -1,0 +1,161 @@
+# macOS Agent — Device Key in the Secure Enclave (sign-through)
+
+**Date:** 2026-07-14
+**Status:** Approved design, pending implementation plan
+**Stacks on:** PR #1412 (`jo/broker-mtls-phase1-mac-cert`) — branch `jo/mac-key-secure-enclave`
+**Scope:** macOS (Swift) agent only. Linux/TPM is an explicit follow-up.
+
+## Goal
+
+Stop persisting the macOS agent's device private key as an extractable file
+(`device-key.pem`, 0600). Instead generate it as a **non-extractable Secure
+Enclave P256 key** whose material never leaves hardware, persist only the
+SE-wrapped blob in the **Keychain**, and have both CSR generation and every mTLS
+handshake (the device gRPC servers **and** the #1412 broker client) sign
+*through* the enclave. An attacker with disk (or process-memory) access can no
+longer exfiltrate a usable device key.
+
+## Non-goals / YAGNI
+- Linux TPM (separate follow-up spec — different secure element, Go agent).
+- Moving non-key secrets. Only the device leaf key is sensitive here; cert and
+  chain are public and stay as files.
+- Proactive forced rotation of already-provisioned devices (they migrate to SE
+  on their next re-provision; see Migration).
+
+## Forward-looking: ML-KEM
+The Secure Enclave supports **only P256** (ECDSA/ECDH) — it cannot hold an
+ML-KEM (FIPS 203) key. So the persistence layer is designed as a **general
+Keychain-backed secret store** (`KeychainStore`) that stores named opaque blobs,
+NOT something hard-wired to "an SE signing key." When ML-KEM lands (key-exchange
+side; the CA chain is already ML-DSA), its private key stores through the same
+`KeychainStore` as an at-rest sealed blob (software-held, since no SE backing
+exists), independent of the sign-through path used for the P256 signing key.
+This spec implements only the P256 signing key; it just doesn't box ML-KEM out.
+
+## Background (current state)
+- `Provisioning/DeviceIdentity.swift` — `generatePrivateKeyPEM()` makes a
+  software `P256.Signing` key; `generateCSRPEM(privateKeyPEM:commonName:)` signs
+  a CSR with it.
+- `Provisioning/ProvisioningStore.swift` — persists `device-key.pem` (0600) +
+  cert/chain files + `provisioning.json` (enrolled marker; key deliberately
+  excluded). Has a legacy in-JSON-key → file migration already.
+- `WendyAgent.swift:461` — `TLSConfig.PrivateKeySource.bytes(...keyPEM...)` feeds
+  the device gRPC server mTLS.
+- `Cloud/TunnelBrokerClient.swift` (via #1412) — the same key/cert feed the
+  broker client mTLS config.
+- TLS stack is **grpc-swift-nio-transport** (`GRPCNIOTransportHTTP2`).
+
+## Feasibility (verified against the pinned checkouts)
+1. **CSR** — `swift-certificates` exposes
+   `Certificate.PrivateKey.init(_ secureEnclaveP256: SecureEnclave.P256.Signing.PrivateKey)`
+   (`X509/CertificatePrivateKey.swift`) + SE signing in `X509/Signature.swift`.
+   The CSR signs directly with the SE key.
+2. **TLS sign-through** — grpc-swift-nio-transport (HTTP2Posix, which
+   `public import NIOSSL`) has a transport-specific private-key path:
+   `_NIOSSLPrivateKeySource.customPrivateKey(any (NIOSSLCustomPrivateKey & Hashable))`
+   surfaced via `PrivateKeySource.nioSSLSpecific(_:)`
+   (`GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift`). **Implementation risk to
+   confirm in Task 0:** that `nioSSLSpecific` / the custom-key case is public (or
+   reachable via a documented `@_spi`); if not, add a thin shim. Fallback if the
+   hook is truly unreachable: keep SE for CSR + at-rest, and note TLS sign-through
+   blocked upstream (escalate) — but the source indicates it is reachable.
+3. **Signing** — `swift-crypto` 4.x `SecureEnclave.P256.Signing.PrivateKey`
+   (`.dataRepresentation` blob, `.signature(for:)` in-enclave). `NIOSSLCustomPrivateKey`
+   needs `signatureAlgorithms`, `derBytes` (may be empty), and a `sign()` that
+   receives **unhashed** data — we SHA-256 then enclave-sign, returning DER ECDSA.
+
+## Architecture
+
+New unit boundaries (each independently testable):
+
+### `KeychainStore` (new, `Provisioning/KeychainStore.swift`)
+General Security-framework wrapper over `kSecClassGenericPassword`.
+- `set(account: String, data: Data)` / `get(account:) -> Data?` / `remove(account:)`.
+- Fixed `service = "sh.wendy.agent"`, attributes
+  `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` (daemon reads without an
+  interactive unlock; never syncs to iCloud / migrates to another Mac).
+- Pure storage; knows nothing about keys. This is the seam ML-KEM reuses.
+
+### `SecureEnclaveIdentity` (new, `Provisioning/SecureEnclaveIdentity.swift`)
+Owns the device signing key lifecycle.
+- `static var isAvailable: Bool` — `SecureEnclave.isAvailable`.
+- `static func generate(store:) throws -> SecureEnclaveIdentity` — create SE key,
+  persist `.dataRepresentation` via `KeychainStore.set(account: "device-key-se")`.
+- `static func load(store:) -> SecureEnclaveIdentity?` — read blob, reconstruct
+  `SecureEnclave.P256.Signing.PrivateKey(dataRepresentation:)`; nil if absent.
+- `var certificatePrivateKey: Certificate.PrivateKey` — `Certificate.PrivateKey(seKey)`
+  for CSR signing.
+- `var nioCustomKey: SEPrivateKey` — the TLS signer (below).
+- `func remove(store:)` — for `clear()`/unprovision.
+
+### `SEPrivateKey` (new, same file) — `NIOSSLCustomPrivateKey & Hashable`
+- `signatureAlgorithms = [.ecdsaSecp256R1Sha256]`, `derBytes = []`.
+- `sign(channel:algorithm:data:)` → SHA-256 the `data`, call
+  `seKey.signature(for:)`, return the DER representation via the promise.
+- `Hashable`/`Equatable` on a stable identity token (the Keychain account name),
+  since NIOSSL requires it and the SE key isn't itself Equatable.
+
+### Wiring changes
+- `DeviceIdentity.generateCSRPEM` — add an overload taking the SE identity and
+  signing the CSR with `identity.certificatePrivateKey`. The software-PEM
+  overload stays for the fallback path.
+- `ProvisioningStore` — represent the key source as an enum in `LoadedState`:
+  `.secureEnclave` (blob in Keychain, no `device-key.pem`) or `.softwarePEM(String)`
+  (legacy file). `save()` for SE devices writes cert/chain files + `provisioning.json`
+  with a `"keyBacking": "secureEnclave"` field, and does NOT write `device-key.pem`.
+  `load()` prefers a present Keychain SE identity, else the file key. `clear()`
+  also removes the Keychain item.
+- `WendyAgent.swift:461` and `TunnelBrokerClient` — build the
+  `TLSConfig.PrivateKeySource` from `SEPrivateKey` (custom-key path) when the
+  identity is SE-backed; `.bytes(keyPEM)` otherwise. A single helper
+  `tlsPrivateKeySource(for: KeyBacking) -> TLSConfig.PrivateKeySource` centralizes
+  the branch so both call sites stay identical.
+
+## Data flow
+Provision (SE-capable Mac): `SecureEnclaveIdentity.generate` → CSR signed by SE
+key → cloud signs → cert/chain written as files, SE blob already in Keychain,
+`provisioning.json{enrolled,keyBacking:secureEnclave}` written last (commit
+marker). Runtime: `load()` → SE identity → TLS sources built from `SEPrivateKey`
+→ handshakes sign in-enclave.
+
+## Migration & fallback
+- **Existing provisioned Macs** have a software `device-key.pem`. A software key
+  **cannot** be imported into the SE, so there is no silent migration. `load()`
+  detects `keyBacking` absent / `device-key.pem` present → software path, works
+  unchanged. Such devices adopt SE only on **re-provision** (which regenerates
+  the identity). This is the agreed behavior.
+- **Macs without a Secure Enclave** (CI, some VMs): `SecureEnclaveIdentity.isAvailable`
+  is false → provisioning uses the existing software-PEM path end-to-end. No
+  regression.
+
+## Error handling
+- SE generate/sign failure → surface a clear provisioning error; do not fall back
+  to software silently on an SE-capable device that chose SE (avoid a silent
+  downgrade). Availability is decided once at provision time.
+- Keychain access failure (e.g. blob missing at runtime though `provisioning.json`
+  says SE) → treat as unprovisioned (fail closed), log, require re-provision —
+  mirroring the store's existing "enrolled marker but no key" safety stance.
+- `SEPrivateKey.sign` failure → fail the promise; the handshake fails closed.
+
+## Testing
+- `KeychainStore`: round-trip set/get/remove against the real login/daemon
+  keychain on a dev Mac (hermetic: unique account names, cleaned up).
+- `SEPrivateKey` signing: verify the produced DER ECDSA validates against the SE
+  public key for representative payloads; exercise the `NIOSSLCustomPrivateKey`
+  `sign` promise path.
+- CSR: SE-signed CSR parses and its signature verifies under the SE public key.
+- `ProvisioningStore`: SE save/load round-trip; legacy `device-key.pem` still
+  loads (software path); `clear()` removes the Keychain item.
+- SE-specific paths are gated by `isAvailable`; on non-SE CI they are skipped with
+  a logged reason, and the software fallback is exercised instead.
+- **Known constraint:** the Swift package does not build on the current dev box
+  (macOS-27 SDK vs swift-crypto), so `swift build`/`swift test` stay CI-deferred,
+  consistent with #1409/#1411/#1412. Hardware manual-verify on an Apple-Silicon
+  Mac is the acceptance gate for the SE paths.
+
+## References
+- `swift/WendyAgentCore/Sources/WendyAgent/Provisioning/{DeviceIdentity,ProvisioningStore,CloudCertificateClient}.swift`
+- `swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift:456` (`mTLSSecurity`)
+- `swift/WendyAgentCore/Sources/WendyAgent/Cloud/TunnelBrokerClient.swift` (#1412)
+- grpc-swift-nio-transport `GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift` (custom-key hook)
+- swift-certificates `X509/CertificatePrivateKey.swift` (SE `Certificate.PrivateKey`)

--- a/specs/2026-07-14-mac-secure-enclave-device-key-plan.md
+++ b/specs/2026-07-14-mac-secure-enclave-device-key-plan.md
@@ -484,9 +484,9 @@ git commit -m "feat(mac): ProvisioningStore KeyBacking (SE vs software), clear()
 - Consumes: `KeyBacking` (Task 4), `SEPrivateKey`/`SecureEnclaveIdentity` (Task 2), the Task-0 wiring form.
 - Produces: `func tlsPrivateKeySource(_ backing: KeyBacking, seKey: SEPrivateKey?) -> TLSConfig.PrivateKeySource`
 
-- [ ] **Step 1: Implement the helper** (`TLSKeySource.swift`), using the Task-0-confirmed form (A public, or B via `@_spi`):
+- [ ] **Step 1: Implement the helper** (`TLSKeySource.swift`). Task 0 confirmed outcome **(A)**: use the PUBLIC factory `TLSConfig.PrivateKeySource.customPrivateKey(_:)` (defined in `GRPCNIOTransportHTTP2Posix/Config+TLS.swift:472` — a public wrapper over the internal `nioSSLSpecific`). **Import `GRPCNIOTransportHTTP2Posix`** (that module is where the public extension lives; the internal `nioSSLSpecific`/`_NIOSSLPrivateKeySource` must NOT be referenced directly):
 ```swift
-import GRPCNIOTransportHTTP2  // or the @_spi(...) import form Task 0 identified
+import GRPCNIOTransportHTTP2Posix
 
 func tlsPrivateKeySource(_ backing: KeyBacking, seKey: SEPrivateKey?) -> TLSConfig.PrivateKeySource {
     switch backing {
@@ -496,10 +496,11 @@ func tlsPrivateKeySource(_ backing: KeyBacking, seKey: SEPrivateKey?) -> TLSConf
         guard let seKey else {
             preconditionFailure("SE key backing requires a loaded SecureEnclaveIdentity")
         }
-        return .nioSSLSpecific(.customPrivateKey(seKey))
+        return .customPrivateKey(seKey)  // public API; NIOPosix transports only
     }
 }
 ```
+(Note from Task 0: `customPrivateKey` is "NIOPosix based transports only" — both the device gRPC server and the broker client use the Posix transport, so this is correct for both.)
 
 - [ ] **Step 2: Wire `WendyAgent.swift:461`** — replace
   `let key = TLSConfig.PrivateKeySource.bytes(Array(certs.keyPEM.utf8), format: .pem)`

--- a/specs/2026-07-14-mac-secure-enclave-device-key-plan.md
+++ b/specs/2026-07-14-mac-secure-enclave-device-key-plan.md
@@ -1,0 +1,571 @@
+# macOS Secure-Enclave Device Key — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Store the macOS agent's device P256 key as a non-extractable Secure Enclave key (SE-wrapped blob in the Keychain) and sign CSRs + all mTLS handshakes (device gRPC servers and the #1412 broker client) through the enclave, with a clean software fallback for non-SE Macs and existing devices.
+
+**Architecture:** A general `KeychainStore` (Security-framework generic-password wrapper) persists opaque secret blobs. `SecureEnclaveIdentity` owns the SE key lifecycle and exposes a `Certificate.PrivateKey` (for CSR) and an `SEPrivateKey: NIOSSLCustomPrivateKey & Hashable` (for TLS sign-through). `ProvisioningStore` gains a `KeyBacking` enum (`.secureEnclave` / `.softwarePEM`); TLS call sites choose the key source via one shared helper.
+
+**Tech Stack:** Swift, swift-crypto 4.x (`SecureEnclave.P256`), swift-certificates 1.x (`Certificate.PrivateKey`), swift-nio-ssl (`NIOSSLCustomPrivateKey`), grpc-swift-nio-transport (`TLSConfig.PrivateKeySource`), swift-testing.
+
+## Global Constraints
+- **macOS-only** feature; Linux/TPM is out of scope (separate follow-up).
+- **Only the device leaf key** moves to secure storage; cert/chain stay public files.
+- **No silent software→SE migration** (impossible): existing `device-key.pem` devices keep the software path until re-provision.
+- **No silent SE→software downgrade** on an SE-capable device that provisioned with SE (fail closed instead).
+- Keychain item: `service = "sh.wendy.agent"`, `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, non-syncable.
+- **Local gate is `swift-format lint --strict`** (`~/.swiftly/bin/swift-format`). `swift build`/`swift test` are **CI-deferred** (macOS-27 SDK vs swift-crypto build blocker, same as #1409/#1411/#1412). SE paths are **hardware-verified on an Apple-Silicon Mac** as the acceptance gate — every task's "run tests" step means "written to pass; executed in CI/hardware."
+- Tests use swift-testing (`import Testing`, `@Test`, `#expect`), matching `Tests/WendyAgentTests/`.
+- Persistence ordering in `ProvisioningStore.save` is unchanged: `provisioning.json` (the `enrolled` commit marker) is written LAST.
+
+## File Structure
+```
+swift/WendyAgentCore/Sources/WendyAgent/Provisioning/
+  KeychainStore.swift            (new) generic Keychain generic-password wrapper
+  SecureEnclaveIdentity.swift    (new) SE key lifecycle + SEPrivateKey (NIOSSLCustomPrivateKey)
+  DeviceIdentity.swift           (modify) SE-backed generateCSRPEM overload
+  ProvisioningStore.swift        (modify) KeyBacking enum; SE save/load; clear() removes Keychain item
+  TLSKeySource.swift             (new) tlsPrivateKeySource(for:) helper shared by both TLS sites
+Sources/WendyAgent/
+  WendyAgent.swift               (modify) mTLSSecurity uses the helper (line ~461)
+  Cloud/TunnelBrokerClient.swift (modify) broker key source uses the helper
+swift/WendyAgentCore/Tests/WendyAgentTests/
+  KeychainStoreTests.swift          (new)
+  SecureEnclaveIdentityTests.swift  (new)
+  ProvisioningStoreTests.swift      (modify)
+```
+
+---
+
+### Task 0: Confirm the grpc custom-private-key hook is reachable
+
+**Files:** none (verification spike). This gates Task 5's approach.
+
+- [ ] **Step 1: Inspect the resolved grpc-swift-nio-transport source**
+
+Run:
+```bash
+DD=$(find ~/Library/Developer/Xcode/DerivedData -maxdepth 1 -iname 'WendyAgent-*' | head -1)
+sed -n '75,120p' "$DD/SourcePackages/checkouts/grpc-swift-nio-transport/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift"
+grep -n "public" "$DD/SourcePackages/checkouts/grpc-swift-nio-transport/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift"
+```
+
+- [ ] **Step 2: Decide the wiring form and record it**
+
+Determine which is true and note it in the Task 5 dispatch:
+- **(A)** `TLSConfig.PrivateKeySource.nioSSLSpecific(.customPrivateKey(key))` is public → use directly.
+- **(B)** It is `@_spi(...)` → add `@_spi(...) import GRPCNIOTransportHTTP2Posix` (or the exact SPI group named in source) at the two call sites.
+- **(C)** Genuinely unreachable → STOP and escalate (spec's documented fallback); do not fake it.
+
+Expected: (A) or (B). No commit (no code changed).
+
+---
+
+### Task 1: `KeychainStore` — generic secret store
+
+**Files:**
+- Create: `swift/WendyAgentCore/Sources/WendyAgent/Provisioning/KeychainStore.swift`
+- Test: `swift/WendyAgentCore/Tests/WendyAgentTests/KeychainStoreTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `struct KeychainStore { init(service: String = "sh.wendy.agent") }`
+  - `func set(_ data: Data, account: String) throws`
+  - `func get(account: String) throws -> Data?`
+  - `func remove(account: String) throws`
+  - `enum KeychainError: Error { case unexpectedStatus(OSStatus) }`
+
+- [ ] **Step 1: Write the failing test**
+
+`KeychainStoreTests.swift`:
+```swift
+import Foundation
+import Testing
+
+@testable import WendyAgent
+
+@Suite(.serialized)
+struct KeychainStoreTests {
+    // Unique account per run so the test is hermetic and self-cleaning.
+    private func account() -> String { "test-\(UUID().uuidString)" }
+
+    @Test func roundTripSetGetRemove() throws {
+        let store = KeychainStore(service: "sh.wendy.agent.tests")
+        let acct = account()
+        defer { try? store.remove(account: acct) }
+
+        #expect(try store.get(account: acct) == nil)
+        let blob = Data("secret-bytes".utf8)
+        try store.set(blob, account: acct)
+        #expect(try store.get(account: acct) == blob)
+
+        // set() is upsert: writing again replaces.
+        let blob2 = Data("rotated".utf8)
+        try store.set(blob2, account: acct)
+        #expect(try store.get(account: acct) == blob2)
+
+        try store.remove(account: acct)
+        #expect(try store.get(account: acct) == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails** — `swift test` is CI/hardware-deferred. Local proxy: `~/.swiftly/bin/swift-format lint --strict swift/WendyAgentCore/Tests/WendyAgentTests/KeychainStoreTests.swift` must pass (file is syntactically well-formed); the test references `KeychainStore`, which does not yet exist (would fail to compile in CI).
+
+- [ ] **Step 3: Implement**
+
+`KeychainStore.swift`:
+```swift
+import Foundation
+import Security
+
+/// Minimal wrapper over the macOS Keychain (`kSecClassGenericPassword`) for
+/// storing opaque secret blobs. Deliberately key-agnostic so future secrets
+/// (e.g. an ML-KEM private key that cannot be Secure-Enclave-backed) reuse it.
+struct KeychainStore {
+    let service: String
+
+    enum KeychainError: Error, CustomStringConvertible {
+        case unexpectedStatus(OSStatus)
+        var description: String {
+            switch self {
+            case .unexpectedStatus(let s): return "Keychain error: OSStatus \(s)"
+            }
+        }
+    }
+
+    init(service: String = "sh.wendy.agent") {
+        self.service = service
+    }
+
+    private func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    func set(_ data: Data, account: String) throws {
+        // Upsert: delete any existing item, then add with the fixed accessibility.
+        try self.remove(account: account)
+        var attrs = self.baseQuery(account: account)
+        attrs[kSecValueData as String] = data
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(attrs as CFDictionary, nil)
+        guard status == errSecSuccess else { throw KeychainError.unexpectedStatus(status) }
+    }
+
+    func get(account: String) throws -> Data? {
+        var query = self.baseQuery(account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var out: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &out)
+        switch status {
+        case errSecSuccess: return out as? Data
+        case errSecItemNotFound: return nil
+        default: throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func remove(account: String) throws {
+        let status = SecItemDelete(self.baseQuery(account: account) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Verify** — `~/.swiftly/bin/swift-format lint --strict` clean on both files. (Compile/test in CI/hardware.)
+
+- [ ] **Step 5: Commit**
+```bash
+git add swift/WendyAgentCore/Sources/WendyAgent/Provisioning/KeychainStore.swift swift/WendyAgentCore/Tests/WendyAgentTests/KeychainStoreTests.swift
+git commit -m "feat(mac): KeychainStore generic secret wrapper"
+```
+
+---
+
+### Task 2: `SecureEnclaveIdentity` + `SEPrivateKey`
+
+**Files:**
+- Create: `swift/WendyAgentCore/Sources/WendyAgent/Provisioning/SecureEnclaveIdentity.swift`
+- Test: `swift/WendyAgentCore/Tests/WendyAgentTests/SecureEnclaveIdentityTests.swift`
+
+**Interfaces:**
+- Consumes: `KeychainStore` (Task 1).
+- Produces:
+  - `struct SecureEnclaveIdentity`
+  - `static var isAvailable: Bool`
+  - `static func generate(store: KeychainStore, account: String = "device-key-se") throws -> SecureEnclaveIdentity`
+  - `static func load(store: KeychainStore, account: String = "device-key-se") throws -> SecureEnclaveIdentity?`
+  - `func removeFromStore(_ store: KeychainStore, account: String = "device-key-se") throws`
+  - `var certificatePrivateKey: Certificate.PrivateKey` (for CSR signing)
+  - `var nioCustomKey: SEPrivateKey` (for TLS)
+  - `struct SEPrivateKey: NIOSSLCustomPrivateKey & Hashable`
+
+- [ ] **Step 1: Write the failing test** (skips cleanly on non-SE CI)
+
+`SecureEnclaveIdentityTests.swift`:
+```swift
+import Crypto
+import Foundation
+import NIOSSL
+import Testing
+
+@testable import WendyAgent
+
+@Suite(.serialized)
+struct SecureEnclaveIdentityTests {
+    @Test func generateStoresBlobAndSignsVerifiably() throws {
+        try #require(SecureEnclaveIdentity.isAvailable, "no Secure Enclave on this host")
+        let store = KeychainStore(service: "sh.wendy.agent.tests")
+        let acct = "se-\(UUID().uuidString)"
+        let id = try SecureEnclaveIdentity.generate(store: store, account: acct)
+        defer { try? id.removeFromStore(store, account: acct) }
+
+        // Blob persisted; load() reconstructs a working key.
+        let reloaded = try #require(try SecureEnclaveIdentity.load(store: store, account: acct))
+
+        // The NIO custom key signs; the signature verifies under the SE public key.
+        let payload = Data("handshake-bytes".utf8)
+        let sig = try reloaded.signForTesting(payload)
+        #expect(reloaded.publicKeyVerify(sig, over: payload))
+    }
+
+    @Test func loadReturnsNilWhenAbsent() throws {
+        let store = KeychainStore(service: "sh.wendy.agent.tests")
+        #expect(try SecureEnclaveIdentity.load(store: store, account: "missing-\(UUID().uuidString)") == nil)
+    }
+}
+```
+(The two `*ForTesting`/`publicKeyVerify` helpers are declared in the implementation below so the signing path is exercisable without a live TLS handshake.)
+
+- [ ] **Step 2: Verify it fails** — swift-format clean; type undefined (CI compile fail).
+
+- [ ] **Step 3: Implement**
+
+`SecureEnclaveIdentity.swift`:
+```swift
+import Crypto
+import Foundation
+import NIOSSL
+import X509
+
+/// The device signing key, held in the Secure Enclave. Only the SE-wrapped blob
+/// (useless off this Mac) is persisted, via `KeychainStore`. CSR and TLS both
+/// sign through the enclave — the raw key never exists in process memory.
+struct SecureEnclaveIdentity {
+    private let key: SecureEnclave.P256.Signing.PrivateKey
+    private let accountToken: String  // stable identity for Hashable on the NIO key
+
+    static var isAvailable: Bool { SecureEnclave.isAvailable }
+
+    static func generate(store: KeychainStore, account: String = "device-key-se") throws
+        -> SecureEnclaveIdentity
+    {
+        let key = try SecureEnclave.P256.Signing.PrivateKey()
+        try store.set(key.dataRepresentation, account: account)
+        return SecureEnclaveIdentity(key: key, accountToken: account)
+    }
+
+    static func load(store: KeychainStore, account: String = "device-key-se") throws
+        -> SecureEnclaveIdentity?
+    {
+        guard let blob = try store.get(account: account) else { return nil }
+        let key = try SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: blob)
+        return SecureEnclaveIdentity(key: key, accountToken: account)
+    }
+
+    func removeFromStore(_ store: KeychainStore, account: String = "device-key-se") throws {
+        try store.remove(account: account)
+    }
+
+    /// swift-certificates wrapper used to sign the CSR (see DeviceIdentity).
+    var certificatePrivateKey: Certificate.PrivateKey { Certificate.PrivateKey(self.key) }
+
+    /// NIOSSL custom key for TLS sign-through.
+    var nioCustomKey: SEPrivateKey { SEPrivateKey(key: self.key, token: self.accountToken) }
+
+    // -- test hooks (exercise signing without a TLS handshake) --
+    func signForTesting(_ data: Data) throws -> Data {
+        try self.key.signature(for: SHA256.hash(data: data)).derRepresentation
+    }
+    func publicKeyVerify(_ sig: Data, over data: Data) -> Bool {
+        guard let s = try? P256.Signing.ECDSASignature(derRepresentation: sig) else { return false }
+        return self.key.publicKey.isValidSignature(s, for: SHA256.hash(data: data))
+    }
+}
+
+/// Signs TLS handshake bytes through the Secure Enclave. `data` arrives unhashed;
+/// we SHA-256 then produce a DER ECDSA signature. `derBytes` is empty (BoringSSL
+/// uses the custom-sign path, not raw key bytes).
+struct SEPrivateKey: NIOSSLCustomPrivateKey, Hashable {
+    fileprivate let key: SecureEnclave.P256.Signing.PrivateKey
+    private let token: String
+
+    fileprivate init(key: SecureEnclave.P256.Signing.PrivateKey, token: String) {
+        self.key = key
+        self.token = token
+    }
+
+    var signatureAlgorithms: [SignatureAlgorithm] { [.ecdsaSecp256R1Sha256] }
+    var derBytes: [UInt8] { [] }
+
+    func sign(
+        channel: Channel,
+        algorithm: SignatureAlgorithm,
+        data: ByteBuffer
+    ) -> EventLoopFuture<ByteBuffer> {
+        let promise = channel.eventLoop.makePromise(of: ByteBuffer.self)
+        do {
+            let bytes = Data(data.readableBytesView)
+            let sig = try self.key.signature(for: SHA256.hash(data: bytes)).derRepresentation
+            var buf = channel.allocator.buffer(capacity: sig.count)
+            buf.writeBytes(sig)
+            promise.succeed(buf)
+        } catch {
+            promise.fail(error)
+        }
+        return promise.futureResult
+    }
+
+    // Hashable/Equatable on the stable account token (the SE key isn't Equatable).
+    static func == (lhs: SEPrivateKey, rhs: SEPrivateKey) -> Bool { lhs.token == rhs.token }
+    func hash(into hasher: inout Hasher) { hasher.combine(self.token) }
+}
+```
+Notes for the implementer: `sign` needs `NIOCore` types (`Channel`, `ByteBuffer`, `EventLoopFuture`) — add `import NIOCore`. Confirm the exact `NIOSSLCustomPrivateKey.sign` signature against the resolved swift-nio-ssl checkout (Task 0 inspected the protocol); adjust parameter labels to match that version exactly.
+
+- [ ] **Step 4: Verify** — swift-format clean on both files.
+
+- [ ] **Step 5: Commit**
+```bash
+git add swift/WendyAgentCore/Sources/WendyAgent/Provisioning/SecureEnclaveIdentity.swift swift/WendyAgentCore/Tests/WendyAgentTests/SecureEnclaveIdentityTests.swift
+git commit -m "feat(mac): SecureEnclaveIdentity + SEPrivateKey (NIOSSL sign-through)"
+```
+
+---
+
+### Task 3: SE-backed CSR in `DeviceIdentity`
+
+**Files:**
+- Modify: `swift/WendyAgentCore/Sources/WendyAgent/Provisioning/DeviceIdentity.swift`
+- Test: `swift/WendyAgentCore/Tests/WendyAgentTests/DeviceIdentityTests.swift` (add a case)
+
+**Interfaces:**
+- Consumes: `SecureEnclaveIdentity.certificatePrivateKey` (Task 2).
+- Produces: `static func generateCSRPEM(identity: SecureEnclaveIdentity, commonName: String) throws -> String`.
+
+- [ ] **Step 1: Write the failing test** (add to `DeviceIdentityTests.swift`)
+```swift
+@Test func csrFromSecureEnclaveIdentityHasValidSignatureAndCN() throws {
+    try #require(SecureEnclaveIdentity.isAvailable, "no Secure Enclave")
+    let store = KeychainStore(service: "sh.wendy.agent.tests")
+    let acct = "csr-\(UUID().uuidString)"
+    let id = try SecureEnclaveIdentity.generate(store: store, account: acct)
+    defer { try? id.removeFromStore(store, account: acct) }
+
+    let pem = try DeviceIdentity.generateCSRPEM(identity: id, commonName: "device-42")
+    let csr = try CertificateSigningRequest(pemEncoded: pem)
+    #expect(csr.subject.description.contains("device-42"))
+    // swift-certificates validates the CSR self-signature on decode/verify.
+}
+```
+
+- [ ] **Step 2: Verify it fails** — swift-format clean; new overload undefined.
+
+- [ ] **Step 3: Implement** — add alongside the existing PEM-based overload:
+```swift
+static func generateCSRPEM(identity: SecureEnclaveIdentity, commonName: String) throws -> String {
+    let key = identity.certificatePrivateKey
+    let name = try DistinguishedName { CommonName(commonName) }
+    let csr = try CertificateSigningRequest(
+        version: .v1,
+        subject: name,
+        privateKey: key,
+        attributes: CertificateSigningRequest.Attributes(),
+        signatureAlgorithm: .ecdsaWithSHA256
+    )
+    var serializer = DER.Serializer()
+    try serializer.serialize(csr)
+    return try csr.serializeAsPEM().pemString
+}
+```
+Note: mirror the exact `CertificateSigningRequest` initializer + PEM serialization already used by the existing `generateCSRPEM(privateKeyPEM:commonName:)` in this file — reuse its subject-building and PEM helpers verbatim so only the key source differs.
+
+- [ ] **Step 4: Verify** — swift-format clean.
+
+- [ ] **Step 5: Commit**
+```bash
+git add swift/WendyAgentCore/Sources/WendyAgent/Provisioning/DeviceIdentity.swift swift/WendyAgentCore/Tests/WendyAgentTests/DeviceIdentityTests.swift
+git commit -m "feat(mac): SE-backed CSR generation"
+```
+
+---
+
+### Task 4: `ProvisioningStore` key backing
+
+**Files:**
+- Modify: `swift/WendyAgentCore/Sources/WendyAgent/Provisioning/ProvisioningStore.swift`
+- Test: `swift/WendyAgentCore/Tests/WendyAgentTests/ProvisioningStoreTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `enum KeyBacking: Equatable { case secureEnclave; case softwarePEM(String) }`
+  - `LoadedState.keyBacking: KeyBacking` (replaces the raw `keyPEM: String` for consumers; keep `certPEM`/`chainPEM`).
+  - `func save(cloudHost:orgID:assetID:keyBacking:certPEM:chainPEM:) throws`
+  - `clear()` additionally removes the Keychain SE item.
+
+- [ ] **Step 1: Write the failing tests** (add to `ProvisioningStoreTests.swift`)
+```swift
+@Test func softwareKeyRoundTripsAndLegacyFileStillLoads() throws {
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+    let store = ProvisioningStore(configPath: dir)
+    try store.save(cloudHost: "h", orgID: 1, assetID: 2,
+                   keyBacking: .softwarePEM("KEYPEM"), certPEM: "CERT", chainPEM: "CHAIN")
+    let loaded = try #require(store.load())
+    #expect(loaded.keyBacking == .softwarePEM("KEYPEM"))
+    #expect(loaded.certPEM == "CERT")
+}
+
+@Test func secureEnclaveBackingPersistsNoKeyFile() throws {
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+    let store = ProvisioningStore(configPath: dir)
+    try store.save(cloudHost: "h", orgID: 1, assetID: 2,
+                   keyBacking: .secureEnclave, certPEM: "CERT", chainPEM: "CHAIN")
+    #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent("device-key.pem").path))
+    let loaded = try #require(store.load())
+    #expect(loaded.keyBacking == .secureEnclave)
+}
+```
+
+- [ ] **Step 2: Verify it fails** — swift-format clean; new API undefined.
+
+- [ ] **Step 3: Implement** — changes to `ProvisioningStore.swift`:
+  - Add `enum KeyBacking: Equatable { case secureEnclave; case softwarePEM(String) }`.
+  - `PersistedState`: add `var keyBacking: String?` (values `"secureEnclave"` / absent = legacy software).
+  - `LoadedState`: replace `keyPEM: String` with `keyBacking: KeyBacking`.
+  - `load()`: if `state.keyBacking == "secureEnclave"` → `.secureEnclave` (do NOT read/write `device-key.pem`). Else read `device-key.pem` (with the existing legacy-in-JSON migration) → `.softwarePEM(pem)`; if empty, return nil (fail closed).
+  - `save(...keyBacking:...)`: for `.softwarePEM(pem)` keep current behavior (write `device-key.pem` etc.); for `.secureEnclave` write cert/ca/marker files but NOT the key file, and set `keyBacking = "secureEnclave"` in the JSON (written last).
+  - `clear()`: after removing files, also `try? KeychainStore().remove(account: "device-key-se")`.
+- Complete code for the load branch:
+```swift
+let backing: KeyBacking
+if state.keyBacking == "secureEnclave" {
+    backing = .secureEnclave
+} else {
+    // existing legacy device-key.pem read + in-JSON migration stays here
+    guard !keyPEM.isEmpty else { return nil }
+    backing = .softwarePEM(keyPEM)
+}
+```
+
+- [ ] **Step 4: Update existing callers** of `save`/`LoadedState.keyPEM` in `ProvisioningService`/`WendyAgent` to the `keyBacking` shape (search `keyPEM:` and `.keyPEM`). Software path passes `.softwarePEM(pem)`; SE path passes `.secureEnclave`. (This compiles-couples Task 4 with Task 6's provisioning changes — keep both in this task's branch if the reviewer flags a compile gap.)
+
+- [ ] **Step 5: Verify** — swift-format clean; commit.
+```bash
+git add swift/WendyAgentCore/Sources/WendyAgent/Provisioning/ProvisioningStore.swift swift/WendyAgentCore/Tests/WendyAgentTests/ProvisioningStoreTests.swift
+git commit -m "feat(mac): ProvisioningStore KeyBacking (SE vs software), clear() purges Keychain"
+```
+
+---
+
+### Task 5: TLS key-source helper + wire both mTLS sites
+
+**Files:**
+- Create: `swift/WendyAgentCore/Sources/WendyAgent/Provisioning/TLSKeySource.swift`
+- Modify: `swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift` (`mTLSSecurity`, ~line 461)
+- Modify: `swift/WendyAgentCore/Sources/WendyAgent/Cloud/TunnelBrokerClient.swift`
+
+**Interfaces:**
+- Consumes: `KeyBacking` (Task 4), `SEPrivateKey`/`SecureEnclaveIdentity` (Task 2), the Task-0 wiring form.
+- Produces: `func tlsPrivateKeySource(_ backing: KeyBacking, seKey: SEPrivateKey?) -> TLSConfig.PrivateKeySource`
+
+- [ ] **Step 1: Implement the helper** (`TLSKeySource.swift`), using the Task-0-confirmed form (A public, or B via `@_spi`):
+```swift
+import GRPCNIOTransportHTTP2  // or the @_spi(...) import form Task 0 identified
+
+func tlsPrivateKeySource(_ backing: KeyBacking, seKey: SEPrivateKey?) -> TLSConfig.PrivateKeySource {
+    switch backing {
+    case .softwarePEM(let pem):
+        return .bytes(Array(pem.utf8), format: .pem)
+    case .secureEnclave:
+        guard let seKey else {
+            preconditionFailure("SE key backing requires a loaded SecureEnclaveIdentity")
+        }
+        return .nioSSLSpecific(.customPrivateKey(seKey))
+    }
+}
+```
+
+- [ ] **Step 2: Wire `WendyAgent.swift:461`** — replace
+  `let key = TLSConfig.PrivateKeySource.bytes(Array(certs.keyPEM.utf8), format: .pem)`
+  with `let key = tlsPrivateKeySource(certs.keyBacking, seKey: certs.seKey)`.
+  (`ProvisioningCerts` carries `keyBacking: KeyBacking` and an optional `seKey: SEPrivateKey?`; add those fields alongside the existing `certPEM`/`chainPEM` — update `ProvisioningService.ProvisioningCerts`.)
+
+- [ ] **Step 3: Wire `TunnelBrokerClient`** — the broker's `TLSConfig` private key (added by #1412) uses the same helper: `privateKey: tlsPrivateKeySource(config.keyBacking, seKey: config.seKey)`, threading `keyBacking`/`seKey` through `TunnelBrokerClient.Config` in place of the raw `keyPEM`.
+
+- [ ] **Step 4: Verify** — swift-format clean on all three files. (Compile in CI.)
+
+- [ ] **Step 5: Commit**
+```bash
+git add swift/WendyAgentCore/Sources/WendyAgent/Provisioning/TLSKeySource.swift swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift swift/WendyAgentCore/Sources/WendyAgent/Cloud/TunnelBrokerClient.swift
+git commit -m "feat(mac): route device + broker mTLS key source through SE custom key"
+```
+
+---
+
+### Task 6: Provisioning flow — generate SE identity, gate on availability
+
+**Files:**
+- Modify: `swift/WendyAgentCore/Sources/WendyAgent/Provisioning/` provisioning service (the caller of `DeviceIdentity.generatePrivateKeyPEM`/`generateCSRPEM` and `ProvisioningStore.save`).
+- Test: extend `ProvisioningServiceTests.swift` (behavioral: SE path chosen when available; software when not).
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Write the failing test** — inject an `isSEAvailable` bool into the provisioning routine; assert that `true` → `save` receives `.secureEnclave` and no `device-key.pem` is written, `false` → `.softwarePEM`. (Use a temp `configPath`; on non-SE hosts the actual generate is skipped by the same flag.)
+
+- [ ] **Step 2: Verify it fails** — swift-format clean; behavior not implemented.
+
+- [ ] **Step 3: Implement** — at provisioning:
+```swift
+if SecureEnclaveIdentity.isAvailable {
+    let id = try SecureEnclaveIdentity.generate(store: KeychainStore())
+    let csr = try DeviceIdentity.generateCSRPEM(identity: id, commonName: cn)
+    // ... submit csr, receive cert/chain ...
+    try store.save(cloudHost: ..., orgID: ..., assetID: ..., keyBacking: .secureEnclave, certPEM: cert, chainPEM: chain)
+} else {
+    let keyPEM = try DeviceIdentity.generatePrivateKeyPEM()
+    let csr = try DeviceIdentity.generateCSRPEM(privateKeyPEM: keyPEM, commonName: cn)
+    // ...
+    try store.save(cloudHost: ..., orgID: ..., assetID: ..., keyBacking: .softwarePEM(keyPEM), certPEM: cert, chainPEM: chain)
+}
+```
+- On load, build `ProvisioningCerts.seKey` = `try? SecureEnclaveIdentity.load(store: KeychainStore())?.nioCustomKey` when `keyBacking == .secureEnclave`; if the backing says SE but load fails, fail closed (log + treat unprovisioned).
+
+- [ ] **Step 4: Verify** — swift-format clean; commit.
+```bash
+git commit -am "feat(mac): provision SE-backed device key when the enclave is available"
+```
+
+---
+
+### Task 7: Docs + PR polish
+
+- [ ] Update any provisioning doc/comment that says the key lives in `device-key.pem` to note the SE/Keychain backing + software fallback. Commit.
+
+---
+
+## Self-Review
+
+**Spec coverage:** KeychainStore→T1; SecureEnclaveIdentity/SEPrivateKey→T2; SE CSR→T3; ProvisioningStore KeyBacking + clear()→T4; TLS sign-through both sites→T5 (+T0 de-risk); availability gate + fallback + fail-closed load→T6; ML-KEM seam = `KeychainStore` generality (T1). Migration (no silent import; re-provision) = T4 load branch + T6. ✓
+
+**Placeholder scan:** Task 0 is a real verification gate (its outcome is recorded, not deferred). Tasks 4/5/6 note the exact call sites to update via `grep` rather than repeating unknown surrounding code — acceptable because the changed lines are given verbatim and the neighbors are located precisely. swift-certificates CSR init in T3 says "mirror the existing overload" — the existing code is the authority; the implementer copies it. No TBD/TODO left.
+
+**Type consistency:** `KeyBacking` (`.secureEnclave` / `.softwarePEM(String)`), `SEPrivateKey`, `SecureEnclaveIdentity.{generate,load,nioCustomKey,certificatePrivateKey}`, `tlsPrivateKeySource(_:seKey:)`, `KeychainStore.{set,get,remove}` are consistent across T1–T6. `ProvisioningCerts` gains `keyBacking` + `seKey`, used identically in T5's two sites. ✓
+
+**Known risk:** Task 0's custom-key API visibility is the single gating unknown; the source strongly indicates it is reachable, and the task records the exact form before any wiring.

--- a/swift/WendyAgentCore/Sources/WendyAgent/Cloud/TunnelBrokerClient.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Cloud/TunnelBrokerClient.swift
@@ -42,8 +42,12 @@ struct TunnelBrokerClient: Sendable {
         /// The device's own leaf certificate (PEM), presented to the broker for
         /// mTLS. Empty on an unprovisioned device.
         var certPEM: String
-        /// The private key (PEM) for `certPEM`.
-        var keyPEM: String
+        /// How the private key for `certPEM` is stored: software PEM or
+        /// Secure Enclave. `.softwarePEM("")` on an unprovisioned device.
+        var keyBacking: ProvisioningStore.KeyBacking
+        /// The loaded Secure Enclave signer, required when `keyBacking` is
+        /// `.secureEnclave`.
+        var seKey: SEPrivateKey?
         var chainPEM: String
         var mtlsPort: Int
     }
@@ -241,11 +245,16 @@ struct TunnelBrokerClient: Sendable {
         // is not transmitted on the wire; presenting it readies the device for
         // the broker to require client certs (phase 2) without a flag-day
         // cutover. Only the leaf is offered (not the ML-DSA CA chain).
+        let hasKey: Bool
+        switch config.keyBacking {
+        case .softwarePEM(let pem): hasKey = !pem.isEmpty
+        case .secureEnclave: hasKey = config.seKey != nil
+        }
         let clientChain: [TLSConfig.CertificateSource]
         let clientKey: TLSConfig.PrivateKeySource?
-        if !config.certPEM.isEmpty, !config.keyPEM.isEmpty {
+        if !config.certPEM.isEmpty, hasKey {
             clientChain = [.bytes(Array(config.certPEM.utf8), format: .pem)]
-            clientKey = .bytes(Array(config.keyPEM.utf8), format: .pem)
+            clientKey = tlsPrivateKeySource(config.keyBacking, seKey: config.seKey)
         } else {
             clientChain = []
             clientKey = nil

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/DeviceIdentity.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/DeviceIdentity.swift
@@ -53,4 +53,39 @@ enum DeviceIdentity {
 
         return try csr.serializeAsPEM().pemString
     }
+
+    /// A PEM-encoded PKCS#10 CSR for `commonName`, signed through a Secure
+    /// Enclave-backed identity (the raw key never enters process memory).
+    /// Otherwise identical to `generateCSRPEM(privateKeyPEM:commonName:)`: same
+    /// subject, same critical `digitalSignature` key usage, same client/server
+    /// EKUs — only the key source differs.
+    static func generateCSRPEM(identity: SecureEnclaveIdentity, commonName: String) throws -> String
+    {
+        let privateKey = identity.certificatePrivateKey
+
+        let subject = try DistinguishedName {
+            CommonName(commonName)
+        }
+
+        let extensions = try Certificate.Extensions {
+            Critical(
+                KeyUsage(digitalSignature: true)
+            )
+            try ExtendedKeyUsage([.clientAuth, .serverAuth])
+        }
+
+        let attributes = try CertificateSigningRequest.Attributes([
+            .init(ExtensionRequest(extensions: extensions))
+        ])
+
+        let csr = try CertificateSigningRequest(
+            version: .v1,
+            subject: subject,
+            privateKey: privateKey,
+            attributes: attributes,
+            signatureAlgorithm: .ecdsaWithSHA256
+        )
+
+        return try csr.serializeAsPEM().pemString
+    }
 }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/KeychainStore.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/KeychainStore.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Security
+
+/// Minimal wrapper over the macOS Keychain (`kSecClassGenericPassword`) for
+/// storing opaque secret blobs. Deliberately key-agnostic so future secrets
+/// (e.g. an ML-KEM private key that cannot be Secure-Enclave-backed) reuse it.
+struct KeychainStore {
+    let service: String
+
+    enum KeychainError: Error, CustomStringConvertible {
+        case unexpectedStatus(OSStatus)
+
+        var description: String {
+            switch self {
+            case .unexpectedStatus(let s): return "Keychain error: OSStatus \(s)"
+            }
+        }
+    }
+
+    init(service: String = "sh.wendy.agent") {
+        self.service = service
+    }
+
+    private func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    func set(_ data: Data, account: String) throws {
+        // Upsert: delete any existing item, then add with the fixed accessibility.
+        try self.remove(account: account)
+        var attrs = self.baseQuery(account: account)
+        attrs[kSecValueData as String] = data
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(attrs as CFDictionary, nil)
+        guard status == errSecSuccess else { throw KeychainError.unexpectedStatus(status) }
+    }
+
+    func get(account: String) throws -> Data? {
+        var query = self.baseQuery(account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var out: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &out)
+        switch status {
+        case errSecSuccess: return out as? Data
+        case errSecItemNotFound: return nil
+        default: throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func remove(account: String) throws {
+        let status = SecItemDelete(self.baseQuery(account: account) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/ProvisioningStore.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/ProvisioningStore.swift
@@ -4,7 +4,9 @@ import Logging
 /// On-disk persistence of provisioning state and certificate material. Mirrors
 /// the Go agent's layout so behavior (file names, permissions, legacy key
 /// migration) matches. The private key is never written into
-/// `provisioning.json`; it lives only in `device-key.pem`.
+/// `provisioning.json`; for a software-backed key it lives only in
+/// `device-key.pem`. A Secure-Enclave-backed key never touches disk at all —
+/// only the SE-wrapped blob lives in the Keychain (`KeychainStore`).
 struct ProvisioningStore {
     let configPath: URL
     private let logger = Logger(label: "sh.wendy.agent.provisioning.store")
@@ -13,12 +15,19 @@ struct ProvisioningStore {
         self.configPath = configPath
     }
 
+    /// How the device's private key is stored: in the Secure Enclave (no key
+    /// material on disk) or as a software PEM file (`device-key.pem`).
+    enum KeyBacking: Equatable, Sendable {
+        case secureEnclave
+        case softwarePEM(String)
+    }
+
     struct LoadedState {
         var enrolled: Bool
         var cloudHost: String
         var orgID: Int32
         var assetID: Int32
-        var keyPEM: String
+        var keyBacking: KeyBacking
         var certPEM: String
         var chainPEM: String
     }
@@ -29,6 +38,7 @@ struct ProvisioningStore {
         var orgId: Int32?
         var assetId: Int32?
         var keyPem: String?
+        var keyBacking: String?
         var certPem: String?
         var chainPem: String?
     }
@@ -46,26 +56,42 @@ struct ProvisioningStore {
             return nil
         }
 
-        var keyPEM = (try? String(contentsOf: self.keyPath, encoding: .utf8)) ?? ""
-        if keyPEM.isEmpty, let legacy = state.keyPem, !legacy.isEmpty {
-            // Migrate a legacy in-JSON key into device-key.pem, then rewrite the
-            // JSON without it.
-            keyPEM = legacy
-            try? self.writeFile(self.keyPath, contents: legacy, permissions: 0o600)
-            var stripped = state
-            stripped.keyPem = nil
-            if let rewritten = try? JSONEncoder().encode(stripped) {
-                try? self.writeFile(self.statePath, data: rewritten, permissions: 0o600)
-            }
-            self.logger.info("Migrated device key from provisioning.json to device-key.pem")
-        }
-
         let certPEM = state.certPem ?? ""
         let chainPEM = state.chainPem ?? ""
 
-        // Restore individual PEM files if missing (e.g., lost across an update).
-        if !keyPEM.isEmpty, !certPEM.isEmpty {
-            try? self.writePEMFiles(keyPEM: keyPEM, certPEM: certPEM, chainPEM: chainPEM)
+        let backing: KeyBacking
+        if state.keyBacking == "secureEnclave" {
+            // No key file for SE-backed devices; still restore cert/ca/marker
+            // if lost across an update (mirrors the software-key path below).
+            if !certPEM.isEmpty {
+                try? self.writeFile(self.certPath, contents: certPEM, permissions: 0o644)
+                try? self.writeFile(self.caPath, contents: chainPEM, permissions: 0o644)
+                try? self.writeFile(self.markerPath, contents: "", permissions: 0o644)
+            }
+            backing = .secureEnclave
+        } else {
+            var keyPEM = (try? String(contentsOf: self.keyPath, encoding: .utf8)) ?? ""
+            if keyPEM.isEmpty, let legacy = state.keyPem, !legacy.isEmpty {
+                // Migrate a legacy in-JSON key into device-key.pem, then rewrite the
+                // JSON without it.
+                keyPEM = legacy
+                try? self.writeFile(self.keyPath, contents: legacy, permissions: 0o600)
+                var stripped = state
+                stripped.keyPem = nil
+                if let rewritten = try? JSONEncoder().encode(stripped) {
+                    try? self.writeFile(self.statePath, data: rewritten, permissions: 0o600)
+                }
+                self.logger.info("Migrated device key from provisioning.json to device-key.pem")
+            }
+
+            // Restore individual PEM files if missing (e.g., lost across an update).
+            if !keyPEM.isEmpty, !certPEM.isEmpty {
+                try? self.writePEMFiles(keyPEM: keyPEM, certPEM: certPEM, chainPEM: chainPEM)
+            }
+
+            // Fail closed: an enrolled-but-keyless software device is not usable.
+            guard !keyPEM.isEmpty else { return nil }
+            backing = .softwarePEM(keyPEM)
         }
 
         return LoadedState(
@@ -73,7 +99,7 @@ struct ProvisioningStore {
             cloudHost: state.cloudHost ?? "",
             orgID: state.orgId ?? 0,
             assetID: state.assetId ?? 0,
-            keyPEM: keyPEM,
+            keyBacking: backing,
             certPEM: certPEM,
             chainPEM: chainPEM
         )
@@ -83,7 +109,7 @@ struct ProvisioningStore {
         cloudHost: String,
         orgID: Int32,
         assetID: Int32,
-        keyPEM: String,
+        keyBacking: KeyBacking,
         certPEM: String,
         chainPEM: String
     ) throws {
@@ -98,7 +124,18 @@ struct ProvisioningStore {
         // of truth, so it must be written LAST: if anything above fails, the
         // device is left honestly unprovisioned (no json => load() -> nil)
         // rather than "enrolled" on disk with no private key.
-        try self.writePEMFiles(keyPEM: keyPEM, certPEM: certPEM, chainPEM: chainPEM)
+        let keyBackingValue: String?
+        switch keyBacking {
+        case .softwarePEM(let pem):
+            try self.writePEMFiles(keyPEM: pem, certPEM: certPEM, chainPEM: chainPEM)
+            keyBackingValue = nil
+        case .secureEnclave:
+            // No key file: the key never leaves the Secure Enclave.
+            try self.writeFile(self.certPath, contents: certPEM, permissions: 0o644)
+            try self.writeFile(self.caPath, contents: chainPEM, permissions: 0o644)
+            try self.writeFile(self.markerPath, contents: "", permissions: 0o644)
+            keyBackingValue = "secureEnclave"
+        }
 
         // provisioning.json WITHOUT the key, mode 0600.
         let state = PersistedState(
@@ -107,6 +144,7 @@ struct ProvisioningStore {
             orgId: orgID,
             assetId: assetID,
             keyPem: nil,
+            keyBacking: keyBackingValue,
             certPem: certPEM,
             chainPem: chainPEM
         )
@@ -127,6 +165,10 @@ struct ProvisioningStore {
                 continue
             }
         }
+        // Best-effort: also purge any Secure-Enclave-backed key blob so a
+        // re-provision on this device starts clean. A missing Keychain item
+        // is not an error here.
+        try? KeychainStore().remove(account: "device-key-se")
     }
 
     private func writePEMFiles(keyPEM: String, certPEM: String, chainPEM: String) throws {

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/SecureEnclaveIdentity.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/SecureEnclaveIdentity.swift
@@ -1,0 +1,106 @@
+import Crypto
+import Foundation
+import NIOCore
+import NIOSSL
+import X509
+
+/// The device signing key, held in the Secure Enclave. Only the SE-wrapped blob
+/// (useless off this Mac) is persisted, via `KeychainStore`. CSR and TLS both
+/// sign through the enclave — the raw key never exists in process memory.
+struct SecureEnclaveIdentity {
+    private let key: SecureEnclave.P256.Signing.PrivateKey
+    private let accountToken: String  // stable identity for Hashable on the NIO key
+
+    static var isAvailable: Bool { SecureEnclave.isAvailable }
+
+    static func generate(
+        store: KeychainStore,
+        account: String = "device-key-se"
+    ) throws
+        -> SecureEnclaveIdentity
+    {
+        let key = try SecureEnclave.P256.Signing.PrivateKey()
+        try store.set(key.dataRepresentation, account: account)
+        return SecureEnclaveIdentity(key: key, accountToken: account)
+    }
+
+    static func load(
+        store: KeychainStore,
+        account: String = "device-key-se"
+    ) throws
+        -> SecureEnclaveIdentity?
+    {
+        guard let blob = try store.get(account: account) else { return nil }
+        let key = try SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: blob)
+        return SecureEnclaveIdentity(key: key, accountToken: account)
+    }
+
+    func removeFromStore(_ store: KeychainStore, account: String = "device-key-se") throws {
+        try store.remove(account: account)
+    }
+
+    /// swift-certificates wrapper used to sign the CSR (see DeviceIdentity).
+    var certificatePrivateKey: Certificate.PrivateKey { Certificate.PrivateKey(self.key) }
+
+    /// NIOSSL custom key for TLS sign-through.
+    var nioCustomKey: SEPrivateKey { SEPrivateKey(key: self.key, token: self.accountToken) }
+
+    // -- test hooks (exercise signing without a TLS handshake) --
+    func signForTesting(_ data: Data) throws -> Data {
+        try self.key.signature(for: SHA256.hash(data: data)).derRepresentation
+    }
+
+    func publicKeyVerify(_ sig: Data, over data: Data) -> Bool {
+        guard let s = try? P256.Signing.ECDSASignature(derRepresentation: sig) else { return false }
+        return self.key.publicKey.isValidSignature(s, for: SHA256.hash(data: data))
+    }
+}
+
+/// Signs TLS handshake bytes through the Secure Enclave. `data` arrives unhashed;
+/// we SHA-256 then produce a DER ECDSA signature. `derBytes` is empty (BoringSSL
+/// uses the custom-sign path, not raw key bytes).
+struct SEPrivateKey: NIOSSLCustomPrivateKey, Hashable {
+    fileprivate let key: SecureEnclave.P256.Signing.PrivateKey
+    private let token: String
+
+    /// EC keys never support raw RSA decryption; this satisfies the protocol
+    /// requirement (it has no default implementation) but is never invoked —
+    /// BoringSSL only calls `decrypt` for RSA key exchange.
+    enum Error: Swift.Error {
+        case decryptionUnsupported
+    }
+
+    fileprivate init(key: SecureEnclave.P256.Signing.PrivateKey, token: String) {
+        self.key = key
+        self.token = token
+    }
+
+    var signatureAlgorithms: [SignatureAlgorithm] { [.ecdsaSecp256R1Sha256] }
+    var derBytes: [UInt8] { [] }
+
+    func sign(
+        channel: Channel,
+        algorithm: SignatureAlgorithm,
+        data: ByteBuffer
+    ) -> EventLoopFuture<ByteBuffer> {
+        let promise = channel.eventLoop.makePromise(of: ByteBuffer.self)
+        do {
+            let bytes = Data(data.readableBytesView)
+            let sig = try self.key.signature(for: SHA256.hash(data: bytes)).derRepresentation
+            var buf = channel.allocator.buffer(capacity: sig.count)
+            buf.writeBytes(sig)
+            promise.succeed(buf)
+        } catch {
+            promise.fail(error)
+        }
+        return promise.futureResult
+    }
+
+    func decrypt(channel: Channel, data: ByteBuffer) -> EventLoopFuture<ByteBuffer> {
+        channel.eventLoop.makeFailedFuture(Error.decryptionUnsupported)
+    }
+
+    // Hashable/Equatable on the stable account token (the SE key isn't Equatable).
+    static func == (lhs: SEPrivateKey, rhs: SEPrivateKey) -> Bool { lhs.token == rhs.token }
+    func hash(into hasher: inout Hasher) { hasher.combine(self.token) }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/TLSKeySource.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/TLSKeySource.swift
@@ -1,4 +1,4 @@
-import GRPCNIOTransportHTTP2Posix
+import GRPCNIOTransportHTTP2
 
 /// Resolves a `KeyBacking` (software PEM or Secure Enclave) into the
 /// `TLSConfig.PrivateKeySource` grpc-swift-nio-transport expects, shared by

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/TLSKeySource.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/TLSKeySource.swift
@@ -1,0 +1,26 @@
+import GRPCNIOTransportHTTP2Posix
+
+/// Resolves a `KeyBacking` (software PEM or Secure Enclave) into the
+/// `TLSConfig.PrivateKeySource` grpc-swift-nio-transport expects, shared by
+/// both mTLS sites: the device's own gRPC server (`WendyAgent.mTLSSecurity`)
+/// and the tunnel-broker client (`TunnelBrokerClient`).
+///
+/// `TLSConfig.PrivateKeySource.customPrivateKey(_:)` is a public factory
+/// (`GRPCNIOTransportHTTP2Posix/Config+TLS.swift`) over the otherwise-internal
+/// `nioSSLSpecific`/`_NIOSSLPrivateKeySource` case, and is documented as
+/// "NIOPosix based transports only" — both mTLS sites here use the Posix
+/// transport, so it applies to both.
+func tlsPrivateKeySource(
+    _ backing: ProvisioningStore.KeyBacking,
+    seKey: SEPrivateKey?
+) -> TLSConfig.PrivateKeySource {
+    switch backing {
+    case .softwarePEM(let pem):
+        return .bytes(Array(pem.utf8), format: .pem)
+    case .secureEnclave:
+        guard let seKey else {
+            preconditionFailure("SE key backing requires a loaded SecureEnclaveIdentity")
+        }
+        return .customPrivateKey(seKey)
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
@@ -17,7 +17,8 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
     struct ProvisioningCerts: Sendable {
         var certPEM: String
         var chainPEM: String
-        var keyPEM: String
+        var keyBacking: ProvisioningStore.KeyBacking
+        var seKey: SEPrivateKey?
     }
 
     private let store: ProvisioningStore
@@ -28,7 +29,8 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
     private var cloudHost = ""
     private var orgID: Int32 = 0
     private var assetID: Int32 = 0
-    private var keyPEM = ""
+    private var keyBacking: ProvisioningStore.KeyBacking = .softwarePEM("")
+    private var seKey: SEPrivateKey?
     private var certPEM = ""
     private var chainPEM = ""
 
@@ -38,19 +40,29 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
     init(configPath: URL, cloudClient: CloudCertificateClient = .live) {
         self.store = ProvisioningStore(configPath: configPath)
         self.cloudClient = cloudClient
-        if let loaded = self.store.load() {
-            self.enrolled = loaded.enrolled
-            self.cloudHost = loaded.cloudHost
-            self.orgID = loaded.orgID
-            self.assetID = loaded.assetID
-            // Secure-Enclave-backed devices have no PEM key material; this
-            // field is superseded by keyBacking/seKey wiring in a later task.
-            if case .softwarePEM(let pem) = loaded.keyBacking {
-                self.keyPEM = pem
+        guard let loaded = self.store.load() else { return }
+
+        if loaded.keyBacking == .secureEnclave {
+            // Fail closed: if the SE blob can't be reconstructed (e.g. the
+            // Keychain item vanished, or this isn't the Mac that created it),
+            // treat the device as unprovisioned rather than silently falling
+            // back to no key or a software one. Re-provisioning is required.
+            guard let identity = try? SecureEnclaveIdentity.load(store: KeychainStore()) else {
+                self.logger.error(
+                    "Provisioning state says secureEnclave but the Keychain blob could not be loaded; treating device as unprovisioned"
+                )
+                return
             }
-            self.certPEM = loaded.certPEM
-            self.chainPEM = loaded.chainPEM
+            self.seKey = identity.nioCustomKey
         }
+
+        self.enrolled = loaded.enrolled
+        self.cloudHost = loaded.cloudHost
+        self.orgID = loaded.orgID
+        self.assetID = loaded.assetID
+        self.keyBacking = loaded.keyBacking
+        self.certPEM = loaded.certPEM
+        self.chainPEM = loaded.chainPEM
     }
 
     func setCallbacks(
@@ -75,7 +87,8 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
         return ProvisioningCerts(
             certPEM: self.certPEM,
             chainPEM: self.chainPEM,
-            keyPEM: self.keyPEM
+            keyBacking: self.keyBacking,
+            seKey: self.seKey
         )
     }
 
@@ -160,7 +173,8 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
         self.cloudHost = request.cloudHost
         self.orgID = request.organizationID
         self.assetID = request.assetID
-        self.keyPEM = keyPEM
+        self.keyBacking = .softwarePEM(keyPEM)
+        self.seKey = nil
         self.certPEM = issued.certPEM
         self.chainPEM = issued.chainPEM
 
@@ -173,7 +187,8 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
             let certs = ProvisioningCerts(
                 certPEM: self.certPEM,
                 chainPEM: self.chainPEM,
-                keyPEM: self.keyPEM
+                keyBacking: self.keyBacking,
+                seKey: self.seKey
             )
             await cb(certs)
         }
@@ -228,7 +243,8 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
         self.cloudHost = ""
         self.orgID = 0
         self.assetID = 0
-        self.keyPEM = ""
+        self.keyBacking = .softwarePEM("")
+        self.seKey = nil
         self.certPEM = ""
         self.chainPEM = ""
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
@@ -23,6 +23,9 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
 
     private let store: ProvisioningStore
     private let cloudClient: CloudCertificateClient
+    /// Overridable so tests can force the SE / software branch deterministically
+    /// regardless of the host's actual hardware. Defaults to the real check.
+    private let isSecureEnclaveAvailable: @Sendable () -> Bool
     private let logger = Logger(label: "sh.wendy.agent.provisioning")
 
     private var enrolled = false
@@ -37,9 +40,16 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
     private var onProvisioned: (@Sendable (ProvisioningCerts) async -> Void)?
     private var onUnprovisioned: (@Sendable () async -> Void)?
 
-    init(configPath: URL, cloudClient: CloudCertificateClient = .live) {
+    init(
+        configPath: URL,
+        cloudClient: CloudCertificateClient = .live,
+        isSecureEnclaveAvailable: @Sendable @escaping () -> Bool = {
+            SecureEnclaveIdentity.isAvailable
+        }
+    ) {
         self.store = ProvisioningStore(configPath: configPath)
         self.cloudClient = cloudClient
+        self.isSecureEnclaveAvailable = isSecureEnclaveAvailable
         guard let loaded = self.store.load() else { return }
 
         if loaded.keyBacking == .secureEnclave {
@@ -114,28 +124,58 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
             ]
         )
 
-        let keyPEM: String
-        do {
-            keyPEM = try DeviceIdentity.generatePrivateKeyPEM()
-        } catch {
-            throw RPCError(
-                code: .internalError,
-                message: "failed to generate key pair: \(error)"
-            )
-        }
-
         let commonName = DeviceIdentity.commonName(
             organizationID: request.organizationID,
             assetID: request.assetID
         )
+
+        // Prefer the Secure Enclave when this Mac has one: the key is
+        // generated and signs entirely inside the enclave and never exists as
+        // extractable key material. Falls back to a software PEM key
+        // otherwise (older Macs, or hardware without an SE).
+        let keyBacking: ProvisioningStore.KeyBacking
+        let seKey: SEPrivateKey?
         let csrPEM: String
-        do {
-            csrPEM = try DeviceIdentity.generateCSRPEM(
-                privateKeyPEM: keyPEM,
-                commonName: commonName
-            )
-        } catch {
-            throw RPCError(code: .internalError, message: "failed to generate CSR: \(error)")
+        if self.isSecureEnclaveAvailable() {
+            let identity: SecureEnclaveIdentity
+            do {
+                identity = try SecureEnclaveIdentity.generate(store: KeychainStore())
+            } catch {
+                throw RPCError(
+                    code: .internalError,
+                    message: "failed to generate Secure Enclave key: \(error)"
+                )
+            }
+            do {
+                csrPEM = try DeviceIdentity.generateCSRPEM(
+                    identity: identity,
+                    commonName: commonName
+                )
+            } catch {
+                throw RPCError(code: .internalError, message: "failed to generate CSR: \(error)")
+            }
+            keyBacking = .secureEnclave
+            seKey = identity.nioCustomKey
+        } else {
+            let keyPEM: String
+            do {
+                keyPEM = try DeviceIdentity.generatePrivateKeyPEM()
+            } catch {
+                throw RPCError(
+                    code: .internalError,
+                    message: "failed to generate key pair: \(error)"
+                )
+            }
+            do {
+                csrPEM = try DeviceIdentity.generateCSRPEM(
+                    privateKeyPEM: keyPEM,
+                    commonName: commonName
+                )
+            } catch {
+                throw RPCError(code: .internalError, message: "failed to generate CSR: \(error)")
+            }
+            keyBacking = .softwarePEM(keyPEM)
+            seKey = nil
         }
 
         let issued = try await self.cloudClient.issue(
@@ -154,7 +194,7 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
                 cloudHost: request.cloudHost,
                 orgID: request.organizationID,
                 assetID: request.assetID,
-                keyBacking: .softwarePEM(keyPEM),
+                keyBacking: keyBacking,
                 certPEM: issued.certPEM,
                 chainPEM: issued.chainPEM
             )
@@ -173,8 +213,8 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
         self.cloudHost = request.cloudHost
         self.orgID = request.organizationID
         self.assetID = request.assetID
-        self.keyBacking = .softwarePEM(keyPEM)
-        self.seKey = nil
+        self.keyBacking = keyBacking
+        self.seKey = seKey
         self.certPEM = issued.certPEM
         self.chainPEM = issued.chainPEM
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
@@ -43,7 +43,11 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
             self.cloudHost = loaded.cloudHost
             self.orgID = loaded.orgID
             self.assetID = loaded.assetID
-            self.keyPEM = loaded.keyPEM
+            // Secure-Enclave-backed devices have no PEM key material; this
+            // field is superseded by keyBacking/seKey wiring in a later task.
+            if case .softwarePEM(let pem) = loaded.keyBacking {
+                self.keyPEM = pem
+            }
             self.certPEM = loaded.certPEM
             self.chainPEM = loaded.chainPEM
         }
@@ -137,7 +141,7 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
                 cloudHost: request.cloudHost,
                 orgID: request.organizationID,
                 assetID: request.assetID,
-                keyPEM: keyPEM,
+                keyBacking: .softwarePEM(keyPEM),
                 certPEM: issued.certPEM,
                 chainPEM: issued.chainPEM
             )

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
@@ -376,7 +376,8 @@ public actor WendyAgent {
             orgID: info.orgID,
             assetID: info.assetID,
             certPEM: certs.certPEM,
-            keyPEM: certs.keyPEM,
+            keyBacking: certs.keyBacking,
+            seKey: certs.seKey,
             chainPEM: certs.chainPEM,
             mtlsPort: self.configuration.port + 1
         )
@@ -458,7 +459,7 @@ public actor WendyAgent {
     ) -> HTTP2ServerTransport.Posix.TransportSecurity {
         let leaf = TLSConfig.CertificateSource.bytes(Array(certs.certPEM.utf8), format: .pem)
         let chain = TLSConfig.CertificateSource.bytes(Array(certs.chainPEM.utf8), format: .pem)
-        let key = TLSConfig.PrivateKeySource.bytes(Array(certs.keyPEM.utf8), format: .pem)
+        let key = tlsPrivateKeySource(certs.keyBacking, seKey: certs.seKey)
 
         let trustRootsPEM = certs.chainPEM
         let deviceOrg = ClientCertAuthorizer.organizationID(fromLeafPEM: certs.certPEM)

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/DeviceIdentityTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/DeviceIdentityTests.swift
@@ -45,4 +45,26 @@ struct DeviceIdentityTests {
         #expect(eku.contains(.clientAuth))
         #expect(eku.contains(.serverAuth))
     }
+
+    @Test("CSR from a SecureEnclaveIdentity has the same subject, keyUsage, and EKUs")
+    func csrFromSecureEnclaveIdentityHasValidSignatureAndCN() throws {
+        try #require(SecureEnclaveIdentity.isAvailable, "no Secure Enclave")
+        let store = KeychainStore(service: "sh.wendy.agent.tests")
+        let acct = "csr-\(UUID().uuidString)"
+        let id = try SecureEnclaveIdentity.generate(store: store, account: acct)
+        defer { try? id.removeFromStore(store, account: acct) }
+
+        let pem = try DeviceIdentity.generateCSRPEM(identity: id, commonName: "device-42")
+        let csr = try CertificateSigningRequest(pemEncoded: pem)
+        #expect(csr.subject.description.contains("device-42"))
+
+        // Same extension shape as the software-key overload.
+        let exts = try #require(csr.attributes.extensionRequest?.extensions)
+        let keyUsage = try #require(try exts.keyUsage)
+        #expect(keyUsage.digitalSignature)
+        let eku = try #require(try exts.extendedKeyUsage)
+        #expect(eku.contains(.clientAuth))
+        #expect(eku.contains(.serverAuth))
+        // swift-certificates validates the CSR self-signature on decode/verify.
+    }
 }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/KeychainStoreTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/KeychainStoreTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import WendyAgentCore
+
+@Suite(.serialized)
+struct KeychainStoreTests {
+    // Unique account per run so the test is hermetic and self-cleaning.
+    private func account() -> String { "test-\(UUID().uuidString)" }
+
+    @Test func roundTripSetGetRemove() throws {
+        let store = KeychainStore(service: "sh.wendy.agent.tests")
+        let acct = self.account()
+        defer { try? store.remove(account: acct) }
+
+        #expect(try store.get(account: acct) == nil)
+        let blob = Data("secret-bytes".utf8)
+        try store.set(blob, account: acct)
+        #expect(try store.get(account: acct) == blob)
+
+        // set() is upsert: writing again replaces.
+        let blob2 = Data("rotated".utf8)
+        try store.set(blob2, account: acct)
+        #expect(try store.get(account: acct) == blob2)
+
+        try store.remove(account: acct)
+        #expect(try store.get(account: acct) == nil)
+    }
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ProvisioningServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ProvisioningServiceTests.swift
@@ -5,7 +5,15 @@ import WendyAgentGRPC
 
 @testable import WendyAgentCore
 
-@Suite("ProvisioningService")
+// Serialized: every test drives the real ProvisioningService, which stores the
+// device SE key at the fixed production keychain account "device-key-se". Run
+// in parallel (swift-testing's default), concurrent provisioning attempts race
+// on that shared account — KeychainStore.set's remove-then-add is not atomic, so
+// two racing set()s collide with errSecDuplicateItem (OSStatus -25299). A device
+// is never provisioned concurrently in reality, so serial execution is the
+// faithful model and removes the race. Each provisioning test also clears the
+// account in a defer so it never leaks into the CI/dev login keychain.
+@Suite("ProvisioningService", .serialized)
 struct ProvisioningServiceTests {
     private func tempDir() -> URL {
         FileManager.default.temporaryDirectory
@@ -22,6 +30,7 @@ struct ProvisioningServiceTests {
     func provisionSucceeds() async throws {
         let dir = tempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
+        defer { try? KeychainStore().remove(account: "device-key-se") }
         let service = ProvisioningService(configPath: dir, cloudClient: stubClient())
 
         let provisioned = ManagedAtomicFlag()
@@ -101,6 +110,7 @@ struct ProvisioningServiceTests {
     func unprovisionSucceeds() async throws {
         let dir = tempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
+        defer { try? KeychainStore().remove(account: "device-key-se") }
         let service = ProvisioningService(configPath: dir, cloudClient: stubClient())
         let unprovisioned = ManagedAtomicFlag()
         await service.setCallbacks(

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ProvisioningServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ProvisioningServiceTests.swift
@@ -142,6 +142,70 @@ struct ProvisioningServiceTests {
             )
         }
     }
+
+    @Test("provisioning prefers the Secure Enclave when available and writes no device-key.pem")
+    func provisionUsesSecureEnclaveWhenAvailable() async throws {
+        // Forcing `isSecureEnclaveAvailable` to `true` only selects the SE
+        // branch; `SecureEnclaveIdentity.generate` still calls the real
+        // Security framework underneath, so this needs an actual enclave.
+        try #require(SecureEnclaveIdentity.isAvailable, "no Secure Enclave on this host")
+
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let service = ProvisioningService(
+            configPath: dir,
+            cloudClient: stubClient(),
+            isSecureEnclaveAvailable: { true }
+        )
+
+        var req = Wendy_Agent_Services_V1_StartProvisioningRequest()
+        req.organizationID = 7
+        req.assetID = 42
+        req.cloudHost = "cloud.example:50051"
+        req.enrollmentToken = "tok"
+        _ = try await service.startProvisioning(request: req, context: ctx("StartProvisioning"))
+        defer { try? KeychainStore().remove(account: "device-key-se") }
+
+        let certs = try #require(await service.provisioningCerts())
+        #expect(certs.keyBacking == .secureEnclave)
+        #expect(certs.seKey != nil)
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: dir.appendingPathComponent("device-key.pem").path
+            )
+        )
+    }
+
+    @Test("provisioning falls back to a software key when the Secure Enclave is unavailable")
+    func provisionUsesSoftwareKeyWhenSecureEnclaveUnavailable() async throws {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let service = ProvisioningService(
+            configPath: dir,
+            cloudClient: stubClient(),
+            isSecureEnclaveAvailable: { false }
+        )
+
+        var req = Wendy_Agent_Services_V1_StartProvisioningRequest()
+        req.organizationID = 7
+        req.assetID = 42
+        req.cloudHost = "cloud.example:50051"
+        req.enrollmentToken = "tok"
+        _ = try await service.startProvisioning(request: req, context: ctx("StartProvisioning"))
+
+        let certs = try #require(await service.provisioningCerts())
+        guard case .softwarePEM(let pem) = certs.keyBacking else {
+            Issue.record("expected softwarePEM, got \(certs.keyBacking)")
+            return
+        }
+        #expect(!pem.isEmpty)
+        #expect(certs.seKey == nil)
+        #expect(
+            FileManager.default.fileExists(
+                atPath: dir.appendingPathComponent("device-key.pem").path
+            )
+        )
+    }
 }
 
 /// Minimal async flag for asserting a callback fired.

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ProvisioningStoreTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ProvisioningStoreTests.swift
@@ -21,7 +21,7 @@ struct ProvisioningStoreTests {
             cloudHost: "cloud.example:50051",
             orgID: 7,
             assetID: 42,
-            keyPEM: "KEYPEM",
+            keyBacking: .softwarePEM("KEYPEM"),
             certPEM: "CERTPEM",
             chainPEM: "CHAINPEM"
         )
@@ -31,7 +31,7 @@ struct ProvisioningStoreTests {
         #expect(loaded.cloudHost == "cloud.example:50051")
         #expect(loaded.orgID == 7)
         #expect(loaded.assetID == 42)
-        #expect(loaded.keyPEM == "KEYPEM")
+        #expect(loaded.keyBacking == .softwarePEM("KEYPEM"))
         #expect(loaded.certPEM == "CERTPEM")
         #expect(loaded.chainPEM == "CHAINPEM")
 
@@ -73,7 +73,7 @@ struct ProvisioningStoreTests {
 
         let store = ProvisioningStore(configPath: dir)
         let loaded = try #require(store.load())
-        #expect(loaded.keyPEM == "LEGACYKEY")
+        #expect(loaded.keyBacking == .softwarePEM("LEGACYKEY"))
         // Migrated to device-key.pem and stripped from json.
         let migratedKey = try String(
             contentsOf: dir.appendingPathComponent("device-key.pem"),
@@ -136,7 +136,7 @@ struct ProvisioningStoreTests {
                 cloudHost: "c:50051",
                 orgID: 1,
                 assetID: 2,
-                keyPEM: "KEYPEM",
+                keyBacking: .softwarePEM("KEYPEM"),
                 certPEM: "CERTPEM",
                 chainPEM: "CHAINPEM"
             )
@@ -161,7 +161,7 @@ struct ProvisioningStoreTests {
             cloudHost: "c:50051",
             orgID: 1,
             assetID: 2,
-            keyPEM: "K",
+            keyBacking: .softwarePEM("K"),
             certPEM: "C",
             chainPEM: "CH"
         )
@@ -175,5 +175,31 @@ struct ProvisioningStoreTests {
         }
         // Second clear on an empty dir does not throw.
         try store.clear()
+    }
+
+    @Test("Secure-Enclave-backed save persists no device-key.pem, and round-trips")
+    func secureEnclaveBackingPersistsNoKeyFile() throws {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ProvisioningStore(configPath: dir)
+
+        try store.save(
+            cloudHost: "h",
+            orgID: 1,
+            assetID: 2,
+            keyBacking: .secureEnclave,
+            certPEM: "CERT",
+            chainPEM: "CHAIN"
+        )
+
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: dir.appendingPathComponent("device-key.pem").path
+            )
+        )
+        let loaded = try #require(store.load())
+        #expect(loaded.keyBacking == .secureEnclave)
+        #expect(loaded.certPEM == "CERT")
+        #expect(loaded.chainPEM == "CHAIN")
     }
 }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/SecureEnclaveIdentityTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/SecureEnclaveIdentityTests.swift
@@ -1,0 +1,31 @@
+import Crypto
+import Foundation
+import NIOSSL
+import Testing
+
+@testable import WendyAgentCore
+
+@Suite(.serialized)
+struct SecureEnclaveIdentityTests {
+    @Test func generateStoresBlobAndSignsVerifiably() throws {
+        try #require(SecureEnclaveIdentity.isAvailable, "no Secure Enclave on this host")
+        let store = KeychainStore(service: "sh.wendy.agent.tests")
+        let acct = "se-\(UUID().uuidString)"
+        let id = try SecureEnclaveIdentity.generate(store: store, account: acct)
+        defer { try? id.removeFromStore(store, account: acct) }
+
+        // Blob persisted; load() reconstructs a working key.
+        let reloaded = try #require(try SecureEnclaveIdentity.load(store: store, account: acct))
+
+        // The NIO custom key signs; the signature verifies under the SE public key.
+        let payload = Data("handshake-bytes".utf8)
+        let sig = try reloaded.signForTesting(payload)
+        #expect(reloaded.publicKeyVerify(sig, over: payload))
+    }
+
+    @Test func loadReturnsNilWhenAbsent() throws {
+        let store = KeychainStore(service: "sh.wendy.agent.tests")
+        let missing = "missing-\(UUID().uuidString)"
+        #expect(try SecureEnclaveIdentity.load(store: store, account: missing) == nil)
+    }
+}


### PR DESCRIPTION
## macOS agent — device key in the Secure Enclave (mTLS sign-through)

Stacked on #1412. Moves the macOS agent's device P256 key into the **Secure Enclave**: the key material never leaves hardware, only the SE-wrapped blob is persisted (in the **Keychain**), and both CSR generation and every mTLS handshake — the device gRPC servers *and* the #1412 broker client — sign **through** the enclave. Disk or process-memory access no longer yields a usable device key.

Design + plan: `specs/2026-07-14-mac-secure-enclave-device-key-{design,plan}.md`.

### What
- **`KeychainStore`** — generic `kSecClassGenericPassword` wrapper (`AfterFirstUnlockThisDeviceOnly`, non-syncable). Deliberately key-agnostic so a **future ML-KEM key** (which the SE cannot hold) reuses the same seam.
- **`SecureEnclaveIdentity` + `SEPrivateKey`** — SE P256 lifecycle; `SEPrivateKey` is a `NIOSSLCustomPrivateKey & Hashable` that SHA-256s + enclave-signs.
- **SE-backed CSR** via `Certificate.PrivateKey(secureEnclaveP256:)`.
- **`ProvisioningStore`** gains a `KeyBacking` enum (`.secureEnclave` / `.softwarePEM`); SE devices persist no `device-key.pem`; `clear()` purges the Keychain item.
- **TLS wiring** — one `tlsPrivateKeySource(_:seKey:)` helper routes both mTLS sites; SE path uses the **public** `TLSConfig.PrivateKeySource.customPrivateKey(_:)` (`import GRPCNIOTransportHTTP2`).
- **Fallback / migration** — no Secure Enclave (CI/VM) → software-PEM path unchanged; existing `device-key.pem` devices keep working and adopt SE only on **re-provision** (a software key can't be imported into the SE). SE-capable devices that chose SE fail closed rather than silently downgrade.

### Scope
macOS only; **Linux/TPM is a deliberate follow-up** (different secure element, Go agent). Only the device leaf key moves; cert/chain stay public files.

### Verification status — please read
- `swift-format --strict` clean on all 13 touched files.
- **Full `swift build` / `swift test` (including the SE tests, which execute on Apple-Silicon hardware) are pending** — this branch is stacked on #1412, whose swift-crypto pin (4.5.0) does not build against the macOS-27 SDK (`ContiguousBytes.withBytes`). That's a **repo-wide dependency issue already resolved on the security-hardening/main track**, not in this feature. Rebasing onto the main that carries the newer swift-crypto revision unblocks compile + the enclave tests.
- Implementation notes surfaced during grounding: `NIOSSLCustomPrivateKey.decrypt` has no default impl, so a failing `decrypt` was added for conformance; test module is `WendyAgentCore`; the SE CSR mirrors the existing CSR's KeyUsage/EKU extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
