### PR TITLE
fix(cli): stop tour tests scaffolding sample apps into ~/Documents

### DIFF
--- a/go/internal/cli/commands/main_test.go
+++ b/go/internal/cli/commands/main_test.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain sandboxes HOME/USERPROFILE to a throwaway directory for the whole
+// package. Several commands (notably `wendy tour`) derive real filesystem paths
+// from the user's home directory; without this guard a test that drives those
+// code paths would scaffold into the developer's real ~/Documents or mutate
+// ~/.wendy. Individual tests may still override HOME via t.Setenv.
+func TestMain(m *testing.M) {
+	if tmp, err := os.MkdirTemp("", "wendy-commands-test-home-"); err == nil {
+		os.Setenv("HOME", tmp)
+		os.Setenv("USERPROFILE", tmp) // Windows: os.UserHomeDir consults this
+		code := m.Run()
+		os.RemoveAll(tmp)
+		os.Exit(code)
+	}
+	os.Exit(m.Run())
+}

--- a/go/internal/cli/commands/tour.go
+++ b/go/internal/cli/commands/tour.go
@@ -226,6 +226,10 @@ type tourWizardModel struct {
 	// project
 	projectPath string
 	projectID   string
+	// projectBaseDir is the parent directory sample projects are scaffolded
+	// into. Empty means the default (~/Documents, via resolveProjectBaseDir);
+	// tests set it to a temp dir so the tour never writes to the real home.
+	projectBaseDir string
 
 	// template picker
 	repoMeta         *repoMeta
@@ -1810,12 +1814,25 @@ func (m tourWizardModel) downloadTourTemplateCmd() tea.Cmd {
 
 // ─── project creation ─────────────────────────────────────────────────────────
 
-func (m *tourWizardModel) createPythonProject() error {
-	docs, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("finding home directory: %w", err)
+// resolveProjectBaseDir returns the parent directory that sample projects are
+// scaffolded into. When projectBaseDir is set (tests inject a temp dir) it is
+// used as-is; otherwise it defaults to the user's ~/Documents.
+func (m *tourWizardModel) resolveProjectBaseDir() (string, error) {
+	if m.projectBaseDir != "" {
+		return m.projectBaseDir, nil
 	}
-	docs = filepath.Join(docs, "Documents")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, "Documents"), nil
+}
+
+func (m *tourWizardModel) createPythonProject() error {
+	docs, err := m.resolveProjectBaseDir()
+	if err != nil {
+		return err
+	}
 
 	appID := "sh.wendy.hello"
 	if m.deviceName != "" {
@@ -1854,11 +1871,10 @@ func (m *tourWizardModel) createPythonProject() error {
 }
 
 func (m *tourWizardModel) createProjectFromTemplate() error {
-	docs, err := os.UserHomeDir()
+	docs, err := m.resolveProjectBaseDir()
 	if err != nil {
-		return fmt.Errorf("finding home directory: %w", err)
+		return err
 	}
-	docs = filepath.Join(docs, "Documents")
 
 	appID := "sh.wendy.hello"
 	if m.deviceName != "" {

--- a/go/internal/cli/commands/tour_characterization_test.go
+++ b/go/internal/cli/commands/tour_characterization_test.go
@@ -205,7 +205,8 @@ func TestTourCreateProjectPromptSkip(t *testing.T) {
 func TestTourTemplatePickerBuiltIn(t *testing.T) {
 	m := newTourWizardModel()
 	m.phase = phaseTemplatePicker
-	m.templateItems = nil // only the built-in row exists
+	m.templateItems = nil          // only the built-in row exists
+	m.projectBaseDir = t.TempDir() // never scaffold into the real ~/Documents
 	got, _ := stepTour(t, m, key("enter"))
 	// Built-in selection creates the project then advances.
 	if got.phase != phaseCreateProject && got.phase != phaseError {

--- a/go/internal/cli/commands/tour_scaffold_test.go
+++ b/go/internal/cli/commands/tour_scaffold_test.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestTourCreatePythonProjectStaysInBaseDir pins the fix for sample projects
+// leaking into the developer's real ~/Documents: createPythonProject must
+// scaffold under the injected projectBaseDir and nowhere else, and must pick a
+// non-conflicting "-N" name when the base name already exists rather than
+// overwrite it.
+func TestTourCreatePythonProjectStaysInBaseDir(t *testing.T) {
+	base := t.TempDir()
+
+	m := newTourWizardModel()
+	m.projectBaseDir = base
+	if err := m.createPythonProject(); err != nil {
+		t.Fatalf("createPythonProject: %v", err)
+	}
+
+	want := filepath.Join(base, "wendy-hello")
+	if m.projectPath != want {
+		t.Errorf("projectPath = %q, want %q", m.projectPath, want)
+	}
+	for _, name := range []string{"wendy.json", "app.py", "Dockerfile", "requirements.txt"} {
+		if _, err := os.Stat(filepath.Join(want, name)); err != nil {
+			t.Errorf("expected scaffolded file %s: %v", name, err)
+		}
+	}
+
+	// A second run must not overwrite the first; it increments the suffix.
+	m2 := newTourWizardModel()
+	m2.projectBaseDir = base
+	if err := m2.createPythonProject(); err != nil {
+		t.Fatalf("createPythonProject (2nd): %v", err)
+	}
+	if want2 := filepath.Join(base, "wendy-hello-1"); m2.projectPath != want2 {
+		t.Errorf("second projectPath = %q, want %q", m2.projectPath, want2)
+	}
+
+	// Exactly the two scaffolds should exist under base — nothing escaped it.
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("base dir has %d entries, want 2 (wendy-hello, wendy-hello-1)", len(entries))
+	}
+}


### PR DESCRIPTION
## Problem

Numbered `wendy-hello-N` folders were silently accumulating in the developer's real `~/Documents` (12 of them observed locally). They aren't created by the terminal, a scheduler, WendyOS, or the MCP server — they're a **test side effect**.

## Root cause

`wendy tour`'s "deploy a sample app" step (`createPythonProject` / `createProjectFromTemplate` in `tour.go`) resolves its destination from `os.UserHomeDir()/Documents` and runs **synchronously inside the tour's bubbletea `Update()`** (not inside a returned `tea.Cmd`).

The tour characterization tests drive the state machine through that transition. `TestTourTemplatePickerBuiltIn` sets `templateItems = nil` and presses enter, falling into the built-in-template branch that calls `createPythonProject()` — and that test file never sandboxes `HOME`. So **every `go test ./internal/cli/commands/...` run scaffolded a real `wendy-hello[-N]` project into `~/Documents`** (auto-incrementing the suffix, never cleaning up). It stayed invisible because test runs via tooling don't touch shell history.

## Fix

- **Design:** add an injectable `projectBaseDir` seam (`resolveProjectBaseDir`) so the destination no longer hardcodes the real home. Empty preserves the `~/Documents` default for real runs.
- **Test hygiene (targeted):** `TestTourTemplatePickerBuiltIn` now points `projectBaseDir` at `t.TempDir()`.
- **Test hygiene (defense-in-depth):** a package `TestMain` sandboxes `HOME`/`USERPROFILE` to a temp dir so no test in `internal/cli/commands` can ever write to the real home or `~/.wendy`.
- **Regression test:** `TestTourCreatePythonProjectStaysInBaseDir` pins that scaffolds stay under the injected base dir and increment (`-N`) instead of overwriting.

## Verification

- `go build` / `go vet` / `gofmt` clean.
- Full `internal/cli/commands` suite passes.
- Before/after check: running the full suite with a real `HOME` no longer adds any folder to `~/Documents` (count unchanged), whereas previously it added one per run. Confirmed the original leak by reproducing it against a fake `HOME` first.

## Follow-up (not in this PR)

Moving sample-project creation out of `Update()` into a returned `tea.Cmd` would be a cleaner architectural fix, but it rewrites several state-machine test expectations, so it's deferred. The injectable seam + `HOME` sandbox already close the leak and its whole class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)