### PR TITLE
test: exercise Swift E2E analytics specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAnalyticsDisableTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAnalyticsDisableTests.swift
@@ -2,194 +2,421 @@ import Foundation
 import Testing
 import WendyE2ETesting
 
-/// Disables anonymous usage analytics.
-///
-/// Synopsis:
-///
-/// `wendy analytics disable`
-///
-/// `wendy analytics disable` writes the user's preference to the CLI
-/// configuration file and immediately disables analytics for the current
-/// process so no further events are emitted during this invocation.
-///
-/// The command does not accept arguments or flags. It is always
-/// non-interactive and deterministic.
 @Suite
 struct `'wendy analytics disable'` {
     let scenario = CLIAndAgentScenario()
 
-    // MARK: - Happy paths
+    /**
+     Displays usage for `wendy analytics disable`, including inherited global
+     flags, without consulting authentication, project, or device state.
+     */
+    @Test
+    func `prints command help`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics disable --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Disable anonymous usage analytics"))
+                #expect(stdout.contains("Usage:"))
+                #expect(stdout.contains("wendy analytics disable [flags]"))
+                #expect(stdout.contains("--help"))
+                #expect(stdout.contains("--device"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
+    }
 
     /**
-     Disabling analytics writes `{"analytics":{"enabled":false}}` to
-     `~/.wendy/config.json`. The command prints a concise confirmation to
-     stdout and emits nothing to stderr.
+     Disabling analytics stores `analytics.enabled=false`, prints a concise
+     confirmation to stdout, and emits nothing to stderr.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1935: 'wendy analytics disable' writes its normal confirmation to stderr instead of stdout."
+        )
+    )
     func `disables analytics and prints confirmation`() async throws {
-        // TODO: implement.
+        // TODO: enable when successful analytics command output uses stdout (WDY-1935).
     }
 
     /**
-     When analytics is already disabled, the command still writes the
-     preference and prints the same confirmation. The stored state and
-     output do not change.
+     Running the command repeatedly stores the same disabled preference.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `is idempotent when analytics is already disabled`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics disable") { #expect($0.status.isSuccess) }
+            try await cli.sh("wendy analytics disable") { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\": false"))
+            }
+        }
     }
 
     /**
-     Disabling analytics does not remove other configuration keys such as
-     `auth`, `defaultDevice`, or `lastCLIUpdateCheck`. Only the
-     `analytics` object is updated.
+     Disabling analytics preserves known authentication-independent config
+     fields and changes only the analytics preference.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `preserves unrelated configuration keys`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.wendy"
+                    printf '%s\n' '{"defaultDevice":"keep-device","lastCLIUpdateCheck":"2026-07-20T12:00:00Z","availableCLIUpdate":"2026.07.20","completionPromptDismissed":true,"analytics":{"enabled":true}}' > "$HOME/.wendy/config.json"
+                    """,
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"defaultDevice":"keep-device","lastCLIUpdateCheck":"2026-07-20T12:00:00Z","availableCLIUpdate":"2026.07.20","completionPromptDismissed":true,"analytics":{"enabled":true}}'
+                    """
+            )
+
+            try await cli.sh("wendy analytics disable") { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                #expect(json["defaultDevice"] as? String == "keep-device")
+                #expect(json["lastCLIUpdateCheck"] as? String == "2026-07-20T12:00:00Z")
+                #expect(json["availableCLIUpdate"] as? String == "2026.07.20")
+                #expect(json["completionPromptDismissed"] as? Bool == true)
+                let analytics = try #require(json["analytics"] as? [String: Any])
+                #expect(analytics["enabled"] as? Bool == false)
+            }
+        }
     }
 
     /**
-     Disabling analytics does not delete the anonymous analytics ID stored
-     at `~/.wendy/analytics_id`. The ID is retained so that a later
-     `analytics enable` can resume using the same identifier.
+     Disabling analytics retains the anonymous analytics identifier so a
+     later enable can resume with the same identity.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `retains the analytics identifier file`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf 'stable-id\\n' > \"$HOME/.wendy/analytics_id\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/analytics_id') -Value 'stable-id'
+                    """
+            )
+            try await cli.sh("wendy analytics disable") { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/analytics_id\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/analytics_id')"
+            ) { result in
+                #expect(
+                    result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "stable-id"
+                )
+            }
+        }
     }
 
-    // MARK: - Invalid input / missing state
-
     /**
-     The command does not accept positional arguments. Passing an argument
-     produces a usage diagnostic and exits with a failure status without
-     touching the configuration file.
+     Extra positional arguments are rejected without changing config state.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy analytics disable' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
     func `rejects positional arguments`() async throws {
-        // TODO: implement.
+        // TODO: enable when analytics leaf commands reject positional arguments (WDY-1934).
     }
 
     /**
-     If the `~/.wendy` directory does not exist, the command creates it
-     (with appropriate permissions) and then writes the configuration
-     file. It does not fail when the directory is absent.
+     Unknown flags fail before config mutation.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
+    func `rejects unknown flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{\"analytics\":{\"enabled\":true}}\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"analytics":{"enabled":true}}'
+                    """
+            )
+            try await cli.sh("wendy analytics disable --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\":true"))
+            }
+        }
+    }
+
+    /**
+     Creates the Wendy config directory when absent.
+     */
+    @Test
     func `creates the config directory when absent`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics disable") { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: """
