### PR TITLE
feat(cli): add "Headless Mac" option to `wendy install`

### DIFF
--- a/go/internal/cli/assets/docs/agent.sh
+++ b/go/internal/cli/assets/docs/agent.sh
@@ -33,7 +33,7 @@ Environment:
   WENDY_VERSION   Install a specific version (e.g. v0.2.0) instead of latest
   WENDY_ENROLLMENT_TOKEN
                   Pre-enroll this device into a Wendy Cloud org on first start.
-                  Obtain it from 'wendy install' → "Linux Desktop".
+                  Obtain it from 'wendy install' → "Linux Desktop" or "Headless Mac".
   WENDY_CLOUD_HOST
                   Wendy Cloud gRPC host (required when WENDY_ENROLLMENT_TOKEN is set).
 EOF

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -401,11 +401,11 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	}
 
 	if selected == linuxDesktopValue {
-		return installLinuxDesktop(ctx, preOpts, deviceName, linuxDesktopMachineLabel)
+		return installDesktop(ctx, preOpts, deviceName, linuxDesktopMachineLabel)
 	}
 
 	if selected == headlessMacValue {
-		return installLinuxDesktop(ctx, preOpts, deviceName, headlessMacMachineLabel)
+		return installDesktop(ctx, preOpts, deviceName, headlessMacMachineLabel)
 	}
 
 	device := deviceMap[selected]

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -349,6 +349,14 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 			SortKey:     "2_linux_desktop",
 			Value:       linuxDesktopValue,
 		})
+
+		items = append(items, tui.PickerItem{
+			Name:        "Headless Mac",
+			Description: "Install wendy-agent on an existing Mac (Apple Silicon)",
+			Section:     "Headless Mac",
+			SortKey:     "3_headless_mac",
+			Value:       headlessMacValue,
+		})
 	}
 
 	// Resolve device — use flag or interactive picker.
@@ -393,7 +401,11 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	}
 
 	if selected == linuxDesktopValue {
-		return installLinuxDesktop(ctx, preOpts, deviceName)
+		return installLinuxDesktop(ctx, preOpts, deviceName, linuxDesktopMachineLabel)
+	}
+
+	if selected == headlessMacValue {
+		return installLinuxDesktop(ctx, preOpts, deviceName, headlessMacMachineLabel)
 	}
 
 	device := deviceMap[selected]

--- a/go/internal/cli/commands/os_install_linux_desktop.go
+++ b/go/internal/cli/commands/os_install_linux_desktop.go
@@ -96,14 +96,14 @@ var linuxDesktopTokenFn = createLinuxDesktopToken
 // without reading ~/.wendy/config.json from disk.
 var linuxDesktopConfigLoad = config.Load
 
-// installLinuxDesktop prints agent.sh install instructions for turning an
+// installDesktop prints agent.sh install instructions for turning an
 // existing Linux machine or Mac into a managed Wendy device. machineLabel
 // names the target in the printed prose ("Linux machine" or "Mac"); the
 // agent.sh command is identical for both because the script auto-detects the
 // platform. When the user is logged in and does not decline, it mints a
 // short-lived enrollment token and prints the pre-enrollment one-liner. It
 // never writes a drive or downloads an image.
