### PR TITLE
fix(swift-agent): path-traversal containment validation (C2)

### DIFF
--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -1324,8 +1324,11 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
                 )
             }
 
-            let blobPath = "\(blobsDirectory)/sha256/\(expectedHash)"
-            try accumulated.write(to: URL(fileURLWithPath: blobPath))
+            let blobURL = try validateContainedPath(
+                base: URL(fileURLWithPath: blobsDirectory),
+                relative: "sha256/\(expectedHash)"
+            )
+            try accumulated.write(to: blobURL)
 
             logger.info(
                 "WriteLayer completed (OCI blob)",
@@ -1410,7 +1413,10 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
 
     private func readBlob(digest: String) throws -> Data {
         // digest is "sha256:<hex>" — map to blobsDirectory/sha256/<hex>.
-        let blobPath = "\(blobsDirectory)/\(digest.replacingOccurrences(of: ":", with: "/"))"
+        let blobPath = try validateContainedPath(
+            base: URL(fileURLWithPath: blobsDirectory),
+            relative: digest.replacingOccurrences(of: ":", with: "/")
+        ).path
         guard let data = FileManager.default.contents(atPath: blobPath) else {
             throw RPCError(code: .notFound, message: "Blob not found at \(blobPath)")
         }
@@ -1418,7 +1424,10 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     }
 
     private func extractTarGz(blobDigest: String, to destinationDirectory: String) async throws {
-        let blobPath = "\(blobsDirectory)/\(blobDigest.replacingOccurrences(of: ":", with: "/"))"
+        let blobPath = try validateContainedPath(
+            base: URL(fileURLWithPath: blobsDirectory),
+            relative: blobDigest.replacingOccurrences(of: ":", with: "/")
+        ).path
         let tarProcess = Foundation.Process()
         tarProcess.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
         tarProcess.arguments = ["-xzf", blobPath, "-C", destinationDirectory]

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -753,7 +753,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         let nativeLaunchInfo: NativeLaunchInfo
         if imageName.hasPrefix("sha256:") {
             // OCI image: parse manifest → config → extract layer.
-            let appDirectory = appsBase.appendingPathComponent(appName).path
+            let appDirectory = try validateContainedPath(base: appsBase, relative: appName).path
             try FileManager.default.createDirectory(
                 atPath: appDirectory,
                 withIntermediateDirectories: true
@@ -801,7 +801,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             )
         } else if !imageName.isEmpty {
             // Legacy: imageName is the binary name directly.
-            let appDirectory = appsBase.appendingPathComponent(appName).path
+            let appDirectory = try validateContainedPath(base: appsBase, relative: appName).path
             let binaryPath = "\(appDirectory)/\(imageName)"
             guard FileManager.default.fileExists(atPath: binaryPath) else {
                 throw RPCError(code: .notFound, message: "Binary not found at \(binaryPath)")
@@ -823,7 +823,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
                 // Nothing to register — container will fall back to --appPath.
                 return ServerResponse(message: Wendy_Agent_Services_V1_CreateContainerResponse())
             }
-            let appDirectory = appsBase.appendingPathComponent(appName).path
+            let appDirectory = try validateContainedPath(base: appsBase, relative: appName).path
             let binaryPath = "\(appDirectory)/\(cmd)"
 
             guard FileManager.default.fileExists(atPath: binaryPath) else {
@@ -1350,18 +1350,18 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
                 )
             }
 
-            let appDirectory = appsBase.appendingPathComponent(appName).path
+            let appDirectoryURL = try validateContainedPath(base: appsBase, relative: appName)
             try FileManager.default.createDirectory(
-                atPath: appDirectory,
+                at: appDirectoryURL,
                 withIntermediateDirectories: true
             )
-            let filePath = "\(appDirectory)/\(filename)"
-            try accumulated.write(to: URL(fileURLWithPath: filePath))
+            let fileURL = try validateContainedPath(base: appDirectoryURL, relative: filename)
+            try accumulated.write(to: fileURL)
 
             if filename != "sandbox.sb" {
                 try FileManager.default.setAttributes(
                     [.posixPermissions: 0o755],
-                    ofItemAtPath: filePath
+                    ofItemAtPath: fileURL.path
                 )
             }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/FileSyncService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/FileSyncService.swift
@@ -71,7 +71,7 @@ actor FileSyncService: Wendy_Agent_Services_V1_WendyFileSyncService.ServiceProto
         }
 
         let appID = startMsg.appID
-        let workDir = appsBase.appendingPathComponent(appID)
+        let workDir = try validateContainedPath(base: appsBase, relative: appID)
 
         // Ensure working directory exists.
         try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/PathValidation+RPCError.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/PathValidation+RPCError.swift
@@ -1,0 +1,16 @@
+public import GRPCCore
+
+/// Surfaces `PathValidationError` as a `.invalidArgument` RPC status instead of
+/// grpc-swift-2's default `.unknown` fallback for opaque `Error` types.
+///
+/// Kept in a separate file so `PathValidation.swift` (the actual path-containment
+/// check) stays a pure, Foundation-only helper with no gRPC dependency.
+extension PathValidationError: RPCErrorConvertible {
+    public var rpcErrorCode: RPCError.Code { .invalidArgument }
+
+    public var rpcErrorMessage: String {
+        switch self {
+        case .unsafePath(let path): return "unsafe path rejected: \(path)"
+        }
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/PathValidation.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/PathValidation.swift
@@ -12,6 +12,13 @@ public enum PathValidationError: Error, Equatable {
 ///
 /// Mirrors the existing `ContainerService.removeNativeAppDirectory` containment
 /// check (standardized-path prefix), generalized for reuse.
+///
+/// Containment is LEXICAL: `standardizedFileURL` collapses `.`/`..` syntactically
+/// but does not resolve symlinks. That is sufficient for the current call sites
+/// (app/blob directories are agent-created, and FileSyncService validates each
+/// per-file destination with symlink resolution downstream). A new call site that
+/// writes through a path an attacker could pre-seed with a symlink must resolve
+/// symlinks itself (or add resolution here) to also defeat symlink-based TOCTOU.
 public func validateContainedPath(base: URL, relative: String) throws -> URL {
     guard !relative.isEmpty, !relative.hasPrefix("/") else {
         throw PathValidationError.unsafePath(relative)

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/PathValidation.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/PathValidation.swift
@@ -1,0 +1,25 @@
+public import Foundation
+
+/// Error thrown when an untrusted path component would escape its base directory.
+public enum PathValidationError: Error, Equatable {
+    case unsafePath(String)
+}
+
+/// Joins `relative` onto `base` and guarantees the standardized result stays
+/// contained within `base`. Rejects empty input, absolute paths, `..` traversal,
+/// and any result that escapes `base`. Used for every RPC-supplied path component
+/// (app name, file name, blob digest, app id) before a filesystem read or write.
+///
+/// Mirrors the existing `ContainerService.removeNativeAppDirectory` containment
+/// check (standardized-path prefix), generalized for reuse.
+public func validateContainedPath(base: URL, relative: String) throws -> URL {
+    guard !relative.isEmpty, !relative.hasPrefix("/") else {
+        throw PathValidationError.unsafePath(relative)
+    }
+    let baseStd = base.standardizedFileURL
+    let candidate = baseStd.appendingPathComponent(relative).standardizedFileURL
+    guard candidate.path == baseStd.path || candidate.path.hasPrefix(baseStd.path + "/") else {
+        throw PathValidationError.unsafePath(relative)
+    }
+    return candidate
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
@@ -876,6 +876,115 @@ struct ContainerServiceTests {
             )
         )
     }
+
+    @Test("createContainer rejects OCI manifest digest path traversal (readBlob)")
+    func createContainerRejectsManifestDigestTraversal() async throws {
+        let stateDir = try makeTempDir()
+        defer { cleanup(stateDir) }
+        let stateURL = URL(fileURLWithPath: stateDir)
+
+        let service = ContainerService(
+            broadcaster: TelemetryBroadcaster(),
+            executablePath: "/usr/bin/false",
+            stateDirectory: stateURL
+        )
+
+        // Plant a file outside blobsDirectory (a sibling of stateDir/blobs, inside
+        // the writable temp state dir) that the traversal digest would resolve to
+        // if the path derivation were unguarded.
+        let escapeTarget = stateURL.appendingPathComponent("evil-manifest")
+        try "not-a-manifest".write(to: escapeTarget, atomically: true, encoding: .utf8)
+
+        let appID = "sh.wendy.tests.ManifestTraversal"
+        var request = Wendy_Agent_Services_V1_CreateContainerRequest()
+        request.appName = appID
+        request.imageName = "sha256:../../evil-manifest"
+
+        await #expect(throws: PathValidationError.self) {
+            _ = try await service.createContainer(
+                request: ServerRequest(metadata: [:], message: request),
+                context: makeServerContext(method: "CreateContainer")
+            )
+        }
+    }
+
+    @Test("createContainer rejects OCI layer digest path traversal (extractTarGz)")
+    func createContainerRejectsLayerDigestTraversal() async throws {
+        let stateDir = try makeTempDir()
+        defer { cleanup(stateDir) }
+        let stateURL = URL(fileURLWithPath: stateDir)
+        let blobsShaDir = stateURL.appendingPathComponent("blobs").appendingPathComponent("sha256")
+
+        let service = ContainerService(
+            broadcaster: TelemetryBroadcaster(),
+            executablePath: "/usr/bin/false",
+            stateDirectory: stateURL
+        )
+
+        // Legitimate config blob, stored inside blobsDirectory (no traversal).
+        let config = OCIImageConfig(
+            architecture: "arm64",
+            os: "darwin",
+            config: OCIContainerConfig(
+                Entrypoint: ["./marker.sh"],
+                Cmd: nil,
+                WorkingDir: nil,
+                Env: nil,
+                ExposedPorts: nil
+            ),
+            rootfs: nil
+        )
+        let configData = try JSONEncoder().encode(config)
+        let configHash = SHA256.hash(data: configData).map { String(format: "%02x", $0) }.joined()
+        try configData.write(to: blobsShaDir.appendingPathComponent(configHash))
+
+        // Malicious tar.gz planted OUTSIDE blobsDirectory (a sibling of it, inside
+        // the writable temp state dir), containing the marker binary.
+        let evilLayerURL = stateURL.appendingPathComponent("evil-layer")
+        try makeTarGz(containing: [("marker.sh", "#!/bin/sh\necho pwned\n")], at: evilLayerURL)
+
+        // Legitimate manifest, stored inside blobsDirectory, referencing the config
+        // normally but pointing its layer digest OUTSIDE blobsDirectory via traversal.
+        let manifest = OCIManifest(
+            schemaVersion: 2,
+            config: OCIDescriptor(
+                mediaType: "application/vnd.oci.image.config.v1+json",
+                digest: "sha256:\(configHash)",
+                size: Int64(configData.count)
+            ),
+            layers: [
+                OCIDescriptor(
+                    mediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+                    digest: "sha256:../../evil-layer",
+                    size: 1
+                )
+            ]
+        )
+        let manifestData = try JSONEncoder().encode(manifest)
+        let manifestHash = SHA256.hash(data: manifestData).map { String(format: "%02x", $0) }
+            .joined()
+        try manifestData.write(to: blobsShaDir.appendingPathComponent(manifestHash))
+
+        let appID = "sh.wendy.tests.LayerTraversal"
+        var request = Wendy_Agent_Services_V1_CreateContainerRequest()
+        request.appName = appID
+        request.imageName = "sha256:\(manifestHash)"
+
+        await #expect(throws: PathValidationError.self) {
+            _ = try await service.createContainer(
+                request: ServerRequest(metadata: [:], message: request),
+                context: makeServerContext(method: "CreateContainer")
+            )
+        }
+
+        // The malicious layer must never be extracted into the app directory.
+        let appDirectory = stateURL.appendingPathComponent("apps").appendingPathComponent(appID)
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: appDirectory.appendingPathComponent("marker.sh").path
+            )
+        )
+    }
 }
 
 // MARK: - Helpers