+                    test -d "$HOME/.wendy"
+                    if stat -f '%Lp' "$HOME/.wendy" >/dev/null 2>&1; then
+                      stat -f '%Lp' "$HOME/.wendy"
+                    else
+                      stat -c '%a' "$HOME/.wendy"
+                    fi
+                    """,
+                power: """
+                    if (-not (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy') -PathType Container)) { throw '.wendy missing' }
+                    Write-Output 'present'
+                    """
+            ) { result in
+                if cli.machine.os == .windows {
+                    #expect(result.stdout.contains("present"))
+                } else {
+                    #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "700")
+                }
+            }
+        }
     }
 
     /**
-     If `~/.wendy/config.json` does not exist, the command treats the
-     state as empty, writes the disabled preference, and succeeds.
+     Treats a missing config file as empty and creates it with the disabled
+     preference.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `creates the config file when absent`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics disable") { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\": false"))
+            }
+        }
     }
 
     /**
-     If `~/.wendy/config.json` exists but contains malformed JSON, the
-     command reports the parse error, exits with a failure status, and does
-     not modify the file.
+     Reports malformed config and leaves its bytes unchanged.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports invalid configuration without mutating the file`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{ invalid json\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -NoNewline -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{ invalid json'
+                    """
+            )
+            try await cli.sh("wendy analytics disable") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("parsing config"))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("{ invalid json"))
+            }
+        }
     }
 
