### PR TITLE
test: classify Swift E2E provisioning workflow specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceEnrollTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceEnrollTests.swift
@@ -1,93 +1,95 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device enroll'` {
-    /**
-     Displays usage for `wendy device enroll`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device enroll --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Creates an enrollment token"))
+                #expect(result.stdout.contains("wendy device enroll [flags]"))
+                #expect(result.stdout.contains("--name"))
+                #expect(result.stdout.contains("--org"))
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: explicit-target enrollment needs isolated auth, PKI/cloud, and disposable provisioning fixtures."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device enroll --name Example --org 1 --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1949: connection and incompatible-RPC failures need disposable provisioning and auth fixtures."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1949: successful enrollment needs isolated auth, token issuance, certificate, and disposable device fixtures."
+        )
+    )
+    func `enrolls the selected device with Wendy Cloud`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1959: auth is currently resolved only after target connection and optional WiFi inspection."
+        )
+    )
+    func `reports missing auth before touching the device`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1949: partial-failure rollback needs controllable token, certificate, and provisioning failure fixtures."
+        )
+    )
+    func `does not leave partial credentials on enrollment failure`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1949: JSON enrollment metadata needs isolated successful PKI/cloud and device fixtures."
+        )
+    )
+    func `prints JSON enrollment metadata`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device enroll --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Uses the stored auth session to create an enrollment token and provisions
-     the device with mTLS credentials and an optional name.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `enrolls the selected device with Wendy Cloud`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Without a usable auth session, reports that login is required and performs
-     no device provisioning.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing auth before touching the device`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Token creation, certificate issuance, or device provisioning failures
-     leave previous device credentials usable and report the failing stage.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `does not leave partial credentials on enrollment failure`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits enrollment status and certificate metadata without
-     printing tokens or private keys.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON enrollment metadata`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device enroll`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device enroll' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceSetupTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceSetupTests.swift
@@ -1,85 +1,85 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device setup'` {
-    /**
-     Displays usage for `wendy device setup`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device setup --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Walks through enrollment"))
+                #expect(result.stdout.contains("wendy device setup [flags]"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target setup needs seeded provisioning, auth, WiFi, and version state."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device setup --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: the setup wizard needs seeded provisioning/auth/WiFi state plus scripted PTY interaction."
+        )
+    )
+    func `walks through new device setup`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: setup resume behavior needs seeded partially configured device and auth state."
+        )
+    )
+    func `uses existing state to skip completed setup steps`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: setup cancellation needs seeded state and harness process control across wizard stages."
+        )
+    )
+    func `cancels without continuing later setup`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device setup --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Guides the user through device naming, cloud enrollment, and WiFi
-     configuration for a new device, explaining each side effect before
-     applying it.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `walks through new device setup`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Existing auth sessions, device names, or WiFi configuration are detected
-     and not repeated unless the user chooses to change them.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses existing state to skip completed setup steps`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling the setup flow stops at the current step and avoids applying
-     later enrollment or WiFi changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `cancels without continuing later setup`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device setup`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device setup' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUpdateTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUpdateTests.swift
@@ -1,93 +1,92 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy device update'` {
-    /**
-     Displays usage for `wendy device update`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device update --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Updates the agent binary on the device"))
+                #expect(result.stdout.contains("wendy device update [flags]"))
+                #expect(result.stdout.contains("--binary"))
+                #expect(result.stdout.contains("--nightly"))
+                #expect(result.stdout.contains("--artifact-url"))
+                #expect(result.stdout.contains("--yes"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the target device hostname and skips discovery and
-     pickers. The command does not read or change the saved default device when
-     an explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: explicit-target update needs a disposable seeded agent and isolated release/artifact fixtures."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device update --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("no device specified"))
+                #expect(!result.stderr.contains("Select a device"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need a disposable seeded agent with controllable responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: release update needs isolated downloads and a disposable agent restart/reconnect target."
+        )
+    )
+    func `updates the device agent from the latest release`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: local binary upload needs an architecture fixture and disposable agent restart/reconnect target."
+        )
+    )
+    func `uploads a local binary when requested`() async throws {}
+
+    @Test(.disabled("WDY-1952: nightly selection needs isolated release and OS manifest fixtures."))
+    func `uses nightly releases when requested`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: failure preservation needs controllable download/upload/restart stages on a disposable agent."
+        )
+    )
+    func `preserves the running agent on failed update`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy device update --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Downloads the selected agent release, verifies it, uploads it to the
-     device, and reports the installed version after update.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `updates the device agent from the latest release`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--binary` skips release download and uploads the provided local agent
-     binary after validating that it is readable.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uploads a local binary when requested`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--nightly` selects a prerelease agent build and reports that prerelease
-     channel in output.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses nightly releases when requested`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Download, verification, upload, or restart failures report the failing
-     stage and do not claim the update completed.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `preserves the running agent on failed update`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy device update`.
-     Extra positional arguments or unknown flags produce a usage diagnostic
-     on stderr, return a failure status, emit no success output, and leave
-     existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy device update' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }


### PR DESCRIPTION
> **In plain terms:** No device is enrolled, configured, updated, or restarted. This replaces setup/enroll/update placeholders with deterministic CLI checks while preserving provisioning and update workflows for disposable fixtures.

## Summary

- Exercise help, missing-target behavior, and unknown-flag rejection for setup, enrollment, and agent update.
- Remove all 26 generic markers: 9 tests execute and 20 are specifically disabled.
- Track auth/PKI/cloud fixtures under WDY-1949, disposable managed-agent fixtures under WDY-1952, positional validation under WDY-1934, and auth-before-device ordering under WDY-1959.
- Keep credentials, WiFi, downloads, uploads, enrollment, restarts, managed agents, cloud, and physical devices dormant.

## Stack

- Stacked on #1479; review commit `d5f5ae75a` for this iteration only.
- Test-only; no helpers, harness changes, or product code.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyDeviceSetupTests" --filter "WendyDeviceEnrollTests" --filter "WendyDeviceUpdateTests"`
- Result: `Test run with 29 tests in 3 suites passed` (9 executed, 20 intentionally skipped).
