### PR TITLE
test: exercise Swift E2E device aliases

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBtListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBtListTests.swift
@@ -1,30 +1,47 @@
 import Testing
+import WendyE2ETesting
 
 /// Public alias path for `wendy device bluetooth list`.
-///
-/// The `bt` shorthand remains available for command entry and shell completion,
-/// while canonical documentation continues to prefer `bluetooth`.
 @Suite
 struct `'wendy device bt list'` {
-    // MARK: - Compatibility
+    let scenario = CLIAndAgentScenario()
 
-    /**
-     Resolves through the `bt` alias and displays the same help as `wendy device
-     bluetooth list`, including inherited device/global flags and validation
-     behavior.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Resolves `bt` to the canonical Bluetooth list command and option surface. */
+    @Test
     func `prints '... bluetooth list help' through the 'bt' alias`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bt list --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("Scan for Bluetooth peripherals"))
+                #expect(stdout.contains("wendy device bluetooth list [flags]"))
+                #expect(stdout.contains("--help"))
+                #expect(stdout.contains("--device"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Lists Bluetooth peripherals using the same output contract as `wendy device
-     bluetooth list`. The alias does not change target selection, JSON output,
-     or error diagnostics.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1952: canonical/alias peripheral inventory equivalence needs seeded managed-agent Bluetooth responses without physical hardware."
+        )
+    )
     func `aliases '... device bluetooth list'`() async throws {
-        // TODO: implement.
+        // TODO: enable with seeded managed-agent Bluetooth fixtures (WDY-1952).
+    }
+
+    /** Missing target fails before scanning or prompting. */
+    @Test
+    func `reports missing device without scanning`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bt list --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDevicePsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDevicePsTests.swift
@@ -1,39 +1,59 @@
 import Testing
+import WendyE2ETesting
 
-/// Public compatibility alias for `wendy device apps list`.
-///
-/// The short `ps` form remains visible in help for users who expect a
-/// container-style listing command.
+/// Hidden compatibility alias for `wendy device apps list`.
 @Suite
 struct `'wendy device ps'` {
-    // MARK: - Compatibility
+    let scenario = CLIAndAgentScenario()
 
-    /**
-     Displays usage for `wendy device ps`. The output identifies the command as
-     an alias for `wendy device apps list`, lists the same inherited global
-     flags, exits successfully, and emits no stderr.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** The hidden alias remains directly invocable and identifies its canonical command. */
+    @Test
     func `prints '... device ps' alias help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(!result.stdout.contains("  ps"))
