### PR TITLE
test: classify Swift E2E auth specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthLoginTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthLoginTests.swift
@@ -1,78 +1,133 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy auth login'` {
-    /**
-     Displays usage for `wendy auth login`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays browser and API-key login modes without opening a browser. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth login --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("opens a browser for authentication"))
+                #expect(stdout.contains("wendy auth login [flags]"))
+                #expect(stdout.contains("--api-key"))
+                #expect(stdout.contains("--cloud"))
+                #expect(stdout.contains("--cloud-grpc"))
+                #expect(stdout.contains("--org"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Without `--api-key`, starts the Wendy Cloud browser login flow,
-     receives the callback token, generates client credentials, and
-     stores the resulting session in the CLI configuration. Success
-     output gives concise next-step guidance and stderr stays empty.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1949: browser login needs a protected callback/token/PKI fixture and injectable browser; real browsers and personal cloud auth are prohibited."
+        )
+    )
     func `starts browser-based login and stores the auth session`() async throws {
-        // TODO: implement.
+        // TODO: enable with protected browser and auth fixtures (WDY-1949).
     }
 
-    /**
-     With `--api-key`, authenticates against the selected cloud gRPC or
-     local pki-core endpoint using the provided bearer token. The token
-     is not echoed to stdout, stderr, command records, or saved config.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1949: API-key login needs an ephemeral protected pki-core endpoint with recorder redaction; production or personal keys cannot be used."
+        )
+    )
     func `logs in with an API key without opening a browser`() async throws {
-        // TODO: implement.
+        // TODO: enable with protected PKI and secret-redaction fixtures (WDY-1949).
     }
 
-    /**
-     `--cloud` and `--cloud-grpc` bind the login to a specific Wendy
-     Cloud environment. The stored session records enough endpoint
-     identity for later commands to choose the same environment.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1949: endpoint selection needs multiple protected cloud/PKI fixtures so stored identity can be verified without production auth."
+        )
+    )
     func `selects the intended cloud endpoint explicitly`() async throws {
-        // TODO: implement.
+        // TODO: enable with protected multi-cloud fixtures (WDY-1949).
     }
 
-    /**
-     Cancelling or timing out the browser callback reports a login
-     failure, exits non-zero, and leaves prior authentication state
-     unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1949: cancellation and timeout require controllable browser callback process state rather than opening a real browser."
+        )
+    )
     func `reports cancelled browser login without storing credentials`() async throws {
-        // TODO: implement.
+        // TODO: enable with the protected browser callback fixture (WDY-1949).
     }
 
-    /**
-     A successful login for a cloud that already has stored credentials
-     replaces the old credentials atomically while preserving sessions
-     for other clouds.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1949: atomic session replacement needs protected certificate issuance for two cloud identities without personal auth state."
+        )
+    )
     func `replaces an existing session for the same cloud`() async throws {
-        // TODO: implement.
+        // TODO: enable with protected multi-session auth fixtures (WDY-1949).
     }
 
-    /**
-     Reads the Wendy CLI configuration before performing work that depends on
-     user state. Malformed configuration is reported as a configuration error,
-     no prompts open, no network connection is attempted, and the original file
-     remains byte-for-byte unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Malformed config fails before browser or network activity and remains unchanged. */
+    @Test
     func `reports invalid CLI configuration before acting`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{ invalid json\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -NoNewline -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{ invalid json'
+                    """
+            )
+            try await cli.sh("wendy auth login --api-key fixture-value --cloud-grpc localhost:1") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("parsing config"))
+                #expect(!result.stderr.contains("fixture-value"))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("{ invalid json"))
+            }
+        }
+    }
+
+    /** API-key mode requires a local/cloud gRPC endpoint before network access. */
+    @Test
+    func `requires an endpoint for API key login`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth login --api-key fixture-value") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("--cloud-grpc is required"))
+                #expect(!result.stderr.contains("fixture-value"))
+            }
+        }
+    }
+
+    /** Unknown flags fail before browser or network access. */
+    @Test
+    func `rejects unknown flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth login --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
+    }
+
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy auth login' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when auth login rejects positional arguments (WDY-1934).
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthLogoutTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthLogoutTests.swift
@@ -1,76 +1,136 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy auth logout'` {
-    /**
-     Displays usage for `wendy auth logout`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays logout usage without reading or changing config. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth logout --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Log out from Wendy Cloud"))
+                #expect(result.stdout.contains("wendy auth logout [flags]"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Deletes stored Wendy Cloud credentials for the selected session and
-     prints a concise confirmation. Other configuration keys and cached
-     project files remain intact.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Removes a sole stored session while preserving unrelated known config fields. */
+    @Test
     func `removes the active auth session`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.wendy"
+                    printf '%s\n' '{"auth":[{"cloudDashboard":"https://fixture.invalid","cloudGRPC":"fixture.invalid:443","certificates":[{"organizationId":42,"userId":"fixture-user"}]}],"defaultDevice":"keep-device","lastCLIUpdateCheck":"2026-07-20T12:00:00Z"}' > "$HOME/.wendy/config.json"
+                    """,
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"auth":[{"cloudDashboard":"https://fixture.invalid","cloudGRPC":"fixture.invalid:443","certificates":[{"organizationId":42,"userId":"fixture-user"}]}],"defaultDevice":"keep-device","lastCLIUpdateCheck":"2026-07-20T12:00:00Z"}'
+                    """
+            )
+            try await cli.sh("wendy auth logout") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Logged out"))
+                #expect(result.stderr == "")
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                #expect(json["auth"] == nil)
+                #expect(json["defaultDevice"] as? String == "keep-device")
+                #expect(json["lastCLIUpdateCheck"] as? String == "2026-07-20T12:00:00Z")
+            }
+        }
     }
 
-    /**
-     With no stored auth session, reports that the user is logged out and
-     exits successfully without creating configuration files.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1947: already-logged-out logout creates/rewrites config and claims credentials were removed instead of remaining a non-mutating no-op."
+        )
+    )
     func `is idempotent when already logged out`() async throws {
-        // TODO: implement.
+        // TODO: enable when logged-out logout does not create state (WDY-1947).
     }
 
-    /**
-     When more than one auth session exists, targets the active or
-     explicitly selected cloud and leaves unrelated sessions available.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1947: logout always clears every auth entry and has no active/explicit session selector, so unrelated cloud sessions cannot be preserved."
+        )
+    )
     func `selects one session when multiple clouds are configured`() async throws {
-        // TODO: implement.
+        // TODO: enable when logout is session-aware (WDY-1947).
     }
 
-    /**
-     With `--json`, emits one JSON object describing whether credentials
-     were removed. JSON mode emits no human confirmation text and no
-     stderr on success.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1909: 'wendy auth logout --json' ignores JSON mode and prints a human confirmation."
+        )
+    )
     func `prints JSON logout result for automation`() async throws {
-        // TODO: implement.
+        // TODO: enable when auth logout implements global --json (WDY-1909).
     }
 
-    /**
-     Reads the Wendy CLI configuration before performing work that depends on
-     user state. Malformed configuration is reported as a configuration error,
-     no prompts open, no network connection is attempted, and the original file
-     remains byte-for-byte unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Malformed config fails without mutation. */
+    @Test
     func `reports invalid CLI configuration before acting`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{ broken\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -NoNewline -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{ broken'
+                    """
+            )
+            try await cli.sh("wendy auth logout") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("parsing config"))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("{ broken"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy auth logout`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    /** Unknown flags fail before config mutation. */
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth logout --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+            try await cli.sh(
+                posix: "test ! -f \"$HOME/.wendy/config.json\"",
+                power:
+                    "if (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy/config.json')) { throw 'config created' }"
+            )
+        }
+    }
+
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy auth logout' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when auth logout rejects positional arguments (WDY-1934).
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthRefreshCertsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthRefreshCertsTests.swift
@@ -1,79 +1,114 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy auth refresh-certs'` {
-    /**
-     Displays usage for `wendy auth refresh-certs`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays certificate-refresh usage without loading or contacting auth state. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth refresh-certs --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Generates a new key pair and CSR"))
+                #expect(result.stdout.contains("wendy auth refresh-certs [flags]"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Uses an existing auth session to generate a new key pair and CSR,
-     obtains fresh client certificates, and atomically replaces the old
-     certificate material. Success output identifies the refreshed
-     session without printing secrets.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1949: certificate refresh success needs a protected PKI/cloud endpoint with ephemeral stored credentials; personal sessions are prohibited."
+        )
+    )
     func `refreshes certificates using stored credentials`() async throws {
-        // TODO: implement.
+        // TODO: enable with the protected PKI/cloud fixture (WDY-1949).
     }
 
-    /**
-     When no login session is available, reports that authentication is
-     required. No key pair, CSR, certificate, or partial configuration
-     update is written.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Missing auth fails locally without generating keys or creating config. */
+    @Test
     func `reports missing auth session without creating credentials`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth refresh-certs") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+            try await cli.sh(
+                posix: "test ! -f \"$HOME/.wendy/config.json\"",
+                power:
+                    "if (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy/config.json')) { throw 'config created' }"
+            )
+        }
     }
 
