### PR TITLE
fix(cli): gate postStart on readiness, bracket IPv6 URLs, prefer stable IPv4

### DIFF
--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -350,16 +350,14 @@ func tryDeployFastPath(ctx context.Context, conn *grpcclient.AgentConnection, ap
 }
 
 // runPostStartHostHook mirrors the normal detached deploy path's host-side
-// postStart handling: wait for readiness, then fire the host hook
-// fire-and-forget on a background context so it outlives the CLI process. The
-// agent-side (in-container) hook is attached separately to the StartContainer
-// RPC's context, so it only runs when the fast path actually (re)starts the
-// container.
+// postStart handling: wait for readiness, then announce the reachable URL and
+// fire the host hook fire-and-forget on a background context so it outlives
+// the CLI process. A failed readiness probe skips both (see
+// runPostStartIfReady). The agent-side (in-container) hook is attached
+// separately to the StartContainer RPC's context, so it only runs when the
+// fast path actually (re)starts the container.
 func runPostStartHostHook(ctx context.Context, conn *grpcclient.AgentConnection, appCfg *appconfig.AppConfig) {
-	if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
-		warnReadiness(ctx, conn, appCfg.AppID, err)
-	}
-	startPostStartHook(context.Background(), appCfg, conn.Host)
+	runPostStartIfReady(ctx, context.Background(), conn, appCfg)
 }
 
 // containerExitDetail returns a short human summary of why appID's container

--- a/go/internal/cli/commands/network_format.go
+++ b/go/internal/cli/commands/network_format.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -54,6 +55,24 @@ func bestReachableIP(ifaces []*agentpb.NetworkInterface) string {
 	return firstAny
 }
 
+// isIPv6Literal reports whether host parses as a bare (unbracketed) IPv6
+// literal, zone ID included; hostnames, IPv4, and IPv4-mapped forms are false.
+func isIPv6Literal(host string) bool {
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.Is6() && !addr.Is4In6()
+}
+
+// urlSafeHost returns host formatted for the authority part of a URL: IPv6
+// literals are bracketed, with any zone ID percent-escaped per RFC 6874. An
+// unbracketed IPv6 literal in "http://host:port" is unparseable — the port
+// digits read as one more hextet. Hostnames and IPv4 pass through unchanged.
+func urlSafeHost(host string) string {
+	if !isIPv6Literal(host) {
+		return host
+	}
+	return "[" + strings.ReplaceAll(host, "%", "%25") + "]"
+}
+
 // reachableAppURL builds a browser-openable URL for a freshly started app,
 // using a routable device IP instead of the (often unresolvable) .local
 // hostname that `wendy run` otherwise reports.
