### PR TITLE
test: classify cloud audio operation specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioListenTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioListenTests.swift
@@ -1,95 +1,97 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device audio listen'` {
-    /**
-     Displays usage for `wendy cloud device audio listen`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio listen --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Stream raw audio from a device microphone"))
+                #expect(result.stdout.contains("wendy cloud device audio listen [flags]"))
+                #expect(result.stdout.contains("--sample-rate"))
+                #expect(result.stdout.contains("--channels"))
+                #expect(result.stdout.contains("--stdout"))
+                #expect(result.stdout.contains("--buffer-ms"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target listening needs a seeded managed agent and simulated audio capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio listen --device target --stdout --json") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: microphone streaming needs seeded managed-agent audio frames without physical hardware."
+        )
+    )
+    func `streams microphone audio`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: raw PCM routing needs seeded managed-agent audio frames and stream process control."
+        )
+    )
+    func `writes raw PCM to stdout when requested`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1956: semantic audio parameter ranges are not validated locally before target connection/RPC."
+        )
+    )
+    func `validates audio parameters before streaming`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio listen --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Streams audio from the selected microphone using the requested device id,
-     channel count, and sample rate. The stream continues until cancelled or
-     the device ends it.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `streams microphone audio`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--stdout` writes raw PCM bytes to stdout and sends diagnostics to stderr
-     so piping to another process is safe.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `writes raw PCM to stdout when requested`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Invalid ids, channel counts, or sample rates fail before a stream is
-     opened.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `validates audio parameters before streaming`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     audio listen`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud device audio listen' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioMonitorTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioMonitorTests.swift
@@ -1,94 +1,94 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device audio monitor'` {
-    /**
-     Displays usage for `wendy cloud device audio monitor`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio monitor --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Real-time VU meter for audio levels"))
+                #expect(result.stdout.contains("wendy cloud device audio monitor [flags]"))
+                #expect(result.stdout.contains("--id"))
+                #expect(result.stdout.contains("--rate"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target monitoring needs a seeded managed agent and simulated audio capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio monitor --device target --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: VU rendering needs seeded managed-agent level frames plus controlled terminal output."
+        )
+    )
+    func `renders live audio levels`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1956: semantic audio parameter ranges are not validated locally before target connection/RPC."
+        )
+    )
+    func `validates monitor parameters before streaming`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: cancellation cleanup needs seeded streaming RPC state and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio monitor --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays a live VU meter for the selected audio input at the requested
-     update rate and keeps diagnostics separate from the terminal UI.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `renders live audio levels`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Invalid device ids or update rates fail before a monitoring stream is
-     opened.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `validates monitor parameters before streaming`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling the monitor closes the remote stream and restores terminal
-     output without modifying device settings.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     audio monitor`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud device audio monitor' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioSetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioSetDefaultTests.swift
@@ -1,94 +1,98 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device audio set-default'` {
-    /**
-     Displays usage for `wendy cloud device audio set-default`. The output
-     includes the command synopsis, local flags, inherited global flags,
-     and concise descriptions. Help exits successfully, writes to stdout,
-     emits no stderr, and leaves configuration, cache, project, cloud, and
-     device state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio set-default --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Set the default audio device"))
+                #expect(result.stdout.contains("wendy cloud device audio set-default [flags]"))
+                #expect(result.stdout.contains("--id"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target mutation needs seeded managed-agent audio state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio set-default --device target --id 4 --json") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     Sets the selected audio device id as the device default and prints a
-     concise confirmation with the chosen id or name.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `sets the default audio device`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: successful default selection needs seeded managed-agent audio device state."
+        )
+    )
+    func `sets the default audio device`() async throws {}
 
-    /**
-     Missing or invalid `--id` values produce a usage diagnostic before
-     contacting or mutating audio settings.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires an audio device id`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio set-default") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("required flag(s) \"id\" not set"))
+            }
+        }
     }
 
-    /**
-     If the agent rejects the id or does not support default audio selection,
-     the previous default remains active.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unsupported devices without changing defaults`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: rejection and previous-default preservation need seeded managed-agent audio state."
+        )
+    )
+    func `reports unsupported devices without changing defaults`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device audio set-default --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     audio set-default`. Extra positional arguments or unknown flags
-     produce a usage diagnostic on stderr, return a failure status, emit no
-     success output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud device audio set-default' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }


### PR DESCRIPTION
> **In plain terms:** No microphone, speaker, cloud tunnel, or device is touched. This verifies that cloud audio commands document their controls, reject bad input, and require login before remote work.

## Summary

- Exercise help, missing-auth preflight, required audio-device ID validation, and unknown-flag rejection.
- Keep audio streams, cancellation, device state, semantic range validation, and tunnel failures behind WDY-1949, WDY-1952, WDY-1956, and WDY-1934.
- Remove all 27 generic markers: 10 tests execute and 20 are specifically disabled.

## Stack

- Stacked on #1486; review commit `08c6bcef2` for this iteration only.
- Test-only; no helper, harness, product, cloud, or device changes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyCloudDeviceAudioListenTests" --filter "WendyCloudDeviceAudioMonitorTests" --filter "WendyCloudDeviceAudioSetDefaultTests"`
- Result: `Test run with 30 tests in 3 suites passed` (10 executed, 20 intentionally skipped).
