### PR TITLE
test: exercise Swift E2E MCP specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyMcpServeTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyMcpServeTests.swift
@@ -1,66 +1,189 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy mcp serve'` {
+    let scenario = CLIAndAgentScenario()
+
     /**
-     Displays usage for `wendy mcp serve`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
+     Displays stdio server usage and flags without starting the protocol loop.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy mcp serve --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Model Context Protocol server"))
+                #expect(stdout.contains("Usage:"))
+                #expect(stdout.contains("wendy mcp serve [flags]"))
+                #expect(stdout.contains("--device"))
+                #expect(stdout.contains("--help"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
     /**
-     Starts a Model Context Protocol server on stdin and stdout with
-     Wendy device tools registered. Protocol messages are written only
-     to stdout; diagnostics and logs use stderr.
+     Negotiates an MCP session over newline-delimited stdio and lists Wendy
+     tools without mixing diagnostics into protocol stdout.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `serves MCP tools over stdio`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    printf '%s\n' \
+                      '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"swift-e2e","version":"1"}}}' \
+                      '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+                      '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+                    | wendy mcp serve
+                    """,
+                power: """
+                    @(
+                      '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"swift-e2e","version":"1"}}}',
+                      '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}',
+                      '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+                    ) | wendy mcp serve
+                    exit $LASTEXITCODE
+                    """
+            ) { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stderr == "")
+
+                let lines = result.normalizedStdout.split(separator: "\n")
+                #expect(lines.count == 2)
+                let initialize = try #require(
+                    try JSONSerialization.jsonObject(with: Data(lines[0].utf8))
+                        as? [String: Any]
+                )
+                #expect(initialize["jsonrpc"] as? String == "2.0")
+                #expect(initialize["id"] as? Int == 1)
+                let initializeResult = try #require(initialize["result"] as? [String: Any])
+                #expect(initializeResult["protocolVersion"] as? String == "2024-11-05")
+                let serverInfo = try #require(initializeResult["serverInfo"] as? [String: Any])
+                #expect(serverInfo["name"] as? String == "wendy")
+
+                let toolsResponse = try #require(
+                    try JSONSerialization.jsonObject(with: Data(lines[1].utf8))
+                        as? [String: Any]
+                )
+                #expect(toolsResponse["id"] as? Int == 2)
+                let toolsResult = try #require(toolsResponse["result"] as? [String: Any])
+                let tools = try #require(toolsResult["tools"] as? [[String: Any]])
+                let names = Set(tools.compactMap { $0["name"] as? String })
+                #expect(names.contains("wendy_status"))
+                #expect(names.contains("device_connect"))
+                #expect(names.contains("cloud_connect"))
+            }
+        }
     }
 
     /**
-     `--device` preselects a device for tools that need one. Startup
-     reports device connection problems through MCP errors without
-     corrupting the stdio protocol stream.
+     An initial device failure remains disconnected and is exposed through
+     structured MCP state or errors without corrupting protocol stdout.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1942: --device uses a lazy gRPC connection, records an unreachable target as active, and exposes the failure only as a stderr warning during container scanning rather than structured MCP state."
+        )
+    )
     func `connects to an initial device when provided`() async throws {
-        // TODO: implement.
+        // TODO: enable with an unreachable loopback endpoint when MCP reports accurate structured connection state (WDY-1942).
     }
 
     /**
-     The server is suitable for AI assistant launches. It does not open
-     interactive pickers, browser windows, or terminal UI while handling
-     protocol requests.
+     Handles protocol requests without opening interactive pickers, browser
+     windows, or terminal UI.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `does not prompt while serving`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    printf '%s\n' \
+                      '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"swift-e2e","version":"1"}}}' \
+                      '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+                      '{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}' \
+                    | wendy mcp serve
+                    """,
+                power: """
+                    @(
+                      '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"swift-e2e","version":"1"}}}',
+                      '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}',
+                      '{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}'
+                    ) | wendy mcp serve
+                    exit $LASTEXITCODE
+                    """
+            ) { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stderr == "")
+                #expect(!result.stdout.lowercased().contains("select a device"))
+                #expect(!result.stdout.lowercased().contains("press enter"))
+
+                let lines = result.normalizedStdout.split(separator: "\n")
+                #expect(lines.count == 2)
+                let resourcesResponse = try #require(
+                    try JSONSerialization.jsonObject(with: Data(lines[1].utf8))
+                        as? [String: Any]
+                )
+                #expect(resourcesResponse["id"] as? Int == 2)
+                #expect(resourcesResponse["error"] == nil)
+                let resourcesResult = try #require(resourcesResponse["result"] as? [String: Any])
+                let resources = try #require(resourcesResult["resources"] as? [[String: Any]])
+                #expect(resources.contains { $0["uri"] as? String == "wendy://guide" })
+            }
+        }
     }
 
     /**
-     Closing stdin or sending the MCP shutdown request releases device
-     connections and exits without leaving background processes.
+     Closing stdin terminates the server successfully without protocol output
+     or a lingering child process.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `shuts down cleanly when stdin closes`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: "wendy mcp serve < /dev/null",
+                power: """
+                    $null | wendy mcp serve
+                    exit $LASTEXITCODE
+                    """
+            ) { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout == "")
+                #expect(result.stderr == "")
+            }
+        }
     }
 
     /**
-     Accepts only the documented arguments and flags for `wendy mcp serve`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
+     Unknown flags fail before the stdio protocol loop starts.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy mcp serve --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
+    }
+
+    /**
+     Extra positional arguments are rejected instead of being silently
+     ignored while the server starts.
+     */
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy mcp serve' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when MCP leaf commands reject positional arguments (WDY-1934).
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyMcpSetupTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyMcpSetupTests.swift
@@ -1,64 +1,195 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy mcp setup'` {
+    let scenario = CLIAndAgentScenario()
+
     /**
-     Displays usage for `wendy mcp setup`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
+     Displays setup usage and inherited flags without inspecting or changing
+     assistant configuration.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy mcp setup --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Detects installed AI tools"))
+                #expect(stdout.contains("Usage:"))
+                #expect(stdout.contains("wendy mcp setup [flags]"))
+                #expect(stdout.contains("--help"))
+                #expect(stdout.contains("--device"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
     /**
-     Detects supported AI tools and writes configuration that launches
-     `wendy mcp serve`. Existing unrelated tool configuration remains
-     intact.
+     Detects a supported assistant from its config directory, adds the Wendy
+     stdio MCP entry, and preserves unrelated settings and servers.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `adds Wendy MCP configuration to detected AI tools`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.cursor"
+                    printf '%s\n' '{"theme":"dark","mcpServers":{"other":{"command":"other","args":["serve"]}}}' > "$HOME/.cursor/mcp.json"
+                    wendy_path=$(command -v wendy)
+                    PATH="$(dirname "$wendy_path"):/usr/bin:/bin" "$wendy_path" mcp setup
+                    """,
+                power: """
+                    $cursorDirectory = Join-Path $env:HOME '.cursor'
+                    New-Item -ItemType Directory -Force -Path $cursorDirectory | Out-Null
+                    Set-Content -LiteralPath (Join-Path $cursorDirectory 'mcp.json') -Value '{"theme":"dark","mcpServers":{"other":{"command":"other","args":["serve"]}}}'
+                    $wendyPath = (Get-Command wendy).Source
+                    $env:PATH = (Split-Path -Parent $wendyPath) + ';' + (Join-Path $env:SystemRoot 'System32')
+                    & $wendyPath mcp setup
+                    exit $LASTEXITCODE
+                    """
+            ) { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Cursor: configured at"))
+                #expect(result.stdout.contains(".cursor"))
+                #expect(result.stderr == "")
+            }
+
+            try await cli.sh(
+                posix: "cat \"$HOME/.cursor/mcp.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.cursor/mcp.json')"
+            ) { result in
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                #expect(json["theme"] as? String == "dark")
+                let servers = try #require(json["mcpServers"] as? [String: Any])
+                let other = try #require(servers["other"] as? [String: Any])
+                #expect(other["command"] as? String == "other")
+                let wendy = try #require(servers["wendy"] as? [String: Any])
+                #expect(wendy["type"] as? String == "stdio")
+                #expect((wendy["command"] as? String)?.lowercased().contains("wendy") == true)
+                #expect(wendy["args"] as? [String] == ["mcp", "serve"])
+            }
+
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"lastMCPSetupVersion\": \"dev\""))
+            }
+        }
     }
 
     /**
-     Running setup repeatedly updates the managed Wendy MCP entry without
-     duplicating entries or reordering unrelated configuration.
+     Re-running setup produces the same managed entry without duplicating it
+     or changing unrelated assistant configuration.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `is idempotent when configuration already exists`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.cursor"
+                    printf '%s\n' '{"theme":"dark","mcpServers":{"other":{"command":"other"}}}' > "$HOME/.cursor/mcp.json"
+                    wendy_path=$(command -v wendy)
+                    PATH="$(dirname "$wendy_path"):/usr/bin:/bin" "$wendy_path" mcp setup >/dev/null
+                    cp "$HOME/.cursor/mcp.json" "$HOME/first-mcp.json"
+                    PATH="$(dirname "$wendy_path"):/usr/bin:/bin" "$wendy_path" mcp setup >/dev/null
+                    cmp "$HOME/first-mcp.json" "$HOME/.cursor/mcp.json"
+                    """,
+                power: """
+                    $cursorDirectory = Join-Path $env:HOME '.cursor'
+                    New-Item -ItemType Directory -Force -Path $cursorDirectory | Out-Null
+                    $configPath = Join-Path $cursorDirectory 'mcp.json'
+                    Set-Content -LiteralPath $configPath -Value '{"theme":"dark","mcpServers":{"other":{"command":"other"}}}'
+                    $wendyPath = (Get-Command wendy).Source
+                    $env:PATH = (Split-Path -Parent $wendyPath) + ';' + (Join-Path $env:SystemRoot 'System32')
+                    & $wendyPath mcp setup | Out-Null
+                    $first = Get-Content -Raw -LiteralPath $configPath
+                    & $wendyPath mcp setup | Out-Null
+                    $second = Get-Content -Raw -LiteralPath $configPath
+                    if ($first -ne $second) { throw 'MCP config changed on the second setup' }
+                    """
+            )
+
+            try await cli.sh(
+                posix: "cat \"$HOME/.cursor/mcp.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.cursor/mcp.json')"
+            ) { result in
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                let servers = try #require(json["mcpServers"] as? [String: Any])
+                #expect(Set(servers.keys) == Set(["other", "wendy"]))
+                #expect(json["theme"] as? String == "dark")
+            }
+        }
     }
 
     /**
-     When no supported tool configuration is present, reports the available
-     manual setup command and leaves the filesystem unchanged.
+     With no supported tool installed, prints manual stdio setup guidance and
+     leaves Wendy and assistant files untouched.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1941: the no-tools path creates ~/.wendy/config.json and records lastMCPSetupVersion even though nothing was configured; it also omits the manual 'wendy mcp serve' instruction."
+        )
+    )
     func `reports unsupported or missing AI tools without writing files`() async throws {
-        // TODO: implement.
+        // TODO: enable when no-tool setup is non-mutating and provides manual instructions (WDY-1941).
     }
 
     /**
-     With `--json`, emits one JSON object listing detected tools, changed
-     files, skipped files, and manual instructions.
+     With `--json`, emits a structured summary of detected tools and changed
+     or skipped files.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1909: 'wendy mcp setup --json' ignores JSON mode and prints the human setup summary."
+        )
+    )
     func `prints JSON setup summary for automation`() async throws {
-        // TODO: implement.
+        // TODO: enable when MCP setup implements global --json (WDY-1909).
     }
 
     /**
-     Accepts only the documented arguments and flags for `wendy mcp setup`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
+     Unknown flags fail before assistant or Wendy config is written.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy mcp setup --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+            try await cli.sh(
+                posix:
+                    "test ! -e \"$HOME/.wendy/config.json\" && test ! -e \"$HOME/.cursor/mcp.json\"",
+                power: """
+                    if (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy/config.json')) { throw 'Wendy config created' }
+                    if (Test-Path -LiteralPath (Join-Path $env:HOME '.cursor/mcp.json')) { throw 'Cursor config created' }
+                    """
+            )
+        }
+    }
+
+    /**
+     Unexpected positional arguments are rejected rather than silently
+     ignored while setup mutates detected tool configuration.
+     */
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy mcp setup' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when MCP leaf commands reject positional arguments (WDY-1934).
     }
 }


### PR DESCRIPTION
> **In plain terms:** No CLI behavior changes — this replaces the placeholder MCP tests with real checks that Wendy configures supported assistants safely and speaks valid Model Context Protocol over standard input and output. Unsupported behavior remains explicitly skipped and linked to follow-up work.

## Summary

- Exercise `wendy mcp setup` help, Cursor config preservation, idempotence, version recording, and unknown-flag rejection in an isolated home directory.
- Exercise `wendy mcp serve` initialization, tool/resource listing, non-interactive stdio behavior, clean EOF shutdown, help, and unknown-flag rejection.
- Remove all 12 generic `SPEC STUB` markers from the two MCP suites: 9 tests execute and 5 are specifically disabled.
- Track unsupported contracts with WDY-1909 (`--json`), WDY-1934 (positional arguments), WDY-1941 (no-tools setup mutation/guidance), and WDY-1942 (structured initial-device failure state).

## Stack

- Continues after merged iterations #1462 and #1463.
- Test-only; no shared helpers, harness changes, product code, network services, or physical routes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyMcp"`
- Result: `Test run with 14 tests in 2 suites passed` (9 executed, 5 intentionally skipped).
