### PR TITLE
test: classify remaining Swift E2E device inventory specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceHardwareListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceHardwareListTests.swift
@@ -1,84 +1,81 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device hardware list'` {
-    /**
-     Displays usage for `wendy device hardware list`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device hardware list --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("List hardware capabilities"))
+                #expect(result.stdout.contains("wendy device hardware list [flags]"))
+                #expect(result.stdout.contains("--category"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target inventory needs seeded managed-agent hardware state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device hardware list --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled("WDY-1952: human hardware inventory needs seeded managed-agent capability state.")
+    )
+    func `lists hardware capabilities`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: category filtering needs seeded multi-category managed-agent capability state."
+        )
+    )
+    func `filters by category`() async throws {}
+
+    @Test(.disabled("WDY-1952: JSON hardware schema needs seeded managed-agent capability state."))
+    func `prints JSON hardware inventory`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device hardware list --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays hardware capabilities such as GPU, audio, camera, storage, and
-     buses with ids and user-facing labels.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `lists hardware capabilities`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--category` restricts output to matching capabilities. Unknown categories
-     produce an empty successful result or clear validation diagnostic.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `filters by category`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits hardware objects grouped or labeled by category with
-     stable field names.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON hardware inventory`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device hardware
-     list`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device hardware list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVolumesListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVolumesListTests.swift
@@ -1,75 +1,79 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device volumes list'` {
-    /**
-     Displays usage for `wendy device volumes list`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device volumes list --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("List persistent volumes"))
+                #expect(result.stdout.contains("wendy device volumes list [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target inventory needs seeded managed-agent volume state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device volumes list --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: human volume inventory needs seeded empty/populated managed-agent storage state."
+        )
+    )
+    func `lists persistent volumes`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSON volume schema needs seeded empty/populated managed-agent storage state."
+        )
+    )
+    func `prints JSON volume inventory`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device volumes list --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays persistent volumes with names, paths, sizes, owning applications,
-     and usage metadata when available.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `lists persistent volumes`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits volume objects with stable name, path, size, and
-     owner fields. No volumes is a successful empty result.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON volume inventory`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device volumes
-     list`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device volumes list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiListTests.swift
@@ -1,75 +1,79 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device wifi list'` {
-    /**
-     Displays usage for `wendy device wifi list`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi list --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("List available WiFi networks"))
+                #expect(result.stdout.contains("wendy device wifi list [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target scans need a seeded managed agent and simulated WiFi capability without physical radios."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi list --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: human WiFi inventory needs simulated network state without scanning physical radios."
+        )
+    )
+    func `lists available WiFi networks`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSON WiFi schema needs simulated empty/populated network state without physical radios."
+        )
+    )
+    func `prints JSON WiFi scan results`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi list --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays scanned WiFi networks with SSID, signal strength, security, saved
-     status, and current connection markers when available.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `lists available WiFi networks`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits WiFi network objects with stable SSID, signal,
-     security, saved, and connected fields.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON WiFi scan results`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device wifi
-     list`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device wifi list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiStatusTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiStatusTests.swift
@@ -1,75 +1,79 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device wifi status'` {
-    /**
-     Displays usage for `wendy device wifi status`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi status --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Get current WiFi connection status"))
+                #expect(result.stdout.contains("wendy device wifi status [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target status needs a seeded managed agent and simulated WiFi capability without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi status --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: human WiFi status needs simulated connected/disconnected managed-agent network state."
+        )
+    )
+    func `prints current WiFi status`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSON WiFi status needs simulated connected/disconnected managed-agent network state."
+        )
+    )
+    func `prints JSON WiFi status`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi status --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Reports whether WiFi is connected, the active SSID, signal quality, IP
-     details, and known-network state when available.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints current WiFi status`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits one JSON object with connection state and nullable
-     fields for disconnected devices.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON WiFi status`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device wifi
-     status`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device wifi status' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }


### PR DESCRIPTION
> **In plain terms:** No device hardware, storage, or WiFi state is queried. This replaces the remaining read-only inventory placeholders with real checks for safe local CLI validation, while leaving managed-agent and physical-radio behavior for dedicated fixtures.

## Summary

- Exercise help, missing-target behavior, and unknown-flag rejection for hardware, persistent-volume, WiFi-list, and WiFi-status commands.
- Remove all 29 generic markers: 12 tests execute and 21 are specifically disabled (combined argument specs become separate flag and positional-argument contracts).
- Track seeded managed-agent/RPC/hardware requirements under WDY-1952 and missing positional validation under WDY-1934.
- Keep hardware inspection, volume access, WiFi scanning, cloud, managed-agent, and physical-device routes dormant.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceHardwareListTests" --filter "WendyDeviceVolumesListTests" --filter "WendyDeviceWifiListTests" --filter "WendyDeviceWifiStatusTests"`
- Result: `Test run with 33 tests in 4 suites passed` (12 executed, 21 intentionally skipped).
