### PR TITLE
fix(cli): report the real outcome of apps start

### DIFF
--- a/.github/ci-tests/swift-start-detach/Package.swift
+++ b/.github/ci-tests/swift-start-detach/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CISwiftStartDetach",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-container-plugin", from: "1.0.0")
+    ],
+    targets: [
+        .executableTarget(name: "CISwiftStartDetach")
+    ]
+)

--- a/.github/ci-tests/swift-start-detach/Sources/main.swift
+++ b/.github/ci-tests/swift-start-detach/Sources/main.swift
@@ -1,0 +1,14 @@
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+// Long-running so a successful `apps start` is a stable RUNNING signal for the
+// integration test that verifies a detached start returns only once the
+// container is actually running.
+print("swift-start-detach: running")
+fflush(nil)
+while true {
+    sleep(10)
+}

--- a/.github/ci-tests/swift-start-detach/wendy.json
+++ b/.github/ci-tests/swift-start-detach/wendy.json
@@ -1,0 +1,5 @@
+{
+    "appId": "sh.wendy.ci.swift-start-detach",
+    "version": "1.0.0",
+    "language": "swift"
+}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -330,7 +330,7 @@ jobs:
               exit 0
             fi
           else
-            for t in swift-hello swift-network swift-bluetooth swift-resources python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-no-kexec-module python-network-host-admin python-no-net-admin python-resources python-multiservice python-multiservice-resources python-servicename python-device-top otel-localhost-only; do
+            for t in swift-hello swift-start-detach swift-network swift-bluetooth swift-resources python-hello python-network python-gpu python-onnx-gpu python-bluetooth python-no-network python-no-bluetooth python-no-ptrace python-no-unshare python-no-kexec-module python-network-host-admin python-no-net-admin python-resources python-multiservice python-multiservice-resources python-servicename python-device-top otel-localhost-only; do
               TEST_ARGS+=(-t "$t")
             done
           fi

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/apps/start.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/apps/start.md
@@ -10,7 +10,7 @@ If the container keeps exiting and the agent has already performed at least one 
 
 | Flag | Description |
 |------|-------------|
-| `-d`, `--detach` | Start the app and return immediately without streaming output. |
+| `-d`, `--detach` | Start the app and return once the agent confirms it has started, without streaming output. |
 
 ## Examples
 
