### PR TITLE
feat(auth): prompt re-login on expired cloud session

### DIFF
--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -419,7 +419,19 @@ func newAuthRefreshCertsCmd() *cobra.Command {
 		Short: "Refresh mTLS certificates",
 		Long:  "Generates a new key pair and CSR, then issues new certificates using existing credentials.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return refreshAllCerts(cmd.Context())
+			ctx := cmd.Context()
+			err := refreshAllCerts(ctx)
+			if err == nil {
+				return nil
+			}
+			// An expired/absent session cannot be fixed by refreshing (there is no
+			// valid identity to refresh with) — offer to log in again instead, which
+			// issues fresh certificates directly.
+			if offerReloginOnUnauthenticated(ctx, firstAuthEntryForRelogin(), err) {
+				fmt.Println(tui.SuccessMessage("Logged in again and issued fresh certificates."))
+				return nil
+			}
+			return err
 		},
 	}
 }
@@ -439,6 +451,7 @@ func refreshAllCerts(ctx context.Context) error {
 	}
 
 	refreshed := 0
+	var lastErr error
 	for i, auth := range cfg.Auth {
 		if len(auth.Certificates) == 0 {
 			fmt.Println(tui.WarningMessage(fmt.Sprintf("Skipping %s: no certificates to refresh", auth.CloudDashboard)))
@@ -449,6 +462,7 @@ func refreshAllCerts(ctx context.Context) error {
 
 		if err := refreshCertsForAuth(ctx, &cfg.Auth[i]); err != nil {
 			fmt.Println(tui.ErrorMessage(fmt.Sprintf("Failed to refresh for %s: %v", auth.CloudDashboard, err)))
+			lastErr = err
 			continue
 		}
 
@@ -461,9 +475,32 @@ func refreshAllCerts(ctx context.Context) error {
 	}
 
 	if refreshed == 0 {
+		// Preserve the underlying failure (e.g. an unauthorized CertificateError)
+		// so the caller can detect an expired session and offer re-login.
+		if lastErr != nil {
+			return lastErr
+		}
 		return fmt.Errorf("no certificates were refreshed")
 	}
 	return nil
+}
+
+// firstAuthEntryForRelogin returns the stored auth entry a re-login should target
+// — the default session when one is set, otherwise the first entry — or nil when
+// there is nothing stored (the caller then falls back to the built-in defaults).
+func firstAuthEntryForRelogin() *config.AuthConfig {
+	cfg, err := config.Load()
+	if err != nil || len(cfg.Auth) == 0 {
+		return nil
+	}
+	if cfg.DefaultCloudGRPC != "" {
+		for i := range cfg.Auth {
+			if cfg.Auth[i].CloudGRPC == cfg.DefaultCloudGRPC {
+				return &cfg.Auth[i]
+			}
+		}
+	}
+	return &cfg.Auth[0]
 }
 
 // certCommonName extracts the Subject CN from a PEM-encoded certificate.
@@ -540,6 +577,14 @@ func refreshCertsForAuth(ctx context.Context, auth *config.AuthConfig) error {
 	})
 	if err != nil {
 		return fmt.Errorf("refreshing certificate: %w", err)
+	}
+
+	// The cloud reports refresh failures via a structured error field on an
+	// otherwise-successful response (not a gRPC status). Surface its code/message
+	// so the caller can react — an unauthorized code means the session expired and
+	// the user should log in again — instead of the generic "no certificate" below.
+	if respErr := refreshResp.GetError(); respErr != nil {
+		return cloudCertError{code: respErr.GetCode(), message: respErr.GetMessage()}
 	}
 
 	cert := refreshResp.GetCertificate()

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -406,8 +406,28 @@ func resolveCloudAsset(assets []*cloudpb.Asset, deviceName string) (*cloudpb.Ass
 }
 
 func pickCloudDevice(ctx context.Context, auth *config.AuthConfig, deviceName, brokerURL string) (*cloudpb.Asset, error) {
+	return pickCloudDeviceWithRelogin(ctx, auth, deviceName, brokerURL, true)
+}
+
+// pickCloudDeviceWithRelogin lists the org's cloud devices and lets the user
+// pick one. When the cloud rejects the session as unauthenticated and allowRelogin
+// is set, it offers to log in again (the spinner has already exited, so the
+// terminal is free for the prompt) and retries once with the fresh credentials.
+func pickCloudDeviceWithRelogin(ctx context.Context, auth *config.AuthConfig, deviceName, brokerURL string, allowRelogin bool) (*cloudpb.Asset, error) {
 	if len(auth.Certificates) == 0 {
 		return nil, fmt.Errorf("auth entry has no certificates; re-run 'wendy auth login'")
+	}
+
+	retryAfterRelogin := func(cause error) (*cloudpb.Asset, error, bool) {
+		if !allowRelogin || !offerReloginOnUnauthenticated(ctx, auth, cause) {
+			return nil, nil, false
+		}
+		fresh := reloadAuthEntry(auth)
+		if fresh == nil {
+			return nil, nil, false
+		}
+		asset, err := pickCloudDeviceWithRelogin(ctx, fresh, deviceName, brokerURL, false)
+		return asset, err, true
 	}
 
 	var assets []*cloudpb.Asset
@@ -426,12 +446,18 @@ func pickCloudDevice(ctx context.Context, auth *config.AuthConfig, deviceName, b
 			return nil, ErrUserCancelled
 		}
 		if fetchErr != nil {
+			if asset, err, handled := retryAfterRelogin(fetchErr); handled {
+				return asset, err
+			}
 			return nil, fetchErr
 		}
 	} else {
 		var err error
 		assets, err = fetchCloudAssets(ctx, auth)
 		if err != nil {
+			if asset, rerr, handled := retryAfterRelogin(err); handled {
+				return asset, rerr
+			}
 			return nil, err
 		}
 	}

--- a/go/internal/cli/commands/helpers_cloudauth.go
+++ b/go/internal/cli/commands/helpers_cloudauth.go
@@ -1,0 +1,125 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// cloudCertError wraps the structured CertificateError that the cloud returns in
+// a *successful* RPC response body. IssueCertificate and RefreshCertificate
+// report failures this way (an error field on the response) rather than as a
+// gRPC status, so the machine-readable code would otherwise be lost when the
+// caller only inspects the certificate field. Carrying the code lets callers
+// distinguish an expired/absent session (unauthorized) from other failures.
+type cloudCertError struct {
+	code    cloudpb.CertificateErrorCode
+	message string
+}
+
+func (e cloudCertError) Error() string {
+	if e.message != "" {
+		return e.message
+	}
+	return e.code.String()
+}
+
+// isUnauthenticatedCloudError reports whether err indicates the cloud rejected
+// the caller's identity — an expired or missing session — for which logging in
+// again is the remedy. It matches both the gRPC Unauthenticated status code
+// (transport-level rejection) and the structured CertificateError unauthorized
+// code carried in a response body.
+func isUnauthenticatedCloudError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ce cloudCertError
+	if errors.As(err, &ce) {
+		return ce.code == cloudpb.CertificateErrorCode_CERTIFICATE_ERROR_UNAUTHORIZED
+	}
+	// Unwrap toward a gRPC status; status.FromError does not unwrap %w chains on
+	// every grpc-go version, so walk the chain ourselves.
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if se, ok := e.(interface{ GRPCStatus() *status.Status }); ok {
+			return se.GRPCStatus().Code() == codes.Unauthenticated
+		}
+	}
+	return false
+}
+
+// loginTargetsForAuth returns the (dashboard, gRPC) endpoints to re-authenticate
+// against, preferring the failed auth entry's own endpoints and falling back to
+// the built-in defaults. The dashboard is normalized to include a scheme so the
+// browser-login flow can open it.
+func loginTargetsForAuth(auth *config.AuthConfig) (dashboard, grpc string) {
+	dashboard = defaultCloudDashboard
+	grpc = defaultCloudGRPC
+	if auth != nil {
+		if auth.CloudDashboard != "" {
+			dashboard = auth.CloudDashboard
+		}
+		if auth.CloudGRPC != "" {
+			grpc = auth.CloudGRPC
+		}
+	}
+	if !strings.HasPrefix(dashboard, "http://") && !strings.HasPrefix(dashboard, "https://") {
+		dashboard = "https://" + dashboard
+	}
+	return dashboard, grpc
+}
+
+// reloadAuthEntry re-reads the stored auth entry matching prev (by gRPC
+// endpoint) after a re-login replaced its certificates, so a retry uses the
+// fresh credentials rather than the stale pointer the caller still holds.
+// Returns nil when nothing matches.
+func reloadAuthEntry(prev *config.AuthConfig) *config.AuthConfig {
+	if prev == nil {
+		return nil
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return nil
+	}
+	for i := range cfg.Auth {
+		if cfg.Auth[i].CloudGRPC == prev.CloudGRPC {
+			return &cfg.Auth[i]
+		}
+	}
+	return nil
+}
+
+// performLoginFn is the login entry point, indirected so tests can stub it.
+var performLoginFn = performLogin
+
+// offerReloginOnUnauthenticated detects an unauthenticated cloud error (an
+// expired or missing session) and, in an interactive terminal, tells the user
+// their session expired and offers to run the login flow. It returns true only
+// when the user accepted and a fresh login succeeded — in which case the caller
+// may proceed or retry with the new credentials. Non-interactive or JSON runs
+// never prompt (they surface the original error to the caller unchanged).
+func offerReloginOnUnauthenticated(ctx context.Context, auth *config.AuthConfig, err error) bool {
+	if !isUnauthenticatedCloudError(err) {
+		return false
+	}
+	if jsonOutput || !isInteractiveTerminal() {
+		return false
+	}
+	fmt.Fprintln(os.Stderr, tui.WarningMessage("Your session has expired. You need to log in again."))
+	if !confirmFn("Log in again now?") {
+		return false
+	}
+	dashboard, grpc := loginTargetsForAuth(auth)
+	if lerr := performLoginFn(ctx, dashboard, grpc); lerr != nil {
+		fmt.Fprintln(os.Stderr, tui.ErrorMessage(fmt.Sprintf("Login failed: %v", lerr)))
+		return false
+	}
+	return true
+}