-func installLinuxDesktop(ctx context.Context, preOpts preEnrollOptions, deviceName, machineLabel string) error {
+func installDesktop(ctx context.Context, preOpts preEnrollOptions, deviceName, machineLabel string) error {
 	interactive := isInteractiveTerminal()
 
 	cfg, err := linuxDesktopConfigLoad()

--- a/go/internal/cli/commands/os_install_linux_desktop.go
+++ b/go/internal/cli/commands/os_install_linux_desktop.go
@@ -22,7 +22,14 @@ import (
 
 const (
 	linuxDesktopValue    = "linux-desktop"
+	headlessMacValue     = "headless-mac"
 	linuxDesktopAgentURL = "https://install.wendy.dev/agent.sh"
+
+	// Machine labels woven into the install instructions. The agent.sh command
+	// is identical for both — it auto-detects the platform (uname -s) and does
+	// the right thing — so only the surrounding prose differs.
+	linuxDesktopMachineLabel = "Linux machine"
+	headlessMacMachineLabel  = "Mac"
 )
 
 // linuxDesktopCmdStyle renders the copyable install command in bold sky (the
@@ -32,19 +39,22 @@ const (
 var linuxDesktopCmdStyle = lipgloss.NewStyle().Foreground(tui.Sky500).Bold(true)
 
 // renderLinuxDesktopInstructions returns the text printed when the user picks
-// "Linux Desktop". With an empty token it prints the plain (unenrolled) docs
-// command; with a token it prints the pre-enrollment one-liner.
-func renderLinuxDesktopInstructions(token, cloudHost, orgName string, expiresAt time.Time) string {
+// "Linux Desktop" or "Headless Mac". machineLabel names the target machine in
+// the prose (e.g. "Linux machine" or "Mac"); the agent.sh command itself is
+// identical, since the script auto-detects the platform. With an empty token
+// it prints the plain (unenrolled) docs command; with a token it prints the
+// pre-enrollment one-liner.
+func renderLinuxDesktopInstructions(token, cloudHost, orgName, machineLabel string, expiresAt time.Time) string {
 	var b strings.Builder
 	if token == "" {
-		fmt.Fprintf(&b, "%s\n\n", tui.Header("Install wendy-agent on your Linux machine:"))
+		fmt.Fprintf(&b, "%s\n\n", tui.Header("Install wendy-agent on your "+machineLabel+":"))
 		fmt.Fprintf(&b, "  %s\n\n", linuxDesktopCmdStyle.Render(linuxDesktopCommand("", "")))
 		fmt.Fprintf(&b, "The device is discovered over your local network — run %s.\n", tui.Command("wendy discover"))
 		fmt.Fprintf(&b, "To enroll it into an org later, run %s\n", tui.Command("wendy device enroll"))
 		fmt.Fprintf(&b, "%s\n", tui.Dim("(or re-run `wendy install` while logged in for a pre-enrollment token)."))
 		return b.String()
 	}
-	fmt.Fprintf(&b, "Install wendy-agent on your Linux machine; it will enroll into %s automatically.\n\n", tui.Device(orgName))
+	fmt.Fprintf(&b, "Install wendy-agent on your %s; it will enroll into %s automatically.\n\n", machineLabel, tui.Device(orgName))
 	fmt.Fprintf(&b, "  %s\n\n", linuxDesktopCmdStyle.Render(linuxDesktopCommand(token, cloudHost)))
 	fmt.Fprintf(&b, "This enrollment token expires at %s (about 1 hour). Run the command before then.\n", tui.Value(expiresAt.Format(time.RFC1123)))
 	fmt.Fprintf(&b, "After it boots, run %s to find the device.\n", tui.Command("wendy discover"))
@@ -87,10 +97,13 @@ var linuxDesktopTokenFn = createLinuxDesktopToken
 var linuxDesktopConfigLoad = config.Load
 
 // installLinuxDesktop prints agent.sh install instructions for turning an
-// existing Linux machine into a managed Wendy device. When the user is logged
-// in and does not decline, it mints a short-lived enrollment token and prints
-// the pre-enrollment one-liner. It never writes a drive or downloads an image.
-func installLinuxDesktop(ctx context.Context, preOpts preEnrollOptions, deviceName string) error {
+// existing Linux machine or Mac into a managed Wendy device. machineLabel
+// names the target in the printed prose ("Linux machine" or "Mac"); the
+// agent.sh command is identical for both because the script auto-detects the
+// platform. When the user is logged in and does not decline, it mints a
+// short-lived enrollment token and prints the pre-enrollment one-liner. It
+// never writes a drive or downloads an image.
+func installLinuxDesktop(ctx context.Context, preOpts preEnrollOptions, deviceName, machineLabel string) error {
 	interactive := isInteractiveTerminal()
 
 	cfg, err := linuxDesktopConfigLoad()
@@ -155,7 +168,7 @@ func installLinuxDesktop(ctx context.Context, preOpts preEnrollOptions, deviceNa
 		}
 	}
 
-	fmt.Fprint(os.Stdout, renderLinuxDesktopInstructions(token, cloudHost, orgName, expiresAt))
+	fmt.Fprint(os.Stdout, renderLinuxDesktopInstructions(token, cloudHost, orgName, machineLabel, expiresAt))
 	copyLinuxDesktopCommand(token, cloudHost, interactive)
 	return nil
 }

--- a/go/internal/cli/commands/os_install_linux_desktop_test.go
+++ b/go/internal/cli/commands/os_install_linux_desktop_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRenderLinuxDesktopInstructions_Plain(t *testing.T) {
-	out := renderLinuxDesktopInstructions("", "", "", time.Time{})
+	out := renderLinuxDesktopInstructions("", "", "", linuxDesktopMachineLabel, time.Time{})
 	if !strings.Contains(out, "curl -fsSL https://install.wendy.dev/agent.sh | bash") {
 		t.Fatalf("plain output missing curl command:\n%s", out)
 	}
@@ -23,11 +23,30 @@ func TestRenderLinuxDesktopInstructions_Plain(t *testing.T) {
 	if !strings.Contains(out, "wendy device enroll") {
 		t.Fatalf("plain output should point at later enrollment:\n%s", out)
 	}
+	if !strings.Contains(out, "Linux machine") {
+		t.Fatalf("plain output should name the Linux machine target:\n%s", out)
+	}
+}
+
+// The Headless Mac path reuses the same renderer with a Mac label: the command
+// is byte-for-byte identical (agent.sh auto-detects the platform) but the
+// surrounding prose names the Mac.
+func TestRenderLinuxDesktopInstructions_HeadlessMac(t *testing.T) {
+	out := renderLinuxDesktopInstructions("", "", "", headlessMacMachineLabel, time.Time{})
+	if !strings.Contains(out, "curl -fsSL https://install.wendy.dev/agent.sh | bash") {
+		t.Fatalf("mac output missing curl command:\n%s", out)
+	}
+	if !strings.Contains(out, "your Mac") {
+		t.Fatalf("mac output should name the Mac target:\n%s", out)
+	}
+	if strings.Contains(out, "Linux machine") {
+		t.Fatalf("mac output should not mention a Linux machine:\n%s", out)
+	}
 }
 
 func TestRenderLinuxDesktopInstructions_Enrolled(t *testing.T) {
 	exp := time.Date(2026, 7, 7, 15, 4, 5, 0, time.UTC)
-	out := renderLinuxDesktopInstructions("tok-abc", "cloud.wendy.dev:443", "Acme", exp)
+	out := renderLinuxDesktopInstructions("tok-abc", "cloud.wendy.dev:443", "Acme", linuxDesktopMachineLabel, exp)
 	for _, want := range []string{
 		"WENDY_ENROLLMENT_TOKEN=tok-abc",
 		"WENDY_CLOUD_HOST=cloud.wendy.dev:443",
@@ -51,7 +70,7 @@ func TestInstallLinuxDesktop_SkipMode_PrintsPlain(t *testing.T) {
 	t.Cleanup(func() { linuxDesktopTokenFn = origTok })
 
 	out := captureStdout(t, func() {
-		if err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollSkip}, ""); err != nil {
+		if err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollSkip}, "", linuxDesktopMachineLabel); err != nil {
 			t.Fatalf("installLinuxDesktop: %v", err)
 		}
 	})
@@ -101,7 +120,7 @@ func TestInstallLinuxDesktop_EnrolledPrintsToken(t *testing.T) {
 	t.Cleanup(func() { linuxDesktopTokenFn = origTok })
 
 	out := captureStdout(t, func() {
-		if err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "my-box"); err != nil {
+		if err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "my-box", linuxDesktopMachineLabel); err != nil {
 			t.Fatalf("installLinuxDesktop: %v", err)
 		}
 	})
@@ -142,7 +161,7 @@ func TestInstallLinuxDesktop_EnrolledValidatesDeviceName(t *testing.T) {
 	}
 	t.Cleanup(func() { linuxDesktopTokenFn = origTok })
 
-	err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "BadName")
+	err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "BadName", linuxDesktopMachineLabel)
 	if err == nil {
 		t.Fatal("expected an error for an invalid --device-name, got nil")
 	}
@@ -226,7 +245,7 @@ func TestInstallLinuxDesktop_ForcedNonInteractive_TokenError(t *testing.T) {
 	}
 	t.Cleanup(func() { linuxDesktopTokenFn = origTok })
 
-	err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "my-box")
+	err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "my-box", linuxDesktopMachineLabel)
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}

--- a/go/internal/cli/commands/os_install_linux_desktop_test.go
+++ b/go/internal/cli/commands/os_install_linux_desktop_test.go
@@ -70,8 +70,8 @@ func TestInstallLinuxDesktop_SkipMode_PrintsPlain(t *testing.T) {
 	t.Cleanup(func() { linuxDesktopTokenFn = origTok })
 
 	out := captureStdout(t, func() {
-		if err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollSkip}, "", linuxDesktopMachineLabel); err != nil {
-			t.Fatalf("installLinuxDesktop: %v", err)
+		if err := installDesktop(context.Background(), preEnrollOptions{mode: preEnrollSkip}, "", linuxDesktopMachineLabel); err != nil {
+			t.Fatalf("installDesktop: %v", err)
 		}
 	})
 	if called {
@@ -120,8 +120,8 @@ func TestInstallLinuxDesktop_EnrolledPrintsToken(t *testing.T) {
 	t.Cleanup(func() { linuxDesktopTokenFn = origTok })
 
 	out := captureStdout(t, func() {
-		if err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "my-box", linuxDesktopMachineLabel); err != nil {
-			t.Fatalf("installLinuxDesktop: %v", err)
+		if err := installDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "my-box", linuxDesktopMachineLabel); err != nil {
+			t.Fatalf("installDesktop: %v", err)
 		}
 	})
 
@@ -161,7 +161,7 @@ func TestInstallLinuxDesktop_EnrolledValidatesDeviceName(t *testing.T) {
 	}
 	t.Cleanup(func() { linuxDesktopTokenFn = origTok })
 
-	err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "BadName", linuxDesktopMachineLabel)
+	err := installDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "BadName", linuxDesktopMachineLabel)
 	if err == nil {
 		t.Fatal("expected an error for an invalid --device-name, got nil")
 	}
@@ -245,7 +245,7 @@ func TestInstallLinuxDesktop_ForcedNonInteractive_TokenError(t *testing.T) {
 	}
 	t.Cleanup(func() { linuxDesktopTokenFn = origTok })
 
-	err := installLinuxDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "my-box", linuxDesktopMachineLabel)
+	err := installDesktop(context.Background(), preEnrollOptions{mode: preEnrollForced}, "my-box", linuxDesktopMachineLabel)
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}