@@ -68,7 +87,7 @@ func reachableAppURL(hookURL, appID, deviceIP string, readiness *appconfig.Readi
 		return ""
 	}
 	if hookURL != "" && strings.Contains(hookURL, "WENDY_HOSTNAME") {
-		return expandHookEnv(hookURL, deviceIP, appID)
+		return expandHookEnv(hookURL, urlSafeHost(deviceIP), appID)
 	}
 	if readiness != nil && readiness.TCPSocket != nil && readiness.TCPSocket.Port != 0 {
 		return "http://" + net.JoinHostPort(deviceIP, strconv.Itoa(readiness.TCPSocket.Port))

--- a/go/internal/cli/commands/network_format.go
+++ b/go/internal/cli/commands/network_format.go
@@ -56,18 +56,25 @@ func bestReachableIP(ifaces []*agentpb.NetworkInterface) string {
 }
 
 // isIPv6Literal reports whether host parses as a bare (unbracketed) IPv6
-// literal, zone ID included; hostnames, IPv4, and IPv4-mapped forms are false.
+// literal, zone ID included. Hostnames and IPv4 are false.
 func isIPv6Literal(host string) bool {
 	addr, err := netip.ParseAddr(host)
-	return err == nil && addr.Is6() && !addr.Is4In6()
+	return err == nil && addr.Is6()
 }
 
 // urlSafeHost returns host formatted for the authority part of a URL: IPv6
-// literals are bracketed, with any zone ID percent-escaped per RFC 6874. An
-// unbracketed IPv6 literal in "http://host:port" is unparseable — the port
-// digits read as one more hextet. Hostnames and IPv4 pass through unchanged.
+// literals are bracketed, with any zone ID percent-escaped per RFC 6874. IPv4
+// and hostnames pass through unchanged. IPv4-mapped IPv6 literals are unmapped
+// to plain IPv4 so the result remains URL-safe.
 func urlSafeHost(host string) string {
-	if !isIPv6Literal(host) {
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return host
+	}
+	if addr.Is4In6() {
+		return addr.Unmap().String()
+	}
+	if !addr.Is6() {
 		return host
 	}
 	return "[" + strings.ReplaceAll(host, "%", "%25") + "]"

--- a/go/internal/cli/commands/network_format_test.go
+++ b/go/internal/cli/commands/network_format_test.go
@@ -163,7 +163,7 @@ func TestURLSafeHost(t *testing.T) {
 		{"192.168.0.159", "192.168.0.159"},           // IPv4 untouched
 		{"2001:db8::1", "[2001:db8::1]"},             // IPv6 bracketed
 		{"fe80::1%en0", "[fe80::1%25en0]"},           // zone percent-escaped (RFC 6874)
-		{"::ffff:192.168.0.1", "::ffff:192.168.0.1"}, // IPv4-mapped treated as IPv4
+		{"::ffff:192.168.0.1", "192.168.0.1"},        // IPv4-mapped unmapped to plain IPv4
 		{"[2001:db8::1]", "[2001:db8::1]"},           // already bracketed passes through
 		{"", ""},
 	}

--- a/go/internal/cli/commands/network_format_test.go
+++ b/go/internal/cli/commands/network_format_test.go
@@ -159,12 +159,12 @@ func TestURLSafeHost(t *testing.T) {
 		host string
 		want string
 	}{
-		{"device.local", "device.local"},             // hostname untouched
-		{"192.168.0.159", "192.168.0.159"},           // IPv4 untouched
-		{"2001:db8::1", "[2001:db8::1]"},             // IPv6 bracketed
-		{"fe80::1%en0", "[fe80::1%25en0]"},           // zone percent-escaped (RFC 6874)
-		{"::ffff:192.168.0.1", "192.168.0.1"},        // IPv4-mapped unmapped to plain IPv4
-		{"[2001:db8::1]", "[2001:db8::1]"},           // already bracketed passes through
+		{"device.local", "device.local"},      // hostname untouched
+		{"192.168.0.159", "192.168.0.159"},    // IPv4 untouched
+		{"2001:db8::1", "[2001:db8::1]"},      // IPv6 bracketed
+		{"fe80::1%en0", "[fe80::1%25en0]"},    // zone percent-escaped (RFC 6874)
+		{"::ffff:192.168.0.1", "192.168.0.1"}, // IPv4-mapped unmapped to plain IPv4
+		{"[2001:db8::1]", "[2001:db8::1]"},    // already bracketed passes through
 		{"", ""},
 	}
 	for _, tc := range cases {

--- a/go/internal/cli/commands/network_format_test.go
+++ b/go/internal/cli/commands/network_format_test.go
@@ -133,6 +133,12 @@ func TestReachableAppURL(t *testing.T) {
 			want:      "http://[2001:db8::1]:3001",
 		},
 		{
+			name:     "IPv6 address is bracketed in a hook URL template",
+			hookURL:  "http://${WENDY_HOSTNAME}:3001/dashboard",
+			deviceIP: "2001:db8::1",
+			want:     "http://[2001:db8::1]:3001/dashboard",
+		},
+		{
 			name:     "no hook URL and no readiness port yields nothing",
 			deviceIP: "192.168.1.42",
 			want:     "",
@@ -145,5 +151,25 @@ func TestReachableAppURL(t *testing.T) {
 				t.Errorf("reachableAppURL() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestURLSafeHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"device.local", "device.local"},             // hostname untouched
+		{"192.168.0.159", "192.168.0.159"},           // IPv4 untouched
+		{"2001:db8::1", "[2001:db8::1]"},             // IPv6 bracketed
+		{"fe80::1%en0", "[fe80::1%25en0]"},           // zone percent-escaped (RFC 6874)
+		{"::ffff:192.168.0.1", "::ffff:192.168.0.1"}, // IPv4-mapped treated as IPv4
+		{"[2001:db8::1]", "[2001:db8::1]"},           // already bracketed passes through
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := urlSafeHost(tc.host); got != tc.want {
+			t.Errorf("urlSafeHost(%q) = %q, want %q", tc.host, got, tc.want)
+		}
 	}
 }

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1667,13 +1667,9 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 			return fmt.Errorf("waiting for container start: %w", err)
 		}
 		cliLogln("Application %s running in detached mode.", containerDisplayName(appCfg))
-		// Wait for readiness before firing hook.
-		if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
-			warnReadiness(ctx, conn, appCfg.AppID, err)
-		}
-		announceReachableURL(ctx, conn, appCfg)
-		// Fire-and-forget: post-start hook outlives the CLI process.
-		startPostStartHook(context.Background(), appCfg, conn.Host)
+		// Announce + fire-and-forget post-start hook (outlives the CLI process),
+		// but only if the app passes readiness.
+		runPostStartIfReady(ctx, context.Background(), conn, appCfg)
 		return nil
 	}
 
@@ -1700,18 +1696,9 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		runCancel()
 	}()
 
