### PR TITLE
docs: refresh compose and ROS 2 docs, rewrite Foxglove page for shipped CLI

### DIFF
--- a/go/internal/cli/assets/docs/apps/compose.md
+++ b/go/internal/cli/assets/docs/apps/compose.md
@@ -1,16 +1,18 @@
 # Multi-Service Apps with Docker Compose
 
-Wendy supports running multi-service applications defined in a standard `docker-compose.yml` (or `compose.yml`) file. This is the recommended approach when your app needs more than one container — for example, an API service alongside a database, or a perception pipeline with several processing stages.
+Wendy supports running multi-service applications defined in a standard `docker-compose.yml` (or `compose.yml`) file. This is the recommended approach when your app needs more than one container, for example an API service alongside a database, or a perception pipeline with several processing stages.
 
 ## How it works
 
-When you run `wendy run` in a directory that contains a compose file but no `wendy.json`, Wendy automatically detects it as a compose project. Each service is built, pushed to the device's embedded container registry, and started in dependency order.
+When you run `wendy run` in a directory that contains a compose file, Wendy automatically detects it as a compose project. Each service is built, pushed to the device's embedded container registry, and started in dependency order. No `wendy.json` is required; each service carries its own configuration, and an optional companion `wendy.json` in the same directory is merged in when present (see [Readiness probes and postStart hooks](#readiness-probes-and-poststart-hooks)).
 
-Supported compose file names (checked in order):
+Supported compose file names (checked in order, first found wins):
 - `docker-compose.yml`
 - `docker-compose.yaml`
 - `compose.yml`
 - `compose.yaml`
+
+A compose file takes precedence over a `Dockerfile` in the same directory. To force the single-container Docker path instead, pass `--build-type docker` or `--dockerfile <path>`.
 
 ## Quickstart
 
@@ -43,7 +45,7 @@ services:
 wendy run
 ```
 
-Wendy selects a device, builds each service image, pushes them to the device, and starts them concurrently with interleaved log output. Each service's lines are prefixed with a color-coded, column-aligned service name. Colors rotate through cyan, yellow, green, magenta, blue, and red. Log lines are never interleaved mid-line — each line is written atomically:
+Wendy selects a device, builds each service image, pushes them to the device, and starts them concurrently with interleaved log output. Each service's lines are prefixed with a color-coded, column-aligned service name. Colors rotate through cyan, yellow, green, magenta, blue, and red. Log lines are never interleaved mid-line; each line is written atomically:
 
 ```
 [api]     Listening on :8080
@@ -74,9 +76,11 @@ Wendy honours the following compose fields. Fields not listed here are ignored.
 | `ports` | Port mappings (`host:container`). Adds a `network` entitlement when present. |
 | `network_mode: host` | Adds a `host` network entitlement. |
 | `volumes` | Named volumes are created as `persist` entitlements. Host bind mounts (paths starting with `.` or `/`) are silently skipped. |