@@ -1121,6 +1230,37 @@ private func makeTempDir() throws -> String {
         .appendingPathComponent("wendy-test-\(UUID().uuidString)").path
     try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
     return path
+}
+
+/// Builds a real gzipped tarball at `destination` containing the given files,
+/// mirroring the `/usr/bin/tar -xzf` extraction ContainerService performs.
+private func makeTarGz(
+    containing files: [(name: String, content: String)],
+    at destination: URL
+)
+    throws
+{
+    let stagingDir = destination.deletingLastPathComponent()
+        .appendingPathComponent("tar-staging-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: stagingDir) }
+
+    for file in files {
+        try file.content.write(
+            to: stagingDir.appendingPathComponent(file.name),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    let process = Foundation.Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+    process.arguments = ["-czf", destination.path, "-C", stagingDir.path] + files.map(\.name)
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        throw TestError(description: "Failed to build test tar.gz at \(destination.path)")
+    }
 }
 
 private func canonicalPath(_ path: String) throws -> String {

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
@@ -1,3 +1,4 @@
+import Crypto
 import Darwin
 import Foundation
 import GRPCCore
@@ -840,6 +841,41 @@ struct ContainerServiceTests {
             #expect("\(error)".contains("brewfile path must be relative"))
         }
     }
+
+    @Test("WriteLayer legacy rejects app name path traversal")
+    func writeLayerRejectsAppNameTraversal() async throws {
+        let appsBase = try makeTempDir()
+        defer { cleanup(appsBase) }
+
+        let service = ContainerService(
+            broadcaster: TelemetryBroadcaster(),
+            executablePath: "/usr/bin/false",
+            appsBase: URL(fileURLWithPath: appsBase)
+        )
+
+        // A sibling directory of appsBase, inside the writable temp root, so a
+        // permission error (rather than the path-validation guard) can't mask
+        // whether the traversal actually escaped appsBase.
+        let escapeTarget = URL(fileURLWithPath: appsBase)
+            .deletingLastPathComponent()
+            .appendingPathComponent("wendy-evil-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: escapeTarget) }
+
+        let payload = Data("x".utf8)
+        let hash = SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+        // Legacy digest: "<appName>:<filename>:sha256:<hash>". appName escapes appsBase.
+        let digest = "../\(escapeTarget.lastPathComponent):pwned.sh:sha256:\(hash)"
+
+        await #expect(throws: (any Error).self) {
+            try await driveWriteLayer(service: service, digest: digest, chunks: [payload])
+        }
+        // Nothing was written outside appsBase.
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: escapeTarget.appendingPathComponent("pwned.sh").path
+            )
+        )
+    }
 }
 
 // MARK: - Helpers
