### PR TITLE
fix: preserve cloud tunnel half-closes

### DIFF
--- a/Examples/HelloPython/app.py
+++ b/Examples/HelloPython/app.py
@@ -9,12 +9,18 @@ import os
 import socket
 
 class HelloWorldHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def send_body(self, status, content_type, body):
+        payload = body.encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-type', content_type)
+        self.send_header('Content-Length', str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
     def do_GET(self):
         if self.path == '/':
-            self.send_response(200)
-            self.send_header('Content-type', 'text/html')
-            self.end_headers()
-            
             html_content = """
             <!DOCTYPE html charset="utf-8">
             <html lang="en">
@@ -48,67 +54,47 @@ class HelloWorldHandler(BaseHTTPRequestHandler):
             </body>
             </html>
             """
-            self.wfile.write(html_content.encode())
+            self.send_body(200, 'text/html', html_content)
             
         elif self.path == '/api/hello':
-            self.send_response(200)
-            self.send_header('Content-type', 'application/json')
-            self.end_headers()
-            
             response = {
                 "message": "Hello World!",
                 "status": "success",
                 "server": "Python HTTP Server"
             }
-            self.wfile.write(json.dumps(response, indent=2).encode())
+            self.send_body(200, 'application/json', json.dumps(response, indent=2))
             
         elif self.path == '/health':
-            self.send_response(200)
-            self.send_header('Content-type', 'application/json')
-            self.end_headers()
-            
             health_response = {
                 "status": "healthy",
                 "message": "Server is running"
             }
-            self.wfile.write(json.dumps(health_response).encode())
+            self.send_body(200, 'application/json', json.dumps(health_response))
             
         else:
-            self.send_response(404)
-            self.send_header('Content-type', 'application/json')
-            self.end_headers()
-            
             error_response = {
                 "error": "Not Found",
                 "message": f"Path {self.path} not found"
             }
-            self.wfile.write(json.dumps(error_response).encode())
+            self.send_body(404, 'application/json', json.dumps(error_response))
 
     def do_POST(self):
         if self.path == '/api/echo':
             content_length = int(self.headers['Content-Length'])
             post_data = self.rfile.read(content_length)
             
-            self.send_response(200)
-            self.send_header('Content-type', 'application/json')
-            self.end_headers()
-            
             response = {
                 "message": "Echo endpoint",
                 "received_data": post_data.decode('utf-8'),
                 "status": "success"
             }
-            self.wfile.write(json.dumps(response, indent=2).encode())
+            self.send_body(200, 'application/json', json.dumps(response, indent=2))
         else:
-            self.send_response(404)
-            self.send_header('Content-type', 'application/json')
-            self.end_headers()
-            
             error_response = {
                 "error": "Not Found",
                 "message": f"POST endpoint {self.path} not found"
             }
-            self.wfile.write(json.dumps(error_response).encode())
+            self.send_body(404, 'application/json', json.dumps(error_response))
 
     def log_message(self, format, *args):
         print(f"[{self.date_time_string()}] {format % args}", flush=True)

--- a/go/internal/agent/services/tunnel_broker_client.go
+++ b/go/internal/agent/services/tunnel_broker_client.go
@@ -303,8 +303,14 @@ func (c *TunnelBrokerClient) handleDialRequest(ctx context.Context, client cloud
 	c.relay(callCtx, cancel, tcpConn, agentStream)
 }
 
+type agentTunnelStream interface {
+	Send(*cloudpb.TunnelData) error
+	Recv() (*cloudpb.TunnelData, error)
+	CloseSend() error
+}
+
 func (c *TunnelBrokerClient) relay(ctx context.Context, cancel context.CancelFunc,
-	tcpConn net.Conn, stream cloudpb.TunnelBrokerService_AgentTunnelClient) {
+	tcpConn net.Conn, stream agentTunnelStream) {
 	done := make(chan struct{}, 2)
 
 	// gRPC -> TCP
@@ -354,10 +360,15 @@ func (c *TunnelBrokerClient) relay(ctx context.Context, cancel context.CancelFun
 		_ = stream.CloseSend()
 	}()
 
-	select {
-	case <-done:
-		cancel()
-	case <-ctx.Done():
+	// A clean half-close in either direction must not tear down the other
+	// direction before its final frames have reached the broker or backend.
+	for completed := 0; completed < 2; completed++ {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			cancel()
+			<-done
+			return
+		}
 	}
-	<-done
 }

--- a/go/internal/agent/services/tunnel_broker_client_test.go
+++ b/go/internal/agent/services/tunnel_broker_client_test.go
@@ -1,0 +1,103 @@
+package services
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+type testAgentTunnelStream struct {
+	ctx      context.Context
+	received chan *cloudpb.TunnelData
+	sent     chan *cloudpb.TunnelData
+}
+
+func (s *testAgentTunnelStream) Send(message *cloudpb.TunnelData) error {
+	copy := *message
+	copy.Payload = append([]byte(nil), message.Payload...)
+	select {
+	case s.sent <- &copy:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
+}
+
+func (s *testAgentTunnelStream) Recv() (*cloudpb.TunnelData, error) {
+	select {
+	case message, ok := <-s.received:
+		if !ok {
+			return nil, io.EOF
+		}
+		return message, nil
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	}
+}
+
+func (s *testAgentTunnelStream) CloseSend() error { return nil }
+
+func TestTunnelBrokerRelayDoesNotCancelAfterBackendEOF(t *testing.T) {
+	ctx, cancelContext := context.WithCancel(context.Background())
+	defer cancelContext()
+
+	var cancelled atomic.Bool
+	cancel := func() {
+		cancelled.Store(true)
+		cancelContext()
+	}
+	stream := &testAgentTunnelStream{
+		ctx:      ctx,
+		received: make(chan *cloudpb.TunnelData),
+		sent:     make(chan *cloudpb.TunnelData, 4),
+	}
+	relayConn, backendConn := net.Pipe()
+	defer relayConn.Close()
+
+	client := &TunnelBrokerClient{}
+	relayDone := make(chan struct{})
+	go func() {
+		client.relay(ctx, cancel, relayConn, stream)
+		close(relayDone)
+	}()
+
+	const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"
+	go func() {
+		_, _ = backendConn.Write([]byte(response))
+		_ = backendConn.Close()
+	}()
+
+	var payload []byte
+	for {
+		select {
+		case message := <-stream.sent:
+			payload = append(payload, message.Payload...)
+			if message.HalfClose {
+				goto receivedHalfClose
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for agent half-close")
+		}
+	}
+
+receivedHalfClose:
+	if string(payload) != response {
+		t.Fatalf("relayed payload = %q, want %q", payload, response)
+	}
+	time.Sleep(25 * time.Millisecond)
+	if cancelled.Load() {
+		t.Fatal("relay cancelled the stream before the broker closed its direction")
+	}
+
+	close(stream.received)
+	select {
+	case <-relayDone:
+	case <-time.After(time.Second):
+		t.Fatal("relay did not finish after both directions closed")
+	}
+}

--- a/go/internal/agent/services/tunnel_broker_client_test.go
+++ b/go/internal/agent/services/tunnel_broker_client_test.go
@@ -18,10 +18,13 @@ type testAgentTunnelStream struct {
 }
 
 func (s *testAgentTunnelStream) Send(message *cloudpb.TunnelData) error {
-	copy := *message
-	copy.Payload = append([]byte(nil), message.Payload...)
+	messageCopy := &cloudpb.TunnelData{
+		SessionId: message.SessionId,
+		Payload:   append([]byte(nil), message.Payload...),
+		HalfClose: message.HalfClose,
+	}
 	select {
-	case s.sent <- &copy:
+	case s.sent <- messageCopy:
 		return nil
 	case <-s.ctx.Done():
 		return s.ctx.Err()


### PR DESCRIPTION
## Summary

Preserve TCP half-close semantics in the device agent cloud tunnel relay and make the HelloPython example emit explicit HTTP/1.1 response lengths.

## Root cause

The agent cancelled the shared gRPC context as soon as either relay direction completed. When a backend closed after writing its response, that cancellation could discard the final payload before the broker delivered it to the desktop tunnel.

## Changes

- wait for both relay directions during normal completion
- retain immediate cancellation when the parent context is cancelled
- add a regression test proving backend EOF does not cancel the broker direction
- add HTTP/1.1 and `Content-Length` framing to every HelloPython response

## Impact

HTTP services reached through `device-<id>.cloud.wendy.dev:<port>` can return their final response reliably instead of hanging or producing an empty response.

## Validation

- `go test ./go/internal/agent/services -count=1`
- `PYTHONPYCACHEPREFIX=/tmp/wendy-pycache python3 -m py_compile Examples/HelloPython/app.py`
- `git diff --check`
- deployed the agent and HelloPython example to device 294; `curl http://device-294.cloud.wendy.dev:8000/api/hello` returns the expected JSON response