-    // MARK: - Filesystem/config side effects
-
     /**
-     The command writes `config.json` with restrictive permissions
-     (typically `0o600`) because the file may contain sensitive
-     authentication material in other keys.
+     Writes config with owner-only POSIX permissions because the same file may
+     contain authentication material.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `writes config with restricted permissions`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics disable") { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: """
+                    if stat -f '%Lp' "$HOME/.wendy/config.json" >/dev/null 2>&1; then
+                      stat -f '%Lp' "$HOME/.wendy/config.json"
+                    else
+                      stat -c '%a' "$HOME/.wendy/config.json"
+                    fi
+                    """,
+                power: """
+                    $path = Join-Path $env:HOME '.wendy/config.json'
+                    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw 'config.json missing' }
+                    Write-Output 'present'
+                    """
+            ) { result in
+                if cli.machine.os == .windows {
+                    #expect(result.stdout.contains("present"))
+                } else {
+                    #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "600")
+                }
+            }
+        }
     }
 
     /**
-     If the configuration file is read-only, the command reports the write
-     error, exits with a failure status, and leaves the existing file
-     untouched.
+     Reports a read-only config write failure and leaves the preference
+     unchanged.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports a read-only config file without mutating it`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.wendy"
+                    printf '{"analytics":{"enabled":true}}\n' > "$HOME/.wendy/config.json"
+                    chmod 400 "$HOME/.wendy/config.json"
+                    """,
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    $path = Join-Path $env:HOME '.wendy/config.json'
+                    Set-Content -LiteralPath $path -Value '{"analytics":{"enabled":true}}'
+                    (Get-Item -LiteralPath $path).IsReadOnly = $true
+                    """
+            )
+            try await cli.sh(
+                posix: """
+                    wendy analytics disable
+                    status=$?
+                    chmod 600 "$HOME/.wendy/config.json"
+                    exit $status
+                    """,
+                power: """
+                    $path = Join-Path $env:HOME '.wendy/config.json'
+                    try {
+                        wendy analytics disable
+                        $status = $LASTEXITCODE
+                    } finally {
+                        (Get-Item -LiteralPath $path).IsReadOnly = $false
+                    }
+                    exit $status
+                    """
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("writing config"))
+                #expect(!result.stderr.contains("Analytics disabled."))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\":true"))
+            }
+        }
     }
 
-    // MARK: - Environment isolation
-
     /**
-     The `WENDY_ANALYTICS` environment variable does not prevent
-     `analytics disable` from writing the config file. The command stores
-     the user's preference regardless of the env var, even though the env
-     var may override the effective runtime behavior of other commands.
+     Stores the preference despite the `WENDY_ANALYTICS` runtime override.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `stores preference regardless of WENDY_ANALYTICS env var`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: "WENDY_ANALYTICS=true wendy analytics disable",
+                power: """
+                    $env:WENDY_ANALYTICS = 'true'
+                    wendy analytics disable
+                    exit $LASTEXITCODE
+                    """
+            ) { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\": false"))
+            }
+        }
     }
 
     /**
-     Running inside a CI environment (e.g. with `CI=true`) does not prevent
-     the command from writing the disabled preference. The CI kill switch
-     affects runtime tracking, not the user's stored preference.
+     Stores the preference when CI detection disables runtime tracking.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `stores preference regardless of CI environment detection`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: "CI=true WENDY_ANALYTICS=true wendy analytics disable",
+                power: """
+                    $env:CI = 'true'
+                    $env:WENDY_ANALYTICS = 'true'
+                    wendy analytics disable
+                    exit $LASTEXITCODE
+                    """
+            ) { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\": false"))
+            }
+        }
     }
 
-    // MARK: - stdout/stderr/exit status
-
     /**
-     On success, the command prints exactly `Analytics disabled.` to
-     stdout followed by a newline, and emits nothing to stderr. The exit
-     status is zero.
+     On failure, emits a diagnostic only on stderr and returns non-zero.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints confirmation to stdout and nothing to stderr`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     On failure, the command prints a diagnostic to stderr and emits
-     nothing to stdout. The exit status is non-zero.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `prints diagnostics to stderr on failure`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{ broken\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{ broken'
+                    """
+            )
+            try await cli.sh("wendy analytics disable") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("parsing config"))
+            }
+        }
     }
 
-    // MARK: - Interaction with analytics enable
-
     /**
-     After `analytics disable`, a subsequent `analytics enable` overwrites
-     the stored preference with `{"analytics":{"enabled":true}}` and
-     resumes event emission. The two commands are exact inverses at the
-     configuration level.
+     A later enable command reverses the stored preference while preserving
+     the rest of config state.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `is reversible with analytics enable`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics disable") { #expect($0.status.isSuccess) }
+            try await cli.sh("wendy analytics enable") { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\": true"))
+            }
+        }
     }
 
-    // MARK: - In-process side effect
-
     /**
-     When `analytics disable` is invoked as part of a longer CLI command
-     chain or script, it immediately disables in-memory analytics for the
-     current process. No further events are tracked during the same
-     invocation, even before the process exits.
+     Emits structured output describing the stored preference when `--json`
+     is requested.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `disables in-memory analytics for the current process`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1909: 'wendy analytics disable --json' ignores JSON mode and prints the human confirmation."
+        )
+    )
+    func `prints JSON disable result for automation`() async throws {
+        // TODO: enable when analytics mutations implement global --json (WDY-1909).
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAnalyticsEnableTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAnalyticsEnableTests.swift
@@ -1,88 +1,261 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy analytics enable'` {
+    let scenario = CLIAndAgentScenario()
+
     /**
-     Displays usage for `wendy analytics enable`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
+     Displays usage for `wendy analytics enable`, including inherited global
+     flags, without consulting authentication, project, or device state.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics enable --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Enable anonymous usage analytics"))
+                #expect(stdout.contains("Usage:"))
+                #expect(stdout.contains("wendy analytics enable [flags]"))
+                #expect(stdout.contains("--help"))
+                #expect(stdout.contains("--device"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
     /**
-     Writes `{"analytics":{"enabled":true}}` to the Wendy CLI
-     configuration and enables analytics for future invocations. The command
-     prints `Analytics enabled.` followed by a newline, emits no stderr, and
-     exits successfully.
+     Writes `analytics.enabled=true`, prints `Analytics enabled.` to stdout,
+     emits no stderr, and exits successfully.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1935: 'wendy analytics enable' writes its normal confirmation to stderr instead of stdout."
+        )
+    )
     func `enables analytics and prints confirmation`() async throws {
-        // TODO: implement.
+        // TODO: enable when successful analytics command output uses stdout (WDY-1935).
     }
 
     /**
-     Running the command with analytics already enabled stores the same
-     preference and prints the same confirmation. Existing analytics
-     identity state remains unchanged.
+     Running the command repeatedly stores the same preference without
+     changing an existing analytics identity.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `is idempotent when analytics is already enabled`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf 'stable-id\\n' > \"$HOME/.wendy/analytics_id\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/analytics_id') -Value 'stable-id'
+                    """
+            )
+
+            try await cli.sh("wendy analytics enable") { #expect($0.status.isSuccess) }
+            try await cli.sh("wendy analytics enable") { #expect($0.status.isSuccess) }
+
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"; cat \"$HOME/.wendy/analytics_id\"",
+                power: """
+                    Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')
+                    Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/analytics_id')
+                    """
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\": true"))
+                #expect(result.stdout.contains("stable-id"))
+            }
+        }
     }
 
     /**
-     Updates only the analytics preference. Authentication sessions,
-     default device selection, update check metadata, and unknown future
-     configuration keys remain intact.
+     Updates only the analytics preference while preserving known
+     authentication, device, and update-check configuration fields.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `preserves unrelated configuration keys`() async throws {
-        // TODO: implement.
+    @Test
+    func `preserves unrelated known configuration keys`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.wendy"
+                    printf '%s\n' '{"defaultDevice":"keep-device","lastCLIUpdateCheck":"2026-07-20T12:00:00Z","availableCLIUpdate":"2026.07.20","completionPromptDismissed":true,"analytics":{"enabled":false}}' > "$HOME/.wendy/config.json"
+                    """,
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"defaultDevice":"keep-device","lastCLIUpdateCheck":"2026-07-20T12:00:00Z","availableCLIUpdate":"2026.07.20","completionPromptDismissed":true,"analytics":{"enabled":false}}'
+                    """
+            )
+
+            try await cli.sh("wendy analytics enable") { #expect($0.status.isSuccess) }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                #expect(json["defaultDevice"] as? String == "keep-device")
+                #expect(json["lastCLIUpdateCheck"] as? String == "2026-07-20T12:00:00Z")
+                #expect(json["availableCLIUpdate"] as? String == "2026.07.20")
+                #expect(json["completionPromptDismissed"] as? Bool == true)
+                let analytics = try #require(json["analytics"] as? [String: Any])
+                #expect(analytics["enabled"] as? Bool == true)
+            }
+        }
     }
 
     /**
-     Creates `~/.wendy` and `~/.wendy/config.json` when they are absent,
-     then stores the enabled preference with restrictive file permissions.
+     Preserves unrecognized top-level fields so an older CLI cannot erase
+     configuration introduced by a newer Wendy component.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1940: typed config load/save currently discards unknown top-level keys during analytics mutations."
+        )
+    )
+    func `preserves unknown future configuration keys`() async throws {
+        // TODO: enable when config mutations round-trip unknown fields (WDY-1940).
+    }
+
+    /**
+     Creates the Wendy config directory and file when absent, storing the
+     enabled preference with restrictive POSIX permissions.
+     */
+    @Test
     func `creates missing configuration state`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics enable") { result in