@@ -1024,6 +1060,35 @@ private func makeServerContext(method: String) -> ServerContext {
         remotePeer: "in-process:test",
         localPeer: "in-process:test",
         cancellation: .init()
+    )
+}
+
+private func driveWriteLayer(
+    service: ContainerService,
+    digest: String,
+    chunks: [Data]
+) async throws {
+    let stream = AsyncThrowingStream<Wendy_Agent_Services_V1_WriteLayerRequest, any Error> {
+        continuation in
+        var first = true
+        for chunk in chunks {
+            var message = Wendy_Agent_Services_V1_WriteLayerRequest()
+            if first {
+                message.digest = digest
+                first = false
+            }
+            message.data = chunk
+            continuation.yield(message)
+        }
+        continuation.finish()
+    }
+    let request = StreamingServerRequest<Wendy_Agent_Services_V1_WriteLayerRequest>(
+        metadata: [:],
+        messages: RPCAsyncSequence(wrapping: stream)
+    )
+    _ = try await service.writeLayer(
+        request: request,
+        context: makeServerContext(method: "WriteLayer")
     )
 }
 

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/FileSyncServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/FileSyncServiceTests.swift
@@ -805,6 +805,27 @@ struct RunSessionTests {
         #expect(responses.count == 2)
     }
 
