### PR TITLE
fix(ci): resolve repo root in publish-install-scripts.sh

### DIFF
--- a/.github/scripts/publish-install-scripts.sh
+++ b/.github/scripts/publish-install-scripts.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 
 : "${VERSION:?}" "${IS_RELEASE:?}" "${BUCKET:?}" "${PROJECT:?}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# SCRIPT_DIR is .github/scripts, so go up two levels to reach the repo root.
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 DOCS_DIR="${REPO_ROOT}/go/internal/cli/assets/docs"
 gcloud config set project "$PROJECT" >/dev/null
 


### PR DESCRIPTION
## Problem

The **Publish install scripts to GCS** job on `main` fails:

```
Uploading .../.github/go/internal/cli/assets/docs/agent.sh -> gs://wendy-install-public/agent.sh
ERROR: (gcloud.storage.cp) The following URLs matched no objects or files:
.../.github/go/internal/cli/assets/docs/agent.sh
```

(e.g. [run 29796934684](https://github.com/wendylabsinc/WendyOS/actions/runs/29796934684))

## Cause

`SCRIPT_DIR` is `.github/scripts`, but `REPO_ROOT` was computed as `${SCRIPT_DIR}/..`, which is `.github` — one level short of the repo root. That made `DOCS_DIR` resolve to the nonexistent `.github/go/internal/cli/assets/docs`.

## Fix

Go up **two** levels so `REPO_ROOT` is the repository root. This matches the sibling `install-scripts_test.sh`, which already uses `cd ../..` from `.github/scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)