### PR TITLE
test: classify final Swift E2E cloud specs

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDiscoverTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDiscoverTests.swift
@@ -1,65 +1,100 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud discover'` {
-    /**
-     Displays usage for `wendy cloud discover`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud discover --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("List enrolled devices in Wendy Cloud"))
+                #expect(result.stdout.contains("wendy cloud discover [flags]"))
+                #expect(result.stdout.contains("--all"))
+                #expect(result.stdout.contains("--broker-url"))
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Uses the stored Wendy Cloud auth session to list enrolled devices
-     with names, online status, and connection metadata. Success output
-     is a finite list and emits no stderr.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `lists enrolled cloud devices`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: enrolled-device discovery needs isolated cloud auth and seeded asset inventory."
+        )
+    )
+    func `lists enrolled cloud devices`() async throws {}
 
-    /**
-     `--all` includes offline devices and marks their state clearly.
-     Without `--all`, the default listing focuses on currently usable
-     devices.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `includes offline devices when requested`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: offline-device filtering needs isolated cloud auth and seeded online/offline asset inventory."
+        )
+    )
+    func `includes offline devices when requested`() async throws {}
 
-    /**
-     With no auth session, reports that login is required and performs no
-     cloud discovery request.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports missing auth before contacting discovery services`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud discover --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     With `--json`, emits device objects with stable id, name, status,
-     and endpoint fields. JSON mode emits no table formatting.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON cloud discovery results for automation`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: JSON cloud discovery schema needs isolated auth and seeded asset inventory."
+        )
+    )
+    func `prints JSON cloud discovery results for automation`() async throws {}
 
-    /**
-     Reads the Wendy CLI configuration before performing work that depends on
-     user state. Malformed configuration is reported as a configuration error,
-     no prompts open, no network connection is attempted, and the original file
-     remains byte-for-byte unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `reports invalid CLI configuration before acting`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                posix:
+                    "mkdir -p \"$HOME/.wendy\"; printf '{ broken\\n' > \"$HOME/.wendy/config.json\"",
+                power: """
+                    New-Item -ItemType Directory -Force -Path (Join-Path $env:HOME '.wendy') | Out-Null
+                    Set-Content -NoNewline -LiteralPath (Join-Path $env:HOME '.wendy/config.json') -Value '{ broken'
+                    """
+            )
+            try await cli.sh("wendy cloud discover --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("parsing config"))
+            }
+            try await cli.sh(
+                posix: "cat \"$HOME/.wendy/config.json\"",
+                power: "Get-Content -Raw -LiteralPath (Join-Path $env:HOME '.wendy/config.json')"
+            ) { result in
+                #expect(result.stdout.contains("{ broken"))
+            }
+        }
     }
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud discover --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
+    }
+
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud discover' silently accepts positional arguments because the command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudEnrollDeviceTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudEnrollDeviceTests.swift
@@ -1,66 +1,78 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud enroll-device'` {
-    /**
-     Displays usage for `wendy cloud enroll-device`. The output includes the
-     command synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud enroll-device --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Alias for 'wendy device enroll'"))
+                #expect(result.stdout.contains("wendy cloud enroll-device [flags]"))
+                #expect(result.stdout.contains("--cloud-grpc"))
+                #expect(result.stdout.contains("--name"))
+                #expect(result.stdout.contains("--org"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stdout.contains("--json"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Creates an enrollment token with the stored cloud auth session and
-     provisions the selected device with mTLS credentials. Output
-     matches the device enrollment flow apart from the command name.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `acts as the cloud alias for device enrollment`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1952: alias parity needs isolated PKI auth and a disposable seeded device provisioning target."
+        )
+    )
+    func `acts as the cloud alias for device enrollment`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1949: endpoint selection needs multiple isolated cloud/PKI auth sessions and token issuance fixtures."
+        )
+    )
+    func `uses the requested cloud endpoint`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1959: cloud enroll-device connects to and may inspect WiFi on the local device before resolving auth; WDY-1949 tracks isolated failure fixtures."
+        )
+    )
+    func `reports missing auth or unreachable devices without partial enrollment`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1949: JSON enrollment output needs isolated successful PKI/cloud and disposable device fixtures."
+        )
+    )
+    func `prints JSON enrollment result for automation`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1959: invalid auth configuration is not read until after local device connection and optional WiFi inspection."
+        )
+    )
+    func `reports invalid CLI configuration before acting`() async throws {}
+
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud enroll-device --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
     }
 
-    /**
-     `--cloud-grpc` selects the cloud or pki-core endpoint when more
-     than one auth session exists. Sessions for other endpoints remain
-     untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses the requested cloud endpoint`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Authentication failures, token creation failures, and device
-     connection failures leave the device and local credential store in
-     their previous state.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports missing auth or unreachable devices without partial enrollment`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     With `--json`, emits cloud, device, certificate, and enrollment
-     status fields without printing token or private key material.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON enrollment result for automation`() async throws {
-        // TODO: implement.
-    }
-
-    /**
-     Reads the Wendy CLI configuration before performing work that depends on
-     user state. Malformed configuration is reported as a configuration error,
-     no prompts open, no network connection is attempted, and the original file
-     remains byte-for-byte unchanged.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports invalid CLI configuration before acting`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud enroll-device' silently accepts positional arguments because the command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudRunTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudRunTests.swift
@@ -1,95 +1,118 @@
 import Testing
+import WendyE2ETesting
 
 @Suite
 struct `'wendy cloud run'` {
-    /**
-     Displays usage for `wendy cloud run`. The output includes the command
-     synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    let scenario = CLIAndAgentScenario()
+
+    @Test
     func `prints command help`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud run --help") { result in
+                #expect(result.status.isSuccess)
+                #expect(result.stdout.contains("Deprecated: use 'wendy run' instead"))
+                #expect(result.stdout.contains("wendy cloud run [flags]"))
+                #expect(result.stdout.contains("--build-type"))
+                #expect(result.stdout.contains("--deploy"))
+                #expect(result.stdout.contains("--detach"))
+                #expect(result.stdout.contains("--user-args"))
+                #expect(result.stdout.contains("--prefix"))
+                #expect(result.stdout.contains("--device"))
+                #expect(result.stderr == "")
+            }
+        }
     }
 
-    /**
-     Reads the project configuration, builds the application image,
-     deploys it through the Wendy Cloud tunnel broker, and starts the
-     container. Success output makes the running app and target device
-     clear.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `builds, deploys, and starts the current project`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1950: cloud build/deploy/start needs isolated projects, builders, auth, tunnels, images, and a disposable managed-agent target."
+        )
+    )
+    func `builds, deploys, and starts the current project`() async throws {}
 
-    /**
-     `--deploy` creates or updates the container on the target device and
-     leaves it stopped. The command exits successfully after deployment and
-     prints no live log stream.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `deploys without starting when requested`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1950: stopped cloud deployment needs an isolated project and disposable managed-agent container state."
+        )
+    )
+    func `deploys without starting when requested`() async throws {}
 
-    /**
-     `--detach` starts the application and returns after start-up status is
-     known. Output includes the app name and how to view logs later.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `detaches after starting when requested`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1950: detached cloud startup needs an isolated built app and disposable managed-agent target."
+        )
+    )
+    func `detaches after starting when requested`() async throws {}
 
-    /**
-     `--user-args` preserves argument boundaries and forwards the provided
-     values to the started application without interpreting secrets or shell
-     metacharacters locally.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `passes user arguments to the container`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1950: user-argument boundaries need an argv-reporting fixture app deployed through an isolated cloud tunnel."
+        )
+    )
+    func `passes user arguments to the container`() async throws {}
 
-    /**
-     `--prefix` selects the project directory and `--device` names the cloud
-     device and skips the picker. The command does not read unrelated
-     `wendy.json` files or open interactive device selection.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `uses explicit project and device selection`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1950: explicit project/device success needs isolated project, auth, tunnel, and managed-target fixtures."
+        )
+    )
+    func `uses explicit project and device selection`() async throws {}
 
-    /**
-     Requires a valid Wendy Cloud auth session before opening the tunnel.
-     Missing or ambiguous sessions produce an auth diagnostic without
-     building, deploying, or contacting a device.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
+    @Test
     func `uses cloud authentication before connecting`() async throws {
-        // TODO: implement.
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud run --device target --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("not logged in"))
+                #expect(result.stderr.contains("wendy auth login"))
+            }
+        }
     }
 
-    /**
-     Build failures, invalid project configuration, unreachable devices, or
-     deployment errors return a failure status. Partial remote resources are
-     either cleaned up or identified clearly for manual cleanup.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `reports build or deployment failure without claiming success`() async throws {
-        // TODO: implement.
+    @Test(
+        .disabled(
+            "WDY-1949/WDY-1950: build/deployment failure cleanup needs controllable builder, tunnel, and managed-agent failure modes."
+        )
+    )
+    func `reports build or deployment failure without claiming success`() async throws {}
+
+    @Test(
+        .disabled(
+            "WDY-1909/WDY-1949/WDY-1950: cloud run lacks complete JSON results and needs isolated deployment fixtures to verify stream separation."
+        )
+    )
+    func `prints JSON run metadata for automation`() async throws {}
+
+    @Test
+    func `rejects a missing project prefix before cloud access`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud run --prefix missing-project") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("resolving working directory"))
+                #expect(result.stderr.contains("does not exist"))
+                #expect(!result.stderr.contains("not logged in"))
+            }
+        }
     }
 
-    /**
-     With `--json`, emits structured build, deploy, start, and app metadata.
-     Progress and streamed container logs do not corrupt stdout JSON.
-     */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `prints JSON run metadata for automation`() async throws {
-        // TODO: implement.
+    @Test
+    func `rejects undocumented flags`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh("wendy cloud run --bogus") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("unknown flag"))
+                #expect(result.stderr.contains("--bogus"))
+            }
+        }
     }