@@ -27,4 +27,8 @@ wendy device apps start --detach my-app
 wendy device apps start -d my-app
 ```
 
-When `--detach` is used, the CLI sends the start request to the agent and exits as soon as the container start is initiated, without waiting for or streaming any output.
+When `--detach` is used, the CLI waits for the agent to confirm the container has started, then returns without streaming any output. If the agent reports an error or closes the stream before confirming the start, the command exits with a non-zero status instead of reporting success.
+
+## Reported outcome
+
+When an attached start returns, the CLI reports the app's state at that point: `started` if it is still running (for example a multi-service app), `stopped` — or a short reason such as `crashed (exit 1)` — if it has exited, or `crash-looping` if it keeps restarting.

--- a/go/internal/cli/commands/apps.go
+++ b/go/internal/cli/commands/apps.go
@@ -363,10 +363,18 @@ func newAppsStartCmd() *cobra.Command {
 
 			if target.Agent != nil {
 				if detach {
-					if _, err := target.Agent.ContainerService.StartContainer(ctx, &agentpb.StartContainerRequest{
+					stream, err := target.Agent.ContainerService.StartContainer(ctx, &agentpb.StartContainerRequest{
 						AppName:       appName,
 						RestartPolicy: &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED},
-					}); err != nil {
+					})
+					if err != nil {
+						return fmt.Errorf("starting container: %w", err)
+					}
+					// Wait for the agent's Started confirmation before returning.
+					// Returning immediately (the old behavior) closed the connection
+					// and canceled the RPC before the agent had loaded the container,
+					// so the start silently failed while we reported success.
+					if err := awaitStarted(stream); err != nil {
 						return fmt.Errorf("starting container: %w", err)
 					}
 					cliSuccess("Application %s started.", appName)
@@ -377,7 +385,7 @@ func newAppsStartCmd() *cobra.Command {
 					return err
 				}
 				gotFirstResponse := false
-				gotOutput := false
+				gotStarted := false
 				for {
 					resp, err := outStream.Recv()
 					if err == io.EOF {
@@ -399,22 +407,25 @@ func newAppsStartCmd() *cobra.Command {
 						return fmt.Errorf("receiving start response: %w", err)
 					}
 					gotFirstResponse = true
+					if resp.GetStarted() != nil {
+						gotStarted = true
+					}
 					if out := resp.GetStdoutOutput(); out != nil {
 						os.Stdout.Write(out.GetData())
-						gotOutput = true
 					}
 					if out := resp.GetStderrOutput(); out != nil {
 						os.Stderr.Write(out.GetData())
-						gotOutput = true
 					}
 				}
-				// Group starts return immediately without streaming output; distinguish
-				// from single containers that ran and exited.
-				if gotOutput {
-					cliSuccess("Application %s stopped.", appName)
-				} else {
-					cliSuccess("Application %s started.", appName)
+				// The agent never confirmed the start: the container did not run.
+				if !gotStarted {
+					return fmt.Errorf("container %q did not start", appName)
 				}
+				// The stream ended. A single container's stream ends when it
+				// exits; a group start's stream ends immediately while the
+				// services keep running. Report the actual state instead of
+				// guessing from whether any output was seen.
+				reportStartOutcome(ctx, target.Agent.ContainerService, appName)
 				return nil
 			}
 
@@ -436,6 +447,79 @@ func newAppsStartCmd() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&detach, "detach", "d", false, "Start without streaming output")
 	return cmd
+}
+
+// awaitStarted consumes a start/run response stream until the agent sends its
+// Started marker (returning nil). It returns an error if the stream fails or
+// closes before Started arrives — which means the container never started.
+// Interleaved output frames before Started are discarded (detached callers do
+// not stream output).
+func awaitStarted(stream containerOutputStream) error {
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			return fmt.Errorf("agent closed the stream before confirming the container started")
+		}
+		if err != nil {
+			return err
+		}
+		if resp.GetStarted() != nil {
+			return nil
+		}
+	}
+}
+
+// reportStartOutcome prints the container's actual post-start state after a
+// non-detached start stream ends, so the message reflects reality rather than
+// guessing from streamed output. RUNNING (a group start, or a container still
+// up) reads as started; a terminated single container reports how it ended.
+// A failure state (crash, crash-loop) is a neutral notice, not success styling;
+// the exit status stays 0 because the start itself was confirmed.
+func reportStartOutcome(ctx context.Context, svc agentpb.WendyContainerServiceClient, appName string) {
+	c := fetchAppContainer(ctx, svc, appName)
+	if c == nil {
+		cliSuccess("Application %s started.", appName)
+		return
+	}
+	switch c.GetRunningState() {
+	case agentpb.AppRunningState_RUNNING:
+		cliSuccess("Application %s started.", appName)
+	case agentpb.AppRunningState_CRASH_LOOPING:
+		cliNotice("Application %s is crash-looping (%s).", appName,
+			terminationSummary(c.GetTerminationReason(), c.GetExitCode()))
+	default: // STOPPED
+		switch c.GetTerminationReason() {
+		case "", "exited":
+			if summary := terminationSummary(c.GetTerminationReason(), c.GetExitCode()); summary != "" {
+				cliSuccess("Application %s %s.", appName, summary)
+			} else {
+				cliSuccess("Application %s stopped.", appName)
+			}
+		default: // crashed / oom_killed / start_failed / entitlement_denied
+			cliNotice("Application %s %s.", appName,
+				terminationSummary(c.GetTerminationReason(), c.GetExitCode()))
+		}
+	}
+}
+
+// fetchAppContainer returns the AppContainer for appName from the agent's
+// container list, or nil if it cannot be read or found.
+func fetchAppContainer(ctx context.Context, svc agentpb.WendyContainerServiceClient, appName string) *agentpb.AppContainer {
+	stream, err := svc.ListContainers(ctx, &agentpb.ListContainersRequest{})
+	if err != nil {
+		return nil
+	}
+	var found *agentpb.AppContainer
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			break
+		}
+		if c := resp.GetContainer(); c != nil && c.GetAppName() == appName {
+			found = c
+		}
+	}
+	return found
 }
 
 func newAppsStopCmd() *cobra.Command {

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -189,6 +189,7 @@ fi
 
 ALL_TESTS=(
     swift-hello
+    swift-start-detach
     swift-network
     swift-bluetooth
     swift-resources
@@ -361,6 +362,50 @@ for test_name in "${TESTS[@]}"; do
             return 0
         }
         run_test "python-device-top (snapshot reports host + container)" device_top_snapshot
+
+        "$WENDY" device apps remove "$app_id" --device "$HOSTNAME" --force --cleanup >/dev/null 2>&1 || true
+        continue
+    fi
+
+    # ── apps start reporting (detached start must confirm the start) ──────
+    # A detached `apps start` must return only after the agent confirms the
+    # container started (deploy first WITHOUT starting so no prior restart
+    # policy masks the result), and must fail — not falsely succeed — when the
+    # target app does not exist.
+    if [[ "$test_name" == "swift-start-detach" ]]; then
+        echo -e "${BOLD}── $test_name${RESET}"
+        app_id="sh.wendy.ci.swift-start-detach"
+
+        run_test "swift-start-detach (deploy, not started)" \
+            "$WENDY" run --device "$HOSTNAME" --prefix "$test_dir" --deploy
+
+        detach_start_reaches_running() {
+            if ! "$WENDY" device apps start "$app_id" --device "$HOSTNAME" --detach; then
+                echo "apps start --detach returned non-zero"
+                return 1
+            fi
+            local out
+            for _ in 1 2 3 4 5; do
+                out=$("$WENDY" device apps list --device "$HOSTNAME" --json 2>&1)
+                if echo "$out" | jq -e --arg a "$app_id" \
+                    '(.[] | select(.name==$a) | .runningState) == "RUNNING"' >/dev/null 2>&1; then
+                    return 0
+                fi
+                sleep 1
+            done
+            echo "app '$app_id' never reached RUNNING after detached start: $out"
+            return 1
+        }
+        run_test "swift-start-detach (detached start reaches RUNNING)" detach_start_reaches_running
+
+        detach_start_missing_app_fails() {
+            if "$WENDY" device apps start sh.wendy.ci.does-not-exist --device "$HOSTNAME" --detach >/dev/null 2>&1; then
+                echo "apps start --detach of a nonexistent app unexpectedly reported success"
+                return 1
+            fi
+            return 0
+        }
+        run_test "swift-start-detach (missing app start fails)" detach_start_missing_app_fails
 
         "$WENDY" device apps remove "$app_id" --device "$HOSTNAME" --force --cleanup >/dev/null 2>&1 || true
         continue


### PR DESCRIPTION
## Problem

Two ways `wendy device apps start` reported success it hadn't verified:

1. **`--detach`** fired the server-streaming `StartContainer`, discarded the stream, and returned immediately. That closed the connection and cancelled the RPC before the agent had loaded the container, so the start failed ("loading container: context canceled") while the CLI printed "Application X started." exit 0.
2. **Non-detached** start guessed "started" vs "stopped" from whether any output was streamed, so a container that failed before printing anything was reported as "started".

## Fix

- Detached start consumes the stream until the agent's `Started` marker (`awaitStarted`). If the stream errors or closes first, the start is reported as failed.
- Non-detached start, after the stream ends, queries the app's actual state and reports it — running (group start / still up), stopped/exited, or crash-looping — instead of the output heuristic.

## Validation

Pi 4, agent `2026.07.20-035949` (no agent-side fix), this CLI:

| scenario | old CLI | this CLI |
|---|---|---|
| `apps start --detach` (good app) ×3 → actual state | STOPPED ×15 | **RUNNING ×3** |
| `apps start --detach` of a non-existent app | "started", exit 0 | **error, exit 1** |
| non-detach start of an app that exits immediately (no output) | "started" | **"stopped"** |

The CLI fix alone happens to also resolves the stuck-start against an unpatched agent. That one is properly fixed in #1459.