-	// Wait for readiness before firing hook.
-	if err := waitForReadiness(runCtx, appCfg.Readiness, conn.Host); err != nil {
-		if runCtx.Err() == nil {
-			warnReadiness(runCtx, conn, appCfg.AppID, err)
-		}
-	}
-	if runCtx.Err() == nil {
-		announceReachableURL(runCtx, conn, appCfg)
-	}
-
-	// Post-start hook tied to runCtx so Ctrl+C kills it.
-	postStartCmd := startPostStartHook(runCtx, appCfg, conn.Host)
+	// Announce + post-start hook, gated on readiness; the hook is tied to
+	// runCtx so Ctrl+C kills it.
+	postStartCmd := runPostStartIfReady(runCtx, runCtx, conn, appCfg)
 
 	gotFirstResponse := false
 	// Set when the stream ends on a genuine failure (as opposed to a clean
@@ -1856,25 +1843,62 @@ var browserOpen = browseropen.Open
 // from one of them. It is best-effort: it only queries the device when there is
 // something to show (a postStart openURL or a readiness TCP port) and stays
 // silent on any error or when no reachable address can be determined.
-func announceReachableURL(ctx context.Context, conn *grpcclient.AgentConnection, appCfg *appconfig.AppConfig) {
+// Returns the device IP the printed URL uses, or "" when nothing was announced.
+func announceReachableURL(ctx context.Context, conn *grpcclient.AgentConnection, appCfg *appconfig.AppConfig) string {
 	var hookURL string
 	if appCfg.Hooks != nil && appCfg.Hooks.PostStart != nil {
 		hookURL = appCfg.Hooks.PostStart.OpenURL
 	}
 	hasPort := appCfg.Readiness != nil && appCfg.Readiness.TCPSocket != nil && appCfg.Readiness.TCPSocket.Port != 0
 	if hookURL == "" && !hasPort {
-		return
+		return ""
 	}
 
 	resp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
 	if err != nil {
-		return
+		return ""
 	}
-	url := reachableAppURL(hookURL, appCfg.AppID, bestReachableIP(resp.GetNetworkInterfaces()), appCfg.Readiness)
+	ip := bestReachableIP(resp.GetNetworkInterfaces())
+	url := reachableAppURL(hookURL, appCfg.AppID, ip, appCfg.Readiness)
 	if url == "" {
-		return
+		return ""
 	}
 	cliLogln("App reachable at %s", tui.Value(url))
+	return ip
+}
+
+// runPostStartIfReady gates `wendy run`'s post-start side effects on the
+// readiness probe: the reachable-URL announcement and the host-side postStart
+// hook fire only when the app actually came up. Firing them after a failed
+// probe reported a success that never happened — "App reachable at ..." and a
+// browser tab pointed at a container that had already exited.
+//
+// hookCtx bounds the hook's CLI child process; detached callers pass
+// context.Background() so the hook outlives the CLI. Returns the hook's cmd
+// for the caller to reap, nil when no CLI hook ran.
+func runPostStartIfReady(ctx, hookCtx context.Context, conn *grpcclient.AgentConnection, appCfg *appconfig.AppConfig) *exec.Cmd {
+	if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
+		if ctx.Err() == nil {
+			warnReadiness(ctx, conn, appCfg.AppID, err)
+			if appCfg.Hooks != nil && appCfg.Hooks.PostStart != nil &&
+				(appCfg.Hooks.PostStart.OpenURL != "" || appCfg.Hooks.PostStart.CLI != "") {
+				cliLogln("Skipping postStart hook: %s is not ready.", containerDisplayName(appCfg))
+			}
+		}
+		return nil
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+	hookHost := conn.Host
+	if ip := announceReachableURL(ctx, conn, appCfg); ip != "" && isIPv6Literal(conn.Host) {
+		// The CLI dialed the device at a bare IPv6 literal — often an RFC 4941
+		// temporary (privacy) address picked up from mDNS that rotates away.
+		// Point the hook at the device's best self-reported IP (IPv4-preferred)
+		// so the URL it opens matches the "App reachable at" line.
+		hookHost = ip
+	}
+	return startPostStartHook(hookCtx, appCfg, hookHost)
 }
 
 // startPostStartHook fires the postStart hook actions for appCfg.
@@ -1892,7 +1916,9 @@ func startPostStartHook(ctx context.Context, appCfg *appconfig.AppConfig, hostna
 	hook := appCfg.Hooks.PostStart
 
 	if hook.OpenURL != "" {
-		url := expandHookEnv(hook.OpenURL, hostname, appCfg.AppID)
+		// openURL is a URL by definition, so an IPv6 hostname must be
+		// bracketed; the CLI hook below stays raw for shell contexts.
+		url := expandHookEnv(hook.OpenURL, urlSafeHost(hostname), appCfg.AppID)
 		if err := browserOpen(url); err != nil {
 			cliLogln("Warning: postStart openURL failed: %v", err)
 		} else {
@@ -1994,11 +2020,7 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 				// then return without tailing logs. The container keeps running
 				// independently of this (now-abandoned) output stream.
 				cliLogln("Application %s running in detached mode.", containerDisplayName(appCfg))
-				if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
-					warnReadiness(ctx, conn, appCfg.AppID, err)
-				}
-				announceReachableURL(ctx, conn, appCfg)
-				startPostStartHook(context.Background(), appCfg, conn.Host)
+				runPostStartIfReady(ctx, context.Background(), conn, appCfg)
 				return nil
 			}
 			// Attached: mirror startAndStreamContainer's attached branch — wait
@@ -2008,11 +2030,7 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 			// hookFired guards against a malformed stream sending Started twice.
 			if !hookFired {
 				hookFired = true
-				if err := waitForReadiness(ctx, appCfg.Readiness, conn.Host); err != nil {
-					warnReadiness(ctx, conn, appCfg.AppID, err)
-				}
-				announceReachableURL(ctx, conn, appCfg)
-				postStartCmd = startPostStartHook(hookCtx, appCfg, conn.Host)
+				postStartCmd = runPostStartIfReady(ctx, hookCtx, conn, appCfg)
 			}
 			continue
 		}

--- a/go/internal/cli/commands/run_hooks_test.go
+++ b/go/internal/cli/commands/run_hooks_test.go
@@ -8,9 +8,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
+
+// fakeAgentVersionClient stubs the single AgentService RPC that
+// announceReachableURL issues, so runPostStartIfReady tests can control which
+// device IPs the agent reports (or fail the query outright).
+type fakeAgentVersionClient struct {
+	agentpb.WendyAgentServiceClient // embedded nil — satisfies interface
+
+	resp *agentpb.GetAgentVersionResponse
+	err  error
+}
+
+func (f *fakeAgentVersionClient) GetAgentVersion(_ context.Context, _ *agentpb.GetAgentVersionRequest, _ ...grpc.CallOption) (*agentpb.GetAgentVersionResponse, error) {
+	return f.resp, f.err
+}
 
 func testPort(t *testing.T, ln net.Listener) int {
 	t.Helper()
@@ -161,6 +178,134 @@ func TestWaitForReadiness_ContextCancelled(t *testing.T) {
 	}
 	if elapsed > 3*time.Second {
 		t.Errorf("took %v, expected ~500ms (context cancel)", elapsed)
+	}
+}
+
+// TestRunPostStartIfReady_SkipsHookWhenProbeFails locks the fix for the bug
+// where `wendy run` printed "App reachable at ..." and opened the postStart
+// URL even after the readiness probe timed out and the container had exited.
+func TestRunPostStartIfReady_SkipsHookWhenProbeFails(t *testing.T) {
+	original := browserOpen
+	t.Cleanup(func() { browserOpen = original })
+	opened := false
+	browserOpen = func(string) error {
+		opened = true
+		return nil
+	}
+
+	// Grab a free port, then release it so nothing listens and the probe fails.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	port := testPort(t, ln)
+	ln.Close()
+
+	appCfg := &appconfig.AppConfig{
+		AppID:     "not-ready-app",
+		Readiness: &appconfig.ReadinessConfig{TCPSocket: &appconfig.TCPSocketProbe{Port: port}, TimeoutSeconds: 1},
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{
+				OpenURL: "http://${WENDY_HOSTNAME}:3001",
+				CLI:     "echo should-not-run",
+			},
+		},
+	}
+	// ContainerService backs warnReadiness's exit-detail lookup; AgentService
+	// must not be reached at all when the probe fails (it is nil, so a call
+	// would panic the test).
+	conn := &grpcclient.AgentConnection{
+		Host:             "127.0.0.1",
+		ContainerService: &fastPathContainerClient{appName: appCfg.AppID, state: agentpb.AppRunningState_STOPPED},
+	}
+
+	cmd := runPostStartIfReady(context.Background(), context.Background(), conn, appCfg)
+	if cmd != nil {
+		t.Errorf("runPostStartIfReady returned a hook cmd despite a failed probe")
+	}
+	if opened {
+		t.Errorf("postStart openURL fired despite a failed readiness probe")
+	}
+}
+
+// TestRunPostStartIfReady_IPv6HostSwappedForReportedIP verifies that when the
+// CLI dialed the device at an IPv6 literal (often a rotating RFC 4941
+// temporary address from mDNS), the postStart openURL targets the device's
+// best self-reported IP instead — the same address the "App reachable at"
+// line prints.
+func TestRunPostStartIfReady_IPv6HostSwappedForReportedIP(t *testing.T) {
+	ln, err := net.Listen("tcp", "[::1]:0")
+	if err != nil {
+		t.Skipf("IPv6 loopback unavailable: %v", err)
+	}
+	defer ln.Close()
+	port := testPort(t, ln)
+
+	original := browserOpen
+	t.Cleanup(func() { browserOpen = original })
+	var opened string
+	browserOpen = func(url string) error {
+		opened = url
+		return nil
+	}
+
+	appCfg := &appconfig.AppConfig{
+		AppID:     "v6-app",
+		Readiness: &appconfig.ReadinessConfig{TCPSocket: &appconfig.TCPSocketProbe{Port: port}, TimeoutSeconds: 5},
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{OpenURL: "http://${WENDY_HOSTNAME}:3001"},
+		},
+	}
+	conn := &grpcclient.AgentConnection{
+		Host: "::1",
+		AgentService: &fakeAgentVersionClient{resp: &agentpb.GetAgentVersionResponse{
+			NetworkInterfaces: []*agentpb.NetworkInterface{{Name: "eth0", IpAddresses: []string{"192.168.0.159"}}},
+		}},
+	}
+
+	if cmd := runPostStartIfReady(context.Background(), context.Background(), conn, appCfg); cmd != nil {
+		t.Errorf("expected nil cmd for openURL-only hook, got %v", cmd)
+	}
+	if opened != "http://192.168.0.159:3001" {
+		t.Errorf("openURL = %q, want the device-reported IPv4 URL", opened)
+	}
+}
+
+// TestRunPostStartIfReady_IPv6FallbackIsBracketed verifies that when the
+// device's IPs can't be queried, the hook falls back to the dialed IPv6
+// literal — bracketed, so the URL parses (an unbracketed IPv6 literal reads
+// the port as one more hextet).
+func TestRunPostStartIfReady_IPv6FallbackIsBracketed(t *testing.T) {
+	ln, err := net.Listen("tcp", "[::1]:0")
+	if err != nil {
+		t.Skipf("IPv6 loopback unavailable: %v", err)
+	}
+	defer ln.Close()
+	port := testPort(t, ln)
+
+	original := browserOpen
+	t.Cleanup(func() { browserOpen = original })
+	var opened string
+	browserOpen = func(url string) error {
+		opened = url
+		return nil
+	}
+
+	appCfg := &appconfig.AppConfig{
+		AppID:     "v6-fallback-app",
+		Readiness: &appconfig.ReadinessConfig{TCPSocket: &appconfig.TCPSocketProbe{Port: port}, TimeoutSeconds: 5},
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{OpenURL: "http://${WENDY_HOSTNAME}:3001"},
+		},
+	}
+	conn := &grpcclient.AgentConnection{
+		Host:         "::1",
+		AgentService: &fakeAgentVersionClient{err: errors.New("agent unreachable")},
+	}
+
+	runPostStartIfReady(context.Background(), context.Background(), conn, appCfg)
+	if opened != "http://[::1]:3001" {
+		t.Errorf("openURL = %q, want bracketed IPv6 fallback URL", opened)
 	}
 }
 