+    @Test("appID traversal in working directory root rejected")
+    func appIDTraversalRejected() async throws {
+        let appsBase = try makeTempDir()
+        defer { cleanup(appsBase) }
+        let appsBaseURL = URL(fileURLWithPath: appsBase)
+
+        // Sibling of appsBase: writable/user-owned because the test itself just
+        // created appsBase under the same parent directory. Must NOT be created.
+        let evilName = "wendy-evil-\(UUID().uuidString)"
+        let evilAppID = "../\(evilName)"
+        let escapedURL = appsBaseURL.deletingLastPathComponent().appendingPathComponent(evilName)
+        defer { cleanup(escapedURL.path) }
+
+        await expectRunSessionFailure(
+            messages: [startRequest(appID: evilAppID, manifest: [])],
+            appsBase: appsBaseURL
+        )
+
+        #expect(!FileManager.default.fileExists(atPath: escapedURL.path))
+    }
+
     @Test("delete during active transfer rejected")
     func deleteDuringActiveTransferRejected() async throws {
         let appsBase = try makeTempDir()

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/PathValidationTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/PathValidationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRPCCore
 import Testing
 
 @testable import WendyAgentCore
@@ -45,5 +46,12 @@ struct PathValidationTests {
         #expect(throws: PathValidationError.self) {
             _ = try validateContainedPath(base: base, relative: "a/../../b")
         }
+    }
+
+    @Test("PathValidationError maps to invalidArgument RPC status")
+    func mapsToInvalidArgument() {
+        let rpcError = RPCError(PathValidationError.unsafePath("../x"))
+        #expect(rpcError.code == .invalidArgument)
+        #expect(rpcError.message == "unsafe path rejected: ../x")
     }
 }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/PathValidationTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/PathValidationTests.swift