+                #expect(result.status.isSuccess)
+            }
+
+            try await cli.sh(
+                posix: """
+                    test -f "$HOME/.wendy/config.json"
+                    if stat -f '%Lp' "$HOME/.wendy/config.json" >/dev/null 2>&1; then
+                      stat -f '%Lp' "$HOME/.wendy/config.json"
+                    else
+                      stat -c '%a' "$HOME/.wendy/config.json"
+                    fi
+                    """,
+                power: """
+                    $path = Join-Path $env:HOME '.wendy/config.json'
+                    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw 'config.json missing' }
+                    Write-Output 'present'
+                    """
+            ) { result in
+                if cli.machine.os == .windows {
+                    #expect(result.stdout.contains("present"))
+                } else {
+                    #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "600")
+                }
+            }
+        }
     }
 
     /**
-     Reads the Wendy CLI configuration before performing work that depends on
-     user state. Malformed configuration is reported as a configuration error,
-     no prompts open, no network connection is attempted, and the original file
-     remains byte-for-byte unchanged.
+     Malformed configuration is reported before mutation and remains
+     byte-for-byte unchanged.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports invalid CLI configuration before acting`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{ invalid json\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -NoNewline -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{ invalid json'
+                    """
+            )
+
+            try await cli.sh("wendy analytics enable") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("parsing config"))
+                #expect(!result.stderr.contains("Analytics enabled."))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("{ invalid json"))
+            }
+        }
     }
 
     /**
-     Accepts only the documented arguments and flags for `wendy analytics
-     enable`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
+     Unknown flags produce a failure diagnostic and leave existing config
+     state unchanged.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{\"analytics\":{\"enabled\":false}}\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"analytics":{"enabled":false}}'
+                    """
+            )
+
+            try await cli.sh("wendy analytics enable --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\":false"))
+            }
+        }
     }
 
     /**
-     Stores the user's preference even when `WENDY_ANALYTICS` or CI
-     environment detection changes effective runtime tracking. Environment
-     kill switches do not prevent the configuration write.
+     Extra positional arguments are rejected instead of being silently
+     ignored while the preference is changed.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy analytics enable' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when analytics leaf commands reject positional arguments (WDY-1934).
+    }
+
+    /**
+     Stores the explicit preference even when runtime environment kill
+     switches make analytics ineffective for this process.
+     */
+    @Test
     func `stores preference regardless of analytics environment overrides`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: "CI=true WENDY_ANALYTICS=false wendy analytics enable",
