### PR TITLE
ci: grant id-token/attestations perms to build-go-macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,6 +264,12 @@ jobs:
     name: ${{ matrix.artifact-name }}
     runs-on: macos-15
     needs: [determine-version]
+    # Attest SLSA build provenance in the job that produces the archive, so the
+    # provenance reflects the actual build environment (not a downstream job).
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Problem

The release build (`Build products and release`) fails at the **Attest build provenance** step of the `wendy-cli-darwin-arm64` job:

```
##[error]Failed to get ID token: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

Failing run: https://github.com/wendylabsinc/WendyOS/actions/runs/29388325503/job/87266181677

## Root cause

The `build-go-macos` job in `.github/workflows/build.yml` runs `actions/attest-build-provenance` but declared **no job-level `permissions:` block**, so it inherited only the workflow-level `permissions: contents: write`. The attestation action needs `id-token: write` (for OIDC) and `attestations: write`; without the ID token, the request URL env var is never injected and the step fails.

Every sibling build job (Linux amd64/arm64, Windows) already declares these permissions — only the macOS CLI job was missing them, which is why it was the sole failure.

## Fix

Add the same permissions block used by the sibling jobs:

```yaml
    permissions:
      contents: read
      id-token: write
      attestations: write
```

No functional/code change — CI configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgYun4g3mXeHMJCVTkrN1U