### PR TITLE
test: classify Swift E2E cloud device aliases

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBtListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBtListTests.swift
@@ -1,30 +1,31 @@
 import Testing
+import WendyE2ETesting
 
 /// Public alias path for `wendy cloud device bluetooth list`.
-///
-/// The `bt` shorthand remains available for cloud-routed command entry and shell
-/// completion, while canonical documentation continues to prefer `bluetooth`.
 @Suite
 struct `'wendy cloud device bt list'` {
-    // MARK: - Compatibility
+    let scenario = CLIAndAgentScenario()
 
-    /**
-     Resolves through the `bt` alias and displays the same help as `wendy cloud
-     device bluetooth list`, including inherited cloud/device/global flags and
-     validation behavior.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints '... bluetooth list help' through the 'bt' alias`() async throws {
-        // TODO: implement.
+    @Test
+    func `prints canonical Bluetooth list help through the bt alias`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bt list --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Scan for Bluetooth peripherals"))
+                #expect(result.stdout.contains("wendy cloud device bluetooth list [flags]"))
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--broker-url"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Lists Bluetooth peripherals over the cloud tunnel using the same output
-     contract as `wendy cloud device bluetooth list`. The alias does not change
-     cloud authentication, target selection, JSON output, or error diagnostics.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `aliases '... cloud device bluetooth list'`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: cloud-routed alias equivalence needs seeded tunnel/auth and simulated managed-agent Bluetooth state."
+        )
+    )
+    func `aliases cloud device bluetooth list`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDevicePsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDevicePsTests.swift
@@ -1,39 +1,38 @@
 import Testing
+import WendyE2ETesting
 
 /// Public compatibility alias for `wendy cloud device apps list`.
-///
-/// The short `ps` form remains visible in cloud-routed device help for users who
-/// expect a container-style listing command.
 @Suite
 struct `'wendy cloud device ps'` {
-    // MARK: - Compatibility
+    let scenario = CLIAndAgentScenario()
 
-    /**
-     Displays usage for `wendy cloud device ps`. The output identifies the
-     command as an alias for `wendy cloud device apps list`, lists cloud and
-     global inherited flags, exits successfully, and emits no stderr.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints '... cloud device ps' alias help`() async throws {
-        // TODO: implement.
+    @Test
+    func `prints cloud device ps alias help`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device ps --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("List running containers (alias for 'apps list')"))
+                #expect(result.stdout.contains("wendy cloud device ps [flags]"))
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--broker-url"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Produces the same cloud-routed application inventory as `wendy cloud device
-     apps list` after selecting and authenticating the cloud device. The alias
-     does not introduce additional prompts or state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `aliases '... cloud device apps list'`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: cloud-routed alias equivalence needs seeded tunnel/auth and managed-agent application state."
+        )
+    )
+    func `aliases cloud device apps list`() async throws {}
 
-    /**
-     With `--json`, emits the same application inventory schema as `wendy cloud
-     device apps list` and keeps stdout machine-readable for automation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `'--json' keeps '... cloud device apps list' output clean`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: cloud-routed JSON schema equivalence needs seeded tunnel/auth and managed-agent application state."
+        )
+    )
+    func `JSON keeps cloud device apps list output clean`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVersionTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVersionTests.swift
@@ -1,42 +1,48 @@
 import Testing
+import WendyE2ETesting
 
 /// Hidden deprecated compatibility command for `wendy cloud device info`.
-///
-/// Use `wendy cloud device info` in new scripts and documentation.
 @Suite
 struct `'wendy cloud device version'` {
-    // MARK: - Compatibility
+    let scenario = CLIAndAgentScenario()
 
-    /**
-     The hidden command remains directly invocable for older scripts, but
-     `wendy cloud device --help` does not advertise it. Direct help preserves
-     the `wendy cloud device info` option surface for users who still discover
-     the legacy command explicitly.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `is hidden from parent help while direct help mirrors '... cloud device info'`()
-        async throws
-    {
-        // TODO: implement.
+    @Test
+    func `is hidden from parent help while direct help mirrors cloud device info`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("info"))
+                #expect(!result.stdout.contains("\n  version "))
+                #expect(result.stderr == "")
+            }
+            try await cli.sh("wendy cloud device version --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(
+                    result.stdout.contains(
+                        "Show agent version, OS, architecture, GPU, and hardware info"
+                    )
+                )
+                #expect(result.stdout.contains("wendy cloud device version [flags]"))
+                #expect(result.stdout.contains("--check-updates"))
+                #expect(result.stdout.contains("--prerelease"))
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--broker-url"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     In human-readable mode, the deprecated command reports the same cloud-routed
-     device information as `wendy cloud device info` and writes a deprecation
-     warning that names `wendy cloud device info` as the replacement command.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `aliases '... cloud device info' with a deprecation notice`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: cloud-routed info equivalence and deprecation output need seeded tunnel/auth and managed-agent metadata."
+        )
+    )
+    func `aliases cloud device info with a deprecation notice`() async throws {}
 
-    /**
-     With `--json` or non-interactive JSON output, deprecation guidance stays
-     out of stdout and stderr so existing scripts can continue parsing the
-     response.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `'--json' keeps JSON output clean`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: cloud-routed JSON compatibility needs seeded tunnel/auth and managed-agent metadata."
+        )
+    )
+    func `JSON keeps output clean`() async throws {}
 }


### PR DESCRIPTION
> **In plain terms:** No cloud tunnel or device is contacted. This replaces the cloud `bt`, `ps`, and deprecated `version` alias placeholders with local help and visibility checks while preserving routed equivalence for seeded fixtures.

## Summary

- Exercise canonical Bluetooth help through `bt`, `ps` alias help, and hidden/direct `version` help behavior.
- Remove all 8 generic markers: 3 tests execute and 5 are specifically disabled.
- Track cloud tunnel/auth/managed-agent equivalence under WDY-1952.
- Keep authentication, tunnels, inventory RPCs, cloud, and physical devices dormant.

## Stack

- Stacked on #1480; review commit `603bf2f90` for this iteration only.
- Test-only; no helpers, harness changes, or product code.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyCloudDeviceBtListTests" --filter "WendyCloudDevicePsTests" --filter "WendyCloudDeviceVersionTests"`
- Result: `Test run with 8 tests in 3 suites passed` (3 executed, 5 intentionally skipped).
