### PR TITLE
test: exercise Swift E2E discovery specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDiscoverTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDiscoverTests.swift
@@ -1,62 +1,170 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy discover'` {
+    let scenario = CLIAndAgentScenario()
+
     /**
-     Displays usage for `wendy discover`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
+     Displays bounded and continuous discovery usage, transport choices, and
+     inherited flags without starting a scan.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy discover --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Continuously scan for WendyOS devices"))
+                #expect(stdout.contains("Usage:"))
+                #expect(stdout.contains("wendy discover [flags]"))
+                #expect(stdout.contains("--timeout"))
+                #expect(stdout.contains("--type"))
+                #expect(stdout.contains("usb, lan, bluetooth, external, all"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
     /**
-     With `--timeout`, scans the requested discovery transports for the
-     bounded duration, prints discovered WendyOS devices, and exits
-     successfully when the scan completes.
+     A bounded external-provider scan completes promptly without touching USB,
+     LAN, Bluetooth, cloud, or physical-device routes.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `discovers local devices for a bounded timeout`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy discover --type external --timeout 1ms --json") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stderr == "")
+
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                let external = try #require(json["externalDevices"] as? [[String: Any]])
+                #expect(external.contains { $0["providerKey"] as? String == "local" })
+            }
+        }
     }
 
     /**
-      `--type` restricts discovery to USB, LAN, BLE, external, or all
-      transports. Output identifies the transport that produced each device.
-      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+     `--type external` limits results to local runtime providers and does not
+     invoke or populate physical discovery transports.
+     */
+    @Test
     func `filters by discovery transport`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy discover --type external --timeout 1ms --json") { result in
