### PR TITLE
test: exercise Swift E2E default-device specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceSetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceSetDefaultTests.swift
@@ -1,85 +1,122 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device set-default'` {
-    /**
-     Displays usage for `wendy device set-default`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays positional hostname usage without discovery or config access. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device set-default --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Set the default device hostname"))
+                #expect(result.stdout.contains("wendy device set-default [hostname] [flags]"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1943: omitted-hostname selection enters physical discovery/picker flow; deterministic non-interactive behavior needs injected discovery fixtures."
+        )
+    )
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        // TODO: enable with deterministic picker/discovery fixtures (WDY-1943).
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Writes the provided hostname as the CLI default device and prints a
-     concise confirmation. Future device commands use this value when no
-     explicit device is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Stores an offline hostname locally; reachability pinning remains best-effort. */
+    @Test
     func `saves the default device hostname`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device set-default 127.0.0.1:1") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Default device set to: 127.0.0.1:1"))
+                #expect(result.stderr == "")
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"defaultDevice\": \"127.0.0.1:1\""))
+            }
+        }
     }
 
-    /**
-     Only the default device selection changes. Auth sessions, analytics
-     settings, and unknown config keys remain intact.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `preserves unrelated configuration keys`() async throws {
-        // TODO: implement.
+    /** Preserves unrelated known config while changing only the default hostname. */
+    @Test
+    func `preserves unrelated known configuration keys`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.wendy"
+                    printf '%s\n' '{"analytics":{"enabled":false},"lastCLIUpdateCheck":"2026-07-20T12:00:00Z","completionPromptDismissed":true}' > "$HOME/.wendy/config.json"
+                    """,
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"analytics":{"enabled":false},"lastCLIUpdateCheck":"2026-07-20T12:00:00Z","completionPromptDismissed":true}'
+                    """
+            )
+            try await cli.sh("wendy device set-default 127.0.0.1:1") { result in
+                #expect(result.status.isSuccess)
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                #expect(json["defaultDevice"] as? String == "127.0.0.1:1")
+                #expect((json["analytics"] as? [String: Any])?["enabled"] as? Bool == false)
+                #expect(json["lastCLIUpdateCheck"] as? String == "2026-07-20T12:00:00Z")
+                #expect(json["completionPromptDismissed"] as? Bool == true)
+            }
+        }
     }
 
-    /**
-     Missing or empty hostnames produce a usage diagnostic and leave the
-     configuration file unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `requires a hostname`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1940: typed config load/save discards unknown top-level keys during default-device mutation."
+        )
+    )
+    func `preserves unknown future configuration keys`() async throws {
+        // TODO: enable when config mutations round-trip unknown keys (WDY-1940).
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy device set-
-     default`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1953: an explicit empty hostname is accepted, saved as an empty default, and reported as success instead of failing validation."
+        )
+    )
+    func `requires a nonempty hostname`() async throws {
+        // TODO: enable when empty/whitespace hostnames are rejected (WDY-1953).
+    }
+
+    /** Too many positional arguments and unknown flags fail before config mutation. */
+    @Test
     func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device set-default first second") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg"))
+            }
+            try await cli.sh("wendy device set-default --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+            try await cli.sh(
+                posix: "test ! -f \"$HOME/.wendy/config.json\"",
+                power:
+                    "if (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy/config.json')) { throw 'config created' }"
+            )
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUnsetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUnsetDefaultTests.swift
@@ -1,75 +1,91 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device unset-default'` {
-    /**
-     Displays usage for `wendy device unset-default`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays local clear-default usage without reading config or selecting a device. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device unset-default --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Clear the default device"))
+                #expect(result.stdout.contains("wendy device unset-default [flags]"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Removes the saved default device from CLI configuration and prints a
-     concise confirmation. Other configuration keys remain intact.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Clears only the saved default and preserves unrelated known config. */
+    @Test
     func `clears the saved default device`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.wendy"
+                    printf '%s\n' '{"defaultDevice":"old-device","analytics":{"enabled":false},"lastCLIUpdateCheck":"2026-07-20T12:00:00Z"}' > "$HOME/.wendy/config.json"
+                    """,
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"defaultDevice":"old-device","analytics":{"enabled":false},"lastCLIUpdateCheck":"2026-07-20T12:00:00Z"}'
+                    """
+            )
+            try await cli.sh("wendy device unset-default") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout == "Default device cleared.\n")
+                #expect(result.stderr == "")
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                #expect(json["defaultDevice"] == nil)
+                #expect((json["analytics"] as? [String: Any])?["enabled"] as? Bool == false)
+                #expect(json["lastCLIUpdateCheck"] as? String == "2026-07-20T12:00:00Z")
+            }
+        }
     }
 
-    /**
-     With no saved default device, reports a no-op success and avoids creating
-     unrelated configuration state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1953: with no saved default, unset-default creates/rewrites config and reports a clear instead of remaining a non-mutating no-op."
+        )
+    )
     func `is idempotent when no default is configured`() async throws {
-        // TODO: implement.
+        // TODO: enable when no-default unset is non-mutating (WDY-1953).
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy device unset-
-     default`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    /** Unknown flags fail before config mutation. */
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device unset-default --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+            try await cli.sh(
+                posix: "test ! -f \"$HOME/.wendy/config.json\"",
+                power:
+                    "if (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy/config.json')) { throw 'config created' }"
+            )
+        }
+    }
+
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device unset-default' silently accepts extra positional arguments because the command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when unset-default rejects positional arguments (WDY-1934).
     }
 }


### PR DESCRIPTION
> **In plain terms:** No device operation is performed. This corrects copied placeholders that treated default-device commands like remote RPCs, then tests their real job: safely updating local Wendy configuration while preserving unrelated settings.

## Summary

- Exercise `device set-default` help, offline hostname persistence, known-config preservation, and argument/flag validation.
- Exercise `device unset-default` help, local clearing with known-config preservation, and flag validation.
- Remove all 15 generic markers: 7 tests execute and 5 are specifically disabled; three copied remote-operation specs per command are removed as obsolete where applicable.
- Track unknown config preservation under WDY-1940, omitted-hostname discovery under WDY-1943, positional args under WDY-1934, and empty/no-op semantics under WDY-1953.
- Preserve offline-host behavior: set-default intentionally saves first and treats identity pinning as best-effort.

## Stack

- Stacked on #1470; review commit `2b5cede24` for this iteration only.
- Test-only; no helpers, harness changes, product code, physical discovery, cloud, or device RPC assertions.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceSetDefaultTests" --filter "WendyDeviceUnsetDefaultTests"`
- Result: `Test run with 12 tests in 2 suites passed` (7 executed, 5 intentionally skipped).

