### PR TITLE
test: classify cloud Bluetooth mutation specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothConnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothConnectTests.swift
@@ -1,94 +1,114 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device bluetooth connect'` {
-    /**
-     Displays usage for `wendy cloud device bluetooth connect`. The output
-     includes the command synopsis, local flags, inherited global flags,
-     and concise descriptions. Help exits successfully, writes to stdout,
-     emits no stderr, and leaves configuration, cache, project, cloud, and
-     device state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth connect --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Connect to a Bluetooth peripheral"))
+                #expect(
+                    result.stdout.contains("wendy cloud device bluetooth connect [address] [flags]")
+                )
+                #expect(result.stdout.contains("--pair"))
+                #expect(result.stdout.contains("--trust"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target connection needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                "wendy cloud device bluetooth connect AA:BB:CC:DD:EE:FF --device target --json"
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     Connects to the requested peripheral address and applies pair and trust
-     options. Success output identifies the connected address.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `connects to a Bluetooth peripheral`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: pair/trust/connect behavior needs simulated managed-agent Bluetooth state without physical radios."
+        )
+    )
+    func `connects to a Bluetooth peripheral`() async throws {}
 
-    /**
-     Missing or malformed addresses produce a usage diagnostic before a
-     Bluetooth operation starts.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires a peripheral address`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth connect") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 0"))
+            }
+        }
     }
 
-    /**
-     Pairing, trust, or connection failures report the failed stage and do not
-     claim the peripheral is connected.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports pairing failures without trusting the device`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
+        )
+    )
+    func `rejects malformed peripheral addresses`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: staged pair/trust/connect failures need controllable simulated managed-agent Bluetooth responses."
+        )
+    )
+    func `reports pairing failures without trusting the device`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth connect AA:BB:CC:DD:EE:FF --bogus") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     bluetooth connect`. Extra positional arguments or unknown flags
-     produce a usage diagnostic on stderr, return a failure status, emit no
-     success output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth connect one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothDisconnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothDisconnectTests.swift
@@ -1,94 +1,114 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device bluetooth disconnect'` {
-    /**
-     Displays usage for `wendy cloud device bluetooth disconnect`. The output
-     includes the command synopsis, local flags, inherited global flags,
-     and concise descriptions. Help exits successfully, writes to stdout,
-     emits no stderr, and leaves configuration, cache, project, cloud, and
-     device state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth disconnect --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Disconnect a Bluetooth peripheral"))
+                #expect(
+                    result.stdout.contains(
+                        "wendy cloud device bluetooth disconnect [address] [flags]"
+                    )
+                )
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target disconnection needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                "wendy cloud device bluetooth disconnect AA:BB:CC:DD:EE:FF --device target --json"
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     Disconnects the requested peripheral address and prints a concise
-     confirmation after the agent reports it disconnected.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `disconnects a Bluetooth peripheral`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: successful disconnection needs simulated managed-agent Bluetooth connection state."
+        )
+    )
+    func `disconnects a Bluetooth peripheral`() async throws {}
 
-    /**
-     Missing or malformed addresses produce a usage diagnostic and no Bluetooth
-     operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires a peripheral address`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth disconnect") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 0"))
+            }
+        }
     }
 
-    /**
-     A peripheral that is not connected produces a clear no-op or not-connected
-     result without affecting pairing state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `handles already disconnected peripherals predictably`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
+        )
+    )
+    func `rejects malformed peripheral addresses`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: already-disconnected semantics need simulated managed-agent Bluetooth state."
+        )
+    )
+    func `handles already disconnected peripherals predictably`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth disconnect AA:BB:CC:DD:EE:FF --bogus") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     bluetooth disconnect`. Extra positional arguments or unknown flags
-     produce a usage diagnostic on stderr, return a failure status, emit no
-     success output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth disconnect one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothForgetTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothForgetTests.swift
@@ -1,94 +1,112 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device bluetooth forget'` {
-    /**
-     Displays usage for `wendy cloud device bluetooth forget`. The output
-     includes the command synopsis, local flags, inherited global flags,
-     and concise descriptions. Help exits successfully, writes to stdout,
-     emits no stderr, and leaves configuration, cache, project, cloud, and
-     device state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth forget --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Forget a paired Bluetooth peripheral"))
+                #expect(
+                    result.stdout.contains("wendy cloud device bluetooth forget [address] [flags]")
+                )
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target forget needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                "wendy cloud device bluetooth forget AA:BB:CC:DD:EE:FF --device target --json"
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
 
-    /**
-     Removes pairing and trust state for the requested peripheral address
-     without changing unrelated peripherals.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `forgets a paired Bluetooth peripheral`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1952: successful forget needs simulated managed-agent pairing/trust state without physical radios."
+        )
+    )
+    func `forgets a paired Bluetooth peripheral`() async throws {}
 
-    /**
-     Missing or malformed addresses produce a usage diagnostic and no Bluetooth
-     operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires a peripheral address`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth forget") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 0"))
+            }
+        }
     }
 
-    /**
-     Forgetting an address unknown to the device reports a not-found result and
-     preserves other pairings.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown peripherals without changing known devices`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
+        )
+    )
+    func `rejects malformed peripheral addresses`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-address isolation needs seeded neighboring managed-agent pairing state."
+        )
+    )
+    func `reports unknown peripherals without changing known devices`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth forget AA:BB:CC:DD:EE:FF --bogus") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     bluetooth forget`. Extra positional arguments or unknown flags produce
-     a usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device bluetooth forget one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts 1 arg(s), received 2"))
+            }
+        }
     }
 }


### PR DESCRIPTION
> **In plain terms:** No Bluetooth radio, peripheral, cloud tunnel, or device is touched. This verifies cloud connect, disconnect, and forget syntax plus login preflight before remote work.

## Summary

- Exercise help, missing-auth preflight, required-address validation, unknown flags, and extra positional arguments.
- Keep pairing, trust, peripheral state, malformed-address semantics, and tunnel failures behind WDY-1949, WDY-1952, and WDY-1957.
- Remove all 27 generic markers: 15 tests execute and 18 are specifically disabled.

## Stack

- Stacked on #1487; review commit `5fef4916e` for this iteration only.
- Test-only; no helper, harness, product, cloud, device, or radio changes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyCloudDeviceBluetoothConnectTests" --filter "WendyCloudDeviceBluetoothDisconnectTests" --filter "WendyCloudDeviceBluetoothForgetTests"`
- Result: `Test run with 33 tests in 3 suites passed` (15 executed, 18 intentionally skipped).
