### PR TITLE
Refresh cached flashpacks when a --pr build is republished

### DIFF
--- a/go/internal/cli/commands/os_install_orin.go
+++ b/go/internal/cli/commands/os_install_orin.go
@@ -47,6 +47,16 @@ func installOrin(ctx context.Context, opts t234InstallOptions) error {
 	}
 	ref := flashpack.RecoveryRef{Device: opts.DeviceType, Storage: opts.Storage, Version: opts.Version}
 
+	// Announce a stale cache before the flash UI takes over, mirroring the Thor
+	// path. resolveT234Flashpack does the same detection later, but reports it via
+	// a step-status line that the download progress immediately overwrites — so the
+	// reason for the re-download would otherwise be invisible.
+	if extracted := flashpack.RecoveryExtractedCachePath(cacheDir, ref); flashpack.StampStale(extracted, opts.Artifact.Checksum) {
+		if _, err := os.Stat(filepath.Join(extracted, "manifest.json")); err == nil {
+			fmt.Println(tui.Dim(fmt.Sprintf("Cached WendyOS %s is outdated; downloading the current build.", opts.Version)))
+		}
+	}
+
 	// Identity/verify/status files pass between this process and the root
 	// __t234-write helper. Keep them in a private 0700 dir, not shared /tmp:
 	// Linux fs.protected_regular denies root an O_CREAT open of a file this
@@ -257,55 +267,77 @@ func (w *progressWriter) Write(p []byte) (int, error) {
 }
 
 func resolveT234Flashpack(cacheDir string, ref flashpack.RecoveryRef, info *recoveryFlashpackInfo, detail func(string)) (*flashpack.Flashpack, bool, error) {
+	if info.Checksum == "" {
+		return nil, false, fmt.Errorf("manifest entry has no recovery flashpack checksum")
+	}
 	extracted := flashpack.RecoveryExtractedCachePath(cacheDir, ref)
 	tarball := flashpack.RecoveryTarballCachePath(cacheDir, ref)
+
+	// A cached tree whose recorded source checksum still matches the manifest is
+	// current — use it. If the manifest republished this version (e.g. a --pr
+	// re-push, whose tag is stable), the stamp differs: drop the stale tree and
+	// re-download. A tree with no stamp predates stamping and is trusted as-is.
 	if _, err := os.Stat(filepath.Join(extracted, "manifest.json")); err == nil {
-		fp, err := flashpack.ResolveRecovery(cacheDir, ref)
-		if err == nil {
-			// Reclaim a tarball an earlier interrupted run left behind: the
-			// extracted tree is the cache from here on.
-			_ = os.Remove(tarball)
+		if !flashpack.StampStale(extracted, info.Checksum) {
+			fp, err := flashpack.ResolveRecovery(cacheDir, ref)
+			return fp, true, err
 		}
-		return fp, true, err
+		detail("cached build is outdated — refreshing")
+		flashpack.Purge(extracted, tarball)
 	}
+
 	cached := true
 	if _, err := os.Stat(tarball); err != nil {
 		cached = false
-		if info.Checksum == "" {
-			return nil, false, fmt.Errorf("manifest entry has no recovery flashpack checksum")
-		}
-		img := &imageInfo{DownloadURL: info.URL, ImageSize: info.SizeBytes, Version: info.Version}
-		tmp, err := downloadImageInto(img, throttledDetail(detail, byteProgress))
-		if err != nil {
-			return nil, false, fmt.Errorf("downloading recovery flashpack: %w", err)
-		}
-		detail("verifying download")
-		if err := verifySHA256(tmp, info.Checksum); err != nil {
-			_ = os.Remove(tmp)
+		if err := downloadRecoveryTarball(info, tarball, detail); err != nil {
 			return nil, false, err
-		}
-		if err := os.Rename(tmp, tarball); err != nil {
-			_ = os.Remove(tmp)
-			return nil, false, fmt.Errorf("caching recovery flashpack: %w", err)
 		}
 	} else {
 		detail("verifying cached recovery download")
-		if info.Checksum == "" {
-			return nil, true, fmt.Errorf("manifest entry has no recovery flashpack checksum")
-		}
 		if err := verifySHA256(tarball, info.Checksum); err != nil {
-			return nil, true, fmt.Errorf("cached recovery flashpack failed verification: %w", err)
+			// A leftover tarball that no longer matches the manifest is a stale or
+			// interrupted download; replace it rather than failing the flash.
+			cached = false
+			_ = os.Remove(tarball)
+			if err := downloadRecoveryTarball(info, tarball, detail); err != nil {
+				return nil, false, err
+			}
 		}
 	}
+
+	// The tarball on disk now matches the manifest. Stamp provenance before
+	// extraction so even an interrupted extraction leaves a stale-detectable
+	// cache. Best-effort: a missing stamp is grandfathered as current.
+	_ = flashpack.WriteStamp(extracted, info.Checksum)
+
 	detail("extracting and verifying every consumed file")
+	// ResolveRecovery drops the .tar.zst once the extracted tree verifies, so a
+	// version's on-disk footprint isn't doubled.
 	fp, err := flashpack.ResolveRecovery(cacheDir, ref)
 	if err != nil {
 		return nil, cached, err
 	}
-	// The extracted tree is the cache; drop the large .tar.zst so a version's
-	// on-disk footprint isn't doubled (mirrors the pre-schema-v2 bundle flow).
-	_ = os.Remove(tarball)
 	return fp, cached, nil
+}
+
+// downloadRecoveryTarball fetches info's artifact to tarball, verifying its
+// checksum before it lands in the cache.
+func downloadRecoveryTarball(info *recoveryFlashpackInfo, tarball string, detail func(string)) error {
+	img := &imageInfo{DownloadURL: info.URL, ImageSize: info.SizeBytes, Version: info.Version}
+	tmp, err := downloadImageInto(img, throttledDetail(detail, byteProgress))
+	if err != nil {
+		return fmt.Errorf("downloading recovery flashpack: %w", err)
+	}
+	detail("verifying download")
+	if err := verifySHA256(tmp, info.Checksum); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, tarball); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("caching recovery flashpack: %w", err)
+	}
+	return nil
 }
 
 // prepareT234Workspace hard-links immutable partition images into a per-run

