### PR TITLE
test: classify cloud stream and storage specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceCameraViewTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceCameraViewTests.swift
@@ -1,103 +1,105 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device camera view'` {
-    /**
-     Displays usage for `wendy cloud device camera view`. The output includes
-     the command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device camera view --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Stream H.264 video from a device camera"))
+                #expect(result.stdout.contains("wendy cloud device camera view [flags]"))
+                #expect(result.stdout.contains("--id"))
+                #expect(result.stdout.contains("--width"))
+                #expect(result.stdout.contains("--height"))
+                #expect(result.stdout.contains("--fps"))
+                #expect(result.stdout.contains("--stdout"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target viewing needs a seeded managed agent and simulated camera capability without physical hardware."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device camera view --device target --stdout --json") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: camera playback needs seeded encoded frames plus controlled local viewer dependencies."
+        )
+    )
+    func `streams camera video`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: encoded stdout routing needs seeded frames and bounded stream process control."
+        )
+    )
+    func `writes encoded video to stdout when requested`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1958: semantic camera dimensions and frame rates are not validated locally before target connection/RPC."
+        )
+    )
+    func `validates camera parameters before streaming`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: viewer cancellation cleanup needs seeded streaming RPC state and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device camera view --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Streams video from the selected camera using the requested dimensions and
-     frame rate. Interactive mode opens a viewer when available.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `streams camera video`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     `--stdout` writes the encoded video stream to stdout and keeps diagnostics
-     on stderr for safe piping.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `writes encoded video to stdout when requested`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Invalid camera ids, dimensions, or frame rates fail before a remote camera
-     stream is opened.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `validates camera parameters before streaming`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling the viewer closes the remote stream and local viewer process
-     without changing camera settings.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     camera view`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud device camera view' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceDashboardTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceDashboardTests.swift
@@ -1,95 +1,96 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device dashboard'` {
-    /**
-     Displays usage for `wendy cloud device dashboard`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device dashboard --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(
+                    result.stdout.contains("Live dashboard showing metrics and logs from a device")
+                )
+                #expect(result.stdout.contains("wendy cloud device dashboard [flags]"))
+                #expect(result.stdout.contains("--app"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target dashboard startup needs a seeded managed agent with telemetry state."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device dashboard --device target --app Example") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: live dashboard rendering needs seeded metrics/log streams and scripted terminal control."
+        )
+    )
+    func `shows a live device dashboard`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: terminal capability behavior needs a seeded target plus controlled TTY/non-TTY execution."
+        )
+    )
+    func `reports non-interactive dashboard limitations`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: dashboard cancellation cleanup needs seeded streams and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device dashboard --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Displays live metrics and logs for the selected device, optionally
-     filtered to an application. The dashboard is informational and does not
-     mutate device state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shows a live device dashboard`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Without an interactive terminal, reports that the live dashboard requires
-     a terminal or suggests machine-readable alternatives.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports non-interactive dashboard limitations`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling the dashboard closes log and metric streams and restores
-     terminal output.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     dashboard`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud device dashboard' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceLogsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceLogsTests.swift
@@ -1,94 +1,100 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device logs'` {
-    /**
-     Displays usage for `wendy cloud device logs`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device logs --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Stream logs from containers on the device"))
+                #expect(result.stdout.contains("wendy cloud device logs [app] [flags]"))
+                #expect(result.stdout.contains("--app"))
+                #expect(result.stdout.contains("--service"))
+                #expect(result.stdout.contains("--level"))
+                #expect(result.stdout.contains("--tail"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target log streaming needs a seeded managed agent with telemetry state."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device logs Example --device target --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: filtered log streaming needs seeded managed-agent container and telemetry records."
+        )
+    )
+    func `streams device logs`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSON log framing needs seeded managed-agent telemetry records and bounded stream control."
+        )
+    )
+    func `prints structured log entries in JSON mode`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: log cancellation cleanup needs a seeded stream and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device logs --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Streams logs from the selected device and applies app, service, level, and
-     severity filters before presenting entries.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `streams device logs`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits newline-delimited or array-wrapped structured log
-     entries suitable for automation, without table formatting.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints structured log entries in JSON mode`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling log streaming closes the remote stream without changing app or
-     device state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     logs`. Extra positional arguments or unknown flags produce a usage
-     diagnostic on stderr, return a failure status, emit no success output,
-     and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device logs one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceTelemetryStreamTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceTelemetryStreamTests.swift
@@ -1,95 +1,100 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device telemetry-stream'` {
-    /**
-     Displays usage for `wendy cloud device telemetry-stream`. The output
-     includes the command synopsis, local flags, inherited global flags,
-     and concise descriptions. Help exits successfully, writes to stdout,
-     emits no stderr, and leaves configuration, cache, project, cloud, and
-     device state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device telemetry-stream --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(
+                    result.stdout.contains("Stream telemetry data (logs, metrics, traces) as JSONL")
+                )
+                #expect(result.stdout.contains("wendy cloud device telemetry-stream [flags]"))
+                #expect(result.stdout.contains("--app"))
+                #expect(result.stdout.contains("--service"))
+                #expect(result.stdout.contains("--logs"))
+                #expect(result.stdout.contains("--metrics"))
+                #expect(result.stdout.contains("--traces"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target telemetry needs a seeded managed agent with logs, metrics, and traces."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device telemetry-stream --device target --logs --json") {
+                result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: JSONL framing needs seeded logs, metrics, and traces plus bounded stream control."
+        )
+    )
+    func `streams telemetry as JSONL`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: telemetry filtering needs seeded neighboring app/service records across all signal types."
+        )
+    )
+    func `applies telemetry filters`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: telemetry cancellation cleanup needs seeded streams and harness process control."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device telemetry-stream --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Streams selected logs, metrics, and traces as JSON lines with stable
-     envelope fields and timestamps. The stream continues until cancelled or
-     the device closes it.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `streams telemetry as JSONL`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     App, service, logs, metrics, and traces filters constrain the stream
-     before entries are emitted to stdout.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `applies telemetry filters`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Cancelling the stream closes the remote telemetry subscription and emits
-     no malformed trailing JSON.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     telemetry-stream`. Extra positional arguments or unknown flags produce
-     a usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud device telemetry-stream' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVolumesRemoveTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVolumesRemoveTests.swift
@@ -1,94 +1,99 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud device volumes remove'` {
-    /**
-     Displays usage for `wendy cloud device volumes remove`. The output
-     includes the command synopsis, local flags, inherited global flags,
-     and concise descriptions. Help exits successfully, writes to stdout,
-     emits no stderr, and leaves configuration, cache, project, cloud, and
-     device state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device volumes remove --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Remove a persistent volume"))
+                #expect(result.stdout.contains("wendy cloud device volumes remove [name] [flags]"))
+                #expect(result.stdout.contains("--force"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     `--device` selects the cloud device and skips local discovery and pickers.
-     The command does not read or change the saved default device when an
-     explicit target is supplied.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit device selection without prompting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: explicit cloud-target removal needs seeded managed-agent persistent-volume state without a physical device."
+        )
+    )
+    func `uses explicit device selection without prompting`() async throws {}
 
-    /**
-     Without an explicit or configured device in a non-interactive context,
-     reports that a device selection is required, emits no prompt escape
-     sequences, and performs no device operation.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing device selection in non-interactive mode`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
+        )
+    )
+    func `reports missing device selection in non-interactive mode`() async throws {}
 
-    /**
-     Cloud-routed device commands validate the selected Wendy Cloud auth
-     session before connecting to the broker. Missing or ambiguous auth fails
-     before device state changes.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                "wendy cloud device volumes remove example --force --device target --json"
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Connection failures, timeouts, and incompatible agent responses produce
-     stderr diagnostics and a failure status. Output does not claim that the
-     operation succeeded.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unreachable devices without partial success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
+        )
+    )
+    func `reports unreachable devices without partial success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: confirmation and successful removal need seeded managed-agent persistent-volume state."
+        )
+    )
+    func `removes a persistent volume after confirmation`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: omitted names intentionally open a device-backed volume picker and need seeded list results."
+        )
+    )
+    func `selects a missing volume name interactively`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1952: unknown-volume isolation needs seeded neighboring volume and application state."
+        )
+    )
+    func `reports unknown volumes without deleting data`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device volumes remove example --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+            }
+        }
     }
 
-    /**
-     Removes the named volume only after confirmation or `--force`. Success
-     output identifies the removed volume.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `removes a persistent volume after confirmation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Missing or empty volume names produce a usage diagnostic before contacting
-     the device.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `requires a volume name`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     An unknown volume name fails without deleting similarly named volumes or
-     application containers.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports unknown volumes without deleting data`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Accepts only the documented arguments and flags for `wendy cloud device
-     volumes remove`. Extra positional arguments or unknown flags produce a
-     usage diagnostic on stderr, return a failure status, emit no success
-     output, and leave existing state unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `rejects undocumented arguments and flags`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects extra positional arguments`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud device volumes remove one two") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("accepts at most 1 arg(s), received 2"))
+            }
+        }
     }
 }


### PR DESCRIPTION
> **In plain terms:** No camera, dashboard, log stream, telemetry stream, volume, cloud tunnel, or device is touched. This verifies local syntax and login preflight while leaving remote state and long-running interfaces dormant.

## Summary

- Exercise help, missing-auth preflight, unknown flags, and supported extra-argument validation across camera, dashboard, logs, telemetry, and volume removal.
- Keep media playback, terminal control, cancellation, telemetry data, storage state, and tunnel failures behind WDY-1949, WDY-1952, WDY-1958, and WDY-1934.
- Remove all 46 generic markers: 17 tests execute and 34 are specifically disabled.

## Stack

- Stacked on #1489; review commit `05f0dad31` for this iteration only.
- Test-only; no helper, harness, product, cloud, device, media, or storage changes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyCloudDeviceCameraViewTests" --filter "WendyCloudDeviceDashboardTests" --filter "WendyCloudDeviceLogsTests" --filter "WendyCloudDeviceTelemetryStreamTests" --filter "WendyCloudDeviceVolumesRemoveTests"`
- Result: `Test run with 51 tests in 5 suites passed` (17 executed, 34 intentionally skipped).
