### PR TITLE
feat(pki): put org identity URN in CSR SANs

### DIFF
--- a/go/cmd/local-pki-test/main.go
+++ b/go/cmd/local-pki-test/main.go
@@ -131,7 +131,7 @@ func main() {
 		log.Fatalf("GenerateKeyPair: %v", err)
 	}
 
-	clientCSRPEM, err := certs.GenerateCSR([]byte(clientKeyPEM), "sh/wendy/test-client")
+	clientCSRPEM, err := certs.GenerateCSR([]byte(clientKeyPEM), "sh/wendy/test-client", "")
 	if err != nil {
 		log.Fatalf("GenerateCSR: %v", err)
 	}

--- a/go/internal/agent/services/provisioning_service.go
+++ b/go/internal/agent/services/provisioning_service.go
@@ -169,7 +169,8 @@ func (s *ProvisioningService) StartProvisioning(ctx context.Context, req *agentp
 	// as both a TLS client (to the cloud) and a TLS server (agent gRPC and tunnel
 	// endpoints), so request both EKUs.
 	commonName := fmt.Sprintf("sh/wendy/%d/%d", req.GetOrganizationId(), req.GetAssetId())
-	csrPEM, err := certs.GenerateCSR(keyPEM, commonName,
+	identityURN := certs.AssetURN(req.GetOrganizationId(), req.GetAssetId())
+	csrPEM, err := certs.GenerateCSR(keyPEM, commonName, identityURN,
 		x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to generate CSR: %v", err)

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -309,11 +309,12 @@ func enrollmentTokenIdentity(token string) (commonName, identityURN string, err 
 		if claims.UserID == "" {
 			return "", "", fmt.Errorf("user enrollment token missing user_id")
 		}
+		cn := fmt.Sprintf("wendy/user/%s", claims.UserID)
 		if claims.OrganizationID == 0 {
-			return "", "", fmt.Errorf("user enrollment token missing org_id")
+			// Legacy token without an org claim: keep login working, CN only.
+			return cn, "", nil
 		}
-		return fmt.Sprintf("wendy/user/%s", claims.UserID),
-			certs.UserURN(claims.OrganizationID, claims.UserID), nil
+		return cn, certs.UserURN(claims.OrganizationID, claims.UserID), nil
 	case "asset_enrollment":
 		if claims.OrganizationID == 0 || claims.AssetID == 0 {
 			return "", "", fmt.Errorf("asset enrollment token missing org_id or asset_id")

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -214,11 +214,11 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 		return fmt.Errorf("generating key pair: %w", err)
 	}
 
-	commonName, err := enrollmentTokenCommonName(result.EnrollmentToken)
+	commonName, identityURN, err := enrollmentTokenIdentity(result.EnrollmentToken)
 	if err != nil {
 		return fmt.Errorf("reading enrollment token identity: %w", err)
 	}
-	csrPEM, err := certs.GenerateCSR([]byte(privateKeyPEM), commonName)
+	csrPEM, err := certs.GenerateCSR([]byte(privateKeyPEM), commonName, identityURN)
 	if err != nil {
 		return fmt.Errorf("generating CSR: %w", err)
 	}
@@ -295,24 +295,33 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	return nil
 }
 
-func enrollmentTokenCommonName(token string) (string, error) {
+// enrollmentTokenIdentity derives the CSR Subject CommonName and the
+// authoritative identity URI SAN from an enrollment token's claims. The URN
+// ("urn:wendy:org:<org>:user:<userID>" for users, "urn:wendy:org:<org>:asset:<assetID>"
+// for assets) is what IdentityFromCert prefers over the legacy CommonName.
+func enrollmentTokenIdentity(token string) (commonName, identityURN string, err error) {
 	claims, err := enrolltoken.Parse(token)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	switch claims.Type {
 	case "user_enrollment":
 		if claims.UserID == "" {
-			return "", fmt.Errorf("user enrollment token missing user_id")
+			return "", "", fmt.Errorf("user enrollment token missing user_id")
 		}
-		return fmt.Sprintf("wendy/user/%s", claims.UserID), nil
+		if claims.OrganizationID == 0 {
+			return "", "", fmt.Errorf("user enrollment token missing org_id")
+		}
+		return fmt.Sprintf("wendy/user/%s", claims.UserID),
+			certs.UserURN(claims.OrganizationID, claims.UserID), nil
 	case "asset_enrollment":
 		if claims.OrganizationID == 0 || claims.AssetID == 0 {
-			return "", fmt.Errorf("asset enrollment token missing org_id or asset_id")
+			return "", "", fmt.Errorf("asset enrollment token missing org_id or asset_id")
 		}
-		return fmt.Sprintf("wendy/%d/%d", claims.OrganizationID, claims.AssetID), nil
+		return fmt.Sprintf("wendy/%d/%d", claims.OrganizationID, claims.AssetID),
+			certs.AssetURN(claims.OrganizationID, claims.AssetID), nil
 	default:
-		return "", fmt.Errorf("unsupported enrollment token type %q", claims.Type)
+		return "", "", fmt.Errorf("unsupported enrollment token type %q", claims.Type)
 	}
 }
 
@@ -338,12 +347,13 @@ func performLocalLogin(ctx context.Context, cloudGRPC, apiKey string, orgID int3
 	}
 	// Reconstruct the device_id that pki-core stored in the token.
 	deviceID := fmt.Sprintf("sh/wendy/%d/%d", tokenResp.GetOrganizationId(), tokenResp.GetAssetId())
+	identityURN := certs.AssetURN(tokenResp.GetOrganizationId(), tokenResp.GetAssetId())
 
 	privateKeyPEM, err := certs.GenerateKeyPair()
 	if err != nil {
 		return fmt.Errorf("generating key pair: %w", err)
 	}
-	csrPEM, err := certs.GenerateCSR([]byte(privateKeyPEM), deviceID)
+	csrPEM, err := certs.GenerateCSR([]byte(privateKeyPEM), deviceID, identityURN)
 	if err != nil {
 		return fmt.Errorf("generating CSR: %w", err)
 	}
@@ -486,6 +496,22 @@ func certCommonName(pemCertificate string) (string, error) {
 	return parsed.Subject.CommonName, nil
 }
 
+// storedCertIdentityURN builds the authoritative Wendy identity URN from a
+// stored certificate's org/user/asset fields, or "" when there is no positive
+// org id to anchor it (a legacy entry that predates org-scoped identity).
+func storedCertIdentityURN(cert config.CertificateInfo) string {
+	if cert.OrganizationID <= 0 {
+		return ""
+	}
+	if cert.UserID != "" {
+		return certs.UserURN(int32(cert.OrganizationID), cert.UserID)
+	}
+	if cert.AssetID > 0 {
+		return certs.AssetURN(int32(cert.OrganizationID), int32(cert.AssetID))
+	}
+	return ""
+}
+
 // refreshCertsForAuth generates a new CSR and refreshes certificates for a single auth entry.
 func refreshCertsForAuth(ctx context.Context, auth *config.AuthConfig) error {
 	if len(auth.Certificates) == 0 {
@@ -499,13 +525,19 @@ func refreshCertsForAuth(ctx context.Context, auth *config.AuthConfig) error {
 		return fmt.Errorf("reading existing cert CN: %w", err)
 	}
 
+	// Carry the authoritative identity URN forward so the refreshed cert keeps
+	// its "urn:wendy:org:..." SAN. The org/user/asset are taken from the stored
+	// config (the cert's own CN may be a legacy "wendy/user/<uid>" that carries
+	// no parseable org).
+	identityURN := storedCertIdentityURN(existingCert)
+
 	// Generate new key pair.
 	newKeyPEM, err := certs.GenerateKeyPair()
 	if err != nil {
 		return fmt.Errorf("generating key pair: %w", err)
 	}
 
-	csrPEM, err := certs.GenerateCSR([]byte(newKeyPEM), cn)
+	csrPEM, err := certs.GenerateCSR([]byte(newKeyPEM), cn, identityURN)
 	if err != nil {
 		return fmt.Errorf("generating CSR: %w", err)
 	}

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -309,6 +309,12 @@ func enrollmentTokenIdentity(token string) (commonName, identityURN string, err 
 		if claims.UserID == "" {
 			return "", "", fmt.Errorf("user enrollment token missing user_id")
 		}
+		if strings.Contains(claims.UserID, ":") {
+			// A ':' in the user ID would make the URN unreadable for every
+			// identity parser (they expect exactly 6 colon-separated parts),
+			// yielding a cert that cannot authenticate anywhere.
+			return "", "", fmt.Errorf("user_id %q contains ':', cannot build identity URN", claims.UserID)
+		}
 		cn := fmt.Sprintf("wendy/user/%s", claims.UserID)
 		if claims.OrganizationID == 0 {
 			// Legacy token without an org claim: keep login working, CN only.
@@ -505,6 +511,11 @@ func storedCertIdentityURN(cert config.CertificateInfo) string {
 		return ""
 	}
 	if cert.UserID != "" {
+		if strings.Contains(cert.UserID, ":") {
+			// A ':' would make the URN unreadable for every identity parser;
+			// refresh CN-only rather than minting a cert nothing can parse.
+			return ""
+		}
 		return certs.UserURN(int32(cert.OrganizationID), cert.UserID)
 	}
 	if cert.AssetID > 0 {

--- a/go/internal/cli/commands/auth_test.go
+++ b/go/internal/cli/commands/auth_test.go
@@ -11,6 +11,8 @@ import (
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 )
 
 func testEnrollmentToken(t *testing.T, payload string) string {
@@ -36,8 +38,23 @@ func TestEnrollmentTokenIdentity_UserEnrollment(t *testing.T) {
 func TestEnrollmentTokenIdentity_UserEnrollmentMissingOrg(t *testing.T) {
 	token := testEnrollmentToken(t, `{"type":"user_enrollment","user_id":"user-123"}`)
 
+	cn, urn, err := enrollmentTokenIdentity(token)
+	if err != nil {
+		t.Fatalf("enrollmentTokenIdentity() error = %v, want nil (legacy org-less token should keep login working)", err)
+	}
+	if cn != "wendy/user/user-123" {
+		t.Fatalf("enrollmentTokenIdentity() cn = %q, want %q", cn, "wendy/user/user-123")
+	}
+	if urn != "" {
+		t.Fatalf("enrollmentTokenIdentity() urn = %q, want empty (CN-only for org-less token)", urn)
+	}
+}
+
+func TestEnrollmentTokenIdentity_UserEnrollmentUserIDContainsColon(t *testing.T) {
+	token := testEnrollmentToken(t, `{"type":"user_enrollment","org_id":1,"user_id":"user:123"}`)
+
 	if _, _, err := enrollmentTokenIdentity(token); err == nil {
-		t.Fatal("expected error for user token missing org_id")
+		t.Fatal("expected error for user_id containing ':'")
 	}
 }
 
@@ -59,6 +76,27 @@ func TestEnrollmentTokenIdentity_AssetEnrollment(t *testing.T) {
 func TestEnrollmentTokenIdentity_InvalidToken(t *testing.T) {
 	if _, _, err := enrollmentTokenIdentity("not-a-jwt"); err == nil {
 		t.Fatal("expected invalid token error")
+	}
+}
+
+func TestStoredCertIdentityURN_User(t *testing.T) {
+	cert := config.CertificateInfo{OrganizationID: 1, UserID: "user-123"}
+	if urn := storedCertIdentityURN(cert); urn != "urn:wendy:org:1:user:user-123" {
+		t.Fatalf("storedCertIdentityURN() = %q, want %q", urn, "urn:wendy:org:1:user:user-123")
+	}
+}
+
+func TestStoredCertIdentityURN_UserIDContainsColon(t *testing.T) {
+	cert := config.CertificateInfo{OrganizationID: 1, UserID: "user:123"}
+	if urn := storedCertIdentityURN(cert); urn != "" {
+		t.Fatalf("storedCertIdentityURN() = %q, want empty (CN-only refresh for unparseable user ID)", urn)
+	}
+}
+
+func TestStoredCertIdentityURN_Asset(t *testing.T) {
+	cert := config.CertificateInfo{OrganizationID: 7, AssetID: 42}
+	if urn := storedCertIdentityURN(cert); urn != "urn:wendy:org:7:asset:42" {
+		t.Fatalf("storedCertIdentityURN() = %q, want %q", urn, "urn:wendy:org:7:asset:42")
 	}
 }
 

--- a/go/internal/cli/commands/auth_test.go
+++ b/go/internal/cli/commands/auth_test.go
@@ -18,32 +18,46 @@ func testEnrollmentToken(t *testing.T, payload string) string {
 	return "header." + base64.RawURLEncoding.EncodeToString([]byte(payload)) + ".signature"
 }
 
-func TestEnrollmentTokenCommonName_UserEnrollment(t *testing.T) {
+func TestEnrollmentTokenIdentity_UserEnrollment(t *testing.T) {
 	token := testEnrollmentToken(t, `{"type":"user_enrollment","org_id":1,"user_id":"user-123"}`)
 
-	got, err := enrollmentTokenCommonName(token)
+	cn, urn, err := enrollmentTokenIdentity(token)
 	if err != nil {
-		t.Fatalf("enrollmentTokenCommonName() error = %v", err)
+		t.Fatalf("enrollmentTokenIdentity() error = %v", err)
 	}
-	if got != "wendy/user/user-123" {
-		t.Fatalf("enrollmentTokenCommonName() = %q, want %q", got, "wendy/user/user-123")
+	if cn != "wendy/user/user-123" {
+		t.Fatalf("enrollmentTokenIdentity() cn = %q, want %q", cn, "wendy/user/user-123")
+	}
+	if urn != "urn:wendy:org:1:user:user-123" {
+		t.Fatalf("enrollmentTokenIdentity() urn = %q, want %q", urn, "urn:wendy:org:1:user:user-123")
 	}
 }
 
-func TestEnrollmentTokenCommonName_AssetEnrollment(t *testing.T) {
+func TestEnrollmentTokenIdentity_UserEnrollmentMissingOrg(t *testing.T) {
+	token := testEnrollmentToken(t, `{"type":"user_enrollment","user_id":"user-123"}`)
+
+	if _, _, err := enrollmentTokenIdentity(token); err == nil {
+		t.Fatal("expected error for user token missing org_id")
+	}
+}
+
+func TestEnrollmentTokenIdentity_AssetEnrollment(t *testing.T) {
 	token := testEnrollmentToken(t, `{"type":"asset_enrollment","org_id":7,"asset_id":42}`)
 
-	got, err := enrollmentTokenCommonName(token)
+	cn, urn, err := enrollmentTokenIdentity(token)
 	if err != nil {
-		t.Fatalf("enrollmentTokenCommonName() error = %v", err)
+		t.Fatalf("enrollmentTokenIdentity() error = %v", err)
 	}
-	if got != "wendy/7/42" {
-		t.Fatalf("enrollmentTokenCommonName() = %q, want %q", got, "wendy/7/42")
+	if cn != "wendy/7/42" {
+		t.Fatalf("enrollmentTokenIdentity() cn = %q, want %q", cn, "wendy/7/42")
+	}
+	if urn != "urn:wendy:org:7:asset:42" {
+		t.Fatalf("enrollmentTokenIdentity() urn = %q, want %q", urn, "urn:wendy:org:7:asset:42")
 	}
 }
 
-func TestEnrollmentTokenCommonName_InvalidToken(t *testing.T) {
-	if _, err := enrollmentTokenCommonName("not-a-jwt"); err == nil {
+func TestEnrollmentTokenIdentity_InvalidToken(t *testing.T) {
+	if _, _, err := enrollmentTokenIdentity("not-a-jwt"); err == nil {
 		t.Fatal("expected invalid token error")
 	}
 }

--- a/go/internal/cli/commands/os_provision.go
+++ b/go/internal/cli/commands/os_provision.go
@@ -98,6 +98,7 @@ func preEnrollDevice(ctx context.Context, auth *config.AuthConfig, deviceName st
 	// Device identity acts as both a TLS client (to the cloud) and a TLS server
 	// (agent gRPC and tunnel endpoints), so request both EKUs.
 	csrPEM, err := certs.GenerateCSR([]byte(keyPEM), fmt.Sprintf("sh/wendy/%d/%d", resolvedOrgID, assetID),
+		certs.AssetURN(resolvedOrgID, assetID),
 		x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth)
 	if err != nil {
 		return nil, fmt.Errorf("generating CSR: %w", err)

--- a/go/internal/shared/certs/certs.go
+++ b/go/internal/shared/certs/certs.go
@@ -11,6 +11,7 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
+	"net/url"
 )
 
 // GenerateKeyPair generates a new P-256 EC private key and returns it as a PEM-encoded string.
@@ -34,8 +35,15 @@ func GenerateKeyPair() (privateKeyPEM string, err error) {
 }
 
 // GenerateCSR creates a PKCS#10 certificate signing request using the provided
-// PEM-encoded private key (as bytes, so callers can zero the slice after use)
-// and common name. The CSR is returned as a PEM string.
+// PEM-encoded private key (as bytes, so callers can zero the slice after use),
+// common name, and identity URN. The CSR is returned as a PEM string.
+//
+// identityURN, when non-empty, is placed in the CSR as a URI Subject
+// Alternative Name. Callers pass the canonical Wendy identity URN — build it
+// with UserURN ("urn:wendy:org:<org>:user:<userID>") for CLI/user certificates
+// and AssetURN ("urn:wendy:org:<org>:asset:<assetID>") for device/agent
+// certificates. This is the authoritative identity IdentityFromCert prefers
+// over the legacy CommonName. Pass "" to omit the SAN (e.g. test fixtures).
 //
 // The CSR requests digitalSignature key usage and the supplied extended key
 // usages so that CAs honoring CSR extensions issue certs the wendy-agent mTLS
@@ -46,7 +54,7 @@ func GenerateKeyPair() (privateKeyPEM string, err error) {
 // as a TLS client to the cloud and a TLS server for the agent's gRPC and tunnel
 // endpoints. The Wendy cloud backends set key usages server-side and ignore
 // these, so this only matters for CAs that derive extensions from the CSR.
-func GenerateCSR(privateKeyPEM []byte, commonName string, extKeyUsages ...x509.ExtKeyUsage) (csrPEM string, err error) {
+func GenerateCSR(privateKeyPEM []byte, commonName, identityURN string, extKeyUsages ...x509.ExtKeyUsage) (csrPEM string, err error) {
 	key, err := parseECPrivateKey(privateKeyPEM)
 	if err != nil {
 		return "", err
@@ -74,10 +82,23 @@ func GenerateCSR(privateKeyPEM []byte, commonName string, extKeyUsages ...x509.E
 		return "", fmt.Errorf("marshaling extended key usage: %w", err)
 	}
 
+	var uris []*url.URL
+	if identityURN != "" {
+		u, err := url.Parse(identityURN)
+		if err != nil {
+			return "", fmt.Errorf("parsing identity URN %q: %w", identityURN, err)
+		}
+		uris = append(uris, u)
+	}
+
 	template := &x509.CertificateRequest{
 		Subject: pkix.Name{
 			CommonName: commonName,
 		},
+		// URIs populates the subjectAltName extension (id-ce-subjectAltName,
+		// 2.5.29.17), which is distinct from the key-usage extensions below, so
+		// there is no extension collision.
+		URIs: uris,
 		ExtraExtensions: []pkix.Extension{
 			{
 				Id:       asn1.ObjectIdentifier{2, 5, 29, 15}, // id-ce-keyUsage

--- a/go/internal/shared/certs/certs_test.go
+++ b/go/internal/shared/certs/certs_test.go
@@ -47,7 +47,7 @@ func TestGenerateCSR(t *testing.T) {
 		t.Fatalf("GenerateKeyPair() error = %v", err)
 	}
 
-	csrPEM, err := GenerateCSR([]byte(keyPEM), "test-device.example.com")
+	csrPEM, err := GenerateCSR([]byte(keyPEM), "test-device.example.com", "")
 	if err != nil {
 		t.Fatalf("GenerateCSR() error = %v", err)
 	}
@@ -69,6 +69,69 @@ func TestGenerateCSR(t *testing.T) {
 
 	if csr.Subject.CommonName != "test-device.example.com" {
 		t.Errorf("CSR CommonName = %q, want %q", csr.Subject.CommonName, "test-device.example.com")
+	}
+
+	// An empty identityURN must not add any URI SAN.
+	if len(csr.URIs) != 0 {
+		t.Errorf("CSR with empty identityURN has %d URI SANs, want 0", len(csr.URIs))
+	}
+}
+
+// TestGenerateCSRIncludesIdentityURN verifies both entity flavours the callers
+// use (user for the CLI, asset for the agent) land in the CSR as a single URI
+// SAN that IdentityFromCert reads back as the authoritative identity.
+func TestGenerateCSRIncludesIdentityURN(t *testing.T) {
+	cases := []struct {
+		name   string
+		urn    string
+		wantID WendyIdentity
+	}{
+		{"user", UserURN(1, "user-123"), WendyIdentity{OrgID: 1, EntityType: "user", EntityID: "user-123"}},
+		{"asset", AssetURN(7, 42), WendyIdentity{OrgID: 7, EntityType: "asset", EntityID: "42"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			keyPEM, err := GenerateKeyPair()
+			if err != nil {
+				t.Fatalf("GenerateKeyPair() error = %v", err)
+			}
+
+			csrPEM, err := GenerateCSR([]byte(keyPEM), "sh/wendy/legacy", tc.urn)
+			if err != nil {
+				t.Fatalf("GenerateCSR() error = %v", err)
+			}
+
+			block, _ := pem.Decode([]byte(csrPEM))
+			csr, err := x509.ParseCertificateRequest(block.Bytes)
+			if err != nil {
+				t.Fatalf("parsing generated CSR: %v", err)
+			}
+			if err := csr.CheckSignature(); err != nil {
+				t.Fatalf("CSR signature invalid: %v", err)
+			}
+
+			if len(csr.URIs) != 1 {
+				t.Fatalf("CSR has %d URI SANs, want 1", len(csr.URIs))
+			}
+			if got := csr.URIs[0].String(); got != tc.urn {
+				t.Errorf("CSR URI SAN = %q, want %q", got, tc.urn)
+			}
+
+			// The SAN must be what IdentityFromCert resolves. A CertificateRequest
+			// and a Certificate share the URIs field, so read it via a synthetic
+			// leaf carrying the same SANs.
+			leaf := &x509.Certificate{Subject: csr.Subject, URIs: csr.URIs}
+			id, ok, err := IdentityFromCert(leaf)
+			if err != nil {
+				t.Fatalf("IdentityFromCert() error = %v", err)
+			}
+			if !ok {
+				t.Fatal("IdentityFromCert() found no identity in a URN-bearing cert")
+			}
+			if id != tc.wantID {
+				t.Errorf("IdentityFromCert() = %+v, want %+v", id, tc.wantID)
+			}
+		})
 	}
 }
 
@@ -236,7 +299,7 @@ func TestGenerateAndCSR_RoundTrip(t *testing.T) {
 	}
 
 	// Generate a CSR with the key.
-	csrPEM, err := GenerateCSR([]byte(keyPEM), "roundtrip.example.com")
+	csrPEM, err := GenerateCSR([]byte(keyPEM), "roundtrip.example.com", "")
 	if err != nil {
 		t.Fatalf("GenerateCSR() error = %v", err)
 	}
@@ -274,7 +337,7 @@ func TestGenerateCSRRequestsClientAuthUsage(t *testing.T) {
 		t.Fatalf("GenerateKeyPair() error = %v", err)
 	}
 
-	csrPEM, err := GenerateCSR([]byte(keyPEM), "wendy/user/abc")
+	csrPEM, err := GenerateCSR([]byte(keyPEM), "wendy/user/abc", "")
 	if err != nil {
 		t.Fatalf("GenerateCSR() error = %v", err)
 	}
@@ -335,7 +398,7 @@ func TestGenerateCSRRequestsClientAndServerAuthUsage(t *testing.T) {
 		t.Fatalf("GenerateKeyPair() error = %v", err)
 	}
 
-	csrPEM, err := GenerateCSR([]byte(keyPEM), "sh/wendy/1/2",
+	csrPEM, err := GenerateCSR([]byte(keyPEM), "sh/wendy/1/2", AssetURN(1, 2),
 		x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth)
 	if err != nil {
 		t.Fatalf("GenerateCSR() error = %v", err)

--- a/go/internal/shared/certs/orgident.go
+++ b/go/internal/shared/certs/orgident.go
@@ -22,6 +22,20 @@ func (w WendyIdentity) IdentityKey() string {
 	return fmt.Sprintf("urn:wendy:org:%d:%s:%s", w.OrgID, w.EntityType, w.EntityID)
 }
 
+// UserURN returns the canonical Wendy identity URN for a user:
+// "urn:wendy:org:<org>:user:<userID>". This is the URI SAN a user (CLI)
+// certificate carries as its authoritative identity.
+func UserURN(orgID int32, userID string) string {
+	return WendyIdentity{OrgID: orgID, EntityType: "user", EntityID: userID}.IdentityKey()
+}
+
+// AssetURN returns the canonical Wendy identity URN for an asset:
+// "urn:wendy:org:<org>:asset:<assetID>". This is the URI SAN a device (agent)
+// certificate carries as its authoritative identity.
+func AssetURN(orgID, assetID int32) string {
+	return WendyIdentity{OrgID: orgID, EntityType: "asset", EntityID: strconv.Itoa(int(assetID))}.IdentityKey()
+}
+
 // IdentityFromCert extracts the Wendy org+entity identity from a certificate.
 //
 // Resolution order:

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/DeviceIdentity.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/DeviceIdentity.swift
@@ -21,11 +21,25 @@ enum DeviceIdentity {
         "sh/wendy/\(organizationID)/\(assetID)"
     }
 
+    /// The authoritative Wendy identity URN for a device (asset):
+    /// `urn:wendy:org:<org>:asset:<assetID>`. This is placed in the CSR as a URI
+    /// SAN and is what `OrgIdentity.identity(fromLeaf:)` prefers over the
+    /// CommonName. Mirrors the Go agent's `certs.AssetURN`.
+    static func assetURN(organizationID: Int32, assetID: Int32) -> String {
+        "urn:wendy:org:\(organizationID):asset:\(assetID)"
+    }
+
     /// A PEM-encoded PKCS#10 CSR for `commonName`, signed with the given key.
     /// Requests digitalSignature key usage (critical) and clientAuth+serverAuth
     /// EKUs so the device identity can act as both a TLS client to the cloud and
-    /// a TLS server for the agent's gRPC endpoint.
-    static func generateCSRPEM(privateKeyPEM: String, commonName: String) throws -> String {
+    /// a TLS server for the agent's gRPC endpoint. `identityURN`, when non-empty,
+    /// is added as a URI SAN carrying the authoritative Wendy identity (build it
+    /// with `assetURN(organizationID:assetID:)`).
+    static func generateCSRPEM(
+        privateKeyPEM: String,
+        commonName: String,
+        identityURN: String
+    ) throws -> String {
         let privateKey = try Certificate.PrivateKey(pemEncoded: privateKeyPEM)
 
         let subject = try DistinguishedName {
@@ -37,6 +51,9 @@ enum DeviceIdentity {
                 KeyUsage(digitalSignature: true)
             )
             try ExtendedKeyUsage([.clientAuth, .serverAuth])
+            if !identityURN.isEmpty {
+                SubjectAlternativeNames([.uniformResourceIdentifier(identityURN)])
+            }
         }
 
         let attributes = try CertificateSigningRequest.Attributes([

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ProvisioningService.swift
@@ -111,11 +111,16 @@ actor ProvisioningService: Wendy_Agent_Services_V1_WendyProvisioningService.Simp
             organizationID: request.organizationID,
             assetID: request.assetID
         )
+        let identityURN = DeviceIdentity.assetURN(
+            organizationID: request.organizationID,
+            assetID: request.assetID
+        )
         let csrPEM: String
         do {
             csrPEM = try DeviceIdentity.generateCSRPEM(
                 privateKeyPEM: keyPEM,
-                commonName: commonName
+                commonName: commonName,
+                identityURN: identityURN
             )
         } catch {
             throw RPCError(code: .internalError, message: "failed to generate CSR: \(error)")

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/DeviceIdentityTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/DeviceIdentityTests.swift
@@ -21,12 +21,20 @@ struct DeviceIdentityTests {
         #expect(DeviceIdentity.commonName(organizationID: 7, assetID: 42) == "sh/wendy/7/42")
     }
 
+    @Test("asset URN matches the Go format")
+    func assetURNFormat() {
+        #expect(
+            DeviceIdentity.assetURN(organizationID: 7, assetID: 42) == "urn:wendy:org:7:asset:42"
+        )
+    }
+
     @Test("CSR has the expected subject, critical keyUsage, and both EKUs")
     func csrExtensions() throws {
         let keyPEM = try DeviceIdentity.generatePrivateKeyPEM()
         let csrPEM = try DeviceIdentity.generateCSRPEM(
             privateKeyPEM: keyPEM,
-            commonName: "sh/wendy/7/42"
+            commonName: "sh/wendy/7/42",
+            identityURN: DeviceIdentity.assetURN(organizationID: 7, assetID: 42)
         )
         #expect(csrPEM.contains("BEGIN CERTIFICATE REQUEST"))
 
@@ -44,5 +52,44 @@ struct DeviceIdentityTests {
         let eku = try #require(try exts.extendedKeyUsage)
         #expect(eku.contains(.clientAuth))
         #expect(eku.contains(.serverAuth))
+    }
+
+    @Test("CSR carries the identity URN as a URI SAN that OrgIdentity reads back")
+    func csrIdentityURN() throws {
+        let keyPEM = try DeviceIdentity.generatePrivateKeyPEM()
+        let urn = DeviceIdentity.assetURN(organizationID: 7, assetID: 42)
+        let csrPEM = try DeviceIdentity.generateCSRPEM(
+            privateKeyPEM: keyPEM,
+            commonName: "sh/wendy/7/42",
+            identityURN: urn
+        )
+
+        let csr = try CertificateSigningRequest(pemEncoded: csrPEM)
+        let exts = try #require(csr.attributes.extensionRequest?.extensions)
+        let sans = try #require(try exts.subjectAlternativeNames)
+        let uris = sans.compactMap { name -> String? in
+            if case .uniformResourceIdentifier(let uri) = name { return uri }
+            return nil
+        }
+        #expect(uris == [urn])
+
+        // OrgIdentity resolves the SAN as the authoritative asset identity. Wrap
+        // the CSR's SANs in a self-signed leaf so the shared reader path is used.
+        let privateKey = try Certificate.PrivateKey(pemEncoded: keyPEM)
+        let leaf = try Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: privateKey.publicKey,
+            notValidBefore: Date(timeIntervalSince1970: 0),
+            notValidAfter: Date(timeIntervalSince1970: 4_000_000_000),
+            issuer: try DistinguishedName { CommonName("test") },
+            subject: try DistinguishedName { CommonName("sh/wendy/7/42") },
+            extensions: try Certificate.Extensions {
+                SubjectAlternativeNames([.uniformResourceIdentifier(urn)])
+            },
+            issuerPrivateKey: privateKey
+        )
+        let identity = try #require(try OrgIdentity.identity(fromLeaf: leaf))
+        #expect(identity == OrgIdentity.WendyIdentity(orgID: 7, entityType: "asset", entityID: "42"))
     }
 }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/DeviceIdentityTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/DeviceIdentityTests.swift
@@ -90,6 +90,7 @@ struct DeviceIdentityTests {
             issuerPrivateKey: privateKey
         )
         let identity = try #require(try OrgIdentity.identity(fromLeaf: leaf))
-        #expect(identity == OrgIdentity.WendyIdentity(orgID: 7, entityType: "asset", entityID: "42"))
+        let expected = OrgIdentity.WendyIdentity(orgID: 7, entityType: "asset", entityID: "42")
+        #expect(identity == expected)
     }
 }


### PR DESCRIPTION
## What

Make the CLI and agent CSRs carry the authoritative Wendy identity as a URI Subject Alternative Name — `urn:wendy:org:<org>:user:<userID>` for user (CLI) certs and `urn:wendy:org:<org>:asset:<assetID>` for device/agent certs.

## Why

The identity format already existed and was **preferred** on the reading side (`certs.IdentityFromCert` in Go, `OrgIdentity` in Swift both resolve a `urn:wendy:org:` URI SAN over the legacy `sh/wendy/<org>/<asset>` CommonName). But nothing ever **wrote** it — every CSR set only the Subject CommonName, so the authoritative SAN was never present in issued certs.

## Changes

**Go**
- `certs.GenerateCSR` gains an `identityURN` parameter that populates a URI SAN (empty string omits it). New `certs.UserURN` / `certs.AssetURN` helpers centralize the URN format (reusing `WendyIdentity.IdentityKey`).
- CLI user login builds the user URN from the enrollment-token claims (`enrollmentTokenCommonName` → `enrollmentTokenIdentity`).
- CLI dev/local login, `os provision`, and the Go agent provisioning path build the asset URN.
- Cert refresh carries the stored org/user/asset identity forward as the SAN.

**Swift**
- `DeviceIdentity.generateCSRPEM` adds a `SubjectAlternativeNames` URI, plus a `DeviceIdentity.assetURN` helper mirroring the Go format.

## Tests

- Go: `TestGenerateCSRIncludesIdentityURN` asserts both user and asset URNs round-trip back through `IdentityFromCert`; `enrollmentTokenIdentity` tests cover the URN derivation.
- Swift: `DeviceIdentityTests` assert the CSR carries the URI SAN and that `OrgIdentity` reads it back as the asset identity.

All Go tests (`certs`, `cli/commands`, `agent/services`) and the Swift `DeviceIdentity` suite pass; `gofmt`/`go vet` clean.

## Coordinated server change

The cloud certificate service validates this SAN against the enrollment-token / mTLS identity at issuance time. The corresponding backend change lands alongside this one; they should be merged together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123Qu4xWexYo7DHuvyptySN
