### PR TITLE
test: classify Swift E2E WiFi mutation specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiConnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiConnectTests.swift
@@ -1,93 +1,95 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device wifi connect'` {
-    /**
-     Displays usage for `wendy device wifi connect`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi connect --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Connect to a WiFi network"))
+                #expect(result.stdout.contains("wendy device wifi connect [flags]"))
+                #expect(result.stdout.contains("--ssid"))
+                #expect(result.stdout.contains("--password"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target connection needs a seeded managed agent and simulated WiFi capability without physical radios."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi connect --ssid Example --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Password"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: successful connection needs simulated managed-agent WiFi association state without physical radios."
+        )
+    )
+    func `connects to a WiFi network`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: password prompting and redaction need a scripted PTY plus simulated secured-network state."
+        )
+    )
+    func `prompts for missing password only in interactive mode`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: omitted SSID intentionally opens a device-backed network picker and needs simulated scan results."
+        )
+    )
+    func `selects a missing SSID interactively`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: failed-credential preservation needs seeded neighboring managed-agent network profiles."
+        )
+    )
+    func `does not save failed credentials`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi connect --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Connects the device to the requested SSID using the supplied password when
-     needed and reports the resulting connection status.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `connects to a WiFi network`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     For secured networks without `--password`, prompts in an interactive
-     terminal without echoing the secret. Non-interactive mode reports that a
-     password is required.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prompts for missing password only in interactive mode`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Missing `--ssid` produces a usage diagnostic and no WiFi operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `requires an SSID`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Authentication or association failures report the error and do not replace
-     existing working network credentials.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `does not save failed credentials`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device wifi
-     connect`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device wifi connect' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiDisconnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiDisconnectTests.swift
@@ -1,75 +1,78 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device wifi disconnect'` {
-    /**
-     Displays usage for `wendy device wifi disconnect`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi disconnect --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Disconnect from the current WiFi network"))
+                #expect(result.stdout.contains("wendy device wifi disconnect [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target disconnection needs a seeded managed agent and simulated WiFi capability without physical radios."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi disconnect --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: successful disconnection needs simulated managed-agent WiFi connection state."
+        )
+    )
+    func `disconnects from the current WiFi network`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: already-disconnected semantics need simulated managed-agent WiFi state."
+        )
+    )
+    func `handles already disconnected devices predictably`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi disconnect --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Disconnects the active WiFi connection and reports the resulting
-     disconnected state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `disconnects from the current WiFi network`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     A device with no active WiFi connection reports a no-op or already-
-     disconnected result without changing saved networks.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `handles already disconnected devices predictably`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device wifi
-     disconnect`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device wifi disconnect' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiForgetTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiForgetTests.swift
@@ -1,83 +1,88 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device wifi forget'` {
-    /**
-     Displays usage for `wendy device wifi forget`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi forget --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Remove a known WiFi network"))
+                #expect(result.stdout.contains("wendy device wifi forget [flags]"))
+                #expect(result.stdout.contains("--ssid"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target forget needs a seeded managed agent and simulated WiFi capability without physical radios."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi forget --ssid Example --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     Removes saved credentials for the requested SSID without affecting other
-     known networks or current nonmatching connections.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `forgets a known WiFi network`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled("WDY-1952: successful forget needs simulated managed-agent saved-network state.")
+    )
+    func `forgets a known WiFi network`() async throws {}
 
-    /**
-     Missing `--ssid` produces a usage diagnostic and no WiFi operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires an SSID`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi forget") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("--ssid is required"))
+            }
+        }
     }
 
-    /**
-     Forgetting an SSID that is not saved reports a clear result and leaves all
-     known networks unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown networks without changing saved credentials`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-network isolation needs seeded neighboring managed-agent network profiles."
+        )
+    )
+    func `reports unknown networks without changing saved credentials`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi forget --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy device wifi
-     forget`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device wifi forget' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiRankTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiRankTests.swift
@@ -1,84 +1,104 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device wifi rank'` {
-    /**
-     Displays usage for `wendy device wifi rank`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi rank --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Set the priority of a single known network"))
+                #expect(result.stdout.contains("wendy device wifi rank [flags]"))
+                #expect(result.stdout.contains("--ssid"))
+                #expect(result.stdout.contains("--priority"))
+                #expect(result.stdout.contains("--order"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target ranking needs seeded managed-agent saved-network state without physical radios."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi rank --ssid Example --priority 10 --json") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     `--ssid` with `--priority` updates one saved network's autoconnect
-     priority and leaves other priorities unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `sets priority for a single known network`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: single-network ranking needs seeded neighboring managed-agent priority state."
+        )
+    )
+    func `sets priority for a single known network`() async throws {}
 
-    /**
-     `--order` assigns priorities to the listed SSIDs from highest to lowest
-     while preserving unlisted known networks.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `bulk reorders known networks`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: bulk ranking needs seeded listed/unlisted managed-agent priority state."
+        )
+    )
+    func `bulk reorders known networks`() async throws {}
 
-    /**
-     Supplying incomplete or conflicting ranking flags produces a usage
-     diagnostic before WiFi settings are changed.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `validates mutually exclusive ranking modes`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi rank") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("must pass either --order or --ssid"))
+            }
+            try await cli.sh("wendy device wifi rank --ssid Example") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("--priority is required when --ssid is set"))
+            }
+            try await cli.sh("wendy device wifi rank --ssid Example --priority 1 --order Other") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("--order and --ssid are mutually exclusive"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy device wifi
-     rank`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device wifi rank --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
+
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device wifi rank' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }


### PR DESCRIPTION
> **In plain terms:** No WiFi radio, credentials, or saved network is changed. This replaces connect/disconnect/forget/rank placeholders with deterministic CLI checks while preserving network behavior for simulated managed-agent fixtures.

## Summary

- Exercise help, missing-target behavior, unknown-flag rejection, required SSID validation, and all local ranking-mode validation.
- Remove all 32 generic markers: 14 tests execute and 22 are specifically disabled.
- Track simulated WiFi/RPC/PTY state under WDY-1952 and missing positional validation under WDY-1934.
- Reconcile the stale connect contract: omitted `--ssid` intentionally opens a picker rather than being a usage error.
- Keep passwords, profiles, associations, radios, managed agents, cloud, and physical devices dormant.

## Stack

- Stacked on #1476; review commit `02a2654ea` for this iteration only.
- Test-only; no helpers, harness changes, or product code.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceWifiConnectTests" --filter "WendyDeviceWifiDisconnectTests" --filter "WendyDeviceWifiForgetTests" --filter "WendyDeviceWifiRankTests"`
- Result: `Test run with 36 tests in 4 suites passed` (14 executed, 22 intentionally skipped).