@@ -48,6 +48,16 @@ struct PathValidationTests {
         }
     }
 
+    // Regression lock for the load-bearing trailing "/" in the containment check:
+    // a sibling directory that shares `base` as a string prefix (…/apps vs …/apps-evil)
+    // must be rejected. Without the "+ \"/\"" a bare hasPrefix would wrongly accept it.
+    @Test("rejects a prefix-sibling escape (…/apps vs …/apps-evil)")
+    func rejectsPrefixSiblingEscape() {
+        #expect(throws: PathValidationError.self) {
+            _ = try validateContainedPath(base: base, relative: "../apps-evil/secret")
+        }
+    }
+
     @Test("PathValidationError maps to invalidArgument RPC status")
     func mapsToInvalidArgument() {
         let rpcError = RPCError(PathValidationError.unsafePath("../x"))

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/PathValidationTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/PathValidationTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import WendyAgentCore
+
+@Suite("validateContainedPath")
+struct PathValidationTests {
+    let base = URL(fileURLWithPath: "/var/lib/wendy/apps", isDirectory: true)
+
+    @Test("accepts a simple single component")
+    func acceptsSimpleComponent() throws {
+        let got = try validateContainedPath(base: base, relative: "my-app")
+        #expect(got.standardizedFileURL.path == "/var/lib/wendy/apps/my-app")
+    }
+
+    @Test("accepts a multi-component relative path (blob digest shape)")
+    func acceptsMultiComponent() throws {
+        let got = try validateContainedPath(base: base, relative: "sha256/deadbeef")
+        #expect(got.standardizedFileURL.path == "/var/lib/wendy/apps/sha256/deadbeef")
+    }
+
+    @Test("rejects dot-dot traversal")
+    func rejectsDotDot() {
+        #expect(throws: PathValidationError.self) {
+            _ = try validateContainedPath(base: base, relative: "../../../etc/passwd")
+        }
+    }
+
+    @Test("rejects an absolute path")
+    func rejectsAbsolute() {
+        #expect(throws: PathValidationError.self) {
+            _ = try validateContainedPath(base: base, relative: "/etc/passwd")
+        }
+    }
+
+    @Test("rejects empty")
+    func rejectsEmpty() {
+        #expect(throws: PathValidationError.self) {
+            _ = try validateContainedPath(base: base, relative: "")
+        }
+    }
+
+    @Test("rejects a component that escapes via embedded dot-dot")
+    func rejectsEmbeddedEscape() {
+        #expect(throws: PathValidationError.self) {
+            _ = try validateContainedPath(base: base, relative: "a/../../b")
+        }
+    }
+}


