### PR TITLE
test: classify Swift E2E OS workflow specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsDownloadTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsDownloadTests.swift
@@ -1,66 +1,87 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy os download'` {
-    /**
-     Displays usage for `wendy os download`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays image-download usage and cache controls without fetching a manifest. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os download --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Download a WendyOS image"))
+                #expect(stdout.contains("wendy os download [flags]"))
+                #expect(stdout.contains("--version"))
+                #expect(stdout.contains("--overwrite"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Downloads the requested WendyOS image version, verifies the artifact,
-     and stores it in the OS cache for later installation. Success
-     output includes device type, version, cache path, and size.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Downloads and verifies a pinned image into an isolated OS cache. */
+    @Test(
+        .disabled(
+            "WDY-1944: deterministic download success requires a pinned local manifest/artifact server and checksum fixture rather than the mutable public catalog."
+        )
+    )
     func `downloads a selected WendyOS image into the cache`() async throws {
-        // TODO: implement.
+        // TODO: enable with the protected OS artifact fixture (WDY-1944).
     }
 
-    /**
-     When the requested image already exists and verifies successfully,
-     uses the cached artifact. `--overwrite` replaces it after a
-     successful new download.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Reuses a verified cached image unless overwrite is explicitly requested. */
+    @Test(
+        .disabled(
+            "WDY-1944: cache-hit and overwrite coverage requires a pinned manifest plus known artifact/checksum bytes."
+        )
+    )
     func `uses cached images unless overwrite is requested`() async throws {
-        // TODO: implement.
+        // TODO: enable with the protected OS artifact fixture (WDY-1944).
     }
 
-    /**
-     Unknown versions, unavailable manifests, network failures, or failed
-     verification leave existing cached artifacts untouched and report a
-     failure on stderr.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Download and verification failures preserve an existing cached artifact. */
+    @Test(
+        .disabled(
+            "WDY-1944: unavailable-version, network-failure, and checksum-failure paths need a controllable local manifest/artifact server."
+        )
+    )
     func `reports unavailable versions without changing the cache`() async throws {
-        // TODO: implement.
+        // TODO: enable with failure modes from the protected OS artifact fixture (WDY-1944).
     }
 