--- a/go/internal/cli/commands/os_install_thor_shared.go
+++ b/go/internal/cli/commands/os_install_thor_shared.go
@@ -80,6 +80,12 @@ func installThor(ctx context.Context, version string, nightly, force bool, wifi 
 	if err != nil {
 		return err
 	}
+	if plan.offline {
+		fmt.Println(tui.WarningMessage(fmt.Sprintf("Offline — using cached WendyOS %s; cannot confirm it is the latest build.", plan.version)))
+	}
+	if plan.refreshed {
+		fmt.Println(tui.Dim(fmt.Sprintf("Cached WendyOS %s is outdated; downloading the current build.", plan.version)))
+	}
 
 	// Fail fast on a full disk, before the user starts cabling the Thor.
 	if err := checkThorDiskSpace(cacheDir, plan); err != nil {
@@ -287,26 +293,53 @@ func injectConfigPartition(img string, creds []wendyconf.WifiCredential, deviceN
 
 // thorFlashPlan is the resolved flashpack to install and whether it is cached.
 type thorFlashPlan struct {
-	version string
-	cached  bool
-	info    *thorFlashpackInfo
+	version   string
+	cached    bool
+	offline   bool // resolved from cache without reaching the manifest (unverifiable)
+	refreshed bool // a stale cached copy was purged; a fresh download will run
+	info      *thorFlashpackInfo
 }
 
+// planThorFlashpack decides whether to reuse the cache or download. It always
+// tries the manifest first so it can compare the published checksum against the
+// cached copy's provenance stamp: a --pr build keeps a stable "pr-N" version tag
+// across re-pushes, so an existence-only cache check would silently flash an
+// outdated build. On a checksum change it purges and re-downloads; when the
+// manifest is unreachable it falls back to a nameable cached copy so an offline
+// bench flash isn't blocked.
 func planThorFlashpack(cacheDir, version string, nightly bool, pr int) (thorFlashPlan, error) {
-	if version != "" && flashpackCached(cacheDir, version) {
-		return thorFlashPlan{version: version, cached: true}, nil
-	}
 	info, err := getThorFlashpackInfo(version, nightly, pr)
 	if err != nil {
+		if v := offlineThorVersion(version, pr); v != "" && flashpackCached(cacheDir, v) {
+			return thorFlashPlan{version: v, cached: true, offline: true}, nil
+		}
 		if version != "" {
 			return thorFlashPlan{}, fmt.Errorf("flashpack %s not in cache and manifest lookup failed: %w", version, err)
 		}
 		return thorFlashPlan{}, err
 	}
 	if flashpackCached(cacheDir, info.Version) {
+		extracted := filepath.Join(cacheDir, flashpack.FlashpackName(info.Version))
+		if flashpack.StampStale(extracted, info.Checksum) {
+			flashpack.Purge(extracted, flashpack.TarballCachePath(cacheDir, info.Version))
+			return thorFlashPlan{version: info.Version, refreshed: true, info: info}, nil
+		}
 		return thorFlashPlan{version: info.Version, cached: true}, nil
 	}
 	return thorFlashPlan{version: info.Version, info: info}, nil
+}
+
+// offlineThorVersion names the cached flashpack to try when the manifest can't be
+// reached: the explicit --version, or a PR's conventional "pr-N" tag. Empty when
+// neither applies (a bare latest/nightly needs the manifest to resolve a tag).
+func offlineThorVersion(version string, pr int) string {
+	if version != "" {
+		return version
+	}
+	if pr > 0 {
+		return fmt.Sprintf("pr-%d", pr)
+	}
+	return ""
 }
 
 func flashpackCached(cacheDir, version string) bool {
@@ -378,6 +411,11 @@ func downloadAndExtractFlashpack(cacheDir string, plan thorFlashPlan, detail fun
 			os.Remove(tmp)
 			return nil, false, fmt.Errorf("caching flashpack: %w", err)
 		}
+		// Record provenance next to the (soon-to-be) extracted tree so a later
+		// resolve can detect an upstream re-publish under the same version tag.
+		// Best-effort: a missing stamp is grandfathered as current, so a write
+		// failure forfeits only the staleness check, never the flash.
+		_ = flashpack.WriteStamp(filepath.Join(cacheDir, flashpack.FlashpackName(plan.version)), plan.info.Checksum)
 	}
 	detail("extracting")
 	fp, err := flashpack.Resolve(cacheDir, plan.version)

--- a/go/internal/cli/commands/os_install_thor_test.go
+++ b/go/internal/cli/commands/os_install_thor_test.go
@@ -133,6 +133,24 @@ func TestFlashpackCached(t *testing.T) {
 	}
 }
 
+func TestOfflineThorVersion(t *testing.T) {
+	cases := []struct {
+		version string
+		pr      int
+		want    string
+	}{
+		{"0.17.0", 0, "0.17.0"}, // explicit version wins
+		{"0.17.0", 5, "0.17.0"}, // ...even alongside --pr
+		{"", 189, "pr-189"},     // --pr resolves to the conventional tag
+		{"", 0, ""},             // bare latest/nightly needs the manifest
+	}
+	for _, c := range cases {
+		if got := offlineThorVersion(c.version, c.pr); got != c.want {
+			t.Errorf("offlineThorVersion(%q, %d) = %q, want %q", c.version, c.pr, got, c.want)
+		}
+	}
+}
+
 func TestThorFlashpackSpaceNeeded(t *testing.T) {
 	dir := t.TempDir()
 	const version = "0.16.1"

--- a/go/internal/cli/tegraflash/flashpack/flashpack.go
+++ b/go/internal/cli/tegraflash/flashpack/flashpack.go
@@ -206,6 +206,53 @@ func RecoveryExtractedCachePath(cacheDir string, ref RecoveryRef) string {
 	return filepath.Join(cacheDir, ref.cacheBase())
 }
 
+// StampPath is the sibling file recording the source .tar.zst checksum a cached
+// flashpack tree was built from. Its presence lets a later resolve detect that an
+// upstream artifact (typically a --pr build, whose version tag is stable across
+// re-pushes) was republished under the same version, and refresh — without
+// re-hashing the multi-GiB tree. extractedDir is the tree's on-disk path, e.g.
+// TarballCachePath's dir sibling; the stamp lives next to it as "<name>.sha256".
+func StampPath(extractedDir string) string {
+	return extractedDir + ".sha256"
+}
+
+// WriteStamp records the tarball checksum next to the extracted tree. Callers
+// treat this as best-effort: a missing stamp is grandfathered as current (see
+// StampStale), so a write failure only forfeits future staleness detection.
+func WriteStamp(extractedDir, checksum string) error {
+	return os.WriteFile(StampPath(extractedDir), []byte(strings.TrimSpace(checksum)+"\n"), 0o644)
+}
+
+// ReadStamp returns the recorded checksum and whether a stamp exists. Any
+// missing/unreadable stamp reports ok=false: a legacy cache predates stamping,
+// so callers trust it as current rather than force a re-download.
+func ReadStamp(extractedDir string) (checksum string, ok bool) {
+	b, err := os.ReadFile(StampPath(extractedDir))
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(b)), true
+}
+
+// StampStale reports whether a cached tree must be purged and re-fetched given the
+// manifest's current checksum. Grandfather rule: no stamp → not stale. A present
+// stamp that differs (case-insensitively, whitespace-tolerant) → stale.
+func StampStale(extractedDir, manifestChecksum string) bool {
+	sum, ok := ReadStamp(extractedDir)
+	if !ok {
+		return false
+	}
+	return !strings.EqualFold(sum, strings.TrimSpace(manifestChecksum))
+}
+
+// Purge removes a cached flashpack's extracted tree, its .tar.zst (if any), and
+// its checksum stamp, so a stale artifact is fully dropped before re-downloading.
+func Purge(extractedDir, tarball string) {
+	_ = os.RemoveAll(extractedDir)
+	_ = os.Remove(tarball)
+	_ = os.Remove(StampPath(extractedDir))
+}
+
 // Resolve returns the flashpack for version, cache-first: an already-extracted tree,
 // else a planted/downloaded .tar.zst extracted on demand (atomically). The stage-1
 // files are integrity-checked against the manifest before the flashpack is returned,
@@ -240,7 +287,13 @@ func ResolveRecovery(cacheDir string, ref RecoveryRef) (*Flashpack, error) {
 func resolvePaths(extracted, tarball, version string) (*Flashpack, error) {
 	var extractedErr error
 	if fp, err := open(extracted); err == nil {
-		return fp, fp.verifyIntegrity()
+		if verr := fp.verifyIntegrity(); verr != nil {
+			return fp, verr
+		}
+		// The verified tree is the cache from here on; reclaim any tarball an
+		// earlier run left behind so a version's footprint isn't doubled.
+		_ = os.Remove(tarball)
+		return fp, nil
 	} else if _, statErr := os.Stat(extracted); statErr == nil {
 		extractedErr = err
 	}
@@ -252,7 +305,12 @@ func resolvePaths(extracted, tarball, version string) (*Flashpack, error) {
 		if err != nil {
 			return nil, err
 		}
-		return fp, fp.verifyIntegrity()
+		if verr := fp.verifyIntegrity(); verr != nil {
+			return fp, verr
+		}
+		// Extraction succeeded and the tree verified; drop the tarball.
+		_ = os.Remove(tarball)
+		return fp, nil
 	}
 	if extractedErr != nil {
 		return nil, fmt.Errorf("opening extracted flashpack: %w", extractedErr)

--- a/go/internal/cli/tegraflash/flashpack/stamp_test.go
+++ b/go/internal/cli/tegraflash/flashpack/stamp_test.go
@@ -1,0 +1,87 @@
+package flashpack
+
+import (
+	"archive/tar"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStampRoundTripAndStaleness(t *testing.T) {
+	dir := t.TempDir()
+	extracted := filepath.Join(dir, "jetson-agx-thor-pr-1.flashpack")
+	const sum = "ABCDEF0123456789"
+
+	// Missing stamp is grandfathered as current, never stale.
+	if _, ok := ReadStamp(extracted); ok {
+		t.Fatal("ReadStamp reported a stamp before one was written")
+	}
+	if StampStale(extracted, sum) {
+		t.Fatal("a missing stamp must be treated as current, not stale")
+	}
+
+	if err := WriteStamp(extracted, sum); err != nil {
+		t.Fatalf("WriteStamp: %v", err)
+	}
+	got, ok := ReadStamp(extracted)
+	if !ok || got != sum {
+		t.Fatalf("ReadStamp = (%q, %v), want (%q, true)", got, ok, sum)
+	}
+
+	// Whitespace and hex case must not cause a false mismatch.
+	if StampStale(extracted, "  abcdef0123456789\n") {
+		t.Fatal("stamp compare should trim whitespace and ignore hex case")
+	}
+	// A genuinely different checksum is stale.
+	if !StampStale(extracted, "0000000000000000") {
+		t.Fatal("a differing manifest checksum must be reported stale")
+	}
+}
+
+func TestPurgeRemovesTreeTarballAndStamp(t *testing.T) {
+	dir := t.TempDir()
+	extracted := filepath.Join(dir, "pack.flashpack")
+	tarball := extracted + ".tar.zst"
+	if err := os.MkdirAll(extracted, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{tarball, filepath.Join(extracted, "manifest.json")} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := WriteStamp(extracted, "deadbeef"); err != nil {
+		t.Fatal(err)
+	}
+
+	Purge(extracted, tarball)
+
+	for _, p := range []string{extracted, tarball, StampPath(extracted)} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("Purge left %s behind (err=%v)", p, err)
+		}
+	}
+}
+
+// TestResolveDropsTarballAfterExtract pins the Thor/T234 convergence: once the
+// extracted tree verifies, resolvePaths deletes the .tar.zst so a version's
+// footprint isn't doubled.
+func TestResolveDropsTarballAfterExtract(t *testing.T) {
+	cache := t.TempDir()
+	const version = "0.18.0"
+	tarball := TarballCachePath(cache, version)
+	writeZstTar(t, tarball,
+		[]tar.Header{{Name: "manifest.json", Mode: 0o644, Typeflag: tar.TypeReg}},
+		[]string{`{"schema":1,"wendyos_version":"0.18.0","layout":{"stage1":"stage1","flash_workspace":"stage2/out/flash_workspace"},"files":{}}`},
+	)
+
+	if _, err := Resolve(cache, version); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if _, err := os.Stat(tarball); !os.IsNotExist(err) {
+		t.Fatalf("tarball should be dropped after extraction (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(cache, FlashpackName(version), "manifest.json")); err != nil {
+		t.Fatalf("extracted tree missing after Resolve: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

Flashpack cache identity is the version tag alone, and the "is it cached?" check is pure file existence — the freshly-fetched manifest checksum is discarded on a cache hit. A `--pr N` build keeps a stable `pr-N` tag across re-pushes, so once a PR is updated the CLI silently flashes the **outdated** cached build.

## Fix

- **Provenance stamp.** On cache write, record the source `.tar.zst` checksum in a `<name>.flashpack.sha256` sibling. On resolve, compare it against the manifest and purge + re-download on a mismatch. A missing stamp is grandfathered as current, so existing caches keep working.
- **Tarball removal.** Thor's `resolvePaths` now drops the `.tar.zst` once the extracted tree verifies. Thor previously kept it, doubling a version's on-disk footprint (~3 GB); T234 already dropped it.

## Known gap

Offline fallback is effective for Thor but not Orin — the Orin flow fetches the device manifest much earlier (device picker), so it can't reach the flash step offline at all. Staleness detection (the actual bug) is fixed for both. Making Orin installable offline needs manifest caching, a separate change.

## Tests

Unit coverage for the stamp round-trip / grandfather / whitespace-and-case staleness rules, `Purge`, the tarball-drop convergence, and offline `pr-N` resolution.

## Hardware validation (Linux host, Thor + Orin devkits)

Built the branch and validated every changed path the hardware can reach:

| Path | Proves | Result |
|---|---|---|
| Thor cache-hit (`0.17.0`) | already-extracted resolve + `verifyIntegrity` + tarball drop | ✅ full flash; 3 GB tarball dropped |
| Thor stale→refresh | detect → purge → download → verify → stamp → flash | ✅ full flash; stamp == manifest checksum |
| Orin cache-hit (`nightly-…20`) | T234 resolve + grandfather (unstamped) + good tree | ✅ resolved `cached`, flashed |
| Orin stale→refresh | T234 detect → purge → download → verify → stamp → drop tarball | ✅ resolve+stamp confirmed on disk (stamp == manifest); flashed |

Also validated non-destructively against the live binary/manifest: offline fallback (network blocked → `⚠ Offline — using cached …`), stale detection (`Cached … is outdated; downloading…`), online grandfathering (no re-download, no stamp on a cache hit), and a real 3 GB tarball extract→verify→drop integration run. Full `go test ./...` green on Linux (only pre-existing, unrelated `agent/services` perms failures, which also fail on `main`).