+                #expect(result.status.isSuccess)
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                #expect(json["usbDevices"] is NSNull)
+                #expect(json["lanDevices"] is NSNull)
+                #expect(json["bluetoothDevices"] is NSNull)
+                #expect(json["ethernetDevices"] is NSNull)
+                #expect(json["externalDevices"] is [[String: Any]])
+            }
+        }
     }
 
     /**
-     A completed scan with no matching devices prints an empty result or
-     concise no-devices message, emits no stderr, and exits successfully.
+     A completed physical scan with no matching devices prints a concise
+     no-devices result and succeeds.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1943: deterministic empty USB/LAN/Bluetooth results require an injectable discovery fixture; runner hardware cannot safely define this contract."
+        )
+    )
     func `reports no devices as an empty successful scan`() async throws {
-        // TODO: implement.
+        // TODO: enable with a deterministic empty discovery fixture (WDY-1943).
     }
 
     /**
-     With `--json`, emits an array of discovered device objects containing
-     name, address, transport, and reachability fields.
+     JSON mode emits one object grouped by transport, with external devices
+     carrying stable provider, display-name, OS, and architecture fields.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `prints JSON discovery results for automation`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy discover --type external --timeout 1ms --json") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stderr == "")
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                let external = try #require(json["externalDevices"] as? [[String: Any]])
+                let local = try #require(
+                    external.first { $0["providerKey"] as? String == "local" }
+                )
+                #expect((local["displayName"] as? String)?.isEmpty == false)
+                #expect((local["id"] as? String)?.isEmpty == false)
+                #expect((local["os"] as? String)?.isEmpty == false)
+                #expect((local["cpuArchitecture"] as? String)?.isEmpty == false)
+                #expect(local["isWendyDevice"] as? Bool == false)
+            }
+        }
     }
 
     /**
-     Cancelling a continuous scan closes discovery resources, prints no
-     partial error stack, and leaves configuration unchanged.
+     Invalid transport names fail before any discovery work starts and list
+     every accepted value.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
+    func `rejects unknown discovery transports`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy discover --type nonsense --timeout 1ms --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown discovery type: nonsense"))
+                #expect(result.stderr.contains("usb, lan, bluetooth, external, all"))
+            }
+        }
+    }
+
+    /**
+     Unknown flags fail before discovery or config mutation.
+     */
+    @Test
+    func `rejects unknown flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy discover --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
+    }
+
+    /**
+     Unexpected positional arguments are rejected instead of silently
+     starting discovery.
+     */
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy discover' silently accepts extra positional arguments because the command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when discover rejects positional arguments (WDY-1934).
+    }
+
+    /**
+     Cancelling a continuous scan closes discovery resources and exits without
+     a partial error or leaked process.
+     */
+    @Test(
+        .disabled(
+            "WDY-1943: continuous cancellation needs harness process control that can start the TUI, send Ctrl-C, and assert cleanup without enabling physical discovery in CI."
+        )
+    )
     func `stops cleanly on cancellation`() async throws {
-        // TODO: implement.
+        // TODO: enable with deterministic discovery fixtures and cancellation control (WDY-1943).
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDiscoverTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDiscoverTests.swift
@@ -29,13 +29,26 @@ struct `'wendy discover'` {
     }
 
     /**
-     A bounded external-provider scan completes promptly without touching USB,
+     `--timeout` bounds every selected transport, including local runtime
+     providers that may invoke Docker or Apple Container subprocesses.
+     */
+    @Test(
+        .disabled(
+            "WDY-1954: --timeout is not applied to external providers, so a 1 ms scan still waits seconds for ambient Docker/Apple Container probes."
+        )
+    )
+    func `discovers local devices for a bounded timeout`() async throws {
+        // TODO: enable when external providers respect the discovery deadline (WDY-1954).
+    }
+
+    /**
+     Takes one external-provider snapshot without invoking or populating USB,
      LAN, Bluetooth, cloud, or physical-device routes.
      */
     @Test
-    func `discovers local devices for a bounded timeout`() async throws {
+    func `takes an external-provider snapshot`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
-            try await cli.sh("wendy discover --type external --timeout 1ms --json") { result in
+            try await cli.sh("wendy discover --type external --json") { result in
                 #expect(result.status.isSuccess)
                 #expect(result.stderr == "")
 
@@ -56,7 +69,7 @@ struct `'wendy discover'` {
     @Test
     func `filters by discovery transport`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
-            try await cli.sh("wendy discover --type external --timeout 1ms --json") { result in
+            try await cli.sh("wendy discover --type external --json") { result in
                 #expect(result.status.isSuccess)
                 let json = try #require(
                     try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
@@ -91,7 +104,7 @@ struct `'wendy discover'` {
     @Test
     func `prints JSON discovery results for automation`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
-            try await cli.sh("wendy discover --type external --timeout 1ms --json") { result in
+            try await cli.sh("wendy discover --type external --json") { result in
                 #expect(result.status.isSuccess)
                 #expect(result.stderr == "")
                 let json = try #require(


### PR DESCRIPTION
> **In plain terms:** No CLI behavior changes — this replaces placeholder discovery tests with real checks for machine-local provider snapshots and their JSON contract. Hardware-dependent empty scans, continuous cancellation, and the currently unbounded external-provider timeout stay disabled with explicit follow-up tracking.

## Summary

- Exercise `wendy discover` help, external-provider snapshots, transport filtering, structured JSON fields, invalid transport diagnostics, and unknown-flag rejection.
- Keep USB, LAN, Bluetooth, cloud, and physical-device routes dormant; active tests inspect only local runtime providers.
- Remove all 6 generic `SPEC STUB` markers: 6 tests execute and 4 are specifically disabled.
- Track unsupported contracts with WDY-1934 (positional arguments), WDY-1943 (deterministic discovery fixtures/cancellation), and WDY-1954 (external providers do not honor `--timeout`).
- Reconcile the stale JSON prose with the current grouped-by-transport object contract rather than asserting an obsolete flat array.

## Stack

- Stacked on #1464; review commits `8144b307b` and `68d9f65be` for this iteration only.
- Test-only; no helpers, harness changes, product code, network services, or physical routes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDiscoverTests"`
- Result: `Test run with 10 tests in 1 suite passed` (6 executed, 4 intentionally skipped).
