### PR TITLE
fix(cli): device update reports 'already up to date' instead of a false success

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
@@ -1,4 +1,13 @@
-Updates the wendy-agent installation on the remote device, then checks for a newer WendyOS image. By default downloads the latest release binary from GitHub matching the device's CPU architecture. Pass `--binary <path>` to upload a locally built binary instead (e.g. a cross-compiled development build). The command waits for the restarted agent to become reachable before reporting success.
+Updates the wendy-agent installation on the remote device, then checks for a newer WendyOS image. By default downloads the latest release binary from GitHub matching the device's CPU architecture. Pass `--binary <path>` to upload a locally built binary instead (e.g. a cross-compiled development build). When an upload is performed, the command waits for the restarted agent to become reachable before reporting success.
+
+## Already up to date
+
+On the auto-download path, the command compares the device's running version to the resolved release before uploading. When the device is already at (or ahead of) that version, the upload and agent restart are skipped and the command reports that it is already up to date:
+
+- **Human-readable:** `Agent is already up to date (‹version›).`
+- **JSON:** `{"status":"up-to-date","message":"Agent is already up to date.","version":"‹version›"}` (compared to `{"status":"success","message":"Agent updated successfully."}` when an update is applied).
+
+The OS update step below still runs afterward (in human-readable mode; JSON mode returns immediately to keep output stable). The `--binary` path is unaffected — an explicitly supplied local binary is always uploaded, regardless of the device's current version.
 
 GitHub release lookups use the `GITHUB_TOKEN` environment variable for authentication when it is present, and fall back to unauthenticated requests otherwise.
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
@@ -1,13 +1,6 @@
 Updates the wendy-agent installation on the remote device, then checks for a newer WendyOS image. By default downloads the latest release binary from GitHub matching the device's CPU architecture. Pass `--binary <path>` to upload a locally built binary instead (e.g. a cross-compiled development build). When an upload is performed, the command waits for the restarted agent to become reachable before reporting success.
 
-## Already up to date
-
-On the auto-download path, the command compares the device's running version to the resolved release before uploading. When the device is already at (or ahead of) that version, the upload and agent restart are skipped and the command reports that it is already up to date:
-
-- **Human-readable:** `Agent is already up to date (‹version›).`
-- **JSON:** `{"status":"up-to-date","message":"Agent is already up to date.","version":"‹version›"}` (compared to `{"status":"success","message":"Agent updated successfully."}` when an update is applied).
-
-The OS update step below still runs afterward (in human-readable mode; JSON mode returns immediately to keep output stable). The `--binary` path is unaffected — an explicitly supplied local binary is always uploaded, regardless of the device's current version.
+On the auto-download path, if the device already runs the resolved release version, the upload and agent restart are skipped and the command reports that it is already up to date. The OS update step below still runs afterward — except in `--json` mode, where the command returns immediately and the OS update step is not run.
 
 GitHub release lookups use the `GITHUB_TOKEN` environment variable for authentication when it is present, and fall back to unauthenticated requests otherwise.
 

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -2179,7 +2179,8 @@ func newDeviceUpdateCmd() *cobra.Command {
 					}
 				}
 			} else {
-				// Auto-download: detect arch, fetch release, download binary.
+				// Auto-download: detect arch, resolve the release version, and
+				// download the binary only when the device isn't already on it.
 				if !jsonOutput {
 					fmt.Println(tui.InfoMessage("Detecting device architecture..."))
 				}
@@ -2197,33 +2198,47 @@ func newDeviceUpdateCmd() *cobra.Command {
 					fmt.Printf("%s %s\n", tui.Dim("Architecture:"), tui.Value(arch))
 				}
 
-				if !jsonOutput {
-					releaseType := "stable"
-					if nightly {
-						releaseType = "nightly"
-					}
-					fmt.Println(tui.InfoMessage(fmt.Sprintf("Fetching latest %s agent for linux/%s...", releaseType, arch)))
-				}
-
-				var source, resolvedVer string
-				binaryData, resolvedVer, source, err = resolveAgentBinary(arch, nightly)
+				// Resolve the version first — this reads only manifest/release
+				// metadata, so an already-current device never downloads the
+				// tarball. Record it so an upload whose confirmation was lost to
+				// a mid-stream agent restart can still be verified.
+				resolvedVer, source, err := resolveAgentVersion(nightly)
 				if err != nil {
-					return fmt.Errorf("resolving agent binary: %w", err)
+					return fmt.Errorf("resolving agent version: %w", err)
 				}
-				// Record the resolved version so an upload whose confirmation
-				// was lost to a mid-stream agent restart can still be verified.
 				expectedAgentVersion = resolvedVer
 				if !jsonOutput {
 					fmt.Printf("%s %s %s\n", tui.Dim("Release:"), tui.Value(resolvedVer), tui.Dim("(from "+source+")"))
 				}
 				// Reported >= resolved means the device is already at (or ahead
-				// of) the version we'd install; nothing to upload.
-				agentAlreadyCurrent = agentUpdateVerified(preUpdateVersion.GetVersion(), resolvedVer)
+				// of) the version we'd install; nothing to upload. A dev build
+				// compares as newest, but an explicit update must overwrite it
+				// with the release, so dev builds never count as current here.
+				agentAlreadyCurrent = !version.IsDev(preUpdateVersion.GetVersion()) &&
+					agentUpdateVerified(preUpdateVersion.GetVersion(), resolvedVer)
+
+				if !agentAlreadyCurrent {
+					if !jsonOutput {
+						releaseType := "stable"
+						if nightly {
+							releaseType = "nightly"
+						}
+						fmt.Println(tui.InfoMessage(fmt.Sprintf("Fetching latest %s agent for linux/%s...", releaseType, arch)))
+					}
+					binaryData, _, _, err = resolveAgentBinary(arch, nightly)
+					if err != nil {
+						return fmt.Errorf("resolving agent binary: %w", err)
+					}
+				}
 			}
 
