### PR TITLE
test: cover cloud default-device mutations

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceSetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceSetDefaultTests.swift
@@ -1,95 +1,127 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device set-default'` {
-    /**
-     Displays usage for `wendy cloud device set-default`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays positional hostname usage without auth, discovery, or config access. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device set-default --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Set the default device hostname"))
+                #expect(
+                    result.stdout.contains(
+                        "wendy cloud device set-default [hostname] [flags]"
+                    )
+                )
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1943: omitted-hostname selection enters physical discovery/picker flow; deterministic non-interactive behavior needs injected discovery fixtures."
+        )
+    )
     func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
+        // TODO: enable with deterministic picker/discovery fixtures (WDY-1943).
     }
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+    /** Stores an offline hostname locally; cloud reachability pinning remains best-effort. */
+    @Test
+    func `saves the default device hostname without cloud authentication`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device set-default 127.0.0.1:1") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Default device set to: 127.0.0.1:1"))
+                #expect(result.stderr == "")
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("\"defaultDevice\": \"127.0.0.1:1\""))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    /** Preserves unrelated known config while changing only the default hostname. */
+    @Test
+    func `preserves unrelated known configuration keys`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.wendy"
+                    printf '%s\n' '{"analytics":{"enabled":false},"lastCLIUpdateCheck":"2026-07-20T12:00:00Z","completionPromptDismissed":true}' > "$HOME/.wendy/config.json"
+                    """,
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"analytics":{"enabled":false},"lastCLIUpdateCheck":"2026-07-20T12:00:00Z","completionPromptDismissed":true}'
+                    """
+            )
+            try await cli.sh("wendy cloud device set-default 127.0.0.1:1") { result in
+                #expect(result.status.isSuccess)
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                #expect(json["defaultDevice"] as? String == "127.0.0.1:1")
+                #expect((json["analytics"] as? [String: Any])?["enabled"] as? Bool == false)
+                #expect(json["lastCLIUpdateCheck"] as? String == "2026-07-20T12:00:00Z")
+                #expect(json["completionPromptDismissed"] as? Bool == true)
+            }
+        }
     }
 
-    /**
-     Writes the provided hostname as the CLI default device and prints a
-     concise confirmation. Future device commands use this value when no
-     explicit device is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `saves the default device hostname`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1940: typed config load/save discards unknown top-level keys during default-device mutation."
+        )
+    )
+    func `preserves unknown future configuration keys`() async throws {
+        // TODO: enable when config mutations round-trip unknown keys (WDY-1940).
     }
 
-    /**
-     Only the default device selection changes. Auth sessions, analytics
-     settings, and unknown config keys remain intact.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `preserves unrelated configuration keys`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1953: an explicit empty hostname is accepted, saved as an empty default, and reported as success instead of failing validation."
+        )
+    )
+    func `requires a nonempty hostname`() async throws {
+        // TODO: enable when empty/whitespace hostnames are rejected (WDY-1953).
     }
 
-    /**
-     Missing or empty hostnames produce a usage diagnostic and leave the
-     configuration file unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `requires a hostname`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     set-default`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Too many positional arguments and unknown flags fail before config mutation. */
+    @Test
     func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device set-default first second") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg"))
+            }
+            try await cli.sh("wendy cloud device set-default --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+            try await cli.sh(
+                posix: "test ! -f \"$HOME/.wendy/config.json\"",
+                power:
+                    "if (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy/config.json')) { throw 'config created' }"
+            )
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceUnsetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceUnsetDefaultTests.swift
@@ -1,85 +1,94 @@
+import Foundation
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device unset-default'` {
-    /**
-     Displays usage for `wendy cloud device unset-default`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    /** Displays local clear-default usage without reading config or selecting a device. */
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device unset-default --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Clear the default device"))
+                #expect(
+                    result.stdout.contains("wendy cloud device unset-default [flags]")
+                )
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Removes the saved default device from CLI configuration and prints a
-     concise confirmation. Other configuration keys remain intact.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    /** Clears only the saved default and preserves unrelated known config. */
+    @Test
     func `clears the saved default device`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix: """
+                    mkdir -p "$HOME/.wendy"
+                    printf '%s\n' '{"defaultDevice":"old-device","analytics":{"enabled":false},"lastCLIUpdateCheck":"2026-07-20T12:00:00Z"}' > "$HOME/.wendy/config.json"
+                    """,
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{"defaultDevice":"old-device","analytics":{"enabled":false},"lastCLIUpdateCheck":"2026-07-20T12:00:00Z"}'
+                    """
+            )
+            try await cli.sh("wendy cloud device unset-default") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout == "Default device cleared.\n")
+                #expect(result.stderr == "")
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(result.stdout.utf8))
+                        as? [String: Any]
+                )
+                #expect(json["defaultDevice"] == nil)
+                #expect((json["analytics"] as? [String: Any])?["enabled"] as? Bool == false)
+                #expect(json["lastCLIUpdateCheck"] as? String == "2026-07-20T12:00:00Z")
+            }
+        }
     }
 
-    /**
-     With no saved default device, reports a no-op success and avoids creating
-     unrelated configuration state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test(
+        .disabled(
+            "WDY-1953: with no saved default, unset-default creates/rewrites config and reports a clear instead of remaining a non-mutating no-op."
+        )
+    )
     func `is idempotent when no default is configured`() async throws {
-        // TODO: implement.
+        // TODO: enable when no-default unset is non-mutating (WDY-1953).
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     unset-default`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    /** Unknown flags fail before config mutation. */
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device unset-default --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+            try await cli.sh(
+                posix: "test ! -f \"$HOME/.wendy/config.json\"",
+                power:
+                    "if (Test-Path -LiteralPath (Join-Path $env:HOME '.wendy/config.json')) { throw 'config created' }"
+            )
+        }
+    }
+
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud device unset-default' silently accepts extra positional arguments because the mirrored leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {
+        // TODO: enable when unset-default rejects positional arguments (WDY-1934).
     }
 }


### PR DESCRIPTION
> **In plain terms:** No cloud service or device is contacted. These cloud-prefixed default-device commands actually edit local CLI configuration, so this verifies those edits safely and removes copied tunnel expectations that do not apply to them.

## Summary

- Verify cloud `set-default` and `unset-default` help, isolated config mutation, known-field preservation, and argument validation.
- Remove stale copied cloud-selection, authentication, and reachability specs from commands whose primary behavior is local configuration.
- Keep picker/discovery, unknown-key preservation, empty-host validation, and no-op behavior specifically disabled under WDY-1943, WDY-1940, WDY-1953, and WDY-1934.
- Remove all 17 generic markers: 7 tests execute and 5 are specifically disabled.

## Stack

- Stacked on #1483; review commit `59fabbeda` for this iteration only.
- Test-only; no helper, harness, product, cloud, or device changes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyCloudDeviceSetDefaultTests" --filter "WendyCloudDeviceUnsetDefaultTests"`
- Result: `Test run with 12 tests in 2 suites passed` (7 executed, 5 intentionally skipped).
