### PR TITLE
test: classify Swift E2E media and storage specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceCameraViewTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceCameraViewTests.swift
@@ -1,93 +1,97 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device camera view'` {
-    /**
-     Displays usage for `wendy device camera view`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device camera view --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Stream H.264 video from a device camera"))
+                #expect(result.stdout.contains("wendy device camera view [flags]"))
+                #expect(result.stdout.contains("--id"))
+                #expect(result.stdout.contains("--width"))
+                #expect(result.stdout.contains("--height"))
+                #expect(result.stdout.contains("--fps"))
+                #expect(result.stdout.contains("--stdout"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target viewing needs a seeded managed agent and simulated camera capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device camera view --stdout --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: camera playback needs seeded encoded frames plus controlled local viewer dependencies."
+        )
+    )
+    func `streams camera video`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: encoded stdout routing needs seeded frames and bounded stream process control."
+        )
+    )
+    func `writes encoded video to stdout when requested`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1958: semantic camera dimensions and frame rates are not validated locally before target connection/RPC."
+        )
+    )
+    func `validates camera parameters before streaming`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: viewer cancellation cleanup needs seeded streaming RPC state and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device camera view --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Streams video from the selected camera using the requested dimensions and
-     frame rate. Interactive mode opens a viewer when available.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `streams camera video`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--stdout` writes the encoded video stream to stdout and keeps diagnostics
-     on stderr for safe piping.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `writes encoded video to stdout when requested`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Invalid camera ids, dimensions, or frame rates fail before a remote camera
-     stream is opened.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `validates camera parameters before streaming`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling the viewer closes the remote stream and local viewer process
-     without changing camera settings.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device camera
-     view`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device camera view' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVolumesRemoveTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVolumesRemoveTests.swift
@@ -1,84 +1,90 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device volumes remove'` {
-    /**
-     Displays usage for `wendy device volumes remove`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device volumes remove --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Remove a persistent volume"))
+                #expect(result.stdout.contains("wendy device volumes remove [name] [flags]"))
+                #expect(result.stdout.contains("--force"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target removal needs seeded managed-agent persistent-volume state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device volumes remove example --force --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: confirmation and successful removal need seeded managed-agent persistent-volume state."
+        )
+    )
+    func `removes a persistent volume after confirmation`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: omitted names intentionally open a device-backed volume picker and need seeded list results."
+        )
+    )
+    func `selects a missing volume name interactively`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-volume isolation needs seeded neighboring volume and application state."
+        )
+    )
+    func `reports unknown volumes without deleting data`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device volumes remove example --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Removes the named volume only after confirmation or `--force`. Success
-     output identifies the removed volume.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `removes a persistent volume after confirmation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Missing or empty volume names produce a usage diagnostic before contacting
-     the device.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `requires a volume name`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     An unknown volume name fails without deleting similarly named volumes or
-     application containers.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown volumes without deleting data`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device volumes
-     remove`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device volumes remove one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }


### PR DESCRIPTION
> **In plain terms:** No camera stream is opened and no volume is deleted. This replaces camera-view and volume-remove placeholders with deterministic target and argument checks while preserving media and destructive behavior for seeded fixtures.

## Summary

- Exercise help, missing-target behavior, unknown-flag rejection, and volume positional arity.
- Remove all 17 generic markers: 7 tests execute and 12 are specifically disabled.
- Track seeded camera/storage/RPC/process fixtures under WDY-1952, positional validation under WDY-1934, and missing camera range validation under WDY-1958.
- Reconcile the stale volume contract: an omitted name intentionally opens a picker rather than being a usage error.
- Keep encoded video, local viewers, persistent data, confirmations, managed agents, cloud, and physical devices dormant.

## Stack

- Stacked on #1478; review commit `0d813ae01` for this iteration only.
- Test-only; no helpers, harness changes, or product code.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceCameraViewTests" --filter "WendyDeviceVolumesRemoveTests"`
- Result: `Test run with 19 tests in 2 suites passed` (7 executed, 12 intentionally skipped).