-    /**
-     Network, authorization, or certificate issuance failures leave the
-     previous working credentials in place and report the failing stage
-     on stderr.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1949: issuance/network/authorization failure preservation needs a controllable protected PKI endpoint and known prior certificates."
+        )
+    )
     func `preserves old certificates when refresh fails`() async throws {
-        // TODO: implement.
+        // TODO: enable with protected PKI failure modes (WDY-1949).
     }
 
-    /**
-     With `--json`, emits one JSON object with the cloud identity and
-     certificate validity metadata. Secret key material never appears in
-     stdout, stderr, or command records.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1909: 'wendy auth refresh-certs --json' ignores JSON mode; WDY-1949 tracks the protected fixture required for refresh metadata."
+        )
+    )
     func `prints JSON refresh result for automation`() async throws {
-        // TODO: implement.
+        // TODO: enable when refresh implements JSON and has protected fixtures (WDY-1909, WDY-1949).
     }
 
-    /**
-     Reads the Wendy CLI configuration before performing work that depends on
-     user state. Malformed configuration is reported as a configuration error,
-     no prompts open, no network connection is attempted, and the original file
-     remains byte-for-byte unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Malformed config fails locally and remains unchanged. */
+    @Test
     func `reports invalid CLI configuration before acting`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{ broken\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -NoNewline -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{ broken'
+                    """
+            )
+            try await cli.sh("wendy auth refresh-certs") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("parsing config"))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("{ broken"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy auth refresh-
-     certs`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    /** Unknown flags fail before config or PKI access. */
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth refresh-certs --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
+    }
+
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy auth refresh-certs' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when auth refresh-certs rejects positional arguments (WDY-1934).
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthStatusTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthStatusTests.swift
@@ -1,78 +1,131 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy auth status'` {
-    /**
-     Displays usage for `wendy auth status`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays local auth-status usage without reading credentials. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth status --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Show current authentication status"))
+                #expect(result.stdout.contains("wendy auth status [flags]"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     With no stored credentials, reports that the user is not logged in,
-     exits successfully, emits no stderr, and does not create config
-     files.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Reports logged-out state locally without creating a config file. */
+    @Test
     func `prints logged-out status without contacting the cloud`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth status") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Not logged in"))
+                #expect(result.stdout.contains("wendy auth login"))
+                #expect(result.stderr == "")
+            }
+            try await cli.sh(
+                posix: "test ! -f \"$HOME/.wendy/config.json\"",
+                power:
+                    "if (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy/config.json')) { throw 'config created' }"
+            )
+        }
     }
 
-    /**
-     With a stored session, reports the cloud identity and account or
-     organization summary available locally. Secrets and private key
-     material are never printed.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Prints non-secret endpoint, user, and organization metadata from local config. */
+    @Test
     func `prints logged-in status from stored credentials`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.wendy"
+                    printf '%s\n' '{"auth":[{"cloudDashboard":"https://fixture.invalid","cloudGRPC":"fixture.invalid:443","certificates":[{"organizationId":42,"userId":"fixture-user"}]}]}' > "$HOME/.wendy/config.json"
+                    """,
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"auth":[{"cloudDashboard":"https://fixture.invalid","cloudGRPC":"fixture.invalid:443","certificates":[{"organizationId":42,"userId":"fixture-user"}]}]}'
+                    """
+            )
+            try await cli.sh("wendy auth status") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Cloud:  https://fixture.invalid"))
+                #expect(result.stdout.contains("gRPC: fixture.invalid:443"))
+                #expect(result.stdout.contains("User: fixture-user"))
+                #expect(result.stdout.contains("Org:  42"))
+                #expect(!result.stdout.lowercased().contains("private key"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Expired, malformed, or incomplete credentials produce an actionable
-     status that distinguishes local credential problems from cloud
-     connectivity problems.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1948: auth status does not consistently classify malformed/incomplete certificate material; malformed PEM can be silently ignored."
+        )
+    )
     func `reports expired or unusable credentials clearly`() async throws {
-        // TODO: implement.
+        // TODO: enable when local credential states are explicit and actionable (WDY-1948).
     }
 
-    /**
-     With `--json`, emits one JSON object containing login state, cloud
-     endpoint identity, and certificate validity fields. JSON mode emits
-     no prompt text and no stderr on success.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1909: 'wendy auth status --json' ignores JSON mode and prints human status; WDY-1948 tracks missing structured credential validity states."
+        )
+    )
     func `prints JSON auth status for automation`() async throws {
-        // TODO: implement.
+        // TODO: enable when auth status implements structured JSON (WDY-1909, WDY-1948).
     }
 
-    /**
-     Reads the Wendy CLI configuration before performing work that depends on
-     user state. Malformed configuration is reported as a configuration error,
-     no prompts open, no network connection is attempted, and the original file
-     remains byte-for-byte unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Malformed CLI config fails locally and remains unchanged. */
+    @Test
     func `reports invalid CLI configuration before acting`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{ broken\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -NoNewline -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{ broken'
+                    """
+            )
+            try await cli.sh("wendy auth status") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("parsing config"))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("{ broken"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy auth status`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    /** Unknown flags fail before config access. */
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy auth status --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
+    }
+
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy auth status' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when auth status rejects positional arguments (WDY-1934).
     }
 }


### PR DESCRIPTION
> **In plain terms:** No real login, browser, cloud, API key, or certificate issuance occurs. This replaces placeholder auth tests with safe checks for local login state, logout mutation, malformed config, missing-session errors, and input validation, while leaving secret-bearing flows behind dedicated protected-fixture work.

## Summary

- Exercise `auth status` logged-in/logged-out local state using synthetic non-secret metadata, plus malformed config and flag validation.
- Exercise sole-session logout while preserving unrelated known config, missing-session certificate refresh, API-key endpoint preflight, help, and failure safety.
- Remove all 28 generic `SPEC STUB` markers from four auth suites: 17 tests execute and 17 are specifically disabled.
- Track unsupported contracts with WDY-1909 (`--json`), WDY-1934 (positional arguments), WDY-1947 (session-aware/idempotent logout), WDY-1948 (unusable credential status), and WDY-1949 (protected browser/PKI/cloud fixtures).

## Stack

- Stacked on #1466; review commit `f134dabf0` for this iteration only.
- Test-only; no helpers, harness changes, product code, browser launch, secrets, personal auth, cloud access, or device routes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyAuth"`
- Result: `Test run with 34 tests in 4 suites passed` (17 executed, 17 intentionally skipped).