-			// Compute SHA256.
-			h := sha256.Sum256(binaryData)
-			sha256Hash := hex.EncodeToString(h[:])
+			// Hash the binary we're about to upload. Skipped when already
+			// current: no binary was downloaded and no upload happens.
+			var sha256Hash string
+			if !agentAlreadyCurrent {
+				h := sha256.Sum256(binaryData)
+				sha256Hash = hex.EncodeToString(h[:])
+			}
 
 			if agentAlreadyCurrent {
 				if jsonOutput {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -2148,6 +2148,10 @@ func newDeviceUpdateCmd() *cobra.Command {
 			}()
 
 			var preUpdateVersion *agentpb.GetAgentVersionResponse
+			// Set on the auto-download path when the device already runs (at
+			// least) the version we would fetch, so we report that honestly and
+			// skip the no-op re-upload + agent restart.
+			agentAlreadyCurrent := false
 
 			var binaryData []byte
 			// Set on the auto-download path; used to verify an upload whose
@@ -2212,69 +2216,90 @@ func newDeviceUpdateCmd() *cobra.Command {
 				if !jsonOutput {
 					fmt.Printf("%s %s %s\n", tui.Dim("Release:"), tui.Value(resolvedVer), tui.Dim("(from "+source+")"))
 				}
+				// Reported >= resolved means the device is already at (or ahead
+				// of) the version we'd install; nothing to upload.
+				agentAlreadyCurrent = agentUpdateVerified(preUpdateVersion.GetVersion(), resolvedVer)
 			}
 
 			// Compute SHA256.
 			h := sha256.Sum256(binaryData)
 			sha256Hash := hex.EncodeToString(h[:])
 
-			// An unconfirmed upload is not a failure: the agent restarts the
-			// moment the binary lands, which can drop the stream before its
-			// ack arrives. Reconnect below and verify what the device runs.
-			unconfirmed := false
-			if err := uploadAgentBinary(ctx, conn.AgentService, binaryData, sha256Hash, jsonOutput); err != nil {
-				if !errors.Is(err, errAgentUpdateUnconfirmed) {
+			if agentAlreadyCurrent {
+				if jsonOutput {
+					resp := map[string]string{
+						"status":  "up-to-date",
+						"message": "Agent is already up to date.",
+						"version": preUpdateVersion.GetVersion(),
+					}
+					b, err := json.Marshal(resp)
+					if err != nil {
+						return fmt.Errorf("failed to marshal JSON response: %w", err)
+					}
+					fmt.Println(string(b))
+					// OS update check is skipped in JSON mode to keep output stable.
+					return nil
+				}
+				fmt.Println(tui.SuccessMessage(fmt.Sprintf("Agent is already up to date (%s).", preUpdateVersion.GetVersion())))
+			} else {
+				// An unconfirmed upload is not a failure: the agent restarts the
+				// moment the binary lands, which can drop the stream before its
+				// ack arrives. Reconnect below and verify what the device runs.
+				unconfirmed := false
+				if err := uploadAgentBinary(ctx, conn.AgentService, binaryData, sha256Hash, jsonOutput); err != nil {
+					if !errors.Is(err, errAgentUpdateUnconfirmed) {
+						return err
+					}
+					unconfirmed = true
+					if !jsonOutput {
+						fmt.Println(tui.InfoMessage("The connection dropped before the agent confirmed the update — verifying what the device is running..."))
+					}
+				}
+
+				// Keep the connection to the just-restarted agent. maybeCheckOSUpdate
+				// needs a live conn (and its Host/Reconnect) both to drive the OS
+				// update and to re-dial the SAME device after the reboot; passing nil
+				// here would nil-deref once the OS-update gate lets a device through.
+				reconnect := updatedAgentReconnectFunc(ctx, conn)
+				if conn != nil {
+					_ = conn.Close()
+					conn = nil
+				}
+				conn, err = awaitAgentRestart(ctx, reconnect, jsonOutput)
+				if err != nil {
 					return err
 				}
-				unconfirmed = true
-				if !jsonOutput {
-					fmt.Println(tui.InfoMessage("The connection dropped before the agent confirmed the update — verifying what the device is running..."))
-				}
-			}
 
-			// Keep the connection to the just-restarted agent. maybeCheckOSUpdate
-			// needs a live conn (and its Host/Reconnect) both to drive the OS
-			// update and to re-dial the SAME device after the reboot; passing nil
-			// here would nil-deref once the OS-update gate lets a device through.
-			reconnect := updatedAgentReconnectFunc(ctx, conn)
-			if conn != nil {
-				_ = conn.Close()
-				conn = nil
-			}
-			conn, err = awaitAgentRestart(ctx, reconnect, jsonOutput)
-			if err != nil {
-				return err
-			}
+				if unconfirmed {
+					verifyResp, verifyErr := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+					if verifyErr != nil {
+						return fmt.Errorf("could not verify the interrupted agent update: %w", verifyErr)
+					}
+					if !agentUpdateVerified(verifyResp.GetVersion(), expectedAgentVersion) {
+						return fmt.Errorf("the device still reports agent %s after the interrupted update (expected %s); "+
+							"the upload did not apply — re-run 'wendy device update'",
+							verifyResp.GetVersion(), expectedAgentVersion)
+					}
+					if !jsonOutput {
+						fmt.Printf("%s %s\n", tui.Dim("Verified agent version:"), tui.Value(verifyResp.GetVersion()))
+					}
+				}
 
-			if unconfirmed {
-				verifyResp, verifyErr := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
-				if verifyErr != nil {
-					return fmt.Errorf("could not verify the interrupted agent update: %w", verifyErr)
+				if jsonOutput {
+					resp := map[string]string{
+						"status":  "success",
+						"message": "Agent updated successfully.",
+					}
+					b, err := json.Marshal(resp)
+					if err != nil {
+						return fmt.Errorf("failed to marshal JSON response: %w", err)
+					}
+					fmt.Println(string(b))
+					// OS update check is skipped in JSON mode to keep output stable.
+					return nil
 				}
-				if !agentUpdateVerified(verifyResp.GetVersion(), expectedAgentVersion) {
-					return fmt.Errorf("the device still reports agent %s after the interrupted update (expected %s); "+
-						"the upload did not apply — re-run 'wendy device update'",
-						verifyResp.GetVersion(), expectedAgentVersion)
-				}
-				if !jsonOutput {
-					fmt.Printf("%s %s\n", tui.Dim("Verified agent version:"), tui.Value(verifyResp.GetVersion()))
-				}
+				fmt.Println(tui.SuccessMessage("Agent updated successfully."))
 			}
-
-			if jsonOutput {
-				resp := map[string]string{
-					"status":  "success",
-					"message": "Agent updated successfully.",
-				}
-				b, err := json.Marshal(resp)
-				if err != nil {
-					return fmt.Errorf("failed to marshal JSON response: %w", err)
-				}
-				fmt.Println(string(b))
-				// OS update check is skipped in JSON mode to keep output stable.
-				return nil
-			}
-			fmt.Println(tui.SuccessMessage("Agent updated successfully."))
 
 			var outcome osUpdateOutcome
 			if conn != nil {


### PR DESCRIPTION
## Problem

When the device already ran the latest release, `wendy device update` still downloaded and re-uploaded the identical agent binary, restarted the agent, and printed "Agent updated successfully."

## Fix

On the auto-download path, resolve the target release **version** first (from the GCS manifest / GitHub release metadata — no tarball download) and compare it to the device's running version:

- If the device is already at (or ahead of) that version, skip the download, upload, and agent restart entirely, and report it: `Agent is already up to date (<version>).`
- Otherwise download the binary and proceed as before.

A dev-build agent (`-dev`) is treated as out of date on an explicit `device update`, so the command overwrites it with the release. Dev builds still compare as newest everywhere else (e.g. the passive update check). The `--binary` path is unaffected: an explicitly supplied local binary is always uploaded.

The OS-update check still runs afterward in human-readable mode. In `--json` mode the command returns immediately after the agent result and does not run the OS-update step. This existing divergence is tracked separately in WDY-1961.

## Validation

Pi 4 already on the latest release (`2026.07.20-035949`), `device update --json`:

| | before | after |
|---|---|---|
| output | `{"status":"success","message":"Agent updated successfully."}` | `{"status":"up-to-date","message":"Agent is already up to date.","version":"2026.07.20-035949"}` |
| time | 12.17s (re-upload + agent restart) | 1.47s (no download, no restart) |