### PR DESCRIPTION
## What

Add path-traversal containment validation to the Swift macOS agent. A shared `validateContainedPath` helper guarantees that every filesystem path built from an RPC-supplied component stays inside its intended base directory; each write/read sink is routed through it.

## Why

A security review found the Swift agent building filesystem paths from unvalidated RPC fields. Most seriously, the legacy `WriteLayer` path split a client-controlled `appName`/`filename` out of the layer digest and wrote the payload to `appsBase/<appName>/<filename>` (then `chmod 0755`) with no containment check — a `../`-laden `appName` escaped the app directory. Related sinks: `createContainer` app-directory derivations, OCI blob paths in `readBlob`/`extractTarGz` (arbitrary-read / tar zip-slip via a crafted digest), and the `FileSyncService` working-directory root (`appID`).

## What changed

- **`validateContainedPath(base:relative:)`** (new, pure Foundation) — rejects empty, absolute, `..` traversal, and any escape (including the prefix-sibling case `…/apps` vs `…/apps-evil`); accepts legitimate single- and multi-component relative paths. Generalizes the existing `removeNativeAppDirectory` guard. Lexical containment (documented; per-file symlink resolution already happens downstream in `FileSyncService.validatedDestination`).
- Routed **all six sinks** through it: `WriteLayer` appName+filename, `createContainer` (×3), `WriteLayer` OCI blob, `readBlob`, `extractTarGz`, and `FileSyncService` `appID`.
- `PathValidationError` maps to an **`.invalidArgument`** RPC status (matching sibling rejections in these services) via an isolated `RPCErrorConvertible` conformance — the helper file itself stays gRPC-free.

## Tests

TDD throughout. Traversal tests plant their escape targets as **writable siblings of the temp base**, so each RED reflects a genuine out-of-bounds write/extract (verified, not an incidental permissions error). `swift test`: PathValidationTests 8/8, ContainerServiceTests 30/30, FileSyncServiceTests 39/39.

## Scope & notes

- **Path-containment only — no mTLS/provisioning/transport changes.** The Swift agent's unauthenticated pre-provisioning reachability is a separately-tracked, accepted risk (Linear WDY-1899); this PR reduces that surface's blast radius (no arbitrary out-of-tree writes), it does not close the reachability itself.
- Two defense-in-depth follow-ups are tracked in WDY-1899: validating the binary-component exec path (`cmd`/`imageName` → `executableURL`), and deduping `removeNativeAppDirectory` onto the shared helper.
- swift-testing framework. Building the package requires the MacOSX26.5 SDK (`SDKROOT`) on macOS-27 boxes (pre-existing swift-crypto vs SDK issue, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
