### PR TITLE
test: classify Swift E2E observability stream specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceDashboardTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceDashboardTests.swift
@@ -1,85 +1,88 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device dashboard'` {
-    /**
-     Displays usage for `wendy device dashboard`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device dashboard --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(
+                    result.stdout.contains("Live dashboard showing metrics and logs from a device")
+                )
+                #expect(result.stdout.contains("wendy device dashboard [flags]"))
+                #expect(result.stdout.contains("--app"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target dashboard startup needs a seeded managed agent with telemetry state."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device dashboard --app Example") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: live dashboard rendering needs seeded metrics/log streams and scripted terminal control."
+        )
+    )
+    func `shows a live device dashboard`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: terminal capability behavior needs a seeded target plus controlled TTY/non-TTY execution."
+        )
+    )
+    func `reports non-interactive dashboard limitations`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: dashboard cancellation cleanup needs seeded streams and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device dashboard --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays live metrics and logs for the selected device, optionally
-     filtered to an application. The dashboard is informational and does not
-     mutate device state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shows a live device dashboard`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Without an interactive terminal, reports that the live dashboard requires
-     a terminal or suggests machine-readable alternatives.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports non-interactive dashboard limitations`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling the dashboard closes log and metric streams and restores
-     terminal output.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device
-     dashboard`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device dashboard' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceLogsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceLogsTests.swift
@@ -1,84 +1,93 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device logs'` {
-    /**
-     Displays usage for `wendy device logs`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device logs --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Stream logs from containers on the device"))
+                #expect(result.stdout.contains("wendy device logs [app] [flags]"))
+                #expect(result.stdout.contains("--app"))
+                #expect(result.stdout.contains("--service"))
+                #expect(result.stdout.contains("--level"))
+                #expect(result.stdout.contains("--tail"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target log streaming needs a seeded managed agent with telemetry state."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device logs Example --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: filtered log streaming needs seeded managed-agent container and telemetry records."
+        )
+    )
+    func `streams device logs`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSON log framing needs seeded managed-agent telemetry records and bounded stream control."
+        )
+    )
+    func `prints structured log entries in JSON mode`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: log cancellation cleanup needs a seeded stream and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device logs --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Streams logs from the selected device and applies app, service, level, and
-     severity filters before presenting entries.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `streams device logs`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits newline-delimited or array-wrapped structured log
-     entries suitable for automation, without table formatting.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints structured log entries in JSON mode`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling log streaming closes the remote stream without changing app or
-     device state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device logs`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device logs one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceTelemetryStreamTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceTelemetryStreamTests.swift
@@ -1,85 +1,92 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device telemetry-stream'` {
-    /**
-     Displays usage for `wendy device telemetry-stream`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device telemetry-stream --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(
+                    result.stdout.contains("Stream telemetry data (logs, metrics, traces) as JSONL")
+                )
+                #expect(result.stdout.contains("wendy device telemetry-stream [flags]"))
+                #expect(result.stdout.contains("--app"))
+                #expect(result.stdout.contains("--service"))
+                #expect(result.stdout.contains("--logs"))
+                #expect(result.stdout.contains("--metrics"))
+                #expect(result.stdout.contains("--traces"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target telemetry needs a seeded managed agent with logs, metrics, and traces."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device telemetry-stream --logs --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSONL framing needs seeded logs, metrics, and traces plus bounded stream control."
+        )
+    )
+    func `streams telemetry as JSONL`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: telemetry filtering needs seeded neighboring app/service records across all signal types."
+        )
+    )
+    func `applies telemetry filters`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: telemetry cancellation cleanup needs seeded streams and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device telemetry-stream --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Streams selected logs, metrics, and traces as JSON lines with stable
-     envelope fields and timestamps. The stream continues until cancelled or
-     the device closes it.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `streams telemetry as JSONL`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     App, service, logs, metrics, and traces filters constrain the stream
-     before entries are emitted to stdout.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `applies telemetry filters`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling the stream closes the remote telemetry subscription and emits
-     no malformed trailing JSON.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device
-     telemetry-stream`. Extra positional arguments or unknown flags produce
-     a usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device telemetry-stream' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }


### PR DESCRIPTION
> **In plain terms:** No dashboard or telemetry stream is opened. This replaces observability placeholders with deterministic CLI checks while preserving live rendering, JSON framing, filtering, and cancellation for seeded stream fixtures.

## Summary

- Exercise help, missing-target behavior, unknown-flag rejection, and logs positional arity.
- Remove all 24 generic markers: 10 tests execute and 17 are specifically disabled.
- Track seeded telemetry/RPC/PTY/process fixtures under WDY-1952 and missing positional validation under WDY-1934.
- Keep metrics, logs, traces, terminal UIs, managed agents, cloud, and physical devices dormant.

## Stack

- Stacked on #1477; review commit `5262a8856` for this iteration only.
- Test-only; no helpers, harness changes, or product code.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceDashboardTests" --filter "WendyDeviceLogsTests" --filter "WendyDeviceTelemetryStreamTests"`
- Result: `Test run with 27 tests in 3 suites passed` (10 executed, 17 intentionally skipped).
