### PR TITLE
test: classify Swift E2E Bluetooth mutation specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothConnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothConnectTests.swift
@@ -1,84 +1,102 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device bluetooth connect'` {
-    /**
-     Displays usage for `wendy device bluetooth connect`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth connect --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Connect to a Bluetooth peripheral"))
+                #expect(result.stdout.contains("wendy device bluetooth connect [address] [flags]"))
+                #expect(result.stdout.contains("--pair"))
+                #expect(result.stdout.contains("--trust"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target connection needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth connect AA:BB:CC:DD:EE:FF --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     Connects to the requested peripheral address and applies pair and trust
-     options. Success output identifies the connected address.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `connects to a Bluetooth peripheral`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: pair/trust/connect behavior needs simulated managed-agent Bluetooth state without physical radios."
+        )
+    )
+    func `connects to a Bluetooth peripheral`() async throws {}
 
-    /**
-     Missing or malformed addresses produce a usage diagnostic before a
-     Bluetooth operation starts.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires a peripheral address`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth connect") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 0"))
+            }
+        }
     }
 
-    /**
-     Pairing, trust, or connection failures report the failed stage and do not
-     claim the peripheral is connected.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports pairing failures without trusting the device`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
+        )
+    )
+    func `rejects malformed peripheral addresses`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: staged pair/trust/connect failures need controllable simulated managed-agent Bluetooth responses."
+        )
+    )
+    func `reports pairing failures without trusting the device`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth connect AA:BB:CC:DD:EE:FF --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy device
-     bluetooth connect`. Extra positional arguments or unknown flags
-     produce a usage diagnostic on stderr, return a failure status, emit no
-     success output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth connect one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothDisconnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothDisconnectTests.swift
@@ -1,84 +1,104 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device bluetooth disconnect'` {
-    /**
-     Displays usage for `wendy device bluetooth disconnect`. The output
-     includes the command synopsis, local flags, inherited global flags,
-     and concise descriptions. Help exits successfully, writes to stdout,
-     emits no stderr, and leaves configuration, cache, project, cloud, and
-     device state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth disconnect --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Disconnect a Bluetooth peripheral"))
+                #expect(
+                    result.stdout.contains("wendy device bluetooth disconnect [address] [flags]")
+                )
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target disconnection needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth disconnect AA:BB:CC:DD:EE:FF --json") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     Disconnects the requested peripheral address and prints a concise
-     confirmation after the agent reports it disconnected.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `disconnects a Bluetooth peripheral`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: successful disconnection needs simulated managed-agent Bluetooth connection state."
+        )
+    )
+    func `disconnects a Bluetooth peripheral`() async throws {}
 
-    /**
-     Missing or malformed addresses produce a usage diagnostic and no Bluetooth
-     operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires a peripheral address`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth disconnect") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 0"))
+            }
+        }
     }
 
-    /**
-     A peripheral that is not connected produces a clear no-op or not-connected
-     result without affecting pairing state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `handles already disconnected peripherals predictably`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
+        )
+    )
+    func `rejects malformed peripheral addresses`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: already-disconnected semantics need simulated managed-agent Bluetooth state."
+        )
+    )
+    func `handles already disconnected peripherals predictably`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth disconnect AA:BB:CC:DD:EE:FF --bogus") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy device
-     bluetooth disconnect`. Extra positional arguments or unknown flags
-     produce a usage diagnostic on stderr, return a failure status, emit no
-     success output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth disconnect one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothForgetTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothForgetTests.swift
@@ -1,84 +1,100 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device bluetooth forget'` {
-    /**
-     Displays usage for `wendy device bluetooth forget`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth forget --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Forget a paired Bluetooth peripheral"))
+                #expect(result.stdout.contains("wendy device bluetooth forget [address] [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target forget needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth forget AA:BB:CC:DD:EE:FF --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     Removes pairing and trust state for the requested peripheral address
-     without changing unrelated peripherals.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `forgets a paired Bluetooth peripheral`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: successful forget needs simulated managed-agent pairing/trust state without physical radios."
+        )
+    )
+    func `forgets a paired Bluetooth peripheral`() async throws {}
 
-    /**
-     Missing or malformed addresses produce a usage diagnostic and no Bluetooth
-     operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires a peripheral address`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth forget") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 0"))
+            }
+        }
     }
 
-    /**
-     Forgetting an address unknown to the device reports a not-found result and
-     preserves other pairings.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown peripherals without changing known devices`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
+        )
+    )
+    func `rejects malformed peripheral addresses`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-address isolation needs seeded neighboring managed-agent pairing state."
+        )
+    )
+    func `reports unknown peripherals without changing known devices`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth forget AA:BB:CC:DD:EE:FF --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy device
-     bluetooth forget`. Extra positional arguments or unknown flags produce
-     a usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device bluetooth forget one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 2"))
+            }
+        }
     }
 }


### PR DESCRIPTION
> **In plain terms:** No Bluetooth radio or peripheral is touched. This replaces connect/disconnect/forget placeholders with deterministic address-arity and target checks, while preserving pairing behavior for simulated managed-agent fixtures.

## Summary

- Exercise help, missing-target behavior, required-address validation, unknown-flag rejection, and extra positional-argument rejection.
- Remove all 24 generic markers: 15 tests execute and 15 are specifically disabled.
- Track simulated Bluetooth/RPC state under WDY-1952 and missing local address-format validation under WDY-1957.
- Keep pairing, trust, connection state, radios, managed agents, cloud, and physical peripherals dormant.

## Stack

- Stacked on #1475; review commit `19436f2ab` for this iteration only.
- Test-only; no helpers, harness changes, or product code.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceBluetoothConnectTests" --filter "WendyDeviceBluetoothDisconnectTests" --filter "WendyDeviceBluetoothForgetTests"`
- Result: `Test run with 30 tests in 3 suites passed` (15 executed, 15 intentionally skipped).