--- a/go/internal/cli/commands/helpers_cloudauth_test.go
+++ b/go/internal/cli/commands/helpers_cloudauth_test.go
@@ -1,0 +1,175 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsUnauthenticatedCloudError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{
+			name: "structured unauthorized cert error",
+			err:  cloudCertError{code: cloudpb.CertificateErrorCode_CERTIFICATE_ERROR_UNAUTHORIZED, message: "no valid client certificate identity"},
+			want: true,
+		},
+		{
+			name: "structured unauthorized wrapped in %w",
+			err:  fmt.Errorf("refreshing certificate: %w", cloudCertError{code: cloudpb.CertificateErrorCode_CERTIFICATE_ERROR_UNAUTHORIZED}),
+			want: true,
+		},
+		{
+			name: "structured cert error with a different code",
+			err:  cloudCertError{code: cloudpb.CertificateErrorCode_CERTIFICATE_ERROR_INVALID_CSR},
+			want: false,
+		},
+		{
+			name: "gRPC Unauthenticated status",
+			err:  status.Error(codes.Unauthenticated, "identity required"),
+			want: true,
+		},
+		{
+			name: "gRPC Unauthenticated wrapped in %w",
+			err:  fmt.Errorf("listing devices: %w", status.Error(codes.Unauthenticated, "identity required")),
+			want: true,
+		},
+		{
+			name: "gRPC PermissionDenied is not unauthenticated",
+			err:  status.Error(codes.PermissionDenied, "forbidden"),
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUnauthenticatedCloudError(tc.err); got != tc.want {
+				t.Errorf("isUnauthenticatedCloudError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoginTargetsForAuth(t *testing.T) {
+	t.Run("nil falls back to defaults", func(t *testing.T) {
+		dash, grpc := loginTargetsForAuth(nil)
+		if dash != defaultCloudDashboard || grpc != defaultCloudGRPC {
+			t.Errorf("got (%q, %q), want defaults (%q, %q)", dash, grpc, defaultCloudDashboard, defaultCloudGRPC)
+		}
+	})
+	t.Run("prefers the auth entry endpoints and adds a scheme", func(t *testing.T) {
+		dash, grpc := loginTargetsForAuth(&config.AuthConfig{CloudDashboard: "cloud.example.com", CloudGRPC: "grpc.example.com:443"})
+		if dash != "https://cloud.example.com" {
+			t.Errorf("dashboard = %q, want https-prefixed", dash)
+		}
+		if grpc != "grpc.example.com:443" {
+			t.Errorf("grpc = %q", grpc)
+		}
+	})
+}
+
+// withStubbedReloginDeps swaps the package vars the re-login flow depends on and
+// restores them via t.Cleanup, so tests can drive the prompt deterministically.
+func withStubbedReloginDeps(t *testing.T, interactive, json, confirm bool, login func(ctx context.Context, dashboard, grpc string) error) {
+	t.Helper()
+	origInteractive := isInteractiveTerminalFn
+	origJSON := jsonOutput
+	origConfirm := confirmFn
+	origLogin := performLoginFn
+	t.Cleanup(func() {
+		isInteractiveTerminalFn = origInteractive
+		jsonOutput = origJSON
+		confirmFn = origConfirm
+		performLoginFn = origLogin
+	})
+	isInteractiveTerminalFn = func() bool { return interactive }
+	jsonOutput = json
+	confirmFn = func(string) bool { return confirm }
+	performLoginFn = login
+}
+
+func TestOfferReloginOnUnauthenticated(t *testing.T) {
+	unauth := cloudCertError{code: cloudpb.CertificateErrorCode_CERTIFICATE_ERROR_UNAUTHORIZED}
+
+	t.Run("non-unauthenticated error never prompts", func(t *testing.T) {
+		called := false
+		withStubbedReloginDeps(t, true, false, true, func(context.Context, string, string) error { called = true; return nil })
+		if offerReloginOnUnauthenticated(context.Background(), nil, errors.New("boom")) {
+			t.Error("expected false for a non-auth error")
+		}
+		if called {
+			t.Error("login must not run for a non-auth error")
+		}
+	})
+
+	t.Run("json mode does not prompt", func(t *testing.T) {
+		called := false
+		withStubbedReloginDeps(t, true, true, true, func(context.Context, string, string) error { called = true; return nil })
+		if offerReloginOnUnauthenticated(context.Background(), nil, unauth) {
+			t.Error("expected false in json mode")
+		}
+		if called {
+			t.Error("login must not run in json mode")
+		}
+	})
+
+	t.Run("non-interactive does not prompt", func(t *testing.T) {
+		called := false
+		withStubbedReloginDeps(t, false, false, true, func(context.Context, string, string) error { called = true; return nil })
+		if offerReloginOnUnauthenticated(context.Background(), nil, unauth) {
+			t.Error("expected false when non-interactive")
+		}
+		if called {
+			t.Error("login must not run when non-interactive")
+		}
+	})
+
+	t.Run("user declines the prompt", func(t *testing.T) {
+		called := false
+		withStubbedReloginDeps(t, true, false, false, func(context.Context, string, string) error { called = true; return nil })
+		if offerReloginOnUnauthenticated(context.Background(), nil, unauth) {
+			t.Error("expected false when the user declines")
+		}
+		if called {
+			t.Error("login must not run when declined")
+		}
+	})
+
+	t.Run("accepted and login succeeds", func(t *testing.T) {
+		var gotDash, gotGRPC string
+		withStubbedReloginDeps(t, true, false, true, func(_ context.Context, dash, grpc string) error {
+			gotDash, gotGRPC = dash, grpc
+			return nil
+		})
+		auth := &config.AuthConfig{CloudDashboard: "https://cloud.wendy.dev", CloudGRPC: "grpc.wendy.dev:443"}
+		if !offerReloginOnUnauthenticated(context.Background(), auth, unauth) {
+			t.Error("expected true after a successful re-login")
+		}
+		if gotDash != "https://cloud.wendy.dev" || gotGRPC != "grpc.wendy.dev:443" {
+			t.Errorf("login targeted (%q, %q), want the auth entry's endpoints", gotDash, gotGRPC)
+		}
+	})
+
+	t.Run("accepted but login fails", func(t *testing.T) {
+		withStubbedReloginDeps(t, true, false, true, func(context.Context, string, string) error {
+			return errors.New("browser flow cancelled")
+		})
+		if offerReloginOnUnauthenticated(context.Background(), nil, unauth) {
+			t.Error("expected false when the login flow fails")
+		}
+	})
+}


### PR DESCRIPTION
## What

When the cloud rejects a session as **unauthenticated**, the CLI now tells the user their session expired and offers to log in again `[Y/n]`, runs the browser login flow, and retries once with the fresh credentials.

## Why

Two failure modes were opaque:

1. `wendy auth refresh-certs` printed **"no certificate returned from refresh"** — the CLI discarded the structured `CertificateError` the cloud returns in the response body (`RefreshCertificate` reports failures there, not as a gRPC status).
2. A stored cert whose identity fields are empty (certs issued before the identity URI SAN) makes `certXFCC` send **no** `x-wendy-client-cert` header, so the server rejects it as `unauthorized`. Refreshing can't fix that — there's no valid identity to refresh *with*. The remedy is a fresh login.

## How

- **`helpers_cloudauth.go`** (new): `cloudCertError` (carries the structured code), `isUnauthenticatedCloudError` (matches gRPC `Unauthenticated` **and** structured `CERTIFICATE_ERROR_UNAUTHORIZED`, unwrapping `%w` chains), `offerReloginOnUnauthenticated` (interactive + non-JSON only → "Your session has expired…" → `[Y/n]` → `performLogin`), plus `loginTargetsForAuth` / `reloadAuthEntry`.
- **`auth.go`**: `refreshCertsForAuth` surfaces the structured error; `refreshAllCerts` propagates the real cause; `refresh-certs` offers re-login on an expired session.
- **`cloud_tunnel.go`**: `pickCloudDevice` offers re-login + a bounded one-shot retry with fresh creds — wired *after* the fetch spinner exits so it never collides with an active TUI.
- **`helpers_cloudauth_test.go`** (new): covers the detector, login-target selection, and every prompt gate (non-auth error, JSON, non-interactive, decline, accept+success, accept+login-fail).

## Verification

- `go build ./...` and `go vet ./internal/cli/commands/` — clean.
- Full `go test ./internal/cli/commands/` — pass (incl. new tests, no regressions).

## Related

The re-login flow works end-to-end only once the cloud CAS config-mode fix ships: wendylabsinc/cloud#284 (login is currently blocked by an HTTP 400 there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)