### PR DESCRIPTION
## What

Adds a **"Headless Mac"** entry at the bottom of the `wendy install` device picker, right after "Linux Desktop". Selecting it turns an existing Apple Silicon Mac into a managed Wendy device using the **same `agent.sh` one-liner** already used for Linux Desktop.

## Why

We already print an `agent.sh` install command for "Linux Desktop", and `agent.sh` already auto-detects the platform (`uname -s` → `darwin`/`linux`) and does the right thing on macOS — installing `WendyAgentMac.app` via the Homebrew cask or the signed/notarized zip, with identical enrollment-token staging. There was just no picker entry surfacing this for Macs.

## How

CLI-side wiring only — no changes to what `agent.sh` does at runtime:

- **`os_install.go`** — new "Headless Mac" picker item (own section, sort key `3_headless_mac`), routed to the existing `installLinuxDesktop` flow with a Mac machine label.
- **`os_install_linux_desktop.go`** — added `headlessMacValue` + machine-label constants; parameterized `renderLinuxDesktopInstructions` / `installLinuxDesktop` by a `machineLabel` so the prose reads "your Mac" vs "your Linux machine". The `curl … agent.sh` command is byte-for-byte identical for both paths.
- **`agent.sh`** — help text now lists "Headless Mac" alongside "Linux Desktop" as a `WENDY_ENROLLMENT_TOKEN` source.
- **Tests** — updated existing call sites for the new signature; added `TestRenderLinuxDesktopInstructions_HeadlessMac` pinning that the Mac path emits the identical command with Mac-worded prose (no "Linux machine" leakage).

The pre-enrollment token flow works unchanged: a logged-in user gets the `WENDY_ENROLLMENT_TOKEN`/`WENDY_CLOUD_HOST` one-liner and the Mac self-enrolls on first launch.

## Notes

"Headless Mac" installs the menu-bar `WendyAgentMac.app` (that's what `agent.sh`'s darwin path does today), not a GUI-less binary-only agent. A truly headless (no `.app`) macOS install mode would be a separate change to `agent.sh`.

## Testing

- `gofmt` clean, `go build ./internal/cli/...`, `go vet` clean on changed files
- `go test ./internal/cli/commands/` passing (incl. new Mac-variant test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)