### PR TITLE
fix(agent): stop force-restarting healthy single-service apps registered under their bare appID

### DIFF
--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -390,6 +390,13 @@ func (m *ContainerMonitor) planRestarts(containers []*agentpb.AppContainer) []st
 			}
 			// Keep in sync with containerd.ContainerName.
 			running[c.GetAppName()+"_"+s.GetName()] = true
+			// Single-service apps deploy as a bare-named container (see
+			// AppConfig.ContainerName: ServiceName == "" → bare appID) while
+			// still reporting a services list here, so their monitor state is
+			// registered under the bare appID. Without the bare-key mark the
+			// monitor believes the app is down and force-restarts a healthy
+			// container every tick — the same failure mode as WDY-1552.
+			running[c.GetAppName()] = true
 		}
 	}
 

--- a/go/internal/agent/container/monitor_checkcontainers_test.go
+++ b/go/internal/agent/container/monitor_checkcontainers_test.go
@@ -183,6 +183,37 @@ func TestCheckContainers_SingleServiceMapApp_NotRestarted(t *testing.T) {
 	}
 }
 
+// Single-service apps deploy as a BARE-named container (AppConfig.ContainerName
+// returns the appID when ServiceName is empty), so their monitor state is
+// registered under the bare appID — while ListContainers still reports the
+// service via Services. The monitor must recognize the bare registration as
+// running too, or it force-restarts the healthy app every tick.
+func TestCheckContainers_SingleServiceMapApp_BareRegistration_NotRestarted(t *testing.T) {
+	fake := &fakeContainerd{
+		containers: []*agentpb.AppContainer{{
+			AppName:      "myapp",
+			RunningState: agentpb.AppRunningState_RUNNING,
+			Services: []*agentpb.ServiceEntry{
+				{Name: "web", RunningState: agentpb.AppRunningState_RUNNING},
+			},
+		}},
+	}
+	m := newMonitorWithClient(fake)
+	m.Register("myapp", RestartUnlessStopped, 0)
+
+	m.checkContainers(context.Background())
+
+	if calls := fake.startCallsSnapshot(); len(calls) != 0 {
+		t.Fatalf("StartContainer called for healthy service: %v", calls)
+	}
+	m.mu.Lock()
+	fc := m.states["myapp"].FailureCount
+	m.mu.Unlock()
+	if fc != 0 {
+		t.Fatalf("FailureCount = %d, want 0 (no spurious restart)", fc)
+	}
+}
+
 func TestReconcileBootContainers_StartsStoppedApp(t *testing.T) {
 	fake := &fakeContainerd{
 		started:        make(chan string, 1),


### PR DESCRIPTION
## Problem

Any **single-service** app deployed detached gets SIGKILLed and restarted by the agent's container monitor every ~15 seconds, forever. Observed live on a Jetson Orin Nano (`jetson-arm`): `wendylabs.yam-arm-control` hit `failure_count` 90+, with `Task exited (exit_code 137)` → `Container started` every 15s. `--no-restart` doesn't help (the persisted label re-registers on the next start), and the loop makes any stateful app unusable — in our case it reset a robot-arm controller mid-request.

## Root cause

Single-service apps deploy as a **bare-named container** (`AppConfig.ContainerName` returns the appID when `ServiceName == ""`), so their monitor state is registered under the bare appID. But `ListContainers` reports the service via `Services`, and `planRestarts` keys its running-set only by `{appID}_{serviceName}` for services-map apps. The keys never match → the monitor believes the healthy app is down → force-restart every tick.

Same failure family as WDY-1552 (#1041), which fixed the `{appID}_{serviceName}` registration path but not the bare-name one.

## Fix

One line in `planRestarts`: when any service of an app is RUNNING, also mark the **bare app name** as running.

## Testing

- New regression test `TestCheckContainers_SingleServiceMapApp_BareRegistration_NotRestarted` — fails before the fix (`FailureCount = 1`), passes after.
- `go test ./internal/agent/container/` green; `gofmt`/`vet` clean.
- Field-verified: patched agent side-loaded onto `jetson-arm` — restart loop gone (0 restarts over extended observation, previously one every 15s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)