-    /**
-     With `--json`, emits one JSON object containing version, device type,
-     artifact path, checksum, byte count, and cache-hit status.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Emits structured version, path, checksum, size, and cache-hit metadata. */
+    @Test(
+        .disabled(
+            "WDY-1909: 'wendy os download' does not implement global --json; WDY-1944 tracks the deterministic artifact fixture needed to exercise a successful result."
+        )
+    )
     func `prints JSON download metadata for automation`() async throws {
-        // TODO: implement.
+        // TODO: enable when download implements JSON and has a pinned fixture (WDY-1909, WDY-1944).
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy os download`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    /** Unknown flags fail before manifest or cache access. */
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os download --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
+    }
+
+    /** Extra positional arguments are rejected before manifest or cache access. */
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy os download' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when OS download rejects positional arguments (WDY-1934).
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsInstallTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsInstallTests.swift
@@ -1,75 +1,135 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy os install'` {
-    /**
-     Displays usage for `wendy os install`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays install modes, destructive safeguards, and preseed flags without listing drives. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os install --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Interactively select a supported device"))
+                #expect(stdout.contains("wendy os install [image] [drive] [flags]"))
+                #expect(stdout.contains("--force"))
+                #expect(stdout.contains("--yes-overwrite-internal"))
+                #expect(stdout.contains("--wifi"))
+                #expect(stdout.contains("--pre-enroll"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Writes the selected WendyOS image or firmware to the target drive
-     after the user confirms the destructive operation. Output reports
-     progress and final device preparation status.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Writes a selected image only to a protected disposable drive after confirmation. */
+    @Test(
+        .disabled(
+            "WDY-1944: install success requires a disposable virtual block device and pinned image fixture with safeguards against host disks."
+        )
+    )
     func `installs an image to a selected removable drive`() async throws {
-        // TODO: implement.
+        // TODO: enable with the protected virtual-drive fixture (WDY-1944).
     }
 
-    /**
-     When image path, drive id, and `--force` are provided, skips
-     interactive pickers and confirmation prompts while preserving the
-     same safety checks for drive identity.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Runs image-plus-drive mode without prompts while retaining drive safety checks. */
+    @Test(
+        .disabled(
+            "WDY-1944: non-interactive flashing still requires a disposable virtual drive; physical runner disks must remain unavailable to E2E."
+        )
+    )
     func `runs non-interactively with image, drive, and force`() async throws {
-        // TODO: implement.
+        // TODO: enable with the protected virtual-drive fixture (WDY-1944).
     }
 
-    /**
-     Internal or non-removable drives are protected. Non-interactive
-     installs require the dedicated overwrite flag before any bytes are
-     written.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Refuses protected internal drives unless the dedicated consent flag is present. */
+    @Test(
+        .disabled(
+            "WDY-1944: internal-drive safety needs a synthetic inventory and disposable target; it cannot be asserted against a runner's real disks."
+        )
+    )
     func `refuses to overwrite internal drives without explicit consent`() async throws {
-        // TODO: implement.
+        // TODO: enable with the protected virtual-drive inventory (WDY-1944).
     }
 
-    /**
-     WiFi flags and device-name flags are written into first-boot
-     configuration for the image. Invalid WiFi definitions fail before
-     the target drive is modified.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Validates and writes WiFi/device identity into a disposable image before flashing. */
+    @Test(
+        .disabled(
+            "WDY-1944: first-boot preseed verification requires a pinned image that can be mounted and inspected without touching a physical drive."
+        )
+    )
     func `preseeds WiFi and device identity when requested`() async throws {
-        // TODO: implement.
+        // TODO: enable with the protected image and virtual-drive fixture (WDY-1944).
     }
 
-    /**
-     `--pre-enroll` uses the stored auth session to add enrollment data
-     to the image. Missing or expired auth fails before writing the
-     drive.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Pre-enrollment uses a dedicated protected cloud session and disposable image. */
+    @Test(
+        .disabled(
+            "WDY-1944: pre-enrollment needs protected auth, a pinned image, and a disposable drive fixture; personal auth and physical disks are prohibited."
+        )
+    )
     func `pre-enrolls only with valid cloud authentication`() async throws {
-        // TODO: implement.
+        // TODO: enable with protected cloud and OS install fixtures (WDY-1944).
+    }
+
+    /** Emits one JSON result without progress text corrupting stdout. */
+    @Test(
+        .disabled(
+            "WDY-1909: 'wendy os install' does not implement global --json; WDY-1944 tracks the protected fixture needed for a successful install."
+        )
+    )
+    func `prints JSON install result for automation`() async throws {
+        // TODO: enable when install implements JSON and has protected fixtures (WDY-1909, WDY-1944).
     }
 
     /**
-     With `--json`, emits structured drive, image, version, and outcome
-     metadata. Progress output does not corrupt stdout JSON.
+     Rejects incomplete positional mode and mutually exclusive direct/manifest
+     options before image, drive, elevation, network, or auth access.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON install result for automation`() async throws {
-        // TODO: implement.
+    @Test
+    func `validates install mode arguments before destructive work`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os install image-only") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("must be provided as [image] [drive]"))
+            }
+            try await cli.sh("wendy os install image drive extra") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stderr.contains("accepts at most 2 arg"))
+            }
+            try await cli.sh("wendy os install image drive --rootfs-only") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stderr.contains("--rootfs-only cannot be combined"))
+            }
+            try await cli.sh("wendy os install image drive --device-type raspberry-pi-5") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(
+                    result.stderr.contains(
+                        "positional [image] [drive] arguments cannot be combined"
+                    )
+                )
+            }
+            try await cli.sh("wendy os install --nightly --version 1.0.0") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stderr.contains("--nightly and --version are mutually exclusive"))
+            }
+        }
+    }
+
+    /** Unknown flags fail before image or drive access. */
+    @Test
+    func `rejects unknown flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os install --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsListDrivesTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsListDrivesTests.swift
@@ -1,64 +1,107 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy os list-drives'` {
-    /**
-     Displays usage for `wendy os list-drives`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays drive-listing usage and flags without enumerating disks. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os list-drives --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("List available drives"))
+                #expect(stdout.contains("wendy os list-drives [flags]"))
+                #expect(stdout.contains("--all"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
     /**
-     Displays candidate removable drives with stable identifiers, sizes,
-     names, and safety classification. The command performs no writes.
+     Lists only candidate external drives by default. The operation is
+     read-only and an empty runner inventory is a successful result.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `lists removable drives by default`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os list-drives --json") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stderr == "")
+                let drives = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [[String: Any]]
+                )
+                for drive in drives {
+                    #expect((drive["id"] as? String)?.isEmpty == false)
+                    #expect((drive["name"] as? String)?.isEmpty == false)
+                    #expect(
+                        (drive["capacity"] as? Int64) != nil || (drive["capacity"] as? Int) != nil
+                    )
+                    #expect(drive["isExternal"] as? Bool == true)
+                }
+            }
+        }
     }
 
     /**
-     `--all` includes internal and non-removable drives and labels them
-     clearly so destructive install flows can keep applying stricter
-     confirmation rules.
+     `--all` safely inventories the broader drive set and marks each entry's
+     external classification without writing to any disk.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `includes non-removable drives when requested`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os list-drives --all --json") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stderr == "")
+                let drives = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [[String: Any]]
+                )
+                for drive in drives {
+                    #expect(drive["isExternal"] is Bool)
+                }
+            }
+        }
     }
 
     /**
-     With `--json`, emits an array of drive objects with identifiers,
-     mount state, size, removability, and safety metadata.
+     JSON inventory includes mount, removability, and explicit safety metadata
+     in addition to stable identifiers, names, and capacity.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1946: list-drives JSON currently exposes only id, name, capacity, and isExternal; mount state, removability, and safety classification are absent."
+        )
+    )
     func `prints JSON drive inventory for automation`() async throws {
-        // TODO: implement.
+        // TODO: enable when structured drive safety metadata is available (WDY-1946).
     }
 
-    /**
-     On unsupported platforms, reports that drive listing is unavailable
-     with a failure status and does not fall back to unsafe guesses.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `handles platforms without drive listing support`() async throws {
-        // TODO: implement.
+    /** Unknown flags fail before disk enumeration. */
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os list-drives --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy os list-
-     drives`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    /** Extra positional arguments are rejected before disk enumeration. */
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy os list-drives' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when list-drives rejects positional arguments (WDY-1934).
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsUpdateTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsUpdateTests.swift
@@ -1,73 +1,112 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy os update'` {
-    /**
-     Displays usage for `wendy os update`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays local, remote, nightly, and PR update modes without connecting to a device. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os update --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Update WendyOS using an OS update artifact"))
+                #expect(stdout.contains("wendy os update [artifact-path] [flags]"))
+                #expect(stdout.contains("--artifact-url"))
+                #expect(stdout.contains("--nightly"))
+                #expect(stdout.contains("--pr"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Serves the provided Mender artifact to the selected device and
-     requests an OS update. Success output identifies the artifact and
-     device update status.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Serves a pinned local Mender artifact to a hosted update-capable WendyOS target. */
+    @Test(
+        .disabled(
+            "WDY-1944: local-artifact OTA success requires a hosted update-capable WendyOS fixture and pinned Mender artifact."
+        )
+    )
     func `updates WendyOS from a local artifact`() async throws {
-        // TODO: implement.
+        // TODO: enable with the protected hosted OTA fixture (WDY-1944).
     }
 
-    /**
-     `--artifact-url` instructs the device to fetch a remote artifact
-     directly. The URL is validated before the update request is sent.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Validates a remote artifact URL locally before contacting the target device. */
+    @Test(
+        .disabled(
+            "WDY-1945: --artifact-url is not validated until after device connection and version RPCs, so malformed URLs cannot fail locally as specified."
+        )
+    )
     func `updates WendyOS from a remote artifact URL`() async throws {
-        // TODO: implement.
+        // TODO: enable when URL validation precedes device access (WDY-1945).
     }
 
-    /**
-     `--nightly` selects the latest prerelease OS and agent artifacts
-     from the manifest and reports the chosen versions before updating.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Resolves pinned nightly artifacts and applies them to a hosted OTA target. */
+    @Test(
+        .disabled(
+            "WDY-1944: nightly resolution and update success need a pinned manifest plus hosted update-capable WendyOS fixture."
+        )
+    )
     func `uses nightly artifacts when requested`() async throws {
-        // TODO: implement.
+        // TODO: enable with protected manifest and OTA fixtures (WDY-1944).
     }
 
-    /**
-     If the target device cannot be reached, the command stops any
-     temporary local artifact server and exits with a clear diagnostic.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Cleans up a temporary local artifact server when the hosted target is unreachable. */
+    @Test(
+        .disabled(
+            "WDY-1944: cleanup observation needs a controllable hosted OTA target and local artifact-server fixture rather than a physical device."
+        )
+    )
     func `reports unreachable devices without serving stale artifacts`() async throws {
-        // TODO: implement.
+        // TODO: enable with protected OTA and artifact-server fixtures (WDY-1944).
     }
 
-    /**
-     With `--json`, emits one JSON object containing device, artifact,
-     version, and update request status fields.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Emits structured device, artifact, version, and request-status metadata. */
+    @Test(
+        .disabled(
+            "WDY-1909: 'wendy os update' does not implement global --json; WDY-1944 tracks the hosted fixture needed for update metadata."
+        )
+    )
     func `prints JSON update metadata for automation`() async throws {
-        // TODO: implement.
+        // TODO: enable when update implements JSON and has a hosted fixture (WDY-1909, WDY-1944).
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy os update`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Rejects conflicting artifact sources before device access. */
+    @Test
+    func `rejects conflicting artifact sources locally`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                "wendy os update local.mender --artifact-url https://example.invalid/update.mender"
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("either a local artifact path or --artifact-url"))
+            }
+            try await cli.sh("wendy os update local.mender --pr 123") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("--pr cannot be combined"))
+            }
+        }
+    }
+
+    /** Rejects too many positional arguments and unknown flags before device access. */
+    @Test
     func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy os update first.mender second.mender") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg"))
+            }
+            try await cli.sh("wendy os update --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
     }
 }


### PR DESCRIPTION
> **In plain terms:** No OS images are downloaded, no disks are written, and no devices are updated. This replaces placeholder OS workflow tests with safe checks for help, drive inventory, and local argument validation, while explicitly gating every destructive, networked, cloud, and physical success path behind protected follow-up fixtures.

## Summary

- Exercise `os list-drives` read-only JSON inventory on the runner, including `--all`, help, and flag validation.
- Exercise local help and preflight validation for `os download`, `install`, and `update` without manifest downloads, elevation, drive writes, device connections, or auth.
- Remove all 26 generic `SPEC STUB` markers from four suites: 12 tests execute and 18 are specifically disabled.
- Track unsupported contracts with WDY-1909 (`--json`), WDY-1934 (positional arguments), WDY-1944 (protected image/drive/OTA fixtures), WDY-1945 (early artifact URL validation), and WDY-1946 (drive safety metadata).
- Remove the obsolete unsupported-platform placeholder: drive listing has implementations for every CLI target platform.

## Stack

- Stacked on #1465; review commit `9b7fff2ae` for this iteration only.
- Test-only; no helpers, harness changes, product code, downloads, elevation, disk writes, cloud auth, device access, or physical routes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyOs"`
- Result: `Test run with 43 tests in 6 suites passed`, including the four touched suites (30 tests: 12 executed, 18 intentionally skipped).