+            }
+            try await cli.sh("wendy device ps --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("alias for 'apps list'"))
+                #expect(stdout.contains("wendy device ps [flags]"))
+                #expect(stdout.contains("--device"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Produces the same human-readable application inventory as `wendy device
-     apps list`, including empty-device output and table formatting. The alias
-     does not introduce additional prompts or state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1952: human inventory equivalence needs seeded managed-agent application state without a physical device."
+        )
+    )
     func `aliases '... device apps list'`() async throws {
-        // TODO: implement.
+        // TODO: enable with seeded managed-agent app fixtures (WDY-1952).
     }
 
-    /**
-     With `--json`, emits the same application inventory schema as `wendy device
-     apps list` and keeps stdout machine-readable for automation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1952: JSON inventory schema equivalence needs seeded managed-agent application state without a physical device."
+        )
+    )
     func `'--json' keeps '... device apps list' output clean`() async throws {
-        // TODO: implement.
+        // TODO: enable with seeded managed-agent app fixtures (WDY-1952).
+    }
+
+    /** Missing target fails before prompts or alias-specific output. */
+    @Test
+    func `reports missing device without prompting`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device ps --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVersionTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVersionTests.swift
@@ -1,66 +1,53 @@
-import Foundation
 import Testing
 import WendyE2ETesting
 
 /// Deprecated compatibility alias for `wendy device info`.
-///
-/// Use `wendy device info` in new scripts and documentation.
 @Suite
 struct `'wendy device version'` {
     let scenario = CLIAndAgentScenario()
 
-    // MARK: - Compatibility
-
-    /**
-     The hidden command remains directly invocable for older scripts, but
-     `wendy device --help` does not advertise it. Direct help preserves the
-     `wendy device info` option surface for users who still discover the legacy
-     command explicitly.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** The hidden alias stays absent from parent help while direct help mirrors `device info`. */
+    @Test
     func `is hidden from parent help while direct help mirrors '... device info'`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     In human-readable mode, the deprecated command reports the same device information as `wendy device info` and directs users to the replacement command.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `aliases '... device info' with a deprecation notice`() async throws {
-        try await self.scenario.run { cli, agent in
-            let agentAddress = agent.machine.address
-
-            try await cli.sh("wendy --json=false --device \(agentAddress) device version") {
-                result in
-
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device --help") { result in
                 #expect(result.status.isSuccess)
-                #expect(result.stderr.localizedCaseInsensitiveContains("deprecated"))
-                #expect(result.stderr.contains("wendy device info"))
-                #expect(result.stdout.contains("Agent Version:"))
-                #expect(result.stdout.contains("OS:"))
-                #expect(result.stdout.contains("Architecture:"))
-                #expect(result.stdout.contains("CLI Version:"))
+                #expect(!result.stdout.contains("  version"))
+                #expect(result.stderr == "")
+            }
+            try await cli.sh("wendy device version --help") { result in
+                let stdout = result.stdout
+                #expect(result.status.isSuccess)
+                #expect(stdout.contains("agent version, OS, architecture"))
+                #expect(stdout.contains("wendy device version [flags]"))
+                #expect(stdout.contains("--check-updates"))
+                #expect(stdout.contains("--prerelease"))
+                #expect(stdout.contains("--device"))
+                #expect(stdout.contains("--json"))
+                #expect(result.stderr == "")
             }
         }
     }
 
-    /**
-     With `--json`, deprecation guidance stays out of stdout and stderr so existing scripts can continue parsing the response.
-     */
+    @Test(
+        .disabled(
+            "WDY-1952: human alias equivalence and deprecation output need a seeded managed-agent info response without a physical device."
+        )
+    )
+    func `aliases '... device info' with a deprecation notice`() async throws {
+        // TODO: enable with the seeded managed-agent fixture (WDY-1952).
+    }
+
+    /** JSON mode fails cleanly before deprecation text when no target is selected. */
     @Test
     func `'--json' keeps JSON output clean`() async throws {
-        try await self.scenario.run { cli, _ in
+        try await self.scenario.run(authenticated: false) { cli, _ in
             try await cli.sh("wendy device version --json") { result in
                 let stderr = result.stderr
-
-                #expect(!result.status.isSuccess)
+                #expect(result.status.isFailure)
                 #expect(result.stdout == "")
-                #expect(
-                    stderr.contains(
-                        "no device specified; use --device flag or set a default"
-                    )
-                )
-                #expect(!stderr.localizedCaseInsensitiveContains("deprecated"))
+                #expect(stderr.contains("no device specified; use --device flag or set a default"))
+                #expect(!stderr.lowercased().contains("deprecated"))
                 #expect(!stderr.contains("Select a device"))
             }
         }


### PR DESCRIPTION
> **In plain terms:** No device or Bluetooth hardware is contacted. This replaces compatibility-alias placeholders with checks that the old `version`, `ps`, and `bt list` paths still route to the right commands, stay hidden or visible as intended, and fail cleanly when no device is selected.

## Summary

- Verify hidden `device version` help mirrors `device info`, while existing JSON no-target behavior remains free of deprecation text.
- Verify hidden `device ps` identifies `apps list` and fails without prompting when no target exists.
- Verify public `device bt list` resolves to canonical `device bluetooth list` help and does not scan without a target.
- Remove all 7 generic markers: 6 tests execute and 4 agent-backed equivalence tests are specifically disabled under WDY-1952.
- Reconcile stale prose that described `ps` as visible; the command is intentionally registered with `Hidden: true`.

## Stack

- Stacked on #1469; review commit `cec130e36` for this iteration only.
- Test-only; no helpers, harness changes, product code, agents, Bluetooth scans, cloud, or physical routes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceVersionTests" --filter "WendyDevicePsTests" --filter "WendyDeviceBtListTests"`
- Result: `Test run with 10 tests in 3 suites passed` (6 executed, 4 intentionally skipped).

