### PR TITLE
ci: drop stale wendy-cli-darwin-amd64 from SBOM+attest matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,7 +447,8 @@ jobs:
           - { artifact-name: wendy-cli-linux-arm64,   binary: wendy,       ext: tar.gz }
           - { artifact-name: wendy-cli-windows-amd64, binary: wendy.exe,   ext: zip }
           - { artifact-name: wendy-cli-windows-arm64, binary: wendy.exe,   ext: zip }
-          - { artifact-name: wendy-cli-darwin-amd64,  binary: wendy,       ext: tar.gz }
+          # Intel (amd64) macOS CLI is not built (see build-go-macos), so there
+          # is no wendy-cli-darwin-amd64 archive to attest.
           - { artifact-name: wendy-cli-darwin-arm64,  binary: wendy,       ext: tar.gz }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Problem

The `SBOM+attest (wendy-cli-darwin-amd64)` job fails at the *Download archive* step:

```
Unable to download artifact(s): Artifact not found for name: wendy-cli-darwin-amd64-<version>.tar.gz
```

(e.g. [this run](https://github.com/wendylabsinc/WendyOS/actions/runs/29389061622/job/87268508359))

## Root cause

The `build-go-macos` job only produces `wendy-cli-darwin-arm64`. Intel/amd64 macOS was intentionally dropped because the CLI links libusb via cgo and x86_64 can't cross-compile against the arm64-only Homebrew libusb on the `macos-15` runner (see the comment in `build-go-macos`).

The `sbom-binaries` matrix, however, still listed `wendy-cli-darwin-amd64`, so it tried to download and attest an archive that nothing uploads.

## Fix

Remove the stale `wendy-cli-darwin-amd64` entry from the `sbom-binaries` matrix, with a comment mirroring the one in `build-go-macos`. No other darwin-amd64 references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JveqF7osA6yryZxUQpnvQb