+
+    @Test(
+        .disabled(
+            "WDY-1934: 'wendy cloud run' silently accepts positional arguments because the command has no cobra.NoArgs validator."
+        )
+    )
+    func `rejects undocumented positional arguments`() async throws {}
 }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudTunnelTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudTunnelTests.swift
@@ -47,19 +47,23 @@ struct `'wendy cloud tunnel'` {
      the requested remote port on the selected device through the Wendy
      Cloud tunnel broker.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `forwards local connections through the cloud broker`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: forwarding needs an isolated authenticated broker, disposable device endpoint, and observable bidirectional connection fixture."
+        )
+    )
+    func `forwards local connections through the cloud broker`() async throws {}
 
     /**
      `--device`, `--broker-url`, and `--cloud-grpc` bypass interactive
      selection and bind the tunnel to a specific cloud route.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `selects device and broker explicitly`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: explicit route selection needs isolated auth plus seeded broker and cloud-device inventory."
+        )
+    )
+    func `selects device and broker explicitly`() async throws {}
 
     /**
      Malformed mappings, privileged local ports without permission, or
@@ -109,8 +113,10 @@ struct `'wendy cloud tunnel'` {
      Cancelling the tunnel closes active connections and the local
      listener without modifying configuration.
      */
-    @Test(.disabled("SPEC STUB: behavior agreed, implementation pending"))
-    func `shuts down cleanly on cancellation`() async throws {
-        // TODO: implement.
-    }
+    @Test(
+        .disabled(
+            "WDY-1949: cancellation cleanup needs an authenticated disposable tunnel plus harness process control and listener observability."
+        )
+    )
+    func `shuts down cleanly on cancellation`() async throws {}
 }


