### PR TITLE
os install: fix Orin Linux recovery failing unless run under sudo

### DIFF
--- a/go/internal/cli/tegraflash/t234/flash.go
+++ b/go/internal/cli/tegraflash/t234/flash.go
@@ -103,7 +103,7 @@ func (s *Stage2) SendFlashPackage(ctx context.Context) error {
 		return fmt.Errorf("flashpkg disk %s is smaller (%d bytes) than the flash package (%d bytes)", disk.DevPath, disk.SizeBytes, flashpkgSize)
 	}
 
-	s.unmount(disk)
+	s.unmount(ctx, disk)
 	if err := s.verifyDeviceIdentity(ctx, disk); err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (s *Stage2) WriteRootfsDevice(ctx context.Context) error {
 		return fmt.Errorf("exported %s (%d bytes) is smaller than the flash layout (%d bytes)", s.Plan.RootfsDevice, disk.SizeBytes, min)
 	}
 
-	s.unmount(disk)
+	s.unmount(ctx, disk)
 	fmt.Fprintf(s.Out, "Writing GPT + %d partitions...\n", len(s.Plan.Partitions))
 	start := time.Now()
 	err = s.RunHelper(ctx, HelperRequest{Writer: WriterOptions{Device: disk.RawPath, WritePlan: true, LayoutPath: s.LayoutPath, ImagesDir: s.ImagesDir, RootfsDevice: s.Plan.RootfsDevice}},
@@ -270,7 +270,7 @@ func (s *Stage2) WriteRootfsDevice(ctx context.Context) error {
 	fmt.Fprintf(s.Out, "  partitions written in %v\n", time.Since(start).Round(time.Second))
 	// macOS re-probes the disk when the writer closes it and may auto-mount
 	// the freshly written FAT config partition; unmount before releasing.
-	s.unmount(disk)
+	s.unmount(ctx, disk)
 	return s.release(ctx, disk)
 }
 
@@ -291,7 +291,7 @@ func (s *Stage2) AwaitFinalStatus(ctx context.Context) (*FinalStatus, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.unmount(disk)
+	s.unmount(ctx, disk)
 
 	tmp, err := os.CreateTemp(s.TempDir, "t234-flashpkg-*.ext4")
 	if err != nil {
@@ -344,9 +344,10 @@ func (s *Stage2) AwaitFinalStatus(ctx context.Context) (*FinalStatus, error) {
 
 // unmount locks/unmounts the LUN's volumes, reporting (not failing on) a
 // volume that stayed mounted — the raw write that follows produces the real
-// error, and the warning explains it.
-func (s *Stage2) unmount(disk UMSDisk) {
-	if err := unmountUMSDisk(disk); err != nil {
+// error, and the warning explains it. Routed through the root helper: umount
+// (Linux) and diskutil (macOS) need privilege the unprivileged parent lacks.
+func (s *Stage2) unmount(ctx context.Context, disk UMSDisk) {
+	if err := s.RunHelper(ctx, HelperRequest{Unmount: true, Writer: WriterOptions{Device: disk.DevPath}}, nil); err != nil {
 		fmt.Fprintf(s.Out, "  warning: %v\n", err)
 	}
 }
@@ -361,8 +362,13 @@ func (s *Stage2) release(ctx context.Context, disk UMSDisk) error {
 	// device's initrd waits for before finalizing the LUN and moving to its
 	// next command — e.g. exporting the rootfs device. A USB-level disconnect
 	// alone makes the device leave the flashpkg but can be too blunt for it to
-	// then bring up the next LUN.
-	ejectUMSDisk(disk)
+	// then bring up the next LUN. Routed through the root helper: eject
+	// (Linux/macOS) and udisksctl power-off (denied by polkit for a non-root,
+	// seatless SSH session) need privilege the unprivileged parent lacks —
+	// running it here left the LUN unreleased and forced the unbind fallback.
+	if err := s.RunHelper(ctx, HelperRequest{Eject: true, Writer: WriterOptions{Device: disk.DevPath}}, nil); err != nil {
+		fmt.Fprintf(s.Out, "  warning: eject failed (%v); trying a USB disconnect\n", err)
+	}
 	gone, err := s.waitForDiskGone(ctx, disk)
 	if err != nil {
 		return err

--- a/go/internal/cli/tegraflash/t234/helper_args.go
+++ b/go/internal/cli/tegraflash/t234/helper_args.go
@@ -8,15 +8,20 @@ import (
 	"strconv"
 )
 
-// HelperRequest is one parsed `__t234-write` invocation: either a USB release
-// or exactly one writer operation. Stage2 builds the argument lists (see
-// flash.go); this parser is shared by the privileged helper subcommand
-// (macOS/Linux, re-exec'd under sudo) and the in-process path (Windows, where
-// the whole process is already elevated), so both sides always agree.
+// HelperRequest is one parsed `__t234-write` invocation: a USB release, a LUN
+// unmount or eject, or exactly one writer operation. Stage2 builds the argument
+// lists (see flash.go); this parser is shared by the privileged helper
+// subcommand (macOS/Linux, re-exec'd under sudo) and the in-process path
+// (Windows, where the whole process is already elevated), so both sides always
+// agree. Unmount and Eject are privileged too (umount/diskutil/udisksctl/eject
+// all need root on Linux/macOS), so they route through the same helper rather
+// than running in the unprivileged parent; Writer.Device carries their target.
 type HelperRequest struct {
 	Release       bool
 	ReleaseSerial string
 	ReleasePort   string
+	Unmount       bool
+	Eject         bool
 	Writer        WriterOptions
 }
 
@@ -25,7 +30,8 @@ type HelperRequest struct {
 // requests in-process and never serializes). TestHelperArgsRoundTrip pins the
 // two directions against each other.
 func (r HelperRequest) Args() []string {
-	if r.Release {
+	switch {
+	case r.Release:
 		args := []string{"--release"}
 		if r.ReleaseSerial != "" {
 			args = append(args, "--serial", r.ReleaseSerial)
@@ -34,6 +40,10 @@ func (r HelperRequest) Args() []string {
 			args = append(args, "--port", r.ReleasePort)
 		}
 		return args
+	case r.Unmount:
+		return []string{"--unmount", "--device", r.Writer.Device}
+	case r.Eject:
+		return []string{"--eject", "--device", r.Writer.Device}
 	}
 	w := r.Writer
 	args := []string{"--device", w.Device}
@@ -89,6 +99,10 @@ func ParseWriterArgs(args []string) (HelperRequest, error) {
 			i++
 		case "--release":
 			req.Release = true
+		case "--unmount":
+			req.Unmount = true
+		case "--eject":
+			req.Eject = true
 		case "--serial":
 			req.ReleaseSerial, err = next(i, flag)
 			i++
@@ -108,8 +122,14 @@ func ParseWriterArgs(args []string) (HelperRequest, error) {
 // RunHelperRequest executes a parsed helper request, writing "PROGRESS"
 // lines to progress (may be nil).
 func RunHelperRequest(req HelperRequest, progress io.Writer) error {
-	if req.Release {
+	switch {
+	case req.Release:
 		return ReleaseUSB(req.ReleaseSerial, req.ReleasePort)
+	case req.Unmount:
+		return unmountUMSDisk(UMSDisk{DevPath: req.Writer.Device})
+	case req.Eject:
+		ejectUMSDisk(UMSDisk{DevPath: req.Writer.Device})
+		return nil
 	}
 	opts := req.Writer
 	opts.Progress = progress

--- a/go/internal/cli/tegraflash/t234/helper_args_test.go
+++ b/go/internal/cli/tegraflash/t234/helper_args_test.go
@@ -17,6 +17,8 @@ func TestHelperArgsRoundTrip(t *testing.T) {
 		{Writer: WriterOptions{Device: "/dev/rdisk4", DumpTo: "/tmp/out", DumpBytes: flashpkgSize}},
 		{Writer: WriterOptions{Device: "/dev/sdb", WritePlan: true, LayoutPath: "l.xml", ImagesDir: "/imgs", RootfsDevice: "mmcblk0"}},
 		{Release: true, ReleaseSerial: "12ab34cd", ReleasePort: "PCIROOT(0)#PCI(1400)#USBROOT(0)#USB(2)"},
+		{Unmount: true, Writer: WriterOptions{Device: "/dev/sda"}},
+		{Eject: true, Writer: WriterOptions{Device: "/dev/sda"}},
 	}
 	for _, want := range requests {
 		got, err := ParseWriterArgs(want.Args())

--- a/go/internal/cli/tegraflash/t234/release_linux.go
+++ b/go/internal/cli/tegraflash/t234/release_linux.go
@@ -3,10 +3,12 @@
 package t234
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"syscall"
 	"time"
 )
 
@@ -45,6 +47,12 @@ func ReleaseUSB(serial, port string) error {
 		}
 		time.Sleep(time.Second)
 		if err := os.WriteFile("/sys/bus/usb/drivers/usb/bind", []byte(name), 0o200); err != nil {
+			// ENODEV means the gadget already left this port (it re-enumerates the
+			// next LUN elsewhere after the unbind) — the disconnect we wanted has
+			// happened, so the release succeeded.
+			if errors.Is(err, syscall.ENODEV) {
+				return nil
+			}
 			return fmt.Errorf("rebinding %s: %w", name, err)
 		}
 		return nil


### PR DESCRIPTION
## Summary

The AGX Orin (T234) USB-recovery flow failed partway through stage 2 on Linux unless the entire `wendy os install` command was run under `sudo`. Root cause: the flow elevates only its raw block writes (re-exec'd as `sudo wendy __t234-write`) and keeps the parent process unprivileged — but the per-LUN **unmount** and **eject** ran directly in that unprivileged parent (`umount`, `eject`, `udisksctl power-off`, none prefixed with `sudo`).

On a normal non-root host — especially a seatless SSH session, where polkit denies `udisksctl power-off` — the eject silently failed, the LUN was never cleanly released, and the flow fell through to the fragile USB unbind/rebind fallback and died with:

```
FAILED (step 3): releasing /dev/sda: ✗ rebinding 1-10: write /sys/bus/usb/drivers/usb/bind: no such device
```

It only completed when the whole command ran under `sudo`, where the parent was already root and the eject succeeded.

## Changes

- **Route stage-2 unmount/eject through the root `__t234-write` helper** (`helper_args.go`, `flash.go`). They now run as root on Linux/macOS and in-process on already-elevated Windows — the same elevation boundary as every other privileged op. This keeps the primary (clean) release path working without a wrapping `sudo`, so the unbind/rebind fallback is no longer forced.
- **Treat `ENODEV` on the USB rebind as a successful release** (`release_linux.go`). After the unbind, the gadget re-enumerates its next LUN on a different port, so binding the old name returns `ENODEV` — a gadget that has left the port is exactly the disconnect this path wants, not a fatal error.

## Testing

- End-to-end AGX Orin eMMC recovery on a Linux host (over SSH, non-root invocation) — previously failed at stage 2, now completes.
- `go test ./internal/cli/tegraflash/t234/ ./internal/cli/commands/` green on Linux and macOS.
- darwin and windows (cross) builds green; `helper_args` round-trip test covers the two new helper actions.