### PR TITLE
test: classify Swift E2E app lifecycle specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsRemoveTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsRemoveTests.swift
@@ -1,86 +1,92 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device apps remove'` {
-    /**
-     Displays usage for `wendy device apps remove`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps remove --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Remove an application"))
+                #expect(result.stdout.contains("wendy device apps remove [app-name] [flags]"))
+                #expect(result.stdout.contains("--cleanup"))
+                #expect(result.stdout.contains("--delete-volumes"))
+                #expect(result.stdout.contains("--force"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target removal needs seeded managed-agent application state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps remove example --force --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: confirmation and successful removal need seeded managed-agent application state."
+        )
+    )
+    func `removes an application after confirmation`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: cleanup isolation needs seeded application, image, and persistent-volume state."
+        )
+    )
+    func `honors cleanup and volume deletion flags`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-application behavior needs seeded neighboring application and resource state."
+        )
+    )
+    func `reports unknown applications without deleting resources`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps remove example --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Removes the named application only after confirmation or `--force`.
-     Success output identifies the removed app and any optional cleanup
-     performed.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `removes an application after confirmation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--cleanup` removes the container image and `--delete-volumes` removes
-     persistent volumes only for the named app. Omitted cleanup flags leave
-     those resources intact.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `honors cleanup and volume deletion flags`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     An app name that is not deployed produces a failure diagnostic and does
-     not remove images, volumes, or other apps.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown applications without deleting resources`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device apps
-     remove`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps remove one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsStartTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsStartTests.swift
@@ -1,85 +1,91 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device apps start'` {
-    /**
-     Displays usage for `wendy device apps start`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps start --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Start an application"))
+                #expect(result.stdout.contains("wendy device apps start [app-name] [flags]"))
+                #expect(result.stdout.contains("--detach"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target startup needs seeded managed-agent application state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps start example --detach --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: startup and streamed output need seeded managed-agent application/container state plus process control."
+        )
+    )
+    func `starts an application and streams output`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: detached startup needs seeded managed-agent application/container state."
+        )
+    )
+    func `starts detached when requested`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-application behavior needs seeded managed-agent application/container state."
+        )
+    )
+    func `reports unknown applications without creating containers`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps start example --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Starts the named deployed application and streams container output until
-     the app exits or the user cancels. Startup failure is reported as command
-     failure.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `starts an application and streams output`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--detach` starts the app and returns after start-up status is known
-     without streaming logs.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `starts detached when requested`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     A missing app name or unknown deployed app produces a usage or not-found
-     diagnostic and no new container is created.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown applications without creating containers`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device apps
-     start`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps start one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsStopTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsStopTests.swift
@@ -1,84 +1,90 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device apps stop'` {
-    /**
-     Displays usage for `wendy device apps stop`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps stop --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Stop an application"))
+                #expect(result.stdout.contains("wendy device apps stop [app-name] [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target stop needs seeded managed-agent application state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps stop example --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: successful stop needs seeded running managed-agent application/container state."
+        )
+    )
+    func `stops a running application`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: stopped-app idempotence needs seeded stopped managed-agent application/container state."
+        )
+    )
+    func `handles already stopped applications predictably`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-app isolation needs seeded neighboring managed-agent application/container state."
+        )
+    )
+    func `reports unknown applications without side effects`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps stop example --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Stops the named application and prints a concise confirmation after the
-     agent reports it stopped.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `stops a running application`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     An already stopped app produces a clear no-op or not-running result
-     without affecting other applications.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `handles already stopped applications predictably`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Unknown app names fail without stopping containers that have similar
-     names.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown applications without side effects`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device apps
-     stop`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device apps stop one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }


### PR DESCRIPTION
> **In plain terms:** No application or container is changed. This replaces app remove/start/stop placeholders with deterministic checks for local targeting and CLI validation, while preserving lifecycle behavior for seeded managed-agent fixtures.

## Summary

- Exercise help, missing-target behavior, unknown-flag rejection, and extra positional-argument validation for app remove/start/stop.
- Remove all 24 generic markers: 12 tests execute and 15 are specifically disabled.
- Track application/container/RPC fixtures under WDY-1952.
- Keep confirmations, images, volumes, containers, streamed logs, managed agents, cloud, and physical devices dormant.

## Stack

- Stacked on #1473; review commit `e9f3d6df9` for this iteration only.
- Test-only; no helpers, harness changes, or product code.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceAppsRemoveTests" --filter "WendyDeviceAppsStartTests" --filter "WendyDeviceAppsStopTests"`
- Result: `Test run with 27 tests in 3 suites passed` (12 executed, 15 intentionally skipped).