--- a/go/internal/cli/commands/run_test.go
+++ b/go/internal/cli/commands/run_test.go
@@ -140,6 +140,35 @@ func TestStartPostStartHook_OpenURL(t *testing.T) {
 	}
 }
 
+// TestStartPostStartHook_OpenURLIPv6HostBracketed locks the fix for the
+// malformed-URL bug: an IPv6 hostname substituted into an openURL template
+// must be bracketed, otherwise "http://2600:...:f7:6001" reads the port as
+// one more hextet and is unparseable.
+func TestStartPostStartHook_OpenURLIPv6HostBracketed(t *testing.T) {
+	original := browserOpen
+	t.Cleanup(func() { browserOpen = original })
+
+	var got string
+	browserOpen = func(url string) error {
+		got = url
+		return nil
+	}
+
+	cfg := &appconfig.AppConfig{
+		AppID: "com.example.app",
+		Hooks: &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{
+				OpenURL: "http://${WENDY_HOSTNAME}:6001",
+			},
+		},
+	}
+
+	startPostStartHook(context.Background(), cfg, "2600:1011:a003:4221:be41:6859:13c0:f7")
+	if got != "http://[2600:1011:a003:4221:be41:6859:13c0:f7]:6001" {
+		t.Errorf("openURL = %q, want bracketed IPv6 URL", got)
+	}
+}
+
 func TestStartPostStartHook_OpenURLWindowsStyleVars(t *testing.T) {
 	original := browserOpen
 	t.Cleanup(func() { browserOpen = original })

--- a/go/internal/shared/discovery/mdns.go
+++ b/go/internal/shared/discovery/mdns.go
@@ -1,5 +1,7 @@
 package discovery
 
+import "net"
+
 // MDNSService represents a generic mDNS service entry discovered on the network.
 type MDNSService struct {
 	InstanceName string
@@ -7,4 +9,22 @@ type MDNSService struct {
 	IPAddress    string
 	Port         int
 	TXTRecords   map[string]string
+}
+
+// preferIPv4Addr returns the first IPv4 address in addrs, or the first address
+// when none is IPv4. mDNS hostname lookups often list IPv6 first, and a
+// device's IPv6 set typically leads with an RFC 4941 temporary (privacy)
+// address that rotates away, leaving a stored address stale for later dials
+// and readiness probes. Preferring IPv4 matches resolveHostMDNSFallback and
+// bestReachableIP on the CLI side.
+func preferIPv4Addr(addrs []string) string {
+	if len(addrs) == 0 {
+		return ""
+	}
+	for _, a := range addrs {
+		if ip := net.ParseIP(a); ip != nil && ip.To4() != nil {
+			return a
+		}
+	}
+	return addrs[0]
 }

--- a/go/internal/shared/discovery/mdns_darwin.go
+++ b/go/internal/shared/discovery/mdns_darwin.go
@@ -106,8 +106,8 @@ func resolveMDNSService(ctx context.Context, inst browseResult, serviceType stri
 	}
 
 	ipAddr := ""
-	if addrs, lookupErr := net.LookupHost(hostname); lookupErr == nil && len(addrs) > 0 {
-		ipAddr = addrs[0]
+	if addrs, lookupErr := net.LookupHost(hostname); lookupErr == nil {
+		ipAddr = preferIPv4Addr(addrs)
 	}
 
 	return MDNSService{

--- a/go/internal/shared/discovery/mdns_test.go
+++ b/go/internal/shared/discovery/mdns_test.go
@@ -1,0 +1,40 @@
+package discovery
+
+import "testing"
+
+func TestPreferIPv4Addr(t *testing.T) {
+	cases := []struct {
+		name  string
+		addrs []string
+		want  string
+	}{
+		{name: "empty", addrs: nil, want: ""},
+		{
+			name:  "IPv4 preferred over an earlier IPv6",
+			addrs: []string{"2600:1011:a003:4221:be41:6859:13c0:f7", "192.168.0.159"},
+			want:  "192.168.0.159",
+		},
+		{
+			name:  "first IPv4 wins",
+			addrs: []string{"192.168.0.159", "10.0.0.5"},
+			want:  "192.168.0.159",
+		},
+		{
+			name:  "falls back to first address when no IPv4",
+			addrs: []string{"2001:db8::1", "2001:db8::2"},
+			want:  "2001:db8::1",
+		},
+		{
+			name:  "unparseable entries are skipped for the IPv4 scan",
+			addrs: []string{"not-an-ip", "192.168.0.159"},
+			want:  "192.168.0.159",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := preferIPv4Addr(tc.addrs); got != tc.want {
+				t.Errorf("preferIPv4Addr(%v) = %q, want %q", tc.addrs, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/shared/discovery/usb_connection.go
+++ b/go/internal/shared/discovery/usb_connection.go
@@ -139,6 +139,15 @@ func preferDiscoveredLANDevice(candidate, existing models.LANDevice) bool {
 	if existing.IPAddress == "" && candidate.IPAddress != "" {
 		return true
 	}
+	// Same device advertised at both an IPv4 and an IPv6 address (avahi emits
+	// one resolve entry per protocol): keep the IPv4 one. A device's IPv6 set
+	// typically leads with an RFC 4941 temporary (privacy) address that
+	// rotates away, so dialing or probing the stored IPv6 later goes stale.
+	if candidate.IPAddress != "" && existing.IPAddress != "" {
+		if c4, e4 := isIPv4LANAddress(candidate.IPAddress), isIPv4LANAddress(existing.IPAddress); c4 != e4 {
+			return c4
+		}
+	}
 	if existing.NetworkInterface == "" && candidate.NetworkInterface != "" {
 		return true
 	}
@@ -175,6 +184,16 @@ func lanDeviceDiscoveryScore(dev models.LANDevice) int {
 		score++
 	}
 	return score
+}
+
+// isIPv4LANAddress reports whether addr (optionally "%zone"-suffixed) is an
+// IPv4 or IPv4-mapped address.
+func isIPv4LANAddress(addr string) bool {
+	if i := strings.IndexByte(addr, '%'); i >= 0 {
+		addr = addr[:i]
+	}
+	a, err := netip.ParseAddr(addr)
+	return err == nil && (a.Is4() || a.Is4In6())
 }
 
 // isRoutableLANAddress reports whether addr is a directly dialable address —

--- a/go/internal/shared/discovery/usb_connection_test.go
+++ b/go/internal/shared/discovery/usb_connection_test.go
@@ -60,3 +60,62 @@ func TestAppendPreferredLANDevicePrefersRoutable(t *testing.T) {
 		t.Fatalf("link-local should be kept when only option, got %+v", devs)
 	}
 }
+
+func TestAppendPreferredLANDevicePrefersIPv4OverGlobalIPv6(t *testing.T) {
+	// avahi resolves the same device once per protocol; the IPv6 entry often
+	// carries a rotating RFC 4941 temporary address. IPv4 must win regardless
+	// of arrival order — before this rule both addresses scored the same, so
+	// whichever resolved first (usually IPv6) was kept.
+	v4 := models.LANDevice{ID: "d", DisplayName: "cam", Hostname: "cam.local", Port: 50052, IPAddress: "192.168.0.159"}
+	v6 := models.LANDevice{ID: "d", DisplayName: "cam", Hostname: "cam.local", Port: 50052, IPAddress: "2600:1011:a003:4221:be41:6859:13c0:f7"}
+	const key = "cam-cam.local-50052"
+
+	// IPv6 discovered first, then IPv4 → IPv4 must win.
+	var devs []models.LANDevice
+	idx := map[string]int{}
+	devs = appendPreferredLANDevice(devs, idx, key, v6)
+	devs = appendPreferredLANDevice(devs, idx, key, v4)
+	if len(devs) != 1 || devs[0].IPAddress != "192.168.0.159" {
+		t.Fatalf("IPv4 should win over global IPv6, got %+v", devs)
+	}
+
+	// IPv4 first, then IPv6 → IPv4 must remain, even when the IPv6 record
+	// carries more metadata (which would otherwise out-score it).
+	v6To := v6
+	v6To.NetworkInterface = "wlan0"
+	devs = nil
+	idx = map[string]int{}
+	devs = appendPreferredLANDevice(devs, idx, key, v4)
+	devs = appendPreferredLANDevice(devs, idx, key, v6To)
+	if len(devs) != 1 || devs[0].IPAddress != "192.168.0.159" {
+		t.Fatalf("IPv4 should remain over global IPv6, got %+v", devs)
+	}
+
+	// Only IPv6 available → it must be kept.
+	devs = nil
+	idx = map[string]int{}
+	devs = appendPreferredLANDevice(devs, idx, key, v6)
+	if len(devs) != 1 || devs[0].IPAddress != v6.IPAddress {
+		t.Fatalf("IPv6 should be kept when only option, got %+v", devs)
+	}
+}
+
+func TestIsIPv4LANAddress(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"192.168.1.10", true},
+		{"169.254.1.1", true},
+		{"::ffff:192.168.1.10", true}, // IPv4-mapped
+		{"2001:db8::1", false},
+		{"fe80::1%wlan0", false},
+		{"", false},
+		{"not-an-ip", false},
+	}
+	for _, tc := range cases {
+		if got := isIPv4LANAddress(tc.addr); got != tc.want {
+			t.Errorf("isIPv4LANAddress(%q) = %v, want %v", tc.addr, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes bugs 1, 1b, and 2 from a field report (hello-world app on a Pi 5 whose mDNS records lead with a rotating RFC 4941 temporary IPv6 address):

- `wendy run` no longer prints "App reachable at ..." or fires the postStart hook after the readiness probe fails — all five call sites now share `runPostStartIfReady`, which warns and skips instead.
- postStart `openURL` and reachable-URL templates bracket IPv6 literals (with RFC 6874 zone escaping); `http://2600:...:f7:6001` was unparseable.
- Discovery prefers the stable IPv4: darwin dns-sd lookups no longer take `addrs[0]` blindly, and avahi's per-protocol resolve entries keep the IPv4 record regardless of arrival order.
- A hook fired against an IPv6-dialed device now opens the device's best self-reported IP (IPv4-preferred), matching the announced URL.
- Not addressed (separate follow-ups): bug 3 (stale `apps list` status), bug 4 (no shutdown/reboot command), and the swift-vs-docker build-type default.
- Tests: `go test -race ./internal/cli/commands/ ./internal/shared/discovery/` pass; new unit tests cover the readiness gate, IPv6 bracketing, and IPv4 preference. `gofmt`/`go vet` clean.

Supersedes #1429 (closed by the branch rename).