### PR DESCRIPTION
> **In plain terms:** This finishes the generic Swift E2E placeholder cleanup without contacting Wendy Cloud, enrolling a device, building an app, or opening a tunnel. Every former placeholder now either executes a safe local contract or clearly identifies the protected fixture needed later.

## Summary

- Exercise cloud discover/run/enroll/tunnel help, auth preflight, malformed-config handling, missing project prefixes, bad flags, and invalid port mappings.
- Specifically defer cloud inventory, enrollment, build/deploy, forwarding, and cancellation under WDY-1949, WDY-1950, WDY-1959, WDY-1934, and WDY-1909.
- Remove the final 24 generic markers. The campaign head now contains zero `SPEC STUB` markers.
- Touched suites contain 34 tests: 13 execute and 21 are specifically disabled.

## Stack

- Stacked on #1491; review commit `c08be8455` for this iteration only.
- Test-only; no helper, harness, product, PKI, cloud, builder, tunnel, or device changes.

## Tests

- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyCloudDiscoverTests" --filter "WendyCloudEnrollDeviceTests" --filter "WendyCloudRunTests" --filter "WendyCloudTunnelTests"`
- Result: `Test run with 34 tests in 4 suites passed` (13 executed, 21 intentionally skipped).
- `rg -n 'SPEC STUB' swift/WendyE2ETests/Tests` returns no matches.
