### PR TITLE
test: classify cloud app lifecycle specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsRemoveTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsRemoveTests.swift
@@ -1,96 +1,106 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device apps remove'` {
-    /**
-     Displays usage for `wendy cloud device apps remove`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device apps remove --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Remove an application"))
+                #expect(
+                    result.stdout.contains(
+                        "wendy cloud device apps remove [app-name] [flags]"
+                    )
+                )
+                #expect(result.stdout.contains("--cleanup"))
+                #expect(result.stdout.contains("--delete-volumes"))
+                #expect(result.stdout.contains("--force"))
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target removal needs isolated auth, tunnel, and seeded managed-agent application state."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                "wendy cloud device apps remove example --device target --force --json"
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: tunnel, connection, and incompatible-RPC failures need controllable seeded cloud and managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: confirmation and successful removal need seeded cloud tunnel and managed-agent application state."
+        )
+    )
+    func `removes an application after confirmation`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: cleanup isolation needs seeded application, image, and persistent-volume state behind a cloud tunnel."
+        )
+    )
+    func `honors cleanup and volume deletion flags`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-application behavior needs seeded neighboring cloud-managed application and resource state."
+        )
+    )
+    func `reports unknown applications without deleting resources`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device apps remove example --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Removes the named application only after confirmation or `--force`.
-     Success output identifies the removed app and any optional cleanup
-     performed.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `removes an application after confirmation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--cleanup` removes the container image and `--delete-volumes` removes
-     persistent volumes only for the named app. Omitted cleanup flags leave
-     those resources intact.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `honors cleanup and volume deletion flags`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     An app name that is not deployed produces a failure diagnostic and does
-     not remove images, volumes, or other apps.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown applications without deleting resources`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     apps remove`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device apps remove one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsStartTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsStartTests.swift
@@ -1,95 +1,105 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device apps start'` {
-    /**
-     Displays usage for `wendy cloud device apps start`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device apps start --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Start an application"))
+                #expect(
+                    result.stdout.contains(
+                        "wendy cloud device apps start [app-name] [flags]"
+                    )
+                )
+                #expect(result.stdout.contains("--detach"))
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target startup needs isolated auth, tunnel, and seeded managed-agent application state."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                "wendy cloud device apps start example --device target --detach --json"
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: tunnel, connection, and incompatible-RPC failures need controllable seeded cloud and managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: startup and streamed output need seeded cloud-managed application/container state plus process control."
+        )
+    )
+    func `starts an application and streams output`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: detached startup needs seeded cloud tunnel and managed-agent application/container state."
+        )
+    )
+    func `starts detached when requested`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-application behavior needs seeded cloud-managed application/container state."
+        )
+    )
+    func `reports unknown applications without creating containers`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device apps start example --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Starts the named deployed application and streams container output until
-     the app exits or the user cancels. Startup failure is reported as command
-     failure.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `starts an application and streams output`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--detach` starts the app and returns after start-up status is known
-     without streaming logs.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `starts detached when requested`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     A missing app name or unknown deployed app produces a usage or not-found
-     diagnostic and no new container is created.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown applications without creating containers`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     apps start`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device apps start one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsStopTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsStopTests.swift
@@ -1,94 +1,104 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device apps stop'` {
-    /**
-     Displays usage for `wendy cloud device apps stop`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device apps stop --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Stop an application"))
+                #expect(
+                    result.stdout.contains(
+                        "wendy cloud device apps stop [app-name] [flags]"
+                    )
+                )
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target stop needs isolated auth, tunnel, and seeded managed-agent application state."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                "wendy cloud device apps stop example --device target --json"
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: tunnel, connection, and incompatible-RPC failures need controllable seeded cloud and managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: successful stop needs seeded running cloud-managed application/container state."
+        )
+    )
+    func `stops a running application`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: stopped-app idempotence needs seeded stopped cloud-managed application/container state."
+        )
+    )
+    func `handles already stopped applications predictably`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-app isolation needs seeded neighboring cloud-managed application/container state."
+        )
+    )
+    func `reports unknown applications without side effects`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device apps stop example --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Stops the named application and prints a concise confirmation after the
-     agent reports it stopped.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `stops a running application`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     An already stopped app produces a clear no-op or not-running result
-     without affecting other applications.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `handles already stopped applications predictably`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Unknown app names fail without stopping containers that have similar
-     names.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown applications without side effects`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     apps stop`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device apps stop one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }


### PR DESCRIPTION
> **In plain terms:** No cloud tunnel or application is touched. This verifies that cloud app start, stop, and remove commands explain themselves, reject bad input, and require login before attempting remote work.

## Summary

- Exercise help, missing-auth preflight, unknown-flag rejection, and extra-argument validation for cloud app lifecycle commands.
- Keep selection, tunnel failures, application state, container output, cleanup, and confirmation behind WDY-1949 and WDY-1952 fixtures.
- Remove all 27 generic markers: 12 tests execute and 18 are specifically disabled.

## Stack

- Stacked on #1485; review commit `2a49afcbc` for this iteration only.
- Test-only; no helper, harness, product, cloud, or device changes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyCloudDeviceAppsRemoveTests" --filter "WendyCloudDeviceAppsStartTests" --filter "WendyCloudDeviceAppsStopTests"`
- Result: `Test run with 30 tests in 3 suites passed` (12 executed, 18 intentionally skipped).