+                power: """
+                    $env:CI = 'true'
+                    $env:WENDY_ANALYTICS = 'false'
+                    wendy analytics enable
+                    exit $LASTEXITCODE
+                    """
+            ) { result in
+                #expect(result.status.isSuccess)
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"enabled\": true"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAnalyticsStatusTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAnalyticsStatusTests.swift
@@ -1,77 +1,144 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy analytics status'` {
+    let scenario = CLIAndAgentScenario()
+
     /**
-     Displays usage for `wendy analytics status`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
+     Displays usage for `wendy analytics status`, including inherited global
+     flags, without consulting auth, project, or device state.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics status --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Show current analytics status"))
+                #expect(stdout.contains("Usage:"))
+                #expect(stdout.contains("wendy analytics status [flags]"))
+                #expect(stdout.contains("--help"))
+                #expect(stdout.contains("--device"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
     /**
-     Treats a missing analytics preference as enabled and prints a concise
-     human-readable status. The command emits no stderr, exits successfully,
-     and does not create or modify configuration files.
+     Treats a missing analytics preference as enabled, prints the status to
+     stdout, and does not create a config file.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1935: 'wendy analytics status' writes the normal enabled status to stderr instead of stdout."
+        )
+    )
     func `prints enabled status by default`() async throws {
-        // TODO: implement.
+        // TODO: enable when successful analytics status output uses stdout (WDY-1935).
     }
 
     /**
-     Reads `analytics.enabled=false` from the CLI configuration and reports
-     analytics as disabled. Other configuration keys and analytics identity
-     files remain unchanged.
+     Reads `analytics.enabled=false`, reports disabled status on stdout, and
+     leaves config and analytics identity state unchanged.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1935: 'wendy analytics status' writes the normal disabled status to stderr instead of stdout."
+        )
+    )
     func `prints disabled status from configuration`() async throws {
-        // TODO: implement.
+        // TODO: enable when successful analytics status output uses stdout (WDY-1935).
     }
 
     /**
-     When `WENDY_ANALYTICS=false` is present, reports analytics as disabled
-     by environment override. The stored preference remains unchanged.
+     Reports a `WENDY_ANALYTICS=false` override on stdout while leaving the
+     stored preference unchanged.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1935: the environment-override status is written to stderr instead of stdout."
+        )
+    )
     func `reports WENDY_ANALYTICS environment overrides`() async throws {
-        // TODO: implement.
+        // TODO: enable when successful analytics status output uses stdout (WDY-1935).
     }
 
     /**
-     With `--json`, emits one JSON object describing the stored preference,
-     effective enabled state, and override source. JSON mode emits no
-     prompt text and no stderr on success.
+     With `--json`, emits a JSON object describing the stored preference,
+     effective state, and override source, with no human output.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1909: 'wendy analytics status --json' ignores JSON mode and prints the human status; WDY-1935 also tracks that it uses stderr."
+        )
+    )
     func `prints JSON status for automation`() async throws {
-        // TODO: implement.
+        // TODO: enable when analytics status implements global --json (WDY-1909).
     }
 
     /**
-     Reads the Wendy CLI configuration before performing work that depends on
-     user state. Malformed configuration is reported as a configuration error,
-     no prompts open, no network connection is attempted, and the original file
-     remains byte-for-byte unchanged.
+     Reports malformed CLI config before status evaluation and leaves the
+     original file unchanged.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports invalid CLI configuration before acting`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{ invalid json\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -NoNewline -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{ invalid json'
+                    """
+            )
+            try await cli.sh("wendy analytics status") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("parsing config"))
+                #expect(!result.stderr.contains("Analytics:"))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("{ invalid json"))
+            }
+        }
     }
 
     /**
-     Accepts only the documented arguments and flags for `wendy analytics
-     status`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
+     Unknown flags fail before reading or changing user config.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy analytics status --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+                #expect(!result.stderr.contains("Analytics:"))
+            }
+            try await cli.sh(
+                posix: "test ! -f \"$HOME/.wendy/config.json\"",
+                power:
+                    "if (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy/config.json')) { throw 'config created' }"
+            )
+        }
+    }
+
+    /**
+     Extra positional arguments are rejected with a usage diagnostic rather
+     than silently ignored.
+     */
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy analytics status' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when analytics leaf commands reject positional arguments (WDY-1934).
     }
 }


### PR DESCRIPTION
> **In plain terms:** No CLI behavior changes — this replaces the placeholder analytics tests with real checks for how Wendy stores and protects the user's analytics preference. Behaviors the CLI does not support yet remain explicitly skipped and linked to follow-up work instead of being treated as correct.

## Summary

- Exercise `wendy analytics enable`, `disable`, and `status` help, config mutation, idempotence, environment overrides, malformed/read-only config failures, permissions, and input validation.
- Remove all 31 generic `SPEC STUB` markers from the three analytics suites: 24 tests now execute and 11 are specifically disabled.
- Keep unsupported contracts tied to WDY-1909 (`--json`), WDY-1934 (positional arguments), WDY-1935 (normal output on stderr), and WDY-1940 (unknown config keys discarded).
- Remove two redundant/non-E2E-observable specs rather than preserving placeholders for duplicate stdout coverage and an in-process side effect that ends with the CLI process.

## Stack

- Stacked on #1462; review commit `2434f71fa` for this iteration only.
- Test-only; physical routes remain dormant.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyAnalytics"`
- Result: `Test run with 35 tests in 3 suites passed` (24 executed, 11 intentionally skipped).
