### PR TITLE
test: classify Swift E2E audio operation specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioListenTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioListenTests.swift
@@ -1,85 +1,89 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device audio listen'` {
-    /**
-     Displays usage for `wendy device audio listen`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio listen --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Stream raw audio from a device microphone"))
+                #expect(result.stdout.contains("wendy device audio listen [flags]"))
+                #expect(result.stdout.contains("--sample-rate"))
+                #expect(result.stdout.contains("--channels"))
+                #expect(result.stdout.contains("--stdout"))
+                #expect(result.stdout.contains("--buffer-ms"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target listening needs a seeded managed agent and simulated audio capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio listen --stdout --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: microphone streaming needs seeded managed-agent audio frames without physical hardware."
+        )
+    )
+    func `streams microphone audio`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: raw PCM routing needs seeded managed-agent audio frames and stream process control."
+        )
+    )
+    func `writes raw PCM to stdout when requested`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1956: semantic audio parameter ranges are not validated locally before target connection/RPC."
+        )
+    )
+    func `validates audio parameters before streaming`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio listen --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Streams audio from the selected microphone using the requested device id,
-     channel count, and sample rate. The stream continues until cancelled or
-     the device ends it.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `streams microphone audio`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--stdout` writes raw PCM bytes to stdout and sends diagnostics to stderr
-     so piping to another process is safe.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `writes raw PCM to stdout when requested`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Invalid ids, channel counts, or sample rates fail before a stream is
-     opened.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `validates audio parameters before streaming`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device audio
-     listen`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device audio listen' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioMonitorTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioMonitorTests.swift
@@ -1,84 +1,87 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device audio monitor'` {
-    /**
-     Displays usage for `wendy device audio monitor`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio monitor --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Real-time VU meter for audio levels"))
+                #expect(result.stdout.contains("wendy device audio monitor [flags]"))
+                #expect(result.stdout.contains("--id"))
+                #expect(result.stdout.contains("--rate"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target monitoring needs a seeded managed agent and simulated audio capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio monitor --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: VU rendering needs seeded managed-agent level frames plus controlled terminal output."
+        )
+    )
+    func `renders live audio levels`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1956: semantic audio parameter ranges are not validated locally before target connection/RPC."
+        )
+    )
+    func `validates monitor parameters before streaming`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: cancellation cleanup needs seeded streaming RPC state and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio monitor --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays a live VU meter for the selected audio input at the requested
-     update rate and keeps diagnostics separate from the terminal UI.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `renders live audio levels`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Invalid device ids or update rates fail before a monitoring stream is
-     opened.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `validates monitor parameters before streaming`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling the monitor closes the remote stream and restores terminal
-     output without modifying device settings.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device audio
-     monitor`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device audio monitor' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioSetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioSetDefaultTests.swift
@@ -1,84 +1,90 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device audio set-default'` {
-    /**
-     Displays usage for `wendy device audio set-default`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio set-default --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Set the default audio device"))
+                #expect(result.stdout.contains("wendy device audio set-default [flags]"))
+                #expect(result.stdout.contains("--id"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target mutation needs seeded managed-agent audio state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio set-default --id 4 --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     Sets the selected audio device id as the device default and prints a
-     concise confirmation with the chosen id or name.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `sets the default audio device`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: successful default selection needs seeded managed-agent audio device state."
+        )
+    )
+    func `sets the default audio device`() async throws {}
 
-    /**
-     Missing or invalid `--id` values produce a usage diagnostic before
-     contacting or mutating audio settings.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires an audio device id`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio set-default") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("required flag(s) \"id\" not set"))
+            }
+        }
     }
 
-    /**
-     If the agent rejects the id or does not support default audio selection,
-     the previous default remains active.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unsupported devices without changing defaults`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: rejection and previous-default preservation need seeded managed-agent audio state."
+        )
+    )
+    func `reports unsupported devices without changing defaults`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device audio set-default --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy device audio
-     set-default`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device audio set-default' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }


### PR DESCRIPTION
> **In plain terms:** No microphone, speaker, or audio setting is touched. This replaces audio listen/monitor/set-default placeholders with deterministic CLI checks and tracks the real streaming and hardware contracts separately.

## Summary

- Exercise help, missing-target behavior, unknown-flag rejection, and required `--id` validation where supported.
- Remove all 24 generic markers: 10 tests execute and 17 are specifically disabled.
- Track seeded audio/RPC/process fixtures under WDY-1952, positional validation under WDY-1934, and missing semantic range validation under WDY-1956.
- Keep audio devices, streams, terminal UIs, cancellation, managed agents, cloud, and physical hardware dormant.

## Stack

- Stacked on #1474; review commit `dfef4a312` for this iteration only.
- Test-only; no helpers, harness changes, or product code.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceAudioListenTests" --filter "WendyDeviceAudioMonitorTests" --filter "WendyDeviceAudioSetDefaultTests"`
- Result: `Test run with 27 tests in 3 suites passed` (10 executed, 17 intentionally skipped).
