### PR TITLE
test: classify Swift E2E device inventory specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsListTests.swift
@@ -1,75 +1,79 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device apps list'` {
-    /**
-     Displays usage for `wendy device apps list`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps list --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("List deployed applications"))
+                #expect(result.stdout.contains("wendy device apps list [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target inventory needs seeded managed-agent application state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps list --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: human application inventory needs seeded empty/populated managed-agent container state."
+        )
+    )
+    func `lists deployed applications`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSON application schema needs seeded empty/populated managed-agent container state."
+        )
+    )
+    func `prints JSON application inventory`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps list --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays deployed applications with names, images, status, restart policy,
-     and relevant ports. An empty device reports an empty successful list.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `lists deployed applications`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits application objects with stable field names and value
-     types. JSON mode emits no table formatting and no stderr on success.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON application inventory`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device apps
-     list`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device apps list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioListTests.swift
@@ -1,75 +1,79 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device audio list'` {
-    /**
-     Displays usage for `wendy device audio list`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio list --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("List audio devices"))
+                #expect(result.stdout.contains("wendy device audio list [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target inventory needs seeded managed-agent audio state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio list --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: human audio inventory needs seeded managed-agent audio hardware/capability state."
+        )
+    )
+    func `lists audio devices`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSON audio schema needs seeded managed-agent audio hardware/capability state."
+        )
+    )
+    func `prints JSON audio device inventory`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio list --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays input and output audio devices with ids, names, channel counts,
-     sample rates, and default markers when available.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `lists audio devices`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits audio device objects with stable id, direction,
-     default, channel, and sample-rate fields.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON audio device inventory`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device audio
-     list`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device audio list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothListTests.swift
@@ -1,75 +1,79 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device bluetooth list'` {
-    /**
-     Displays usage for `wendy device bluetooth list`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth list --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Scan for Bluetooth peripherals"))
+                #expect(result.stdout.contains("wendy device bluetooth list [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target scans need a seeded managed agent and simulated Bluetooth capability without physical peripherals."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth list --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: human Bluetooth inventory needs simulated peripheral state without scanning physical radios."
+        )
+    )
+    func `scans for Bluetooth peripherals`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSON Bluetooth schema needs simulated empty/populated peripheral state without physical radios."
+        )
+    )
+    func `prints JSON Bluetooth inventory`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth list --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays discoverable Bluetooth peripherals with address, name, paired,
-     trusted, and connected status when available.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `scans for Bluetooth peripherals`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits peripheral objects with stable address and status
-     fields. An empty scan is a successful empty result.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON Bluetooth inventory`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device
-     bluetooth list`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device bluetooth list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceCameraListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceCameraListTests.swift
@@ -1,75 +1,79 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device camera list'` {
-    /**
-     Displays usage for `wendy device camera list`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device camera list --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("List cameras"))
+                #expect(result.stdout.contains("wendy device camera list [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target inventory needs seeded managed-agent camera state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device camera list --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: human camera inventory needs seeded managed-agent camera hardware/capability state."
+        )
+    )
+    func `lists cameras`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSON camera schema needs seeded managed-agent camera hardware/capability state."
+        )
+    )
+    func `prints JSON camera inventory`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device camera list --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays cameras with ids, names, supported formats, resolutions, and
-     frame rates when the agent reports them.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `lists cameras`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits camera objects and capability arrays with stable
-     field names. No cameras is a successful empty result.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON camera inventory`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device camera
-     list`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device camera list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }


### PR DESCRIPTION
> **In plain terms:** No device inventory is queried. This replaces four families of copied placeholders with real checks for safe local CLI validation, while clearly preserving all managed-agent and physical-peripheral behavior for dedicated fixtures.

## Summary

- Exercise help, missing-target behavior, and unknown-flag rejection for direct-device application, audio, Bluetooth, and camera inventory commands.
- Remove all 28 generic markers: 12 tests execute and 20 are specifically disabled (the combined argument specs become separate flag and positional-argument contracts).
- Track seeded managed-agent/RPC/peripheral requirements under WDY-1952 and missing positional validation under WDY-1934.
- Keep application/container inspection, audio/camera hardware, Bluetooth radios, discovery, cloud, and physical-device routes dormant.

## Stack

- Stacked on #1471; review commit `59aa2b5c7` for this iteration only.
- Test-only; no helpers, harness changes, product code, managed agents, or physical routes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceAppsListTests" --filter "WendyDeviceAudioListTests" --filter "WendyDeviceBluetoothListTests" --filter "WendyDeviceCameraListTests"`
- Result: `Test run with 32 tests in 4 suites passed` (12 executed, 20 intentionally skipped).