-| `depends_on` | Dependency order: list or condition-map form. Services are created in dependency order; detached starts follow the same order, but the condition-map's own health-check conditions (e.g. `condition: service_healthy`) are not evaluated — ordering is purely topological. To gate a service's own postStart hook on its readiness instead, see [Readiness probes and postStart hooks](#readiness-probes-and-poststart-hooks). |
+| `depends_on` | Dependency order: list or condition-map form. Services are created in dependency order; detached starts follow the same order, but the condition-map's own health-check conditions (e.g. `condition: service_healthy`) are not evaluated; ordering is purely topological. To gate a service's own postStart hook on its readiness instead, see [Readiness probes and postStart hooks](#readiness-probes-and-poststart-hooks). |
 | `restart` | Restart policy: `no`, `on-failure`, `always`, `unless-stopped`. Overridden by CLI flags if specified. |
 | `x-wendy` | Wendy-specific per-service extensions: `readiness` (a readiness probe) and `hooks` (postStart hooks). Same camelCase schema as `wendy.json`'s top-level `readiness`/`hooks` fields. See [Readiness probes and postStart hooks](#readiness-probes-and-poststart-hooks) below. |
+
+The following fields are recognized but intentionally ignored, each with a warning at deploy time: `devices`, `privileged`, `cap_add`, `security_opt`, `ipc`, `pid`, `shm_size`, `healthcheck`, `profiles`, `secrets`, and `extra_hosts`. Hardware access goes through Wendy entitlements in a companion `wendy.json` instead. Anything else (such as `networks`, `deploy`, `entrypoint`, `env_file`, or long-form volume syntax) is ignored silently.
 
 ## Networking
 
@@ -100,7 +104,9 @@ services:
     volumes:
       - shared-data:/data/in
 
-# Named volumes must be declared at the top level
+# Declare named volumes at the top level so the file stays valid for
+# plain `docker compose` too. Wendy itself only reads the `services:`
+# block; the service-level references above are what create the storage.
 volumes:
   shared-data:
 ```
@@ -127,13 +133,13 @@ services:
           openURL: "http://${WENDY_HOSTNAME}:3000"
 ```
 
-`readiness` here gates only `frontend`'s own `postStart` hook — it never delays any other service's startup (`depends_on` ordering is unaffected). `hooks.postStart.agent` (a command run on the device) is attached only to the declaring service's own container.
+`readiness` here gates only `frontend`'s own `postStart` hook; it never delays any other service's startup (`depends_on` ordering is unaffected). `hooks.postStart.agent` (a command run on the device) is attached only to the declaring service's own container.
 
-A companion `wendy.json` in the same directory can also declare `services.<name>.readiness` / `services.<name>.hooks` for a service. When both are present, the companion wins wholesale per field — its `readiness` and `hooks` each replace the `x-wendy` value entirely rather than merging with it.
+A companion `wendy.json` in the same directory can also declare `services.<name>.readiness` / `services.<name>.hooks` for a service. When both are present, the companion wins wholesale per field: its `readiness` and `hooks` each replace the `x-wendy` value entirely rather than merging with it.
 
-A companion `wendy.json`'s *top-level* `readiness`/`hooks` act instead as an app-level fallback: they fire once after every service in the project has started, rather than gating any single service. Both the fallback and a service's own `x-wendy` hooks fire if both are declared. [Examples/WendyMC](../../Examples/WendyMC) is a live example of this: its companion `wendy.json` declares a top-level `readiness.tcpSocket` (port 8080) and `hooks.postStart.openURL`, so `wendy run` waits for the web UI to come up and opens it automatically once both of its services have started. A top-level `hooks.postStart.agent` is the one exception — a compose app has no app-level container to run an agent-side hook in, so it is ignored (with a warning); declare an agent-side hook under a service's `x-wendy.hooks` or the companion's `services.<name>.hooks` instead.
+A companion `wendy.json`'s *top-level* `readiness`/`hooks` act instead as an app-level fallback: they fire once after every service in the project has started, rather than gating any single service. Both the fallback and a service's own `x-wendy` hooks fire if both are declared. [Examples/WendyMC](../../Examples/WendyMC) is a live example of this: its companion `wendy.json` declares a top-level `readiness.tcpSocket` (port 8080) and `hooks.postStart.openURL`, so `wendy run` waits for the web UI to come up and opens it automatically once both of its services have started. A top-level `hooks.postStart.agent` is the one exception: a compose app has no app-level container to run an agent-side hook in, so it is ignored (with a warning); declare an agent-side hook under a service's `x-wendy.hooks` or the companion's `services.<name>.hooks` instead.
 
-In attached mode, each service's readiness→postStart sequence runs asynchronously right after that service's start is acknowledged, so a slow or failing probe never delays starting the next service; Ctrl-C cancels any in-flight readiness wait and kills `cli` hook child processes. In detached mode, readiness is waited sequentially in dependency order after every service has started; hooks outlive the CLI once it exits, and a readiness failure only prints a warning — it never fails the command.
+In attached mode, each service's readiness→postStart sequence runs asynchronously right after that service's start is acknowledged, so a slow or failing probe never delays starting the next service; Ctrl-C cancels any in-flight readiness wait and kills `cli` hook child processes. In detached mode, readiness is waited sequentially in dependency order after every service has started; hooks outlive the CLI once it exits, and a readiness failure only prints a warning; it never fails the command.
 
 Hook commands may reference `${WENDY_HOSTNAME}` (the device host), `${WENDY_APP_ID}`, and `${WENDY_SERVICE_NAME}` (the declaring service's name; empty for the app-level fallback). Windows-style `%VAR%` forms are accepted too.
 
@@ -162,3 +168,6 @@ All `wendy run` flags work with compose projects:
 - Host networking does not imply shared IPC or shared `/dev/shm`; ROS 2 shared-memory transport requires an app shape that can explicitly share namespaces.
 - Linux containers on macOS require a target WendyOS device; local Docker Desktop compose is used as a fallback when no device is targeted.
 - Compose `extends`, `profiles`, and `secrets` are not supported.
+- `wendy fleet run` does not support compose projects yet; deploy to one device at a time.
+- `wendy run --service` applies only to `wendy.json` `services` maps; the compose path always deploys every service.
+- `wendy build` for a compose project shells out to `docker compose build`. The Apple Container builder is not supported for compose; use `--builder docker`.

--- a/go/internal/cli/assets/docs/guides/multi-app-deployments.mdx
+++ b/go/internal/cli/assets/docs/guides/multi-app-deployments.mdx
@@ -1,6 +1,6 @@
 ---
 title: Multi-App Deployments
-description: Run cooperating multi-container stacks on WendyOS from a single wendy.json — with one Dockerfile per service or a companion docker-compose.yml
+description: Run cooperating multi-container stacks on WendyOS from a single wendy.json, with one Dockerfile per service or a companion docker-compose.yml
 ---
 
 ## Run a multi-container stack as one deployment
@@ -11,8 +11,8 @@ The recommended way to ship a stack like this is a **single `wendy.json` at the 
 
 You can shape that `wendy.json` two ways:
 
-- **One Dockerfile per service** — declare a `services` map directly in `wendy.json`, with each service pointing at its own build context. This is the default and gives you full access to Wendy-specific configuration (entitlements, isolation, frameworks).
-- **A companion to `docker-compose.yml`** — if you already have, or prefer, a `docker-compose.yml`, keep it and add a small companion `wendy.json` that layers Wendy-specific settings (such as GPU or network entitlements) on top of the services Compose already defines.
+- **One Dockerfile per service.** Declare a `services` map directly in `wendy.json`, with each service pointing at its own build context. This is the default and gives you full access to Wendy-specific configuration (entitlements, isolation, frameworks).
+- **A companion to `docker-compose.yml`.** If you already have, or prefer, a `docker-compose.yml`, keep it and add a small companion `wendy.json` that layers Wendy-specific settings (such as GPU or network entitlements) on top of the services Compose already defines.
 
 Both shapes deploy with the same command:
 
@@ -41,7 +41,7 @@ For a WendyOS device target, Wendy:
 2. Builds each service that has a `build:` directive for the target device platform.
 3. Pushes built images to the device's embedded registry.
 4. Uses declared `image:` references directly for services without `build:`.
-5. Generates one device app per service, named `<project-folder>-<service>`.
+5. Groups the services under one device app named after the project folder, with one container per service (`<project>_<service>`). A single-service compose project without a companion `wendy.json` keeps the legacy `<project>-<service>` app ID instead; a companion's `appId` always takes over.
 6. Creates service containers in `depends_on` order.
 7. Starts all services and streams logs with a `[service]` prefix.
 
@@ -50,7 +50,7 @@ For ROS 2, set `network_mode: host` on every service that needs DDS discovery, m
 </Callout>
 
 <Callout type="warning">
-Multi-service projects target Linux/WendyOS devices. Headless Mac does not run multi-container stacks — `wendy run` rejects them before any build when the selected target is a Mac.
+Multi-service projects target Linux/WendyOS devices. Headless Mac does not run multi-container stacks; `wendy run` rejects them before any build when the selected target is a Mac.
 </Callout>
 
 ## Recommended: one `wendy.json`, one Dockerfile per service
@@ -76,7 +76,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 CMD ["bash","-lc","source /opt/ros/humble/setup.bash && exec ros2 run demo_nodes_cpp talker"]
 ```
 
-The `wendy.json` declares both services, the start order, and — for ROS 2 — the framework and isolation settings the stack needs:
+The `wendy.json` declares both services, the start order, and, for ROS 2, the framework and isolation settings the stack needs:
 
 ```json
 {
@@ -99,8 +99,8 @@ The `wendy.json` declares both services, the start order, and — for ROS 2 — 
 
 What this gives you:
 
-- **`frameworks.ros2`** auto-injects `ROS_DOMAIN_ID` and `RMW_IMPLEMENTATION` into every service container, so you do not hand-set ROS environment variables per service.
-- **`isolation: "shared-ipc"`** shares the network and IPC namespaces plus `/dev/shm` across all services, so CycloneDDS can use zero-copy intra-host transport — something host networking alone cannot provide.
+- **`frameworks.ros2`** auto-injects `ROS_DOMAIN_ID`, `RMW_IMPLEMENTATION`, and `ROS_LOCALHOST_ONLY=1` into every service container, so you do not hand-set ROS environment variables per service. Omit `domainId` and each app gets a stable domain derived from its `appId`, so unrelated apps never share a domain by accident.
+- **`isolation: "shared-ipc"`** shares the network and IPC namespaces plus `/dev/shm` across all services. With DDS pinned to localhost, a shared network namespace is what lets the services discover each other, and the shared `/dev/shm` is required for Fast DDS shared-memory transport. (CycloneDDS on WendyOS currently runs over loopback with its shared-memory transport disabled.)
 - **`dependsOn`** starts services in dependency order.
 
 Run the stack from the project root:
@@ -125,11 +125,11 @@ Press **Ctrl-C** to stop the stack. Wendy stops services in reverse dependency o
 Build and run only one service and its dependencies with `wendy run --service listener`. Wendy resolves the named service through its `dependsOn` graph and skips everything else.
 </Callout>
 
-For the full `services` schema — including per-service entitlements, `frameworks`, and validation rules — see [Multi-Service Apps with `wendy.json`](/docs/advanced/apps/wendy-services).
+For the full `services` schema, including per-service entitlements, `frameworks`, and validation rules, see [Multi-Service Apps with `wendy.json`](/docs/advanced/apps/wendy-services).
 
 ## Alternative: a companion `wendy.json` over `docker-compose.yml`
 
-If you already maintain a `docker-compose.yml`, keep it as the build plan and add a small `wendy.json` next to it. Compose defines the services, builds, ports, and dependency order; the companion `wendy.json` adds the Wendy-specific configuration that Compose does not express — such as GPU access or explicit network entitlements.
+If you already maintain a `docker-compose.yml`, keep it as the build plan and add a small `wendy.json` next to it. Compose defines the services, builds, ports, and dependency order; the companion `wendy.json` adds the Wendy-specific configuration that Compose does not express, such as GPU access or explicit network entitlements.
 
 ```text
 my-project/
@@ -155,7 +155,7 @@ services:
       - api
 ```
 
-The companion `wendy.json` references the same service names but omits build context (that comes from Compose). It only layers on Wendy settings — here, a GPU entitlement for `api`:
+The companion `wendy.json` references the same service names but omits build context (that comes from Compose). It only layers on Wendy settings, here a GPU entitlement for `api`:
 
 ```json
 {
@@ -172,7 +172,7 @@ The companion `wendy.json` references the same service names but omits build con
 }
 ```
 
-Deploy it the same way — Wendy detects the Compose project and merges the companion:
+Deploy it the same way. Wendy detects the Compose project and merges the companion:
 
 ```bash
 wendy run
@@ -200,7 +200,7 @@ For the full Compose field reference, see [Multi-Service Apps with Docker Compos
 
 ## Add persistent data
 
-Use named volumes for data that should survive redeployments — ROS bags, calibration files, generated maps. In a Compose-based project, declare them in `docker-compose.yml`:
+Use named volumes for data that should survive redeployments: ROS bags, calibration files, generated maps. In a Compose-based project, declare them in `docker-compose.yml`:
 
 ```yaml
 services:
@@ -245,16 +245,15 @@ For long-running robot stacks, start the services without attaching logs:
 wendy run --detach
 ```
 
-Generated app names use the project folder and service name. For the ROS 2 example above, the apps are `ros2-stack-talker` and `ros2-stack-listener`.
-
-Useful follow-up commands:
+The whole stack is one app on the device, named by its `appId` (for the ROS 2 example above, `sh.wendy.examples.ros2`), with one container per service. `wendy device apps list` shows the app as a group with a row per service, and app-level commands act on every service at once:
 
 ```bash
 wendy device apps list
-wendy device logs --app ros2-stack-talker
-wendy device apps stop ros2-stack-listener
-wendy device apps stop ros2-stack-talker
+wendy device logs sh.wendy.examples.ros2 --service talker
+wendy device apps stop sh.wendy.examples.ros2
 ```
+
+A compose project without a companion `wendy.json` is grouped the same way under the project folder name, except a single-service compose project, which keeps the legacy `<project>-<service>` app ID.
 
 <CliShot flow="apps-list" step="apps" alt="The Wendy CLI listing the deployed stack's apps with their version, state, and failure count" />
 
@@ -264,9 +263,9 @@ wendy device apps stop ros2-stack-talker
 
 Both shapes start from a single `wendy.json`. Pick by what your services need:
 
-- **One Dockerfile per service (`services` map).** The default. Use it when services need Wendy-specific configuration that Compose does not express — direct camera, GPU, audio, Bluetooth, USB, I2C, GPIO, SPI, shared IPC, runtime presets, framework injection, or service-specific files. Required for ROS 2 shared-memory transport via `"isolation": "shared-ipc"`.
+- **One Dockerfile per service (`services` map).** The default. Use it when services need Wendy-specific configuration that Compose does not express: direct camera, GPU, audio, Bluetooth, USB, I2C, GPIO, SPI, shared IPC, runtime presets, framework injection, or service-specific files. Required for ROS 2 shared-memory transport via `"isolation": "shared-ipc"`.
 - **Companion to `docker-compose.yml`.** Use it when you already have a Compose file or want to keep using Compose tooling, and only need to layer a few Wendy entitlements (GPU, network) on top.
 
 <Callout type="info">
-Service-specific readiness probes and `postStart` hooks are not available for multi-service stacks yet. Today, `hooks.postStart` applies to single-container `wendy.json` apps, so a stack cannot trigger a browser opener only after one `frontend` service becomes ready.
+Both shapes support service-scoped readiness probes and `postStart` hooks, so a stack can, for example, open a browser only after its `frontend` service becomes ready. In a `services` map, declare `services.<name>.readiness` and `services.<name>.hooks` (see [Multi-Service Apps with `wendy.json`](/docs/advanced/apps/wendy-services)); in a compose file, use the `x-wendy` extension per service (see [Multi-Service Apps with Docker Compose](/docs/advanced/apps/compose)).
 </Callout>

--- a/go/internal/cli/assets/docs/integrations/foxglove.mdx
+++ b/go/internal/cli/assets/docs/integrations/foxglove.mdx
@@ -1,39 +1,13 @@
 ---
 title: Wendy for Foxglove
-description: Bridge a WendyOS device's live ROS 2 topics into Foxglove Studio for real-time visualization, over the CLI's existing secure connection.
+description: Stream a WendyOS device's live ROS 2 topics into Foxglove Studio for real-time visualization, with a single command and nothing to install on the device by hand.
 ---
 
-<Callout type="warning">
-**Coming soon.** Wendy for Foxglove is in active development
-([PR #1165](https://github.com/wendylabsinc/WendyOS/pull/1165)) and not yet
-available in a released CLI. This page previews how it will work. Commands and
-flags may change before release.
-</Callout>
-
 Wendy for Foxglove turns a device's live ROS 2 graph into something you can *see*.
-The CLI hosts a [Foxglove WebSocket Protocol](https://foxglove.dev/) server on your
-machine and bridges it to the device's ROS 2 topics, so you can drop a Raw Message
-panel, plot a signal, or watch a camera feed update in real time — without
-installing anything on the device.
-
-## How it will work
-
-The server runs on your machine (default `127.0.0.1:8765`) and reaches the
-device's ROS 2 system over the existing mutually-authenticated gRPC connection.
-Your data never leaves your machine to a third party.
-
-```
-Foxglove Studio ──ws──► wendy CLI (host) ──gRPC (mTLS)──► wendy-agent ──exec──► ros2 sidecar
- (foxglove.websocket.v1)  foxglove server      ROS2Service          ros2 CLI  (shares app DDS domain)
-```
-
-The CLI discovers the device's ROS 2 topics, advertises them to Foxglove with the
-right encoding and schema, and forwards messages as they arrive — building on the
-same sidecar mechanism as [Wendy for ROS 2](/docs/integrations/ros2).
-
-## Usage (preview)
-
-Start the bridge against your default device:
+One command deploys the standard `foxglove_bridge` node to the device, joins it to
+the device's ROS 2 graph, and forwards its WebSocket port to your machine, so you
+can drop a Raw Message panel, plot a signal, or watch a camera feed update in real
+time.
 
 ```bash
 wendy device foxglove serve
@@ -48,25 +22,77 @@ ws://localhost:8765
 
 Discovered topics appear as channels you can add to any panel.
 
-Planned flags for `wendy device foxglove serve`:
+## How it works
+
+`wendy device foxglove serve` runs three steps for you:
+
+1. **Generates a bridge app.** The CLI writes a temporary app: a Dockerfile based
+   on `ros:<distro>` with the distro's `foxglove_bridge` package installed, and a
+   `wendy.json` with a `frameworks.ros2` block (your `--domain`, `--rmw`, and
+   `--distro`) plus a host-network entitlement. Host networking means the bridge
+   joins the device's whole ROS 2 graph, including a robot's native host ROS 2
+   (for example a Unitree Go2's onboard stack).
+2. **Deploys it.** The app ships through the normal `wendy run` pipeline: built
+   locally, pushed to the device, and started detached under the app ID
+   `sh.wendy.foxglovebridge`. Re-running the command first removes any previous
+   instance, so it is always safe to run again.
+3. **Forwards the port.** The bridge's WebSocket port (8765 inside the app) is
+   forwarded to your machine with `wendy cloud tunnel`, and the CLI prints the
+   `ws://localhost:<port>` URL to connect Foxglove Studio to.
+
+```
+Foxglove Studio --ws--> localhost:8765 --tunnel--> foxglove_bridge (device) --DDS--> your ROS 2 apps
+```
+
+## Prerequisites
+
+- The device must be enrolled with Wendy Cloud and you must be signed in, because
+  the port forward runs through the Wendy Cloud tunnel broker. See
+  [Wendy Cloud](/docs/cloud).
+- Docker on your development machine, so the CLI can build the bridge image.
+- A ROS 2 stack producing topics on the device (your own apps, or a robot's
+  native ROS 2 reachable over the host network).
+
+## Flags
 
 | Flag | Description |
 | --- | --- |
-| `--port` | WebSocket listen port (default `8765`). |
-| `--host` | Bind address (default `127.0.0.1`). |
-| `--domain` | `ROS_DOMAIN_ID` override (default: from the app's ROS 2 config). |
-| `--topic` | Restrict to specific topics; repeatable. Defaults to all topics. |
+| `--port` | Local port to forward the bridge's WebSocket to (default `8765`). |
+| `--domain` | `ROS_DOMAIN_ID` the device's ROS 2 uses (default `0`). |
+| `--rmw` | RMW implementation the device's ROS 2 uses (default `rmw_cyclonedds_cpp`). |
+| `--distro` | ROS 2 distro the bridge image is built from (default `humble`). |
 
-## Scope at launch
+The global `--device` flag selects a device, as with every other command.
 
-The first release is **read-only** — visualize live topics. It's the first of a
-planned three phases:
+<Callout type="warning">
+**Match the bridge to your app's domain.** An app whose `frameworks.ros2` omits
+`domainId` gets a stable auto-derived domain (a hash of its `appId`), not domain 0.
+The bridge always uses an explicit domain (`--domain`, default 0), so for apps
+using an auto-derived domain the bridge will not see their topics. The simplest
+setup: set an explicit `domainId` in your app's `wendy.json` and pass the same
+value with `--domain`.
+</Callout>
 
-- **Available at launch** — subscribe to and visualize live ROS 2 topics.
-- **Later** — Foxglove parameters and service-call support.
-- **Later** — publishing from Foxglove back to the device's topics.
+For a robot whose ROS 2 runs on a non-default domain or middleware, match the
+bridge to it:
 
-## In the meantime
+```bash
+wendy device foxglove serve --domain 42 --rmw rmw_cyclonedds_cpp
+```
 
-You can already inspect, echo, and record the same ROS 2 data from the CLI today
-with [Wendy for ROS 2](/docs/integrations/ros2).
+## Stopping and cleanup
+
+Press **Ctrl-C** to stop the port forward. The bridge app keeps running detached
+on the device. Run `serve` again at any time to redeploy and reconnect. To remove
+the bridge from the device entirely:
+
+```bash
+wendy device apps remove sh.wendy.foxglovebridge --force --cleanup
+```
+
+## Related
+
+- [Wendy for ROS 2](/docs/integrations/ros2) lets you inspect, echo, and record
+  the same ROS 2 data from the CLI.
+- [Multi-app deployments](/docs/guides/multi-app-deployments) shows how to deploy
+  the ROS 2 stack the bridge visualizes.

--- a/go/internal/cli/assets/docs/integrations/index.mdx
+++ b/go/internal/cli/assets/docs/integrations/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Robotics
-description: Build, deploy, and operate ROS 2 robots with WendyOS — standard, upstream ROS 2 from prototype to production fleet.
+description: Build, deploy, and operate ROS 2 robots with WendyOS. Standard, upstream ROS 2 from prototype to production fleet.
 ---
 
-WendyOS is built for ROS 2 robots — and takes them all the way from a prototype on
+WendyOS is built for ROS 2 robots, and takes them all the way from a prototype on
 your desk to a fleet in production. It runs **standard, upstream ROS 2** in
 containers, deploys to NVIDIA Jetson and Raspberry Pi with one command, and lets you
 inspect, debug, and update everything remotely over one secure connection.
@@ -11,10 +11,10 @@ inspect, debug, and update everything remotely over one secure connection.
 ## Why WendyOS for ROS 2
 
 - **Open and standard.** Real upstream ROS 2 in stock containers, with your choice of
-  middleware — CycloneDDS (default), Fast DDS, RTI Connext, or Gurum. Apache-2.0, no
+  middleware: CycloneDDS (default), Fast DDS, RTI Connext, or Gurum. Apache-2.0, no
   lock-in.
 - **Deploy in one command.** Ship a containerized ROS 2 stack to a device with
-  `wendy run` — no flashing, no `source /opt/ros/<distro>/setup.bash`, no toolchain
+  `wendy run`. No flashing, no `source /opt/ros/<distro>/setup.bash`, no toolchain
   setup.
 - **Production from day one.** Over-the-air updates, multi-device fleets, and
   fine-grained entitlements that scope each app's access to GPU, camera, audio, and
@@ -22,10 +22,10 @@ inspect, debug, and update everything remotely over one secure connection.
 
 ## The workflow
 
-1. **Deploy** — declare ROS 2 in your `wendy.json` with a `frameworks.ros2` block and
+1. **Deploy.** Declare ROS 2 in your `wendy.json` with a `frameworks.ros2` block and
    ship the stack. See [Multi-app deployments](/docs/guides/multi-app-deployments).
-2. **Operate** — inspect nodes and topics, echo messages, set parameters, and record
+2. **Operate.** Inspect nodes and topics, echo messages, set parameters, and record
    rosbags on the running device with no SSH. See
    [Wendy for ROS 2](/docs/integrations/ros2).
-3. **Visualize** — bridge live topics into Foxglove Studio for plots and panels. See
+3. **Visualize.** Bridge live topics into Foxglove Studio for plots and panels. See
    [Wendy for Foxglove](/docs/integrations/foxglove).

--- a/go/internal/cli/assets/docs/integrations/ros2.mdx
+++ b/go/internal/cli/assets/docs/integrations/ros2.mdx
@@ -1,15 +1,16 @@
 ---
 title: Wendy for ROS 2
-description: Inspect and debug live ROS 2 systems on a WendyOS device from the CLI — nodes, topics, services, parameters, rosbags, and more, with no SSH.
+description: Inspect and debug live ROS 2 systems on a WendyOS device from the CLI, with no SSH. Nodes, topics, services, parameters, actions, lifecycle nodes, components, and rosbags.
 ---
 
 `wendy device ros2` brings the full `ros2` command-line experience to a remote
 device. List nodes and topics, echo messages, watch publish rates, render the
-connectivity graph, read and set parameters, and record rosbags — all from your
-machine, over the same secure connection the CLI already uses.
+connectivity graph, read and set parameters, drive actions and lifecycle nodes,
+and record rosbags, all from your machine, over the same secure connection the
+CLI already uses.
 
 <Callout type="info">
-**Standard, upstream ROS 2.** WendyOS runs real ROS 2 from stock containers — Humble
+**Standard, upstream ROS 2.** WendyOS runs real ROS 2 from stock containers, Humble
 by default, configurable per app. Choose your middleware with `frameworks.ros2.rmw`:
 CycloneDDS (default), Fast DDS, RTI Connext, or Gurum.
 </Callout>
@@ -35,7 +36,11 @@ DDS), results are tagged with the RMW they came from, such as `[cyclonedds]`.
   [Discovering devices](/docs/device/discovering-devices).
 
 Every subcommand accepts `--domain` to override the `ROS_DOMAIN_ID`. By default it
-is read from the app's ROS 2 config, so you rarely need to set it.
+is read from the app's ROS 2 config, so you rarely need to set it. That includes
+auto-derived domains: an app whose `frameworks.ros2` omits `domainId` gets a
+stable domain hashed from its `appId` (in the 0 to 232 range), and the CLI
+follows it automatically. Every subcommand also honors the global `--json` flag
+for machine-readable output.
 
 ## Explore the graph
 
@@ -85,7 +90,7 @@ wendy device ros2 hz /chatter
 
 ## Parameters
 
-Read parameters across the whole system or a single node, and change them live —
+Read parameters across the whole system or a single node, and change them live,
 no restart required:
 
 ```bash
@@ -107,6 +112,51 @@ wendy device ros2 call /reset std_srvs/srv/Empty
 Pass a request payload as the optional third argument when the service type needs
 one.
 
+## Actions
+
+List action servers, inspect one, and send goals with live feedback:
+
+```bash
+wendy device ros2 action list
+wendy device ros2 action info /navigate
+
+# Send a goal; add --feedback to stream feedback while it runs
+wendy device ros2 action send_goal /navigate nav2_msgs/action/NavigateToPose "{pose: ...}" --feedback
+```
+
+Cancel all in-flight goals on an action server (a Wendy extension; the upstream
+`ros2 action` CLI has no cancel verb):
+
+```bash
+wendy device ros2 action cancel /navigate
+```
+
+## Lifecycle nodes
+
+Inspect and drive managed (lifecycle) nodes through their state machine:
+
+```bash
+# Lifecycle nodes on the system
+wendy device ros2 lifecycle nodes
+
+# Current state and available transitions for one node
+wendy device ros2 lifecycle get /lifecycle_talker
+wendy device ros2 lifecycle list /lifecycle_talker
+
+# Trigger a transition (configure, activate, deactivate, cleanup, shutdown)
+wendy device ros2 lifecycle set /lifecycle_talker configure
+```
+
+## Components
+
+Manage composable nodes in a running component container:
+
+```bash
+wendy device ros2 component list
+wendy device ros2 component load /ComponentManager composition composition::Talker
+wendy device ros2 component unload /ComponentManager 1
+```
+
 ## Record rosbags
 
 Record topics to a bag on the device, list what's been recorded, and pull a bag
@@ -125,6 +175,11 @@ wendy device ros2 bag list
 # Download a bag to a local directory
 wendy device ros2 bag download drive-test ./local-bags
 ```
+
+Run `bag download` with no arguments to pick from the device's bags
+interactively. On a device running apps across multiple RMW implementations,
+recording all topics captures one RMW's graph and warns about the others;
+record explicit topic lists per RMW if you need both.
 
 ## Health checks
 
@@ -152,7 +207,7 @@ into Foxglove Studio with [Wendy for Foxglove](/docs/integrations/foxglove).
 
 ## Related
 
-- [Multi-app deployments](/docs/guides/multi-app-deployments) — deploy a ROS 2
-  stack with `docker-compose.yml`.
-- [Entitlements](/docs/device/entitlements) — the host-network access ROS 2
+- [Multi-app deployments](/docs/guides/multi-app-deployments): deploy a ROS 2
+  stack with `wendy.json` services or `docker-compose.yml`.
+- [Entitlements](/docs/device/entitlements): the host-network access ROS 2
   discovery requires.

--- a/go/internal/cli/assets/docs/integrations/ros2.mdx
+++ b/go/internal/cli/assets/docs/integrations/ros2.mdx
@@ -12,7 +12,7 @@ CLI already uses.
 <Callout type="info">
 **Standard, upstream ROS 2.** WendyOS runs real ROS 2 from stock containers, Humble
 by default, configurable per app. Choose your middleware with `frameworks.ros2.rmw`:
-CycloneDDS (default), Fast DDS, RTI Connext, or Gurum.
+CycloneDDS (default), Fast DDS, RTI Connext, or GurumDDS.
 </Callout>
 
 ## How it works


### PR DESCRIPTION
## Summary

Audited the compose and ROS 2 docs against the current Go implementation and fixed everything that had drifted. Also removed emdashes from every edited page.

- **integrations/foxglove.mdx**: full rewrite. The page still said "coming soon" (PR #1165) and described a speculative local-WebSocket bridge. It now documents the shipped `wendy device foxglove serve` flow: generates a `foxglove_bridge` app, deploys it detached with host networking under `sh.wendy.foxglovebridge`, and forwards port 8765 via `wendy cloud tunnel`. Adds the real flags (`--port`, `--domain`, `--rmw`, `--distro`), the Wendy Cloud prerequisite, cleanup instructions, and a warning that the bridge's explicit domain will not match apps using auto-derived `ROS_DOMAIN_ID`s.
- **integrations/ros2.mdx**: adds the previously undocumented `action` (including the Wendy-only `action cancel`), `lifecycle`, and `component` command groups, plus auto-derived domain IDs, the global `--json` flag, interactive `bag download`, and the mixed-RMW recording caveat.
- **apps/compose.md**: fixes the claim that compose is only detected "with no wendy.json" (a companion is supported and merged), adds compose-over-Dockerfile detection precedence and the `--build-type docker`/`--dockerfile` overrides, lists the warn-ignored fields (`devices`, `privileged`, `healthcheck`, ...), notes that the top-level `volumes:` block is not parsed, and adds limitations: `wendy fleet run`, the Apple Container builder, and `wendy run --service` on the compose path.
- **guides/multi-app-deployments.mdx**: corrects app naming (multi-service deployments group under one app with `<project>_<service>` containers; examples now use the appId plus `--service`), fixes the CycloneDDS zero-copy claim (CycloneDDS shared memory is disabled on WendyOS since no iox-roudi ships; Fast DDS is what needs `shared-ipc`'s shared `/dev/shm`), and replaces the stale callout saying per-service readiness/postStart hooks are unavailable (both shapes support them now).
- **integrations/index.mdx**: emdash cleanup only.

All claims were verified against the source: `go/internal/cli/commands/{compose,run,ros2,foxglove,device}.go`, `go/internal/shared/appconfig/ros2.go`, and `go/internal/agent/containerd/{client,ros2}.go`.

## Testing

- `npm run dev` (docs site) and loaded all four updated pages; they render with no new console errors
- `git diff --check` clean
- Docs-only change; no Go code touched